### PR TITLE
Align broadcast

### DIFF
--- a/HOW_TO_RELEASE
+++ b/HOW_TO_RELEASE
@@ -1,0 +1,70 @@
+How to issue an xarray release in 15 easy steps
+
+Time required: about an hour.
+
+ 1. Ensure your master branch is synced to upstream:
+       git pull upstream master
+ 2. Look over whats-new.rst and the docs. Make sure "What's New" is complete
+    (check the date!) and add a brief summary note describing the release at the
+    top.
+ 3. Update the version in setup.py and switch to `ISRELEASED = True`.
+ 4. If you have any doubts, run the full test suite one final time!
+      py.test
+ 5. On the master branch, commit the release in git:
+      git commit -a -m 'Release v0.X.Y'
+ 6. Tag the release:
+      git tag -a v0.8.1 -m 'v0.X.Y'
+ 7. Build source and binary wheels for pypi:
+      python setup.py bdist_wheel sdist
+ 8. Use twine to register and upload the release on pypi. Be careful, you can't
+    take this back!
+      twine register dist/xarray-0.X.Y-py2.py3-none-any.whl
+      twine upload dist/xarray-0.X.Y*
+    You will need to be listed as a package owner at
+    https://pypi.python.org/pypi/xarray for this to work.
+ 9. Push your changes to master:
+      git push upstream master
+      git push upstream --tags
+ 9. Update the stable branch (used by ReadTheDocs) and switch back to master:
+      git checkout stable
+      git rebase master
+      git push upstream stable
+      git checkout master
+    We also update the stable branch with `git cherrypick` for documentation
+    only fixes that apply the current released version.
+10. Revert ISRELEASED in setup.py back to False. Don't change the version
+    number: in normal development, we keep the version number in setup.py as the
+    last releaseld version.
+11. Commit your changes and push to master again:
+      git commit -a -m 'Revert to dev version'
+      git push upstream master
+    You're done pushing to master!
+12. Issue the release on GitHub. Click on "Draft a new release" at
+    https://github.com/pydata/xarray/releases and paste in the latest from
+    whats-new.rst.
+13. Update the docs. Login to https://readthedocs.org/projects/xray/versions/
+    and switch your new release tag (at the bottom) from "Inactive" to "Active".
+    It should now build automatically.
+14. Update conda-forge. Clone https://github.com/conda-forge/xarray-feedstock
+    and update the version number and sha256 in meta.yaml. (On OS X, you can
+    calculate sha256 with `shasum -a 256 xarray-0.X.Y.tar.gz`). Submit a pull
+    request (and merge it, once CI passes).
+15. Issue the release announcement! For bug fix releases, I usually only email
+    xarray@googlegroups.com. For major/feature releases, I will email a broader
+    list (no more than once every 3-6 months):
+      pydata@googlegroups.com, xarray@googlegroups.com,
+      numpy-discussion@scipy.org, scipy-user@scipy.org,
+      pyaos@lists.johnny-lin.com
+    Google search will turn up examples of prior release announcements (look for
+    "ANN xarray").
+
+Note on version numbering:
+
+We follow a rough approximation of semantic version. Only major releases (0.X.0)
+show include breaking changes. Minor releases (0.X.Y) are for bug fixes and
+backwards compatible new features, but if a sufficient number of new features
+have arrived we will issue a major release even if there are no compatibility
+breaks.
+
+Once the project reaches a sufficient level of maturity for a 1.0.0 release, we
+intend to follow semantic versioning more strictly.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -24,6 +24,11 @@ Enhancements
 - New documentation on :ref:`panel transition`. By
   `Maximilian Roos <https://github.com/MaximilianR>`_.
 
+- Added exclude and indexes optional parameters to align(), and exclude optional parameter
+  to broadcast(). By `Guido Imperiale <https://github.com/crusaderky>`_.
+- broadcast() and concat() will now auto-align inputs.
+  By `Guido Imperiale <https://github.com/crusaderky>`_.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -24,10 +24,11 @@ Enhancements
 - New documentation on :ref:`panel transition`. By
   `Maximilian Roos <https://github.com/MaximilianR>`_.
 
-- Added exclude and indexes optional parameters to align(), and exclude optional parameter
-  to broadcast(). By `Guido Imperiale <https://github.com/crusaderky>`_.
-- broadcast() and concat() will now auto-align inputs.
+- Added ``exclude`` and ``indexes`` optional parameters to :py:func:`~xarray.align`,
+  and ``exclude`` optional parameter to :py:func:`~xarray.broadcast`.
   By `Guido Imperiale <https://github.com/crusaderky>`_.
+- :py:func:`~xarray.broadcast` and :py:func:`~xarray.concat` will now auto-align inputs,
+  using ``join=outer``. By `Guido Imperiale <https://github.com/crusaderky>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -356,17 +356,22 @@ def broadcast(*args, **kwargs):
         return res
 
     def _broadcast_dataset(ds):
-        # Add excluded dims to a copy of dims_map    
-        ds_dims_map = dims_map.copy()
-        for dim in exclude:
-            try:
-                ds_dims_map[dim] = ds.dims[dim]
-            except KeyError:
-                pass
-
         data_vars = OrderedDict()
         for k in ds.data_vars:
-            data_vars[k] = ds.variables[k].expand_dims(ds_dims_map)
+            var = ds.variables[k]
+            # Add excluded dims to a copy of dims_map    
+            var_dims_map = dims_map.copy()
+            for dim in exclude:
+                try:
+                    var_dims_map[dim] = var.shape[var.dims.index(dim)]
+                except ValueError:
+                    # dim not in var.dims
+                    try:
+                        del var_dims_map[dim]
+                    except KeyError:
+                        pass
+        
+            data_vars[k] = var.expand_dims(var_dims_map)
 
         coords = OrderedDict(ds.coords)
         coords.update(common_coords)

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -9,7 +9,7 @@ from . import ops, utils
 from .common import _maybe_promote
 from .pycompat import iteritems, OrderedDict
 from .utils import is_full_slice, is_dict_like
-from .variable import Variable, Coordinate, broadcast_variables
+from .variable import Variable, Coordinate
 
 
 def _get_joiner(join):
@@ -71,24 +71,16 @@ def align(*objects, **kwargs):
         If ``copy=True``, the returned objects contain all new variables. If
         ``copy=False`` and no reindexing is required then the aligned objects
         will include original variables.
+    exclude : sequence of str, optional
+        Dimensions that must be excluded from alignment
+    indexes : dict-like, optional
+        Any indexes explicitly provided with the `indexes` argument should be
+        used in preference to the aligned indexes.
 
     Returns
     -------
     aligned : same as *objects
         Tuple of objects with aligned coordinates.
-    """
-    return partial_align(*objects, exclude=None, **kwargs)
-
-
-def partial_align(*objects, **kwargs):
-    """partial_align(*objects, join='inner', copy=True, indexes=None,
-                     exclude=set())
-
-    Like align, but don't align along dimensions in exclude. Any indexes
-    explicitly provided with the `indexes` argument should be used in preference
-    to the aligned indexes.
-
-    Not public API.
     """
     join = kwargs.pop('join', 'inner')
     copy = kwargs.pop('copy', True)
@@ -247,7 +239,7 @@ def reindex_variables(variables, indexes, indexers, method=None,
     return reindexed
 
 
-def broadcast(*args):
+def broadcast(*args, **kwargs):
     """Explicitly broadcast any number of DataArray or Dataset objects against
     one another.
 
@@ -256,12 +248,18 @@ def broadcast(*args):
 
     Parameters
     ----------
-    *args: DataArray or Dataset objects
+    *args : DataArray or Dataset objects
         Arrays to broadcast against each other.
+    copy : bool, optional
+        If ``copy=True``, the returned objects contain all new variables. If
+        ``copy=False`` and no reindexing is required then the broadcasted objects
+        will include original variables.
+    exclude : sequence of str, optional
+        Dimensions that must not be broadcasted
 
     Returns
     -------
-    broadcast: tuple of xarray objects
+    broadcast : tuple of xarray objects
         The same data as the input arrays, but with additional dimensions
         inserted so that all data arrays have the same dimensions and shape.
 
@@ -322,32 +320,54 @@ def broadcast(*args):
     from .dataarray import DataArray
     from .dataset import Dataset
 
-    all_indexes = _get_all_indexes(args)
-    for k, v in all_indexes.items():
-        if not all(v[0].equals(vi) for vi in v[1:]):
-            raise ValueError('cannot broadcast arrays: the %s index is not '
-                             'aligned (use xarray.align first)' % k)
+    copy = kwargs.pop('copy', True)
+    exclude = kwargs.pop('exclude', None)
+    if exclude is None:
+        exclude = set()
+    if kwargs:
+        raise TypeError('broadcast() got unexpected keyword arguments: %s'
+                        % list(kwargs))
+
+    args = align(*args, join='outer', copy=False, exclude=exclude)
 
     common_coords = OrderedDict()
     dims_map = OrderedDict()
     for arg in args:
         for dim in arg.dims:
-            if dim not in common_coords:
+            if dim not in common_coords and dim not in exclude:
                 common_coords[dim] = arg.coords[dim].variable
                 dims_map[dim] = common_coords[dim].size
 
     def _broadcast_array(array):
-        data = array.variable.expand_dims(dims_map)
+        # Add excluded dims to a copy of dims_map
+        array_dims_map = dims_map.copy()
+        for dim in exclude:
+            if dim in ds.dims:
+                array_dims_map[dim] = ds.shape[ds.dims.index(dim)]
+
+        dims = tuple(array_dims_map)
+        if not copy and set(dims) == set(array.dims):
+            return array
+
+        data = array.variable.expand_dims(array_dims_map)
         coords = OrderedDict(array.coords)
         coords.update(common_coords)
-        dims = tuple(common_coords)
         return DataArray(data, coords, dims, name=array.name,
                          attrs=array.attrs, encoding=array.encoding)
 
     def _broadcast_dataset(ds):
+        # Add excluded dims to a copy of dims_map    
+        ds_dims_map = dims_map.copy()
+        for dim in exclude:
+            if dim in ds.dims:
+                ds_dims_map[dim] = ds.dims[dim]
+
+        if not copy and dict(ds.dims) == dict(ds_dims_map):
+            return ds
+
         data_vars = OrderedDict()
         for k in ds.data_vars:
-            data_vars[k] = ds.variables[k].expand_dims(dims_map)
+            data_vars[k] = ds.variables[k].expand_dims(ds_dims_map)
 
         coords = OrderedDict(ds.coords)
         coords.update(common_coords)
@@ -367,6 +387,7 @@ def broadcast(*args):
 
 
 def broadcast_arrays(*args):
+    import warnings
     warnings.warn('xarray.broadcast_arrays is deprecated: use '
                   'xarray.broadcast instead', DeprecationWarning, stacklevel=2)
     return broadcast(*args)

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -3,6 +3,7 @@ import warnings
 import pandas as pd
 
 from . import utils
+from .alignment import align
 from .merge import merge
 from .pycompat import iteritems, OrderedDict, basestring
 from .variable import Variable, as_variable, Coordinate, concat as concat_vars
@@ -202,10 +203,9 @@ def _dataset_concat(datasets, dim, data_vars, coords, compat, positions):
         raise ValueError("compat=%r invalid: must be 'equals' "
                          "or 'identical'" % compat)
 
-    # don't bother trying to work with datasets as a generator instead of a
-    # list; the gains would be minimal
-    datasets = [as_dataset(ds) for ds in datasets]
     dim, coord = _calc_concat_dim_coord(dim)
+    datasets = [as_dataset(ds) for ds in datasets]
+    datasets = align(*datasets, join='outer', copy=False, exclude=[dim])
 
     concat_over = _calc_concat_over(datasets, dim, data_vars, coords)
 

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from . import utils
 from .merge import merge
+from .alignment import broadcast
 from .pycompat import iteritems, OrderedDict, basestring
 from .variable import Variable, as_variable, Coordinate, concat as concat_vars
 
@@ -105,6 +106,8 @@ def concat(objs, dim=None, data_vars='all', coords='different',
         raise ValueError('`concat_over` is no longer a valid argument to '
                          'xarray.concat; it has been split into the `data_vars` '
                          'and `coords` arguments')
+
+    #objs = broadcast(*objs, copy=False, exclude=[dim])
 
     if isinstance(first_obj, DataArray):
         f = _dataarray_concat

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -4,7 +4,6 @@ import pandas as pd
 
 from . import utils
 from .merge import merge
-from .alignment import broadcast
 from .pycompat import iteritems, OrderedDict, basestring
 from .variable import Variable, as_variable, Coordinate, concat as concat_vars
 
@@ -106,8 +105,6 @@ def concat(objs, dim=None, data_vars='all', coords='different',
         raise ValueError('`concat_over` is no longer a valid argument to '
                          'xarray.concat; it has been split into the `data_vars` '
                          'and `coords` arguments')
-
-    #objs = broadcast(*objs, copy=False, exclude=[dim])
 
     if isinstance(first_obj, DataArray):
         f = _dataarray_concat

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from .alignment import partial_align
+from .alignment import align
 from .utils import Frozen, is_dict_like
 from .variable import as_variable, default_index_coordinate
 from .pycompat import (basestring, OrderedDict)
@@ -322,7 +322,7 @@ def _align_for_merge(input_objects, join, copy, indexes=None,
         # https://github.com/pydata/xarray/issues/943
         return input_objects
 
-    aligned = partial_align(*targets, join=join, copy=copy, indexes=indexes)
+    aligned = align(*targets, join=join, copy=copy, indexes=indexes)
 
     for position, key, aligned_obj in zip(positions, keys, aligned):
         if key is no_key:

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -1636,9 +1636,14 @@ class TestDataArray(TestCase):
         self.assertDataArrayIdentical(expected_x2, x2)
         self.assertDataArrayIdentical(expected_y2, y2)
 
-        z = DataArray([1, 2], coords=[('a', [-10, 20])])
-        with self.assertRaisesRegexp(ValueError, 'cannot broadcast'):
-            broadcast(x, z)
+        # broadcast on misaligned coords must auto-align
+        x = DataArray([[1, 2], [3, 4]], coords=[('a', [-1, -2]), ('b', [3, 4])])
+        y = DataArray([1, 2], coords=[('a', [-1, 20])])
+        expected_x2 = DataArray([[3, 4], [1, 2], [np.nan, np.nan]], coords=[('a', [-2, -1, 20]), ('b', [3, 4])])
+        expected_y2 = DataArray([[np.nan, np.nan], [1, 1], [2, 2]], coords=[('a', [-2, -1, 20]), ('b', [3, 4])])
+        x2, y2 = broadcast(x, y)
+        self.assertDataArrayIdentical(expected_x2, x2)
+        self.assertDataArrayIdentical(expected_y2, y2)
 
     def test_broadcast_coordinates(self):
         # regression test for GH649

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -1618,6 +1618,60 @@ class TestDataArray(TestCase):
         c, d = align(a, b, join='outer')
         self.assertEqual(c.dtype, np.float32)
 
+    def test_align_copy(self):
+        x = DataArray([1, 2, 3], coords=[('a', [1, 2, 3])])
+        y = DataArray([1, 2], coords=[('a', [3, 1])])
+        
+        expected_x2 = x
+        expected_y2 = DataArray([2, np.nan, 1], coords=[('a', [1, 2, 3])])
+
+        x2, y2 = align(x, y, join='outer', copy=False)
+        self.assertDataArrayIdentical(expected_x2, x2)
+        self.assertDataArrayIdentical(expected_y2, y2)
+        assert x2.data is x.data
+    
+        x2, y2 = align(x, y, join='outer', copy=True)
+        self.assertDataArrayIdentical(expected_x2, x2)
+        self.assertDataArrayIdentical(expected_y2, y2)
+        assert x2.data is not x.data
+
+        # Trivial align - 1 element
+        x = DataArray([1, 2, 3], coords=[('a', [1, 2, 3])])
+        x2, = align(x, copy=False)
+        self.assertDataArrayIdentical(x, x2)
+        assert x2.data is x.data
+    
+        x2, = align(x, copy=True)
+        self.assertDataArrayIdentical(x, x2)
+        assert x2.data is not x.data
+
+    def test_align_exclude(self):
+        x = DataArray([[1, 2], [3, 4]], coords=[('a', [-1, -2]), ('b', [3, 4])])
+        y = DataArray([[1, 2], [3, 4]], coords=[('a', [-1, 20]), ('b', [5, 6])])
+        z = DataArray([1], dims=['a'], coords={'a': [20], 'b': 7})
+        
+        x2, y2, z2 = align(x, y, z, join='outer', exclude=['b'])
+        expected_x2 = DataArray([[3, 4], [1, 2], [np.nan, np.nan]], coords=[('a', [-2, -1, 20]), ('b', [3, 4])])
+        expected_y2 = DataArray([[np.nan, np.nan], [1, 2], [3, 4]], coords=[('a', [-2, -1, 20]), ('b', [5, 6])])
+        expected_z2 = DataArray([np.nan, np.nan, 1], dims=['a'], coords={'a': [-2, -1, 20], 'b': 7})
+        self.assertDataArrayIdentical(expected_x2, x2)
+        self.assertDataArrayIdentical(expected_y2, y2)
+        self.assertDataArrayIdentical(expected_z2, z2)        
+
+    def test_align_indexes(self):
+        x = DataArray([1, 2, 3], coords=[('a', [-1, 10, -2])])
+        y = DataArray([1, 2], coords=[('a', [-2, -1])])
+
+        x2, y2 = align(x, y, join='outer', indexes={'a': [10, -1, -2]})
+        expected_x2 = DataArray([2, 1, 3], coords=[('a', [10, -1, -2])])
+        expected_y2 = DataArray([np.nan, 2, 1], coords=[('a', [10, -1, -2])])
+        self.assertDataArrayIdentical(expected_x2, x2)
+        self.assertDataArrayIdentical(expected_y2, y2)
+
+        x2, = align(x, join='outer', indexes={'a': [-2, 7, 10, -1]})
+        expected_x2 = DataArray([3, np.nan, 2, 1], coords=[('a', [-2, 7, 10, -1])])
+        self.assertDataArrayIdentical(expected_x2, x2)
+
     def test_broadcast_arrays(self):
         x = DataArray([1, 2], coords=[('a', [-1, -2])], name='x')
         y = DataArray([1, 2], coords=[('b', [3, 4])], name='y')
@@ -1646,30 +1700,22 @@ class TestDataArray(TestCase):
         self.assertDataArrayIdentical(expected_x2, x2)
         self.assertDataArrayIdentical(expected_y2, y2)
 
-    def test_broadcast_arrays_copy(self):
+    def test_broadcast_arrays_nocopy(self):
+        # Test that input data is not copied over in case no alteration is needed
         x = DataArray([1, 2], coords=[('a', [-1, -2])], name='x')
         y = DataArray(3, name='y')
         expected_x2 = DataArray([1, 2], coords=[('a', [-1, -2])], name='x')
         expected_y2 = DataArray([3, 3], coords=[('a', [-1, -2])], name='y')
 
-        x2, y2 = broadcast(x, y, copy=False)
+        x2, y2 = broadcast(x, y)
         self.assertDataArrayIdentical(expected_x2, x2)
         self.assertDataArrayIdentical(expected_y2, y2)
         assert x2.data is x.data
         
-        x2, y2 = broadcast(x, y, copy=True)
-        self.assertDataArrayIdentical(expected_x2, x2)
-        self.assertDataArrayIdentical(expected_y2, y2)
-        assert x2.data is not x.data
-
         # single-element broadcast (trivial case)
-        x2, = broadcast(x, copy=False)
+        x2, = broadcast(x)
         self.assertDataArrayIdentical(x, x2)
         assert x2.data is x.data
-
-        x2, = broadcast(x, copy=True)
-        self.assertDataArrayIdentical(x, x2)
-        assert x2.data is not x.data
 
     def test_broadcast_arrays_exclude(self):
         x = DataArray([[1, 2], [3, 4]], coords=[('a', [-1, -2]), ('b', [3, 4])])

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -1628,22 +1628,22 @@ class TestDataArray(TestCase):
         x2, y2 = align(x, y, join='outer', copy=False)
         self.assertDataArrayIdentical(expected_x2, x2)
         self.assertDataArrayIdentical(expected_y2, y2)
-        assert x2.data is x.data
+        assert source_ndarray(x2.data) is source_ndarray(x.data)
     
         x2, y2 = align(x, y, join='outer', copy=True)
         self.assertDataArrayIdentical(expected_x2, x2)
         self.assertDataArrayIdentical(expected_y2, y2)
-        assert x2.data is not x.data
+        assert source_ndarray(x2.data) is not source_ndarray(x.data)
 
         # Trivial align - 1 element
         x = DataArray([1, 2, 3], coords=[('a', [1, 2, 3])])
         x2, = align(x, copy=False)
         self.assertDataArrayIdentical(x, x2)
-        assert x2.data is x.data
+        assert source_ndarray(x2.data) is source_ndarray(x.data)
     
         x2, = align(x, copy=True)
         self.assertDataArrayIdentical(x, x2)
-        assert x2.data is not x.data
+        assert source_ndarray(x2.data) is not source_ndarray(x.data)
 
     def test_align_exclude(self):
         x = DataArray([[1, 2], [3, 4]], coords=[('a', [-1, -2]), ('b', [3, 4])])
@@ -1710,12 +1710,12 @@ class TestDataArray(TestCase):
         x2, y2 = broadcast(x, y)
         self.assertDataArrayIdentical(expected_x2, x2)
         self.assertDataArrayIdentical(expected_y2, y2)
-        assert x2.data is x.data
+        assert source_ndarray(x2.data) is source_ndarray(x.data)
         
         # single-element broadcast (trivial case)
         x2, = broadcast(x)
         self.assertDataArrayIdentical(x, x2)
-        assert x2.data is x.data
+        assert source_ndarray(x2.data) is source_ndarray(x.data)
 
     def test_broadcast_arrays_exclude(self):
         x = DataArray([[1, 2], [3, 4]], coords=[('a', [-1, -2]), ('b', [3, 4])])

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -1065,6 +1065,13 @@ class TestDataset(TestCase):
         actual, = broadcast(ds)
         self.assertDatasetIdentical(expected, actual)
 
+        # Test copy flag
+        actual, = broadcast(expected, copy=True)
+        self.assertDatasetIdentical(expected, actual)        
+        assert actual is not expected
+        actual, = broadcast(expected, copy=False)
+        assert actual is expected
+
         ds_x = Dataset({'foo': ('x', [1])})
         ds_y = Dataset({'bar': ('y', [2, 3])})
         expected_x = Dataset({'foo': (('x', 'y'), [[1, 1]])})
@@ -1072,6 +1079,15 @@ class TestDataset(TestCase):
         actual_x, actual_y = broadcast(ds_x, ds_y)
         self.assertDatasetIdentical(expected_x, actual_x)
         self.assertDatasetIdentical(expected_y, actual_y)
+
+        # Test copy flag
+        actual_x, actual_y = broadcast(expected_x, ds_y, copy=False)
+        self.assertDatasetIdentical(expected_y, actual_y)
+        assert actual_x is expected_x
+        actual_x, actual_y = broadcast(expected_x, ds_y, copy=True)
+        self.assertDatasetIdentical(expected_x, actual_x)
+        self.assertDatasetIdentical(expected_y, actual_y)
+        assert actual_x is not expected_x
 
         array_y = ds_y['bar']
         expected_y = expected_y['bar']

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -1066,13 +1066,6 @@ class TestDataset(TestCase):
         actual, = broadcast(ds)
         self.assertDatasetIdentical(expected, actual)
 
-        # Test copy flag
-        actual, = broadcast(expected, copy=True)
-        self.assertDatasetIdentical(expected, actual)        
-        assert actual is not expected
-        actual, = broadcast(expected, copy=False)
-        assert actual is expected
-
         ds_x = Dataset({'foo': ('x', [1])})
         ds_y = Dataset({'bar': ('y', [2, 3])})
         expected_x = Dataset({'foo': (('x', 'y'), [[1, 1]])})
@@ -1081,14 +1074,16 @@ class TestDataset(TestCase):
         self.assertDatasetIdentical(expected_x, actual_x)
         self.assertDatasetIdentical(expected_y, actual_y)
 
-        # Test copy flag
-        actual_x, actual_y = broadcast(expected_x, ds_y, copy=False)
-        self.assertDatasetIdentical(expected_y, actual_y)
-        assert actual_x is expected_x
-        actual_x, actual_y = broadcast(expected_x, ds_y, copy=True)
+        # Test that data is not copied if not needed
+        actual_x, actual_y = broadcast(expected_x, ds_y)
         self.assertDatasetIdentical(expected_x, actual_x)
         self.assertDatasetIdentical(expected_y, actual_y)
-        assert actual_x is not expected_x
+        assert actual_x['foo'].data is expected_x['foo'].data
+        assert actual_x['bar'].data is expected_x['bar'].data
+        actual_x, = broadcast(expected_x)
+        self.assertDatasetIdentical(expected_x, actual_x)
+        assert actual_x['foo'].data is expected_x['foo'].data
+        assert actual_x['bar'].data is expected_x['bar'].data
 
         array_y = ds_y['bar']
         expected_y = expected_y['bar']

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -1069,15 +1069,18 @@ class TestDataset(TestCase):
     def test_align_nocopy(self):
         x = Dataset({'foo': DataArray([1, 2, 3], coords={'x': [1, 2, 3]})})
         y = Dataset({'foo': DataArray([1, 2], coords={'x': [1, 2]})})
-        x2, y2 = align(x, y, join='outer')
-
         expected_x2 = x
         expected_y2 = Dataset({'foo': DataArray([1, 2, np.nan], coords={'x': [1, 2, 3]})})
+
+        x2, y2 = align(x, y, copy=False, join='outer')
         self.assertDatasetIdentical(expected_x2, x2)
         self.assertDatasetIdentical(expected_y2, y2)
-
-        # Test that data copies will be avoided if not necessary
         assert source_ndarray(x['foo'].data) is source_ndarray(x2['foo'].data)
+
+        x2, y2 = align(x, y, copy=True, join='outer')
+        self.assertDatasetIdentical(expected_x2, x2)
+        self.assertDatasetIdentical(expected_y2, y2)
+        assert source_ndarray(x['foo'].data) is not source_ndarray(x2['foo'].data)
 
     def test_align_indexes(self):
         x = Dataset({'foo': DataArray([1, 2, 3], coords={'x': [1, 2, 3]})})


### PR DESCRIPTION
- Removed partial_align()
- Added exclude and indexes optional parameters to align() public API
- Added exclude optional parameter to broadcast() public API
- Added various unit tests to check that align() and broadcast() do not perform needless data copies
- broadcast() to automatically align inputs

Note: there is a failed unit test, TestDataset.test_broadcast_nocopy, which shows broadcast on dataset doing a data copy whereas it shouldn't. Could you look into it?