### PR TITLE
Allow for plotting dummy netCDF4.datetime objects.

### DIFF
--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -32,7 +32,9 @@ def _ensure_plottable(*args):
     Raise exception if there is anything in args that can't be plotted on
     an axis.
     """
-    plottypes = [np.floating, np.integer, np.timedelta64, np.datetime64]
+    from netCDF4 import datetime as nc4datetime
+    plottypes = [np.floating, np.integer, np.timedelta64, np.datetime64, 
+                 nc4datetime]
 
     # Lists need to be converted to np.arrays here.
     if not any(_right_dtype(np.array(x), plottypes) for x in args):

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -13,34 +13,49 @@ import warnings
 
 import numpy as np
 import pandas as pd
+from datetime import datetime
 
 from .utils import _determine_cmap_params, _infer_xy_labels, get_axis
 from .facetgrid import FacetGrid
 from xarray.core.pycompat import basestring
 
 
-# Maybe more appropriate to keep this in .utils
-def _right_dtype(arr, types):
+def _valid_numpy_subdtype(x, numpy_types):
     """
-    Is the numpy array a sub dtype of anything in types?
+    Is any dtype from numpy_types superior to the dtype of x?
     """
-    return any(np.issubdtype(arr.dtype, t) for t in types)
+    # If any of the types given in numpy_types is understood as numpy.generic,
+    # all possible x will be considered valid.  This is probably unwanted.
+    # Warn then.
+    for t in numpy_types:
+        if np.issubdtype(np.generic, t):
+            warnings.warn('{} is treated as numpy.generic.'.format(t),
+                          RuntimeWarning, stacklevel=3)
+
+    return any(np.issubdtype(x.dtype, t) for t in numpy_types)
+
+
+def _valid_other_type(x, types):
+    """
+    Do all elements of x have a type from types?
+    """
+    return all(any(isinstance(el, t) for t in types)
+            for el in np.ravel(x))
 
 
 def _ensure_plottable(*args):
     """
-    Raise exception if there is anything in args that can't be plotted on
-    an axis.
+    Raise exception if there is anything in args that can't be plotted on an
+    axis.
     """
-    from netCDF4 import datetime as nc4datetime
-    plottypes = [np.floating, np.integer, np.timedelta64, np.datetime64, 
-                 nc4datetime]
+    numpy_types = [np.floating, np.integer, np.timedelta64, np.datetime64]
+    other_types = [datetime]
 
-    # Lists need to be converted to np.arrays here.
-    if not any(_right_dtype(np.array(x), plottypes) for x in args):
-        raise TypeError('Plotting requires coordinates to be numeric '
-                        'or dates.')
-
+    for x in args:
+        if not (_valid_numpy_subdtype(np.array(x), numpy_types)
+                or _valid_other_type(np.array(x), other_types)):
+            raise TypeError('Plotting requires coordinates to be numeric '
+                            'or dates.')
 
 def _easy_facetgrid(darray, plotfunc, x, y, row=None, col=None,
                     col_wrap=None, sharex=True, sharey=True, aspect=None,

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -37,7 +37,7 @@ def _valid_other_type(x, types):
     Do all elements of x have a type from types?
     """
     return all(any(isinstance(el, t) for t in types)
-            for el in np.ravel(x))
+               for el in np.ravel(x))
 
 
 def _ensure_plottable(*args):

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -36,8 +36,10 @@ def _valid_other_type(x, types):
     """
     Do all elements of x have a type from types?
     """
-    return all(any(isinstance(el, t) for t in types)
-               for el in np.ravel(x))
+    if not np.issubdtype(np.generic, x.dtype):
+        return False
+    else:
+        return all(any(isinstance(el, t) for t in types) for el in np.ravel(x))
 
 
 def _ensure_plottable(*args):

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -26,11 +26,8 @@ def _valid_numpy_subdtype(x, numpy_types):
     """
     # If any of the types given in numpy_types is understood as numpy.generic,
     # all possible x will be considered valid.  This is probably unwanted.
-    # Warn then.
     for t in numpy_types:
-        if np.issubdtype(np.generic, t):
-            warnings.warn('{} is treated as numpy.generic.'.format(t),
-                          RuntimeWarning, stacklevel=3)
+        assert not np.issubdtype(np.generic, t)
 
     return any(np.issubdtype(x.dtype, t) for t in numpy_types)
 

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -78,7 +78,6 @@ except ImportError:
 # slighly simpler construction that the full functions.
 # Generally `pytest.importorskip('package')` inline is even easier
 requires_matplotlib = pytest.mark.skipif(not has_matplotlib, reason='requires matplotlib')
-requires_netCDF4 = pytest.mark.skipif(not has_netCDF4, reason='requires netCDF4')
 
 
 def requires_scipy(test):

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -78,6 +78,7 @@ except ImportError:
 # slighly simpler construction that the full functions.
 # Generally `pytest.importorskip('package')` inline is even easier
 requires_matplotlib = pytest.mark.skipif(not has_matplotlib, reason='requires matplotlib')
+requires_netCDF4 = pytest.mark.skipif(not has_netCDF4, reason='requires netCDF4')
 
 
 def requires_scipy(test):

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -16,6 +16,7 @@ import inspect
 
 import numpy as np
 import pandas as pd
+from datetime import datetime
 
 from xarray import DataArray
 
@@ -25,12 +26,7 @@ from xarray.plot.utils import (_determine_cmap_params,
                                _build_discrete_cmap,
                                _color_palette)
 
-try:
-    from netCDF4 import datetime as nc4datetime
-except ImportError:
-    pass
-
-from . import TestCase, requires_matplotlib, requires_netCDF4
+from . import TestCase, requires_matplotlib
 
 
 def text_in_fig():
@@ -1215,23 +1211,20 @@ class TestFacetGrid4d(PlotTestCase):
             self.assertTrue(substring_in_axes(label, ax))
 
 
-@requires_netCDF4
 class TestDatetimePlot(PlotTestCase):
 
     def setUp(self):
         '''
-        Create a DataArray with a time-axis that contains netCDF4.datetime
-        objects.
+        Create a DataArray with a time-axis that contains datetime objects.
         '''
         month = np.arange(1, 13, 1)
         data = np.sin(2 * np.pi * month / 12.0)
 
         darray = DataArray(data, dims=['time'])
-        darray.coords['time'] = \
-                np.array([nc4datetime(2017, m, 1) for m in month])
+        darray.coords['time'] = np.array([datetime(2017, m, 1) for m in month])
 
         self.darray = darray
 
-    def test_netcdftime_line_plot(self):
+    def test_datetime_line_plot(self):
         # test if line plot raises no Exception
         self.darray.plot.line()


### PR DESCRIPTION
Currently, xarray/plot.py raises a `TypeError` if the data to be plotted are not among `[np.floating, np.integer, np.timedelta64, np.datetime64]`.

This PR adds `netCDF4.datetime` objects to the list of allowed data types. These occur, because xarray/conventions.py passes undecoded `netCDF4.datetime` objects if decoding to `numpy.datetime64` fails. 
