### PR TITLE
Improved netcdf4 error message when opening non existent file

### DIFF
--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -187,9 +187,10 @@ def _open_netcdf4_group(filename, mode, group=None, **kwargs):
         ds = nc4.Dataset(filename, mode=mode, **kwargs)
     except IOError as e:
         message = e.args[0]
+        err_num = e.errno
         if 'No such file or directory' in message:
-            raise FileNotFoundError(errno.ENOENT, message, filename)
-        raise IOError(e.errno, message, filename)
+            err_num = errno.ENOENT
+        raise IOError(err_num, message, filename)
 
     with close_on_error(ds):
         ds = _nc4_group(ds, group, mode)

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 import functools
 import operator
+import errno
 
 import numpy as np
 
@@ -184,8 +185,11 @@ def _open_netcdf4_group(filename, mode, group=None, **kwargs):
 
     try:
         ds = nc4.Dataset(filename, mode=mode, **kwargs)
-    except (OSError, IOError) as e:
-        raise OSError("Error opening %r" % filename, e)
+    except IOError as e:
+        message = e.args[0]
+        if 'No such file or directory' in message:
+            raise FileNotFoundError(errno.ENOENT, message, filename)
+        raise IOError(e.errno, message, filename)
 
     with close_on_error(ds):
         ds = _nc4_group(ds, group, mode)

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -182,7 +182,10 @@ def _extract_nc4_variable_encoding(variable, raise_on_invalid=False,
 def _open_netcdf4_group(filename, mode, group=None, **kwargs):
     import netCDF4 as nc4
 
-    ds = nc4.Dataset(filename, mode=mode, **kwargs)
+    try:
+        ds = nc4.Dataset(filename, mode=mode, **kwargs)
+    except OSError as e:
+        raise OSError("Error opening %r" % filename, e)
 
     with close_on_error(ds):
         ds = _nc4_group(ds, group, mode)

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -184,7 +184,7 @@ def _open_netcdf4_group(filename, mode, group=None, **kwargs):
 
     try:
         ds = nc4.Dataset(filename, mode=mode, **kwargs)
-    except OSError as e:
+    except (OSError, IOError) as e:
         raise OSError("Error opening %r" % filename, e)
 
     with close_on_error(ds):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -852,10 +852,10 @@ class NetCDF4DataTest(BaseNetCDF4Test, TestCase):
                 self.assertIn('first by calling .load', str(err))
 
     def test_informative_open_error(self):
-        with self.assertRaisesRegexp(FileNotFoundError, 'not_a_file.nc'):
+        with self.assertRaisesRegexp(IOError, 'not_a_file.nc'):
             open_dataset('not_a_file.nc', engine='netcdf4')
 
-        with self.assertRaisesRegexp(FileNotFoundError, 'not_a_file.nc'):
+        with self.assertRaisesRegexp(IOError, 'not_a_file.nc'):
             open_mfdataset(['not_a_file.nc'], engine='netcdf4')
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -852,10 +852,10 @@ class NetCDF4DataTest(BaseNetCDF4Test, TestCase):
                 self.assertIn('first by calling .load', str(err))
 
     def test_informative_open_error(self):
-        with self.assertRaisesRegexp(OSError, 'not_a_file.nc'):
+        with self.assertRaisesRegexp(FileNotFoundError, 'not_a_file.nc'):
             open_dataset('not_a_file.nc', engine='netcdf4')
 
-        with self.assertRaisesRegexp(OSError, 'not_a_file.nc'):
+        with self.assertRaisesRegexp(FileNotFoundError, 'not_a_file.nc'):
             open_mfdataset(['not_a_file.nc'], engine='netcdf4')
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -851,6 +851,13 @@ class NetCDF4DataTest(BaseNetCDF4Test, TestCase):
             except IndexError as err:
                 self.assertIn('first by calling .load', str(err))
 
+    def test_informative_open_error(self):
+        with self.assertRaisesRegexp(OSError, 'not_a_file.nc'):
+            open_dataset('not_a_file.nc', engine='netcdf4')
+
+        with self.assertRaisesRegexp(OSError, 'not_a_file.nc'):
+            open_mfdataset(['not_a_file.nc'], engine='netcdf4')
+
 
 class NetCDF4DataStoreAutocloseTrue(NetCDF4DataTest):
     autoclose = True


### PR DESCRIPTION
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``

This is particularly helpful when using `open_mfdataset` with a list of files. For example:

Current behavior (unclear which file is causing open_dataset to choke):
```Python-traceback
In [2]: xr.open_mfdataset(['foo.nc', 'bar.nc'], engine='netcdf4')
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
<ipython-input-2-12b24f38f025> in <module>()
----> 1 xr.open_mfdataset(['foo.nc', 'bar.nc'], engine='netcdf4')

...

/Users/jhamman/Dropbox/src/xarray/xarray/backends/netCDF4_.py in _open_netcdf4_group(filename, mode, group, **kwargs)
    183     import netCDF4 as nc4
    184
--> 185     ds = nc4.Dataset(filename, mode=mode, **kwargs)
    186
    187     with close_on_error(ds):

netCDF4/_netCDF4.pyx in netCDF4._netCDF4.Dataset.__init__()

netCDF4/_netCDF4.pyx in netCDF4._netCDF4._ensure_nc_success()

OSError: No such file or directory
```

And the new behavior
```Python-traceback
In [2]: xr.open_mfdataset(['foo.nc', 'bar.nc'], engine='netcdf4')

...

/Users/jhamman/Dropbox/src/xarray/xarray/backends/netCDF4_.py in _open_netcdf4_group(filename, mode, group, **kwargs)
    186         ds = nc4.Dataset(filename, mode=mode, **kwargs)
    187     except OSError as e:
--> 188         raise OSError("Error opening %r" % filename, e)
    189
    190     with close_on_error(ds):

OSError: [Errno Error opening '/Users/jhamman/Dropbox/src/xarray/foo.nc'] No such file or directory
