### PR TITLE
Fix the test suite on dask 0.15.3

### DIFF
--- a/ci/requirements-py27-min.yml
+++ b/ci/requirements-py27-min.yml
@@ -1,6 +1,4 @@
 name: test_env
-channels:
-  - conda-forge
 dependencies:
   - python=2.7
   - pytest

--- a/ci/requirements-py27-min.yml
+++ b/ci/requirements-py27-min.yml
@@ -1,4 +1,6 @@
 name: test_env
+channels:
+  - conda-forge
 dependencies:
   - python=2.7
   - pytest

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -479,8 +479,8 @@ class TestDataArrayAndDataset(DaskTestCase):
         self.assertLazyAndIdentical(self.lazy_array, a)
 
 
-@requires_dask
 @pytest.mark.parametrize("method", ['load', 'compute'])
+@requires_dask
 def test_dask_kwargs_variable(method):
     x = Variable('y', da.from_array(np.arange(3), chunks=(2,)))
     # args should be passed on to da.Array.compute()
@@ -490,8 +490,8 @@ def test_dask_kwargs_variable(method):
     mock_compute.assert_called_with(foo='bar')
 
 
-@requires_dask
 @pytest.mark.parametrize("method", ['load', 'compute', 'persist'])
+@requires_dask
 def test_dask_kwargs_dataarray(method):
     data = da.from_array(np.arange(3), chunks=(2,))
     x = DataArray(data)
@@ -505,8 +505,8 @@ def test_dask_kwargs_dataarray(method):
     mock_func.assert_called_with(data, foo='bar')
 
 
-@requires_dask
 @pytest.mark.parametrize("method", ['load', 'compute', 'persist'])
+@requires_dask
 def test_dask_kwargs_dataset(method):
     data = da.from_array(np.arange(3), chunks=(2,))
     x = Dataset({'x': (('y'), data)})

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -4,6 +4,8 @@ from __future__ import print_function
 
 import pickle
 from textwrap import dedent
+
+from distutils.version import LooseVersion
 import numpy as np
 import pandas as pd
 import pytest
@@ -252,6 +254,10 @@ class TestDataArrayAndDataset(DaskTestCase):
         self.assertLazyAndAllClose(u, actual)
 
     def test_groupby(self):
+        if LooseVersion(dask.__version__) == LooseVersion('0.15.3'):
+            pytest.xfail('upstream bug in dask: '
+                         'https://github.com/dask/dask/issues/2718')
+
         u = self.eager_array
         v = self.lazy_array
 

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -18,7 +18,7 @@ from . import TestCase
 
 from xarray.tests import mock
 
-dask = pytest.importerskip('dask')
+dask = pytest.importorskip('dask')
 import dask.array as da
 
 

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -14,13 +14,12 @@ import xarray as xr
 from xarray import Variable, DataArray, Dataset
 import xarray.ufuncs as xu
 from xarray.core.pycompat import suppress
-from . import TestCase, requires_dask
+from . import TestCase
 
 from xarray.tests import mock
 
-with suppress(ImportError):
-    import dask
-    import dask.array as da
+dask = pytest.importerskip('dask')
+import dask.array as da
 
 
 class DaskTestCase(TestCase):
@@ -46,7 +45,6 @@ class DaskTestCase(TestCase):
             assert False
 
 
-@requires_dask
 class TestVariable(DaskTestCase):
     def assertLazyAndIdentical(self, expected, actual):
         self.assertLazyAnd(expected, actual, self.assertVariableIdentical)
@@ -208,7 +206,6 @@ class TestVariable(DaskTestCase):
         self.assertLazyAndAllClose(np.maximum(u, 0), xu.maximum(0, v))
 
 
-@requires_dask
 class TestDataArrayAndDataset(DaskTestCase):
     def assertLazyAndIdentical(self, expected, actual):
         self.assertLazyAnd(expected, actual, self.assertDataArrayIdentical)
@@ -480,7 +477,6 @@ class TestDataArrayAndDataset(DaskTestCase):
 
 
 @pytest.mark.parametrize("method", ['load', 'compute'])
-@requires_dask
 def test_dask_kwargs_variable(method):
     x = Variable('y', da.from_array(np.arange(3), chunks=(2,)))
     # args should be passed on to da.Array.compute()
@@ -491,7 +487,6 @@ def test_dask_kwargs_variable(method):
 
 
 @pytest.mark.parametrize("method", ['load', 'compute', 'persist'])
-@requires_dask
 def test_dask_kwargs_dataarray(method):
     data = da.from_array(np.arange(3), chunks=(2,))
     x = DataArray(data)
@@ -506,7 +501,6 @@ def test_dask_kwargs_dataarray(method):
 
 
 @pytest.mark.parametrize("method", ['load', 'compute', 'persist'])
-@requires_dask
 def test_dask_kwargs_dataset(method):
     data = da.from_array(np.arange(3), chunks=(2,))
     x = Dataset({'x': (('y'), data)})


### PR DESCRIPTION
Our test suite is currently failing due to https://github.com/dask/dask/issues/2718. This marks the failure as expected, which will make our CI a reliable indicator again.