### PR TITLE
keep_attrs for Dataset.resample and DataArray.resample

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,9 +22,25 @@ This release includes
 
 Enhancements
 ~~~~~~~~~~~~
+
 - DataArray and Dataset method :py:meth:`where` now supports a ``drop=True``
   option that clips coordinate elements that are fully masked.  By
   `Phillip J. Wolfram <https://github.com/pwolfram>`_.
+
+- DataArray and Dataset method :py:meth:`resample` now supports the 
+  ``keep_attrs=False`` option that determines whether variable and dataset
+  attributes are retained in the resampled object. By
+  `Jeremy McGibbon <https://github.com/mcgibbon>`_.
+
+Bug fixes
+~~~~~~~~~
+
+- Attributes were being retained by default for some resampling
+  operations when they should not. With the ``keep_attrs=False`` option, they
+  will no longer be retained by default. This may be backwards-incompatible
+  with some scripts, but the attributes may be kept by adding the
+  ``keep_attrs=True`` option. By
+  `Jeremy McGibbon <https://github.com/mcgibbon>`_.
 
 .. _whats-new.0.7.2:
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -374,7 +374,7 @@ class BaseDataObject(AttrAccessMixin):
                                 center=center, **windows)
 
     def resample(self, freq, dim, how='mean', skipna=None, closed=None,
-                 label=None, base=0, keep_attrs=None):
+                 label=None, base=0, keep_attrs=False):
         """Resample this object to a new temporal resolution.
 
         Handles both downsampling and upsampling. Upsampling with filling is
@@ -419,10 +419,9 @@ class BaseDataObject(AttrAccessMixin):
             aggregated intervals. For example, for '24H' frequency, base could
             range from 0 through 23.
         keep_attrs : bool, optional
-            If True, the object's variable attributes (`attrs`) will be copied from
-            the original object to the new one.  If False, the new
-            object will be returned without transferring attributes. By default keep_attrs
-            is True if how is 'first' or 'last', and False otherwise.
+            If True, the object's attributes (`attrs`) will be copied from
+            the original object to the new one.  If False (default), the new
+            object will be returned without attributes.
 
         Returns
         -------
@@ -443,18 +442,14 @@ class BaseDataObject(AttrAccessMixin):
         time_grouper = pd.TimeGrouper(freq=freq, how=how, closed=closed,
                                       label=label, base=base)
         gb = self.groupby_cls(self, group, grouper=time_grouper)
-        if keep_attrs is None:
-            keep_attrs_kwarg = {}
-        else:
-            keep_attrs_kwarg = {'keep_attrs': keep_attrs}
         if isinstance(how, basestring):
             f = getattr(gb, how)
             if how in ['first', 'last']:
-                result = f(skipna=skipna, **keep_attrs_kwarg)
+                result = f(skipna=skipna, keep_attrs=keep_attrs)
             else:
-                result = f(dim=dim.name, skipna=skipna, **keep_attrs_kwarg)
+                result = f(dim=dim.name, skipna=skipna, keep_attrs=keep_attrs)
         else:
-            result = gb.reduce(how, dim=dim.name, **keep_attrs_kwarg)
+            result = gb.reduce(how, dim=dim.name, keep_attrs=keep_attrs)
         result = result.rename({RESAMPLE_DIM: dim.name})
         return result
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -338,7 +338,7 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
         new_order = sorted(stacked.dims, key=lookup_order)
         return stacked.transpose(*new_order)
 
-    def apply(self, func, shortcut=False, **kwargs):
+    def apply(self, func, shortcut=False, keep_attrs=None, **kwargs):
         """Apply a function over each array in the group and concatenate them
         together into a new array.
 
@@ -382,6 +382,8 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
         applied = (maybe_wrap_array(arr, func(arr, **kwargs)) for arr in grouped)
         combined = self._concat(applied, shortcut=shortcut)
         result = self._maybe_restore_empty_groups(combined)
+        if keep_attrs is False:
+            result.attrs.clear()
         return result
 
     def _concat(self, applied, shortcut=False):

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -431,8 +431,8 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
             removed.
         """
         def reduce_array(ar):
-            return ar.reduce(func, dim, axis, keep_attrs=keep_attrs, **kwargs)
-        return self.apply(reduce_array, shortcut=shortcut)
+            return ar.reduce(func, dim, axis, **kwargs)
+        return self.apply(reduce_array, shortcut=shortcut, keep_attrs=keep_attrs)
 
 ops.inject_reduce_methods(DataArrayGroupBy)
 ops.inject_binary_ops(DataArrayGroupBy)

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -320,7 +320,6 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
         # compiled language)
         stacked = Variable.concat(
             applied, concat_dim, positions, shortcut=True)
-        stacked.attrs.update(self.obj.attrs)
         result = self.obj._replace_maybe_drop_dims(stacked)
         result._coords[concat_dim.name] = as_variable(concat_dim, copy=True)
         return result
@@ -338,7 +337,7 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
         new_order = sorted(stacked.dims, key=lookup_order)
         return stacked.transpose(*new_order)
 
-    def apply(self, func, shortcut=False, keep_attrs=None, **kwargs):
+    def apply(self, func, shortcut=False, **kwargs):
         """Apply a function over each array in the group and concatenate them
         together into a new array.
 
@@ -382,8 +381,6 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
         applied = (maybe_wrap_array(arr, func(arr, **kwargs)) for arr in grouped)
         combined = self._concat(applied, shortcut=shortcut)
         result = self._maybe_restore_empty_groups(combined)
-        if keep_attrs is False:
-            result.attrs.clear()
         return result
 
     def _concat(self, applied, shortcut=False):
@@ -431,8 +428,8 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
             removed.
         """
         def reduce_array(ar):
-            return ar.reduce(func, dim, axis, **kwargs)
-        return self.apply(reduce_array, shortcut=shortcut, keep_attrs=keep_attrs)
+            return ar.reduce(func, dim, axis, keep_attrs=keep_attrs, **kwargs)
+        return self.apply(reduce_array, shortcut=shortcut)
 
 ops.inject_reduce_methods(DataArrayGroupBy)
 ops.inject_binary_ops(DataArrayGroupBy)

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -1413,17 +1413,12 @@ class TestDataArray(TestCase):
         array.attrs['meta'] = 'data'
 
         resampled_array = array.resample('1D', dim='time', how='first', keep_attrs=True)
-        actual = resampled_array.meta
-        expected = 'data'
+        actual = resampled_array.attrs
+        expected = array.attrs
         self.assertEqual(expected, actual)
 
         resampled_array = array.resample('1D', dim='time', how='first', keep_attrs=False)
-        try:
-            resampled_array.meta
-        except AttributeError:
-            pass
-        else:
-            self.fail('metadata should be discarded when keep_attrs=False')
+        assert resampled_array.attrs == {}
 
     def test_resample_mean_keep_attrs(self):
         times = pd.date_range('2000-01-01', freq='6H', periods=10)
@@ -1431,17 +1426,12 @@ class TestDataArray(TestCase):
         array.attrs['meta'] = 'data'
 
         resampled_array = array.resample('1D', dim='time', how='mean', keep_attrs=True)
-        actual = resampled_array.meta
-        expected = 'data'
+        actual = resampled_array.attrs
+        expected = array.attrs
         self.assertEqual(expected, actual)
 
         resampled_array = array.resample('1D', dim='time', how='mean', keep_attrs=False)
-        try:
-            resampled_array.meta
-        except AttributeError:
-            pass
-        else:
-            self.fail('metadata should be discarded when keep_attrs=False')
+        assert resampled_array.attrs == {}
 
     def test_resample_skipna(self):
         times = pd.date_range('2000-01-01', freq='6H', periods=10)

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -1407,6 +1407,42 @@ class TestDataArray(TestCase):
                              name='time')
         self.assertDataArrayIdentical(expected, actual)
 
+    def test_resample_first_keep_attrs(self):
+        times = pd.date_range('2000-01-01', freq='6H', periods=10)
+        array = DataArray(np.arange(10), [('time', times)])
+        array.attrs['meta'] = 'data'
+
+        resampled_array = array.resample('1D', dim='time', how='first', keep_attrs=True)
+        actual = resampled_array.meta
+        expected = 'data'
+        self.assertEqual(expected, actual)
+
+        resampled_array = array.resample('1D', dim='time', how='first', keep_attrs=False)
+        try:
+            resampled_array.meta
+        except AttributeError:
+            pass
+        else:
+            self.fail('metadata should be discarded when keep_attrs=False')
+
+    def test_resample_mean_keep_attrs(self):
+        times = pd.date_range('2000-01-01', freq='6H', periods=10)
+        array = DataArray(np.arange(10), [('time', times)])
+        array.attrs['meta'] = 'data'
+
+        resampled_array = array.resample('1D', dim='time', how='mean', keep_attrs=True)
+        actual = resampled_array.meta
+        expected = 'data'
+        self.assertEqual(expected, actual)
+
+        resampled_array = array.resample('1D', dim='time', how='mean', keep_attrs=False)
+        try:
+            resampled_array.meta
+        except AttributeError:
+            pass
+        else:
+            self.fail('metadata should be discarded when keep_attrs=False')
+
     def test_resample_skipna(self):
         times = pd.date_range('2000-01-01', freq='6H', periods=10)
         array = DataArray(np.ones(10), [('time', times)])

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -1647,7 +1647,7 @@ class TestDataset(TestCase):
                       'bar': ('time', np.random.randn(10), {'meta': 'data'}),
                       'time': times})
 
-        actual = ds.resample('1D', dim='time', how='first')
+        actual = ds.resample('1D', dim='time', how='first', keep_attrs=True)
         expected = ds.isel(time=[0, 4, 8])
         self.assertDatasetIdentical(expected, actual)
 
@@ -1663,10 +1663,15 @@ class TestDataset(TestCase):
         ds = Dataset({'foo': (['time', 'x', 'y'], np.random.randn(10, 5, 3)),
                       'bar': ('time', np.random.randn(10), {'meta': 'data'}),
                       'time': times})
+        ds.attrs['dsmeta'] = 'dsdata'
 
         resampled_ds = ds.resample('1D', dim='time', how='mean', keep_attrs=True)
         actual = resampled_ds['bar'].meta
         expected = 'data'
+        self.assertEqual(expected, actual)
+
+        actual = resampled_ds.dsmeta
+        expected = 'dsdata'
         self.assertEqual(expected, actual)
 
     def test_resample_by_mean_discarding_attrs(self):
@@ -1674,10 +1679,19 @@ class TestDataset(TestCase):
         ds = Dataset({'foo': (['time', 'x', 'y'], np.random.randn(10, 5, 3)),
                       'bar': ('time', np.random.randn(10), {'meta': 'data'}),
                       'time': times})
+        ds.attrs['dsmeta'] = 'dsdata'
 
         resampled_ds = ds.resample('1D', dim='time', how='mean', keep_attrs=False)
+
         try:
             resampled_ds['bar'].meta
+        except AttributeError:
+            pass
+        else:
+            self.fail('metadata should be discarded when keep_attrs=False')
+
+        try:
+            resampled_ds.dsmeta
         except AttributeError:
             pass
         else:

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -1658,6 +1658,31 @@ class TestDataset(TestCase):
             actual = ds.resample('3H', 'time', how=how)
             self.assertDatasetEqual(expected, actual)
 
+    def test_resample_by_mean_with_keep_attrs(self):
+        times = pd.date_range('2000-01-01', freq='6H', periods=10)
+        ds = Dataset({'foo': (['time', 'x', 'y'], np.random.randn(10, 5, 3)),
+                      'bar': ('time', np.random.randn(10), {'meta': 'data'}),
+                      'time': times})
+
+        resampled_ds = ds.resample('1D', dim='time', how='mean', keep_attrs=True)
+        actual = resampled_ds['bar'].meta
+        expected = 'data'
+        self.assertEqual(expected, actual)
+
+    def test_resample_by_mean_discarding_attrs(self):
+        times = pd.date_range('2000-01-01', freq='6H', periods=10)
+        ds = Dataset({'foo': (['time', 'x', 'y'], np.random.randn(10, 5, 3)),
+                      'bar': ('time', np.random.randn(10), {'meta': 'data'}),
+                      'time': times})
+
+        resampled_ds = ds.resample('1D', dim='time', how='mean', keep_attrs=False)
+        try:
+            resampled_ds['bar'].meta
+        except AttributeError:
+            pass
+        else:
+            self.fail('metadata should be discarded when keep_attrs=False')
+
     def test_to_array(self):
         ds = Dataset(OrderedDict([('a', 1), ('b', ('x', [1, 2, 3]))]),
                      coords={'c': 42}, attrs={'Conventions': 'None'})

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -1666,12 +1666,12 @@ class TestDataset(TestCase):
         ds.attrs['dsmeta'] = 'dsdata'
 
         resampled_ds = ds.resample('1D', dim='time', how='mean', keep_attrs=True)
-        actual = resampled_ds['bar'].meta
-        expected = 'data'
+        actual = resampled_ds['bar'].attrs
+        expected = ds['bar'].attrs
         self.assertEqual(expected, actual)
 
-        actual = resampled_ds.dsmeta
-        expected = 'dsdata'
+        actual = resampled_ds.attrs
+        expected = ds.attrs
         self.assertEqual(expected, actual)
 
     def test_resample_by_mean_discarding_attrs(self):
@@ -1683,33 +1683,20 @@ class TestDataset(TestCase):
 
         resampled_ds = ds.resample('1D', dim='time', how='mean', keep_attrs=False)
 
-        try:
-            resampled_ds['bar'].meta
-        except AttributeError:
-            pass
-        else:
-            self.fail('metadata should be discarded when keep_attrs=False')
-
-        try:
-            resampled_ds.dsmeta
-        except AttributeError:
-            pass
-        else:
-            self.fail('metadata should be discarded when keep_attrs=False')
+        assert resampled_ds['bar'].attrs == {}
+        assert resampled_ds.attrs == {}
 
     def test_resample_by_last_discarding_attrs(self):
         times = pd.date_range('2000-01-01', freq='6H', periods=10)
         ds = Dataset({'foo': (['time', 'x', 'y'], np.random.randn(10, 5, 3)),
                       'bar': ('time', np.random.randn(10), {'meta': 'data'}),
                       'time': times})
+        ds.attrs['dsmeta'] = 'dsdata'
 
         resampled_ds = ds.resample('1D', dim='time', how='last', keep_attrs=False)
-        try:
-            resampled_ds['bar'].meta
-        except AttributeError:
-            pass
-        else:
-            self.fail('metadata should be discarded when keep_attrs=False')
+
+        assert resampled_ds['bar'].attrs == {}
+        assert resampled_ds.attrs == {}
 
     def test_to_array(self):
         ds = Dataset(OrderedDict([('a', 1), ('b', ('x', [1, 2, 3]))]),

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -1683,6 +1683,20 @@ class TestDataset(TestCase):
         else:
             self.fail('metadata should be discarded when keep_attrs=False')
 
+    def test_resample_by_last_discarding_attrs(self):
+        times = pd.date_range('2000-01-01', freq='6H', periods=10)
+        ds = Dataset({'foo': (['time', 'x', 'y'], np.random.randn(10, 5, 3)),
+                      'bar': ('time', np.random.randn(10), {'meta': 'data'}),
+                      'time': times})
+
+        resampled_ds = ds.resample('1D', dim='time', how='last', keep_attrs=False)
+        try:
+            resampled_ds['bar'].meta
+        except AttributeError:
+            pass
+        else:
+            self.fail('metadata should be discarded when keep_attrs=False')
+
     def test_to_array(self):
         ds = Dataset(OrderedDict([('a', 1), ('b', ('x', [1, 2, 3]))]),
                      coords={'c': 42}, attrs={'Conventions': 'None'})


### PR DESCRIPTION
Closes #825 and #828

This update might break some scripts, because of bugs that existed in the code before. resample was inconsistent as to when it would and would not keep attributes. In particular, Dataset resampling usually threw out attributes, but not when how='first' or how='last', and DataArray preserved attributes for everything I tested ('first', 'last', and 'mean').