### PR TITLE
Automatic parallelization for dask arrays in apply_ufunc

### DIFF
--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -64,7 +64,7 @@ class _UFuncSignature(object):
         return self._all_core_dims
 
     @property
-    def n_inputs(self):
+    def num_inputs(self):
         return len(self.input_core_dims)
 
     @property

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -148,7 +148,7 @@ def fillna(data, other, join="left", dataset_join="left"):
 
     return apply_ufunc(duck_array_ops.fillna, data, other,
                        join=join,
-                       dask_array="allowed",
+                       dask="allowed",
                        dataset_join=dataset_join,
                        dataset_fill_value=np.nan,
                        keep_attrs=True)
@@ -176,7 +176,7 @@ def where_method(self, cond, other=dtypes.NA):
                        self, cond, other,
                        join=join,
                        dataset_join=join,
-                       dask_array='allowed',
+                       dask='allowed',
                        keep_attrs=True)
 
 

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -188,8 +188,8 @@ def raises_regex(error, pattern):
     with pytest.raises(error) as excinfo:
         yield
     message = str(excinfo.value)
-    if not re.match(pattern, message):
-        raise AssertionError('exception %r did not match pattern %s'
+    if not re.search(pattern, message):
+        raise AssertionError('exception %r did not match pattern %r'
                              % (excinfo.value, pattern))
 
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -607,7 +607,7 @@ def test_apply_dask_parallelized_errors():
                     dask='parallelized')
     with raises_regex(ValueError, 'dtypes'):
         apply_ufunc(identity, data_array, dask='parallelized')
-    with raises_regex(ValueError, 'wrong number'):
+    with raises_regex(ValueError, 'must have the same length'):
         apply_ufunc(identity, data_array, dask='parallelized',
                     output_dtypes=[float, float])
     with raises_regex(ValueError, 'output_sizes'):

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -607,6 +607,9 @@ def test_apply_dask_parallelized_errors():
                     dask='parallelized')
     with raises_regex(ValueError, 'dtypes'):
         apply_ufunc(identity, data_array, dask='parallelized')
+    with raises_regex(TypeError, 'list'):
+        apply_ufunc(identity, data_array, dask='parallelized',
+                    output_dtypes=float)
     with raises_regex(ValueError, 'must have the same length'):
         apply_ufunc(identity, data_array, dask='parallelized',
                     output_dtypes=[float, float])
@@ -628,20 +631,20 @@ def test_apply_dask_multiple_inputs():
     rs = np.random.RandomState(42)
     array1 = da.from_array(rs.randn(4, 4), chunks=(2, 2))
     array2 = da.from_array(rs.randn(4, 4), chunks=(2, 2))
-    data_array_1 = xr.DataArray(array1, dims=('x', 'y'))
-    data_array_2 = xr.DataArray(array2, dims=('x', 'y'))
+    data_array_1 = xr.DataArray(array1, dims=('x', 'z'))
+    data_array_2 = xr.DataArray(array2, dims=('y', 'z'))
 
     expected = apply_ufunc(
         covariance, data_array_1.compute(), data_array_2.compute(),
-        input_core_dims=[['y'], ['y']])
+        input_core_dims=[['z'], ['z']])
     allowed = apply_ufunc(
-        covariance, data_array_1, data_array_2, input_core_dims=[['y'], ['y']],
+        covariance, data_array_1, data_array_2, input_core_dims=[['z'], ['z']],
         dask='allowed')
     assert isinstance(allowed.data, da.Array)
     xr.testing.assert_allclose(expected, allowed.compute())
 
     parallelized = apply_ufunc(
-        covariance, data_array_1, data_array_2, input_core_dims=[['y'], ['y']],
+        covariance, data_array_1, data_array_2, input_core_dims=[['z'], ['z']],
         dask='parallelized', output_dtypes=[float])
     assert isinstance(parallelized.data, da.Array)
     xr.testing.assert_allclose(expected, parallelized.compute())

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -585,15 +585,6 @@ def test_apply_dask_parallelized():
     assert actual.data.chunks == array.chunks
     assert_identical(data_array, actual)
 
-    # check rechunking of core dimensions
-    actual = apply_ufunc(identity, data_array, dask='parallelized',
-                         output_dtypes=[float],
-                         input_core_dims=[('y',)],
-                         output_core_dims=[('y',)])
-    assert isinstance(actual.data, da.Array)
-    assert actual.data.chunks == ((1, 1), (2,))
-    assert_identical(data_array, actual)
-
 
 @requires_dask
 def test_apply_dask_parallelized_errors():
@@ -619,6 +610,12 @@ def test_apply_dask_parallelized_errors():
     with raises_regex(ValueError, 'at least one input is an xarray object'):
         apply_ufunc(identity, array, dask='parallelized')
 
+    with raises_regex(ValueError, 'consists of multiple chunks'):
+        apply_ufunc(identity, data_array, dask='parallelized',
+                    output_dtypes=[float],
+                    input_core_dims=[('y',)],
+                    output_core_dims=[('y',)])
+
 
 @requires_dask
 def test_apply_dask_multiple_inputs():
@@ -629,8 +626,8 @@ def test_apply_dask_multiple_inputs():
                 * (y - y.mean(axis=-1, keepdims=True))).mean(axis=-1)
 
     rs = np.random.RandomState(42)
-    array1 = da.from_array(rs.randn(4, 4), chunks=(2, 2))
-    array2 = da.from_array(rs.randn(4, 4), chunks=(2, 2))
+    array1 = da.from_array(rs.randn(4, 4), chunks=(2, 4))
+    array2 = da.from_array(rs.randn(4, 4), chunks=(2, 4))
     data_array_1 = xr.DataArray(array1, dims=('x', 'z'))
     data_array_2 = xr.DataArray(array2, dims=('y', 'z'))
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -275,7 +275,7 @@ def test_apply_output_core_dimension():
 
     def stack_negative(obj):
         def func(x):
-            return xr.core.npcompat.stack([x, -x], axis=-1)
+            return np.stack([x, -x], axis=-1)
         result = apply_ufunc(func, obj, output_core_dims=[['sign']])
         if isinstance(result, (xr.Dataset, xr.DataArray)):
             result.coords['sign'] = [1, -1]
@@ -303,7 +303,7 @@ def test_apply_output_core_dimension():
 
     def original_and_stack_negative(obj):
         def func(x):
-            return (x, xr.core.npcompat.stack([x, -x], axis=-1))
+            return (x, np.stack([x, -x], axis=-1))
         result = apply_ufunc(func, obj, output_core_dims=[[], ['sign']])
         if isinstance(result[1], (xr.Dataset, xr.DataArray)):
             result[1].coords['sign'] = [1, -1]
@@ -656,7 +656,7 @@ def test_apply_dask_new_output_dimension():
 
     def stack_negative(obj):
         def func(x):
-            return xr.core.npcompat.stack([x, -x], axis=-1)
+            return np.stack([x, -x], axis=-1)
         return apply_ufunc(func, obj, output_core_dims=[['sign']],
                            dask='parallelized', output_dtypes=[obj.dtype],
                            output_sizes={'sign': 2})

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -30,8 +30,8 @@ def test_signature_properties():
     assert sig.output_core_dims == (('z',),)
     assert sig.all_input_core_dims == frozenset(['x', 'y'])
     assert sig.all_output_core_dims == frozenset(['z'])
-    assert sig.n_inputs == 2
-    assert sig.n_outputs == 1
+    assert sig.num_inputs == 2
+    assert sig.num_outputs == 1
     # dimension names matter
     assert _UFuncSignature([['x']]) != _UFuncSignature([['y']])
 


### PR DESCRIPTION
This lets you parallelize a function designed for numpy inputs just by adding a few keyword arguments to `apply_ufunc`.

Example usage, to calculate rank correlation between two variables (this will probably turn into an example for the docs):
```python
import numpy as np
import xarray as xr
import bottleneck

def covariance_gufunc(x, y):
    return ((x - x.mean(axis=-1, keepdims=True))
            * (y - y.mean(axis=-1, keepdims=True))).mean(axis=-1)

def correlation_gufunc(x, y):
    return covariance_gufunc(x, y) / (x.std(axis=-1) * y.std(axis=-1))

def spearman_correlation_gufunc(x, y):
    x_ranks = bottleneck.rankdata(x, axis=-1)
    y_ranks = bottleneck.rankdata(y, axis=-1)
    return correlation_gufunc(x_ranks, y_ranks)

def spearman_correlation(x, y, dim):
    return xr.core.compuation.apply_ufunc(
        spearman_correlation_gufunc, x, y,
        input_core_dims=[[dim], [dim]],
        dask='parallelized',
        output_dtypes=[float])
```
We get a nice 5x speedup for this compute bound task:
```
In [56]: rs = np.random.RandomState(0)

In [57]: array1 = xr.DataArray(rs.randn(1000, 100000), dims=['place', 'time'])  # 800MB

In [58]: array2 = array1 + 0.5 * rs.randn(1000, 100000)

# using one core, on numpy arrays
In [61]: %time _ = spearman_correlation(array1, array2, 'time')
CPU times: user 21.6 s, sys: 2.84 s, total: 24.5 s
Wall time: 24.9 s

# using all my laptop's cores, with dask
In [63]: r = spearman_correlation(array1.chunk({'place': 10}), array2.chunk({'place': 10}), 'time')

In [64]: %time _ = r.compute()
CPU times: user 30.9 s, sys: 1.74 s, total: 32.6 s
Wall time: 4.59 s
```

Still needs examples in the documentation.

The next step is finally expose `apply_ufunc` as public API :).

 - [x] Closes #585
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

cc @mrocklin 