### PR TITLE
New properties `Dataset.sizes` and `DataArray.sizes`

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -39,6 +39,7 @@ Attributes
    :toctree: generated/
 
    Dataset.dims
+   Dataset.sizes
    Dataset.data_vars
    Dataset.coords
    Dataset.attrs
@@ -187,6 +188,7 @@ Attributes
    DataArray.data
    DataArray.coords
    DataArray.dims
+   DataArray.sizes
    DataArray.name
    DataArray.attrs
    DataArray.encoding

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -77,6 +77,11 @@ Enhancements
   :py:meth:`~xarray.DataArray.cumprod`.  By `Phillip J. Wolfram
   <https://github.com/pwolfram>`_.
 
+- New properties :py:attr:`Dataset.sizes` and :py:attr:`DataArray.sizes` for
+  providing consistent access to dimension length on both ``Dataset`` and
+  ``DataArray`` (:issue:`921`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
+
 Bug fixes
 ~~~~~~~~~
 - ``groupby_bins`` now restores empty bins by default (:issue:`1019`).

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1,4 +1,3 @@
-import contextlib
 import functools
 import warnings
 
@@ -13,7 +12,7 @@ from . import rolling
 from . import ops
 from . import utils
 from .alignment import align
-from .common import AbstractArray, BaseDataObject, squeeze
+from .common import AbstractArray, BaseDataObject
 from .coordinates import (DataArrayCoordinates, LevelCoordinates,
                           Indexes)
 from .dataset import Dataset
@@ -411,7 +410,12 @@ class DataArray(AbstractArray, BaseDataObject):
 
     @property
     def dims(self):
-        """Dimension names associated with this array."""
+        """Tuple of dimension names associated with this array.
+
+        Note that the type of this property is inconsistent with `Dataset.dims`.
+        See `Dataset.sizes` and `DataArray.sizes` for consistently named
+        properties.
+        """
         return self.variable.dims
 
     @dims.setter
@@ -910,33 +914,6 @@ class DataArray(AbstractArray, BaseDataObject):
         """
         variable = self.variable.transpose(*dims)
         return self._replace(variable)
-
-    def squeeze(self, dim=None):
-        """Return a new DataArray object with squeezed data.
-
-        Parameters
-        ----------
-        dim : None or str or tuple of str, optional
-            Selects a subset of the length one dimensions. If a dimension is
-            selected with length greater than one, an error is raised. If
-            None, all length one dimensions are squeezed.
-
-        Returns
-        -------
-        squeezed : DataArray
-            This array, but with with all or a subset of the dimensions of
-            length 1 removed.
-
-        Notes
-        -----
-        Although this operation returns a view of this array's data, it is
-        not lazy -- the data will be fully loaded.
-
-        See Also
-        --------
-        numpy.squeeze
-        """
-        return squeeze(self, dict(zip(self.dims, self.shape)), dim)
 
     def drop(self, labels, dim=None):
         """Drop coordinates or index labels from this DataArray.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -291,10 +291,28 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
     def dims(self):
         """Mapping from dimension names to lengths.
 
-        This dictionary cannot be modified directly, but is updated when adding
-        new variables.
+        Cannot be modified directly, but is updated when adding new variables.
+
+        Note that type of this object differs from `DataArray.dims`.
+        See `Dataset.sizes` and `DataArray.sizes` for consistently named
+        properties.
         """
         return Frozen(SortedKeysDict(self._dims))
+
+    @property
+    def sizes(self):
+        """Mapping from dimension names to lengths.
+
+        Cannot be modified directly, but is updated when adding new variables.
+
+        This is an alias for `Dataset.dims` provided for the benefit of
+        consistency with `DataArray.sizes`.
+
+        See also
+        --------
+        DataArray.sizes
+        """
+        return self.dims
 
     def load(self):
         """Manually trigger loading of this dataset's data from disk or a
@@ -1583,33 +1601,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
     @property
     def T(self):
         return self.transpose()
-
-    def squeeze(self, dim=None):
-        """Returns a new dataset with squeezed data.
-
-        Parameters
-        ----------
-        dim : None or str or tuple of str, optional
-            Selects a subset of the length one dimensions. If a dimension is
-            selected with length greater than one, an error is raised.  If
-            None, all length one dimensions are squeezed.
-
-        Returns
-        -------
-        squeezed : Dataset
-            This dataset, but with with all or a subset of the dimensions of
-            length 1 removed.
-
-        Notes
-        -----
-        Although this operation returns a view of each variable's data, it is
-        not lazy -- all variable data will be fully loaded.
-
-        See Also
-        --------
-        numpy.squeeze
-        """
-        return common.squeeze(self, self.dims, dim)
 
     def dropna(self, dim, how='any', thresh=None, subset=None):
         """Returns a new dataset with dropped labels for missing values along

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -178,10 +178,7 @@ class GroupBy(object):
             raise ValueError("`group` must have a 'dims' attribute")
         group_dim, = group.dims
 
-        try:
-            expected_size = obj.dims[group_dim]
-        except TypeError:
-            expected_size = obj.shape[obj.get_axis_num(group_dim)]
+        expected_size = obj.sizes[group_dim]
         if group.size != expected_size:
             raise ValueError('the group variable\'s length does not '
                              'match the length of this variable along its '

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -159,6 +159,13 @@ class TestDataArray(TestCase):
         with self.assertRaisesRegexp(AttributeError, 'you cannot assign'):
             arr.dims = ('w', 'z')
 
+    def test_sizes(self):
+        array = DataArray(np.zeros((3, 4)), dims=['x', 'y'])
+        self.assertEqual(array.sizes, {'x': 3, 'y': 4})
+        self.assertEqual(tuple(array.sizes), array.dims)
+        with self.assertRaises(TypeError):
+            array.sizes['foo'] = 5
+
     def test_encoding(self):
         expected = {'foo': 'bar'}
         self.dv.encoding['foo'] = 'bar'

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -338,6 +338,7 @@ class TestDataset(TestCase):
         self.assertEqual(ds.dims,
                          {'dim1': 8, 'dim2': 9, 'dim3': 10, 'time': 20})
         self.assertEqual(list(ds.dims), sorted(ds.dims))
+        self.assertEqual(ds.sizes, ds.dims)
 
         # These exact types aren't public API, but this makes sure we don't
         # change them inadvertently:

--- a/xarray/test/test_variable.py
+++ b/xarray/test/test_variable.py
@@ -26,6 +26,7 @@ class VariableSubclassTestCases(object):
         self.assertEqual(v.dtype, float)
         self.assertEqual(v.shape, (10,))
         self.assertEqual(v.size, 10)
+        self.assertEqual(v.sizes, {'time': 10})
         self.assertEqual(v.nbytes, 80)
         self.assertEqual(v.ndim, 1)
         self.assertEqual(len(v), 10)


### PR DESCRIPTION
This allows for consistent access to dimension lengths on ``Dataset`` and
``DataArray``

xref #921 (doesn't resolve it 100%, but should help significantly)