### PR TITLE
Add sphinx-gallery to the docs

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -48,6 +48,7 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf generated/*
+	rm -rf auto_gallery/
 
 .PHONY: html
 html:
@@ -66,6 +67,12 @@ singlehtml:
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
+
+.PHONY: html-noplot
+html-noplot:
+	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 .PHONY: pickle
 pickle:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -91,11 +91,17 @@ extensions = [
     'numpydoc',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
+    'sphinx_gallery.gen_gallery',
 ]
 
 extlinks = {'issue': ('https://github.com/pydata/xarray/issues/%s', 'GH'),
             'pull': ('https://github.com/pydata/xarray/pull/%s', 'PR'),
             }
+
+sphinx_gallery_conf = {'examples_dirs': 'gallery',
+                       'gallery_dirs': 'auto_gallery',
+                       'backreferences_dir': False
+                       }
 
 autosummary_generate = True
 

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -15,3 +15,5 @@ dependencies:
   - netCDF4=1.2.5
   - hdf4=4.2.12  # temporary install to get netCD4 working (GH1106)
   - cartopy=0.14.3
+  - pip:
+    - sphinx-gallery

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -8,3 +8,4 @@ Examples
     examples/weather-data
     examples/monthly-means
     examples/multidimensional-coords
+    auto_gallery/index

--- a/doc/gallery/README.txt
+++ b/doc/gallery/README.txt
@@ -1,5 +1,5 @@
-.. _gallery:
+.. _recipes:
 
-Gallery
+Recipes
 =======
 

--- a/doc/gallery/README.txt
+++ b/doc/gallery/README.txt
@@ -1,0 +1,5 @@
+.. _gallery:
+
+Gallery
+=======
+

--- a/doc/gallery/plot_cartopy_facetgrid.py
+++ b/doc/gallery/plot_cartopy_facetgrid.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+==================================
+Multiple plots and map projections
+==================================
+
+Control the map projection parameters on multiple axes
+
+This example illustrates how to plot multiple maps and control their extent
+and aspect ratio so that the map preserves the its aspect ratio.
+
+For more details see `this discussion`_ on github.
+
+.. _this discussion: https://github.com/pydata/xarray/issues/1397#issuecomment-299190567
+"""
+
+import xarray as xr
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+
+# Load the data
+ds = xr.tutorial.load_dataset('air_temperature')
+air = ds.air.isel(time=[0, 724]) - 273.15
+
+# This is the map projection we want to plot *onto*
+map_proj = ccrs.LambertConformal(central_longitude=-95, central_latitude=45)
+
+p = air.plot(transform=ccrs.PlateCarree(),  # the data's projection
+             col='time', col_wrap=1,  # multiplot settings
+             aspect=ds.dims['lon']/ds.dims['lat'],  # for a sensible figsize
+             subplot_kws={'projection': map_proj})  # the plot's projection
+
+# We have to set the map's options on all four axes
+for ax in p.axes.flat:
+    ax.coastlines()
+    ax.set_extent([-160, -30, 5, 75])
+    # Without this aspect attributes the maps will look chaotic and the
+    # "extent" attribute above might be ignored
+    ax.set_aspect('equal', 'box-forced')
+
+plt.show()

--- a/doc/gallery/plot_cartopy_facetgrid.py
+++ b/doc/gallery/plot_cartopy_facetgrid.py
@@ -7,7 +7,7 @@ Multiple plots and map projections
 Control the map projection parameters on multiple axes
 
 This example illustrates how to plot multiple maps and control their extent
-and aspect ratio so that the map preserves the its aspect ratio.
+and aspect ratio.
 
 For more details see `this discussion`_ on github.
 
@@ -35,7 +35,7 @@ for ax in p.axes.flat:
     ax.coastlines()
     ax.set_extent([-160, -30, 5, 75])
     # Without this aspect attributes the maps will look chaotic and the
-    # "extent" attribute above might be ignored
+    # "extent" attribute above will be ignored
     ax.set_aspect('equal', 'box-forced')
 
 plt.show()

--- a/doc/gallery/plot_colorbar_center.py
+++ b/doc/gallery/plot_colorbar_center.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+==================
+Centered colormaps
+==================
+
+xarray's automatic colormaps choice
+
+"""
+
+import xarray as xr
+import matplotlib.pyplot as plt
+
+# Load the data
+ds = xr.tutorial.load_dataset('air_temperature')
+air = ds.air.isel(time=0)
+
+f, ((ax1, ax2), (ax3, ax4))  = plt.subplots(2, 2, figsize=(8, 6))
+
+# The first plot (in kelvins) chooses "viridis" and uses the data's min/max
+air.plot(ax=ax1, cbar_kwargs={'label':'K'})
+ax1.set_title('Kelvins: default')
+ax2.set_xlabel('')
+
+# The secon plot (in celsius) now chooses "BuRd" and center min/max arounf 0
+airc = air - 273.15
+airc.plot(ax=ax2, cbar_kwargs={'label':'°C'})
+ax2.set_title('Celsius: default')
+ax2.set_xlabel('')
+ax2.set_ylabel('')
+
+# The center doesn't have to be 0
+air.plot(ax=ax3, center=273.15, cbar_kwargs={'label':'K'})
+ax3.set_title('Kelvins: Set center to a value')
+
+# Or it can be ignored
+airc.plot(ax=ax4, center=False, cbar_kwargs={'label':'°C'})
+ax4.set_title('Celsius: set center to False')
+ax4.set_ylabel('')
+
+plt.tight_layout()
+plt.show()

--- a/doc/gallery/plot_colorbar_center.py
+++ b/doc/gallery/plot_colorbar_center.py
@@ -22,7 +22,7 @@ air.plot(ax=ax1, cbar_kwargs={'label':'K'})
 ax1.set_title('Kelvins: default')
 ax2.set_xlabel('')
 
-# The secon plot (in celsius) now chooses "BuRd" and center min/max arounf 0
+# The second plot (in celsius) now chooses "BuRd" and centers min/max around 0
 airc = air - 273.15
 airc.plot(ax=ax2, cbar_kwargs={'label':'°C'})
 ax2.set_title('Celsius: default')
@@ -31,12 +31,13 @@ ax2.set_ylabel('')
 
 # The center doesn't have to be 0
 air.plot(ax=ax3, center=273.15, cbar_kwargs={'label':'K'})
-ax3.set_title('Kelvins: Set center to a value')
+ax3.set_title('Kelvins: center=273.15')
 
 # Or it can be ignored
 airc.plot(ax=ax4, center=False, cbar_kwargs={'label':'°C'})
-ax4.set_title('Celsius: set center to False')
+ax4.set_title('Celsius: center=False')
 ax4.set_ylabel('')
 
+# Mke it nice
 plt.tight_layout()
 plt.show()

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -51,7 +51,6 @@ Documentation
    io
    dask
    plotting
-   auto_gallery/index
    api
    internals
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -51,6 +51,7 @@ Documentation
    io
    dask
    plotting
+   auto_gallery/index
    api
    internals
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,6 +40,13 @@ By `Ryan Abernathey <https://github.com/rabernat>`_.
 ``data_vars``.
 By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 
+Documentation
+~~~~~~~~~~~~~
+
+- A new `gallery <http://xarray.pydata.org/en/latest/auto_gallery/index.html>`_
+  allows to add interactive examples to the documentation.
+  By `Fabien Maussion <https://github.com/fmaussion>`_.
+
 .. _whats-new.0.9.5:
 
 v0.9.5 (17 April, 2017)


### PR DESCRIPTION
 - [x] Closes https://github.com/pydata/xarray/issues/1061
 - [ ] Tests added / passed
 - [ ] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

This uses [sphinx-gallery](http://sphinx-gallery.readthedocs.io) to illustrate some examples of the xarray workflow. See it rendered [here](http://xarray.pydata.org/en/fix-docs/auto_gallery/index.html)

It's nicer for the gallery if there is a plot to draw in the end but it doesn't *have* to be a plot. Once the gallery gets more examples it's possible to sort them by topic (see the sphinx gallery documentation for an overview of the possibilities).

I could think of several other things we could add (including moving or copying @jhamman and @rabernat 's examples to the gallery), but I thought it's better to merge quickly in order to encourage the community to contribute with more examples before the next release.
