### PR TITLE
Compatibility fixes for pandas 0.18 and numpy 1.11

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -31,6 +31,7 @@ Bug fixes
   was causing ``pandas.PeriodIndex`` dimensions to lose their type (:issue:`749`)
 - `~xray.Dataset` labels remain as their native type on ``.to_dataset``. Previously they were
   coerced to strings (:issue:`745`)
+- Compatibility fixes for the upcoming pandas v0.18 and NumPy v1.11 releases.
 
 .. _whats-new.0.7.0:
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -131,7 +131,7 @@ class GroupBy(object):
             if first_items.isnull().any():
                 full_index = first_items.index
                 first_items = first_items.dropna()
-            bins = first_items.values
+            bins = first_items.values.astype(np.int64)
             group_indices = ([slice(i, j) for i, j in zip(bins[:-1], bins[1:])] +
                              [slice(bins[-1], None)])
             unique_coord = Coordinate(group.name, first_items.index)

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -1231,7 +1231,7 @@ class TestDataArray(TestCase):
         self.assertDataArrayIdentical(array, actual)
 
         actual = array.resample('24H', dim='time')
-        expected = DataArray(array.to_series().resample('24H'))
+        expected = DataArray(array.to_series().resample('24H', how='mean'))
         self.assertDataArrayIdentical(expected, actual)
 
         actual = array.resample('24H', dim='time', how=np.mean)

--- a/xarray/test/test_indexing.py
+++ b/xarray/test/test_indexing.py
@@ -17,7 +17,7 @@ class TestIndexers(TestCase):
         y = np.arange(5)
         I = ReturnItem()
         for i in [I[:], I[...], I[0, :, 10], I[..., 10], I[:5, ..., 0],
-                  I[..., 0, ...], I[y], I[y, y], I[..., y, y],
+                  I[..., 0, :], I[y], I[y, y], I[..., y, y],
                   I[..., 0, 1, 2, 3, 4]]:
             j = indexing.expanded_indexer(i, x.ndim)
             self.assertArrayEqual(x[i], x[j])


### PR DESCRIPTION
We need to supply how='mean' to resample because the resample API is changing.