### PR TITLE
Expose options for axis sharing between subplots

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -104,6 +104,10 @@ Enhancements
 - New top-level functions :py:func:`~xarray.full_like`,
   :py:func:`~xarray.zeros_like`, and :py:func:`~xarray.ones_like`
   By `Guido Imperiale <https://github.com/crusaderky>`_.
+- Options for axes sharing between subplots are exposed to
+  :py:class:`FacetGrid` and :py:func:`~xarray.plot.plot`, so axes
+  sharing can be disabled for polar plots.
+  By `Bas Hoonhout <https://github.com/hoonhout>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -72,7 +72,8 @@ class FacetGrid(object):
     """
 
     def __init__(self, data, col=None, row=None, col_wrap=None,
-                 aspect=1, size=3, subplot_kws=None):
+                 sharex=True, sharey=True, aspect=1, size=3,
+                 subplot_kws=None):
         """
         Parameters
         ----------
@@ -83,6 +84,10 @@ class FacetGrid(object):
             on separate facets in the grid.
         col_wrap : int, optional
             "Wrap" the column variable at this width, so that the column facets
+        sharex : bool, optional
+            If true, the facets will share x axes
+        sharey : bool, optional
+            If true, the facets will share y axes
         aspect : scalar, optional
             Aspect ratio of each facet, so that ``aspect * size`` gives the
             width of each facet in inches
@@ -141,7 +146,7 @@ class FacetGrid(object):
         figsize = (ncol * size * aspect + cbar_space, nrow * size)
 
         fig, axes = plt.subplots(nrow, ncol,
-                                 sharex=True, sharey=True, squeeze=False,
+                                 sharex=sharex, sharey=sharey, squeeze=False,
                                  figsize=figsize, subplot_kw=subplot_kws)
 
         # Set up the lists of names for the row and column facet variables

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -39,8 +39,9 @@ def _ensure_plottable(*args):
                         'or dates.')
 
 
-def _easy_facetgrid(darray, plotfunc, x, y, row=None, col=None, col_wrap=None,
-                    aspect=1, size=3, subplot_kws=None, **kwargs):
+def _easy_facetgrid(darray, plotfunc, x, y, row=None, col=None,
+                    col_wrap=None, sharex=True, sharey=True, aspect=1,
+                    size=3, subplot_kws=None, **kwargs):
     """
     Convenience method to call xarray.plot.FacetGrid from 2d plotting methods
 
@@ -51,7 +52,8 @@ def _easy_facetgrid(darray, plotfunc, x, y, row=None, col=None, col_wrap=None,
         raise ValueError("Can't use axes when making faceted plots.")
 
     g = FacetGrid(data=darray, col=col, row=row, col_wrap=col_wrap,
-                  aspect=aspect, size=size, subplot_kws=subplot_kws)
+                  sharex=sharex, sharey=sharey, aspect=aspect,
+                  size=size, subplot_kws=subplot_kws)
     return g.map_dataarray(plotfunc, x, y, **kwargs)
 
 

--- a/xarray/test/test_plot.py
+++ b/xarray/test/test_plot.py
@@ -1101,7 +1101,13 @@ class TestFacetGrid(PlotTestCase):
         d.plot.imshow(x='x', y='y', col='z', add_colorbar=False)
         self.assertEqual(0, len(find_possible_colorbars()))
 
+    def test_facetgrid_polar(self):
+        # test if polar projection in FacetGrid does not raise an exception
+        self.darray.plot.pcolormesh(col='z',
+                                    subplot_kws=dict(projection='polar'),
+                                    sharex=False, sharey=False)
 
+        
 class TestFacetGrid4d(PlotTestCase):
 
     def setUp(self):
@@ -1127,3 +1133,5 @@ class TestFacetGrid4d(PlotTestCase):
         # Top row should be labeled
         for label, ax in zip(self.darray.coords['col'].values, g.axes[0, :]):
             self.assertTrue(substring_in_axes(label, ax))
+        
+        


### PR DESCRIPTION
Typical usage for xarray.DataArray's for us is to store directional wave data (time, location, direction and frequency). In order to plot directional data stored in DataArray's it would be convenient to use a combination of FacetGrid and polar projections.

Currently, this is not possible with the xarray.plot modules as axes are hard-coded set to be shared among subplots, which conflicts with the fact that polar axes are by definition "box"-adjustable. Therefore we need the ability to turn off axes sharing.

The simple modification attached exposes the sharex/y options to the xarray.plot routines.