### PR TITLE
Fix encoding if dtype is the same as the original

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,6 +34,11 @@ Bug fixes
   (:issue:`980`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
 
+- Setting ``dtype`` via the ``encoding`` parameter of ``to_netcdf`` failed if
+  the encoded dtype was the same as the dtype of the original array
+  (:issue:`873`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
+
 .. _whats-new.0.8.2:
 
 v0.8.2 (18 August 2016)

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -621,7 +621,7 @@ def maybe_encode_dtype(var, name=None):
     if 'dtype' in var.encoding:
         dims, data, attrs, encoding = _var_as_tuple(var)
         dtype = np.dtype(encoding.pop('dtype'))
-        if dtype != var.dtype and dtype.kind != 'O':
+        if dtype != var.dtype:
             if np.issubdtype(dtype, np.integer):
                 if (np.issubdtype(var.dtype, np.floating) and
                         '_FillValue' not in var.attrs):
@@ -634,7 +634,7 @@ def maybe_encode_dtype(var, name=None):
                 data = string_to_char(np.asarray(data, 'S'))
                 dims = dims + ('string%s' % data.shape[-1],)
             data = data.astype(dtype=dtype)
-            var = Variable(dims, data, attrs, encoding)
+        var = Variable(dims, data, attrs, encoding)
     return var
 
 

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -401,6 +401,13 @@ class CFEncodedDataTest(DatasetIOTestCases):
             self.assertEqual(actual.t.encoding['units'], units)
             self.assertDatasetIdentical(actual, ds)
 
+    def test_encoding_same_dtype(self):
+        ds = Dataset({'x': ('y', np.arange(10.0, dtype='f4'))})
+        kwargs = dict(encoding={'x': {'dtype': 'f4'}})
+        with self.roundtrip(ds, save_kwargs=kwargs) as actual:
+            self.assertEqual(actual.x.encoding['dtype'], 'f4')
+        self.assertEqual(ds.x.encoding, {})
+
 
 _counter = itertools.count()
 


### PR DESCRIPTION
Previously, this resulted in an error: https://github.com/pydata/xarray/issues/873#issuecomment-241540585