### PR TITLE
Cleanup storage of Dataset internal state

### DIFF
--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -1,12 +1,9 @@
-from collections import Mapping
 import contextlib
 import functools
 import warnings
 
-import numpy as np
 import pandas as pd
 
-from . import formatting
 from . import indexing
 from . import groupby
 from . import ops
@@ -16,6 +13,7 @@ from .common import AbstractArray
 from .coordinates import DataArrayCoordinates
 from .dataset import Dataset
 from .pycompat import iteritems, basestring, OrderedDict, zip
+from .utils import FrozenOrderedDict
 from .variable import as_variable, _as_compatible_data, Coordinate
 
 
@@ -189,9 +187,9 @@ class DataArray(AbstractArray):
         all validation)
         """
         obj = object.__new__(cls)
-        obj._dataset = dataset._copy_listed([name])
+        obj._dataset = dataset._copy_listed([name], keep_attrs=False)
         obj._name = name
-        if name not in dataset.dims:
+        if name not in dataset._dims:
             obj._dataset._coord_names.discard(name)
         return obj
 
@@ -375,8 +373,8 @@ class DataArray(AbstractArray):
     def indexes(self):
         """OrderedDict of pandas.Index objects used for label based indexing
         """
-        return utils.FrozenOrderedDict(
-            (k, self[k].to_index()) for k in self.dims)
+        return FrozenOrderedDict((k, self._dataset._variables[k].to_index())
+                                 for k in self.dims)
 
     @property
     def coords(self):

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -354,7 +354,7 @@ class TestDataArray(TestCase):
 
         self.assertEquals(2, len(da.coords))
 
-        self.assertEquals(['x', 'y'], list(da.coords))
+        self.assertEqual(['x', 'y'], list(da.coords))
 
         self.assertTrue(coords[0].identical(da.coords['x']))
         self.assertTrue(coords[1].identical(da.coords['y']))

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -192,7 +192,7 @@ class TestDataset(TestCase):
         self.assertTrue('foo' in a)
         a['bar'] = (('time', 'x',), d)
         # order of creation is preserved
-        self.assertEqual(list(a.variables.keys()),  ['foo', 'time', 'x', 'bar'])
+        self.assertEqual(list(a.variables),  ['foo', 'time', 'x', 'bar'])
         self.assertTrue(all([a.variables['foo'][i].values == d[i]
                              for i in np.ndindex(*d.shape)]))
         # try to add variable with dim (10,3) with data that's (3,10)


### PR DESCRIPTION
`_variables` and `_dims` are now stored as OrderedDict and dict, not my funny
dict subclasses VariablesDict (which I'm pleased to say is gone) and
SortedKeysDict (which is now created on demand when accessing the `dims`
property). This speeds things up a bit and makes the internal state more
obvious.
