### PR TITLE
Pin package versions on RTD

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,6 +42,11 @@ try:
 except ImportError:
     print("no matplotlib")
 try:
+    import dask
+    print("dask: %s, %s" % (dask.__version__, dask.__file__))
+except ImportError:
+    print("no dask")
+try:
     import IPython
     print("ipython: %s, %s" % (IPython.__version__, IPython.__file__))
 except ImportError:

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,14 +3,15 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python
-  - numpy
-  - pandas
-  - numpydoc
-  - seaborn
-  - dask
+  - python=3.5
+  - numpy=1.11.2
+  - pandas=0.19.1
+  - numpydoc=0.6.0
+  - matplotlib=1.5.3
+  - seaborn=0.7.1
+  - dask=0.12.0
   - ipython=4.0.1
-  - sphinx
-  - netCDF4
-  - hdf4  # temporary install to get netCD4 working (GH1106)
-  - cartopy
+  - sphinx=1.4.8
+  - netCDF4=1.2.4
+  - hdf4=4.2.12  # temporary install to get netCD4 working (GH1106)
+  - cartopy=0.14.3


### PR DESCRIPTION
Now that we seem to have everything working on RTD, re-pin package versions

(follow-up to https://github.com/pydata/xarray/pull/1101)