### PR TITLE
Fix test suite failure in TestDataset.test_sel

### DIFF
--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -873,8 +873,10 @@ class TestDataset(TestCase):
         data = Dataset({'x': ('td', np.arange(3)), 'td': td})
         self.assertDatasetEqual(data, data.sel(td=td))
         self.assertDatasetEqual(data, data.sel(td=slice('3 days')))
-        self.assertDatasetEqual(data.isel(td=0), data.sel(td='0 days'))
-        self.assertDatasetEqual(data.isel(td=0), data.sel(td='0h'))
+        self.assertDatasetEqual(data.isel(td=0),
+                                data.sel(td=pd.Timedelta('0 days')))
+        self.assertDatasetEqual(data.isel(td=0),
+                                data.sel(td=pd.Timedelta('0h')))
         self.assertDatasetEqual(data.isel(td=slice(1, 3)),
                                 data.sel(td=slice('1 days', '2 days')))
 


### PR DESCRIPTION
This is a temporary work around for https://github.com/pandas-dev/pandas/issues/16896, which was introduced by pandas 0.20.3

We can safely revert it after the next pandas release.