### PR TITLE
Set a default _FillValue of NaN for float types

### DIFF
--- a/doc/io.rst
+++ b/doc/io.rst
@@ -241,7 +241,9 @@ These encoding options work on any version of the netCDF file format:
   or ``'float32'``. This controls the type of the data written on disk.
 - ``_FillValue``:  Values of ``NaN`` in xarray variables are remapped to this value when
   saved on disk. This is important when converting floating point with missing values
-  to integers on disk, because ``NaN`` is not a valid dtype for integer dtypes.
+  to integers on disk, because ``NaN`` is not a valid dtype for integer dtypes. As a
+  default, variables with float types are attributed a ``_FillValue`` of ``NaN`` in the
+  output file.
 - ``scale_factor`` and ``add_offset``: Used to convert from encoded data on disk to
   to the decoded data in memory, according to the formula
   ``decoded = scale_factor * encoded + add_offset``.
@@ -251,6 +253,7 @@ example, to save the variable ``foo`` with a precision of 0.1 in 16-bit integers
 converting ``NaN`` to ``-9999``, we would use
 ``encoding={'foo': {'dtype': 'int16', 'scale_factor': 0.1, '_FillValue': -9999}}``.
 Compression and decompression with such discretization is extremely fast.
+
 
 Chunk based compression
 .......................

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,6 +21,8 @@ v0.9.0 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- By default ``to_netcdf()`` add a ``_FillValue = NaN`` attributes to float types.
+
 - Index coordinates for each dimensions are now optional, and no longer created
   by default :issue:`1017`. This has a number of implications:
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -567,7 +567,7 @@ def to_netcdf(dataset, path=None, mode='w', format=None, group=None,
                     pass
             except ValueError:
                 pass
-            
+
     # validate Dataset keys, DataArray names, and attr keys/values
     _validate_dataset_names(dataset)
     _validate_attrs(dataset)

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -549,6 +549,25 @@ def to_netcdf(dataset, path=None, mode='w', format=None, group=None,
             engine = _get_default_engine(path)
         path = _normalize_path(path)
 
+    for var in encoding:
+        # This section sets the default _FillValue
+        # to NaNs
+        if '_FillValue' not in encoding[var]:
+            if 'dtype' in encoding[var]:
+                dtype = encoding[var]['dtype']
+            else:
+                dtype = dataset[var].dtype
+            try:
+                # Test whether NaNs are accepted for
+                # the requested dtype:
+                np.asarray(np.nan, dtype=dtype)
+                try:
+                    encoding[var]['_FillValue'] = 'NaN'
+                except TypeError:
+                    pass
+            except ValueError:
+                pass
+            
     # validate Dataset keys, DataArray names, and attr keys/values
     _validate_dataset_names(dataset)
     _validate_attrs(dataset)

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -549,25 +549,6 @@ def to_netcdf(dataset, path=None, mode='w', format=None, group=None,
             engine = _get_default_engine(path)
         path = _normalize_path(path)
 
-    for var in encoding:
-        # This section sets the default _FillValue
-        # to NaNs
-        if '_FillValue' not in encoding[var]:
-            if 'dtype' in encoding[var]:
-                dtype = encoding[var]['dtype']
-            else:
-                dtype = dataset[var].dtype
-            try:
-                # Test whether NaNs are accepted for
-                # the requested dtype:
-                np.asarray(np.nan, dtype=dtype)
-                try:
-                    encoding[var]['_FillValue'] = np.nan
-                except TypeError:
-                    pass
-            except ValueError:
-                pass
-
     # validate Dataset keys, DataArray names, and attr keys/values
     _validate_dataset_names(dataset)
     _validate_attrs(dataset)

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -562,7 +562,7 @@ def to_netcdf(dataset, path=None, mode='w', format=None, group=None,
                 # the requested dtype:
                 np.asarray(np.nan, dtype=dtype)
                 try:
-                    encoding[var]['_FillValue'] = 'NaN'
+                    encoding[var]['_FillValue'] = np.nan
                 except TypeError:
                     pass
             except ValueError:

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -641,6 +641,14 @@ def maybe_encode_dtype(var, name=None):
     return var
 
 
+def maybe_default_fill_value(var):
+    # make NaN the fill value for float types:
+    if ('_FillValue' not in var.attrs and
+       np.issubdtype(var.dtype, np.floating)):
+        var.attrs['_FillValue'] = np.nan
+    return var
+
+
 def maybe_encode_bools(var):
     if ((var.dtype == np.bool) and
             ('dtype' not in var.encoding) and ('dtype' not in var.attrs)):
@@ -724,6 +732,7 @@ def encode_cf_variable(var, needs_copy=True, name=None):
     var, needs_copy = maybe_encode_offset_and_scale(var, needs_copy)
     var, needs_copy = maybe_encode_fill_value(var, needs_copy)
     var = maybe_encode_dtype(var, name)
+    var = maybe_default_fill_value(var)
     var = maybe_encode_bools(var)
     var = ensure_dtype_not_object(var)
     return var

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -424,27 +424,6 @@ class CFEncodedDataTest(DatasetIOTestCases):
             self.assertEqual(actual.x.encoding['dtype'], 'f4')
         self.assertEqual(ds.x.encoding, {})
 
-        # Test default encoding for float:
-        ds = Dataset({'x': ('y', np.arange(10.0))})
-        kwargs = dict(encoding={'x': {'dtype': 'f4'}})
-        with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            self.assertEqual(actual.x.encoding['_FillValue'],
-                             np.nan)
-        self.assertEqual(ds.x.encoding, {})
-
-        # Test default encoding for int:
-        ds = Dataset({'x': ('y', np.arange(10.0))})
-        kwargs = dict(encoding={'x': {'dtype': 'int16'}})
-        with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            self.assertTrue('_FillValue' not in actual.x.encoding)
-        self.assertEqual(ds.x.encoding, {})
-
-        # Test default encoding for implicit int:
-        ds = Dataset({'x': ('y', np.arange(10, dtype='int16'))})
-        with self.roundtrip(ds) as actual:
-            self.assertTrue('_FillValue' not in actual.x.encoding)
-        self.assertEqual(ds.x.encoding, {})
-
         kwargs = dict(encoding={'x': {'foo': 'bar'}})
         with self.assertRaisesRegexp(ValueError, 'unexpected encoding'):
             with self.roundtrip(ds, save_kwargs=kwargs) as actual:
@@ -466,6 +445,28 @@ class CFEncodedDataTest(DatasetIOTestCases):
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
             self.assertEqual(actual.t.encoding['units'], units)
             self.assertDatasetIdentical(actual, ds)
+
+    def test_default_fill_value(self):
+        # Test default encoding for float:
+        ds = Dataset({'x': ('y', np.arange(10.0))})
+        kwargs = dict(encoding={'x': {'dtype': 'f4'}})
+        with self.roundtrip(ds, save_kwargs=kwargs) as actual:
+            self.assertEqual(actual.x.encoding['_FillValue'],
+                             np.nan)
+        self.assertEqual(ds.x.encoding, {})
+
+        # Test default encoding for int:
+        ds = Dataset({'x': ('y', np.arange(10.0))})
+        kwargs = dict(encoding={'x': {'dtype': 'int16'}})
+        with self.roundtrip(ds, save_kwargs=kwargs) as actual:
+            self.assertTrue('_FillValue' not in actual.x.encoding)
+        self.assertEqual(ds.x.encoding, {})
+
+        # Test default encoding for implicit int:
+        ds = Dataset({'x': ('y', np.arange(10, dtype='int16'))})
+        with self.roundtrip(ds) as actual:
+            self.assertTrue('_FillValue' not in actual.x.encoding)
+        self.assertEqual(ds.x.encoding, {})
 
     def test_encoding_same_dtype(self):
         ds = Dataset({'x': ('y', np.arange(10.0, dtype='f4'))})

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -424,6 +424,26 @@ class CFEncodedDataTest(DatasetIOTestCases):
             self.assertEqual(actual.x.encoding['dtype'], 'f4')
         self.assertEqual(ds.x.encoding, {})
 
+        # Test default encoding for float:
+        ds = Dataset({'x': ('y', np.arange(10.0))})
+        kwargs = dict(encoding={'x': {'dtype': 'f4'}})
+        with self.roundtrip(ds, save_kwargs=kwargs) as actual:
+            self.assertEqual(actual.x.encoding['_FillValue'], b'NaN')
+        self.assertEqual(ds.x.encoding, {})
+
+        # Test default encoding for int:
+        ds = Dataset({'x': ('y', np.arange(10.0))})
+        kwargs = dict(encoding={'x': {'dtype': 'int16'}})
+        with self.roundtrip(ds, save_kwargs=kwargs) as actual:
+            self.assertTrue('_FillValue' not  in actual.x.encoding)
+        self.assertEqual(ds.x.encoding, {})
+
+        # Test default encoding for implicit int:
+        ds = Dataset({'x': ('y', np.arange(10, dtype='int16'))})
+        with self.roundtrip(ds) as actual:
+            self.assertTrue('_FillValue' not  in actual.x.encoding)
+        self.assertEqual(ds.x.encoding, {})
+
         kwargs = dict(encoding={'x': {'foo': 'bar'}})
         with self.assertRaisesRegexp(ValueError, 'unexpected encoding'):
             with self.roundtrip(ds, save_kwargs=kwargs) as actual:

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -428,16 +428,8 @@ class CFEncodedDataTest(DatasetIOTestCases):
         ds = Dataset({'x': ('y', np.arange(10.0))})
         kwargs = dict(encoding={'x': {'dtype': 'f4'}})
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            fill_value = actual.x.encoding['_FillValue']
-            try:
-                fill_value = np.asscalar(fill_value)
-            except AttributeError:
-                pass
-            try:
-                fill_value = fill_value.lower()
-            except AttributeError:
-                fill_value = str.encode(str(fill_value))
-            self.assertEqual(fill_value, b'nan')
+            self.assertEqual(actual.x.encoding['_FillValue'],
+                             np.nan)
         self.assertEqual(ds.x.encoding, {})
 
         # Test default encoding for int:

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -435,13 +435,13 @@ class CFEncodedDataTest(DatasetIOTestCases):
         ds = Dataset({'x': ('y', np.arange(10.0))})
         kwargs = dict(encoding={'x': {'dtype': 'int16'}})
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            self.assertTrue('_FillValue' not  in actual.x.encoding)
+            self.assertTrue('_FillValue' not in actual.x.encoding)
         self.assertEqual(ds.x.encoding, {})
 
         # Test default encoding for implicit int:
         ds = Dataset({'x': ('y', np.arange(10, dtype='int16'))})
         with self.roundtrip(ds) as actual:
-            self.assertTrue('_FillValue' not  in actual.x.encoding)
+            self.assertTrue('_FillValue' not in actual.x.encoding)
         self.assertEqual(ds.x.encoding, {})
 
         kwargs = dict(encoding={'x': {'foo': 'bar'}})

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -428,7 +428,12 @@ class CFEncodedDataTest(DatasetIOTestCases):
         ds = Dataset({'x': ('y', np.arange(10.0))})
         kwargs = dict(encoding={'x': {'dtype': 'f4'}})
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            self.assertEqual(actual.x.encoding['_FillValue'], b'NaN')
+            fill_value = actual.x.encoding['_FillValue']
+            try:
+                fill_value = np.asscalar(fill_value)
+            except AttributeError:
+                pass
+            self.assertEqual(fill_value.lower(), b'nan')
         self.assertEqual(ds.x.encoding, {})
 
         # Test default encoding for int:

--- a/xarray/test/test_backends.py
+++ b/xarray/test/test_backends.py
@@ -433,7 +433,11 @@ class CFEncodedDataTest(DatasetIOTestCases):
                 fill_value = np.asscalar(fill_value)
             except AttributeError:
                 pass
-            self.assertEqual(fill_value.lower(), b'nan')
+            try:
+                fill_value = fill_value.lower()
+            except AttributeError:
+                fill_value = str.encode(str(fill_value))
+            self.assertEqual(fill_value, b'nan')
         self.assertEqual(ds.x.encoding, {})
 
         # Test default encoding for int:


### PR DESCRIPTION
This PR attempts to solve #1163 by systematically including a default ``_FillValue`` of ``NaN`` whenever the user do not explicitly specify a FillValue. The idea is that third party software should work properly in these situations and if they don't then it is a bug on their side.