### PR TITLE
Shortened display of NumPy arrays in DataArray.__repr__

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -84,6 +84,10 @@ Breaking changes
 - By default ``to_netcdf()`` add a ``_FillValue = NaN`` attributes to float types.
   By `Frederic Laliberte <https://github.com/laliberte>`_.
 
+- ``repr`` on ``DataArray`` objects uses an shortened display for NumPy array
+  data (:issue:`TBD`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
+
 - xarray no longer supports python 3.3, versions of dask prior to v0.9.0,
   or versions of bottleneck prior to v1.0.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -85,7 +85,7 @@ Breaking changes
   By `Frederic Laliberte <https://github.com/laliberte>`_.
 
 - ``repr`` on ``DataArray`` objects uses an shortened display for NumPy array
-  data (:issue:`TBD`).
+  data that is less likely to overflow onto multiple pages (:issue:`1207`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 - xarray no longer supports python 3.3, versions of dask prior to v0.9.0,

--- a/xarray/test/test_formatting.py
+++ b/xarray/test/test_formatting.py
@@ -130,3 +130,26 @@ class TestFormatting(TestCase):
         expected = '2300-12-01'
         result = formatting.format_timestamp(date)
         self.assertEqual(result, expected)
+
+
+def test_set_numpy_options():
+    original_options = np.get_printoptions()
+    with formatting.set_numpy_options(threshold=10):
+        assert len(repr(np.arange(500))) < 200
+    # original optiosn are restored
+    assert np.get_printoptions() == original_options
+
+
+def test_short_array_repr():
+    cases = [
+        np.random.randn(500),
+        np.random.randn(20, 20),
+        np.random.randn(5, 10, 15),
+        np.random.randn(5, 10, 15, 3),
+    ]
+    # number of lines:
+    # for default numpy repr: 167, 140, 254, 248
+    # for short_array_repr: 1, 7, 24, 19
+    for array in cases:
+        num_lines = formatting.short_array_repr(array).count('\n') + 1
+        assert num_lines < 30

--- a/xarray/test/test_formatting.py
+++ b/xarray/test/test_formatting.py
@@ -136,7 +136,7 @@ def test_set_numpy_options():
     original_options = np.get_printoptions()
     with formatting.set_numpy_options(threshold=10):
         assert len(repr(np.arange(500))) < 200
-    # original optiosn are restored
+    # original options are restored
     assert np.get_printoptions() == original_options
 
 


### PR DESCRIPTION
Fixes #680

This shortens the array portion of the DataArray repr to reasonable lengths for high dimensional arrays:

| Array                         | Old length | New length
| ----------------------------- | ----------- | ----------
| np.random.randn(500)          | 167        | 1
| np.random.randn(20, 20)       | 150        | 7
| np.random.randn(5, 10, 15)    | 254        | 24
| np.random.randn(5, 10, 15, 3) | 248        | 19
| air_temperature['air']        | 41         | 24
| rasm['Tair']                  | 37         | 24

The last two entries refer to the corresponding datasets loaded from `xarray.tutorial.load_dataset`.

Importantly, this change does not preclude future improvements, such as those suggested in #1044.

Example of why I switched to lower precision:
```
In [24]: x = np.random.randn(20, 100)

In [25]: x
Out[25]:
array([[-0.11684307,  0.67454961, -0.0617408 , ..., -0.08199539,
         0.11447149,  1.18730556],
       [ 1.17061389, -0.72944301, -0.45572465, ...,  1.4337907 ,
        -0.80810471,  0.51210789],
       [-0.69365824, -1.1452782 ,  1.8398729 , ...,  0.06559557,
         1.77739577,  2.12243584],
       ...,
       [-2.52712434,  0.53711727, -0.08554198, ...,  0.79291491,
        -0.4017885 , -0.58840279],
       [ 0.12926157, -0.71417823, -0.40803449, ...,  0.97339737,
         1.58154386, -0.78457038],
       [ 1.71986036, -1.02348818,  1.79216626, ..., -0.11309842,
        -1.00089845,  0.11611589]])

In [27]: print(xr.core.formatting.short_array_repr(x))
array([[-0.116843,  0.67455 , -0.061741, ..., -0.081995,  0.114471,  1.187306],
       [ 1.170614, -0.729443, -0.455725, ...,  1.433791, -0.808105,  0.512108],
       [-0.693658, -1.145278,  1.839873, ...,  0.065596,  1.777396,  2.122436],
       ...,
       [-2.527124,  0.537117, -0.085542, ...,  0.792915, -0.401788, -0.588403],
       [ 0.129262, -0.714178, -0.408034, ...,  0.973397,  1.581544, -0.78457 ],
       [ 1.71986 , -1.023488,  1.792166, ..., -0.113098, -1.000898,  0.116116]])
```