### PR TITLE
Remove unused version check for pandas.

### DIFF
--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -452,10 +452,9 @@ class TestDatetime(TestCase):
             (['NaT', '0s', '1s'], None, [np.nan, 0, 1]),
             (['30m', '60m'], 'hours', [0.5, 1.0]),
         ]
-        if pd.__version__ >= '0.16':
-            # not quite sure why, but these examples don't work on older pandas
-            examples.extend([(np.timedelta64('NaT', 'ns'), 'days', np.nan),
-                             (['NaT', 'NaT'], 'days', [np.nan, np.nan])])
+        # not quite sure why, but these examples don't work on older pandas
+        examples.extend([(np.timedelta64('NaT', 'ns'), 'days', np.nan),
+                         (['NaT', 'NaT'], 'days', [np.nan, np.nan])])
 
         for timedeltas, units, numbers in examples:
             timedeltas = pd.to_timedelta(timedeltas, box=False)

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -451,10 +451,9 @@ class TestDatetime(TestCase):
             ('1us', 'microseconds', np.int64(1)),
             (['NaT', '0s', '1s'], None, [np.nan, 0, 1]),
             (['30m', '60m'], 'hours', [0.5, 1.0]),
+            (np.timedelta64('NaT', 'ns'), 'days', np.nan),
+            (['NaT', 'NaT'], 'days', [np.nan, np.nan]),
         ]
-        # not quite sure why, but these examples don't work on older pandas
-        examples.extend([(np.timedelta64('NaT', 'ns'), 'days', np.nan),
-                         (['NaT', 'NaT'], 'days', [np.nan, np.nan])])
 
         for timedeltas, units, numbers in examples:
             timedeltas = pd.to_timedelta(timedeltas, box=False)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -537,13 +537,9 @@ class TestDataArray(TestCase):
         actual = data.sel(y=['ab', 'ba'], method='pad')
         self.assertDataArrayIdentical(expected, actual)
 
-        if pd.__version__ >= '0.17':
-            expected = data.sel(x=[1, 2])
-            actual = data.sel(x=[0.9, 1.9], method='backfill', tolerance=1)
-            self.assertDataArrayIdentical(expected, actual)
-        else:
-            with self.assertRaisesRegexp(TypeError, 'tolerance'):
-                data.sel(x=[0.9, 1.9], method='backfill', tolerance=1)
+        expected = data.sel(x=[1, 2])
+        actual = data.sel(x=[0.9, 1.9], method='backfill', tolerance=1)
+        self.assertDataArrayIdentical(expected, actual)
 
     def test_sel_drop(self):
         data = DataArray([1, 2, 3], [('x', [0, 1, 2])])
@@ -917,10 +913,9 @@ class TestDataArray(TestCase):
     def test_reindex_method(self):
         x = DataArray([10, 20], dims='y', coords={'y': [0, 1]})
         y = [-0.1, 0.5, 1.1]
-        if pd.__version__ >= '0.17':
-            actual = x.reindex(y=y, method='backfill', tolerance=0.2)
-            expected = DataArray([10, np.nan, np.nan], coords=[('y', y)])
-            self.assertDataArrayIdentical(expected, actual)
+        actual = x.reindex(y=y, method='backfill', tolerance=0.2)
+        expected = DataArray([10, np.nan, np.nan], coords=[('y', y)])
+        self.assertDataArrayIdentical(expected, actual)
 
         alt = Dataset({'y': y})
         actual = x.reindex_like(alt, method='backfill')
@@ -2051,7 +2046,7 @@ class TestDataArray(TestCase):
                              ('x', 'y', 'time'))
         self.assertDataArrayIdentical(expected, actual)
 
-    @requires_scipy 
+    @requires_scipy
     def test_upsample_interpolate(self):
         from scipy.interpolate import interp1d
         xs = np.arange(6)
@@ -2807,7 +2802,7 @@ def da_dask(seed=123):
     da['time'] = times
     return da
 
-  
+
 def test_rolling_iter(da):
 
     rolling_obj = da.rolling(time=7)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1016,24 +1016,21 @@ class TestDataset(TestCase):
                                  method='pad')
         self.assertDatasetIdentical(expected, actual)
 
-        if pd.__version__ >= '0.17':
-            with self.assertRaises(KeyError):
-                data.sel_points(x=[2.5], y=[2.0], method='pad', tolerance=1e-3)
+        with self.assertRaises(KeyError):
+            data.sel_points(x=[2.5], y=[2.0], method='pad', tolerance=1e-3)
 
     def test_sel_method(self):
         data = create_test_data()
 
-        if pd.__version__ >= '0.16':
-            expected = data.sel(dim2=1)
-            actual = data.sel(dim2=0.95, method='nearest')
-            self.assertDatasetIdentical(expected, actual)
+        expected = data.sel(dim2=1)
+        actual = data.sel(dim2=0.95, method='nearest')
+        self.assertDatasetIdentical(expected, actual)
 
-        if pd.__version__ >= '0.17':
-            actual = data.sel(dim2=0.95, method='nearest', tolerance=1)
-            self.assertDatasetIdentical(expected, actual)
+        actual = data.sel(dim2=0.95, method='nearest', tolerance=1)
+        self.assertDatasetIdentical(expected, actual)
 
-            with self.assertRaises(KeyError):
-                actual = data.sel(dim2=np.pi, method='nearest', tolerance=0)
+        with self.assertRaises(KeyError):
+            actual = data.sel(dim2=np.pi, method='nearest', tolerance=0)
 
         expected = data.sel(dim2=[1.5])
         actual = data.sel(dim2=[1.45], method='backfill')
@@ -1194,13 +1191,9 @@ class TestDataset(TestCase):
         expected = Dataset({'x': ('y', [10, 20, np.nan]), 'y': y})
         self.assertDatasetIdentical(expected, actual)
 
-        if pd.__version__ >= '0.17':
-            actual = ds.reindex(y=y, method='backfill', tolerance=0.1)
-            expected = Dataset({'x': ('y', 3 * [np.nan]), 'y': y})
-            self.assertDatasetIdentical(expected, actual)
-        else:
-            with self.assertRaisesRegexp(TypeError, 'tolerance'):
-                ds.reindex(y=y, method='backfill', tolerance=0.1)
+        actual = ds.reindex(y=y, method='backfill', tolerance=0.1)
+        expected = Dataset({'x': ('y', 3 * [np.nan]), 'y': y})
+        self.assertDatasetIdentical(expected, actual)
 
         actual = ds.reindex(y=y, method='pad')
         expected = Dataset({'x': ('y', [np.nan, 10, 20]), 'y': y})
@@ -2404,10 +2397,6 @@ class TestDataset(TestCase):
         # we can't do perfectly, but we should be at least as faithful as
         # np.asarray
         expected = df.apply(np.asarray)
-        if pd.__version__ < '0.17':
-            # datetime with timezone dtype is not consistent on old pandas
-            roundtripped = roundtripped.drop(['h'], axis=1)
-            expected = expected.drop(['h'], axis=1)
         assert roundtripped.equals(expected)
 
     def test_to_and_from_dict(self):


### PR DESCRIPTION
 - [x] Closes #1593
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [n.a.] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Currently some tests fail due to dask bug in #1591 