### PR TITLE
Refactor merge alignment into _align_for_merge

### DIFF
--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from . import formatting
 from .utils import Frozen
-from .merge import merge_coords_only, align_and_merge_coords
+from .merge import merge_coords, merge_coords_without_align
 from .pycompat import iteritems, basestring, OrderedDict
 from .variable import default_index_coordinate
 
@@ -62,9 +62,9 @@ class AbstractCoordinates(Mapping, formatting.ReprMixin):
 
     def update(self, other):
         other_vars = getattr(other, 'variables', other)
-        coords = align_and_merge_coords([self.variables, other_vars],
-                                        priority_arg=1,
-                                        indexes=self.indexes)
+        coords = merge_coords([self.variables, other_vars],
+                              priority_arg=1, indexes=self.indexes,
+                              indexes_from_arg=0)
         self._update_coords(coords)
 
     def _merge_raw(self, other):
@@ -73,7 +73,8 @@ class AbstractCoordinates(Mapping, formatting.ReprMixin):
             variables = OrderedDict(self.variables)
         else:
             # don't align because we already called xarray.align
-            variables = merge_coords_only([self.variables, other.variables])
+            variables = merge_coords_without_align(
+                [self.variables, other.variables])
         return variables
 
     @contextmanager
@@ -86,7 +87,7 @@ class AbstractCoordinates(Mapping, formatting.ReprMixin):
             # first
             priority_vars = OrderedDict(
                 (k, v) for k, v in self.variables.items() if k not in self.dims)
-            variables = merge_coords_only(
+            variables = merge_coords_without_align(
                 [self.variables, other.variables], priority_vars=priority_vars)
             yield
             self._update_coords(variables)
@@ -119,7 +120,7 @@ class AbstractCoordinates(Mapping, formatting.ReprMixin):
             return self.to_dataset()
         else:
             other_vars = getattr(other, 'variables', other)
-            coords = merge_coords_only([self.variables, other_vars])
+            coords = merge_coords_without_align([self.variables, other_vars])
             return Dataset._from_vars_and_coord_names(coords, set(coords))
 
 


### PR DESCRIPTION
This is a cleaner fix for the issues from #943

Moving the logic from `deep_align` into `_align_for_merge` gives us better separation of concerns between the modules for alignment and merging, and puts the special rules for alignment as part of merging in a much more obvious location (no more `skip_single_target`).

xref #927 (cc @crusaderky)