### PR TITLE
Fix rasterio builds in docs

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -12,9 +12,9 @@ dependencies:
   - dask=0.12.0
   - ipython=5.1.0
   - sphinx=1.5
-  - netCDF4
+  - netCDF4=1.2.9
   - hdf4=4.2.12  # temporary install to get netCD4 working (GH1106)
-  - cartopy
+  - cartopy=0.15.1
   - rasterio=0.36.0
   - pip:
     - sphinx-gallery

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -12,9 +12,9 @@ dependencies:
   - dask=0.12.0
   - ipython=5.1.0
   - sphinx=1.5
-  - netCDF4=1.2.5
+  - netCDF4
   - hdf4=4.2.12  # temporary install to get netCD4 working (GH1106)
-  - cartopy=0.14.3
+  - cartopy
   - rasterio=0.36.0
   - pip:
     - sphinx-gallery

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -15,6 +15,6 @@ dependencies:
   - netCDF4=1.2.5
   - hdf4=4.2.12  # temporary install to get netCD4 working (GH1106)
   - cartopy=0.14.3
-  - rasterio=1.0a9
+  - rasterio=0.36.0
   - pip:
     - sphinx-gallery


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Passes ``git diff upstream/master | flake8 --diff``
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

The pinned version of rasterio we use for the doc builds isn't available anymore: https://github.com/conda-forge/rasterio-feedstock/pull/36

Tests:
- builds: https://readthedocs.org/projects/xray/builds/5796746/
- displays correctly:  http://xarray.pydata.org/en/fix-docs/auto_gallery/plot_rasterio.html#sphx-glr-auto-gallery-plot-rasterio-py
