### PR TITLE
BUG: Don't transpose variables of one dimension

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,6 +21,13 @@ Enhancements
 - ``Dataset.rename`` and ``DataArray.rename`` support the old and new names being the same.  This had been supported prior to v0.7.0 but was broken in 0.7.0.
 - ``DataArray.reindex_like`` now maintains the dtype of complex numbers when reindexing leads to na values.
 
+
+Bug fixes
+~~~~~~~~~
+
+- Single dimension variables no longer transpose as part of a broader ``.transpose``. This behavior
+  was causing ``pandas.PeriodIndex`` dimensions to lose their type
+
 .. _whats-new.0.7.0:
 
 v0.7.0 (21 January 2016)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -648,6 +648,8 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         if len(dims) == 0:
             dims = self.dims[::-1]
         axes = self.get_axis_num(dims)
+        if len(dims) < 2: # no need to transpose if only one dimension
+            return self.copy(deep=False)
         data = ops.transpose(self.data, axes)
         return type(self)(dims, data, self._attrs, self._encoding, fastpath=True)
 

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -2259,6 +2259,15 @@ class TestDataset(TestCase):
         with self.assertRaisesRegexp(ValueError, 'arguments to transpose'):
             ds.transpose('dim1', 'dim2', 'dim3', 'time', 'extra_dim')
 
+    def test_dataset_retains_period_index_on_transpose(self):
+
+        ds = create_test_data()
+        ds['time'] = pd.period_range('2000-01-01', periods=20)
+
+        transposed = ds.transpose()
+
+        self.assertIsInstance(transposed.time.to_index(), pd.PeriodIndex)
+
     def test_dataset_diff_n1_simple(self):
         ds = Dataset({'foo': ('x', [5, 5, 6, 6])})
         actual = ds.diff('x')


### PR DESCRIPTION
Resolves https://github.com/pydata/xarray/issues/745

A bit of a 'convenient hack'. Let me know if you think there's a better way to do this