### PR TITLE
Moved register_dataset_accessor examples docs to appropriate docstring

### DIFF
--- a/xarray/core/extensions.py
+++ b/xarray/core/extensions.py
@@ -64,6 +64,22 @@ def register_dataarray_accessor(name):
         Name under which the accessor should be registered. A warning is issued
         if this name conflicts with a preexisting attribute.
 
+    See also
+    --------
+    register_dataset_accessor
+    """
+    return _register_accessor(name, DataArray)
+
+
+def register_dataset_accessor(name):
+    """Register a custom property on xarray.Dataset objects.
+
+    Parameters
+    ----------
+    name : str
+        Name under which the accessor should be registered. A warning is issued
+        if this name conflicts with a preexisting attribute.
+
     Examples
     --------
 
@@ -95,22 +111,6 @@ def register_dataarray_accessor(name):
         (5.0, 10.0)
         >>> ds.geo.plot()
         # plots data on a map
-
-    See also
-    --------
-    register_dataset_accessor
-    """
-    return _register_accessor(name, DataArray)
-
-
-def register_dataset_accessor(name):
-    """Register a custom property on xarray.Dataset objects.
-
-    Parameters
-    ----------
-    name : str
-        Name under which the accessor should be registered. A warning is issued
-        if this name conflicts with a preexisting attribute.
 
     See also
     --------


### PR DESCRIPTION
Just noticed this when reading through the code - VERY minor.

The Examples docstring for register_dataarray_accessor referred
to register_dataset_accessor instead.  Moved the example to
register_dataset_accessor.

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Passes ``git diff upstream/master | flake8 --diff``
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

^ hopefully don't need to fill these in