### PR TITLE
scalar_level in MultiIndex

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -23,7 +23,7 @@ from .coordinates import (DataArrayCoordinates, LevelCoordinatesSource,
 from .dataset import Dataset, merge_indexes, split_indexes
 from .pycompat import iteritems, basestring, OrderedDict, zip, range
 from .variable import (as_variable, Variable, as_compatible_data,
-                       IndexVariable,
+                       get_IndexVariable, IndexVariable,
                        assert_unique_multiindex_level_names)
 from .formatting import format_item
 from .utils import decode_numpy_dict_values, ensure_us_time_resolution
@@ -261,7 +261,7 @@ class DataArray(AbstractArray, BaseDataObject):
             return self
         coords = self._coords.copy()
         for name, idx in indexes.items():
-            coords[name] = IndexVariable(name, idx)
+            coords[name] = get_IndexVariable(name, idx)
         obj = self._replace(coords=coords)
 
         # switch from dimension to level names, if necessary
@@ -968,7 +968,7 @@ class DataArray(AbstractArray, BaseDataObject):
             index = coord.to_index()
             if not isinstance(index, pd.MultiIndex):
                 raise ValueError("coordinate %r has no MultiIndex" % dim)
-            replace_coords[dim] = IndexVariable(coord.dims,
+            replace_coords[dim] = get_IndexVariable(coord.dims,
                                                 index.reorder_levels(order))
         coords = self._coords.copy()
         coords.update(replace_coords)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -23,7 +23,7 @@ from .coordinates import (DataArrayCoordinates, LevelCoordinatesSource,
 from .dataset import Dataset, merge_indexes, split_indexes
 from .pycompat import iteritems, basestring, OrderedDict, zip, range
 from .variable import (as_variable, Variable, as_compatible_data,
-                       get_IndexVariable, IndexVariable,
+                       IndexVariable,
                        assert_unique_multiindex_level_names)
 from .formatting import format_item
 from .utils import decode_numpy_dict_values, ensure_us_time_resolution
@@ -261,7 +261,7 @@ class DataArray(AbstractArray, BaseDataObject):
             return self
         coords = self._coords.copy()
         for name, idx in indexes.items():
-            coords[name] = get_IndexVariable(name, idx)
+            coords[name] = IndexVariable(name, idx)
         obj = self._replace(coords=coords)
 
         # switch from dimension to level names, if necessary
@@ -968,7 +968,7 @@ class DataArray(AbstractArray, BaseDataObject):
             index = coord.to_index()
             if not isinstance(index, pd.MultiIndex):
                 raise ValueError("coordinate %r has no MultiIndex" % dim)
-            replace_coords[dim] = get_IndexVariable(coord.dims,
+            replace_coords[dim] = IndexVariable(coord.dims,
                                                 index.reorder_levels(order))
         coords = self._coords.copy()
         coords.update(replace_coords)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -575,11 +575,15 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         return obj
 
     def _replace_indexes(self, indexes):
+        """
+        Make some index_level to scalar_level.
+        indexes: mapping from dimension name to new index.
+        """
         if not len(indexes):
             return self
         variables = self._variables.copy()
         for name, idx in indexes.items():
-            variables[name] = variables[name].reset_levels(idx)
+                variables[name] = variables[name].reset_levels(idx.names)
         return self._replace_vars_and_dims(variables)
 
     def copy(self, deep=False):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -621,7 +621,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         for cname in self._coord_names:
             var = self.variables[cname]
             if var.ndim == 1:
-                level_names = var.level_names
+                level_names = var.all_level_names
                 if level_names is not None:
                     dim, = var.dims
                     level_coords.update({lname: dim for lname in level_names})

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -214,13 +214,20 @@ def _summarize_var_or_coord(name, var, col_width, show_values=True,
     return front_str + values_str
 
 
-def _summarize_coord_multiindex(coord, col_width, marker):
-    first_col = pretty_print(u'  %s %s ' % (marker, coord.name), col_width)
-    return u'%s(%s) MultiIndex' % (first_col, unicode_type(coord.dims[0]))
+def _summarize_coord_multiindex(coord, col_width, marker, name=None):
+    name = name or coord.name
+    first_col = pretty_print(u'  %s %s ' % (marker, name), col_width)
+    if len(coord.dims) == 0:
+        return u'%sMultiIndex' % (first_col)
+    else:
+        return u'%s(%s) MultiIndex' % (first_col, unicode_type(coord.dims[0]))
 
 
 def _summarize_coord_levels(coord, col_width, marker=u'-'):
-    relevant_coord = coord[:30]
+    if len(coord.dims) == 0:
+        relevant_coord = coord  # scalar MultiIndex
+    else:
+        relevant_coord = coord[:30]
     return u'\n'.join(
         [_summarize_var_or_coord(lname,
                                  relevant_coord.get_level_variable(lname),
@@ -247,11 +254,11 @@ def summarize_coord(name, var, col_width):
     is_index = name in var.dims
     show_values = is_index or _not_remote(var)
     marker = u'*' if is_index else u' '
-    if is_index:
-        coord = var.variable.to_index_variable()
+    if name in var.coords:
+        coord = var.variable
         if coord.level_names is not None:
             return u'\n'.join(
-                [_summarize_coord_multiindex(coord, col_width, marker),
+                [_summarize_coord_multiindex(coord, col_width, marker, name),
                  _summarize_coord_levels(coord, col_width)])
     return _summarize_var_or_coord(name, var, col_width, show_values, marker)
 

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -225,7 +225,7 @@ def _summarize_coord_levels(coord, col_width, marker=u'-'):
         [_summarize_var_or_coord(lname,
                                  relevant_coord.get_level_variable(lname),
                                  col_width, marker=marker)
-         for lname in coord.level_names])
+         for lname in coord.all_level_names])
 
 
 def _not_remote(var):

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -212,7 +212,6 @@ def convert_label_indexer(index, label, index_name='', method=None,
             indexer, new_index = index.get_loc_level(
                 label, level=list(range(len(label)))
             )
-
     else:
         label = _asarray_tuplesafe(label)
         if label.ndim == 0:

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -575,7 +575,6 @@ class PandasMultiIndexAdapter(PandasIndexAdapter):
         # tuple does not have level names
         if array.ndim == 0 and len(scalars) == 0:
             raise ValueError('Name of levels is necessary for 0d-array input.')
-
         if isinstance(self.array, pd.MultiIndex):
             if self.array.names[0] is None:
                 self.array.set_names(scalars)

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -286,13 +286,6 @@ def get_dim_indexers(data_obj, indexers):
     return dim_indexers
 
 
-def remap_level_indexers(data_obj, indexers):
-    """Given an xarray data object and position based level-indexers,
-    return a mapping of equivalent location based dim-indexers.
-    """
-    dim_indexers = indexers.copy()
-
-
 def remap_label_indexers(data_obj, indexers, method=None, tolerance=None):
     """Given an xarray data object and label based indexers, return a mapping
     of equivalent location based indexers. Also return a mapping of updated

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -96,7 +96,9 @@ def _maybe_wrap_data(data):
     NumpyArrayAdapter, PandasIndexAdapter and LazilyIndexedArray should
     all pass through unmodified.
     """
-    if isinstance(data, pd.Index):
+    if isinstance(data, pd.MultiIndex):
+        return PandasMultiIndexAdapter(data)
+    elif isinstance(data, pd.Index):
         return PandasIndexAdapter(data)
     return data
 
@@ -1340,7 +1342,6 @@ class MultiIndexVariable(IndexVariable):
         """Return MultiIndex level names or None if this IndexVariable has no
         MultiIndex.
         """
-        print(self._data.array.names)
         index = self.to_index()
         if isinstance(index, pd.MultiIndex):
             return index.names
@@ -1349,8 +1350,7 @@ class MultiIndexVariable(IndexVariable):
 
     def get_level_variable(self, level):
         """Return a new IndexVariable from a given MultiIndex level."""
-        index = self.to_index()
-        return IndexVariable(self.dims, index.get_level_values(level))
+        return IndexVariable(self.dims, self._data.get_level_values(level))
 
 
 def get_IndexVariable(dims, index, attrs=None, encoding=None,
@@ -1360,9 +1360,9 @@ def get_IndexVariable(dims, index, attrs=None, encoding=None,
     (If a pd.MultiIndex is included, MultiIndexVariable is returned.)
     """
     index = as_compatible_data(index)
-    if not isinstance(index, PandasIndexAdapter):
-        index = PandasIndexAdapter(index)
-    if isinstance(index.array, pd.MultiIndex):
+    if isinstance(index, PandasIndexAdapter):
+        index = index.array
+    if isinstance(index, pd.MultiIndex):
         return MultiIndexVariable(dims, index, attrs,
                                   encoding=encoding, fastpath=True)
     else:

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -9,6 +9,7 @@ import xarray as xr
 from xarray import Variable, DataArray, Dataset
 import xarray.ufuncs as xu
 from xarray.core.pycompat import suppress
+from xarray.core.indexing import PandasMultiIndexAdapter
 from . import TestCase, requires_dask
 
 from xarray.tests import unittest
@@ -32,7 +33,8 @@ class DaskTestCase(TestCase):
             self.assertIsInstance(actual.data, da.Array)
             for k, v in actual.coords.items():
                 if k in actual.dims:
-                    self.assertIsInstance(v.data, np.ndarray)
+                    self.assertIsInstance(v.data, (np.ndarray,
+                                                   PandasMultiIndexAdapter))
                 else:
                     self.assertIsInstance(v.data, da.Array)
         elif isinstance(actual, Variable):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1082,7 +1082,7 @@ class TestDataset(TestCase):
             else:
                 if scalared_dim:
                     self.assertTrue(scalared_dim in
-                                    ds['x'].variable.index_level_names)
+                                    ds['x'].variable.level_names)
                 self.assertVariableIdentical(ds['var'].variable,
                                              expected_ds['var'].variable)
                 self.assertVariableNotEqual(ds['x'], expected_ds['x'])
@@ -1120,6 +1120,13 @@ class TestDataset(TestCase):
 
         mdata2 = mdata.isel(x=[0, 1]).sel(one='a', two=1)
         mdata3 = mdata.sel(one='a', two=1).isel(three=[0, 1])
+        self.assertDatasetIdentical(mdata2, mdata3)
+
+        mdata = xr.Dataset({'foo': (('x', 'y'), np.random.randn(3, 4))},
+                           {'x': ['a', 'b', 'c'], 'y': [1, 2, 3, 4]})
+        mdata = mdata.stack(space=['x', 'y'])
+        mdata2 = mdata.isel(space=[0, 1]).sel(x='a')
+        mdata3 = mdata.sel(x='a').isel(y=[0, 1])
         self.assertDatasetIdentical(mdata2, mdata3)
 
     def test_reindex_like(self):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -204,8 +204,8 @@ class TestDataset(TestCase):
 
     def test_repr_period_index(self):
         data = create_test_data(seed=456)
-        data.coords['time'] = pd.period_range('2000-01-01', periods=20, freq='B')
-
+        data.coords['time'] = pd.period_range('2000-01-01', periods=20,
+                                              freq='B')
         # check that creating the repr doesn't raise an error #GH645
         repr(data)
 
@@ -1178,7 +1178,7 @@ class TestDataset(TestCase):
 
         # expand scalar-level
         actual = mdata.sel(one='a').expand_dims('one')
-        expected = mdata.isel(x=[0, 1, 2, 3 ])
+        expected = mdata.isel(x=[0, 1, 2, 3])
         self.assertDatasetIdentical(actual, expected)
         self.assertTrue(actual.variables['x'].level_names ==
                         expected.variables['x'].level_names)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -197,7 +197,7 @@ class TestDataset(TestCase):
           * y        (y) {0} 0 1 2 3
             z        MultiIndex
           - level_1  {1} 'a'
-          - level_2  {2} 1
+          - level_2  int64 1
         Data variables:
             x        (y) float64 1.0 1.0 1.0 1.0""".format(
             np.asarray(1).dtype, np.asarray('a').dtype, np.asarray(1).dtype))

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -55,7 +55,7 @@ def create_test_data(seed=None):
 
 
 def create_test_multiindex():
-    mindex = pd.MultiIndex.from_product([[u'a', u'b'], [1, 2]],
+    mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2]],
                                         names=('level_1', 'level_2'))
     return Dataset({}, {'x': mindex})
 
@@ -156,10 +156,10 @@ class TestDataset(TestCase):
         Dimensions:  (x: 2)
         Coordinates:
           * x        (x) MultiIndex
-          - level_1  <U1 'a'
+          - level_1  %s 'a'
           - level_2  (x) int64 1 2
         Data variables:
-            *empty*""")
+            *empty*""" % np.asarray('a').dtype)
         actual = '\n'.join(x.rstrip() for x in repr(data).split('\n'))
         print(actual)
         self.assertEqual(expected, actual)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -185,8 +185,10 @@ class TestDataset(TestCase):
     def test_repr_scalar_multiindex(self):
         mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2]],
                                             names=('level_1', 'level_2'))
-        data = Dataset({'x': (('y'), np.ones(4))},
-                       {'y': np.arange(4), 'z': mindex})
+        coords = OrderedDict()
+        coords['y'] = np.arange(4)
+        coords['z'] = mindex
+        data = Dataset({'x': (('y'), np.ones(4))}, coords=coords)
         data = data.isel(z=0)  # scalar multiindex
         expected = dedent("""\
         <xarray.Dataset>
@@ -195,10 +197,10 @@ class TestDataset(TestCase):
           * y        (y) {0} 0 1 2 3
             z        MultiIndex
           - level_1  {1} 'a'
-          - level_2  int64 1
+          - level_2  {2} 1
         Data variables:
             x        (y) float64 1.0 1.0 1.0 1.0""".format(
-            np.asarray(1).dtype, np.asarray('a').dtype))
+            np.asarray(1).dtype, np.asarray('a').dtype, np.asarray(1).dtype))
         actual = '\n'.join(x.rstrip() for x in repr(data).split('\n'))
         print(actual)
         self.assertEqual(expected, actual)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -55,7 +55,7 @@ def create_test_data(seed=None):
 
 
 def create_test_multiindex():
-    mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2]],
+    mindex = pd.MultiIndex.from_product([[u'a', u'b'], [1, 2]],
                                         names=('level_1', 'level_2'))
     return Dataset({}, {'x': mindex})
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1112,6 +1112,16 @@ class TestDataset(TestCase):
         self.assertDatasetIdentical(mdata.sel(x={'one': 'a', 'two': 1}),
                                     mdata.sel(one='a', two=1))
 
+    def test_isel_multiindex(self):
+        mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2], [-1, -2]],
+                                            names=('one', 'two', 'three'))
+        mdata = Dataset(data_vars={'var': ('x', range(8))},
+                        coords={'x': mindex})
+
+        mdata2 = mdata.isel(x=[0, 1]).sel(one='a', two=1)
+        mdata3 = mdata.sel(one='a', two=1).isel(three=[0, 1])
+        self.assertDatasetIdentical(mdata2, mdata3)
+
     def test_reindex_like(self):
         data = create_test_data()
         data['letters'] = ('dim3', 10 * ['a'])

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -192,12 +192,13 @@ class TestDataset(TestCase):
         <xarray.Dataset>
         Dimensions:  (y: 4)
         Coordinates:
-          * y        (y) int64 0 1 2 3
+          * y        (y) {0} 0 1 2 3
             z        MultiIndex
-          - level_1  %s 'a'
+          - level_1  {1} 'a'
           - level_2  int64 1
         Data variables:
-            x        (y) float64 1.0 1.0 1.0 1.0""" % np.asarray('a').dtype)
+            x        (y) float64 1.0 1.0 1.0 1.0""".format(
+            np.asarray(1).dtype, np.asarray('a').dtype))
         actual = '\n'.join(x.rstrip() for x in repr(data).split('\n'))
         print(actual)
         self.assertEqual(expected, actual)

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -309,6 +309,11 @@ class TestPandasMultiIndexAdapter(TestCase):
         index = index.reset_scalar(['level_1', 'level_2'])
         self.assertTrue(index.get_level_values('level_2')[0] ==
                         idx.get_level_values('level_2')[0])
+        # works even if 1-item case.
+        index = indexing.PandasMultiIndexAdapter(idx)
+        index1 = index[0]
+        self.assertTrue(index1.get_level_values('level_2') ==
+                        index.get_level_values('level_2')[0])
 
     def test_eq(self):
         idx = pd.MultiIndex.from_product([list('abc'), [0, 1]])

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -280,7 +280,7 @@ class TestPandasMultiIndexAdapter(TestCase):
 
         index = index.set_scalar(['level_2'])
         # indexing should keep scalars
-        self.assertTrue(index[0].scalars == ['level_2'])
+        self.assertTrue(index[0].scalars == ['level_1', 'level_2'])
         self.assertTrue(index[np.array([0, 1])].scalars == ['level_2'])
 
     def test_get_level_values(self):

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -250,7 +250,7 @@ class TestMemoryCachedArray(TestCase):
 class TestPandasMultiIndexAdapter(TestCase):
     def test_multi(self):
         idx = pd.MultiIndex.from_product([list('abc'), [0, 1]])
-        idx = idx.set_names(['level_1', 'level_2'])    
+        idx = idx.set_names(['level_1', 'level_2'])
         index = indexing.PandasMultiIndexAdapter(idx)
         self.assertTrue(index.scalars == [])
 
@@ -270,3 +270,30 @@ class TestPandasMultiIndexAdapter(TestCase):
         idx = idx.set_names(['l1', 'l2'])
         expected = indexing.PandasMultiIndexAdapter(idx, scalars=['l2'])
         self.assertArrayEqual(actual, expected)
+
+    def test_get_level_values(self):
+        idx = pd.MultiIndex.from_product([list('abc'), [0, 1]])
+        idx = idx.set_names(['level_1', 'level_2'])
+        index = indexing.PandasMultiIndexAdapter(idx)
+        self.assertTrue(all(index.get_level_values('level_1') ==
+                            idx.get_level_values('level_1')))
+        # set scalar
+        index = index.set_scalar(['level_2'])
+        self.assertTrue(index.get_level_values('level_2') ==
+                        idx.get_level_values('level_2')[0])
+        self.assertTrue(all(index.get_level_values('level_1') ==
+                            idx.get_level_values('level_1')))
+        # reset scalar
+        index = index.reset_scalar(['level_2'])
+        self.assertTrue(all(index.get_level_values('level_2') ==
+                            idx.get_level_values('level_2')))
+        self.assertTrue(all(index.get_level_values('level_1') ==
+                            idx.get_level_values('level_1')))
+        # set scalar and reduce to 1 element
+        index = index.set_scalar(['level_1', 'level_2'])
+        self.assertTrue(index.get_level_values('level_2') ==
+                        idx.get_level_values('level_2')[0])
+        # restore the size 1 MultiIndex
+        index = index.reset_scalar(['level_1', 'level_2'])
+        self.assertTrue(index.get_level_values('level_2')[0] ==
+                        idx.get_level_values('level_2')[0])

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -271,6 +271,18 @@ class TestPandasMultiIndexAdapter(TestCase):
         expected = indexing.PandasMultiIndexAdapter(idx, scalars=['l2'])
         self.assertArrayEqual(actual, expected)
 
+    def test_getitem(self):
+        idx = pd.MultiIndex.from_product([list('abc'), [0, 1]])
+        idx = idx.set_names(['level_1', 'level_2'])
+        index = indexing.PandasMultiIndexAdapter(idx)
+        self.assertTrue(all(index.get_level_values('level_1') ==
+                            idx.get_level_values('level_1')))
+
+        index = index.set_scalar(['level_2'])
+        # indexing should keep scalars
+        self.assertTrue(index[0].scalars == ['level_2'])
+        self.assertTrue(index[np.array([0, 1])].scalars == ['level_2'])
+
     def test_get_level_values(self):
         idx = pd.MultiIndex.from_product([list('abc'), [0, 1]])
         idx = idx.set_names(['level_1', 'level_2'])
@@ -297,3 +309,10 @@ class TestPandasMultiIndexAdapter(TestCase):
         index = index.reset_scalar(['level_1', 'level_2'])
         self.assertTrue(index.get_level_values('level_2')[0] ==
                         idx.get_level_values('level_2')[0])
+
+    def test_eq(self):
+        idx = pd.MultiIndex.from_product([list('abc'), [0, 1]])
+        idx = idx.set_names(['level_1', 'level_2'])
+        index = indexing.PandasMultiIndexAdapter(idx)
+        self.assertTrue(index == index)
+        self.assertTrue(index != index.set_scalar(['level_1']))

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1133,6 +1133,18 @@ class TestIndexVariable(TestCase, VariableSubclassTestCases):
         v2 = v.reset_levels(['level_1'])
         self.assertFalse(v.equals(v2))
 
+    def test_multiindex_isel(self):
+        idx = pd.MultiIndex.from_product([list('abc'), [0, 1]])
+        idx = idx.set_names(['level_1', 'level_2'])
+        v = IndexVariable('x', idx)
+        with self.assertRaises(ValueError):
+            v.isel(level_1=[0,1])
+        v2 = v.reset_levels(['level_2'])  # level_1 becomes scalar
+        # unable indexing for the scalar level
+        with self.assertRaises(ValueError):
+            v2.isel(level_1=[0, 1])
+        self.assertTrue(v2.isel(x=[0, 1]).equals(v2.isel(level_2=[0, 1])))
+
 
 class TestAsCompatibleData(TestCase):
     def test_unchanged_types(self):


### PR DESCRIPTION
 - [x] Closes #1408
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

[Edit for more clarity]
I restarted a new branch to fix #1408 (I closed the older one #1412).

![my_proposal](https://cloud.githubusercontent.com/assets/6815844/26553065/f6562366-44c4-11e7-8c9c-3ef7facfe056.png)

Because the changes I made is relatively large, here I summarize this PR.


# Sumamry
In this PR, I newly added two kinds of levels in MultiIndex, `index-level` and `scalar-level`.
`index-level` is an ordinary level in MultiIndex (as in current implementation), 
while `scalar-level` indicates dropped level (which is newly added in this PR).

# Changes in behaviors.
1. Indexing a scalar at a particular level changes that level to `scalar-level` instead of dropping that level (changed from #767).
2. Indexing a scalar from a MultiIndex, the selected value now becomes a `MultiIndex-scalar` rather than a scalar of tuple.
3. Enabled indexing along a `index-level` if the MultiIndex has only a single `index-level`.

Examples of the output are shown below. 
Any suggestions for these behaviors are welcome.

```python
In [1]: import numpy as np
   ...: import xarray as xr
   ...: 
   ...: ds1 = xr.Dataset({'foo': (('x',), [1, 2, 3])}, {'x': [1, 2, 3], 'y': 'a'})
   ...: ds2 = xr.Dataset({'foo': (('x',), [4, 5, 6])}, {'x': [1, 2, 3], 'y': 'b'})
   ...: # example data
   ...: ds = xr.concat([ds1, ds2], dim='y').stack(yx=['y', 'x'])
   ...: ds
Out[1]: 
<xarray.Dataset>
Dimensions:  (yx: 6)
Coordinates:
  * yx       (yx) MultiIndex
  - y        (yx) object 'a' 'a' 'a' 'b' 'b' 'b'  # <--- this is index-level
  - x        (yx) int64 1 2 3 1 2 3            # <--- this is also index-level
Data variables:
    foo      (yx) int64 1 2 3 4 5 6

In [2]: # 1. indexing a scalar converts `index-level` x to `scalar-level`.
   ...: ds.sel(x=1)
Out[2]: 
<xarray.Dataset>
Dimensions:  (yx: 2)
Coordinates:
  * yx       (yx) MultiIndex
  - y        (yx) object 'a' 'b'  # <--- this is index-level
  - x        int64 1              # <--- this is scalar-level
Data variables:
    foo      (yx) int64 1 4

In [3]: # 2. indexing a single element from MultiIndex makes a `MultiIndex-scalar`
   ...: ds.isel(yx=0)
Out[3]: 
<xarray.Dataset>
Dimensions:  ()
Coordinates:
    yx       MultiIndex          # <--- this is MultiIndex-scalar
  - y        <U1 'a'
  - x        int64 1
Data variables:
    foo      int64 1

In [6]: # 3. Enables to selecting along a `index-level` if only one `index-level` exists in MultiIndex
   ...: ds.sel(x=1).isel(y=[0,1])
Out[6]: 
<xarray.Dataset>
Dimensions:  (yx: 2)
Coordinates:
  * yx       (yx) MultiIndex
  - y        (yx) object 'a' 'b'
  - x        int64 1
Data variables:
    foo      (yx) int64 1 4

```

# Changes in the public APIs
Some changes were necessary to the public APIs, though I tried to minimize them.

+ `level_names`, `get_level_values` methods were moved from `IndexVariable` to `Variable`.
This is because `IndexVariable` cannnot handle 0-d array, which I want to support in 2.

+ `scalar_level_names` and `all_level_names` properties were added to `Variable`

+ `reset_levels` method was added to `Variable` class to control `scalar-level` and `index-level`.


# Implementation summary
The main changes in the implementation is the addition of our own wrapper of `pd.MultiIndex`, `PandasMultiIndexAdapter`.
This does most of `MultiIndex`-related operations, such as indexing, concatenation, conversion between 'scalar-level` and `index-level`.

# What we can do now
The main merit of this proposal is that it enables us to handle `MultiIndex` more consistent way to the normal `Variable`.
Now we can 

+ recover the MultiIndex with dropped level.
```python
In [5]: ds.sel(x=1).expand_dims('x')
Out[5]: 
<xarray.Dataset>
Dimensions:  (yx: 2)
Coordinates:
  * yx       (yx) MultiIndex
  - y        (yx) object 'a' 'b'
  - x        (yx) int64 1 1
Data variables:
    foo      (yx) int64 1 4
```

+ construct a MultiIndex by concatenation of MultiIndex-scalar.
```python
In [8]: xr.concat([ds.isel(yx=i) for i in range(len(ds['yx']))], dim='yx')
Out[8]: 
<xarray.Dataset>
Dimensions:  (yx: 6)
Coordinates:
  * yx       (yx) MultiIndex
  - y        (yx) object 'a' 'a' 'a' 'b' 'b' 'b'
  - x        (yx) int64 1 2 3 1 2 3
Data variables:
    foo      (yx) int64 1 2 3 4 5 6
```

# What we cannot do now
With the current implementation, we can do
```python
ds.sel(y='a').rolling(x=2)
```
but with this PR we cannot, because `x` is not yet an ordinary coordinate, but a MultiIndex with a single `index-level`.
I think it is better if we can handle such a MultiIndex with a single `index-level` as very similar way to an ordinary coordinate.

Similary, we can neither do `ds.sel(y='a').mean(dim='x')`.
Also, `ds.sel(y='a').to_netcdf('file')` (#719)

# What are to be decided
+ How to `repr` these new levels (Current formatting is shown in Out[2] and Out[3] above.) 
+ Terminologies such as `index-level`, `scalar-level`, `MultiIndex-scalar` are clear enough?
+ How much operations should we support for a single `index-level` MultiIndex?
  Do we support `ds.sel(y='a').rolling(x=2)` and `ds.sel(y='a').mean(dim='x')`?

# TODOs
- [ ] Support indexing with DataAarray, `ds.sel(x=ds.x[0])`
- [ ] Support `stack`, `unstack`, `set_index`, `reset_index` methods with `scalar-level` MultiIndex.
- [ ] Add a full document
- [ ] Clean up the code related to MultiIndex
- [ ] Fix issues (#1428, #1430, #1431) related to MultiIndex
