### PR TITLE
Fix a bug in assert_allclose where rtol and atol were ignored

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -43,6 +43,10 @@ Bug fixes
   case). See (:issue:`1477`) for details.
   By `Prakhar Goel <https://github.com/newt0311>`_.
 
+- Fix :py:func:`xarray.testing.assert_allclose` to actually use ``atol`` and
+  ``rtol`` arguments when called on ``DataArray`` objects.
+  By `Stephan Hoyer <http://github.com/shoyer>`_.
+
 .. _whats-new.0.9.6:
 
 v0.9.6 (8 June 2017)

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -116,30 +116,26 @@ def assert_allclose(a, b, rtol=1e-05, atol=1e-08, decode_bytes=True):
     import xarray as xr
     ___tracebackhide__ = True  # noqa: F841
     assert type(a) == type(b)
+    kwargs = dict(rtol=rtol, atol=atol, decode_bytes=decode_bytes)
     if isinstance(a, xr.Variable):
         assert a.dims == b.dims
-        allclose = _data_allclose_or_equiv(a.values, b.values,
-                                           rtol=rtol, atol=atol,
-                                           decode_bytes=decode_bytes)
+        allclose = _data_allclose_or_equiv(a.values, b.values, **kwargs)
         assert allclose, '{}\n{}'.format(a.values, b.values)
     elif isinstance(a, xr.DataArray):
-        assert_allclose(a.variable, b.variable)
+        assert_allclose(a.variable, b.variable, **kwargs)
         assert set(a.coords) == set(b.coords)
         for v in a.coords.variables:
             # can't recurse with this function as coord is sometimes a
             # DataArray, so call into _data_allclose_or_equiv directly
             allclose = _data_allclose_or_equiv(a.coords[v].values,
-                                               b.coords[v].values,
-                                               rtol=rtol, atol=atol,
-                                               decode_bytes=decode_bytes)
+                                               b.coords[v].values, **kwargs)
             assert allclose, '{}\n{}'.format(a.coords[v].values,
                                              b.coords[v].values)
     elif isinstance(a, xr.Dataset):
         assert set(a) == set(b)
         assert set(a.coords) == set(b.coords)
         for k in list(a.variables) + list(a.coords):
-            assert_allclose(a[k], b[k], rtol=rtol, atol=atol,
-                            decode_bytes=decode_bytes)
+            assert_allclose(a[k], b[k], **kwargs)
 
     else:
         raise TypeError('{} not supported by assertion comparison'

--- a/xarray/tests/test_testing.py
+++ b/xarray/tests/test_testing.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import xarray as xr
+
+
+def test_allclose_regression():
+    x = xr.DataArray(1.01)
+    y = xr.DataArray(1.02)
+    xr.testing.assert_allclose(x, y, atol=0.01)


### PR DESCRIPTION
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

~~This still probably should have a regression test.~~ Done