### PR TITLE
ENH: Revamped Dataset update methods

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -32,7 +32,7 @@ Dataset contents
 ~~~~~~~~~~~~~~~~
 
 Datasets implement the mapping interface with keys given by variable names
-and values given by ``DataArray`` objects focused on each variable name.
+and values given by ``DataArray`` objects.
 
 .. autosummary::
    :toctree: generated/
@@ -40,8 +40,11 @@ and values given by ``DataArray`` objects focused on each variable name.
    Dataset.__getitem__
    Dataset.__setitem__
    Dataset.__delitem__
+   Dataset.update
    Dataset.merge
    Dataset.copy
+   Dataset.iteritems
+   Dataset.itervalues
 
 Selecting
 ~~~~~~~~~
@@ -54,7 +57,6 @@ Selecting
    Dataset.reindex
    Dataset.reindex_like
    Dataset.rename
-   Dataset.replace
    Dataset.select
    Dataset.unselect
    Dataset.squeeze

--- a/src/xray/utils.py
+++ b/src/xray/utils.py
@@ -1,3 +1,5 @@
+# TODO: separate out these utilities into different modules based on whether
+# they are for internal or external use
 import netCDF4 as nc4
 import operator
 from collections import OrderedDict, Mapping, MutableMapping
@@ -451,3 +453,33 @@ class SortedKeysDict(MutableMapping):
 
     def __repr__(self):
         return '%s(%r)' % (type(self).__name__, self.mapping)
+
+
+class ChainMap(MutableMapping):
+    """Partial backport of collections.ChainMap from Python>=3.3
+
+    Don't return this from any public APIs, since some of the public methods
+    for a MutableMapping are missing (they will raise a NotImplementedError)
+    """
+    def __init__(self, *maps):
+        self.maps = maps
+
+    def __getitem__(self, key):
+        for mapping in self.maps:
+            try:
+                return mapping[key]
+            except KeyError:
+                pass
+        raise KeyError(key)
+
+    def __setitem__(self, key, value):
+        self.maps[0][key] = value
+
+    def __delitem__(self, value):
+        raise NotImplementedError
+
+    def __iter__(self):
+        raise NotImplementedError
+
+    def __len__(self):
+        raise NotImplementedError

--- a/test/test_dataset_array.py
+++ b/test/test_dataset_array.py
@@ -142,7 +142,7 @@ class TestDataArray(TestCase):
         self.assertDSArrayEquiv(a, a + 0 * a)
         self.assertDSArrayEquiv(a, 0 * a + a)
         # test different indices
-        ds2 = self.ds.replace('x', XArray(['x'], 3 + np.arange(10)))
+        ds2 = self.ds.update({'x': ('x', 3 + np.arange(10))}, inplace=False)
         b = DataArray(ds2, 'foo')
         with self.assertRaisesRegexp(ValueError, 'not aligned'):
             a + b


### PR DESCRIPTION
New in this patch:
- Added an `update` method to override variables and attributes.
- Unified `__init__`, `__setitem__`, `update` and `merge` to call the same
  private methods/functions for processing dictionaries of variables.
- If a variable is provided as a `DataArray`, it is automatically unpacked
  into variables including all its coordinates.
- It is now possible to alter the size of existing dimensions via
  `__setitem__` or `update`.
- Removed "decode_cf" as a parameter to `Dataset.__init__`. Now this flag
  can only be used in `Dataset.load_store`.
- Generally cleaned up dataset.py.

Replaces PR #62
