### PR TITLE
Restored dim order in DataArray.rolling().reduce() 

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -24,6 +24,9 @@ Enhancements
 
 Bug fixes
 ~~~~~~~~~
+- ``rolling`` now keeps its original dimension order (:issue:`1125`).
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+
 
 .. _whats-new.0.9.1:
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -177,6 +177,8 @@ class Rolling(object):
         counts = concat([window.count(dim=self.dim) for _, window in self],
                         dim=concat_dim)
         result = concat(windows, dim=concat_dim)
+        # restore dim order
+        result = result.transpose(*self.obj.dims)
 
         result = result.where(counts >= self._min_periods)
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2408,8 +2408,8 @@ class TestDataArray(TestCase):
 def da(request):
     if request.param == 1:
         times = pd.date_range('2000-01-01', freq='1D', periods=21)
-        values = np.random.random((3,21, 4))
-        da = DataArray(values, dims=('a','time', 'x'))
+        values = np.random.random((3, 21, 4))
+        da = DataArray(values, dims=('a', 'time', 'x'))
         da['time'] = times
         return da
 
@@ -2427,6 +2427,7 @@ def test_rolling_iter(da):
 
     for i, (label, window_da) in enumerate(rolling_obj):
         assert label == da['time'].isel(time=i)
+
 
 def test_rolling_properties(da):
     pytest.importorskip('bottleneck', minversion='1.0')
@@ -2463,7 +2464,8 @@ def test_rolling_wrapped_bottleneck(da, name, center, min_periods):
 
     func_name = 'move_{0}'.format(name)
     actual = getattr(rolling_obj, name)()
-    expected = getattr(bn, func_name)(da.values, window=7, axis=1, min_count=min_periods)
+    expected = getattr(bn, func_name)(da.values, window=7, axis=1,
+                                      min_count=min_periods)
     assert_array_equal(actual.values, expected)
 
     # Test center

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2518,4 +2518,4 @@ def test_rolling_reduce(da, center, min_periods, window, name):
     actual = rolling_obj.reduce(getattr(np, 'nan%s' % name))
     expected = getattr(rolling_obj, name)()
     assert_allclose(actual, expected)
-    assert(da.dims == expected.dims)
+    assert da.dims == expected.dims

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2408,8 +2408,8 @@ class TestDataArray(TestCase):
 def da(request):
     if request.param == 1:
         times = pd.date_range('2000-01-01', freq='1D', periods=21)
-        values = np.random.random((21, 4))
-        da = DataArray(values, dims=('time', 'x'))
+        values = np.random.random((3,21, 4))
+        da = DataArray(values, dims=('a','time', 'x'))
         da['time'] = times
         return da
 
@@ -2428,13 +2428,12 @@ def test_rolling_iter(da):
     for i, (label, window_da) in enumerate(rolling_obj):
         assert label == da['time'].isel(time=i)
 
-
 def test_rolling_properties(da):
     pytest.importorskip('bottleneck', minversion='1.0')
 
     rolling_obj = da.rolling(time=4)
 
-    assert rolling_obj._axis_num == 0
+    assert rolling_obj._axis_num == 1
 
     # catching invalid args
     with pytest.raises(ValueError) as exception:
@@ -2464,7 +2463,7 @@ def test_rolling_wrapped_bottleneck(da, name, center, min_periods):
 
     func_name = 'move_{0}'.format(name)
     actual = getattr(rolling_obj, name)()
-    expected = getattr(bn, func_name)(da.values, window=7, axis=0, min_count=min_periods)
+    expected = getattr(bn, func_name)(da.values, window=7, axis=1, min_count=min_periods)
     assert_array_equal(actual.values, expected)
 
     # Test center
@@ -2517,3 +2516,4 @@ def test_rolling_reduce(da, center, min_periods, window, name):
     actual = rolling_obj.reduce(getattr(np, 'nan%s' % name))
     expected = getattr(rolling_obj, name)()
     assert_allclose(actual, expected)
+    assert(da.dims == expected.dims)


### PR DESCRIPTION
 - [x] closes #1125 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew 

Added 1 line to fix #1125.

I hope this is enough.
If another care is necessary, please let me know.