### PR TITLE
Deprecate checking coordinates in DataArray.__contains__

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -78,8 +78,13 @@ Breaking changes
   disk when calling ``repr`` (:issue:`1522`).
   By `Guido Imperiale <https://github.com/crusaderky>`_.
 
-- ``Dataset.T`` has been deprecated an alias for ``Dataset.transpose()``
-  (:issue:`1232`).
+- Deprecations:
+
+  - ``Dataset.T`` has been deprecated an alias for ``Dataset.transpose()``
+    (:issue:`1232`).
+  - ``key in data_array`` currently checks for membership in
+    ``data_array.coords``. This is now deprecated: in the future, it will check
+    membership in ``data_array.values`` instead.
 
 
 Backward Incompatible Changes

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -490,6 +490,10 @@ class DataArray(AbstractArray, BaseDataObject):
         return [self.coords, LevelCoordinatesSource(self), self.attrs]
 
     def __contains__(self, key):
+        warnings.warn(
+            'xarray.DataArray.__contains__ currently checks membership in '
+            'DataArray.coords, but in xarray v0.11 will change to check '
+            'membership in array values.', FutureWarning, stacklevel=2)
         return key in self._coords
 
     @property

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -205,7 +205,7 @@ class GroupBy(object):
                 raise TypeError('`group` must be an xarray.DataArray or the '
                                 'name of an xarray variable or dimension')
             group = obj[group]
-            if group.name not in obj and group.name in obj.dims:
+            if group.name not in obj.coords and group.name in obj.dims:
                 # DummyGroups should not appear on groupby results
                 group = _DummyGroup(obj, group.name, group.coords)
 

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -174,7 +174,7 @@ class DataArrayResample(DataArrayGroupBy, Resample):
         # If the aggregation function didn't drop the original resampling
         # dimension, then we need to do so before we can rename the proxy
         # dimension we used.
-        if self._dim in combined:
+        if self._dim in combined.coords:
             combined = combined.drop(self._dim)
 
         if self._resample_dim in combined.dims:

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -205,7 +205,10 @@ class DataArrayRolling(Rolling):
                    for _, window in self]
 
         # Find valid windows based on count
-        concat_dim = self.window_labels if self.dim in self.obj else self.dim
+        if self.dim in self.obj.coords:
+            concat_dim = self.window_labels
+        else:
+            concat_dim = self.dim
         counts = concat([window.count(dim=self.dim) for _, window in self],
                         dim=concat_dim)
         result = concat(windows, dim=concat_dim)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -508,6 +508,11 @@ class TestDataArray(TestCase):
             expected[t] = 1
             self.assertArrayEqual(orig.values, expected)
 
+    def test_contains(self):
+        data_array = DataArray(1, coords={'x': 2})
+        with pytest.warns(FutureWarning):
+            assert 'x' in data_array
+
     def test_attr_sources_multiindex(self):
         # make sure attr-style access for multi-index levels
         # returns DataArray objects


### PR DESCRIPTION
In the future, this should check array values. For now, issue a FutureWarning.

 - [x] xref #1267
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
