### PR TITLE
change NotImplemented to NotImplementedError for h5netcdf autoclose=True

### DIFF
--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -62,9 +62,10 @@ class H5NetCDFStore(WritableCFDataStore, DataStorePickleMixin):
                                    group=group)
         self.ds = opener()
         if autoclose:
-            raise NotImplemented('autoclose=True is not implemented '
-                                 'for the h5netcdf backend pending further '
-                                 'exploration, e.g., bug fixes (in h5netcdf?)')
+            raise NotImplementedError('autoclose=True is not implemented '
+                                      'for the h5netcdf backend pending '
+                                      'further exploration, e.g., bug fixes '
+                                      '(in h5netcdf?)')
         self._autoclose = False
         self._isopen = True
         self.format = format


### PR DESCRIPTION
Solves this error:

```
TypeError: 'NotImplementedType' object is not callable
```