### PR TITLE
Insert minimal dimensions when broadcasting in apply_ufunc

### DIFF
--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -498,9 +498,15 @@ def broadcast_compat_data(variable, broadcast_dims, core_dims):
         data = ops.transpose(data, order)
 
     if new_dims != reordered_dims:
-        key = tuple(SLICE_NONE if dim in set_old_dims else None
-                    for dim in new_dims)
-        data = data[key]
+        key_parts = []
+        for dim in new_dims:
+            if dim in set_old_dims:
+                key_parts.append(SLICE_NONE)
+            elif key_parts:
+                # no need to insert new axes at the beginning that are already
+                # handled by broadcasting
+                key_parts.append(np.newaxis)
+        data = data[tuple(key_parts)]
 
     return data
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -442,8 +442,8 @@ def test_broadcast_compat_data_1d():
 
     assert_identical(data, broadcast_compat_data(var, ('x',), ()))
     assert_identical(data, broadcast_compat_data(var, (), ('x',)))
-    assert_identical(data[None, :], broadcast_compat_data(var, ('w',), ('x',)))
-    assert_identical(data[None, :, None],
+    assert_identical(data[:], broadcast_compat_data(var, ('w',), ('x',)))
+    assert_identical(data[:, None],
                      broadcast_compat_data(var, ('w', 'x', 'y'), ()))
 
     with pytest.raises(ValueError):
@@ -462,15 +462,12 @@ def test_broadcast_compat_data_2d():
     assert_identical(data, broadcast_compat_data(var, (), ('x', 'y')))
     assert_identical(data.T, broadcast_compat_data(var, ('y', 'x'), ()))
     assert_identical(data.T, broadcast_compat_data(var, ('y',), ('x',)))
-    assert_identical(data[None, :, :],
-                     broadcast_compat_data(var, ('w', 'x'), ('y',)))
-    assert_identical(data[None, :, :],
-                     broadcast_compat_data(var, ('w',), ('x', 'y')))
-    assert_identical(data.T[None, :, :],
-                     broadcast_compat_data(var, ('w',), ('y', 'x')))
-    assert_identical(data[None, :, :, None],
+    assert_identical(data, broadcast_compat_data(var, ('w', 'x'), ('y',)))
+    assert_identical(data, broadcast_compat_data(var, ('w',), ('x', 'y')))
+    assert_identical(data.T, broadcast_compat_data(var, ('w',), ('y', 'x')))
+    assert_identical(data[:, :, None],
                      broadcast_compat_data(var, ('w', 'x', 'y', 'z'), ()))
-    assert_identical(data.T[None, :, :, None],
+    assert_identical(data[None, :, :].T,
                      broadcast_compat_data(var, ('w', 'y', 'x', 'z'), ()))
 
 


### PR DESCRIPTION
Leading dimensions do not need to be inserted because broadcasting already
inserts them. Not including them is handy for some uses of apply_ufunc that
don't really want the broadcasting part. Now, they can simply list all of an
argument's dimensions as "core" to avoid any broadcasting.

This is necessary for @jcmgray's proposed use of `apply_ufunc` in https://github.com/pydata/xarray/issues/60#issuecomment-275778443

 - [x] passes ``git diff upstream/master | flake8 --diff``