### PR TITLE
return bytes from DataArray.to_netcdf when path is not provided

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -124,6 +124,10 @@ Bug fixes
   it is none.
   By `Leevi Annala <https://github.com/leevei>`_.
 
+- Fix :py:func:`xarray.DataArray.to_netcdf` to return bytes when if no path is
+  provided (:issue:`1410`).
+  By `Joe Hamman <https://github.com/jhamman>`_.
+
 .. _whats-new.0.9.6:
 
 v0.9.6 (8 June 2017)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1352,7 +1352,7 @@ class DataArray(AbstractArray, BaseDataObject):
             # No problems with the name - so we're fine!
             dataset = self.to_dataset()
 
-        dataset.to_netcdf(*args, **kwargs)
+        return dataset.to_netcdf(*args, **kwargs)
 
     def to_dict(self):
         """

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1985,6 +1985,12 @@ class TestDataArrayToNetCDF(TestCase):
             with open_dataarray(tmp, drop_variables=['y']) as loaded:
                 self.assertDataArrayIdentical(expected, loaded)
 
+    def test_dataarray_to_netcdf_return_bytes(self):
+        # regression test for GH1410
+        data = xr.DataArray([1, 2, 3])
+        output = data.to_netcdf()
+        assert isinstance(output, bytes)
+
     @requires_pathlib
     def test_dataarray_to_netcdf_no_name_pathlib(self):
         original_da = DataArray(np.arange(12).reshape((3, 4)))


### PR DESCRIPTION
 - [x] Closes #1410
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
