### PR TITLE
Use "equivalence" for all dictionary equality checks

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -92,7 +92,7 @@ class TestCase(unittest.TestCase):
     def assertDatasetIdentical(self, d1, d2):
         # this method is functionally equivalent to `assert d1.identical(d2)`,
         # but it checks each aspect of equality separately for easier debugging
-        assert utils.dict_equal(d1.attrs, d2.attrs), (d1.attrs, d2.attrs)
+        assert utils.dict_equiv(d1.attrs, d2.attrs), (d1.attrs, d2.attrs)
         self.assertEqual(sorted(d1.variables), sorted(d2.variables))
         for k in d1:
             v1 = d1.variables[k]

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -38,6 +38,15 @@ class TestDictionaries(TestCase):
         self.y = {'c': 'C', 'b': 'B'}
         self.z = {'a': 'Z'}
 
+    def test_equivalent(self):
+        self.assertTrue(utils.equivalent(0, 0))
+        self.assertTrue(utils.equivalent(np.nan, np.nan))
+        self.assertTrue(utils.equivalent(0, np.array(0.0)))
+        self.assertTrue(utils.equivalent([0], np.array([0])))
+        self.assertTrue(utils.equivalent(np.array([0]), [0]))
+        self.assertTrue(utils.equivalent(np.arange(3), 1.0 * np.arange(3)))
+        self.assertFalse(utils.equivalent(0, np.zeros(3)))
+
     def test_safe(self):
         # should not raise exception:
         utils.update_safety_check(self.x, self.y)
@@ -47,35 +56,34 @@ class TestDictionaries(TestCase):
             utils.update_safety_check(self.x, self.z)
 
     def test_ordered_dict_intersection(self):
-        self.assertEqual({'a': 'A', 'b': 'B'},
-                         utils.ordered_dict_intersection(self.x, self.y))
         self.assertEqual({'b': 'B'},
-                          utils.ordered_dict_intersection(self.x, self.z))
+                         utils.ordered_dict_intersection(self.x, self.y))
+        self.assertEqual({}, utils.ordered_dict_intersection(self.x, self.z))
 
-    def test_dict_equal(self):
+    def test_dict_equiv(self):
         x = OrderedDict()
         x['a'] = 3
         x['b'] = np.array([1, 2, 3])
         y = OrderedDict()
         y['b'] = np.array([1.0, 2.0, 3.0])
         y['a'] = 3
-        self.assertTrue(utils.dict_equal(x, y)) # two nparrays are equal
+        self.assertTrue(utils.dict_equiv(x, y)) # two nparrays are equal
         y['b'] = [1, 2, 3] # np.array not the same as a list
-        self.assertTrue(utils.dict_equal(x, y)) # nparray == list
+        self.assertTrue(utils.dict_equiv(x, y)) # nparray == list
         x['b'] = [1.0, 2.0, 3.0]
-        self.assertTrue(utils.dict_equal(x, y)) # list vs. list
+        self.assertTrue(utils.dict_equiv(x, y)) # list vs. list
         x['c'] = None
-        self.assertFalse(utils.dict_equal(x, y)) # new key in x
+        self.assertFalse(utils.dict_equiv(x, y)) # new key in x
         x['c'] = np.nan
         y['c'] = np.nan
-        self.assertFalse(utils.dict_equal(x, y)) # as intended, nan != nan
+        self.assertTrue(utils.dict_equiv(x, y)) # as intended, nan is nan
         x['c'] = np.inf
         y['c'] = np.inf
-        self.assertTrue(utils.dict_equal(x, y)) # inf == inf
+        self.assertTrue(utils.dict_equiv(x, y)) # inf == inf
         y = dict(y)
-        self.assertTrue(utils.dict_equal(x, y)) # different dictionary types are fine
+        self.assertTrue(utils.dict_equiv(x, y)) # different dictionary types are fine
         y['b'] = 3 * np.arange(3)
-        self.assertFalse(utils.dict_equal(x, y)) # not equal when arrays differ
+        self.assertFalse(utils.dict_equiv(x, y)) # not equal when arrays differ
 
     def test_frozen(self):
         x = utils.Frozen(self.x)

--- a/test/test_variable.py
+++ b/test/test_variable.py
@@ -227,11 +227,11 @@ class VariableSubclassTestCases(object):
         v = self.cls(['a'], x)
         w = self.cls(['a'], y)
         self.assertVariableIdentical(Variable(['b', 'a'], np.array([x, y])),
-                               Variable.concat([v, w], 'b'))
+                                     Variable.concat([v, w], 'b'))
         self.assertVariableIdentical(Variable(['b', 'a'], np.array([x, y])),
-                               Variable.concat((v, w), 'b'))
+                                     Variable.concat((v, w), 'b'))
         self.assertVariableIdentical(Variable(['b', 'a'], np.array([x, y])),
-                               Variable.concat((v, w), 'b', length=2))
+                                     Variable.concat((v, w), 'b', length=2))
         with self.assertRaisesRegexp(ValueError, 'actual length'):
             Variable.concat([v, w], 'b', length=1)
         with self.assertRaisesRegexp(ValueError, 'actual length'):
@@ -246,7 +246,19 @@ class VariableSubclassTestCases(object):
         # test dimension order
         self.assertVariableIdentical(v, Variable.concat([v[:, :5], v[:, 5:]], 'x'))
         self.assertVariableIdentical(v.transpose(),
-                               Variable.concat([v[:, 0], v[:, 1:]], 'x'))
+                                     Variable.concat([v[:, 0], v[:, 1:]], 'x'))
+
+    def test_concat_attrs(self):
+        # different or conflicting attributes should be removed
+        v = self.cls('a', np.arange(5), {'foo': 'bar'})
+        w = self.cls('a', np.ones(5))
+        expected = self.cls('a', np.concatenate([np.arange(5), np.ones(5)]))
+        self.assertVariableIdentical(expected, Variable.concat([v, w], 'a'))
+        w.attrs['foo'] = 2
+        self.assertVariableIdentical(expected, Variable.concat([v, w], 'a'))
+        w.attrs['foo'] = 'bar'
+        expected.attrs['foo'] = 'bar'
+        self.assertVariableIdentical(expected, Variable.concat([v, w], 'a'))
 
     def test_copy(self):
         v = self.cls('x', 0.5 * np.arange(10), {'foo': 'bar'})

--- a/xray/dataset.py
+++ b/xray/dataset.py
@@ -485,7 +485,7 @@ class Dataset(Mapping):
         the same global attributes.
         """
         try:
-            return (utils.dict_equal(self.attrs, other.attrs)
+            return (utils.dict_equiv(self.attrs, other.attrs)
                     and len(self) == len(other)
                     and all(k1 == k2 and v1.identical(v2)
                             for (k1, v1), (k2, v2)
@@ -1173,7 +1173,7 @@ class Dataset(Mapping):
         # across all datasets
         for ds in datasets[1:]:
             if (compat == 'identical'
-                    and not utils.dict_equal(ds.attrs, concatenated.attrs)):
+                    and not utils.dict_equiv(ds.attrs, concatenated.attrs)):
                 raise ValueError('dataset global attributes not equal')
             for k, v in iteritems(ds.variables):
                 if k not in concatenated and k not in concat_over:

--- a/xray/variable.py
+++ b/xray/variable.py
@@ -633,7 +633,7 @@ class Variable(AbstractArray):
         """Like equals, but also checks attributes.
         """
         try:
-            return (utils.dict_equal(self.attrs, other.attrs)
+            return (utils.dict_equiv(self.attrs, other.attrs)
                     and self.equals(other))
         except (TypeError, AttributeError):
             return False


### PR DESCRIPTION
This should fix a bug @mgarvert encountered with concatenating variables with
different array attributes.

In the process of fixing this issue, I encountered and fixed another bug with
utils.remove_incompatible_items.
