### PR TITLE
Coordinate -> IndexVariable and other deprecations

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,6 +21,19 @@ v0.9.0 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+Deprecations
+~~~~~~~~~~~~
+
+- Renamed the ``Coordinate`` class from xarray's low level API to
+  :py:class:`~xarray.IndexVariable``.
+- Deprecated supplying ``coords`` as a dictionary to the ``DataArray``
+  constructor without also supplying an explicit ``dims`` argument. The old
+  behavior encouraged relying on the iteration order of dictionaries, which is
+  a bad practice (:issue:`727`).
+- Removed a number of methods deprecated since v0.7.0 or earlier:
+  ``load_data``, ``vars``, ``drop_vars``, ``dump``, ``dumps`` and the
+  ``variables`` keyword argument alias to ``Dataset``.
+
 Enhancements
 ~~~~~~~~~~~~
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,14 +25,17 @@ Deprecations
 ~~~~~~~~~~~~
 
 - Renamed the ``Coordinate`` class from xarray's low level API to
-  :py:class:`~xarray.IndexVariable``.
+  :py:class:`~xarray.IndexVariable`. ``Variable.to_variable`` and
+  ``Variable.to_coord`` have been renamed to
+  :py:meth:`~xarray.Variable.to_base_variable` and
+  :py:meth:`~xarray.Variable.to_index_variable`.
 - Deprecated supplying ``coords`` as a dictionary to the ``DataArray``
   constructor without also supplying an explicit ``dims`` argument. The old
   behavior encouraged relying on the iteration order of dictionaries, which is
   a bad practice (:issue:`727`).
 - Removed a number of methods deprecated since v0.7.0 or earlier:
   ``load_data``, ``vars``, ``drop_vars``, ``dump``, ``dumps`` and the
-  ``variables`` keyword argument alias to ``Dataset``.
+  ``variables`` keyword argument to ``Dataset``.
 
 Enhancements
 ~~~~~~~~~~~~

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -2,7 +2,7 @@ from .core.alignment import align, broadcast, broadcast_arrays
 from .core.combine import concat, auto_combine
 from .core.extensions import (register_dataarray_accessor,
                               register_dataset_accessor)
-from .core.variable import Variable, Coordinate
+from .core.variable import Variable, IndexVariable, Coordinate
 from .core.dataset import Dataset
 from .core.dataarray import DataArray
 from .core.merge import merge, MergeError

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -9,7 +9,7 @@ from . import ops, utils
 from .common import _maybe_promote
 from .pycompat import iteritems, OrderedDict
 from .utils import is_full_slice, is_dict_like
-from .variable import Variable, Coordinate
+from .variable import Variable, IndexVariable
 
 
 def _get_joiner(join):
@@ -119,7 +119,7 @@ def reindex_variables(variables, indexes, indexers, method=None,
     variables : dict-like
         Dictionary of xarray.Variable objects.
     indexes : dict-like
-        Dictionary of xarray.Coordinate objects associated with variables.
+        Dictionary of xarray.IndexVariable objects associated with variables.
     indexers : dict
         Dictionary with keys given by dimension names and values given by
         arrays of coordinates tick labels. Any mis-matched coordinate values
@@ -200,8 +200,8 @@ def reindex_variables(variables, indexes, indexers, method=None,
     for name, var in iteritems(variables):
         if name in indexers:
             # no need to copy, because index data is immutable
-            new_var = Coordinate(var.dims, indexers[name], var.attrs,
-                                 var.encoding)
+            new_var = IndexVariable(var.dims, indexers[name], var.attrs,
+                                    var.encoding)
         else:
             assign_to = var_indexers(var, to_indexers)
             assign_from = var_indexers(var, from_indexers)

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -6,7 +6,7 @@ from . import utils
 from .alignment import align
 from .merge import merge
 from .pycompat import iteritems, OrderedDict, basestring
-from .variable import Variable, as_variable, Coordinate, concat as concat_vars
+from .variable import Variable, as_variable, IndexVariable, concat as concat_vars
 
 
 def concat(objs, dim=None, data_vars='all', coords='different',
@@ -125,11 +125,11 @@ def _calc_concat_dim_coord(dim):
     if isinstance(dim, basestring):
         coord = None
     elif not hasattr(dim, 'dims'):
-        # dim is not a DataArray or Coordinate
+        # dim is not a DataArray or IndexVariable
         dim_name = getattr(dim, 'name', None)
         if dim_name is None:
             dim_name = 'concat_dim'
-        coord = Coordinate(dim_name, dim)
+        coord = IndexVariable(dim_name, dim)
         dim = dim_name
     elif not hasattr(dim, 'name'):
         coord = as_variable(dim).to_coord()

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -132,7 +132,7 @@ def _calc_concat_dim_coord(dim):
         coord = IndexVariable(dim_name, dim)
         dim = dim_name
     elif not hasattr(dim, 'name'):
-        coord = as_variable(dim).to_coord()
+        coord = as_variable(dim).to_index_variable()
         dim, = coord.dims
     else:
         coord = dim

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -326,7 +326,7 @@ class BaseDataObject(AttrAccessMixin):
 
         Parameters
         ----------
-        group : str, DataArray or Coordinate
+        group : str, DataArray or IndexVariable
             Array whose unique values should be used to group this array. If a
             string, must be the name of a variable contained in this dataset.
         squeeze : boolean, optional
@@ -353,7 +353,7 @@ class BaseDataObject(AttrAccessMixin):
 
         Parameters
         ----------
-        group : str, DataArray or Coordinate
+        group : str, DataArray or IndexVariable
             Array whose binned values should be used to group this array. If a
             string, must be the name of a variable contained in this dataset.
         bins : int or array of scalars

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -177,8 +177,7 @@ class DataArrayCoordinates(AbstractCoordinates):
     """Dictionary like container for DataArray coordinates.
 
     Essentially an OrderedDict with keys given by the array's
-    dimensions and the values given by the corresponding xarray.Coordinate
-    objects.
+    dimensions and the values given by corresponding DataArray objects.
     """
     def __init__(self, dataarray):
         self._data = dataarray

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -46,7 +46,7 @@ def _infer_coords_and_dims(shape, coords, dims):
                 dims = list(coords.keys())
             else:
                 for n, (dim, coord) in enumerate(zip(dims, coords)):
-                    coord = as_variable(coord, name=dims[n]).to_coord()
+                    coord = as_variable(coord, name=dims[n]).to_index_variable()
                     dims[n] = coord.name
         dims = tuple(dims)
     else:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1279,7 +1279,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
 
         for k, v in iteritems(self.variables):
             dims = tuple(dims_dict.get(dim, dim) for dim in v.dims)
-            var = v.to_coord() if k in result_dims else v.to_variable()
+            if k in result_dims:
+                var = v.to_index_variable()
+            else:
+                var = v.to_base_variable()
             var.dims = dims
             variables[k] = var
 

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -99,7 +99,7 @@ def format_timestamp(t):
         datetime_str = unicode_type(pd.Timestamp(t))
     except OutOfBoundsDatetime:
         datetime_str = unicode_type(t)
-        
+
     try:
         date_str, time_str = datetime_str.split()
     except ValueError:
@@ -271,7 +271,7 @@ def indexes_repr(indexes):
 
 
 def array_repr(arr):
-    # used for DataArray, Variable and Coordinate
+    # used for DataArray, Variable and IndexVariable
     if hasattr(arr, 'name') and arr.name is not None:
         name_str = '%r ' % arr.name
     else:

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -10,7 +10,7 @@ from .common import (
 )
 from .pycompat import zip
 from .utils import peek_at, maybe_wrap_array, safe_cast_to_index
-from .variable import as_variable, Variable, Coordinate
+from .variable import as_variable, Variable, IndexVariable
 
 
 def unique_value_groups(ar, sort=True):
@@ -63,6 +63,7 @@ def _dummy_copy(xarray_obj):
                         dict((k, _get_fill_value(v.dtype))
                              for k, v in xarray_obj.coords.items()
                              if k not in xarray_obj.dims),
+                        dims=[],
                         name=xarray_obj.name,
                         attrs=xarray_obj.attrs)
     else:  # pragma: no cover
@@ -140,7 +141,7 @@ class GroupBy(object):
         ----------
         obj : Dataset or DataArray
             Object to group.
-        group : DataArray or Coordinate
+        group : DataArray or IndexVariable
             1-dimensional array with the group values.
         squeeze : boolean, optional
             If "group" is a coordinate of object, `squeeze` controls whether
@@ -206,7 +207,7 @@ class GroupBy(object):
             sbins = first_items.values.astype(np.int64)
             group_indices = ([slice(i, j) for i, j in zip(sbins[:-1], sbins[1:])] +
                              [slice(sbins[-1], None)])
-            unique_coord = Coordinate(group.name, first_items.index)
+            unique_coord = IndexVariable(group.name, first_items.index)
         elif group.name in obj.dims and bins is None:
             # assume that group already has sorted, unique values
             # (if using bins, the group will have the same name as a dimension
@@ -224,7 +225,7 @@ class GroupBy(object):
             # look through group to find the unique values
             sort = bins is None
             unique_values, group_indices = unique_value_groups(group, sort=sort)
-            unique_coord = Coordinate(group.name, unique_values)
+            unique_coord = IndexVariable(group.name, unique_values)
 
         self.obj = obj
         self.group = group

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -21,21 +21,12 @@ def alias_warning(old_name, new_name, stacklevel=3):  # pragma: no cover
                   FutureWarning, stacklevel=stacklevel)
 
 
-def function_alias(obj, old_name):  # pragma: no cover
+def alias(obj, old_name):  # pragma: no cover
     @functools.wraps(obj)
     def wrapper(*args, **kwargs):
         alias_warning(old_name, obj.__name__)
         return obj(*args, **kwargs)
     return wrapper
-
-
-def class_alias(obj, old_name):  # pragma: no cover
-    class Wrapper(obj):
-        def __new__(cls, *args, **kwargs):
-            alias_warning(old_name, obj.__name__)
-            return super(Wrapper, cls).__new__(cls, *args, **kwargs)
-    Wrapper.__name__ = obj.__name__
-    return Wrapper
 
 
 def safe_cast_to_index(array):

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -15,17 +15,23 @@ from . import ops
 from .pycompat import iteritems, OrderedDict, basestring, bytes_type
 
 
-def alias_warning(old_name, new_name, stacklevel=3):  # pragma: no cover
-    warnings.warn('%s has been deprecated and renamed to %s'
-                  % (old_name, new_name),
-                  FutureWarning, stacklevel=stacklevel)
+def alias_message(old_name, new_name):
+    return '%s has been deprecated. Use %s instead.' % (old_name, new_name)
 
 
-def alias(obj, old_name):  # pragma: no cover
+def alias_warning(old_name, new_name, stacklevel=3):
+    warnings.warn(alias_message(old_name, new_name), FutureWarning,
+                  stacklevel=stacklevel)
+
+
+def alias(obj, old_name):
+    assert isinstance(old_name, basestring)
+
     @functools.wraps(obj)
     def wrapper(*args, **kwargs):
         alias_warning(old_name, obj.__name__)
         return obj(*args, **kwargs)
+    wrapper.__doc__ = alias_message(old_name, obj.__name__)
     return wrapper
 
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -77,7 +77,7 @@ def as_variable(obj, name=None, copy=False):
                 'dimensions %r. xarray disallows such variables because they '
                 'conflict with the coordinates used to label dimensions.'
                 % (name, obj.dims))
-        obj = obj.to_coord()
+        obj = obj.to_index_variable()
 
     return obj
 
@@ -306,19 +306,23 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
     def values(self, values):
         self.data = values
 
-    def to_variable(self):
+    def to_base_variable(self):
         """Return this variable as a base xarray.Variable"""
         return Variable(self.dims, self._data, self._attrs,
                         encoding=self._encoding, fastpath=True)
 
-    def to_coord(self):
+    to_variable = utils.alias(to_base_variable, 'to_variable')
+
+    def to_index_variable(self):
         """Return this variable as an xarray.IndexVariable"""
         return IndexVariable(self.dims, self._data, self._attrs,
                              encoding=self._encoding, fastpath=True)
 
+    to_coord = utils.alias(to_index_variable, 'to_coord')
+
     def to_index(self):
         """Convert this variable to a pandas.Index"""
-        return self.to_coord().to_index()
+        return self.to_index_variable().to_index()
 
     @property
     def dims(self):
@@ -1147,9 +1151,11 @@ class IndexVariable(Variable):
     def _data_equals(self, other):
         return self.to_index().equals(other.to_index())
 
-    def to_coord(self):
+    def to_index_variable(self):
         """Return this variable as an xarray.IndexVariable"""
         return self
+
+    to_coord = utils.alias(to_index_variable, 'to_coord')
 
     def to_index(self):
         """Convert this variable to a pandas.Index"""

--- a/xarray/test/test_combine.py
+++ b/xarray/test/test_combine.py
@@ -107,8 +107,8 @@ class TestConcatDataset(TestCase):
         self.assertDatasetIdentical(data, actual)
 
     def test_concat_autoalign(self):
-        ds1 = Dataset({'foo': DataArray([1, 2], coords={'x': [1, 2]})})
-        ds2 = Dataset({'foo': DataArray([1, 2], coords={'x': [1, 3]})})        
+        ds1 = Dataset({'foo': DataArray([1, 2], coords=[('x', [1, 2])])})
+        ds2 = Dataset({'foo': DataArray([1, 2], coords=[('x', [1, 3])])})
         actual = concat([ds1, ds2], 'y')
         expected = Dataset({'foo': DataArray([[1, 2, np.nan], [1, np.nan, 2]],
                                              dims=['y', 'x'], coords={'y': [0, 1], 'x': [1, 2, 3]})})

--- a/xarray/test/test_utils.py
+++ b/xarray/test/test_utils.py
@@ -6,6 +6,16 @@ from xarray.core.pycompat import OrderedDict
 from . import TestCase
 
 
+class TestAlias(TestCase):
+    def test(self):
+        def new_method():
+            pass
+        old_method = utils.alias(new_method, 'old_method')
+        assert 'deprecated' in old_method.__doc__
+        with self.assertWarns('deprecated'):
+            old_method()
+
+
 class TestSafeCastToIndex(TestCase):
     def test(self):
         dates = pd.date_range('2000-01-01', periods=10)


### PR DESCRIPTION
- Renamed the ``Coordinate`` class from xarray's low level API to
  ``IndexVariable``. xref https://github.com/pydata/xarray/pull/947#issuecomment-238549129
- Deprecated supplying ``coords`` as a dictionary to the ``DataArray``
  constructor without also supplying an explicit ``dims`` argument. The old
  behavior encouraged relying on the iteration order of dictionaries, which is
  a bad practice (fixes #727).
- Removed a number of methods deprecated since v0.7.0 or earlier:
  ``load_data``, ``vars``, ``drop_vars``, ``dump``, ``dumps`` and the
  ``variables`` keyword argument alias to ``Dataset``.
