### PR TITLE
Fix rasterio backend for rasterio=1.0a10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ matrix:
     env: CONDA_ENV=py36-condaforge-rc
   - python: 3.6
     env: CONDA_ENV=py36-pynio-dev
+  - python: 3.6
+    env: CONDA_ENV=py36-rasterio1.0alpha
   allow_failures:
   - python: 3.6
     env:
@@ -63,6 +65,8 @@ matrix:
     env: CONDA_ENV=py36-condaforge-rc
   - python: 3.6
     env: CONDA_ENV=py36-pynio-dev
+  - python: 3.6
+    env: CONDA_ENV=py36-rasterio1.0alpha
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/ci/requirements-py36-rasterio1.0alpha.yml
+++ b/ci/requirements-py36-rasterio1.0alpha.yml
@@ -1,0 +1,24 @@
+name: test_env
+channels:
+  - conda-forge
+  - conda-forge/label/dev
+dependencies:
+  - python=3.6
+  - dask
+  - distributed
+  - h5py
+  - h5netcdf
+  - matplotlib
+  - netcdf4
+  - pytest
+  - numpy
+  - pandas
+  - scipy
+  - seaborn
+  - toolz
+  - rasterio>=1.*
+  - bottleneck
+  - pip:
+    - coveralls
+    - pytest-cov
+    - pydap

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -304,6 +304,8 @@ Bug fixes
 - Fix ``seaborn`` import warning for Seaborn versions 0.8 and newer when the
   ``apionly`` module was deprecated.
   (:issue:`1633`). By `Joe Hamman <https://github.com/jhamman>`_.
+- Fix ``rasterio`` backend for Rasterio versions 1.0alpha10 and newer.
+  (:issue:`1641`). By `Chris Holden <https://github.com/ceholden>`_.
 
 .. _whats-new.0.9.6:
 

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -74,7 +74,7 @@ class RasterioArrayWrapper(NdimSizeLenMixin, DunderArrayMixin):
                     raise IndexError(_ERROR_MSG)
             window.append((start, stop))
 
-        out = self.rasterio_ds.read(band_key, window=window)
+        out = self.rasterio_ds.read(band_key, window=tuple(window))
         if squeeze_axis:
             out = np.squeeze(out, axis=squeeze_axis)
         return out


### PR DESCRIPTION
 - [x] Closes #1641
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

First commit should fix rasterio backend for the current alpha release `rasterio=1.0a10` and for future stable releases. Behind the scenes rasterio converts to a `Window` using `Window.from_slices`. I thought about doing the conversion within xarray and passing a `Window` directly, but that would require importing rasterio within the `__getitem__`, which seems not very great.

Second commit updates the CI service configurations to use the conda-forge development channel that the rasterio alphas are published on. I put the dev channel behind existing channels, and pinned the version of rasterio to anything `1.0` and beyond. Not so sure what the best course of action here is and I'm happy to take suggestions.

Still have to add to the `whats-new`. I'm assuming I can ignore flake8 warnings from the conda environment files (e.g., `git diff upstream/master -- '*.py' | flake8 --diff`)?