### PR TITLE
ENH: three argument version of where

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -18,6 +18,7 @@ Top-level functions
    broadcast
    concat
    merge
+   where
    set_options
    full_like
    zeros_like

--- a/doc/computation.rst
+++ b/doc/computation.rst
@@ -25,7 +25,7 @@ numpy) over all array values:
 
 .. ipython:: python
 
-    arr = xr.DataArray(np.random.randn(2, 3),
+    arr = xr.DataArray(np.random.RandomState(0).randn(2, 3),
                        [('x', ['a', 'b']), ('y', [10, 20, 30])])
     arr - 3
     abs(arr)
@@ -38,6 +38,12 @@ __ http://docs.scipy.org/doc/numpy/reference/ufuncs.html
 .. ipython:: python
 
     np.sin(arr)
+
+Use :py:func:`~xarray.where` to conditionally switch between values:
+
+.. ipython:: python
+
+    xr.where(arr > 0, 'positive', 'negative')
 
 Data arrays also implement many :py:class:`numpy.ndarray` methods:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -31,6 +31,9 @@ Enhancements
 
 - Speed-up (x 100) of :py:func:`~xarray.conventions.decode_cf_datetime`.
   By `Christian Chwala <https://github.com/cchwala>`_.
+- :py:meth:`~xarray.Dataset.where` now supports the ``other`` argument, for
+  filling with a value other than ``NaN`` (:issue:`576`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 Bug fixes
 ~~~~~~~~~
@@ -49,7 +52,7 @@ Bug fixes
 
 - Fix :py:func:`xarray.testing.assert_allclose` to actually use ``atol`` and
   ``rtol`` arguments when called on ``DataArray`` objects.
-  By `Stephan Hoyer <http://github.com/shoyer>`_.
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 .. _whats-new.0.9.6:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -31,8 +31,28 @@ Enhancements
 
 - Speed-up (x 100) of :py:func:`~xarray.conventions.decode_cf_datetime`.
   By `Christian Chwala <https://github.com/cchwala>`_.
-- :py:meth:`~xarray.Dataset.where` now supports the ``other`` argument, for
-  filling with a value other than ``NaN`` (:issue:`576`).
+
+- New function :py:func:`~xarray.where` for conditionally switching between
+  values in xarray objects, like :py:func:`numpy.where`:
+
+  .. ipython::
+    :verbatim:
+
+    In [1]: import xarray as xr
+
+    In [2]: arr = xr.DataArray([[1, 2, 3], [4, 5, 6]], dims=('x', 'y'))
+
+    In [3]: xr.where(arr % 2, 'even', 'odd')
+    Out[3]:
+    <xarray.DataArray (x: 2, y: 3)>
+    array([['even', 'odd', 'even'],
+           ['odd', 'even', 'odd']],
+          dtype='<U4')
+    Dimensions without coordinates: x, y
+
+  Equivalently, the :py:meth:`~xarray.Dataset.where` method also now supports
+  the ``other`` argument, for filling with a value other than ``NaN``
+  (:issue:`576`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 Bug fixes

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from .core.alignment import align, broadcast, broadcast_arrays
 from .core.common import full_like, zeros_like, ones_like
 from .core.combine import concat, auto_combine
+from .core.computation import where
 from .core.extensions import (register_dataarray_accessor,
                               register_dataset_accessor)
 from .core.variable import as_variable, Variable, IndexVariable, Coordinate

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -2,10 +2,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from .common import is_datetime_like
+from .dtypes import is_datetime_like
 from .pycompat import dask_array_type
-
-from functools import partial
 
 import numpy as np
 import pandas as pd

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -7,8 +7,9 @@ from collections import defaultdict
 
 import numpy as np
 
-from . import duck_array_ops, utils
-from .common import _maybe_promote
+from . import duck_array_ops
+from . import dtypes
+from . import utils
 from .indexing import get_indexer
 from .pycompat import iteritems, OrderedDict, suppress
 from .utils import is_full_slice, is_dict_like
@@ -368,7 +369,7 @@ def reindex_variables(variables, sizes, indexes, indexers, method=None,
             if any_not_full_slices(assign_to):
                 # there are missing values to in-fill
                 data = var[assign_from].data
-                dtype, fill_value = _maybe_promote(var.dtype)
+                dtype, fill_value = dtypes.maybe_promote(var.dtype)
 
                 if isinstance(data, np.ndarray):
                     shape = tuple(new_sizes.get(dim, size)

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -560,7 +560,7 @@ class BaseDataObject(AttrAccessMixin):
         return result
 
     def where(self, cond, other=dtypes.NA, drop=False):
-        """Return elements from `self` or `other` depending on `cond`.
+        """Filter elements from this object according to a condition.
 
         This operation follows the normal broadcasting and alignment rules that
         xarray uses for binary arithmetic.
@@ -609,6 +609,11 @@ class BaseDataObject(AttrAccessMixin):
                [ 10.,  11.,  nan,  nan],
                [ 15.,  nan,  nan,  nan]])
         Dimensions without coordinates: x, y
+
+        See also
+        --------
+        numpy.where : corresponding numpy function
+        where : equivalent function
         """
         from .alignment import align
         from .dataarray import DataArray
@@ -638,7 +643,7 @@ class BaseDataObject(AttrAccessMixin):
             self = self.isel(**indexers)
             cond = cond.isel(**indexers)
 
-        return ops.where(self, cond, other)
+        return ops.where_method(self, cond, other)
 
     def close(self):
         """Close any files linked to this object

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -20,6 +20,7 @@ from .utils import is_dict_like
 _DEFAULT_FROZEN_SET = frozenset()
 _DEFAULT_FILL_VALUE = object()
 _DEFAULT_NAME = object()
+_JOINS_WITHOUT_FILL_VALUES = frozenset({'inner', 'exact'})
 
 
 class _UFuncSignature(object):
@@ -225,7 +226,9 @@ def assert_and_return_exact_match(all_keys):
     first_keys = all_keys[0]
     for keys in all_keys[1:]:
         if keys != first_keys:
-            raise ValueError('exact match required for variable names')
+            raise ValueError(
+                'exact match required for all data variable names, but %r != %r'
+                % (keys, first_keys))
     return first_keys
 
 
@@ -330,7 +333,8 @@ def apply_dataset_ufunc(func, *args, **kwargs):
     keep_attrs = kwargs.pop('keep_attrs', False)
     first_obj = args[0]  # we'll copy attrs from this in case keep_attrs=True
 
-    if dataset_join != 'inner' and fill_value is _DEFAULT_FILL_VALUE:
+    if (dataset_join not in _JOINS_WITHOUT_FILL_VALUES and
+            fill_value is _DEFAULT_FILL_VALUE):
         raise TypeError('To apply an operation to datasets with different ',
                         'data variables, you must supply the ',
                         'dataset_fill_value argument.')

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -19,6 +19,7 @@ from .utils import is_dict_like
 
 _DEFAULT_FROZEN_SET = frozenset()
 _DEFAULT_FILL_VALUE = object()
+_DEFAULT_NAME = object()
 
 
 class _UFuncSignature(object):
@@ -109,8 +110,8 @@ def result_name(objects):
     # type: List[object] -> Any
     # use the same naming heuristics as pandas:
     # https://github.com/blaze/blaze/issues/458#issuecomment-51936356
-    names = {getattr(obj, 'name', None) for obj in objects}
-    names.discard(None)
+    names = {getattr(obj, 'name', _DEFAULT_NAME) for obj in objects}
+    names.discard(_DEFAULT_NAME)
     if len(names) == 1:
         name, = names
     else:
@@ -220,11 +221,20 @@ def ordered_set_intersection(all_keys):
     return [key for key in all_keys[0] if key in intersection]
 
 
+def assert_and_return_exact_match(all_keys):
+    first_keys = all_keys[0]
+    for keys in all_keys[1:]:
+        if keys != first_keys:
+            raise ValueError('exact match required for variable names')
+    return first_keys
+
+
 _JOINERS = {
     'inner': ordered_set_intersection,
     'outer': ordered_set_union,
     'left': operator.itemgetter(0),
     'right': operator.itemgetter(-1),
+    'exact': assert_and_return_exact_match,
 }
 
 

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -764,3 +764,45 @@ def apply_ufunc(func, *args, **kwargs):
         return variables_ufunc(*args)
     else:
         return array_ufunc(*args)
+
+
+def where(cond, x, y):
+    """Return elements from `x` or `y` depending on `cond`.
+
+    Performs xarray-like broadcasting across input arguments.
+
+    Parameters
+    ----------
+    cond : scalar, array, Variable, DataArray or Dataset with boolean dtype
+        When True, return values from `x`, otherwise returns values from `y`.
+    x, y : scalar, array, Variable, DataArray or Dataset
+        Values from which to choose. All dimension coordinates on these objects
+        must be aligned with each other and with `cond`.
+
+    Returns
+    -------
+    In priority order: Dataset, DataArray, Variable or array, whichever
+    type appears as an input argument.
+
+    Examples
+    --------
+
+    >>> cond = xr.DataArray([True, False], dims=['x'])
+    >>> x = xr.DataArray([1, 2], dims=['y'])
+    >>> xr.where(cond, x, 0)
+    <xarray.DataArray (x: 2, y: 2)>
+    array([[1, 2],
+           [0, 0]])
+    Dimensions without coordinates: x, y
+
+    See also
+    --------
+    numpy.where : corresponding numpy function
+    Dataset.where, DataArray.where : equivalent methods
+    """
+    # alignment for three arguments is complicated, so don't support it yet
+    return apply_ufunc(duck_array_ops.where,
+                       cond, x, y,
+                       join='exact',
+                       dataset_join='exact',
+                       dask_array='allowed')

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -22,7 +22,8 @@ from . import duck_array_ops
 from .. import conventions
 from .alignment import align
 from .coordinates import DatasetCoordinates, LevelCoordinatesSource, Indexes
-from .common import ImplementsDatasetReduce, BaseDataObject, is_datetime_like
+from .common import ImplementsDatasetReduce, BaseDataObject
+from .dtypes import is_datetime_like
 from .merge import (dataset_update_method, dataset_merge_method,
                     merge_data_and_coords)
 from .utils import (Frozen, SortedKeysDict, maybe_wrap_array, hashable,

--- a/xarray/core/dtypes.py
+++ b/xarray/core/dtypes.py
@@ -1,0 +1,58 @@
+import numpy as np
+
+
+class NA(object):
+    """Sentinel value to indicate a dtype appropriate NA value."""
+
+
+def maybe_promote(dtype):
+    """Simpler equivalent of pandas.core.common._maybe_promote
+
+    Parameters
+    ----------
+    dtype : np.dtype
+
+    Returns
+    -------
+    dtype : Promoted dtype that can hold missing values.
+    fill_value : Valid missing value for the promoted dtype.
+    """
+    # N.B. these casting rules should match pandas
+    if np.issubdtype(dtype, float):
+        fill_value = np.nan
+    elif np.issubdtype(dtype, int):
+        # convert to floating point so NaN is valid
+        dtype = float
+        fill_value = np.nan
+    elif np.issubdtype(dtype, complex):
+        fill_value = np.nan + np.nan * 1j
+    elif np.issubdtype(dtype, np.datetime64):
+        fill_value = np.datetime64('NaT')
+    elif np.issubdtype(dtype, np.timedelta64):
+        fill_value = np.timedelta64('NaT')
+    else:
+        dtype = object
+        fill_value = np.nan
+    return np.dtype(dtype), fill_value
+
+
+def get_fill_value(dtype):
+    """Return an appropriate fill value for this dtype.
+
+    Parameters
+    ----------
+    dtype : np.dtype
+
+    Returns
+    -------
+    fill_value : Missing value corresponding to this dtype.
+    """
+    _, fill_value = maybe_promote(dtype)
+    return fill_value
+
+
+def is_datetime_like(dtype):
+    """Check if a dtype is a subclass of the numpy datetime types
+    """
+    return (np.issubdtype(dtype, np.datetime64) or
+            np.issubdtype(dtype, np.timedelta64))

--- a/xarray/core/dtypes.py
+++ b/xarray/core/dtypes.py
@@ -2,7 +2,7 @@ import numpy as np
 
 
 class NA(object):
-    """Sentinel value to indicate a dtype appropriate NA value."""
+    """Use as a sentinel value to indicate a dtype appropriate NA value."""
 
 
 def maybe_promote(dtype):

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 
 from . import npcompat
+from . import dtypes
 from .pycompat import dask_array_type
 from .nputils import nanfirst, nanlast
 
@@ -148,11 +149,14 @@ def count(data, axis=None):
     return sum(~isnull(data), axis=axis)
 
 
-def where_method(data, cond, other=np.nan):
-    """Select values from this object that are True in cond. Everything else
-    gets masked with other. Follows normal broadcasting and alignment rules.
-    """
+def where_method(data, cond, other=dtypes.NA):
+    if other is dtypes.NA:
+        other = dtypes.get_fill_value(data.dtype)
     return where(cond, data, other)
+
+
+def fillna(data, other):
+    return where(isnull(data), other, data)
 
 
 @contextlib.contextmanager

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -5,12 +5,13 @@ import functools
 import numpy as np
 import pandas as pd
 
+from . import dtypes
 from . import duck_array_ops
 from . import nputils
 from . import ops
 from .combine import concat
 from .common import (
-    ImplementsArrayReduce, ImplementsDatasetReduce, _maybe_promote,
+    ImplementsArrayReduce, ImplementsDatasetReduce,
 )
 from .pycompat import range, zip, integer_types
 from .utils import hashable, peek_at, maybe_wrap_array, safe_cast_to_index
@@ -44,27 +45,19 @@ def unique_value_groups(ar, sort=True):
     return values, groups
 
 
-def _get_fill_value(dtype):
-    """Return a fill value that appropriately promotes types when used with
-    np.concatenate
-    """
-    dtype, fill_value = _maybe_promote(dtype)
-    return fill_value
-
-
 def _dummy_copy(xarray_obj):
     from .dataset import Dataset
     from .dataarray import DataArray
     if isinstance(xarray_obj, Dataset):
-        res = Dataset(dict((k, _get_fill_value(v.dtype))
+        res = Dataset(dict((k, dtypes.get_fill_value(v.dtype))
                            for k, v in xarray_obj.data_vars.items()),
-                      dict((k, _get_fill_value(v.dtype))
+                      dict((k, dtypes.get_fill_value(v.dtype))
                            for k, v in xarray_obj.coords.items()
                            if k not in xarray_obj.dims),
                       xarray_obj.attrs)
     elif isinstance(xarray_obj, DataArray):
-        res = DataArray(_get_fill_value(xarray_obj.dtype),
-                        dict((k, _get_fill_value(v.dtype))
+        res = DataArray(dtypes.get_fill_value(xarray_obj.dtype),
+                        dict((k, dtypes.get_fill_value(v.dtype))
                              for k, v in xarray_obj.coords.items()
                              if k not in xarray_obj.dims),
                         dims=[],
@@ -387,16 +380,16 @@ class GroupBy(object):
         out = ops.fillna(self, value)
         return out
 
-    def where(self, cond):
-        """Return an object of the same shape with all entries where cond is
-        True and all other entries masked.
-
-        This operation follows the normal broadcasting and alignment rules that
-        xarray uses for binary arithmetic.
+    def where(self, cond, other=dtypes.NA):
+        """Return elements from `self` or `other` depending on `cond`.
 
         Parameters
         ----------
-        cond : DataArray or Dataset
+        cond : DataArray or Dataset with boolean dtype
+            Locations at which to preserve this objects values.
+        other : scalar, DataArray or Dataset, optional
+            Value to use for locations in this object where ``cond`` is False.
+            By default, inserts missing values.
 
         Returns
         -------
@@ -406,7 +399,7 @@ class GroupBy(object):
         --------
         Dataset.where
         """
-        return self._where(cond)
+        return ops.where(self, cond, other)
 
     def _first_or_last(self, op, skipna, keep_attrs):
         if isinstance(self._group_indices[0], integer_types):

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -399,7 +399,7 @@ class GroupBy(object):
         --------
         Dataset.where
         """
-        return ops.where(self, cond, other)
+        return ops.where_method(self, cond, other)
 
     def _first_or_last(self, op, skipna, keep_attrs):
         if isinstance(self._group_indices[0], integer_types):

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -154,7 +154,7 @@ def fillna(data, other, join="left", dataset_join="left"):
                        keep_attrs=True)
 
 
-def where(self, cond, other=dtypes.NA):
+def where_method(self, cond, other=dtypes.NA):
     """Return elements from `self` or `other` depending on `cond`.
 
     Parameters

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -15,6 +15,7 @@ from distutils.version import LooseVersion
 import numpy as np
 import pandas as pd
 
+from . import dtypes
 from . import duck_array_ops
 from .pycompat import PY3
 from .nputils import array_eq, array_ne
@@ -145,11 +146,34 @@ def fillna(data, other, join="left", dataset_join="left"):
     """
     from .computation import apply_ufunc
 
-    def _fillna(data, other):
-        return duck_array_ops.where(duck_array_ops.isnull(data), other, data)
-    return apply_ufunc(_fillna, data, other, join=join, dask_array="allowed",
+    return apply_ufunc(duck_array_ops.fillna, data, other,
+                       join=join,
+                       dask_array="allowed",
                        dataset_join=dataset_join,
                        dataset_fill_value=np.nan,
+                       keep_attrs=True)
+
+
+def where(self, cond, other=dtypes.NA):
+    """Return elements from `self` or `other` depending on `cond`.
+
+    Parameters
+    ----------
+    cond : DataArray or Dataset with boolean dtype
+        Locations at which to preserve this objects values.
+    other : scalar, DataArray or Dataset, optional
+        Value to use for locations in this object where ``cond`` is False.
+        By default, inserts missing values.
+
+    Returns
+    -------
+    Same type as caller.
+    """
+    from .computation import apply_ufunc
+
+    return apply_ufunc(duck_array_ops.where_method,
+                       self, cond, other,
+                       dask_array='allowed',
                        keep_attrs=True)
 
 
@@ -267,10 +291,6 @@ def inject_binary_ops(cls, inplace=False):
 
     for name, f in [('eq', array_eq), ('ne', array_ne)]:
         setattr(cls, op_str(name), cls._binary_op(f))
-
-    # patch in where
-    f = _func_slash_method_wrapper(duck_array_ops.where_method, 'where')
-    setattr(cls, '_where', cls._binary_op(f))
 
     for name in NUM_BINARY_OPS:
         # only numeric operations have in-place and reflexive variants

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -170,9 +170,12 @@ def where(self, cond, other=dtypes.NA):
     Same type as caller.
     """
     from .computation import apply_ufunc
-
+    # alignment for three arguments is complicated, so don't support it yet
+    join = 'inner' if other is dtypes.NA else 'exact'
     return apply_ufunc(duck_array_ops.where_method,
                        self, cond, other,
+                       join=join,
+                       dataset_join=join,
                        dask_array='allowed',
                        keep_attrs=True)
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -899,7 +899,7 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         return ops.fillna(self, value)
 
     def where(self, cond, other=dtypes.NA):
-        return ops.where(self, cond, other)
+        return ops.where_method(self, cond, other)
 
     def reduce(self, func, dim=None, axis=None, keep_attrs=False,
                allow_lazy=False, **kwargs):

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import warnings
 from contextlib import contextmanager
 from distutils.version import LooseVersion
+import re
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -186,7 +187,10 @@ class TestCase(unittest.TestCase):
 def raises_regex(error, pattern):
     with pytest.raises(error) as excinfo:
         yield
-    excinfo.match(pattern)
+    message = str(excinfo.value)
+    if not re.match(pattern, message):
+        raise AssertionError('exception %r did not match pattern %s'
+                             % (excinfo.value, pattern))
 
 
 class UnexpectedDataAccess(Exception):

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -182,6 +182,13 @@ class TestCase(unittest.TestCase):
         assert_allclose(ar1, ar2, rtol=rtol, atol=atol)
 
 
+@contextmanager
+def raises_regex(error, pattern):
+    with pytest.raises(error) as excinfo:
+        yield
+    excinfo.match(pattern)
+
+
 class UnexpectedDataAccess(Exception):
     pass
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -578,3 +578,10 @@ def test_apply_dask():
     actual = dask_safe_identity(dataset)
     assert isinstance(actual['y'].data, da.Array)
     assert_identical(dataset, actual)
+
+
+def test_where():
+    cond = xr.DataArray([True, False], dims='x')
+    actual = xr.where(cond, 1, 0)
+    expected = xr.DataArray([1, 0], dims='x')
+    assert_identical(expected, actual)

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -9,7 +9,7 @@ import pytest
 
 import xarray as xr
 from xarray.core.computation import (
-    _UFuncSignature, broadcast_compat_data, collect_dict_values,
+    _UFuncSignature, result_name, broadcast_compat_data, collect_dict_values,
     join_dict_keys, ordered_set_intersection, ordered_set_union,
     unified_dim_sizes, apply_ufunc)
 
@@ -36,6 +36,19 @@ def test_signature_properties():
     assert _UFuncSignature([['x']]) != _UFuncSignature([['y']])
 
 
+def test_result_name():
+
+    class Named(object):
+        def __init__(self, name=None):
+            self.name = name
+
+    assert result_name([1, 2]) is None
+    assert result_name([Named()]) is None
+    assert result_name([Named('foo'), 2]) == 'foo'
+    assert result_name([Named('foo'), Named('bar')]) is None
+    assert result_name([Named('foo'), Named()]) is None
+
+
 def test_ordered_set_union():
     assert list(ordered_set_union([[1, 2]])) == [1, 2]
     assert list(ordered_set_union([[1, 2], [2, 1]])) == [1, 2]
@@ -55,6 +68,8 @@ def test_join_dict_keys():
     assert list(join_dict_keys(dicts, 'right')) == ['y', 'z']
     assert list(join_dict_keys(dicts, 'inner')) == ['y']
     assert list(join_dict_keys(dicts, 'outer')) == ['x', 'y', 'z']
+    with pytest.raises(ValueError):
+        join_dict_keys(dicts, 'exact')
     with pytest.raises(KeyError):
         join_dict_keys(dicts, 'foobar')
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2667,16 +2667,27 @@ class TestDataset(TestCase):
         self.assertEqual(actual.a.attrs, ds.a.attrs)
 
         # attrs
-        da = DataArray(range(5), name='a', attrs={'attr':'da'})
+        da = DataArray(range(5), name='a', attrs={'attr': 'da'})
         actual = da.where(da.values > 1)
         self.assertEqual(actual.name, 'a')
         self.assertEqual(actual.attrs, da.attrs)
 
-        ds = Dataset({'a': da}, attrs={'attr':'ds'})
+        ds = Dataset({'a': da}, attrs={'attr': 'ds'})
         actual = ds.where(ds > 0)
         self.assertEqual(actual.attrs, ds.attrs)
         self.assertEqual(actual.a.name, 'a')
         self.assertEqual(actual.a.attrs, ds.a.attrs)
+
+    def test_where_other(self):
+        ds = Dataset({'a': ('x', range(5))})
+        expected = Dataset({'a': ('x', [-1, -1, 2, 3, 4])})
+        actual = ds.where(ds > 1, -1)
+        assert_equal(expected, actual)
+        assert actual.a.dtype == int
+
+        with pytest.raises(ValueError) as excinfo:
+            ds.where(ds > 1, other=0, drop=True)
+        assert "cannot set" in str(excinfo.value)
 
     def test_where_drop(self):
         # if drop=True


### PR DESCRIPTION
Example usage:
```python
>>> a.where(a.x + a.y < 5, -1)
<xarray.DataArray (x: 5, y: 5)>
array([[ 0,  1,  2,  3,  4],
       [ 5,  6,  7,  8, -1],
       [10, 11, 12, -1, -1],
       [15, 16, -1, -1, -1],
       [20, -1, -1, -1, -1]])
Dimensions without coordinates: x, y
```
 - [x] Closes #576
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

CC @MaximilianR 