### PR TITLE
Alternative Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
+# Based on https://github.com/Jorge-C/ordination/blob/master/.travis.yml
 language: python
 python:
   - "2.7"
-# command to install dependencies
+# Setup anaconda
 before_install:
-  - sudo apt-get install -qq liblapack-dev gfortran libblas-dev
+  - wget http://repo.continuum.io/miniconda/Miniconda-3.0.5-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/anaconda/bin:$PATH
+  # Update conda itself
+  - conda update --yes conda
+  # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda
+  - sudo rm -rf /dev/shm
+  - sudo ln -s /run/shm /dev/shm
+# Install packages
 install:
-  - "pip install -q --use-mirrors numpy"
-  # do not quiet scipy since compiling takes so long; travis-ci assumes there
-  # has been an error if no output received in 10m
-  - "pip install --use-mirrors scipy"
-  - "pip install -q --use-mirrors netCDF4"
-  - "pip install -q --use-mirrors pandas"
-  - "pip install ."
-# command to run tests
-script: nosetests
+  - conda create --yes -n env_name python=$TRAVIS_PYTHON_VERSION pip numpy scipy netCDF4 pandas
+  - source activate env_name
+  - python setup.py install
+# Run test
+script:
+  - nosetests


### PR DESCRIPTION
This versions should be faster since it uses Anaconda binaries instead of
building from scratch.
