### PR TITLE
netcdf4/h5netcdf cross engine test broken on Python 2

### DIFF
--- a/ci/requirements-py27-cdat+pynio.yml
+++ b/ci/requirements-py27-cdat+pynio.yml
@@ -15,7 +15,7 @@ dependencies:
   - pytest-cov
   - cyordereddict
   - h5py
-  - netcdf4
+  - h5netcdf
   - matplotlib
   - seaborn
   - pip:


### PR DESCRIPTION
This is not really a bugfix or enhancement. In fact, it's just a bug report right now. I'm having trouble running tests on Python 2 with both netcdf4 and h5netcdf installed due to the cross engine test (
`H5NetCDFDataTest.test_cross_engine_read_write_netcdf4`).

I noticed that the requirements list `netcdf4` twice; I assume this was a typo and the second one should be `h5netcdf`. By switching the duplicate out, I'm hoping to trigger the problem on CI as a way to report this bug.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry
