### PR TITLE
Support for DataArray.expand_dims()

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -80,6 +80,7 @@ Dataset contents
    Dataset.merge
    Dataset.rename
    Dataset.swap_dims
+   Dataset.expand_dims
    Dataset.drop
    Dataset.set_coords
    Dataset.reset_coords

--- a/doc/reshaping.rst
+++ b/doc/reshaping.rst
@@ -27,6 +27,28 @@ on a :py:class:`~xarray.Dataset`, use :py:meth:`~xarray.DataArray.transpose` or 
     ds.transpose('y', 'z', 'x')
     ds.T
 
+Expand and squeeze dimensions
+-----------------------------
+
+To expand a :py:class:`~xarray.DataArray` or all
+variables on a :py:class:`~xarray.Dataset` along a new dimension,
+use :py:meth:`~xarray.DataArray.expand_dims`
+
+.. ipython:: python
+
+    expanded  = ds.expand_dims('w')
+    expanded
+
+This method attaches a new dimension with size 1 to all data variable.
+
+To remove such a size-1 dimension from the py:class:`~xarray.DataArray`
+or :py:class:`~xarray.Dataset`,
+use :py:meth:`~xarray.DataArray.squeeze`
+
+.. ipython:: python
+
+    expanded.squeeze('w')
+
 Converting between datasets and arrays
 --------------------------------------
 

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -489,7 +489,7 @@ def broadcast(*args, **kwargs):
                 if dim in arg.coords:
                     common_coords[dim] = arg.coords[dim].variable
 
-    def _expand_dims(var):
+    def _set_dims(var):
         # Add excluded dims to a copy of dims_map
         var_dims_map = dims_map.copy()
         for dim in exclude:
@@ -497,10 +497,10 @@ def broadcast(*args, **kwargs):
                 # ignore dim not in var.dims
                 var_dims_map[dim] = var.shape[var.dims.index(dim)]
 
-        return var.expand_dims(var_dims_map)
+        return var.set_dims(var_dims_map)
 
     def _broadcast_array(array):
-        data = _expand_dims(array.variable)
+        data = _set_dims(array.variable)
         coords = OrderedDict(array.coords)
         coords.update(common_coords)
         return DataArray(data, coords, data.dims, name=array.name,
@@ -508,7 +508,7 @@ def broadcast(*args, **kwargs):
 
     def _broadcast_dataset(ds):
         data_vars = OrderedDict(
-            (k, _expand_dims(ds.variables[k]))
+            (k, _set_dims(ds.variables[k]))
             for k in ds.data_vars)
         coords = OrderedDict(ds.coords)
         coords.update(common_coords)

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -263,7 +263,7 @@ def _dataset_concat(datasets, dim, data_vars, coords, compat, positions):
             if var.dims != common_dims:
                 common_shape = tuple(non_concat_dims.get(d, dim_len)
                                      for d in common_dims)
-                var = var.expand_dims(common_dims, common_shape)
+                var = var.set_dims(common_dims, common_shape)
             yield var
 
     # stack up each variable to fill-out the dataset (in order)

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -291,6 +291,48 @@ class BaseDataObject(AttrAccessMixin):
         dims = get_squeeze_dims(self, dim)
         return self.isel(drop=drop, **{d: 0 for d in dims})
 
+    def expand_dims(self, dim=None, axis=None):
+        """Return a new object with an additional axis (or axes) inserted at the
+        corresponding position in the array shape.
+
+        Parameters
+        ----------
+        dim : str, (list or tuple) of strs, or None
+            Name(s) of new dimension.
+            If a list (or tuple) of strings is passed, multiple axes are
+            inserted. In this case, axis argument should be None or same length
+            of integers indicating new axes positions.
+        axis : integer, list (or tuple) of integers or None
+            Axis position(s) where new axis is to be inserted (position(s) on
+            the result array). If a list (or tuple) of integers is passed,
+            multiple axes are inserted. In this case, dim arguments should be
+            None or same length list. If None is passed, all the axis will be
+            inserted to the start of the result array.
+
+        Returns
+        -------
+        expanded : same type as caller
+            This object, but with an additional dimension.
+
+        Raises
+        -------
+        ValueError:
+               If the length of axis and dim are different.
+               If the axis is a list containing identical integers
+               If axis is invalid (larger than the original dimension+1)
+        """
+        # Some error checking
+        if axis is None and dim is None:
+            raise ValueError('At least one of axis or dim should be specified\
+            in expand_dims')
+        # Make sure user does not do `expand_dims(0)`
+        if dim is not None and not isinstance(dim, (str, list, tuple)):
+            raise TypeError('dim should be str or list of str or tuple of str')
+
+        if axis is None:
+            axis = list(range(len(dim)))
+
+
     def get_index(self, key):
         """Get an index for a dimension, with fall-back to a default RangeIndex
         """

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -864,51 +864,8 @@ class DataArray(AbstractArray, BaseDataObject):
         expanded : same type as caller
             This object, but with an additional dimension(s).
         """
-        # Make sure user does not do `expand_dims(0)`
-        if isinstance(dim, int):
-            raise ValueError('dim should be str or sequence of strs or dict')
-
-        # Make axis and dims a pair of lists
-        if isinstance(dim, basestring):
-            dim = [dim]
-        if axis is not None and not isinstance(axis, (list, tuple)):
-            axis = [axis]
-
-        # infer None arguments.
-        if axis is None:
-            axis = list(range(len(dim)))
-
-        # Error checking
-        # Make sure the length of axis and dims are identical
-        if len(dim) != len(axis):
-            raise ValueError('lengths of dim and axis should be identical.')
-        # make sure any of dim does not already exist
-        for d in dim:
-            if d in self.dims:
-                raise ValueError('{dim} already exists.'.format(dim=d))
-
-        # make sure there is no duplicates in axis or dims
-        if len(axis) != len(set(axis)):
-            raise ValueError('axis should not contain same values.')
-        if len(dim) != len(set(dim)):
-            raise ValueError('dims should not contain same values.')
-
-        # sort dim and axis, so that axis is in order.
-        axis, dim = zip(*sorted(zip(axis, dim)))
-        # dims of the result array. This will be passed to Variable.expand_dims
-        all_dims = list(self.dims)
-        for a, d in zip(axis, dim):
-            all_dims.insert(a, d)
-
-        # If dims includes a label of a scalar variables,
-        # it will be promoted to a 1D coordinate consisting of a single value.
-        coords = OrderedDict(self._coords)
-        for d in dim:
-            if d in self._coords:
-                coords[d] = coords[d].expand_dims(d)
-
-        return DataArray(self._variable.expand_dims(all_dims),
-                         dims=all_dims, coords=coords, attrs=self.attrs)
+        ds = self._to_temp_dataset().expand_dims(dim, axis)
+        return self._from_temp_dataset(ds)
 
     def set_index(self, append=False, inplace=False, **indexes):
         """Set DataArray (multi-)indexes using one or more existing coordinates.

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -856,7 +856,7 @@ class DataArray(AbstractArray, BaseDataObject):
             Axis position(s) where new axis is to be inserted (position(s) on
             the result array). If a list (or tuple) of integers is passed,
             multiple axes are inserted. In this case, dim arguments should be
-            same length list or None. If None is passed, all the axes will be
+            same length list. If axis=None is passed, all the axes will be
             inserted to the start of the result array.
 
         Returns

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -840,6 +840,67 @@ class DataArray(AbstractArray, BaseDataObject):
         ds = self._to_temp_dataset().swap_dims(dims_dict)
         return self._from_temp_dataset(ds)
 
+    def expand_dims(self, dim=None, axis=None):
+        """Return a new object with an additional axis (or axes) inserted at the
+        corresponding position in the array shape.
+
+        Parameters
+        ----------
+        dim : str, (list, tuple) of strs, or None
+            Name(s) of new dimension.
+            If a list (or tuple) of strings is passed, multiple axes are
+            inserted. In this case, axis argument should be None or same length
+            of integers indicating new axes positions.
+        axis : integer, list (or tuple) of integers or None
+            Axis position(s) where new axis is to be inserted (position(s) on
+            the result array). If a list (or tuple) of integers is passed,
+            multiple axes are inserted. In this case, dim arguments should be
+            None or same length list. If None is passed, all the axis will be
+            inserted to the start of the result array.
+
+        Returns
+        -------
+        expanded : same type as caller
+            This object, but with an additional dimension.
+
+        Raises
+        -------
+        ValueError:
+               If the length of axis and dim are different.
+               If the axis is a list containing identical integers
+               If axis is invalid (larger than the original dimension+1)
+        """
+        # Some error checking
+        if axis is None and dim is None:
+            raise ValueError('At least one of axis or dim should be specified\
+            in expand_dims')
+        if dim is not None:
+            if isinstance(dim, str):
+                dim = [dim]
+            # Make sure user does not do `expand_dims(0)`
+            if not isinstance(dim, (list, tuple)):
+                raise TypeError('dim should be str or list of str or tuple of \
+                                 str')
+            # Make sure the length of axis and dims are identical
+            if isinstance(axis, int) and len(dim) == 1 or len(dim) != len(axis):
+                raise TypeError('lengths of dim and axis should be identical.')
+            # make sure any of dim does not already exist
+            for d in dim:
+                if d in self.dims:
+                    raise ValueError('{dim} already exists.'.format(dim=d))
+
+        if axis is None:
+            axis = list(range(len(dim)))
+        # make sure there is no duplicate in axis
+        if len(axis) != len(set(axis)):
+            raise ValueError('axis should not contain same values.')
+        # sort dim and axis, so that axis is in order.
+        axis, dim = zip(*sorted(zip(axis, dim)))
+        new_shape = self.shape
+        for a in axis:
+            new_shape.insert(a, 1)
+
+
     def set_index(self, append=False, inplace=False, **indexes):
         """Set DataArray (multi-)indexes using one or more existing coordinates.
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -876,7 +876,7 @@ class DataArray(AbstractArray, BaseDataObject):
         def create_dim_name(src_dims):
             """ A function to automatically generate dimension name. """
             for i in range(len(src_dims)+1):
-                dim = 'dim'+str(i)
+                dim = 'dim_'+str(i)
                 if dim not in src_dims:
                     return dim
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1591,7 +1591,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
             Axis position(s) where new axis is to be inserted (position(s) on
             the result array). If a list (or tuple) of integers is passed,
             multiple axes are inserted. In this case, dim arguments should be
-            the same length list or None. If None is passed, all the axes will
+            the same length list. If axis=None is passed, all the axes will
             be inserted to the start of the result array.
 
         Returns

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1616,6 +1616,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
             if d in self.dims:
                 raise ValueError(
                             'Dimension {dim} already exists.'.format(dim=d))
+            if d in self._variables.keys() and \
+                    not utils.is_scalar(self._variables[d]):
+                raise ValueError(
+                            '{dim} already exists as coordinate or'
+                            ' variable name.'.format(dim=d))
 
         if len(dim) != len(set(dim)):
             raise ValueError('dims should not contain duplicate values.')
@@ -1631,7 +1636,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
                         if a < -result_ndim or result_ndim - 1 < a:
                             raise IndexError(
                                 'Axis {a} is out of bounds of the expanded'
-                                'dimension size {dim}.'.format(
+                                ' dimension size {dim}.'.format(
                                                a=a, v=k, dim=result_ndim))
 
                     axis_pos = [a if a >= 0 else result_ndim + a

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1640,14 +1640,14 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
                     # If dims includes a label of a scalar variables,
                     # it will be promoted to a 1D coordinate consisting
                     # of a single value.
-                    variables[k] = v.expand_dims(k)
+                    variables[k] = v.set_dims(k)
             else:
                 # all the dims of the result array
-                # to be passed to Variable.expand_dims
+                # to be passed to Variable.set_dims
                 all_dims = list(v.dims)
                 for a, d in zip(axis, dim):
                     all_dims.insert(a, d)
-                variables[k] = v.expand_dims(all_dims)
+                variables[k] = v.set_dims(all_dims)
 
         return self._replace_vars_and_dims(variables, self._coord_names)
 
@@ -1752,7 +1752,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
                     add_dims = [d for d in dims if d not in var.dims]
                     vdims = list(var.dims) + add_dims
                     shape = [self.dims[d] for d in vdims]
-                    exp_var = var.expand_dims(vdims, shape)
+                    exp_var = var.set_dims(vdims, shape)
                     stacked_var = exp_var.stack(**{new_dim: dims})
                     variables[name] = stacked_var
                 else:
@@ -2293,7 +2293,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
 
     def _to_dataframe(self, ordered_dims):
         columns = [k for k in self if k not in self.dims]
-        data = [self._variables[k].expand_dims(ordered_dims).values.reshape(-1)
+        data = [self._variables[k].set_dims(ordered_dims).values.reshape(-1)
                 for k in columns]
         index = self.coords.to_index(ordered_dims)
         return pd.DataFrame(OrderedDict(zip(columns, data)), index=index)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1616,8 +1616,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
             if d in self.dims:
                 raise ValueError(
                             'Dimension {dim} already exists.'.format(dim=d))
-            if d in self._variables.keys() and \
-                    not utils.is_scalar(self._variables[d]):
+            if (d in self._variables and
+                    not utils.is_scalar(self._variables[d])):
                 raise ValueError(
                             '{dim} already exists as coordinate or'
                             ' variable name.'.format(dim=d))

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -72,7 +72,7 @@ def unique_variable(name, variables, compat='broadcast_equals'):
 
         if compat == 'broadcast_equals':
             dim_lengths = broadcast_dimension_size(variables)
-            out = out.expand_dims(dim_lengths)
+            out = out.set_dims(dim_lengths)
 
         if compat == 'no_conflicts':
             combine_method = 'fillna'

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -706,8 +706,9 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         data = ops.transpose(self.data, axes)
         return type(self)(dims, data, self._attrs, self._encoding, fastpath=True)
 
-    def expand_dims(self, dims, shape=None):
-        """Return a new variable with expanded dimensions.
+    def set_dims(self, dims, shape=None):
+        """Return a new variable with given set of dimensions.
+        This method might be used to attach new dimension(s) to variable.
 
         When possible, this operation does not copy this variable's data.
 
@@ -1336,7 +1337,7 @@ def _unified_dims(variables):
 
 def _broadcast_compat_variables(*variables):
     dims = tuple(_unified_dims(variables))
-    return tuple(var.expand_dims(dims) if var.dims != dims else var
+    return tuple(var.set_dims(dims) if var.dims != dims else var
                  for var in variables)
 
 
@@ -1352,7 +1353,7 @@ def broadcast_variables(*variables):
     """
     dims_map = _unified_dims(variables)
     dims_tuple = tuple(dims_map)
-    return tuple(var.expand_dims(dims_map) if var.dims != dims_tuple else var
+    return tuple(var.set_dims(dims_map) if var.dims != dims_tuple else var
                  for var in variables)
 
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -706,6 +706,13 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         data = ops.transpose(self.data, axes)
         return type(self)(dims, data, self._attrs, self._encoding, fastpath=True)
 
+    def expand_dims(self, *args):
+        import warnings
+        warnings.warn('Variable.expand_dims is deprecated: use '
+                      'Variable.set_dims instead', DeprecationWarning,
+                      stacklevel=2)
+        return self.expand_dims(*args)
+
     def set_dims(self, dims, shape=None):
         """Return a new variable with given set of dimensions.
         This method might be used to attach new dimension(s) to variable.

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -928,6 +928,8 @@ class TestDataArray(TestCase):
                              coords={'x': np.linspace(0.0, 1.0, 3)},
                              attrs={'key': 'entry'})
         self.assertDataArrayIdentical(expected, actual)
+        roundtripped = actual.squeeze('y', drop=True)
+        self.assertDatasetIdentical(array, roundtripped)
 
         # pass multiple dims
         actual = array.expand_dims(dim=['y', 'z'])
@@ -937,6 +939,8 @@ class TestDataArray(TestCase):
                              coords={'x': np.linspace(0.0, 1.0, 3)},
                              attrs={'key': 'entry'})
         self.assertDataArrayIdentical(expected, actual)
+        roundtripped = actual.squeeze(['y', 'z'], drop=True)
+        self.assertDatasetIdentical(array, roundtripped)
 
         # pass multiple dims and axis. Axis is out of order
         actual = array.expand_dims(dim=['z', 'y'], axis=[2, 1])
@@ -946,6 +950,10 @@ class TestDataArray(TestCase):
                              coords={'x': np.linspace(0.0, 1.0, 3)},
                              attrs={'key': 'entry'})
         self.assertDataArrayIdentical(expected, actual)
+        # make sure the attrs are tracked
+        self.assertTrue(actual.attrs['key'] == 'entry')
+        roundtripped = actual.squeeze(['z', 'y'], drop=True)
+        self.assertDatasetIdentical(array, roundtripped)
 
     def test_expand_dims_with_scalar_coordinate(self):
         array = DataArray(np.random.randn(3, 4), dims=['x', 'dim_0'],
@@ -958,6 +966,8 @@ class TestDataArray(TestCase):
                                      'z': np.ones(1)},
                              attrs={'key': 'entry'})
         self.assertDataArrayIdentical(expected, actual)
+        roundtripped = actual.squeeze(['z'], drop=False)
+        self.assertDatasetIdentical(array, roundtripped)
 
     def test_set_index(self):
         indexes = [self.mindex.get_level_values(n) for n in self.mindex.names]

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -915,23 +915,23 @@ class TestDataArray(TestCase):
 
     def test_expand_dims_error(self):
         array = DataArray(np.random.randn(3, 4), dims=['x', 'dim_0'],
-                          coords={'x': np.linspace(0.0, 1.0, 3)},
+                          coords={'x': np.linspace(0.0, 1.0, 3.0)},
                           attrs={'key': 'entry'})
 
-        with self.assertRaises(ValueError):
-            array.expand_dims(0)  # the first argument should not be an integer
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegexp(ValueError, 'dim should be str or'):
+            array.expand_dims(0)
+        with self.assertRaisesRegexp(ValueError, 'lengths of dim and axis'):
             # dims and axis argument should be the same length
             array.expand_dims(dim=['a', 'b'], axis=[1, 2, 3])
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegexp(ValueError, 'Dimension x already'):
             # Should not pass the already existing dimension.
             array.expand_dims(dim=['x'])
         # raise if duplicate
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegexp(ValueError, 'duplicate values.'):
             array.expand_dims(dim=['y', 'y'])
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegexp(ValueError, 'duplicate values.'):
             array.expand_dims(dim=['y', 'z'], axis=[1, 1])
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegexp(ValueError, 'duplicate values.'):
             array.expand_dims(dim=['y', 'z'], axis=[2, -2])
 
         # out of bounds error, axis must be in [-4, 3]

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -913,7 +913,7 @@ class TestDataArray(TestCase):
         actual = array.swap_dims({'x': 'y'})
         self.assertDataArrayIdentical(expected, actual)
 
-    def test_expand_dims(self):
+    def test_expand_dims_error(self):
         array = DataArray(np.random.randn(3, 4), dims=['x', 'dim_0'],
                           coords={'x': np.linspace(0.0, 1.0, 3)},
                           attrs={'key': 'entry'})
@@ -934,7 +934,19 @@ class TestDataArray(TestCase):
         with self.assertRaises(ValueError):
             array.expand_dims(dim=['y', 'z'], axis=[2, -2])
 
-        # Working test
+        # out of bounds error, axis must be in [-4, 3]
+        with self.assertRaises(IndexError):
+            array.expand_dims(dim=['y', 'z'], axis=[2, 4])
+        with self.assertRaises(IndexError):
+            array.expand_dims(dim=['y', 'z'], axis=[2, -5])
+        # Does not raise an IndexError
+        array.expand_dims(dim=['y', 'z'], axis=[2, -4])
+        array.expand_dims(dim=['y', 'z'], axis=[2, 3])
+
+    def test_expand_dims(self):
+        array = DataArray(np.random.randn(3, 4), dims=['x', 'dim_0'],
+                          coords={'x': np.linspace(0.0, 1.0, 3)},
+                          attrs={'key': 'entry'})
         # pass only dim label
         actual = array.expand_dims(dim='y')
         expected = DataArray(np.expand_dims(array.values, 0),

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -919,9 +919,6 @@ class TestDataArray(TestCase):
         with self.assertRaises(ValueError):
             # Should not pass the already existing dimension.
             array.expand_dims(dim=['x'])
-        with self.assertRaises(ValueError):
-            # There should not be a duplicate
-            array.expand_dims(axis=[1, 2, 1])
 
         # Working test
         # pass only dim label
@@ -946,15 +943,6 @@ class TestDataArray(TestCase):
         expected = DataArray(np.expand_dims(np.expand_dims(array.values, 1),
                                             2),
                              dims=['x', 'y', 'z', 'dim_0'],
-                             coords={'x': np.linspace(0.0, 1.0, 3)},
-                             attrs={'key': 'entry'})
-        self.assertDataArrayIdentical(expected, actual)
-
-        # pass Only axies.
-        actual = array.expand_dims(axis=[2, 1])
-        expected = DataArray(np.expand_dims(np.expand_dims(array.values, 1),
-                                            2),
-                             dims=['x', 'dim_2', 'dim_1', 'dim_0'],
                              coords={'x': np.linspace(0.0, 1.0, 3)},
                              attrs={'key': 'entry'})
         self.assertDataArrayIdentical(expected, actual)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -907,7 +907,7 @@ class TestDataArray(TestCase):
         self.assertDataArrayIdentical(expected, actual)
 
     def test_expand_dims(self):
-        array = DataArray(np.random.randn(3, 4), dims=['x', 'dim0'],
+        array = DataArray(np.random.randn(3, 4), dims=['x', 'dim_0'],
                           coords={'x': np.linspace(0.0, 1.0, 3)},
                           attrs={'key': 'entry'})
         # Error checking
@@ -927,7 +927,7 @@ class TestDataArray(TestCase):
         # pass only dim label
         actual = array.expand_dims(dim='y')
         expected = DataArray(np.expand_dims(array.values, 0),
-                             dims=['y', 'x', 'dim0'],
+                             dims=['y', 'x', 'dim_0'],
                              coords={'x': np.linspace(0.0, 1.0, 3)},
                              attrs={'key': 'entry'})
         self.assertDataArrayIdentical(expected, actual)
@@ -936,7 +936,7 @@ class TestDataArray(TestCase):
         actual = array.expand_dims(dim=['y', 'z'])
         expected = DataArray(np.expand_dims(np.expand_dims(array.values, 0),
                                             0),
-                             dims=['y', 'z', 'x', 'dim0'],
+                             dims=['y', 'z', 'x', 'dim_0'],
                              coords={'x': np.linspace(0.0, 1.0, 3)},
                              attrs={'key': 'entry'})
         self.assertDataArrayIdentical(expected, actual)
@@ -945,7 +945,7 @@ class TestDataArray(TestCase):
         actual = array.expand_dims(dim=['z', 'y'], axis=[2, 1])
         expected = DataArray(np.expand_dims(np.expand_dims(array.values, 1),
                                             2),
-                             dims=['x', 'y', 'z', 'dim0'],
+                             dims=['x', 'y', 'z', 'dim_0'],
                              coords={'x': np.linspace(0.0, 1.0, 3)},
                              attrs={'key': 'entry'})
         self.assertDataArrayIdentical(expected, actual)
@@ -954,18 +954,18 @@ class TestDataArray(TestCase):
         actual = array.expand_dims(axis=[2, 1])
         expected = DataArray(np.expand_dims(np.expand_dims(array.values, 1),
                                             2),
-                             dims=['x', 'dim2', 'dim1', 'dim0'],
+                             dims=['x', 'dim_2', 'dim_1', 'dim_0'],
                              coords={'x': np.linspace(0.0, 1.0, 3)},
                              attrs={'key': 'entry'})
         self.assertDataArrayIdentical(expected, actual)
 
     def test_expand_dims_with_scalar_coordinate(self):
-        array = DataArray(np.random.randn(3, 4), dims=['x', 'dim0'],
+        array = DataArray(np.random.randn(3, 4), dims=['x', 'dim_0'],
                           coords={'x': np.linspace(0.0, 1.0, 3), 'z': 1.0},
                           attrs={'key': 'entry'})
         actual = array.expand_dims(dim='z')
         expected = DataArray(np.expand_dims(array.values, 0),
-                             dims=['z', 'x', 'dim0'],
+                             dims=['z', 'x', 'dim_0'],
                              coords={'x': np.linspace(0.0, 1.0, 3),
                                      'z': np.ones(1)},
                              attrs={'key': 'entry'})

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1509,6 +1509,26 @@ class TestDataset(TestCase):
         with self.assertRaisesRegexp(ValueError, 'replacement dimension'):
             original.swap_dims({'x': 'z'})
 
+    def test_expand_dims(self):
+        original = Dataset({'x': ('a', np.random.randn(3)),
+                            'y': (['b', 'a'], np.random.randn(4, 3))},
+                            coords={'a': np.linspace(0, 1, 3),
+                                    'b': np.linspace(0, 1, 4),
+                                    'c': np.linspace(0, 1, 5)},
+                            attrs={'key': 'entry'})
+        expected = Dataset({'x': original['x'].expand_dims('z', 1),
+                            'y': original['y'].expand_dims('z', 1),},
+                            coords={'a': np.linspace(0, 1, 3),
+                                    'b': np.linspace(0, 1, 4),
+                                    'c': np.linspace(0, 1, 5)},
+                            attrs={'key': 'entry'})
+
+        actual = original.expand_dims(['z'], [1])
+        self.assertDatasetIdentical(expected, actual)
+        # make sure squeeze restores the original data set.
+        roundtripped = actual.squeeze('z')
+        self.assertDatasetIdentical(original, roundtripped)
+
     def test_set_index(self):
         expected = create_test_multiindex()
         mindex = expected['x'].to_index()

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1512,18 +1512,31 @@ class TestDataset(TestCase):
     def test_expand_dims(self):
         original = Dataset({'x': ('a', np.random.randn(3)),
                             'y': (['b', 'a'], np.random.randn(4, 3))},
-                            coords={'a': np.linspace(0, 1, 3),
-                                    'b': np.linspace(0, 1, 4),
-                                    'c': np.linspace(0, 1, 5)},
-                            attrs={'key': 'entry'})
-        expected = Dataset({'x': original['x'].expand_dims('z', 1),
-                            'y': original['y'].expand_dims('z', 1),},
-                            coords={'a': np.linspace(0, 1, 3),
-                                    'b': np.linspace(0, 1, 4),
-                                    'c': np.linspace(0, 1, 5)},
-                            attrs={'key': 'entry'})
+                           coords={'a': np.linspace(0, 1, 3),
+                                   'b': np.linspace(0, 1, 4),
+                                   'c': np.linspace(0, 1, 5)},
+                           attrs={'key': 'entry'})
 
         actual = original.expand_dims(['z'], [1])
+        expected = Dataset({'x': original['x'].expand_dims('z', 1),
+                            'y': original['y'].expand_dims('z', 1)},
+                           coords={'a': np.linspace(0, 1, 3),
+                                   'b': np.linspace(0, 1, 4),
+                                   'c': np.linspace(0, 1, 5)},
+                           attrs={'key': 'entry'})
+        self.assertDatasetIdentical(expected, actual)
+        # make sure squeeze restores the original data set.
+        roundtripped = actual.squeeze('z')
+        self.assertDatasetIdentical(original, roundtripped)
+
+        # another test with a negative axis
+        actual = original.expand_dims(['z'], [-1])
+        expected = Dataset({'x': original['x'].expand_dims('z', -1),
+                            'y': original['y'].expand_dims('z', -1)},
+                           coords={'a': np.linspace(0, 1, 3),
+                                   'b': np.linspace(0, 1, 4),
+                                   'c': np.linspace(0, 1, 5)},
+                           attrs={'key': 'entry'})
         self.assertDatasetIdentical(expected, actual)
         # make sure squeeze restores the original data set.
         roundtripped = actual.squeeze('z')

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1509,6 +1509,24 @@ class TestDataset(TestCase):
         with self.assertRaisesRegexp(ValueError, 'replacement dimension'):
             original.swap_dims({'x': 'z'})
 
+    def test_expand_dims_error(self):
+        original = Dataset({'x': ('a', np.random.randn(3)),
+                            'y': (['b', 'a'], np.random.randn(4, 3)),
+                            'z': ('a', np.random.randn(3))},
+                           coords={'a': np.linspace(0, 1, 3),
+                                   'b': np.linspace(0, 1, 4),
+                                   'c': np.linspace(0, 1, 5)},
+                           attrs={'key': 'entry'})
+
+        with self.assertRaisesRegexp(ValueError, 'already exists'):
+            original.expand_dims(dim=['x'])
+
+        # Make sure it raises true error also for non-dimensional coordinates
+        # which has dimension.
+        original.set_coords('z', inplace=True)
+        with self.assertRaisesRegexp(ValueError, 'already exists'):
+            original.expand_dims(dim=['z'])
+
     def test_expand_dims(self):
         original = Dataset({'x': ('a', np.random.randn(3)),
                             'y': (['b', 'a'], np.random.randn(4, 3))},

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2026,7 +2026,7 @@ class TestDataset(TestCase):
                         'letters': ('y', ['a', 'a', 'b', 'b'])})
 
         expected = data.mean('y')
-        expected['yonly'] = expected['yonly'].variable.expand_dims({'x': 3})
+        expected['yonly'] = expected['yonly'].variable.set_dims({'x': 3})
         actual = data.groupby('x').mean()
         self.assertDatasetAllClose(expected, actual)
 
@@ -2036,7 +2036,7 @@ class TestDataset(TestCase):
         letters = data['letters']
         expected = Dataset({'xy': data['xy'].groupby(letters).mean(),
                             'xonly': (data['xonly'].mean().variable
-                                      .expand_dims({'letters': 2})),
+                                      .set_dims({'letters': 2})),
                             'yonly': data['yonly'].groupby(letters).mean()})
         actual = data.groupby('letters').mean()
         self.assertDatasetAllClose(expected, actual)

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -324,7 +324,7 @@ class VariableSubclassTestCases(object):
                        expected[...],
                        expected.squeeze(),
                        expected.isel(x=slice(None)),
-                       expected.expand_dims({'x': 3}),
+                       expected.set_dims({'x': 3}),
                        expected.copy(deep=True),
                        expected.copy(deep=False)]:
 
@@ -818,30 +818,30 @@ class TestVariable(TestCase, VariableSubclassTestCases):
         with self.assertRaisesRegexp(ValueError, 'not found in array dim'):
             v.get_axis_num('foobar')
 
-    def test_expand_dims(self):
+    def test_set_dims(self):
         v = Variable(['x'], [0, 1])
-        actual = v.expand_dims(['x', 'y'])
+        actual = v.set_dims(['x', 'y'])
         expected = Variable(['x', 'y'], [[0], [1]])
         self.assertVariableIdentical(actual, expected)
 
-        actual = v.expand_dims(['y', 'x'])
+        actual = v.set_dims(['y', 'x'])
         self.assertVariableIdentical(actual, expected.T)
 
-        actual = v.expand_dims(OrderedDict([('x', 2), ('y', 2)]))
+        actual = v.set_dims(OrderedDict([('x', 2), ('y', 2)]))
         expected = Variable(['x', 'y'], [[0, 0], [1, 1]])
         self.assertVariableIdentical(actual, expected)
 
         v = Variable(['foo'], [0, 1])
-        actual = v.expand_dims('foo')
+        actual = v.set_dims('foo')
         expected = v
         self.assertVariableIdentical(actual, expected)
 
         with self.assertRaisesRegexp(ValueError, 'must be a superset'):
-            v.expand_dims(['z'])
+            v.set_dims(['z'])
 
-    def test_expand_dims_object_dtype(self):
+    def test_set_dims_object_dtype(self):
         v = Variable([], ('a', 1))
-        actual = v.expand_dims(('x',), (3,))
+        actual = v.set_dims(('x',), (3,))
         exp_values = np.empty((3,), dtype=object)
         for i in range(3):
             exp_values[i] = ('a', 1)


### PR DESCRIPTION
 - [x] closes #1326
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

I added a DataArray's method `expand_dims` based on the discussion in #1326 .
The proposed API is similar to `numpy.expand_dims` and slightly different from `Variables.expand_dims`, which requires whole sequences of `dims` of the result array.

My concern is that I do not yet fully understand the lazy data manipulation in xarray.
Does Variable.expand_dims do it?