### PR TITLE
Fix failing CI tests on Python 2.6

### DIFF
--- a/ci/requirements-py26.yml
+++ b/ci/requirements-py26.yml
@@ -9,7 +9,6 @@ dependencies:
   - pandas=0.16.2
   - matplotlib=1.4
   - openssl
-  - toolz
   # no seaborn
   - scipy=0.16.0
   - unittest2
@@ -19,3 +18,4 @@ dependencies:
     - cyordereddict
     - dask
     - h5netcdf
+    - toolz


### PR DESCRIPTION
It turns out we need the latest toolz from pip, not conda
(which is no longer building packages for Python 2.6).

xref https://github.com/dask/dask/issues/1046