### PR TITLE
Error when attempting to assign using attribute style syntax

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -66,6 +66,9 @@ Bug fixes
 
 - Fixes for several issues found on ``DataArray`` objects with the same name
   as one of their coordinates (see :ref:`v0.7.0.breaking` for more details).
+- Attempting to assign a ``Dataset`` or ``DataArray`` variable/attribute using
+  attribute-style syntax (e.g., ``ds.foo = 42``) now raises an error rather
+  than silently failing (:issue:`656`, :issue:`714`).
 
 - ``DataArray.to_masked_array`` always returns masked array with mask being an array
 (not a scalar value) (:issue:`684`)

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -213,6 +213,7 @@ class DataArray(AbstractArray, BaseDataObject):
         self._variable = variable
         self._coords = coords
         self._name = name
+        self._initialized = True
 
     __default = object()
 

--- a/xray/core/dataset.py
+++ b/xray/core/dataset.py
@@ -209,6 +209,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             self._set_init_vars_and_dims(data_vars, coords, compat)
         if attrs is not None:
             self.attrs = attrs
+        self._initialized = True
 
     def _add_missing_coords_inplace(self):
         """Add missing coordinates to self._variables
@@ -370,6 +371,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         obj._dims = dims
         obj._attrs = attrs
         obj._file_obj = file_obj
+        obj._initialized = True
         return obj
 
     __default_attrs = object()

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -1558,3 +1558,12 @@ class TestDataArray(TestCase):
         array = DataArray(1 + 2j)
         self.assertDataArrayIdentical(array.real, DataArray(1))
         self.assertDataArrayIdentical(array.imag, DataArray(2))
+
+    def test_setattr_raises(self):
+        array = DataArray(0, coords={'scalar': 1}, attrs={'foo': 'bar'})
+        with self.assertRaisesRegexp(AttributeError, 'cannot set attr'):
+            array.scalar = 2
+        with self.assertRaisesRegexp(AttributeError, 'cannot set attr'):
+            array.foo = 2
+        with self.assertRaisesRegexp(AttributeError, 'cannot set attr'):
+            array.other = 2

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -2289,3 +2289,12 @@ class TestDataset(TestCase):
 
         expected_im = Dataset({'x': ((), 2, attrs)}, attrs=attrs)
         self.assertDatasetIdentical(ds.imag, expected_im)
+
+    def test_setattr_raises(self):
+        ds = Dataset({}, coords={'scalar': 1}, attrs={'foo': 'bar'})
+        with self.assertRaisesRegexp(AttributeError, 'cannot set attr'):
+            ds.scalar = 2
+        with self.assertRaisesRegexp(AttributeError, 'cannot set attr'):
+            ds.foo = 2
+        with self.assertRaisesRegexp(AttributeError, 'cannot set attr'):
+            ds.other = 2


### PR DESCRIPTION
This should fail noisily rather than silently:

    ds.foo = 12

Fixes #656
Fixes #714