### PR TITLE
Add DatetimeAccessor for accessing datetime fields via `.dt` attribute

### DIFF
--- a/doc/time-series.rst
+++ b/doc/time-series.rst
@@ -88,7 +88,22 @@ For more details, read the pandas documentation.
 Datetime components
 -------------------
 
-xarray supports a notion of "virtual" or "derived" coordinates for
+Similar `to pandas`_, the components of datetime objects contained in a
+given ``DataArray`` can be quickly computed using a special ``.dt`` accessor.
+
+.. _to pandas: http://pandas.pydata.org/pandas-docs/stable/basics.html#basics-dt-accessors
+
+.. ipython:: python
+
+    time = time = pd.date_range('2000-01-01', freq='6H', periods=365 * 4)
+    ds = xr.Dataset({'foo': ('time', np.arange(365 * 24)), 'time': time})
+    ds.time.dt.hour
+    ds.time.dt.dayofweek
+
+The ``.dt`` accessor works on both coordinate dimensions as well as
+multi-dimensional data.
+
+xarray also supports a notion of "virtual" or "derived" coordinates for
 `datetime components`__ implemented by pandas, including "year", "month",
 "day", "hour", "minute", "second", "dayofyear", "week", "dayofweek", "weekday"
 and "quarter":
@@ -100,7 +115,8 @@ __ http://pandas.pydata.org/pandas-docs/stable/api.html#time-date-components
     ds['time.month']
     ds['time.dayofyear']
 
-xarray adds ``'season'`` to the list of datetime components supported by pandas:
+For use as a derived coordinate, xarray adds ``'season'`` to the list of
+datetime components supported by pandas:
 
 .. ipython:: python
 
@@ -124,7 +140,7 @@ calculate the mean by time of day:
 
 For upsampling or downsampling temporal resolutions, xarray offers a
 :py:meth:`~xarray.Dataset.resample` method building on the core functionality
-offered by the pandas method of the same name. Resample uses essentialy the
+offered by the pandas method of the same name. Resample uses essentially the
 same api as ``resample`` `in pandas`_.
 
 .. _in pandas: http://pandas.pydata.org/pandas-docs/stable/timeseries.html#up-and-downsampling

--- a/doc/time-series.rst
+++ b/doc/time-series.rst
@@ -121,6 +121,7 @@ datetime components supported by pandas:
 .. ipython:: python
 
     ds['time.season']
+    ds['time'].dt.season
 
 The set of valid seasons consists of 'DJF', 'MAM', 'JJA' and 'SON', labeled by
 the first letters of the corresponding months.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -14,6 +14,45 @@ What's New
     np.random.seed(123456)
 
 
+.. _whats-new.0.9.3:
+
+v0.9.3 (unreleased)
+-------------------
+
+Enhancements
+~~~~~~~~~~~~
+
+- Add ``.dt`` accessor to DataArrays for computing datetime-like properties
+  for the values they contain, similar to ``pandas.Series`` (:issue:`358`).
+  By `Daniel Rothenberg <https://github.com/darothen>`_.
+
+- Add ``.persist()`` method to Datasets and DataArrays to enable persisting
+  data in distributed memory (:issue:`1344`).
+  By `Matthew Rocklin <https://github.com/mrocklin>`_.
+
+- New :py:meth:`~xarray.DataArray.expand_dims` method for ``DataArray`` and
+  ``Dataset`` (:issue:`1326`).
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+
+Bug fixes
+~~~~~~~~~
+
+- Fixed writing to file-like objects with :py:meth:`~xarray.Dataset.to_netcdf`
+  (:issue:`1320`).
+  `Stephan Hoyer <https://github.com/shoyer>`_.
+- Fixed explicitly setting ``engine='scipy'`` with ``to_netcdf`` when not
+  providing a path (:issue:`1321`).
+  `Stephan Hoyer <https://github.com/shoyer>`_.
+
+- Fixed open_dataarray does not pass properly its parameters to open_dataset
+  (:issue:`1359`).
+  `Stephan Hoyer <https://github.com/shoyer>`_.
+
+- Ensure test suite works when runs from an installed version of xarray
+  (:issue:`1336`). Use ``@pytest.mark.slow`` instead of a custom flag to mark
+  slow tests.
+  By `Stephan Hoyer <https://github.com/shoyer>`_
+
 .. _whats-new.0.9.2:
 
 v0.9.2 (2 April, 2017)
@@ -23,6 +62,8 @@ The minor release includes bug-fixes and backwards compatible enhancements.
 
 Enhancements
 ~~~~~~~~~~~~
+
+- ``rolling`` on Dataset is now supported (:issue:`859`).
 
 - ``.rolling()`` on Dataset is now supported (:issue:`859`).
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -18,6 +18,10 @@ What's New
 v0.9.6 (unreleased)
 -------------------
 
+- Add ``.dt`` accessor to DataArrays for computing datetime-like properties
+for the values they contain, similar to ``pandas.Series`` (:issue:`358`).
+By `Daniel Rothenberg <https://github.com/darothen>`_.
+
 Enhancements
 ~~~~~~~~~~~~
 
@@ -48,10 +52,6 @@ Enhancements
 - New :py:meth:`~xarray.DataArray.expand_dims` method for ``DataArray`` and
   ``Dataset`` (:issue:`1326`).
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
-  
-- Add ``.dt`` accessor to DataArrays for computing datetime-like properties
-  for the values they contain, similar to ``pandas.Series`` (:issue:`358`).
-  By `Daniel Rothenberg <https://github.com/darothen>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from .core.accessors import DatetimeAccessor
 from .core.alignment import align, broadcast, broadcast_arrays
 from .core.common import full_like, zeros_like, ones_like
 from .core.combine import concat, auto_combine

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from .core.accessors import DatetimeAccessor
 from .core.alignment import align, broadcast, broadcast_arrays
 from .core.common import full_like, zeros_like, ones_like
 from .core.combine import concat, auto_combine

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+
 from .core.accessors import DatetimeAccessor
 from .core.alignment import align, broadcast, broadcast_arrays
 from .core.common import full_like, zeros_like, ones_like

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -30,6 +30,7 @@ def _access_through_series(values, name):
         field_values = getattr(values_as_series.dt, name).values
     return field_values.reshape(values.shape)
 
+
 def _get_date_field(values, name):
     """Indirectly access pandas' libts.get_date_field by wrapping data
     as a Series and calling through `.dt` attribute.
@@ -132,3 +133,7 @@ class DatetimeAccessor(object):
     daysinmonth = days_in_month
 
     season = _tslib_field_accessor("season", "Season of the year (ex: DJF)")
+
+    time = _tslib_field_accessor(
+        "time", "Timestamps corresponding to datetimes"
+    )

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -60,7 +60,7 @@ class DatetimeAccessor(object):
                   'daysinmonth', 'microsecond',
                   'nanosecond']
 
-    def _tslib_field_accessor(name, field, docstring=None):
+    def _tslib_field_accessor(name, docstring=None):
         def f(self):
             from .dataarray import DataArray
             result = _get_date_field(self._dt, name)
@@ -71,40 +71,36 @@ class DatetimeAccessor(object):
         f.__doc__ = docstring
         return property(f)
 
-
-    year = _tslib_field_accessor('year', 'Y', "The year of the datetime")
+    year = _tslib_field_accessor('year', "The year of the datetime")
     month = _tslib_field_accessor(
-        'month', 'M', "The month as January=1, December=12"
+        'month', "The month as January=1, December=12"
     )
-    day = _tslib_field_accessor('day', 'D', "The days of the datetime")
-    hour = _tslib_field_accessor('hour', 'h', "The hours of the datetime")
-    minute = _tslib_field_accessor('minute', 'm', "The minutes of the datetime")
-    second = _tslib_field_accessor('second', 's', "The seconds of the datetime")
+    day = _tslib_field_accessor('day', "The days of the datetime")
+    hour = _tslib_field_accessor('hour', "The hours of the datetime")
+    minute = _tslib_field_accessor('minute', "The minutes of the datetime")
+    second = _tslib_field_accessor('second', "The seconds of the datetime")
     microsecond = _tslib_field_accessor(
-        'microsecond', 'us', "The microseconds of the datetime"
+        'microsecond', "The microseconds of the datetime"
     )
     nanosecond = _tslib_field_accessor(
-        'nanosecond', 'ns', "The nanoseconds of the datetime"
+        'nanosecond', "The nanoseconds of the datetime"
     )
     weekofyear = _tslib_field_accessor(
-        'weekofyear', 'woy', "The week ordinal of the year"
+        'weekofyear', "The week ordinal of the year"
     )
     week = weekofyear
     dayofweek = _tslib_field_accessor(
-        'dayofweek', 'dow', "The day of the week with Monday=0, Sunday=6"
+        'dayofweek', "The day of the week with Monday=0, Sunday=6"
     )
     weekday = dayofweek
 
     weekday_name = _tslib_field_accessor(
-        'weekday_name', 'weekday_name',
-        "The name of day in a week (ex: Friday)"
+        'weekday_name', "The name of day in a week (ex: Friday)"
     )
 
-    dayofyear = _tslib_field_accessor(
-        'dayofyear', 'doy', "The ordinal day of the year"
-    )
-    quarter = _tslib_field_accessor('quarter', 'q', "The quarter of the date")
+    dayofyear = _tslib_field_accessor('dayofyear', "The ordinal day of the year")
+    quarter = _tslib_field_accessor('quarter', "The quarter of the date")
     days_in_month = _tslib_field_accessor(
-        'days_in_month', 'dim', "The number of days in the month"
+        'days_in_month', "The number of days in the month"
     )
     daysinmonth = days_in_month

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -23,6 +23,32 @@ def _get_date_field(array, name):
     field_values = getattr(series.dt, name).values
     return field_values.reshape(array.shape)
 
+_date_field_ops_and_descrs = [
+    ('year', "The year of the datetime"),
+    ('month', "The month as January=1, December=12"),
+    ('day', "The days of the datetime"),
+    ('hour', "The hours of the datetime"),
+    ('minute', "The minutes of the datetime"),
+    ('second', "The seconds of the datetime"),
+    ('microsecond', "The microseconds of the datetime"),
+    ('nanosecond', "The nanoseconds of the datetime"),
+    ('weekofyear',  "The week ordinal of the year"),
+    ('week', "The week ordinal of the year"),
+    ('weekday', "The day of the week with Monday=0, Sunday=6"),
+    ('weekday_name',
+     "The name of day in a week (ex: Friday)"),
+    ('dayofweek', "The day of the week with Monday=0, Sunday=6"),
+    ('dayofyear',  "The ordinal day of the year"),
+    ('quarter', "The quarter of the date"),
+    ('days_in_month', "The number of days in the month"),
+    ('daysinmonth', "The number of days in the month"),
+]
+
+def inject_date_field_accessors(cls):
+    for op, descr in _date_field_ops_and_descrs:
+        prop = cls._date_field_accessor(op, docstring=descr)
+        setattr(cls, op, prop)
+
 
 @register_dataarray_accessor('dt')
 class DatetimeAccessor(object):
@@ -54,12 +80,6 @@ class DatetimeAccessor(object):
         self._obj = xarray_obj
         self._dt = None
 
-    _field_ops = ['year', 'month', 'day', 'hour', 'minute', 'second',
-                  'weekofyear', 'week', 'weekday', 'dayofweek',
-                  'dayofyear', 'quarter', 'days_in_month',
-                  'daysinmonth', 'microsecond',
-                  'nanosecond']
-
     @property
     def dt(self):
         """Attribute to cache a view of the underlying datetime-like
@@ -69,7 +89,7 @@ class DatetimeAccessor(object):
             self._dt = self._obj.values
         return self._dt
 
-    def _tslib_field_accessor(name, field, docstring=None):
+    def _date_field_accessor(name, docstring=None):
         def f(self):
             from .dataarray import DataArray
             result = _get_date_field(self.dt, name)
@@ -80,40 +100,4 @@ class DatetimeAccessor(object):
         f.__doc__ = docstring
         return property(f)
 
-
-    year = _tslib_field_accessor('year', 'Y', "The year of the datetime")
-    month = _tslib_field_accessor(
-        'month', 'M', "The month as January=1, December=12"
-    )
-    day = _tslib_field_accessor('day', 'D', "The days of the datetime")
-    hour = _tslib_field_accessor('hour', 'h', "The hours of the datetime")
-    minute = _tslib_field_accessor('minute', 'm', "The minutes of the datetime")
-    second = _tslib_field_accessor('second', 's', "The seconds of the datetime")
-    microsecond = _tslib_field_accessor(
-        'microsecond', 'us', "The microseconds of the datetime"
-    )
-    nanosecond = _tslib_field_accessor(
-        'nanosecond', 'ns', "The nanoseconds of the datetime"
-    )
-    weekofyear = _tslib_field_accessor(
-        'weekofyear', 'woy', "The week ordinal of the year"
-    )
-    week = weekofyear
-    dayofweek = _tslib_field_accessor(
-        'dayofweek', 'dow', "The day of the week with Monday=0, Sunday=6"
-    )
-    weekday = dayofweek
-
-    weekday_name = _tslib_field_accessor(
-        'weekday_name', 'weekday_name',
-        "The name of day in a week (ex: Friday)"
-    )
-
-    dayofyear = _tslib_field_accessor(
-        'dayofyear', 'doy', "The ordinal day of the year"
-    )
-    quarter = _tslib_field_accessor('quarter', 'q', "The quarter of the date")
-    days_in_month = _tslib_field_accessor(
-        'days_in_month', 'dim', "The number of days in the month"
-    )
-    daysinmonth = days_in_month
+inject_date_field_accessors(DatetimeAccessor)

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -23,32 +23,6 @@ def _get_date_field(array, name):
     field_values = getattr(series.dt, name).values
     return field_values.reshape(array.shape)
 
-_date_field_ops_and_descrs = [
-    ('year', "The year of the datetime"),
-    ('month', "The month as January=1, December=12"),
-    ('day', "The days of the datetime"),
-    ('hour', "The hours of the datetime"),
-    ('minute', "The minutes of the datetime"),
-    ('second', "The seconds of the datetime"),
-    ('microsecond', "The microseconds of the datetime"),
-    ('nanosecond', "The nanoseconds of the datetime"),
-    ('weekofyear',  "The week ordinal of the year"),
-    ('week', "The week ordinal of the year"),
-    ('weekday', "The day of the week with Monday=0, Sunday=6"),
-    ('weekday_name',
-     "The name of day in a week (ex: Friday)"),
-    ('dayofweek', "The day of the week with Monday=0, Sunday=6"),
-    ('dayofyear',  "The ordinal day of the year"),
-    ('quarter', "The quarter of the date"),
-    ('days_in_month', "The number of days in the month"),
-    ('daysinmonth', "The number of days in the month"),
-]
-
-def inject_date_field_accessors(cls):
-    for op, descr in _date_field_ops_and_descrs:
-        prop = cls._date_field_accessor(op, docstring=descr)
-        setattr(cls, op, prop)
-
 
 @register_dataarray_accessor('dt')
 class DatetimeAccessor(object):
@@ -80,6 +54,12 @@ class DatetimeAccessor(object):
         self._obj = xarray_obj
         self._dt = None
 
+    _field_ops = ['year', 'month', 'day', 'hour', 'minute', 'second',
+                  'weekofyear', 'week', 'weekday', 'dayofweek',
+                  'dayofyear', 'quarter', 'days_in_month',
+                  'daysinmonth', 'microsecond',
+                  'nanosecond']
+
     @property
     def dt(self):
         """Attribute to cache a view of the underlying datetime-like
@@ -89,7 +69,7 @@ class DatetimeAccessor(object):
             self._dt = self._obj.values
         return self._dt
 
-    def _date_field_accessor(name, docstring=None):
+    def _tslib_field_accessor(name, field, docstring=None):
         def f(self):
             from .dataarray import DataArray
             result = _get_date_field(self.dt, name)
@@ -100,4 +80,40 @@ class DatetimeAccessor(object):
         f.__doc__ = docstring
         return property(f)
 
-inject_date_field_accessors(DatetimeAccessor)
+
+    year = _tslib_field_accessor('year', 'Y', "The year of the datetime")
+    month = _tslib_field_accessor(
+        'month', 'M', "The month as January=1, December=12"
+    )
+    day = _tslib_field_accessor('day', 'D', "The days of the datetime")
+    hour = _tslib_field_accessor('hour', 'h', "The hours of the datetime")
+    minute = _tslib_field_accessor('minute', 'm', "The minutes of the datetime")
+    second = _tslib_field_accessor('second', 's', "The seconds of the datetime")
+    microsecond = _tslib_field_accessor(
+        'microsecond', 'us', "The microseconds of the datetime"
+    )
+    nanosecond = _tslib_field_accessor(
+        'nanosecond', 'ns', "The nanoseconds of the datetime"
+    )
+    weekofyear = _tslib_field_accessor(
+        'weekofyear', 'woy', "The week ordinal of the year"
+    )
+    week = weekofyear
+    dayofweek = _tslib_field_accessor(
+        'dayofweek', 'dow', "The day of the week with Monday=0, Sunday=6"
+    )
+    weekday = dayofweek
+
+    weekday_name = _tslib_field_accessor(
+        'weekday_name', 'weekday_name',
+        "The name of day in a week (ex: Friday)"
+    )
+
+    dayofyear = _tslib_field_accessor(
+        'dayofyear', 'doy', "The ordinal day of the year"
+    )
+    quarter = _tslib_field_accessor('quarter', 'q', "The quarter of the date")
+    days_in_month = _tslib_field_accessor(
+        'days_in_month', 'dim', "The number of days in the month"
+    )
+    daysinmonth = days_in_month

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -52,7 +52,7 @@ class DatetimeAccessor(object):
             raise TypeError("'dt' accessor only available for "
                             "DataArray with datetime64 or timedelta64 dtype")
         self._obj = xarray_obj
-        self._dt = None
+        self._dt = self._obj.values
 
     _field_ops = ['year', 'month', 'day', 'hour', 'minute', 'second',
                   'weekofyear', 'week', 'weekday', 'dayofweek',
@@ -60,19 +60,10 @@ class DatetimeAccessor(object):
                   'daysinmonth', 'microsecond',
                   'nanosecond']
 
-    @property
-    def dt(self):
-        """Attribute to cache a view of the underlying datetime-like
-        array for passing to pandas.tslib for date_field operations
-        """
-        if self._dt is None:
-            self._dt = self._obj.values
-        return self._dt
-
     def _tslib_field_accessor(name, field, docstring=None):
         def f(self):
             from .dataarray import DataArray
-            result = _get_date_field(self.dt, name)
+            result = _get_date_field(self._dt, name)
             return DataArray(result, name=name,
                              coords=self._obj.coords, dims=self._obj.dims)
 

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -18,7 +18,7 @@ class DatetimeAccessor(object):
         ...                                            freq='D', periods=100)})
         >>> ds.time.dt
         <xarray.core.accessors.DatetimeAccessor at 0x10c369f60>
-        >>> ds.time.dt.dayofyear[5]
+        >>> ds.time.dt.dayofyear[:5]
         <xarray.DataArray 'dayofyear' (time: 5)>
         array([1, 2, 3, 4, 5], dtype=int32)
         Coordinates:
@@ -26,14 +26,14 @@ class DatetimeAccessor(object):
 
      All of the pandas fields are accessible here. Note that these fields are not
      calendar-aware; if your datetimes are encoded with a non-Gregorian calendar
-     (e.g. a 360-day calendar), then some fields like `dayofyear` may not be
-     accurate.
+     (e.g. a 360-day calendar) using netcdftime, then some fields like
+     `dayofyear` may not be accurate.
 
      """
     def __init__(self, xarray_obj):
         if not is_datetime_like(xarray_obj.dtype):
             raise TypeError("'dt' accessor only available for "
-                            "DataArray with datetime64 dtype")
+                            "DataArray with datetime64 or timedelta64 dtype")
         self._obj = xarray_obj
         self._dt = None
 
@@ -65,6 +65,7 @@ class DatetimeAccessor(object):
         f.__name__ = name
         f.__doc__ = docstring
         return property(f)
+
 
     year = _tslib_field_accessor('year', 'Y', "The year of the datetime")
     month = _tslib_field_accessor(

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -1,0 +1,104 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from .common import is_datetime_like
+from .extensions import register_dataarray_accessor
+
+from pandas import tslib as libts
+
+@register_dataarray_accessor('dt')
+class DatetimeAccessor(object):
+    """Access datetime fields for DataArrays with datetime-like dtypes.
+
+     Similar to pandas, fields can be accessed through the `.dt` attribute
+     for applicable DataArrays:
+
+        >>> ds = xarray.Dataset({'time': pd.date_range(start='2000/01/01',
+        ...                                            freq='D', periods=100)})
+        >>> ds.time.dt
+        <xarray.core.accessors.DatetimeAccessor at 0x10c369f60>
+        >>> ds.time.dt.dayofyear[5]
+        <xarray.DataArray 'dayofyear' (time: 5)>
+        array([1, 2, 3, 4, 5], dtype=int32)
+        Coordinates:
+          * time     (time) datetime64[ns] 2000-01-01 2000-01-02 2000-01-03 ...
+
+     All of the pandas fields are accessible here. Note that these fields are not
+     calendar-aware; if your datetimes are encoded with a non-Gregorian calendar
+     (e.g. a 360-day calendar), then some fields like `dayofyear` may not be
+     accurate.
+
+     """
+    def __init__(self, xarray_obj):
+        if not is_datetime_like(xarray_obj.dtype):
+            raise TypeError("'dt' accessor only available for "
+                            "DataArray with datetime64 dtype")
+        self._obj = xarray_obj
+        self._dt = None
+
+    _field_ops = ['year', 'month', 'day', 'hour', 'minute', 'second',
+                  'weekofyear', 'week', 'weekday', 'dayofweek',
+                  'dayofyear', 'quarter', 'days_in_month',
+                  'daysinmonth', 'microsecond',
+                  'nanosecond']
+
+    @property
+    def dt(self):
+        """Attribute to cache a view of the underlying datetime-like
+        array for passing to pandas.tslib for date_field operations
+        """
+        if self._dt is None:
+            datetimes_asi8 = self._obj.values.view('i8')
+            self._dt = datetimes_asi8
+        return self._dt
+
+    # Modified from https://github.com/pandas-dev/pandas/pandas/tseries/index.py#L59
+    def _tslib_field_accessor(name, field, docstring=None):
+        def f(self):
+            from .dataarray import DataArray
+            values = self.dt
+            result = libts.get_date_field(values, field)
+            return DataArray(result, name=name,
+                             coords=self._obj.coords, dims=self._obj.dims)
+
+        f.__name__ = name
+        f.__doc__ = docstring
+        return property(f)
+
+    year = _tslib_field_accessor('year', 'Y', "The year of the datetime")
+    month = _tslib_field_accessor(
+        'month', 'M', "The month as January=1, December=12"
+    )
+    day = _tslib_field_accessor('day', 'D', "The days of the datetime")
+    hour = _tslib_field_accessor('hour', 'h', "The hours of the datetime")
+    minute = _tslib_field_accessor('minute', 'm', "The minutes of the datetime")
+    second = _tslib_field_accessor('second', 's', "The seconds of the datetime")
+    microsecond = _tslib_field_accessor(
+        'microsecond', 'us', "The microseconds of the datetime"
+    )
+    nanosecond = _tslib_field_accessor(
+        'nanosecond', 'ns', "The nanoseconds of the datetime"
+    )
+    weekofyear = _tslib_field_accessor(
+        'weekofyear', 'woy', "The week ordinal of the year"
+    )
+    week = weekofyear
+    dayofweek = _tslib_field_accessor(
+        'dayofweek', 'dow', "The day of the week with Monday=0, Sunday=6"
+    )
+    weekday = dayofweek
+
+    weekday_name = _tslib_field_accessor(
+        'weekday_name', 'weekday_name',
+        "The name of day in a week (ex: Friday)"
+    )
+
+    dayofyear = _tslib_field_accessor(
+        'dayofyear', 'doy', "The ordinal day of the year"
+    )
+    quarter = _tslib_field_accessor('quarter', 'q', "The quarter of the date")
+    days_in_month = _tslib_field_accessor(
+        'days_in_month', 'dim', "The number of days in the month"
+    )
+    daysinmonth = days_in_month

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -9,6 +9,7 @@ from .pycompat import dask_array_type
 import numpy as np
 import pandas as pd
 
+
 def _get_date_field(values, name):
     """Indirectly access pandas' libts.get_date_field by wrapping data
     as a Series and calling through `.dt` attribute.
@@ -52,9 +53,9 @@ class DatetimeAccessor(object):
         Coordinates:
           * time     (time) datetime64[ns] 2000-01-01 2000-01-02 2000-01-03 ...
 
-     All of the pandas fields are accessible here. Note that these fields are not
-     calendar-aware; if your datetimes are encoded with a non-Gregorian calendar
-     (e.g. a 360-day calendar) using netcdftime, then some fields like
+     All of the pandas fields are accessible here. Note that these fields are
+     not calendar-aware; if your datetimes are encoded with a non-Gregorian
+     calendar (e.g. a 360-day calendar) using netcdftime, then some fields like
      `dayofyear` may not be accurate.
 
      """
@@ -103,7 +104,9 @@ class DatetimeAccessor(object):
         'weekday_name', "The name of day in a week (ex: Friday)"
     )
 
-    dayofyear = _tslib_field_accessor('dayofyear', "The ordinal day of the year")
+    dayofyear = _tslib_field_accessor(
+        'dayofyear', "The ordinal day of the year"
+    )
     quarter = _tslib_field_accessor('quarter', "The quarter of the date")
     days_in_month = _tslib_field_accessor(
         'days_in_month', "The number of days in the month"

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -757,3 +757,10 @@ def ones_like(other, dtype=None):
     """Shorthand for full_like(other, 1, dtype)
     """
     return full_like(other, 1, dtype)
+
+
+def is_datetime_like(dtype):
+    """Check if a dtype is a subclass of the numpy datetime types
+    """
+    return (np.issubdtype(dtype, np.datetime64) or
+            np.issubdtype(dtype, np.timedelta64))

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -15,6 +15,7 @@ from . import groupby
 from . import rolling
 from . import ops
 from . import utils
+from .accessors import DatetimeAccessor
 from .alignment import align, reindex_like_indexers
 from .common import AbstractArray, BaseDataObject
 from .coordinates import (DataArrayCoordinates, LevelCoordinatesSource,
@@ -158,6 +159,7 @@ class DataArray(AbstractArray, BaseDataObject):
     """
     _groupby_cls = groupby.DataArrayGroupBy
     _rolling_cls = rolling.DataArrayRolling
+    dt = property(DatetimeAccessor)
 
     def __init__(self, data, coords=None, dims=None, name=None,
                  attrs=None, encoding=None, fastpath=False):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -80,7 +80,7 @@ def _get_virtual_variable(variables, key, level_vars=None, dim_sizes=None):
             ref_var = xr.DataArray(ref_var)
             data = getattr(ref_var.dt, var_name).data
         else:
-            data = getattr(ref_var).data
+            data = getattr(ref_var, var_name).data
         virtual_var = Variable(ref_var.dims, data)
 
     return ref_name, var_name, virtual_var

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -78,9 +78,9 @@ def _get_virtual_variable(variables, key, level_vars=None, dim_sizes=None):
     else:
         if is_datetime_like(ref_var.dtype):
             ref_var = xr.DataArray(ref_var)
-            data = getattr(ref_var.dt, var_name)
+            data = getattr(ref_var.dt, var_name).data
         else:
-            data = getattr(ref_var)
+            data = getattr(ref_var).data
         virtual_var = Variable(ref_var.dims, data)
 
     return ref_name, var_name, virtual_var

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -21,7 +21,7 @@ from . import duck_array_ops
 from .. import conventions
 from .alignment import align
 from .coordinates import DatasetCoordinates, LevelCoordinatesSource, Indexes
-from .common import ImplementsDatasetReduce, BaseDataObject
+from .common import ImplementsDatasetReduce, BaseDataObject, is_datetime_like
 from .merge import (dataset_update_method, dataset_merge_method,
                     merge_data_and_coords)
 from .utils import (Frozen, SortedKeysDict, maybe_wrap_array, hashable,
@@ -31,6 +31,8 @@ from .variable import (Variable, as_variable, IndexVariable,
 from .pycompat import (iteritems, basestring, OrderedDict,
                        integer_types, dask_array_type, range)
 from .options import OPTIONS
+
+import xarray as xr
 
 # list of attributes of pd.DatetimeIndex that are ndarrays of time info
 _DATETIMEINDEX_COMPONENTS = ['year', 'month', 'day', 'hour', 'minute',
@@ -74,20 +76,11 @@ def _get_virtual_variable(variables, key, level_vars=None, dim_sizes=None):
         virtual_var = ref_var
         var_name = key
     else:
-        if ref_var.ndim == 1:
-            date = ref_var.to_index()
-        elif ref_var.ndim == 0:
-            date = pd.Timestamp(ref_var.values)
+        if is_datetime_like(ref_var.dtype):
+            ref_var = xr.DataArray(ref_var)
+            data = getattr(ref_var.dt, var_name)
         else:
-            raise KeyError(key)
-
-        if var_name == 'season':
-            # TODO: move 'season' into pandas itself
-            seasons = np.array(['DJF', 'MAM', 'JJA', 'SON'])
-            month = date.month
-            data = seasons[(month // 3) % 4]
-        else:
-            data = getattr(date, var_name)
+            data = getattr(ref_var)
         virtual_var = Variable(ref_var.dims, data)
 
     return ref_name, var_name, virtual_var

--- a/xarray/tests/test_accessors.py
+++ b/xarray/tests/test_accessors.py
@@ -1,10 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
 
 import xarray as xr
 import numpy as np
@@ -34,9 +30,9 @@ class TestDatetimeAccessor(TestCase):
         years = xr.DataArray(self.times.year, name='year',
                              coords=[self.times, ], dims=['time', ])
         months = xr.DataArray(self.times.month, name='month',
-                             coords=[self.times, ], dims=['time', ])
+                              coords=[self.times, ], dims=['time', ])
         days = xr.DataArray(self.times.day, name='day',
-                             coords=[self.times, ], dims=['time', ])
+                            coords=[self.times, ], dims=['time', ])
         hours = xr.DataArray(self.times.hour, name='hour',
                              coords=[self.times, ], dims=['time', ])
 
@@ -89,4 +85,3 @@ class TestDatetimeAccessor(TestCase):
         self.assertDataArrayEqual(months, dask_month.compute())
         self.assertDataArrayEqual(days, dask_day.compute())
         self.assertDataArrayEqual(hours, dask_hour.compute())
-

--- a/xarray/tests/test_accessors.py
+++ b/xarray/tests/test_accessors.py
@@ -10,16 +10,17 @@ import xarray as xr
 import numpy as np
 import pandas as pd
 
-from . import TestCase
+from . import TestCase, requires_dask
 
 
 class TestDatetimeAccessor(TestCase):
     def setUp(self):
-        nt = 10000
+        nt = 100
         data = np.random.rand(10, 10, nt)
         lons = np.linspace(0, 11, 10)
         lats = np.linspace(0, 20, 10)
         self.times = pd.date_range(start="2000/01/01", freq='H', periods=nt)
+        self.times_arr = np.random.choice(self.times, size=(10, 10, nt))
 
         self.data = xr.DataArray(data, coords=[lons, lats, self.times],
                                  dims=['lon', 'lat', 'time'], name='data')
@@ -46,3 +47,49 @@ class TestDatetimeAccessor(TestCase):
         nontime_data['time'].values = int_data
         with self.assertRaisesRegexp(TypeError, 'dt'):
             nontime_data.time.dt.year
+
+    @requires_dask
+    def test_dask_field_access(self):
+        import dask.array as da
+
+        # Safely pre-compute comparison fields by passing through Pandas
+        # machinery
+        def _getattr_and_reshape(arr, attr):
+            data = getattr(arr.dt, attr).values.reshape(self.times_arr.shape)
+            return xr.DataArray(data, coords=self.data.coords,
+                                dims=self.data.dims, name=attr)
+        times_arr_as_series = pd.Series(self.times_arr.ravel())
+        years = _getattr_and_reshape(times_arr_as_series, 'year')
+        months = _getattr_and_reshape(times_arr_as_series,'month')
+        days = _getattr_and_reshape(times_arr_as_series, 'day')
+        hours = _getattr_and_reshape(times_arr_as_series, 'hour')
+
+        dask_times_arr = da.from_array(self.times_arr, chunks=(5, 5, 50))
+        dask_times_2d = xr.DataArray(dask_times_arr,
+                                     coords=self.data.coords,
+                                     dims=self.data.dims,
+                                     name='data')
+        dask_year = dask_times_2d.dt.year
+        dask_month = dask_times_2d.dt.month
+        dask_day = dask_times_2d.dt.day
+        dask_hour = dask_times_2d.dt.hour
+
+        # Test that the data isn't eagerly evaluated
+        assert isinstance(dask_year.data, da.Array)
+        assert isinstance(dask_month.data, da.Array)
+        assert isinstance(dask_day.data, da.Array)
+        assert isinstance(dask_hour.data, da.Array)
+
+        # Double check that outcome chunksize is unchanged
+        dask_chunks = dask_times_2d.chunks
+        self.assertEqual(dask_year.data.chunks, dask_chunks)
+        self.assertEqual(dask_month.data.chunks, dask_chunks)
+        self.assertEqual(dask_day.data.chunks, dask_chunks)
+        self.assertEqual(dask_hour.data.chunks, dask_chunks)
+
+        # Check the actual output from the accessors
+        self.assertDataArrayEqual(years, dask_year.compute())
+        self.assertDataArrayEqual(months, dask_month.compute())
+        self.assertDataArrayEqual(days, dask_day.compute())
+        self.assertDataArrayEqual(hours, dask_hour.compute())
+

--- a/xarray/tests/test_accessors.py
+++ b/xarray/tests/test_accessors.py
@@ -85,3 +85,12 @@ class TestDatetimeAccessor(TestCase):
         self.assertDataArrayEqual(months, dask_month.compute())
         self.assertDataArrayEqual(days, dask_day.compute())
         self.assertDataArrayEqual(hours, dask_hour.compute())
+
+    def test_seasons(self):
+        dates = pd.date_range(start="2000/01/01", freq="M", periods=12)
+        dates = xr.DataArray(dates)
+        seasons = ["DJF", "DJF", "MAM", "MAM", "MAM", "JJA", "JJA", "JJA",
+                   "SON", "SON", "SON", "DJF"]
+        seasons = xr.DataArray(seasons)
+
+        self.assertArrayEqual(seasons.values, dates.dt.season.values)

--- a/xarray/tests/test_accessors.py
+++ b/xarray/tests/test_accessors.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+import xarray as xr
+import numpy as np
+import pandas as pd
+
+from . import TestCase
+
+
+class TestDatetimeAccessor(TestCase):
+    def setUp(self):
+        nt = 10000
+        data = np.random.rand(10, 10, nt)
+        lons = np.linspace(0, 11, 10)
+        lats = np.linspace(0, 20, 10)
+        self.times = pd.date_range(start="2000/01/01", freq='H', periods=nt)
+
+        self.data = xr.DataArray(data, coords=[lons, lats, self.times],
+                                 dims=['lon', 'lat', 'time'], name='data')
+
+    def test_field_access(self):
+        years = self.times.year
+        months = self.times.month
+        days = self.times.day
+        hours = self.times.hour
+
+        self.assertArrayEqual(years, self.data.time.dt.year)
+        self.assertArrayEqual(months, self.data.time.dt.month)
+        self.assertArrayEqual(days, self.data.time.dt.day)
+        self.assertArrayEqual(hours, self.data.time.dt.hour)
+
+    def test_not_datetime_type(self):
+        nontime_data = self.data.copy()
+        nontime_data['time'].values = \
+            np.arange(len(self.data.time)).astype('int8')
+        with self.assertRaisesRegexp(TypeError, 'dt'):
+            nontime_data.time.dt.year

--- a/xarray/tests/test_accessors.py
+++ b/xarray/tests/test_accessors.py
@@ -25,19 +25,24 @@ class TestDatetimeAccessor(TestCase):
                                  dims=['lon', 'lat', 'time'], name='data')
 
     def test_field_access(self):
-        years = self.times.year
-        months = self.times.month
-        days = self.times.day
-        hours = self.times.hour
+        years = xr.DataArray(self.times.year, name='year',
+                             coords=[self.times, ], dims=['time', ])
+        months = xr.DataArray(self.times.month, name='month',
+                             coords=[self.times, ], dims=['time', ])
+        days = xr.DataArray(self.times.day, name='day',
+                             coords=[self.times, ], dims=['time', ])
+        hours = xr.DataArray(self.times.hour, name='hour',
+                             coords=[self.times, ], dims=['time', ])
 
-        self.assertArrayEqual(years, self.data.time.dt.year)
-        self.assertArrayEqual(months, self.data.time.dt.month)
-        self.assertArrayEqual(days, self.data.time.dt.day)
-        self.assertArrayEqual(hours, self.data.time.dt.hour)
+
+        self.assertDataArrayEqual(years, self.data.time.dt.year)
+        self.assertDataArrayEqual(months, self.data.time.dt.month)
+        self.assertDataArrayEqual(days, self.data.time.dt.day)
+        self.assertDataArrayEqual(hours, self.data.time.dt.hour)
 
     def test_not_datetime_type(self):
         nontime_data = self.data.copy()
-        nontime_data['time'].values = \
-            np.arange(len(self.data.time)).astype('int8')
+        int_data = np.arange(len(self.data.time)).astype('int8')
+        nontime_data['time'].values = int_data
         with self.assertRaisesRegexp(TypeError, 'dt'):
             nontime_data.time.dt.year


### PR DESCRIPTION
 - [x] Partially closes #358 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

This uses the `register_dataarray_accessor` to add attributes similar to those in pandas` timeseries which let the users quickly access datetime fields from an underlying array of datetime-like values. The referenced issue (#358) also asks about adding similar accessors for `.str`, but this is a more complex topic - I think a compelling use-case would help in figuring out what the critical functionality is

## Virtual time fields

Presumably this could be used to augment `Dataset._get_virtual_variable()`. A **season** field would need to be added as a special field to the accessor.