### PR TITLE
Ensures drop=True case works with empty mask

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -49,6 +49,9 @@ Bug fixes
 - Fix ``sel`` with ``method='nearest'`` on Python 2.7 and 64-bit Windows
   (:issue:`1140`).
   `Stephan Hoyer <https://github.com/shoyer>`_.
+- Fixes ``where`` with ``drop='True'`` for empty masks (:issue:`1341`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_ and
+  `Phillip J. Wolfram <https://github.com/pwolfram>`_.
 
 .. _whats-new.0.9.1:
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -300,7 +300,8 @@ class BaseDataObject(AttrAccessMixin):
         try:
             return self.indexes[key]
         except KeyError:
-            return pd.Index(range(self.sizes[key]), name=key)
+            # need to ensure dtype=int64 in case range is empty on Python 2
+            return pd.Index(range(self.sizes[key]), name=key, dtype=np.int64)
 
     def _calc_assign_results(self, kwargs):
         results = SortedKeysDict()

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -106,6 +106,13 @@ class TestDataArray(TestCase):
         with self.assertRaises(KeyError):
             array.get_index('z')
 
+    def test_get_index_size_zero(self):
+        array = DataArray(np.zeros((0,)), dims=['x'])
+        actual = array.get_index('x')
+        expected = pd.Index([], dtype=np.int64)
+        assert actual.equals(expected)
+        assert actual.dtype == expected.dtype
+
     def test_struct_array_dims(self):
         """
         This test checks subraction of two DataArrays for the case

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2602,14 +2602,6 @@ class TestDataset(TestCase):
     def test_where_drop(self):
         # if drop=True
 
-        # empty case
-        array = DataArray(np.random.rand(100, 10),
-                          dims=['nCells', 'nVertLevels'])
-        mask = DataArray(np.zeros((100,), dtype='bool'), dims='nCells')
-        actual = array.where(mask, drop=True)
-        expected = DataArray(np.zeros((0, 10)), dims=['nCells', 'nVertLevels'])
-        self.assertDatasetIdentical(expected, actual)
-
         # 1d
         # data array case
         array = DataArray(range(5), coords=[range(5)], dims=['x'])
@@ -2662,6 +2654,15 @@ class TestDataset(TestCase):
         ds = Dataset({'a': (('x', 'y'), [[0, 1], [2, 3]]), 'b': (('x','y'), [[4, 5], [6, 7]])})
         expected = Dataset({'a': (('x', 'y'), [[np.nan, 1], [2, 3]]), 'b': (('x', 'y'), [[4, 5], [6,7]])})
         actual = ds.where(ds > 0, drop=True)
+        self.assertDatasetIdentical(expected, actual)
+
+    def test_where_drop_empty(self):
+        # regression test for GH1341
+        array = DataArray(np.random.rand(100, 10),
+                          dims=['nCells', 'nVertLevels'])
+        mask = DataArray(np.zeros((100,), dtype='bool'), dims='nCells')
+        actual = array.where(mask, drop=True)
+        expected = DataArray(np.zeros((0, 10)), dims=['nCells', 'nVertLevels'])
         self.assertDatasetIdentical(expected, actual)
 
     def test_reduce(self):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2602,6 +2602,14 @@ class TestDataset(TestCase):
     def test_where_drop(self):
         # if drop=True
 
+        # empty case
+        array = DataArray(np.random.rand(100, 10),
+                          dims=['nCells', 'nVertLevels'])
+        mask = DataArray(np.zeros((100,), dtype='bool'), dims='nCells')
+        actual = array.where(mask, drop=True)
+        expected = DataArray(np.zeros((0, 10)), dims=['nCells', 'nVertLevels'])
+        self.assertDatasetIdentical(expected, actual)
+
         # 1d
         # data array case
         array = DataArray(range(5), coords=[range(5)], dims=['x'])


### PR DESCRIPTION
Resolves error occurring for python 2.7 for the case of `where(mask, drop=True)` where the mask is empty.

 - [x] closes #1341
 - [X] tests added
 - [x]  tests passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
