### PR TITLE
xarray.core.variable.as_variable part of the public API

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -22,6 +22,7 @@ Top-level functions
    full_like
    zeros_like
    ones_like
+   as_variable
 
 Dataset
 =======

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -22,7 +22,6 @@ Top-level functions
    full_like
    zeros_like
    ones_like
-   as_variable
 
 Dataset
 =======
@@ -490,6 +489,7 @@ Advanced API
 
    Variable
    IndexVariable
+   as_variable
    register_dataset_accessor
    register_dataarray_accessor
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,6 +38,10 @@ Enhancements
   to ``py.test`` (:issue:`1393`).
   By `Matthew Gidden <https://github.com/gidden>`_.
 
+- ``xarray.core.variable.as_variable`` is now part of the public API and
+  can be accessed using :py:meth:`~xarray.as_variable` (:issue:`1303`).
+  By `Benoit Bovy <https://github.com/benbovy>`_.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -7,7 +7,7 @@ from .core.common import full_like, zeros_like, ones_like
 from .core.combine import concat, auto_combine
 from .core.extensions import (register_dataarray_accessor,
                               register_dataset_accessor)
-from .core.variable import Variable, IndexVariable, Coordinate
+from .core.variable import as_variable, Variable, IndexVariable, Coordinate
 from .core.dataset import Dataset
 from .core.dataarray import DataArray
 from .core.merge import merge, MergeError

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -539,7 +539,7 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
             combined = self._restore_dim_order(combined)
         if coord is not None:
             if shortcut:
-                combined._coords[coord.name] = as_variable(coord, copy=True)
+                combined._coords[coord.name] = as_variable(coord)
             else:
                 combined.coords[coord.name] = coord
         combined = self._maybe_restore_empty_groups(combined)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -65,7 +65,10 @@ def as_variable(obj, name=None):
         obj = obj.copy(deep=False)
     elif hasattr(obj, 'dims') and (hasattr(obj, 'data') or
                                    hasattr(obj, 'values')):
-        obj = Variable(obj.dims, getattr(obj, 'data', obj.values),
+        obj_data = getattr(obj, 'data', None)
+        if obj_data is None:
+            obj_data = getattr(obj, 'values')
+        obj = Variable(obj.dims, obj_data,
                        getattr(obj, 'attrs', None),
                        getattr(obj, 'encoding', None))
     elif isinstance(obj, tuple):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -35,13 +35,19 @@ def as_variable(obj, name=None):
     ----------
     obj : object
         Object to convert into a Variable.
-        If the object is already a Variable, return a shallow copy.
-        Otherwise, if the object has 'dims' and 'data' attributes, convert
-        it into a new Variable.
-        If all else fails, attempt to convert the object into a Variable by
-        unpacking it into the arguments for creating a new Variable.
+
+        - If the object is already a Variable, return a shallow copy.
+        - Otherwise, if the object has 'dims' and 'data' attributes, convert
+          it into a new Variable.
+        - If all else fails, attempt to convert the object into a Variable by
+          unpacking it into the arguments for creating a new Variable.
     name : str, optional
-        Dimension name (only if data in `obj` is 1-dimensional).
+        If provided
+
+        - `obj` can be a 1D array, which is assumed to label coordinate values
+          along a dimension of this given name.
+        - Variables with name matching one of their dimensions are converted
+          into `IndexVariable` objects.
 
     Returns
     -------

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -42,7 +42,7 @@ def as_variable(obj, name=None):
         - If all else fails, attempt to convert the object into a Variable by
           unpacking it into the arguments for creating a new Variable.
     name : str, optional
-        If provided
+        If provided:
 
         - `obj` can be a 1D array, which is assumed to label coordinate values
           along a dimension of this given name.

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -28,14 +28,26 @@ except ImportError:
     pass
 
 
-def as_variable(obj, name=None, copy=False):
-    """Convert an object into an Variable.
+def as_variable(obj, name=None):
+    """Convert an object into a Variable.
 
-    - If the object is already an `Variable`, return a shallow copy.
-    - Otherwise, if the object has 'dims' and 'data' attributes, convert
-      it into a new `Variable`.
-    - If all else fails, attempt to convert the object into an `Variable` by
-      unpacking it into the arguments for `Variable.__init__`.
+    Parameters
+    ----------
+    obj : object
+        Object to convert into a Variable.
+        If the object is already a Variable, return a shallow copy.
+        Otherwise, if the object has 'dims' and 'data' attributes, convert
+        it into a new Variable.
+        If all else fails, attempt to convert the object into a Variable by
+        unpacking it into the arguments for creating a new Variable.
+    name : str, optional
+        Dimension name (only if data in `obj` is 1-dimensional).
+
+    Returns
+    -------
+    var : Variable
+        The newly created variable.
+
     """
     # TODO: consider extending this method to automatically handle Iris and
     # pandas objects.
@@ -75,7 +87,7 @@ def as_variable(obj, name=None, copy=False):
                         'explicit list of dimensions: %r' % obj)
 
     if name is not None and name in obj.dims:
-        # convert the into an Index
+        # convert the Variable into an Index
         if obj.ndim != 1:
             raise ValueError(
                 '%r has more than 1-dimension and the same name as one of its '

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -654,10 +654,10 @@ class TestVariable(TestCase, VariableSubclassTestCases):
 
         data = np.arange(9).reshape((3, 3))
         expected = Variable(('x', 'y'), data)
-        with self.assertRaisesRegex(
+        with self.assertRaisesRegexp(
                 ValueError, 'without explicit dimension names'):
             as_variable(data, name='x')
-        with self.assertRaisesRegex(
+        with self.assertRaisesRegexp(
                 ValueError, 'has more than 1-dimension'):
             as_variable(expected, name='x')
 


### PR DESCRIPTION
 - [x] Closes #1303 
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff`` (if we ignore messages for .rst files and "imported but not used" messages for `xarray.__init__.py`)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Make `xarray.core.variable.as_variable` part of the public API and accessible as a top-level function: `xarray.as_variable`.

I changed the docstrings to follow the numpydoc format more closely.

I also removed the `copy=False` keyword arguments as apparently it was unused. 