### PR TITLE
Unpin python on RTD

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.5
+  - python
   - numpy=1.11.2
   - pandas=0.19.1
   - numpydoc=0.6.0


### PR DESCRIPTION
Pinning python to 3.5 introduced new [problems](https://readthedocs.org/projects/xray/builds/4723418/).

Despite the default python being 3 [here](https://github.com/pydata/xarray/blob/master/readthedocs.yml#L4) and also in our RTD preferences (dashboard->advanced), RTD seems to still use py2 per default...

Anyway, going back to py2 is the easiest for now, I might come back to this when I have more time.