### PR TITLE
Fix errors with isnull() that appear with pandas 0.21

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -100,6 +100,8 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- Fix ``isnull()`` to account for changes with pandas 0.21.
+
 - :py:func:`~xarray.open_rasterio` method now shifts the rasterio
   coordinates so that they are centered in each pixel.
   By `Greg Brener <https://github.com/gbrener>`_.

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -319,7 +319,7 @@ def inject_all_ops_and_reduce_methods(cls, priority=50, array_only=True):
         setattr(cls, name, cls._unary_op(_method_wrapper(name)))
 
     for name in PANDAS_UNARY_FUNCTIONS:
-        f = _func_slash_method_wrapper(getattr(pd, name))
+        f = _func_slash_method_wrapper(getattr(pd, name), name=name)
         setattr(cls, name, cls._unary_op(f))
 
     f = _func_slash_method_wrapper(duck_array_ops.around, name='round')


### PR DESCRIPTION
xref #1542

 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
