### PR TITLE
Add a filter_by_attrs method to Dataset

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -394,6 +394,7 @@ Dataset methods
    Dataset.close
    Dataset.load
    Dataset.chunk
+   Dataset.get_variables_by_attributes
 
 DataArray methods
 -----------------

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -394,7 +394,7 @@ Dataset methods
    Dataset.close
    Dataset.load
    Dataset.chunk
-   Dataset.get_variables_by_attributes
+   Dataset.filter_by_attrs
 
 DataArray methods
 -----------------

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -69,9 +69,9 @@ Enhancements
   allowing more control on the colorbar (:issue:`872`).
   By `Fabien Maussion <https://github.com/fmaussion>`_.
 
-- New Dataset method :py:meth:`get_variables_by_attributes`, akin to
+- New Dataset method :py:meth:`filter_by_attrs`, akin to
   ``netCDF4.Dataset.get_variables_by_attributes``, to easily filter
-  data variables using the its attributes.
+  data variables using its attributes.
   `Filipe Fernandes <https://github.com/ocefpaf>`_.
 
 Bug fixes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -70,8 +70,8 @@ Enhancements
   By `Fabien Maussion <https://github.com/fmaussion>`_.
 
 - New Dataset method :py:meth:`get_variables_by_attributes`, akin to
-  ``netCDF4.Dataset.get_variables_by_attributes``, to easily find variable
-  in a Dataset via its attributes information.
+  ``netCDF4.Dataset.get_variables_by_attributes``, to easily filter coordinates
+  and variables using the attributes information.
   `Filipe Fernandes <https://github.com/ocefpaf>`_.
 
 Bug fixes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -70,8 +70,8 @@ Enhancements
   By `Fabien Maussion <https://github.com/fmaussion>`_.
 
 - New Dataset method :py:meth:`get_variables_by_attributes`, akin to
-  ``netCDF4.Dataset.get_variables_by_attributes``, to easily filter coordinates
-  and variables using the attributes information.
+  ``netCDF4.Dataset.get_variables_by_attributes``, to easily filter
+  data variables using the its attributes.
   `Filipe Fernandes <https://github.com/ocefpaf>`_.
 
 Bug fixes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -69,6 +69,11 @@ Enhancements
   allowing more control on the colorbar (:issue:`872`).
   By `Fabien Maussion <https://github.com/fmaussion>`_.
 
+- New Dataset method :py:meth:`get_variables_by_attributes`, akin to
+  ``netCDF4.Dataset.get_variables_by_attributes``, to easily find variable
+  in a Dataset via its attributes information.
+  `Filipe Fernandes <https://github.com/ocefpaf>`_.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2224,6 +2224,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
 
         Examples
         --------
+        # "Create an example dataset:
         >>> import numpy as np
         >>> import pandas as pd
         >>> import xarray as xr

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2250,25 +2250,13 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             *empty*
 
         """
-        vs = []
-
-        has_value_flag  = False
-        for vname, data_array in self.items():
-            for k, v in kwargs.items():
-                if callable(v):
-                    has_value_flag = v(getattr(data_array, k, None))
-                    if has_value_flag is False:
-                        break
-                elif hasattr(data_array, k) and getattr(data_array, k) == v:
-                    has_value_flag = True
-                else:
-                    has_value_flag = False
-                    break
-
-            if has_value_flag is True:
-                vs.append(vname)
-        if len(self) < len(vs) > 1:
-            vs = [vs]
-        return self[vs]
+        selection = []
+        for var_name, variable in self.items():
+            for attr_name, pattern in kwargs.items():
+                attr_value = variable.attrs.get(attr_name)
+                if ((callable(pattern) and pattern(attr_value))
+                        or attr_value == pattern):
+                    selection.append(var_name)
+        return self[selection]
 
 ops.inject_all_ops_and_reduce_methods(Dataset, array_only=False)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2203,8 +2203,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         Can pass in ``key=value ``or ``key=callable``.  Variables are returned
         that contain all of the matches or callable returns True.  If using a
         callable note that it should accept a single parameter only,
-        the attribute value.  None is given as the attribute value when the
-        attribute does not exist on the variable.
+        the attribute value.
 
         Examples
         --------
@@ -2258,9 +2257,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
                 if ((callable(pattern) and pattern(attr_value))
                         or attr_value == pattern):
                     selection.append(var_name)
-        if selection:
-            return self[selection]
-        else:
-            return None
+        return self[selection]
 
 ops.inject_all_ops_and_reduce_methods(Dataset, array_only=False)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2248,10 +2248,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         <xarray.Dataset>
         Dimensions:         (time: 3, x: 2, y: 2)
         Coordinates:
-        * x               (x) int64 0 1
-        * time            (time) datetime64[ns] 2014-09-06 2014-09-07 2014-09-08
+          * x               (x) int64 0 1
+          * time            (time) datetime64[ns] 2014-09-06 2014-09-07 2014-09-08
             lat             (x, y) float64 42.25 42.21 42.63 42.59
-        * y               (y) int64 0 1
+          * y               (y) int64 0 1
             reference_time  datetime64[ns] 2014-09-05
             lon             (x, y) float64 -99.83 -99.32 -99.79 -99.23
         Data variables:
@@ -2264,9 +2264,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         Coordinates:
             lon             (x, y) float64 -99.83 -99.32 -99.79 -99.23
             lat             (x, y) float64 42.25 42.21 42.63 42.59
-        * x               (x) int64 0 1
-        * y               (y) int64 0 1
-        * time            (time) datetime64[ns] 2014-09-06 2014-09-07 2014-09-08
+          * x               (x) int64 0 1
+          * y               (y) int64 0 1
+          * time            (time) datetime64[ns] 2014-09-06 2014-09-07 2014-09-08
             reference_time  datetime64[ns] 2014-09-05
         Data variables:
             temperature     (x, y, time) float64 25.86 20.82 6.954 23.13 10.25 11.68 ...

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2205,6 +2205,18 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         callable note that it should accept a single parameter only,
         the attribute value.
 
+        Parameters
+        ----------
+        **kwargs : key=value
+            key : str
+                Filter variables based on a string attribute.
+            value : str or callable
+                Filter variables based on callable False/True answer.
+
+        Returns
+        -------
+        new : Dataset
+
         Examples
         --------
         >>> import numpy as np

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2198,7 +2198,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
     def imag(self):
         return self._unary_op(lambda x: x.imag, keep_attrs=True)(self)
 
-    def get_variables_by_attributes(self, **kwargs):
+    def filter_by_attrs(self, **kwargs):
         """Returns a ``Dataset`` with variables that match specific conditions.
 
         Can pass in ``key=value ``or ``key=callable``.  Variables are returned
@@ -2244,8 +2244,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         ...         'time': pd.date_range('2014-09-06', periods=3),
         ...         'reference_time': pd.Timestamp('2014-09-05')})
         >>> # Get variables matching a specific standard_name.
-        >>> ds.get_variables_by_attributes(
-        ...     standard_name='convective_precipitation_flux')
+        >>> ds.filter_by_attrs(standard_name='convective_precipitation_flux')
         <xarray.Dataset>
         Dimensions:         (time: 3, x: 2, y: 2)
         Coordinates:
@@ -2259,7 +2258,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             precipitation   (x, y, time) float64 4.178 2.307 6.041 6.046 0.06648 ...
         >>> # Get all variables that have a standard_name attribute.
         >>> standard_name = lambda v: v is not None
-        >>> ds.get_variables_by_attributes(standard_name=standard_name)
+        >>> ds.filter_by_attrs(standard_name=standard_name)
         <xarray.Dataset>
         Dimensions:         (time: 3, x: 2, y: 2)
         Coordinates:

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -2532,7 +2532,7 @@ class TestDataset(TestCase):
         with self.assertRaisesRegexp(AttributeError, 'cannot set attr'):
             ds.other = 2
 
-    def test_get_variables_by_attributes(self):
+    def test_filter_by_attrs(self):
         precip = dict(standard_name='convective_precipitation_flux')
         temp0 = dict(standard_name='air_potential_temperature', height='0 m')
         temp10 = dict(standard_name='air_potential_temperature', height='10 m')
@@ -2542,28 +2542,28 @@ class TestDataset(TestCase):
                     coords={'time': (['t'], [0], dict(axis='T'))})
 
         # Test return empty Dataset.
-        ds.get_variables_by_attributes(standard_name='invalid_standard_name')
-        new_ds = ds.get_variables_by_attributes(standard_name='invalid_standard_name')
+        ds.filter_by_attrs(standard_name='invalid_standard_name')
+        new_ds = ds.filter_by_attrs(standard_name='invalid_standard_name')
         self.assertFalse(bool(new_ds.data_vars))
 
         # Test return one DataArray.
-        new_ds = ds.get_variables_by_attributes(standard_name='convective_precipitation_flux')
+        new_ds = ds.filter_by_attrs(standard_name='convective_precipitation_flux')
         self.assertEqual(new_ds['precipitation'].standard_name, 'convective_precipitation_flux')
         self.assertDatasetEqual(new_ds['precipitation'], ds['precipitation'])
 
         # Test return more than one DataArray.
-        new_ds = ds.get_variables_by_attributes(standard_name='air_potential_temperature')
+        new_ds = ds.filter_by_attrs(standard_name='air_potential_temperature')
         self.assertEqual(len(new_ds.data_vars), 2)
         for var in new_ds.data_vars:
             self.assertEqual(new_ds[var].standard_name, 'air_potential_temperature')
 
         # Test callable.
-        new_ds = ds.get_variables_by_attributes(height=lambda v: v is not None)
+        new_ds = ds.filter_by_attrs(height=lambda v: v is not None)
         self.assertEqual(len(new_ds.data_vars), 2)
         for var in new_ds.data_vars:
             self.assertEqual(new_ds[var].standard_name, 'air_potential_temperature')
 
-        new_ds = ds.get_variables_by_attributes(height='10 m')
+        new_ds = ds.filter_by_attrs(height='10 m')
         self.assertEqual(len(new_ds.data_vars), 1)
         for var in new_ds.data_vars:
             self.assertEqual(new_ds[var].height, '10 m')

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -2533,9 +2533,12 @@ class TestDataset(TestCase):
             ds.other = 2
 
     def test_get_variables_by_attributes(self):
-        ds = Dataset({'temperature_0': (['t'],  [0], dict(standard_name='air_potential_temperature', height='0 m')),
-                      'temperature_10': (['t'],  [0], dict(standard_name='air_potential_temperature', height='10 m')),
-                      'precipitation': (['t'], [0], dict(standard_name='convective_precipitation_flux'))},
+        precip = dict(standard_name='convective_precipitation_flux')
+        temp0 = dict(standard_name='air_potential_temperature', height='0 m')
+        temp10 = dict(standard_name='air_potential_temperature', height='10 m')
+        ds = Dataset({'temperature_0': (['t'], [0], temp0),
+                      'temperature_10': (['t'], [0], temp10),
+                      'precipitation': (['t'], [0], precip)},
                     coords={'time': (['t'], [0], dict(axis='T'))})
 
         # Test return empty Dataset.
@@ -2543,12 +2546,12 @@ class TestDataset(TestCase):
         new_ds = ds.get_variables_by_attributes(standard_name='invalid_standard_name')
         self.assertFalse(bool(new_ds))
 
-        # Test return one Dataset.
+        # Test return one DataArray.
         new_ds = ds.get_variables_by_attributes(standard_name='convective_precipitation_flux')
         self.assertEqual(new_ds['precipitation'].standard_name, 'convective_precipitation_flux')
         self.assertDatasetEqual(new_ds['precipitation'], ds['precipitation'])
 
-        # Test return more than one Dataset.
+        # Test return more than one DataArray.
         new_ds = ds.get_variables_by_attributes(standard_name='air_potential_temperature')
         self.assertEqual(len(new_ds.data_vars), 2)
         for var in new_ds.data_vars:

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -2541,7 +2541,7 @@ class TestDataset(TestCase):
         # Test return empty Dataset.
         ds.get_variables_by_attributes(standard_name='invalid_standard_name')
         new_ds = ds.get_variables_by_attributes(standard_name='invalid_standard_name')
-        self.assertIsNone(new_ds)
+        self.assertFalse(bool(new_ds))
 
         # Test return one Dataset.
         new_ds = ds.get_variables_by_attributes(standard_name='convective_precipitation_flux')

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -2541,13 +2541,7 @@ class TestDataset(TestCase):
         # Test return empty Dataset.
         ds.get_variables_by_attributes(standard_name='invalid_standard_name')
         new_ds = ds.get_variables_by_attributes(standard_name='invalid_standard_name')
-        self.assertIsInstance(new_ds, Dataset)
-        self.assertFalse(new_ds.data_vars)
-
-        # Test return coords only Dataset.
-        new_ds = ds.get_variables_by_attributes(axis='T')
-        self.assertEqual(new_ds.coords['time'].axis, 'T')
-        self.assertFalse(new_ds.data_vars)
+        self.assertIsNone(new_ds)
 
         # Test return one Dataset.
         new_ds = ds.get_variables_by_attributes(standard_name='convective_precipitation_flux')

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -2544,7 +2544,7 @@ class TestDataset(TestCase):
         # Test return empty Dataset.
         ds.get_variables_by_attributes(standard_name='invalid_standard_name')
         new_ds = ds.get_variables_by_attributes(standard_name='invalid_standard_name')
-        self.assertFalse(bool(new_ds))
+        self.assertFalse(bool(new_ds.data_vars))
 
         # Test return one DataArray.
         new_ds = ds.get_variables_by_attributes(standard_name='convective_precipitation_flux')

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -2531,3 +2531,45 @@ class TestDataset(TestCase):
             ds.foo = 2
         with self.assertRaisesRegexp(AttributeError, 'cannot set attr'):
             ds.other = 2
+
+    def test_get_variables_by_attributes(self):
+        temp_0 = 15 + 8 * np.random.randn(2, 2, 3)
+        temp_10 = 5 + 8 * np.random.randn(2, 2, 3)
+        precip = 10 * np.random.rand(2, 2, 3)
+        lon = [[-99.83, -99.32], [-99.79, -99.23]]
+        lat = [[42.25, 42.21], [42.63, 42.59]]
+
+        ds = Dataset({'temperature_0': (['x', 'y', 'time'],  temp_0, dict(standard_name='air_potential_temperature', height='0 m')),
+                      'temperature_10': (['x', 'y', 'time'],  temp_10, dict(standard_name='air_potential_temperature', height='10 m')),
+                      'precipitation': (['x', 'y', 'time'], precip, dict(standard_name='convective_precipitation_flux'))},
+                    coords={'lon': (['x', 'y'], lon, dict(axis='X')),
+                            'lat': (['x', 'y'], lat, dict(axis='Y')),
+                            'time': pd.date_range('2014-09-06', periods=3),
+                            'reference_time': pd.Timestamp('2014-09-05')})
+        # Test empty returns Dataset.
+        ds.get_variables_by_attributes(standard_name='invalid_standard_name')
+        new_ds = ds.get_variables_by_attributes(standard_name='invalid_standard_name')
+        self.assertIsInstance(new_ds, Dataset)
+        self.assertFalse(new_ds.data_vars)
+
+        # Test find 1 Dataset.
+        new_ds = ds.get_variables_by_attributes(standard_name='convective_precipitation_flux')
+        self.assertEqual(new_ds['precipitation'].standard_name, 'convective_precipitation_flux')
+        self.assertDatasetEqual(new_ds['precipitation'], ds['precipitation'])
+
+        # Test find more than 1 Dataset.
+        new_ds = ds.get_variables_by_attributes(standard_name='air_potential_temperature')
+        self.assertEqual(len(new_ds.data_vars), 2)
+        for var in new_ds.data_vars:
+            self.assertEqual(new_ds[var].standard_name, 'air_potential_temperature')
+
+        # Test callable.
+        new_ds = ds.get_variables_by_attributes(height=lambda v: v is not None)
+        self.assertEqual(len(new_ds.data_vars), 2)
+        for var in new_ds.data_vars:
+            self.assertEqual(new_ds[var].standard_name, 'air_potential_temperature')
+
+        new_ds = ds.get_variables_by_attributes(height='10 m')
+        self.assertEqual(len(new_ds.data_vars), 1)
+        for var in new_ds.data_vars:
+            self.assertEqual(new_ds[var].height, '10 m')


### PR DESCRIPTION
This PR adds the `get_variables_by_attributes` method similar to the one in `netCDF4-python` and netcdf-java libraries. It is useful to filter a Dataset to known/expected attributes.

@shoyer I don't really like the docs nor the change log entry I created. I will look at them again tomorrow with fresh eyes to see if I can improve them.

Closes https://github.com/pydata/xarray/issues/567

xref: https://github.com/pydata/xarray/issues/567#issuecomment-216947679