### PR TITLE
Multi-index levels as coordinates

### DIFF
--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -115,10 +115,6 @@ If you create a ``DataArray`` by supplying a pandas
     df
     xr.DataArray(df)
 
-Xarray supports labeling coordinate values with a :py:class:`pandas.MultiIndex`.
-While it handles multi-indexes with unnamed levels, it is recommended that you
-explicitly set the names of the levels.
-
 DataArray properties
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -531,6 +527,41 @@ dimension and whose the values are ``Index`` objects:
 .. ipython:: python
 
     ds.indexes
+
+MultiIndex coordinates
+~~~~~~~~~~~~~~~~~~~~~~
+
+Xarray supports labeling coordinate values with a :py:class:`pandas.MultiIndex`:
+
+.. ipython:: python
+
+    midx = pd.MultiIndex.from_arrays([['R', 'R', 'V', 'V'], [.1, .2, .7, .9]],
+                                     names=('band', 'wn'))
+    mda = xr.DataArray(np.random.rand(4), coords={'spec': midx}, dims='spec')
+    mda
+
+For convenience multi-index levels are directly accessible as "virtual" or
+"derived" coordinates (marked by ``-`` when printing a dataset or data array):
+
+.. ipython:: python
+
+     mda['band']
+     mda.wn
+
+Indexing with multi-index levels is also possible using the ``sel`` method
+(see :ref:`multi-level indexing`).
+
+Unlike other coordinates, "virtual" level coordinates are not stored in
+the ``coords`` attribute of ``DataArray`` and ``Dataset`` objects
+(although they are shown when printing the ``coords`` attribute).
+Consequently, most of the coordinates related methods don't apply for them.
+It also can't be used to replace one particular level.
+
+Because in a ``DataArray`` or ``Dataset`` object each multi-index level is
+accessible as a "virtual" coordinate, its name must not conflict with the names
+of the other levels, coordinates and data variables of the same object.
+Even though Xarray set default names for multi-indexes with unnamed levels,
+it is recommended that you explicitly set the names of the levels.
 
 .. [1] Latitude and longitude are 2D arrays because the dataset uses
    `projected coordinates`__. ``reference_time`` refers to the reference time

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -325,11 +325,25 @@ Additionally, xarray supports dictionaries:
 .. ipython:: python
 
    mda.sel(x={'one': 'a', 'two': 0})
-   mda.loc[{'one': 'a'}, ...]
+
+For convenience, ``sel`` also accepts multi-index levels directly
+as keyword arguments:
+
+.. ipython:: python
+
+   mda.sel(one='a', two=0)
+
+Note that using ``sel`` it is not possible to mix a dimension
+indexer with level indexers for that dimension
+(e.g., ``mda.sel(x={'one': 'a'}, two=0)`` will raise a ``ValueError``).
 
 Like pandas, xarray handles partial selection on multi-index (level drop).
-As shown in the last example above, it also renames the dimension / coordinate
-when the multi-index is reduced to a single index.
+As shown below, it also renames the dimension / coordinate when the
+multi-index is reduced to a single index.
+
+.. ipython:: python
+
+   mda.loc[{'one': 'a'}, ...]
 
 Unlike pandas, xarray does not guess whether you provide index levels or
 dimensions when using ``loc`` in some ambiguous cases. For example, for

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,6 +40,13 @@ Deprecations
 Enhancements
 ~~~~~~~~~~~~
 
+- Multi-index levels are now accessible as "virtual" coordinate variables,
+  e.g., ``ds['time']`` can pull out the ``'time'`` level of a multi-index
+  (see :ref:`coordinates`). ``sel`` also accepts providing multi-index levels
+  as keyword arguments, e.g., ``ds.sel(time='2000-01')``
+  (see :ref:`multi-level indexing`).
+  By `Benoit Bovy <https://github.com/benbovy>`_.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -151,12 +151,6 @@ class DatasetCoordinates(AbstractCoordinates):
     def _update_coords(self, coords):
         from .dataset import calculate_dimensions
 
-        for key in coords:
-            if key in self._data._level_coords:
-                raise ValueError("%r is already a MultiIndex level of "
-                                 "coordinate %r"
-                                 % (key, self._data._level_coords[key]))
-
         variables = self._data._variables.copy()
         variables.update(coords)
 
@@ -201,12 +195,6 @@ class DataArrayCoordinates(AbstractCoordinates):
 
     def _update_coords(self, coords):
         from .dataset import calculate_dimensions
-
-        for key in coords:
-            if key in self._data._level_coords:
-                raise ValueError("%r is already a MultiIndex level of "
-                                 "coordinate %r"
-                                 % (key, self._data._level_coords[key]))
 
         dims = calculate_dimensions(coords)
         if set(dims) != set(self.dims):

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -166,13 +166,6 @@ class DatasetCoordinates(AbstractCoordinates):
         self._data._coord_names.update(updated_coord_names)
         self._data._dims = dict(dims)
 
-    def __setitem__(self, key, value):
-        if key in self._data._level_coords:
-            raise ValueError("cannot replace MultiIndex level %r, replace %r "
-                             "coordinate instead"
-                             % (key, self._data._level_coords[key]))
-        return super(DatasetCoordinates, self).__setitem__(key, value)
-
     def __delitem__(self, key):
         if key in self:
             del self._data[key]
@@ -214,13 +207,6 @@ class DataArrayCoordinates(AbstractCoordinates):
 
     def to_dataset(self):
         return self._to_dataset()
-
-    def __setitem__(self, key, value):
-        if key in self._data._level_coords:
-            raise ValueError("cannot replace MultiIndex level %r, replace %r "
-                             "coordinate instead"
-                             % (key, self._data._level_coords[key]))
-        return super(DataArrayCoordinates, self).__setitem__(key, value)
 
     def __delitem__(self, key):
         if key in self.dims:

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -245,8 +245,8 @@ class DataArrayLevelCoordinates(AbstractCoordinates):
     @property
     def variables(self):
         level_coords = OrderedDict(
-            (k, self._data[v].variable.get_level_coord(k))
-            for k, v in self._data._level_coords.items())
+            (k, self._data[v].variable.get_level_variable(k))
+             for k, v in self._data._level_coords.items())
         return Frozen(level_coords)
 
 

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -151,6 +151,12 @@ class DatasetCoordinates(AbstractCoordinates):
     def _update_coords(self, coords):
         from .dataset import calculate_dimensions
 
+        for key in coords:
+            if key in self._data._level_coords:
+                raise ValueError("%r is already a MultiIndex level of "
+                                 "coordinate %r"
+                                 % (key, self._data._level_coords[key]))
+
         variables = self._data._variables.copy()
         variables.update(coords)
 
@@ -195,6 +201,12 @@ class DataArrayCoordinates(AbstractCoordinates):
 
     def _update_coords(self, coords):
         from .dataset import calculate_dimensions
+
+        for key in coords:
+            if key in self._data._level_coords:
+                raise ValueError("%r is already a MultiIndex level of "
+                                 "coordinate %r"
+                                 % (key, self._data._level_coords[key]))
 
         dims = calculate_dimensions(coords)
         if set(dims) != set(self.dims):

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -231,6 +231,9 @@ class DataArrayCoordinates(AbstractCoordinates):
 
 class DataArrayLevelCoordinates(AbstractCoordinates):
     """Dictionary like container for DataArray MultiIndex level coordinates.
+
+    Used for attribute style lookup. Not returned directly by any
+    public methods.
     """
     def __init__(self, dataarray):
         self._data = dataarray

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -215,6 +215,22 @@ class DataArrayCoordinates(AbstractCoordinates):
         del self._data._coords[key]
 
 
+class DataArrayLevelCoordinates(AbstractCoordinates):
+    """Dictionary like container for DataArray multi-index
+    level coordinates.
+    """
+    def __init__(self, dataarray):
+        self._data = dataarray
+
+    @property
+    def _names(self):
+        return set(self._data._level_coords)
+
+    @property
+    def variables(self):
+        return Frozen(self._data._level_coords)
+
+
 class Indexes(Mapping, formatting.ReprMixin):
     """Ordered Mapping[str, pandas.Index] for xarray objects.
     """

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -429,7 +429,7 @@ class DataArray(AbstractArray, BaseDataObject):
         level_coords = OrderedDict()
         for cname, var in self._coords.items():
             if var.ndim == 1:
-                level_names = var.to_coord().level_names
+                level_names = var.to_index_variable().level_names
                 if level_names is not None:
                     dim = var.dims[0]
                     level_coords.update({lname: dim for lname in level_names})

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -14,7 +14,8 @@ from . import ops
 from . import utils
 from .alignment import align
 from .common import AbstractArray, BaseDataObject, squeeze
-from .coordinates import DataArrayCoordinates, Indexes
+from .coordinates import (DataArrayCoordinates, DataArrayLevelCoordinates,
+                          Indexes)
 from .dataset import Dataset
 from .pycompat import iteritems, basestring, OrderedDict, zip
 from .variable import (as_variable, Variable, as_compatible_data, IndexVariable,
@@ -421,9 +422,8 @@ class DataArray(AbstractArray, BaseDataObject):
     def _level_coords(self):
         level_coords = OrderedDict()
         for name, var in self._coords.items():
-            if name not in self.dims:
-                continue
-            level_coords.update(var.to_coord().get_level_coords())
+            if var.ndim == 1:
+                level_coords.update(var.to_coord().get_level_coords())
         return level_coords
 
     def __getitem__(self, key):
@@ -455,7 +455,7 @@ class DataArray(AbstractArray, BaseDataObject):
     @property
     def _attr_sources(self):
         """List of places to look-up items for attribute-style access"""
-        return [self.coords, self._level_coords, self.attrs]
+        return [self.coords, DataArrayLevelCoordinates(self), self.attrs]
 
     def __contains__(self, key):
         return key in self._coords

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -431,18 +431,13 @@ class DataArray(AbstractArray, BaseDataObject):
     @property
     def _level_coords(self):
         """Return a mapping of all MultiIndex levels and their corresponding
-        coordinate name. Raise a `ValueError`` if two or more levels have
-        the same name.
+        coordinate name.
         """
         level_coords = OrderedDict()
         for cname, var in self._coords.items():
             if var.ndim == 1:
                 level_names = var.to_coord().level_names
                 if level_names is not None:
-                    duplicate_names = set(level_names) & set(level_coords)
-                    if duplicate_names:
-                        raise ValueError("duplicate MultiIndex level names %r"
-                                         % duplicate_names)
                     dim = var.dims[0]
                     level_coords.update({lname: dim for lname in level_names})
         return level_coords

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -71,6 +71,7 @@ def _infer_coords_and_dims(shape, coords, dims):
             new_coords[dim] = default_index_coordinate(dim, size)
 
     sizes = dict(zip(dims, shape))
+    level_names = {}
     for k, v in new_coords.items():
         if any(d not in dims for d in v.dims):
             raise ValueError('coordinate %s has dimensions %s, but these '
@@ -82,6 +83,15 @@ def _infer_coords_and_dims(shape, coords, dims):
                 raise ValueError('conflicting sizes for dimension %r: '
                                  'length %s on the data but length %s on '
                                  'coordinate %r' % (d, sizes[d], s, k))
+
+        if v.ndim == 1:
+            idx_level_names = v.to_coord().level_names or []
+            for n in idx_level_names:
+                if n in level_names:
+                    raise ValueError('found duplicate MultiIndex level '
+                                     'name %r for coordinates %r and %r'
+                                     % (n, k, level_names[n]))
+                level_names[n] = k
 
     return new_coords, dims
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -431,7 +431,7 @@ class DataArray(AbstractArray, BaseDataObject):
             if var.ndim == 1:
                 level_names = var.to_index_variable().level_names
                 if level_names is not None:
-                    dim = var.dims[0]
+                    dim, = var.dims
                     level_coords.update({lname: dim for lname in level_names})
         return level_coords
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -19,7 +19,8 @@ from .coordinates import (DataArrayCoordinates, DataArrayLevelCoordinates,
 from .dataset import Dataset
 from .pycompat import iteritems, basestring, OrderedDict, zip
 from .variable import (as_variable, Variable, as_compatible_data, IndexVariable,
-                       default_index_coordinate)
+                       default_index_coordinate,
+                       assert_unique_multiindex_level_names)
 from .formatting import format_item
 
 
@@ -84,14 +85,7 @@ def _infer_coords_and_dims(shape, coords, dims):
                                  'length %s on the data but length %s on '
                                  'coordinate %r' % (d, sizes[d], s, k))
 
-        if v.ndim == 1:
-            idx_level_names = v.to_coord().level_names or []
-            for n in idx_level_names:
-                if n in level_names:
-                    raise ValueError('found duplicate MultiIndex level '
-                                     'name %r for coordinates %r and %r'
-                                     % (n, k, level_names[n]))
-                level_names[n] = k
+    assert_unique_multiindex_level_names(new_coords)
 
     return new_coords, dims
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -72,7 +72,6 @@ def _infer_coords_and_dims(shape, coords, dims):
             new_coords[dim] = default_index_coordinate(dim, size)
 
     sizes = dict(zip(dims, shape))
-    level_names = {}
     for k, v in new_coords.items():
         if any(d not in dims for d in v.dims):
             raise ValueError('coordinate %s has dimensions %s, but these '

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -551,6 +551,12 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         if utils.is_dict_like(key):
             raise NotImplementedError('cannot yet use a dictionary as a key '
                                       'to set Dataset values')
+
+        if key in self._level_coords:
+            raise ValueError("%r is already a MultiIndex level of "
+                             "coordinate %r"
+                             % (key, self._level_coords[key]))
+
         self.update({key: value})
 
     def __delitem__(self, key):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -457,8 +457,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
     @property
     def _level_coords(self):
         """Return a mapping of all MultiIndex levels and their corresponding
-        coordinate name. Raise a `ValueError`` if two or more levels have
-        the same name.
+        coordinate name.
         """
         level_coords = OrderedDict()
         for cname in self._coord_names:
@@ -466,10 +465,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
             if var.ndim == 1:
                 level_names = var.to_coord().level_names
                 if level_names is not None:
-                    duplicate_names = set(level_names) & set(level_coords)
-                    if duplicate_names:
-                        raise ValueError("duplicate MultiIndex level names %r"
-                                         % duplicate_names)
                     dim = var.dims[0]
                     level_coords.update({lname: dim for lname in level_names})
         return level_coords

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -424,6 +424,16 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
 
         return self._construct_direct(variables, coord_names, dims, attrs)
 
+    @property
+    def _level_coords(self):
+        level_coords = OrderedDict()
+        for name in self._coord_names:
+            var = self.variables[name]
+            if name != var.dims[0]:
+                continue
+            level_coords.update(var.to_coord().get_level_coords())
+        return level_coords
+
     def _copy_listed(self, names):
         """Create a new Dataset with the listed variables from this dataset and
         the all relevant coordinates. Skips all validation.
@@ -450,7 +460,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         from .dataarray import DataArray
 
         try:
-            variable = self._variables[name]
+            variable = self._variables.get(name)
+            if variable is None:
+                variable = self._level_coords[name]
         except KeyError:
             _, name, variable = _get_virtual_variable(self._variables, name)
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -216,7 +216,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
             coords = {}
         if data_vars is not None or coords is not None:
             self._set_init_vars_and_dims(data_vars, coords, compat)
-            self._check_multiindex_level_names()
         if attrs is not None:
             self.attrs = attrs
         self._initialized = True
@@ -242,21 +241,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         self._variables = variables
         self._coord_names = coord_names
         self._dims = dims
-
-    def _check_multiindex_level_names(self):
-        """Check for uniqueness of MultiIndex level names
-        """
-        level_names = {}
-        for c in self._coord_names:
-            v = self._variables[c]
-            if v.ndim == 1 and v._in_memory:
-                idx_level_names = v.to_coord().level_names or []
-                for n in idx_level_names:
-                    if n in level_names:
-                        raise ValueError('found duplicate MultiIndex level '
-                                         'name %r for coordinates %r and %r'
-                                         % (n, c, level_names[n]))
-                    level_names[n] = c
 
     @classmethod
     def load_store(cls, store, decoder=None):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -429,9 +429,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         level_coords = OrderedDict()
         for name in self._coord_names:
             var = self.variables[name]
-            if name != var.dims[0]:
-                continue
-            level_coords.update(var.to_coord().get_level_coords())
+            if var.ndim == 1:
+                level_coords.update(var.to_coord().get_level_coords())
         return level_coords
 
     def _copy_listed(self, names):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -449,7 +449,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
             if var.ndim == 1:
                 level_names = var.to_index_variable().level_names
                 if level_names is not None:
-                    dim = var.dims[0]
+                    dim, = var.dims
                     level_coords.update({lname: dim for lname in level_names})
         return level_coords
 
@@ -551,11 +551,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         if utils.is_dict_like(key):
             raise NotImplementedError('cannot yet use a dictionary as a key '
                                       'to set Dataset values')
-
-        if key in self._level_coords:
-            raise ValueError("%r is already a MultiIndex level of "
-                             "coordinate %r"
-                             % (key, self._level_coords[key]))
 
         self.update({key: value})
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -50,7 +50,7 @@ def _get_virtual_variable(variables, key, level_vars={}):
 
     if ref_name in level_vars:
         dim_var = variables[level_vars[ref_name]]
-        ref_var = dim_var.to_coord().get_level_coord(ref_name)
+        ref_var = dim_var.to_index_variable().get_level_variable(ref_name)
     else:
         ref_var = variables[ref_name]
 
@@ -447,7 +447,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         for cname in self._coord_names:
             var = self.variables[cname]
             if var.ndim == 1:
-                level_names = var.to_coord().level_names
+                level_names = var.to_index_variable().level_names
                 if level_names is not None:
                     dim = var.dims[0]
                     level_coords.update({lname: dim for lname in level_names})

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -13,7 +13,6 @@ from pandas.tslib import OutOfBoundsDatetime
 
 from .options import OPTIONS
 from .pycompat import PY2, iteritems, unicode_type, bytes_type, dask_array_type
-from .indexing import PandasIndexAdapter
 
 
 def pretty_print(x, numchars):
@@ -259,11 +258,13 @@ def _get_col_items(mapping):
     """Get all column items to format, including both keys of `mapping`
     and MultiIndex levels if any.
     """
+    from .variable import IndexVariable
+
     col_items = []
     for k, v in mapping.items():
         col_items.append(k)
         var = getattr(v, 'variable', v)
-        if isinstance(var._data, PandasIndexAdapter):
+        if isinstance(var, IndexVariable):
             level_names = var.to_index_variable().level_names
             if level_names is not None:
                 col_items += list(level_names)

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -13,6 +13,7 @@ from pandas.tslib import OutOfBoundsDatetime
 
 from .options import OPTIONS
 from .pycompat import PY2, iteritems, unicode_type, bytes_type, dask_array_type
+from .indexing import PandasIndexAdapter
 
 
 def pretty_print(x, numchars):
@@ -254,9 +255,24 @@ def summarize_attr(key, value, col_width=None):
 EMPTY_REPR = u'    *empty*'
 
 
-def _calculate_col_width(mapping):
-    max_name_length = (max(len(unicode_type(k)) for k in mapping)
-                       if mapping else 0)
+def _get_col_items(mapping):
+    """Get all column items to format, including both keys of `mapping`
+    and MultiIndex levels if any.
+    """
+    col_items = []
+    for k, v in mapping.items():
+        col_items.append(k)
+        var = getattr(v, 'variable', v)
+        if isinstance(var._data, PandasIndexAdapter):
+            level_names = var.to_index_variable().level_names
+            if level_names is not None:
+                col_items += list(level_names)
+    return col_items
+
+
+def _calculate_col_width(col_items):
+    max_name_length = (max(len(unicode_type(s)) for s in col_items)
+                       if col_items else 0)
     col_width = max(max_name_length, 7) + 6
     return col_width
 
@@ -272,16 +288,19 @@ def _mapping_repr(mapping, title, summarizer, col_width=None):
     return u'\n'.join(summary)
 
 
-coords_repr = functools.partial(_mapping_repr, title=u'Coordinates',
-                                summarizer=summarize_coord)
-
-
 vars_repr = functools.partial(_mapping_repr, title=u'Data variables',
                               summarizer=summarize_var)
 
 
 attrs_repr = functools.partial(_mapping_repr, title=u'Attributes',
                                summarizer=summarize_attr)
+
+
+def coords_repr(coords, col_width=None):
+    if col_width is None:
+        col_width = _calculate_col_width(_get_col_items(coords))
+    return _mapping_repr(coords, title=u'Coordinates',
+                         summarizer=summarize_coord, col_width=col_width)
 
 
 def indexes_repr(indexes):
@@ -323,7 +342,7 @@ def array_repr(arr):
 def dataset_repr(ds):
     summary = [u'<xarray.%s>' % type(ds).__name__]
 
-    col_width = _calculate_col_width(ds)
+    col_width = _calculate_col_width(_get_col_items(ds))
 
     dims_start = pretty_print(u'Dimensions:', col_width)
     all_dim_strings = [u'%s: %s' % (k, v) for k, v in iteritems(ds.dims)]

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -209,10 +209,10 @@ def _summarize_coord_multiindex(coord, col_width, marker):
     return u'%s(%s) MultiIndex' % (first_col, unicode_type(coord.dims[0]))
 
 
-def _summarize_coord_levels(coord, col_width, marker):
-    # TODO: maybe slicing based on calculated number of displayed values
+def _summarize_coord_levels(coord, col_width, marker=u'-'):
+    relevant_coord = coord[:30]
     return u'\n'.join(
-        [_summarize_var_or_coord(lname, coord[:30].get_level_coord(lname),
+        [_summarize_var_or_coord(lname, relevant_coord.get_level_coord(lname),
                                  col_width, marker=marker)
          for lname in coord.level_names])
 
@@ -241,7 +241,7 @@ def summarize_coord(name, var, col_width):
         if coord.level_names is not None:
             return u'\n'.join(
                 [_summarize_coord_multiindex(coord, col_width, marker),
-                 _summarize_coord_levels(coord, col_width, u'-')])
+                 _summarize_coord_levels(coord, col_width)])
     return _summarize_var_or_coord(name, var, col_width, show_values, marker)
 
 

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -222,6 +222,14 @@ def summarize_coord(name, var, col_width):
     is_index = name in var.dims
     show_values = is_index or _not_remote(var)
     marker = u'*' if is_index else u' '
+    if is_index:
+        level_coords = var.variable.to_coord().get_level_coords()
+        if level_coords:
+            return u'\n'.join([
+                _summarize_var_or_coord(coord_name, coord, col_width,
+                                        show_values, marker)
+                for coord_name, coord in level_coords.items()
+            ])
     return _summarize_var_or_coord(name, var, col_width, show_values, marker)
 
 

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -212,7 +212,8 @@ def _summarize_coord_multiindex(coord, col_width, marker):
 def _summarize_coord_levels(coord, col_width, marker=u'-'):
     relevant_coord = coord[:30]
     return u'\n'.join(
-        [_summarize_var_or_coord(lname, relevant_coord.get_level_coord(lname),
+        [_summarize_var_or_coord(lname,
+                                 relevant_coord.get_level_variable(lname),
                                  col_width, marker=marker)
          for lname in coord.level_names])
 
@@ -237,7 +238,7 @@ def summarize_coord(name, var, col_width):
     show_values = is_index or _not_remote(var)
     marker = u'*' if is_index else u' '
     if is_index:
-        coord = var.variable.to_coord()
+        coord = var.variable.to_index_variable()
         if coord.level_names is not None:
             return u'\n'.join(
                 [_summarize_coord_multiindex(coord, col_width, marker),

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -283,7 +283,7 @@ class GroupBy(object):
                 raise TypeError('GroupBy objects only support binary ops '
                                 'when the other argument is a Dataset or '
                                 'DataArray')
-            except KeyError:
+            except (KeyError, ValueError):
                 if self.group.name not in other.dims:
                     raise ValueError('incompatible dimensions for a grouped '
                                      'binary operation: the group variable %r '

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -218,7 +218,7 @@ def get_dim_indexers(data_obj, indexers):
     """Given an xarray data object and label based indexers, return a mapping
     of indexers with only dimension names as keys.
 
-    It tries to group multiple indexers given on a multi-index dimension
+    It groups multiple level indexers given on a multi-index dimension
     into a single, dictionary indexer for that dimension (Raise a ValueError
     if it is not possible).
     """
@@ -241,20 +241,10 @@ def get_dim_indexers(data_obj, indexers):
             dim_indexers[key] = label
 
     for dim, level_labels in iteritems(level_indexers):
-        dim_idx = dim_indexers.get(dim, False)
-        if dim_idx:
-            if is_dict_like(dim_idx):
-                if len(set(dim_idx.keys() & set(level_labels.keys()))):
-                    raise ValueError("Duplicate multi-index level indexer(s) "
-                                     "given for dimension %s" % dim)
-                else:
-                    dim_indexers[dim].update(level_labels)
-            else:
-                raise ValueError("Cannot combine multi-index level indexers "
-                                 "with a non-dict indexer for dimension %s"
-                                 % dim)
-        else:
-            dim_indexers[dim] = level_labels
+        if dim_indexers.get(dim, False):
+            raise ValueError("Cannot combine multi-index level indexers "
+                             "with an indexer for dimension %s" % dim)
+        dim_indexers[dim] = level_labels
 
     return dim_indexers
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -216,8 +216,8 @@ def convert_label_indexer(index, label, index_name='', method=None,
 
 
 def get_dim_indexers(data_obj, indexers):
-    """Given an xarray data object and label based indexers, return a mapping
-    of indexers with only dimension names as keys.
+    """Given a xarray data object and label based indexers, return a mapping
+    of label indexers with only dimension names as keys.
 
     It groups multiple level indexers given on a multi-index dimension
     into a single, dictionary indexer for that dimension (Raise a ValueError

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -241,7 +241,7 @@ def get_dim_indexers(data_obj, indexers):
 
     for dim, level_labels in iteritems(level_indexers):
         if dim_indexers.get(dim, False):
-            raise ValueError("Cannot combine multi-index level indexers "
+            raise ValueError("cannot combine multi-index level indexers "
                              "with an indexer for dimension %s" % dim)
         dim_indexers[dim] = level_labels
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -222,11 +222,18 @@ def get_dim_indexers(data_obj, indexers):
     into a single, dictionary indexer for that dimension (Raise a ValueError
     if it is not possible).
     """
+    invalid = [k for k in indexers
+               if k not in data_obj.dims and k not in data_obj._level_coords]
+    if invalid:
+        raise ValueError("dimensions or multi-index levels %r do not exist"
+                         % invalid)
+
     level_indexers = {}
     dim_indexers = {}
     for key, label in iteritems(indexers):
         dim = data_obj[key].dims[0]
         if key != dim:
+            # assume here multi-index level indexer
             if not level_indexers.get(dim, False):
                 level_indexers[dim] = {}
             level_indexers[dim][key] = label

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from collections import defaultdict
 import numpy as np
 import pandas as pd
 
@@ -228,14 +229,12 @@ def get_dim_indexers(data_obj, indexers):
         raise ValueError("dimensions or multi-index levels %r do not exist"
                          % invalid)
 
-    level_indexers = {}
+    level_indexers = defaultdict(dict)
     dim_indexers = {}
     for key, label in iteritems(indexers):
-        dim = data_obj[key].dims[0]
+        dim, = data_obj[key].dims
         if key != dim:
             # assume here multi-index level indexer
-            if not level_indexers.get(dim, False):
-                level_indexers[dim] = {}
             level_indexers[dim][key] = label
         else:
             dim_indexers[key] = label

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -2,7 +2,8 @@ import pandas as pd
 
 from .alignment import align
 from .utils import Frozen, is_dict_like
-from .variable import as_variable, default_index_coordinate
+from .variable import (as_variable, default_index_coordinate,
+                       assert_unique_multiindex_level_names)
 from .pycompat import (basestring, OrderedDict)
 
 
@@ -110,7 +111,7 @@ def merge_variables(
         If provided, variables are always taken from this dict in preference to
         the input variable dictionaries, without checking for conflicts.
     compat : {'identical', 'equals', 'broadcast_equals', 'minimal'}, optional
-        Type of equality check to use wben checking for conflicts.
+        Type of equality check to use when checking for conflicts.
 
     Returns
     -------
@@ -278,6 +279,7 @@ def merge_coords_without_align(objs, priority_vars=None):
     """
     expanded = expand_variable_dicts(objs)
     variables = merge_variables(expanded, priority_vars)
+    assert_unique_multiindex_level_names(variables)
     return variables
 
 
@@ -370,6 +372,7 @@ def merge_coords(objs, compat='minimal', join='outer', priority_arg=None,
     expanded = expand_variable_dicts(aligned)
     priority_vars = _get_priority_vars(aligned, priority_arg, compat=compat)
     variables = merge_variables(expanded, priority_vars, compat=compat)
+    assert_unique_multiindex_level_names(variables)
 
     return variables
 
@@ -431,6 +434,7 @@ def merge_core(objs, compat='broadcast_equals', join='outer', priority_arg=None,
 
     priority_vars = _get_priority_vars(aligned, priority_arg, compat=compat)
     variables = merge_variables(expanded, priority_vars, compat=compat)
+    assert_unique_multiindex_level_names(variables)
 
     dims = calculate_dimensions(variables)
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1321,13 +1321,16 @@ def assert_unique_multiindex_level_names(variables):
             idx_level_names = var.to_coord().level_names
             if idx_level_names is not None:
                 for n in idx_level_names:
-                    level_names[n].append(var_name)
+                    level_names[n].append('%r (%s)' % (n, var_name))
+
+    for n in level_names:
+        if n in variables:
+            level_names[n].append('(%s)' % n)
 
     duplicate_level_names = {k: v for k, v in level_names.items()
                              if len(v) > 1}
     if duplicate_level_names:
-        duplicate_str = '\n'.join(['level %r found in %s'
-                                   % (k, ' and '.join(v))
-                                   for k, v in duplicate_level_names.items()])
-        raise ValueError('conflicting MultiIndex level names:\n%s'
+        duplicate_str = '\n'.join([', '.join(v)
+                                   for v in duplicate_level_names.values()])
+        raise ValueError('conflicting MultiIndex level name(s):\n%s'
                          % duplicate_str)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1323,14 +1323,12 @@ def assert_unique_multiindex_level_names(variables):
                 for n in idx_level_names:
                     level_names[n].append('%r (%s)' % (n, var_name))
 
-    for n in level_names:
-        if n in variables:
-            level_names[n].append('(%s)' % n)
+    for k, v in level_names.items():
+        if k in variables:
+            v.append('(%s)' % n)
 
-    duplicate_level_names = {k: v for k, v in level_names.items()
-                             if len(v) > 1}
-    if duplicate_level_names:
-        duplicate_str = '\n'.join([', '.join(v)
-                                   for v in duplicate_level_names.values()])
+    duplicate_names = [v for v in level_names.values() if len(v) > 1]
+    if duplicate_names:
+        conflict_str = '\n'.join([', '.join(v) for v in duplicate_names])
         raise ValueError('conflicting MultiIndex level name(s):\n%s'
-                         % duplicate_str)
+                         % conflict_str)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1075,16 +1075,20 @@ class IndexVariable(Variable):
     unless another name is given.
     """
 
-    def __init__(self, name, data, dim=None, attrs=None, encoding=None,
-                 fastpath=False):
+    def __init__(self, name, data, attrs=None, encoding=None,
+                 fastpath=False, dim=None):
         if dim is None:
             dim = name
-        self._name = name
 
         super(IndexVariable, self).__init__(dim, data, attrs, encoding, fastpath)
         if self.ndim != 1:
             raise ValueError('%s objects must be 1-dimensional' %
                              type(self).__name__)
+
+        if isinstance(name, basestring):
+            self._name = name
+        else:
+            self._name = self.dims[0]
 
     def _data_cached(self):
         if not isinstance(self._data, PandasIndexAdapter):
@@ -1097,8 +1101,8 @@ class IndexVariable(Variable):
         if not hasattr(values, 'ndim') or values.ndim == 0:
             return Variable((), values, self._attrs, self._encoding)
         else:
-            return type(self)(self._name, values, self.dims, self._attrs,
-                              self._encoding, fastpath=True)
+            return type(self)(self._name, values, self._attrs,
+                              self._encoding, fastpath=True, dim=self.dims)
 
     def __setitem__(self, key, value):
         raise TypeError('%s values cannot be modified' % type(self).__name__)
@@ -1150,8 +1154,8 @@ class IndexVariable(Variable):
         # there is no need to copy the index values here even if deep=True
         # since pandas.Index objects are immutable
         data = PandasIndexAdapter(self) if deep else self._data
-        return type(self)(self._name, data, self.dims, self._attrs,
-                          self._encoding, fastpath=True)
+        return type(self)(self._name, data, self._attrs,
+                          self._encoding, fastpath=True, dim=self.dims)
 
     def _data_equals(self, other):
         return self.to_index().equals(other.to_index())

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1182,20 +1182,27 @@ class IndexVariable(Variable):
             index = index.set_names(self.name)
         return index
 
-    def get_level_coords(self):
-        """Return an OrderedDict of independent coordinates for each
-        index level, or return an empty OrderedDict if the coordinate
-        has no MultiIndex.
+    @property
+    def level_names(self):
+        """Return MultiIndex level names or None if Coordinate has no
+        MultiIndex.
         """
-        level_coords = OrderedDict()
         index = self.to_index()
-        if not isinstance(index, pd.MultiIndex):
-            return level_coords
-        for level_name in index.names:
-            level_coords[level_name] = type(self)(
-                level_name, index.get_level_values(level_name), dim=self.name
-            )
-        return level_coords
+        if isinstance(index, pd.MultiIndex):
+            return index.names
+        else:
+            return None
+
+    @level_names.setter
+    def level_names(self, value):
+        raise AttributeError('cannot modify level names of Coordinate in-place')
+
+    def get_level_coord(self, level):
+        """Return a new Coordinate from a given MultiIndex level."""
+        if self.level_names is None:
+            raise ValueError("Coordinate %s has no MultiIndex" % self.name)
+        index = self.to_index()
+        return type(self)(level, index.get_level_values(level), dim=self.name)
 
     @property
     def name(self):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1079,7 +1079,8 @@ class IndexVariable(Variable):
     def __init__(self, dims, data, attrs=None, encoding=None,
                  name=None, fastpath=False):
 
-        super(IndexVariable, self).__init__(dim, data, attrs, encoding, fastpath)
+        super(IndexVariable, self).__init__(dims, data, attrs, encoding,
+                                            fastpath)
         if self.ndim != 1:
             raise ValueError('%s objects must be 1-dimensional' %
                              type(self).__name__)
@@ -1183,7 +1184,7 @@ class IndexVariable(Variable):
 
     @property
     def level_names(self):
-        """Return MultiIndex level names or None if Coordinate has no
+        """Return MultiIndex level names or None if this IndexVariable has no
         MultiIndex.
         """
         index = self.to_index()
@@ -1194,12 +1195,13 @@ class IndexVariable(Variable):
 
     @level_names.setter
     def level_names(self, value):
-        raise AttributeError('cannot modify level names of Coordinate in-place')
+        raise AttributeError('cannot modify level names of '
+                             'IndexVariable in-place')
 
-    def get_level_coord(self, level):
-        """Return a new Coordinate from a given MultiIndex level."""
+    def get_level_variable(self, level):
+        """Return a new IndexVariable from a given MultiIndex level."""
         if self.level_names is None:
-            raise ValueError("Coordinate %s has no MultiIndex" % self.name)
+            raise ValueError("IndexVariable %r has no MultiIndex" % self.name)
         index = self.to_index()
         return type(self)(self.dims, index.get_level_values(level), name=level)
 
@@ -1318,7 +1320,7 @@ def assert_unique_multiindex_level_names(variables):
     level_names = defaultdict(list)
     for var_name, var in variables.items():
         if isinstance(var._data, PandasIndexAdapter):
-            idx_level_names = var.to_coord().level_names
+            idx_level_names = var.to_index_variable().level_names
             if idx_level_names is not None:
                 for n in idx_level_names:
                     level_names[n].append('%r (%s)' % (n, var_name))

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1075,10 +1075,8 @@ class IndexVariable(Variable):
     unless another name is given.
     """
 
-    def __init__(self, name, data, attrs=None, encoding=None,
-                 fastpath=False, dim=None):
-        if dim is None:
-            dim = name
+    def __init__(self, dims, data, attrs=None, encoding=None,
+                 name=None, fastpath=False):
 
         super(IndexVariable, self).__init__(dim, data, attrs, encoding, fastpath)
         if self.ndim != 1:
@@ -1101,8 +1099,8 @@ class IndexVariable(Variable):
         if not hasattr(values, 'ndim') or values.ndim == 0:
             return Variable((), values, self._attrs, self._encoding)
         else:
-            return type(self)(self._name, values, self._attrs,
-                              self._encoding, fastpath=True, dim=self.dims)
+            return type(self)(self.dims, values, self._attrs,
+                              self._encoding, name=self._name, fastpath=True)
 
     def __setitem__(self, key, value):
         raise TypeError('%s values cannot be modified' % type(self).__name__)
@@ -1154,8 +1152,8 @@ class IndexVariable(Variable):
         # there is no need to copy the index values here even if deep=True
         # since pandas.Index objects are immutable
         data = PandasIndexAdapter(self) if deep else self._data
-        return type(self)(self._name, data, self._attrs,
-                          self._encoding, fastpath=True, dim=self.dims)
+        return type(self)(self.dims, data, self._attrs,
+                          self._encoding, name=self._name, fastpath=True)
 
     def _data_equals(self, other):
         return self.to_index().equals(other.to_index())
@@ -1202,7 +1200,7 @@ class IndexVariable(Variable):
         if self.level_names is None:
             raise ValueError("Coordinate %s has no MultiIndex" % self.name)
         index = self.to_index()
-        return type(self)(level, index.get_level_values(level), dim=self.name)
+        return type(self)(self.dims, index.get_level_values(level), name=level)
 
     @property
     def name(self):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1327,7 +1327,7 @@ def assert_unique_multiindex_level_names(variables):
 
     for k, v in level_names.items():
         if k in variables:
-            v.append('(%s)' % n)
+            v.append('(%s)' % k)
 
     duplicate_names = [v for v in level_names.values() if len(v) > 1]
     if duplicate_names:

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1171,7 +1171,7 @@ class IndexVariable(Variable):
         if isinstance(index, pd.MultiIndex):
             # set default names for multi-index unnamed levels so that
             # we can safely rename dimension / coordinate later
-            valid_level_names = [name or '{}_level_{}'.format(self.name, i)
+            valid_level_names = [name or '{}_level_{}'.format(self.dims[0], i)
                                  for i, name in enumerate(index.names)]
             index = index.set_names(valid_level_names)
         else:
@@ -1181,7 +1181,7 @@ class IndexVariable(Variable):
     def get_level_coords(self):
         """Return an OrderedDict of independent coordinates for each
         index level, or return an empty OrderedDict if the coordinate
-        has not a MultiIndex.
+        has no MultiIndex.
         """
         level_coords = OrderedDict()
         index = self.to_index()

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1076,19 +1076,12 @@ class IndexVariable(Variable):
     unless another name is given.
     """
 
-    def __init__(self, dims, data, attrs=None, encoding=None,
-                 name=None, fastpath=False):
-
+    def __init__(self, dims, data, attrs=None, encoding=None, fastpath=False):
         super(IndexVariable, self).__init__(dims, data, attrs, encoding,
                                             fastpath)
         if self.ndim != 1:
             raise ValueError('%s objects must be 1-dimensional' %
                              type(self).__name__)
-
-        if isinstance(name, basestring):
-            self._name = name
-        else:
-            self._name = self.dims[0]
 
     def _data_cached(self):
         if not isinstance(self._data, PandasIndexAdapter):
@@ -1102,7 +1095,7 @@ class IndexVariable(Variable):
             return Variable((), values, self._attrs, self._encoding)
         else:
             return type(self)(self.dims, values, self._attrs,
-                              self._encoding, name=self._name, fastpath=True)
+                              self._encoding, fastpath=True)
 
     def __setitem__(self, key, value):
         raise TypeError('%s values cannot be modified' % type(self).__name__)
@@ -1155,7 +1148,7 @@ class IndexVariable(Variable):
         # since pandas.Index objects are immutable
         data = PandasIndexAdapter(self) if deep else self._data
         return type(self)(self.dims, data, self._attrs,
-                          self._encoding, name=self._name, fastpath=True)
+                          self._encoding, fastpath=True)
 
     def _data_equals(self, other):
         return self.to_index().equals(other.to_index())
@@ -1198,11 +1191,11 @@ class IndexVariable(Variable):
         if self.level_names is None:
             raise ValueError("IndexVariable %r has no MultiIndex" % self.name)
         index = self.to_index()
-        return type(self)(self.dims, index.get_level_values(level), name=level)
+        return type(self)(self.dims, index.get_level_values(level))
 
     @property
     def name(self):
-        return self._name
+        return self.dims[0]
 
     @name.setter
     def name(self, value):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1193,11 +1193,6 @@ class IndexVariable(Variable):
         else:
             return None
 
-    @level_names.setter
-    def level_names(self, value):
-        raise AttributeError('cannot modify level names of '
-                             'IndexVariable in-place')
-
     def get_level_variable(self, level):
         """Return a new IndexVariable from a given MultiIndex level."""
         if self.level_names is None:

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -543,7 +543,7 @@ class TestDataArray(TestCase):
         self.assertEqual(data.loc[True], 0)
         self.assertEqual(data.loc[False], 1)
 
-    def test_multiindex(self):
+    def test_selection_multiindex(self):
         mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2], [-1, -2]],
                                             names=('one', 'two', 'three'))
         mdata = DataArray(range(8), [('x', mindex)])
@@ -581,6 +581,9 @@ class TestDataArray(TestCase):
                                       mdata.sel(x={'one': 'a'}))
         with self.assertRaises(IndexError):
             mdata.loc[('a', 1)]
+
+        self.assertDataArrayIdentical(mdata.sel(x={'one': 'a', 'two': 1}),
+                                      mdata.sel(one='a', two=1))
 
     def test_time_components(self):
         dates = pd.date_range('2000-01-01', periods=10)

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -579,8 +579,6 @@ class TestDataArray(TestCase):
                                       mdata.sel(x=('a', 1)))
         self.assertDataArrayIdentical(mdata.loc[{'one': 'a'}, ...],
                                       mdata.sel(x={'one': 'a'}))
-        with self.assertRaises(KeyError):
-            mdata.loc[{'one': 'a'}]
         with self.assertRaises(IndexError):
             mdata.loc[('a', 1)]
 

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -651,7 +651,7 @@ class TestDataArray(TestCase):
         with self.assertRaisesRegexp(ValueError, 'cannot delete'):
             del da.coords['x']
 
-        with self.assertRaisesRegexp(ValueError, 'cannot replace MultiIndex'):
+        with self.assertRaisesRegexp(ValueError, 'conflicting MultiIndex'):
             self.mda['level_1'] = np.arange(4)
             self.mda.coords['level_1'] = np.arange(4)
 

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -24,6 +24,10 @@ class TestDataArray(TestCase):
         self.ds = Dataset({'foo': self.v})
         self.dv = self.ds['foo']
 
+        self.mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2]],
+                                                 names=('level_1', 'level_2'))
+        self.mda = DataArray([0, 1, 2, 3], coords={'x': self.mindex}, dims='x')
+
     def test_repr(self):
         v = Variable(['time', 'x'], [[1, 2, 3], [4, 5, 6]], {'foo': 'bar'})
         data_array = DataArray(v, {'other': np.int64(0)}, name='my_variable')
@@ -38,6 +42,16 @@ class TestDataArray(TestCase):
         Attributes:
             foo: bar""")
         self.assertEqual(expected, repr(data_array))
+
+    def test_repr_multiindex(self):
+        expected = dedent("""\
+        <xarray.DataArray (x: 4)>
+        array([0, 1, 2, 3])
+        Coordinates:
+          * x        (x) MultiIndex
+          - level_1  (x) object 'a' 'a' 'b' 'b'
+          - level_2  (x) int64 1 2 1 2""")
+        self.assertEqual(expected, repr(self.mda))
 
     def test_properties(self):
         self.assertVariableEqual(self.dv.variable, self.v)
@@ -236,6 +250,11 @@ class TestDataArray(TestCase):
         with self.assertRaisesRegexp(ValueError, 'conflicting sizes for dim'):
             DataArray([1, 2], coords={'x': [0, 1], 'y': ('x', [1])}, dims='x')
 
+        with self.assertRaisesRegexp(ValueError, 'conflicting MultiIndex'):
+            DataArray(np.random.rand(4, 4),
+                      [('x', self.mindex), ('y', self.mindex)])
+            DataArray(np.random.rand(4, 4),
+                      [('x', mindex), ('level_1', range(4))])
 
     def test_constructor_from_self_described(self):
         data = [[-0.1, 21], [0, 2]]
@@ -404,6 +423,11 @@ class TestDataArray(TestCase):
                        'y2': 'c', 'xy': ('x', ['d', 'e'])},
             dims='x')
         self.assertDataArrayIdentical(expected, actual)
+
+    def test_attr_sources_multiindex(self):
+        # make sure attr-style access for multi-index levels
+        # returns DataArray objects
+        self.assertIsInstance(self.mda.level_1, DataArray)
 
     def test_pickle(self):
         data = DataArray(np.random.random((3, 3)), dims=('id', 'time'))
@@ -627,6 +651,10 @@ class TestDataArray(TestCase):
         with self.assertRaisesRegexp(ValueError, 'cannot delete'):
             del da.coords['x']
 
+        with self.assertRaisesRegexp(ValueError, 'cannot replace MultiIndex'):
+            self.mda['level_1'] = np.arange(4)
+            self.mda.coords['level_1'] = np.arange(4)
+
     def test_coord_coords(self):
         orig = DataArray([10, 20],
                          {'x': [1, 2], 'x2': ('x', ['a', 'b']), 'z': 4},
@@ -706,6 +734,9 @@ class TestDataArray(TestCase):
         expected = array.copy()
         expected.coords['d'] = ('x', [1.5, 1.5, 3.5, 3.5])
         self.assertDataArrayIdentical(actual, expected)
+
+        with self.assertRaisesRegexp(ValueError, 'conflicting MultiIndex'):
+            self.mda.assign_coords(level_1=range(4))
 
     def test_coords_alignment(self):
         lhs = DataArray([1, 2, 3], [('x', [0, 1, 2])])

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -916,8 +916,6 @@ class TestDataset(TestCase):
                                     mdata.sel(x=('a', 1)))
         self.assertDatasetIdentical(mdata.loc[{'x': ('a', 1, -1)}],
                                     mdata.sel(x=('a', 1, -1)))
-        with self.assertRaises(KeyError):
-            mdata.loc[{'one': 'a'}]
 
     def test_reindex_like(self):
         data = create_test_data()
@@ -1744,9 +1742,9 @@ class TestDataset(TestCase):
         actual = zeros + grouped
         self.assertDatasetEqual(expected, actual)
 
-        with self.assertRaisesRegexp(ValueError, 'dimensions .* do not exist'):
+        with self.assertRaisesRegexp(ValueError, 'incompat.* grouped binary'):
             grouped + ds
-        with self.assertRaisesRegexp(ValueError, 'dimensions .* do not exist'):
+        with self.assertRaisesRegexp(ValueError, 'incompat.* grouped binary'):
             ds + grouped
         with self.assertRaisesRegexp(TypeError, 'only support binary ops'):
             grouped + 1

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -48,7 +48,7 @@ def create_test_data(seed=None):
 def create_test_multiindex():
     mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2]],
                                         names=('level_1', 'level_2'))
-    return Dataset(data_vars={'foo': ('x', range(4))}, coords={'x': mindex})
+    return Dataset({}, {'x': mindex})
 
 
 class InaccessibleVariableDataStore(backends.InMemoryDataStore):
@@ -126,7 +126,7 @@ class TestDataset(TestCase):
           - level_1  (x) object 'a' 'a' 'b' 'b'
           - level_2  (x) int64 1 2 1 2
         Data variables:
-            foo      (x) int64 0 1 2 3""")
+            *empty*""")
         actual = '\n'.join(x.rstrip() for x in repr(data).split('\n'))
         print(actual)
         self.assertEqual(expected, actual)
@@ -135,7 +135,7 @@ class TestDataset(TestCase):
         mindex = pd.MultiIndex.from_product(
             [['a', 'b'], [1, 2]],
             names=('a_quite_long_level_name', 'level_2'))
-        data = data.assign_coords(x=mindex)
+        data = Dataset({}, {'x': mindex})
         expected = dedent("""\
         <xarray.Dataset>
         Dimensions:                  (x: 4)
@@ -144,7 +144,7 @@ class TestDataset(TestCase):
           - a_quite_long_level_name  (x) object 'a' 'a' 'b' 'b'
           - level_2                  (x) int64 1 2 1 2
         Data variables:
-            foo                      (x) int64 0 1 2 3""")
+            *empty*""")
         actual = '\n'.join(x.rstrip() for x in repr(data).split('\n'))
         print(actual)
         self.assertEqual(expected, actual)

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -513,7 +513,7 @@ class TestDataset(TestCase):
 
     def test_coords_setitem_multiindex(self):
         data = create_test_multiindex()
-        with self.assertRaisesRegexp(ValueError, 'cannot replace MultiIndex'):
+        with self.assertRaisesRegexp(ValueError, 'conflicting MultiIndex'):
             data.coords['level_1'] = range(4)
 
     def test_coords_set(self):
@@ -1693,7 +1693,7 @@ class TestDataset(TestCase):
 
     def test_setitem_multiindex_level(self):
         data = create_test_multiindex()
-        with self.assertRaisesRegexp(ValueError, 'already a MultiIndex level'):
+        with self.assertRaisesRegexp(ValueError, 'conflicting MultiIndex'):
             data['level_1'] = range(4)
 
     def test_delitem(self):

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -45,6 +45,12 @@ def create_test_data(seed=None):
     return obj
 
 
+def create_test_multiindex():
+    mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2]],
+                                        names=('level_1', 'level_2'))
+    return Dataset(data_vars={'foo': ('x', range(4))}, coords={'x': mindex})
+
+
 class InaccessibleVariableDataStore(backends.InMemoryDataStore):
     def get_variables(self):
         def lazy_inaccessible(x):
@@ -109,6 +115,39 @@ class TestDataset(TestCase):
         # verify long attributes are truncated
         data = Dataset(attrs={'foo': 'bar' * 1000})
         self.assertTrue(len(repr(data)) < 1000)
+
+    def test_repr_multiindex(self):
+        data = create_test_multiindex()
+        expected = dedent("""\
+        <xarray.Dataset>
+        Dimensions:  (x: 4)
+        Coordinates:
+          * x        (x) MultiIndex
+          - level_1  (x) object 'a' 'a' 'b' 'b'
+          - level_2  (x) int64 1 2 1 2
+        Data variables:
+            foo      (x) int64 0 1 2 3""")
+        actual = '\n'.join(x.rstrip() for x in repr(data).split('\n'))
+        print(actual)
+        self.assertEqual(expected, actual)
+
+        # verify that long level names are not truncated
+        mindex = pd.MultiIndex.from_product(
+            [['a', 'b'], [1, 2]],
+            names=('a_quite_long_level_name', 'level_2'))
+        data = data.assign_coords(x=mindex)
+        expected = dedent("""\
+        <xarray.Dataset>
+        Dimensions:                  (x: 4)
+        Coordinates:
+          * x                        (x) MultiIndex
+          - a_quite_long_level_name  (x) object 'a' 'a' 'b' 'b'
+          - level_2                  (x) int64 1 2 1 2
+        Data variables:
+            foo                      (x) int64 0 1 2 3""")
+        actual = '\n'.join(x.rstrip() for x in repr(data).split('\n'))
+        print(actual)
+        self.assertEqual(expected, actual)
 
     def test_repr_period_index(self):
         data = create_test_data(seed=456)
@@ -288,6 +327,12 @@ class TestDataset(TestCase):
         self.assertFalse(ds.data_vars)
         self.assertItemsEqual(ds.coords.keys(), ['x', 'a'])
 
+        mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2]],
+                                            names=('level_1', 'level_2'))
+        with self.assertRaisesRegexp(ValueError, 'conflicting MultiIndex'):
+            Dataset({}, {'x': mindex, 'y': mindex})
+            Dataset({}, {'x': mindex, 'level_1': range(4)})
+
     def test_properties(self):
         ds = create_test_data()
         self.assertEqual(ds.dims,
@@ -465,6 +510,11 @@ class TestDataset(TestCase):
         actual.coords['foo'] = ('x', [1, 2, 3])
         expected = Dataset(coords={'foo': ('x', [1, 2, 3])})
         self.assertDatasetIdentical(expected, actual)
+
+    def test_coords_setitem_multiindex(self):
+        data = create_test_multiindex()
+        with self.assertRaisesRegexp(ValueError, 'cannot replace MultiIndex'):
+            data.coords['level_1'] = range(4)
 
     def test_coords_set(self):
         one_coord = Dataset({'x': ('x', [0]),
@@ -876,7 +926,7 @@ class TestDataset(TestCase):
         with self.assertRaises(TypeError):
             data.loc[dict(dim3='a')] = 0
 
-    def test_multiindex(self):
+    def test_selection_multiindex(self):
         mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2], [-1, -2]],
                                             names=('one', 'two', 'three'))
         mdata = Dataset(data_vars={'var': ('x', range(8))},
@@ -1474,6 +1524,22 @@ class TestDataset(TestCase):
         expected = DataArray(times.time, [('time', times)], name='time')
         self.assertDataArrayIdentical(actual, expected)
 
+    def test_virtual_variable_multiindex(self):
+        # access multi-index levels as virtual variables
+        data = create_test_multiindex()
+        expected = DataArray(['a', 'a', 'b', 'b'], name='level_1',
+                             coords=[data['x'].to_index()], dims='x')
+        self.assertDataArrayIdentical(expected, data['level_1'])
+
+        # combine multi-index level and datetime
+        dr_index = pd.date_range('1/1/2011', periods=4, freq='H')
+        mindex = pd.MultiIndex.from_arrays([['a', 'a', 'b', 'b'], dr_index],
+                                           names=('level_str', 'level_date'))
+        data = Dataset({}, {'x': mindex})
+        expected = DataArray(mindex.get_level_values('level_date').hour,
+                             name='hour', coords=[mindex], dims='x')
+        self.assertDataArrayIdentical(expected, data['level_date.hour'])
+
     def test_time_season(self):
         ds = Dataset({'t': pd.date_range('2000-01-01', periods=12, freq='M')})
         expected = ['DJF'] * 2 + ['MAM'] * 3 + ['JJA'] * 3 + ['SON'] * 3 + ['DJF']
@@ -1590,6 +1656,12 @@ class TestDataset(TestCase):
         expected = expected.set_coords('c')
         self.assertDatasetIdentical(actual, expected)
 
+    def test_assign_multiindex_level(self):
+        data = create_test_multiindex()
+        with self.assertRaisesRegexp(ValueError, 'conflicting MultiIndex'):
+            data.assign(level_1=range(4))
+            data.assign_coords(level_1=range(4))
+
     def test_setitem_original_non_unique_index(self):
         # regression test for GH943
         original = Dataset({'data': ('x', np.arange(5))},
@@ -1618,6 +1690,11 @@ class TestDataset(TestCase):
         actual = array.rename('first').to_dataset()
         actual['second'] = array
         self.assertDatasetIdentical(expected, actual)
+
+    def test_setitem_multiindex_level(self):
+        data = create_test_multiindex()
+        with self.assertRaisesRegexp(ValueError, 'already a MultiIndex level'):
+            data['level_1'] = range(4)
 
     def test_delitem(self):
         data = create_test_data()

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -917,6 +917,9 @@ class TestDataset(TestCase):
         self.assertDatasetIdentical(mdata.loc[{'x': ('a', 1, -1)}],
                                     mdata.sel(x=('a', 1, -1)))
 
+        self.assertDatasetIdentical(mdata.sel(x={'one': 'a', 'two': 1}),
+                                    mdata.sel(one='a', two=1))
+
     def test_reindex_like(self):
         data = create_test_data()
         data['letters'] = ('dim3', 10 * ['a'])

--- a/xarray/test/test_indexing.py
+++ b/xarray/test/test_indexing.py
@@ -107,8 +107,22 @@ class TestIndexers(TestCase):
             # slice is always a view.
             indexing.convert_label_indexer(index, slice('2001', '2002'))
 
+    def test_get_dim_indexers(self):
+        mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2]],
+                                            names=('one', 'two'))
+        mdata = DataArray(range(4), [('x', mindex)])
+
+        dim_indexers = indexing.get_dim_indexers(mdata, {'one': 'a', 'two': 1})
+        self.assertEqual(dim_indexers, {'x': {'one': 'a', 'two': 1}})
+
+        with self.assertRaisesRegexp(ValueError, 'cannot combine'):
+            _ = indexing.get_dim_indexers(mdata, {'x': 'a', 'two': 1})
+
+        with self.assertRaisesRegexp(ValueError, 'do not exist'):
+            _ = indexing.get_dim_indexers(mdata, {'y': 'a'})
+            _ = indexing.get_dim_indexers(data, {'four': 1})
+
     def test_remap_label_indexers(self):
-        # TODO: fill in more tests!
         def test_indexer(data, x, expected_pos, expected_idx=None):
             pos, idx = indexing.remap_label_indexers(data, {'x': x})
             self.assertArrayEqual(pos.get('x'), expected_pos)

--- a/xarray/test/test_variable.py
+++ b/xarray/test/test_variable.py
@@ -1035,9 +1035,6 @@ class TestIndexVariable(TestCase, VariableSubclassTestCases):
         coord = IndexVariable('x', [10.0])
         self.assertEqual(coord.name, 'x')
 
-        coord = IndexVariable('x', [10.0], name='y')
-        self.assertEqual(coord.name, 'y')
-
         with self.assertRaises(AttributeError):
             coord.name = 'y'
 
@@ -1053,8 +1050,7 @@ class TestIndexVariable(TestCase, VariableSubclassTestCases):
         midx = pd.MultiIndex.from_product([['a', 'b'], [1, 2]],
                                           names=['level_1', 'level_2'])
         x = IndexVariable('x', midx)
-        level_1 = IndexVariable('x', midx.get_level_values('level_1'),
-                                name='level_1')
+        level_1 = IndexVariable('x', midx.get_level_values('level_1'))
         self.assertVariableIdentical(x.get_level_variable('level_1'), level_1)
 
         with self.assertRaisesRegexp(ValueError, 'has no MultiIndex'):

--- a/xarray/test/test_variable.py
+++ b/xarray/test/test_variable.py
@@ -1047,9 +1047,6 @@ class TestIndexVariable(TestCase, VariableSubclassTestCases):
         x = IndexVariable('x', midx)
         self.assertEqual(x.level_names, midx.names)
 
-        with self.assertRaisesRegexp(AttributeError, 'cannot modify'):
-            x.level_names = ['one', 'two']
-
         self.assertIsNone(IndexVariable('y', [10.0]).level_names)
 
     def test_get_level_variable(self):

--- a/xarray/test/test_variable.py
+++ b/xarray/test/test_variable.py
@@ -1035,8 +1035,33 @@ class TestIndexVariable(TestCase, VariableSubclassTestCases):
         coord = IndexVariable('x', [10.0])
         self.assertEqual(coord.name, 'x')
 
+        coord = IndexVariable('x', [10.0], name='y')
+        self.assertEqual(coord.name, 'y')
+
         with self.assertRaises(AttributeError):
             coord.name = 'y'
+
+    def test_level_names(self):
+        midx = pd.MultiIndex.from_product([['a', 'b'], [1, 2]],
+                                          names=['level_1', 'level_2'])
+        x = IndexVariable('x', midx)
+        self.assertEqual(x.level_names, midx.names)
+
+        with self.assertRaisesRegexp(AttributeError, 'cannot modify'):
+            x.level_names = ['one', 'two']
+
+        self.assertIsNone(IndexVariable('y', [10.0]).level_names)
+
+    def test_get_level_variable(self):
+        midx = pd.MultiIndex.from_product([['a', 'b'], [1, 2]],
+                                          names=['level_1', 'level_2'])
+        x = IndexVariable('x', midx)
+        level_1 = IndexVariable('x', midx.get_level_values('level_1'),
+                                name='level_1')
+        self.assertVariableIdentical(x.get_level_variable('level_1'), level_1)
+
+        with self.assertRaisesRegexp(ValueError, 'has no MultiIndex'):
+            IndexVariable('y', [10.0]).get_level_variable('level')
 
     def test_concat_periods(self):
         periods = pd.period_range('2000-01-01', periods=10)


### PR DESCRIPTION
Implements 2, 4 and 5 in #719.

Demo:

```
In [1]: import numpy as np

In [2]: import pandas as pd

In [3]: import xarray as xr

In [4]: index = pd.MultiIndex.from_product((list('ab'), range(2)),
   ...:                                    names= ('level_1', 'level_2'))

In [5]: da = xr.DataArray(np.random.rand(4, 4), coords={'x': index},
   ...:                   dims=('x', 'y'), name='test')

In [6]: da
Out[6]: 
<xarray.DataArray 'test' (x: 4, y: 4)>
array([[ 0.15036153,  0.68974802,  0.40082234,  0.94451318],
       [ 0.26732938,  0.49598123,  0.8679231 ,  0.6149102 ],
       [ 0.3313594 ,  0.93857424,  0.73023367,  0.44069622],
       [ 0.81304837,  0.81244159,  0.37274953,  0.86405196]])
Coordinates:
  * level_1  (x) object 'a' 'a' 'b' 'b'
  * level_2  (x) int64 0 1 0 1
  * y        (y) int64 0 1 2 3

In [7]: da['level_1']
Out[7]: 
<xarray.DataArray 'level_1' (x: 4)>
array(['a', 'a', 'b', 'b'], dtype=object)
Coordinates:
  * level_1  (x) object 'a' 'a' 'b' 'b'
  * level_2  (x) int64 0 1 0 1

In [8]: da.sel(x='a', level_2=1)
Out[8]: 
<xarray.DataArray 'test' (y: 4)>
array([ 0.26732938,  0.49598123,  0.8679231 ,  0.6149102 ])
Coordinates:
    x        object ('a', 1)
  * y        (y) int64 0 1 2 3

In [9]: da.sel(level_2=1)
Out[9]: 
<xarray.DataArray 'test' (level_1: 2, y: 4)>
array([[ 0.26732938,  0.49598123,  0.8679231 ,  0.6149102 ],
       [ 0.81304837,  0.81244159,  0.37274953,  0.86405196]])
Coordinates:
  * level_1  (level_1) object 'a' 'b'
  * y        (y) int64 0 1 2 3
```

Some notes about the implementation:

- I slightly modified `Coordinate` so that it allows setting different values for the names of the coordinate and its dimension. There is no breaking change.
- I also added a `Coordinate.get_level_coords` method to get independent, single-index coordinates objects from a MultiIndex coordinate.

Remaining issues:

- `Coordinate.get_level_coords` calls `pandas.MultiIndex.get_level_values` for each level and is itself called each time when indexing and for repr. This can be very costly!! It would be nice to return some kind of lazy index object instead of computing the actual level values.
- repr replace a MultiIndex coordinate by its level coordinates. That can be confusing in some cases (see below). Maybe we can set a different marker than `*`  for level coordinates.

```
In [6]: [name for name in da.coords]
Out[6]: ['x', 'y']

In [7]: da.coords.keys()
Out[7]: 
KeysView(Coordinates:
  * level_1  (x) object 'a' 'a' 'b' 'b'
  * level_2  (x) int64 0 1 0 1
  * y        (y) int64 0 1 2 3)
```

- `DataArray.level_1` doesn't return another `DataArray` object:

```
In [10]: da.level_1
Out[10]: 
<xarray.Coordinate 'level_1' (x: 4)>
array(['a', 'a', 'b', 'b'], dtype=object)
```

- Maybe we need to test the uniqueness of level names at `DataArray` or `Dataset` creation.
 
Of course still needs proper tests and docs... 
