### PR TITLE
BUG: Stringify DS attrs in dir

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -26,6 +26,10 @@ Bug fixes
 
 - Fix to ensure xarray works with h5netcdf v0.3.0 for arrays with ``dtype=str``
   (:issue:`953`). By `Stephan Hoyer <https://github.com/shoyer>`_.
+- ``Dataset.__dir__()`` (i.e. the method python calls to get autocomplete options) failed
+  if one of the ``Dataset``'s keys was not a string (:issue:`852`). By
+  `Maximilian Roos <https://github.com/maximilianr>`_.
+
 
 .. _whats-new.0.8.1:
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from .pycompat import basestring, iteritems, suppress, dask_array_type
+from .pycompat import basestring, iteritems, suppress, dask_array_type, bytes_type
 from . import formatting
 from .utils import SortedKeysDict, not_implemented
 
@@ -211,8 +211,9 @@ class AttrAccessMixin(object):
         """Provide method name lookup and completion. Only provide 'public'
         methods.
         """
-        extra_attrs = [item for sublist in self._attr_sources
-                       for item in sublist]
+        extra_attrs = [
+            item for sublist in self._attr_sources for item in sublist
+            if isinstance(item, (basestring))]
         return sorted(set(dir(type(self)) + extra_attrs))
 
 

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -12,6 +12,7 @@ except ImportError:
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from xarray import (align, broadcast, concat, merge, conventions, backends,
                     Dataset, DataArray, Variable, Coordinate, auto_combine,
@@ -2555,3 +2556,30 @@ class TestDataset(TestCase):
         self.assertEqual(len(new_ds.data_vars), 1)
         for var in new_ds.data_vars:
             self.assertEqual(new_ds[var].height, '10 m')
+
+
+### Py.test tests
+
+
+@pytest.fixture()
+def data_set(seed=None):
+    return create_test_data(seed)
+
+
+def test_dir_expected_attrs(data_set):
+
+    some_expected_attrs = {'pipe', 'mean', 'isnull', 'var1',
+                           'dim1', 'numbers'}
+    result = dir(data_set)
+    assert set(result) >= some_expected_attrs
+
+def test_dir_non_string(data_set):
+    # add a numbered key to ensure this doesn't break dir
+    data_set[5] = 'foo'
+    result = dir(data_set)
+    assert not (5 in result)
+
+def test_dir_unicode(data_set):
+    data_set[u'unicode'] = 'uni'
+    result = dir(data_set)
+    assert u'unicode' in result


### PR DESCRIPTION
Previously:

```python
In [21]: ds
Out[21]: 
<xarray.Dataset>
Dimensions:  (abc: 3)
Coordinates:
  * abc      (abc) int64 0 1 2
Data variables:
    0        (abc) float64 0.3168 0.1132 0.6664
    1        (abc) float64 0.9799 0.9663 0.01084
    2        (abc) float64 0.9171 0.6848 0.5028


In [22]: dir(ds)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-22-fd55ce5c03db> in <module>()
----> 1 dir(ds)

/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xarray/core/common.py in __dir__(self)
    157         extra_attrs = [item for sublist in self._attr_sources
    158                        for item in sublist]
--> 159         return sorted(set(dir(type(self)) + extra_attrs))
    160 
    161 

TypeError: unorderable types: numpy.ndarray() > str()
```