### PR TITLE
WIP: preserve variables order in Dataset.concat() 

### DIFF
--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -6,7 +6,7 @@ import functools
 import itertools
 import re
 import warnings
-from collections import Mapping, MutableMapping, Iterable
+from collections import Mapping, MutableMapping, Iterable, MutableSet
 
 import numpy as np
 import pandas as pd
@@ -258,6 +258,74 @@ def ordered_dict_intersection(first_dict, second_dict, compat=equivalent):
     new_dict = OrderedDict(first_dict)
     remove_incompatible_items(new_dict, second_dict, compat)
     return new_dict
+
+
+class OrderedSet(MutableSet):
+    # Recipe: https://code.activestate.com/recipes/576694/
+
+    def __init__(self, iterable=None):
+        self.end = end = []
+        end += [None, end, end]         # sentinel node for doubly linked list
+        self.map = {}                   # key --> [key, prev, next]
+        if iterable is not None:
+            self |= iterable
+
+    def __len__(self):
+        return len(self.map)
+
+    def __contains__(self, key):
+        return key in self.map
+
+    def __add__(self, other):
+        self.update(other)
+        return self
+
+    def add(self, key):
+        if key not in self.map:
+            end = self.end
+            curr = end[1]
+            curr[2] = end[1] = self.map[key] = [key, curr, end]
+
+    def update(self, ite):
+        for k in ite:
+            self.add(k)
+
+    def discard(self, key):
+        if key in self.map:
+            key, prev, next = self.map.pop(key)
+            prev[2] = next
+            next[1] = prev
+
+    def __iter__(self):
+        end = self.end
+        curr = end[2]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[2]
+
+    def __reversed__(self):
+        end = self.end
+        curr = end[1]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[1]
+
+    def pop(self, last=True):
+        if not self:
+            raise KeyError('set is empty')
+        key = self.end[1][0] if last else self.end[2][0]
+        self.discard(key)
+        return key
+
+    def __repr__(self):
+        if not self:
+            return '%s()' % (self.__class__.__name__,)
+        return '%s(%r)' % (self.__class__.__name__, list(self))
+
+    def __eq__(self, other):
+        if isinstance(other, OrderedSet):
+            return len(self) == len(other) and list(self) == list(other)
+        return set(self) == set(other)
 
 
 class SingleSlotPickleMixin(object):

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -277,8 +277,9 @@ class OrderedSet(MutableSet):
         return key in self.map
 
     def __add__(self, other):
-        self.update(other)
-        return self
+        out = OrderedSet(self)
+        out.update(other)
+        return out
 
     def add(self, key):
         if key not in self.map:
@@ -302,20 +303,6 @@ class OrderedSet(MutableSet):
         while curr is not end:
             yield curr[0]
             curr = curr[2]
-
-    def __reversed__(self):
-        end = self.end
-        curr = end[1]
-        while curr is not end:
-            yield curr[0]
-            curr = curr[1]
-
-    def pop(self, last=True):
-        if not self:
-            raise KeyError('set is empty')
-        key = self.end[1][0] if last else self.end[2][0]
-        self.discard(key)
-        return key
 
     def __repr__(self):
         if not self:

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -1858,6 +1858,21 @@ class TestDataset(TestCase):
         expected = Dataset({'foo': ('bar', [1.5, 3]), 'bar': [1, 2]})
         self.assertDatasetIdentical(actual, expected)
 
+    def test_groupby_order(self):
+        # groupby should preserve variables order
+        ds = Dataset()
+        for vn in ['a', 'b', 'c']:
+            ds[vn] = DataArray(np.arange(10), dims=['t'])
+        all_vars_ref = list(ds.variables.keys())
+        data_vars_ref = list(ds.data_vars.keys())
+        ds = ds.groupby('t').mean()
+        all_vars = list(ds.variables.keys())
+        data_vars = list(ds.data_vars.keys())
+        self.assertEqual(data_vars, data_vars_ref)
+        # coords are now at the end of the list, so the test below fails
+        # self.assertEqual(all_vars, all_vars_ref)
+
+
     def test_resample_and_first(self):
         times = pd.date_range('2000-01-01', freq='6H', periods=10)
         ds = Dataset({'foo': (['time', 'x', 'y'], np.random.randn(10, 5, 3)),

--- a/xarray/test/test_utils.py
+++ b/xarray/test/test_utils.py
@@ -182,3 +182,9 @@ class Test_OrderedSet(TestCase):
         self.assertEqual(s1 + s3, set(['a', 'b', 'c', 'd', 'e']))
         s1.update(s3)
         self.assertEqual(s1, set(['a', 'b', 'c', 'd', 'e']))
+        s1.discard('e')
+        self.assertEqual(s1, set(['a', 'b', 'c', 'd']))
+
+
+
+

--- a/xarray/test/test_utils.py
+++ b/xarray/test/test_utils.py
@@ -168,3 +168,17 @@ class Test_hashable(TestCase):
             self.assertTrue(utils.hashable(v))
         for v in [[5, 6], ['seven', '8'], {9: 'ten'}]:
             self.assertFalse(utils.hashable(v))
+
+
+class Test_OrderedSet(TestCase):
+
+    def test_set_op(self):
+        s1 = utils.OrderedSet(['a', 'b', 'c'])
+        s2 = utils.OrderedSet(['b'])
+        s3 = utils.OrderedSet(['d', 'e'])
+        self.assertEqual(s1 - s3, s1)
+        self.assertEqual(s1 - s2, set(['a', 'c']))
+        self.assertEqual(s1 + s2, s1)
+        self.assertEqual(s1 + s3, set(['a', 'b', 'c', 'd', 'e']))
+        s1.update(s3)
+        self.assertEqual(s1, set(['a', 'b', 'c', 'd', 'e']))


### PR DESCRIPTION
addresses https://github.com/pydata/xarray/issues/1042

The problem is that sets aren't ordered. I tried something based on an OrderedSet recipe, but I'm not sure that this is the most elegant way to go.

A remaining issue is that the coord variable is still not in place (`['t', 'a', 'b', 'c']` becomes `['a', 'b', 'c', 't']`), but I'm not sure it's possible to do it better (it happens [here](https://github.com/pydata/xarray/blob/master/xarray/core/combine.py#L273-L274)).

Any idea welcome