### PR TITLE
Fixed DataArray.reduce to use the axis argument like numpy

### DIFF
--- a/test/test_xarray.py
+++ b/test/test_xarray.py
@@ -348,20 +348,22 @@ class TestXArray(TestCase, XArraySubclassTestCases):
         self.assertArrayEqual(v.data, np.arange(5) + 1)
 
     def test_reduce(self):
-        v = XArray(['time', 'x'], self.d)
-        # intentionally test with an operation for which order matters
-        self.assertXArrayEqual(v.reduce(np.std, 'time'),
-                               XArray(['x'], self.d.std(axis=0),
-                                      {'cell_methods': 'time: std'}))
+        v = XArray(['x', 'y'], self.d)
+        self.assertXArrayEqual(v.reduce(np.std, 'x'),
+                               XArray(['y'], self.d.std(axis=0),
+                                      {'cell_methods': 'x: std'}))
         self.assertXArrayEqual(v.reduce(np.std, axis=0),
-                               v.reduce(np.std, dimension='time'))
-        self.assertXArrayEqual(v.reduce(np.std, ['x', 'time']),
-                               XArray([], self.d.std(axis=1).std(axis=0),
-                                      {'cell_methods': 'x: std time: std'}))
+                               v.reduce(np.std, dimension='x'))
+        self.assertXArrayEqual(v.reduce(np.std, ['y', 'x']),
+                               XArray([], self.d.std(axis=(0, 1)),
+                                      {'cell_methods': 'x: y: std'}))
         self.assertXArrayEqual(v.reduce(np.std),
                                XArray([], self.d.std(),
-                                      {'cell_methods': 'time: x: std'}))
-        self.assertXArrayEqual(v.mean('time'), v.reduce(np.mean, 'time'))
+                                      {'cell_methods': 'x: y: std'}))
+        self.assertXArrayEqual(v.reduce(np.mean, 'x').reduce(np.std, 'y'),
+                               XArray([], self.d.mean(axis=0).std(),
+                                      {'cell_methods': 'x: mean y: std'}))
+        self.assertXArrayEqual(v.mean('x'), v.reduce(np.mean, 'x'))
 
     def test_groupby(self):
         agg_var = XArray(['y'], np.array(['a', 'a', 'b']))

--- a/xray/common.py
+++ b/xray/common.py
@@ -71,20 +71,14 @@ class AbstractArray(ImplementsReduce):
         Parameters
         ----------
         dimension : str or sequence of str, optional
-            Dimension(s) over which to repeatedly apply `{name}`.
+            Dimension(s) over which to apply `{name}`.
         axis : int or sequence of int, optional
-            Axis(es) over which to repeatedly apply `{name}`. Only one of the
-            'dimension' and 'axis' arguments can be supplied. If neither are
-            supplied, then `{name}` is calculated over the flattened array
-            (by calling `{name}(x)` without an axis argument).
+            Axis(es) over which to apply `{name}`. Only one of the 'dimension'
+            and 'axis' arguments can be supplied. If neither are supplied, then
+            `{name}` is calculated over the flattened array (by calling
+            `{name}(x)` without an axis argument).
         **kwargs : dict
             Additional keyword arguments passed on to `{name}`.
-
-        Notes
-        -----
-        If this method is called with multiple dimensions (or axes, which are
-        converted into dimensions), then `{name}` is performed repeatedly along
-        each dimension in turn from left to right.
 
         Returns
         -------

--- a/xray/data_array.py
+++ b/xray/data_array.py
@@ -431,7 +431,7 @@ class DataArray(AbstractArray):
             `f(x, axis=axis, **kwargs)` to return the result of reducing an
             np.ndarray over an integer valued axis.
         dimension : str or sequence of str, optional
-            Dimension(s) over which to repeatedly apply `func`.
+            Dimension(s) over which to apply `func`.
         axis : int or sequence of int, optional
             Axis(es) over which to repeatedly apply `func`. Only one of the
             'dimension' and 'axis' arguments can be supplied. If neither are
@@ -439,12 +439,6 @@ class DataArray(AbstractArray):
             (by calling `f(x)` without an axis argument).
         **kwargs : dict
             Additional keyword arguments passed on to `func`.
-
-        Notes
-        -----
-        If `reduce` is called with multiple dimensions (or axes, which
-        are converted into dimensions), then the reduce operation is
-        performed repeatedly along each dimension in turn from left to right.
 
         Returns
         -------

--- a/xray/groupby.py
+++ b/xray/groupby.py
@@ -216,21 +216,17 @@ class ArrayGroupBy(GroupBy, ImplementsReduce):
             `func(x, axis=axis, **kwargs)` to return the result of collapsing an
             np.ndarray over an integer valued axis.
         dimension : str or sequence of str, optional
-            Dimension(s) over which to repeatedly apply `func`.
+            Dimension(s) over which to apply `func`.
         axis : int or sequence of int, optional
-            Axis(es) over which to repeatedly apply `func`. Only one of the
-            'dimension' and 'axis' arguments can be supplied. If neither are
-            supplied, then `{name}` is calculated over the axis of the variable
-            over which the group was formed.
+            Axis(es) over which to apply `func`. Only one of the 'dimension'
+            and 'axis' arguments can be supplied. If neither are supplied, then
+            `{name}` is calculated over the axis of the variable over which the
+            group was formed.
         **kwargs : dict
             Additional keyword arguments passed on to `func`.
 
         Notes
         -----
-        If `reduce` is called with multiple dimensions (or axes, which
-        are converted into dimensions), then the reduce operation is
-        performed repeatedly along each dimension in turn from left to right.
-
         `Ellipsis` is used as a sentinel value for the default dimension and
         axis to indicate that this operation is applied along the axis over
         which the group was formed, instead of all axes. To instead apply
@@ -261,21 +257,17 @@ class ArrayGroupBy(GroupBy, ImplementsReduce):
         Parameters
         ----------
         dimension : str or sequence of str, optional
-            Dimension(s) over which to repeatedly apply `{name}`.
+            Dimension(s) over which to apply `{name}`.
         axis : int or sequence of int, optional
-            Axis(es) over which to repeatedly apply `{name}`. Only one of the
-            'dimension' and 'axis' arguments can be supplied. If neither are
-            supplied, then `{name}` is calculated over the axis of the variable
-            over which the group was formed.
+            Axis(es) over which to apply `{name}`. Only one of the 'dimension'
+            and 'axis' arguments can be supplied. If neither are supplied, then
+            `{name}` is calculated over the axis of the variable over which the
+            group was formed.
         **kwargs : dict
             Additional keyword arguments passed on to `{name}`.
 
         Notes
         -----
-        If this method is called with multiple dimensions (or axes, which are
-        converted into dimensions), then `{name}` is performed repeatedly along
-        each dimension in turn from left to right.
-
         `Ellipsis` is used as a sentinel value for the default dimension and
         axis to indicate that this operation is applied along the axis over
         which the group was formed, instead of all axes. To instead apply


### PR DESCRIPTION
Previously, the axis argument (if given as a list) was used to apply the
reduction repeatedly one dimension at a time. That wasn't like numpy, and
could potentially lead to hard to recognize errors if using an aggregator
where order matters.
