### PR TITLE
Fix Dataset.argmin

### DIFF
--- a/xray/dataset.py
+++ b/xray/dataset.py
@@ -1130,11 +1130,20 @@ class Dataset(Mapping, common.ImplementsDatasetReduce):
             reduce_dims = [dim for dim in var.dimensions if dim in dims]
             if reduce_dims:
                 if name not in self.dimensions:
+                    if len(reduce_dims) == 1:
+                        # unpack dimensions for the benefit of functions like
+                        # np.argmin which can't handle tuple arguments
+                        reduce_dims, = reduce_dims
                     try:
                         variables[name] = var.reduce(func,
                                                      dimension=reduce_dims,
                                                      **kwargs)
                     except TypeError:
+                        # array (e.g., string) does not support this reduction,
+                        # so skip it
+                        # TODO: rethink silently passing, because the problem
+                        # may be the dimensions and kwargs arguments, not the
+                        # dtype of the array
                         pass
             else:
                 variables[name] = var


### PR DESCRIPTION
Fixes #205.

Includes a failing test (currently skipped) for #209.

The ultimate issue turned out to be that `np.argmin` was passed a tuple of axes like `(0,)`, even though it can't handle tuple arguments. `TypeError` was raised but passed silently.
