### PR TITLE
Handle non-numpy dtypes without erroring

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -69,6 +69,9 @@ Bug fixes
 
 - ``DataArray.to_masked_array`` always returns masked array with mask being an array
 (not a scalar value) (:issue:`684`)
+- You can now pass pandas objects with non-numpy dtypes (e.g., ``categorical``
+  or ``datetime64`` with a timezone) into xray without an error
+  (:issue:`716`).
 
 v0.6.2 (unreleased)
 -------------------

--- a/xray/core/indexing.py
+++ b/xray/core/indexing.py
@@ -371,6 +371,10 @@ class PandasIndexAdapter(utils.NDArrayMixin):
             # if a PeriodIndex, force an object dtype
             if isinstance(array, pd.PeriodIndex):
                 dtype = np.dtype('O')
+            elif hasattr(array, 'categories'):
+                dtype = array.categories.dtype
+            elif not utils.is_valid_numpy_dtype(array.dtype):
+                dtype = np.dtype('O')
             else:
                 dtype = array.dtype
         self._dtype = dtype
@@ -387,7 +391,7 @@ class PandasIndexAdapter(utils.NDArrayMixin):
             with suppress(AttributeError):
                 # this might not be public API
                 array = array.asobject
-        return array.values.astype(dtype)
+        return np.asarray(array, dtype)
 
     def __getitem__(self, key):
         if isinstance(key, tuple) and len(key) == 1:

--- a/xray/core/utils.py
+++ b/xray/core/utils.py
@@ -169,6 +169,15 @@ def is_scalar(value):
             value is None)
 
 
+def is_valid_numpy_dtype(dtype):
+    try:
+        np.dtype(dtype)
+    except (TypeError, ValueError):
+        return False
+    else:
+        return True
+
+
 def dict_equiv(first, second, compat=equivalent):
     """Test equivalence of two dict-like objects. If any of the values are
     numpy arrays, compare them correctly.


### PR DESCRIPTION
Of course, we still need to coerce them to a numpy dtype for use in xray (e.g., object)

Fixes #716