### PR TITLE
Allow for reading variable length strings from NetCDF4

### DIFF
--- a/test/test_xarray.py
+++ b/test/test_xarray.py
@@ -213,8 +213,11 @@ class TestXArray(TestCase, XArraySubclassTestCases):
         xarray_tuple = (expected.dimensions, expected.data)
         self.assertXArrayEqual(expected, as_xarray(xarray_tuple))
 
-        with self.assertRaisesRegexp(TypeError, 'cannot convert arg'):
+        with self.assertRaisesRegexp(TypeError, 'cannot convert numpy'):
             as_xarray(data)
+        with self.assertRaisesRegexp(TypeError, 'cannot convert arg'):
+            as_xarray(list(data))
+
 
     def test_repr(self):
         v = XArray(['time', 'x'], [[1, 2, 3], [4, 5, 6]], {'foo': 'bar'})

--- a/xray/backends/pydap_.py
+++ b/xray/backends/pydap_.py
@@ -1,24 +1,12 @@
 import numpy as np
 
 import xray
-from xray.utils import FrozenOrderedDict, Frozen
+from xray.utils import FrozenOrderedDict, Frozen, NDArrayMixin
 
 
-class _ArrayWrapper(object):
+class PydapArrayWrapper(NDArrayMixin):
     def __init__(self, array):
         self.array = array
-
-    @property
-    def ndim(self):
-        return len(self.array.shape)
-
-    @property
-    def shape(self):
-        return self.array.shape
-
-    @property
-    def size(self):
-        return np.prod(self.shape)
 
     @property
     def dtype(self):
@@ -30,9 +18,6 @@ class _ArrayWrapper(object):
             return np.dtype('O')
         else:
             return np.dtype(t.typecode + str(t.size))
-
-    def __array__(self):
-        return np.asarray(self[...])
 
     def __getitem__(self, key):
         if not isinstance(key, tuple):
@@ -61,7 +46,7 @@ class PydapDataStore(object):
     @property
     def variables(self):
         return FrozenOrderedDict((k, xray.XArray(v.dimensions,
-                                                 _ArrayWrapper(v),
+                                                 PydapArrayWrapper(v),
                                                  v.attributes))
                                 for k, v in self.ds.iteritems())
 

--- a/xray/conventions.py
+++ b/xray/conventions.py
@@ -1,6 +1,5 @@
 import unicodedata
 
-import functools
 import numpy as np
 import pandas as pd
 from datetime import datetime
@@ -254,37 +253,7 @@ def encode_cf_datetime(dates, units=None, calendar=None):
     return (num, units, calendar)
 
 
-class LazyArrayMixin(object):
-    """Wrapper around array-like objects to create a new indexable object where
-    values, when accessesed, are automatically transformed.
-    """
-    @property
-    def dtype(self):
-        return self.array.dtype
-
-    @property
-    def shape(self):
-        return self.array.shape
-
-    @property
-    def size(self):
-        return self.array.size
-
-    @property
-    def ndim(self):
-        return self.array.ndim
-
-    def __len__(self):
-        return len(self.array)
-
-    def __array__(self):
-        return self[...]
-
-    def __getitem__(self, key):
-        raise NotImplementedError
-
-
-class MaskedAndScaledArray(LazyArrayMixin):
+class MaskedAndScaledArray(utils.NDArrayMixin):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessesed, are automatically scaled and masked according to
     CF conventions for packed and missing data values.
@@ -341,7 +310,7 @@ class MaskedAndScaledArray(LazyArrayMixin):
 
 
 
-class DecodedCFDatetimeArray(LazyArrayMixin):
+class DecodedCFDatetimeArray(utils.NDArrayMixin):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessesed, are automatically converted into datetime objects
     using decode_cf_datetime.
@@ -360,7 +329,7 @@ class DecodedCFDatetimeArray(LazyArrayMixin):
                                   calendar=self.calendar)
 
 
-class CharToStringArray(LazyArrayMixin):
+class CharToStringArray(utils.NDArrayMixin):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessesed, are automatically concatenated along the last
     dimension
@@ -385,20 +354,6 @@ class CharToStringArray(LazyArrayMixin):
     @property
     def shape(self):
         return self.array.shape[:-1]
-
-    @property
-    def size(self):
-        return np.prod(self.shape)
-
-    @property
-    def ndim(self):
-        return max(self.array.ndim - 1, 0)
-
-    def __len__(self):
-        if self.ndim > 0:
-            return len(self.array)
-        else:
-            raise TypeError('len() of unsized object')
 
     def __str__(self):
         if self.ndim == 0:

--- a/xray/utils.py
+++ b/xray/utils.py
@@ -383,3 +383,40 @@ class ChainMap(MutableMapping):
 
     def __len__(self):
         raise NotImplementedError
+
+
+class NDArrayMixin(object):
+    """Mixin class for making wrappers of N-dimensional arrays that conform
+    to the ndarray interface that xray expects for the data argument to XArray
+    objects.
+
+    A subclass should set the `array` property and override one or more of
+    `dtype`, `shape` and `__getitem__`.
+    """
+    @property
+    def dtype(self):
+        return self.array.dtype
+
+    @property
+    def shape(self):
+        return self.array.shape
+
+    @property
+    def ndim(self):
+        return len(self.shape)
+
+    @property
+    def size(self):
+        return np.prod(self.shape)
+
+    def __len__(self):
+        try:
+            return self.shape[0]
+        except IndexError:
+            raise TypeError('len() of unsized object')
+
+    def __array__(self):
+        return np.asarray(self[...])
+
+    def __getitem__(self, key):
+        raise self.array[key]


### PR DESCRIPTION
Creating the NetCDF4ArrayWrapper object also let me clean-up some other internal code for XArray objects.

I also created utils.NDArrayMixin to consolidate all my ndarray-like subclasses.

Partial fix for #57 -- we still could use support for _writing_ variable length strings, but that is much less urgent.
