### PR TITLE
fix: transpose non-linked coordinates in 2d plots

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -59,6 +59,8 @@ Bug fixes
   by the inference of the axis interval breaks. This change chooses not to modify
   the coordinate variables when the axes have the attribute ``projection``, allowing
   Cartopy to handle the extent of pcolormesh plots (:issue:`781`).
+- 2D plots now better handle additional coordinates which are not linked to the
+  dimensions of ``DataArray`` (:issue:`788`).
 
 .. _whats-new.0.7.1:
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -378,7 +378,8 @@ def _plot2d(plotfunc):
         zval = darray.to_masked_array(copy=False)
 
         # May need to transpose for correct x, y labels
-        if xlab == darray.dims[0]:
+        # xlab may be the name of a coord, we have to check for dim names
+        if darray[xlab].dims[-1] == darray.dims[0]:
             zval = zval.T
 
         _ensure_plottable(xval, yval)

--- a/xarray/test/test_plot.py
+++ b/xarray/test/test_plot.py
@@ -588,6 +588,32 @@ class Common2dMixin:
         self.assertIn('y', self.darray.coords)
         self.plotmethod(y='y', x='x')
 
+    def test_non_linked_coords(self):
+        # plot with coordinate names that are not dimensions
+        self.darray.coords['newy'] = self.darray.y + 150
+        # Normal case, without transpose
+        self.plotfunc(self.darray, x='x', y='newy')
+        ax = plt.gca()
+        self.assertEqual('x', ax.get_xlabel())
+        self.assertEqual('newy', ax.get_ylabel())
+        # ax limits might change bewteen plotfuncs
+        # simply ensure that these high coords were passed over
+        self.assertTrue(np.min(ax.get_ylim()) > 100.)
+
+    def test_non_linked_coords_transpose(self):
+        # plot with coordinate names that are not dimensions,
+        # and with transposed y and x axes
+        # This used to raise an error with pcolormesh and contour
+        # https://github.com/pydata/xarray/issues/788
+        self.darray.coords['newy'] = self.darray.y + 150
+        self.plotfunc(self.darray, x='newy', y='x')
+        ax = plt.gca()
+        self.assertEqual('newy', ax.get_xlabel())
+        self.assertEqual('x', ax.get_ylabel())
+        # ax limits might change bewteen plotfuncs
+        # simply ensure that these high coords were passed over
+        self.assertTrue(np.min(ax.get_xlim()) > 100.)
+
     def test_default_title(self):
         a = DataArray(easy_array((4, 3, 2)), dims=['a', 'b', 'c'])
         a.coords['d'] = u'foo'


### PR DESCRIPTION
Should fix https://github.com/pydata/xarray/issues/788