### PR TITLE
Fix URL to dask example

### DIFF
--- a/doc/dask.rst
+++ b/doc/dask.rst
@@ -13,7 +13,7 @@ dependency in a future version of xarray.
 For a full example of how to use xarray's dask integration, read the
 `blog post introducing xarray and dask`_.
 
-.. _blog post introducing xarray and dask: http://continuum.io/blog/xray-dask
+.. _blog post introducing xarray and dask: https://www.anaconda.com/blog/developer-blog/xray-dask-out-core-labeled-arrays-python/
 
 What is a dask array?
 ---------------------


### PR DESCRIPTION
It seems that the continuum folks moved the bolg. They have a redirect at the old URL, but unfortunately it's broken. This appears to be the new url: https://www.anaconda.com/blog/developer-blog/xray-dask-out-core-labeled-arrays-python/
