### PR TITLE
WIP: remove some refs to xray

### DIFF
--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -370,7 +370,7 @@ methods (like pandas) for transforming datasets into new objects.
 
 For removing variables, you can select and drop an explicit list of
 variables by indexing with a list of names or using the
-:py:meth:`~xray.Dataset.drop` methods to return a new ``Dataset``. These
+:py:meth:`~xarray.Dataset.drop` methods to return a new ``Dataset``. These
 operations keep around coordinates:
 
 .. ipython:: python

--- a/doc/examples/monthly-means.rst
+++ b/doc/examples/monthly-means.rst
@@ -8,7 +8,7 @@ Author: `Joe Hamman <https://github.com/jhamman/>`__
 The data used for this example can be found in the
 `xarray-data <https://github.com/pydata/xarray-data>`__ repository.
 
-Suppose we have a netCDF or xray Dataset of monthly mean data and we
+Suppose we have a netCDF or xarray Dataset of monthly mean data and we
 want to calculate the seasonal average. To do this properly, we need to
 calculate the weighted average considering that each month has a
 different number of days.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -8,7 +8,7 @@ What's New
 
     import numpy as np
     import pandas as pd
-    import xray
+    import xarray as xray
     import xarray
     import xarray as xr
     np.random.seed(123456)
@@ -436,7 +436,7 @@ The following individuals contributed to this release:
 v0.7.0 (21 January 2016)
 ------------------------
 
-This major release includes redesign of :py:class:`~xray.DataArray`
+This major release includes redesign of :py:class:`~xarray.DataArray`
 internals, as well as new methods for reshaping, rolling and shifting
 data. It includes preliminary support for :py:class:`pandas.MultiIndex`,
 as well as a number of other features and bug fixes, several of which

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -723,12 +723,12 @@ def _full_like_dataarray(arr, keep_attrs=False, fill_value=None):
     return DataArray(values, dims=arr.dims, coords=arr.coords, attrs=attrs)
 
 
-def _full_like(xray_obj, keep_attrs=False, fill_value=None):
+def _full_like(xarray_obj, keep_attrs=False, fill_value=None):
     """Return a new object with the same shape and type as a given object.
 
     Parameters
     ----------
-    xray_obj : DataArray or Dataset
+    xarray_obj : DataArray or Dataset
         Return a full object with the same shape/dims/coords/attrs.
             `func` is calculated over all dimension for each group item.
     keep_attrs : bool, optional
@@ -740,19 +740,19 @@ def _full_like(xray_obj, keep_attrs=False, fill_value=None):
 
     Returns
     -------
-    out : same as xray_obj
+    out : same as xarray_obj
         New object with the same shape and type as a given object.
     """
     from .dataarray import DataArray
     from .dataset import Dataset
 
-    if isinstance(xray_obj, Dataset):
-        attrs = xray_obj.attrs if keep_attrs else {}
+    if isinstance(xarray_obj, Dataset):
+        attrs = xarray_obj.attrs if keep_attrs else {}
 
         return Dataset(dict((k, _full_like_dataarray(v, keep_attrs=keep_attrs,
                                                      fill_value=fill_value))
-                            for k, v in iteritems(xray_obj.data_vars)),
-                       name=xray_obj.name, attrs=attrs)
-    elif isinstance(xray_obj, DataArray):
-        return _full_like_dataarray(xray_obj, keep_attrs=keep_attrs,
+                            for k, v in iteritems(xarray_obj.data_vars)),
+                       name=xarray_obj.name, attrs=attrs)
+    elif isinstance(xarray_obj, DataArray):
+        return _full_like_dataarray(xarray_obj, keep_attrs=keep_attrs,
                                     fill_value=fill_value)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -865,7 +865,7 @@ class DataArray(AbstractArray, BaseDataObject):
         >>> arr = DataArray(np.arange(6).reshape(2, 3),
         ...                 coords=[('x', ['a', 'b']), ('y', [0, 1, 2])])
         >>> arr
-        <xray.DataArray (x: 2, y: 3)>
+        <xarray.DataArray (x: 2, y: 3)>
         array([[0, 1, 2],
                [3, 4, 5]])
         Coordinates:


### PR DESCRIPTION
There are some uses of xray that needed to be fixed.

WIP: merge after you decide what to do with https://github.com/pydata/xarray/issues/1135

Also, I'd be in favor of removing the two notebooks in https://github.com/pydata/xarray/tree/master/examples since they are also available in the docs (http://xarray.pydata.org/en/latest/examples.html). The example on RTD have the disadvantage that it's less easy to do copy/paste with them, but notebooks are more error prone since they need to be maintained externally. 