### PR TITLE
stop skipping test_bivariate_ufunc in test_dask.py

### DIFF
--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -12,7 +12,7 @@ import xarray.ufuncs as xu
 from xarray.core.pycompat import suppress
 from . import TestCase, requires_dask
 
-from xarray.tests import unittest, mock
+from xarray.tests import mock
 
 with suppress(ImportError):
     import dask
@@ -176,7 +176,6 @@ class TestVariable(DaskTestCase):
         v = self.lazy_var
         self.assertLazyAndAllClose(np.sin(u), xu.sin(v))
 
-    @unittest.skip('currently broken in dask, see GH1090')
     def test_bivariate_ufunc(self):
         u = self.eager_var
         v = self.lazy_var


### PR DESCRIPTION
 - [x] Closes #1090
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``

The fix for this issue went into dask v.0.13 (Jan 2, 2017).

xrefs https://github.com/dask/dask/pull/1799, https://github.com/dask/dask/issues/1764