### PR TITLE
Fix decoding for multi-dimensional time variables

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -280,6 +280,11 @@ Bug fixes
 
 - Fix to make ``.copy()`` actually copy dask arrays, which will be relevant for
   future releases of dask in which dask arrays will be mutable (:issue:`1180`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
+
+- Fix opening NetCDF files with multi-dimensional time variables
+  (:issue:`1229`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -90,13 +90,13 @@ def first_n_items(x, n_desired):
 
 
 def last_item(x):
-    """Returns the last item of an array"""
+    """Returns the last item of an array, as a list of length zero or one."""
     if x.size == 0:
         # work around for https://github.com/numpy/numpy/issues/5195
         return []
 
-    indexer = (slice(-1, None), ) * x.ndim
-    return np.array(x[indexer], ndmin=1)
+    indexer = (slice(-1, None),) * x.ndim
+    return np.ravel(x[indexer]).tolist()
 
 
 def format_timestamp(t):
@@ -331,7 +331,7 @@ def unindexed_dims_repr(dims, coords):
     else:
         return None
 
-      
+
 @contextlib.contextmanager
 def set_numpy_options(*args, **kwargs):
     original = np.get_printoptions()

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -90,7 +90,7 @@ def first_n_items(x, n_desired):
 
 
 def last_item(x):
-    """Returns the last item of an array, as a list of length zero or one."""
+    """Returns the last item of an array in a list or an empty list."""
     if x.size == 0:
         # work around for https://github.com/numpy/numpy/issues/5195
         return []

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -403,6 +403,15 @@ class TestDatetime(TestCase):
             expected = np.array(expected_list, dtype='datetime64[ns]')
             self.assertArrayEqual(expected, actual)
 
+    @requires_netCDF4
+    def test_decoded_cf_datetime_array_2d(self):
+        # regression test for GH1229
+        array = conventions.DecodedCFDatetimeArray(np.array([[0, 1], [2, 3]]),
+                                                   'days since 2000-01-01')
+        assert array.dtype == 'datetime64[ns]'
+        expected = pd.date_range('2000-01-01', periods=4).values.reshape(2, 2)
+        self.assertArrayEqual(np.asarray(array), expected)
+
     def test_infer_datetime_units(self):
         for dates, expected in [(pd.date_range('1900-01-01', periods=5),
                                  'days since 1900-01-01 00:00:00'),

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -44,7 +44,7 @@ class TestFormatting(TestCase):
         array = np.arange(100)
 
         reshape = ((10, 10), (1, 100), (2, 2, 5, 5))
-        expected = np.array(99)
+        expected = np.array([99])
 
         for r in reshape:
             result = formatting.last_item(array.reshape(r))


### PR DESCRIPTION
 - [x] closes #1229
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
