### PR TITLE
fix datetime issues

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -26,6 +26,8 @@ Enhancements
 
 Bug fixes
 ~~~~~~~~~
+- Fix issues for dates outside the valid range of pandas timestamps
+  (:issue:`975`). By `Mathias Hauser <https://github.com/mathause>`_.
 
 .. _whats-new.0.8.2:
 

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -376,15 +376,11 @@ class DecodedCFDatetimeArray(utils.NDArrayMixin):
         self.units = units
         self.calendar = calendar
 
-        # Verify that at least the first and last date can be decoded 
-        # successfully. Otherwise, tracebacks end up swallowed by 
+        # Verify that at least the first and last date can be decoded
+        # successfully. Otherwise, tracebacks end up swallowed by
         # Dataset.__repr__ when users try to view their lazily decoded array.
-        example_value = first_n_items(array, 1) or [0]
-
-        if array.size > 1:
-            # fixes (part of) https://github.com/pydata/xarray/issues/975
-            example_value_end = last_item(array)
-            example_value = np.concatenate((example_value, example_value_end))
+        example_value = np.concatenate([first_n_items(array, 1),
+                                        last_item(array), [0]])
 
         try:
             result = decode_cf_datetime(example_value, units, calendar)

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -90,16 +90,15 @@ def last_item(x):
         return []
 
     indexer = (slice(-1, None), ) * x.ndim
-    return x[indexer]
-
+    return np.array(x[indexer], ndmin=1)
 
 def format_timestamp(t):
     """Cast given object to a Timestamp and return a nicely formatted string"""
-	# Timestamp is only valid for 1678 to 2262
+    # Timestamp is only valid for 1678 to 2262
     try:
         datetime_str = unicode_type(pd.Timestamp(t))
     except OutOfBoundsDatetime:
-        datetime_str = unicode_type(t.__str__())
+        datetime_str = unicode_type(t)
         
     try:
         date_str, time_str = datetime_str.split()

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -9,6 +9,7 @@ import functools
 
 import numpy as np
 import pandas as pd
+from pandas.tslib import OutOfBoundsDatetime
 
 from .options import OPTIONS
 from .pycompat import PY2, iteritems, unicode_type, bytes_type, dask_array_type
@@ -82,10 +83,24 @@ def first_n_items(x, n_desired):
         x = x[indexer]
     return np.asarray(x).flat[:n_desired]
 
+def last_item(x):
+    """Returns the last item of an array"""
+    if x.size == 0:
+        # work around for https://github.com/numpy/numpy/issues/5195
+        return []
+
+    indexer = (slice(-1, None), ) * x.ndim
+    return x[indexer]
+
 
 def format_timestamp(t):
     """Cast given object to a Timestamp and return a nicely formatted string"""
-    datetime_str = unicode_type(pd.Timestamp(t))
+	# Timestamp is only valid for 1678 to 2262
+    try:
+        datetime_str = unicode_type(pd.Timestamp(t))
+    except OutOfBoundsDatetime:
+        datetime_str = unicode_type(t.__str__())
+        
     try:
         date_str, time_str = datetime_str.split()
     except ValueError:

--- a/xarray/test/test_conventions.py
+++ b/xarray/test/test_conventions.py
@@ -186,6 +186,35 @@ class TestDatetime(TestCase):
                             pd.Index(actual), units, calendar)
                         self.assertArrayEqual(num_dates, np.around(encoded, 1))
 
+    def test_decode_cf_datetime_overflow(self):
+        # checks for 
+        # https://github.com/pydata/pandas/issues/14068
+        # https://github.com/pydata/xarray/issues/975
+
+        from datetime import datetime        
+        units = 'days since 2000-01-01 00:00:00'
+
+        # date after 2262 and before 1678
+        days = (-117608, 95795)
+        expected = (datetime(1677, 12, 31), datetime(2262, 4, 12))
+
+        for i, day in enumerate(days):
+            result = conventions.decode_cf_datetime(day, units)
+            self.assertEqual(result, expected[i])
+
+    def test_decode_cf_datetime_transition_to_invalid(self):
+        # manually create dataset with not-decoded date
+        from datetime import datetime
+        ds = Dataset(coords={'time' : [0, 266 * 365]})
+        units = 'days since 2000-01-01 00:00:00'
+        ds.time.attrs = dict(units=units)
+        ds_decoded = conventions.decode_cf(ds)
+
+        expected = [datetime(2000, 1, 1, 0, 0),
+                    datetime(2265, 10, 28, 0, 0)]
+
+        self.assertArrayEqual(ds_decoded.time.values, expected)
+
     def test_decoded_cf_datetime_array(self):
         actual = conventions.DecodedCFDatetimeArray(
             np.array([0, 1, 2]), 'days since 1900-01-01', 'standard')

--- a/xarray/test/test_conventions.py
+++ b/xarray/test/test_conventions.py
@@ -186,6 +186,7 @@ class TestDatetime(TestCase):
                             pd.Index(actual), units, calendar)
                         self.assertArrayEqual(num_dates, np.around(encoded, 1))
 
+    @requires_netCDF4
     def test_decode_cf_datetime_overflow(self):
         # checks for 
         # https://github.com/pydata/pandas/issues/14068
@@ -202,6 +203,7 @@ class TestDatetime(TestCase):
             result = conventions.decode_cf_datetime(day, units)
             self.assertEqual(result, expected[i])
 
+    @requires_netCDF4
     def test_decode_cf_datetime_transition_to_invalid(self):
         # manually create dataset with not-decoded date
         from datetime import datetime
@@ -369,6 +371,7 @@ class TestDatetime(TestCase):
                 self.assertEqual(actual.dtype, np.dtype('O'))
                 self.assertArrayEqual(actual, expected)
 
+    @requires_netCDF4
     def test_cf_datetime_nan(self):
         for num_dates, units, expected_list in [
                 ([np.nan], 'days since 2000-01-01', ['NaT']),

--- a/xarray/test/test_formatting.py
+++ b/xarray/test/test_formatting.py
@@ -85,30 +85,30 @@ class TestFormatting(TestCase):
             self.assertEqual(expected, actual)
 
     
-def test_format_array_flat(self):
-        actual = formatting.format_array_flat(np.arange(100), 13)
-        expected = '0 1 2 3 4 ...'
-        self.assertEqual(expected, actual)
+    def test_format_array_flat(self):
+            actual = formatting.format_array_flat(np.arange(100), 13)
+            expected = '0 1 2 3 4 ...'
+            self.assertEqual(expected, actual)
 
-        actual = formatting.format_array_flat(np.arange(100.0), 11)
-        expected = '0.0 1.0 ...'
-        self.assertEqual(expected, actual)
+            actual = formatting.format_array_flat(np.arange(100.0), 11)
+            expected = '0.0 1.0 ...'
+            self.assertEqual(expected, actual)
 
-        actual = formatting.format_array_flat(np.arange(100.0), 1)
-        expected = '0.0 ...'
-        self.assertEqual(expected, actual)
+            actual = formatting.format_array_flat(np.arange(100.0), 1)
+            expected = '0.0 ...'
+            self.assertEqual(expected, actual)
 
-        actual = formatting.format_array_flat(np.arange(3), 5)
-        expected = '0 1 2'
-        self.assertEqual(expected, actual)
+            actual = formatting.format_array_flat(np.arange(3), 5)
+            expected = '0 1 2'
+            self.assertEqual(expected, actual)
 
-        actual = formatting.format_array_flat(np.arange(4.0), 11)
-        expected = '0.0 1.0 ...'
-        self.assertEqual(expected, actual)
+            actual = formatting.format_array_flat(np.arange(4.0), 11)
+            expected = '0.0 1.0 ...'
+            self.assertEqual(expected, actual)
 
-        actual = formatting.format_array_flat(np.arange(4), 0)
-        expected = '0 ...'
-        self.assertEqual(expected, actual)
+            actual = formatting.format_array_flat(np.arange(4), 0)
+            expected = '0 ...'
+            self.assertEqual(expected, actual)
 
     def test_pretty_print(self):
         self.assertEqual(formatting.pretty_print('abcdefghij', 8), 'abcde...')

--- a/xarray/test/test_formatting.py
+++ b/xarray/test/test_formatting.py
@@ -37,6 +37,16 @@ class TestFormatting(TestCase):
         with self.assertRaisesRegexp(ValueError, 'at least one item'):
             formatting.first_n_items(array, 0)
 
+    def test_last_item(self):
+        array = np.arange(100)
+
+        reshape = ((10, 10), (1, 100), (2, 2, 5, 5))
+        expected = np.array(99)
+
+        for r in reshape:
+            result = formatting.last_item(array.reshape(r))
+            self.assertEqual(result, expected)
+
     def test_format_item(self):
         cases = [
             (pd.Timestamp('2000-01-01T12'), '2000-01-01T12:00:00'),
@@ -74,8 +84,8 @@ class TestFormatting(TestCase):
             actual = ' '.join(formatting.format_items(item))
             self.assertEqual(expected, actual)
 
-
-    def test_format_array_flat(self):
+    
+def test_format_array_flat(self):
         actual = formatting.format_array_flat(np.arange(100), 13)
         expected = '0 1 2 3 4 ...'
         self.assertEqual(expected, actual)
@@ -106,3 +116,15 @@ class TestFormatting(TestCase):
 
     def test_maybe_truncate(self):
         self.assertEqual(formatting.maybe_truncate(u'ß', 10), u'ß')
+
+    def test_format_timestamp_out_of_bounds(self):
+        from datetime import datetime
+        date = datetime(1300, 12, 1)
+        expected = '1300-12-01'
+        result = formatting.format_timestamp(date)
+        self.assertEqual(result, expected)
+        
+        date = datetime(2300, 12, 1)
+        expected = '2300-12-01'
+        result = formatting.format_timestamp(date)
+        self.assertEqual(result, expected)

--- a/xarray/test/test_formatting.py
+++ b/xarray/test/test_formatting.py
@@ -84,31 +84,31 @@ class TestFormatting(TestCase):
             actual = ' '.join(formatting.format_items(item))
             self.assertEqual(expected, actual)
 
-    
+
     def test_format_array_flat(self):
-            actual = formatting.format_array_flat(np.arange(100), 13)
-            expected = '0 1 2 3 4 ...'
-            self.assertEqual(expected, actual)
+        actual = formatting.format_array_flat(np.arange(100), 13)
+        expected = '0 1 2 3 4 ...'
+        self.assertEqual(expected, actual)
 
-            actual = formatting.format_array_flat(np.arange(100.0), 11)
-            expected = '0.0 1.0 ...'
-            self.assertEqual(expected, actual)
+        actual = formatting.format_array_flat(np.arange(100.0), 11)
+        expected = '0.0 1.0 ...'
+        self.assertEqual(expected, actual)
 
-            actual = formatting.format_array_flat(np.arange(100.0), 1)
-            expected = '0.0 ...'
-            self.assertEqual(expected, actual)
+        actual = formatting.format_array_flat(np.arange(100.0), 1)
+        expected = '0.0 ...'
+        self.assertEqual(expected, actual)
 
-            actual = formatting.format_array_flat(np.arange(3), 5)
-            expected = '0 1 2'
-            self.assertEqual(expected, actual)
+        actual = formatting.format_array_flat(np.arange(3), 5)
+        expected = '0 1 2'
+        self.assertEqual(expected, actual)
 
-            actual = formatting.format_array_flat(np.arange(4.0), 11)
-            expected = '0.0 1.0 ...'
-            self.assertEqual(expected, actual)
+        actual = formatting.format_array_flat(np.arange(4.0), 11)
+        expected = '0.0 1.0 ...'
+        self.assertEqual(expected, actual)
 
-            actual = formatting.format_array_flat(np.arange(4), 0)
-            expected = '0 ...'
-            self.assertEqual(expected, actual)
+        actual = formatting.format_array_flat(np.arange(4), 0)
+        expected = '0 ...'
+        self.assertEqual(expected, actual)
 
     def test_pretty_print(self):
         self.assertEqual(formatting.pretty_print('abcdefghij', 8), 'abcde...')


### PR DESCRIPTION
fixes: #975
work around: pydata/pandas#14068

I finally found 3 issues:

(1) pretty print fails when date is out of bounds
(2) pandas Overflow error (https://github.com/pydata/pandas/issues/14068)
(3) decode_cf_datetime when first date is in bound but later dates are not

    import xarray as xr
    from datetime import datetime


    # (1) pretty print
    xr.core.formatting.format_timestamp(datetime(2800, 1, 1))

    # (2) overflow error
    ds = xr.Dataset(coords={'time' : [0, 266 * 365]})
    units = 'days since 2000-01-01 00:00:00'
    ds.time.attrs = dict(units=units)
    ds_decoded = xr.conventions.decode_cf(ds)
    ds_decoded.time

    import netCDF4 as nc
    import numpy as np
    import xarray as xr

    # (3) create netCDF file
    ncf = nc.Dataset('test_future.nc', 'w')
    ncf.createDimension('time')
    ncf.createVariable('time', np.int, dimensions=('time'))
    ncf.variables['time'].units = 'days since 1850-01-01 00:00:00'
    ncf.variables['time'].calendar = 'standard'
    ncf.variables['time'][:] = np.arange(850) * 365
    ncf.close()

    # open with xr
    ds = xr.open_dataset('test_future.nc')
    # this works
    ds
    # ds.time is a datetime64[ns] object
    # this fails
    ds.time