### PR TITLE
Ensure Dataset.dims wraps a normal dict, not an OrderedDict

### DIFF
--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -164,7 +164,7 @@ class DatasetCoordinates(AbstractCoordinates):
 
         self._data._variables = variables
         self._data._coord_names.update(updated_coord_names)
-        self._data._dims = dims
+        self._data._dims = dict(dims)
 
     def __delitem__(self, key):
         if key in self:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -69,7 +69,7 @@ def calculate_dimensions(variables):
     Returns dictionary mapping from dimension names to sizes. Raises ValueError
     if any of the dimension sizes conflict.
     """
-    dims = OrderedDict()
+    dims = {}
     last_used = {}
     scalar_vars = set(k for k, v in iteritems(variables) if not v.dims)
     for k, var in iteritems(variables):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -69,7 +69,7 @@ def calculate_dimensions(variables):
     Returns dictionary mapping from dimension names to sizes. Raises ValueError
     if any of the dimension sizes conflict.
     """
-    dims = {}
+    dims = OrderedDict()
     last_used = {}
     scalar_vars = set(k for k, v in iteritems(variables) if not v.dims)
     for k, var in iteritems(variables):
@@ -351,7 +351,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
 
     @classmethod
     def _from_vars_and_coord_names(cls, variables, coord_names):
-        dims = calculate_dimensions(variables)
+        dims = dict(calculate_dimensions(variables))
         return cls._construct_direct(variables, coord_names, dims)
 
     def _replace_vars_and_dims(self, variables, coord_names=None, dims=None,

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -395,7 +395,7 @@ def merge_core(objs, compat='broadcast_equals', join='outer', priority_arg=None,
                          'coordinates or not in the merged result: %s'
                          % ambiguous_coords)
 
-    return variables, coord_names, dims
+    return variables, coord_names, dict(dims)
 
 
 def merge(objects, compat='broadcast_equals', join='outer'):

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -297,6 +297,13 @@ class TestDataset(TestCase):
         ds = create_test_data()
         self.assertEqual(ds.dims,
                          {'dim1': 8, 'dim2': 9, 'dim3': 10, 'time': 20})
+        self.assertEqual(list(ds.dims), sorted(ds.dims))
+
+        # These exact types aren't public API, but this makes sure we don't
+        # change them inadvertently:
+        self.assertIsInstance(ds.dims, utils.Frozen)
+        self.assertIsInstance(ds.dims.mapping, utils.SortedKeysDict)
+        self.assertIs(type(ds.dims.mapping.mapping), dict)
 
         self.assertItemsEqual(ds, list(ds.variables))
         self.assertItemsEqual(ds.keys(), list(ds.variables))


### PR DESCRIPTION
This was introduced by #857.