### PR TITLE
Better error message for _FillValue vs missing_value conflicts

### DIFF
--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -861,7 +861,7 @@ def decode_cf_variable(var, concat_characters=True, mask_and_scale=True,
                 raise ValueError("Conflicting _FillValue and missing_value "
                                  "attributes on a variable: {} vs. {}\n\n"
                                  "Consider opening the offending dataset "
-                                 "using decode_cf=False, corrected the "
+                                 "using decode_cf=False, correcting the "
                                  "attributes and decoding explicitly using "
                                  "xarray.decode_cf()."
                                  .format(attributes['_FillValue'],

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -858,12 +858,14 @@ def decode_cf_variable(var, concat_characters=True, mask_and_scale=True,
             if ('_FillValue' in attributes and
                 not utils.equivalent(attributes['_FillValue'],
                                      attributes['missing_value'])):
-                raise ValueError("Discovered conflicting _FillValue "
-                                 "and missing_value.  Considering "
-                                 "opening the offending dataset using "
-                                 "decode_cf=False, corrected the attributes",
-                                 "and decoding explicitly using "
-                                 "xarray.conventions.decode_cf(ds)")
+                raise ValueError("Conflicting _FillValue and missing_value "
+                                 "attributes on a variable: {} vs. {}\n\n"
+                                 "Consider opening the offending dataset "
+                                 "using decode_cf=False, corrected the "
+                                 "attributes and decoding explicitly using "
+                                 "xarray.decode_cf()."
+                                 .format(attributes['_FillValue'],
+                                         attributes['missing_value']))
             attributes['_FillValue'] = attributes.pop('missing_value')
         fill_value = np.array(pop_to(attributes, encoding, '_FillValue'))
         if fill_value.size > 1:


### PR DESCRIPTION
New behavior:
```
In [2]: ds = xarray.open_dataset('http://oos.soest.hawaii.edu/thredds/dodsC/hioos/tide_mhi', decode_cf=True)
...
ValueError: Conflicting _FillValue and missing_value attributes on a variable: -999.99 vs. -999.989990234

Consider opening the offending dataset using decode_cf=False, corrected the attributes and decoding explicitly using xarray.decode_cf().
```

 - [x] Passes ``git diff upstream/master | flake8 --diff``

I'm not writing new tests or a what's new notice for this.