### PR TITLE
BUG: reindexing an array with complex values should keep dtype=complex

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -19,6 +19,7 @@ Enhancements
 ------------
 
 - ``Dataset.rename`` and ``DataArray.rename`` support the old and new names being the same.  This had been supported prior to v0.7.0 but was broken in 0.7.0.
+- ``DataArray.reindex_like`` now maintains the dtype of complex numbers when reindexing leads to na values.
 
 .. _whats-new.0.7.0:
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -418,6 +418,8 @@ def _maybe_promote(dtype):
         # convert to floating point so NaN is valid
         dtype = float
         fill_value = np.nan
+    elif np.issubdtype(dtype, complex):
+        fill_value = np.nan + np.nan * 1j
     elif np.issubdtype(dtype, np.datetime64):
         fill_value = np.datetime64('NaT')
     elif np.issubdtype(dtype, np.timedelta64):

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -635,6 +635,13 @@ class TestDataArray(TestCase):
         actual = expected.reindex(time=time2)
         self.assertDataArrayIdentical(actual, expected)
 
+        # regression test for #736, reindex can not change complex nums dtype
+        x = np.array([1, 2, 3], dtype=np.complex)
+        x = DataArray(x, coords=[[0.1, 0.2, 0.3]])
+        y = DataArray([2, 5, 6, 7, 8], coords=[[-1.1, 0.21, 0.31, 0.41, 0.51]])
+        re_dtype = x.reindex_like(y, method='pad').dtype
+        self.assertEqual(x.dtype, re_dtype)
+
     def test_reindex_method(self):
         x = DataArray([10, 20], dims='y')
         y = [-0.1, 0.5, 1.1]


### PR DESCRIPTION
Fixes #738 

I have added a simple behaviour for complex numbers in _maybe_promote. This fix means that  _maybe_promote does indeed return (dtype, np.nan + 0j) for complex dtypes, and the complex -> object conversion shown in #738 does not occur.