### PR TITLE
Add vectorize=True option to apply_ufunc

### DIFF
--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -651,7 +651,7 @@ def apply_ufunc(func, *args, **kwargs):
         expected to vectorize (broadcast) over axes of positional arguments in
         the style of NumPy universal functions [1]_ (if this is not the case,
         set ``vectorize=True``). If this function returns multiple outputs, you
-        most set ``output_core_dims`` as well.
+        must set ``output_core_dims`` as well.
     *args : Dataset, DataArray, GroupBy, Variable, numpy/dask arrays or scalars
         Mix of labeled and/or unlabeled arrays to which to apply the function.
     input_core_dims : Sequence[Sequence], optional

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -794,15 +794,17 @@ def apply_ufunc(func, *args, **kwargs):
             result[dim] = new_coord
             return result
 
+    If your function is not vectorized but can be applied only to core
+    dimensions, you can use ``vectorize=True`` to turn a :
+
     Most of NumPy's builtin functions already broadcast their inputs
     appropriately for use in `apply`. You may find helper functions such as
-    numpy.broadcast_arrays or numpy.vectorize helpful in writing your function.
-    `apply_ufunc` also works well with numba's vectorize and guvectorize.
+    numpy.broadcast_arrays helpful in writing your function. `apply_ufunc` also
+    works well with numba's vectorize and guvectorize.
 
     See also
     --------
     numpy.broadcast_arrays
-    numpy.vectorize
     numba.vectorize
     numba.guvectorize
 

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -814,7 +814,7 @@ def apply_ufunc(func, *args, **kwargs):
     function. This wraps :py:func:`numpy.vectorize`, so the operation isn't
     terribly fast. Here we'll use it to calculate the distance between
     empirical samples from two probability distributions, using a scipy
-    function that needs to be applied to vectors:
+    function that needs to be applied to vectors::
 
         import scipy.stats
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -2,8 +2,10 @@ import functools
 import operator
 from collections import OrderedDict
 
+from distutils.version import LooseVersion
 import numpy as np
 from numpy.testing import assert_array_equal
+import pandas as pd
 
 import pytest
 
@@ -32,6 +34,7 @@ def test_signature_properties():
     assert sig.all_output_core_dims == frozenset(['z'])
     assert sig.num_inputs == 2
     assert sig.num_outputs == 1
+    assert str(sig) == '(x),(x,y)->(z)'
     # dimension names matter
     assert _UFuncSignature([['x']]) != _UFuncSignature([['y']])
 
@@ -667,6 +670,37 @@ def test_apply_dask_new_output_dimension():
     assert actual.dims == ('x', 'y', 'sign')
     assert actual.shape == (2, 2, 2)
     assert isinstance(actual.data, da.Array)
+    assert_identical(expected, actual)
+
+
+def pandas_median(x):
+    return pd.Series(x).median()
+
+
+def test_vectorize():
+    if LooseVersion(np.__version__) < LooseVersion('1.12.0'):
+        pytest.skip('numpy 1.12 or later to support vectorize=True.')
+
+    data_array = xr.DataArray([[0, 1, 2], [1, 2, 3]], dims=('x', 'y'))
+    expected = xr.DataArray([1, 2], dims=['x'])
+    actual = apply_ufunc(pandas_median, data_array,
+                         input_core_dims=[['y']],
+                         vectorize=True)
+    assert_identical(expected, actual)
+
+
+@requires_dask
+def test_vectorize_dask():
+    if LooseVersion(np.__version__) < LooseVersion('1.12.0'):
+        pytest.skip('numpy 1.12 or later to support vectorize=True.')
+
+    data_array = xr.DataArray([[0, 1, 2], [1, 2, 3]], dims=('x', 'y'))
+    expected = xr.DataArray([1, 2], dims=['x'])
+    actual = apply_ufunc(pandas_median, data_array.chunk({'x': 1}),
+                         input_core_dims=[['y']],
+                         vectorize=True,
+                         dask='parallelized',
+                         output_dtypes=[float])
     assert_identical(expected, actual)
 
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -35,6 +35,7 @@ def test_signature_properties():
     assert sig.num_inputs == 2
     assert sig.num_outputs == 1
     assert str(sig) == '(x),(x,y)->(z)'
+    assert sig.to_gufunc_string() == '(dim0),(dim0,dim1)->(dim2)'
     # dimension names matter
     assert _UFuncSignature([['x']]) != _UFuncSignature([['y']])
 


### PR DESCRIPTION
This provides an easier way to use `apply_ufunc`, for wrapping non-ufuncs that only act on core dimensions.

 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
