### PR TITLE
Dask broadcast

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -26,8 +26,8 @@ Breaking changes
   ``xarray.MergeError``. Set ``compat='broadcast_equals'`` to restore the
   previous default.
 - Pickling an xarray object based on the dask backend, or reading its
-  :py:meth:`values` property, won't automatically convert the backend to numpy
-  in the original object anymore.
+  :py:meth:`values` property, won't automatically convert the array from dask
+  to numpy in the original object anymore.
   By `Guido Imperiale <https://github.com/crusaderky>`_.
 
 Deprecations
@@ -72,8 +72,9 @@ Enhancements
   :py:func:`~xarray.open_mfdataset` to disable inferring a dimension along
   which to concatenate.
   By `Stephan Hoyer <https://github.com/shoyer>`_.
-- Added :py:meth:`compute` method to :py:class:`DataArray`, :py:class:`Dataset`,
-  and :py:class:`Variable` as a non-destructive alternative to :py:meth:`load`.
+- Added methods :py:meth:`DataArray.compute`, :py:meth:`Dataset.compute`, and
+  :py:meth:`Variable.compute` as a non-mutating alternative to
+  :py:meth:`~DataArray.load`.
   By `Guido Imperiale <https://github.com/crusaderky>`_.
 
 Bug fixes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,6 +25,10 @@ Breaking changes
   merges will now succeed in cases that previously raised
   ``xarray.MergeError``. Set ``compat='broadcast_equals'`` to restore the
   previous default.
+- Pickling an xarray object based on the dask backend, or reading its
+  :py:meth:`values` property, won't automatically convert the backend to numpy
+  in the original object anymore.
+  By `Guido Imperiale <https://github.com/crusaderky>`_.
 
 Deprecations
 ~~~~~~~~~~~~
@@ -45,33 +49,32 @@ Deprecations
 Enhancements
 ~~~~~~~~~~~~
 - Add checking of ``attr`` names and values when saving to netCDF, raising useful
-error messages if they are invalid. (:issue:`911`).
-By `Robin Wilson <https://github.com/robintw>`_.
-
+  error messages if they are invalid. (:issue:`911`).
+  By `Robin Wilson <https://github.com/robintw>`_.
 - Added ability to save ``DataArray`` objects directly to netCDF files using
   :py:meth:`~xarray.DataArray.to_netcdf`, and to load directly from netCDF files
   using :py:func:`~xarray.open_dataarray` (:issue:`915`). These remove the need
   to convert a ``DataArray`` to a ``Dataset`` before saving as a netCDF file,
   and deals with names to ensure a perfect 'roundtrip' capability.
   By `Robin Wilson <https://github.com/robintw`_.
-
 - Multi-index levels are now accessible as "virtual" coordinate variables,
   e.g., ``ds['time']`` can pull out the ``'time'`` level of a multi-index
   (see :ref:`coordinates`). ``sel`` also accepts providing multi-index levels
   as keyword arguments, e.g., ``ds.sel(time='2000-01')``
   (see :ref:`multi-level indexing`).
   By `Benoit Bovy <https://github.com/benbovy>`_.
-
 - Added the ``compat`` option ``'no_conflicts'`` to ``merge``, allowing the
   combination of xarray objects with disjoint (:issue:`742`) or
   overlapping (:issue:`835`) coordinates as long as all present data agrees.
   By `Johnnie Gray <https://github.com/jcmgray>`_. See
   :ref:`combining.no_conflicts` for more details.
-
 - It is now possible to set ``concat_dim=None`` explicitly in
   :py:func:`~xarray.open_mfdataset` to disable inferring a dimension along
   which to concatenate.
   By `Stephan Hoyer <https://github.com/shoyer>`_.
+- Added :py:meth:`compute` method to :py:class:`DataArray`, :py:class:`Dataset`,
+  and :py:class:`Variable` as a non-destructive alternative to :py:meth:`load`.
+  By `Guido Imperiale <https://github.com/crusaderky>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -99,6 +99,9 @@ Bug fixes
 - ``.where()`` and ``.fillna()`` now preserve attributes(:issue:`1009`).
   By `Fabien Maussion <https://github.com/fmaussion>`_.
 
+- Applying :py:func:`broadcast()` to an xarray object based on the dask backend
+  won't accidentally convert the array from dask to numpy anymore (:issue:`978`).
+  By `Guido Imperiale <https://github.com/crusaderky>`_.
 .. _whats-new.0.8.2:
 
 v0.8.2 (18 August 2016)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -561,6 +561,19 @@ class DataArray(AbstractArray, BaseDataObject):
         self._coords = new._coords
         return self
 
+    def compute(self):
+        """Manually trigger loading of this array's data from disk or a
+        remote source into memory and return a new array. The original is
+        left unaltered.
+
+        Normally, it should not be necessary to call this method in user code,
+        because all xarray functions should either work on deferred data or
+        load data automatically. However, this method can be necessary when
+        working with many file objects on disk.
+        """
+        new = self.copy(deep=False)
+        return new.load()
+
     def copy(self, deep=True):
         """Returns a copy of this array.
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -255,8 +255,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         return obj
 
     def __getstate__(self):
-        """Always load data in-memory before pickling"""
-        self.load()
+        """Load data in-memory before pickling (except for Dask data)"""
+        for v in self.variables.values():
+            if not isinstance(v.data, dask_array_type):
+                v.load()
+
         # self.__dict__ is the default pickle object, we don't need to
         # implement our own __setstate__ method to make pickle work
         state = self.__dict__.copy()
@@ -306,7 +309,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         """
         # access .data to coerce everything to numpy or dask arrays
         all_data = dict((k, v.data) for k, v in self.variables.items())
-        lazy_data = dict((k, v) for k, v in all_data.items()
+        lazy_data = OrderedDict((k, v) for k, v in all_data.items()
                          if isinstance(v, dask_array_type))
         if lazy_data:
             import dask.array as da
@@ -318,6 +321,40 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
                 self.variables[k].data = data
 
         return self
+
+    def compute(self):
+        """Manually trigger loading of this dataset's data from disk or a
+        remote source into memory and return a new dataset. The original is
+        left unaltered.
+
+        Normally, it should not be necessary to call this method in user code,
+        because all xarray functions should either work on deferred data or
+        load data automatically. However, this method can be necessary when
+        working with many file objects on disk.
+        """
+        # Can't just do the below, because new.variables[k] is the
+        # same object as self.variables[k]!
+        # new = self.copy(deep=False)
+        # return new.load()
+
+        variables = OrderedDict((k, v.copy(deep=False))
+                                for (k, v) in self.variables.items())
+        lazy_data = OrderedDict((k, v.data) for k, v in variables.items()
+                                if isinstance(v.data, dask_array_type))
+
+        if lazy_data:
+            import dask.array as da
+
+            # evaluate all the dask arrays simultaneously
+            evaluated_data = da.compute(*lazy_data.values())
+
+            for k, data in zip(lazy_data, evaluated_data):
+                variables[k] = variables[k].copy(deep=False)
+                variables[k].data = data
+
+        # skip __init__ to avoid costly validation
+        return self._construct_direct(variables, self._coord_names.copy(),
+                                     self._dims.copy(), self._attrs_copy())
 
     @classmethod
     def _construct_direct(cls, variables, coord_names, dims=None, attrs=None,

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -119,6 +119,9 @@ def as_compatible_data(data, fastpath=False):
         # can't use fastpath (yet) for scalars
         return _maybe_wrap_data(data)
 
+    if isinstance(data, Variable):
+        return data.data
+
     # add a custom fast-path for dask.array to avoid expensive checks for the
     # dtype attribute
     if isinstance(data, dask_array_type):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -271,19 +271,20 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
                 "replacement data must match the Variable's shape")
         self._data = data
 
+    def _data_cast(self):
+        if isinstance(self._data, (np.ndarray, PandasIndexAdapter)):
+            return self._data
+        else:
+            return np.asarray(self._data)
+
     def _data_cached(self):
         """Load data into memory and return it.
         Do not cache dask arrays automatically; that should
         require an explicit load() call.
         """
-        if isinstance(self._data, (np.ndarray, PandasIndexAdapter)):
-            new_data = self._data
-        else:
-            new_data = np.asarray(self._data)
-
+        new_data = self._data_cast()
         if not isinstance(self._data, dask_array_type):
             self._data = new_data
-
         return new_data
 
     @property
@@ -1115,20 +1116,11 @@ class IndexVariable(Variable):
             raise ValueError('%s objects must be 1-dimensional' %
                              type(self).__name__)
 
-    def _data_cached(self):
-        """Load data into memory and return it.
-        Do not cache dask arrays automatically; that should
-        require an explicit load() call.
-        """
+    def _data_cast(self):
         if isinstance(self._data, PandasIndexAdapter):
-            new_data = self._data
+            return self._data
         else:
-            new_data = PandasIndexAdapter(self._data)
-
-        if not isinstance(self._data, dask_array_type):
-            self._data = new_data
-
-        return new_data
+            return PandasIndexAdapter(self._data)
 
     def __getitem__(self, key):
         key = self._item_key_to_tuple(key)

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -159,11 +159,8 @@ class DatasetIOTestCases(object):
 
             computed = actual.compute()
 
-            # indexes are going to be loaded in memory anyway, even
-            # with compute(). This is by design.
             for v in actual.data_vars.values():
                 self.assertFalse(v._in_memory)
-    
             for v in computed.variables.values():
                 self.assertTrue(v._in_memory)
 
@@ -1021,38 +1018,15 @@ class DaskTest(TestCase, DatasetIOTestCases):
             self.assertEqual(original_names, repeat_names)
 
     def test_dataarray_compute(self):
+        # Test DataArray.compute() on dask backend.
+        # The test for Dataset.compute() is already in DatasetIOTestCases;
+        # however dask is the only tested backend which supports DataArrays
         actual = DataArray([1,2]).chunk()
         computed = actual.compute()
         self.assertFalse(actual._in_memory)
         self.assertTrue(computed._in_memory)
         self.assertDataArrayAllClose(actual, computed)
-
-    def test_pickle(self):
-        # Test that pickling/unpickling does not convert the dask
-        # backend to numpy
-        a1 = DataArray([1,2]).chunk()
-        self.assertFalse(a1._in_memory)        
-        a2 = pickle.loads(pickle.dumps(a1))
-        self.assertDataArrayIdentical(a1, a2)
-        self.assertFalse(a1._in_memory)
-        self.assertFalse(a2._in_memory)        
-
-        ds1 = Dataset({'a': [1,2]}).chunk()
-        self.assertFalse(ds1['a']._in_memory)        
-        ds2 = pickle.loads(pickle.dumps(ds1))
-        self.assertDatasetIdentical(ds1, ds2)
-        self.assertFalse(ds1['a']._in_memory)
-        self.assertFalse(ds2['a']._in_memory)        
-
-    def test_values(self):
-        # Test that invoking the values property does not convert the dask
-        # backend to numpy
-        a = DataArray([1,2]).chunk()
-        self.assertFalse(a._in_memory)
-        self.assertEquals(a.values.tolist(), [1, 2])
-        self.assertFalse(a._in_memory)
-
-
+        
 @requires_scipy_or_netCDF4
 @requires_pydap
 class PydapTest(TestCase):

--- a/xarray/test/test_dask.py
+++ b/xarray/test/test_dask.py
@@ -1,3 +1,4 @@
+import pickle
 import numpy as np
 import pandas as pd
 
@@ -321,3 +322,29 @@ class TestDataArrayAndDataset(DaskTestCase):
         eager = self.eager_array.dot(self.eager_array[0])
         lazy = self.lazy_array.dot(self.lazy_array[0])
         self.assertLazyAndAllClose(eager, lazy)
+
+    def test_dataarray_pickle(self):
+        # Test that pickling/unpickling does not convert the dask
+        # backend to numpy
+        a1 = DataArray([1,2]).chunk()
+        self.assertFalse(a1._in_memory)        
+        a2 = pickle.loads(pickle.dumps(a1))
+        self.assertDataArrayIdentical(a1, a2)
+        self.assertFalse(a1._in_memory)
+        self.assertFalse(a2._in_memory)        
+
+    def test_dataset_pickle(self):
+        ds1 = Dataset({'a': [1,2]}).chunk()
+        self.assertFalse(ds1['a']._in_memory)        
+        ds2 = pickle.loads(pickle.dumps(ds1))
+        self.assertDatasetIdentical(ds1, ds2)
+        self.assertFalse(ds1['a']._in_memory)
+        self.assertFalse(ds2['a']._in_memory)        
+
+    def test_values(self):
+        # Test that invoking the values property does not convert the dask
+        # backend to numpy
+        a = DataArray([1,2]).chunk()
+        self.assertFalse(a._in_memory)
+        self.assertEquals(a.values.tolist(), [1, 2])
+        self.assertFalse(a._in_memory)        

--- a/xarray/test/test_dask.py
+++ b/xarray/test/test_dask.py
@@ -348,3 +348,10 @@ class TestDataArrayAndDataset(DaskTestCase):
         self.assertFalse(a._in_memory)
         self.assertEquals(a.values.tolist(), [1, 2])
         self.assertFalse(a._in_memory)        
+
+    def test_from_dask_variable(self):
+        # Test array creation from Variable with dask backend.
+        # This is used e.g. in broadcast()
+        a = DataArray(self.lazy_array.variable)
+        self.assertLazyAndIdentical(self.lazy_array, a)
+

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -1287,10 +1287,13 @@ class TestDataset(TestCase):
 
         for copied in [data.copy(deep=False), copy(data)]:
             self.assertDatasetIdentical(data, copied)
-            for k in data:
+            # Note: IndexVariable objects with string dtype are always
+            # copied because of xarray.core.util.safe_cast_to_index.
+            # Limiting the test to data variables.
+            for k in data.data_vars:
                 v0 = data.variables[k]
                 v1 = copied.variables[k]
-                self.assertIs(v0, v1)
+                assert source_ndarray(v0.data) is source_ndarray(v1.data)
             copied['foo'] = ('z', np.arange(5))
             self.assertNotIn('foo', data)
 


### PR DESCRIPTION
 Applying broadcast() to an xarray object based on the dask backend won't accidentally convert the array from dask to numpy anymore