### PR TITLE
Expose more information in DataArray.__repr__

### DIFF
--- a/test/test_data_array.py
+++ b/test/test_data_array.py
@@ -17,11 +17,17 @@ class TestDataArray(TestCase):
 
     def test_repr(self):
         v = Variable(['time', 'x'], [[1, 2, 3], [4, 5, 6]], {'foo': 'bar'})
-        data_array = Dataset({'my_variable': v})['my_variable']
+        data_array = Dataset({'my_variable': v, 'other': ([], 0)}
+                             )['my_variable']
         expected = dedent("""
         <xray.DataArray 'my_variable' (time: 2, x: 3)>
         array([[1, 2, 3],
                [4, 5, 6]])
+        Coordinates:
+            time: Int64Index([0, 1], dtype='int64')
+            x: Int64Index([0, 1, 2], dtype='int64')
+        Linked dataset variables:
+            other
         Attributes:
             foo: bar
         """).strip()

--- a/xray/common.py
+++ b/xray/common.py
@@ -119,6 +119,13 @@ def _summarize_attributes(data):
     return attr_summary
 
 
+def _wrap_indent(text, start='', length=None):
+    if length is None:
+        length = len(start)
+    indent = '\n' + ' ' * length
+    return start + indent.join(x for x in text.splitlines())
+
+
 def array_repr(arr):
     name_str = ('%r ' % arr.name) if hasattr(arr, 'name') else ''
     dim_summary = ', '.join('%s: %s' % (k, v) for k, v
@@ -128,6 +135,16 @@ def array_repr(arr):
         summary.append(repr(arr.values))
     else:
         summary.append('[%s values with dtype=%s]' % (arr.size, arr.dtype))
+    if hasattr(arr, 'name'):
+        if arr.coordinates:
+            summary.append('Coordinates:')
+            for k, v in arr.coordinates.items():
+                summary.append(_wrap_indent(repr(v.as_index), '    %s: ' % k))
+        other_vars = [k for k in arr.dataset
+                      if k not in arr.coordinates and k != arr.name]
+        if other_vars:
+            summary.append('Linked dataset variables:')
+            summary.append('    ' + ', '.join(other_vars))
     summary.append('Attributes:\n%s' % _summarize_attributes(arr))
     return '\n'.join(summary)
 


### PR DESCRIPTION
This PR changes the `DataArray` representation so that it displays more of the information associated with a data array:
- "Coordinates" are indicated by their name and the `repr` of the
  corresponding pandas.Index object (to indicate how they are used as
  indices).
- "Linked" dataset variables are also listed.
  - These are other variables in the dataset associated with a DataArray
    which are also indexed along with the DataArray.
  - They accessible from the `dataset` attribute or by indexing the data
    array with a string.
  - Perhaps their most convenient aspect is that they enable [`groupby`
    operations by
    name](http://xray.readthedocs.org/en/latest/tutorial.html#apply) for
    DataArray objets.
  - This is an admitedly somewhat confusing (though convenient) notion that I
    am considering [removing](https://github.com/xray-
    pydata/xray/issues/117), but we if we don't remove them we should
    certainly expose their existence more clearly, given the potential
    benefits in expressiveness and costs in performance.

Questions to resolve:
- Is "Linked dataset variables" the best name for these?
- Perhaps it would be useful to show more information about these linked
  variables, such as their dimensions and/or shape?

Examples of the new repr are on nbviewer:
http://nbviewer.ipython.org/gist/shoyer/94936e5b71613683d95a
