### PR TITLE
Remove extra words in docs

### DIFF
--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -372,10 +372,9 @@ Transforming datasets
 In addition to dictionary-like methods (described above), xarray has additional
 methods (like pandas) for transforming datasets into new objects.
 
-For removing variables, you can select and drop an explicit list of
-variables by using the by indexing with a list of names or using the
-:py:meth:`~xarray.Dataset.drop` methods to return a new ``Dataset``. These
-operations keep around coordinates:
+For removing variables, you can select and drop an explicit list of variables
+by indexing with a list of names or using the :py:meth:`~xarray.Dataset.drop`
+methods to return a new ``Dataset``. These operations keep around coordinates:
 
 .. ipython:: python
 


### PR DESCRIPTION
The "by using the" in this paragraph looks like a typo.