### PR TITLE
Fix .where(drop=True) when arguments do not have indexes

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -29,6 +29,11 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- Fix ``.where()`` with ``drop=True`` when arguments do not have indexes
+  (:issue:`1350`). This bug, introduced in v0.9, resulted in xarray producing
+  incorrect results in some cases.
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
+
 .. _whats-new.0.9.2:
 
 v0.9.2 (2 April, 2017)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2668,6 +2668,12 @@ class TestDataset(TestCase):
         expected = DataArray(np.zeros((0, 10)), dims=['nCells', 'nVertLevels'])
         self.assertDatasetIdentical(expected, actual)
 
+    def test_where_drop_no_indexes(self):
+        ds = Dataset({'foo': ('x', [0.0, 1.0])})
+        expected = Dataset({'foo': ('x', [1.0])})
+        actual = ds.where(ds == 1, drop=True)
+        self.assertDatasetIdentical(expected, actual)
+
     def test_reduce(self):
         data = create_test_data()
 


### PR DESCRIPTION
There might be cleaner ways to fix this than aligning twice, but this will do for now.

 - [x] closes #1350
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
