### PR TITLE
dont infer interval breaks in pcolormesh when ax is a cartopy axis

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -53,6 +53,11 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- Fixed an issue where plots using pcolormesh and Cartopy axes were being distorted
+  by the inference of the axis interval breaks. This change chooses not to modify
+  the coordinate variables when the axes have the attribute ``projection``, allowing
+  Cartopy to handle the extent of pcolormesh plots (:issue:`781`).
+
 .. _whats-new.0.7.1:
 
 v0.7.1 (16 February 2016)

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -540,8 +540,10 @@ def pcolormesh(x, y, z, ax, **kwargs):
 
     Wraps matplotlib.pyplot.pcolormesh
     """
-    x = _infer_interval_breaks(x)
-    y = _infer_interval_breaks(y)
+
+    if not hasattr(ax, 'projection'):
+        x = _infer_interval_breaks(x)
+        y = _infer_interval_breaks(y)
 
     primitive = ax.pcolormesh(x, y, z, **kwargs)
 

--- a/xarray/test/test_plot.py
+++ b/xarray/test/test_plot.py
@@ -8,8 +8,8 @@ from xarray import DataArray
 import xarray.plot as xplt
 from xarray.plot.plot import _infer_interval_breaks
 from xarray.plot.utils import (_determine_cmap_params,
-                             _build_discrete_cmap,
-                             _color_palette)
+                               _build_discrete_cmap,
+                               _color_palette)
 
 from . import TestCase, requires_matplotlib, incompatible_2_6
 
@@ -772,6 +772,16 @@ class TestPcolormesh(Common2dMixin, PlotTestCase):
         ax = plt.gca()
         self.assertEqual('x2d', ax.get_xlabel())
         self.assertEqual('y2d', ax.get_ylabel())
+
+    def test_dont_infer_interval_breaks_for_cartopy(self):
+        # Regression for GH 781
+        ax = plt.gca()
+        # Simulate a Cartopy Axis
+        setattr(ax, 'projection', True)
+        artist = self.plotmethod(x='x2d', y='y2d', ax=ax)
+        self.assertTrue(isinstance(artist, mpl.collections.QuadMesh))
+        # Let cartopy handle the axis limits and artist size
+        self.assertTrue(artist.get_array().size <= self.darray.size)
 
 
 class TestImshow(Common2dMixin, PlotTestCase):


### PR DESCRIPTION
This PR chooses not to infer interval breaks in pcolormesh if the axis is a Cartopy axis. Below is an example of a plot using the new behavior - compare to https://github.com/pydata/xarray/issues/781#issuecomment-191595449.
![xarray_new](https://cloud.githubusercontent.com/assets/2443309/13486346/313825d4-e0c5-11e5-97a3-795d3958b39e.png)

I'll come up with a few tests here.

closes #781.