### PR TITLE
Feature/support bn 1 1

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -217,6 +217,7 @@ DataArray contents
    :toctree: generated/
 
    DataArray.assign_coords
+   DataArray.pipe
    DataArray.rename
    DataArray.swap_dims
    DataArray.drop

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,6 +21,10 @@ v0.9.2 (unreleased)
 
 Enhancements
 ~~~~~~~~~~~~
+- When bottleneck version 1.1 or later is installed, use bottleneck for rolling
+  `var`, `argmin`, `argmax`, and `rank` computations. Also, `rolling.median`
+  now also accepts a `min_periods` argument (:issue:`1276`).
+  By `Joe Hamman <https://github.com/jhamman>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -52,7 +52,9 @@ NAN_REDUCE_METHODS = ['argmax', 'argmin', 'max', 'min', 'mean', 'prod', 'sum',
 NAN_CUM_METHODS = ['cumsum', 'cumprod']
 BOTTLENECK_ROLLING_METHODS = {'move_sum': 'sum', 'move_mean': 'mean',
                               'move_std': 'std', 'move_min': 'min',
-                              'move_max': 'max'}
+                              'move_max': 'max', 'move_var': 'var',
+                              'move_argmin': 'argmin', 'move_argmax': 'argmax',
+                              'move_rank': 'rank'}
 # TODO: wrap take, dot, sort
 
 
@@ -520,24 +522,40 @@ def inject_bottleneck_rolling_methods(cls):
     for name, f in methods:
         func = cls._reduce_method(f)
         func.__name__ = name
-        func.__doc__ = _ROLLING_REDUCE_DOCSTRING_TEMPLATE.format(name=func.__name__)
+        func.__doc__ = _ROLLING_REDUCE_DOCSTRING_TEMPLATE.format(
+            name=func.__name__)
         setattr(cls, name, func)
 
     # bottleneck rolling methods
     if has_bottleneck:
-        if LooseVersion(bn.__version__) < LooseVersion('1.0'):
+        bn_version = LooseVersion(bn.__version__)
+        bn_min_version = LooseVersion('1.0')
+        bn_version_1_1 = LooseVersion('1.1')
+        if bn_version < bn_min_version:
             return
 
         for bn_name, method_name in BOTTLENECK_ROLLING_METHODS.items():
-            f = getattr(bn, bn_name)
-            func = cls._bottleneck_reduce(f)
-            func.__name__ = method_name
-            func.__doc__ = _ROLLING_REDUCE_DOCSTRING_TEMPLATE.format(name=func.__name__)
-            setattr(cls, method_name, func)
+            try:
+                f = getattr(bn, bn_name)
+                func = cls._bottleneck_reduce(f)
+                func.__name__ = method_name
+                func.__doc__ = _ROLLING_REDUCE_DOCSTRING_TEMPLATE.format(
+                    name=func.__name__)
+                setattr(cls, method_name, func)
+            except AttributeError as e:
+                # skip functions not in Bottleneck 1.0
+                if ((bn_version < bn_version_1_1) and
+                        (bn_name not in ['move_var', 'move_argmin',
+                                         'move_argmax', 'move_rank'])):
+                    raise e
 
-        # bottleneck rolling methods without min_count
+        # bottleneck rolling methods without min_count (bn.__version__ < 1.1)
         f = getattr(bn, 'move_median')
-        func = cls._bottleneck_reduce_without_min_count(f)
+        if bn_version >= bn_version_1_1:
+            func = cls._bottleneck_reduce(f)
+        else:
+            func = cls._bottleneck_reduce_without_min_count(f)
         func.__name__ = 'median'
-        func.__doc__ = _ROLLING_REDUCE_DOCSTRING_TEMPLATE.format(name=func.__name__)
+        func.__doc__ = _ROLLING_REDUCE_DOCSTRING_TEMPLATE.format(
+            name=func.__name__)
         setattr(cls, 'median', func)

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -53,8 +53,7 @@ NAN_CUM_METHODS = ['cumsum', 'cumprod']
 BOTTLENECK_ROLLING_METHODS = {'move_sum': 'sum', 'move_mean': 'mean',
                               'move_std': 'std', 'move_min': 'min',
                               'move_max': 'max', 'move_var': 'var',
-                              'move_argmin': 'argmin', 'move_argmax': 'argmax',
-                              'move_rank': 'rank'}
+                              'move_argmin': 'argmin', 'move_argmax': 'argmax'}
 # TODO: wrap take, dot, sort
 
 
@@ -528,6 +527,8 @@ def inject_bottleneck_rolling_methods(cls):
 
     # bottleneck rolling methods
     if has_bottleneck:
+        # TODO: Bump the required version of bottlneck to 1.1 and remove all
+        # these version checks (see GH#1278)
         bn_version = LooseVersion(bn.__version__)
         bn_min_version = LooseVersion('1.0')
         bn_version_1_1 = LooseVersion('1.1')


### PR DESCRIPTION
Bottleneck added support for rolling variance calculations (`bn.move_var`) as well as a few other functions in version 1.1.  This PR conditionally uses those new functions, when they are available.

 - [x] closes #1276
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

cc @shoyer and @d-chambers