### PR TITLE
Switch AppVeyor CI to use conda env / requirements.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,12 @@ environment:
     - PYTHON: "C:\\Python27-conda32"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
+      CONDA_ENV: "py27-cdat+pynio"
 
     - PYTHON: "C:\\Python36-conda64"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
+      CONDA_ENV: "py36"
 
 install:
   # Install miniconda Python
@@ -28,8 +30,9 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  # install xarray and depenencies
-  - "conda install --yes --quiet pip pytest numpy pandas scipy netCDF4 matplotlib dask"
+  # install xarray and dependencies
+  - "conda env create --file ./ci/requirements-%CONDA_ENV%.yml"
+  - "activate test_env"
   - "python setup.py install"
 
 build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,12 @@ environment:
     - PYTHON: "C:\\Python27-conda32"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
-      CONDA_ENV: "py27-cdat+pynio"
+      CONDA_ENV: "py27-windows"
 
     - PYTHON: "C:\\Python36-conda64"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
-      CONDA_ENV: "py36"
+      CONDA_ENV: "py36-windows"
 
 install:
   # Install miniconda Python

--- a/ci/requirements-py27-windows.yml
+++ b/ci/requirements-py27-windows.yml
@@ -1,0 +1,13 @@
+name: test_env
+channels:
+  - conda-forge
+dependencies:
+  - python=2.7
+  - dask
+  - matplotlib
+  - netCDF4
+  - numpy
+  - pandas
+  - pip
+  - pytest
+  - scipy

--- a/ci/requirements-py36-windows.yml
+++ b/ci/requirements-py36-windows.yml
@@ -1,0 +1,13 @@
+name: test_env
+channels:
+  - conda-forge
+dependencies:
+  - python=3.6
+  - dask
+  - matplotlib
+  - netCDF4
+  - numpy
+  - pandas
+  - pip
+  - pytest
+  - scipy


### PR DESCRIPTION
 - [x] closes #1127 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry

@shoyer here I'm reusing existing requirements files.  Is this along the lines of what you were looking for in #1127?

I think this should solve the AppVeyor test failures in #1252, as it should install version 1.2.7 of netCDF4, rather than version 1.2.4.