### PR TITLE
Better repr for coordinates without dimensions

### DIFF
--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -69,8 +69,8 @@ in with default values:
 
 As you can see, dimension names are always present in the xarray data model: if
 you do not provide them, defaults of the form ``dim_N`` will be created.
-However, coordinates are optional. If you do not specific coordinates for a
-dimension, the axis name will appear under the list of "Unindexed dimensions".
+However, coordinates are always optional, and dimensions do not have automatic
+coordinate labels.
 
 .. note::
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -13,6 +13,16 @@ What's New
     import xarray as xr
     np.random.seed(123456)
 
+
+.. _whats-new.0.9.0:
+
+v0.9.1 (29 January 2017)
+------------------------
+
+Renamed the "Unindexed dimensions" section in the ``Dataset`` and
+``DataArray`` repr (added in v0.9.0) to "Dimensions without coordinates"
+(:issue:`1199`).
+
 .. _whats-new.0.9.0:
 
 v0.9.0 (25 January 2017)
@@ -48,9 +58,9 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 - Index coordinates for each dimensions are now optional, and no longer created
-  by default :issue:`1017`. You can identify such dimensions without indexes by
-  their appearance in list of "Unindexed dimensions" in the ``Dataset`` or
-  ``DataArray`` repr:
+  by default :issue:`1017`. You can identify such dimensions without coordinates
+  by their appearance in list of "Dimensions without coordinates" in the
+  ``Dataset`` or ``DataArray`` repr:
 
   .. ipython::
     :verbatim:
@@ -59,10 +69,7 @@ Breaking changes
     Out[1]:
     <xarray.Dataset>
     Dimensions:  (x: 1, y: 2)
-    Coordinates:
-        *empty*
-    Unindexed dimensions:
-        x, y
+    Dimensions without coordinates: x, y
     Data variables:
         foo      (x, y) int64 1 2
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -14,9 +14,9 @@ What's New
     np.random.seed(123456)
 
 
-.. _whats-new.0.9.0:
+.. _whats-new.0.9.1:
 
-v0.9.1 (29 January 2017)
+v0.9.1 (30 January 2017)
 ------------------------
 
 Renamed the "Unindexed dimensions" section in the ``Dataset`` and

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -327,7 +327,7 @@ def unindexed_dims_repr(dims, coords):
     unindexed_dims = [d for d in dims if d not in coords]
     if unindexed_dims:
         dims_str = u', '.join(u'%s' % d for d in unindexed_dims)
-        return u'Unindexed dimensions:\n' + u' ' * 4 + dims_str
+        return u'Dimensions without coordinates: ' + dims_str
     else:
         return None
 
@@ -399,7 +399,8 @@ def dataset_repr(ds):
     dims_start = pretty_print(u'Dimensions:', col_width)
     summary.append(u'%s(%s)' % (dims_start, dim_summary(ds)))
 
-    summary.append(coords_repr(ds.coords, col_width=col_width))
+    if ds.coords:
+        summary.append(coords_repr(ds.coords, col_width=col_width))
 
     unindexed_dims_str = unindexed_dims_repr(ds.dims, ds.coords)
     if unindexed_dims_str:

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -47,8 +47,7 @@ class TestDataArray(TestCase):
         Coordinates:
           * x        (x) int64 0 1 2
             other    int64 0
-        Unindexed dimensions:
-            time
+        Dimensions without coordinates: time
         Attributes:
             foo: bar""")
         self.assertEqual(expected, repr(data_array))

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -91,8 +91,7 @@ class TestDataset(TestCase):
           * dim2     (dim2) float64 0.0 0.5 1.0 1.5 2.0 2.5 3.0 3.5 4.0
           * dim3     (dim3) %s 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j'
             numbers  (dim3) int64 0 1 2 0 0 1 1 2 2 3
-        Unindexed dimensions:
-            dim1
+        Dimensions without coordinates: dim1
         Data variables:
             var1     (dim1, dim2) float64 -1.086 0.9973 0.283 -1.506 -0.5786 1.651 ...
             var2     (dim1, dim2) float64 1.162 -1.097 -2.123 1.04 -0.4034 -0.126 ...
@@ -110,8 +109,6 @@ class TestDataset(TestCase):
         expected = dedent("""\
         <xarray.Dataset>
         Dimensions:  ()
-        Coordinates:
-            *empty*
         Data variables:
             *empty*""")
         actual = '\n'.join(x.rstrip() for x in repr(Dataset()).split('\n'))
@@ -123,8 +120,6 @@ class TestDataset(TestCase):
         expected = dedent("""\
         <xarray.Dataset>
         Dimensions:  ()
-        Coordinates:
-            *empty*
         Data variables:
             foo      float64 1.0""")
         actual = '\n'.join(x.rstrip() for x in repr(data).split('\n'))


### PR DESCRIPTION
 - [x] closes #1199
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

Old:

     <xarray.Dataset>
     Dimensions:  (x: 1, y: 2)
     Coordinates:
        *empty*
     Unindexed dimensions:
        x, y
     Data variables:
         foo      (x, y) int64 1 2

New:

     <xarray.Dataset>
     Dimensions:  (x: 1, y: 2)
     Dimensions without coordinates: x, y
     Data variables:
         foo      (x, y) int64 1 2