### PR TITLE
Add figsize, size, and aspect arguments to plotting methods

### DIFF
--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -156,7 +156,10 @@ resulting image via the formula ``figsize = (aspect * size, size)``:
     # create a dummy figure so sphinx plots everything below normally
     plt.figure()
 
-This feature also works with :ref:`plotting.faceting`.
+This feature also works with :ref:`plotting.faceting`. For facet plots,
+``size`` and ``aspect`` refer to a single panel (so that ``aspect * size``
+gives the width of each facet in inches), while ``figsize`` refers to the
+entire figure (as for matplotlib's ``figsize`` argument).
 
 .. note::
 

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -134,6 +134,42 @@ axes created by ``plt.subplots``.
 
 On the right is a histogram created by :py:func:`xarray.plot.hist`.
 
+.. _plotting.figsize:
+
+Controlling the figure size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can pass a ``figsize`` argument to all xarray's plotting methods to
+control the figure size. For convenience, xarray's plotting methods also
+support the ``aspect`` and ``size`` arguments which control the size of the
+resulting image via the formula ``figsize = (aspect * size, size)``:
+
+.. ipython:: python
+
+    air1d.plot(aspect=2, size=3)
+    @savefig plotting_example_size_and_aspect.png
+    plt.tight_layout()
+
+.. ipython:: python
+    :suppress:
+
+    # create a dummy figure so sphinx plots everything below normally
+    plt.figure()
+
+This feature also works with :ref:`plotting.faceting`.
+
+.. note::
+
+    If ``figsize`` or ``size`` are used, a new figure is created,
+    so this is mutually exclusive with the ``ax`` argument.
+
+.. note::
+
+    The convention used by xarray (``figsize = (aspect * size, size)``) is
+    borrowed from seaborn: it is therefore `not equivalent to matplotlib's`_.
+
+.. _not equivalent to matplotlib's: https://github.com/mwaskom/seaborn/issues/746
+
 Two Dimensions
 --------------
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -143,6 +143,10 @@ Enhancements
   :py:class:`FacetGrid` and :py:func:`~xarray.plot.plot`, so axes
   sharing can be disabled for polar plots.
   By `Bas Hoonhout <https://github.com/hoonhout>`_.
+- ``figsize``, ``size`` and ``aspect`` plot arguments are now supported for all
+  plots (:issue:`897`). See :ref:`plotting.figsize` for more details.
+  By `Stephan Hoyer <https://github.com/shoyer>`_ and
+  `Fabien Maussion <https://github.com/fmaussion>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -72,7 +72,7 @@ class FacetGrid(object):
     """
 
     def __init__(self, data, col=None, row=None, col_wrap=None,
-                 sharex=True, sharey=True, aspect=1, size=3,
+                 sharex=True, sharey=True, figsize=None, aspect=1, size=3,
                  subplot_kws=None):
         """
         Parameters
@@ -88,6 +88,8 @@ class FacetGrid(object):
             If true, the facets will share x axes
         sharey : bool, optional
             If true, the facets will share y axes
+        figsize : tuple, optional
+            A tuple (width, height) in inches. If set, overrides ``size``.
         aspect : scalar, optional
             Aspect ratio of each facet, so that ``aspect * size`` gives the
             width of each facet in inches
@@ -140,10 +142,11 @@ class FacetGrid(object):
         # Set the subplot kwargs
         subplot_kws = {} if subplot_kws is None else subplot_kws
 
-        # Calculate the base figure size with extra horizontal space for a
-        # colorbar
-        cbar_space = 1
-        figsize = (ncol * size * aspect + cbar_space, nrow * size)
+        if figsize is None:
+            # Calculate the base figure size with extra horizontal space for a
+            # colorbar
+            cbar_space = 1
+            figsize = (ncol * size * aspect + cbar_space, nrow * size)
 
         fig, axes = plt.subplots(nrow, ncol,
                                  sharex=sharex, sharey=sharey, squeeze=False,

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -89,7 +89,8 @@ class FacetGrid(object):
         sharey : bool, optional
             If true, the facets will share y axes
         figsize : tuple, optional
-            A tuple (width, height) in inches. If set, overrides ``size``.
+            A tuple (width, height) of the figure in inches.
+            If set, overrides ``size`` and ``aspect``.
         aspect : scalar, optional
             Aspect ratio of each facet, so that ``aspect * size`` gives the
             width of each facet in inches

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -472,7 +472,7 @@ def _plot2d(plotfunc):
 
         if 'imshow' == plotfunc.__name__ and isinstance(aspect, basestring):
             # forbid usage of mpl strings
-            raise ValueError("plt.imshow's `aspect` kwarg is not available " \
+            raise ValueError("plt.imshow's `aspect` kwarg is not available "
                              "in xarray")
 
         ax = get_axis(figsize, size, aspect, ax)

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -148,8 +148,8 @@ def line(darray, *args, **kwargs):
     darray : DataArray
         Must be 1 dimensional
     figsize : tuple, optional
-        A tuple (width, height) in inches. Mutually exclusive with ``size``
-        and ``ax``.
+        A tuple (width, height) of the figure in inches.
+        Mutually exclusive with ``size`` and ``ax``.
     aspect : scalar, optional
         Aspect ratio of plot, so that ``aspect * size`` gives the width in
         inches. Only used if a ``size`` is provided.
@@ -212,8 +212,8 @@ def hist(darray, figsize=None, size=None, aspect=None, ax=None, **kwargs):
     darray : DataArray
         Can be any dimension
     figsize : tuple, optional
-        A tuple (width, height) in inches. Mutually exclusive with ``size``
-        and ``ax``.
+        A tuple (width, height) of the figure in inches.
+        Mutually exclusive with ``size`` and ``ax``.
     aspect : scalar, optional
         Aspect ratio of plot, so that ``aspect * size`` gives the width in
         inches. Only used if a ``size`` is provided.
@@ -303,8 +303,8 @@ def _plot2d(plotfunc):
     y : string, optional
         Coordinate for y axis. If None use darray.dims[0]
     figsize : tuple, optional
-        A tuple (width, height) in inches. Mutually exclusive with ``size``
-        and ``ax``.
+        A tuple (width, height) of the figure in inches.
+        Mutually exclusive with ``size`` and ``ax``.
     aspect : scalar, optional
         Aspect ratio of plot, so that ``aspect * size`` gives the width in
         inches. Only used if a ``size`` is provided.
@@ -471,9 +471,9 @@ def _plot2d(plotfunc):
         kwargs.setdefault('norm', cmap_params['norm'])
 
         if 'imshow' == plotfunc.__name__ and isinstance(aspect, basestring):
-            # user probably wants something else than xarray's behavior
-            aspect = None
-            kwargs['aspect'] = aspect
+            # forbid usage of mpl strings
+            raise ValueError("plt.imshow's `aspect` kwarg is not available " \
+                             "in xarray")
 
         ax = get_axis(figsize, size, aspect, ax)
         primitive = plotfunc(xval, yval, zval, ax=ax, cmap=cmap_params['cmap'],

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -14,8 +14,9 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from .utils import _determine_cmap_params, _infer_xy_labels
+from .utils import _determine_cmap_params, _infer_xy_labels, get_axis
 from .facetgrid import FacetGrid
+from xarray.core.pycompat import basestring
 
 
 # Maybe more appropriate to keep this in .utils
@@ -40,16 +41,23 @@ def _ensure_plottable(*args):
 
 
 def _easy_facetgrid(darray, plotfunc, x, y, row=None, col=None,
-                    col_wrap=None, sharex=True, sharey=True, aspect=1,
-                    size=3, subplot_kws=None, **kwargs):
+                    col_wrap=None, sharex=True, sharey=True, aspect=None,
+                    size=None, subplot_kws=None, **kwargs):
     """
     Convenience method to call xarray.plot.FacetGrid from 2d plotting methods
 
     kwargs are the arguments to 2d plotting method
     """
     ax = kwargs.pop('ax', None)
+    figsize = kwargs.pop('figsize', None)
     if ax is not None:
         raise ValueError("Can't use axes when making faceted plots.")
+    if figsize is not None:
+        raise ValueError("Can't use ``figsize`` when making faceted plots.")
+    if aspect is None:
+        aspect = 1
+    if size is None:
+        size = 3
 
     g = FacetGrid(data=darray, col=col, row=row, col_wrap=col_wrap,
                   sharex=sharex, sharey=sharey, aspect=aspect,
@@ -139,8 +147,18 @@ def line(darray, *args, **kwargs):
     ----------
     darray : DataArray
         Must be 1 dimensional
-    ax : matplotlib axes, optional
-        If not passed, uses the current axis
+    figsize : tuple, optional
+        A tuple (width, height) in inches. Mutually exclusive with ``size``
+        and ``ax``.
+    aspect : scalar, optional
+        Aspect ratio of plot, so that ``aspect * size`` gives the width in
+        inches. Only used if a ``size`` is provided.
+    size : scalar, optional
+        If provided, create a new figure for the plot with the given size.
+        Height (in inches) of each plot. See also: ``aspect``.
+    ax : matplotlib axes object, optional
+        Axis on which to plot this figure. By default, use the current axis.
+        Mutually exclusive with ``size`` and ``figsize``.
     *args, **kwargs : optional
         Additional arguments to matplotlib.pyplot.plot
 
@@ -154,10 +172,12 @@ def line(darray, *args, **kwargs):
                          'dimensions'.format(ndims=ndims))
 
     # Ensures consistency with .plot method
+    figsize = kwargs.pop('figsize', None)
+    aspect = kwargs.pop('aspect', None)
+    size = kwargs.pop('size', None)
     ax = kwargs.pop('ax', None)
 
-    if ax is None:
-        ax = plt.gca()
+    ax = get_axis(figsize, size, aspect, ax)
 
     xlabel, = darray.dims
     x = darray.coords[xlabel]
@@ -179,7 +199,7 @@ def line(darray, *args, **kwargs):
     return primitive
 
 
-def hist(darray, ax=None, **kwargs):
+def hist(darray, figsize=None, size=None, aspect=None, ax=None, **kwargs):
     """
     Histogram of DataArray
 
@@ -191,16 +211,25 @@ def hist(darray, ax=None, **kwargs):
     ----------
     darray : DataArray
         Can be any dimension
-    ax : matplotlib axes, optional
-        If not passed, uses the current axis
+    figsize : tuple, optional
+        A tuple (width, height) in inches. Mutually exclusive with ``size``
+        and ``ax``.
+    aspect : scalar, optional
+        Aspect ratio of plot, so that ``aspect * size`` gives the width in
+        inches. Only used if a ``size`` is provided.
+    size : scalar, optional
+        If provided, create a new figure for the plot with the given size.
+        Height (in inches) of each plot. See also: ``aspect``.
+    ax : matplotlib axes object, optional
+        Axis on which to plot this figure. By default, use the current axis.
+        Mutually exclusive with ``size`` and ``figsize``.
     **kwargs : optional
         Additional keyword arguments to matplotlib.pyplot.hist
 
     """
     import matplotlib.pyplot as plt
 
-    if ax is None:
-        ax = plt.gca()
+    ax = get_axis(figsize, size, aspect, ax)
 
     no_nan = np.ravel(darray.values)
     no_nan = no_nan[pd.notnull(no_nan)]
@@ -273,8 +302,18 @@ def _plot2d(plotfunc):
         Coordinate for x axis. If None use darray.dims[1]
     y : string, optional
         Coordinate for y axis. If None use darray.dims[0]
+    figsize : tuple, optional
+        A tuple (width, height) in inches. Mutually exclusive with ``size``
+        and ``ax``.
+    aspect : scalar, optional
+        Aspect ratio of plot, so that ``aspect * size`` gives the width in
+        inches. Only used if a ``size`` is provided.
+    size : scalar, optional
+        If provided, create a new figure for the plot with the given size.
+        Height (in inches) of each plot. See also: ``aspect``.
     ax : matplotlib axes object, optional
-        If None, uses the current axis
+        Axis on which to plot this figure. By default, use the current axis.
+        Mutually exclusive with ``size`` and ``figsize``.
     row : string, optional
         If passed, make row faceted plots on this dimension name
     col : string, optional
@@ -347,7 +386,8 @@ def _plot2d(plotfunc):
     plotfunc.__doc__ = '\n'.join((plotfunc.__doc__, commondoc))
 
     @functools.wraps(plotfunc)
-    def newplotfunc(darray, x=None, y=None, ax=None, row=None, col=None,
+    def newplotfunc(darray, x=None, y=None, figsize=None, size=None,
+                    aspect=None, ax=None, row=None, col=None,
                     col_wrap=None, xincrease=True, yincrease=True,
                     add_colorbar=None, add_labels=True, vmin=None, vmax=None,
                     cmap=None, center=None, robust=False, extend=None,
@@ -386,9 +426,6 @@ def _plot2d(plotfunc):
             warnings.warn("Specifying a list of colors in cmap is deprecated. "
                           "Use colors keyword instead.",
                           DeprecationWarning, stacklevel=3)
-
-        if ax is None:
-            ax = plt.gca()
 
         xlab, ylab = _infer_xy_labels(darray=darray, x=x, y=y)
 
@@ -433,11 +470,16 @@ def _plot2d(plotfunc):
         # This allows the user to pass in a custom norm coming via kwargs
         kwargs.setdefault('norm', cmap_params['norm'])
 
-        ax, primitive = plotfunc(xval, yval, zval, ax=ax,
-                                 cmap=cmap_params['cmap'],
-                                 vmin=cmap_params['vmin'],
-                                 vmax=cmap_params['vmax'],
-                                 **kwargs)
+        if 'imshow' == plotfunc.__name__ and isinstance(aspect, basestring):
+            # user probably wants something else than xarray's behavior
+            aspect = None
+            kwargs['aspect'] = aspect
+
+        ax = get_axis(figsize, size, aspect, ax)
+        primitive = plotfunc(xval, yval, zval, ax=ax, cmap=cmap_params['cmap'],
+                             vmin=cmap_params['vmin'],
+                             vmax=cmap_params['vmax'],
+                             **kwargs)
 
         # Label the plot with metadata
         if add_labels:
@@ -466,12 +508,13 @@ def _plot2d(plotfunc):
 
     # For use as DataArray.plot.plotmethod
     @functools.wraps(newplotfunc)
-    def plotmethod(_PlotMethods_obj, x=None, y=None, ax=None, row=None,
-                   col=None, col_wrap=None, xincrease=True, yincrease=True,
-                   add_colorbar=None, add_labels=True, vmin=None, vmax=None,
-                   cmap=None, colors=None, center=None, robust=False,
-                   extend=None, levels=None, infer_intervals=None,
-                   subplot_kws=None, cbar_ax=None, cbar_kwargs=None, **kwargs):
+    def plotmethod(_PlotMethods_obj, x=None, y=None, figsize=None, size=None,
+                   aspect=None, ax=None, row=None, col=None, col_wrap=None,
+                   xincrease=True, yincrease=True, add_colorbar=None,
+                   add_labels=True, vmin=None, vmax=None, cmap=None,
+                   colors=None, center=None, robust=False, extend=None,
+                   levels=None, infer_intervals=None, subplot_kws=None,
+                   cbar_ax=None, cbar_kwargs=None, **kwargs):
         """
         The method should have the same signature as the function.
 
@@ -531,7 +574,7 @@ def imshow(x, y, z, ax, **kwargs):
 
     primitive = ax.imshow(z, **defaults)
 
-    return ax, primitive
+    return primitive
 
 
 @_plot2d
@@ -542,7 +585,7 @@ def contour(x, y, z, ax, **kwargs):
     Wraps matplotlib.pyplot.contour
     """
     primitive = ax.contour(x, y, z, **kwargs)
-    return ax, primitive
+    return primitive
 
 
 @_plot2d
@@ -553,7 +596,7 @@ def contourf(x, y, z, ax, **kwargs):
     Wraps matplotlib.pyplot.contourf
     """
     primitive = ax.contourf(x, y, z, **kwargs)
-    return ax, primitive
+    return primitive
 
 
 def _infer_interval_breaks(coord, axis=0):
@@ -612,4 +655,4 @@ def pcolormesh(x, y, z, ax, infer_intervals=None, **kwargs):
         ax.set_xlim(x[0], x[-1])
         ax.set_ylim(y[0], y[-1])
 
-    return ax, primitive
+    return primitive

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -52,16 +52,16 @@ def _easy_facetgrid(darray, plotfunc, x, y, row=None, col=None,
     figsize = kwargs.pop('figsize', None)
     if ax is not None:
         raise ValueError("Can't use axes when making faceted plots.")
-    if figsize is not None:
-        raise ValueError("Can't use ``figsize`` when making faceted plots.")
     if aspect is None:
         aspect = 1
     if size is None:
         size = 3
+    elif figsize is not None:
+        raise ValueError('cannot provide both `figsize` and `size` arguments')
 
     g = FacetGrid(data=darray, col=col, row=row, col_wrap=col_wrap,
-                  sharex=sharex, sharey=sharey, aspect=aspect,
-                  size=size, subplot_kws=subplot_kws)
+                  sharex=sharex, sharey=sharey, figsize=figsize,
+                  aspect=aspect, size=size, subplot_kws=subplot_kws)
     return g.map_dataarray(plotfunc, x, y, **kwargs)
 
 

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -226,10 +226,10 @@ def get_axis(figsize, size, aspect, ax):
 
     if figsize is not None:
         if ax is not None:
-            raise ValueError('cannot provide both `figsize` and ' \
+            raise ValueError('cannot provide both `figsize` and '
                              '`ax` arguments')
         if size is not None:
-            raise ValueError('cannot provide both `figsize` and ' \
+            raise ValueError('cannot provide both `figsize` and '
                              '`size` arguments')
         _, ax = plt.subplots(figsize=figsize)
     elif size is not None:

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -218,3 +218,31 @@ def _infer_xy_labels(darray, x, y):
     elif any(k not in darray.coords and k not in darray.dims for k in (x, y)):
         raise ValueError('x and y must be coordinate variables')
     return x, y
+
+
+def get_axis(figsize, size, aspect, ax):
+    import matplotlib as mpl
+    import matplotlib.pyplot as plt
+
+    if figsize is not None:
+        if ax is not None:
+            raise TypeError('cannot provide both `figsize` and `ax` arguments')
+        if size is not None:
+            raise TypeError('cannot provide both `figsize` and ' \
+                            '`size` arguments')
+        _, ax = plt.subplots(figsize=figsize)
+    elif size is not None:
+        if ax is not None:
+            raise TypeError('cannot provide both `size` and `ax` arguments')
+        if aspect is None:
+            width, height = mpl.rcParams['figure.figsize']
+            aspect = width / height
+        figsize = (size * aspect, size)
+        _, ax = plt.subplots(figsize=figsize)
+    elif aspect is not None:
+        raise TypeError('cannot provide `aspect` argument without `size`')
+
+    if ax is None:
+        ax = plt.gca()
+
+    return ax

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -226,21 +226,22 @@ def get_axis(figsize, size, aspect, ax):
 
     if figsize is not None:
         if ax is not None:
-            raise TypeError('cannot provide both `figsize` and `ax` arguments')
+            raise ValueError('cannot provide both `figsize` and ' \
+                             '`ax` arguments')
         if size is not None:
-            raise TypeError('cannot provide both `figsize` and ' \
-                            '`size` arguments')
+            raise ValueError('cannot provide both `figsize` and ' \
+                             '`size` arguments')
         _, ax = plt.subplots(figsize=figsize)
     elif size is not None:
         if ax is not None:
-            raise TypeError('cannot provide both `size` and `ax` arguments')
+            raise ValueError('cannot provide both `size` and `ax` arguments')
         if aspect is None:
             width, height = mpl.rcParams['figure.figsize']
             aspect = width / height
         figsize = (size * aspect, size)
         _, ax = plt.subplots(figsize=figsize)
     elif aspect is not None:
-        raise TypeError('cannot provide `aspect` argument without `size`')
+        raise ValueError('cannot provide `aspect` argument without `size`')
 
     if ax is None:
         ax = plt.gca()

--- a/xarray/test/test_plot.py
+++ b/xarray/test/test_plot.py
@@ -175,16 +175,16 @@ class TestPlot(PlotTestCase):
         self.darray.plot(size=5, aspect=2)
         assert tuple(plt.gcf().get_size_inches()) == (10, 5)
 
-        with self.assertRaisesRegexp(TypeError, 'cannot provide both'):
+        with self.assertRaisesRegexp(ValueError, 'cannot provide both'):
             self.darray.plot(ax=plt.gca(), figsize=(3, 4))
 
-        with self.assertRaisesRegexp(TypeError, 'cannot provide both'):
+        with self.assertRaisesRegexp(ValueError, 'cannot provide both'):
             self.darray.plot(size=5, figsize=(3, 4))
 
-        with self.assertRaisesRegexp(TypeError, 'cannot provide both'):
+        with self.assertRaisesRegexp(ValueError, 'cannot provide both'):
             self.darray.plot(size=5, ax=plt.gca())
 
-        with self.assertRaisesRegexp(TypeError, 'cannot provide `aspect`'):
+        with self.assertRaisesRegexp(ValueError, 'cannot provide `aspect`'):
             self.darray.plot(aspect=1)
 
     def test_convenient_facetgrid_4d(self):
@@ -1082,7 +1082,10 @@ class TestFacetGrid(PlotTestCase):
         g = xplt.FacetGrid(self.darray, col='z', size=4, aspect=0.5)
         self.assertArrayEqual(g.fig.get_size_inches(), (7, 4))
 
-        with self.assertRaisesRegexp(ValueError, "Can't use"):
+        g = xplt.FacetGrid(self.darray, col='z', figsize=(9, 4))
+        self.assertArrayEqual(g.fig.get_size_inches(), (9, 4))
+
+        with self.assertRaisesRegexp(ValueError, "cannot provide both"):
             g = xplt.plot(self.darray, row=2, col='z', figsize=(6, 4), size=6)
 
         with self.assertRaisesRegexp(ValueError, "Can't use"):

--- a/xarray/test/test_plot.py
+++ b/xarray/test/test_plot.py
@@ -162,6 +162,31 @@ class TestPlot(PlotTestCase):
         for ax in g.axes.flat:
             self.assertEqual(ax.get_axis_bgcolor(), 'r')
 
+    def test_plot_size(self):
+        self.darray[:, 0, 0].plot(figsize=(13, 5))
+        assert tuple(plt.gcf().get_size_inches()) == (13, 5)
+
+        self.darray.plot(figsize=(13, 5))
+        assert tuple(plt.gcf().get_size_inches()) == (13, 5)
+
+        self.darray.plot(size=5)
+        assert plt.gcf().get_size_inches()[1] == 5
+
+        self.darray.plot(size=5, aspect=2)
+        assert tuple(plt.gcf().get_size_inches()) == (10, 5)
+
+        with self.assertRaisesRegexp(TypeError, 'cannot provide both'):
+            self.darray.plot(ax=plt.gca(), figsize=(3, 4))
+
+        with self.assertRaisesRegexp(TypeError, 'cannot provide both'):
+            self.darray.plot(size=5, figsize=(3, 4))
+
+        with self.assertRaisesRegexp(TypeError, 'cannot provide both'):
+            self.darray.plot(size=5, ax=plt.gca())
+
+        with self.assertRaisesRegexp(TypeError, 'cannot provide `aspect`'):
+            self.darray.plot(aspect=1)
+
     def test_convenient_facetgrid_4d(self):
         a = easy_array((10, 15, 2, 3))
         d = DataArray(a, dims=['y', 'x', 'columns', 'rows'])
@@ -900,6 +925,10 @@ class TestImshow(Common2dMixin, PlotTestCase):
     def test_can_change_aspect(self):
         self.darray.plot.imshow(aspect='equal')
         self.assertEqual('equal', plt.gca().get_aspect())
+        # with numbers we fall back to fig control
+        self.darray.plot.imshow(size=5, aspect=2)
+        self.assertEqual('auto', plt.gca().get_aspect())
+        assert tuple(plt.gcf().get_size_inches()) == (10, 5)
 
     def test_primitive_artist_returned(self):
         artist = self.plotmethod()
@@ -1052,6 +1081,12 @@ class TestFacetGrid(PlotTestCase):
 
         g = xplt.FacetGrid(self.darray, col='z', size=4, aspect=0.5)
         self.assertArrayEqual(g.fig.get_size_inches(), (7, 4))
+
+        with self.assertRaisesRegexp(ValueError, "Can't use"):
+            g = xplt.plot(self.darray, row=2, col='z', figsize=(6, 4), size=6)
+
+        with self.assertRaisesRegexp(ValueError, "Can't use"):
+            g = xplt.plot(self.darray, row=2, col='z', ax=plt.gca(), size=6)
 
     def test_num_ticks(self):
         nticks = 100

--- a/xarray/test/test_plot.py
+++ b/xarray/test/test_plot.py
@@ -922,9 +922,11 @@ class TestImshow(Common2dMixin, PlotTestCase):
         self.darray.plot.imshow()
         self.assertEqual('auto', plt.gca().get_aspect())
 
-    def test_can_change_aspect(self):
-        self.darray.plot.imshow(aspect='equal')
-        self.assertEqual('equal', plt.gca().get_aspect())
+    def test_cannot_change_mpl_aspect(self):
+
+        with self.assertRaisesRegexp(ValueError, 'not available in xarray'):
+            self.darray.plot.imshow(aspect='equal')
+
         # with numbers we fall back to fig control
         self.darray.plot.imshow(size=5, aspect=2)
         self.assertEqual('auto', plt.gca().get_aspect())


### PR DESCRIPTION
Extends and finishes https://github.com/pydata/xarray/pull/637

I chose to keep seaborn's convention for two reasons:
- it doesn't break existing code
- now that ``figsize`` is also available, I expect the ``size`` and ``aspect`` kwargs to be less used in non-facetgrid plots

Closes https://github.com/pydata/xarray/issues/897