### PR TITLE
Remove caching logic from xarray.Variable

### DIFF
--- a/ci/requirements-py27-cdat+pynio.yml
+++ b/ci/requirements-py27-cdat+pynio.yml
@@ -5,6 +5,7 @@ dependencies:
   - python=2.7
   - cdat-lite
   - dask
+  - distributed
   - pytest
   - numpy
   - pandas>=0.15.0

--- a/ci/requirements-py27-netcdf4-dev.yml
+++ b/ci/requirements-py27-netcdf4-dev.yml
@@ -3,6 +3,7 @@ dependencies:
   - python=2.7
   - cython
   - dask
+  - distributed
   - h5py
   - pytest
   - numpy

--- a/ci/requirements-py27-pydap.yml
+++ b/ci/requirements-py27-pydap.yml
@@ -2,6 +2,7 @@ name: test_env
 dependencies:
   - python=2.7
   - dask
+  - distributed
   - h5py
   - netcdf4
   - pytest

--- a/ci/requirements-py35.yml
+++ b/ci/requirements-py35.yml
@@ -3,6 +3,7 @@ dependencies:
   - python=3.5
   - cython
   - dask
+  - distributed
   - h5py
   - matplotlib
   - netcdf4

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,12 +25,14 @@ Breaking changes
   merges will now succeed in cases that previously raised
   ``xarray.MergeError``. Set ``compat='broadcast_equals'`` to restore the
   previous default.
-- Pickling an xarray object based on the dask backend, or reading its
-  :py:meth:`values` property, won't automatically convert the array from dask
-  to numpy in the original object anymore.
-  If a dask object is used as a coord of a :py:class:`~xarray.DataArray` or
-  :py:class:`~xarray.Dataset`, its values are eagerly computed and cached,
-  but only if it's used to index a dim (e.g. it's used for alignment).
+- Pickling an xarray object or reading its :py:attr:`~DataArray.values`
+  property no longer always caches values in a NumPy array. Caching
+  of ``.values`` read from netCDF files on disk is still the default when
+  :py:func:`open_dataset` is called with ``cache=True``.
+  By `Guido Imperiale <https://github.com/crusaderky>`_ and
+  `Stephan Hoyer <https://github.com/shoyer>`_.
+- Coordinates used to index a dimension are now loaded eagerly into
+  :py:class:`pandas.Index` objects, instead of loading the values lazily.
   By `Guido Imperiale <https://github.com/crusaderky>`_.
 
 Deprecations

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,12 +25,18 @@ Breaking changes
   merges will now succeed in cases that previously raised
   ``xarray.MergeError``. Set ``compat='broadcast_equals'`` to restore the
   previous default.
-- Pickling an xarray object or reading its :py:attr:`~DataArray.values`
-  property no longer always caches values in a NumPy array. Caching
-  of ``.values`` read from netCDF files on disk is still the default when
-  :py:func:`open_dataset` is called with ``cache=True``.
+- Reading :py:attr:`~DataArray.values` no longer always caches values in a NumPy
+  array :issue:`1128`. Caching of ``.values`` on variables read from netCDF
+  files on disk is still the default when :py:func:`open_dataset` is called with
+  ``cache=True``.
   By `Guido Imperiale <https://github.com/crusaderky>`_ and
   `Stephan Hoyer <https://github.com/shoyer>`_.
+- Pickling a ``Dataset`` or ``DataArray`` linked to a file on disk no longer
+  caches its values into memory before pickling :issue:`1128`. Instead, pickle
+  stores file paths and restores objects by reopening file references. This
+  enables preliminary, experimental use of xarray for opening files with
+  `dask.distributed <https://distributed.readthedocs.io>`_.
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
 - Coordinates used to index a dimension are now loaded eagerly into
   :py:class:`pandas.Index` objects, instead of loading the values lazily.
   By `Guido Imperiale <https://github.com/crusaderky>`_.

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -16,7 +16,6 @@ from .common import ArrayWriter
 from ..core import indexing
 from ..core.combine import auto_combine
 from ..core.utils import close_on_error, is_remote_uri
-from ..core.variable import Variable, IndexVariable
 from ..core.pycompat import basestring
 
 DATAARRAY_NAME = '__xarray_dataarray_name__'

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -235,3 +235,22 @@ class WritableCFDataStore(AbstractWritableDataStore):
         cf_variables, cf_attrs = cf_encoder(variables, attributes)
         AbstractWritableDataStore.store(self, cf_variables, cf_attrs,
                                         check_encoding_set)
+
+
+class DataStorePickleMixin(object):
+    """Subclasses must define `ds`, `_opener` and `_mode` attributes.
+
+    Do not subclass this class: it is not part of xarray's external API.
+    """
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        del state['ds']
+        if self._mode == 'w':
+            # file has already been created, don't override when restoring
+            state['_mode'] = 'a'
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.ds = self._opener(mode=self._mode)

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -5,7 +5,8 @@ import functools
 
 from .. import Variable
 from ..core import indexing
-from ..core.utils import (FrozenOrderedDict, close_on_error, Frozen)
+from ..core.utils import (FrozenOrderedDict, close_on_error, Frozen,
+                          normalize_path)
 from ..core.pycompat import iteritems, bytes_type, unicode_type, OrderedDict
 
 from .common import WritableCFDataStore, DataStorePickleMixin
@@ -51,6 +52,7 @@ class H5NetCDFStore(WritableCFDataStore, DataStorePickleMixin):
                  writer=None):
         if format not in [None, 'NETCDF4']:
             raise ValueError('invalid format for h5netcdf backend')
+        filename = normalize_path(filename)
         opener = functools.partial(_open_h5netcdf_group, filename, mode=mode,
                                    group=group)
         self.ds = opener()

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -5,7 +5,8 @@ import functools
 
 from .. import Variable
 from ..core import indexing
-from ..core.utils import FrozenOrderedDict, close_on_error, Frozen
+from ..core.utils import (FrozenOrderedDict, close_on_error, Frozen,
+                          NoPickleMixin)
 from ..core.pycompat import iteritems, bytes_type, unicode_type, OrderedDict
 
 from .common import WritableCFDataStore
@@ -37,7 +38,7 @@ _extract_h5nc_encoding = functools.partial(_extract_nc4_encoding,
                                            lsd_okay=False, backend='h5netcdf')
 
 
-class H5NetCDFStore(WritableCFDataStore):
+class H5NetCDFStore(WritableCFDataStore, NoPickleMixin):
     """Store for reading and writing data via h5netcdf
     """
     def __init__(self, filename, mode='r', format=None, group=None,

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -5,11 +5,10 @@ import functools
 
 from .. import Variable
 from ..core import indexing
-from ..core.utils import (FrozenOrderedDict, close_on_error, Frozen,
-                          NoPickleMixin)
+from ..core.utils import (FrozenOrderedDict, close_on_error, Frozen)
 from ..core.pycompat import iteritems, bytes_type, unicode_type, OrderedDict
 
-from .common import WritableCFDataStore
+from .common import WritableCFDataStore, DataStorePickleMixin
 from .netCDF4_ import (_nc4_group, _nc4_values_and_dtype, _extract_nc4_encoding,
                        BaseNetCDF4Array)
 
@@ -38,24 +37,32 @@ _extract_h5nc_encoding = functools.partial(_extract_nc4_encoding,
                                            lsd_okay=False, backend='h5netcdf')
 
 
-class H5NetCDFStore(WritableCFDataStore, NoPickleMixin):
+def _open_h5netcdf_group(filename, mode, group):
+    import h5netcdf.legacyapi
+    ds = h5netcdf.legacyapi.Dataset(filename, mode=mode)
+    with close_on_error(ds):
+        return _nc4_group(ds, group, mode)
+
+
+class H5NetCDFStore(WritableCFDataStore, DataStorePickleMixin):
     """Store for reading and writing data via h5netcdf
     """
     def __init__(self, filename, mode='r', format=None, group=None,
                  writer=None):
-        import h5netcdf.legacyapi
         if format not in [None, 'NETCDF4']:
             raise ValueError('invalid format for h5netcdf backend')
-        ds = h5netcdf.legacyapi.Dataset(filename, mode=mode)
-        with close_on_error(ds):
-            self.ds = _nc4_group(ds, group, mode)
+        opener = functools.partial(_open_h5netcdf_group, filename, mode=mode,
+                                   group=group)
+        self.ds = opener()
         self.format = format
+        self._opener = opener
         self._filename = filename
+        self._mode = mode
         super(H5NetCDFStore, self).__init__(writer)
 
-    def open_store_variable(self, var):
+    def open_store_variable(self, name, var):
         dimensions = var.dimensions
-        data = indexing.LazilyIndexedArray(BaseNetCDF4Array(var))
+        data = indexing.LazilyIndexedArray(BaseNetCDF4Array(name, self))
         attrs = _read_attributes(var)
 
         # netCDF4 specific encoding
@@ -70,7 +77,7 @@ class H5NetCDFStore(WritableCFDataStore, NoPickleMixin):
         return Variable(dimensions, data, attrs, encoding)
 
     def get_variables(self):
-        return FrozenOrderedDict((k, self.open_store_variable(v))
+        return FrozenOrderedDict((k, self.open_store_variable(k, v))
                                  for k, v in iteritems(self.ds.variables))
 
     def get_attrs(self):

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -5,8 +5,7 @@ import functools
 
 from .. import Variable
 from ..core import indexing
-from ..core.utils import (FrozenOrderedDict, close_on_error, Frozen,
-                          normalize_path)
+from ..core.utils import FrozenOrderedDict, close_on_error, Frozen
 from ..core.pycompat import iteritems, bytes_type, unicode_type, OrderedDict
 
 from .common import WritableCFDataStore, DataStorePickleMixin
@@ -52,7 +51,6 @@ class H5NetCDFStore(WritableCFDataStore, DataStorePickleMixin):
                  writer=None):
         if format not in [None, 'NETCDF4']:
             raise ValueError('invalid format for h5netcdf backend')
-        filename = normalize_path(filename)
         opener = functools.partial(_open_h5netcdf_group, filename, mode=mode,
                                    group=group)
         self.ds = opener()

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -10,7 +10,7 @@ from .. import Variable
 from ..conventions import pop_to, cf_encoder
 from ..core import indexing
 from ..core.utils import (FrozenOrderedDict, NDArrayMixin,
-                          close_on_error, is_remote_uri, normalize_path)
+                          close_on_error, is_remote_uri)
 from ..core.pycompat import iteritems, basestring, OrderedDict, PY3
 
 from .common import WritableCFDataStore, robust_getitem, DataStorePickleMixin
@@ -199,7 +199,6 @@ class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
                  writer=None, clobber=True, diskless=False, persist=False):
         if format is None:
             format = 'NETCDF4'
-        filename = normalize_path(filename)
         opener = functools.partial(_open_netcdf4_group, filename, mode=mode,
                                    group=group, clobber=clobber,
                                    diskless=diskless, persist=persist,

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -10,7 +10,7 @@ from .. import Variable
 from ..conventions import pop_to, cf_encoder
 from ..core import indexing
 from ..core.utils import (FrozenOrderedDict, NDArrayMixin,
-                          close_on_error, is_remote_uri)
+                          close_on_error, is_remote_uri, normalize_path)
 from ..core.pycompat import iteritems, basestring, OrderedDict, PY3
 
 from .common import WritableCFDataStore, robust_getitem, DataStorePickleMixin
@@ -199,6 +199,7 @@ class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
                  writer=None, clobber=True, diskless=False, persist=False):
         if format is None:
             format = 'NETCDF4'
+        filename = normalize_path(filename)
         opener = functools.partial(_open_netcdf4_group, filename, mode=mode,
                                    group=group, clobber=clobber,
                                    diskless=diskless, persist=persist,

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -9,7 +9,7 @@ import numpy as np
 from .. import Variable
 from ..conventions import pop_to, cf_encoder
 from ..core import indexing
-from ..core.utils import (FrozenOrderedDict, NDArrayMixin,
+from ..core.utils import (FrozenOrderedDict, NDArrayMixin, NoPickleMixin,
                           close_on_error, is_remote_uri)
 from ..core.pycompat import iteritems, basestring, OrderedDict, PY3
 
@@ -25,7 +25,7 @@ _endian_lookup = {'=': 'native',
                   '|': 'native'}
 
 
-class BaseNetCDF4Array(NDArrayMixin):
+class BaseNetCDF4Array(NDArrayMixin, NoPickleMixin):
     def __init__(self, array, is_remote=False):
         self.array = array
         self.is_remote = is_remote
@@ -176,7 +176,7 @@ def _extract_nc4_encoding(variable, raise_on_invalid=False, lsd_okay=True,
     return encoding
 
 
-class NetCDF4DataStore(WritableCFDataStore):
+class NetCDF4DataStore(WritableCFDataStore, NoPickleMixin):
     """Store for reading and writing data via the Python-NetCDF4 library.
 
     This store supports NetCDF3, NetCDF4 and OpenDAP datasets.

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -1,19 +1,19 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+import functools
 import operator
-from functools import partial
 
 import numpy as np
 
 from .. import Variable
 from ..conventions import pop_to, cf_encoder
 from ..core import indexing
-from ..core.utils import (FrozenOrderedDict, NDArrayMixin, NoPickleMixin,
+from ..core.utils import (FrozenOrderedDict, NDArrayMixin,
                           close_on_error, is_remote_uri)
 from ..core.pycompat import iteritems, basestring, OrderedDict, PY3
 
-from .common import WritableCFDataStore, robust_getitem
+from .common import WritableCFDataStore, robust_getitem, DataStorePickleMixin
 from .netcdf3 import (encode_nc3_attr_value, encode_nc3_variable,
                       maybe_convert_to_char_array)
 
@@ -25,10 +25,14 @@ _endian_lookup = {'=': 'native',
                   '|': 'native'}
 
 
-class BaseNetCDF4Array(NDArrayMixin, NoPickleMixin):
-    def __init__(self, array, is_remote=False):
-        self.array = array
-        self.is_remote = is_remote
+class BaseNetCDF4Array(NDArrayMixin):
+    def __init__(self, variable_name, datastore):
+        self.datastore = datastore
+        self.variable_name = variable_name
+
+    @property
+    def array(self):
+        return self.datastore.ds.variables[self.variable_name]
 
     @property
     def dtype(self):
@@ -42,13 +46,9 @@ class BaseNetCDF4Array(NDArrayMixin, NoPickleMixin):
 
 
 class NetCDF4ArrayWrapper(BaseNetCDF4Array):
-    def __init__(self, array, is_remote=False):
-        self.array = array
-        self.is_remote = is_remote
-
     def __getitem__(self, key):
-        if self.is_remote:  # pragma: no cover
-            getitem = partial(robust_getitem, catch=RuntimeError)
+        if self.datastore.is_remote:  # pragma: no cover
+            getitem = functools.partial(robust_getitem, catch=RuntimeError)
         else:
             getitem = operator.getitem
 
@@ -176,31 +176,44 @@ def _extract_nc4_encoding(variable, raise_on_invalid=False, lsd_okay=True,
     return encoding
 
 
-class NetCDF4DataStore(WritableCFDataStore, NoPickleMixin):
+def _open_netcdf4_group(filename, mode, group=None, **kwargs):
+    import netCDF4 as nc4
+
+    ds = nc4.Dataset(filename, mode=mode, **kwargs)
+
+    with close_on_error(ds):
+        ds = _nc4_group(ds, group, mode)
+
+    for var in ds.variables.values():
+        # we handle masking and scaling ourselves
+        var.set_auto_maskandscale(False)
+    return ds
+
+
+class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
     """Store for reading and writing data via the Python-NetCDF4 library.
 
     This store supports NetCDF3, NetCDF4 and OpenDAP datasets.
     """
     def __init__(self, filename, mode='r', format='NETCDF4', group=None,
                  writer=None, clobber=True, diskless=False, persist=False):
-        import netCDF4 as nc4
         if format is None:
             format = 'NETCDF4'
-        ds = nc4.Dataset(filename, mode=mode, clobber=clobber,
-                         diskless=diskless, persist=persist,
-                         format=format)
-        with close_on_error(ds):
-            self.ds = _nc4_group(ds, group, mode)
+        opener = functools.partial(_open_netcdf4_group, filename, mode=mode,
+                                   group=group, clobber=clobber,
+                                   diskless=diskless, persist=persist,
+                                   format=format)
+        self.ds = opener()
         self.format = format
         self.is_remote = is_remote_uri(filename)
+        self._opener = opener
         self._filename = filename
+        self._mode = 'a' if mode == 'w' else mode
         super(NetCDF4DataStore, self).__init__(writer)
 
-    def open_store_variable(self, var):
-        var.set_auto_maskandscale(False)
+    def open_store_variable(self, name, var):
         dimensions = var.dimensions
-        data = indexing.LazilyIndexedArray(NetCDF4ArrayWrapper(
-            var, self.is_remote))
+        data = indexing.LazilyIndexedArray(NetCDF4ArrayWrapper(name, self))
         attributes = OrderedDict((k, var.getncattr(k))
                                  for k in var.ncattrs())
         _ensure_fill_value_valid(data, attributes)
@@ -227,7 +240,7 @@ class NetCDF4DataStore(WritableCFDataStore, NoPickleMixin):
         return Variable(dimensions, data, attributes, encoding)
 
     def get_variables(self):
-        return FrozenOrderedDict((k, self.open_store_variable(v))
+        return FrozenOrderedDict((k, self.open_store_variable(k, v))
                                  for k, v in iteritems(self.ds.variables))
 
     def get_attrs(self):

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -7,7 +7,7 @@ import functools
 import numpy as np
 
 from .. import Variable
-from ..core.utils import FrozenOrderedDict, Frozen, NDArrayMixin
+from ..core.utils import FrozenOrderedDict, Frozen, NDArrayMixin, normalize_path
 from ..core import indexing
 
 from .common import AbstractDataStore, DataStorePickleMixin
@@ -38,6 +38,7 @@ class NioDataStore(AbstractDataStore, DataStorePickleMixin):
     """
     def __init__(self, filename, mode='r'):
         import Nio
+        filename = normalize_path(filename)
         opener = functools.partial(Nio.open_file, filename, mode=mode)
         self.ds = opener()
         self._opener = opener

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -4,13 +4,13 @@ from __future__ import print_function
 import numpy as np
 
 from .. import Variable
-from ..core.utils import FrozenOrderedDict, Frozen, NDArrayMixin
+from ..core.utils import FrozenOrderedDict, Frozen, NDArrayMixin, NoPickleMixin
 from ..core import indexing
 
 from .common import AbstractDataStore
 
 
-class NioArrayWrapper(NDArrayMixin):
+class NioArrayWrapper(NDArrayMixin, NoPickleMixin):
     def __init__(self, array, ds):
         self.array = array
         self._ds = ds  # make an explicit reference because pynio uses weakrefs
@@ -25,7 +25,7 @@ class NioArrayWrapper(NDArrayMixin):
         return self.array[key]
 
 
-class NioDataStore(AbstractDataStore):
+class NioDataStore(AbstractDataStore, NoPickleMixin):
     """Store for accessing datasets via PyNIO
     """
     def __init__(self, filename, mode='r'):

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -1,19 +1,27 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+
+import functools
+
 import numpy as np
 
 from .. import Variable
-from ..core.utils import FrozenOrderedDict, Frozen, NDArrayMixin, NoPickleMixin
+from ..core.utils import FrozenOrderedDict, Frozen, NDArrayMixin
 from ..core import indexing
 
-from .common import AbstractDataStore
+from .common import AbstractDataStore, DataStorePickleMixin
 
 
-class NioArrayWrapper(NDArrayMixin, NoPickleMixin):
-    def __init__(self, array, ds):
-        self.array = array
-        self._ds = ds  # make an explicit reference because pynio uses weakrefs
+class NioArrayWrapper(NDArrayMixin):
+
+    def __init__(self, variable_name, datastore):
+        self.datastore = datastore
+        self.variable_name = variable_name
+
+    @property
+    def array(self):
+        return self.datastore.ds.variables[self.variable_name]
 
     @property
     def dtype(self):
@@ -25,19 +33,22 @@ class NioArrayWrapper(NDArrayMixin, NoPickleMixin):
         return self.array[key]
 
 
-class NioDataStore(AbstractDataStore, NoPickleMixin):
+class NioDataStore(AbstractDataStore, DataStorePickleMixin):
     """Store for accessing datasets via PyNIO
     """
     def __init__(self, filename, mode='r'):
         import Nio
-        self.ds = Nio.open_file(filename, mode=mode)
+        opener = functools.partial(Nio.open_file, filename, mode=mode)
+        self.ds = opener()
+        self._opener = opener
+        self._mode = mode
 
-    def open_store_variable(self, var):
-        data = indexing.LazilyIndexedArray(NioArrayWrapper(var, self.ds))
+    def open_store_variable(self, name, var):
+        data = indexing.LazilyIndexedArray(NioArrayWrapper(name, self))
         return Variable(var.dimensions, data, var.attributes)
 
     def get_variables(self):
-        return FrozenOrderedDict((k, self.open_store_variable(v))
+        return FrozenOrderedDict((k, self.open_store_variable(k, v))
                                  for k, v in self.ds.variables.iteritems())
 
     def get_attrs(self):

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -7,7 +7,7 @@ import functools
 import numpy as np
 
 from .. import Variable
-from ..core.utils import FrozenOrderedDict, Frozen, NDArrayMixin, normalize_path
+from ..core.utils import FrozenOrderedDict, Frozen, NDArrayMixin
 from ..core import indexing
 
 from .common import AbstractDataStore, DataStorePickleMixin
@@ -38,7 +38,6 @@ class NioDataStore(AbstractDataStore, DataStorePickleMixin):
     """
     def __init__(self, filename, mode='r'):
         import Nio
-        filename = normalize_path(filename)
         opener = functools.partial(Nio.open_file, filename, mode=mode)
         self.ds = opener()
         self._opener = opener

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -8,7 +8,7 @@ import warnings
 
 from .. import Variable
 from ..core.pycompat import iteritems, basestring, OrderedDict
-from ..core.utils import Frozen, FrozenOrderedDict
+from ..core.utils import Frozen, FrozenOrderedDict, NoPickleMixin
 from ..core.indexing import NumpyIndexingAdapter
 
 from .common import WritableCFDataStore
@@ -29,7 +29,7 @@ def _decode_attrs(d):
                        for (k, v) in iteritems(d))
 
 
-class ScipyArrayWrapper(NumpyIndexingAdapter):
+class ScipyArrayWrapper(NumpyIndexingAdapter, NoPickleMixin):
     def __init__(self, netcdf_file, variable_name):
         self.netcdf_file = netcdf_file
         self.variable_name = variable_name
@@ -57,7 +57,7 @@ class ScipyArrayWrapper(NumpyIndexingAdapter):
         return data
 
 
-class ScipyDataStore(WritableCFDataStore):
+class ScipyDataStore(WritableCFDataStore, NoPickleMixin):
     """Store for reading and writing data via scipy.io.netcdf.
 
     This store has the advantage of being able to be initialized with a

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -9,7 +9,7 @@ import warnings
 
 from .. import Variable
 from ..core.pycompat import iteritems, basestring, OrderedDict
-from ..core.utils import Frozen, FrozenOrderedDict
+from ..core.utils import Frozen, FrozenOrderedDict, normalize_path
 from ..core.indexing import NumpyIndexingAdapter
 
 from .common import WritableCFDataStore, DataStorePickleMixin
@@ -89,6 +89,10 @@ class ScipyDataStore(WritableCFDataStore, DataStorePickleMixin):
                 filename_or_obj.startswith(b'CDF')):
             # it's a NetCDF3 bytestring
             filename_or_obj = BytesIO(filename_or_obj)
+
+        if isinstance(filename_or_obj, basestring):
+            # not a file-like object
+            filename_or_obj = normalize_path(filename_or_obj)
 
         opener = functools.partial(scipy.io.netcdf_file,
                                    filename=filename_or_obj,

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -248,6 +248,14 @@ class AttrAccessMixin(object):
             if isinstance(item, basestring)]
         return sorted(set(dir(type(self)) + extra_attrs))
 
+    def __getstate__(self):
+        """Get this object's state for pickling"""
+        # we need a custom method to avoid
+
+        # self.__dict__ is the default pickle object, we don't need to
+        # implement our own __setstate__ method to make pickle work
+        return self.__dict__
+
 
 class SharedMethodsMixin(object):
     """Shared methods for Dataset, DataArray and Variable."""

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -248,14 +248,6 @@ class AttrAccessMixin(object):
             if isinstance(item, basestring)]
         return sorted(set(dir(type(self)) + extra_attrs))
 
-    def __getstate__(self):
-        """Get this object's state for pickling"""
-        # we need a custom method to avoid
-
-        # self.__dict__ is the default pickle object, we don't need to
-        # implement our own __setstate__ method to make pickle work
-        return self.__dict__
-
 
 class SharedMethodsMixin(object):
     """Shared methods for Dataset, DataArray and Variable."""

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -259,14 +259,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         obj._file_obj = store
         return obj
 
-    def __getstate__(self):
-        """Get this object's state for pickling"""
-        # we need a custom method to avoid
-
-        # self.__dict__ is the default pickle object, we don't need to
-        # implement our own __setstate__ method to make pickle work
-        return self.__dict__
-
     @property
     def variables(self):
         """Frozen dictionary of xarray.Variable objects constituting this

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -260,17 +260,12 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         return obj
 
     def __getstate__(self):
-        """Load data in-memory before pickling (except for Dask data)"""
-        for v in self.variables.values():
-            if not isinstance(v.data, dask_array_type):
-                v.load()
+        """Get this object's state for pickling"""
+        # we need a custom method to avoid
 
         # self.__dict__ is the default pickle object, we don't need to
         # implement our own __setstate__ method to make pickle work
-        state = self.__dict__.copy()
-        # throw away any references to datastores in the pickle
-        state['_file_obj'] = None
-        return state
+        return self.__dict__
 
     @property
     def variables(self):
@@ -331,9 +326,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         working with many file objects on disk.
         """
         # access .data to coerce everything to numpy or dask arrays
-        all_data = dict((k, v.data) for k, v in self.variables.items())
-        lazy_data = dict((k, v) for k, v in all_data.items()
-                         if isinstance(v, dask_array_type))
+        lazy_data = {k: v._data for k, v in self.variables.items()
+                     if isinstance(v._data, dask_array_type)}
         if lazy_data:
             import dask.array as da
 
@@ -342,6 +336,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
 
             for k, data in zip(lazy_data, evaluated_data):
                 self.variables[k].data = data
+
+        # load everything else sequentially
+        for k, v in self.variables.items():
+            if k not in lazy_data:
+                v.load()
 
         return self
 

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 import contextlib
 import functools
 import itertools
+import os.path
 import re
 import warnings
 from collections import Mapping, MutableMapping, Iterable
@@ -434,6 +435,13 @@ def close_on_error(f):
 
 def is_remote_uri(path):
     return bool(re.search('^https?\://', path))
+
+
+def normalize_path(path):
+    if is_remote_uri(path):
+        return path
+    else:
+        return os.path.abspath(os.path.expanduser(path))
 
 
 def is_uniform_spaced(arr, **kwargs):

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -420,13 +420,6 @@ class NDArrayMixin(NdimSizeLenMixin):
         return '%s(array=%r)' % (type(self).__name__, self.array)
 
 
-class NoPickleMixin(object):
-    def __getstate__(self):
-        raise TypeError(
-            'cannot pickle objects of type %r: call .compute() or .load() '
-            'to load data into memory first.' % type(self))
-
-
 @contextlib.contextmanager
 def close_on_error(f):
     """Context manager to ensure that a file opened by xarray is closed if an

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -420,6 +420,13 @@ class NDArrayMixin(NdimSizeLenMixin):
         return '%s(array=%r)' % (type(self).__name__, self.array)
 
 
+class NoPickleMixin(object):
+    def __getstate__(self):
+        raise TypeError(
+            'cannot pickle objects of type %r: call .compute() or .load() '
+            'to load data into memory first.' % type(self))
+
+
 @contextlib.contextmanager
 def close_on_error(f):
     """Context manager to ensure that a file opened by xarray is closed if an

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -437,13 +437,6 @@ def is_remote_uri(path):
     return bool(re.search('^https?\://', path))
 
 
-def normalize_path(path):
-    if is_remote_uri(path):
-        return path
-    else:
-        return os.path.abspath(os.path.expanduser(path))
-
-
 def is_uniform_spaced(arr, **kwargs):
     """Return True if values of an array are uniformly spaced and sorted.
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1087,6 +1087,10 @@ class IndexVariable(Variable):
         if not isinstance(self._data, PandasIndexAdapter):
             self._data = PandasIndexAdapter(self._data)
 
+    def load(self):
+        # data is already loaded into memory for IndexVariable
+        return self
+
     @Variable.data.setter
     def data(self, data):
         Variable.data.fset(self, data)

--- a/xarray/test/__init__.py
+++ b/xarray/test/__init__.py
@@ -126,6 +126,12 @@ def data_allclose_or_equiv(arr1, arr2, rtol=1e-05, atol=1e-08):
         return ops.allclose_or_equiv(arr1, arr2, rtol=rtol, atol=atol)
 
 
+def assert_dataset_allclose(first, second):
+    # TODO(shoyer): make a lighter weight version of this that doesn't require
+    # constructing a dummy TestCase.
+    TestCase.assertDatasetAllClose(TestCase(), first, second)
+
+
 class TestCase(unittest.TestCase):
     if PY3:
         # Python 3 assertCountEqual is roughly equivalent to Python 2

--- a/xarray/test/__init__.py
+++ b/xarray/test/__init__.py
@@ -126,10 +126,16 @@ def data_allclose_or_equiv(arr1, arr2, rtol=1e-05, atol=1e-08):
         return ops.allclose_or_equiv(arr1, arr2, rtol=rtol, atol=atol)
 
 
-def assert_dataset_allclose(first, second):
-    # TODO(shoyer): make a lighter weight version of this that doesn't require
-    # constructing a dummy TestCase.
-    TestCase.assertDatasetAllClose(TestCase(), first, second)
+def assert_dataset_allclose(d1, d2, rtol=1e-05, atol=1e-08):
+    assert sorted(d1, key=str) == sorted(d2, key=str)
+    assert sorted(d1.coords, key=str) == sorted(d2.coords, key=str)
+    for k in d1:
+        v1 = d1.variables[k]
+        v2 = d2.variables[k]
+        assert v1.dims == v2.dims
+        allclose = data_allclose_or_equiv(
+            v1.values, v2.values, rtol=rtol, atol=atol)
+        assert allclose, (k, v1.values, v2.values)
 
 
 class TestCase(unittest.TestCase):

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -179,6 +179,7 @@ class DatasetIOTestCases(object):
             unpickled_ds = pickle.loads(pickle.dumps(roundtripped))
             self.assertDatasetIdentical(expected, unpickled_ds)
 
+        with self.roundtrip(expected) as roundtripped:
             unpickled_array = pickle.loads(pickle.dumps(roundtripped['foo']))
             self.assertDatasetIdentical(expected['foo'], unpickled_array)
 

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -182,6 +182,7 @@ class DatasetIOTestCases(object):
             roundtripped.close()
             unpickled_ds = pickle.loads(raw_pickle)
             self.assertDatasetIdentical(expected, unpickled_ds)
+            unpickled_ds.close()
 
     @pytest.mark.skipif(sys.platform == 'win32',
                         reason='all files on Windows must be closed to delete')

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -178,7 +178,9 @@ class DatasetIOTestCases(object):
         expected = Dataset({'foo': ('x', [42])})
         with self.roundtrip(expected) as roundtripped:
             raw_pickle = pickle.dumps(roundtripped)
-        with pickle.loads(raw_pickle) as unpickled_ds:
+            # windows doesn't like opening the same file twice
+            roundtripped.close()
+            unpickled_ds = pickle.loads(raw_pickle)
             self.assertDatasetIdentical(expected, unpickled_ds)
 
     @pytest.mark.skipif(sys.platform == 'win32',

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -173,12 +173,14 @@ class DatasetIOTestCases(object):
             self.assertDatasetAllClose(expected, actual)
             self.assertDatasetAllClose(expected, computed)
 
-    def test_pickle(self):
+    def test_pickle_dataset(self):
         expected = Dataset({'foo': ('x', [42])})
         with self.roundtrip(expected) as roundtripped:
             unpickled_ds = pickle.loads(pickle.dumps(roundtripped))
             self.assertDatasetIdentical(expected, unpickled_ds)
 
+    def test_pickle_dataarray(self):
+        expected = Dataset({'foo': ('x', [42])})
         with self.roundtrip(expected) as roundtripped:
             unpickled_array = pickle.loads(pickle.dumps(roundtripped['foo']))
             self.assertDatasetIdentical(expected['foo'], unpickled_array)

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -177,9 +177,9 @@ class DatasetIOTestCases(object):
     def test_pickle(self):
         expected = Dataset({'foo': ('x', [42])})
         with self.roundtrip(expected) as roundtripped:
-            unpickled_ds = pickle.loads(pickle.dumps(roundtripped))
-            with unpickled_ds:
-                self.assertDatasetIdentical(expected, unpickled_ds)
+            raw_pickle = pickle.dumps(roundtripped)
+        with pickle.loads(raw_pickle) as unpickled_ds:
+            self.assertDatasetIdentical(expected, unpickled_ds)
 
     @pytest.mark.skipif(sys.platform == 'win32',
                         reason='all files on Windows must be closed to delete')

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -182,7 +182,6 @@ class DatasetIOTestCases(object):
             roundtripped.close()
             unpickled_ds = pickle.loads(raw_pickle)
             self.assertDatasetIdentical(expected, unpickled_ds)
-            unpickled_ds.close()
 
     @pytest.mark.skipif(sys.platform == 'win32',
                         reason='all files on Windows must be closed to delete')
@@ -724,6 +723,12 @@ class NetCDF4ViaDaskDataTest(NetCDF4DataTest):
     def test_dataset_caching(self):
         # caching behavior differs for dask
         pass
+
+    @pytest.mark.skipif(
+        sys.platform == 'win32',
+        reason='something related to deleting unclosed files, see GH1128')
+    def test_pickle(self):
+        super(NetCDF4ViaDaskDataTest, self).test_pickle()
 
 
 @requires_scipy

--- a/xarray/test/test_conventions.py
+++ b/xarray/test/test_conventions.py
@@ -626,7 +626,8 @@ class TestCFEncodedDataStore(CFEncodedDataTest, TestCase):
         yield CFEncodedInMemoryStore()
 
     @contextlib.contextmanager
-    def roundtrip(self, data, save_kwargs={}, open_kwargs={}):
+    def roundtrip(self, data, save_kwargs={}, open_kwargs={},
+                  allow_cleanup_failure=False):
         store = CFEncodedInMemoryStore()
         data.dump_to_store(store, **save_kwargs)
         yield open_dataset(store, **open_kwargs)

--- a/xarray/test/test_conventions.py
+++ b/xarray/test/test_conventions.py
@@ -9,7 +9,7 @@ import warnings
 from xarray import conventions, Variable, Dataset, open_dataset
 from xarray.core import utils, indexing
 from . import TestCase, requires_netCDF4, unittest
-from .test_backends import CFEncodedDataTest
+from .test_backends import CFEncodedDataTest, PickleSupportedMixin
 from xarray.core.pycompat import iteritems
 from xarray.backends.memory import InMemoryDataStore
 from xarray.backends.common import WritableCFDataStore
@@ -191,11 +191,11 @@ class TestDatetime(TestCase):
 
     @requires_netCDF4
     def test_decode_cf_datetime_overflow(self):
-        # checks for 
+        # checks for
         # https://github.com/pydata/pandas/issues/14068
         # https://github.com/pydata/xarray/issues/975
 
-        from datetime import datetime        
+        from datetime import datetime
         units = 'days since 2000-01-01 00:00:00'
 
         # date after 2262 and before 1678
@@ -620,7 +620,7 @@ def null_wrap(ds):
 
 
 @requires_netCDF4
-class TestCFEncodedDataStore(CFEncodedDataTest, TestCase):
+class TestCFEncodedDataStore(CFEncodedDataTest, PickleSupportedMixin, TestCase):
     @contextlib.contextmanager
     def create_store(self):
         yield CFEncodedInMemoryStore()

--- a/xarray/test/test_conventions.py
+++ b/xarray/test/test_conventions.py
@@ -9,7 +9,7 @@ import warnings
 from xarray import conventions, Variable, Dataset, open_dataset
 from xarray.core import utils, indexing
 from . import TestCase, requires_netCDF4, unittest
-from .test_backends import CFEncodedDataTest, PickleSupportedMixin
+from .test_backends import CFEncodedDataTest
 from xarray.core.pycompat import iteritems
 from xarray.backends.memory import InMemoryDataStore
 from xarray.backends.common import WritableCFDataStore
@@ -620,7 +620,7 @@ def null_wrap(ds):
 
 
 @requires_netCDF4
-class TestCFEncodedDataStore(CFEncodedDataTest, PickleSupportedMixin, TestCase):
+class TestCFEncodedDataStore(CFEncodedDataTest, TestCase):
     @contextlib.contextmanager
     def create_store(self):
         yield CFEncodedInMemoryStore()

--- a/xarray/test/test_distributed.py
+++ b/xarray/test/test_distributed.py
@@ -1,0 +1,36 @@
+import pytest
+import xarray as xr
+from xarray.core.pycompat import suppress
+
+distributed = pytest.importorskip('distributed')
+da = pytest.importorskip('dask.array')
+from distributed.utils_test import cluster, loop
+
+from xarray.test.test_backends import create_tmp_file
+from xarray.test.test_dataset import create_test_data
+
+from . import assert_dataset_allclose, has_scipy, has_netCDF4, has_h5netcdf
+
+
+ENGINES = []
+if has_scipy:
+    ENGINES.append('scipy')
+if has_netCDF4:
+    ENGINES.append('netcdf4')
+if has_h5netcdf:
+    ENGINES.append('h5netcdf')
+
+
+@pytest.mark.parametrize('engine', ENGINES)
+def test_dask_distributed_integration_test(loop, engine):
+    with cluster() as (s, _):
+        with distributed.Client(('127.0.0.1', s['port']), loop=loop):
+            original = create_test_data()
+            with create_tmp_file() as filename:
+                original.to_netcdf(filename, engine=engine)
+                # TODO: should be able to serialize locks
+                restored = xr.open_dataset(filename, chunks=3, lock=False,
+                                           engine=engine)
+                assert isinstance(restored.var1.data, da.Array)
+                computed = restored.compute()
+                assert_dataset_allclose(original, computed)

--- a/xarray/test/test_indexing.py
+++ b/xarray/test/test_indexing.py
@@ -200,3 +200,45 @@ class TestLazyArray(TestCase):
             actual = lazy[i][j]
             self.assertEqual(expected.shape, actual.shape)
             self.assertArrayEqual(expected, actual)
+
+
+class TestCopyOnWriteArray(TestCase):
+    def test_setitem(self):
+        original = np.arange(10)
+        wrapped = indexing.CopyOnWriteArray(original)
+        wrapped[:] = 0
+        self.assertArrayEqual(original, np.arange(10))
+        self.assertArrayEqual(wrapped, np.zeros(10))
+
+    def test_sub_array(self):
+        original = np.arange(10)
+        wrapped = indexing.CopyOnWriteArray(original)
+        child = wrapped[:5]
+        self.assertIsInstance(child, indexing.CopyOnWriteArray)
+        child[:] = 0
+        self.assertArrayEqual(original, np.arange(10))
+        self.assertArrayEqual(wrapped, np.arange(10))
+        self.assertArrayEqual(child, np.zeros(5))
+
+
+class TestMemoryCachedArray(TestCase):
+    def test_wrapper(self):
+        original = indexing.LazilyIndexedArray(np.arange(10))
+        wrapped = indexing.MemoryCachedArray(original)
+        self.assertArrayEqual(wrapped, np.arange(10))
+        self.assertIsInstance(wrapped.array, np.ndarray)
+
+    def test_sub_array(self):
+        original = indexing.LazilyIndexedArray(np.arange(10))
+        wrapped = indexing.MemoryCachedArray(original)
+        child = wrapped[:5]
+        self.assertIsInstance(child, indexing.MemoryCachedArray)
+        self.assertArrayEqual(child, np.arange(5))
+        self.assertIsInstance(child.array, np.ndarray)
+        self.assertIsInstance(wrapped.array, indexing.LazilyIndexedArray)
+
+    def test_setitem(self):
+        original = np.arange(10)
+        wrapped = indexing.MemoryCachedArray(original)
+        wrapped[:] = 0
+        self.assertArrayEqual(original, np.zeros(10))

--- a/xarray/test/test_utils.py
+++ b/xarray/test/test_utils.py
@@ -174,9 +174,3 @@ class Test_hashable(TestCase):
             self.assertTrue(utils.hashable(v))
         for v in [[5, 6], ['seven', '8'], {9: 'ten'}]:
             self.assertFalse(utils.hashable(v))
-
-
-def test_no_pickle_mixin():
-    obj = utils.NoPickleMixin()
-    with pytest.raises(TypeError):
-        pickle.dumps(obj)

--- a/xarray/test/test_utils.py
+++ b/xarray/test/test_utils.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+import pickle
+import pytest
+
 import numpy as np
 import pandas as pd
 
@@ -171,3 +174,9 @@ class Test_hashable(TestCase):
             self.assertTrue(utils.hashable(v))
         for v in [[5, 6], ['seven', '8'], {9: 'ten'}]:
             self.assertFalse(utils.hashable(v))
+
+
+def test_no_pickle_mixin():
+    obj = utils.NoPickleMixin()
+    with pytest.raises(TypeError):
+        pickle.dumps(obj)

--- a/xarray/test/test_variable.py
+++ b/xarray/test/test_variable.py
@@ -449,6 +449,15 @@ class VariableSubclassTestCases(object):
         self.assertVariableIdentical(Variable((), ('a', 0)), v[0])
         self.assertVariableIdentical(v, v[:])
 
+    def test_load(self):
+        array = self.cls('x', np.arange(5))
+        orig_data = array._data
+        copied = array.copy(deep=True)
+        array.load()
+        assert type(array._data) is type(orig_data)
+        assert type(copied._data) is type(orig_data)
+        self.assertVariableIdentical(array, copied)
+
 
 class TestVariable(TestCase, VariableSubclassTestCases):
     cls = staticmethod(Variable)


### PR DESCRIPTION
This is a follow-up to generalize the changes from #1024:

- Caching and copy-on-write behavior has been moved to separate array classes
  that are explicitly used in `open_dataset` to wrap arrays loaded from disk (if
  `cache=True`).
- Dask specific logic has been removed from the caching/loading logic on
  `xarray.Variable`.
- Pickle no longer caches automatically under any circumstances.
- DataStore objects are now pickleable. This makes it feasible to use xarray's IO with dask-distributed or multi-processing.

~~Still needs tests for the `cache` argument to `open_dataset`, but everything
else seems to be working.~~

@crusaderky @kynan please review