### PR TITLE
data_vars option added to open_mfdataset

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,7 +38,7 @@ Backward Incompatible Changes
 
 Enhancements
 ~~~~~~~~~~~~
-- Support for data_vars and coords keywords added to
+- Support for ``data_vars`` and ``coords`` keywords added to
   :py:func:`~xarray.open_mfdataset`
   (:issue:`438`):
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -39,8 +39,8 @@ Backward Incompatible Changes
 Enhancements
 ~~~~~~~~~~~~
 - Support for data_vars keyword added to
-  py: func: `~xarray.open_mfdataset`
-  (:issue: `438`):
+  py:func:`~xarray.open_mfdataset`
+  (:issue:`438`):
 
   .. ipython::
     :verbatim:

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -50,7 +50,7 @@ Enhancements
     In [8]: ds = xarray.concat([xarray.open_dataset(p, chunks={"time": 100}) for p in paths], data_vars="minimal", dim="time")
     # in the cases when they contain the same coordinate variables that should not be concantenated (i.e lon, lat)
 
-  By `Huziy Oleksandr <https://github.com/guziy>`_.
+  By `Oleksandr Huziy <https://github.com/guziy>`_.
 
 - Support for `pathlib.Path` objects added to
   :py:func:`~xarray.open_dataset`, :py:func:`~xarray.open_mfdataset`,

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -45,7 +45,7 @@ Enhancements
   .. ipython::
     :verbatim:
     #allows to open multiple files as
-    ds = xarray.open_mfdataset(paths, chunks={"time": 100}, data_vars="minimal", dim="time")
+    ds = xarray.open_mfdataset(paths, chunks={"time": 100}, data_vars="minimal")
     #instead of
     ds = xarray.concat([xarray.open_dataset(p, chunks={"time": 100}) for p in paths], data_vars="minimal", dim="time")
     # in the cases when they contain the same coordinate variables that should not be concantenated (i.e lon, lat)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,7 +38,7 @@ Backward Incompatible Changes
 
 Enhancements
 ~~~~~~~~~~~~
-- Support for data_vars keyword added to
+- Support for data_vars and coords keywords added to
   :py:func:`~xarray.open_mfdataset`
   (:issue:`438`):
 
@@ -49,6 +49,19 @@ Enhancements
     #instead of
     ds = xarray.concat([xarray.open_dataset(p, chunks={"time": 100}) for p in paths], data_vars="minimal", dim="time")
     # in the cases when they contain the same coordinate variables that should not be concantenated (i.e lon, lat)
+
+    # in case of 'minimal' does not add time dimension to spatial coordinates
+    In [1]: ds = xarray.open_mfdataset("daymet_v3_tmin_*", data_vars="all")
+
+    In [2]: ds["lon"].shape
+
+    Out[2]: (13505, 808, 782)
+
+    In [3]: ds = xarray.open_mfdataset("daymet_v3_tmin_*", data_vars="minimal")
+
+    In [4]: ds["lon"].shape
+
+    Out[4]: (808, 782)
 
   By `Oleksandr Huziy <https://github.com/guziy>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -39,7 +39,7 @@ Backward Incompatible Changes
 Enhancements
 ~~~~~~~~~~~~
 - Support for data_vars keyword added to
-  py:func:`~xarray.open_mfdataset`
+  :py:func:`~xarray.open_mfdataset`
   (:issue:`438`):
 
   .. ipython::

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -45,23 +45,25 @@ Enhancements
   .. ipython::
     :verbatim:
     #allows to open multiple files as
-    ds = xarray.open_mfdataset(paths, chunks={"time": 100}, data_vars="minimal")
+    ds = xarray.open_mfdataset(paths, chunks={'time': 100}, data_vars='minimal')
     #instead of
-    ds = xarray.concat([xarray.open_dataset(p, chunks={"time": 100}) for p in paths], data_vars="minimal", dim="time")
+    ds = xarray.concat([xarray.open_dataset(p, chunks={'time': 100}) for p in paths], data_vars='minimal', dim='time')
     # in the cases when they contain the same coordinate variables that should not be concantenated (i.e lon, lat)
 
     # in case of 'minimal' does not add time dimension to spatial coordinates
-    In [1]: ds = xarray.open_mfdataset("daymet_v3_tmin_*", data_vars="all")
+    In [1]: ds = xarray.open_mfdataset('daymet_v3_tmin_*', data_vars='all')
 
-    In [2]: ds["lon"].shape
+    In [2]: ds['lon'].shape
 
     Out[2]: (13505, 808, 782)
 
-    In [3]: ds = xarray.open_mfdataset("daymet_v3_tmin_*", data_vars="minimal")
+    In [3]: ds = xarray.open_mfdataset('daymet_v3_tmin_*', data_vars='minimal')
 
-    In [4]: ds["lon"].shape
+    In [4]: ds['lon'].shape
 
     Out[4]: (808, 782)
+
+    # I also noticed that my memory-intensive applications use much less memory and faster, when ``data_vars='minimal'`` is used.
 
   By `Oleksandr Huziy <https://github.com/guziy>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -41,12 +41,14 @@ Enhancements
 - Support for data_vars keyword added to
   py:func:`~xarray.open_mfdataset`
   (:issue:`438`):
+
   .. ipython::
     :verbatim:
     #allows to open multiple files as
     In [8]: ds = xarray.open_mfdataset(paths, chunks={"time": 100}, data_vars="minimal", dim="time")
     #instead of
     In [8]: ds = xarray.concat([xarray.open_dataset(p, chunks={"time": 100}) for p in paths], data_vars="minimal", dim="time")
+    # in the cases when they contain the same coordinate variables that should not be concantenated (i.e lon, lat)
 
   By `Huziy Oleksandr <https://github.com/guziy>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,6 +38,17 @@ Backward Incompatible Changes
 
 Enhancements
 ~~~~~~~~~~~~
+- Support for data_vars keyword added to
+  py:func:`~xarray.open_mfdataset`
+  (:issue:`438`):
+  .. ipython::
+    :verbatim:
+    #allows to open multiple files as
+    In [8]: ds = xarray.open_mfdataset(paths, chunks={"time": 100}, data_vars="minimal", dim="time")
+    #instead of
+    In [8]: ds = xarray.concat([xarray.open_dataset(p, chunks={"time": 100}) for p in paths], data_vars="minimal", dim="time")
+
+  By `Huziy Oleksandr <https://github.com/guziy>`_.
 
 - Support for `pathlib.Path` objects added to
   :py:func:`~xarray.open_dataset`, :py:func:`~xarray.open_mfdataset`,

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -39,15 +39,15 @@ Backward Incompatible Changes
 Enhancements
 ~~~~~~~~~~~~
 - Support for data_vars keyword added to
-  py:func:`~xarray.open_mfdataset`
-  (:issue:`438`):
+  py: func: `~xarray.open_mfdataset`
+  (:issue: `438`):
 
   .. ipython::
     :verbatim:
     #allows to open multiple files as
-    In [8]: ds = xarray.open_mfdataset(paths, chunks={"time": 100}, data_vars="minimal", dim="time")
+    ds = xarray.open_mfdataset(paths, chunks={"time": 100}, data_vars="minimal", dim="time")
     #instead of
-    In [8]: ds = xarray.concat([xarray.open_dataset(p, chunks={"time": 100}) for p in paths], data_vars="minimal", dim="time")
+    ds = xarray.concat([xarray.open_dataset(p, chunks={"time": 100}) for p in paths], data_vars="minimal", dim="time")
     # in the cases when they contain the same coordinate variables that should not be concantenated (i.e lon, lat)
 
   By `Oleksandr Huziy <https://github.com/guziy>`_.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -63,7 +63,7 @@ Enhancements
 
     Out[4]: (808, 782)
 
-    # I also noticed that my memory-intensive applications use much less memory and faster, when ``data_vars='minimal'`` is used.
+    # I also noticed that my memory-intensive applications use much less memory and run faster, when ``data_vars='minimal'`` is used.
 
   By `Oleksandr Huziy <https://github.com/guziy>`_.
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -431,7 +431,7 @@ _CONCAT_DIM_DEFAULT = '__infer_concat_dim__'
 
 def open_mfdataset(paths, chunks=None, concat_dim=_CONCAT_DIM_DEFAULT,
                    compat='no_conflicts', preprocess=None, engine=None,
-                   lock=None, data_vars='all', **kwargs):
+                   lock=None, data_vars='all', coords='different', **kwargs):
     """Open multiple files as a single dataset.
 
     Requires dask to be installed.  Attributes from the first dataset file
@@ -499,6 +499,20 @@ def open_mfdataset(paths, chunks=None, concat_dim=_CONCAT_DIM_DEFAULT,
           * 'all': All data variables will be concatenated.
           * list of str: The listed data variables will be concatenated, in
             addition to the 'minimal' data variables.
+    coords : {'minimal', 'different', 'all' o list of str}, optional
+        These coordinate variables will be concatenated together:
+          * 'minimal': Only coordinates in which the dimension already appears
+            are included.
+          * 'different': Coordinates which are not equal (ignoring attributes)
+            across all datasets are also concatenated (as well as all for which
+            dimension already appears). Beware: this option may load the data
+            payload of coordinate variables into memory if they are not already
+            loaded.
+          * 'all': All coordinate variables will be concatenated, except
+            those corresponding to other dimensions.
+          * list of str: The listed coordinate variables will be concatenated,
+            in addition the 'minimal' coordinates.
+
     **kwargs : optional
         Additional arguments passed on to :py:func:`xarray.open_dataset`.
 
@@ -532,10 +546,11 @@ def open_mfdataset(paths, chunks=None, concat_dim=_CONCAT_DIM_DEFAULT,
     try:
         if concat_dim is _CONCAT_DIM_DEFAULT:
             combined = auto_combine(datasets, compat=compat,
-                                    data_vars=data_vars)
+                                    data_vars=data_vars, coords=coords)
         else:
             combined = auto_combine(datasets, concat_dim=concat_dim,
-                                    compat=compat, data_vars=data_vars)
+                                    compat=compat,
+                                    data_vars=data_vars, coords=coords)
     except ValueError:
         for ds in datasets:
             ds.close()

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -536,12 +536,15 @@ def open_mfdataset(paths, chunks=None, concat_dim=_CONCAT_DIM_DEFAULT,
         else:
             combined = auto_combine(datasets, concat_dim=concat_dim,
                                     compat=compat, data_vars=data_vars)
-        combined._file_obj = _MultiFileCloser(file_objs)
-        combined.attrs = datasets[0].attrs
-    except ValueError as ve:
+    except ValueError:
         for ds in datasets:
             ds.close()
-        raise ve
+        raise
+
+    combined._file_obj = _MultiFileCloser(file_objs)
+    combined.attrs = datasets[0].attrs
+
+
 
     return combined
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -531,7 +531,8 @@ def open_mfdataset(paths, chunks=None, concat_dim=_CONCAT_DIM_DEFAULT,
     if concat_dim is _CONCAT_DIM_DEFAULT:
         combined = auto_combine(datasets, compat=compat, data_vars=data_vars)
     else:
-        combined = auto_combine(datasets, concat_dim=concat_dim, compat=compat, data_vars=data_vars)
+        combined = auto_combine(datasets, concat_dim=concat_dim, compat=compat,
+                                data_vars=data_vars)
     combined._file_obj = _MultiFileCloser(file_objs)
     combined.attrs = datasets[0].attrs
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -543,9 +543,6 @@ def open_mfdataset(paths, chunks=None, concat_dim=_CONCAT_DIM_DEFAULT,
 
     combined._file_obj = _MultiFileCloser(file_objs)
     combined.attrs = datasets[0].attrs
-
-
-
     return combined
 
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -531,10 +531,11 @@ def open_mfdataset(paths, chunks=None, concat_dim=_CONCAT_DIM_DEFAULT,
     # close datasets in case of a ValueError
     try:
         if concat_dim is _CONCAT_DIM_DEFAULT:
-            combined = auto_combine(datasets, compat=compat, data_vars=data_vars)
-        else:
-            combined = auto_combine(datasets, concat_dim=concat_dim, compat=compat,
+            combined = auto_combine(datasets, compat=compat,
                                     data_vars=data_vars)
+        else:
+            combined = auto_combine(datasets, concat_dim=concat_dim,
+                                    compat=compat, data_vars=data_vars)
         combined._file_obj = _MultiFileCloser(file_objs)
         combined.attrs = datasets[0].attrs
     except ValueError as ve:

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -309,7 +309,7 @@ def _dataarray_concat(arrays, dim, data_vars, coords, compat,
     return arrays[0]._from_temp_dataset(ds, name)
 
 
-def _auto_concat(datasets, dim=None):
+def _auto_concat(datasets, dim=None, data_vars="all"):
     if len(datasets) == 1:
         return datasets[0]
     else:
@@ -331,7 +331,7 @@ def _auto_concat(datasets, dim=None):
                                  'supply the ``concat_dim`` argument '
                                  'explicitly')
             dim, = concat_dims
-        return concat(datasets, dim=dim)
+        return concat(datasets, dim=dim, data_vars=data_vars)
 
 
 _CONCAT_DIM_DEFAULT = '__infer_concat_dim__'
@@ -339,7 +339,7 @@ _CONCAT_DIM_DEFAULT = '__infer_concat_dim__'
 
 def auto_combine(datasets,
                  concat_dim=_CONCAT_DIM_DEFAULT,
-                 compat='no_conflicts'):
+                 compat='no_conflicts', data_vars="all"):
     """Attempt to auto-magically combine the given datasets into one.
 
     This method attempts to combine a list of datasets into a single entity by
@@ -380,6 +380,8 @@ def auto_combine(datasets,
         - 'no_conflicts': only values which are not null in both datasets
           must be equal. The returned dataset then contains the combination
           of all non-null values.
+     data_vars : {'minimal', 'different', 'all' or list of str}, optional
+        Details in the documentation of xarray.concat
 
     Returns
     -------

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -397,7 +397,7 @@ def auto_combine(datasets,
         dim = None if concat_dim is _CONCAT_DIM_DEFAULT else concat_dim
         grouped = itertoolz.groupby(lambda ds: tuple(sorted(ds.data_vars)),
                                     datasets).values()
-        concatenated = [_auto_concat(ds, dim=dim) for ds in grouped]
+        concatenated = [_auto_concat(ds, dim=dim, data_vars=data_vars) for ds in grouped]
     else:
         concatenated = datasets
     merged = merge(concatenated, compat=compat)

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -309,7 +309,7 @@ def _dataarray_concat(arrays, dim, data_vars, coords, compat,
     return arrays[0]._from_temp_dataset(ds, name)
 
 
-def _auto_concat(datasets, dim=None, data_vars='all'):
+def _auto_concat(datasets, dim=None, data_vars='all', coords='different'):
     if len(datasets) == 1:
         return datasets[0]
     else:
@@ -331,7 +331,7 @@ def _auto_concat(datasets, dim=None, data_vars='all'):
                                  'supply the ``concat_dim`` argument '
                                  'explicitly')
             dim, = concat_dims
-        return concat(datasets, dim=dim, data_vars=data_vars)
+        return concat(datasets, dim=dim, data_vars=data_vars, coords=coords)
 
 
 _CONCAT_DIM_DEFAULT = '__infer_concat_dim__'
@@ -339,7 +339,8 @@ _CONCAT_DIM_DEFAULT = '__infer_concat_dim__'
 
 def auto_combine(datasets,
                  concat_dim=_CONCAT_DIM_DEFAULT,
-                 compat='no_conflicts', data_vars='all'):
+                 compat='no_conflicts',
+                 data_vars='all', coords='different'):
     """Attempt to auto-magically combine the given datasets into one.
 
     This method attempts to combine a list of datasets into a single entity by
@@ -380,8 +381,10 @@ def auto_combine(datasets,
         - 'no_conflicts': only values which are not null in both datasets
           must be equal. The returned dataset then contains the combination
           of all non-null values.
-     data_vars : {'minimal', 'different', 'all' or list of str}, optional
-        Details in the documentation of xarray.concat
+    data_vars : {'minimal', 'different', 'all' or list of str}, optional
+        Details are in the documentation of concat
+    coords : {'minimal', 'different', 'all' o list of str}, optional
+        Details are in the documentation of concat
 
     Returns
     -------
@@ -397,7 +400,8 @@ def auto_combine(datasets,
         dim = None if concat_dim is _CONCAT_DIM_DEFAULT else concat_dim
         grouped = itertoolz.groupby(lambda ds: tuple(sorted(ds.data_vars)),
                                     datasets).values()
-        concatenated = [_auto_concat(ds, dim=dim, data_vars=data_vars)
+        concatenated = [_auto_concat(ds, dim=dim,
+                                     data_vars=data_vars, coords=coords)
                         for ds in grouped]
     else:
         concatenated = datasets

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -397,7 +397,8 @@ def auto_combine(datasets,
         dim = None if concat_dim is _CONCAT_DIM_DEFAULT else concat_dim
         grouped = itertoolz.groupby(lambda ds: tuple(sorted(ds.data_vars)),
                                     datasets).values()
-        concatenated = [_auto_concat(ds, dim=dim, data_vars=data_vars) for ds in grouped]
+        concatenated = [_auto_concat(ds, dim=dim, data_vars=data_vars)
+                        for ds in grouped]
     else:
         concatenated = datasets
     merged = merge(concatenated, compat=compat)

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -309,7 +309,7 @@ def _dataarray_concat(arrays, dim, data_vars, coords, compat,
     return arrays[0]._from_temp_dataset(ds, name)
 
 
-def _auto_concat(datasets, dim=None, data_vars="all"):
+def _auto_concat(datasets, dim=None, data_vars='all'):
     if len(datasets) == 1:
         return datasets[0]
     else:
@@ -339,7 +339,7 @@ _CONCAT_DIM_DEFAULT = '__infer_concat_dim__'
 
 def auto_combine(datasets,
                  concat_dim=_CONCAT_DIM_DEFAULT,
-                 compat='no_conflicts', data_vars="all"):
+                 compat='no_conflicts', data_vars='all'):
     """Attempt to auto-magically combine the given datasets into one.
 
     This method attempts to combine a list of datasets into a single entity by

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1266,6 +1266,7 @@ class OpenMFDatasetManyFilesTest(TestCase):
     def test_4_open_large_num_files_h5netcdf(self):
         self.validate_open_mfdataset_large_num_files(engine=['h5netcdf'])
 
+
 @requires_scipy_or_netCDF4
 class OpenMFDatasetDataVarsKWTest(TestCase):
     coord_name = 'lon'
@@ -1307,9 +1308,11 @@ class OpenMFDatasetDataVarsKWTest(TestCase):
                 ds1.to_netcdf(tmpfile1)
                 ds2.to_netcdf(tmpfile2)
 
+                files = [tmpfile1, tmpfile2]
                 for opt in ['all', 'minimal']:
-                    with open_mfdataset([tmpfile1, tmpfile2], data_vars=opt) as ds:
-                        ds_expect = xr.concat([ds1, ds2], data_vars=opt, dim='t')
+                    with open_mfdataset(files, data_vars=opt) as ds:
+                        kwargs = dict(data_vars=opt, dim='t')
+                        ds_expect = xr.concat([ds1, ds2], **kwargs)
 
                         data = ds[self.var_name][:]
                         data_expect = ds_expect[self.var_name][:]
@@ -1329,8 +1332,9 @@ class OpenMFDatasetDataVarsKWTest(TestCase):
                 ds1.to_netcdf(tmpfile1)
                 ds2.to_netcdf(tmpfile2)
 
+                files = [tmpfile1, tmpfile2]
                 # open the files with the default data_vars='all'
-                with open_mfdataset([tmpfile1, tmpfile2], data_vars='all') as ds:
+                with open_mfdataset(files, data_vars='all') as ds:
 
                     coord_shape = ds[self.coord_name].shape
                     coord_shape1 = ds1[self.coord_name].shape
@@ -1357,8 +1361,9 @@ class OpenMFDatasetDataVarsKWTest(TestCase):
                 ds1.to_netcdf(tmpfile1)
                 ds2.to_netcdf(tmpfile2)
 
+                files = [tmpfile1, tmpfile2]
                 # open the files with the default data_vars='all'
-                with open_mfdataset([tmpfile1, tmpfile2], data_vars='minimal') as ds:
+                with open_mfdataset(files, data_vars='minimal') as ds:
 
                     coord_shape = ds[self.coord_name].shape
                     coord_shape1 = ds1[self.coord_name].shape
@@ -1384,7 +1389,8 @@ class OpenMFDatasetDataVarsKWTest(TestCase):
                     ds1.to_netcdf(tmpfile1)
                     ds2.to_netcdf(tmpfile2)
 
-                    with open_mfdataset([tmpfile1, tmpfile2], data_vars='minimum'):
+                    files = [tmpfile1, tmpfile2]
+                    with open_mfdataset(files, data_vars='minimum'):
                         pass
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1268,7 +1268,7 @@ class OpenMFDatasetManyFilesTest(TestCase):
 
 
 @requires_scipy_or_netCDF4
-class OpenMFDatasetDataVarsKWTest(TestCase):
+class OpenMFDatasetWithDataVarsAndCoordsKwTest(TestCase):
     coord_name = 'lon'
     var_name = 'v1'
 
@@ -1309,9 +1309,16 @@ class OpenMFDatasetDataVarsKWTest(TestCase):
                 ds2.to_netcdf(tmpfile2)
 
                 files = [tmpfile1, tmpfile2]
-                for opt in ['all', 'minimal']:
+
+                options = ['all', 'minimal', 'different', ]
+                for opt in options:
                     with open_mfdataset(files, data_vars=opt) as ds:
                         kwargs = dict(data_vars=opt, dim='t')
+                        ds_expect = xr.concat([ds1, ds2], **kwargs)
+                        self.assertDatasetIdentical(ds, ds_expect)
+
+                    with open_mfdataset(files, coords=opt) as ds:
+                        kwargs = dict(coords=opt, dim='t')
                         ds_expect = xr.concat([ds1, ds2], **kwargs)
                         self.assertDatasetIdentical(ds, ds_expect)
 
@@ -1367,6 +1374,11 @@ class OpenMFDatasetDataVarsKWTest(TestCase):
                 files = [tmpfile1, tmpfile2]
                 with self.assertRaises(ValueError):
                     with open_mfdataset(files, data_vars='minimum'):
+                        pass
+
+                # test invalid coord parameter
+                with self.assertRaises(ValueError):
+                    with open_mfdataset(files, coords='minimum'):
                         pass
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1266,7 +1266,7 @@ class OpenMFDatasetManyFilesTest(TestCase):
     def test_4_open_large_num_files_h5netcdf(self):
         self.validate_open_mfdataset_large_num_files(engine=['h5netcdf'])
 
-
+@requires_scipy_or_netCDF4
 class OpenMFDatasetDataVarsKWTest(TestCase):
     coord_name = 'lon'
     var_name = 'v1'

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1308,19 +1308,17 @@ class OpenMFDatasetDataVarsKWTest(TestCase):
                 ds2.to_netcdf(tmpfile2)
 
                 for opt in ['all', 'minimal']:
-                    ds = open_mfdataset([tmpfile1, tmpfile2], data_vars=opt)
-                    ds_expect = xr.concat([ds1, ds2], data_vars=opt, dim='t')
+                    with open_mfdataset([tmpfile1, tmpfile2], data_vars=opt) as ds:
+                        ds_expect = xr.concat([ds1, ds2], data_vars=opt, dim='t')
 
-                    data = ds[self.var_name][:]
-                    data_expect = ds_expect[self.var_name][:]
+                        data = ds[self.var_name][:]
+                        data_expect = ds_expect[self.var_name][:]
 
-                    coord = ds[self.coord_name][:]
-                    coord_expect = ds_expect[self.coord_name][:]
+                        coord = ds[self.coord_name][:]
+                        coord_expect = ds_expect[self.coord_name][:]
 
-                    self.assertArrayEqual(data, data_expect)
-                    self.assertArrayEqual(coord, coord_expect)
-
-                    ds.close()
+                        self.assertArrayEqual(data, data_expect)
+                        self.assertArrayEqual(coord, coord_expect)
 
     def test_common_coord_dims_should_change_when_datavars_all(self):
         with create_tmp_file() as tmpfile1:
@@ -1332,23 +1330,23 @@ class OpenMFDatasetDataVarsKWTest(TestCase):
                 ds2.to_netcdf(tmpfile2)
 
                 # open the files with the default data_vars='all'
-                ds = open_mfdataset([tmpfile1, tmpfile2], data_vars='all')
+                with open_mfdataset([tmpfile1, tmpfile2], data_vars='all') as ds:
 
-                coord_shape = ds[self.coord_name].shape
-                coord_shape1 = ds1[self.coord_name].shape
-                coord_shape2 = ds2[self.coord_name].shape
+                    coord_shape = ds[self.coord_name].shape
+                    coord_shape1 = ds1[self.coord_name].shape
+                    coord_shape2 = ds2[self.coord_name].shape
 
-                var_shape = ds[self.var_name].shape
-                var_shape1 = ds1[self.var_name].shape
-                var_shape2 = ds2[self.var_name].shape
+                    var_shape = ds[self.var_name].shape
+                    var_shape1 = ds1[self.var_name].shape
+                    var_shape2 = ds2[self.var_name].shape
 
-                self.assertNotEqual(coord_shape1, coord_shape)
-                self.assertNotEqual(coord_shape2, coord_shape)
+                    self.assertNotEqual(coord_shape1, coord_shape)
+                    self.assertNotEqual(coord_shape2, coord_shape)
 
-                self.assertEqual(var_shape[0],
-                                 var_shape1[0] + var_shape2[0])
+                    self.assertEqual(var_shape[0],
+                                     var_shape1[0] + var_shape2[0])
 
-                self.assertEqual(var_shape, coord_shape)
+                    self.assertEqual(var_shape, coord_shape)
 
     def test_common_coord_dims_should_not_change_when_datavars_minimal(self):
         with create_tmp_file() as tmpfile1:
@@ -1360,21 +1358,21 @@ class OpenMFDatasetDataVarsKWTest(TestCase):
                 ds2.to_netcdf(tmpfile2)
 
                 # open the files with the default data_vars='all'
-                ds = open_mfdataset([tmpfile1, tmpfile2], data_vars='minimal')
+                with open_mfdataset([tmpfile1, tmpfile2], data_vars='minimal') as ds:
 
-                coord_shape = ds[self.coord_name].shape
-                coord_shape1 = ds1[self.coord_name].shape
-                coord_shape2 = ds2[self.coord_name].shape
+                    coord_shape = ds[self.coord_name].shape
+                    coord_shape1 = ds1[self.coord_name].shape
+                    coord_shape2 = ds2[self.coord_name].shape
 
-                var_shape = ds[self.var_name].shape
-                var_shape1 = ds1[self.var_name].shape
-                var_shape2 = ds2[self.var_name].shape
+                    var_shape = ds[self.var_name].shape
+                    var_shape1 = ds1[self.var_name].shape
+                    var_shape2 = ds2[self.var_name].shape
 
-                self.assertEqual(coord_shape1, coord_shape)
+                    self.assertEqual(coord_shape1, coord_shape)
 
-                self.assertEqual(coord_shape2, coord_shape)
-                self.assertEqual(var_shape[0],
-                                 var_shape1[0] + var_shape2[0])
+                    self.assertEqual(coord_shape2, coord_shape)
+                    self.assertEqual(var_shape[0],
+                                     var_shape1[0] + var_shape2[0])
 
     def test_invalid_data_vars_value_should_fail(self):
         with self.assertRaises(ValueError):
@@ -1386,7 +1384,8 @@ class OpenMFDatasetDataVarsKWTest(TestCase):
                     ds1.to_netcdf(tmpfile1)
                     ds2.to_netcdf(tmpfile2)
 
-                    open_mfdataset([tmpfile1, tmpfile2], data_vars='minimum')
+                    with open_mfdataset([tmpfile1, tmpfile2], data_vars='minimum'):
+                        pass
 
 
 @requires_dask

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1267,6 +1267,19 @@ class OpenMFDatasetManyFilesTest(TestCase):
         self.validate_open_mfdataset_large_num_files(engine=['h5netcdf'])
 
 
+class OpenMFDatasetDataVarsKWTest(TestCase):
+    def create_files_with_common_coordinates_and_time(self):
+        # TODO: implement
+
+        pass
+
+    def test_common_coordinate_dimensions_should_not_change_when_datavars_all(self):
+        #TODO: implement
+        assert False
+        pass
+
+
+
 @requires_dask
 @requires_scipy
 @requires_netCDF4

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1336,15 +1336,24 @@ class OpenMFDatasetDataVarsKWTest(TestCase):
 
                         var_shape = ds[self.var_name].shape
 
+                        tests = []
+                        # shape pairs to be compared
+                        shape_pairs = [
+                            (var_shape, coord_shape),
+                            (coord_shape1, coord_shape),
+                            (coord_shape2, coord_shape)
+                        ]
+                        # tests to be applied to respective pairs
                         if opt == 'all':
-                            self.assertEqual(var_shape, coord_shape)
-                            self.assertNotEqual(coord_shape1, coord_shape)
-                            self.assertNotEqual(coord_shape2, coord_shape)
+                            tests = [self.assertEqual,
+                                     self.assertNotEqual, self.assertNotEqual]
 
                         if opt == 'minimal':
-                            self.assertEqual(coord_shape1, coord_shape)
-                            self.assertEqual(coord_shape2, coord_shape)
+                            tests = [self.assertNotEqual,
+                                     self.assertEqual, self.assertEqual]
 
+                        for a_test, a_shape_pair in zip(tests, shape_pairs):
+                            a_test(*a_shape_pair)
 
     def test_invalid_data_vars_value_should_fail(self):
         with create_tmp_file() as tmpfile1:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1304,10 +1304,10 @@ class OpenMFDatasetDataVarsKWTest(TestCase):
 
                 for opt in ['all', 'minimal']:
                     ds = open_mfdataset([tmpfile1, tmpfile2], data_vars=opt)
-                    ds_expect = xr.concat([ds1, ds2], data_vars=opt, dim="t")
+                    ds_expect = xr.concat([ds1, ds2], data_vars=opt, dim='t')
 
-                    self.assertArrayEqual(ds["v1"][:], ds_expect["v1"][:])
-                    self.assertArrayEqual(ds["lon"][:], ds_expect["lon"][:])
+                    self.assertArrayEqual(ds['v1'][:], ds_expect['v1'][:])
+                    self.assertArrayEqual(ds['lon'][:], ds_expect['lon'][:])
 
                     ds.close()
 


### PR DESCRIPTION
 - [x] Closes #438
 - [x] Added tests (they are passing currently)
 - [x] Passes ``git diff upstream/master | flake8 --diff`` 
There were some long lines that in my opinion look better when not broken, but I complied with flake8 request to shorten them.

 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (Do not think the change is big enough to be added to the files)
