### PR TITLE
Add attributes to rasterio backend

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,7 +22,7 @@ Enhancements
 ~~~~~~~~~~~~
 
 - More attributes available in :py:attr:`~xarray.Dataset.attrs` dictionary when
-  raster files are opened with :py:func:`~xarray.open_rasterio`
+  raster files are opened with :py:func:`~xarray.open_rasterio`.
   By `Greg Brener <https://github.com/gbrener>`_
 
 Bug fixes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,6 +21,10 @@ v0.9.7 (unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
+- More attributes available in :py:attr:`~xarray.Dataset.attrs` dictionary when
+  raster files are opened with :py:func:`~xarray.open_rasterio`
+  By `Greg Brener <https://github.com/gbrener>`_
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -148,7 +148,7 @@ def open_rasterio(filename, chunks=None, cache=None, lock=None):
        (hasattr(riods, 'profile') and 'tiled' in riods.profile):
         # Is the TIF tiled? (bool)
         # We cast it to an int for netCDF compatibility
-        attrs['tiled'] = np.uint8(riods.tiled if hasattr(riods, 'tiled') \
+        attrs['tiled'] = np.uint8(riods.tiled if hasattr(riods, 'tiled')
                                   else riods.profile['tiled'])
     if hasattr(riods, 'transform'):
         # Affine transformation matrix (tuple of floats)

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -144,12 +144,10 @@ def open_rasterio(filename, chunks=None, cache=None, lock=None):
     if hasattr(riods, 'res'):
         # (width, height) tuple of pixels in units of CRS
         attrs['res'] = riods.res
-    if hasattr(riods, 'tiled') or \
-       (hasattr(riods, 'profile') and 'tiled' in riods.profile):
+    if hasattr(riods, 'is_tiled'):
         # Is the TIF tiled? (bool)
         # We cast it to an int for netCDF compatibility
-        attrs['tiled'] = np.uint8(riods.tiled if hasattr(riods, 'tiled')
-                                  else riods.profile['tiled'])
+        attrs['is_tiled'] = np.uint8(riods.is_tiled)
     if hasattr(riods, 'transform'):
         # Affine transformation matrix (tuple of floats)
         # Describes coefficients mapping pixel coordinates to CRS

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -141,7 +141,19 @@ def open_rasterio(filename, chunks=None, cache=None, lock=None):
         # CRS is a dict-like object specific to rasterio
         # We convert it back to a PROJ4 string using rasterio itself
         attrs['crs'] = riods.crs.to_string()
-    # Maybe we'd like to parse other attributes here (for later)
+    if hasattr(riods, 'res'):
+        # (width, height) tuple of pixels in units of CRS
+        attrs['res'] = riods.res
+    if hasattr(riods, 'tiled') or \
+       (hasattr(riods, 'profile') and 'tiled' in riods.profile):
+        # Is the TIF tiled? (bool)
+        # We cast it to an int for netCDF compatibility
+        attrs['tiled'] = np.uint8(riods.tiled if hasattr(riods, 'tiled') \
+                                  else riods.profile['tiled'])
+    if hasattr(riods, 'transform'):
+        # Affine transformation matrix (tuple of floats)
+        # Describes coefficients mapping pixel coordinates to CRS
+        attrs['transform'] = tuple(riods.transform)
 
     data = indexing.LazilyIndexedArray(RasterioArrayWrapper(riods))
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1475,8 +1475,8 @@ class TestRasterio(TestCase):
                 assert isinstance(rioda.attrs['crs'], basestring)
                 assert 'res' in rioda.attrs
                 assert isinstance(rioda.attrs['res'], tuple)
-                assert 'tiled' in rioda.attrs
-                assert isinstance(rioda.attrs['tiled'], np.uint8)
+                assert 'is_tiled' in rioda.attrs
+                assert isinstance(rioda.attrs['is_tiled'], np.uint8)
                 assert 'transform' in rioda.attrs
                 assert isinstance(rioda.attrs['transform'], tuple)
 
@@ -1518,8 +1518,8 @@ class TestRasterio(TestCase):
                 assert isinstance(rioda.attrs['crs'], basestring)
                 assert 'res' in rioda.attrs
                 assert isinstance(rioda.attrs['res'], tuple)
-                assert 'tiled' in rioda.attrs
-                assert isinstance(rioda.attrs['tiled'], np.uint8)
+                assert 'is_tiled' in rioda.attrs
+                assert isinstance(rioda.attrs['is_tiled'], np.uint8)
                 assert 'transform' in rioda.attrs
                 assert isinstance(rioda.attrs['transform'], tuple)
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from io import BytesIO
 from threading import Lock
+import collections
 import contextlib
 import itertools
 import os.path
@@ -1473,6 +1474,12 @@ class TestRasterio(TestCase):
                 assert_allclose(rioda, expected)
                 assert 'crs' in rioda.attrs
                 assert isinstance(rioda.attrs['crs'], basestring)
+                assert 'res' in rioda.attrs
+                assert isinstance(rioda.attrs['res'], tuple)
+                assert 'tiled' in rioda.attrs
+                assert isinstance(rioda.attrs['tiled'], np.uint8)
+                assert 'transform' in rioda.attrs
+                assert isinstance(rioda.attrs['transform'], tuple)
 
                 # Write it to a netcdf and read again (roundtrip)
                 with create_tmp_file(suffix='.nc') as tmp_nc_file:
@@ -1510,6 +1517,12 @@ class TestRasterio(TestCase):
                 assert_allclose(rioda, expected)
                 assert 'crs' in rioda.attrs
                 assert isinstance(rioda.attrs['crs'], basestring)
+                assert 'res' in rioda.attrs
+                assert isinstance(rioda.attrs['res'], tuple)
+                assert 'tiled' in rioda.attrs
+                assert isinstance(rioda.attrs['tiled'], np.uint8)
+                assert 'transform' in rioda.attrs
+                assert isinstance(rioda.attrs['transform'], tuple)
 
                 # Write it to a netcdf and read again (roundtrip)
                 with create_tmp_file(suffix='.nc') as tmp_nc_file:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 from io import BytesIO
 from threading import Lock
-import collections
 import contextlib
 import itertools
 import os.path


### PR DESCRIPTION
Adds the 'res', 'is_tiled', and 'transform' attributes to xarray's rasterio backend.

 - [X] Closes #1456
 - [X] Tests added / passed
 - [X] Passes ``git diff upstream/master | flake8 --diff``
 - [X] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

EDIT: fixed typo; 'tiled' attribute name updated to 'is_tiled'