### PR TITLE
BUG/TST: Retain encoding upon concatenation

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -975,13 +975,14 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
             data = ops.stack(arrays, axis=axis)
 
         attrs = OrderedDict(first_var.attrs)
+        encoding = OrderedDict(first_var.encoding)
         if not shortcut:
             for var in variables:
                 if var.dims != first_var.dims:
                     raise ValueError('inconsistent dimensions')
                 utils.remove_incompatible_items(attrs, var.attrs)
 
-        return cls(dims, data, attrs)
+        return cls(dims, data, attrs, encoding)
 
     def equals(self, other, equiv=ops.array_equiv):
         """True if two Variables have the same dimensions and values;

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -268,6 +268,11 @@ class TestConcatDataArray(TestCase):
         with self.assertRaisesRegexp(ValueError, 'not a valid argument'):
             concat([foo, bar], dim='w', data_vars='minimal')
 
+        # gh-1297
+        foo.encoding = {"complevel": 5}
+        self.assertEqual(concat([foo, foo], dim="x").encoding,
+                         foo.encoding)
+
     @requires_dask
     def test_concat_lazy(self):
         import dask.array as da


### PR DESCRIPTION
Retain encoding upon concatenation of DataArray or Dataset.

 - [x] closes #1297 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry
