### PR TITLE
Dataset.__getitem__ returns a DatasetArray linked to the same dataset

### DIFF
--- a/src/xray/xarray.py
+++ b/src/xray/xarray.py
@@ -403,10 +403,22 @@ class XArray(AbstractArray):
             dimension is unchanged. Where to insert the new dimension is
             determined by the first variable.
         stacked_indexers : iterable of indexers, optional
+            Iterable of indexers of the same length as variables which
+            specifies how to assign variables along the given dimension. If
+            not supplied, stacked_indexers is inferred from the length of each
+            variable along the dimension, and the variables are stacked in the
+            given order.
         length : int, optional
             Length of the new dimension. This is used to allocate the new data
             array for the stacked variable data before iterating over all
-            items, which is thus more memory efficient and a bit faster.
+            items, which is thus more memory efficient and a bit faster. If
+            dimension is provided as an array, length is calculated
+            automatically.
+        template : XArray, optional
+            This option is used internally to speed-up groupby operations. The
+            template's attributes are added to the returned array's attributes.
+            Furthermore, if a template is given, some checks of internal
+            consistency between arrays to stack are skipped.
 
         Returns
         -------

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -277,11 +277,10 @@ class TestDataset(TestCase):
         data['time'] = ('time', pd.date_range('2000-01-01', periods=1000))
         self.assertIsInstance(data['var1'], DatasetArray)
         self.assertXArrayEqual(data['var1'], data.variables['var1'])
-        self.assertItemsEqual(data['var1'].dataset.variables,
-                              {'var1', 'dim1', 'dim2'})
+        self.assertIs(data['var1'].dataset, data)
         # access virtual variables
         self.assertXArrayEqual(data['time.dayofyear'][:300],
-                            XArray('time', 1 + np.arange(300)))
+                               XArray('time', 1 + np.arange(300)))
         self.assertArrayEqual(data['time.month'].data,
                               data.variables['time'].data.month)
 


### PR DESCRIPTION
Originally, `Dataset.__getitem__` would "select" out the given variable to use
as the dataset for new DatasetArray. The rationale was that you don't really
want to keep track of extra dataset variables that are no longer relevant.

The problem is that this means that modifying an item from a dataset would not
modify the original dataset. An example might make this clearer:

```
>>> ds = xray.Dataset({'x': ('x', np.arange(10))})
>>> ds['x'].attributes['units'] = 'meters'  # this was actually a no-op
```

This is clearly a pretty blatant violation of the norms for a Python
container, and it certaintly surprised @akleeman. So this PR simplies this
behavior so that `ds['x']` gives a DatasetArray linked to the dataset `ds`,
and does some related clean-up of `DatasetArray.from_stack`. The new method
`DatasetArray.select` lets you reproduce the old behavior if desired, by using
`ds['x'].select()` instead of `ds['x']`. A bonus is that the new behavior is
actually faster, because it doesn't need to create a new Dataset object.
