### PR TITLE
ENH: Improved copy methods

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -41,6 +41,7 @@ and values given by ``DatasetArray`` objects focused on each variable name.
    Dataset.__setitem__
    Dataset.__delitem__
    Dataset.merge
+   Dataset.copy
 
 Selecting
 ~~~~~~~~~
@@ -134,6 +135,7 @@ IO / Conversion
 
    DatasetArray.to_dataframe
    DatasetArray.to_series
+   DatasetArray.copy
 
 
 XArray

--- a/src/xray/dataset.py
+++ b/src/xray/dataset.py
@@ -225,17 +225,27 @@ class Dataset(Mapping):
         """
         return Frozen(self._dimensions)
 
-    def copy(self):
+    def copy(self, deep=False):
+        """Returns a copy of this dataset.
+
+        If `deep=True`, a deep copy is made of each of the component variables.
+        Otherwise, a shallow copy is made, so each variable in the new dataset
+        is also a variable in the original dataset.
         """
-        Returns a shallow copy of the current object.
-        """
-        return self.__copy__()
+        if deep:
+            variables = OrderedDict((k, v.copy(deep=True))
+                                    for k, v in self.variables.iteritems())
+        else:
+            variables = self.variables
+        return type(self)(variables, self.attributes)
 
     def __copy__(self):
-        """
-        Returns a shallow copy of the current object.
-        """
-        return type(self)(self.variables, self.attributes)
+        return self.copy(deep=False)
+
+    def __deepcopy__(self, memo=None):
+        # memo does nothing but is required for compatability with
+        # copy.deepcopy
+        return self.copy(deep=True)
 
     def __contains__(self, key):
         """The 'in' operator will return true or false depending on whether
@@ -511,12 +521,9 @@ class Dataset(Mapping):
         for k, v in self.variables.iteritems():
             name = name_dict.get(k, k)
             dims = tuple(name_dict.get(dim, dim) for dim in v.dimensions)
-            #TODO: public interface for renaming a variable without loading
-            # data?
-            kwargs = {'dtype': v.dtype} if hasattr(v, '_dtype') else {}
-            # perserve the type of the variable (XArray vs CoordXArray)
-            variables[name] = type(v)(dims, v._data, v.attributes, v.encoding,
-                                      v._indexing_mode, **kwargs)
+            var = v.copy(deep=False)
+            var.dimensions = dims
+            variables[name] = var
         return type(self)(variables, self.attributes)
 
     def merge(self, other, inplace=False, overwrite_vars=None):

--- a/src/xray/dataset_array.py
+++ b/src/xray/dataset_array.py
@@ -164,12 +164,22 @@ class DatasetArray(AbstractArray):
         return FrozenOrderedDict((k, self.dataset.variables[k])
                                  for k in self.dimensions)
 
-    def copy(self):
-        return self.__copy__()
+    def copy(self, deep=True):
+        """Returns a copy of this dataset array.
+
+        If `deep=True`, a deep copy is made of all variables in the underlying
+        dataset. Otherwise, a shallow copy is made, so each variable in the new
+        dataset array's dataset is also a variable in this array's dataset.
+        """
+        return type(self)(self.dataset.copy(deep=deep), self.focus)
 
     def __copy__(self):
-        # shallow copy the underlying dataset
-        return DatasetArray(self.dataset.copy(), self.focus)
+        return self.copy(deep=False)
+
+    def __deepcopy__(self, memo=None):
+        # memo does nothing but is required for compatability with
+        # copy.deepcopy
+        return self.copy(deep=True)
 
     # mutable objects should not be hashable
     __hash__ = None

--- a/test/test_xarray.py
+++ b/test/test_xarray.py
@@ -138,10 +138,16 @@ class XArraySubclassTestCases(object):
 
     def test_copy(self):
         v = self.cls('x', 0.5 * np.arange(10))
-        w = v.copy()
-        self.assertIs(type(v), type(w))
-        self.assertXArrayEqual(v, w)
-        self.assertEqual(v.dtype, w.dtype)
+        for deep in [True, False]:
+            w = v.copy(deep=deep)
+            self.assertIs(type(v), type(w))
+            self.assertXArrayEqual(v, w)
+            self.assertEqual(v.dtype, w.dtype)
+            if self.cls is XArray:
+                if deep:
+                    self.assertIsNot(v.data, w.data)
+                else:
+                    self.assertIs(v.data, w.data)
 
 
 class TestXArray(TestCase, XArraySubclassTestCases):


### PR DESCRIPTION
The new copy methods have a uniform API (which also matches pandas): they take
a keyword argument `deep`.

`deep=False` no longer always loads data into a numpy array. This makes it
possible to write functions to using the public API to rename variable
dimensions without always loading variables into memory.
