### PR TITLE
Adds dask lock capability for backend writes

### DIFF
--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -3,6 +3,7 @@ import itertools
 import logging
 import time
 import traceback
+import threading
 from collections import Mapping
 
 from ..conventions import cf_encoder
@@ -162,7 +163,11 @@ class ArrayWriter(object):
     def sync(self):
         if self.sources:
             import dask.array as da
-            da.store(self.sources, self.targets)
+            import dask
+            if dask.__version__ > '0.8.1':
+                da.store(self.sources, self.targets, lock=threading.Lock())
+            else:
+                da.store(self.sources, self.targets)
             self.sources = []
             self.targets = []
 


### PR DESCRIPTION
This fixes an error on an asynchronous write for `to_netcdf`
resulting in an `dask.async.RuntimeError: NetCDF: HDF error`

Resolves issue https://github.com/pydata/xarray/issues/793
following dask improvement at https://github.com/dask/dask/pull/1053
following advice of @shoyer.