### PR TITLE
Fix performance regression for decode_cf_variable

### DIFF
--- a/src/xray/conventions.py
+++ b/src/xray/conventions.py
@@ -354,6 +354,7 @@ def decode_cf_variable(var, mask_and_scale=True):
     if 'units' in attributes and 'since' in attributes['units']:
         # convert CF times to datetimes
         # TODO: make this lazy
+        data = var.data
         units = pop_to(attributes, encoding, 'units')
         calendar = pop_to(attributes, encoding, 'calendar')
         data = utils.decode_cf_datetime(data, units=units, calendar=calendar)


### PR DESCRIPTION
We were passing the netCDF4 Variable directly to decode_cf_datetime, which
does a very expensive np.asarray() call (fixed in the master branch of
netCDF4-python). By passing the data as a numpy array, this call is _much_
faster.
