### PR TITLE
Added validation of attrs before saving to netCDF files

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -23,6 +23,9 @@ Breaking changes
 
 Enhancements
 ~~~~~~~~~~~~
+- Add checking of ``attr`` names and values when saving to netCDF, raising useful
+error messages if they are invalid. (:issue:`911`).
+By `Robin Wilson <https://github.com/robintw>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -6,7 +6,6 @@ from distutils.version import StrictVersion
 from glob import glob
 from io import BytesIO
 from numbers import Number
-from collections.abc import Iterable
 
 import numpy as np
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -94,30 +94,24 @@ def _validate_attrs(dataset):
                                  '1 or greater for serialization to netCDF '
                                  'files')
         else:
-            raise TypeError('Invalid name for attr: must be a string for '
-                            'serialization to netCDF files')
+            raise TypeError("Invalid name for attr: {} must be a string for "
+                            "serialization to netCDF files".format(name))
 
-        if not isinstance(value, basestring) and not isinstance(value, Number) and \
-           not isinstance(value, np.ndarray) and not isinstance(value, list) and \
-           not isinstance(value, tuple):
-                raise TypeError('Invalid value for attr: must be a number '
-                                'string, ndarray or a list/tuple of numbers/strings '
-                                'for serialization to netCDF files')
+        if not isinstance(value, (basestring, Number, np.ndarray, np.number,
+                                  list, tuple)):
+            raise TypeError('Invalid value for attr: {} must be a number '
+                            'string, ndarray or a list/tuple of numbers/strings '
+                            'for serialization to netCDF '
+                            'files'.format(value))
 
     # Check attrs on the dataset itself
     for k, v in dataset.attrs.items():
         check_attr(k, v)
 
     # Check attrs on each variable within the dataset
-    for var_name in dataset.data_vars:
+    for var_name in dataset.variables:
         for k, v in dataset[var_name].attrs.items():
             check_attr(k, v)
-
-    # Check attrs on each coord within the dataset
-    for coord_name in dataset.coords:
-        for k, v in dataset.coords[coord_name].attrs.items():
-            check_attr(k, v)
-
 
 def open_dataset(filename_or_obj, group=None, decode_cf=True,
                  mask_and_scale=True, decode_times=True,

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -108,9 +108,10 @@ def _validate_attrs(dataset):
         check_attr(k, v)
 
     # Check attrs on each variable within the dataset
-    for var_name in dataset.variables:
-        for k, v in dataset[var_name].attrs.items():
+    for variable in dataset.variables.values():
+        for k, v in variable.attrs.items():
             check_attr(k, v)
+
 
 def open_dataset(filename_or_obj, group=None, decode_cf=True,
                  mask_and_scale=True, decode_times=True,

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -1063,3 +1063,131 @@ class TestEncodingInvalid(TestCase):
                           {'least_sigificant_digit': 2})
         with self.assertRaisesRegexp(ValueError, 'unexpected encoding'):
             _extract_nc4_encoding(var, raise_on_invalid=True)
+
+
+class MiscObject:
+    pass
+
+
+class TestValidateAttrs(TestCase):
+
+    def test_invalid_attr_names(self):
+        ds = Dataset({'data': ('y', np.arange(10.0))})
+        self.assert_invalid_attr_names_for_obj(ds.attrs, ds)
+
+        ds = Dataset({'data': ('y', np.arange(10.0))})
+        self.assert_invalid_attr_names_for_obj(ds.data.attrs, ds)
+
+        ds = Dataset({'data': ('y', np.arange(10.0))})
+        self.assert_invalid_attr_names_for_obj(ds.coords['y'].attrs, ds)
+
+    def test_invalid_attr_values(self):
+        ds = Dataset({'data': ('y', np.arange(10.0))})
+        self.assert_invalid_attr_values_for_obj(ds.attrs, ds)
+
+        ds = Dataset({'data': ('y', np.arange(10.0))})
+        self.assert_invalid_attr_values_for_obj(ds.data.attrs, ds)
+
+        ds = Dataset({'data': ('y', np.arange(10.0))})
+        self.assert_invalid_attr_values_for_obj(ds.coords['y'].attrs, ds)
+
+    def test_valid_attr_values(self):
+        ds = Dataset({'data': ('y', np.arange(10.0))})
+        self.assert_valid_attr_values_for_obj(ds.attrs, ds)
+
+        ds = Dataset({'data': ('y', np.arange(10.0))})
+        self.assert_valid_attr_values_for_obj(ds.data.attrs, ds)
+
+        ds = Dataset({'data': ('y', np.arange(10.0))})
+        self.assert_valid_attr_values_for_obj(ds.coords['y'].attrs, ds)
+
+    def assert_invalid_attr_names_for_obj(self, obj, ds):
+        # Helper function for `test_invalid_attr_names`
+        # In this function `obj` is an 'attrs' object (eg. ds.attrs or
+        # data.var.attrs, and `ds` is the dataset object
+
+        obj.clear()
+        obj[123] = 'test'
+        with self.assertRaisesRegexp(TypeError, 'Invalid name for attr'):
+            ds.to_netcdf('test.nc')
+
+        obj.clear()
+        obj[MiscObject()] = 'test'
+        with self.assertRaisesRegexp(TypeError, 'Invalid name for attr'):
+            ds.to_netcdf('test.nc')
+
+        obj.clear()
+        obj[''] = 'test'
+        with self.assertRaisesRegexp(ValueError, 'Invalid name for attr'):
+            ds.to_netcdf('test.nc')
+
+        # This one should work
+        obj.clear()
+        obj['test'] = 'test'
+        with create_tmp_file() as tmp_file:
+            ds.to_netcdf(tmp_file)
+
+    def assert_invalid_attr_values_for_obj(self, obj, ds):
+        # Helper function for `test_invalid_attr_values`
+        # In this function `obj` is an 'attrs' object (eg. ds.attrs or
+        # data.var.attrs, and `ds` is the dataset object
+
+        obj.clear()
+        obj['test'] = {'a': 5}
+        with self.assertRaisesRegexp(TypeError, 'Invalid value for attr'):
+            ds.to_netcdf('test.nc')
+
+        obj.clear()
+        obj['test'] = MiscObject()
+        with self.assertRaisesRegexp(TypeError, 'Invalid value for attr'):
+            ds.to_netcdf('test.nc')
+
+    def assert_valid_attr_values_for_obj(self, obj, ds):
+        # Helper function for `test_valid_attr_values`
+        # In this function `obj` is an 'attrs' object (eg. ds.attrs or
+        # data.var.attrs, and `ds` is the dataset object
+
+        obj.clear()
+        obj['test'] = 5
+        with create_tmp_file() as tmp_file:
+            ds.to_netcdf(tmp_file)
+
+        obj.clear()
+        obj['test'] = 3.14
+        with create_tmp_file() as tmp_file:
+            ds.to_netcdf(tmp_file)
+
+        obj.clear()
+        obj['test'] = [1, 2, 3, 4]
+        with create_tmp_file() as tmp_file:
+            ds.to_netcdf(tmp_file)
+
+        obj.clear()
+        obj['test'] = (1.9, 2.5)
+        with create_tmp_file() as tmp_file:
+            ds.to_netcdf(tmp_file)
+
+        obj.clear()
+        obj['test'] = np.arange(5)
+        with create_tmp_file() as tmp_file:
+            ds.to_netcdf(tmp_file)
+
+        obj.clear()
+        obj['test'] = np.arange(12).reshape(3, 4)
+        with create_tmp_file() as tmp_file:
+            ds.to_netcdf(tmp_file)
+
+        obj.clear()
+        obj['test'] = 'This is a string'
+        with create_tmp_file() as tmp_file:
+            ds.to_netcdf(tmp_file)
+
+        obj.clear()
+        obj['test'] = ''
+        with create_tmp_file() as tmp_file:
+            ds.to_netcdf(tmp_file)
+
+        obj.clear()
+        obj['test'] = np.arange(12).reshape(3, 4)
+        with create_tmp_file() as tmp_file:
+            ds.to_netcdf(tmp_file)

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -1070,124 +1070,103 @@ class MiscObject:
 
 
 class TestValidateAttrs(TestCase):
+    def test_validating_attrs(self):
+        def new_dataset():
+            return Dataset({'data': ('y', np.arange(10.0))})
 
-    def test_invalid_attr_names(self):
-        ds = Dataset({'data': ('y', np.arange(10.0))})
-        self.assert_invalid_attr_names_for_obj(ds.attrs, ds)
+        def new_dataset_and_dataset_attrs():
+            ds = new_dataset()
+            return ds, ds.attrs
 
-        ds = Dataset({'data': ('y', np.arange(10.0))})
-        self.assert_invalid_attr_names_for_obj(ds.data.attrs, ds)
+        def new_dataset_and_data_attrs():
+            ds = new_dataset()
+            return ds, ds.data.attrs
 
-        ds = Dataset({'data': ('y', np.arange(10.0))})
-        self.assert_invalid_attr_names_for_obj(ds.coords['y'].attrs, ds)
+        def new_dataset_and_coord_attrs():
+            ds = new_dataset()
+            return ds, ds.coords['y'].attrs
 
-    def test_invalid_attr_values(self):
-        ds = Dataset({'data': ('y', np.arange(10.0))})
-        self.assert_invalid_attr_values_for_obj(ds.attrs, ds)
+        for new_dataset_and_attrs in [new_dataset_and_dataset_attrs,
+                                      new_dataset_and_data_attrs,
+                                      new_dataset_and_coord_attrs]:
+            ds, attrs = new_dataset_and_attrs()
 
-        ds = Dataset({'data': ('y', np.arange(10.0))})
-        self.assert_invalid_attr_values_for_obj(ds.data.attrs, ds)
+            attrs[123] = 'test'
+            with self.assertRaisesRegexp(TypeError, 'Invalid name for attr'):
+                ds.to_netcdf('test.nc')
 
-        ds = Dataset({'data': ('y', np.arange(10.0))})
-        self.assert_invalid_attr_values_for_obj(ds.coords['y'].attrs, ds)
+            ds, attrs = new_dataset_and_attrs()
+            attrs[MiscObject()] = 'test'
+            with self.assertRaisesRegexp(TypeError, 'Invalid name for attr'):
+                ds.to_netcdf('test.nc')
 
-    def test_valid_attr_values(self):
-        ds = Dataset({'data': ('y', np.arange(10.0))})
-        self.assert_valid_attr_values_for_obj(ds.attrs, ds)
+            ds, attrs = new_dataset_and_attrs()
+            attrs[''] = 'test'
+            with self.assertRaisesRegexp(ValueError, 'Invalid name for attr'):
+                ds.to_netcdf('test.nc')
 
-        ds = Dataset({'data': ('y', np.arange(10.0))})
-        self.assert_valid_attr_values_for_obj(ds.data.attrs, ds)
+            # This one should work
+            ds, attrs = new_dataset_and_attrs()
+            attrs['test'] = 'test'
+            with create_tmp_file() as tmp_file:
+                ds.to_netcdf(tmp_file)
 
-        ds = Dataset({'data': ('y', np.arange(10.0))})
-        self.assert_valid_attr_values_for_obj(ds.coords['y'].attrs, ds)
 
-    def assert_invalid_attr_names_for_obj(self, obj, ds):
-        # Helper function for `test_invalid_attr_names`
-        # In this function `obj` is an 'attrs' object (eg. ds.attrs or
-        # data.var.attrs, and `ds` is the dataset object
 
-        obj.clear()
-        obj[123] = 'test'
-        with self.assertRaisesRegexp(TypeError, 'Invalid name for attr'):
-            ds.to_netcdf('test.nc')
 
-        obj.clear()
-        obj[MiscObject()] = 'test'
-        with self.assertRaisesRegexp(TypeError, 'Invalid name for attr'):
-            ds.to_netcdf('test.nc')
+            ds, attrs = new_dataset_and_attrs()
+            attrs['test'] = {'a': 5}
+            with self.assertRaisesRegexp(TypeError, 'Invalid value for attr'):
+                ds.to_netcdf('test.nc')
 
-        obj.clear()
-        obj[''] = 'test'
-        with self.assertRaisesRegexp(ValueError, 'Invalid name for attr'):
-            ds.to_netcdf('test.nc')
+            ds, attrs = new_dataset_and_attrs()
+            attrs['test'] = MiscObject()
+            with self.assertRaisesRegexp(TypeError, 'Invalid value for attr'):
+                ds.to_netcdf('test.nc')
 
-        # This one should work
-        obj.clear()
-        obj['test'] = 'test'
-        with create_tmp_file() as tmp_file:
-            ds.to_netcdf(tmp_file)
 
-    def assert_invalid_attr_values_for_obj(self, obj, ds):
-        # Helper function for `test_invalid_attr_values`
-        # In this function `obj` is an 'attrs' object (eg. ds.attrs or
-        # data.var.attrs, and `ds` is the dataset object
 
-        obj.clear()
-        obj['test'] = {'a': 5}
-        with self.assertRaisesRegexp(TypeError, 'Invalid value for attr'):
-            ds.to_netcdf('test.nc')
+            ds, attrs = new_dataset_and_attrs()
+            attrs['test'] = 5
+            with create_tmp_file() as tmp_file:
+                ds.to_netcdf(tmp_file)
 
-        obj.clear()
-        obj['test'] = MiscObject()
-        with self.assertRaisesRegexp(TypeError, 'Invalid value for attr'):
-            ds.to_netcdf('test.nc')
+            ds, attrs = new_dataset_and_attrs()
+            attrs['test'] = 3.14
+            with create_tmp_file() as tmp_file:
+                ds.to_netcdf(tmp_file)
 
-    def assert_valid_attr_values_for_obj(self, obj, ds):
-        # Helper function for `test_valid_attr_values`
-        # In this function `obj` is an 'attrs' object (eg. ds.attrs or
-        # data.var.attrs, and `ds` is the dataset object
+            ds, attrs = new_dataset_and_attrs()
+            attrs['test'] = [1, 2, 3, 4]
+            with create_tmp_file() as tmp_file:
+                ds.to_netcdf(tmp_file)
 
-        obj.clear()
-        obj['test'] = 5
-        with create_tmp_file() as tmp_file:
-            ds.to_netcdf(tmp_file)
+            ds, attrs = new_dataset_and_attrs()
+            attrs['test'] = (1.9, 2.5)
+            with create_tmp_file() as tmp_file:
+                ds.to_netcdf(tmp_file)
 
-        obj.clear()
-        obj['test'] = 3.14
-        with create_tmp_file() as tmp_file:
-            ds.to_netcdf(tmp_file)
+            ds, attrs = new_dataset_and_attrs()
+            attrs['test'] = np.arange(5)
+            with create_tmp_file() as tmp_file:
+                ds.to_netcdf(tmp_file)
 
-        obj.clear()
-        obj['test'] = [1, 2, 3, 4]
-        with create_tmp_file() as tmp_file:
-            ds.to_netcdf(tmp_file)
+            ds, attrs = new_dataset_and_attrs()
+            attrs['test'] = np.arange(12).reshape(3, 4)
+            with create_tmp_file() as tmp_file:
+                ds.to_netcdf(tmp_file)
 
-        obj.clear()
-        obj['test'] = (1.9, 2.5)
-        with create_tmp_file() as tmp_file:
-            ds.to_netcdf(tmp_file)
+            ds, attrs = new_dataset_and_attrs()
+            attrs['test'] = 'This is a string'
+            with create_tmp_file() as tmp_file:
+                ds.to_netcdf(tmp_file)
 
-        obj.clear()
-        obj['test'] = np.arange(5)
-        with create_tmp_file() as tmp_file:
-            ds.to_netcdf(tmp_file)
+            ds, attrs = new_dataset_and_attrs()
+            attrs['test'] = ''
+            with create_tmp_file() as tmp_file:
+                ds.to_netcdf(tmp_file)
 
-        obj.clear()
-        obj['test'] = np.arange(12).reshape(3, 4)
-        with create_tmp_file() as tmp_file:
-            ds.to_netcdf(tmp_file)
-
-        obj.clear()
-        obj['test'] = 'This is a string'
-        with create_tmp_file() as tmp_file:
-            ds.to_netcdf(tmp_file)
-
-        obj.clear()
-        obj['test'] = ''
-        with create_tmp_file() as tmp_file:
-            ds.to_netcdf(tmp_file)
-
-        obj.clear()
-        obj['test'] = np.arange(12).reshape(3, 4)
-        with create_tmp_file() as tmp_file:
-            ds.to_netcdf(tmp_file)
+            ds, attrs = new_dataset_and_attrs()
+            attrs['test'] = np.arange(12).reshape(3, 4)
+            with create_tmp_file() as tmp_file:
+                ds.to_netcdf(tmp_file)

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -1068,7 +1068,7 @@ class TestEncodingInvalid(TestCase):
 class MiscObject:
     pass
 
-
+@requires_netCDF4
 class TestValidateAttrs(TestCase):
     def test_validating_attrs(self):
         def new_dataset():

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -1111,9 +1111,6 @@ class TestValidateAttrs(TestCase):
             with create_tmp_file() as tmp_file:
                 ds.to_netcdf(tmp_file)
 
-
-
-
             ds, attrs = new_dataset_and_attrs()
             attrs['test'] = {'a': 5}
             with self.assertRaisesRegexp(TypeError, 'Invalid value for attr'):
@@ -1123,8 +1120,6 @@ class TestValidateAttrs(TestCase):
             attrs['test'] = MiscObject()
             with self.assertRaisesRegexp(TypeError, 'Invalid value for attr'):
                 ds.to_netcdf('test.nc')
-
-
 
             ds, attrs = new_dataset_and_attrs()
             attrs['test'] = 5


### PR DESCRIPTION
This allows us to give nice errors if users try to save a Dataset with
attr values that can't be written to a netCDF file.

Fixes #911.

I've added tests to `test_backends.py` as I can't see a better place to put them. I've also made the tests fairly extensive, but also used some helper functions to stop too much repetition. Please let me know if any of this doesn't fit within the xarray style.