### PR TITLE
Remove non-existing empty_like from Sphinx autosummary

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -17,7 +17,6 @@ Top-level functions
    align
    broadcast
    concat
-   empty_like
    set_options
 
 Dataset


### PR DESCRIPTION
I noticed that `empty_like` is listed in the top-level function API:
http://xarray.pydata.org/en/latest/api.html#top-level-functions

But I think it doesn't exist in xarray.
This PR removes the entry from the automodsummary list.

Also: I was the 100th person to fork xarray a minute ago.
What's my prize? I could use a better :car:  or a :house_with_garden: .