### PR TITLE
Added convenience method for saving DataArray to netCDF file

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -405,7 +405,9 @@ DataArray methods
 .. autosummary::
    :toctree: generated/
 
+   open_dataarray
    DataArray.to_dataset
+   DataArray.to_netcdf
    DataArray.to_pandas
    DataArray.to_series
    DataArray.to_dataframe

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -117,6 +117,14 @@ We can load netCDF files to create a new Dataset using
     ds_disk = xr.open_dataset('saved_on_disk.nc')
     ds_disk
 
+Similarly, a DataArray can be saved to disk using the
+:py:attr:`DataArray.to_netcdf <xarray.DataArray.to_netcdf>` method, and loaded
+from disk using the :py:func:`~xarray.open_dataarray` function. As netCDF files
+correspond to :py:class:`~xarray.Dataset` objects, these functions internally
+convert the ``DataArray`` to a ``Dataset`` before saving, and then convert back
+when loading, ensuring that the ``DataArray`` that is loaded is always exactly
+the same as the one that was saved.
+
 A dataset can also be loaded or written to a specific group within a netCDF
 file. To load from a group, pass a ``group`` keyword argument to the
 ``open_dataset`` function. The group can be specified as a path-like

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -45,9 +45,10 @@ By `Robin Wilson <https://github.com/robintw>`_.
 
 - Added ability to save ``DataArray`` objects directly to netCDF files using
   :py:meth:`~xarray.DataArray.to_netcdf`, and to load directly from netCDF files
-  using :py:func:`~xarray.open_dataarray`. These remove the need to convert a
-  ``DataArray`` to a ``Dataset`` before saving as a netCDF file, and deals with
-  names to ensure a perfect 'roundtrip' capability.
+  using :py:func:`~xarray.open_dataarray` (:issue:`915`). These remove the need
+  to convert a ``DataArray`` to a ``Dataset`` before saving as a netCDF file,
+  and deals with names to ensure a perfect 'roundtrip' capability.
+  By `Robin Wilson <https://github.com/robintw`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -43,6 +43,12 @@ Enhancements
 error messages if they are invalid. (:issue:`911`).
 By `Robin Wilson <https://github.com/robintw>`_.
 
+- Added ability to save ``DataArray`` objects directly to netCDF files using
+  :py:meth:`~xarray.DataArray.to_netcdf`, and to load directly from netCDF files
+  using :py:func:`~xarray.open_dataarray`. These remove the need to convert a
+  ``DataArray`` to a ``Dataset`` before saving as a netCDF file, and deals with
+  names to ensure a perfect 'roundtrip' capability.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -8,7 +8,8 @@ from .core.dataarray import DataArray
 from .core.merge import merge, MergeError
 from .core.options import set_options
 
-from .backends.api import open_dataset, open_mfdataset, save_mfdataset
+from .backends.api import (open_dataset, open_dataarray, open_mfdataset,
+                           save_mfdataset)
 from .conventions import decode_cf
 
 try:

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -328,8 +328,8 @@ def open_dataarray(*args, **kwargs):
 
     Notes
     -----
-    This is designed to be fully compatible with `DataArray.to_netcdf`.
-    Saving using `DataArray.to_netcdf` and then loading with this function will
+    This is designed to be fully compatible with `DataArray.to_netcdf`. Saving
+    using `DataArray.to_netcdf` and then loading with this function will
     produce an identical result.
 
     All parameters are passed directly to `xarray.open_dataset`. See that

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -267,7 +267,10 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
     return maybe_decode_store(store)
 
 
-def open_dataarray(*args, **kwargs):
+def open_dataarray(filename_or_obj, group=None, decode_cf=True,
+                   mask_and_scale=True, decode_times=True,
+                   concat_characters=True, decode_coords=True, engine=None,
+                   chunks=None, lock=None, drop_variables=None):
     """
     Opens an DataArray from a netCDF file containing a single data variable.
 
@@ -339,7 +342,10 @@ def open_dataarray(*args, **kwargs):
     --------
     open_dataset
     """
-    dataset = open_dataset(*args, **kwargs)
+    dataset = open_dataset(filename_or_obj, group, decode_cf,
+                           mask_and_scale, decode_times,
+                           concat_characters, decode_coords, engine,
+                           chunks, lock, drop_variables)
 
     if len(dataset.data_vars) != 1:
         raise ValueError('Given file dataset contains more than one variable. '

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -267,6 +267,27 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
     return maybe_decode_store(store)
 
 
+def open_dataarray(*args, **kwargs):
+    """
+    Opens an `xarray.DataArray` from a netCDF file, reading the variable called
+    `data`.
+
+    This is designed to read files saved with `xarray.DataArray.to_netcdf`.
+
+    Parameters
+    ----------
+    All parameters are passed directly to `xarray.open_dataset`.
+    """
+    dataset = open_dataset(*args, **kwargs)
+
+    try:
+        return dataset['data']
+    except KeyError:
+        raise ValueError('Given file dataset does not contain the variable `data`.'
+                         'If dataset was not saved using `xarray.DataArray.to_netcdf` then'
+                         'it must be loaded with `xarray.open_dataset`.')
+
+
 class _MultiFileCloser(object):
     def __init__(self, file_objs):
         self.file_objs = file_objs

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -15,6 +15,8 @@ from ..core.combine import auto_combine
 from ..core.utils import close_on_error, is_remote_uri
 from ..core.pycompat import basestring
 
+DATAARRAY_NAME = '__xarray_dataarray_name__'
+DATAARRAY_VARIABLE = '__xarray_dataarray_variable__'
 
 def _get_default_engine(path, allow_remote=False):
     if allow_remote and is_remote_uri(path):  # pragma: no cover
@@ -348,9 +350,9 @@ def open_dataarray(filename_or_obj, group=None, decode_cf=True,
                            chunks, lock, drop_variables)
 
     if len(dataset.data_vars) != 1:
-        raise ValueError('Given file dataset contains more than one variable. '
-                         'Please read with xarray.open_dataset and then select '
-                         'the variable you want.')
+        raise ValueError('Given file dataset contains more than one data '
+                         'variable. Please read with xarray.open_dataset and '
+                         'then select the variable you want.')
     else:
         data_array, = dataset.data_vars.values()
 
@@ -358,11 +360,11 @@ def open_dataarray(filename_or_obj, group=None, decode_cf=True,
 
     # Reset names if they were changed during saving
     # to ensure that we can 'roundtrip' perfectly
-    if '__xarray_dataarray_name__' in dataset.attrs:
-        data_array.name = dataset.attrs['__xarray_dataarray_name__']
-        del dataset.attrs['__xarray_dataarray_name__']
+    if DATAARRAY_NAME in dataset.attrs:
+        data_array.name = dataset.attrs[DATAARRAY_NAME]
+        del dataset.attrs[DATAARRAY_NAME]
 
-    if data_array.name == '__xarray_dataarray_variable__':
+    if data_array.name == DATAARRAY_VARIABLE:
         data_array.name = None
 
     return data_array

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -269,15 +269,75 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
 
 def open_dataarray(*args, **kwargs):
     """
-    Opens an `xarray.DataArray` from a netCDF file, and returns the single
-    variable that is within the file. If multiple variables are present then
-    a ValueError is raised.
+    Opens an DataArray from a netCDF file containing a single data variable.
 
-    This is designed to read files saved with `xarray.DataArray.to_netcdf`.
+    This is designed to read netCDF files with only one data variable. If
+    multiple variables are present then a ValueError is raised.
 
     Parameters
     ----------
-    All parameters are passed directly to `xarray.open_dataset`.
+    filename_or_obj : str, file or xarray.backends.*DataStore
+        Strings are interpreted as a path to a netCDF file or an OpenDAP URL
+        and opened with python-netCDF4, unless the filename ends with .gz, in
+        which case the file is gunzipped and opened with scipy.io.netcdf (only
+        netCDF3 supported). File-like objects are opened with scipy.io.netcdf
+        (only netCDF3 supported).
+    group : str, optional
+        Path to the netCDF4 group in the given file to open (only works for
+        netCDF4 files).
+    decode_cf : bool, optional
+        Whether to decode these variables, assuming they were saved according
+        to CF conventions.
+    mask_and_scale : bool, optional
+        If True, replace array values equal to `_FillValue` with NA and scale
+        values according to the formula `original_values * scale_factor +
+        add_offset`, where `_FillValue`, `scale_factor` and `add_offset` are
+        taken from variable attributes (if they exist).  If the `_FillValue` or
+        `missing_value` attribute contains multiple values a warning will be
+        issued and all array values matching one of the multiple values will
+        be replaced by NA.
+    decode_times : bool, optional
+        If True, decode times encoded in the standard NetCDF datetime format
+        into datetime objects. Otherwise, leave them encoded as numbers.
+    concat_characters : bool, optional
+        If True, concatenate along the last dimension of character arrays to
+        form string arrays. Dimensions will only be concatenated over (and
+        removed) if they have no corresponding variable and if they are only
+        used as the last dimension of character arrays.
+    decode_coords : bool, optional
+        If True, decode the 'coordinates' attribute to identify coordinates in
+        the resulting dataset.
+    engine : {'netcdf4', 'scipy', 'pydap', 'h5netcdf', 'pynio'}, optional
+        Engine to use when reading files. If not provided, the default engine
+        is chosen based on available dependencies, with a preference for
+        'netcdf4'.
+    chunks : int or dict, optional
+        If chunks is provided, it used to load the new dataset into dask
+        arrays. This is an experimental feature; see the documentation for more
+        details.
+    lock : False, True or threading.Lock, optional
+        If chunks is provided, this argument is passed on to
+        :py:func:`dask.array.from_array`. By default, a per-variable lock is
+        used when reading data from netCDF files with the netcdf4 and h5netcdf
+        engines to avoid issues with concurrent access when using dask's
+        multithreaded backend.
+    drop_variables: string or iterable, optional
+        A variable or list of variables to exclude from being parsed from the
+        dataset. This may be useful to drop variables with problems or
+        inconsistent values.
+
+    Notes
+    -----
+    This is designed to be fully compatible with `DataArray.to_netcdf`.
+    Saving using `DataArray.to_netcdf` and then loading with this function will
+    produce an identical result.
+
+    All parameters are passed directly to `xarray.open_dataset`. See that
+    documentation for further details.
+
+    See also
+    --------
+    open_dataset
     """
     dataset = open_dataset(*args, **kwargs)
 
@@ -287,6 +347,15 @@ def open_dataarray(*args, **kwargs):
                          'the variable you want.')
     else:
         data_array, = dataset.data_vars.values()
+
+    # Reset names if they were changed during saving
+    # to ensure that we can 'roundtrip' perfectly
+    if '__xarray_dataarray_name__' in dataset.attrs:
+        data_array.name = dataset.attrs['__xarray_dataarray_name__']
+        del dataset.attrs['__xarray_dataarray_name__']
+
+    if data_array.name == '__xarray_dataarray_variable__':
+        data_array.name = None
 
     return data_array
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -348,6 +348,8 @@ def open_dataarray(*args, **kwargs):
     else:
         data_array, = dataset.data_vars.values()
 
+    data_array._file_obj = dataset._file_obj
+
     # Reset names if they were changed during saving
     # to ensure that we can 'roundtrip' perfectly
     if '__xarray_dataarray_name__' in dataset.attrs:

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -269,8 +269,9 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
 
 def open_dataarray(*args, **kwargs):
     """
-    Opens an `xarray.DataArray` from a netCDF file, reading the variable called
-    `data`.
+    Opens an `xarray.DataArray` from a netCDF file, and returns the single
+    variable that is within the file. If multiple variables are present then
+    a ValueError is raised.
 
     This is designed to read files saved with `xarray.DataArray.to_netcdf`.
 
@@ -280,12 +281,14 @@ def open_dataarray(*args, **kwargs):
     """
     dataset = open_dataset(*args, **kwargs)
 
-    try:
-        return dataset['data']
-    except KeyError:
-        raise ValueError('Given file dataset does not contain the variable `data`.'
-                         'If dataset was not saved using `xarray.DataArray.to_netcdf` then'
-                         'it must be loaded with `xarray.open_dataset`.')
+    if len(dataset.data_vars) != 1:
+        raise ValueError('Given file dataset contains more than one variable. '
+                         'Please read with xarray.open_dataset and then select '
+                         'the variable you want.')
+    else:
+        data_array, = dataset.data_vars.values()
+
+    return data_array
 
 
 class _MultiFileCloser(object):

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -579,7 +579,7 @@ class BaseDataObject(AttrAccessMixin):
         return outobj._where(outcond)
 
     def close(self):
-        """Close any files linked to this dataset
+        """Close any files linked to this object
         """
         if self._file_obj is not None:
             self._file_obj.close()

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -578,6 +578,19 @@ class BaseDataObject(AttrAccessMixin):
 
         return outobj._where(outcond)
 
+    def close(self):
+        """Close any files linked to this dataset
+        """
+        if self._file_obj is not None:
+            self._file_obj.close()
+        self._file_obj = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
     # this has no runtime function - these are listed so IDEs know these methods
     # are defined and don't warn on these operations
     __lt__ = __le__ =__ge__ = __gt__ = __add__ = __sub__ = __mul__ = \

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1152,14 +1152,16 @@ class DataArray(AbstractArray, BaseDataObject):
 
         All parameters are passed directly to `xarray.Dataset.to_netcdf`.
         """
+        from ..backends.api import DATAARRAY_NAME, DATAARRAY_VARIABLE
+
         if not self.name:
             # If no name is set then use a generic xarray name
-            dataset = self.to_dataset(name='__xarray_dataarray_variable__')
+            dataset = self.to_dataset(name=DATAARRAY_VARIABLE)
         elif self.name in list(self.coords):
             # The name is the same as one of the coords names, which netCDF
             # doesn't support, so rename it but keep track of the old name
-            dataset = self.to_dataset(name='__xarray_dataarray_variable__')
-            dataset.attrs['__xarray_dataarray_name__'] = self.name
+            dataset = self.to_dataset(name=DATAARRAY_VARIABLE)
+            dataset.attrs[DATAARRAY_NAME] = self.name
         else:
             # No problems with the name - so we're fine!
             dataset = self.to_dataset()

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -221,7 +221,11 @@ class DataArray(AbstractArray, BaseDataObject):
         self._variable = variable
         self._coords = coords
         self._name = name
+
+        self._file_obj = None
+
         self._initialized = True
+
 
     __default = object()
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1104,9 +1104,17 @@ class DataArray(AbstractArray, BaseDataObject):
         -----
         Only xarray.Dataset objects can be written to netCDF files, so
         the xarray.DataArray is converted to a xarray.Dataset object
-        containing a single variable with the name `data`.
+        containing a single variable. If the DataArray has no name, then
+        it is given the name 'data'.
         """
-        dataset = self.to_dataset(name='data')
+        if not self.name and self.name not in list(self.coords):
+            # If the name isn't blank/None or the same as one of the coords
+            # (as the latter is invalid for a netCDF file) then give it a name
+            # of `data`
+            dataset = self.to_dataset(name='data')
+        else:
+            dataset = self.to_dataset()
+
         dataset.to_netcdf(*args, **kwargs)
 
     def to_dict(self):

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1092,6 +1092,23 @@ class DataArray(AbstractArray, BaseDataObject):
         isnull = pd.isnull(self.values)
         return np.ma.MaskedArray(data=self.values, mask=isnull, copy=copy)
 
+    def to_netcdf(self, *args, **kwargs):
+        """
+        Write DataArray contents to a netCDF file.
+
+        Parameters
+        ----------
+        All parameters are passed directly to `xarray.Dataset.to_netcdf`.
+
+        Notes
+        -----
+        Only xarray.Dataset objects can be written to netCDF files, so
+        the xarray.DataArray is converted to a xarray.Dataset object
+        containing a single variable with the name `data`.
+        """
+        dataset = self.to_dataset(name='data')
+        dataset.to_netcdf(*args, **kwargs)
+
     def to_dict(self):
         """
         Convert this xarray.DataArray into a dictionary following xarray

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -240,19 +240,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         obj._file_obj = store
         return obj
 
-    def close(self):
-        """Close any files linked to this dataset
-        """
-        if self._file_obj is not None:
-            self._file_obj.close()
-        self._file_obj = None
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.close()
-
     def __getstate__(self):
         """Always load data in-memory before pickling"""
         self.load()

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -13,7 +13,8 @@ import numpy as np
 import pandas as pd
 
 import xarray as xr
-from xarray import Dataset, open_dataset, open_mfdataset, backends, save_mfdataset
+from xarray import (Dataset, DataArray, open_dataset, open_dataarray,
+                    open_mfdataset, backends, save_mfdataset)
 from xarray.backends.common import robust_getitem
 from xarray.backends.netCDF4_ import _extract_nc4_encoding
 from xarray.core.pycompat import iteritems, PY3
@@ -1071,7 +1072,6 @@ class TestEncodingInvalid(TestCase):
         with self.assertRaisesRegexp(ValueError, 'unexpected encoding'):
             _extract_nc4_encoding(var, raise_on_invalid=True)
 
-
 class MiscObject:
     pass
 
@@ -1172,3 +1172,28 @@ class TestValidateAttrs(TestCase):
             attrs['test'] = np.arange(12).reshape(3, 4)
             with create_tmp_file() as tmp_file:
                 ds.to_netcdf(tmp_file)
+
+class TestDataArrayToNetCDF(TestCase):
+
+    def test_dataarray_to_netcdf_no_name(self):
+        original_da = DataArray(np.arange(12).reshape((3, 4)))
+
+        with create_tmp_file() as tmp:
+            original_da.to_netcdf(tmp)
+
+            loaded_da = open_dataarray(tmp)
+
+        self.assertDataArrayEqual(original_da, loaded_da)
+        self.assertEqual(loaded_da.name, 'data')
+
+    def test_dataarray_to_netcdf_with_name(self):
+        original_da = DataArray(np.arange(12).reshape((3, 4)),
+                                name='test')
+
+        with create_tmp_file() as tmp:
+            original_da.to_netcdf(tmp)
+
+            loaded_da = open_dataarray(tmp)
+
+        self.assertDataArrayIdentical(original_da, loaded_da)
+        self.assertEqual(loaded_da.name, 'test')

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -1183,8 +1183,7 @@ class TestDataArrayToNetCDF(TestCase):
 
             loaded_da = open_dataarray(tmp)
 
-        self.assertDataArrayEqual(original_da, loaded_da)
-        self.assertEqual(loaded_da.name, 'data')
+        self.assertDataArrayIdentical(original_da, loaded_da)
 
     def test_dataarray_to_netcdf_with_name(self):
         original_da = DataArray(np.arange(12).reshape((3, 4)),
@@ -1196,4 +1195,15 @@ class TestDataArrayToNetCDF(TestCase):
             loaded_da = open_dataarray(tmp)
 
         self.assertDataArrayIdentical(original_da, loaded_da)
-        self.assertEqual(loaded_da.name, 'test')
+
+    def test_dataarray_to_netcdf_coord_name_clash(self):
+        original_da = DataArray(np.arange(12).reshape((3, 4)),
+                                dims=['x', 'y'],
+                                name='x')
+
+        with create_tmp_file() as tmp:
+            original_da.to_netcdf(tmp)
+
+            loaded_da = open_dataarray(tmp)
+
+        self.assertDataArrayIdentical(original_da, loaded_da)

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -1173,6 +1173,7 @@ class TestValidateAttrs(TestCase):
             with create_tmp_file() as tmp_file:
                 ds.to_netcdf(tmp_file)
 
+@requires_netCDF4
 class TestDataArrayToNetCDF(TestCase):
 
     def test_dataarray_to_netcdf_no_name(self):

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -1183,8 +1183,9 @@ class TestDataArrayToNetCDF(TestCase):
             original_da.to_netcdf(tmp)
 
             loaded_da = open_dataarray(tmp)
+            self.assertDataArrayIdentical(original_da, loaded_da)
+            loaded_da.close()
 
-        self.assertDataArrayIdentical(original_da, loaded_da)
 
     def test_dataarray_to_netcdf_with_name(self):
         original_da = DataArray(np.arange(12).reshape((3, 4)),
@@ -1194,17 +1195,18 @@ class TestDataArrayToNetCDF(TestCase):
             original_da.to_netcdf(tmp)
 
             loaded_da = open_dataarray(tmp)
+            self.assertDataArrayIdentical(original_da, loaded_da)
+            loaded_da.close()
 
-        self.assertDataArrayIdentical(original_da, loaded_da)
 
     def test_dataarray_to_netcdf_coord_name_clash(self):
         original_da = DataArray(np.arange(12).reshape((3, 4)),
                                 dims=['x', 'y'],
-                                name='x')
+                                name='r')
 
         with create_tmp_file() as tmp:
             original_da.to_netcdf(tmp)
 
             loaded_da = open_dataarray(tmp)
-
-        self.assertDataArrayIdentical(original_da, loaded_da)
+            self.assertDataArrayIdentical(original_da, loaded_da)
+            loaded_da.close()

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -1182,9 +1182,8 @@ class TestDataArrayToNetCDF(TestCase):
         with create_tmp_file() as tmp:
             original_da.to_netcdf(tmp)
 
-            loaded_da = open_dataarray(tmp)
-            self.assertDataArrayIdentical(original_da, loaded_da)
-            loaded_da.close()
+            with open_dataarray(tmp) as loaded_da:
+                self.assertDataArrayIdentical(original_da, loaded_da)
 
 
     def test_dataarray_to_netcdf_with_name(self):
@@ -1194,19 +1193,17 @@ class TestDataArrayToNetCDF(TestCase):
         with create_tmp_file() as tmp:
             original_da.to_netcdf(tmp)
 
-            loaded_da = open_dataarray(tmp)
-            self.assertDataArrayIdentical(original_da, loaded_da)
-            loaded_da.close()
+            with open_dataarray(tmp) as loaded_da:
+                self.assertDataArrayIdentical(original_da, loaded_da)
 
 
     def test_dataarray_to_netcdf_coord_name_clash(self):
         original_da = DataArray(np.arange(12).reshape((3, 4)),
                                 dims=['x', 'y'],
-                                name='r')
+                                name='x')
 
         with create_tmp_file() as tmp:
             original_da.to_netcdf(tmp)
 
-            loaded_da = open_dataarray(tmp)
-            self.assertDataArrayIdentical(original_da, loaded_da)
-            loaded_da.close()
+            with open_dataarray(tmp) as loaded_da:
+                self.assertDataArrayIdentical(original_da, loaded_da)


### PR DESCRIPTION
Added a simple function to DataArray that creates a dataset with one variable
called 'data' and then saves it to a netCDF file. All parameters are passed through
to to_netcdf().

Added an equivalent function called `open_dataarray` to be used to load from these files.

Fixes #915.