### PR TITLE
Add backends integration test for roundtripping datetime arrays

### DIFF
--- a/xray/conventions.py
+++ b/xray/conventions.py
@@ -203,11 +203,11 @@ def encode_cf_datetime(dates, units=None, calendar=None):
         # note: numpy's broken datetime conversion only works for us precision
         dates = dates.astype('M8[us]').astype(datetime)
 
-    if hasattr(dates, 'ndim') and dates.ndim == 0:
-        # unpack dates because date2num doesn't like 0-dimensional arguments
-        dates = dates.item()
+    def encode_datetime(d):
+        return np.nan if d is None else nc4.date2num(d, units, calendar)
 
-    num = nc4.date2num(dates, units, calendar)
+    num = np.array([encode_datetime(d) for d in dates.flat])
+    num = num.reshape(dates.shape)
     return (num, units, calendar)
 
 

--- a/xray/test/test_backends.py
+++ b/xray/test/test_backends.py
@@ -152,6 +152,12 @@ class DatasetIOTestCases(object):
                 expected['x'] = expected['x'].astype('S')
             self.assertDatasetIdentical(expected, actual)
 
+    def test_roundtrip_datetime_data(self):
+        times = pd.to_datetime(['2000-01-01', '2000-01-02', 'NaT'])
+        expected = Dataset({'t': ('t', times)})
+        with self.roundtrip(expected) as actual:
+            self.assertDatasetIdentical(expected, actual)
+
     def test_roundtrip_example_1_netcdf(self):
         expected = open_example_dataset('example_1.nc')
         with self.roundtrip(expected) as actual:


### PR DESCRIPTION
Not sure how we missed this before.

Also includes a fix for writing datetime arrays with missing values.
