### PR TITLE
Handle bool in NetCDF4 conversion

### DIFF
--- a/xray/backends/netCDF4_.py
+++ b/xray/backends/netCDF4_.py
@@ -57,6 +57,10 @@ def _nc4_values_and_dtype(var):
         data, dims = maybe_convert_to_char_array(var.data, var.dims)
         var = Variable(dims, data, var.attrs, var.encoding)
         dtype = var.dtype
+    elif var.dtype.kind == 'b':
+        # store bool as 1-byte integer
+        var = var.astype('i1')
+        dtype = 'i1'
     else:
         raise ValueError('cannot infer dtype for netCDF4 variable')
     return var, dtype


### PR DESCRIPTION
I am working on some code that creates `xray.Datasets` with a 'bool' dtype.

Trying to call `Dataset.to_netcdf()` on this code causes `_nc4_values_and_dtype()` to raise a `ValueError`, so I added these few lines to force the storage of these variables as 1-byte integers.

Perhaps it should be 'u1' instead; I can change that if need be.