### PR TITLE
Parsing wavelength info from rasterio tags

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,6 +25,10 @@ Changes since v0.10.0 rc1 (Unreleased)
 - Experimental support for the Dask collection interface (:issue:`1674`).
   By `Matthew Rocklin <https://github.com/mrocklin>`_.
 
+- Experimental support for parsing ENVI metadata to coordinates and attributes
+  in :py:func:`xarray.open_rasterio`.
+  By `Matti Eskelinen <https://github.com/maaleske>`
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -108,10 +108,8 @@ def _parse_envi(meta):
     def default(s):
         return s.strip('{}')
 
-    parse = {
-        'wavelength': parsevec,
-        'fwhm': parsevec,
-        }
+    parse = {'wavelength': parsevec,
+             'fwhm': parsevec}
     parsed_meta = {k: parse.get(k, default)(v) for k, v in meta.items()}
     return parsed_meta
 
@@ -194,9 +192,7 @@ def open_rasterio(filename, chunks=None, cache=None, lock=None):
         attrs['transform'] = tuple(riods.transform)
 
     # Parse extra metadata from tags, if supported
-    parsers = {
-            'ENVI': _parse_envi,
-            }
+    parsers = {'ENVI': _parse_envi}
 
     driver = riods.driver
     if driver in parsers:

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -165,6 +165,9 @@ def open_rasterio(filename, chunks=None, cache=None, lock=None):
         # Affine transformation matrix (tuple of floats)
         # Describes coefficients mapping pixel coordinates to CRS
         attrs['transform'] = tuple(riods.transform)
+    if 'wavelength_units' in riods.tags(1):
+        # Unit for the wavelengths (string)
+        attrs['wavelength_units'] = riods.tags(1)['wavelength_units']
 
     data = indexing.LazilyIndexedArray(RasterioArrayWrapper(riods))
 

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -135,7 +135,7 @@ def open_rasterio(filename, chunks=None, cache=None, lock=None):
     if 'wavelength' in riods.tags(1):
         coords['radiation_wavelength'] = ('band', np.fromiter(
                 map(lambda b: riods.tags(b)['wavelength'], riods.indexes),
-                dtype=np.float))
+                dtype=np.float, count=riods.count))
 
     # Get geo coords
     nx, ny = riods.width, riods.height

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -82,6 +82,7 @@ class RasterioArrayWrapper(NdimSizeLenMixin, DunderArrayMixin,
             out = np.squeeze(out, axis=squeeze_axis)
         return out
 
+
 def _parse_envi(meta):
     """Parse ENVI metadata into Python data structures.
 
@@ -108,12 +109,12 @@ def _parse_envi(meta):
         return s.strip('{}')
 
     parse = {
-        'wavelength' : parsevec,
-        'fwhm'       : parsevec,
+        'wavelength': parsevec,
+        'fwhm': parsevec,
         }
-
-    parsed_meta = {k : parse.get(k, default)(v) for k, v in meta.items()}
+    parsed_meta = {k: parse.get(k, default)(v) for k, v in meta.items()}
     return parsed_meta
+
 
 def open_rasterio(filename, chunks=None, cache=None, lock=None):
     """Open a file with rasterio (experimental).
@@ -163,7 +164,6 @@ def open_rasterio(filename, chunks=None, cache=None, lock=None):
         raise ValueError('Unknown dims')
     coords['band'] = np.asarray(riods.indexes)
 
-
     # Get geo coords
     nx, ny = riods.width, riods.height
     dx, dy = riods.res[0], -riods.res[1]
@@ -195,7 +195,7 @@ def open_rasterio(filename, chunks=None, cache=None, lock=None):
 
     # Parse extra metadata from tags, if supported
     parsers = {
-            'ENVI' : _parse_envi,
+            'ENVI': _parse_envi,
             }
 
     driver = riods.driver
@@ -209,7 +209,6 @@ def open_rasterio(filename, chunks=None, cache=None, lock=None):
                 coords[k] = ('band', np.asarray(v))
             else:
                 attrs[k] = v
-
 
     data = indexing.LazilyIndexedArray(RasterioArrayWrapper(riods))
 

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -131,6 +131,12 @@ def open_rasterio(filename, chunks=None, cache=None, lock=None):
         raise ValueError('Unknown dims')
     coords['band'] = np.asarray(riods.indexes)
 
+    # Get wavelengths
+    if 'wavelength' in riods.tags(1):
+        coords['radiation_wavelength'] = ('band', np.fromiter(
+                map(lambda b: riods.tags(b)['wavelength'], riods.indexes),
+                dtype=np.float))
+
     # Get geo coords
     nx, ny = riods.width, riods.height
     dx, dy = riods.res[0], -riods.res[1]

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2113,8 +2113,7 @@ class TestRasterio(TestCase):
                         ns='ENVI',
                         description='{Tagged file}',
                         wavelength='{123.000000, 234.234000, 345.345678}',
-                        fwhm='{1.000000, 0.234000, 0.000345}',
-                        )
+                        fwhm='{1.000000, 0.234000, 0.000345}')
                 s.write(data)
                 dx, dy = s.res[0], -s.res[1]
 
@@ -2126,14 +2125,10 @@ class TestRasterio(TestCase):
                                      'x': np.arange(nx) * 1000 + 5000 + dx/2,
                                      'wavelength': (
                                          'band',
-                                         np.array([123, 234.234, 345.345678]),
-                                         ),
+                                         np.array([123, 234.234, 345.345678])),
                                      'fwhm': (
                                          'band',
-                                         np.array([1, 0.234, 0.000345]),
-                                         ),
-                                    },
-                                 )
+                                         np.array([1, 0.234, 0.000345]))})
 
             with xr.open_rasterio(tmp_file) as rioda:
                 assert_allclose(rioda, expected)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2092,7 +2092,7 @@ class TestRasterio(TestCase):
                 assert_allclose(ac, ex)
 
     def test_ENVI_tags(self):
-        import rasterio
+        rasterio = pytest.importorskip('rasterio', minversion='1.0a')
         from rasterio.transform import from_origin
 
         # Create an ENVI file with some tags in the ENVI namespace

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2154,7 +2154,6 @@ class TestRasterio(TestCase):
                 assert isinstance(rioda.attrs['samples'], basestring)
 
 
-
 class TestEncodingInvalid(TestCase):
 
     def test_extract_nc4_variable_encoding(self):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2091,6 +2091,69 @@ class TestRasterio(TestCase):
                 ex = expected.sel(band=1).mean(dim='x')
                 assert_allclose(ac, ex)
 
+    def test_ENVI_tags(self):
+        import rasterio
+        from rasterio.transform import from_origin
+
+        # Create an ENVI file with some tags in the ENVI namespace
+        with create_tmp_file(suffix='.dat') as tmp_file:
+            # data
+            nx, ny, nz = 4, 3, 3
+            data = np.arange(nx*ny*nz,
+                             dtype=rasterio.float32).reshape(nz, ny, nx)
+            transform = from_origin(5000, 80000, 1000, 2000.)
+            with rasterio.open(
+                    tmp_file, 'w',
+                    driver='ENVI', height=ny, width=nx, count=nz,
+                    crs={'units': 'm', 'no_defs': True, 'ellps': 'WGS84',
+                         'proj': 'utm', 'zone': 18},
+                    transform=transform,
+                    dtype=rasterio.float32) as s:
+                s.update_tags(
+                        ns='ENVI',
+                        description='{Tagged file}',
+                        wavelength='{123.000000, 234.234000, 345.345678}',
+                        fwhm='{1.000000, 0.234000, 0.000345}',
+                        )
+                s.write(data)
+                dx, dy = s.res[0], -s.res[1]
+
+            # Tests
+            expected = DataArray(data, dims=('band', 'y', 'x'),
+                                 coords={
+                                     'band': [1, 2, 3],
+                                     'y': -np.arange(ny) * 2000 + 80000 + dy/2,
+                                     'x': np.arange(nx) * 1000 + 5000 + dx/2,
+                                     'wavelength': (
+                                         'band',
+                                         np.array([123, 234.234, 345.345678]),
+                                         ),
+                                     'fwhm': (
+                                         'band',
+                                         np.array([1, 0.234, 0.000345]),
+                                         ),
+                                    },
+                                 )
+
+            with xr.open_rasterio(tmp_file) as rioda:
+                assert_allclose(rioda, expected)
+                assert 'crs' in rioda.attrs
+                assert isinstance(rioda.attrs['crs'], basestring)
+                assert 'res' in rioda.attrs
+                assert isinstance(rioda.attrs['res'], tuple)
+                assert 'is_tiled' in rioda.attrs
+                assert isinstance(rioda.attrs['is_tiled'], np.uint8)
+                assert 'transform' in rioda.attrs
+                assert isinstance(rioda.attrs['transform'], tuple)
+                # from ENVI tags
+                assert 'description' in rioda.attrs
+                assert isinstance(rioda.attrs['description'], basestring)
+                assert 'map_info' in rioda.attrs
+                assert isinstance(rioda.attrs['map_info'], basestring)
+                assert 'samples' in rioda.attrs
+                assert isinstance(rioda.attrs['samples'], basestring)
+
+
 
 class TestEncodingInvalid(TestCase):
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2132,20 +2132,13 @@ class TestRasterio(TestCase):
 
             with xr.open_rasterio(tmp_file) as rioda:
                 assert_allclose(rioda, expected)
-                assert 'crs' in rioda.attrs
                 assert isinstance(rioda.attrs['crs'], basestring)
-                assert 'res' in rioda.attrs
                 assert isinstance(rioda.attrs['res'], tuple)
-                assert 'is_tiled' in rioda.attrs
                 assert isinstance(rioda.attrs['is_tiled'], np.uint8)
-                assert 'transform' in rioda.attrs
                 assert isinstance(rioda.attrs['transform'], tuple)
                 # from ENVI tags
-                assert 'description' in rioda.attrs
                 assert isinstance(rioda.attrs['description'], basestring)
-                assert 'map_info' in rioda.attrs
                 assert isinstance(rioda.attrs['map_info'], basestring)
-                assert 'samples' in rioda.attrs
                 assert isinstance(rioda.attrs['samples'], basestring)
 
 


### PR DESCRIPTION
Proof of concept for reading info from rasterio `tags()` in `open_rasterio`. Not quite a solution to #1582, but possibly workable to a more general solution.

Currently implements the following:
 - Reads `tags(band_idx)` for each band and extracts the wavelength values from the result dictionaries as a coordinate for the returned DataArray.
 - Reads the wavelength_units from `tags(1)` and sets it as an attribute (assumes it's the same for each band, which it is for ENVI format files)


- [x] Closes #1582 (Maybe?)
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
