### PR TITLE
BUG: fix loading all variable data during slicing

### DIFF
--- a/src/xray/xarray.py
+++ b/src/xray/xarray.py
@@ -236,7 +236,7 @@ class XArray(AbstractArray):
         if invalid:
             raise ValueError("dimensions %r do not exist" % invalid)
 
-        key = [slice(None)] * self.data.ndim
+        key = [slice(None)] * self.ndim
         for i, dim in enumerate(self.dimensions):
             if dim in indexers:
                 key[i] = indexers[dim]


### PR DESCRIPTION
Accessing the data attribute loads all data into memory as a numpy array, which is obviously problematic! This fix replaces `self.data.ndim` with `self.ndim`, which means the data doesn't all need to be loaded.
