### PR TITLE
Correctly concatenate pandas.Index objects

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -59,6 +59,10 @@ Bug fixes
   ``keep_attrs=True`` option. By
   `Jeremy McGibbon <https://github.com/mcgibbon>`_.
 
+- Concatenating xarray objects along an axis with a MultiIndex or PeriodIndex
+  preserves the nature of the index (:issue:`TBD`). By
+  `Stephan Hoyer <https://github.com/shoyer>`_.
+
 - ``decode_cf_timedelta`` now accepts arrays with ``ndim`` >1 (:issue:`842`).
    This fixes issue :issue:`665`.
    `Filipe Fernandes <https://github.com/ocefpaf>`_.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -60,7 +60,7 @@ Bug fixes
   `Jeremy McGibbon <https://github.com/mcgibbon>`_.
 
 - Concatenating xarray objects along an axis with a MultiIndex or PeriodIndex
-  preserves the nature of the index (:issue:`TBD`). By
+  preserves the nature of the index (:issue:`875`). By
   `Stephan Hoyer <https://github.com/shoyer>`_.
 
 - ``decode_cf_timedelta`` now accepts arrays with ``ndim`` >1 (:issue:`842`).

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from . import utils
 from .pycompat import iteritems, reduce, OrderedDict, basestring
-from .variable import Variable, as_variable, Coordinate
+from .variable import Variable, as_variable, Coordinate, concat as concat_vars
 
 
 def concat(objs, dim=None, data_vars='all', coords='different',
@@ -265,7 +265,7 @@ def _dataset_concat(datasets, dim, data_vars, coords, compat, positions):
     # stack up each variable to fill-out the dataset
     for k in concat_over:
         vars = ensure_common_dims([ds.variables[k] for ds in datasets])
-        combined = Variable.concat(vars, dim, positions)
+        combined = concat_vars(vars, dim, positions)
         insert_result_variable(k, combined)
 
     result = Dataset(result_vars, attrs=result_attrs)

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -34,24 +34,23 @@ def nanlast(values, axis):
     return _select_along_axis(values, idx_last, axis)
 
 
-def _calc_concat_shape(arrays, axis=0):
-    first_shape = arrays[0].shape
-    length = builtins.sum(a.shape[axis] for a in arrays)
-    result_shape = first_shape[:axis] + (length,) + first_shape[(axis + 1):]
-    return result_shape
+def inverse_permutation(indices):
+    """Return indices for an inverse permutation.
 
+    Parameters
+    ----------
+    indices : 1D np.ndarray with dtype=int
+        Integer positions to assign elements to.
 
-def interleaved_concat(arrays, indices, axis=0):
-    arrays = [np.asarray(a) for a in arrays]
-    axis = _validate_axis(arrays[0], axis)
-    result_shape = _calc_concat_shape(arrays, axis=axis)
-    dtype = reduce(np.promote_types, [a.dtype for a in arrays])
-    result = np.empty(result_shape, dtype)
-    key = [slice(None)] * result.ndim
-    for a, ind in zip(arrays, indices):
-        key[axis] = ind
-        result[key] = a
-    return result
+    Returns
+    -------
+    inverse_permutation : 1D np.ndarray with dtype=int
+        Integer indices to take from the original array to create the
+        permutation.
+    """
+    inverse_permutation = np.empty(len(indices), dtype=np.int64)
+    inverse_permutation[indices] = np.arange(len(indices))
+    return inverse_permutation
 
 
 def _ensure_bool_is_ndarray(result, *args):

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -49,7 +49,7 @@ def inverse_permutation(indices):
         permutation.
     """
     inverse_permutation = np.empty(len(indices), dtype=np.int64)
-    inverse_permutation[indices] = np.arange(len(indices))
+    inverse_permutation[indices] = np.arange(len(indices), dtype=np.int64)
     return inverse_permutation
 
 

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -48,8 +48,9 @@ def inverse_permutation(indices):
         Integer indices to take from the original array to create the
         permutation.
     """
-    inverse_permutation = np.empty(len(indices), dtype=np.int64)
-    inverse_permutation[indices] = np.arange(len(indices), dtype=np.int64)
+    # use intp instead of int64 because of windows :(
+    inverse_permutation = np.empty(len(indices), dtype=np.intp)
+    inverse_permutation[indices] = np.arange(len(indices), dtype=np.intp)
     return inverse_permutation
 
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -10,6 +10,7 @@ from . import common
 from . import indexing
 from . import ops
 from . import utils
+from . import nputils
 from .pycompat import basestring, OrderedDict, zip, dask_array_type
 from .indexing import (PandasIndexAdapter, orthogonally_indexable,
                        LazyIntegerRange)
@@ -711,6 +712,10 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         self_dims = set(self.dims)
         expanded_dims = tuple(
             d for d in dims if d not in self_dims) + self.dims
+
+        if expanded_dims == self.dims:
+            return self.copy(deep=False)
+
         if shape is not None:
             dims_map = dict(zip(dims, shape))
             tmp_shape = [dims_map[d] for d in expanded_dims]
@@ -926,10 +931,12 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         if dim in first_var.dims:
             axis = first_var.get_axis_num(dim)
             dims = first_var.dims
-            if positions is None:
-                data = ops.concatenate(arrays, axis=axis)
-            else:
-                data = ops.interleaved_concat(arrays, positions, axis=axis)
+            data = ops.concatenate(arrays, axis=axis)
+            if positions is not None:
+                # TODO: deprecate this option -- we don't need it for groupby
+                # any more.
+                indices = nputils.inverse_permutation(np.concatenate(positions))
+                data = ops.take(data, indices, axis=axis)
         else:
             axis = 0
             dims = (dim,) + first_var.dims
@@ -1071,6 +1078,44 @@ class Coordinate(Variable):
     def __setitem__(self, key, value):
         raise TypeError('%s values cannot be modified' % type(self).__name__)
 
+    @classmethod
+    def concat(cls, variables, dim='concat_dim', positions=None,
+               shortcut=False):
+        """Specialized version of Variable.concat for Coordinate variables.
+
+        This exists because we want to avoid converting Index objects to NumPy
+        arrays, if possible.
+        """
+        if not isinstance(dim, basestring):
+            dim, = dim.dims
+
+        variables = list(variables)
+        first_var = variables[0]
+
+        if any(not isinstance(v, cls) for v in variables):
+            raise TypeError('Coordinate.concat requires that all input '
+                            'variables be Coordinate objects')
+
+        arrays = [v._data_cached().array for v in variables]
+
+        if not arrays:
+            data = []
+        else:
+            data = arrays[0].append(arrays[1:])
+
+            if positions is not None:
+                indices = nputils.inverse_permutation(np.concatenate(positions))
+                data = data.take(indices)
+
+        attrs = OrderedDict(first_var.attrs)
+        if not shortcut:
+            for var in variables:
+                if var.dims != first_var.dims:
+                    raise ValueError('inconsistent dimensions')
+                utils.remove_incompatible_items(attrs, var.attrs)
+
+        return cls(first_var.dims, data, attrs)
+
     def copy(self, deep=True):
         """Returns a copy of this object.
 
@@ -1163,3 +1208,41 @@ def _broadcast_compat_data(self, other):
         other_data = other
         dims = self.dims
     return self_data, other_data, dims
+
+
+def concat(variables, dim='concat_dim', positions=None, shortcut=False):
+    """Concatenate variables along a new or existing dimension.
+
+    Parameters
+    ----------
+    variables : iterable of Array
+        Arrays to stack together. Each variable is expected to have
+        matching dimensions and shape except for along the stacked
+        dimension.
+    dim : str or DataArray, optional
+        Name of the dimension to stack along. This can either be a new
+        dimension name, in which case it is added along axis=0, or an
+        existing dimension name, in which case the location of the
+        dimension is unchanged. Where to insert the new dimension is
+        determined by the first variable.
+    positions : None or list of integer arrays, optional
+        List of integer arrays which specifies the integer positions to which
+        to assign each dataset along the concatenated dimension. If not
+        supplied, objects are concatenated in the provided order.
+    shortcut : bool, optional
+        This option is used internally to speed-up groupby operations.
+        If `shortcut` is True, some checks of internal consistency between
+        arrays to concatenate are skipped.
+
+    Returns
+    -------
+    stacked : Variable
+        Concatenated Variable formed by stacking all the supplied variables
+        along the given dimension.
+    """
+    variables = list(variables)
+    print(variables)
+    if all(isinstance(v, Coordinate) for v in variables):
+        return Coordinate.concat(variables, dim, positions, shortcut)
+    else:
+        return Variable.concat(variables, dim, positions, shortcut)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1241,7 +1241,6 @@ def concat(variables, dim='concat_dim', positions=None, shortcut=False):
         along the given dimension.
     """
     variables = list(variables)
-    print(variables)
     if all(isinstance(v, Coordinate) for v in variables):
         return Coordinate.concat(variables, dim, positions, shortcut)
     else:

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -714,17 +714,17 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
             d for d in dims if d not in self_dims) + self.dims
 
         if expanded_dims == self.dims:
-            return self.copy(deep=False)
-
-        if shape is not None:
-            dims_map = dict(zip(dims, shape))
-            tmp_shape = [dims_map[d] for d in expanded_dims]
-            expanded_data = ops.broadcast_to(self.data, tmp_shape)
+            expanded_var = self
         else:
-            expanded_data = self.data[
-                (None,) * (len(expanded_dims) - self.ndim)]
-        expanded_var = Variable(expanded_dims, expanded_data, self._attrs,
-                                self._encoding, fastpath=True)
+            if shape is not None:
+                dims_map = dict(zip(dims, shape))
+                tmp_shape = [dims_map[d] for d in expanded_dims]
+                expanded_data = ops.broadcast_to(self.data, tmp_shape)
+            else:
+                expanded_data = self.data[
+                    (None,) * (len(expanded_dims) - self.ndim)]
+            expanded_var = Variable(expanded_dims, expanded_data, self._attrs,
+                                    self._encoding, fastpath=True)
         return expanded_var.transpose(*dims)
 
     def _stack_once(self, dims, new_dim):

--- a/xarray/test/test_combine.py
+++ b/xarray/test/test_combine.py
@@ -214,6 +214,14 @@ class TestConcatDataset(TestCase):
         actual = concat(objs, coord)
         self.assertDatasetIdentical(actual, expected)
 
+    def test_concat_multiindex(self):
+        x = pd.MultiIndex.from_product([[1, 2, 3], ['a', 'b']])
+        expected = Dataset({'x': x})
+        actual = concat([expected.isel(x=slice(2)),
+                         expected.isel(x=slice(2, None))], 'x')
+        assert expected.equals(actual)
+        assert isinstance(actual.x.to_index(), pd.MultiIndex)
+
     @requires_dask  # only for toolz
     def test_auto_combine(self):
         objs = [Dataset({'x': [0]}), Dataset({'x': [1]})]

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -1066,6 +1066,7 @@ class TestDataArray(TestCase):
 
         def identity(x):
             return x
+
         for g in ['x', 'y', 'abc', idx]:
             for shortcut in [False, True]:
                 for squeeze in [False, True]:
@@ -1818,29 +1819,29 @@ class TestDataArray(TestCase):
         actual = _full_like(DataArray([1, 2, 3]), fill_value=np.nan)
         self.assertEqual(actual.dtype, np.float)
         np.testing.assert_equal(actual.values, np.nan)
-    
+
     def test_dot(self):
         x = np.linspace(-3, 3, 6)
         y = np.linspace(-3, 3, 5)
-        z = range(4) 
+        z = range(4)
         da_vals = np.arange(6 * 5 * 4).reshape((6, 5, 4))
         da = DataArray(da_vals, coords=[x, y, z], dims=['x', 'y', 'z'])
-        
+
         dm_vals = range(4)
         dm = DataArray(dm_vals, coords=[z], dims=['z'])
-        
+
         # nd dot 1d
         actual = da.dot(dm)
         expected_vals = np.tensordot(da_vals, dm_vals, [2, 0])
         expected = DataArray(expected_vals, coords=[x, y], dims=['x', 'y'])
         self.assertDataArrayEqual(expected, actual)
-        
+
         # all shared dims
         actual = da.dot(da)
         expected_vals = np.tensordot(da_vals, da_vals, axes=([0, 1, 2], [0, 1, 2]))
         expected = DataArray(expected_vals)
         self.assertDataArrayEqual(expected, actual)
-        
+
         # multiple shared dims
         dm_vals = np.arange(20 * 5 * 4).reshape((20, 5, 4))
         j = np.linspace(-3, 3, 20)
@@ -1849,7 +1850,7 @@ class TestDataArray(TestCase):
         expected_vals = np.tensordot(da_vals, dm_vals, axes=([1, 2], [1, 2]))
         expected = DataArray(expected_vals, coords=[x, j], dims=['x', 'j'])
         self.assertDataArrayEqual(expected, actual)
-        
+
         with self.assertRaises(NotImplementedError):
             da.dot(dm.to_dataset(name='dm'))
         with self.assertRaises(TypeError):

--- a/xarray/test/test_ops.py
+++ b/xarray/test/test_ops.py
@@ -4,7 +4,6 @@ from xarray.core import ops
 from xarray.core.ops import (
     first, last, count, mean
 )
-from xarray.core.nputils import interleaved_concat as interleaved_concat_numpy
 
 from . import TestCase
 
@@ -75,60 +74,3 @@ class TestOps(TestCase):
 
     def test_all_nan_arrays(self):
         assert np.isnan(mean([np.nan, np.nan]))
-
-    def test_interleaved_concat(self):
-        for interleaved_concat in [interleaved_concat_numpy,
-                                   ops._interleaved_concat_slow,
-                                   ops.interleaved_concat]:
-            x = np.arange(5)
-            self.assertArrayEqual(x, interleaved_concat([x], [x]))
-
-            arrays = np.arange(10).reshape(2, -1)
-            indices = np.arange(10).reshape(2, -1, order='F')
-            actual = interleaved_concat(arrays, indices)
-            expected = np.array([0, 5, 1, 6, 2, 7, 3, 8, 4, 9])
-            self.assertArrayEqual(expected, actual)
-
-            arrays2 = arrays.reshape(2, 5, 1)
-
-            actual = interleaved_concat(arrays2, indices, axis=0)
-            self.assertArrayEqual(expected.reshape(10, 1), actual)
-
-            actual = interleaved_concat(arrays2, [[0], [1]], axis=1)
-            self.assertArrayEqual(arrays.T, actual)
-
-            actual = interleaved_concat(arrays2, [slice(1), slice(1, 2)], axis=-1)
-            self.assertArrayEqual(arrays.T, actual)
-
-            with self.assertRaises(IndexError):
-                interleaved_concat(arrays, indices, axis=1)
-            with self.assertRaises(IndexError):
-                interleaved_concat(arrays, indices, axis=-2)
-            with self.assertRaises(IndexError):
-                interleaved_concat(arrays2, [0, 1], axis=2)
-
-    def test_interleaved_concat_dtypes(self):
-        for interleaved_concat in [interleaved_concat_numpy,
-                                   ops._interleaved_concat_slow,
-                                   ops.interleaved_concat]:
-            a = np.array(['a'])
-            b = np.array(['bc'])
-            actual = interleaved_concat([a, b], [[0], [1]])
-            expected = np.array(['a', 'bc'])
-            self.assertArrayEqual(expected, actual)
-
-            c = np.array([np.nan], dtype=object)
-            actual = interleaved_concat([a, b, c], [[0], [1], [2]])
-            expected = np.array(['a', 'bc', np.nan], dtype=object)
-            self.assertArrayEqual(expected, actual)
-
-    def test_interleaved_indices_required(self):
-        self.assertFalse(ops._interleaved_indices_required([[0]]))
-        self.assertFalse(ops._interleaved_indices_required([[0, 1], [2, 3, 4]]))
-        self.assertFalse(ops._interleaved_indices_required([slice(3), slice(3, 4)]))
-        self.assertFalse(ops._interleaved_indices_required([slice(0, 2, 1)]))
-        self.assertTrue(ops._interleaved_indices_required([[0], [2]]))
-        self.assertTrue(ops._interleaved_indices_required([[1], [2, 3]]))
-        self.assertTrue(ops._interleaved_indices_required([[0, 1], [2, 4]]))
-        self.assertTrue(ops._interleaved_indices_required([[0, 1], [3.5, 4]]))
-        self.assertTrue(ops._interleaved_indices_required([slice(None, None, 2)]))

--- a/xarray/test/test_variable.py
+++ b/xarray/test/test_variable.py
@@ -1004,7 +1004,7 @@ class TestCoordinate(TestCase, VariableSubclassTestCases):
         assert isinstance(actual.to_index(), pd.PeriodIndex)
 
     def test_concat_multiindex(self):
-        idx = pd.MultiIndex.from_array([[0, 1, 2], ['a', 'b']])
+        idx = pd.MultiIndex.from_product([[0, 1, 2], ['a', 'b']])
         coords = [Coordinate('x', idx[:2]), Coordinate('x', idx[2:])]
         expected = Coordinate('x', idx)
         actual = Coordinate.concat(coords, dim='x')

--- a/xarray/test/test_variable.py
+++ b/xarray/test/test_variable.py
@@ -308,8 +308,8 @@ class VariableSubclassTestCases(object):
             self.assertEqual(expected.encoding, actual.encoding)
 
     def test_concat(self):
-        x = np.arange(5)
-        y = np.arange(5, 10)
+        x = np.arange(5, dtype=np.int64)
+        y = np.arange(5, 10, dtype=np.int64)
         v = self.cls(['a'], x)
         w = self.cls(['a'], y)
         self.assertVariableIdentical(Variable(['b', 'a'], np.array([x, y])),

--- a/xarray/test/test_variable.py
+++ b/xarray/test/test_variable.py
@@ -308,8 +308,8 @@ class VariableSubclassTestCases(object):
             self.assertEqual(expected.encoding, actual.encoding)
 
     def test_concat(self):
-        x = np.arange(5, dtype=np.int64)
-        y = np.arange(5, 10, dtype=np.int64)
+        x = np.arange(5)
+        y = np.arange(5, 10)
         v = self.cls(['a'], x)
         w = self.cls(['a'], y)
         self.assertVariableIdentical(Variable(['b', 'a'], np.array([x, y])),
@@ -323,8 +323,7 @@ class VariableSubclassTestCases(object):
         # test indexers
         actual = Variable.concat(
             [v, w],
-            positions=[np.arange(0, 10, 2, dtype=np.int64),
-                       np.arange(1, 10, 2, dtype=np.int64)],
+            positions=[np.arange(0, 10, 2), np.arange(1, 10, 2)],
             dim='a')
         expected = Variable('a', np.array([x, y]).ravel(order='F'))
         self.assertVariableIdentical(expected, actual)

--- a/xarray/test/test_variable.py
+++ b/xarray/test/test_variable.py
@@ -990,6 +990,27 @@ class TestCoordinate(TestCase, VariableSubclassTestCases):
         with self.assertRaises(AttributeError):
             coord.name = 'y'
 
+    def test_concat_periods(self):
+        periods = pd.period_range('2000-01-01', periods=10)
+        coords = [Coordinate('t', periods[:5]), Coordinate('t', periods[5:])]
+        expected = Coordinate('t', periods)
+        actual = Coordinate.concat(coords, dim='t')
+        assert actual.identical(expected)
+        assert isinstance(actual.to_index(), pd.PeriodIndex)
+
+        positions = [list(range(5)), list(range(5, 10))]
+        actual = Coordinate.concat(coords, dim='t', positions=positions)
+        assert actual.identical(expected)
+        assert isinstance(actual.to_index(), pd.PeriodIndex)
+
+    def test_concat_multiindex(self):
+        idx = pd.MultiIndex.from_array([[0, 1, 2], ['a', 'b']])
+        coords = [Coordinate('x', idx[:2]), Coordinate('x', idx[2:])]
+        expected = Coordinate('x', idx)
+        actual = Coordinate.concat(coords, dim='x')
+        assert actual.identical(expected)
+        assert isinstance(actual.to_index(), pd.MultiIndex)
+
 
 class TestAsCompatibleData(TestCase):
     def test_unchanged_types(self):

--- a/xarray/test/test_variable.py
+++ b/xarray/test/test_variable.py
@@ -321,8 +321,11 @@ class VariableSubclassTestCases(object):
         with self.assertRaisesRegexp(ValueError, 'inconsistent dimensions'):
             Variable.concat([v, Variable(['c'], y)], 'b')
         # test indexers
-        actual = Variable.concat([v, w], positions=[range(0, 10, 2),
-                                 range(1, 10, 2)], dim='a')
+        actual = Variable.concat(
+            [v, w],
+            positions=[np.arange(0, 10, 2, dtype=np.int64),
+                       np.arange(1, 10, 2, dtype=np.int64)],
+            dim='a')
         expected = Variable('a', np.array([x, y]).ravel(order='F'))
         self.assertVariableIdentical(expected, actual)
         # test concatenating along a dimension


### PR DESCRIPTION
We now have a dedicated method, Coordinate.concat that will correctly
concatenate pandas.Index objects, even if they can't be properly expressed as
NumPy arrays (e.g., PeriodIndex and MultiIndex).

As part of this change, I removed and replaced the internal `interleaved_concat`
routine. It turns out we can do this with an inverse permutation instead, which
results in much simpler and cleaner code. In particular, we no longer need a
special path to support dask.array.

This should help with #818.