### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -125,9 +125,9 @@ and the libraries that implement them on this page.
 Here are several existing libraries that build functionality upon xarray.
 They may be useful points of reference for your work:
 
-- `xgcm <http://xgcm.readthedocs.org/>`_: General Circulation Model
+- `xgcm <https://xgcm.readthedocs.io/>`_: General Circulation Model
   Postprocessing. Uses subclassing and custom xarray backends.
-- `PyGDX <http://pygdx.readthedocs.org/en/latest/>`_: Python 3 package for
+- `PyGDX <https://pygdx.readthedocs.io/en/latest/>`_: Python 3 package for
   accessing data stored in GAMS Data eXchange (GDX) files. Also uses a custom
   subclass.
 - `windspharm <http://ajdawson.github.io/windspharm/index.html>`_: Spherical


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.