### PR TITLE
Discovered conflicting _FillValue and missing_value, but both are NaN

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -65,6 +65,10 @@ Bug fixes
   (:issue:`873`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
 
+- Fix issues with variables where both attributes ``_FillValue`` and
+  ``missing_value`` are set to ``NaN`` (:issue:`997`).
+  By `Marco Zühlke <https://github.com/mzuehlke>`_.
+
 .. _whats-new.0.8.2:
 
 v0.8.2 (18 August 2016)

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -96,16 +96,10 @@ def equivalent(first, second):
     """Compare two objects for equivalence (identity or equality), using
     array_equiv if either object is an ndarray
     """
-    def both_nan(first, second):
-        try:
-            return np.isnan(first) and np.isnan(second)
-        except TypeError:
-            return False
-
     if isinstance(first, np.ndarray) or isinstance(second, np.ndarray):
         return ops.array_equiv(first, second)
     else:
-        return first is second or first == second or both_nan(first, second)
+        return first is second or first == second or (pd.isnull(first) and pd.isnull(second))
 
 
 def peek_at(iterable):

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -96,10 +96,16 @@ def equivalent(first, second):
     """Compare two objects for equivalence (identity or equality), using
     array_equiv if either object is an ndarray
     """
+    def both_nan(first, second):
+        try:
+            return np.isnan(first) and np.isnan(second)
+        except TypeError:
+            return False
+
     if isinstance(first, np.ndarray) or isinstance(second, np.ndarray):
         return ops.array_equiv(first, second)
     else:
-        return first is second or first == second
+        return first is second or first == second or both_nan(first, second)
 
 
 def peek_at(iterable):

--- a/xarray/test/test_conventions.py
+++ b/xarray/test/test_conventions.py
@@ -259,6 +259,20 @@ class TestDatetime(TestCase):
         self.assertRaisesRegexp(ValueError, "_FillValue and missing_value",
                                 lambda: conventions.decode_cf_variable(var))
 
+        var = Variable(['t'], np.arange(10),
+                       {'units': 'foobar',
+                        'missing_value': np.nan,
+                        '_FillValue': np.nan})
+        var = conventions.decode_cf_variable(var)
+        self.assertIsNotNone(var)
+
+        var = Variable(['t'], np.arange(10),
+                               {'units': 'foobar',
+                                'missing_value': np.float32(np.nan),
+                                '_FillValue': np.float32(np.nan)})
+        var = conventions.decode_cf_variable(var)
+        self.assertIsNotNone(var)
+
     @requires_netCDF4
     def test_decode_cf_datetime_non_iso_strings(self):
         # datetime strings that are _almost_ ISO compliant but not quite,


### PR DESCRIPTION
Added test and code change to fix issue #997 

The first added testcase (using `np.nan`) passes even without the change in `core.utils.equivalent`.