### PR TITLE
Fix failing tests for h5netcdf that use dtype=str

### DIFF
--- a/HOW_TO_RELEASE
+++ b/HOW_TO_RELEASE
@@ -13,7 +13,7 @@ Time required: about an hour.
  5. On the master branch, commit the release in git:
       git commit -a -m 'Release v0.X.Y'
  6. Tag the release:
-      git tag -a v0.8.1 -m 'v0.X.Y'
+      git tag -a v0.X.Y -m 'v0.X.Y'
  7. Build source and binary wheels for pypi:
       python setup.py bdist_wheel sdist
  8. Use twine to register and upload the release on pypi. Be careful, you can't

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -24,6 +24,9 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- Fix to ensure xarray works with h5netcdf v0.3.0 for arrays with ``dtype=str``
+  (:issue:`953`). By `Stephan Hoyer <https://github.com/shoyer>`_.
+
 .. _whats-new.0.8.1:
 
 v0.8.1 (5 August 2016)
@@ -33,7 +36,7 @@ Bug fixes
 ~~~~~~~~~
 
 - Fix bug in v0.8.0 that broke assignment to Datasets with non-unique
-  indexes (:issue:`943`).
+  indexes (:issue:`943`). By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 .. _whats-new.0.8.0:
 
@@ -122,7 +125,7 @@ Bug fixes
   `Stephan Hoyer <https://github.com/shoyer>`_.
 
 - Fixed bug in arithmetic operations on DataArray objects whose dimensions
-  are numpy structured arrays or recarrays :issue:`861`, :issue:`837`.
+  are numpy structured arrays or recarrays :issue:`861`, :issue:`837`. By
   `Maciek Swat <https://github.com/maciekswat>`_.
 
 - ``decode_cf_timedelta`` now accepts arrays with ``ndim`` >1 (:issue:`842`).

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -7,7 +7,8 @@ from ..core.utils import FrozenOrderedDict, close_on_error, Frozen
 from ..core.pycompat import iteritems, bytes_type, unicode_type, OrderedDict
 
 from .common import WritableCFDataStore
-from .netCDF4_ import _nc4_group, _nc4_values_and_dtype, _extract_nc4_encoding
+from .netCDF4_ import (_nc4_group, _nc4_values_and_dtype, _extract_nc4_encoding,
+                       BaseNetCDF4Array)
 
 
 def maybe_decode_bytes(txt):
@@ -51,7 +52,7 @@ class H5NetCDFStore(WritableCFDataStore):
 
     def open_store_variable(self, var):
         dimensions = var.dimensions
-        data = indexing.LazilyIndexedArray(var)
+        data = indexing.LazilyIndexedArray(BaseNetCDF4Array(var))
         attrs = _read_attributes(var)
 
         # netCDF4 specific encoding

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -22,7 +22,7 @@ _endian_lookup = {'=': 'native',
                   '|': 'native'}
 
 
-class NetCDF4ArrayWrapper(NDArrayMixin):
+class BaseNetCDF4Array(NDArrayMixin):
     def __init__(self, array, is_remote=False):
         self.array = array
         self.is_remote = is_remote
@@ -36,6 +36,12 @@ class NetCDF4ArrayWrapper(NDArrayMixin):
             # string concatenation via conventions.decode_cf_variable
             dtype = np.dtype('O')
         return dtype
+
+
+class NetCDF4ArrayWrapper(BaseNetCDF4Array):
+    def __init__(self, array, is_remote=False):
+        self.array = array
+        self.is_remote = is_remote
 
     def __getitem__(self, key):
         if self.is_remote:  # pragma: no cover


### PR DESCRIPTION
This was caused by a recent PR I merged in h5netcdf which switched to using dtype=str in the legacy API (like netCDF4):
https://github.com/shoyer/h5netcdf/pull/11