### PR TITLE
Add mention of in breaking change about default fill value

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,6 +22,7 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 - By default ``to_netcdf()`` add a ``_FillValue = NaN`` attributes to float types.
+  By `Frederic Laliberte <https://github.com/laliberte>`_.
 
 - Index coordinates for each dimensions are now optional, and no longer created
   by default :issue:`1017`. This has a number of implications:


### PR DESCRIPTION
Quick PR to attribute credit to Frederic Laliberte for the default fill value in the ``.to_netcdf()`` method.