### PR TITLE
Change default of ArrayGroupBy.reduce to dimension=None

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -164,6 +164,9 @@ Computations
 Comparisons
 ~~~~~~~~~~~
 
+.. autosummary::
+   :toctree: generated/
+
    DataArray.equals
    DataArray.identical
 

--- a/test/test_data_array.py
+++ b/test/test_data_array.py
@@ -289,11 +289,11 @@ class TestDataArray(TestCase):
                                                 self.x[:, 9:10].sum()]).T),
              'abc': Variable(['abc'], np.array(['a', 'b', 'c']))})['foo']
         self.assertDataArrayAllClose(
-            expected_sum_all, grouped.reduce(np.sum, dimension=None))
+            expected_sum_all, grouped.reduce(np.sum))
         self.assertDataArrayAllClose(
-            expected_sum_all, grouped.sum(dimension=None))
+            expected_sum_all, grouped.sum())
         self.assertDataArrayAllClose(
-            expected_sum_all, grouped.sum(axis=None))
+            expected_sum_all, grouped.sum())
         expected_unique = Variable('abc', ['a', 'b', 'c'])
         self.assertVariableEqual(expected_unique, grouped.unique_coord)
         self.assertEqual(3, len(grouped))
@@ -308,8 +308,8 @@ class TestDataArray(TestCase):
                                              self.x[:, 9:10].sum(1)]).T),
              'x': self.ds.variables['x'],
              'abc': Variable(['abc'], np.array(['a', 'b', 'c']))})['foo']
-        self.assertDataArrayAllClose(expected_sum_axis1, grouped.reduce(np.sum))
-        self.assertDataArrayAllClose(expected_sum_axis1, grouped.sum())
+        self.assertDataArrayAllClose(expected_sum_axis1,
+                                     grouped.reduce(np.sum, 'y'))
         self.assertDataArrayAllClose(expected_sum_axis1, grouped.sum('y'))
 
         def center(x):

--- a/xray/common.py
+++ b/xray/common.py
@@ -1,8 +1,7 @@
 class ImplementsReduce(object):
     @classmethod
     def _reduce_method(cls, f, name=None, module=None):
-        def func(self, dimension=cls._reduce_dimension_default,
-                 axis=cls._reduce_axis_default, **kwargs):
+        def func(self, dimension=None, axis=None, **kwargs):
             return self.reduce(f, dimension, axis, **kwargs)
         if name is None:
             name = f.__name__

--- a/xray/groupby.py
+++ b/xray/groupby.py
@@ -246,9 +246,10 @@ class ArrayGroupBy(GroupBy, ImplementsReduce):
         reordered = self._restore_dim_order(combined, concat_dim)
         return reordered
 
-    def reduce(self, func, dimension=Ellipsis, axis=Ellipsis, shortcut=True,
+    def reduce(self, func, dimension=None, axis=None, shortcut=True,
                **kwargs):
-        """Reduce this variable by applying `func` along some dimension(s).
+        """Reduce the items in this group by applying `func` along some
+        dimension(s).
 
         Parameters
         ----------
@@ -261,18 +262,9 @@ class ArrayGroupBy(GroupBy, ImplementsReduce):
         axis : int or sequence of int, optional
             Axis(es) over which to apply `func`. Only one of the 'dimension'
             and 'axis' arguments can be supplied. If neither are supplied, then
-            `{name}` is calculated over the axis of the variable over which the
-            group was formed.
+            `func` is calculated over all dimension for each group item.
         **kwargs : dict
             Additional keyword arguments passed on to `func`.
-
-        Notes
-        -----
-        `Ellipsis` is used as a sentinel value for the default dimension and
-        axis to indicate that this operation is applied along the axis over
-        which the group was formed, instead of all axes. To instead apply
-        `{name}` simultaneously over all grouped values, use `dimension=None`
-        (or equivalently `axis=None`).
 
         Returns
         -------
@@ -280,19 +272,12 @@ class ArrayGroupBy(GroupBy, ImplementsReduce):
             Array with summarized data and the indicated dimension(s)
             removed.
         """
-        # Ellipsis is used as a sentinel value for the altered default
-        if axis is Ellipsis and dimension is Ellipsis:
-            dimension = self.group_dim
-        if dimension is Ellipsis:
-            dimension = None
-        if axis is Ellipsis:
-            axis = None
         def reduce_array(ar):
             return ar.reduce(func, dimension, axis, **kwargs)
         return self.apply(reduce_array, shortcut=shortcut)
 
     _reduce_method_docstring = \
-        """Reduce this {cls}'s data' by applying `{name}` along some
+        """Reduce the items in this group by applying `{name}` along some
         dimension(s).
 
         Parameters
@@ -302,18 +287,9 @@ class ArrayGroupBy(GroupBy, ImplementsReduce):
         axis : int or sequence of int, optional
             Axis(es) over which to apply `{name}`. Only one of the 'dimension'
             and 'axis' arguments can be supplied. If neither are supplied, then
-            `{name}` is calculated over the axis of the variable over which the
-            group was formed.
+            `{name}` is calculated over all dimension for each group item.
         **kwargs : dict
             Additional keyword arguments passed on to `{name}`.
-
-        Notes
-        -----
-        `Ellipsis` is used as a sentinel value for the default dimension and
-        axis to indicate that this operation is applied along the axis over
-        which the group was formed, instead of all axes. To instead apply
-        `{name}` simultaneously over all grouped values, use `dimension=None`
-        (or equivalently `axis=None`).
 
         Returns
         -------
@@ -321,10 +297,6 @@ class ArrayGroupBy(GroupBy, ImplementsReduce):
             New {cls} object with `{name}` applied to its data and the
             indicated dimension(s) removed.
         """
-
-    _reduce_dimension_default = Ellipsis
-    _reduce_axis_default = Ellipsis
-
 
 inject_reduce_methods(ArrayGroupBy)
 


### PR DESCRIPTION
This makes xray consistent with pandas: `obj.groupby('year').sum()`
should return an object with 'year' as a dimension, not an object
where the 'year' dimension is summed out.

As a bonus, the implementation is simpler (less code).
