### PR TITLE
Add DataArray.to_pandas

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -266,8 +266,9 @@ IO / Conversion
    :toctree: generated/
 
    DataArray.to_dataset
-   DataArray.to_dataframe
+   DataArray.to_pandas
    DataArray.to_series
+   DataArray.to_dataframe
    DataArray.to_index
    DataArray.from_series
    DataArray.load_data


### PR DESCRIPTION
Implements half of #225

We still need documentation updates, and for consistency should probably add `Dataset.to_pandas` as well.
