### PR TITLE
Switch dataset.coordinates values to variables

### DIFF
--- a/src/polyglot/data.py
+++ b/src/polyglot/data.py
@@ -438,12 +438,11 @@ class Dataset(object):
     def coordinates(self):
         # A coordinate variable is a 1-dimensional variable with the
         # same name as its dimension
-        return OrderedDict([(dim, length)
-                for (dim, length) in self.dimensions.iteritems()
-                if (dim in self.variables) and
-                (self.variables[dim].data.ndim == 1) and
-                (self.variables[dim].dimensions == (dim,))
-                ])
+        return OrderedDict([(dim, self.variables[dim])
+                for dim in self.dimensions
+                if dim in self.variables and
+                self.variables[dim].data.ndim == 1 and
+                self.variables[dim].dimensions == (dim,)])
 
     @property
     def noncoordinates(self):


### PR DESCRIPTION
This makes it consistent with dataset.noncoordinates. If you want the old
behavior (values as dimension lengths), then you can just use
dataset.dimensions instead.
