### PR TITLE
Use LooseVersion rather than StrictVersion

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 import gzip
 import os.path
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 from glob import glob
 from io import BytesIO
 from numbers import Number
@@ -230,7 +230,7 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
             except ImportError:
                 # raise the usual error if dask is entirely missing
                 import dask
-                if StrictVersion(dask.__version__) < StrictVersion('0.6'):
+                if LooseVersion(dask.__version__) < LooseVersion('0.6'):
                     raise ImportError(
                         'xarray requires dask version 0.6 or newer')
                 else:

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -6,7 +6,7 @@ import logging
 import time
 import traceback
 from collections import Mapping
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 from ..conventions import cf_encoder
 from ..core.utils import FrozenOrderedDict
@@ -164,7 +164,7 @@ class ArrayWriter(object):
         if self.sources:
             import dask.array as da
             import dask
-            if StrictVersion(dask.__version__) > StrictVersion('0.8.1'):
+            if LooseVersion(dask.__version__) > LooseVersion('0.8.1'):
                 da.store(self.sources, self.targets, lock=GLOBAL_LOCK)
             else:
                 da.store(self.sources, self.targets)


### PR DESCRIPTION
LooseVersion plays nicer when development versions of other libraries (e.g.,
dask) are installed.

 - [x] passes ``git diff upstream/master | flake8 --diff``
