### PR TITLE
Multiindex scalar coords, fixes #1408

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,6 +40,10 @@ By `Ryan Abernathey <https://github.com/rabernat>`_.
 ``data_vars``.
 By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 
+- Fix a bug where selected levels of Multi-Index were lost by ``isel()`` and ``sel()`` (:issue:1408).
+  Now, the selected levels are automatically converted to scalar coordinates.
+By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+
 .. _whats-new.0.9.5:
 
 v0.9.5 (17 April, 2017)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -103,11 +103,11 @@ class _LocIndexer(object):
         return indexing.remap_label_indexers(self.data_array, key)
 
     def __getitem__(self, key):
-        pos_indexers, new_indexes = self._remap_key(key)
+        pos_indexers, new_indexes, _ = self._remap_key(key)
         return self.data_array[pos_indexers]._replace_indexes(new_indexes)
 
     def __setitem__(self, key, value):
-        pos_indexers, _ = self._remap_key(key)
+        pos_indexers, _, _ = self._remap_key(key)
         self.data_array[pos_indexers] = value
 
 
@@ -679,9 +679,9 @@ class DataArray(AbstractArray, BaseDataObject):
         Dataset.sel
         DataArray.isel
         """
-        pos_indexers, new_indexes = indexing.remap_label_indexers(
-            self, indexers, method=method, tolerance=tolerance
-        )
+        pos_indexers, new_indexes, selected_dims = \
+            indexing.remap_label_indexers(
+                self, indexers, method=method, tolerance=tolerance)
         result = self.isel(drop=drop, **pos_indexers)
         return result._replace_indexes(new_indexes)
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1142,13 +1142,14 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         for name, var in iteritems(self._variables):
             var_indexers = dict((k, v) for k, v in indexers if k in var.dims)
             new_var = var.isel(**var_indexers)
-            if not drop and isinstance(new_var, OrderedDict):
-                # new_var is an OrderedDict if a single element is extracted
-                # from MultiIndex. See IndexVariable.__getitem__
-                variables.update(new_var)
-                coord_names = coord_names | set(new_var.keys())
-            elif not (drop and name in var_indexers):
-                variables[name] = new_var
+            if not (drop and name in var_indexers):
+                if isinstance(new_var, OrderedDict):
+                    # new_var is an OrderedDict if a single element is
+                    # extracted from MultiIndex. See IndexVariable.__getitem__
+                    variables.update(new_var)
+                    coord_names = coord_names | set(new_var.keys())
+                else:
+                    variables[name] = new_var
         coord_names = set(coord_names) & set(variables)
         return self._replace_vars_and_dims(variables, coord_names=coord_names)
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -367,6 +367,8 @@ class GroupBy(object):
         """ This constructs MultiIndex if applied does not have dim.
         It may happen if a single item is selected from MultiIndex-ed array.
         """
+        if not hasattr(self._group, 'to_index'):
+            return applied
         index = self._group.to_index()
         if not isinstance(index, pd.MultiIndex):
             return applied

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -298,7 +298,6 @@ class GroupBy(object):
             yield self._obj.isel(**{self._group_dim: indices})
 
     def _infer_concat_args(self, applied_example):
-
         if self._group_dim in applied_example.dims:
             coord = self._group
             positions = self._group_indices
@@ -364,7 +363,8 @@ class GroupBy(object):
         return obj
 
     def _maybe_stack(self, applied):
-        """ This constructs MultiIndex if applied does not have dim.
+        """
+        This constructs MultiIndex if 'applied' does not have self._group_dim.
         It may happen if a single item is selected from MultiIndex-ed array.
         """
         if not hasattr(self._group, 'to_index'):
@@ -374,8 +374,8 @@ class GroupBy(object):
             return applied
         else:
             return [ds if self._group_dim in ds.coords
-                    else ds.expand_dims(index.names).\
-                        stack(**{self._group.name:index.names})
+                    else ds.expand_dims(index.names).stack(
+                        **{self._group.name: index.names})
                     for ds in applied]
 
     def fillna(self, value):

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -364,7 +364,8 @@ class GroupBy(object):
         return obj
 
     def _maybe_stack(self, applied):
-        """ This construct MultiIndex if applied does not have dim.
+        """ This constructs MultiIndex if applied does not have dim.
+        It may happen if a single item is selected from MultiIndex-ed array.
         """
         index = self._group.to_index()
         if not isinstance(index, pd.MultiIndex):

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -273,6 +273,7 @@ def remap_label_indexers(data_obj, indexers, method=None, tolerance=None):
 
     pos_indexers = {}
     new_indexes = {}
+    selected_dims = {}
 
     dim_indexers = get_dim_indexers(data_obj, indexers)
     for dim, label in iteritems(dim_indexers):
@@ -291,8 +292,15 @@ def remap_label_indexers(data_obj, indexers, method=None, tolerance=None):
             pos_indexers[dim] = idxr
             if new_idx is not None:
                 new_indexes[dim] = new_idx
-
-    return pos_indexers, new_indexes
+                if isinstance(new_idx, pd.MultiIndex):
+                    selected_dims[dim] = [name for name in index.names
+                                          if name not in new_idx.names]
+                else:
+                    selected_dims[dim] = [name for name in index.names
+                                          if name != new_idx.name]
+            if isinstance(idxr, int) and idxr in (0, 1):
+                selected_dims[dim] = index.names
+    return pos_indexers, new_indexes, selected_dims
 
 
 def slice_slice(old_slice, applied_slice, size):

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -265,8 +265,11 @@ def get_dim_indexers(data_obj, indexers):
 
 def remap_label_indexers(data_obj, indexers, method=None, tolerance=None):
     """Given an xarray data object and label based indexers, return a mapping
-    of equivalent location based indexers. Also return a mapping of updated
-    pandas index objects (in case of multi-index level drop).
+    of equivalent location based indexers.
+    In case of multi-index level drop, it also returns
+    (new_indexes) a mapping of updated pandas index objects and
+    (selected_dims) a mapping from the original dims to selected (dropped)
+    dims.
     """
     if method is not None and not isinstance(method, str):
         raise TypeError('``method`` must be a string')

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1342,10 +1342,8 @@ def variables_from_multiindex(dims, data, attrs=None, encoding=None,
     dims: tuples, mainly comes from IndexVariable.level_names
     data: 0d-np.ndarray which contains a set of level_values.
     """
-    # needs flattened?
-    data = data.flatten()[0]  # tuple
     variables = OrderedDict()
-    for dim, value in zip(dims, data):
+    for dim, value in zip(dims, data.item()):
         variables[dim] = Variable((), value, attrs, encoding, fastpath)
     return variables
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1205,7 +1205,7 @@ class IndexVariable(Variable):
         if not hasattr(values, 'ndim') or values.ndim == 0:
             level_names = self.level_names
             if level_names:
-                # In case of a single item is selected from MultiIndex,
+                # If a single item is selected from MultiIndex,
                 # returns an OrderedDict with multiple scalar variables
                 return variables_from_multiindex(level_names, values,
                                                  self._attrs, self._encoding)
@@ -1330,8 +1330,9 @@ class IndexVariable(Variable):
     def name(self, value):
         raise AttributeError('cannot modify name of IndexVariable in-place')
 
+
 def variables_from_multiindex(dims, data, attrs=None, encoding=None,
-                                     fastpath=False):
+                              fastpath=False):
     """ Construct an OrderedDict from a single item of MultiIndex.
     keys :level_names
     items: Variable with zero-dimension.

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1203,12 +1203,6 @@ class IndexVariable(Variable):
         key = self._item_key_to_tuple(key)
         values = self._indexable_data[key]
         if not hasattr(values, 'ndim') or values.ndim == 0:
-            level_names = self.level_names
-            if level_names:
-                # If a single item is selected from MultiIndex,
-                # returns an OrderedDict with multiple scalar variables
-                return variables_from_multiindex(level_names, values,
-                                                 self._attrs, self._encoding)
             return Variable((), values, self._attrs, self._encoding)
         else:
             return type(self)(self.dims, values, self._attrs,
@@ -1329,23 +1323,6 @@ class IndexVariable(Variable):
     @name.setter
     def name(self, value):
         raise AttributeError('cannot modify name of IndexVariable in-place')
-
-
-def variables_from_multiindex(dims, data, attrs=None, encoding=None,
-                              fastpath=False):
-    """ Construct an OrderedDict from a single item of MultiIndex.
-    keys :level_names
-    items: Variable with zero-dimension.
-    This conversion is necessary because pandas.MultiIndex losts its
-    hierarchical structure if a single element is selected.
-
-    dims: tuples, mainly comes from IndexVariable.level_names
-    data: 0d-np.ndarray which contains a set of level_values.
-    """
-    variables = OrderedDict()
-    for dim, value in zip(dims, data.item()):
-        variables[dim] = Variable((), value, attrs, encoding, fastpath)
-    return variables
 
 # for backwards compatibility
 Coordinate = utils.alias(IndexVariable, 'Coordinate')

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1203,6 +1203,12 @@ class IndexVariable(Variable):
         key = self._item_key_to_tuple(key)
         values = self._indexable_data[key]
         if not hasattr(values, 'ndim') or values.ndim == 0:
+            level_names = self.level_names
+            if level_names:
+                # In case of a single item is selected from MultiIndex,
+                # returns an OrderedDict with multiple scalar variables
+                return variables_from_multiindex(level_names, values,
+                                                 self._attrs, self._encoding)
             return Variable((), values, self._attrs, self._encoding)
         else:
             return type(self)(self.dims, values, self._attrs,
@@ -1323,6 +1329,24 @@ class IndexVariable(Variable):
     @name.setter
     def name(self, value):
         raise AttributeError('cannot modify name of IndexVariable in-place')
+
+def variables_from_multiindex(dims, data, attrs=None, encoding=None,
+                                     fastpath=False):
+    """ Construct an OrderedDict from a single item of MultiIndex.
+    keys :level_names
+    items: Variable with zero-dimension.
+    This conversion is necessary because pandas.MultiIndex losts its
+    hierarchical structure if a single element is selected.
+
+    dims: tuples, mainly comes from IndexVariable.level_names
+    data: 0d-np.ndarray which contains a set of level_values.
+    """
+    # needs flattened?
+    data = data.flatten()[0]  # tuple
+    variables = OrderedDict()
+    for dim, value in zip(dims, data):
+        variables[dim] = Variable((), value, attrs, encoding, fastpath)
+    return variables
 
 # for backwards compatibility
 Coordinate = utils.alias(IndexVariable, 'Coordinate')

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -684,6 +684,24 @@ class TestDataArray(TestCase):
 
         self.assertDataArrayIdentical(mdata.sel(x={'one': 'a', 'two': 1}),
                                       mdata.sel(one='a', two=1))
+        self.assertTrue('one' in mdata.sel(one='a').coords)
+        self.assertTrue('one' in mdata.sel(one='a', two=1).coords)
+        self.assertTrue('two' in mdata.sel(one='a', two=1).coords)
+        self.assertTrue('three' in mdata.sel(one='a', two=1, three=-1).coords)
+
+    def test_isel_multiindex(self):
+        mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2], [-1, -2]],
+                                            names=('one', 'two', 'three'))
+        mdata = DataArray(range(8), dims=['x'], coords={'x': mindex})
+        selected = mdata.isel(x=0)
+        self.assertTrue('one' in selected.coords)
+        self.assertTrue('two' in selected.coords)
+        self.assertTrue('three' in selected.coords)
+        # drop
+        selected = mdata.isel(x=0, drop=True)
+        self.assertTrue('one' not in selected.coords)
+        self.assertTrue('two' not in selected.coords)
+        self.assertTrue('three' not in selected.coords)
 
     def test_virtual_default_coords(self):
         array = DataArray(np.zeros((5,)), dims='x')

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1096,12 +1096,10 @@ class TestDataset(TestCase):
 
         self.assertDatasetIdentical(mdata.sel(x={'one': 'a', 'two': 1}),
                                     mdata.sel(one='a', two=1))
-        print(mdata.sel(one='a'))
         self.assertTrue('one' in mdata.sel(one='a').coords)
         self.assertTrue('one' in mdata.sel(one='a', two=1).coords)
         self.assertTrue('two' in mdata.sel(one='a', two=1).coords)
         self.assertTrue('three' in mdata.sel(one='a', two=1, three=-1).coords)
-
 
     def test_isel_multiindex(self):
         mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2], [-1, -2]],

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1103,8 +1103,14 @@ class TestDataset(TestCase):
         mdata = Dataset(data_vars={'var': ('x', range(8))},
                         coords={'x': mindex})
         selected = mdata.isel(x=0)
-        print(selected)
         self.assertTrue('one' in selected.coords)
+        self.assertTrue('two' in selected.coords)
+        self.assertTrue('three' in selected.coords)
+        # drop
+        selected = mdata.isel(x=0, drop=True)
+        self.assertTrue('one' not in selected.coords)
+        self.assertTrue('two' not in selected.coords)
+        self.assertTrue('three' not in selected.coords)
 
     def test_reindex_like(self):
         data = create_test_data()

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1100,6 +1100,9 @@ class TestDataset(TestCase):
         self.assertTrue('one' in mdata.sel(one='a', two=1).coords)
         self.assertTrue('two' in mdata.sel(one='a', two=1).coords)
         self.assertTrue('three' in mdata.sel(one='a', two=1, three=-1).coords)
+        # make sure Multiindex coordinate can be a DataArray and it also
+        # as a Multiindex-ed array
+        self.assertTrue('one' in mdata['x'].isel(x=0).coords)
 
     def test_isel_multiindex(self):
         mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2], [-1, -2]],

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1097,6 +1097,15 @@ class TestDataset(TestCase):
         self.assertDatasetIdentical(mdata.sel(x={'one': 'a', 'two': 1}),
                                     mdata.sel(one='a', two=1))
 
+    def test_isel_multiindex(self):
+        mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2], [-1, -2]],
+                                            names=('one', 'two', 'three'))
+        mdata = Dataset(data_vars={'var': ('x', range(8))},
+                        coords={'x': mindex})
+        selected = mdata.isel(x=0)
+        print(selected)
+        self.assertTrue('one' in selected.coords)
+
     def test_reindex_like(self):
         data = create_test_data()
         data['letters'] = ('dim3', 10 * ['a'])

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1096,6 +1096,12 @@ class TestDataset(TestCase):
 
         self.assertDatasetIdentical(mdata.sel(x={'one': 'a', 'two': 1}),
                                     mdata.sel(one='a', two=1))
+        print(mdata.sel(one='a'))
+        self.assertTrue('one' in mdata.sel(one='a').coords)
+        self.assertTrue('one' in mdata.sel(one='a', two=1).coords)
+        self.assertTrue('two' in mdata.sel(one='a', two=1).coords)
+        self.assertTrue('three' in mdata.sel(one='a', two=1, three=-1).coords)
+
 
     def test_isel_multiindex(self):
         mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2], [-1, -2]],

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -23,6 +23,18 @@ def test_consolidate_slices():
         _consolidate_slices([slice(3), 4])
 
 
+def test_multi_index_groupby_apply_dataarray():
+    # regression test for GH873
+    ds = xr.DataArray(np.random.randn(3, 4), dims=['x', 'y'],
+                      coords={'x': ['a', 'b', 'c'], 'y': [1, 2, 3, 4]})
+    doubled = 2 * ds
+    group_doubled = (ds.stack(space=['x', 'y'])
+                     .groupby('space')
+                     .apply(lambda x: 2 * x)
+                     .unstack('space'))
+    assert doubled.equals(group_doubled)
+
+
 def test_multi_index_groupby_apply():
     # regression test for GH873
     ds = xr.Dataset({'foo': (('x', 'y'), np.random.randn(3, 4))},
@@ -70,5 +82,5 @@ def test_groupby_duplicate_coordinate_labels():
     actual = array.groupby('x').sum()
     assert expected.equals(actual)
 
-    
+
 # TODO: move other groupby tests from test_dataset and test_dataarray over here

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -14,7 +14,8 @@ import pandas as pd
 
 from xarray import Variable, IndexVariable, Coordinate, Dataset
 from xarray.core import indexing
-from xarray.core.variable import as_variable, as_compatible_data
+from xarray.core.variable import (as_variable, as_compatible_data,
+                                  variables_from_multiindex)
 from xarray.core.indexing import PandasIndexAdapter, LazilyIndexedArray
 from xarray.core.pycompat import PY3, OrderedDict
 from xarray.core.common import full_like, zeros_like, ones_like
@@ -456,7 +457,12 @@ class VariableSubclassTestCases(object):
     def test_multiindex(self):
         idx = pd.MultiIndex.from_product([list('abc'), [0, 1]])
         v = self.cls('x', idx)
-        self.assertVariableIdentical(Variable((), ('a', 0)), v[0])
+        variables = v[0]  # should returns an OrderedDict
+        if hasattr(self.cls, 'level_names'):
+            self.assertVariableIdentical(Variable((), 'a'),
+                                         variables['x_level_0'])
+        else:
+            self.assertVariableIdentical(Variable((), ('a', 0)), v[0])
         self.assertVariableIdentical(v, v[:])
 
     def test_load(self):

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -456,13 +456,7 @@ class VariableSubclassTestCases(object):
     def test_multiindex(self):
         idx = pd.MultiIndex.from_product([list('abc'), [0, 1]])
         v = self.cls('x', idx)
-        variables = v[0]
-        if hasattr(self.cls, 'level_names'):
-            # returns an OrderedDict if a single item is selected.
-            self.assertVariableIdentical(Variable((), 'a'),
-                                         variables['x_level_0'])
-        else:
-            self.assertVariableIdentical(Variable((), ('a', 0)), v[0])
+        self.assertVariableIdentical(Variable((), ('a', 0)), v[0])
         actual = v[0:1]
         value = np.ndarray((1,), dtype=np.dtype('O'))
         value[0] = ('a', 0)

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -14,8 +14,7 @@ import pandas as pd
 
 from xarray import Variable, IndexVariable, Coordinate, Dataset
 from xarray.core import indexing
-from xarray.core.variable import (as_variable, as_compatible_data,
-                                  variables_from_multiindex)
+from xarray.core.variable import as_variable, as_compatible_data
 from xarray.core.indexing import PandasIndexAdapter, LazilyIndexedArray
 from xarray.core.pycompat import PY3, OrderedDict
 from xarray.core.common import full_like, zeros_like, ones_like

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -457,12 +457,18 @@ class VariableSubclassTestCases(object):
     def test_multiindex(self):
         idx = pd.MultiIndex.from_product([list('abc'), [0, 1]])
         v = self.cls('x', idx)
-        variables = v[0]  # should returns an OrderedDict
+        variables = v[0]
         if hasattr(self.cls, 'level_names'):
+            # returns an OrderedDict if a single item is selected.
             self.assertVariableIdentical(Variable((), 'a'),
                                          variables['x_level_0'])
         else:
             self.assertVariableIdentical(Variable((), ('a', 0)), v[0])
+        actual = v[0:1]
+        value = np.ndarray((1,), dtype=np.dtype('O'))
+        value[0] = ('a', 0)
+        expected = self.cls(('x'), value)
+        self.assertVariableIdentical(actual, expected)
         self.assertVariableIdentical(v, v[:])
 
     def test_load(self):


### PR DESCRIPTION
 - [x] Closes #1408 
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

To fix #1408, 
This modification works, but actually I do not fully satisfied yet.
There are `if` statements in many places.

The major changes I made are
1. `variable.__getitem__` now returns an OrderedDict if a single element is selected from MultiIndex.
2. `indexing.remap_level_indexers` also returns `selected_dims` which is a map from the original dimension to the selected dims which will be a scalar coordinate.

Change 1 keeps level-coordinates even after `ds.isel(yx=0)`.
Change 2 enables to track which levels are selected, then the selected levels are changed to a scalar coordinate.

I guess much smarter solution should exist.
I would be happy if anyone gives me a comment.