### PR TITLE
Groupby bins empty groups

### DIFF
--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -368,9 +368,10 @@ Transforming datasets
 In addition to dictionary-like methods (described above), xarray has additional
 methods (like pandas) for transforming datasets into new objects.
 
-For removing variables, you can select and drop an explicit list of variables
-by indexing with a list of names or using the :py:meth:`~xarray.Dataset.drop`
-methods to return a new ``Dataset``. These operations keep around coordinates:
+For removing variables, you can select and drop an explicit list of
+variables by indexing with a list of names or using the
+:py:meth:`~xray.Dataset.drop` methods to return a new ``Dataset``. These
+operations keep around coordinates:
 
 .. ipython:: python
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -75,6 +75,8 @@ By `Robin Wilson <https://github.com/robintw>`_.
 
 Bug fixes
 ~~~~~~~~~
+- ``groupby_bins`` now restores empty bins by default (:issue:`1019`).
+  By `Ryan Abernathey <https://github.com/rabernat>`_.
 
 - Fix issues for dates outside the valid range of pandas timestamps
   (:issue:`975`). By `Mathias Hauser <https://github.com/mathause>`_.

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -400,7 +400,7 @@ class BaseDataObject(AttrAccessMixin):
                                 cut_kwargs={'right': right, 'labels': labels,
                                             'precision': precision,
                                             'include_lowest': include_lowest},
-                                drop_empty_bins=False)
+                                drop_empty_bins=drop_empty_bins)
 
     def rolling(self, min_periods=None, center=False, **windows):
         """

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -345,7 +345,7 @@ class BaseDataObject(AttrAccessMixin):
         return self.groupby_cls(self, group, squeeze=squeeze)
 
     def groupby_bins(self, group, bins, right=True, labels=None, precision=3,
-                     include_lowest=False, squeeze=True, drop_empty_bins=False):
+                     include_lowest=False, squeeze=True):
         """Returns a GroupBy object for performing grouped operations.
 
         Rather than using all unique values of `group`, the values are discretized
@@ -378,9 +378,6 @@ class BaseDataObject(AttrAccessMixin):
             If "group" is a dimension of any arrays in this dataset, `squeeze`
             controls whether the subarrays have a dimension of length 1 along
             that dimension or if the dimension is squeezed out.
-        drop_empty_bins : boolean, optional
-            If true, empty bins are dropped from the group. If false, they are
-            filled with NaN.
 
         Returns
         -------
@@ -399,8 +396,7 @@ class BaseDataObject(AttrAccessMixin):
         return self.groupby_cls(self, group, squeeze=squeeze, bins=bins,
                                 cut_kwargs={'right': right, 'labels': labels,
                                             'precision': precision,
-                                            'include_lowest': include_lowest},
-                                drop_empty_bins=drop_empty_bins)
+                                            'include_lowest': include_lowest})
 
     def rolling(self, min_periods=None, center=False, **windows):
         """

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -345,7 +345,7 @@ class BaseDataObject(AttrAccessMixin):
         return self.groupby_cls(self, group, squeeze=squeeze)
 
     def groupby_bins(self, group, bins, right=True, labels=None, precision=3,
-                     include_lowest=False, squeeze=True):
+                     include_lowest=False, squeeze=True, drop_empty_bins=True):
         """Returns a GroupBy object for performing grouped operations.
 
         Rather than using all unique values of `group`, the values are discretized
@@ -378,6 +378,9 @@ class BaseDataObject(AttrAccessMixin):
             If "group" is a dimension of any arrays in this dataset, `squeeze`
             controls whether the subarrays have a dimension of length 1 along
             that dimension or if the dimension is squeezed out.
+        drop_empty_bins : boolean, optional
+            If true, empty bins are dropped from the group. If false, they are
+            filled with NaN.
 
         Returns
         -------
@@ -396,7 +399,8 @@ class BaseDataObject(AttrAccessMixin):
         return self.groupby_cls(self, group, squeeze=squeeze, bins=bins,
                                 cut_kwargs={'right': right, 'labels': labels,
                                             'precision': precision,
-                                            'include_lowest': include_lowest})
+                                            'include_lowest': include_lowest},
+                                drop_empty_bins=False)
 
     def rolling(self, min_periods=None, center=False, **windows):
         """

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -345,7 +345,7 @@ class BaseDataObject(AttrAccessMixin):
         return self.groupby_cls(self, group, squeeze=squeeze)
 
     def groupby_bins(self, group, bins, right=True, labels=None, precision=3,
-                     include_lowest=False, squeeze=True, drop_empty_bins=True):
+                     include_lowest=False, squeeze=True, drop_empty_bins=False):
         """Returns a GroupBy object for performing grouped operations.
 
         Rather than using all unique values of `group`, the values are discretized

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -134,7 +134,7 @@ class GroupBy(object):
     DataArray.groupby
     """
     def __init__(self, obj, group, squeeze=False, grouper=None, bins=None,
-                    cut_kwargs={}):
+                    cut_kwargs={}, drop_empty_bins=True):
         """Create a GroupBy object
 
         Parameters
@@ -154,6 +154,9 @@ class GroupBy(object):
             specified bins by `pandas.cut`.
         cut_kwargs : dict, optional
             Extra keyword arguments to pass to `pandas.cut`
+        drop_empty_bins : boolean, optional
+            If true, empty bins are dropped from the group. If false, they are
+            filled with NaN.
         """
         from .dataset import as_dataset
         from .dataarray import DataArray
@@ -193,6 +196,8 @@ class GroupBy(object):
             binned = pd.cut(group.values, bins, **cut_kwargs)
             new_dim_name = group.name + '_bins'
             group = DataArray(binned, group.coords, name=new_dim_name)
+            if not drop_empty_bins:
+                full_index = binned.categories
         if grouper is not None:
             index = safe_cast_to_index(group)
             if not index.is_monotonic:

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -134,7 +134,7 @@ class GroupBy(object):
     DataArray.groupby
     """
     def __init__(self, obj, group, squeeze=False, grouper=None, bins=None,
-                    cut_kwargs={}, drop_empty_bins=True):
+                    cut_kwargs={}):
         """Create a GroupBy object
 
         Parameters
@@ -154,9 +154,7 @@ class GroupBy(object):
             specified bins by `pandas.cut`.
         cut_kwargs : dict, optional
             Extra keyword arguments to pass to `pandas.cut`
-        drop_empty_bins : boolean, optional
-            If true, empty bins are dropped from the group. If false, they are
-            filled with NaN.
+
         """
         from .dataset import as_dataset
         from .dataarray import DataArray
@@ -196,8 +194,7 @@ class GroupBy(object):
             binned = pd.cut(group.values, bins, **cut_kwargs)
             new_dim_name = group.name + '_bins'
             group = DataArray(binned, group.coords, name=new_dim_name)
-            if not drop_empty_bins:
-                full_index = binned.categories
+            full_index = binned.categories
         if grouper is not None:
             index = safe_cast_to_index(group)
             if not index.is_monotonic:

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -1428,12 +1428,6 @@ class TestDataArray(TestCase):
         # (was a problem in earlier versions)
         self.assertEqual(len(array.dim_0), 4)
 
-        # now do the same
-        actual = array.groupby_bins('dim_0', bins, drop_empty_bins=True).sum()
-        expected = DataArray([6], dims='dim_0_bins',
-                        coords={'dim_0_bins': ['(0, 4]']})
-        self.assertDataArrayIdentical(expected, actual)
-
     def test_groupby_bins_multidim(self):
         array = self.make_groupby_multidim_example_array()
         bins = [0,15,20]

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -1416,6 +1416,24 @@ class TestDataArray(TestCase):
         # (would fail with shortcut=True above)
         self.assertEqual(len(array.dim_0), 4)
 
+    def test_groupby_bins_empty(self):
+        array = DataArray(np.arange(4), dims='dim_0')
+        # one of these bins will be empty
+        bins = [0,4,5]
+        actual = array.groupby_bins('dim_0', bins).sum()
+        expected = DataArray([6], dims='dim_0_bins',
+                        coords={'dim_0_bins': ['(0, 4]']})
+        self.assertDataArrayIdentical(expected, actual)
+        # make sure original array is unchanged
+        # (was a problem in earlier versions)
+        self.assertEqual(len(array.dim_0), 4)
+
+        # now do the same
+        actual = array.groupby_bins('dim_0', bins, drop_empty_bins=False).sum()
+        expected = DataArray([6, np.nan], dims='dim_0_bins',
+                        coords={'dim_0_bins': ['(0, 4]','(4, 5]']})
+        self.assertDataArrayIdentical(expected, actual)
+
     def test_groupby_bins_multidim(self):
         array = self.make_groupby_multidim_example_array()
         bins = [0,15,20]

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -1420,7 +1420,8 @@ class TestDataArray(TestCase):
         array = DataArray(np.arange(4), dims='dim_0')
         # one of these bins will be empty
         bins = [0,4,5]
-        actual = array.groupby_bins('dim_0', bins).sum()
+        actual = array.groupby_bins('dim_0', bins, drop_empty_bins=True).sum()
+        print(actual)
         expected = DataArray([6], dims='dim_0_bins',
                         coords={'dim_0_bins': ['(0, 4]']})
         self.assertDataArrayIdentical(expected, actual)

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -1420,19 +1420,18 @@ class TestDataArray(TestCase):
         array = DataArray(np.arange(4), dims='dim_0')
         # one of these bins will be empty
         bins = [0,4,5]
-        actual = array.groupby_bins('dim_0', bins, drop_empty_bins=True).sum()
-        print(actual)
-        expected = DataArray([6], dims='dim_0_bins',
-                        coords={'dim_0_bins': ['(0, 4]']})
+        actual = array.groupby_bins('dim_0', bins).sum()
+        expected = DataArray([6, np.nan], dims='dim_0_bins',
+                        coords={'dim_0_bins': ['(0, 4]','(4, 5]']})
         self.assertDataArrayIdentical(expected, actual)
         # make sure original array is unchanged
         # (was a problem in earlier versions)
         self.assertEqual(len(array.dim_0), 4)
 
         # now do the same
-        actual = array.groupby_bins('dim_0', bins, drop_empty_bins=False).sum()
-        expected = DataArray([6, np.nan], dims='dim_0_bins',
-                        coords={'dim_0_bins': ['(0, 4]','(4, 5]']})
+        actual = array.groupby_bins('dim_0', bins, drop_empty_bins=True).sum()
+        expected = DataArray([6], dims='dim_0_bins',
+                        coords={'dim_0_bins': ['(0, 4]']})
         self.assertDataArrayIdentical(expected, actual)
 
     def test_groupby_bins_multidim(self):


### PR DESCRIPTION
This PR fixes a bug in `groupby_bins` in which empty bins were dropped from the grouped results. Now `groupby_bins` restores any empty bins automatically. To recover the old behavior, one could apply `dropna` after a groupby operation.

Fixes #1019  