### PR TITLE
Add dask specific kwargs to DataArray.chunk()

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -52,6 +52,9 @@ By `Keisuke Fujii <https://github.com/fujiisoup>`_.
   successful download (:issue:`1392`). By `Matthew Gidden
   <https://github.com/gidden>`_.
 
+- ``DataArray.chunk()`` now accepts dask specific kwargs like
+  ``Dataset.chunk()`` does. By `Fabien Maussion <https://github.com/fmaussion>`_.
+
 Documentation
 ~~~~~~~~~~~~~
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -631,7 +631,8 @@ class DataArray(AbstractArray, BaseDataObject):
         """
         return self.variable.chunks
 
-    def chunk(self, chunks=None):
+    def chunk(self, chunks=None, name_prefix='xarray-', token=None,
+              lock=False):
         """Coerce this array's data into a dask arrays with the given chunks.
 
         If this variable is a non-dask array, it will be converted to dask
@@ -647,6 +648,13 @@ class DataArray(AbstractArray, BaseDataObject):
         chunks : int, tuple or dict, optional
             Chunk sizes along each dimension, e.g., ``5``, ``(5, 5)`` or
             ``{'x': 5, 'y': 5}``.
+        name_prefix : str, optional
+            Prefix for the name of the new dask array.
+        token : str, optional
+            Token uniquely identifying this array.
+        lock : optional
+            Passed on to :py:func:`dask.array.from_array`, if the array is not
+            already as dask array.
 
         Returns
         -------
@@ -655,7 +663,8 @@ class DataArray(AbstractArray, BaseDataObject):
         if isinstance(chunks, (list, tuple)):
             chunks = dict(zip(self.dims, chunks))
 
-        ds = self._to_temp_dataset().chunk(chunks)
+        ds = self._to_temp_dataset().chunk(chunks, name_prefix=name_prefix,
+                                           token=token, lock=lock)
         return self._from_temp_dataset(ds)
 
     def isel(self, drop=False, **indexers):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -492,6 +492,12 @@ class TestDataArray(TestCase):
 
         self.assertIsNone(blocked.load().chunks)
 
+        # Check that kwargs are passed
+        import dask.array as da
+        blocked = unblocked.chunk(name_prefix='testname_')
+        self.assertIsInstance(blocked.data, da.Array)
+        assert 'testname_' in blocked.data.name
+
     def test_isel(self):
         self.assertDataArrayIdentical(self.dv[0], self.dv.isel(x=0))
         self.assertDataArrayIdentical(self.dv, self.dv.isel(x=slice(None)))


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

this is needed for the Rasterio PR (https://github.com/pydata/xarray/pull/1260#discussion_r118824181)

There was no test for these functionalities in the xarray test suite for ``Dataset`` either, so I just added a dummy test for one of the keywords.
