### PR TITLE
Retain label type in .to_dataset

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -26,7 +26,9 @@ Bug fixes
 ~~~~~~~~~
 
 - Single dimension variables no longer transpose as part of a broader ``.transpose``. This behavior
-  was causing ``pandas.PeriodIndex`` dimensions to lose their type
+  was causing ``pandas.PeriodIndex`` dimensions to lose their type (:issue:`749`)
+- `~xray.Dataset` labels remain as their native type on ``.to_dataset``. Previously they were
+  coerced to strings (:issue:`745`)
 
 .. _whats-new.0.7.0:
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -252,7 +252,7 @@ class DataArray(AbstractArray, BaseDataObject):
             array.attrs = {}
             return array
 
-        variables = OrderedDict([(str(label), subset(dim, label))
+        variables = OrderedDict([(label, subset(dim, label))
                                  for label in self.indexes[dim]])
         coords = self.coords.to_dataset()
         del coords[dim]

--- a/xarray/test/test_dask.py
+++ b/xarray/test/test_dask.py
@@ -258,7 +258,7 @@ class TestDataArrayAndDataset(DaskTestCase):
         u = self.eager_array
         v = self.lazy_array
 
-        expected = u.assign_coords(x=u['x'].astype(str))
+        expected = u.assign_coords(x=u['x'])
         self.assertLazyAndIdentical(expected, v.to_dataset('x').to_array('x'))
 
     def test_ufuncs(self):

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -1533,9 +1533,23 @@ class TestDataArray(TestCase):
         self.assertDataArrayIdentical(array, roundtripped)
 
         array = DataArray([1, 2, 3], dims='x')
-        expected = Dataset(OrderedDict([('0', 1), ('1', 2), ('2', 3)]))
+        expected = Dataset(OrderedDict([(0, 1), (1, 2), (2, 3)]))
         actual = array.to_dataset('x')
         self.assertDatasetIdentical(expected, actual)
+
+    def test_to_dataset_retains_keys(self):
+
+        # use dates as convenient non-str objects. Not a specific date test
+        import datetime
+        dates = [datetime.date(2000,1,d) for d in range(1,4)]
+
+        array = DataArray([1, 2, 3], coords=[('x', dates)],
+                          attrs={'a': 1})
+
+        # convert to dateset and back again
+        result = array.to_dataset('x').to_array(dim='x')
+
+        self.assertDatasetEqual(array, result)
 
     def test__title_for_slice(self):
         array = DataArray(np.ones((4, 3, 2)), dims=['a', 'b', 'c'])


### PR DESCRIPTION
Not sure if this was a deliberate choice (maybe so integer indexing wasn't disrupted?). This allows objects as dataset keys / labels.

Let me know your thoughts and I'll add a what's new.

(I know I have a few PRs dangling - apologies - will go back and clean them up soon)