### PR TITLE
BUG: dimensionality consistency checks in DataArray constructor

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,6 +25,8 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- Restore checks for shape consistency between data and coordinates in the
+  DataArray constructor (:issue:`758`).
 - Single dimension variables no longer transpose as part of a broader ``.transpose``. This behavior
   was causing ``pandas.PeriodIndex`` dimensions to lose their type
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -64,11 +64,18 @@ def _infer_coords_and_dims(shape, coords, dims):
         if dim not in new_coords:
             new_coords[dim] = default_index_coordinate(dim, size)
 
+    sizes = dict(zip(dims, shape))
     for k, v in new_coords.items():
         if any(d not in dims for d in v.dims):
             raise ValueError('coordinate %s has dimensions %s, but these '
                              'are not a subset of the DataArray '
                              'dimensions %s' % (k, v.dims, dims))
+
+        for d, s in zip(v.dims, v.shape):
+            if s != sizes[d]:
+                raise ValueError('conflicting sizes for dimension %r: '
+                                 'length %s on the data but length %s on '
+                                 'coordinate %r' % (d, sizes[d], s, k))
 
     return new_coords, dims
 

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -171,6 +171,12 @@ class TestDataArray(TestCase):
         with self.assertRaisesRegexp(TypeError, 'is not a string'):
             DataArray(data, dims=['x', None])
 
+        with self.assertRaisesRegexp(ValueError, 'conflicting sizes for dim'):
+            DataArray([1, 2, 3], coords=[('x', [0, 1])])
+        with self.assertRaisesRegexp(ValueError, 'conflicting sizes for dim'):
+            DataArray([1, 2], coords={'x': [0, 1], 'y': ('x', [1])}, dims='x')
+
+
     def test_constructor_from_self_described(self):
         data = [[-0.1, 21], [0, 2]]
         expected = DataArray(data,


### PR DESCRIPTION
Fixes #758

This was a regression from v0.6.1 due to the big DataArray refactor.