### PR TITLE
Feature/rolling

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,6 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
+SPHINXAUTOBUILD = sphinx-autobuild
 PAPER         =
 BUILDDIR      = _build
 
@@ -24,6 +25,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
+	@echo "  livehtml   to make and auto-rebuild standalone HTML files, requires sphinx-autorebuild"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
 	@echo "  pickle     to make pickle files"
@@ -52,6 +54,11 @@ clean:
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+livehtml:
+	$(SPHINXAUTOBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -17,6 +17,7 @@ Top-level functions
    align
    broadcast
    concat
+   empty_like
    set_options
 
 Dataset
@@ -245,6 +246,7 @@ Computation
 
    DataArray.reduce
    DataArray.groupby
+   DataArray.rolling
    DataArray.resample
    DataArray.get_axis_num
    DataArray.diff

--- a/doc/computation.rst
+++ b/doc/computation.rst
@@ -99,6 +99,49 @@ These operations automatically skip missing values, like in pandas:
 If desired, you can disable this behavior by invoking the aggregation method
 with ``skipna=False``.
 
+Rolling window operations
+=========================
+
+``DataArray`` objects include a :py:meth:`~xarray.DataArray.rolling` method. This
+method supports rolling window aggregation:
+
+.. ipython:: python
+
+    arr = xr.DataArray(np.arange(0, 7.5, 0.5).reshape(3, 5),
+                       dims=('x', 'y'))
+    arr
+
+:py:meth:`~xarray.DataArray.rolling` is applied along one dimension using the
+name of the dimension as a key (e.g. ``y``) and the window size as the value
+(e.g. ``3``).  We get back a ``Rolling`` object:
+
+.. ipython:: python
+
+    arr.rolling(y=3)
+
+The label position and minimum number of periods in the rolling window are
+controlled by the ``center`` and ``min_periods`` arguments:
+
+.. ipython:: python
+
+    arr.rolling(y=3, min_periods=2, center=True)
+
+Aggregation and summary methods can be applied directly to the ``Rolling`` object:
+
+.. ipython:: python
+
+    r = arr.rolling(y=3)
+    r.mean()
+    r.reduce(np.std)
+
+Finally, we can manually iterate through ``Rolling`` objects:
+
+.. ipython:: python
+
+   @verbatim
+   for label, arr_window in r:
+      # arr_window is a view of x
+
 Broadcasting by dimension name
 ==============================
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -19,6 +19,37 @@ v0.7.2 (unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
+- Rolling window operations on DataArray objects are now supported via a new
+  :py:meth:`xarray.DataArray.rolling` method.
+
+  .. ipython::
+    :verbatim:
+
+    In [1]: import xarray as xr; import numpy as np
+
+    In [2]: arr = xr.DataArray(np.arange(0, 7.5, 0.5).reshape(3, 5),
+                               dims=('x', 'y'))
+
+    In [3]: arr
+    Out[3]:
+    <xarray.DataArray (x: 3, y: 5)>
+    array([[ 0. ,  0.5,  1. ,  1.5,  2. ],
+           [ 2.5,  3. ,  3.5,  4. ,  4.5],
+           [ 5. ,  5.5,  6. ,  6.5,  7. ]])
+    Coordinates:
+      * x        (x) int64 0 1 2
+      * y        (y) int64 0 1 2 3 4
+
+    In [4]: arr.rolling(y=3, min_periods=2).mean()
+    Out[4]:
+    <xarray.DataArray (x: 3, y: 5)>
+    array([[  nan,  0.25,  0.5 ,  1.  ,  1.5 ],
+           [  nan,  2.75,  3.  ,  3.5 ,  4.  ],
+           [  nan,  5.25,  5.5 ,  6.  ,  6.5 ]])
+    Coordinates:
+      * x        (x) int64 0 1 2
+      * y        (y) int64 0 1 2 3 4
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -110,7 +110,7 @@ def concat(objs, dim=None, data_vars='all', coords='different',
         f = _dataset_concat
     else:
         raise TypeError('can only concatenate xarray Dataset and DataArray '
-                        'objects')
+                        'objects, got %s' % type(first_obj))
     return f(objs, dim, data_vars, coords, compat, positions)
 
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -9,6 +9,7 @@ from ..plot.plot import _PlotMethods
 
 from . import indexing
 from . import groupby
+from . import rolling
 from . import ops
 from . import utils
 from .alignment import align
@@ -152,6 +153,7 @@ class DataArray(AbstractArray, BaseDataObject):
         Dictionary for holding arbitrary metadata.
     """
     groupby_cls = groupby.DataArrayGroupBy
+    rolling_cls = rolling.DataArrayRolling
 
     def __init__(self, data, coords=None, dims=None, name=None,
                  attrs=None, encoding=None, fastpath=False):

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -1,0 +1,179 @@
+import numpy as np
+
+from .pycompat import OrderedDict, zip
+from .common import ImplementsRollingArrayReduce, _full_like
+from .combine import concat
+from .ops import inject_bottleneck_rolling_methods
+
+
+class Rolling(object):
+    """A object that implements the moving window pattern.
+
+    See Also
+    --------
+    Dataset.groupby
+    DataArray.groupby
+    Dataset.rolling
+    DataArray.rolling
+    """
+
+    _attributes = ['window', 'min_periods', 'center', 'dim']
+
+    def __init__(self, obj, min_periods=None, center=False, **windows):
+        """
+        Moving window object.
+
+        Parameters
+        ----------
+        obj : Dataset or DataArray
+            Object to window.
+        min_periods : int, default None
+            Minimum number of observations in window required to have a value
+            (otherwise result is NA). The default, None, is equivalent to
+            setting min_periods equal to the size of the window.
+        center : boolean, default False
+            Set the labels at the center of the window.
+        **windows : dim=window
+            dim : str
+                Name of the dimension to create the rolling iterator
+                along (e.g., `time`).
+            window : int
+                Size of the moving window.
+
+        Returns
+        -------
+        rolling : type of input argument
+        """
+
+        if len(windows) != 1:
+            raise ValueError('exactly one dim/window should be provided')
+
+        dim, window = next(iter(windows.items()))
+
+        if window <= 0:
+            raise ValueError('window must be > 0')
+
+        self.obj = obj
+
+        # attributes
+        self.window = window
+        self.min_periods = min_periods
+        self.center = center
+        self.dim = dim
+
+        self._axis_num = self.obj.get_axis_num(self.dim)
+
+        self._windows = None
+        self._valid_windows = None
+        self.window_indices = None
+        self.window_labels = None
+
+        self._setup_windows(min_periods=min_periods, center=center)
+
+    def __repr__(self):
+        """provide a nice str repr of our rolling object"""
+
+        attrs = ["{k}->{v}".format(k=k, v=getattr(self, k))
+                 for k in self._attributes if getattr(self, k, None) is not None]
+        return "{klass} [{attrs}]".format(klass=self.__class__.__name__,
+                                          attrs=','.join(attrs))
+
+    @property
+    def windows(self):
+        if self._windows is None:
+            self._windows = OrderedDict(zip(self.window_labels,
+                                            self.window_indices))
+        return self._windows
+
+    def __len__(self):
+        return len(self.obj[self.dim])
+
+    def __iter__(self):
+        for (label, indices, valid) in zip(self.window_labels,
+                                           self.window_indices,
+                                           self._valid_windows):
+
+            window = self.obj.isel(**{self.dim: indices})
+
+            if not valid:
+                window = _full_like(window, fill_value=True)
+
+            yield (label, window)
+
+    def _setup_windows(self, min_periods=None, center=False):
+        """
+        Find the indicies and labels for each window
+        """
+        from .dataarray import DataArray
+
+        self.window_labels = self.obj[self.dim]
+
+        window = int(self.window)
+        if min_periods is None:
+            min_periods = window
+
+        dim_size = self.obj[self.dim].size
+
+        stops = np.arange(dim_size) + 1
+        starts = np.maximum(stops - window, 0)
+
+        if min_periods > 1:
+            valid_windows = (stops - starts) >= min_periods
+        else:
+            # No invalid windows
+            valid_windows = np.ones(dim_size, dtype=bool)
+        self._valid_windows = DataArray(valid_windows, dims=(self.dim, ),
+                                        coords=self.obj[self.dim].coords)
+
+        self.window_indices = [slice(start, stop)
+                               for start, stop in zip(starts, stops)]
+
+    def _center_result(self, result):
+        """center result"""
+        shift = (-self.window // 2) + 1
+        return result.shift(**{self.dim: shift})
+
+    def reduce(self, func, **kwargs):
+        """Reduce the items in this group by applying `func` along some
+        dimension(s).
+
+        Parameters
+        ----------
+        func : function
+            Function which can be called in the form
+            `func(x, **kwargs)` to return the result of collapsing an
+            np.ndarray over an the rolling dimension.
+        **kwargs : dict
+            Additional keyword arguments passed on to `func`.
+
+        Returns
+        -------
+        reduced : DataArray
+            Array with summarized data.
+        """
+        from .dataarray import DataArray
+
+        windows = [func(window, axis=self._axis_num, **kwargs)
+                   for _, window in self]
+
+        if not isinstance(windows[0], type(self.obj)):
+            # some functions don't return DataArrays (e.g. np.median)
+            dims = list(self.obj.dims)
+            dims.remove(dims[self._axis_num])
+            windows = [DataArray(window, dims=dims) for window in windows]
+
+        result = concat(windows, dim=self.window_labels)
+
+        result = result.where(self._valid_windows)
+
+        if self.center:
+            result = self._center_result(result)
+
+        return result
+
+
+class DataArrayRolling(Rolling, ImplementsRollingArrayReduce):
+    """Rolling object for DataArrays"""
+
+
+inject_bottleneck_rolling_methods(DataArrayRolling)

--- a/xarray/test/__init__.py
+++ b/xarray/test/__init__.py
@@ -63,6 +63,13 @@ except ImportError:
     has_matplotlib = False
 
 
+try:
+    import bottleneck
+    has_bottleneck = True
+except ImportError:
+    has_bottleneck = False
+
+
 def requires_scipy(test):
     return test if has_scipy else unittest.skip('requires scipy')(test)
 
@@ -94,6 +101,10 @@ def requires_dask(test):
 
 def requires_matplotlib(test):
     return test if has_matplotlib else unittest.skip('requires matplotlib')(test)
+
+
+def requires_bottleneck(test):
+    return test if has_bottleneck else unittest.skip('requires bottleneck')(test)
 
 
 def incompatible_2_6(test):


### PR DESCRIPTION
This is an initial take at the rolling aggregation object and methods in xray.  This PR implements:

- A new `Rolling` class available in `DataArray` objects:
    
    ```Python
    rolling_obj = da.rolling(time=7)
   ```
- `bottleneck.move_*` functions are wrapped and are available in the following manor:

    ```Python
    rolling_obj.mean()
    ```
- generic reduce method

    ```Python
    from numpy import nanpercentile
    rolling_obj.reduce(nanpercentile, q=5)
    ```
- iterating through the rolling object:

    ```Python
     for label, da_window in rolling_obj:
         # da_window is a view of da
    ````

TODO:

- [x] Documentation
- [x] Cleanup `_setup_windows`
- [x] Inject bottleneck methods in some generic way
- [x] ~~Possibly create a `Window` object to hold windowed `DataArray`s~~

closes #641 #130
xref pydata/pandas#11603, pydata/pandas#11704
cc @shoyer @bartnijssen