### PR TITLE
Consistently skip identical indexes in align

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,6 +35,8 @@ Enhancements
   using ``join=outer``. By `Guido Imperiale <https://github.com/crusaderky>`_.
 - Better error message when assigning variables without dimensions
   (:issue:`971`). By `Stephan Hoyer <https://github.com/shoyer>`_.
+- Better error message when reindex/align fails due to duplicate index values
+  (:issue:`956`). By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 Bug fixes
 ~~~~~~~~~
@@ -53,6 +55,8 @@ Bug fixes
   By `Stephan Hoyer <https://github.com/shoyer>`_.
 - ``groupby_bins`` sorted bin labels as strings (:issue:`952`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
+- Fix bug introduced by v0.8.0 that broke assignment to datasets when both the
+  left and right side have the same non-unique index values (:issue:`956`).
 
 .. _whats-new.0.8.1:
 

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -63,8 +63,7 @@ class AbstractCoordinates(Mapping, formatting.ReprMixin):
     def update(self, other):
         other_vars = getattr(other, 'variables', other)
         coords = merge_coords([self.variables, other_vars],
-                              priority_arg=1, indexes=self.indexes,
-                              indexes_from_arg=0)
+                              priority_arg=1, indexes=self.indexes)
         self._update_coords(coords)
 
     def _merge_raw(self, other):


### PR DESCRIPTION
Also give a more informative error message identifying the offending dimension
if reindex/align cannot succeed due to duplicate values along an index.

Fixes #956