### PR TITLE
Patch isel points

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -31,6 +31,10 @@ Bug fixes
 - Fix test suite failure caused by changes to ``pandas.cut`` function (:issue:`1386`).
 By `Ryan Abernathey <https://github.com/rabernat>`_.
 
+- Fix a bug where ``.isel_points`` wrongly assigns unselected coordinate to
+``data_vars``.
+By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+
 .. _whats-new.0.9.5:
 
 v0.9.5 (17 April, 2017)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1267,6 +1267,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         indexers = [(k, np.asarray(v)) for k, v in iteritems(indexers)]
         indexers_dict = dict(indexers)
         non_indexed_dims = set(self.dims) - indexer_dims
+        non_indexed_coords = set(self.coords) - set(coords)
 
         # All the indexers should be iterables
         # Check that indexers are valid dims, integers, and 1D
@@ -1328,8 +1329,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
                 # If not indexed just add it back to variables or coordinates
                 variables[name] = var
 
-        coord_names = set(coords) & set(variables)
-
+        coord_names = (set(coords) & set(variables)) | non_indexed_coords
+        
         dset = self._replace_vars_and_dims(variables, coord_names=coord_names)
         # Add the dim coord to the new dset. Must be done after creation
         # because_replace_vars_and_dims can only access existing coords,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1330,7 +1330,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
                 variables[name] = var
 
         coord_names = (set(coords) & set(variables)) | non_indexed_coords
-        
+
         dset = self._replace_vars_and_dims(variables, coord_names=coord_names)
         # Add the dim coord to the new dset. Must be done after creation
         # because_replace_vars_and_dims can only access existing coords,

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -916,6 +916,8 @@ class TestDataset(TestCase):
 
         actual = data.isel_points(dim1=pdim1, dim2=pdim2)
         assert 'points' in actual.dims
+        assert 'dim3' in actual.dims
+        assert 'dim3' not in actual.data_vars
         np.testing.assert_array_equal(data['dim2'][pdim2], actual['dim2'])
 
         # test that the order of the indexers doesn't matter


### PR DESCRIPTION
 - [x] closes #1337
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

A small fix for the bug reported in #1337, where unselected coords were wrongly assigned as `data_vars` by `sel_points`.
I hope I did not forget anything.