### PR TITLE
Tweaks for opening datasets

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -81,7 +81,7 @@ def _validate_dataset_names(dataset):
 def open_dataset(filename_or_obj, group=None, decode_cf=True,
                  mask_and_scale=True, decode_times=True,
                  concat_characters=True, decode_coords=True, engine=None,
-                 chunks=None, lock=None, drop_variables=None):
+                 chunks=None, lock=None, drop_variables=None, format=''):
     """Load and decode a dataset from a file or file-like object.
 
     Parameters
@@ -135,6 +135,10 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or
         inconsistent values.
+    format: string, optional
+        The format of the file to open (PyNIO engine only). This may be useful 
+        for files with malformed names. Acceptable values are those formats 
+        handled by PyNIO; default is to let it autodetect the format.
 
     Returns
     -------
@@ -214,7 +218,7 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
             elif engine == 'h5netcdf':
                 store = backends.H5NetCDFStore(filename_or_obj, group=group)
             elif engine == 'pynio':
-                store = backends.NioDataStore(filename_or_obj)
+                store = backends.NioDataStore(filename_or_obj, format=format)
             else:
                 raise ValueError('unrecognized engine for open_dataset: %r'
                                  % engine)

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -81,7 +81,8 @@ def _validate_dataset_names(dataset):
 def open_dataset(filename_or_obj, group=None, decode_cf=True,
                  mask_and_scale=True, decode_times=True,
                  concat_characters=True, decode_coords=True, engine=None,
-                 chunks=None, lock=None, drop_variables=None, format=''):
+                 chunks=None, lock=None, drop_variables=None, 
+                 only_variables=None, format=''):
     """Load and decode a dataset from a file or file-like object.
 
     Parameters
@@ -135,6 +136,10 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or
         inconsistent values.
+    only_variables: string or iterable, optional
+        A variable or list of variables to load from the dataset. This is
+        useful if you don't need all the variables in the file and don't want
+        to spend time loading them. Default is to load all variables.
     format: string, optional
         The format of the file to open (PyNIO engine only). This may be useful 
         for files with malformed names. Acceptable values are those formats 
@@ -159,7 +164,7 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
         ds = conventions.decode_cf(
             store, mask_and_scale=mask_and_scale, decode_times=decode_times,
             concat_characters=concat_characters, decode_coords=decode_coords,
-            drop_variables=drop_variables)
+            drop_variables=drop_variables, only_variables=only_variables)
 
         if chunks is not None:
             try:

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -25,9 +25,9 @@ class NioArrayWrapper(NDArrayMixin):
 class NioDataStore(AbstractDataStore):
     """Store for accessing datasets via PyNIO
     """
-    def __init__(self, filename, mode='r'):
+    def __init__(self, filename, format=None, mode='r'):
         import Nio
-        self.ds = Nio.open_file(filename, mode=mode)
+        self.ds = Nio.open_file(filename, format=format, mode=mode)
 
     def open_store_variable(self, var):
         data = indexing.LazilyIndexedArray(NioArrayWrapper(var, self.ds))

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -824,7 +824,8 @@ def decode_cf_variable(var, concat_characters=True, mask_and_scale=True,
 
 def decode_cf_variables(variables, attributes, concat_characters=True,
                         mask_and_scale=True, decode_times=True,
-                        decode_coords=True, drop_variables=None):
+                        decode_coords=True, drop_variables=None, 
+                        only_variables=None):
     """
     Decode a several CF encoded variables.
 
@@ -852,9 +853,15 @@ def decode_cf_variables(variables, attributes, concat_characters=True,
         drop_variables = []
     drop_variables = set(drop_variables)
 
+    if isinstance(only_variables, basestring):
+        only_variables = [only_variables]
+    elif only_variables is None:
+        only_variables = []
+    only_variables = set(only_variables)
+
     new_vars = OrderedDict()
     for k, v in iteritems(variables):
-        if k in drop_variables:
+        if (only_variables != set([]) and k not in only_variables) or k in drop_variables:
             continue
         concat = (concat_characters and v.dtype.kind == 'S' and v.ndim > 0 and
                   stackable(v.dims[-1]))
@@ -879,7 +886,8 @@ def decode_cf_variables(variables, attributes, concat_characters=True,
 
 
 def decode_cf(obj, concat_characters=True, mask_and_scale=True,
-              decode_times=True, decode_coords=True, drop_variables=None):
+              decode_times=True, decode_coords=True, drop_variables=None, 
+              only_variables=None):
     """Decode the given Dataset or Datastore according to CF conventions into
     a new Dataset.
 
@@ -903,6 +911,10 @@ def decode_cf(obj, concat_characters=True, mask_and_scale=True,
         A variable or list of variables to exclude from being parsed from the
         dataset.This may be useful to drop variables with problems or
         inconsistent values.
+    only_variables: string or iterable, optional
+        A variable or list of variables to load from the dataset. This is
+        useful if you don't need all the variables in the file and don't want
+        to spend time loading them. Default is to load all variables.
 
     Returns
     -------
@@ -925,7 +937,7 @@ def decode_cf(obj, concat_characters=True, mask_and_scale=True,
 
     vars, attrs, coord_names = decode_cf_variables(
         vars, attrs, concat_characters, mask_and_scale, decode_times,
-        decode_coords, drop_variables=drop_variables)
+        decode_coords, drop_variables=drop_variables, only_variables=only_variables)
     ds = Dataset(vars, attrs=attrs)
     ds = ds.set_coords(coord_names.union(extra_coords))
     ds._file_obj = file_obj


### PR DESCRIPTION
I tweaked the open_dataset() and open_mfdataset() functions for better performance with the PyNIO engine. 
1. I use a lot of HDF4 files with what I guess I'll call "malformed names," where the file name does not end with ".hdf". PyNIO is able to figure out the format of the file, but it prints an annoying warning. As far as I can tell, the only way to shut off the warning is to tell it the format of the file, which I've added a `format` option for.
2. I added an option called `only_variables` which specifies which variables to load from the dataset in the event you don't want to load all variables. Say, for example, I have a dataset with 47 variables in it, but I only need 3 of them. If the data are not cached, then only loading the 3 I need cuts the I/O time in half. If they _are_ cached, then loading only the 3 takes 20% of the time to load the full dataset. The `only_variables` option behaves pretty similarly to `drop_variables`. The default is to load all variables.
