### PR TITLE
size and aspect arguments for plotting methods even without faceting

### DIFF
--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -134,6 +134,31 @@ axes created by ``plt.subplots``.
 
 On the right is a histogram created by :py:func:`xray.plot.hist`.
 
+.. _plotting.size_and_aspect:
+
+Size and Aspect Ratio
+~~~~~~~~~~~~~~~~~~~~~
+
+For convenience, xray's plotting methods support ``aspect`` and ``size``
+arguments which control the size of the resulting image via the formula
+``figsize = (aspect * size, size)``:
+
+.. ipython:: python
+
+    @savefig plotting_example_size_and_aspect.png
+    air1d.plot(aspect=2, size=2)
+
+.. ipython:: python
+    :suppress:
+
+    # create a dummy figure so sphinx plots everything below normally
+    plt.figure()
+
+This feature also works with :ref:`plotting.faceting_`.
+
+Note that if ``size`` is used, a new figure is created, so this is mutually
+exclusive with the ``ax`` argument for plotting on an existing axis.
+
 Two Dimensions
 --------------
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -16,8 +16,12 @@ Enhancements
 ~~~~~~~~~~~~
 
 - Support for reading GRIB, HDF4 and other file formats via PyNIO_. See
-  :ref:`io.pynio` for more details.
+  :ref:`io.pynio` for more details (:issue:`636`).
+- ``size`` and ``aspect`` plot arguments are supported even when not
+  facetting. See :ref:`plotting.size_and_aspect` for more details
+  (:issue:`637`).
 
+.. _PyNIO: https://www.pyngl.ucar.edu/Nio.shtml
 
 v0.6.1 (21 October 2015)
 ------------------------

--- a/xray/plot/utils.py
+++ b/xray/plot/utils.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import pkg_resources
 
 import numpy as np
@@ -195,3 +197,24 @@ def _infer_xy_labels(darray, x, y):
     elif any(k not in darray.coords for k in (x, y)):
         raise ValueError('x and y must be coordinate variables')
     return x, y
+
+
+def get_axis(size, aspect, ax):
+    import matplotlib as mpl
+    import matplotlib.pyplot as plt
+
+    if size is not None:
+        if ax is not None:
+            raise TypeError('cannot provide both `size` and `ax` arguments')
+        if aspect is None:
+            width, height = mpl.rcParams['figure.figsize']
+            aspect = width / height
+        figsize = (size * aspect, size)
+        _, ax = plt.subplots(figsize=figsize)
+    elif aspect is not None:
+        raise TypeError('cannot provide `aspect` argument without `size`')
+
+    if ax is None:
+        ax = plt.gca()
+
+    return ax

--- a/xray/test/test_plot.py
+++ b/xray/test/test_plot.py
@@ -150,6 +150,19 @@ class TestPlot(PlotTestCase):
         for ax in g.axes.flat:
             self.assertEqual(ax.get_axis_bgcolor(), 'r')
 
+    def test_plot_size(self):
+        self.darray.plot(size=5)
+        assert plt.gcf().get_size_inches()[1] == 5
+
+        self.darray.plot(size=5, aspect=2)
+        assert tuple(plt.gcf().get_size_inches()) == (10, 5)
+
+        with self.assertRaisesRegexp(TypeError, 'cannot provide both'):
+            self.darray.plot(size=5, ax=plt.gca())
+
+        with self.assertRaisesRegexp(TypeError, 'cannot provide `aspect`'):
+            self.darray.plot(aspect=1, ax=plt.gca())
+
     def test_convenient_facetgrid_4d(self):
         a = easy_array((10, 15, 2, 3))
         d = DataArray(a, dims=['y', 'x', 'columns', 'rows'])


### PR DESCRIPTION
I was finding myself writting `plt.figure(figsize=(x, y))` way too
often. This will be a convenient shortcut.

Still needs tests.
