### PR TITLE
Encodings for object data types are not saved.

### DIFF
--- a/src/xray/conventions.py
+++ b/src/xray/conventions.py
@@ -247,10 +247,9 @@ def encode_cf_variable(array):
     dimensions = array.dimensions
     data = array.data
     attributes = array.attributes.copy()
-    encoding = array.encoding
+    encoding = array.encoding.copy()
 
-    if (isinstance(data, pd.DatetimeIndex) or
-        str(data.dtype).startswith('datetime')):
+    if np.issubdtype(data.dtype, np.datetime64):
         # DatetimeIndex objects need to be encoded into numeric arrays
         (data, units, calendar) = utils.datetimeindex2num(data,
                                           units=encoding.pop('units', None),


### PR DESCRIPTION
decode_cf_variable will not save encoding for any 'object' dtypes.

When encoding cf variables check if dtype is np.datetime64 as well as DatetimeIndex.

fixes akleeman/xray/issues/39
