### PR TITLE
{DataArray,Dataset}.indexes no longer creates a new dict

### DIFF
--- a/xray/common.py
+++ b/xray/common.py
@@ -1,3 +1,5 @@
+from collections import Mapping
+
 import numpy as np
 
 from .pycompat import basestring, iteritems
@@ -101,6 +103,27 @@ class AbstractArray(ImplementsArrayReduce):
                              (dim, self.dimensions))
 
 
+class AbstractIndexes(Mapping):
+    def __init__(self, data):
+        self._data = data
+
+    def __getitem__(self, key):
+        raise NotImplementedError
+
+    def __iter__(self):
+        return iter(self._data.dimensions)
+
+    def __len__(self):
+        return len(self._data.dimensions)
+
+    def __contains__(self, key):
+        return key in self._data.dimensions
+
+    def __repr__(self):
+        return '\n'.join(_wrap_indent(repr(v.as_pandas), '%s: ' % k)
+                         for k, v in self.items())
+
+
 def _summarize_attributes(data):
     if data.attrs:
         attr_summary = '\n'.join('    %s: %s' % (k, v) for k, v
@@ -132,8 +155,7 @@ def array_repr(arr):
     if hasattr(arr, 'dataset'):
         if arr.indexes:
             summary.append('Indexes:')
-            for k, v in arr.indexes.items():
-                summary.append(_wrap_indent(repr(v.as_pandas), '    %s: ' % k))
+            summary.append(_wrap_indent(repr(arr.indexes), '    '))
         other_vars = [k for k in arr.dataset
                       if k not in arr.indexes and k != arr.name]
         if other_vars:

--- a/xray/dataset.py
+++ b/xray/dataset.py
@@ -239,6 +239,23 @@ def _item0_str(items):
     return str(items[0])
 
 
+class DatasetIndexes(common.AbstractIndexes):
+    """Dictionary like container for Dataset indexes.
+
+    Essentially an immutable OrderedDict with keys given by the array's
+    dimensions and the values given by the corresponding xray.Index objects.
+    Unlike DataArrayIndexes, does *not* support integer based lookups.
+    """
+    def __getitem__(self, key):
+        if key in self._data.dimensions:
+            return self._data.variables[key]
+        elif isinstance(key, (int, np.integer)):
+            raise KeyError('%r: Dataset indexes do not support integer based '
+                           'lookups' % key)
+        else:
+            raise KeyError(repr(key))
+
+
 def as_dataset(obj):
     """Cast the given object to a Dataset.
 
@@ -531,8 +548,7 @@ class Dataset(Mapping, common.ImplementsDatasetReduce):
     def indexes(self):
         """Dictionary of xray.Index objects used for label based indexing.
         """
-        return FrozenOrderedDict((dim, self.variables[dim])
-                                 for dim in self.dimensions)
+        return DatasetIndexes(self)
 
     @property
     def noncoordinates(self):


### PR DESCRIPTION
According to the toy benchmark below, this shaves off between 20% (diff-indexes) to 40% (same-indexes) of xray's overhead for array math:

```
import numpy as np
import xray
x = np.random.randn(1000, 1000)
y = np.random.randn(1000, 1000)
dx = xray.DataArray(x)
dy = xray.DataArray(y)
%timeit x + x # raw-numpy
%timeit dx + dx # same-indexes
%timeit dx + dy # diff-indexes
```
