### PR TITLE
Include missing conftest.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE
+include LICENSE conftest.py
 recursive-include licenses *
 recursive-include doc *
 prune doc/_build


### PR DESCRIPTION
The tests cannot be run from the release tarball without this file.
