### PR TITLE
Fixes for compat='no_conflicts' and open_mfdataset

### DIFF
--- a/doc/combining.rst
+++ b/doc/combining.rst
@@ -193,6 +193,8 @@ numpy):
 Note that ``NaN`` does not compare equal to ``NaN`` in element-wise comparison;
 you may need to deal with missing values explicitly.
 
+.. _combining.no_conflicts:
+
 Merging with 'no_conflicts'
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,9 +21,9 @@ v0.9.0 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-- The default behavior of ``merge`` is now ``compat='no_conflict'``, so some
+- The default behavior of ``merge`` is now ``compat='no_conflicts'``, so some
   merges will now succeed in cases that previously raised
-  ``xarray.MergeError``. Set ``compat='broadcast_arrays'`` to restore the
+  ``xarray.MergeError``. Set ``compat='broadcast_equals'`` to restore the
   previous default.
 
 Deprecations

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,6 +21,11 @@ v0.9.0 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- The default behavior of ``merge`` is now ``compat='no_conflict'``, so some
+  merges will now succeed in cases that previously raised
+  ``xarray.MergeError``. Set ``compat='broadcast_arrays'`` to restore the
+  previous default.
+
 Deprecations
 ~~~~~~~~~~~~
 
@@ -59,8 +64,14 @@ By `Robin Wilson <https://github.com/robintw>`_.
 
 - Added the ``compat`` option ``'no_conflicts'`` to ``merge``, allowing the
   combination of xarray objects with disjoint (:issue:`742`) or
-  overlapping (:issue:`835`) coordinates as long as any present data agrees.
-  By `Johnnie Gray <https://github.com/jcmgray>`_.
+  overlapping (:issue:`835`) coordinates as long as all present data agrees.
+  By `Johnnie Gray <https://github.com/jcmgray>`_. See
+  :ref:`combining.no_conflicts` for more details.
+
+- It is now possible to set ``concat_dim=None`` explicitly in
+  :py:func:`~xarray.open_mfdataset` to disable inferring a dimension along
+  which to concatenate.
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -340,22 +340,14 @@ def auto_combine(datasets,
     This method attempts to combine a list of datasets into a single entity by
     inspecting metadata and using a combination of concat and merge.
 
-    It does not concatenate along more than one dimension or align or sort data
-    under any circumstances. It will fail in complex cases, for which you
-    should use ``concat`` and ``merge`` explicitly.
+    It does not concatenate along more than one dimension or sort data under any
+    circumstances. It does align coordinates, but different variables on
+    datasets can cause it to fail under some scenarios. In complex cases, you
+    may need to clean up your data and use ``concat``/``merge`` explicitly.
 
-    When ``auto_combine`` may succeed:
-
-    * You have N years of data and M data variables. Each combination of a
-      distinct time period and test of data variables is saved its own dataset.
-
-    Examples of when ``auto_combine`` fails:
-
-    * In the above scenario, one file is missing, containing the data for one
-      year's data for one variable.
-    * In the most recent year, there is an additional data variable.
-    * Your data includes "time" and "station" dimensions, and each year's data
-      has a different set of stations.
+    ``auto_combine`` works well if you have N years of data and M data
+    variables, and each combination of a distinct time period and set of data
+    variables is saved its own dataset.
 
     Parameters
     ----------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1434,8 +1434,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         return self._replace_vars_and_dims(variables, coord_names, dims,
                                            inplace=inplace)
 
-    def merge(self, other, inplace=False, overwrite_vars=set(),
-              compat='broadcast_equals', join='outer'):
+    def merge(self, other, inplace=False, overwrite_vars=frozenset(),
+              compat='no_conflicts', join='outer'):
         """Merge the arrays of two datasets into a single dataset.
 
         This method generally not allow for overriding data, with the exception
@@ -1485,7 +1485,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
             If any variables conflict (see ``compat``).
         """
         variables, coord_names, dims = dataset_merge_method(
-            self, other, overwrite_vars, compat=compat, join=join)
+            self, other, overwrite_vars=overwrite_vars, compat=compat,
+            join=join)
 
         return self._replace_vars_and_dims(variables, coord_names, dims,
                                            inplace=inplace)

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -942,6 +942,15 @@ class DaskTest(TestCase):
                 actual = 1.0 * ds
                 self.assertDatasetAllClose(original, actual)
 
+    def test_open_mfdataset_concat_dim_none(self):
+        with create_tmp_file() as tmp1:
+            with create_tmp_file() as tmp2:
+                data = Dataset({'x': 0})
+                data.to_netcdf(tmp1)
+                Dataset({'x': np.nan}).to_netcdf(tmp2)
+                with open_mfdataset([tmp1, tmp2], concat_dim=None) as actual:
+                    self.assertDatasetIdentical(data, actual)
+
     def test_open_dataset(self):
         original = Dataset({'foo': ('x', np.random.randn(10))})
         with create_tmp_file() as tmp:

--- a/xarray/test/test_combine.py
+++ b/xarray/test/test_combine.py
@@ -241,7 +241,8 @@ class TestConcatDataset(TestCase):
         objs = [Dataset(OrderedDict([('x', ('a', [0])), ('y', ('a', [0]))])),
                 Dataset(OrderedDict([('y', ('a', [1])), ('x', ('a', [1]))]))]
         actual = auto_combine(objs)
-        expected = Dataset({'x': ('a', [0, 1]), 'y': ('a', [0, 1]), 'a': [0, 0]})
+        expected = Dataset(
+            {'x': ('a', [0, 1]), 'y': ('a', [0, 1]), 'a': [0, 0]})
         self.assertDatasetIdentical(expected, actual)
 
         objs = [Dataset({'x': [0], 'y': [0]}), Dataset({'y': [1], 'x': [1]})]
@@ -255,6 +256,22 @@ class TestConcatDataset(TestCase):
         objs = [Dataset({'x': [0], 'y': [0]}), Dataset({'x': [0]})]
         with self.assertRaises(KeyError):
             auto_combine(objs)
+
+    @requires_dask  # only for toolz
+    def test_auto_combine_no_concat(self):
+        objs = [Dataset({'x': 0}), Dataset({'y': 1})]
+        actual = auto_combine(objs)
+        expected = Dataset({'x': 0, 'y': 1})
+        self.assertDatasetIdentical(expected, actual)
+
+        objs = [Dataset({'x': 0, 'y': 1}), Dataset({'y': np.nan, 'z': 2})]
+        actual = auto_combine(objs)
+        expected = Dataset({'x': 0, 'y': 1, 'z': 2})
+        self.assertDatasetIdentical(expected, actual)
+
+        data = Dataset({'x': 0})
+        actual = auto_combine([data, data, data], concat_dim=None)
+        self.assertDatasetIdentical(data, actual)
 
 
 class TestConcatDataArray(TestCase):

--- a/xarray/test/test_combine.py
+++ b/xarray/test/test_combine.py
@@ -222,57 +222,6 @@ class TestConcatDataset(TestCase):
         assert expected.equals(actual)
         assert isinstance(actual.x.to_index(), pd.MultiIndex)
 
-    @requires_dask  # only for toolz
-    def test_auto_combine(self):
-        objs = [Dataset({'x': [0]}), Dataset({'x': [1]})]
-        actual = auto_combine(objs)
-        expected = Dataset({'x': [0, 1]})
-        self.assertDatasetIdentical(expected, actual)
-
-        actual = auto_combine([actual])
-        self.assertDatasetIdentical(expected, actual)
-
-        objs = [Dataset({'x': [0, 1]}), Dataset({'x': [2]})]
-        actual = auto_combine(objs)
-        expected = Dataset({'x': [0, 1, 2]})
-        self.assertDatasetIdentical(expected, actual)
-
-        # ensure auto_combine handles non-sorted dimensions
-        objs = [Dataset(OrderedDict([('x', ('a', [0])), ('y', ('a', [0]))])),
-                Dataset(OrderedDict([('y', ('a', [1])), ('x', ('a', [1]))]))]
-        actual = auto_combine(objs)
-        expected = Dataset(
-            {'x': ('a', [0, 1]), 'y': ('a', [0, 1]), 'a': [0, 0]})
-        self.assertDatasetIdentical(expected, actual)
-
-        objs = [Dataset({'x': [0], 'y': [0]}), Dataset({'y': [1], 'x': [1]})]
-        with self.assertRaisesRegexp(ValueError, 'too many .* dimensions'):
-            auto_combine(objs)
-
-        objs = [Dataset({'x': 0}), Dataset({'x': 1})]
-        with self.assertRaisesRegexp(ValueError, 'cannot infer dimension'):
-            auto_combine(objs)
-
-        objs = [Dataset({'x': [0], 'y': [0]}), Dataset({'x': [0]})]
-        with self.assertRaises(KeyError):
-            auto_combine(objs)
-
-    @requires_dask  # only for toolz
-    def test_auto_combine_no_concat(self):
-        objs = [Dataset({'x': 0}), Dataset({'y': 1})]
-        actual = auto_combine(objs)
-        expected = Dataset({'x': 0, 'y': 1})
-        self.assertDatasetIdentical(expected, actual)
-
-        objs = [Dataset({'x': 0, 'y': 1}), Dataset({'y': np.nan, 'z': 2})]
-        actual = auto_combine(objs)
-        expected = Dataset({'x': 0, 'y': 1, 'z': 2})
-        self.assertDatasetIdentical(expected, actual)
-
-        data = Dataset({'x': 0})
-        actual = auto_combine([data, data, data], concat_dim=None)
-        self.assertDatasetIdentical(data, actual)
-
 
 class TestConcatDataArray(TestCase):
     def test_concat(self):
@@ -319,3 +268,86 @@ class TestConcatDataArray(TestCase):
         combined = concat(arrays, dim='z')
         self.assertEqual(combined.shape, (2, 3, 3))
         self.assertEqual(combined.dims, ('z', 'x', 'y'))
+
+
+class TestAutoCombine(TestCase):
+
+    @requires_dask  # only for toolz
+    def test_auto_combine(self):
+        objs = [Dataset({'x': [0]}), Dataset({'x': [1]})]
+        actual = auto_combine(objs)
+        expected = Dataset({'x': [0, 1]})
+        self.assertDatasetIdentical(expected, actual)
+
+        actual = auto_combine([actual])
+        self.assertDatasetIdentical(expected, actual)
+
+        objs = [Dataset({'x': [0, 1]}), Dataset({'x': [2]})]
+        actual = auto_combine(objs)
+        expected = Dataset({'x': [0, 1, 2]})
+        self.assertDatasetIdentical(expected, actual)
+
+        # ensure auto_combine handles non-sorted variables
+        objs = [Dataset(OrderedDict([('x', ('a', [0])), ('y', ('a', [0]))])),
+                Dataset(OrderedDict([('y', ('a', [1])), ('x', ('a', [1]))]))]
+        actual = auto_combine(objs)
+        expected = Dataset(
+            {'x': ('a', [0, 1]), 'y': ('a', [0, 1]), 'a': [0, 0]})
+        self.assertDatasetIdentical(expected, actual)
+
+        objs = [Dataset({'x': [0], 'y': [0]}), Dataset({'y': [1], 'x': [1]})]
+        with self.assertRaisesRegexp(ValueError, 'too many .* dimensions'):
+            auto_combine(objs)
+
+        objs = [Dataset({'x': 0}), Dataset({'x': 1})]
+        with self.assertRaisesRegexp(ValueError, 'cannot infer dimension'):
+            auto_combine(objs)
+
+        objs = [Dataset({'x': [0], 'y': [0]}), Dataset({'x': [0]})]
+        with self.assertRaises(KeyError):
+            auto_combine(objs)
+
+    @requires_dask  # only for toolz
+    def test_auto_combine_previously_failed(self):
+        # In the above scenario, one file is missing, containing the data for
+        # one year's data for one variable.
+        datasets = [Dataset({'a': ('x', [0]), 'x': [0]}),
+                    Dataset({'b': ('x', [0]), 'x': [0]}),
+                    Dataset({'a': ('x', [1]), 'x': [1]})]
+        expected = Dataset({'a': ('x', [0, 1]), 'b': ('x', [0, np.nan])})
+        actual = auto_combine(datasets)
+        self.assertDatasetIdentical(expected, actual)
+
+        # Your data includes "time" and "station" dimensions, and each year's
+        # data has a different set of stations.
+        datasets = [Dataset({'a': ('x', [2, 3]), 'x': [1, 2]}),
+                    Dataset({'a': ('x', [1, 2]), 'x': [0, 1]})]
+        expected = Dataset({'a': (('t', 'x'),
+                                  [[np.nan, 2, 3], [1, 2, np.nan]])})
+        actual = auto_combine(datasets, concat_dim='t')
+        self.assertDatasetIdentical(expected, actual)
+
+    @requires_dask  # only for toolz
+    def test_auto_combine_still_fails(self):
+        # concat can't handle new variables (yet):
+        # https://github.com/pydata/xarray/issues/508
+        datasets = [Dataset({'x': 0}, {'y': 0}),
+                    Dataset({'x': 1}, {'y': 1, 'z': 1})]
+        with self.assertRaises(ValueError):
+            auto_combine(datasets, 'y')
+
+    @requires_dask  # only for toolz
+    def test_auto_combine_no_concat(self):
+        objs = [Dataset({'x': 0}), Dataset({'y': 1})]
+        actual = auto_combine(objs)
+        expected = Dataset({'x': 0, 'y': 1})
+        self.assertDatasetIdentical(expected, actual)
+
+        objs = [Dataset({'x': 0, 'y': 1}), Dataset({'y': np.nan, 'z': 2})]
+        actual = auto_combine(objs)
+        expected = Dataset({'x': 0, 'y': 1, 'z': 2})
+        self.assertDatasetIdentical(expected, actual)
+
+        data = Dataset({'x': 0})
+        actual = auto_combine([data, data, data], concat_dim=None)
+        self.assertDatasetIdentical(data, actual)

--- a/xarray/test/test_merge.py
+++ b/xarray/test/test_merge.py
@@ -105,6 +105,21 @@ class TestMergeFunction(TestCase):
         actual = xr.merge([data1, data2], compat='no_conflicts')
         assert data.equals(actual)
 
+    def test_merge_no_conflicts_preserve_attrs(self):
+        data = xr.Dataset({'x': ([], 0, {'foo': 'bar'})})
+        actual = xr.merge([data, data])
+        assert data.identical(actual)
+
+    def test_merge_no_conflicts_broadcast(self):
+        datasets = [xr.Dataset({'x': ('y', [0])}), xr.Dataset({'x': np.nan})]
+        actual = xr.merge(datasets)
+        expected = xr.Dataset({'x': ('y', [0])})
+        assert expected.identical(actual)
+
+        datasets = [xr.Dataset({'x': ('y', [np.nan])}), xr.Dataset({'x': 0})]
+        actual = xr.merge(datasets)
+        assert expected.identical(actual)
+
 
 class TestMergeMethod(TestCase):
 

--- a/xarray/test/test_variable.py
+++ b/xarray/test/test_variable.py
@@ -580,6 +580,9 @@ class TestVariable(TestCase, VariableSubclassTestCases):
         self.assertFalse(v1.no_conflicts(d))
         self.assertFalse(v2.no_conflicts(d))
 
+        v4 = Variable(('w', 'x'), [d])
+        self.assertTrue(v1.no_conflicts(v4))
+
     def test_as_variable(self):
         data = np.arange(10)
         expected = Variable('x', data)


### PR DESCRIPTION
- `xarray.merge` now uses `compat='no_conflicts'` by default.
- `compat='no_conflicts'` preserves attributes.
- `Variable.no_conflicts` broadcasts arguments, making it a strictly more
  relaxed check than `broadcast_equals`.
- Allow `concat_dim=None` in `open_mfdataset` and `auto_combine` to disable
  trying to infer a dimension for concatenating.
- Add `compat` as an argument to `open_mfdataset` to allow more control over
  merging.

CC @jcmgray