### PR TITLE
ENH: Array.get_axis_num method

### DIFF
--- a/test/test_xarray.py
+++ b/test/test_xarray.py
@@ -290,6 +290,15 @@ class TestXArray(TestCase, XArraySubclassTestCases):
         with self.assertRaisesRegexp(ValueError, 'cannot select a dimension'):
             v.squeeze('y')
 
+    def test_get_axis_num(self):
+        v = XArray(['x', 'y', 'z'], np.random.randn(2, 3, 4))
+        self.assertEqual(v.get_axis_num('x'), 0)
+        self.assertEqual(v.get_axis_num(['x']), (0,))
+        self.assertEqual(v.get_axis_num(['x', 'y']), (0, 1))
+        self.assertEqual(v.get_axis_num(['z', 'y', 'x']), (2, 1, 0))
+        with self.assertRaisesRegexp(ValueError, 'not found in array dim'):
+            v.get_axis_num('foobar')
+
     def test_broadcasting_math(self):
         x = np.random.randn(2, 3)
         v = XArray(['a', 'b'], x)

--- a/xray/common.py
+++ b/xray/common.py
@@ -39,6 +39,31 @@ class AbstractArray(ImplementsReduce):
     def T(self):
         return self.transpose()
 
+    def get_axis_num(self, dimension):
+        """Return axis number(s) corresponding to dimension(s) in this array.
+
+        Parameters
+        ----------
+        dimension : str or iterable of str
+            Dimension name(s) for which to lookup axes.
+
+        Returns
+        -------
+        int or tuple of int
+            Axis number or numbers corresponding to the given dimensions.
+        """
+        if isinstance(dimension, basestring):
+            return self._get_axis_num(dimension)
+        else:
+            return tuple(self._get_axis_num(dim) for dim in dimension)
+
+    def _get_axis_num(self, dim):
+        try:
+            return self.dimensions.index(dim)
+        except ValueError:
+            raise ValueError("%r not found in array dimensions %r" %
+                             (dim, self.dimensions))
+
     _reduce_method_docstring = \
         """Reduce this {cls}'s data' by applying `{name}` along some
         dimension(s).

--- a/xray/xarray.py
+++ b/xray/xarray.py
@@ -383,6 +383,7 @@ class XArray(AbstractArray):
                                  'which has length greater than one')
         return self.indexed_by(**{dim: 0 for dim in dimension})
 
+
     def reduce(self, func, dimension=None, axis=None, **kwargs):
         """Reduce this array by applying `func` along some dimension(s).
 
@@ -446,7 +447,7 @@ class XArray(AbstractArray):
 
     def _reduce(self, f, dim, **kwargs):
         """Reduce a single dimension"""
-        axis = self.dimensions.index(dim)
+        axis = self.get_axis_num(dim)
         dims = tuple(dim for i, dim in enumerate(self.dimensions)
                      if axis not in [i, i - self.ndim])
         data = f(self.data, axis=axis, **kwargs)
@@ -550,7 +551,7 @@ class XArray(AbstractArray):
         # initialize the stacked variable with empty data
         first_var, variables = groupby.peek_at(variables)
         if dimension in first_var.dimensions:
-            axis = first_var.dimensions.index(dimension)
+            axis = first_var.get_axis_num(dimension)
             shape = tuple(length if n == axis else s
                           for n, s in enumerate(first_var.shape))
             dims = first_var.dimensions


### PR DESCRIPTION
This provides a standard way to get axis numbers for an xray array, i.e., `axis = array.get_axis_num(dim)` instead of `axis = array.dimensions.index(dim)`.

The main advantage is that it gives a sensible error message, instead of the mystifying "ValueError: tuple.index(x): x not in tuple".
