### PR TITLE
Fixes OS error arising from too many files open

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,6 +35,12 @@ Added new method :py:meth:`~Dataset.assign_attrs` to ``DataArray`` and
 ``dict.update`` method on attrs (:issue:`1281`).
 By `Henry S. Harrison <https://hsharrison.github.io>`_.
 
+- It is now possible to set the ``autoclose=True`` argument to
+  :py:func:`~xarray.open_mfdataset` to explicitly close opened files when not
+  in use to prevent occurrence of an OS Error related to too many open files.
+  Note, the default is ``autoclose=False``, which is consistent with previous
+  xarray behavior.  By `Phillip J. Wolfram <https://github.com/pwolfram>`_.
+
 Bug fixes
 ~~~~~~~~~
 - ``rolling`` now keeps its original dimension order (:issue:`1125`).

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -5,6 +5,7 @@ import numpy as np
 import logging
 import time
 import traceback
+import contextlib
 from collections import Mapping
 from distutils.version import LooseVersion
 
@@ -41,6 +42,15 @@ def _decode_variable_name(name):
     return name
 
 
+def find_root(ds):
+    """
+    Helper function to find the root of a netcdf or h5netcdf dataset.
+    """
+    while ds.parent is not None:
+        ds = ds.parent
+    return ds
+
+
 def robust_getitem(array, key, catch=Exception, max_retries=6,
                    initial_delay=500):
     """
@@ -67,6 +77,7 @@ def robust_getitem(array, key, catch=Exception, max_retries=6,
 
 
 class AbstractDataStore(Mapping):
+    _autoclose = False
 
     def __iter__(self):
         return iter(self.variables)
@@ -107,8 +118,8 @@ class AbstractDataStore(Mapping):
         This function will be called anytime variables or attributes
         are requested, so care should be taken to make sure its fast.
         """
-        variables = FrozenOrderedDict((_decode_variable_name(k), v) for k, v in
-                                      iteritems(self.get_variables()))
+        variables = FrozenOrderedDict((_decode_variable_name(k), v)
+                                      for k, v in self.get_variables().items())
         attributes = FrozenOrderedDict(self.get_attrs())
         return variables, attributes
 
@@ -252,3 +263,27 @@ class DataStorePickleMixin(object):
     def __setstate__(self, state):
         self.__dict__.update(state)
         self.ds = self._opener(mode=self._mode)
+
+    @contextlib.contextmanager
+    def ensure_open(self, autoclose):
+        """
+        Helper function to make sure datasets are closed and opened
+        at appropriate times to avoid too many open file errors.
+
+        Use requires `autoclose=True` argument to `open_mfdataset`.
+        """
+        if self._autoclose and not self._isopen:
+            try:
+                self.ds = self._opener()
+                self._isopen = True
+                yield
+            finally:
+                if autoclose:
+                    self.close()
+        else:
+            yield
+
+    def assert_open(self):
+        if not self._isopen:
+            raise AssertionError('internal failure: file must be open '
+                                 'if `autoclose=True` is used.')

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -6,12 +6,18 @@ import warnings
 
 from .. import Variable
 from ..core import indexing
-from ..core.utils import FrozenOrderedDict, close_on_error, Frozen
+from ..core.utils import FrozenOrderedDict, close_on_error
 from ..core.pycompat import iteritems, bytes_type, unicode_type, OrderedDict
 
-from .common import WritableCFDataStore, DataStorePickleMixin
+from .common import WritableCFDataStore, DataStorePickleMixin, find_root
 from .netCDF4_ import (_nc4_group, _nc4_values_and_dtype,
                        _extract_nc4_variable_encoding, BaseNetCDF4Array)
+
+
+class H5NetCDFArrayWrapper(BaseNetCDF4Array):
+    def __getitem__(self, key):
+        with self.datastore.ensure_open(autoclose=True):
+            return self.get_array()[key]
 
 
 def maybe_decode_bytes(txt):
@@ -49,12 +55,18 @@ class H5NetCDFStore(WritableCFDataStore, DataStorePickleMixin):
     """Store for reading and writing data via h5netcdf
     """
     def __init__(self, filename, mode='r', format=None, group=None,
-                 writer=None):
+                 writer=None, autoclose=False):
         if format not in [None, 'NETCDF4']:
             raise ValueError('invalid format for h5netcdf backend')
         opener = functools.partial(_open_h5netcdf_group, filename, mode=mode,
                                    group=group)
         self.ds = opener()
+        if autoclose:
+            raise NotImplemented('autoclose=True is not implemented '
+                                 'for the h5netcdf backend pending further '
+                                 'exploration, e.g., bug fixes (in h5netcdf?)')
+        self._autoclose = False
+        self._isopen = True
         self.format = format
         self._opener = opener
         self._filename = filename
@@ -62,36 +74,44 @@ class H5NetCDFStore(WritableCFDataStore, DataStorePickleMixin):
         super(H5NetCDFStore, self).__init__(writer)
 
     def open_store_variable(self, name, var):
-        dimensions = var.dimensions
-        data = indexing.LazilyIndexedArray(BaseNetCDF4Array(name, self))
-        attrs = _read_attributes(var)
+        with self.ensure_open(autoclose=False):
+            dimensions = var.dimensions
+            data = indexing.LazilyIndexedArray(
+                H5NetCDFArrayWrapper(name, self))
+            attrs = _read_attributes(var)
 
-        # netCDF4 specific encoding
-        encoding = dict(var.filters())
-        chunking = var.chunking()
-        encoding['chunksizes'] = chunking if chunking != 'contiguous' else None
+            # netCDF4 specific encoding
+            encoding = dict(var.filters())
+            chunking = var.chunking()
+            encoding['chunksizes'] = chunking \
+                if chunking != 'contiguous' else None
 
-        # save source so __repr__ can detect if it's local or not
-        encoding['source'] = self._filename
-        encoding['original_shape'] = var.shape
+            # save source so __repr__ can detect if it's local or not
+            encoding['source'] = self._filename
+            encoding['original_shape'] = var.shape
 
         return Variable(dimensions, data, attrs, encoding)
 
     def get_variables(self):
-        return FrozenOrderedDict((k, self.open_store_variable(k, v))
-                                 for k, v in iteritems(self.ds.variables))
+        with self.ensure_open(autoclose=False):
+            return FrozenOrderedDict((k, self.open_store_variable(k, v))
+                                     for k, v in iteritems(self.ds.variables))
 
     def get_attrs(self):
-        return Frozen(_read_attributes(self.ds))
+        with self.ensure_open(autoclose=True):
+            return FrozenOrderedDict(_read_attributes(self.ds))
 
     def get_dimensions(self):
-        return self.ds.dimensions
+        with self.ensure_open(autoclose=True):
+            return self.ds.dimensions
 
     def set_dimension(self, name, length):
-        self.ds.createDimension(name, size=length)
+        with self.ensure_open(autoclose=False):
+            self.ds.createDimension(name, size=length)
 
     def set_attribute(self, key, value):
-        self.ds.setncattr(key, value)
+        with self.ensure_open(autoclose=False):
+            self.ds.setncattr(key, value)
 
     def prepare_variable(self, name, variable, check_encoding=False,
                          unlimited_dims=None):
@@ -129,12 +149,14 @@ class H5NetCDFStore(WritableCFDataStore, DataStorePickleMixin):
         return nc4_var, variable.data
 
     def sync(self):
-        super(H5NetCDFStore, self).sync()
-        self.ds.sync()
+        with self.ensure_open(autoclose=True):
+            super(H5NetCDFStore, self).sync()
+            self.ds.sync()
 
     def close(self):
-        ds = self.ds
-        # netCDF4 only allows closing the root group
-        while ds.parent is not None:
-            ds = ds.parent
-        ds.close()
+        if self._isopen:
+            # netCDF4 only allows closing the root group
+            ds = find_root(self.ds)
+            if not ds._closed:
+                ds.close()
+            self._isopen = False

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -89,3 +89,140 @@ except ImportError:
             #
             # See http://bugs.python.org/issue12029 for more details
             return exctype is not None and issubclass(exctype, self._exceptions)
+try:
+    from contextlib import ExitStack
+except ImportError:
+    # backport from Python 3.5:
+    from collections import deque
+
+    # Inspired by discussions on http://bugs.python.org/issue13585
+    class ExitStack(object):
+        """Context manager for dynamic management of a stack of exit callbacks
+
+        For example:
+
+            with ExitStack() as stack:
+                files = [stack.enter_context(open(fname)) for fname in filenames]
+                # All opened files will automatically be closed at the end of
+                # the with statement, even if attempts to open files later
+                # in the list raise an exception
+
+        """
+        def __init__(self):
+            self._exit_callbacks = deque()
+
+        def pop_all(self):
+            """Preserve the context stack by transferring it to a new instance"""
+            new_stack = type(self)()
+            new_stack._exit_callbacks = self._exit_callbacks
+            self._exit_callbacks = deque()
+            return new_stack
+
+        def _push_cm_exit(self, cm, cm_exit):
+            """Helper to correctly register callbacks to __exit__ methods"""
+            def _exit_wrapper(*exc_details):
+                return cm_exit(cm, *exc_details)
+            _exit_wrapper.__self__ = cm
+            self.push(_exit_wrapper)
+
+        def push(self, exit):
+            """Registers a callback with the standard __exit__ method signature
+
+            Can suppress exceptions the same way __exit__ methods can.
+
+            Also accepts any object with an __exit__ method (registering a call
+            to the method instead of the object itself)
+            """
+            # We use an unbound method rather than a bound method to follow
+            # the standard lookup behaviour for special methods
+            _cb_type = type(exit)
+            try:
+                exit_method = _cb_type.__exit__
+            except AttributeError:
+                # Not a context manager, so assume its a callable
+                self._exit_callbacks.append(exit)
+            else:
+                self._push_cm_exit(exit, exit_method)
+            return exit # Allow use as a decorator
+
+        def callback(self, callback, *args, **kwds):
+            """Registers an arbitrary callback and arguments.
+
+            Cannot suppress exceptions.
+            """
+            def _exit_wrapper(exc_type, exc, tb):
+                callback(*args, **kwds)
+            # We changed the signature, so using @wraps is not appropriate, but
+            # setting __wrapped__ may still help with introspection
+            _exit_wrapper.__wrapped__ = callback
+            self.push(_exit_wrapper)
+            return callback # Allow use as a decorator
+
+        def enter_context(self, cm):
+            """Enters the supplied context manager
+
+            If successful, also pushes its __exit__ method as a callback and
+            returns the result of the __enter__ method.
+            """
+            # We look up the special methods on the type to match the with statement
+            _cm_type = type(cm)
+            _exit = _cm_type.__exit__
+            result = _cm_type.__enter__(cm)
+            self._push_cm_exit(cm, _exit)
+            return result
+
+        def close(self):
+            """Immediately unwind the context stack"""
+            self.__exit__(None, None, None)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_details):
+            received_exc = exc_details[0] is not None
+
+            # We manipulate the exception state so it behaves as though
+            # we were actually nesting multiple with statements
+            frame_exc = sys.exc_info()[1]
+            
+            def _fix_exception_context(new_exc, old_exc):
+                # Context may not be correct, so find the end of the chain
+                while 1:
+                    exc_context = new_exc.__context__
+                    if exc_context is old_exc:
+                        # Context is already set correctly (see issue 20317)
+                        return
+                    if exc_context is None or exc_context is frame_exc:
+                        break
+                    new_exc = exc_context
+                # Change the end of the chain to point to the exception
+                # we expect it to reference
+                new_exc.__context__ = old_exc
+
+            # Callbacks are invoked in LIFO order to match the behaviour of
+            # nested context managers
+            suppressed_exc = False
+            pending_raise = False
+            while self._exit_callbacks:
+                cb = self._exit_callbacks.pop()
+                try:
+                    if cb(*exc_details):
+                        suppressed_exc = True
+                        pending_raise = False
+                        exc_details = (None, None, None)
+                except:
+                    new_exc_details = sys.exc_info()
+                    # simulate the stack of exceptions by setting the context
+                    _fix_exception_context(new_exc_details[1], exc_details[1])
+                    pending_raise = True
+                    exc_details = new_exc_details
+            if pending_raise:
+                try:
+                    # bare "raise exc_details[1]" replaces our carefully
+                    # set-up context
+                    fixed_ctx = exc_details[1].__context__
+                    raise exc_details[1]
+                except BaseException:
+                    exc_details[1].__context__ = fixed_ctx
+                    raise
+            return received_exc and suppressed_exc

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -398,7 +398,12 @@ class NdimSizeLenMixin(object):
             raise TypeError('len() of unsized object')
 
 
-class NDArrayMixin(NdimSizeLenMixin):
+class DunderArrayMixin(object):
+    def __array__(self, dtype=None):
+        return np.asarray(self[...], dtype=dtype)
+
+
+class NDArrayMixin(NdimSizeLenMixin, DunderArrayMixin):
     """Mixin class for making wrappers of N-dimensional arrays that conform to
     the ndarray interface required for the data argument to Variable objects.
 
@@ -412,9 +417,6 @@ class NDArrayMixin(NdimSizeLenMixin):
     @property
     def shape(self):
         return self.array.shape
-
-    def __array__(self, dtype=None):
-        return np.asarray(self[...], dtype=dtype)
 
     def __getitem__(self, key):
         return self.array[key]

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -7,6 +7,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 from numpy.testing import assert_array_equal
+from xarray.core.ops import allclose_or_equiv
 import pytest
 
 from xarray.core import utils
@@ -145,6 +146,9 @@ class TestCase(unittest.TestCase):
 
     def assertEqual(self, a1, a2):
         assert a1 == a2 or (a1 != a1 and a2 != a2)
+
+    def assertAllClose(self, a1, a2, rtol=1e-05, atol=1e-8):
+        assert allclose_or_equiv(a1, a2, rtol=rtol, atol=atol)
 
     def assertDatasetEqual(self, d1, d2):
         assert_equal(d1, d2)


### PR DESCRIPTION
Previously, DataStore  did not judiciously close files, resulting in opening a large number of files that
could result in an OSError related to too many files being open.  This merge provides a solution for the netCDF, scipy, and h5netcdf backends.