### PR TITLE
PERF: Override equals in IndexVariable

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1249,7 +1249,7 @@ class IndexVariable(Variable):
 
     def equals(self, other, equiv=None):
         # if equiv is specified, super up
-        if equiv:
+        if equiv is not None:
             return super(IndexVariable, self).equals(other, equiv)
 
         # otherwise use the native index equals, rather than looking at _data

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1247,6 +1247,19 @@ class IndexVariable(Variable):
         return type(self)(self.dims, self._data, self._attrs,
                           self._encoding, fastpath=True)
 
+    def equals(self, other, equiv=None):
+        # if equiv is specified, super up
+        if equiv:
+            return super(IndexVariable, self).equals(other, equiv)
+
+        # otherwise use the native index equals, rather than looking at _data
+        other = getattr(other, 'variable', other)
+        try:
+            return (self.dims == other.dims and
+                    self._data_equals(other))
+        except (TypeError, AttributeError):
+            return False
+
     def _data_equals(self, other):
         return self.to_index().equals(other.to_index())
 


### PR DESCRIPTION
 - [x] closes #1255
 - [ ] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry
 
I tried adding some tests but couldn't find a good way of doing that

There is a 20x speed-up though (see issues for prior):

```python
In [4]: In [51]: indexes = [pd.PeriodIndex(start=str((1776 + i)), freq='A', periods=300) for i in range(50)]
   ...: In [53]: das = [xr.DataArray(range(300), coords=[index]) for index in indexes]
   ...:
   ...: In [54]: %timeit xr.concat(das)
   ...:


10 loops, best of 3: 70.2 ms per loop
```