### PR TITLE
First pass adding arbitrary object serialization

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -288,7 +288,8 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
                                          allow_remote=True)
         if engine == 'netcdf4':
             store = backends.NetCDF4DataStore(filename_or_obj, group=group,
-                                              autoclose=autoclose)
+                                              autoclose=autoclose,
+                                              allow_object=True)
         elif engine == 'scipy':
             store = backends.ScipyDataStore(filename_or_obj,
                                             autoclose=autoclose)
@@ -534,7 +535,8 @@ WRITEABLE_STORES = {'netcdf4': backends.NetCDF4DataStore,
 
 
 def to_netcdf(dataset, path_or_file=None, mode='w', format=None, group=None,
-              engine=None, writer=None, encoding=None, unlimited_dims=None):
+              engine=None, writer=None, encoding=None, unlimited_dims=None,
+              allow_object=False):
     """This function creates an appropriate datastore for writing a dataset to
     disk as a netCDF file
 
@@ -574,8 +576,8 @@ def to_netcdf(dataset, path_or_file=None, mode='w', format=None, group=None,
     sync = writer is None
 
     target = path_or_file if path_or_file is not None else BytesIO()
-    store = store_cls(target, mode, format, group, writer)
-
+    store = store_cls(target, mode, format, group, writer,
+                      allow_object=allow_object)
     if unlimited_dims is None:
         unlimited_dims = dataset.encoding.get('unlimited_dims', None)
     try:

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -55,7 +55,7 @@ class H5NetCDFStore(WritableCFDataStore, DataStorePickleMixin):
     """Store for reading and writing data via h5netcdf
     """
     def __init__(self, filename, mode='r', format=None, group=None,
-                 writer=None, autoclose=False):
+                 writer=None, autoclose=False, allow_object=False):
         if format not in [None, 'NETCDF4']:
             raise ValueError('invalid format for h5netcdf backend')
         opener = functools.partial(_open_h5netcdf_group, filename, mode=mode,
@@ -71,7 +71,7 @@ class H5NetCDFStore(WritableCFDataStore, DataStorePickleMixin):
         self._opener = opener
         self._filename = filename
         self._mode = mode
-        super(H5NetCDFStore, self).__init__(writer)
+        super(H5NetCDFStore, self).__init__(writer, allow_object=allow_object)
 
     def open_store_variable(self, name, var):
         with self.ensure_open(autoclose=False):

--- a/xarray/backends/memory.py
+++ b/xarray/backends/memory.py
@@ -18,10 +18,12 @@ class InMemoryDataStore(AbstractWritableDataStore):
 
     This store exists purely for internal testing purposes.
     """
-    def __init__(self, variables=None, attributes=None, writer=None):
+    def __init__(self, variables=None, attributes=None, writer=None,
+                 allow_object=False):
         self._variables = OrderedDict() if variables is None else variables
         self._attributes = OrderedDict() if attributes is None else attributes
-        super(InMemoryDataStore, self).__init__(writer)
+        super(InMemoryDataStore, self).__init__(writer,
+                                                allow_object=allow_object)
 
     def get_attrs(self):
         return self._attributes

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -90,7 +90,7 @@ class ScipyDataStore(WritableCFDataStore, DataStorePickleMixin):
     It only supports the NetCDF3 file-format.
     """
     def __init__(self, filename_or_obj, mode='r', format=None, group=None,
-                 writer=None, mmap=None, autoclose=False):
+                 writer=None, mmap=None, autoclose=False, allow_object=False):
         import scipy
         import scipy.io
 
@@ -122,7 +122,7 @@ class ScipyDataStore(WritableCFDataStore, DataStorePickleMixin):
         self._opener = opener
         self._mode = mode
 
-        super(ScipyDataStore, self).__init__(writer)
+        super(ScipyDataStore, self).__init__(writer, allow_object=allow_object)
 
     def open_store_variable(self, name, var):
         with self.ensure_open(autoclose=False):

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -663,7 +663,7 @@ def maybe_encode_bools(var):
     return var
 
 
-def _infer_dtype(array):
+def _infer_dtype(array, allow_object=False):
     """Given an object array with no missing values, infer its dtype from its
     first element
     """
@@ -676,12 +676,15 @@ def _infer_dtype(array):
             # the length of their first element
             dtype = np.dtype(dtype.kind)
         elif dtype.kind == 'O':
-            raise ValueError('unable to infer dtype; xarray cannot '
-                             'serialize arbitrary Python objects')
+            if allow_object:
+                dtype = np.dtype(object)
+            else:
+                raise ValueError('unable to infer dtype; xarray cannot '
+                                 'serialize arbitrary Python objects')
     return dtype
 
 
-def ensure_dtype_not_object(var):
+def maybe_infer_dtype(var, allow_object=False):
     # TODO: move this from conventions to backends? (it's not CF related)
     if var.dtype.kind == 'O':
         dims, data, attrs, encoding = _var_as_tuple(var)
@@ -689,7 +692,8 @@ def ensure_dtype_not_object(var):
         if missing.any():
             # nb. this will fail for dask.array data
             non_missing_values = data[~missing]
-            inferred_dtype = _infer_dtype(non_missing_values)
+            inferred_dtype = _infer_dtype(non_missing_values,
+                                          allow_object=allow_object)
 
             if inferred_dtype.kind in ['S', 'U']:
                 # There is no safe bit-pattern for NA in typical binary string
@@ -706,12 +710,13 @@ def ensure_dtype_not_object(var):
             data = np.array(data, dtype=inferred_dtype, copy=True)
             data[missing] = fill_value
         else:
-            data = data.astype(dtype=_infer_dtype(data))
+            data = data.astype(dtype=_infer_dtype(data,
+                                                  allow_object=allow_object))
         var = Variable(dims, data, attrs, encoding)
     return var
 
 
-def encode_cf_variable(var, needs_copy=True, name=None):
+def encode_cf_variable(var, needs_copy=True, name=None, allow_object=False):
     """
     Converts an Variable into an Variable which follows some
     of the CF conventions:
@@ -725,6 +730,9 @@ def encode_cf_variable(var, needs_copy=True, name=None):
     ----------
     var : xarray.Variable
         A variable holding un-encoded data.
+    allow_object : bool
+        Whether to allow objects to pass the encoder or to throw an error if
+        this is attempted.
 
     Returns
     -------
@@ -738,7 +746,7 @@ def encode_cf_variable(var, needs_copy=True, name=None):
     var = maybe_encode_dtype(var, name)
     var = maybe_default_fill_value(var)
     var = maybe_encode_bools(var)
-    var = ensure_dtype_not_object(var)
+    var = maybe_infer_dtype(var, allow_object=allow_object)
     return var
 
 
@@ -1058,7 +1066,7 @@ def encode_dataset_coordinates(dataset):
                                non_dim_coord_names=non_dim_coord_names)
 
 
-def cf_encoder(variables, attributes):
+def cf_encoder(variables, attributes, allow_object=False):
     """
     A function which takes a dicts of variables and attributes
     and encodes them to conform to CF conventions as much
@@ -1075,6 +1083,9 @@ def cf_encoder(variables, attributes):
         A dictionary mapping from variable name to xarray.Variable
     attributes : dict
         A dictionary mapping from attribute name to value
+    allow_object : bool
+        Whether to allow objects to pass the encoder or to throw an error if
+        this is attempted.
 
     Returns
     -------
@@ -1085,6 +1096,7 @@ def cf_encoder(variables, attributes):
 
     See also: encode_cf_variable
     """
-    new_vars = OrderedDict((k, encode_cf_variable(v, name=k))
+    new_vars = OrderedDict((k, encode_cf_variable(v, name=k,
+                                                  allow_object=allow_object))
                            for k, v in iteritems(variables))
     return new_vars, attributes

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1314,6 +1314,8 @@ class DataArray(AbstractArray, BaseDataObject):
             Nested dictionary with variable names as keys and dictionaries of
             variable specific encodings as values, e.g.,
             ``{'my_variable': {'dtype': 'int16', 'scale_factor': 0.1, 'zlib': True}, ...}``
+        allow_object : bool, optional
+            If True, allow native Python objects to be serialized.
 
         Notes
         -----

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -898,6 +898,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
     def dump_to_store(self, store, encoder=None, sync=True, encoding=None,
                       unlimited_dims=None):
         """Store dataset contents to a backends.*DataStore object."""
+
         if encoding is None:
             encoding = {}
         variables, attrs = conventions.encode_dataset_coordinates(self)
@@ -918,7 +919,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
             store.sync()
 
     def to_netcdf(self, path=None, mode='w', format=None, group=None,
-                  engine=None, encoding=None, unlimited_dims=None):
+                  engine=None, encoding=None, unlimited_dims=None,
+                  allow_object=False):
         """Write dataset contents to a netCDF file.
 
         Parameters
@@ -968,13 +970,16 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
             By default, no dimensions are treated as unlimited dimensions.
             Note that unlimited_dims may also be set via
             ``dataset.encoding['unlimited_dims']``.
+        allow_object : bool, optional
+            If True, allow native Python objects to be serialized.
         """
         if encoding is None:
             encoding = {}
         from ..backends.api import to_netcdf
         return to_netcdf(self, path, mode, format=format, group=group,
                          engine=engine, encoding=encoding,
-                         unlimited_dims=unlimited_dims)
+                         unlimited_dims=unlimited_dims,
+                         allow_object=allow_object)
 
     def __unicode__(self):
         return formatting.dataset_repr(self)

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -9,6 +9,7 @@ import itertools
 import re
 import warnings
 from collections import Mapping, MutableMapping, Iterable
+from six.moves import cPickle as pickle
 
 import numpy as np
 import pandas as pd
@@ -489,3 +490,13 @@ def ensure_us_time_resolution(val):
     elif np.issubdtype(val.dtype, np.timedelta64):
         val = val.astype('timedelta64[us]')
     return val
+
+
+@functools.partial(np.vectorize, otypes='O')
+def encode_pickle(obj):
+    return np.frombuffer(pickle.dumps(obj), dtype=np.uint8)
+
+
+@functools.partial(np.vectorize, otypes='O')
+def decode_pickle(obj):
+    return pickle.loads(obj.tostring())


### PR DESCRIPTION
This adds support for object serialization using the netCDF4-python backend..

Minimum working (at least appears to..) example, no tests yet.

I added `allow_object` kwarg (rather than `allow_pickle`, no reason to firmly attach pickle to the api, could use something else for other backends).

This is now for:

- `to_netcdf`
- `AbstractDataStore` (a `True` value raises `NotImplementedError` for everything but `NetCDF4DataStore`)
- `cf_encoder` which when `True` alters its behaviour to allow `dtype('O')` through.

`NetCDF4DataStore` handles this independently from the cf_encoder/decoder.  The dtype support made it hard to decouple, plus I think object serialization is a backend dependent issue.

There's a lot of potential for refactoring, just pushed this to get opinions about whether this
was a reasonable approach - I'm relatively new to open source, so would appreciate any constructive feedback/criticisms! 


 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Passes ``git diff upstream/master | flake8 --diff``
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

^ these will come later!