### PR TITLE
ENH: Improvements to as_xarray

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -150,6 +150,7 @@ Top-level functions
 .. autosummary::
    :toctree: generated/
 
+   as_xarray
    broadcast_xarrays
    xarray_equal
    align

--- a/src/xray/dataset.py
+++ b/src/xray/dataset.py
@@ -130,16 +130,12 @@ class Dataset(Mapping):
         self._attributes = OrderedDict(attributes)
 
     def _as_variable(self, name, var, decode_cf=False):
-        if isinstance(var, DatasetArray):
+        try:
             var = xarray.as_xarray(var)
-        elif not isinstance(var, xarray.XArray):
-            try:
-                var = xarray.XArray(*var)
-            except TypeError:
-                raise TypeError('Dataset variables must be of type '
-                                'DatasetArray or XArray, or a sequence of the '
-                                'form (dimensions, data[, attributes, '
-                                'encoding])')
+        except TypeError:
+            raise TypeError('Dataset variables must be of type '
+                            'DatasetArray or XArray, or a sequence of the '
+                            'form (dimensions, data[, attributes, encoding])')
         # this will unmask and rescale the data as well as convert
         # time variables to datetime indices.
         if decode_cf:


### PR DESCRIPTION
1. Moved tuple unpacking logic from Dataset._as_variable to as_xarray.
2. Added unit tests.

My intention is to add an as_xarray cast to the top of most functions in xray
which expect arguments as XArray or DatasetArray objects, mathematical
operations excluded.
