### PR TITLE
support dask arrays in rolling computations using bottleneck functions

### DIFF
--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -16,6 +16,7 @@ dependencies:
   - seaborn
   - toolz
   - rasterio
+  - bottleneck
   - pip:
     - coveralls
     - pytest-cov

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -30,7 +30,7 @@ For accelerating xarray
 
 - `bottleneck <https://github.com/kwgoodman/bottleneck>`__: speeds up
   NaN-skipping and rolling window aggregations by a large factor
-  (1.0 or later)
+  (1.1 or later)
 - `cyordereddict <https://github.com/shoyer/cyordereddict>`__: speeds up most
   internal operations with xarray data structures (for python versions < 3.5)
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -108,6 +108,10 @@ Enhancements
   By `Joe Hamman <https://github.com/jhamman>`_ and
   `Gerrit Holl <https://github.com/gerritholl>`_.
 
+- Support applying rolling window operations using bottleneck's moving window
+  functions on data stored as dask arrays (:issue:`1279`).
+  By `Joe Hamman <https://github.com/jhamman>`_.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -32,6 +32,9 @@ Backward Incompatible Changes
 
 - Old numpy < 1.11 and pandas < 0.18 are no longer supported (:issue:`1512`).
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+- The minimum supported version bottleneck has increased to 1.1
+  (:issue:`1279`).
+  By `Joe Hamman <https://github.com/jhamman>`_.
 
 Enhancements
 ~~~~~~~~~~~~

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -24,20 +24,3 @@ def dask_rolling_wrapper(moving_func, a, window, min_count=None, axis=-1):
     # trim array
     result = da.ghost.trim_internal(out, depth)
     return result
-
-
-def dask_rolling_wrapper_without_min_count(moving_func, a, window, axis=-1):
-    '''wrapper to apply bottleneck moving window funcs on dask arrays'''
-    # inputs for ghost
-    if axis < 0:
-        axis = a.ndim + axis
-    depth = {d: 0 for d in range(a.ndim)}
-    depth[axis] = window - 1
-    boundary = {d: np.nan for d in range(a.ndim)}
-    # create ghosted arrays
-    ag = da.ghost.ghost(a, depth=depth, boundary=boundary)
-    # apply rolling func
-    out = ag.map_blocks(moving_func, window, axis=axis, dtype=a.dtype)
-    # trim array
-    result = da.ghost.trim_internal(out, depth)
-    return result

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -1,0 +1,43 @@
+"""Define core operations for xarray objects.
+"""
+import numpy as np
+
+try:
+    import dask.array as da
+except ImportError:
+    pass
+
+
+def dask_rolling_wrapper(moving_func, a, window, min_count=None, axis=-1):
+    '''wrapper to apply bottleneck moving window funcs on dask arrays'''
+    # inputs for ghost
+    if axis < 0:
+        axis = a.ndim + axis
+    depth = {d: 0 for d in range(a.ndim)}
+    depth[axis] = window - 1
+    boundary = {d: np.nan for d in range(a.ndim)}
+    # create ghosted arrays
+    ag = da.ghost.ghost(a, depth=depth, boundary=boundary)
+    # apply rolling func
+    out = ag.map_blocks(moving_func, window, min_count=min_count,
+                        axis=axis, dtype=a.dtype)
+    # trim array
+    result = da.ghost.trim_internal(out, depth)
+    return result
+
+
+def dask_rolling_wrapper_without_min_count(moving_func, a, window, axis=-1):
+    '''wrapper to apply bottleneck moving window funcs on dask arrays'''
+    # inputs for ghost
+    if axis < 0:
+        axis = a.ndim + axis
+    depth = {d: 0 for d in range(a.ndim)}
+    depth[axis] = window - 1
+    boundary = {d: np.nan for d in range(a.ndim)}
+    # create ghosted arrays
+    ag = da.ghost.ghost(a, depth=depth, boundary=boundary)
+    # apply rolling func
+    out = ag.map_blocks(moving_func, window, axis=axis, dtype=a.dtype)
+    # trim array
+    result = da.ghost.trim_internal(out, depth)
+    return result

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -10,7 +10,6 @@ from __future__ import division
 from __future__ import print_function
 
 import operator
-import warnings
 from distutils.version import LooseVersion
 
 import numpy as np
@@ -24,10 +23,7 @@ from .nputils import array_eq, array_ne
 try:
     import bottleneck as bn
     if LooseVersion(bn.__version__) < LooseVersion('1.1'):
-        warnings.warn(
-            "The installed version of bottleneck {ver} is not supported "
-            "in xarray and will be not be used\nThe minimum supported "
-            "version is 1.1\n".format(ver=bn.__version__), UserWarning)
+        # fall back to numpy
         raise ImportError(
             'bottleneck version {} is not supported'.format(bn.__version__))
     has_bottleneck = True

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -10,6 +10,7 @@ from __future__ import division
 from __future__ import print_function
 
 import operator
+import warnings
 from distutils.version import LooseVersion
 
 import numpy as np
@@ -23,7 +24,12 @@ from .nputils import array_eq, array_ne
 try:
     import bottleneck as bn
     if LooseVersion(bn.__version__) < LooseVersion('1.1'):
-        raise ImportError
+        warnings.warn(
+            "The installed version of bottleneck {ver} is not supported "
+            "in xarray and will be not be used\nThe minimum supported "
+            "version is 1.1\n".format(ver=bn.__version__), UserWarning)
+        raise ImportError(
+            'bottleneck version {} is not supported'.format(bn.__version__))
     has_bottleneck = True
 except ImportError:
     # use numpy methods instead

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -28,6 +28,11 @@ except ImportError:
     bn = np
     has_bottleneck = False
 
+try:
+    import dask.array as da
+except ImportError:
+    pass
+
 
 UNARY_OPS = ['neg', 'pos', 'abs', 'invert']
 CMP_BINARY_OPS = ['lt', 'le', 'ge', 'gt']
@@ -242,6 +247,42 @@ def rolling_count(rolling):
     enough_periods = rolling_count >= rolling.min_periods
 
     return rolling_count.where(enough_periods)
+
+
+def dask_rolling_wrapper(moving_func, a, window, min_count=None, axis=-1):
+    '''wrapper to apply bottleneck moving window funcs on dask arrays'''
+    # inputs for ghost
+    if axis < 0:
+        axis = a.ndim + axis
+    depth = {d: 0 for d in range(a.ndim)}
+    depth[axis] = window - 1
+    boundary = {d: np.nan for d in range(a.ndim)}
+    # create ghosted arrays
+    ag = da.ghost.ghost(a, depth=depth, boundary=boundary)
+    # apply rolling func
+    out = ag.map_blocks(moving_func, window, min_count=min_count,
+                        axis=axis, dtype=a.dtype)
+    # trim array
+    result = da.ghost.trim_internal(out, depth)
+    return result
+
+
+def dask_rolling_wrapper_without_min_count(moving_func, a, window, axis=-1):
+    '''wrapper to apply bottleneck moving window funcs on dask arrays'''
+    # inputs for ghost
+    if axis < 0:
+        axis = a.ndim + axis
+    depth = {d: 0 for d in range(a.ndim)}
+    depth[axis] = window - 1
+    boundary = {d: np.nan for d in range(a.ndim)}
+    # create ghosted arrays
+    ag = da.ghost.ghost(a, depth=depth, boundary=boundary)
+    # apply rolling func
+    out = ag.map_blocks(moving_func, window, axis=axis, dtype=a.dtype)
+    # trim array
+    result = da.ghost.trim_internal(out, depth)
+    return result
+
 
 def inject_reduce_methods(cls):
     methods = ([(name, getattr(duck_array_ops, 'array_%s' % name), False)

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -22,6 +22,8 @@ from .nputils import array_eq, array_ne
 
 try:
     import bottleneck as bn
+    if LooseVersion(bn.__version__) < LooseVersion('1.1'):
+        raise ImportError
     has_bottleneck = True
 except ImportError:
     # use numpy methods instead
@@ -51,7 +53,8 @@ NAN_CUM_METHODS = ['cumsum', 'cumprod']
 BOTTLENECK_ROLLING_METHODS = {'move_sum': 'sum', 'move_mean': 'mean',
                               'move_std': 'std', 'move_min': 'min',
                               'move_max': 'max', 'move_var': 'var',
-                              'move_argmin': 'argmin', 'move_argmax': 'argmax'}
+                              'move_argmin': 'argmin', 'move_argmax': 'argmax',
+                              'move_median': 'median'}
 # TODO: wrap take, dot, sort
 
 
@@ -355,40 +358,16 @@ def inject_bottleneck_rolling_methods(cls):
     setattr(cls, 'count', func)
 
     # bottleneck rolling methods
-    if has_bottleneck:
-        # TODO: Bump the required version of bottlneck to 1.1 and remove all
-        # these version checks (see GH#1278)
-        bn_version = LooseVersion(bn.__version__)
-        bn_min_version = LooseVersion('1.0')
-        bn_version_1_1 = LooseVersion('1.1')
-        if bn_version < bn_min_version:
-            return
+    if not has_bottleneck:
+        return
 
-        for bn_name, method_name in BOTTLENECK_ROLLING_METHODS.items():
-            try:
-                f = getattr(bn, bn_name)
-                func = cls._bottleneck_reduce(f)
-                func.__name__ = method_name
-                func.__doc__ = _ROLLING_REDUCE_DOCSTRING_TEMPLATE.format(
-                    name=func.__name__, da_or_ds='DataArray')
-                setattr(cls, method_name, func)
-            except AttributeError as e:
-                # skip functions not in Bottleneck 1.0
-                if ((bn_version < bn_version_1_1) and
-                        (bn_name not in ['move_var', 'move_argmin',
-                                         'move_argmax', 'move_rank'])):
-                    raise e
-
-        # bottleneck rolling methods without min_count (bn.__version__ < 1.1)
-        f = getattr(bn, 'move_median')
-        if bn_version >= bn_version_1_1:
-            func = cls._bottleneck_reduce(f)
-        else:
-            func = cls._bottleneck_reduce_without_min_count(f)
-        func.__name__ = 'median'
+    for bn_name, method_name in BOTTLENECK_ROLLING_METHODS.items():
+        f = getattr(bn, bn_name)
+        func = cls._bottleneck_reduce(f)
+        func.__name__ = method_name
         func.__doc__ = _ROLLING_REDUCE_DOCSTRING_TEMPLATE.format(
             name=func.__name__, da_or_ds='DataArray')
-        setattr(cls, 'median', func)
+        setattr(cls, method_name, func)
 
 
 def inject_datasetrolling_methods(cls):

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -10,7 +10,6 @@ from __future__ import division
 from __future__ import print_function
 
 import operator
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
@@ -22,10 +21,6 @@ from .nputils import array_eq, array_ne
 
 try:
     import bottleneck as bn
-    if LooseVersion(bn.__version__) < LooseVersion('1.1'):
-        # fall back to numpy
-        raise ImportError(
-            'bottleneck version {} is not supported'.format(bn.__version__))
     has_bottleneck = True
 except ImportError:
     # use numpy methods instead

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -28,11 +28,6 @@ except ImportError:
     bn = np
     has_bottleneck = False
 
-try:
-    import dask.array as da
-except ImportError:
-    pass
-
 
 UNARY_OPS = ['neg', 'pos', 'abs', 'invert']
 CMP_BINARY_OPS = ['lt', 'le', 'ge', 'gt']
@@ -247,41 +242,6 @@ def rolling_count(rolling):
     enough_periods = rolling_count >= rolling.min_periods
 
     return rolling_count.where(enough_periods)
-
-
-def dask_rolling_wrapper(moving_func, a, window, min_count=None, axis=-1):
-    '''wrapper to apply bottleneck moving window funcs on dask arrays'''
-    # inputs for ghost
-    if axis < 0:
-        axis = a.ndim + axis
-    depth = {d: 0 for d in range(a.ndim)}
-    depth[axis] = window - 1
-    boundary = {d: np.nan for d in range(a.ndim)}
-    # create ghosted arrays
-    ag = da.ghost.ghost(a, depth=depth, boundary=boundary)
-    # apply rolling func
-    out = ag.map_blocks(moving_func, window, min_count=min_count,
-                        axis=axis, dtype=a.dtype)
-    # trim array
-    result = da.ghost.trim_internal(out, depth)
-    return result
-
-
-def dask_rolling_wrapper_without_min_count(moving_func, a, window, axis=-1):
-    '''wrapper to apply bottleneck moving window funcs on dask arrays'''
-    # inputs for ghost
-    if axis < 0:
-        axis = a.ndim + axis
-    depth = {d: 0 for d in range(a.ndim)}
-    depth[axis] = window - 1
-    boundary = {d: np.nan for d in range(a.ndim)}
-    # create ghosted arrays
-    ag = da.ghost.ghost(a, depth=depth, boundary=boundary)
-    # apply rolling func
-    out = ag.map_blocks(moving_func, window, axis=axis, dtype=a.dtype)
-    # trim array
-    result = da.ghost.trim_internal(out, depth)
-    return result
 
 
 def inject_reduce_methods(cls):

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -10,8 +10,7 @@ from .common import full_like
 from .combine import concat
 from .ops import (inject_bottleneck_rolling_methods,
                   inject_datasetrolling_methods, has_bottleneck, bn)
-from .dask_array_ops import (dask_rolling_wrapper,
-                             dask_rolling_wrapper_without_min_count)
+from .dask_array_ops import dask_rolling_wrapper
 
 
 class Rolling(object):
@@ -101,7 +100,6 @@ class DataArrayRolling(Rolling):
     This class adds the following class methods;
     + _reduce_method(cls, func)
     + _bottleneck_reduce(cls, func)
-    + _bottleneck_reduce_without_min_count(cls, func)
 
     These class methods will be used to inject numpy or bottleneck function
     by doing
@@ -257,35 +255,6 @@ class DataArrayRolling(Rolling):
             else:
                 values = func(self.obj.data, window=self.window,
                               min_count=min_count, axis=axis)
-
-            result = DataArray(values, self.obj.coords)
-
-            if self.center:
-                result = self._center_result(result)
-
-            return result
-        return wrapped_func
-
-    @classmethod
-    def _bottleneck_reduce_without_min_count(cls, func):
-        """
-        Methods to return a wrapped function for `media` bottoleneck method.
-        bottleneck's median does not accept min_periods.
-        """
-        def wrapped_func(self, **kwargs):
-            from .dataarray import DataArray
-
-            if self.min_periods is not None:
-                raise ValueError('Rolling.median does not accept min_periods')
-
-            axis = self.obj.get_axis_num(self.dim)
-
-            if isinstance(self.obj.data, dask_array_type):
-                values = dask_rolling_wrapper_without_min_count(
-                    func, self.obj.data, window=self.window, axis=axis)
-            else:
-                values = func(self.obj.data, window=self.window,
-                              axis=axis)
 
             result = DataArray(values, self.obj.coords)
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -9,8 +9,9 @@ from .pycompat import OrderedDict, zip, dask_array_type
 from .common import full_like
 from .combine import concat
 from .ops import (inject_bottleneck_rolling_methods,
-                  inject_datasetrolling_methods, has_bottleneck, bn,
-                  dask_rolling_wrapper, dask_rolling_wrapper_without_min_count)
+                  inject_datasetrolling_methods, has_bottleneck, bn)
+from .dask_array_ops import (dask_rolling_wrapper,
+                             dask_rolling_wrapper_without_min_count)
 
 
 class Rolling(object):
@@ -82,7 +83,6 @@ class Rolling(object):
             self._min_periods = min_periods
         self.center = center
         self.dim = dim
-        self.axis = self.obj.get_axis_num(self.dim)
 
     def __repr__(self):
         """provide a nice str repr of our rolling object"""
@@ -247,14 +247,16 @@ class DataArrayRolling(Rolling):
             else:
                 min_count = self.min_periods
 
+            axis = self.obj.get_axis_num(self.dim)
+
             if isinstance(self.obj.data, dask_array_type):
                 values = dask_rolling_wrapper(func, self.obj.data,
                                               window=self.window,
                                               min_count=min_count,
-                                              axis=self.axis)
+                                              axis=axis)
             else:
                 values = func(self.obj.data, window=self.window,
-                              min_count=min_count, axis=self.axis)
+                              min_count=min_count, axis=axis)
 
             result = DataArray(values, self.obj.coords)
 
@@ -276,12 +278,14 @@ class DataArrayRolling(Rolling):
             if self.min_periods is not None:
                 raise ValueError('Rolling.median does not accept min_periods')
 
+            axis = self.obj.get_axis_num(self.dim)
+
             if isinstance(self.obj.data, dask_array_type):
                 values = dask_rolling_wrapper_without_min_count(
-                    func, self.obj.data, window=self.window, axis=self.axis)
+                    func, self.obj.data, window=self.window, axis=axis)
             else:
                 values = func(self.obj.data, window=self.window,
-                              axis=self.axis)
+                              axis=axis)
 
             result = DataArray(values, self.obj.coords)
 

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -76,7 +76,7 @@ except ImportError:
 
 try:
     import bottleneck
-    if LooseVersion(bottleneck.__version__) < LooseVersion('1.0'):
+    if LooseVersion(bottleneck.__version__) < LooseVersion('1.1'):
         raise ImportError('Fall back to numpy')
     has_bottleneck = True
 except ImportError:

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2630,6 +2630,7 @@ def da(request):
 
 @pytest.fixture
 def da_dask(seed=123):
+    pytest.importorskip('bottleneck')
     rs = np.random.RandomState(seed)
     times = pd.date_range('2000-01-01', freq='1D', periods=21)
     values = rs.normal(size=(1, 21, 1))
@@ -2680,8 +2681,7 @@ def test_rolling_properties(da):
 @pytest.mark.parametrize('center', (True, False, None))
 @pytest.mark.parametrize('min_periods', (1, None))
 def test_rolling_wrapped_bottleneck(da, name, center, min_periods):
-    pytest.importorskip('bottleneck')
-    import bottleneck as bn
+    bn = pytest.importorskip('bottleneck')
 
     # skip if median and min_periods bottleneck version < 1.1
     if ((min_periods == 1) and
@@ -2714,6 +2714,8 @@ def test_rolling_wrapped_bottleneck(da, name, center, min_periods):
 @pytest.mark.parametrize('center', (True, False, None))
 @pytest.mark.parametrize('min_periods', (1, None))
 def test_rolling_wrapped_bottleneck_dask(da_dask, name, center, min_periods):
+    pytest.importorskip('dask.array')
+    pytest.importorskip('bottleneck')
     # dask version
     rolling_obj = da_dask.rolling(time=7, min_periods=min_periods)
     actual = getattr(rolling_obj, name)().load()

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2702,7 +2702,6 @@ def test_rolling_wrapped_bottleneck(da, name, center, min_periods):
 @pytest.mark.parametrize('min_periods', (1, None))
 def test_rolling_wrapped_bottleneck_dask(da_dask, name, center, min_periods):
     pytest.importorskip('dask.array')
-    pytest.importorskip('bottleneck', minversion="1.1")
     # dask version
     rolling_obj = da_dask.rolling(time=7, min_periods=min_periods)
     actual = getattr(rolling_obj, name)().load()
@@ -2710,7 +2709,7 @@ def test_rolling_wrapped_bottleneck_dask(da_dask, name, center, min_periods):
     rolling_obj = da_dask.load().rolling(time=7, min_periods=min_periods)
     expected = getattr(rolling_obj, name)()
 
-    # using all-close becuase rolling over ghost cells introduces some
+    # using all-close because rolling over ghost cells introduces some
     # precision errors
     assert_allclose(actual, expected)
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3511,8 +3511,6 @@ def ds(request):
 
 
 def test_rolling_properties(ds):
-    pytest.importorskip('bottleneck', minversion='1.1')
-
     # catching invalid args
     with pytest.raises(ValueError) as exception:
         ds.rolling(time=7, x=2)
@@ -3589,9 +3587,8 @@ def test_rolling_reduce(ds, center, min_periods, window, name):
     if min_periods is not None and window < min_periods:
         min_periods = window
 
-    # std with window == 1 seems unstable in bottleneck
     if name == 'std' and window == 1:
-        window = 2
+        pytest.skip('std with window == 1 is unstable in bottleneck')
 
     rolling_obj = ds.rolling(time=window, center=center,
                              min_periods=min_periods)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3511,7 +3511,7 @@ def ds(request):
 
 
 def test_rolling_properties(ds):
-    pytest.importorskip('bottleneck', minversion='1.0')
+    pytest.importorskip('bottleneck', minversion='1.1')
 
     # catching invalid args
     with pytest.raises(ValueError) as exception:
@@ -3527,18 +3527,14 @@ def test_rolling_properties(ds):
         ds.rolling(time2=2)
     assert 'time2' in str(exception)
 
+
 @pytest.mark.parametrize('name',
                          ('sum', 'mean', 'std', 'var', 'min', 'max', 'median'))
 @pytest.mark.parametrize('center', (True, False, None))
 @pytest.mark.parametrize('min_periods', (1, None))
 @pytest.mark.parametrize('key', ('z1', 'z2'))
 def test_rolling_wrapped_bottleneck(ds, name, center, min_periods, key):
-    pytest.importorskip('bottleneck')
-    import bottleneck as bn
-
-    # skip if median and min_periods
-    if (min_periods == 1) and (name == 'median'):
-        pytest.skip()
+    bn = pytest.importorskip('bottleneck', minversion='1.1')
 
     # Test all bottleneck functions
     rolling_obj = ds.rolling(time=7, min_periods=min_periods)
@@ -3556,16 +3552,6 @@ def test_rolling_wrapped_bottleneck(ds, name, center, min_periods, key):
     rolling_obj = ds.rolling(time=7, center=center)
     actual = getattr(rolling_obj, name)()['time']
     assert_equal(actual, ds['time'])
-
-
-def test_rolling_invalid_args(ds):
-    pytest.importorskip('bottleneck', minversion="1.0")
-    import bottleneck as bn
-    if LooseVersion(bn.__version__) >= LooseVersion('1.1'):
-        pytest.skip('rolling median accepts min_periods for bottleneck 1.1')
-    with pytest.raises(ValueError) as exception:
-        da.rolling(time=7, min_periods=1).median()
-    assert 'Rolling.median does not' in str(exception)
 
 
 @pytest.mark.parametrize('center', (True, False))
@@ -3606,8 +3592,6 @@ def test_rolling_reduce(ds, center, min_periods, window, name):
     # std with window == 1 seems unstable in bottleneck
     if name == 'std' and window == 1:
         window = 2
-    if name == 'median':
-        min_periods = None
 
     rolling_obj = ds.rolling(time=window, center=center,
                              min_periods=min_periods)


### PR DESCRIPTION
 - [x] Closes #1279
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

cc @shoyer, @darothen, @arbennett, @vnoel