### PR TITLE
Add default channel to conda on RTD

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,43 +11,56 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 import sys
 import os
 
-print "python exec:", sys.executable
-print "sys.path:", sys.path
+print("python exec:", sys.executable)
+print("sys.path:", sys.path)
 try:
     import numpy
-    print "numpy: %s, %s" % (numpy.__version__, numpy.__file__)
+    print("numpy: %s, %s" % (numpy.__version__, numpy.__file__))
 except ImportError:
-    print "no numpy"
+    print("no numpy")
 try:
     import scipy
-    print "scipy: %s, %s" % (scipy.__version__, scipy.__file__)
+    print("scipy: %s, %s" % (scipy.__version__, scipy.__file__))
 except ImportError:
-    print "no scipy"
+    print("no scipy")
 try:
     import pandas
-    print "pandas: %s, %s" % (pandas.__version__, pandas.__file__)
+    print("pandas: %s, %s" % (pandas.__version__, pandas.__file__))
 except ImportError:
-    print "no pandas"
+    print("no pandas")
 try:
     import matplotlib
     matplotlib.use('Agg')
-    print "matplotlib: %s, %s" % (matplotlib.__version__, matplotlib.__file__)
+    print("matplotlib: %s, %s" % (matplotlib.__version__, matplotlib.__file__))
 except ImportError:
-    print "no matplotlib"
+    print("no matplotlib")
 try:
     import IPython
-    print "ipython: %s, %s" % (IPython.__version__, IPython.__file__)
+    print("ipython: %s, %s" % (IPython.__version__, IPython.__file__))
 except ImportError:
-    print "no ipython"
+    print("no ipython")
 try:
     import seaborn
-    print "seaborn: %s, %s" % (seaborn.__version__, seaborn.__file__)
+    print("seaborn: %s, %s" % (seaborn.__version__, seaborn.__file__))
 except ImportError:
-    print "no seaborn"
+    print("no seaborn")
+try:
+    import cartopy
+    print("cartopy: %s, %s" % (cartopy.__version__, cartopy.__file__))
+except ImportError:
+    print("no cartopy")
+try:
+    import netCDF4
+    print("netCDF4: %s, %s" % (netCDF4.__version__, netCDF4.__file__))
+except ImportError:
+    print("no netCDF4")
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -62,6 +75,7 @@ import linecache
 import re
 from inspect import getsourcefile, getfile, getmodule,\
      ismodule, isclass, ismethod, isfunction, istraceback, isframe, iscode
+
 
 def findsource(object):
     """Return the entire source file and starting line number for an object.

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,6 +1,7 @@
 name: xarray-docs
 channels:
   - conda-forge
+  - defaults
 dependencies:
   - python
   - numpy

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -74,31 +74,3 @@ pandas) installed first. Then, install xarray with pip::
 To run the test suite after installing xarray, install
 `py.test <https://pytest.org>`__ (``pip install pytest``) and run
 ``py.test xarray``.
-
-
-Version of the packages used to build this documentation
---------------------------------------------------------
-
-
-.. ipython:: python
-    :suppress:
-
-    import numpy
-    import pandas
-    import matplotlib
-    import xarray
-    import netCDF4
-    import cartopy
-    import dask
-    import seaborn
-
-.. ipython:: python
-
-    numpy.__version__
-    pandas.__version__
-    dask.__version__
-    netCDF4.__version__
-    matplotlib.__version__
-    cartopy.__version__
-    seaborn.__version__
-    xarray.__version__

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -74,3 +74,31 @@ pandas) installed first. Then, install xarray with pip::
 To run the test suite after installing xarray, install
 `py.test <https://pytest.org>`__ (``pip install pytest``) and run
 ``py.test xarray``.
+
+
+Version of the packages used to build this documentation
+--------------------------------------------------------
+
+
+.. ipython:: python
+    :suppress:
+
+    import numpy
+    import pandas
+    import matplotlib
+    import xarray
+    import netCDF4
+    import cartopy
+    import dask
+    import seaborn
+
+.. ipython:: python
+
+    numpy.__version__
+    pandas.__version__
+    dask.__version__
+    netCDF4.__version__
+    matplotlib.__version__
+    cartopy.__version__
+    seaborn.__version__
+    xarray.__version__


### PR DESCRIPTION
As discussed here: https://github.com/pydata/xarray/issues/1106

I also added a section somewhere to print the packages versions on RTD. It will be useful to pin the versions again once it works, and is useful enough to stay on the docs I think. I just didn't really knew where to put it, other ideas welcome!