### PR TITLE
Fix to_dataframe method for DatetimeIndex indices

### DIFF
--- a/src/xray/dataset_array.py
+++ b/src/xray/dataset_array.py
@@ -407,8 +407,11 @@ class DatasetArray(AbstractArray):
         Unlike `to_dataframe`, only the variable at the focus of this array is
         including in the returned series.
         """
-        index = pd.MultiIndex.from_product(self.coordinates.values(),
-                                           names=self.coordinates.keys())
+        # np.asarray is necessary to work around a pandas bug:
+        # https://github.com/pydata/pandas/issues/6439
+        coords = [np.asarray(v) for v in self.coordinates.values()]
+        index_names = self.coordinates.keys()
+        index = pd.MultiIndex.from_product(coords, names=index_names)
         return pd.Series(self.data.reshape(-1), index=index, name=self.focus)
 
     def __array_wrap__(self, obj, context=None):

--- a/src/xray/utils.py
+++ b/src/xray/utils.py
@@ -165,36 +165,6 @@ def datetimeindex2num(dates, units=None, calendar=None):
     return (num, units, calendar)
 
 
-def unzipped_cartesian_product(arrays):
-    """Given an iterable of arrays, return a list of arrays with elements equal
-    to the tensor product of the original arrays
-
-    Like an unzipped version of itertools.product, but uses numpy array
-    broadcasting. Given separate arrays for each level of a hierarchical index,
-    this function returns a list of arrays suitable for passing to
-    pandas.MultiIndex.from_arrays.
-    """
-    # monkey-patch numpy to apply the fix in GitHub issue #4343
-    from numpy.lib.stride_tricks import DummyArray
-    def as_strided(x, shape=None, strides=None):
-        """ Make an ndarray from the given array with the given shape and strides.
-        """
-        interface = dict(x.__array_interface__)
-        if shape is not None:
-            interface['shape'] = tuple(shape)
-        if strides is not None:
-            interface['strides'] = tuple(strides)
-        array = np.asarray(DummyArray(interface, base=x))
-        # Make sure dtype is correct in case of custom dtype
-        if array.dtype is not np.dtype('O'):
-            array.dtype = x.dtype
-        return array
-    np.lib.stride_tricks.as_strided = as_strided
-
-    # adapted from http://stackoverflow.com/a/11146645/809705
-    return [arr.reshape(-1) for arr in np.broadcast_arrays(*np.ix_(*arrays))]
-
-
 def xarray_equal(v1, v2, rtol=1e-05, atol=1e-08):
     """True if two objects have the same dimensions, attributes and data;
     otherwise False

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -83,13 +83,6 @@ class TestDatetime(TestCase):
             self.assertEquals(expected, utils.guess_time_units(dates))
 
 
-class TestMisc(TestCase):
-    def test_unzipped_cartesian_product(self):
-        self.assertArrayEqual(
-            [[0, 0, 0, 1, 1, 1], ['a', 'b', 'c', 'a', 'b', 'c']],
-            utils.unzipped_cartesian_product([[0, 1], ['a', 'b', 'c']]))
-
-
 class TestDictionaries(TestCase):
     def setUp(self):
         self.x = {'a': 'A', 'b': 'B'}


### PR DESCRIPTION
Also this removes one of our dependencies on pandas==0.13.1.
