### PR TITLE
add info in doc on how to facet with cartopy

### DIFF
--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -450,7 +450,7 @@ When faceting on maps, the projection can be transferred to the plot function us
 
 .. ipython:: python
 
-    p = time_maps.plot(transform=ccrs.PlateCarree(), col='time', subplot_kws={'projection':ccrs.PlateCarree()})`
+    p = time_maps.plot(transform=ccrs.PlateCarree(), col='time', subplot_kws={'projection':ccrs.PlateCarree()})
     for ax in p.axes.flat:
         ax.coastlines()
         ax.gridlines()

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -446,11 +446,11 @@ Here is the resulting image:
 
 .. image:: examples/cartopy_example.png
 
-When faceting on maps, the projection can be transferred to the plot function using the ``subplot_kws`` keyword. Axes for the subplots created by faceting are accessible in the object returned by plot:
+When faceting on maps, the projection can be transferred to the ``plot`` function using the ``subplot_kws`` keyword. Axes for the subplots created by faceting are accessible in the object returned by ``plot``:
 
 .. ipython:: python
 
-    p = time_maps.plot(transform=ccrs.PlateCarree(), col='time', subplot_kws={'projection':ccrs.PlateCarree()})
+    p = time_maps.plot(transform=ccrs.PlateCarree(), col='time', subplot_kws={'projection': ccrs.PlateCarree()})
     for ax in p.axes.flat:
         ax.coastlines()
         ax.gridlines()

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -446,6 +446,16 @@ Here is the resulting image:
 
 .. image:: examples/cartopy_example.png
 
+When faceting on maps, the projection can be transferred to the plot function using the ``subplot_kws`` keyword. Axes for the subplots created by faceting are accessible in the object returned by plot:
+
+.. ipython:: python
+
+    p = time_maps.plot(transform=ccrs.PlateCarree(), col='time', subplot_kws={'projection':ccrs.PlateCarree()})`
+    for ax in p.axes.flat:
+        ax.coastlines()
+        ax.gridlines()
+
+
 Details
 -------
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -298,7 +298,7 @@ def _plot2d(plotfunc):
         The mapping from data values to color space. If not provided, this
         will be either be ``viridis`` (if the function infers a sequential
         dataset) or ``RdBu_r`` (if the function infers a diverging dataset).
-        When when `Seaborn` is installed, ``cmap`` may also be a `seaborn`
+        When `Seaborn` is installed, ``cmap`` may also be a `seaborn`
         color palette. If ``cmap`` is seaborn color palette and the plot type
         is not ``contour`` or ``contourf``, ``levels`` must also be specified.
     colors : discrete colors to plot, optional


### PR DESCRIPTION
This change explains
- how to pass projection arguments to faceted subplots
- how to access the Axes of the created subplots (not relevant only to cartopy), relevant to issue #1202 