### PR TITLE
Deprecate Dataset.T as an alias for Dataset.transpose()

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -158,7 +158,6 @@ Computation
 :py:attr:`~Dataset.imag`
 :py:attr:`~Dataset.round`
 :py:attr:`~Dataset.real`
-:py:attr:`~Dataset.T`
 :py:attr:`~Dataset.cumsum`
 :py:attr:`~Dataset.cumprod`
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -78,6 +78,9 @@ Breaking changes
   disk when calling ``repr`` (:issue:`1522`).
   By `Guido Imperiale <https://github.com/crusaderky>`_.
 
+- ``Dataset.T`` has been deprecated an alias for ``Dataset.transpose()``
+  (:issue:`1232`).
+
 
 Backward Incompatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2189,6 +2189,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
 
     @property
     def T(self):
+        warnings.warn('xarray.Dataset.T has been deprecated as an alias for '
+                      '`.transpose()`. It will be removed in a future version '
+                      'of xarray.',
+                      FutureWarning, stacklevel=2)
         return self.transpose()
 
     def dropna(self, dim, how='any', thresh=None, subset=None):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3576,7 +3576,8 @@ class TestDataset(TestCase):
         expected = ds.apply(lambda x: x.transpose())
         self.assertDatasetIdentical(expected, actual)
 
-        actual = ds.T
+        with pytest.warns(FutureWarning):
+            actual = ds.T
         self.assertDatasetIdentical(expected, actual)
 
         actual = ds.transpose('x', 'y')


### PR DESCRIPTION
 - [x] Closes #1232
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
