### PR TITLE
Actually copy dask arrays in Variable.copy()

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -6,7 +6,7 @@ Installation
 Required dependencies
 ---------------------
 
-- Python 2.7, 3.3, 3.4 or 3.5
+- Python 2.7, 3.4 or 3.5
 - `numpy <http://www.numpy.org/>`__ (1.7 or later)
 - `pandas <http://pandas.pydata.org/>`__ (0.15.0 or later)
 

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -36,7 +36,8 @@ For accelerating xarray
 For parallel computing
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- `dask.array <http://dask.pydata.org>`__: required for :ref:`dask`.
+- `dask.array <http://dask.pydata.org>`__ (0.9.0 or later): required for
+  :ref:`dask`.
 
 For plotting
 ~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -64,7 +64,7 @@ Breaking changes
 - Coordinates used to index a dimension are now loaded eagerly into
   :py:class:`pandas.Index` objects, instead of loading the values lazily.
   By `Guido Imperiale <https://github.com/crusaderky>`_.
-- xarray no longer supports python 3.3
+- xarray no longer supports python 3.3 or versions of dask prior to v0.9.0.
 
 Deprecations
 ~~~~~~~~~~~~
@@ -209,6 +209,9 @@ Bug fixes
 
 - Fixed a bug with facetgrid (the ``norm`` keyword was ignored, :issue:`1159`).
   By `Fabien Maussion <https://github.com/fmaussion>`_.
+
+- Fix to make ``.copy()`` actually copy dask arrays, which will be relevant for
+  future releases of dask in which dask arrays will be mutable (:issue:`1180`).
 
 .. _whats-new.0.8.2:
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -437,10 +437,12 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
             # don't share caching between copies
             data = indexing.MemoryCachedArray(data.array)
 
-        if deep and not isinstance(
-                data, (dask_array_type, PandasIndexAdapter)):
-            # pandas.Index and dask.array objects are immutable
-            data = np.array(data)
+        if deep:
+            if isinstance(data, dask_array_type):
+                data = data.copy()
+            elif not isinstance(data, PandasIndexAdapter):
+                # pandas.Index is immutable
+                data = np.array(data)
 
         # note:
         # dims is already an immutable tuple


### PR DESCRIPTION
Fixes #1166

xref https://github.com/dask/dask/pull/1840

I don't think there's a good way to test this prior to the release of the next version of dask.

For what it's worth, this will make the minimum version of dask 0.9.0, unless we want to add a hack to handle a non-existent `copy()` method.