### PR TITLE
Center the coordinates to pixels for rasterio backend

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,6 +21,10 @@ v0.9.7 (unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
+- :py:func:`~xarray.open_rasterio` method now shifts the rasterio
+  coordinates so that they are centered in each pixel.
+  By `Greg Brener <https://github.com/gbrener>`_.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -138,7 +138,7 @@ def open_rasterio(filename, chunks=None, cache=None, lock=None):
     coords['y'] = np.linspace(start=y0 + dy/2,
                               num=ny,
                               stop=(y0 + (ny - 1) * dy) + dy/2)
-    coords['x'] = np.linspace(start=x0+dx/2,
+    coords['x'] = np.linspace(start=x0 + dx/2,
                               num=nx,
                               stop=(x0 + (nx - 1) * dx) + dx/2)
 

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -132,8 +132,12 @@ def open_rasterio(filename, chunks=None, cache=None, lock=None):
     dx, dy = riods.res[0], -riods.res[1]
     x0 = riods.bounds.right if dx < 0 else riods.bounds.left
     y0 = riods.bounds.top if dy < 0 else riods.bounds.bottom
-    coords['y'] = np.linspace(start=y0, num=ny, stop=(y0 + (ny - 1) * dy))
-    coords['x'] = np.linspace(start=x0, num=nx, stop=(x0 + (nx - 1) * dx))
+    coords['y'] = np.linspace(start=y0 + dy/2,
+                              num=ny,
+                              stop=(y0 + (ny - 1) * dy) + dy/2)
+    coords['x'] = np.linspace(start=x0+dx/2,
+                              num=nx,
+                              stop=(x0 + (nx - 1) * dx) + dx/2)
 
     # Attributes
     attrs = {}

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -135,11 +135,9 @@ def open_rasterio(filename, chunks=None, cache=None, lock=None):
     dx, dy = riods.res[0], -riods.res[1]
     x0 = riods.bounds.right if dx < 0 else riods.bounds.left
     y0 = riods.bounds.top if dy < 0 else riods.bounds.bottom
-    coords['y'] = np.linspace(start=y0 + dy/2,
-                              num=ny,
+    coords['y'] = np.linspace(start=y0 + dy/2, num=ny,
                               stop=(y0 + (ny - 1) * dy) + dy/2)
-    coords['x'] = np.linspace(start=x0 + dx/2,
-                              num=nx,
+    coords['x'] = np.linspace(start=x0 + dx/2, num=nx,
                               stop=(x0 + (nx - 1) * dx) + dx/2)
 
     # Attributes

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -87,7 +87,10 @@ def open_rasterio(filename, chunks=None, cache=None, lock=None):
 
     This should work with any file that rasterio can open (most often:
     geoTIFF). The x and y coordinates are generated automatically from the
-    file's geoinformation.
+    file's geoinformation, shifted to the center of each pixel (see
+    `"PixelIsArea" Raster Space
+    <http://web.archive.org/web/20160326194152/http://remotesensing.org/geotiff/spec/geotiff2.5.html#2.5.2>`_
+    for more information).
 
     Parameters
     ----------

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1443,7 +1443,6 @@ class TestPyNioAutocloseTrue(TestPyNio):
 class TestRasterio(TestCase):
 
     def test_serialization_utm(self):
-
         import rasterio
         from rasterio.transform import from_origin
 
@@ -1462,13 +1461,15 @@ class TestRasterio(TestCase):
                     transform=transform,
                     dtype=rasterio.float32) as s:
                 s.write(data)
+                dx, dy = s.res[0], -s.res[1]
 
             # Tests
             expected = DataArray(data, dims=('band', 'y', 'x'),
-                                 coords={'band': [1, 2, 3],
-                                         'y': -np.arange(ny) * 2000 + 80000,
-                                         'x': np.arange(nx) * 1000 + 5000,
-                                         })
+                                 coords={
+                                     'band': [1, 2, 3],
+                                     'y': -np.arange(ny) * 2000 + 80000 + dy/2,
+                                     'x': np.arange(nx) * 1000 + 5000 + dx/2,
+                                 })
             with xr.open_rasterio(tmp_file) as rioda:
                 assert_allclose(rioda, expected)
                 assert 'crs' in rioda.attrs
@@ -1498,13 +1499,14 @@ class TestRasterio(TestCase):
                     transform=transform,
                     dtype=rasterio.float32) as s:
                 s.write(data, indexes=1)
+                dx, dy = s.res[0], -s.res[1]
 
             # Tests
             expected = DataArray(data[np.newaxis, ...],
                                  dims=('band', 'y', 'x'),
                                  coords={'band': [1],
-                                         'y': -np.arange(ny)*2 + 2,
-                                         'x': np.arange(nx)*0.5 + 1,
+                                         'y': -np.arange(ny)*2 + 2 + dy/2,
+                                         'x': np.arange(nx)*0.5 + 1 + dx/2,
                                          })
             with xr.open_rasterio(tmp_file) as rioda:
                 assert_allclose(rioda, expected)
@@ -1536,11 +1538,12 @@ class TestRasterio(TestCase):
                     transform=transform,
                     dtype=rasterio.float32) as s:
                 s.write(data)
+                dx, dy = s.res[0], -s.res[1]
 
             # ref
             expected = DataArray(data, dims=('band', 'y', 'x'),
-                                 coords={'x': np.arange(nx)*0.5 + 1,
-                                         'y': -np.arange(ny)*2 + 2,
+                                 coords={'x': (np.arange(nx)*0.5 + 1) + dx/2,
+                                         'y': (-np.arange(ny)*2 + 2) + dy/2,
                                          'band': [1, 2, 3]})
 
             with xr.open_rasterio(tmp_file, cache=False) as actual:
@@ -1628,11 +1631,12 @@ class TestRasterio(TestCase):
                     transform=transform,
                     dtype=rasterio.float32) as s:
                 s.write(data)
+                dx, dy = s.res[0], -s.res[1]
 
             # ref
             expected = DataArray(data, dims=('band', 'y', 'x'),
-                                 coords={'x': np.arange(nx)*0.5 + 1,
-                                         'y': -np.arange(ny)*2 + 2,
+                                 coords={'x': (np.arange(nx)*0.5 + 1) + dx/2,
+                                         'y': (-np.arange(ny)*2 + 2) + dy/2,
                                          'band': [1, 2, 3]})
 
             # Cache is the default
@@ -1671,6 +1675,7 @@ class TestRasterio(TestCase):
                     transform=transform,
                     dtype=rasterio.float32) as s:
                 s.write(data)
+                dx, dy = s.res[0], -s.res[1]
 
             # Chunk at open time
             with xr.open_rasterio(tmp_file, chunks=(1, 2, 2)) as actual:
@@ -1681,8 +1686,8 @@ class TestRasterio(TestCase):
 
                 # ref
                 expected = DataArray(data, dims=('band', 'y', 'x'),
-                                     coords={'x': np.arange(nx)*0.5 + 1,
-                                             'y': -np.arange(ny)*2 + 2,
+                                     coords={'x': np.arange(nx)*0.5 + 1 + dx/2,
+                                             'y': -np.arange(ny)*2 + 2 + dy/2,
                                              'band': [1, 2, 3]})
 
                 # do some arithmetic


### PR DESCRIPTION
Rasterio uses edge-based coordinates, which is a different convention from how xarray treats coordinates (based on description here: http://xarray.pydata.org/en/stable/plotting.html#coordinates). This PR centers them, offsetting by half of the resolution.

 - [X] Tests added / passed
 - [X] Passes ``git diff upstream/master | flake8 --diff``
 ~- [ ] Closes #xxxx~
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

CCing @fmaussion since he may be interested.