### PR TITLE
ENH: more control on colorbar

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -49,6 +49,10 @@ Enhancements
   This feature reads/writes a `dtype` attribute to boolean variables in netCDF
   files. By `Joe Hamman <https://github.com/jhamman>`_.
 
+- 2D plotting methods now have two new keywords (`cbar_ax` and `cbar_kwargs`),
+  allowing more control on the colorbar (:issue:`872`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -342,7 +342,7 @@ def _plot2d(plotfunc):
                     add_colorbar=True, add_labels=True, vmin=None, vmax=None,
                     cmap=None, center=None, robust=False, extend=None,
                     levels=None, colors=None, subplot_kws=None,
-                    cbar_ax=None, cbar_kwargs={}, **kwargs):
+                    cbar_ax=None, cbar_kwargs=None, **kwargs):
         # All 2d plots in xarray share this function signature.
         # Method signature below should be consistent.
 
@@ -428,7 +428,7 @@ def _plot2d(plotfunc):
             ax.set_title(darray._title_for_slice())
 
         if add_colorbar:
-            cbar_kwargs = dict(cbar_kwargs)
+            cbar_kwargs = {} if cbar_kwargs is None else dict(cbar_kwargs)
             cbar_kwargs.setdefault('extend', cmap_params['extend'])
             if cbar_ax is None:
                 cbar_kwargs.setdefault('ax', ax)
@@ -437,6 +437,10 @@ def _plot2d(plotfunc):
             cbar = plt.colorbar(primitive, **cbar_kwargs)
             if darray.name and add_labels and 'label' not in cbar_kwargs:
                 cbar.set_label(darray.name, rotation=90)
+        elif cbar_ax is not None or cbar_kwargs is not None:
+            # inform the user about keywords which aren't used
+            raise ValueError("cbar_ax and cbar_kwargs can't be used with "
+                             "add_colorbar=False.")
 
         _update_axes_limits(ax, xincrease, yincrease)
 
@@ -449,7 +453,7 @@ def _plot2d(plotfunc):
                    add_colorbar=True, add_labels=True, vmin=None, vmax=None,
                    cmap=None, colors=None, center=None, robust=False,
                    extend=None, levels=None, subplot_kws=None,
-                   cbar_ax=None, cbar_kwargs={}, **kwargs):
+                   cbar_ax=None, cbar_kwargs=None, **kwargs):
         """
         The method should have the same signature as the function.
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -319,6 +319,10 @@ def _plot2d(plotfunc):
     subplot_kws : dict, optional
         Dictionary of keyword arguments for matplotlib subplots. Only applies
         to FacetGrid plotting.
+    cbar_ax : matplotlib Axes, optional
+        Axes in which to draw the colorbar.
+    cbar_kwargs : dict, optional
+        Dictionary of keyword arguments to pass to the colorbar.
     **kwargs : optional
         Additional arguments to wrapped matplotlib function
 
@@ -337,7 +341,8 @@ def _plot2d(plotfunc):
                     col_wrap=None, xincrease=True, yincrease=True,
                     add_colorbar=True, add_labels=True, vmin=None, vmax=None,
                     cmap=None, center=None, robust=False, extend=None,
-                    levels=None, colors=None, subplot_kws=None, **kwargs):
+                    levels=None, colors=None, subplot_kws=None,
+                    cbar_ax=None, cbar_kwargs={}, **kwargs):
         # All 2d plots in xarray share this function signature.
         # Method signature below should be consistent.
 
@@ -423,8 +428,14 @@ def _plot2d(plotfunc):
             ax.set_title(darray._title_for_slice())
 
         if add_colorbar:
-            cbar = plt.colorbar(primitive, ax=ax, extend=cmap_params['extend'])
-            if darray.name and add_labels:
+            cbar_kwargs = dict(cbar_kwargs)
+            cbar_kwargs.setdefault('extend', cmap_params['extend'])
+            if cbar_ax is None:
+                cbar_kwargs.setdefault('ax', ax)
+            else:
+                cbar_kwargs.setdefault('cax', cbar_ax)
+            cbar = plt.colorbar(primitive, **cbar_kwargs)
+            if darray.name and add_labels and 'label' not in cbar_kwargs:
                 cbar.set_label(darray.name, rotation=90)
 
         _update_axes_limits(ax, xincrease, yincrease)
@@ -437,7 +448,8 @@ def _plot2d(plotfunc):
                    col=None, col_wrap=None, xincrease=True, yincrease=True,
                    add_colorbar=True, add_labels=True, vmin=None, vmax=None,
                    cmap=None, colors=None, center=None, robust=False,
-                   extend=None, levels=None, subplot_kws=None, **kwargs):
+                   extend=None, levels=None, subplot_kws=None,
+                   cbar_ax=None, cbar_kwargs={}, **kwargs):
         """
         The method should have the same signature as the function.
 

--- a/xarray/test/test_plot.py
+++ b/xarray/test/test_plot.py
@@ -618,7 +618,7 @@ class Common2dMixin:
         title = plt.gca().get_title()
         self.assertTrue('c = 1, d = foo' == title or 'd = foo, c = 1' == title)
 
-    def test_colorbar_label(self):
+    def test_colorbar_default_label(self):
         self.darray.name = 'testvar'
         self.plotmethod()
         self.assertIn(self.darray.name, text_in_fig())
@@ -629,6 +629,41 @@ class Common2dMixin:
         alltxt = text_in_fig()
         for string in ['x', 'y', 'testvar']:
             self.assertNotIn(string, alltxt)
+
+    def test_colorbar_kwargs(self):
+        # replace label
+        self.darray.name = 'testvar'
+        self.plotmethod(cbar_kwargs={'label':'MyLabel'})
+        alltxt = text_in_fig()
+        self.assertIn('MyLabel', alltxt)
+        self.assertNotIn('testvar', alltxt)
+        # you can use mapping types as well
+        self.plotmethod(cbar_kwargs=(('label', 'MyLabel'),))
+        alltxt = text_in_fig()
+        self.assertIn('MyLabel', alltxt)
+        self.assertNotIn('testvar', alltxt)
+        # change cbar ax
+        fig, (ax, cax) = plt.subplots(1, 2)
+        self.plotmethod(ax=ax, cbar_ax=cax, cbar_kwargs={'label':'MyBar'})
+        self.assertTrue(ax.has_data())
+        self.assertTrue(cax.has_data())
+        alltxt = text_in_fig()
+        self.assertIn('MyBar', alltxt)
+        self.assertNotIn('testvar', alltxt)
+        # note that there are two ways to achieve this
+        fig, (ax, cax) = plt.subplots(1, 2)
+        self.plotmethod(ax=ax, cbar_kwargs={'label':'MyBar', 'cax':cax})
+        self.assertTrue(ax.has_data())
+        self.assertTrue(cax.has_data())
+        alltxt = text_in_fig()
+        self.assertIn('MyBar', alltxt)
+        self.assertNotIn('testvar', alltxt)
+        # see that no colorbar is respected
+        self.plotmethod(add_colorbar=False)
+        self.assertNotIn('testvar', text_in_fig())
+        # check that error is raised
+        self.assertRaises(ValueError, self.plotmethod,
+                          add_colorbar=False, cbar_kwargs= {'label':'label'})
 
     def test_verbose_facetgrid(self):
         a = easy_array((10, 15, 3))


### PR DESCRIPTION
Addresses https://github.com/pydata/xarray/issues/752 and allows to pass kwargs  to colorbar. For example, it is now possible to do:

```python
import numpy as np
import matplotlib.pyplot as plt
import xarray as xr

x, y = np.meshgrid(np.arange(12), np.arange(12))
z = xr.DataArray(np.sqrt(x**2 + y**2))
ds = z.to_dataset(name='z')

fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, figsize=(12, 12))
ds.z.plot.contourf(ax=ax1)
ds.z.plot.contourf(ax=ax2, cbar_kwargs={'orientation':'horizontal', 'label':'MyLabel'})
ds.z.plot.contourf(ax=ax3, cbar_ax=ax4, cbar_kwargs={'orientation':'horizontal',
                                                     'label':'Funny Cbar',
                                                     'drawedges':True})
plt.tight_layout()
plt.show()
```

![test_cbar](https://cloud.githubusercontent.com/assets/10050469/15856312/f6eb5a04-2cb4-11e6-81b7-a5420b5c8653.png)
