### PR TITLE
ENH: Better Dataset repr

### DIFF
--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -97,11 +97,16 @@ class TestDataset(TestCase):
         data = create_test_data()
         expected = dedent("""
         <xray.Dataset>
-        Coordinates:     (dim1: 100, dim2: 50, dim3: 10, time: 20)
-        Non-coordinates:
-            var1              X          X         -         -
-            var2              X          X         -         -
-            var3              X          -         X         -
+        Dimensions:     (dim1: 100, dim2: 50, dim3: 10, time: 20)
+        Coordinates:
+            dim1             X
+            dim2                        X
+            dim3                                  X
+            time                                            X
+        Noncoordinates:
+            var1             0          1
+            var2             0          1
+            var3             1                    0
         Attributes:
             Empty
         """).strip()
@@ -110,8 +115,10 @@ class TestDataset(TestCase):
 
         expected = dedent("""
         <xray.Dataset>
-        Coordinates:     ()
-        Non-coordinates:
+        Dimensions:     ()
+        Coordinates:
+            None
+        Noncoordinates:
             None
         Attributes:
             Empty


### PR DESCRIPTION
@toddsmall and @hdail both reported surprise that the order of dimensions as
printed in a Dataset's string representation are not necessarily the same as
the order of any variable dimensions.

This patch alters `Dataset.__repr__` so the order of the dimensions for each
variable is now printed. Hopefully this should make things clearer.

Example of the new look:

```
<xray.Dataset>
Dimensions:     (dim1: 100, dim2: 50, dim3: 10, time: 20)
Coordinates:
    dim1             X
    dim2                        X
    dim3                                  X
    time                                            X
Noncoordinates:
    var1             0          1
    var2             0          1
    var3             1                    0
Attributes:
    Empty
```

Vs. the old look:

```
<xray.Dataset>
Coordinates:     (dim1: 100, dim2: 50, dim3: 10, time: 20)
Non-coordinates:
    var1              X          X         -         -
    var2              X          X         -         -
    var3              X          -         X         -
Attributes:
    Empty
```

I added Coordinates to make it clear that these are items in the Dataset.
I removed the dashes `-` because they added visual noise that made it harder
to read the axis numbers.

Note: the commits for this PR are applied on top of those for #83, so
they can be merged sequentially without the need to rebase.
