### PR TITLE
End support for py3.3?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
     env: CONDA_ENV=py27-min
   - python: 2.7
     env: CONDA_ENV=py27-cdat+pynio
-  - python: 3.3
-    env: CONDA_ENV=py33
   - python: 3.4
     env: CONDA_ENV=py34
   - python: 3.5

--- a/ci/requirements-py33.yml
+++ b/ci/requirements-py33.yml
@@ -1,8 +1,0 @@
-name: test_env
-dependencies:
-  - python=3.3
-  - pytest
-  - pandas
-  - pip:
-    - coveralls
-    - pytest-cov

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -64,6 +64,7 @@ Breaking changes
 - Coordinates used to index a dimension are now loaded eagerly into
   :py:class:`pandas.Index` objects, instead of loading the values lazily.
   By `Guido Imperiale <https://github.com/crusaderky>`_.
+- xarray no longer supports python 3.3
 
 Deprecations
 ~~~~~~~~~~~~


### PR DESCRIPTION
Even at the beginning of this year its downloads were 90% lower than 2.6: https://hynek.me/articles/python3-2016/

Impetus is that pytest no longer supports it, and some of the tests I recently wrote don't work on 3.3