### PR TITLE
Small documentation fixes

### DIFF
--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -46,9 +46,11 @@ The :py:class:`~xarray.DataArray` constructor takes:
 
 - ``data``: a multi-dimensional array of values (e.g., a numpy ndarray,
   :py:class:`~pandas.Series`, :py:class:`~pandas.DataFrame` or :py:class:`~pandas.Panel`)
-- ``coords``: a list or dictionary of coordinates
-- ``dims``: a list of dimension names. If omitted, dimension names are
-  taken from ``coords`` if possible (deprecated).
+- ``coords``: a list or dictionary of coordinates. If a list, it should be a
+  list of tuples where the first element is the dimension name and the second
+  element is the corresponding coordinate array_like object.
+- ``dims``: a list of dimension names. If omitted and ``coords`` is a list of
+  tuples, dimension names are taken from ``coords``.
 - ``attrs``: a dictionary of attributes to add to the instance
 - ``name``: a string that names the instance
 

--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -48,7 +48,7 @@ The :py:class:`~xarray.DataArray` constructor takes:
   :py:class:`~pandas.Series`, :py:class:`~pandas.DataFrame` or :py:class:`~pandas.Panel`)
 - ``coords``: a list or dictionary of coordinates
 - ``dims``: a list of dimension names. If omitted, dimension names are
-  taken from ``coords`` if possible.
+  taken from ``coords`` if possible (deprecated).
 - ``attrs``: a dictionary of attributes to add to the instance
 - ``name``: a string that names the instance
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -177,7 +177,7 @@ class DataArray(AbstractArray, BaseDataObject):
             If dict-like, should be a mapping from dimension names to the
             corresponding coordinates.
         dims : str or sequence of str, optional
-            Name(s) of the the data dimension(s). Must be either a string (only
+            Name(s) of the data dimension(s). Must be either a string (only
             for 1D data) or a sequence of strings with length equal to the
             number of dimensions. If this argument is omitted, dimension names
             are taken from ``coords`` (if possible) and otherwise default to

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -175,7 +175,9 @@ class DataArray(AbstractArray, BaseDataObject):
         coords : sequence or dict of array_like objects, optional
             Coordinates (tick labels) to use for indexing along each dimension.
             If dict-like, should be a mapping from dimension names to the
-            corresponding coordinates.
+            corresponding coordinates. If sequence-like, should be a sequence
+            of tuples where the first element is the dimension name and the
+            second element is the corresponding coordinate array_like object.
         dims : str or sequence of str, optional
             Name(s) of the data dimension(s). Must be either a string (only
             for 1D data) or a sequence of strings with length equal to the


### PR DESCRIPTION
- Clarify in documentation that inferring DataArray dimensions from dictionary like ``coords`` has been deprecated.
- DataArray docstring