### PR TITLE
Do not convert subclasses of `ndarray` unless required

### DIFF
--- a/ci/requirements-py27-cdat+pynio.yml
+++ b/ci/requirements-py27-cdat+pynio.yml
@@ -14,3 +14,4 @@ dependencies:
   - cyordereddict
   - pip:
     - coveralls
+    - quantities

--- a/ci/requirements-py27-netcdf4-dev.yml
+++ b/ci/requirements-py27-netcdf4-dev.yml
@@ -12,4 +12,5 @@ dependencies:
     - coveralls
     - pytest-cov
     - h5netcdf
+    - quantities
     - git+https://github.com/Unidata/netcdf4-python.git

--- a/ci/requirements-py27-pydap.yml
+++ b/ci/requirements-py27-pydap.yml
@@ -12,3 +12,4 @@ dependencies:
     - coveralls
     - pytest-cov
     - pydap
+    - quantities

--- a/ci/requirements-py33.yml
+++ b/ci/requirements-py33.yml
@@ -6,3 +6,4 @@ dependencies:
   - pip:
     - coveralls
     - pytest-cov
+    - quantities

--- a/ci/requirements-py34.yml
+++ b/ci/requirements-py34.yml
@@ -7,3 +7,4 @@ dependencies:
   - pip:
     - coveralls
     - pytest-cov
+    - quantities

--- a/ci/requirements-py35-dask-dev.yml
+++ b/ci/requirements-py35-dask-dev.yml
@@ -10,4 +10,5 @@ dependencies:
   - pip:
     - coveralls
     - pytest-cov
+    - quantities
     - git+https://github.com/blaze/dask.git

--- a/ci/requirements-py35-pandas-dev.yml
+++ b/ci/requirements-py35-pandas-dev.yml
@@ -11,4 +11,5 @@ dependencies:
     - coveralls
     - pytest-cov
     - dask
+    - quantities
     - git+https://github.com/pydata/pandas.git

--- a/ci/requirements-py35.yml
+++ b/ci/requirements-py35.yml
@@ -15,3 +15,4 @@ dependencies:
     - coveralls
     - pytest-cov
     - h5netcdf
+    - quantities

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -185,7 +185,7 @@ def _as_array_or_item(data):
 
     TODO: remove this (replace with np.asarray) once these issues are fixed
     """
-    data = np.asanyarray(data)
+    data = np.asarray(data)
     if data.ndim == 0:
         if data.dtype.kind == 'M':
             data = np.datetime64(data, 'ns')
@@ -193,6 +193,19 @@ def _as_array_or_item(data):
             data = np.timedelta64(data, 'ns')
     return data
 
+def _as_any_array_or_item(data):
+    """Return the given values as a numpy array subclass instance, or as an
+    individual item if it's a 0d datetime64 or timedelta64 array.
+
+    The same caveats as for :py:meth:`_as_array_or_item` apply.
+    """
+    data = np.asanyarray(data)
+    if data.ndim == 0:
+        if data.dtype.kind == 'M':
+            data = np.datetime64(data, 'ns')
+        elif data.dtype.kind == 'm':
+            data = np.timedelta64(data, 'ns')
+    return data
 
 class Variable(common.AbstractArray, common.SharedMethodsMixin,
                utils.NdimSizeLenMixin):
@@ -267,7 +280,7 @@ class Variable(common.AbstractArray, common.SharedMethodsMixin,
         if isinstance(self._data, dask_array_type):
             return self._data
         else:
-            return self.values
+            return _as_any_array_or_item(self._data_cached())
 
     @data.setter
     def data(self, data):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -185,7 +185,7 @@ def _as_array_or_item(data):
 
     TODO: remove this (replace with np.asarray) once these issues are fixed
     """
-    data = np.asarray(data)
+    data = np.asanyarray(data)
     if data.ndim == 0:
         if data.dtype.kind == 'M':
             data = np.datetime64(data, 'ns')

--- a/xarray/test/test_quantities.py
+++ b/xarray/test/test_quantities.py
@@ -12,7 +12,7 @@ except ImportError:
     has_quantities = False
 
 def requires_quantities(test):
-    return test if has_quantities else unittest.skip('requires dask')(test)
+    return test if has_quantities else unittest.skip('requires python-quantities')(test)
 
 @requires_quantities
 class TestWithQuantities(TestCase):

--- a/xarray/test/test_quantities.py
+++ b/xarray/test/test_quantities.py
@@ -53,3 +53,10 @@ class TestWithQuantities(TestCase):
         """
         da = self.da
         self.assertEqualWUnits(da.x.data,self.x)
+
+    def test_sel(self):
+        self.assertEqualWUnits(self.da.sel(y=self.y[0]).values,self.v[:,0])
+
+    def test_mean(self):
+        self.assertEqualWUnits(self.da.mean('x').values,self.v.mean(0))
+

--- a/xarray/test/test_quantities.py
+++ b/xarray/test/test_quantities.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pandas as pd
+
+from xarray import (align, broadcast, Dataset, DataArray, Variable)
+
+from xarray.test import (TestCase, unittest)
+
+try:
+    import quantities as pq
+    has_quantities = True
+except ImportError:
+    has_quantities = False
+
+def requires_quantities(test):
+    return test if has_quantities else unittest.skip('requires dask')(test)
+
+@requires_quantities
+class TestWithQuantities(TestCase):
+    def setUp(self):
+        self.x = np.arange(10) * pq.A
+        self.y = np.arange(20)
+        self.xp = np.arange(10) * pq.J
+        self.v = np.arange(10*20).reshape(10,20) * pq.V
+        self.da = DataArray(self.v,dims=['x','y'],coords=dict(x=self.x,y=self.y,xp=(['x'],self.xp)))
+
+    def assertEqualWUnits(self,a,b):
+        self.assertIsNotNone(getattr(a, 'units', None))
+        self.assertIsNotNone(getattr(b, 'units', None))
+        self.assertEqual(a.units,b.units)
+        np.testing.assert_allclose(a.magnitude,b.magnitude)
+
+    def test_units_in_data_and_coords(self):
+        da = self.da
+        self.assertEqualWUnits(da.xp.data,self.xp)
+        self.assertEqualWUnits(da.data,self.v)
+
+    def test_arithmetics(self):
+        da = self.da
+        f = DataArray(np.arange(10*20).reshape(10,20)*pq.A,dims=['x','y'],coords=dict(x=self.x,y=self.y))
+        self.assertEqualWUnits((da*f).data, da.data*f.data)
+
+    def test_unit_checking(self):
+        da = self.da
+        f = DataArray(np.arange(10*20).reshape(10,20)*pq.A,dims=['x','y'],coords=dict(x=self.x,y=self.y))
+        with self.assertRaisesRegex(ValueError,'Unable to convert between units'):
+            da + f
+
+    @unittest.expectedFailure
+    def test_units_in_indexes(self):
+        """
+        Indexes are borrowed from Pandas, and Pandas does not support units.
+        Therefore, we currently don't intend to support units on idexes either.
+        """
+        da = self.da
+        self.assertEqualWUnits(da.x.data,self.x)

--- a/xarray/test/test_quantities.py
+++ b/xarray/test/test_quantities.py
@@ -1,3 +1,14 @@
+""" test_quantities: Test storing and using instances of
+:py:class:`quantities.Quantity` inside :py:class`xarray.DataArray`.
+
+It can be considered a stand-in for other :py:class:`numpy.ndarray`
+subclasses, particularly other units implementations such as
+astropy's. As preservation of subclasses is not a guaranteed feature of
+`xarray`, some operations will discard subclasses. This test
+also serves as documnetation which operations do preserve subclasses
+and which don't.
+"""
+
 import numpy as np
 import pandas as pd
 
@@ -7,12 +18,18 @@ from xarray.test import (TestCase, unittest)
 
 try:
     import quantities as pq
+
     has_quantities = True
 except ImportError:
     has_quantities = False
 
+
 def requires_quantities(test):
-    return test if has_quantities else unittest.skip('requires python-quantities')(test)
+    return (
+        test if has_quantities else
+        unittest.skip('requires python-quantities')(test)
+    )
+
 
 @requires_quantities
 class TestWithQuantities(TestCase):
@@ -20,45 +37,70 @@ class TestWithQuantities(TestCase):
         self.x = np.arange(10) * pq.A
         self.y = np.arange(20)
         self.xp = np.arange(10) * pq.J
-        self.v = np.arange(10*20).reshape(10,20) * pq.V
-        self.da = DataArray(self.v,dims=['x','y'],coords=dict(x=self.x,y=self.y,xp=(['x'],self.xp)))
+        self.v = np.arange(10 * 20).reshape(10, 20) * pq.V
+        self.da = DataArray(self.v, dims=['x', 'y'],
+                            coords=dict(x=self.x, y=self.y, xp=(['x'], self.xp)))
 
-    def assertEqualWUnits(self,a,b):
+    def assertEqualWUnits(self, a, b):
+        # DataArray's are supposed to preserve Quantity instances
+        # but they (currently?) do not expose their behaviour.
+        # We thus need to extract the contained subarray via .data
+        if isinstance(a, DataArray):
+            a = a.data
+        if isinstance(b, DataArray):
+            b = b.data
         self.assertIsNotNone(getattr(a, 'units', None))
         self.assertIsNotNone(getattr(b, 'units', None))
-        self.assertEqual(a.units,b.units)
-        np.testing.assert_allclose(a.magnitude,b.magnitude)
+        self.assertEqual(a.units, b.units)
+        np.testing.assert_allclose(a.magnitude, b.magnitude)
 
     def test_units_in_data_and_coords(self):
         da = self.da
-        self.assertEqualWUnits(da.xp.data,self.xp)
-        self.assertEqualWUnits(da.data,self.v)
+        self.assertEqualWUnits(da.xp.data, self.xp)
+        self.assertEqualWUnits(da.data, self.v)
 
     def test_arithmetics(self):
+        x = self.x
+        y = self.y
+        v = self.v
         da = self.da
-        f = DataArray(np.arange(10*20).reshape(10,20)*pq.A,dims=['x','y'],coords=dict(x=self.x,y=self.y))
-        self.assertEqualWUnits((da*f).data, da.data*f.data)
+
+        f = np.arange(10 * 20).reshape(10, 20) * pq.A
+        g = DataArray(f, dims=['x', 'y'], coords=dict(x=x, y=y))
+        self.assertEqualWUnits(da * g, v * f)
+
+        # swapped dimension order
+        f = np.arange(20 * 10).reshape(20, 10) * pq.V
+        g = DataArray(f, dims=['y', 'x'], coords=dict(x=x, y=y))
+        self.assertEqualWUnits(da + g, v + f.T)
+
+        # broadcasting
+        f = np.arange(10) * pq.m
+        g = DataArray(f, dims=['x'], coords=dict(x=x))
+        self.assertEqualWUnits(da / g, v / f[:,None])
 
     def test_unit_checking(self):
         da = self.da
-        f = DataArray(np.arange(10*20).reshape(10,20)*pq.A,dims=['x','y'],coords=dict(x=self.x,y=self.y))
-        with self.assertRaisesRegexp(ValueError,'Unable to convert between units'):
-            da + f
+        f = np.arange(10 * 20).reshape(10, 20) * pq.A
+        g = DataArray(f, dims=['x', 'y'], coords=dict(x=self.x, y=self.y))
+        with self.assertRaisesRegexp(ValueError,
+                                     'Unable to convert between units'):
+            da + g
 
     @unittest.expectedFailure
     def test_units_in_indexes(self):
-        """
+        """ Test if units survive through xarray indexes.
+
         Indexes are borrowed from Pandas, and Pandas does not support units.
         Therefore, we currently don't intend to support units on indexes either.
         """
         da = self.da
-        self.assertEqualWUnits(da.x.data,self.x)
+        self.assertEqualWUnits(da.x, self.x)
 
     @unittest.expectedFailure
     def test_sel(self):
-        self.assertEqualWUnits(self.da.sel(y=self.y[0]).values,self.v[:,0])
+        self.assertEqualWUnits(self.da.sel(y=self.y[0]), self.v[:, 0])
 
     @unittest.expectedFailure
     def test_mean(self):
-        self.assertEqualWUnits(self.da.mean('x').values,self.v.mean(0))
-
+        self.assertEqualWUnits(self.da.mean('x'), self.v.mean(0))

--- a/xarray/test/test_quantities.py
+++ b/xarray/test/test_quantities.py
@@ -42,7 +42,7 @@ class TestWithQuantities(TestCase):
     def test_unit_checking(self):
         da = self.da
         f = DataArray(np.arange(10*20).reshape(10,20)*pq.A,dims=['x','y'],coords=dict(x=self.x,y=self.y))
-        with self.assertRaisesRegex(ValueError,'Unable to convert between units'):
+        with self.assertRaisesRegexp(ValueError,'Unable to convert between units'):
             da + f
 
     @unittest.expectedFailure

--- a/xarray/test/test_quantities.py
+++ b/xarray/test/test_quantities.py
@@ -54,9 +54,11 @@ class TestWithQuantities(TestCase):
         da = self.da
         self.assertEqualWUnits(da.x.data,self.x)
 
+    @unittest.expectedFailure
     def test_sel(self):
         self.assertEqualWUnits(self.da.sel(y=self.y[0]).values,self.v[:,0])
 
+    @unittest.expectedFailure
     def test_mean(self):
         self.assertEqualWUnits(self.da.mean('x').values,self.v.mean(0))
 

--- a/xarray/test/test_quantities.py
+++ b/xarray/test/test_quantities.py
@@ -49,7 +49,7 @@ class TestWithQuantities(TestCase):
     def test_units_in_indexes(self):
         """
         Indexes are borrowed from Pandas, and Pandas does not support units.
-        Therefore, we currently don't intend to support units on idexes either.
+        Therefore, we currently don't intend to support units on indexes either.
         """
         da = self.da
         self.assertEqualWUnits(da.x.data,self.x)


### PR DESCRIPTION
By changing a single `np.asarray` to `np.asanyarray`, it becomes possible to use `ndarray` subclasses within `DataArray` and  `Dataset`. No guarantee is made at this point that their behaviour is retained under all circumstances, but for some use-cases it will work.

Particularly, this allows to store physical quantities represented using the `Quantity` subclass from the package [python-quantities](https://github.com/python-quantities/python-quantities). In that sense, it is a partial fix for #525. Tests are included to highlight some of the things that do work, and some which don't. It does not work for coordinates when they are used as indexes, since pandas does not support ndarray subclasses. Most likely, it will also not work for any higher-level operation on the data such as those involving `np.concatenate`. Thus, any user of this feature should remain cautious.
Nonetheless, for me, this change provides enough added value, such that I'd consider it worthwhile to keep, assuming it does not harm anywhere else. It does pass the tests on my machine (no dask though), let's see what travis says.

I expect that astropy's units would behave similarly, though since I never worked with them yet, I did not include any tests.