### PR TITLE
Raise an error when attempting to use a scalar variable as a dimension

### DIFF
--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -539,6 +539,10 @@ class TestDataset(TestCase):
         # can't resize a used dimension
         with self.assertRaisesRegexp(ValueError, 'but already exists with'):
             data1['dim1'] = data1['dim1'][:5]
+        # can't use the same dimension name as a scalar var
+        data1['scalar'] = ([], 0)
+        with self.assertRaisesRegexp(ValueError, 'already exists as a scalar'):
+            data1['newvar'] = ('scalar', [3, 4, 5])
 
     def test_delitem(self):
         data = create_test_data()

--- a/xray/dataset.py
+++ b/xray/dataset.py
@@ -199,8 +199,12 @@ def _calculate_dimensions(variables):
     if any of the dimension sizes conflict.
     """
     dimensions = SortedKeysDict()
+    scalar_vars = set(k for k, v in iteritems(variables) if not v.dimensions)
     for k, var in iteritems(variables):
         for dim, size in zip(var.dimensions, var.shape):
+            if dim in scalar_vars:
+                raise ValueError('dimension %s already exists as a scalar '
+                                 'variable' % dim)
             if dim not in dimensions:
                 dimensions[dim] = size
             elif dimensions[dim] != size:


### PR DESCRIPTION
If 'x' was a scalar variable in a dataset and you set a new variable with
'x' as a dimension, you could end up with a broken Dataset object.
