### PR TITLE
Support opening password protected datasets over Opendap (Fixes #1068)

### DIFF
--- a/doc/io.rst
+++ b/doc/io.rst
@@ -403,7 +403,7 @@ HTTP Basic authentication::
                                             session=session)
     ds = xr.open_dataset(store)
 
-`Pydap's cas module`__ have functions that generate custom sessions for 
+`Pydap's cas module`__ has functions that generate custom sessions for 
 servers that use CAS single sign-on. For example, to connect to servers
 that require NASA's URS authentication::
 

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -388,6 +388,38 @@ over the network until we look at particular values:
 
 .. image:: _static/opendap-prism-tmax.png
 
+Some servers require authentication before we can access the data. For this
+purpose we can explicitly create a :py:class:`~xarray.backends.PydapDataStore`
+and pass in a `Requests`__ session object. For example for 
+HTTP Basic authentication::
+
+    import xarray as xr
+    import requests
+
+    session = requests.Session()
+    session.auth = ('username', 'password')
+
+    store = xr.backends.PydapDataStore.open('http://example.com/data',
+                                            session=session)
+    ds = xr.open_dataset(store)
+
+`Pydap's cas module`__ have functions that generate custom sessions for 
+servers that use CAS single sign-on. For example, to connect to servers
+that require NASA's URS authentication::
+
+  import xarray as xr
+  from pydata.cas.urs import setup_session
+
+  ds_url = 'https://gpm1.gesdisc.eosdis.nasa.gov/opendap/hyrax/example.nc'
+
+  session = setup_session('username', 'password', check_url=ds_url)
+  store = xr.backends.PydapDataStore.open(ds_url, session=session)
+
+  ds = xr.open_dataset(store)
+
+__ http://docs.python-requests.org
+__ http://pydap.readthedocs.io/en/latest/client.html#authentication
+
 .. _io.rasterio:
 
 Rasterio

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -111,7 +111,7 @@ Enhancements
 - Changed :py:class:`~xarray.backends.PydapDataStore` to take a Pydap dataset.
   This permits opening Opendap datasets that require authentication, by
   instantiating a Pydap dataset with a session object. Also added
-  :py:func:`xarray.backends.PydapDataStore.open` which takes a url and session
+  :py:meth:`xarray.backends.PydapDataStore.open` which takes a url and session
   object (:issue:`1068`).
   By `Philip Graae <https://github.com/mrpgraae>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -108,6 +108,13 @@ Enhancements
   By `Joe Hamman <https://github.com/jhamman>`_ and
   `Gerrit Holl <https://github.com/gerritholl>`_.
 
+- Changed :py:class:`~xarray.backends.PydapDataStore` to take a Pydap dataset.
+  This permits opening Opendap datasets that require authentication, by
+  instantiating a Pydap dataset with a session object. Also added
+  :py:func:`xarray.backends.PydapDataStore.open` which takes a url and session
+  object (:issue:`1068`).
+  By `Philip Graae <https://github.com/mrpgraae>`_.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -117,6 +117,7 @@ Enhancements
   :py:meth:`xarray.backends.PydapDataStore.open` which takes a url and session
   object (:issue:`1068`).
   By `Philip Graae <https://github.com/mrpgraae>`_.
+
 - Support applying rolling window operations using bottleneck's moving window
   functions on data stored as dask arrays (:issue:`1279`).
   By `Joe Hamman <https://github.com/jhamman>`_.

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -288,7 +288,7 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
             store = backends.ScipyDataStore(filename_or_obj,
                                             autoclose=autoclose)
         elif engine == 'pydap':
-            store = backends.PydapDataStore(filename_or_obj)
+            store = backends.PydapDataStore.open(filename_or_obj)
         elif engine == 'h5netcdf':
             store = backends.H5NetCDFStore(filename_or_obj, group=group,
                                            autoclose=autoclose)

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -60,9 +60,14 @@ class PydapDataStore(AbstractDataStore):
     This store provides an alternative way to access OpenDAP datasets that may
     be useful if the netCDF4 library is not available.
     """
-    def __init__(self, url):
+    def __init__(self, ds):
+        self.ds = ds
+
+    @classmethod
+    def open(cls, url, session=None):
         import pydap.client
-        self.ds = pydap.client.open_url(url)
+        ds = pydap.client.open_url(url, session=session)
+        return cls(ds)
 
     def open_store_variable(self, var):
         data = indexing.LazilyIndexedArray(PydapArrayWrapper(var))

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -61,6 +61,11 @@ class PydapDataStore(AbstractDataStore):
     be useful if the netCDF4 library is not available.
     """
     def __init__(self, ds):
+        """
+        Parameters
+        ----------
+        ds : pydap DatasetType
+        """
         self.ds = ds
 
     @classmethod

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1512,7 +1512,6 @@ class PydapTest(TestCase):
                                     expected.isel(j=slice(1, 2)))
 
     def test_session(self):
-        import pydap
         from pydap.cas.urs import setup_session
 
         session = setup_session('XarrayTestUser', 'Xarray2017')

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1509,6 +1509,22 @@ class PydapTest(TestCase):
             self.assertDatasetEqual(actual.isel(j=slice(1, 2)),
                                     expected.isel(j=slice(1, 2)))
 
+    def test_password(self):
+        from pydap.cas.urs import setup_session
+
+        url = ('https://disc2.gesdisc.eosdis.nasa.gov/opendap/TRMM_RT/'
+               'TRMM_3B42RT_Daily.7/2017/09/3B42RT_Daily.20170902.7.nc4')
+        session = setup_session('XarrayTestUser', 'Xarray2017', check_url=url)
+        store = xr.backends.PydapDataStore.open(url, session=session)
+
+        with xr.open_dataset(store) as ds:
+            expected_vars = ['precipitation_cnt', 'uncal_precipitation',
+                             'uncal_precipitation_cnt', 'precipitation',
+                             'randomError_cnt', 'randomError']
+
+            for var in expected_vars:
+                self.assertTrue(var in ds.data_vars)
+
     @requires_dask
     def test_dask(self):
         with self.create_datasets(chunks={'j': 2}) as (actual, expected):


### PR DESCRIPTION
 - [x] Closes #1068
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Changed `PydapDataStore` to be initialized with a Pydap dataset (returned by `pydap.client.open_url`). Also added a `open` classmethod to PydapDataStore, for opening with a url. The `open` classmethod also takes an optional session object, allowing the api discussed in #1068:

```
pydap_ds = pydap.client.open_url(url, session=session)
store = xarray.backends.PydapDataStore(pydap_ds)
ds = xarray.open_dataset(store)
```
or
```
store = xarray.backends.PydapDataStore.open(url, session=session)
ds = xarray.open_dataset(store)
```

I tested this with NASA Earthdata as you can see in the added testcase, so i used a session object returned from pydap.cas.urs.setup_session() as that function is tailored for that. However, it just returns a `Session` object from the requests library, so maybe homemade requests sessions can work with other sites. I haven't been able to find other freely accessible but password-protected data repositories.

I thought about adding the other keyword parameters from `pydap.client.open_url` to `xarray.backends.PydapDataStore.open` but I was unsure whether that would be a good idea? Also, if we should do it, would it be okay to just pass `**kwargs` on to `pydap.client.open_url`?

Any constructive feedback and/or proposed changes are highly welcome of course. By the way, this is my first time contributing to an open source project like this, so please let me know if there is anything I should have done otherwise!