### PR TITLE
fix value error in data-structures doc

### DIFF
--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -99,7 +99,7 @@ As a dictionary with coords across multiple dimensions:
 .. ipython:: python
 
     xr.DataArray(data, coords={'time': times, 'space': locs, 'const': 42,
-                               'ranking': (('space', 'time'), np.arange(12).reshape(4,3))},
+                               'ranking': (('time', 'space'), np.arange(12).reshape(4,3))},
                  dims=['time', 'space'])
 
 If you create a ``DataArray`` by supplying a pandas


### PR DESCRIPTION
This should fix the error in the docs here: http://xarray.pydata.org/en/latest/data-structures.html

It is a detail, but it occurred to me that the examples of this section don't use the (space, time) dimension order (e.g. `dims=['time', 'space']`). Most of the climate datasets I know of are using the numpy (lat, lon, time) dim order. Is it intentional?