### PR TITLE
Multi-index indexing

### DIFF
--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -115,11 +115,9 @@ If you create a ``DataArray`` by supplying a pandas
     df
     xr.DataArray(df)
 
-xarray does not (yet!) support labeling coordinate values with a
-:py:class:`pandas.MultiIndex` (see :issue:`164`).
-However, the alternate ``from_series`` constructor will automatically unpack
-any hierarchical indexes it encounters by expanding the series into a
-multi-dimensional array, as described in :doc:`pandas`.
+Xarray supports labeling coordinate values with a :py:class:`pandas.MultiIndex`.
+While it handles multi-indexes with unnamed levels, it is recommended that you
+explicitly set the names of the levels.
 
 DataArray properties
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -316,14 +316,11 @@ pandas multi-index ; it automatically renames the dimension and replaces the
 coordinate when a single index is returned (level drop).
 
 Like pandas, it is also possible to use tuples of tuples, lists or slices
-(in that case xarray always returns the full multi-index):
+(for now xarray always returns the full multi-index in that case):
 
 .. ipython:: python
 
    da_midx.sel(x=(list('ab'), [0]))
-
-Indexing with dictionaries uses the ``MultiIndex.get_loc_level`` pandas method
-while indexing with nested tuples uses the ``MultiIndex.get_locs`` method.
 
 Multi-dimensional indexing
 --------------------------

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -315,6 +315,16 @@ As shown in the last example above, xarray handles partial selection on
 pandas multi-index ; it automatically renames the dimension and replaces the
 coordinate when a single index is returned (level drop).
 
+Like pandas, it is also possible to use tuples of tuples, lists or slices
+(in that case xarray always returns the full multi-index):
+
+.. ipython:: python
+
+   da_midx.sel(x=(list('ab'), [0]))
+
+Indexing with dictionaries uses the ``MultiIndex.get_loc_level`` pandas method
+while indexing with nested tuples uses the ``MultiIndex.get_locs`` method.
+
 Multi-dimensional indexing
 --------------------------
 

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -294,6 +294,27 @@ elements that are fully masked:
 
     arr2.where(arr2.y < 2, drop=True)
 
+.. _multi-index indexing:
+
+Multi-index indexing
+--------------------
+
+The ``loc`` and ``sel`` methods of ``Dataset`` and ``DataArray`` both accept
+dictionaries for indexing on multi-index dimensions:
+
+.. ipython:: python
+
+    idx = pd.MultiIndex.from_product([list('abc'), [0, 1]],
+                                     names=('one', 'two'))
+    da_midx = xr.DataArray(range(6), [('x', idx)])
+    da_midx
+    da_midx.sel(x={'one': 'a', 'two': 0})
+    da_midx.loc[{'one': 'a'}, ...]
+
+As shown in the last example above, xarray handles partial selection on
+pandas multi-index ; it automatically renames the dimension and replaces the
+coordinate when a single index is returned (level drop).
+
 Multi-dimensional indexing
 --------------------------
 

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -299,10 +299,10 @@ elements that are fully masked:
 Multi-level indexing
 --------------------
 
-Just like pandas, advanced indexing on multi-level indexes is also possible with
+Just like pandas, advanced indexing on multi-level indexes is possible with
 ``loc`` and ``sel``. You can slice a multi-index by providing multiple indexers,
 i.e., a tuple of slices, labels, list of labels, or any selector allowed by
-pandas (see :doc:`pandas`):
+pandas:
 
 .. ipython:: python
 

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -299,54 +299,45 @@ elements that are fully masked:
 Multi-level indexing
 --------------------
 
-The ``loc`` and ``sel`` methods of ``Dataset`` and ``DataArray`` both accept
-dictionaries for label-based indexing on multi-index dimensions:
+Just like pandas, advanced indexing on multi-level indexes is also possible with
+``loc`` and ``sel``. You can slice a multi-index by providing multiple indexers,
+i.e., a tuple of slices, labels, list of labels, or any selector allowed by
+pandas (see :doc:`pandas`):
 
 .. ipython:: python
 
-    idx = pd.MultiIndex.from_product([list('abc'), [0, 1]],
-                                     names=('one', 'two'))
-    da_midx = xr.DataArray(np.random.rand(6, 3),
-                           [('x', idx), ('y', range(3))])
-    da_midx
-    da_midx.sel(x={'one': 'a', 'two': 0})
-    da_midx.loc[{'one': 'a'}, ...]
+    midx = pd.MultiIndex.from_product([list('abc'), [0, 1]],
+                                      names=('one', 'two'))
+    mda = xr.DataArray(np.random.rand(6, 3),
+                       [('x', midx), ('y', range(3))])
+    mda
+    mda.sel(x=(list('ab'), [0]))
 
-As shown in the last example above, xarray handles partial selection on
-pandas multi-index ; it automatically renames the dimension and replaces the
-coordinate when a single index is returned (level drop).
-
-Like pandas, it is also possible to slice a multi-indexed dimension by providing
-a tuple of multiple indexers (i.e., slices, labels, list of labels, or any
-selector allowed by pandas). Note that for now xarray doesn't fully handle
-partial selection in that case (no level drop is done):
+You can also select multiple elements by providing a list of labels or tuples or
+a slice of tuples:
 
 .. ipython:: python
 
-   da_midx.sel(x=(list('ab'), [0]))
+   mda.sel(x=[('a', 0), ('b', 1)])
 
-Lists or slices of tuples can be used to select several combinations of
-multi-index labels:
-
-.. ipython:: python
-
-   da_midx.sel(x=[('a', 0), ('b', 1)])
-
-A single, flat tuple can be used to select a given combination of
-multi-index labels:
+Additionally, xarray supports dictionaries:
 
 .. ipython:: python
 
-   da_midx.sel(x=('a', 0))
+   mda.sel(x={'one': 'a', 'two': 0})
+   mda.loc[{'one': 'a'}, ...]
 
-Unlike pandas, xarray can't make the distinction between index levels and
+Like pandas, xarray handles partial selection on multi-index (level drop).
+As shown in the last example above, it also renames the dimension / coordinate
+when the multi-index is reduced to a single index.
+
+Unlike pandas, xarray does not guess whether you provide index levels or
 dimensions when using ``loc`` in some ambiguous cases. For example, for
-``da_midx.loc[{'one': 'a', 'two': 0}]`` and ``da_midx.loc['a', 0]`` xarray
+``mda.loc[{'one': 'a', 'two': 0}]`` and ``mda.loc['a', 0]`` xarray
 always interprets ('one', 'two') and ('a', 0) as the names and
 labels of the 1st and 2nd dimension, respectively. You must specify all
 dimensions or use the ellipsis in the ``loc`` specifier, e.g. in the example
-above, ``da_midx.loc[{'one': 'a', 'two': 0}, :]`` or
-``da_midx.loc[('a', 0), ...]``.
+above, ``mda.loc[{'one': 'a', 'two': 0}, :]`` or ``mda.loc[('a', 0), ...]``.
 
 Multi-dimensional indexing
 --------------------------

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -26,6 +26,9 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 - Dropped support for Python 2.6 (:issue:`855`).
+- Indexing on multi-index now drop levels, which is consitent with pandas.
+  It also changes the name of the dimension / coordinate when the multi-index is
+  reduced to a single index.
 
 Enhancements
 ~~~~~~~~~~~~
@@ -39,9 +42,11 @@ Enhancements
   attributes are retained in the resampled object. By
   `Jeremy McGibbon <https://github.com/mcgibbon>`_.
 
-- DataArray and Dataset methods :py:meth:`sel` and :py:meth:`loc` now
-  accept dictionaries or nested tuples for indexing on multi-index dimensions.
-  By `Benoit Bovy <https://github.com/benbovy>`_.
+- Better multi-index support in DataArray and Dataset :py:meth:`sel` and
+  :py:meth:`loc` methods, which now behave more closely to pandas and which
+  also accept dictionaries for indexing based on given level names and labels
+  (see :ref:`multi-level indexing`). By
+  `Benoit Bovy <https://github.com/benbovy>`_.
 
 - New (experimental) decorators :py:func:`~xarray.register_dataset_accessor` and
   :py:func:`~xarray.register_dataarray_accessor` for registering custom xarray

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -39,10 +39,14 @@ Enhancements
   attributes are retained in the resampled object. By
   `Jeremy McGibbon <https://github.com/mcgibbon>`_.
 
+- DataArray and Dataset methods :py:meth:`sel` and :py:meth:`loc` now
+  accept dictionaries or nested tuples for indexing on multi-index dimensions.
+  By `Benoit Bovy <https://github.com/benbovy>`_.
+
 - New (experimental) decorators :py:func:`~xarray.register_dataset_accessor` and
   :py:func:`~xarray.register_dataarray_accessor` for registering custom xarray
   extensions without subclassing. They are described in the new documentation
-  page on :ref:`internals`. By `Stephan Hoyer <https://github.com/shoyer>`
+  page on :ref:`internals`. By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 - Round trip boolean datatypes. Previously, writing boolean datatypes to netCDF
   formats would raise an error since netCDF does not have a `bool` datatype.

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -250,7 +250,7 @@ class DataArray(AbstractArray, BaseDataObject):
         # switch from dimension to level names, if necessary
         dim_names = {}
         for dim, idx in indexes.items():
-            if idx.name != dim:
+            if not isinstance(idx, pd.MultiIndex) and idx.name != dim:
                 dim_names[dim] = idx.name
         if dim_names:
             obj = obj.rename(dim_names)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -600,7 +600,7 @@ class DataArray(AbstractArray, BaseDataObject):
         ds = self._to_temp_dataset().isel(**indexers)
         return self._from_temp_dataset(ds)
 
-    def sel(self, method=None, tolerance=None, drop_levels=True,  **indexers):
+    def sel(self, method=None, tolerance=None, drop_level=True,  **indexers):
         """Return a new DataArray whose dataset is given by selecting
         index labels along the specified dimension(s).
 
@@ -613,7 +613,7 @@ class DataArray(AbstractArray, BaseDataObject):
             self, indexers, method=method, tolerance=tolerance
         )
         obj = self.isel(**pos_indexers)
-        if drop_levels:
+        if drop_level:
             return obj._replace_indexes(new_indexes)
         else:
             return obj

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -600,7 +600,7 @@ class DataArray(AbstractArray, BaseDataObject):
         ds = self._to_temp_dataset().isel(**indexers)
         return self._from_temp_dataset(ds)
 
-    def sel(self, method=None, tolerance=None, drop_level=True,  **indexers):
+    def sel(self, method=None, tolerance=None, **indexers):
         """Return a new DataArray whose dataset is given by selecting
         index labels along the specified dimension(s).
 
@@ -612,11 +612,7 @@ class DataArray(AbstractArray, BaseDataObject):
         pos_indexers, new_indexes = indexing.remap_label_indexers(
             self, indexers, method=method, tolerance=tolerance
         )
-        obj = self.isel(**pos_indexers)
-        if drop_level:
-            return obj._replace_indexes(new_indexes)
-        else:
-            return obj
+        return self.isel(**pos_indexers)._replace_indexes(new_indexes)
 
     def isel_points(self, dim='points', **indexers):
         """Return a new DataArray whose dataset is given by pointwise integer

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -86,28 +86,12 @@ class _LocIndexer(object):
         self.data_array = data_array
 
     def _remap_key(self, key):
-        def lookup_positions(dim, labels):
-            index = self.data_array.indexes[dim]
-            indexer, new_idx = indexing.convert_label_indexer(index, labels)
-            return indexer, new_idx
-
-        if utils.is_dict_like(key):
-            pos_indexers, new_indexes = {}, {}
-            for dim, labels in iteritems(key):
-                pos_indexers[dim], idx = lookup_positions(dim, labels)
-                if idx is not None and not isinstance(idx, pd.MultiIndex):
-                    new_indexes[dim] = idx
-            return pos_indexers, new_indexes
-
-        else:
+        if not utils.is_dict_like(key):
             # expand the indexer so we can handle Ellipsis
-            # doesn't support dict-like key for multi-index
-            key = indexing.expanded_indexer(key, self.data_array.ndim)
-            pos_indexers = tuple(
-                lookup_positions(dim, labels)[0] for dim, labels
-                in zip(self.data_array.dims, key)
-            )
-            return pos_indexers, {}
+            labels = indexing.expanded_indexer(key, self.data_array.ndim)
+            key = dict(zip(self.data_array.dims, labels))
+
+        return indexing.remap_label_indexers(self.data_array, key)
 
     def __getitem__(self, key):
         pos_indexers, new_indexes = self._remap_key(key)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -243,6 +243,8 @@ class DataArray(AbstractArray, BaseDataObject):
     def _replace_indexes(self, indexes):
         obj = self
         for dim, idx in iteritems(indexes):
+            if idx.name is None:
+                idx.name = dim + "_unnamed_level"
             obj = obj.rename({dim: idx.name})
             new_coord = Coordinate(idx.name, idx)
             obj = obj._replace(coords={idx.name: new_coord})

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1140,10 +1140,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         Dataset.isel_points
         DataArray.sel_points
         """
-        obj, pos_indexers = indexing.remap_label_indexers(
+        pos_indexers, new_indexes = indexing.remap_label_indexers(
             self, indexers, method=method, tolerance=tolerance
         )
-        return obj.isel_points(dim=dim, **pos_indexers)
+        return self.isel_points(dim=dim, **pos_indexers)
 
     def reindex_like(self, other, method=None, tolerance=None, copy=True):
         """Conform this object onto the indexes of another object, filling

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -430,7 +430,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         # switch from dimension to level names, if necessary
         dim_names = {}
         for dim, idx in indexes.items():
-            if idx.name != dim:
+            if not isinstance(idx, pd.MultiIndex) and idx.name != dim:
                 dim_names[dim] = idx.name
         if dim_names:
             obj = obj.rename(dim_names)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1418,9 +1418,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         obj = self.reindex(copy=False, **{dim: full_idx})
 
         new_dim_names = index.names
-        if any(name is None for name in new_dim_names):
-            raise ValueError('cannot unstack dimension with unnamed levels')
-
         new_dim_sizes = [lev.size for lev in index.levels]
 
         variables = OrderedDict()

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -420,20 +420,16 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         return obj
 
     def _replace_indexes(self, indexes):
-        obj = self
-        for dim, idx in iteritems(indexes):
-            if idx.name is None:
-                idx.name = dim + "_unnamed_level"
-            obj = obj.rename({dim: idx.name})
-            new_coord = Coordinate(idx.name, idx)
-            variables = OrderedDict()
-            for k, v in iteritems(obj._variables):
-                if k == idx.name:
-                    variables[k] = new_coord
-                else:
-                    variables[k] = v
-            obj = obj._replace_vars_and_dims(variables)
-        return obj
+        variables = OrderedDict()
+        for k, v in iteritems(self._variables):
+            if k in indexes.keys():
+                idx = indexes[k]
+                variables[k] = Coordinate(idx.name, idx)
+            else:
+                variables[k] = v
+        obj = self._replace_vars_and_dims(variables)
+        dim_names = {dim: idx.name for dim, idx in iteritems(indexes)}
+        return obj.rename(dim_names)
 
     def copy(self, deep=False):
         """Returns a copy of this dataset.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -422,6 +422,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
     def _replace_indexes(self, indexes):
         obj = self
         for dim, idx in iteritems(indexes):
+            if idx.name is None:
+                idx.name = dim + "_unnamed_level"
             obj = obj.rename({dim: idx.name})
             new_coord = Coordinate(idx.name, idx)
             variables = OrderedDict()

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -935,7 +935,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             variables[name] = var.isel(**var_indexers)
         return self._replace_vars_and_dims(variables)
 
-    def sel(self, method=None, tolerance=None, drop_level=True, **indexers):
+    def sel(self, method=None, tolerance=None, **indexers):
         """Returns a new dataset with each array indexed by tick labels
         along the specified dimension(s).
 
@@ -966,10 +966,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             matches. The values of the index at the matching locations most
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
             Requires pandas>=0.17.
-        drop_level : bool
-            If True (default), rename dimension and replace coordinate
-            for multi-index reduced into a single index (only if a dict-like
-            object is provided as indexer).
         **indexers : {dim: indexer, ...}
             Keyword arguments with names matching dimensions and values given
             by scalars, slices or arrays of tick labels. For dimensions with
@@ -995,11 +991,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         pos_indexers, new_indexes = indexing.remap_label_indexers(
             self, indexers, method=method, tolerance=tolerance
         )
-        obj = self.isel(**pos_indexers)
-        if drop_level:
-            return obj._replace_indexes(new_indexes)
-        else:
-            return obj
+        return self.isel(**pos_indexers)._replace_indexes(new_indexes)
 
     def isel_points(self, dim='points', **indexers):
         """Returns a new dataset with each array indexed pointwise along the

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -935,7 +935,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             variables[name] = var.isel(**var_indexers)
         return self._replace_vars_and_dims(variables)
 
-    def sel(self, method=None, tolerance=None, drop_levels=True, **indexers):
+    def sel(self, method=None, tolerance=None, drop_level=True, **indexers):
         """Returns a new dataset with each array indexed by tick labels
         along the specified dimension(s).
 
@@ -966,7 +966,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             matches. The values of the index at the matching locations most
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
             Requires pandas>=0.17.
-        drop_levels : bool
+        drop_level : bool
             If True (default), rename dimension and replace coordinate
             for multi-index reduced into a single index (only if a dict-like
             object is provided as indexer).
@@ -996,7 +996,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             self, indexers, method=method, tolerance=tolerance
         )
         obj = self.isel(**pos_indexers)
-        if drop_levels:
+        if drop_level:
             return obj._replace_indexes(new_indexes)
         else:
             return obj

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -200,7 +200,10 @@ def convert_label_indexer(index, label, index_name='', method=None,
     else:
         label = _asarray_tuplesafe(label)
         if label.ndim == 0:
-            indexer = index.get_loc(label.item(), **kwargs)
+            if isinstance(index, pd.MultiIndex):
+                indexer, new_index = index.get_loc_level(label.item(), level=0)
+            else:
+                indexer = index.get_loc(label.item(), **kwargs)
         elif label.dtype.kind == 'b':
             indexer, = np.nonzero(label)
         else:

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -145,8 +145,8 @@ def convert_label_indexer(index, label, index_name='', method=None,
                           tolerance=None):
     """Given a pandas.Index and labels (e.g., from __getitem__) for one
     dimension, return an indexer suitable for indexing an ndarray along that
-    dimension. If label is a dict-like object and a pandas.MultiIndex is given,
-    also return a new pandas.Index, otherwise return None.
+    dimension. If `index` is a pandas.MultiIndex and depending on `label`,
+    return a new pandas.Index or pandas.MultiIndex (otherwise return None).
     """
     # backwards compatibility for pandas<0.16 (method) or pandas<0.17
     # (tolerance)
@@ -213,8 +213,8 @@ def convert_label_indexer(index, label, index_name='', method=None,
 
 def remap_label_indexers(data_obj, indexers, method=None, tolerance=None):
     """Given an xarray data object and label based indexers, return a mapping
-    of equivalent location based indexers. Also return a mapping of pandas'
-    single index objects returned from multi-index objects.
+    of equivalent location based indexers. Also return a mapping of updated
+    pandas index objects (in case of multi-index level drop).
     """
     if method is not None and not isinstance(method, str):
         raise TypeError('``method`` must be a string')

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -199,8 +199,7 @@ def remap_label_indexers(data_obj, indexers, method=None, tolerance=None):
     if method is not None and not isinstance(method, str):
         raise TypeError('``method`` must be a string')
 
-    pos_indexers = dict()
-    new_indexes = dict()
+    pos_indexers, new_indexes = {}, {}
     for dim, label in iteritems(indexers):
         idxr, new_idx = convert_label_indexer(data_obj[dim].to_index(), label,
                                               dim, method, tolerance)

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -222,15 +222,6 @@ def remap_label_indexers(data_obj, indexers, method=None, tolerance=None):
     pos_indexers, new_indexes = {}, {}
     for dim, label in iteritems(indexers):
         index = data_obj[dim].to_index()
-
-        if isinstance(index, pd.MultiIndex):
-            # set default names for multi-index unnamed levels so that
-            # we can safely rename dimension / coordinate later
-            valid_level_names = [name or '{}_level_{}'.format(dim, i)
-                                 for i, name in enumerate(index.names)]
-            index = index.copy()
-            index.names = valid_level_names
-
         idxr, new_idx = convert_label_indexer(index, label,
                                               dim, method, tolerance)
         pos_indexers[dim] = idxr

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -140,7 +140,7 @@ def convert_label_indexer(index, label, index_name='', method=None,
     """Given a pandas.Index and labels (e.g., from __getitem__) for one
     dimension, return an indexer suitable for indexing an ndarray along that
     dimension. If label is a dict-like object and a pandas.MultiIndex is given,
-    also return a new pandas.Index (otherwise return None).
+    also return a new pandas.Index, otherwise return None.
     """
     # backwards compatibility for pandas<0.16 (method) or pandas<0.17
     # (tolerance)
@@ -174,8 +174,8 @@ def convert_label_indexer(index, label, index_name='', method=None,
         if not isinstance(index, pd.MultiIndex):
             raise ValueError('cannot use a dict-like object for selection on a'
                              'dimension that does not have a MultiIndex')
-        indexer, new_index = index.get_loc_level(list(label.values()),
-                                                 level=list(label.keys()))
+        indexer, new_index = index.get_loc_level(tuple(label.values()),
+                                                 level=tuple(label.keys()))
 
     else:
         label = _asarray_tuplesafe(label)

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -135,6 +135,21 @@ def _asarray_tuplesafe(values):
     return result
 
 
+def _is_nested_tuple(tup, index):
+    """Check for a compatible nested tuple and multiindex (taken from
+    pandas.core.indexing.is_nested_tuple).
+    """
+    if not isinstance(tup, tuple):
+        return False
+
+    # are we nested tuple of: tuple,list,slice
+    for i, k in enumerate(tup):
+        if isinstance(k, (tuple, list, slice)):
+            return isinstance(index, pd.MultiIndex)
+
+    return False
+
+
 def convert_label_indexer(index, label, index_name='', method=None,
                           tolerance=None):
     """Given a pandas.Index and labels (e.g., from __getitem__) for one
@@ -176,6 +191,9 @@ def convert_label_indexer(index, label, index_name='', method=None,
                              'dimension that does not have a MultiIndex')
         indexer, new_index = index.get_loc_level(tuple(label.values()),
                                                  level=tuple(label.keys()))
+
+    elif _is_nested_tuple(label, index):
+        indexer = index.get_locs(label)
 
     else:
         label = _asarray_tuplesafe(label)

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -135,19 +135,10 @@ def _asarray_tuplesafe(values):
     return result
 
 
-def _is_nested_tuple(tup, index):
-    """Check for a compatible nested tuple and multiindex (taken from
-    pandas.core.indexing.is_nested_tuple).
-    """
-    if not isinstance(tup, tuple):
-        return False
-
-    # are we nested tuple of: tuple,list,slice
-    for i, k in enumerate(tup):
-        if isinstance(k, (tuple, list, slice)):
-            return isinstance(index, pd.MultiIndex)
-
-    return False
+def _is_nested_tuple(possible_tuple):
+    return (isinstance(possible_tuple, tuple)
+            and any(isinstance(value, (tuple, list, slice))
+                    for value in possible_tuple))
 
 
 def convert_label_indexer(index, label, index_name='', method=None,
@@ -192,7 +183,7 @@ def convert_label_indexer(index, label, index_name='', method=None,
         indexer, new_index = index.get_loc_level(tuple(label.values()),
                                                  level=tuple(label.keys()))
 
-    elif _is_nested_tuple(label, index):
+    elif _is_nested_tuple(label) and isinstance(index, pd.MultiIndex):
         indexer = index.get_locs(label)
 
     else:

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -187,7 +187,7 @@ def convert_label_indexer(index, label, index_name='', method=None,
 
     elif is_dict_like(label):
         if not isinstance(index, pd.MultiIndex):
-            raise ValueError('cannot use a dict-like object for selection on a'
+            raise ValueError('cannot use a dict-like object for selection on a '
                              'dimension that does not have a MultiIndex')
         indexer, new_index = index.get_loc_level(tuple(label.values()),
                                                  level=tuple(label.keys()))
@@ -219,7 +219,17 @@ def remap_label_indexers(data_obj, indexers, method=None, tolerance=None):
 
     pos_indexers, new_indexes = {}, {}
     for dim, label in iteritems(indexers):
-        idxr, new_idx = convert_label_indexer(data_obj[dim].to_index(), label,
+        index = data_obj[dim].to_index()
+
+        if isinstance(index, pd.MultiIndex):
+            # set default names for multi-index unnamed levels so that
+            # we can safely rename dimension / coordinate later
+            valid_level_names = [name or '{}_level_{}'.format(dim, i)
+                                 for i, name in enumerate(index.names)]
+            index = index.copy()
+            index.names = valid_level_names
+
+        idxr, new_idx = convert_label_indexer(index, label,
                                               dim, method, tolerance)
         pos_indexers[dim] = idxr
         if new_idx is not None and not isinstance(new_idx, pd.MultiIndex):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1096,7 +1096,13 @@ class Coordinate(Variable):
         # basically free as pandas.Index objects are immutable
         assert self.ndim == 1
         index = self._data_cached().array
-        if not isinstance(index, pd.MultiIndex):
+        if isinstance(index, pd.MultiIndex):
+            # set default names for multi-index unnamed levels so that
+            # we can safely rename dimension / coordinate later
+            valid_level_names = [name or '{}_level_{}'.format(self.name, i)
+                                 for i, name in enumerate(index.names)]
+            index = index.set_names(valid_level_names)
+        else:
             index = index.set_names(self.name)
         return index
 

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -504,6 +504,8 @@ class TestDataArray(TestCase):
             data.sel(x={'one': 'a'}),
             data.unstack('x').sel(one='a').dropna('two')
         )
+        self.assertDataArrayIdentical(data.sel(x=('a', slice(None))),
+                                      data.isel(x=[0, 1]))
 
         self.assertDataArrayIdentical(data.loc['a'], data[:2])
         self.assertDataArrayIdentical(data.loc[{'one': 'a', 'two': 0}, ...],

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -507,6 +507,7 @@ class TestDataArray(TestCase):
         test_sel(('b', 2, -2), -1)
         test_sel(('a', 1), [0, 1], replaced_idx=True, renamed_dim='three')
         test_sel(('a',), range(4), replaced_idx=True)
+        test_sel('a', range(4), replaced_idx=True)
         test_sel([('a', 1, -1), ('b', 2, -2)], [0, 7])
         test_sel(slice('a', 'b'), range(8))
         test_sel(slice(('a', 1), ('b', 1)), range(6))

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -848,16 +848,16 @@ class TestDataset(TestCase):
 
         def test_sel(lab_indexer, pos_indexer, replaced_idx=False,
                      renamed_dim=None):
-            da = mdata.sel(x=lab_indexer)
-            expected_da = mdata.isel(x=pos_indexer)
+            ds = mdata.sel(x=lab_indexer)
+            expected_ds = mdata.isel(x=pos_indexer)
             if not replaced_idx:
-                self.assertDatasetIdentical(da, expected_da)
+                self.assertDatasetIdentical(ds, expected_ds)
             else:
                 if renamed_dim:
-                    self.assertEqual(da['var'].dims[0], renamed_dim)
-                    da = da.rename({renamed_dim: 'x'})
-                self.assertVariableIdentical(da['var'], expected_da['var'])
-                self.assertVariableNotEqual(da['x'], expected_da['x'])
+                    self.assertEqual(ds['var'].dims[0], renamed_dim)
+                    ds = ds.rename({renamed_dim: 'x'})
+                self.assertVariableIdentical(ds['var'], expected_ds['var'])
+                self.assertVariableNotEqual(ds['x'], expected_ds['x'])
 
         test_sel(('a', 1, -1), 0)
         test_sel(('b', 2, -2), -1)

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -1213,10 +1213,6 @@ class TestDataset(TestCase):
         with self.assertRaisesRegexp(ValueError, 'does not have a MultiIndex'):
             ds.unstack('x')
 
-        ds2 = Dataset({'x': pd.Index([(0, 1)])})
-        with self.assertRaisesRegexp(ValueError, 'unnamed levels'):
-            ds2.unstack('x')
-
     def test_stack_unstack(self):
         ds = Dataset({'a': ('x', [0, 1]),
                       'b': (('x', 'y'), [[0, 1], [2, 3]]),

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -849,7 +849,9 @@ class TestDataset(TestCase):
         self.assertDatasetIdentical(data.sel(x=('c', 1)), data.isel(x=-1))
         self.assertDatasetIdentical(data.sel(x=[('a', 0)]), data.isel(x=[0]))
         self.assertDatasetIdentical(data.sel(x=[('a', 0), ('c', 1)]),
-                                      data.isel(x=[0, -1]))
+                                    data.isel(x=[0, -1]))
+        self.assertDatasetIdentical(data.sel(x=(['a', 'c'], [0, 1])),
+                                    data.isel(x=[0, 1, -2, -1]))
         self.assertDatasetIdentical(data.sel(x='a'), data.isel(x=slice(2)))
         self.assertVariableNotEqual(data.sel(x={'one': slice(None)})['var'],
                                     data['var'])

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -863,6 +863,7 @@ class TestDataset(TestCase):
         test_sel(('b', 2, -2), -1)
         test_sel(('a', 1), [0, 1], replaced_idx=True, renamed_dim='three')
         test_sel(('a',), range(4), replaced_idx=True)
+        test_sel('a', range(4), replaced_idx=True)
         test_sel([('a', 1, -1), ('b', 2, -2)], [0, 7])
         test_sel(slice('a', 'b'), range(8))
         test_sel(slice(('a', 1), ('b', 1)), range(6))
@@ -873,6 +874,12 @@ class TestDataset(TestCase):
 
         self.assertDatasetIdentical(mdata.loc[{'x': {'one': 'a'}}],
                                     mdata.sel(x={'one': 'a'}))
+        self.assertDatasetIdentical(mdata.loc[{'x': 'a'}],
+                                    mdata.sel(x='a'))
+        self.assertDatasetIdentical(mdata.loc[{'x': ('a', 1)}],
+                                    mdata.sel(x=('a', 1)))
+        self.assertDatasetIdentical(mdata.loc[{'x': ('a', 1, -1)}],
+                                    mdata.sel(x=('a', 1, -1)))
         with self.assertRaises(KeyError):
             mdata.loc[{'one': 'a'}]
 

--- a/xarray/test/test_indexing.py
+++ b/xarray/test/test_indexing.py
@@ -85,6 +85,8 @@ class TestIndexers(TestCase):
             indexing.convert_label_indexer(index, [0])
         with self.assertRaises(KeyError):
             indexing.convert_label_indexer(index, 0)
+        with self.assertRaises(ValueError):
+            indexing.convert_label_indexer(index, {'somelevel': 0})
 
     def test_convert_unsorted_datetime_index_raises(self):
         index = pd.to_datetime(['2001', '2000', '2002'])
@@ -100,9 +102,9 @@ class TestIndexers(TestCase):
 
         def test_indexer(x):
             return indexing.remap_label_indexers(data, {'x': x})
-        self.assertEqual({'x': 0}, test_indexer(1))
-        self.assertEqual({'x': 0}, test_indexer(np.int32(1)))
-        self.assertEqual({'x': 0}, test_indexer(Variable([], 1)))
+        self.assertEqual({'x': 0}, test_indexer(1)[0])
+        self.assertEqual({'x': 0}, test_indexer(np.int32(1))[0])
+        self.assertEqual({'x': 0}, test_indexer(Variable([], 1))[0])
 
 
 class TestLazyArray(TestCase):

--- a/xarray/test/test_indexing.py
+++ b/xarray/test/test_indexing.py
@@ -126,6 +126,8 @@ class TestIndexers(TestCase):
         test_indexer(mdata, ('a', 1),
                      [True,  True, False, False, False, False, False, False],
                      [-1, -2])
+        test_indexer(mdata, 'a', slice(0, 4, None),
+                     pd.MultiIndex.from_product([[1, 2], [-1, -2]]))
         test_indexer(mdata, ('a',),
                      [True,  True,  True,  True, False, False, False, False],
                      pd.MultiIndex.from_product([[1, 2], [-1, -2]]))

--- a/xarray/test/test_variable.py
+++ b/xarray/test/test_variable.py
@@ -971,6 +971,11 @@ class TestCoordinate(TestCase, VariableSubclassTestCases):
         v = Coordinate(['time'], data, {'foo': 'bar'})
         self.assertTrue(pd.Index(data, name='time').identical(v.to_index()))
 
+    def test_multiindex_default_level_names(self):
+        midx = pd.MultiIndex.from_product([['a', 'b'], [1, 2]])
+        v = Coordinate(['x'], midx, {'foo': 'bar'})
+        self.assertEqual(v.to_index().names, ('x_level_0', 'x_level_1'))
+
     def test_data(self):
         x = Coordinate('x', np.arange(3.0))
         # data should be initially saved as an ndarray


### PR DESCRIPTION
Follows #767.

This is incomplete (it still needs some tests and documentation updates), but it is working for both `Dataset` and `DataArray` objects. I also don't know if it is fully compatible with lazy indexing (Dask). 

Using the example from #767:

```
In [4]: da.sel(band_wavenumber={'band': 'foo'})
Out[4]:
<xarray.DataArray (wavenumber: 2)>
array([ 0.00017,  0.00014])
Coordinates:
  * wavenumber  (wavenumber) float64 4.05e+03 4.05e+03
```

As shown in this example, similarily to pandas, it automatically renames the dimension and assigns a new coordinate when the selection doesn't return a `pd.MultiIndex` (here it returns a `pd.FloatIndex`).

In some cases this behavior may be unwanted (??), so I added a `drop_level` keyword argument (if `False` it keeps the multi-index and doesn't change the dimension/coordinate names):

```
In [5]: da.sel(band_wavenumber={'band': 'foo'}, drop_level=False)
Out[5]:
<xarray.DataArray (band_wavenumber: 2)>
array([ 0.00017,  0.00014])
Coordinates:
  * band_wavenumber  (band_wavenumber) object ('foo', 4050.2) ('foo', 4050.3)
```

Note that it also works with `DataArray.loc`, but (for now) in that case it always returns the multi-index:

```
In [6]: da.loc[{'band_wavenumber': {'band': 'foo'}}]
Out[6]:
<xarray.DataArray (band_wavenumber: 2)>
array([ 0.00017,  0.00014])
Coordinates:
  * band_wavenumber  (band_wavenumber) object ('foo', 4050.2) ('foo', 4050.3)
```

This is however inconsistent with `Dataset.sel` and `Dataset.loc` that both apply `drop_level=True` by default, due to their different implementation. Two solutions: (1) make `DataArray.loc` apply drop_level by default, or (2) use `drop_level=False` by default everywhere.