### PR TITLE
Attributes from netCDF4 intialization retained

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -437,7 +437,8 @@ def open_mfdataset(paths, chunks=None, concat_dim=_CONCAT_DIM_DEFAULT,
                    lock=None, **kwargs):
     """Open multiple files as a single dataset.
 
-    Experimental. Requires dask to be installed.
+    Requires dask to be installed.  Attributes from the first dataset file
+    are used for the combined dataset.
 
     Parameters
     ----------
@@ -515,6 +516,8 @@ def open_mfdataset(paths, chunks=None, concat_dim=_CONCAT_DIM_DEFAULT,
     else:
         combined = auto_combine(datasets, concat_dim=concat_dim, compat=compat)
     combined._file_obj = _MultiFileCloser(file_objs)
+    combined.attrs = datasets[0].attrs
+
     return combined
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1057,6 +1057,25 @@ class DaskTest(TestCase, DatasetIOTestCases):
         with self.assertRaisesRegexp(IOError, 'no files to open'):
             open_mfdataset('foo-bar-baz-*.nc')
 
+    def test_attrs_mfdataset(self):
+        original = Dataset({'foo': ('x', np.random.randn(10))})
+        with create_tmp_file() as tmp1:
+            with create_tmp_file() as tmp2:
+                ds1 = original.isel(x=slice(5))
+                ds2 = original.isel(x=slice(5, 10))
+                ds1.attrs['test1'] = 'foo'
+                ds2.attrs['test2'] = 'bar'
+                ds1.to_netcdf(tmp1)
+                ds2.to_netcdf(tmp2)
+                with open_mfdataset([tmp1, tmp2]) as actual:
+                    # presumes that attributes inherited from
+                    # first dataset loaded
+                    self.assertEqual(actual.test1, ds1.test1)
+                    # attributes from ds2 are not retained, e.g.,
+                    with self.assertRaisesRegexp(AttributeError,
+                                                 'no attribute'):
+                        actual.test2
+
     def test_preprocess_mfdataset(self):
         original = Dataset({'foo': ('x', np.random.randn(10))})
         with create_tmp_file() as tmp:


### PR DESCRIPTION
Ensures that attrs for open_mfdataset are now retained

cc @shoyer 
