### PR TITLE
Roundtrip unicode strings even when written as character arrays

### DIFF
--- a/doc/io.rst
+++ b/doc/io.rst
@@ -295,10 +295,13 @@ by setting the ``_Encoding`` field in ``encoding``. But
 
 .. warning::
 
-  By default, missing values in bytes or unicode string arrays (represented by
-  ``NaN`` in xarray) are currently written to disk as empty strings ``''``. Thus
+  Missing values in bytes or unicode string arrays (represented by ``NaN`` in
+  xarray) are currently written to disk as empty strings ``''``. This means
   missing values will not be restored when data is loaded from disk.
   This behavior is likely to change in the future (:issue:`1647`).
+  Unfortunately, explicitly setting a ``_FillValue`` for string arrays to handle
+  missing values doesn't work yet either, though we also hope to fix this in the
+  future.
 
 Chunk based compression
 .......................

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -266,6 +266,39 @@ converting ``NaN`` to ``-9999``, we would use
 ``encoding={'foo': {'dtype': 'int16', 'scale_factor': 0.1, '_FillValue': -9999}}``.
 Compression and decompression with such discretization is extremely fast.
 
+.. _io.string-encoding:
+
+String encoding
+...............
+
+xarray can write unicode strings to netCDF files in two ways:
+
+- As variable lengths strings. This is only supported on netCDF4 (HDF5) files.
+- By encoding strings into bytes, and writing encoded bytes as a character
+  array. The default encoding is UTF-8.
+
+By default, we use variable length strings for compatible files and fall-back
+to using encoded character arrays. Character arrays can be selected even for
+netCDF4 files by setting the ``dtype`` field in ``encoding`` to ``S1``
+(corresponding to NumPy's single-character bytes dtype).
+
+If character arrays are used, the string encoding that was used is stored on
+disk in the ``_Encoding`` attribute, which matches an ad-hoc convention
+`adopted by the netCDF4-Python library <https://github.com/Unidata/netcdf4-python/pull/665>`_.
+At the time of this writing (October 2017), a standard convention for indicating
+string encoding for character arrays in netCDF files was
+`still under discussion <https://github.com/Unidata/netcdf-c/issues/402>`_.
+Technically, you can use
+`any string encoding recognized by Python <https://docs.python.org/3/library/codecs.html#standard-encodings>`_ if you feel the need to deviate from UTF-8,
+by setting the ``_Encoding`` field in ``encoding``. But
+`we don't recommend it<http://utf8everywhere.org/>`_.
+
+.. warning::
+
+  By default, missing values in bytes or unicode string arrays (represented by
+  ``NaN`` in xarray) are currently written to disk as empty strings ``''``. Thus
+  missing values will not be restored when data is loaded from disk.
+  This behavior is likely to change in the future (:issue:`1647`).
 
 Chunk based compression
 .......................
@@ -390,7 +423,7 @@ over the network until we look at particular values:
 
 Some servers require authentication before we can access the data. For this
 purpose we can explicitly create a :py:class:`~xarray.backends.PydapDataStore`
-and pass in a `Requests`__ session object. For example for 
+and pass in a `Requests`__ session object. For example for
 HTTP Basic authentication::
 
     import xarray as xr
@@ -403,7 +436,7 @@ HTTP Basic authentication::
                                             session=session)
     ds = xr.open_dataset(store)
 
-`Pydap's cas module`__ has functions that generate custom sessions for 
+`Pydap's cas module`__ has functions that generate custom sessions for
 servers that use CAS single sign-on. For example, to connect to servers
 that require NASA's URS authentication::
 

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -273,7 +273,7 @@ String encoding
 
 xarray can write unicode strings to netCDF files in two ways:
 
-- As variable lengths strings. This is only supported on netCDF4 (HDF5) files.
+- As variable length strings. This is only supported on netCDF4 (HDF5) files.
 - By encoding strings into bytes, and writing encoded bytes as a character
   array. The default encoding is UTF-8.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -73,6 +73,13 @@ Breaking changes
   produce a warning encouraging users to adopt the new syntax.
   By `Daniel Rothenberg <https://github.com/darothen>`_.
 
+- Unicode strings (``str`` on Python 3) are now round-tripped successfully even
+  when written as character arrays (e.g., as netCDF3 files or when using
+  ``engine='scipy'``) (:issue:`1638`). This is controlled by the ``_Encoding``
+  attribute convention, which is also understood directly by the netCDF4-Python
+  interface. See :ref:`io.string-encoding` for full details.
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
+
 - ``repr`` and the Jupyter Notebook won't automatically compute dask variables.
   Datasets loaded with ``open_dataset`` won't automatically read coords from
   disk when calling ``repr`` (:issue:`1522`).

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -237,6 +237,7 @@ class AbstractWritableDataStore(AbstractDataStore):
 
 
 class WritableCFDataStore(AbstractWritableDataStore):
+
     def store(self, variables, attributes, *args, **kwargs):
         # All NetCDF files get CF encoded by default, without this attempting
         # to write times, for example, would fail.

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -137,9 +137,9 @@ class H5NetCDFStore(WritableCFDataStore, DataStorePickleMixin):
         fill_value = attrs.pop('_FillValue', None)
         if dtype is str and fill_value is not None:
             raise NotImplementedError(
-                'netCDF4 does not yet support setting a fill value for '
+                'h5netcdf does not yet support setting a fill value for '
                 'variable-length strings '
-                '(https://github.com/Unidata/netcdf4-python/issues/730). '
+                '(https://github.com/shoyer/h5netcdf/issues/37). '
                 "Either remove '_FillValue' from encoding on variable %r "
                 "or set {'dtype': 'S1'} in encoding to use the fixed width "
                 'NC_CHAR type.' % name)

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -6,18 +6,18 @@ import operator
 
 import numpy as np
 
+from .. import conventions
 from .. import Variable
 from ..conventions import pop_to
 from ..core import indexing
 from ..core.utils import (FrozenOrderedDict, NdimSizeLenMixin,
                           DunderArrayMixin, close_on_error,
                           is_remote_uri)
-from ..core.pycompat import iteritems, basestring, OrderedDict, PY3
+from ..core.pycompat import iteritems, basestring, OrderedDict, PY3, suppress
 
 from .common import (WritableCFDataStore, robust_getitem,
                      DataStorePickleMixin, find_root)
-from .netcdf3 import (encode_nc3_attr_value, encode_nc3_variable,
-                      maybe_convert_to_char_array)
+from .netcdf3 import (encode_nc3_attr_value, encode_nc3_variable)
 
 # This lookup table maps from dtype.byteorder to a readable endian
 # string used by netCDF4.
@@ -72,25 +72,16 @@ class NetCDF4ArrayWrapper(BaseNetCDF4Array):
                     msg += '\n\nOriginal traceback:\n' + traceback.format_exc()
                 raise IndexError(msg)
 
-        if self.ndim == 0:
-            # work around for netCDF4-python's broken handling of 0-d
-            # arrays (slicing them always returns a 1-dimensional array):
-            # https://github.com/Unidata/netcdf4-python/pull/220
-            data = np.asscalar(data)
         return data
 
 
 def _nc4_values_and_dtype(var):
     if var.dtype.kind == 'U':
-        # this entire clause should not be necessary with netCDF4>=1.0.9
-        if len(var) > 0:
-            var = var.astype('O')
         dtype = str
     elif var.dtype.kind == 'S':
         # use character arrays instead of unicode, because unicode support in
         # netCDF4 is still rather buggy
-        data, dims = maybe_convert_to_char_array(var.data, var.dims)
-        var = Variable(dims, data, var.attrs, var.encoding)
+        var = conventions.maybe_encode_as_char_array(var)
         dtype = var.dtype
     elif var.dtype.kind in ['i', 'u', 'f', 'c']:
         dtype = var.dtype
@@ -189,15 +180,27 @@ def _open_netcdf4_group(filename, mode, group=None, **kwargs):
     with close_on_error(ds):
         ds = _nc4_group(ds, group, mode)
 
-    _disable_mask_and_scale(ds)
+    _disable_auto_decode_group(ds)
 
     return ds
 
 
-def _disable_mask_and_scale(ds):
+def _disable_auto_decode_variable(var):
+    """Disable automatic decoding on a netCDF4.Variable.
+
+    We handle these types of decoding ourselves.
+    """
+    var.set_auto_maskandscale(False)
+
+    # only added in netCDF4-python v1.2.8
+    with suppress(AttributeError):
+        var.set_auto_chartostring(False)
+
+
+def _disable_auto_decode_group(ds):
+    """Disable automatic decoding on all variables in a netCDF4.Group."""
     for var in ds.variables.values():
-        # we handle masking and scaling ourselves
-        var.set_auto_maskandscale(False)
+        _disable_auto_decode_variable(var)
 
 
 class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
@@ -211,7 +214,7 @@ class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
         if autoclose and opener is None:
             raise ValueError('autoclose requires an opener')
 
-        _disable_mask_and_scale(netcdf4_dataset)
+        _disable_auto_decode_group(netcdf4_dataset)
 
         self.ds = netcdf4_dataset
         self._autoclose = autoclose
@@ -313,8 +316,6 @@ class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
 
     def prepare_variable(self, name, variable, check_encoding=False,
                          unlimited_dims=None):
-        attrs = variable.attrs.copy()
-
         variable = _force_native_endianness(variable)
 
         if self.format == 'NETCDF4':
@@ -325,11 +326,18 @@ class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
 
         self.set_necessary_dimensions(variable, unlimited_dims=unlimited_dims)
 
+        attrs = variable.attrs.copy()
+
         fill_value = attrs.pop('_FillValue', None)
-        if fill_value in ['', '\x00']:
-            # these are equivalent to the default FillValue, but netCDF4
-            # doesn't like setting fill_value to an empty string
-            fill_value = None
+
+        if datatype is str and fill_value is not None:
+            raise NotImplementedError(
+                'netCDF4 does not yet support setting a fill value for '
+                'variable-length strings '
+                '(https://github.com/Unidata/netcdf4-python/issues/730). '
+                "Either remove '_FillValue' from encoding on variable %r "
+                "or set {'dtype': 'S1'} in encoding to use the fixed width "
+                'NC_CHAR type.' % name)
 
         encoding = _extract_nc4_variable_encoding(
             variable, raise_on_invalid=check_encoding)
@@ -346,7 +354,7 @@ class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
             endian='native',
             least_significant_digit=encoding.get('least_significant_digit'),
             fill_value=fill_value)
-        nc4_var.set_auto_maskandscale(False)
+        _disable_auto_decode_variable(nc4_var)
 
         for k, v in iteritems(attrs):
             # set attributes one-by-one since netCDF4<1.0.10 can't handle

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -19,7 +19,7 @@ def _data_allclose_or_equiv(arr1, arr2, rtol=1e-05, atol=1e-08,
     if any(arr.dtype.kind == 'S' for arr in [arr1, arr2]) and decode_bytes:
         arr1 = _decode_string_data(arr1)
         arr2 = _decode_string_data(arr2)
-    exact_dtypes = ['M', 'm', 'O', 'U']
+    exact_dtypes = ['M', 'm', 'O', 'S', 'U']
     if any(arr.dtype.kind in exact_dtypes for arr in [arr1, arr2]):
         return duck_array_ops.array_equiv(arr1, arr2)
     else:
@@ -49,7 +49,7 @@ def assert_equal(a, b):
     numpy.testing.assert_array_equal
     """
     import xarray as xr
-    ___tracebackhide__ = True  # noqa: F841
+    __tracebackhide__ = True  # noqa: F841
     assert type(a) == type(b)
     if isinstance(a, (xr.Variable, xr.DataArray, xr.Dataset)):
         assert a.equals(b), '{}\n{}'.format(a, b)
@@ -76,7 +76,7 @@ def assert_identical(a, b):
     assert_equal, assert_allclose, Dataset.equals, DataArray.equals
     """
     import xarray as xr
-    ___tracebackhide__ = True  # noqa: F841
+    __tracebackhide__ = True  # noqa: F841
     assert type(a) == type(b)
     if isinstance(a, xr.DataArray):
         assert a.name == b.name
@@ -114,7 +114,7 @@ def assert_allclose(a, b, rtol=1e-05, atol=1e-08, decode_bytes=True):
     assert_identical, assert_equal, numpy.testing.assert_allclose
     """
     import xarray as xr
-    ___tracebackhide__ = True  # noqa: F841
+    __tracebackhide__ = True  # noqa: F841
     assert type(a) == type(b)
     kwargs = dict(rtol=rtol, atol=atol, decode_bytes=decode_bytes)
     if isinstance(a, xr.Variable):

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -89,10 +89,12 @@ class TestCase(unittest.TestCase):
         # Python 3 assertCountEqual is roughly equivalent to Python 2
         # assertItemsEqual
         def assertItemsEqual(self, first, second, msg=None):
+            __tracebackhide__ = True  # noqa: F841
             return self.assertCountEqual(first, second, msg)
 
     @contextmanager
     def assertWarns(self, message):
+        __tracebackhide__ = True  # noqa: F841
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', message)
             yield
@@ -100,50 +102,69 @@ class TestCase(unittest.TestCase):
         assert any(message in str(wi.message) for wi in w)
 
     def assertVariableEqual(self, v1, v2):
+        __tracebackhide__ = True  # noqa: F841
         assert_equal(v1, v2)
 
     def assertVariableIdentical(self, v1, v2):
+        __tracebackhide__ = True  # noqa: F841
         assert_identical(v1, v2)
 
     def assertVariableAllClose(self, v1, v2, rtol=1e-05, atol=1e-08):
+        __tracebackhide__ = True  # noqa: F841
         assert_allclose(v1, v2, rtol=rtol, atol=atol)
 
     def assertVariableNotEqual(self, v1, v2):
+        __tracebackhide__ = True  # noqa: F841
         assert not v1.equals(v2)
 
     def assertArrayEqual(self, a1, a2):
+        __tracebackhide__ = True  # noqa: F841
         assert_array_equal(a1, a2)
 
     def assertEqual(self, a1, a2):
+        __tracebackhide__ = True  # noqa: F841
         assert a1 == a2 or (a1 != a1 and a2 != a2)
 
     def assertAllClose(self, a1, a2, rtol=1e-05, atol=1e-8):
+        __tracebackhide__ = True  # noqa: F841
         assert allclose_or_equiv(a1, a2, rtol=rtol, atol=atol)
 
     def assertDatasetEqual(self, d1, d2):
+        __tracebackhide__ = True  # noqa: F841
         assert_equal(d1, d2)
 
     def assertDatasetIdentical(self, d1, d2):
+        __tracebackhide__ = True  # noqa: F841
         assert_identical(d1, d2)
 
-    def assertDatasetAllClose(self, d1, d2, rtol=1e-05, atol=1e-08):
-        assert_allclose(d1, d2, rtol=rtol, atol=atol)
+    def assertDatasetAllClose(self, d1, d2, rtol=1e-05, atol=1e-08,
+                              decode_bytes=True):
+        __tracebackhide__ = True  # noqa: F841
+        assert_allclose(d1, d2, rtol=rtol, atol=atol,
+                        decode_bytes=decode_bytes)
 
     def assertCoordinatesEqual(self, d1, d2):
+        __tracebackhide__ = True  # noqa: F841
         assert_equal(d1, d2)
 
     def assertDataArrayEqual(self, ar1, ar2):
+        __tracebackhide__ = True  # noqa: F841
         assert_equal(ar1, ar2)
 
     def assertDataArrayIdentical(self, ar1, ar2):
+        __tracebackhide__ = True  # noqa: F841
         assert_identical(ar1, ar2)
 
-    def assertDataArrayAllClose(self, ar1, ar2, rtol=1e-05, atol=1e-08):
-        assert_allclose(ar1, ar2, rtol=rtol, atol=atol)
+    def assertDataArrayAllClose(self, ar1, ar2, rtol=1e-05, atol=1e-08,
+                                decode_bytes=True):
+        __tracebackhide__ = True  # noqa: F841
+        assert_allclose(ar1, ar2, rtol=rtol, atol=atol,
+                        decode_bytes=decode_bytes)
 
 
 @contextmanager
 def raises_regex(error, pattern):
+    __tracebackhide__ = True  # noqa: F841
     with pytest.raises(error) as excinfo:
         yield
     message = str(excinfo.value)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -953,6 +953,7 @@ class NetCDF4ViaDaskDataTestAutocloseTrue(NetCDF4ViaDaskDataTest):
     autoclose = True
 
 
+@requires_scipy
 class ScipyInMemoryDataTest(CFEncodedDataTest, NetCDF3Only, TestCase):
     engine = 'scipy'
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -605,7 +605,7 @@ class CFEncodedDataTest(DatasetIOTestCases):
         # regression for GH1215
         data = create_test_data()
         with self.roundtrip_append(data) as actual:
-            assert_allclose(data, actual)
+            self.assertDatasetIdentical(data, actual)
 
     def test_append_overwrite_values(self):
         # regression for GH1215
@@ -616,7 +616,7 @@ class CFEncodedDataTest(DatasetIOTestCases):
             data['var9'] = data['var2'] * 3
             self.save(data[['var2', 'var9']], tmp_file, mode='a')
             with self.open(tmp_file) as actual:
-                assert_allclose(data, actual)
+                self.assertDatasetIdentical(data, actual)
 
 
 _counter = itertools.count()

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -153,6 +153,13 @@ class TestBytesToStringArray(TestCase):
             actual[:2]
         assert str(actual) == str(expected)
 
+    def test_decode_bytes_array(self):
+        encoding = 'utf-8'
+        raw_array = np.array([b'abc', u'ß∂µ∆'.encode(encoding)])
+        expected = np.array([u'abc', u'ß∂µ∆'], dtype=object)
+        actual = conventions.decode_bytes_array(raw_array, encoding)
+        np.testing.assert_array_equal(actual, expected)
+
 
 class TestUnsignedIntTypeArray(TestCase):
     def test_unsignedinttype_array(self):

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -321,21 +321,22 @@ class TestDatetime(TestCase):
                        {'units': 'foobar',
                         'missing_value': 0,
                         '_FillValue': 1})
-        self.assertRaisesRegexp(ValueError, "_FillValue and missing_value",
-                                lambda: conventions.decode_cf_variable(var))
+        with self.assertRaisesRegexp(
+                ValueError, "_FillValue and missing_value"):
+            conventions.decode_cf_variable('t', var)
 
         var = Variable(['t'], np.arange(10),
                        {'units': 'foobar',
                         'missing_value': np.nan,
                         '_FillValue': np.nan})
-        var = conventions.decode_cf_variable(var)
+        var = conventions.decode_cf_variable('t', var)
         self.assertIsNotNone(var)
 
         var = Variable(['t'], np.arange(10),
                                {'units': 'foobar',
                                 'missing_value': np.float32(np.nan),
                                 '_FillValue': np.float32(np.nan)})
-        var = conventions.decode_cf_variable(var)
+        var = conventions.decode_cf_variable('t', var)
         self.assertIsNotNone(var)
 
     @requires_netCDF4
@@ -639,9 +640,9 @@ class TestDecodeCF(TestCase):
                             {'missing_value': np.array([0, 1])})
         expected = Variable(['t'], [np.nan, np.nan, 2], {})
         with warnings.catch_warnings(record=True) as w:
-            actual = conventions.decode_cf_variable(original)
+            actual = conventions.decode_cf_variable('t', original)
             self.assertDatasetIdentical(expected, actual)
-            self.assertIn('variable has multiple fill', str(w[0].message))
+            self.assertIn('has multiple fill', str(w[0].message))
 
     def test_decode_cf_with_drop_variables(self):
         original = Dataset({


### PR DESCRIPTION
Unicode strings (``str`` on Python 3) are now round-tripped successfully even when written as character arrays (e.g., as netCDF3 files or when using ``engine='scipy'``). This is controlled by the ``_Encoding`` attribute convention, which is also understood directly by the netCDF4-Python interface.

This PR also resolves some long-standing technical debt in the test suite related to the hacky use of `decode_bytes` in `assert_allclose` (recently encountered by @jhamman in https://github.com/pydata/xarray/pull/1609). Once we're sure that we don't need it anymore, I'd like to deprecate and eventually remove the `decode_bytes` option.

Note that there are still a few unresolved issues with regards to serializing missing values in strings, so I've intentionally held off on documenting the handling of `_FillValue` for now. I'd like to resolve those separately after discussion in https://github.com/pydata/xarray/issues/1647, but ideally this could make it in for the v0.10 release.

 - [x] Closes #1638
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
