### PR TITLE
Fix errors in the test suite due to pytest warning changes

### DIFF
--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-import warnings
 from contextlib import contextmanager
 from distutils.version import LooseVersion
 
@@ -119,11 +118,10 @@ class TestCase(unittest.TestCase):
 
     @contextmanager
     def assertWarns(self, message):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', message)
+        with pytest.warns(Warning) as w:
             yield
-            assert len(w) > 0
-            assert any(message in str(wi.message) for wi in w)
+        assert len(w) > 0
+        assert any(message in str(wi.message) for wi in w)
 
     def assertVariableEqual(self, v1, v2):
         assert_equal(v1, v2)

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+import warnings
 from contextlib import contextmanager
 from distutils.version import LooseVersion
 
@@ -118,7 +119,8 @@ class TestCase(unittest.TestCase):
 
     @contextmanager
     def assertWarns(self, message):
-        with pytest.warns(Warning) as w:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', message)
             yield
         assert len(w) > 0
         assert any(message in str(wi.message) for wi in w)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2321,7 +2321,7 @@ class TestDataArray(TestCase):
         self.assertDatasetIdentical(expected, actual)
 
         expected = Dataset({'bar': ('x', [1, 2])})
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             actual = named.to_dataset('bar')
         self.assertDatasetIdentical(expected, actual)
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2321,7 +2321,7 @@ class TestDataArray(TestCase):
         self.assertDatasetIdentical(expected, actual)
 
         expected = Dataset({'bar': ('x', [1, 2])})
-        with self.assertWarns('order of the arguments'):
+        with pytest.deprecated_call():
             actual = named.to_dataset('bar')
         self.assertDatasetIdentical(expected, actual)
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -274,7 +274,7 @@ class TestDataset(TestCase):
             self.assertDatasetIdentical(expected, actual)
 
     def test_constructor_deprecated(self):
-        with pytest.deprecated_call():
+        with pytest.warns(FutureWarning):
             DataArray([1, 2, 3], coords={'x': [0, 1, 2]})
 
     def test_constructor_auto_align(self):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -274,7 +274,7 @@ class TestDataset(TestCase):
             self.assertDatasetIdentical(expected, actual)
 
     def test_constructor_deprecated(self):
-        with self.assertWarns('deprecated'):
+        with pytest.deprecated_call():
             DataArray([1, 2, 3], coords={'x': [0, 1, 2]})
 
     def test_constructor_auto_align(self):


### PR DESCRIPTION
This is causing CI failures for some builds.

This is really a pytest bug (https://github.com/pytest-dev/pytest/issues/2430), but working around this on our end is easy enough (and cleans things up a little).

 - [x] Passes ``git diff upstream/master | flake8 --diff``
