### PR TITLE
MultiIndex level coordinates as Dataset attributes

### DIFF
--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -181,7 +181,7 @@ class AttrAccessMixin(object):
     @property
     def _attr_sources(self):
         """List of places to look-up items for attribute-style access"""
-        return [self, self.attrs]
+        return []
 
     def __getattr__(self, name):
         if name != '__setstate__':

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -215,8 +215,8 @@ class DataArrayCoordinates(AbstractCoordinates):
         del self._data._coords[key]
 
 
-class DataArrayLevelCoordinates(AbstractCoordinates):
-    """Dictionary like container for DataArray MultiIndex level coordinates.
+class LevelCoordinates(AbstractCoordinates):
+    """Dictionary like container for MultiIndex level coordinates.
 
     Used for attribute style lookup. Not returned directly by any
     public methods.
@@ -232,7 +232,7 @@ class DataArrayLevelCoordinates(AbstractCoordinates):
     def variables(self):
         level_coords = OrderedDict(
             (k, self._data[v].variable.get_level_variable(k))
-             for k, v in self._data._level_coords.items())
+            for k, v in self._data._level_coords.items())
         return Frozen(level_coords)
 
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -14,7 +14,7 @@ from . import ops
 from . import utils
 from .alignment import align
 from .common import AbstractArray, BaseDataObject, squeeze
-from .coordinates import (DataArrayCoordinates, DataArrayLevelCoordinates,
+from .coordinates import (DataArrayCoordinates, LevelCoordinates,
                           Indexes)
 from .dataset import Dataset
 from .pycompat import iteritems, basestring, OrderedDict, zip
@@ -467,7 +467,7 @@ class DataArray(AbstractArray, BaseDataObject):
     @property
     def _attr_sources(self):
         """List of places to look-up items for attribute-style access"""
-        return [self.coords, DataArrayLevelCoordinates(self), self.attrs]
+        return [self.coords, LevelCoordinates(self), self.attrs]
 
     def __contains__(self, key):
         return key in self._coords

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -15,7 +15,7 @@ from . import alignment
 from . import formatting
 from .. import conventions
 from .alignment import align
-from .coordinates import DatasetCoordinates, Indexes
+from .coordinates import DatasetCoordinates, LevelCoordinates, Indexes
 from .common import ImplementsDatasetReduce, BaseDataObject
 from .merge import (dataset_update_method, dataset_merge_method,
                     merge_data_and_coords)
@@ -486,6 +486,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         # memo does nothing but is required for compatibility with
         # copy.deepcopy
         return self.copy(deep=True)
+
+    @property
+    def _attr_sources(self):
+        """List of places to look-up items for attribute-style access"""
+        return [self, LevelCoordinates(self), self.attrs]
 
     def __contains__(self, key):
         """The 'in' operator will return true or false depending on whether

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -1540,6 +1540,9 @@ class TestDataset(TestCase):
                              name='hour', coords=[mindex], dims='x')
         self.assertDataArrayIdentical(expected, data['level_date.hour'])
 
+        # attribute style access
+        self.assertDataArrayIdentical(data.level_str, data['level_str'])
+
     def test_time_season(self):
         ds = Dataset({'t': pd.date_range('2000-01-01', periods=12, freq='M')})
         expected = ['DJF'] * 2 + ['MAM'] * 3 + ['JJA'] * 3 + ['SON'] * 3 + ['DJF']


### PR DESCRIPTION
Follow-up on #947

This ensures that you can pull out MultiIndex levels via attribute style
access on Dataset objects, as well as DataArray objects.

CC @benbovy