### PR TITLE
Added show_commit_url to asv.conf

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -36,7 +36,7 @@
     "install_timeout": 600,
 
     // the base URL to show a commit for the project.
-    // "show_commit_url": "http://github.com/owner/project/commit/",
+    "show_commit_url": "http://github.com/pydata/xarray/commit/",
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -36,7 +36,7 @@
     "install_timeout": 600,
 
     // the base URL to show a commit for the project.
-    "show_commit_url": "http://github.com/pydata/xarray/commit/",
+    "show_commit_url": "https://github.com/pydata/xarray/commit/",
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.


### PR DESCRIPTION
This should setup the proper links from the published output to the commit on Github.

FYI the benchmarks should be running stably now, and posted to http://pandas.pydata.org/speed/xarray. http://pandas.pydata.org/speed/xarray/regressions.xml has an RSS feed to the regressions.