### PR TITLE
Internal cleanup: create xarray.core.duck_array_ops

### DIFF
--- a/xarray/backends/netcdf3.py
+++ b/xarray/backends/netcdf3.py
@@ -6,7 +6,7 @@ import unicodedata
 import numpy as np
 
 from .. import conventions, Variable
-from ..core import ops
+from ..core import duck_array_ops
 from ..core.pycompat import basestring, unicode_type, OrderedDict
 
 
@@ -45,7 +45,7 @@ def coerce_nc3_dtype(arr):
         if ((('int' in dtype or 'U' in dtype) and
                 not (cast_arr == arr).all()) or
                 ('float' in dtype and
-                    not ops.allclose_or_equiv(cast_arr, arr))):
+                    not duck_array_ops.allclose_or_equiv(cast_arr, arr))):
             raise ValueError('could not safely cast array from dtype %s to %s'
                              % (dtype, new_dtype))
         arr = cast_arr

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -11,7 +11,7 @@ import pandas as pd
 from collections import defaultdict
 from pandas.tslib import OutOfBoundsDatetime
 
-from .core import indexing, ops, utils
+from .core import duck_array_ops, indexing, ops, utils
 from .core.formatting import format_timestamp, first_n_items, last_item
 from .core.variable import as_variable, Variable
 from .core.pycompat import iteritems, OrderedDict, PY3, basestring
@@ -632,7 +632,7 @@ def maybe_encode_dtype(var, name=None):
                                   'point data as an integer dtype without '
                                   'any _FillValue to use for NaNs' % name,
                                   RuntimeWarning, stacklevel=3)
-                data = ops.around(data)[...]
+                data = duck_array_ops.around(data)[...]
             if dtype == 'S1' and data.dtype != 'S1':
                 data = string_to_char(np.asarray(data, 'S'))
                 dims = dims + ('string%s' % data.shape[-1],)

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 import numpy as np
 
-from . import ops, utils
+from . import duck_array_ops, utils
 from .common import _maybe_promote
 from .indexing import get_indexer
 from .pycompat import iteritems, OrderedDict, suppress
@@ -376,8 +376,8 @@ def reindex_variables(variables, sizes, indexes, indexers, method=None,
                     for axis, indexer in enumerate(assign_to):
                         if not is_full_slice(indexer):
                             indices = np.cumsum(indexer)[~indexer]
-                            data = ops.insert(data, indices, fill_value,
-                                              axis=axis)
+                            data = duck_array_ops.insert(
+                                data, indices, fill_value, axis=axis)
                     new_var = Variable(var.dims, data, var.attrs,
                                        fastpath=True)
 

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -10,7 +10,7 @@ import re
 
 import numpy as np
 
-from . import ops
+from . import duck_array_ops
 from .alignment import deep_align
 from .merge import expand_and_merge_variables
 from .pycompat import OrderedDict, basestring, dask_array_type
@@ -463,7 +463,7 @@ def broadcast_compat_data(variable, broadcast_dims, core_dims):
     reordered_dims = old_broadcast_dims + core_dims
     if reordered_dims != old_dims:
         order = tuple(old_dims.index(d) for d in reordered_dims)
-        data = ops.transpose(data, order)
+        data = duck_array_ops.transpose(data, order)
 
     if new_dims != reordered_dims:
         key_parts = []

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 from ..plot.plot import _PlotMethods
 
+from . import duck_array_ops
 from . import indexing
 from . import groupby
 from . import rolling
@@ -1752,7 +1753,7 @@ class DataArray(AbstractArray, BaseDataObject):
         self, other = align(self, other, join='inner', copy=False)
 
         axes = (self.get_axis_num(dims), other.get_axis_num(dims))
-        new_data = ops.tensordot(self.data, other.data, axes=axes)
+        new_data = duck_array_ops.tensordot(self.data, other.data, axes=axes)
 
         new_coords = self.coords.merge(other.coords)
         new_coords = new_coords.drop([d for d in dims if d in new_coords])

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -17,6 +17,7 @@ from . import rolling
 from . import indexing
 from . import alignment
 from . import formatting
+from . import duck_array_ops
 from .. import conventions
 from .alignment import align
 from .coordinates import DatasetCoordinates, LevelCoordinatesSource, Indexes
@@ -2234,7 +2235,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
 
         data_vars = [self.variables[k] for k in self.data_vars]
         broadcast_vars = broadcast_variables(*data_vars)
-        data = ops.stack([b.data for b in broadcast_vars], axis=0)
+        data = duck_array_ops.stack([b.data for b in broadcast_vars], axis=0)
 
         coords = dict(self.coords)
         coords[dim] = list(self.data_vars)

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -1,0 +1,260 @@
+"""Compatibility module defining operations on duck numpy-arrays.
+
+Currently, this means Dask or NumPy arrays. None of these functions should
+accept or return xarray objects.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from functools import partial
+import contextlib
+import inspect
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from . import npcompat
+from .pycompat import dask_array_type
+from .nputils import nanfirst, nanlast
+
+try:
+    import bottleneck as bn
+    has_bottleneck = True
+except ImportError:
+    # use numpy methods instead
+    bn = np
+    has_bottleneck = False
+
+try:
+    import dask.array as da
+    has_dask = True
+except ImportError:
+    has_dask = False
+
+
+def _dask_or_eager_func(name, eager_module=np, list_of_args=False,
+                        n_array_args=1):
+    """Create a function that dispatches to dask for dask array inputs."""
+    if has_dask:
+        def f(*args, **kwargs):
+            dispatch_args = args[0] if list_of_args else args
+            if any(isinstance(a, da.Array)
+                   for a in dispatch_args[:n_array_args]):
+                module = da
+            else:
+                module = eager_module
+            return getattr(module, name)(*args, **kwargs)
+    else:
+        def f(data, *args, **kwargs):
+            return getattr(eager_module, name)(data, *args, **kwargs)
+    return f
+
+
+def fail_on_dask_array_input(values, msg=None, func_name=None):
+    if isinstance(values, dask_array_type):
+        if msg is None:
+            msg = '%r is not yet a valid method on dask arrays'
+        if func_name is None:
+            func_name = inspect.stack()[1][3]
+        raise NotImplementedError(msg % func_name)
+
+
+around = _dask_or_eager_func('around')
+isclose = _dask_or_eager_func('isclose')
+notnull = _dask_or_eager_func('notnull', pd)
+_isnull = _dask_or_eager_func('isnull', pd)
+
+
+def isnull(data):
+    # GH837, GH861
+    # isnull fcn from pandas will throw TypeError when run on numpy structured
+    # array therefore for dims that are np structured arrays we assume all
+    # data is present
+    try:
+        return _isnull(data)
+    except TypeError:
+        return np.zeros(data.shape, dtype=bool)
+
+
+transpose = _dask_or_eager_func('transpose')
+where = _dask_or_eager_func('where', n_array_args=3)
+insert = _dask_or_eager_func('insert')
+take = _dask_or_eager_func('take')
+broadcast_to = _dask_or_eager_func('broadcast_to', npcompat)
+
+concatenate = _dask_or_eager_func('concatenate', list_of_args=True)
+stack = _dask_or_eager_func('stack', npcompat, list_of_args=True)
+
+array_all = _dask_or_eager_func('all')
+array_any = _dask_or_eager_func('any')
+
+tensordot = _dask_or_eager_func('tensordot', n_array_args=2)
+
+
+def asarray(data):
+    return data if isinstance(data, dask_array_type) else np.asarray(data)
+
+
+def as_like_arrays(*data):
+    if all(isinstance(d, dask_array_type) for d in data):
+        return data
+    else:
+        return tuple(np.asarray(d) for d in data)
+
+
+def allclose_or_equiv(arr1, arr2, rtol=1e-5, atol=1e-8):
+    """Like np.allclose, but also allows values to be NaN in both arrays
+    """
+    arr1, arr2 = as_like_arrays(arr1, arr2)
+    if arr1.shape != arr2.shape:
+        return False
+    return bool(
+        isclose(arr1, arr2, rtol=rtol, atol=atol, equal_nan=True).all())
+
+
+def array_equiv(arr1, arr2):
+    """Like np.array_equal, but also allows values to be NaN in both arrays
+    """
+    arr1, arr2 = as_like_arrays(arr1, arr2)
+    if arr1.shape != arr2.shape:
+        return False
+
+    flag_array = (arr1 == arr2)
+    flag_array |= (isnull(arr1) & isnull(arr2))
+
+    return bool(flag_array.all())
+
+
+def array_notnull_equiv(arr1, arr2):
+    """Like np.array_equal, but also allows values to be NaN in either or both
+    arrays
+    """
+    arr1, arr2 = as_like_arrays(arr1, arr2)
+    if arr1.shape != arr2.shape:
+        return False
+
+    flag_array = (arr1 == arr2)
+    flag_array |= isnull(arr1)
+    flag_array |= isnull(arr2)
+
+    return bool(flag_array.all())
+
+
+def count(data, axis=None):
+    """Count the number of non-NA in this array along the given axis or axes
+    """
+    return sum(~isnull(data), axis=axis)
+
+
+def where_method(data, cond, other=np.nan):
+    """Select values from this object that are True in cond. Everything else
+    gets masked with other. Follows normal broadcasting and alignment rules.
+    """
+    return where(cond, data, other)
+
+
+@contextlib.contextmanager
+def _ignore_warnings_if(condition):
+    if condition:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            yield
+    else:
+        yield
+
+
+def _create_nan_agg_method(name, numeric_only=False, np_compat=False,
+                           no_bottleneck=False, coerce_strings=False,
+                           keep_dims=False):
+    def f(values, axis=None, skipna=None, **kwargs):
+        # ignore keyword args inserted by np.mean and other numpy aggregators
+        # automatically:
+        kwargs.pop('dtype', None)
+        kwargs.pop('out', None)
+
+        values = asarray(values)
+
+        if coerce_strings and values.dtype.kind in 'SU':
+            values = values.astype(object)
+
+        if skipna or (skipna is None and values.dtype.kind in 'cf'):
+            if values.dtype.kind not in ['i', 'f', 'c']:
+                raise NotImplementedError(
+                    'skipna=True not yet implemented for %s with dtype %s'
+                    % (name, values.dtype))
+            nanname = 'nan' + name
+            if (isinstance(axis, tuple) or not values.dtype.isnative or
+                    no_bottleneck):
+                # bottleneck can't handle multiple axis arguments or non-native
+                # endianness
+                if np_compat:
+                    eager_module = npcompat
+                else:
+                    eager_module = np
+            else:
+                eager_module = bn
+            func = _dask_or_eager_func(nanname, eager_module)
+            using_numpy_nan_func = (eager_module is np or
+                                    eager_module is npcompat)
+        else:
+            func = _dask_or_eager_func(name)
+            using_numpy_nan_func = False
+        with _ignore_warnings_if(using_numpy_nan_func):
+            try:
+                return func(values, axis=axis, **kwargs)
+            except AttributeError:
+                if isinstance(values, dask_array_type):
+                    msg = '%s is not yet implemented on dask arrays' % name
+                else:
+                    assert using_numpy_nan_func
+                    msg = ('%s is not available with skipna=False with the '
+                           'installed version of numpy; upgrade to numpy 1.12 '
+                           'or newer to use skipna=True or skipna=None' % name)
+                raise NotImplementedError(msg)
+    f.numeric_only = numeric_only
+    f.keep_dims = keep_dims
+    f.__name__ = name
+    return f
+
+
+argmax = _create_nan_agg_method('argmax', coerce_strings=True)
+argmin = _create_nan_agg_method('argmin', coerce_strings=True)
+max = _create_nan_agg_method('max', coerce_strings=True)
+min = _create_nan_agg_method('min', coerce_strings=True)
+sum = _create_nan_agg_method('sum', numeric_only=True)
+mean = _create_nan_agg_method('mean', numeric_only=True)
+std = _create_nan_agg_method('std', numeric_only=True)
+var = _create_nan_agg_method('var', numeric_only=True)
+median = _create_nan_agg_method('median', numeric_only=True)
+prod = _create_nan_agg_method('prod', numeric_only=True, np_compat=True,
+                              no_bottleneck=True)
+cumprod = _create_nan_agg_method('cumprod', numeric_only=True, np_compat=True,
+                                 no_bottleneck=True, keep_dims=True)
+cumsum = _create_nan_agg_method('cumsum', numeric_only=True, np_compat=True,
+                                no_bottleneck=True, keep_dims=True)
+
+_fail_on_dask_array_input_skipna = partial(
+    fail_on_dask_array_input,
+    msg='%r with skipna=True is not yet implemented on dask arrays')
+
+
+def first(values, axis, skipna=None):
+    """Return the first non-NA elements in this array along the given axis
+    """
+    if (skipna or skipna is None) and values.dtype.kind not in 'iSU':
+        # only bother for dtypes that can hold NaN
+        _fail_on_dask_array_input_skipna(values)
+        return nanfirst(values, axis)
+    return take(values, 0, axis=axis)
+
+
+def last(values, axis, skipna=None):
+    """Return the last non-NA elements in this array along the given axis
+    """
+    if (skipna or skipna is None) and values.dtype.kind not in 'iSU':
+        # only bother for dtypes that can hold NaN
+        _fail_on_dask_array_input_skipna(values)
+        return nanlast(values, axis)
+    return take(values, -1, axis=axis)

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -5,6 +5,7 @@ import functools
 import numpy as np
 import pandas as pd
 
+from . import duck_array_ops
 from . import nputils
 from . import ops
 from .combine import concat
@@ -418,12 +419,12 @@ class GroupBy(object):
     def first(self, skipna=None, keep_attrs=True):
         """Return the first element of each group along the group dimension
         """
-        return self._first_or_last(ops.first, skipna, keep_attrs)
+        return self._first_or_last(duck_array_ops.first, skipna, keep_attrs)
 
     def last(self, skipna=None, keep_attrs=True):
         """Return the last element of each group along the group dimension
         """
-        return self._first_or_last(ops.last, skipna, keep_attrs)
+        return self._first_or_last(duck_array_ops.last, skipna, keep_attrs)
 
     def assign_coords(self, **kwargs):
         """Assign coordinates by group.

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -1,20 +1,23 @@
+"""Define core operations for xarray objects.
+
+TODO(shoyer): rewrite this module, making use of xarray.core.computation,
+NumPy's __array_ufunc__ and mixin classes instead of the unintuitive "inject"
+functions.
+"""
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from functools import partial
-import contextlib
-import inspect
+
 import operator
-import warnings
 from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
 
-from . import npcompat
-from .pycompat import PY3, dask_array_type
-from .nputils import nanfirst, nanlast, array_eq, array_ne
-
+from . import duck_array_ops
+from .pycompat import PY3
+from .nputils import array_eq, array_ne
 
 try:
     import bottleneck as bn
@@ -23,12 +26,6 @@ except ImportError:
     # use numpy methods instead
     bn = np
     has_bottleneck = False
-
-try:
-    import dask.array as da
-    has_dask = True
-except ImportError:
-    has_dask = False
 
 
 UNARY_OPS = ['neg', 'pos', 'abs', 'invert']
@@ -57,119 +54,110 @@ BOTTLENECK_ROLLING_METHODS = {'move_sum': 'sum', 'move_mean': 'mean',
 # TODO: wrap take, dot, sort
 
 
-def _dask_or_eager_func(name, eager_module=np, list_of_args=False,
-                        n_array_args=1):
-    if has_dask:
-        def f(*args, **kwargs):
-            dispatch_args = args[0] if list_of_args else args
-            if any(isinstance(a, da.Array)
-                   for a in dispatch_args[:n_array_args]):
-                module = da
-            else:
-                module = eager_module
-            return getattr(module, name)(*args, **kwargs)
-    else:
-        def f(data, *args, **kwargs):
-            return getattr(eager_module, name)(data, *args, **kwargs)
-    return f
+_CUM_DOCSTRING_TEMPLATE = """\
+Apply `{name}` along some dimension of {cls}.
+
+Parameters
+----------
+{extra_args}
+skipna : bool, optional
+    If True, skip missing values (as marked by NaN). By default, only
+    skips missing values for float dtypes; other dtypes either do not
+    have a sentinel missing value (int) or skipna=True has not been
+    implemented (object, datetime64 or timedelta64).
+keep_attrs : bool, optional
+    If True, the attributes (`attrs`) will be copied from the original
+    object to the new one.  If False (default), the new object will be
+    returned without attributes.
+**kwargs : dict
+    Additional keyword arguments passed on to `{name}`.
+
+Returns
+-------
+cumvalue : {cls}
+    New {cls} object with `{name}` applied to its data along the
+    indicated dimension.
+"""
+
+_REDUCE_DOCSTRING_TEMPLATE = """\
+Reduce this {cls}'s data by applying `{name}` along some dimension(s).
+
+Parameters
+----------
+{extra_args}
+skipna : bool, optional
+    If True, skip missing values (as marked by NaN). By default, only
+    skips missing values for float dtypes; other dtypes either do not
+    have a sentinel missing value (int) or skipna=True has not been
+    implemented (object, datetime64 or timedelta64).
+keep_attrs : bool, optional
+    If True, the attributes (`attrs`) will be copied from the original
+    object to the new one.  If False (default), the new object will be
+    returned without attributes.
+**kwargs : dict
+    Additional keyword arguments passed on to the appropriate array
+    function for calculating `{name}` on this object's data.
+
+Returns
+-------
+reduced : {cls}
+    New {cls} object with `{name}` applied to its data and the
+    indicated dimension(s) removed.
+"""
+
+_ROLLING_REDUCE_DOCSTRING_TEMPLATE = """\
+Reduce this {da_or_ds}'s data windows by applying `{name}` along its dimension.
+
+Parameters
+----------
+**kwargs : dict
+    Additional keyword arguments passed on to `{name}`.
+
+Returns
+-------
+reduced : {da_or_ds}
+    New {da_or_ds} object with `{name}` applied along its rolling dimnension.
+"""
 
 
-def _fail_on_dask_array_input(values, msg=None, func_name=None):
-    if isinstance(values, dask_array_type):
-        if msg is None:
-            msg = '%r is not a valid method on dask arrays'
-        if func_name is None:
-            func_name = inspect.stack()[1][3]
-        raise NotImplementedError(msg % func_name)
+def fillna(data, other, join="left", dataset_join="left"):
+    """Fill missing values in this object with data from the other object.
+    Follows normal broadcasting and alignment rules.
 
-
-around = _dask_or_eager_func('around')
-isclose = _dask_or_eager_func('isclose')
-notnull = _dask_or_eager_func('notnull', pd)
-_isnull = _dask_or_eager_func('isnull', pd)
-
-
-def isnull(data):
-    # GH837, GH861
-    # isnull fcn from pandas will throw TypeError when run on numpy structured
-    # array therefore for dims that are np structured arrays we assume all
-    # data is present
-    try:
-        return _isnull(data)
-    except TypeError:
-        return np.zeros(data.shape, dtype=bool)
-
-
-transpose = _dask_or_eager_func('transpose')
-where = _dask_or_eager_func('where', n_array_args=3)
-insert = _dask_or_eager_func('insert')
-take = _dask_or_eager_func('take')
-broadcast_to = _dask_or_eager_func('broadcast_to', npcompat)
-
-concatenate = _dask_or_eager_func('concatenate', list_of_args=True)
-stack = _dask_or_eager_func('stack', npcompat, list_of_args=True)
-
-array_all = _dask_or_eager_func('all')
-array_any = _dask_or_eager_func('any')
-
-tensordot = _dask_or_eager_func('tensordot', n_array_args=2)
-
-
-def asarray(data):
-    return data if isinstance(data, dask_array_type) else np.asarray(data)
-
-
-def as_like_arrays(*data):
-    if all(isinstance(d, dask_array_type) for d in data):
-        return data
-    else:
-        return tuple(np.asarray(d) for d in data)
-
-
-def allclose_or_equiv(arr1, arr2, rtol=1e-5, atol=1e-8):
-    """Like np.allclose, but also allows values to be NaN in both arrays
+    Parameters
+    ----------
+    join : {'outer', 'inner', 'left', 'right'}, optional
+        Method for joining the indexes of the passed objects along each
+        dimension
+        - 'outer': use the union of object indexes
+        - 'inner': use the intersection of object indexes
+        - 'left': use indexes from the first object with each dimension
+        - 'right': use indexes from the last object with each dimension
+    dataset_join : {'outer', 'inner', 'left', 'right'}, optional
+        Method for joining variables of Dataset objects with mismatched
+        data variables.
+        - 'outer': take variables from both Dataset objects
+        - 'inner': take only overlapped variables
+        - 'left': take only variables from the first object
+        - 'right': take only variables from the last object
     """
-    arr1, arr2 = as_like_arrays(arr1, arr2)
-    if arr1.shape != arr2.shape:
-        return False
-    return bool(isclose(arr1, arr2, rtol=rtol, atol=atol, equal_nan=True).all())
+    from .computation import apply_ufunc
 
-
-def array_equiv(arr1, arr2):
-    """Like np.array_equal, but also allows values to be NaN in both arrays
-    """
-    arr1, arr2 = as_like_arrays(arr1, arr2)
-    if arr1.shape != arr2.shape:
-        return False
-
-    flag_array = (arr1 == arr2)
-    flag_array |= (isnull(arr1) & isnull(arr2))
-
-    return bool(flag_array.all())
-
-
-def array_notnull_equiv(arr1, arr2):
-    """Like np.array_equal, but also allows values to be NaN in either or both
-    arrays
-    """
-    arr1, arr2 = as_like_arrays(arr1, arr2)
-    if arr1.shape != arr2.shape:
-        return False
-
-    flag_array = (arr1 == arr2)
-    flag_array |= isnull(arr1)
-    flag_array |= isnull(arr2)
-
-    return bool(flag_array.all())
+    def _fillna(data, other):
+        return duck_array_ops.where(duck_array_ops.isnull(data), other, data)
+    return apply_ufunc(_fillna, data, other, join=join, dask_array="allowed",
+                       dataset_join=dataset_join,
+                       dataset_fill_value=np.nan,
+                       keep_attrs=True)
 
 
 def _call_possibly_missing_method(arg, name, args, kwargs):
     try:
         method = getattr(arg, name)
     except AttributeError:
-        _fail_on_dask_array_input(arg, func_name=name)
+        duck_array_ops.fail_on_dask_array_input(arg, func_name=name)
         if hasattr(arg, 'data'):
-            _fail_on_dask_array_input(arg.data, func_name=name)
+            duck_array_ops.fail_on_dask_array_input(arg.data, func_name=name)
         raise
     else:
         return method(*args, **kwargs)
@@ -207,225 +195,13 @@ def _func_slash_method_wrapper(f, name=None):
     func.__doc__ = f.__doc__
     return func
 
-_CUM_DOCSTRING_TEMPLATE = \
-        """Apply `{name}` along some dimension of {cls}.
-
-        Parameters
-        ----------
-        {extra_args}
-        skipna : bool, optional
-            If True, skip missing values (as marked by NaN). By default, only
-            skips missing values for float dtypes; other dtypes either do not
-            have a sentinel missing value (int) or skipna=True has not been
-            implemented (object, datetime64 or timedelta64).
-        keep_attrs : bool, optional
-            If True, the attributes (`attrs`) will be copied from the original
-            object to the new one.  If False (default), the new object will be
-            returned without attributes.
-        **kwargs : dict
-            Additional keyword arguments passed on to `{name}`.
-
-        Returns
-        -------
-        cumvalue : {cls}
-            New {cls} object with `{name}` applied to its data along the
-            indicated dimension.
-        """
-
-_REDUCE_DOCSTRING_TEMPLATE = \
-        """Reduce this {cls}'s data by applying `{name}` along some
-        dimension(s).
-
-        Parameters
-        ----------
-        {extra_args}
-        skipna : bool, optional
-            If True, skip missing values (as marked by NaN). By default, only
-            skips missing values for float dtypes; other dtypes either do not
-            have a sentinel missing value (int) or skipna=True has not been
-            implemented (object, datetime64 or timedelta64).
-        keep_attrs : bool, optional
-            If True, the attributes (`attrs`) will be copied from the original
-            object to the new one.  If False (default), the new object will be
-            returned without attributes.
-        **kwargs : dict
-            Additional keyword arguments passed on to `{name}`.
-
-        Returns
-        -------
-        reduced : {cls}
-            New {cls} object with `{name}` applied to its data and the
-            indicated dimension(s) removed.
-        """
-
-_ROLLING_REDUCE_DOCSTRING_TEMPLATE = \
-        """Reduce this {da_or_ds}'s data windows by applying `{name}`
-        along its dimension.
-
-        Parameters
-        ----------
-        **kwargs : dict
-            Additional keyword arguments passed on to `{name}`.
-
-        Returns
-        -------
-        reduced : {da_or_ds}
-            New {da_or_ds} object with `{name}` applied along its rolling dimnension.
-        """
-
-
-def count(data, axis=None):
-    """Count the number of non-NA in this array along the given axis or axes
-    """
-    return sum(~isnull(data), axis=axis)
-
-
-def fillna(data, other, join="left", dataset_join="left"):
-    """Fill missing values in this object with data from the other object.
-    Follows normal broadcasting and alignment rules.
-
-    Parameters
-    ----------
-    join : {'outer', 'inner', 'left', 'right'}, optional
-        Method for joining the indexes of the passed objects along each
-        dimension
-        - 'outer': use the union of object indexes
-        - 'inner': use the intersection of object indexes
-        - 'left': use indexes from the first object with each dimension
-        - 'right': use indexes from the last object with each dimension
-    dataset_join : {'outer', 'inner', 'left', 'right'}, optional
-        Method for joining variables of Dataset objects with mismatched
-        data variables.
-        - 'outer': take variables from both Dataset objects
-        - 'inner': take only overlapped variables
-        - 'left': take only variables from the first object
-        - 'right': take only variables from the last object
-    """
-    from .computation import apply_ufunc
-
-    def _fillna(data, other):
-        return where(isnull(data), other, data)
-    return apply_ufunc(_fillna, data, other, join=join, dask_array="allowed",
-                       dataset_join=dataset_join,
-                       dataset_fill_value=np.nan,
-                       keep_attrs=True)
-
-
-def where_method(data, cond, other=np.nan):
-    """Select values from this object that are True in cond. Everything else
-    gets masked with other. Follows normal broadcasting and alignment rules.
-    """
-    return where(cond, data, other)
-
-
-@contextlib.contextmanager
-def _ignore_warnings_if(condition):
-    if condition:
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            yield
-    else:
-        yield
-
-
-def _create_nan_agg_method(name, numeric_only=False, np_compat=False,
-                           no_bottleneck=False, coerce_strings=False,
-                           keep_dims=False):
-    def f(values, axis=None, skipna=None, **kwargs):
-        # ignore keyword args inserted by np.mean and other numpy aggregators
-        # automatically:
-        kwargs.pop('dtype', None)
-        kwargs.pop('out', None)
-
-        values = asarray(values)
-
-        if coerce_strings and values.dtype.kind in 'SU':
-            values = values.astype(object)
-
-        if skipna or (skipna is None and values.dtype.kind in 'cf'):
-            if values.dtype.kind not in ['i', 'f', 'c']:
-                raise NotImplementedError(
-                    'skipna=True not yet implemented for %s with dtype %s'
-                    % (name, values.dtype))
-            nanname = 'nan' + name
-            if isinstance(axis, tuple) or not values.dtype.isnative or no_bottleneck:
-                # bottleneck can't handle multiple axis arguments or non-native
-                # endianness
-                if np_compat:
-                    eager_module = npcompat
-                else:
-                    eager_module = np
-            else:
-                eager_module = bn
-            func = _dask_or_eager_func(nanname, eager_module)
-            using_numpy_nan_func = eager_module is np or eager_module is npcompat
-        else:
-            func = _dask_or_eager_func(name)
-            using_numpy_nan_func = False
-        with _ignore_warnings_if(using_numpy_nan_func):
-            try:
-                return func(values, axis=axis, **kwargs)
-            except AttributeError:
-                if isinstance(values, dask_array_type):
-                    msg = '%s is not yet implemented on dask arrays' % name
-                else:
-                    assert using_numpy_nan_func
-                    msg = ('%s is not available with skipna=False with the '
-                           'installed version of numpy; upgrade to numpy 1.12 '
-                           'or newer to use skipna=True or skipna=None' % name)
-                raise NotImplementedError(msg)
-    f.numeric_only = numeric_only
-    f.keep_dims = keep_dims
-    f.__name__ = name
-    return f
-
-
-argmax = _create_nan_agg_method('argmax', coerce_strings=True)
-argmin = _create_nan_agg_method('argmin', coerce_strings=True)
-max = _create_nan_agg_method('max', coerce_strings=True)
-min = _create_nan_agg_method('min', coerce_strings=True)
-sum = _create_nan_agg_method('sum', numeric_only=True)
-mean = _create_nan_agg_method('mean', numeric_only=True)
-std = _create_nan_agg_method('std', numeric_only=True)
-var = _create_nan_agg_method('var', numeric_only=True)
-median = _create_nan_agg_method('median', numeric_only=True)
-prod = _create_nan_agg_method('prod', numeric_only=True, np_compat=True,
-                              no_bottleneck=True)
-cumprod = _create_nan_agg_method('cumprod', numeric_only=True, np_compat=True,
-                                 no_bottleneck=True, keep_dims=True)
-cumsum = _create_nan_agg_method('cumsum', numeric_only=True, np_compat=True,
-                                no_bottleneck=True, keep_dims=True)
-
-_fail_on_dask_array_input_skipna = partial(
-    _fail_on_dask_array_input,
-    msg='%r with skipna=True is not yet implemented on dask arrays')
-
-
-def first(values, axis, skipna=None):
-    """Return the first non-NA elements in this array along the given axis
-    """
-    if (skipna or skipna is None) and values.dtype.kind not in 'iSU':
-        # only bother for dtypes that can hold NaN
-        _fail_on_dask_array_input_skipna(values)
-        return nanfirst(values, axis)
-    return take(values, 0, axis=axis)
-
-
-def last(values, axis, skipna=None):
-    """Return the last non-NA elements in this array along the given axis
-    """
-    if (skipna or skipna is None) and values.dtype.kind not in 'iSU':
-        # only bother for dtypes that can hold NaN
-        _fail_on_dask_array_input_skipna(values)
-        return nanlast(values, axis)
-    return take(values, -1, axis=axis)
-
 
 def inject_reduce_methods(cls):
-    methods = ([(name, globals()['array_%s' % name], False) for name
-               in REDUCE_METHODS] +
-               [(name, globals()[name], True) for name in NAN_REDUCE_METHODS] +
-               [('count', count, False)])
+    methods = ([(name, getattr(duck_array_ops, 'array_%s' % name), False)
+                for name in REDUCE_METHODS] +
+               [(name, getattr(duck_array_ops, name), True)
+                for name in NAN_REDUCE_METHODS] +
+               [('count', duck_array_ops.count, False)])
     for name, f, include_skipna in methods:
         numeric_only = getattr(f, 'numeric_only', False)
         func = cls._reduce_method(f, include_skipna, numeric_only)
@@ -437,7 +213,8 @@ def inject_reduce_methods(cls):
 
 
 def inject_cum_methods(cls):
-    methods = ([(name, globals()[name], True) for name in NAN_CUM_METHODS])
+    methods = ([(name, getattr(duck_array_ops, name), True)
+               for name in NAN_CUM_METHODS])
     for name, f, include_skipna in methods:
         numeric_only = getattr(f, 'numeric_only', False)
         func = cls._reduce_method(f, include_skipna, numeric_only)
@@ -472,7 +249,7 @@ def inject_binary_ops(cls, inplace=False):
         setattr(cls, op_str(name), cls._binary_op(f))
 
     # patch in where
-    f = _func_slash_method_wrapper(where_method, 'where')
+    f = _func_slash_method_wrapper(duck_array_ops.where_method, 'where')
     setattr(cls, '_where', cls._binary_op(f))
 
     for name in NUM_BINARY_OPS:
@@ -502,7 +279,7 @@ def inject_all_ops_and_reduce_methods(cls, priority=50, array_only=True):
         f = _func_slash_method_wrapper(getattr(pd, name))
         setattr(cls, name, cls._unary_op(f))
 
-    f = _func_slash_method_wrapper(around, name='round')
+    f = _func_slash_method_wrapper(duck_array_ops.around, name='round')
     setattr(cls, 'round', cls._unary_op(f))
 
     if array_only:
@@ -517,7 +294,8 @@ def inject_all_ops_and_reduce_methods(cls, priority=50, array_only=True):
 
 def inject_bottleneck_rolling_methods(cls):
     # standard numpy reduce methods
-    methods = [(name, globals()[name]) for name in NAN_REDUCE_METHODS]
+    methods = [(name, getattr(duck_array_ops, name))
+               for name in NAN_REDUCE_METHODS]
     for name, f in methods:
         func = cls._reduce_method(f)
         func.__name__ = name
@@ -564,10 +342,11 @@ def inject_bottleneck_rolling_methods(cls):
 
 def inject_datasetrolling_methods(cls):
     # standard numpy reduce methods
-    methods = [(name, globals()[name]) for name in NAN_REDUCE_METHODS]
+    methods = [(name, getattr(duck_array_ops, name))
+               for name in NAN_REDUCE_METHODS]
     for name, f in methods:
         func = cls._reduce_method(f)
         func.__name__ = name
-        func.__doc__ =  _ROLLING_REDUCE_DOCSTRING_TEMPLATE.format(
+        func.__doc__ = _ROLLING_REDUCE_DOCSTRING_TEMPLATE.format(
             name=func.__name__, da_or_ds='Dataset')
         setattr(cls, name, func)

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -13,7 +13,7 @@ from collections import Mapping, MutableMapping, Iterable
 import numpy as np
 import pandas as pd
 
-from . import ops
+from . import duck_array_ops
 from .pycompat import iteritems, OrderedDict, basestring, bytes_type
 
 
@@ -99,7 +99,7 @@ def equivalent(first, second):
     array_equiv if either object is an ndarray
     """
     if isinstance(first, np.ndarray) or isinstance(second, np.ndarray):
-        return ops.array_equiv(first, second)
+        return duck_array_ops.array_equiv(first, second)
     else:
         return ((first is second) or
                 (first == second) or

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -11,10 +11,11 @@ import numpy as np
 import pandas as pd
 
 from . import common
+from . import duck_array_ops
 from . import indexing
+from . import nputils
 from . import ops
 from . import utils
-from . import nputils
 from .pycompat import (basestring, OrderedDict, zip, integer_types,
                        dask_array_type)
 from .indexing import (PandasIndexAdapter, orthogonally_indexable)
@@ -600,7 +601,7 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         else:
             arrays = [trimmed_data, nans]
 
-        data = ops.concatenate(arrays, axis)
+        data = duck_array_ops.concatenate(arrays, axis)
 
         if isinstance(data, dask_array_type):
             # chunked data should come out with the same chunks; this makes
@@ -643,7 +644,7 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         arrays = [self[(slice(None),) * axis + (idx,)].data
                   for idx in indices]
 
-        data = ops.concatenate(arrays, axis)
+        data = duck_array_ops.concatenate(arrays, axis)
 
         if isinstance(data, dask_array_type):
             # chunked data should come out with the same chunks; this makes
@@ -703,8 +704,9 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         axes = self.get_axis_num(dims)
         if len(dims) < 2:  # no need to transpose if only one dimension
             return self.copy(deep=False)
-        data = ops.transpose(self.data, axes)
-        return type(self)(dims, data, self._attrs, self._encoding, fastpath=True)
+        data = duck_array_ops.transpose(self.data, axes)
+        return type(self)(dims, data, self._attrs, self._encoding,
+                          fastpath=True)
 
     def expand_dims(self, dims, shape=None):
         """Return a new variable with expanded dimensions.
@@ -744,7 +746,7 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         elif shape is not None:
             dims_map = dict(zip(dims, shape))
             tmp_shape = tuple(dims_map[d] for d in expanded_dims)
-            expanded_data = ops.broadcast_to(self.data, tmp_shape)
+            expanded_data = duck_array_ops.broadcast_to(self.data, tmp_shape)
         else:
             expanded_data = self.data[
                 (None,) * (len(expanded_dims) - self.ndim)]
@@ -964,16 +966,17 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         if dim in first_var.dims:
             axis = first_var.get_axis_num(dim)
             dims = first_var.dims
-            data = ops.concatenate(arrays, axis=axis)
+            data = duck_array_ops.concatenate(arrays, axis=axis)
             if positions is not None:
                 # TODO: deprecate this option -- we don't need it for groupby
                 # any more.
-                indices = nputils.inverse_permutation(np.concatenate(positions))
-                data = ops.take(data, indices, axis=axis)
+                indices = nputils.inverse_permutation(
+                    np.concatenate(positions))
+                data = duck_array_ops.take(data, indices, axis=axis)
         else:
             axis = 0
             dims = (dim,) + first_var.dims
-            data = ops.stack(arrays, axis=axis)
+            data = duck_array_ops.stack(arrays, axis=axis)
 
         attrs = OrderedDict(first_var.attrs)
         if not shortcut:
@@ -984,7 +987,7 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
 
         return cls(dims, data, attrs)
 
-    def equals(self, other, equiv=ops.array_equiv):
+    def equals(self, other, equiv=duck_array_ops.array_equiv):
         """True if two Variables have the same dimensions and values;
         otherwise False.
 
@@ -1002,7 +1005,7 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         except (TypeError, AttributeError):
             return False
 
-    def broadcast_equals(self, other, equiv=ops.array_equiv):
+    def broadcast_equals(self, other, equiv=duck_array_ops.array_equiv):
         """True if two Variables have the values after being broadcast against
         each other; otherwise False.
 
@@ -1031,7 +1034,8 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         Variables can thus still be equal if there are locations where either,
         or both, contain NaN values.
         """
-        return self.broadcast_equals(other, equiv=ops.array_notnull_equiv)
+        return self.broadcast_equals(
+            other, equiv=duck_array_ops.array_notnull_equiv)
 
     def quantile(self, q, dim=None, interpolation='linear'):
         """Compute the qth quantile of the data along the specified dimension.

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 
 import numpy as np
 
-from xarray.core import ops
+from xarray.core import duck_array_ops
 
 
 def _decode_string_data(data):
@@ -21,9 +21,10 @@ def _data_allclose_or_equiv(arr1, arr2, rtol=1e-05, atol=1e-08,
         arr2 = _decode_string_data(arr2)
     exact_dtypes = ['M', 'm', 'O', 'U']
     if any(arr.dtype.kind in exact_dtypes for arr in [arr1, arr2]):
-        return ops.array_equiv(arr1, arr2)
+        return duck_array_ops.array_equiv(arr1, arr2)
     else:
-        return ops.allclose_or_equiv(arr1, arr2, rtol=rtol, atol=atol)
+        return duck_array_ops.allclose_or_equiv(
+            arr1, arr2, rtol=rtol, atol=atol)
 
 
 def assert_equal(a, b):

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -7,7 +7,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from xarray.core.ops import allclose_or_equiv
+from xarray.core.duck_array_ops import allclose_or_equiv
 import pytest
 
 from xarray.core import utils

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2449,24 +2449,13 @@ def test_rolling_iter(da):
     for i, (label, window_da) in enumerate(rolling_obj):
         assert label == da['time'].isel(time=i)
 
-def test_rolling_doc(da):
 
+def test_rolling_doc(da):
     rolling_obj = da.rolling(time=7)
 
-    assert rolling_obj.mean.__doc__ == \
-        """Reduce this DataArray's data windows by applying `mean`
-        along its dimension.
+    # argument substitution worked
+    assert '`mean`' in rolling_obj.mean.__doc__
 
-        Parameters
-        ----------
-        **kwargs : dict
-            Additional keyword arguments passed on to `mean`.
-
-        Returns
-        -------
-        reduced : DataArray
-            New DataArray object with `mean` applied along its rolling dimnension.
-        """
 
 def test_rolling_properties(da):
     pytest.importorskip('bottleneck', minversion='1.0')

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from pytest import mark
 import numpy as np
 from numpy import array, nan
-from xarray.core.ops import (
+from xarray.core.duck_array_ops import (
     first, last, count, mean, array_notnull_equiv,
 )
 

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -7,7 +7,7 @@ import pytest
 import numpy as np
 import pandas as pd
 
-from xarray.core import ops, utils
+from xarray.core import duck_array_ops, utils
 from xarray.core.pycompat import OrderedDict
 from . import TestCase
 
@@ -53,11 +53,12 @@ class TestArrayEquiv(TestCase):
     def test_0d(self):
         # verify our work around for pd.isnull not working for 0-dimensional
         # object arrays
-        self.assertTrue(ops.array_equiv(0, np.array(0, dtype=object)))
         self.assertTrue(
-            ops.array_equiv(np.nan, np.array(np.nan, dtype=object)))
+            duck_array_ops.array_equiv(0, np.array(0, dtype=object)))
+        self.assertTrue(
+            duck_array_ops.array_equiv(np.nan, np.array(np.nan, dtype=object)))
         self.assertFalse(
-            ops.array_equiv(0, np.array(1, dtype=object)))
+            duck_array_ops.array_equiv(0, np.array(1, dtype=object)))
 
 
 class TestDictionaries(TestCase):

--- a/xarray/ufuncs.py
+++ b/xarray/ufuncs.py
@@ -25,7 +25,7 @@ from .core.dataarray import DataArray as _DataArray
 from .core.groupby import GroupBy as _GroupBy
 
 from .core.pycompat import dask_array_type as _dask_array_type
-from .core.ops import _dask_or_eager_func
+from .core.duck_array_ops import _dask_or_eager_func
 
 
 _xarray_types = (_Variable, _DataArray, _Dataset, _GroupBy)


### PR DESCRIPTION
This PR splits xarray.core.ops into two modules:

- xarray.core.ops: for defining operations on xarray objects.
- xarray.core.duck_array_ops: for "duck array" operations defined on either dask or numpy arrays.

There should be no change to user facing API, since xarray.core.ops is strictly internal.

- [x] passes ``git diff upstream/master | flake8 --diff``
