### PR TITLE
remove the fontsize check in xarray.tests.test_plot.test_no_args, bec…

### DIFF
--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1036,10 +1036,6 @@ class TestFacetGrid(PlotTestCase):
         for ax in self.g.axes.flat:
             self.assertTrue(ax.has_data())
 
-            # default font size should be small
-            fontsize = ax.title.get_size()
-            self.assertLessEqual(fontsize, 12)
-
     @pytest.mark.slow
     def test_names_appear_somewhere(self):
         self.darray.name = 'testvar'


### PR DESCRIPTION
…ause it can be greater than 12 for high-resolution screens

 - [x] Closes #1584
 - [ ] Tests passed
Not sure why continuous integration checks are failing. Do not hink this is because of the change, since the master branch is also failing the continuous integration checks.
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
Change is too small for `whats-new.rst` or `api.rst`.
