### PR TITLE
Update installing.rst to clarify and fix formatting

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -59,9 +59,7 @@ with its recommended dependencies using the conda command line tool::
 
 .. _conda: http://conda.io/
 
-We recommend using the community maintained
-`conda-forge <https://conda-forge.github.io/>`__ channel if you need difficult
-to build dependencies such as cartopy or pynio:
+We recommend using the community maintained `conda-forge <https://conda-forge.github.io/>`__ channel if you need difficult\-to\-build dependencies such as cartopy or pynio::
 
     $ conda install -c conda-forge xarray cartopy pynio
 


### PR DESCRIPTION
*Very* minor fix to poor formatting and clarification on new conda-forge blurb on the "Installation" docs page. This came about from 633aa112ae03214b76a913edbf3b1f43d0e9281b which addressed #944.