### PR TITLE
Don't unnecessarily copy dask arrays

### DIFF
--- a/xray/core/variable.py
+++ b/xray/core/variable.py
@@ -410,7 +410,12 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         If `deep=True`, the data array is loaded into memory and copied onto
         the new object. Dimensions, attributes and encodings are always copied.
         """
-        data = self.values.copy() if deep else self._data
+        if deep and not isinstance(self.data, dask_array_type):
+            # dask arrays don't have a copy method
+            # https://github.com/blaze/dask/issues/911
+            data = self.data.copy()
+        else:
+            data = self._data
         # note:
         # dims is already an immutable tuple
         # attributes and encoding will be copied when the new Array is created

--- a/xray/test/test_dask.py
+++ b/xray/test/test_dask.py
@@ -67,6 +67,11 @@ class TestVariable(DaskTestCase):
         self.assertEqual(self.data.chunks, v.chunks)
         self.assertArrayEqual(self.values, v)
 
+    def test_copy(self):
+        self.assertLazyAndIdentical(self.eager_var, self.lazy_var.copy())
+        self.assertLazyAndIdentical(self.eager_var,
+                                    self.lazy_var.copy(deep=True))
+
     def test_chunk(self):
         for chunks, expected in [(None, ((2, 2), (2, 2, 2))),
                                  (3, ((3, 1), (3, 3))),


### PR DESCRIPTION
There's no reason why `.copy()` needs to load them into memory as numpy arrays -- we have `.load()` for that.

xref https://github.com/blaze/dask/issues/911