### PR TITLE
Docs: don't mention inferring `dims` from `coords`

### DIFF
--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -47,8 +47,7 @@ The :py:class:`~xarray.DataArray` constructor takes:
 - ``data``: a multi-dimensional array of values (e.g., a numpy ndarray,
   :py:class:`~pandas.Series`, :py:class:`~pandas.DataFrame` or :py:class:`~pandas.Panel`)
 - ``coords``: a list or dictionary of coordinates
-- ``dims``: a list of dimension names. If omitted, dimension names are
-  taken from ``coords`` if possible.
+- ``dims``: a list of dimension names.
 - ``attrs``: a dictionary of attributes to add to the instance
 - ``name``: a string that names the instance
 

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ from setuptools import Command
 
 MAJOR = 0
 MINOR = 9
-MICRO = 0
-ISRELEASED = False
+MICRO = 1
+ISRELEASED = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 QUALIFIER = ''
 


### PR DESCRIPTION
Trying this results in a deprecation warning