### PR TITLE
raise error if objects other than datasets are passed to save_mfdataset

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,10 +2,11 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
-PAPER         =
-BUILDDIR      = _build
+SPHINXOPTS      =
+SPHINXBUILD     = sphinx-build
+SPHINXATUOBUILD = sphinx-autobuild
+PAPER           =
+BUILDDIR        = _build
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -18,6 +19,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
+	@echo "  livehtml   Make standalone HTML files and rebuild the documentation when a change is detected. Also includes a livereload enabled web server"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
 	@echo "  pickle     to make pickle files"
@@ -55,6 +57,11 @@ html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+.PHONY: livehtml
+livehtml:
+	# @echo "$(SPHINXATUOBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html"
+	$(SPHINXATUOBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 
 .PHONY: dirhtml
 dirhtml:

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -23,7 +23,8 @@ Breaking changes
 
 - Supplying ``coords`` as a dictionary to the ``DataArray`` constructor without
   also supplying an explicit ``dims`` argument is no longer supported. This
-  behavior was deprecated in version 0.9 but is now an error (:issue:`727`).
+  behavior was deprecated in version 0.9 but will now raise an error
+  (:issue:`727`).
   By `Joe Hamman <https://github.com/jhamman>`_.
 
 Backward Incompatible Changes
@@ -58,7 +59,7 @@ Enhancements
 
 - More attributes available in :py:attr:`~xarray.Dataset.attrs` dictionary when
   raster files are opened with :py:func:`~xarray.open_rasterio`.
-  By `Greg Brener <https://github.com/gbrener>`_
+  By `Greg Brener <https://github.com/gbrener>`_.
 
 - Support for NetCDF files using an ``_Unsigned`` attribute to indicate that a
   a signed integer data type should be interpreted as unsigned bytes
@@ -97,23 +98,26 @@ Enhancements
   other means (:issue:`1459`).
   By `Ryan May <https://github.com/dopplershift>`_.
 
- - Support passing keyword arguments to ``load``, ``compute``, and ``persist``
-   methods. Any keyword arguments supplied to these methods are passed on to
-   the corresponding dask function (:issue:`1523`).
-   By `Joe Hamman <https://github.com/jhamman>`_.
+- Support passing keyword arguments to ``load``, ``compute``, and ``persist``
+  methods. Any keyword arguments supplied to these methods are passed on to
+  the corresponding dask function (:issue:`1523`).
+  By `Joe Hamman <https://github.com/jhamman>`_.
+
 - Encoding attributes are now preserved when xarray objects are concatenated.
   The encoding is copied from the first object  (:issue:`1297`).
   By `Joe Hamman <https://github.com/jhamman>`_ and
-  `Gerrit Holl <https://github.com/gerritholl`_.
+  `Gerrit Holl <https://github.com/gerritholl>`_.
 
 Bug fixes
 ~~~~~~~~~
 
 - Fixes to ensure xarray works properly with the upcoming pandas 0.21 release:
+
   - Fix :py:meth:`~xarray.DataArray.isnull` method (:issue:`1549`).
   - :py:meth:`~xarray.DataArray.to_series` and
     :py:meth:`~xarray.Dataset.to_dataframe` should not return a ``pandas.MultiIndex``
     for 1D data (:issue:`1548`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 - :py:func:`~xarray.open_rasterio` method now shifts the rasterio
   coordinates so that they are centered in each pixel.
@@ -144,6 +148,10 @@ Bug fixes
 
 - Fix :py:func:`xarray.DataArray.to_netcdf` to return bytes when no path is
   provided (:issue:`1410`).
+  By `Joe Hamman <https://github.com/jhamman>`_.
+
+- Fix :py:func:`xarray.save_mfdataset` to properly raise an informative error
+  when objects other than  ``Dataset`` are provided (:issue:`1555`).
   By `Joe Hamman <https://github.com/jhamman>`_.
 
 .. _whats-new.0.9.6:

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 import os.path
-from distutils.version import LooseVersion
 from glob import glob
 from io import BytesIO
 from numbers import Number
@@ -10,7 +9,7 @@ from numbers import Number
 
 import numpy as np
 
-from .. import backends, conventions
+from .. import backends, conventions, Dataset
 from .common import ArrayWriter, GLOBAL_LOCK
 from ..core import indexing
 from ..core.combine import auto_combine
@@ -655,6 +654,11 @@ def save_mfdataset(datasets, paths, mode='w', format=None, groups=None,
     if mode == 'w' and len(set(paths)) < len(paths):
         raise ValueError("cannot use mode='w' when writing multiple "
                          'datasets to the same path')
+
+    for obj in datasets:
+        if not isinstance(obj, Dataset):
+            raise TypeError('save_mfdataset only supports writing Dataset '
+                            'objects, recieved type %s' % type(obj))
 
     if groups is None:
         groups = [None] * len(datasets)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1379,6 +1379,13 @@ class DaskTest(TestCase, DatasetIOTestCases):
         with self.assertRaisesRegexp(ValueError, 'same length'):
             save_mfdataset([ds, ds], ['only one path'])
 
+    def test_save_mfdataset_invalid_dataarray(self):
+        # regression test for GH1555
+        da = DataArray([1, 2])
+        with self.assertRaisesRegexp(TypeError, 'supports writing Dataset'):
+            save_mfdataset([da], ['dataarray'])
+
+
     @requires_pathlib
     def test_save_mfdataset_pathlib_roundtrip(self):
         original = Dataset({'foo': ('x', np.random.randn(10))})


### PR DESCRIPTION
 - [x] Closes #1555
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
