### PR TITLE
roundtrip boolean datatype

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -37,6 +37,11 @@ Enhancements
   extensions without subclassing. They are described in the new documentation
   page on :ref:`internals`. By `Stephan Hoyer <https://github.com/shoyer>`
 
+- Round trip boolean datatypes. Previously, writing boolean datatypes to netCDF
+  formats would raise an error since netCDF does not have a `bool` datatype.
+  This feature reads/writes a `dtype` attribute to boolean variables in netCDF
+  files. By `Joe Hamman <https://github.com/jhamman>`_.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -629,13 +629,12 @@ def maybe_encode_dtype(var, name=None):
     return var
 
 
-def maybe_encode_bools(var, needs_copy=True):
+def maybe_encode_bools(var):
     if ((var.dtype == np.bool) and
             ('dtype' not in var.encoding) and ('dtype' not in var.attrs)):
         dims, data, attrs, encoding = _var_as_tuple(var)
         attrs['dtype'] = 'bool'
-        data = data.astype(dtype='i1', copy=needs_copy)
-        needs_copy = False
+        data = data.astype(dtype='i1', copy=True)
         var = Variable(dims, data, attrs, encoding)
     return var
 
@@ -713,7 +712,7 @@ def encode_cf_variable(var, needs_copy=True, name=None):
     var, needs_copy = maybe_encode_offset_and_scale(var, needs_copy)
     var, needs_copy = maybe_encode_fill_value(var, needs_copy)
     var = maybe_encode_dtype(var, name)
-    var = maybe_encode_bools(var, needs_copy)
+    var = maybe_encode_bools(var)
     var = ensure_dtype_not_object(var)
     return var
 

--- a/xarray/test/test_conventions.py
+++ b/xarray/test/test_conventions.py
@@ -105,6 +105,15 @@ class TestCharToStringArray(TestCase):
         self.assertArrayEqual(actual, expected)
 
 
+class TestBoolTypeArray(TestCase):
+    def test_booltype_array(self):
+        x = np.array([1, 0, 1, 1, 0], dtype='i1')
+        bx = conventions.BoolTypeArray(x)
+        self.assertEqual(bx.dtype, np.bool)
+        self.assertArrayEqual(bx, np.array([True, False, True, True, False],
+                                           dtype=np.bool))
+
+
 @np.vectorize
 def _ensure_naive_tz(dt):
     if hasattr(dt, 'tzinfo'):


### PR DESCRIPTION
This PR allows boolean datatypes to be faithfully roundtripped.  My approach follows @shoyer's suggestions in https://github.com/pydata/xarray/pull/401#issuecomment-96085330.

closes #401 
cc @klapo, @khaeru