### PR TITLE
Arrays with object dtype can now be dumped to netCDF

### DIFF
--- a/src/xray/backends.py
+++ b/src/xray/backends.py
@@ -71,12 +71,12 @@ def convert_to_cf_variable(array):
         attributes['units'] = units
         attributes['calendar'] = calendar
     elif data.dtype == np.dtype('O'):
-        # Unfortunately, pandas.Index arrays are often have dtype=object even
-        # if they were created from an array with a sensible datatype (e.g.,
-        # pandas.Float64Index always dtype=object for some reason). Because we
-        # allow for doing math with coordinates, these object arrays can
-        # propagate onward into other variables, which is why we don't only
-        # apply this check to XArrays with data that is a pandas.Index.
+        # Unfortunately, pandas.Index arrays often have dtype=object even if
+        # they were created from an array with a sensible datatype (e.g.,
+        # pandas.Float64Index always has dtype=object for some reason). Because
+        # we allow for doing math with coordinates, these object arrays can
+        # propagate onward to other variables, which is why we don't only apply
+        # this check to XArrays with data that is a pandas.Index.
         dtype = np.array(data.reshape(-1)[0]).dtype
         # N.B. the "astype" call will fail if data cannot be cast to the type
         # of its first element (which is probably the only sensible thing to


### PR DESCRIPTION
Object arrays arise when using pandas.Index objects that aren't integers.
