### PR TITLE
Fix #665 decode_cf_timedelta 2D

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,7 +27,7 @@ Enhancements
   option that clips coordinate elements that are fully masked.  By
   `Phillip J. Wolfram <https://github.com/pwolfram>`_.
 
-- DataArray and Dataset method :py:meth:`resample` now supports the 
+- DataArray and Dataset method :py:meth:`resample` now supports the
   ``keep_attrs=False`` option that determines whether variable and dataset
   attributes are retained in the resampled object. By
   `Jeremy McGibbon <https://github.com/mcgibbon>`_.
@@ -41,6 +41,10 @@ Bug fixes
   with some scripts, but the attributes may be kept by adding the
   ``keep_attrs=True`` option. By
   `Jeremy McGibbon <https://github.com/mcgibbon>`_.
+
+- ``decode_cf_timedelta`` now accepts arrays with ``ndim`` >1 (:issue:`842`).
+   This fixes issue :issue:`665`.
+   `Filipe Fernandes <https://github.com/ocefpaf>`_.
 
 .. _whats-new.0.7.2:
 

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -151,26 +151,15 @@ def decode_cf_datetime(num_dates, units, calendar=None):
     return dates.reshape(num_dates.shape)
 
 
-def _asarray_or_scalar(x):
-    x = np.asarray(x)
-    if x.ndim > 0:
-        return x
-    else:
-        return x.item()
-
-
 def decode_cf_timedelta(num_timedeltas, units):
     """Given an array of numeric timedeltas in netCDF format, convert it into a
     numpy timedelta64[ns] array.
     """
-    num_timedeltas = _asarray_or_scalar(num_timedeltas)
+    num_timedeltas = np.asarray(num_timedeltas)
     units = _netcdf_to_numpy_timeunit(units)
 
-    shape = None
-    if isinstance(num_timedeltas, np.ndarray):
-        if num_timedeltas.ndim > 1:
-            shape = num_timedeltas.shape
-            num_timedeltas = num_timedeltas.ravel()
+    shape = num_timedeltas.shape
+    num_timedeltas = num_timedeltas.ravel()
 
     result = pd.to_timedelta(num_timedeltas, unit=units, box=False)
     # NaT is returned unboxed with wrong units; this should be fixed in pandas

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -165,11 +165,18 @@ def decode_cf_timedelta(num_timedeltas, units):
     """
     num_timedeltas = _asarray_or_scalar(num_timedeltas)
     units = _netcdf_to_numpy_timeunit(units)
+
+    shape = None
+    if isinstance(num_timedeltas, np.ndarray):
+        if num_timedeltas.ndim > 1:
+            shape = num_timedeltas.shape
+            num_timedeltas = num_timedeltas.ravel()
+
     result = pd.to_timedelta(num_timedeltas, unit=units, box=False)
     # NaT is returned unboxed with wrong units; this should be fixed in pandas
     if result.dtype != 'timedelta64[ns]':
         result = result.astype('timedelta64[ns]')
-    return result
+    return result.reshape(shape)
 
 
 TIME_UNITS = frozenset(['days', 'hours', 'minutes', 'seconds',

--- a/xarray/test/test_conventions.py
+++ b/xarray/test/test_conventions.py
@@ -400,6 +400,16 @@ class TestDatetime(TestCase):
         actual = conventions.decode_cf_timedelta(np.array(np.nan), 'days')
         self.assertArrayEqual(expected, actual)
 
+    def test_cf_timedelta_2d(self):
+        timedeltas, units, numbers = ['1D', '2D', '3D'], 'days', np.atleast_2d([1, 2, 3])
+
+        timedeltas = np.atleast_2d(pd.to_timedelta(timedeltas, box=False))
+        expected = timedeltas
+
+        actual = conventions.decode_cf_timedelta(numbers, units)
+        self.assertArrayEqual(expected, actual)
+        self.assertEqual(expected.dtype, actual.dtype)
+
     def test_infer_timedelta_units(self):
         for deltas, expected in [
                 (pd.to_timedelta(['1 day', '2 days']), 'days'),


### PR DESCRIPTION
Long time listener first time caller :wink: 

I am not 100% about this PR though. I think that there are cases when we need the actual data rather than the `timedelta`. In [this](http://nbviewer.jupyter.org/gist/ocefpaf/6ed33fb35fe526f677e215b3fb304847) notebook we have wave period (`'mper'`) that should be *seconds* ranging `0-30` and not those big numpy timedelta numbers.

I know that I can get that behavior with `decode_times=True` when opening the dataset, but then the `time` coordinate get decoded as well. (Maybe I am way off and there is a way to do this.)