### PR TITLE
fixes for warnings related to unit tests and nan comparisons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,8 @@ install:
   - python setup.py install
 
 script:
-  - py.test xarray --cov=xarray --cov-config ci/.coveragerc --cov-report term-missing --verbose $EXTRA_FLAGS
+  # temporary mod while cleaning up warnings
+  - py.test -W error xarray --cov=xarray --cov-config ci/.coveragerc --cov-report term-missing --verbose $EXTRA_FLAGS
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,8 +83,7 @@ install:
   - python setup.py install
 
 script:
-  # temporary mod while cleaning up warnings
-  - py.test -W error xarray --cov=xarray --cov-config ci/.coveragerc --cov-report term-missing --verbose $EXTRA_FLAGS
+  - py.test xarray --cov=xarray --cov-config ci/.coveragerc --cov-report term-missing --verbose $EXTRA_FLAGS
 
 after_success:
   - coveralls

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -85,6 +85,11 @@ Breaking changes
   disk when calling ``repr`` (:issue:`1522`).
   By `Guido Imperiale <https://github.com/crusaderky>`_.
 
+- Suppress ``RuntimeWarning`` issued by ``numpy`` for "invalid value comparisons"
+  (e.g. NaNs). Xarray now behaves similarly to Pandas in its treatment of
+  binary and unary operations on objects with ``NaN``s (:issue:`1657`).
+  By `Joe Hamman <https://github.com/jhamman>`_.
+
 - Several existing features have been deprecated and will change to new
   behavior in xarray v0.11. If you use any of them with xarray v0.10, you
   should see a ``FutureWarning`` that describes how to update your code:

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1590,10 +1590,9 @@ class DataArray(AbstractArray, BaseDataObject):
             other_variable = getattr(other, 'variable', other)
             other_coords = getattr(other, 'coords', None)
 
-            with np.errstate(all='ignore'):
-                variable = (f(self.variable, other_variable)
-                            if not reflexive
-                            else f(other_variable, self.variable))
+            variable = (f(self.variable, other_variable)
+                        if not reflexive
+                        else f(other_variable, self.variable))
             coords = self.coords._merge_raw(other_coords)
             name = self._result_name(other)
 
@@ -1615,8 +1614,7 @@ class DataArray(AbstractArray, BaseDataObject):
             other_coords = getattr(other, 'coords', None)
             other_variable = getattr(other, 'variable', other)
             with self.coords._merge_inplace(other_coords):
-                with np.errstate(all='ignore'):
-                    f(self.variable, other_variable)
+                f(self.variable, other_variable)
             return self
 
         return func

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1571,7 +1571,9 @@ class DataArray(AbstractArray, BaseDataObject):
     def _unary_op(f):
         @functools.wraps(f)
         def func(self, *args, **kwargs):
-            return self.__array_wrap__(f(self.variable.data, *args, **kwargs))
+            with np.errstate(all='ignore'):
+                return self.__array_wrap__(f(self.variable.data, *args,
+                                             **kwargs))
 
         return func
 
@@ -1588,9 +1590,10 @@ class DataArray(AbstractArray, BaseDataObject):
             other_variable = getattr(other, 'variable', other)
             other_coords = getattr(other, 'coords', None)
 
-            variable = (f(self.variable, other_variable)
-                        if not reflexive
-                        else f(other_variable, self.variable))
+            with np.errstate(all='ignore'):
+                variable = (f(self.variable, other_variable)
+                            if not reflexive
+                            else f(other_variable, self.variable))
             coords = self.coords._merge_raw(other_coords)
             name = self._result_name(other)
 
@@ -1612,7 +1615,8 @@ class DataArray(AbstractArray, BaseDataObject):
             other_coords = getattr(other, 'coords', None)
             other_variable = getattr(other, 'variable', other)
             with self.coords._merge_inplace(other_coords):
-                f(self.variable, other_variable)
+                with np.errstate(all='ignore'):
+                    f(self.variable, other_variable)
             return self
 
         return func

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -25,6 +25,7 @@ if PY3:  # pragma: no cover
     from functools import reduce
     import builtins
     from urllib.request import urlretrieve
+    from inspect import getfullargspec as getargspec
 else:  # pragma: no cover
     # Python 2
     basestring = basestring  # noqa
@@ -43,7 +44,7 @@ else:  # pragma: no cover
     reduce = reduce
     import __builtin__ as builtins
     from urllib import urlretrieve
-
+    from inspect import getargspec
 try:
     from cyordereddict import OrderedDict
 except ImportError:  # pragma: no cover

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1354,7 +1354,8 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
     def _unary_op(f):
         @functools.wraps(f)
         def func(self, *args, **kwargs):
-            return self.__array_wrap__(f(self.data, *args, **kwargs))
+            with np.errstate(all='ignore'):
+                return self.__array_wrap__(f(self.data, *args, **kwargs))
         return func
 
     @staticmethod
@@ -1364,9 +1365,10 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
             if isinstance(other, (xr.DataArray, xr.Dataset)):
                 return NotImplemented
             self_data, other_data, dims = _broadcast_compat_data(self, other)
-            new_data = (f(self_data, other_data)
-                        if not reflexive
-                        else f(other_data, self_data))
+            with np.errstate(all='ignore'):
+                new_data = (f(self_data, other_data)
+                            if not reflexive
+                            else f(other_data, self_data))
             result = Variable(dims, new_data)
             return result
         return func
@@ -1381,7 +1383,8 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
             if dims != self.dims:
                 raise ValueError('dimensions cannot change for in-place '
                                  'operations')
-            self.values = f(self_data, other_data)
+            with np.errstate(all='ignore'):
+                self.values = f(self_data, other_data)
             return self
         return func
 

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -2,13 +2,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import inspect
 import warnings
 import itertools
 import functools
 
 import numpy as np
 
+from ..core.pycompat import getargspec
 from ..core.formatting import format_item
 from .utils import _determine_cmap_params, _infer_xy_labels
 
@@ -227,7 +227,7 @@ class FacetGrid(object):
                        'filled': func.__name__ != 'contour',
                        }
 
-        cmap_args = inspect.getargspec(_determine_cmap_params).args
+        cmap_args = getargspec(_determine_cmap_params).args
         cmap_kwargs.update((a, kwargs[a]) for a in cmap_args if a in kwargs)
 
         cmap_params = _determine_cmap_params(**cmap_kwargs)

--- a/xarray/tests/test_accessors.py
+++ b/xarray/tests/test_accessors.py
@@ -6,7 +6,7 @@ import xarray as xr
 import numpy as np
 import pandas as pd
 
-from . import TestCase, requires_dask
+from . import TestCase, requires_dask, raises_regex
 
 
 class TestDatetimeAccessor(TestCase):
@@ -45,7 +45,7 @@ class TestDatetimeAccessor(TestCase):
         nontime_data = self.data.copy()
         int_data = np.arange(len(self.data.time)).astype('int8')
         nontime_data['time'].values = int_data
-        with self.assertRaisesRegexp(TypeError, 'dt'):
+        with raises_regex(TypeError, 'dt'):
             nontime_data.time.dt
 
     @requires_dask

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1039,7 +1039,7 @@ class ScipyFilePathTest(CFEncodedDataTest, NetCDF3Only, TestCase):
 
     @requires_netCDF4
     def test_nc4_scipy(self):
-        with create_tmp_file() as tmp_file:
+        with create_tmp_file(allow_cleanup_failure=True) as tmp_file:
             with nc4.Dataset(tmp_file, 'w', format='NETCDF4') as rootgrp:
                 rootgrp.createGroup('foo')
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1023,13 +1023,9 @@ class ScipyFilePathTest(CFEncodedDataTest, NetCDF3Only, TestCase):
                 pass
 
     def test_roundtrip_example_1_netcdf_gz(self):
-        if sys.version_info[:2] < (2, 7):
-            with raises_regex(ValueError, 'gzipped netCDF not supported'):
-                open_example_dataset('example_1.nc.gz')
-        else:
-            with open_example_dataset('example_1.nc.gz') as expected:
-                with open_example_dataset('example_1.nc') as actual:
-                    self.assertDatasetIdentical(expected, actual)
+        with open_example_dataset('example_1.nc.gz') as expected:
+            with open_example_dataset('example_1.nc') as actual:
+                self.assertDatasetIdentical(expected, actual)
 
     def test_netcdf3_endianness(self):
         # regression test for GH416

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -3,13 +3,15 @@ from __future__ import division
 from __future__ import print_function
 from copy import deepcopy
 
+import pytest
+
 import numpy as np
 import pandas as pd
 
 from xarray import Dataset, DataArray, auto_combine, concat, Variable
 from xarray.core.pycompat import iteritems, OrderedDict
 
-from . import TestCase, InaccessibleArray, requires_dask
+from . import TestCase, InaccessibleArray, requires_dask, raises_regex
 from .test_dataset import create_test_data
 
 
@@ -91,7 +93,7 @@ class TestConcatDataset(TestCase):
             actual = concat(objs, dim='x', coords=coords)
             self.assertDatasetIdentical(expected, actual)
         for coords in ['minimal', []]:
-            with self.assertRaisesRegexp(ValueError, 'not equal across'):
+            with raises_regex(ValueError, 'not equal across'):
                 concat(objs, dim='x', coords=coords)
 
     def test_concat_constant_index(self):
@@ -102,7 +104,7 @@ class TestConcatDataset(TestCase):
         for mode in ['different', 'all', ['foo']]:
             actual = concat([ds1, ds2], 'y', data_vars=mode)
             self.assertDatasetIdentical(expected, actual)
-        with self.assertRaisesRegexp(ValueError, 'not equal across datasets'):
+        with raises_regex(ValueError, 'not equal across datasets'):
             concat([ds1, ds2], 'y', data_vars='minimal')
 
     def test_concat_size0(self):
@@ -128,41 +130,41 @@ class TestConcatDataset(TestCase):
         split_data = [data.isel(dim1=slice(3)),
                       data.isel(dim1=slice(3, None))]
 
-        with self.assertRaisesRegexp(ValueError, 'must supply at least one'):
+        with raises_regex(ValueError, 'must supply at least one'):
             concat([], 'dim1')
 
-        with self.assertRaisesRegexp(ValueError, 'are not coordinates'):
+        with raises_regex(ValueError, 'are not coordinates'):
             concat([data, data], 'new_dim', coords=['not_found'])
 
-        with self.assertRaisesRegexp(ValueError, 'global attributes not'):
+        with raises_regex(ValueError, 'global attributes not'):
             data0, data1 = deepcopy(split_data)
             data1.attrs['foo'] = 'bar'
             concat([data0, data1], 'dim1', compat='identical')
         self.assertDatasetIdentical(
             data, concat([data0, data1], 'dim1', compat='equals'))
 
-        with self.assertRaisesRegexp(ValueError, 'encountered unexpected'):
+        with raises_regex(ValueError, 'encountered unexpected'):
             data0, data1 = deepcopy(split_data)
             data1['foo'] = ('bar', np.random.randn(10))
             concat([data0, data1], 'dim1')
 
-        with self.assertRaisesRegexp(ValueError, 'compat.* invalid'):
+        with raises_regex(ValueError, 'compat.* invalid'):
             concat(split_data, 'dim1', compat='foobar')
 
-        with self.assertRaisesRegexp(ValueError, 'unexpected value for'):
+        with raises_regex(ValueError, 'unexpected value for'):
             concat([data, data], 'new_dim', coords='foobar')
 
-        with self.assertRaisesRegexp(
+        with raises_regex(
                 ValueError, 'coordinate in some datasets but not others'):
             concat([Dataset({'x': 0}), Dataset({'x': [1]})], dim='z')
 
-        with self.assertRaisesRegexp(
+        with raises_regex(
                 ValueError, 'coordinate in some datasets but not others'):
             concat([Dataset({'x': 0}), Dataset({}, {'x': 1})], dim='z')
 
-        with self.assertRaisesRegexp(ValueError, 'no longer a valid'):
+        with raises_regex(ValueError, 'no longer a valid'):
             concat([data, data], 'new_dim', mode='different')
-        with self.assertRaisesRegexp(ValueError, 'no longer a valid'):
+        with raises_regex(ValueError, 'no longer a valid'):
             concat([data, data], 'new_dim', concat_over='different')
 
     def test_concat_promote_shape(self):
@@ -214,7 +216,7 @@ class TestConcatDataset(TestCase):
 
         objs = [Dataset({'y': ('t', [1])}, {'x': 1, 't': [0]}),
                 Dataset({'y': ('t', [2])}, {'x': 2, 't': [0]})]
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             concat(objs, 't', coords='minimal')
 
     def test_concat_dim_is_variable(self):
@@ -262,10 +264,10 @@ class TestConcatDataArray(TestCase):
         expected = foo[:2].rename({'x': 'concat_dim'})
         self.assertDataArrayIdentical(expected, actual)
 
-        with self.assertRaisesRegexp(ValueError, 'not identical'):
+        with raises_regex(ValueError, 'not identical'):
             concat([foo, bar], dim='w', compat='identical')
 
-        with self.assertRaisesRegexp(ValueError, 'not a valid argument'):
+        with raises_regex(ValueError, 'not a valid argument'):
             concat([foo, bar], dim='w', data_vars='minimal')
 
     def test_concat_encoding(self):
@@ -317,15 +319,15 @@ class TestAutoCombine(TestCase):
         self.assertDatasetIdentical(expected, actual)
 
         objs = [Dataset({'x': [0], 'y': [0]}), Dataset({'y': [1], 'x': [1]})]
-        with self.assertRaisesRegexp(ValueError, 'too many .* dimensions'):
+        with raises_regex(ValueError, 'too many .* dimensions'):
             auto_combine(objs)
 
         objs = [Dataset({'x': 0}), Dataset({'x': 1})]
-        with self.assertRaisesRegexp(ValueError, 'cannot infer dimension'):
+        with raises_regex(ValueError, 'cannot infer dimension'):
             auto_combine(objs)
 
         objs = [Dataset({'x': [0], 'y': [0]}), Dataset({'x': [0]})]
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             auto_combine(objs)
 
     @requires_dask  # only for toolz
@@ -356,7 +358,7 @@ class TestAutoCombine(TestCase):
         # https://github.com/pydata/xarray/issues/508
         datasets = [Dataset({'x': 0}, {'y': 0}),
                     Dataset({'x': 1}, {'y': 1, 'z': 1})]
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             auto_combine(datasets, 'y')
 
     @requires_dask  # only for toolz

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3120,3 +3120,9 @@ def test_rolling_count_correct():
     expected = DataArray(
         [np.nan, np.nan, 2, 3, 3, 4, 5, 5, 5, 5, 5], dims='time')
     assert_equal(result, expected)
+
+
+def test_raise_no_warning_for_nan_in_binary_ops():
+    with pytest.warns(None) as record:
+        xr.DataArray([1, 2, np.NaN]) > 0
+    assert len(record) == 0

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -73,12 +73,12 @@ class TestDataArray(TestCase):
         self.assertItemsEqual(list(self.dv.coords), list(self.ds.coords))
         for k, v in iteritems(self.dv.coords):
             self.assertArrayEqual(v, self.ds.coords[k])
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             self.dv.dataset
         self.assertIsInstance(self.ds['x'].to_index(), pd.Index)
-        with self.assertRaisesRegexp(ValueError, 'must be 1-dimensional'):
+        with raises_regex(ValueError, 'must be 1-dimensional'):
             self.ds['foo'].to_index()
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             self.dv.variable = self.v
 
     def test_data_property(self):
@@ -104,7 +104,7 @@ class TestDataArray(TestCase):
                           dims=['x', 'y'])
         assert array.get_index('x').equals(pd.Index(['a', 'b']))
         assert array.get_index('y').equals(pd.Index([0, 1, 2]))
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             array.get_index('z')
 
     def test_get_index_size_zero(self):
@@ -190,24 +190,24 @@ class TestDataArray(TestCase):
         arr = self.dv
         self.assertEqual(arr.dims, ('x', 'y'))
 
-        with self.assertRaisesRegexp(AttributeError, 'you cannot assign'):
+        with raises_regex(AttributeError, 'you cannot assign'):
             arr.dims = ('w', 'z')
 
     def test_sizes(self):
         array = DataArray(np.zeros((3, 4)), dims=['x', 'y'])
         self.assertEqual(array.sizes, {'x': 3, 'y': 4})
         self.assertEqual(tuple(array.sizes), array.dims)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             array.sizes['foo'] = 5
 
     def test_encoding(self):
         expected = {'foo': 'bar'}
         self.dv.encoding['foo'] = 'bar'
-        self.assertEquals(expected, self.dv.encoding)
+        assert expected, self.d == encoding
 
         expected = {'baz': 0}
         self.dv.encoding = expected
-        self.assertEquals(expected, self.dv.encoding)
+        assert expected, self.d == encoding
         self.assertIsNot(expected, self.dv.encoding)
 
     def test_constructor(self):
@@ -275,26 +275,26 @@ class TestDataArray(TestCase):
     def test_constructor_invalid(self):
         data = np.random.randn(3, 2)
 
-        with self.assertRaisesRegexp(ValueError, 'coords is not dict-like'):
+        with raises_regex(ValueError, 'coords is not dict-like'):
             DataArray(data, [[0, 1, 2]], ['x', 'y'])
 
-        with self.assertRaisesRegexp(ValueError, 'not a subset of the .* dim'):
+        with raises_regex(ValueError, 'not a subset of the .* dim'):
             DataArray(data, {'x': [0, 1, 2]}, ['a', 'b'])
-        with self.assertRaisesRegexp(ValueError, 'not a subset of the .* dim'):
+        with raises_regex(ValueError, 'not a subset of the .* dim'):
             DataArray(data, {'x': [0, 1, 2]})
 
-        with self.assertRaisesRegexp(TypeError, 'is not a string'):
+        with raises_regex(TypeError, 'is not a string'):
             DataArray(data, dims=['x', None])
 
-        with self.assertRaisesRegexp(ValueError, 'conflicting sizes for dim'):
+        with raises_regex(ValueError, 'conflicting sizes for dim'):
             DataArray([1, 2, 3], coords=[('x', [0, 1])])
-        with self.assertRaisesRegexp(ValueError, 'conflicting sizes for dim'):
+        with raises_regex(ValueError, 'conflicting sizes for dim'):
             DataArray([1, 2], coords={'x': [0, 1], 'y': ('x', [1])}, dims='x')
 
-        with self.assertRaisesRegexp(ValueError, 'conflicting MultiIndex'):
+        with raises_regex(ValueError, 'conflicting MultiIndex'):
             DataArray(np.random.rand(4, 4),
                       [('x', self.mindex), ('y', self.mindex)])
-        with self.assertRaisesRegexp(ValueError, 'conflicting MultiIndex'):
+        with raises_regex(ValueError, 'conflicting MultiIndex'):
             DataArray(np.random.rand(4, 4),
                       [('x', self.mindex), ('level_1', range(4))])
 
@@ -596,7 +596,7 @@ class TestDataArray(TestCase):
             da.isel(x=(('points', ), x), y=(('points', ), y)))
 
         # make sure we're raising errors in the right places
-        with self.assertRaisesRegexp(IndexError,
+        with raises_regex(IndexError,
                                      'Dimensions of indexers mismatch'):
             da.isel(y=(('points', ), [1, 2]), x=(('points', ), [1, 2, 3]))
 
@@ -611,7 +611,7 @@ class TestDataArray(TestCase):
         assert 'station' in actual.dims
         self.assertDataArrayIdentical(actual['station'], stations['station'])
 
-        with self.assertRaisesRegexp(ValueError, 'conflicting values for '):
+        with raises_regex(ValueError, 'conflicting values for '):
             da.isel(x=DataArray([0, 1, 2], dims='station',
                                 coords={'station': [0, 1, 2]}),
                     y=DataArray([0, 1, 2], dims='station',
@@ -758,20 +758,20 @@ class TestDataArray(TestCase):
             da.isel_points(x=x, y=y))
 
         # make sure we're raising errors in the right places
-        with self.assertRaisesRegexp(ValueError,
+        with raises_regex(ValueError,
                                      'All indexers must be the same length'):
             da.isel_points(y=[1, 2], x=[1, 2, 3])
-        with self.assertRaisesRegexp(ValueError,
+        with raises_regex(ValueError,
                                      'dimension bad_key does not exist'):
             da.isel_points(bad_key=[1, 2])
-        with self.assertRaisesRegexp(TypeError, 'Indexers must be integers'):
+        with raises_regex(TypeError, 'Indexers must be integers'):
             da.isel_points(y=[1.5, 2.2])
-        with self.assertRaisesRegexp(TypeError, 'Indexers must be integers'):
+        with raises_regex(TypeError, 'Indexers must be integers'):
             da.isel_points(x=[1, 2, 3], y=slice(3))
-        with self.assertRaisesRegexp(ValueError,
+        with raises_regex(ValueError,
                                      'Indexers must be 1 dimensional'):
             da.isel_points(y=1, x=2)
-        with self.assertRaisesRegexp(ValueError,
+        with raises_regex(ValueError,
                                      'Existing dimension names are not'):
             da.isel_points(y=[1, 2], x=[1, 2], dim='x')
 
@@ -855,7 +855,7 @@ class TestDataArray(TestCase):
                                       mdata.sel(x=('a', 1)))
         self.assertDataArrayIdentical(mdata.loc[{'one': 'a'}, ...],
                                       mdata.sel(x={'one': 'a'}))
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             mdata.loc[('a', 1)]
 
         self.assertDataArrayIdentical(mdata.sel(x={'one': 'a', 'two': 1}),
@@ -880,7 +880,7 @@ class TestDataArray(TestCase):
                   IndexVariable('y', np.array([0, 1, 2], 'int64'))]
         da = DataArray(np.random.randn(2, 3), coords, name='foo')
 
-        self.assertEquals(2, len(da.coords))
+        assert 2 == len(da.coords)
 
         self.assertEqual(['x', 'y'], list(da.coords))
 
@@ -891,9 +891,9 @@ class TestDataArray(TestCase):
         self.assertNotIn(0, da.coords)
         self.assertNotIn('foo', da.coords)
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             da.coords[0]
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             da.coords['foo']
 
         expected = dedent("""\
@@ -901,14 +901,14 @@ class TestDataArray(TestCase):
           * x        (x) int64 -1 -2
           * y        (y) int64 0 1 2""")
         actual = repr(da.coords)
-        self.assertEquals(expected, actual)
+        assert expected == actual
 
         del da.coords['x']
         expected = DataArray(da.values, {'y': [0, 1, 2]}, dims=['x', 'y'],
                              name='foo')
         self.assertDataArrayIdentical(da, expected)
 
-        with self.assertRaisesRegexp(ValueError, 'conflicting MultiIndex'):
+        with raises_regex(ValueError, 'conflicting MultiIndex'):
             self.mda['level_1'] = np.arange(4)
             self.mda.coords['level_1'] = np.arange(4)
 
@@ -998,13 +998,13 @@ class TestDataArray(TestCase):
                              dims=['x', 'y'], name='foo')
         self.assertDataArrayIdentical(actual, expected)
 
-        with self.assertRaisesRegexp(ValueError, 'cannot reset coord'):
+        with raises_regex(ValueError, 'cannot reset coord'):
             data.reset_coords(inplace=True)
-        with self.assertRaisesRegexp(ValueError, 'cannot be found'):
+        with raises_regex(ValueError, 'cannot be found'):
             data.reset_coords('foo', drop=True)
-        with self.assertRaisesRegexp(ValueError, 'cannot be found'):
+        with raises_regex(ValueError, 'cannot be found'):
             data.reset_coords('not_found')
-        with self.assertRaisesRegexp(ValueError, 'cannot remove index'):
+        with raises_regex(ValueError, 'cannot remove index'):
             data.reset_coords('y')
 
     def test_assign_coords(self):
@@ -1019,7 +1019,7 @@ class TestDataArray(TestCase):
         expected.coords['d'] = ('x', [1.5, 1.5, 3.5, 3.5])
         self.assertDataArrayIdentical(actual, expected)
 
-        with self.assertRaisesRegexp(ValueError, 'conflicting MultiIndex'):
+        with raises_regex(ValueError, 'conflicting MultiIndex'):
             self.mda.assign_coords(level_1=range(4))
 
     def test_coords_alignment(self):
@@ -1063,7 +1063,7 @@ class TestDataArray(TestCase):
         self.assertDatasetIdentical(foo, foo.reindex_like(foo))
 
         bar = foo[:4]
-        with self.assertRaisesRegexp(
+        with raises_regex(
                 ValueError, 'different size for unlabeled'):
             foo.reindex_like(bar)
 
@@ -1116,26 +1116,26 @@ class TestDataArray(TestCase):
                           coords={'x': np.linspace(0.0, 1.0, 3.0)},
                           attrs={'key': 'entry'})
 
-        with self.assertRaisesRegexp(ValueError, 'dim should be str or'):
+        with raises_regex(ValueError, 'dim should be str or'):
             array.expand_dims(0)
-        with self.assertRaisesRegexp(ValueError, 'lengths of dim and axis'):
+        with raises_regex(ValueError, 'lengths of dim and axis'):
             # dims and axis argument should be the same length
             array.expand_dims(dim=['a', 'b'], axis=[1, 2, 3])
-        with self.assertRaisesRegexp(ValueError, 'Dimension x already'):
+        with raises_regex(ValueError, 'Dimension x already'):
             # Should not pass the already existing dimension.
             array.expand_dims(dim=['x'])
         # raise if duplicate
-        with self.assertRaisesRegexp(ValueError, 'duplicate values.'):
+        with raises_regex(ValueError, 'duplicate values.'):
             array.expand_dims(dim=['y', 'y'])
-        with self.assertRaisesRegexp(ValueError, 'duplicate values.'):
+        with raises_regex(ValueError, 'duplicate values.'):
             array.expand_dims(dim=['y', 'z'], axis=[1, 1])
-        with self.assertRaisesRegexp(ValueError, 'duplicate values.'):
+        with raises_regex(ValueError, 'duplicate values.'):
             array.expand_dims(dim=['y', 'z'], axis=[2, -2])
 
         # out of bounds error, axis must be in [-4, 3]
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             array.expand_dims(dim=['y', 'z'], axis=[2, 4])
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             array.expand_dims(dim=['y', 'z'], axis=[2, -5])
         # Does not raise an IndexError
         array.expand_dims(dim=['y', 'z'], axis=[2, -4])
@@ -1228,7 +1228,7 @@ class TestDataArray(TestCase):
                             coords={'x': ('x', [0, 1]),
                                     'level': ('y', [1, 2])},
                             dims=('x', 'y'))
-        with self.assertRaisesRegexp(ValueError, 'dimension mismatch'):
+        with raises_regex(ValueError, 'dimension mismatch'):
             array2d.set_index(x='level')
 
     def test_reset_index(self):
@@ -1275,11 +1275,11 @@ class TestDataArray(TestCase):
         self.assertDataArrayIdentical(array, expected)
 
         array = DataArray([1, 2], dims='x')
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             array.reorder_levels(x=['level_1', 'level_2'])
 
         array['x'] = [0, 1]
-        with self.assertRaisesRegexp(ValueError, 'has no MultiIndex'):
+        with raises_regex(ValueError, 'has no MultiIndex'):
             array.reorder_levels(x=['level_1', 'level_2'])
 
     def test_dataset_getitem(self):
@@ -1357,9 +1357,9 @@ class TestDataArray(TestCase):
     def test_inplace_math_automatic_alignment(self):
         a = DataArray(range(5), [('x', range(5))])
         b = DataArray(range(1, 6), [('x', range(1, 6))])
-        with self.assertRaises(xr.MergeError):
+        with pytest.raises(xr.MergeError):
             a += b
-        with self.assertRaises(xr.MergeError):
+        with pytest.raises(xr.MergeError):
             b += a
 
     def test_math_name(self):
@@ -1532,14 +1532,14 @@ class TestDataArray(TestCase):
         actual = arr.drop('z')
         self.assertDataArrayIdentical(expected, actual)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             arr.drop('not found')
 
-        with self.assertRaisesRegexp(ValueError, 'cannot be found'):
+        with raises_regex(ValueError, 'cannot be found'):
             arr.drop(None)
 
         renamed = arr.rename('foo')
-        with self.assertRaisesRegexp(ValueError, 'cannot be found'):
+        with raises_regex(ValueError, 'cannot be found'):
             renamed.drop('foo')
 
     def test_drop_index_labels(self):
@@ -1696,10 +1696,10 @@ class TestDataArray(TestCase):
         actual = a.fillna(b[:0])
         self.assertDataArrayIdentical(a, actual)
 
-        with self.assertRaisesRegexp(TypeError, 'fillna on a DataArray'):
+        with raises_regex(TypeError, 'fillna on a DataArray'):
             a.fillna({0: 0})
 
-        with self.assertRaisesRegexp(ValueError, 'broadcast'):
+        with raises_regex(ValueError, 'broadcast'):
             a.fillna([1, 2])
 
         fill_value = DataArray([0, 1], dims='y')
@@ -1864,11 +1864,11 @@ class TestDataArray(TestCase):
         actual_agg = actual.groupby('abc').mean()
         self.assertDataArrayAllClose(expected_agg, actual_agg)
 
-        with self.assertRaisesRegexp(TypeError, 'only support binary ops'):
+        with raises_regex(TypeError, 'only support binary ops'):
             grouped + 1
-        with self.assertRaisesRegexp(TypeError, 'only support binary ops'):
+        with raises_regex(TypeError, 'only support binary ops'):
             grouped + grouped
-        with self.assertRaisesRegexp(TypeError, 'in-place operations'):
+        with raises_regex(TypeError, 'in-place operations'):
             array += grouped
 
     def test_groupby_math_not_aligned(self):
@@ -2009,7 +2009,7 @@ class TestDataArray(TestCase):
         actual = array.resample(time='24H').reduce(np.mean)
         self.assertDataArrayIdentical(expected, actual)
 
-        with self.assertRaisesRegexp(ValueError, 'index must be monotonic'):
+        with raises_regex(ValueError, 'index must be monotonic'):
             array[[2, 0, 1]].resample(time='1D')
 
     def test_resample_first(self):
@@ -2048,7 +2048,7 @@ class TestDataArray(TestCase):
     def test_resample_bad_resample_dim(self):
         times = pd.date_range('2000-01-01', freq='6H', periods=10)
         array = DataArray(np.arange(10), [('__resample_dim__', times)])
-        with self.assertRaisesRegexp(ValueError, 'Proxy resampling dimension'):
+        with raises_regex(ValueError, 'Proxy resampling dimension'):
             array.resample(**{'__resample_dim__': '1D'}).first()
 
     @requires_scipy
@@ -2271,7 +2271,7 @@ class TestDataArray(TestCase):
                           {'time': times, 'x': xs, 'y': ys},
                           ('x', 'y', 'time'))
 
-        with self.assertRaisesRegexp(TypeError,
+        with raises_regex(TypeError,
                                      "dask arrays are not yet supported"):
             array.resample(time='1H').interpolate('linear')
 
@@ -2371,11 +2371,11 @@ class TestDataArray(TestCase):
         self.assertDatasetIdentical(result1, array_with_coord)
 
     def test_align_without_indexes_errors(self):
-        with self.assertRaisesRegexp(ValueError, 'cannot be aligned'):
+        with raises_regex(ValueError, 'cannot be aligned'):
             align(DataArray([1, 2, 3], dims=['x']),
                   DataArray([1, 2], dims=['x']))
 
-        with self.assertRaisesRegexp(ValueError, 'cannot be aligned'):
+        with raises_regex(ValueError, 'cannot be aligned'):
             align(DataArray([1, 2, 3], dims=['x']),
                   DataArray([1, 2], coords=[('x', [0, 1])]))
 
@@ -2487,7 +2487,7 @@ class TestDataArray(TestCase):
             roundtripped = DataArray(da.to_pandas()).drop(dims)
             self.assertDataArrayIdentical(da, roundtripped)
 
-        with self.assertRaisesRegexp(ValueError, 'cannot convert'):
+        with raises_regex(ValueError, 'cannot convert'):
             DataArray(np.random.randn(1, 2, 3, 4, 5)).to_pandas()
 
     def test_to_dataframe(self):
@@ -2511,7 +2511,7 @@ class TestDataArray(TestCase):
         self.assertArrayEqual(expected.index.values, actual.index.values)
 
         arr.name = None  # unnamed
-        with self.assertRaisesRegexp(ValueError, 'unnamed'):
+        with raises_regex(ValueError, 'unnamed'):
             arr.to_dataframe()
 
     def test_to_pandas_name_matches_coordinate(self):
@@ -2586,14 +2586,14 @@ class TestDataArray(TestCase):
         d = {'dims': ('x', 'y'),
              'data': array.values,
              'coords': {'x': {'data': ['a', 'b']}}}
-        with self.assertRaisesRegexp(
+        with raises_regex(
                 ValueError,
                 "cannot convert dict when coords are missing the key 'dims'"):
             DataArray.from_dict(d)
 
         # this one is missing some necessary information
         d = {'dims': ('t')}
-        with self.assertRaisesRegexp(
+        with raises_regex(
                 ValueError, "cannot convert dict without the key 'data'"):
             DataArray.from_dict(d)
 
@@ -2703,7 +2703,7 @@ class TestDataArray(TestCase):
 
     def test_to_dataset_whole(self):
         unnamed = DataArray([1, 2], dims='x')
-        with self.assertRaisesRegexp(ValueError, 'unable to convert unnamed'):
+        with raises_regex(ValueError, 'unable to convert unnamed'):
             unnamed.to_dataset()
 
         actual = unnamed.to_dataset(name='foo')
@@ -2728,7 +2728,7 @@ class TestDataArray(TestCase):
         actual = array.to_dataset('x')
         self.assertDatasetIdentical(expected, actual)
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             array.to_dataset('x', name='foo')
 
         roundtripped = actual.to_array(dim='x')
@@ -2815,11 +2815,11 @@ class TestDataArray(TestCase):
 
     def test_setattr_raises(self):
         array = DataArray(0, coords={'scalar': 1}, attrs={'foo': 'bar'})
-        with self.assertRaisesRegexp(AttributeError, 'cannot set attr'):
+        with raises_regex(AttributeError, 'cannot set attr'):
             array.scalar = 2
-        with self.assertRaisesRegexp(AttributeError, 'cannot set attr'):
+        with raises_regex(AttributeError, 'cannot set attr'):
             array.foo = 2
-        with self.assertRaisesRegexp(AttributeError, 'cannot set attr'):
+        with raises_regex(AttributeError, 'cannot set attr'):
             array.other = 2
 
     def test_full_like(self):
@@ -2838,7 +2838,7 @@ class TestDataArray(TestCase):
         # override dtype
         actual = full_like(da, fill_value=True, dtype=bool)
         expect.values = [[True, True], [True, True]]
-        self.assertEquals(expect.dtype, bool)
+        assert expect.dtype == bool
         self.assertDataArrayIdentical(expect, actual)
 
     def test_dot(self):
@@ -2873,11 +2873,11 @@ class TestDataArray(TestCase):
         expected = DataArray(expected_vals, coords=[x, j], dims=['x', 'j'])
         self.assertDataArrayEqual(expected, actual)
 
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             da.dot(dm.to_dataset(name='dm'))
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             da.dot(dm.values)
-        with self.assertRaisesRegexp(ValueError, 'no shared dimensions'):
+        with raises_regex(ValueError, 'no shared dimensions'):
             da.dot(DataArray(1))
 
     def test_binary_op_join_setting(self):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -272,7 +272,7 @@ class TestDataset(TestCase):
 
         d = pd.Timestamp('2000-01-01T12')
         args = [True, None, 3.4, np.nan, 'hello', u'uni', b'raw',
-                np.datetime64('2000-01-01T00'), d, d.to_datetime(),
+                np.datetime64('2000-01-01'), d, d.to_pydatetime(),
                 Arbitrary()]
         for arg in args:
             print(arg)
@@ -684,7 +684,7 @@ class TestDataset(TestCase):
         self.assertDatasetIdentical(expected, actual)
 
         actual = other_coords.merge(orig_coords)
-        self.assertDatasetIdentical(expected.T, actual)
+        self.assertDatasetIdentical(expected.transpose(), actual)
 
         orig_coords = Dataset(coords={'a': ('x', [np.nan])}).coords
         other_coords = Dataset(coords={'a': np.nan}).coords
@@ -3279,7 +3279,7 @@ class TestDataset(TestCase):
         add_vars = {'var4': ['dim1', 'dim2']}
         for v, dims in sorted(add_vars.items()):
             size = tuple(data1.dims[d] for d in dims)
-            data = np.random.random_integers(0, 100, size=size).astype(np.str_)
+            data = np.random.randint(0, 100, size=size).astype(np.str_)
             data1[v] = (dims, data, {'foo': 'variable'})
 
         self.assertTrue('var4' not in data1.mean())
@@ -3562,7 +3562,7 @@ class TestDataset(TestCase):
         # verify we can rollback in-place operations if something goes wrong
         # nb. inplace datetime64 math actually will work with an integer array
         # but not floats thanks to numpy's inconsistent handling
-        other = DataArray(np.datetime64('2000-01-01T12'), coords={'c': 2})
+        other = DataArray(np.datetime64('2000-01-01'), coords={'c': 2})
         actual = ds.copy(deep=True)
         with pytest.raises(TypeError):
             actual += other

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -233,13 +233,13 @@ class TestDataset(TestCase):
         x2 = ('x', np.arange(1000))
         z = (['x', 'y'], np.arange(1000).reshape(100, 10))
 
-        with self.assertRaisesRegexp(ValueError, 'conflicting sizes'):
+        with raises_regex(ValueError, 'conflicting sizes'):
             Dataset({'a': x1, 'b': x2})
-        with self.assertRaisesRegexp(ValueError, "disallows such variables"):
+        with raises_regex(ValueError, "disallows such variables"):
             Dataset({'a': x1, 'x': z})
-        with self.assertRaisesRegexp(TypeError, 'tuples to convert'):
+        with raises_regex(TypeError, 'tuples to convert'):
             Dataset({'x': (1, 2, 3, 4, 5, 6, 7)})
-        with self.assertRaisesRegexp(ValueError, 'already exists as a scalar'):
+        with raises_regex(ValueError, 'already exists as a scalar'):
             Dataset({'x': 0, 'y': ('x', [1, 2, 3])})
 
         # verify handling of DataArrays
@@ -249,7 +249,7 @@ class TestDataset(TestCase):
 
     def test_constructor_invalid_dims(self):
         # regression for GH1120
-        with self.assertRaises(MergeError):
+        with pytest.raises(MergeError):
             Dataset(data_vars=dict(v=('y', [1, 2, 3, 4])),
                     coords=dict(y=DataArray([.1, .2, .3, .4], dims='x')))
 
@@ -281,7 +281,7 @@ class TestDataset(TestCase):
             self.assertDatasetIdentical(expected, actual)
 
     def test_constructor_deprecated(self):
-        with self.assertRaisesRegexp(ValueError, 'DataArray dimensions'):
+        with raises_regex(ValueError, 'DataArray dimensions'):
             DataArray([1, 2, 3], coords={'x': [0, 1, 2]})
 
     def test_constructor_auto_align(self):
@@ -311,7 +311,7 @@ class TestDataset(TestCase):
         self.assertDatasetIdentical(expected3, actual)
 
         e = ('x', [0, 0])
-        with self.assertRaisesRegexp(ValueError, 'conflicting sizes'):
+        with raises_regex(ValueError, 'conflicting sizes'):
             Dataset({'a': a, 'b': b, 'e': e})
 
     def test_constructor_pandas_sequence(self):
@@ -349,7 +349,7 @@ class TestDataset(TestCase):
     def test_constructor_compat(self):
         data = OrderedDict([('x', DataArray(0, coords={'y': 1})),
                             ('y', ('z', [1, 1, 1]))])
-        with self.assertRaises(MergeError):
+        with pytest.raises(MergeError):
             Dataset(data, compat='equals')
         expected = Dataset({'x': 0}, {'y': ('z', [1, 1, 1])})
         actual = Dataset(data)
@@ -375,7 +375,7 @@ class TestDataset(TestCase):
         self.assertDatasetIdentical(expected, actual)
 
         data = {'x': DataArray(0, coords={'y': 3}), 'y': ('z', [1, 1, 1])}
-        with self.assertRaises(MergeError):
+        with pytest.raises(MergeError):
             Dataset(data)
 
         data = {'x': DataArray(0, coords={'y': 1}), 'y': [1, 1]}
@@ -384,7 +384,7 @@ class TestDataset(TestCase):
         self.assertDatasetIdentical(expected, actual)
 
     def test_constructor_with_coords(self):
-        with self.assertRaisesRegexp(ValueError, 'found in both data_vars and'):
+        with raises_regex(ValueError, 'found in both data_vars and'):
             Dataset({'a': ('x', [1])}, {'a': ('x', [1])})
 
         ds = Dataset({}, {'a': ('x', [1])})
@@ -393,7 +393,7 @@ class TestDataset(TestCase):
 
         mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2]],
                                             names=('level_1', 'level_2'))
-        with self.assertRaisesRegexp(ValueError, 'conflicting MultiIndex'):
+        with raises_regex(ValueError, 'conflicting MultiIndex'):
             Dataset({}, {'x': mindex, 'y': mindex})
             Dataset({}, {'x': mindex, 'level_1': range(4)})
 
@@ -442,7 +442,7 @@ class TestDataset(TestCase):
                      coords={'x': ['a', 'b']})
         assert ds.get_index('x').equals(pd.Index(['a', 'b']))
         assert ds.get_index('y').equals(pd.Index([0, 1, 2]))
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             ds.get_index('z')
 
     def test_attr_access(self):
@@ -473,7 +473,7 @@ class TestDataset(TestCase):
         self.assertEqual(list(a), ['foo', 'bar'])
         self.assertArrayEqual(a['foo'].values, d)
         # try to add variable with dim (10,3) with data that's (3,10)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             a['qux'] = (('time', 'x'), d.T)
 
     def test_modify_inplace(self):
@@ -491,14 +491,14 @@ class TestDataset(TestCase):
         # this should work
         a['x'] = ('x', vec[:5])
         a['z'] = ('x', np.arange(5))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             # now it shouldn't, since there is a conflicting length
             a['x'] = ('x', vec[:4])
         arr = np.random.random((10, 1,))
         scal = np.array(0)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             a['y'] = ('y', arr)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             a['y'] = ('y', scal)
         self.assertTrue('y' not in a.dims)
 
@@ -525,9 +525,9 @@ class TestDataset(TestCase):
         self.assertNotIn(0, data.coords)
         self.assertNotIn('foo', data.coords)
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             data.coords['foo']
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             data.coords[0]
 
         expected = dedent("""\
@@ -556,7 +556,7 @@ class TestDataset(TestCase):
         self.assertArrayEqual(actual['z'], ['a', 'b'])
 
         actual = data.copy(deep=True)
-        with self.assertRaisesRegexp(ValueError, 'conflicting sizes'):
+        with raises_regex(ValueError, 'conflicting sizes'):
             actual.coords['x'] = ('x', [-1])
         self.assertDatasetIdentical(actual, data)  # should not be modified
 
@@ -565,10 +565,10 @@ class TestDataset(TestCase):
         expected = data.reset_coords('b', drop=True)
         self.assertDatasetIdentical(expected, actual)
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             del data.coords['not_found']
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             del data.coords['foo']
 
         actual = data.copy(deep=True)
@@ -584,7 +584,7 @@ class TestDataset(TestCase):
 
     def test_coords_setitem_multiindex(self):
         data = create_test_multiindex()
-        with self.assertRaisesRegexp(ValueError, 'conflicting MultiIndex'):
+        with raises_regex(ValueError, 'conflicting MultiIndex'):
             data.coords['level_1'] = range(4)
 
     def test_coords_set(self):
@@ -621,7 +621,7 @@ class TestDataset(TestCase):
         actual = all_coords.reset_coords('zzz')
         self.assertDatasetIdentical(two_coords, actual)
 
-        with self.assertRaisesRegexp(ValueError, 'cannot remove index'):
+        with raises_regex(ValueError, 'cannot remove index'):
             one_coord.reset_coords('x')
 
         actual = all_coords.reset_coords('zzz', drop=True)
@@ -649,13 +649,13 @@ class TestDataset(TestCase):
         self.assertDatasetIdentical(expected, actual)
 
         other_coords = Dataset(coords={'x': ('x', ['a'])}).coords
-        with self.assertRaises(MergeError):
+        with pytest.raises(MergeError):
             orig_coords.merge(other_coords)
         other_coords = Dataset(coords={'x': ('x', ['a', 'b'])}).coords
-        with self.assertRaises(MergeError):
+        with pytest.raises(MergeError):
             orig_coords.merge(other_coords)
         other_coords = Dataset(coords={'x': ('x', ['a', 'b', 'c'])}).coords
-        with self.assertRaises(MergeError):
+        with pytest.raises(MergeError):
             orig_coords.merge(other_coords)
 
         other_coords = Dataset(coords={'a': ('x', [8, 9])}).coords
@@ -780,7 +780,7 @@ class TestDataset(TestCase):
         self.assertEqual(reblocked.chunks, expected_chunks)
         self.assertDatasetIdentical(reblocked, data)
 
-        with self.assertRaisesRegexp(ValueError, 'some chunks'):
+        with raises_regex(ValueError, 'some chunks'):
             data.chunk({'foo': 10})
 
     @requires_dask
@@ -789,9 +789,9 @@ class TestDataset(TestCase):
         create_test_data().dump_to_store(store)
         ds = open_dataset(store).chunk()
 
-        with self.assertRaises(UnexpectedDataAccess):
+        with pytest.raises(UnexpectedDataAccess):
             ds.load()
-        with self.assertRaises(UnexpectedDataAccess):
+        with pytest.raises(UnexpectedDataAccess):
             ds['var1'].values
 
         # these should not raise UnexpectedDataAccess:
@@ -832,7 +832,7 @@ class TestDataset(TestCase):
             actual = ret[v].values
             np.testing.assert_array_equal(expected, actual)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             data.isel(not_a_dim=slice(0, 2))
 
         ret = data.isel(dim1=0)
@@ -924,11 +924,11 @@ class TestDataset(TestCase):
                                     data.isel(dim2=(('points', ), pdim2),
                                               dim1=(('points', ), pdim1)))
         # make sure we're raising errors in the right places
-        with self.assertRaisesRegexp(IndexError,
+        with raises_regex(IndexError,
                                      'Dimensions of indexers mismatch'):
             data.isel(dim1=(('points', ), [1, 2]),
                       dim2=(('points', ), [1, 2, 3]))
-        with self.assertRaisesRegexp(TypeError, 'cannot use a Dataset'):
+        with raises_regex(TypeError, 'cannot use a Dataset'):
             data.isel(dim1=Dataset({'points': [1, 2]}))
 
         # test to be sure we keep around variables that were not indexed
@@ -949,7 +949,7 @@ class TestDataset(TestCase):
         self.assertDataArrayIdentical(actual['station'].drop(['dim2']),
                                       stations['station'])
 
-        with self.assertRaisesRegexp(ValueError, 'conflicting values for '):
+        with raises_regex(ValueError, 'conflicting values for '):
             data.isel(dim1=DataArray([0, 1, 2], dims='station',
                                      coords={'station': [0, 1, 2]}),
                       dim2=DataArray([0, 1, 2], dims='station',
@@ -996,14 +996,14 @@ class TestDataset(TestCase):
         # Conflict in the dimension coordinate
         indexing_da = DataArray(np.arange(1, 4), dims=['dim2'],
                                 coords={'dim2': np.random.randn(3)})
-        with self.assertRaisesRegexp(
+        with raises_regex(
                 IndexError, "dimension coordinate 'dim2'"):
             actual = data.isel(dim2=indexing_da)
         # Also the case for DataArray
-        with self.assertRaisesRegexp(
+        with raises_regex(
                 IndexError, "dimension coordinate 'dim2'"):
             actual = data['var2'].isel(dim2=indexing_da)
-        with self.assertRaisesRegexp(
+        with raises_regex(
                 IndexError, "dimension coordinate 'dim2'"):
             data['dim2'].isel(dim2=indexing_da)
 
@@ -1059,7 +1059,7 @@ class TestDataset(TestCase):
 
         # indexer generated from coordinates
         indexing_ds = Dataset({}, coords={'dim2': [0, 1, 2]})
-        with self.assertRaisesRegexp(
+        with raises_regex(
                 IndexError, "dimension coordinate 'dim2'"):
             actual = data.isel(dim2=indexing_ds['dim2'])
 
@@ -1190,10 +1190,10 @@ class TestDataset(TestCase):
         self.assertDatasetIdentical(actual_isel, actual_sel)
 
         # Vectorized indexing with level-variables raises an error
-        with self.assertRaisesRegexp(ValueError, 'Vectorized selection is '):
+        with raises_regex(ValueError, 'Vectorized selection is '):
             mds.sel(one=['a', 'b'])
 
-        with self.assertRaisesRegexp(ValueError, 'Vectorized selection is '
+        with raises_regex(ValueError, 'Vectorized selection is '
                                      'not available along MultiIndex variable:'
                                      ' x'):
             mds.sel(x=xr.DataArray([np.array(midx[:2]), np.array(midx[-2:])],
@@ -1246,20 +1246,20 @@ class TestDataset(TestCase):
                                     data.isel_points(dim2=pdim2, dim1=pdim1))
 
         # make sure we're raising errors in the right places
-        with self.assertRaisesRegexp(ValueError,
+        with raises_regex(ValueError,
                                      'All indexers must be the same length'):
             data.isel_points(dim1=[1, 2], dim2=[1, 2, 3])
-        with self.assertRaisesRegexp(ValueError,
+        with raises_regex(ValueError,
                                      'dimension bad_key does not exist'):
             data.isel_points(bad_key=[1, 2])
-        with self.assertRaisesRegexp(TypeError, 'Indexers must be integers'):
+        with raises_regex(TypeError, 'Indexers must be integers'):
             data.isel_points(dim1=[1.5, 2.2])
-        with self.assertRaisesRegexp(TypeError, 'Indexers must be integers'):
+        with raises_regex(TypeError, 'Indexers must be integers'):
             data.isel_points(dim1=[1, 2, 3], dim2=slice(3))
-        with self.assertRaisesRegexp(ValueError,
+        with raises_regex(ValueError,
                                      'Indexers must be 1 dimensional'):
             data.isel_points(dim1=1, dim2=2)
-        with self.assertRaisesRegexp(ValueError,
+        with raises_regex(ValueError,
                                      'Existing dimension names are not valid'):
             data.isel_points(dim1=[1, 2], dim2=[1, 2], dim='dim2')
 
@@ -1327,7 +1327,7 @@ class TestDataset(TestCase):
                                  method='pad')
         self.assertDatasetIdentical(expected, actual)
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             data.sel_points(x=[2.5], y=[2.0], method='pad', tolerance=1e-3)
 
     def test_sel_fancy(self):
@@ -1401,7 +1401,7 @@ class TestDataset(TestCase):
         self.assertDataArrayIdentical(actual['a'].drop('x'), idx_x['a'])
         self.assertDataArrayIdentical(actual['b'].drop('y'), idx_y['b'])
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             data.sel_points(x=[2.5], y=[2.0], method='pad', tolerance=1e-3)
 
     def test_sel_method(self):
@@ -1414,22 +1414,22 @@ class TestDataset(TestCase):
         actual = data.sel(dim2=0.95, method='nearest', tolerance=1)
         self.assertDatasetIdentical(expected, actual)
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             actual = data.sel(dim2=np.pi, method='nearest', tolerance=0)
 
         expected = data.sel(dim2=[1.5])
         actual = data.sel(dim2=[1.45], method='backfill')
         self.assertDatasetIdentical(expected, actual)
 
-        with self.assertRaisesRegexp(NotImplementedError, 'slice objects'):
+        with raises_regex(NotImplementedError, 'slice objects'):
             data.sel(dim2=slice(1, 3), method='ffill')
 
-        with self.assertRaisesRegexp(TypeError, '``method``'):
+        with raises_regex(TypeError, '``method``'):
             # this should not pass silently
             data.sel(data)
 
         # cannot pass method if there is no associated coordinate
-        with self.assertRaisesRegexp(ValueError, 'cannot supply'):
+        with raises_regex(ValueError, 'cannot supply'):
             data.sel(dim1=0, method='nearest')
 
     def test_loc(self):
@@ -1437,9 +1437,9 @@ class TestDataset(TestCase):
         expected = data.sel(dim3='a')
         actual = data.loc[dict(dim3='a')]
         self.assertDatasetIdentical(expected, actual)
-        with self.assertRaisesRegexp(TypeError, 'can only lookup dict'):
+        with raises_regex(TypeError, 'can only lookup dict'):
             data.loc['a']
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             data.loc[dict(dim3='a')] = 0
 
     def test_selection_multiindex(self):
@@ -1521,7 +1521,7 @@ class TestDataset(TestCase):
         actual = data.reindex(dim1=data['dim1'].to_index())
         self.assertDatasetIdentical(actual, expected)
 
-        with self.assertRaisesRegexp(
+        with raises_regex(
                 ValueError, 'cannot reindex or align along dimension'):
             data.reindex(dim1=data['dim1'][:5])
 
@@ -1533,13 +1533,13 @@ class TestDataset(TestCase):
         actual = data.reindex({'dim2': data['dim2']})
         expected = data
         self.assertDatasetIdentical(actual, expected)
-        with self.assertRaisesRegexp(ValueError, 'cannot specify both'):
+        with raises_regex(ValueError, 'cannot specify both'):
             data.reindex({'x': 0}, x=0)
-        with self.assertRaisesRegexp(ValueError, 'dictionary'):
+        with raises_regex(ValueError, 'dictionary'):
             data.reindex('foo')
 
         # invalid dimension
-        with self.assertRaisesRegexp(ValueError, 'invalid reindex dim'):
+        with raises_regex(ValueError, 'invalid reindex dim'):
             data.reindex(invalid=0)
 
         # out of order
@@ -1642,9 +1642,9 @@ class TestDataset(TestCase):
                                     right2.sel(dim3=intersection))
         self.assertTrue(np.isnan(left2['var3'][-2:]).all())
 
-        with self.assertRaisesRegexp(ValueError, 'invalid value for join'):
+        with raises_regex(ValueError, 'invalid value for join'):
             align(left, right, join='foobar')
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             align(left, right, foo='bar')
 
     def test_align_exact(self):
@@ -1655,7 +1655,7 @@ class TestDataset(TestCase):
         self.assertDatasetIdentical(left1, left)
         self.assertDatasetIdentical(left2, left)
 
-        with self.assertRaisesRegexp(ValueError, 'indexes .* not equal'):
+        with raises_regex(ValueError, 'indexes .* not equal'):
             xr.align(left, right, join='exact')
 
     def test_align_exclude(self):
@@ -1707,7 +1707,7 @@ class TestDataset(TestCase):
         assert x1.identical(x) and x2.identical(x)
 
         y = Dataset({'bar': ('x', [6, 7]), 'x': [0, 1]})
-        with self.assertRaisesRegexp(ValueError, 'cannot reindex or align'):
+        with raises_regex(ValueError, 'cannot reindex or align'):
             align(x, y)
 
     def test_broadcast(self):
@@ -1807,7 +1807,7 @@ class TestDataset(TestCase):
         actual = data.drop(['time'])
         self.assertDatasetIdentical(expected, actual)
 
-        with self.assertRaisesRegexp(ValueError, 'cannot be found'):
+        with raises_regex(ValueError, 'cannot be found'):
             data.drop('not_found_here')
 
     def test_drop_index_labels(self):
@@ -1822,11 +1822,11 @@ class TestDataset(TestCase):
         expected = data.isel(x=slice(0, 0))
         self.assertDatasetIdentical(expected, actual)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             # not contained in axis
             data.drop(['c'], dim='x')
 
-        with self.assertRaisesRegexp(
+        with raises_regex(
                 ValueError, 'does not have coordinate labels'):
             data.drop(1, 'y')
 
@@ -1876,24 +1876,24 @@ class TestDataset(TestCase):
         self.assertTrue('var1' not in renamed)
         self.assertTrue('dim2' not in renamed)
 
-        with self.assertRaisesRegexp(ValueError, "cannot rename 'not_a_var'"):
+        with raises_regex(ValueError, "cannot rename 'not_a_var'"):
             data.rename({'not_a_var': 'nada'})
 
-        with self.assertRaisesRegexp(ValueError, "'var1' conflicts"):
+        with raises_regex(ValueError, "'var1' conflicts"):
             data.rename({'var2': 'var1'})
 
         # verify that we can rename a variable without accessing the data
         var1 = data['var1']
         data['var1'] = (var1.dims, InaccessibleArray(var1.values))
         renamed = data.rename(newnames)
-        with self.assertRaises(UnexpectedDataAccess):
+        with pytest.raises(UnexpectedDataAccess):
             renamed['renamed_var1'].values
 
     def test_rename_old_name(self):
         # regtest for GH1477
         data = create_test_data()
 
-        with self.assertRaisesRegexp(ValueError, "'samecol' conflicts"):
+        with raises_regex(ValueError, "'samecol' conflicts"):
             data.rename({'var1': 'samecol', 'var2': 'samecol'})
 
         # This shouldn't cause any problems.
@@ -1913,7 +1913,7 @@ class TestDataset(TestCase):
         data.rename({'x': 'y'}, inplace=True)
         self.assertDatasetIdentical(data, renamed)
         self.assertFalse(data.equals(copied))
-        self.assertEquals(data.dims, {'y': 3, 't': 3})
+        assert data.dims == {'y': 3, 't': 3}
         # check virtual variables
         self.assertArrayEqual(data['t.dayofyear'], [1, 2, 3])
 
@@ -1932,9 +1932,9 @@ class TestDataset(TestCase):
         actual.swap_dims({'x': 'y'}, inplace=True)
         self.assertDatasetIdentical(expected, actual)
 
-        with self.assertRaisesRegexp(ValueError, 'cannot swap'):
+        with raises_regex(ValueError, 'cannot swap'):
             original.swap_dims({'y': 'x'})
-        with self.assertRaisesRegexp(ValueError, 'replacement dimension'):
+        with raises_regex(ValueError, 'replacement dimension'):
             original.swap_dims({'x': 'z'})
 
     def test_expand_dims_error(self):
@@ -1946,13 +1946,13 @@ class TestDataset(TestCase):
                                    'c': np.linspace(0, 1, 5)},
                            attrs={'key': 'entry'})
 
-        with self.assertRaisesRegexp(ValueError, 'already exists'):
+        with raises_regex(ValueError, 'already exists'):
             original.expand_dims(dim=['x'])
 
         # Make sure it raises true error also for non-dimensional coordinates
         # which has dimension.
         original.set_coords('z', inplace=True)
-        with self.assertRaisesRegexp(ValueError, 'already exists'):
+        with raises_regex(ValueError, 'already exists'):
             original.expand_dims(dim=['z'])
 
     def test_expand_dims(self):
@@ -2027,7 +2027,7 @@ class TestDataset(TestCase):
         self.assertDatasetIdentical(ds, expected)
 
         ds = Dataset({}, coords={'x': [1, 2]})
-        with self.assertRaisesRegexp(ValueError, 'has no MultiIndex'):
+        with raises_regex(ValueError, 'has no MultiIndex'):
             ds.reorder_levels(x=['level_1', 'level_2'])
 
     def test_stack(self):
@@ -2063,9 +2063,9 @@ class TestDataset(TestCase):
 
     def test_unstack_errors(self):
         ds = Dataset({'x': [1, 2, 3]})
-        with self.assertRaisesRegexp(ValueError, 'invalid dimension'):
+        with raises_regex(ValueError, 'invalid dimension'):
             ds.unstack('foo')
-        with self.assertRaisesRegexp(ValueError, 'does not have a MultiIndex'):
+        with raises_regex(ValueError, 'does not have a MultiIndex'):
             ds.unstack('x')
 
     def test_stack_unstack(self):
@@ -2109,7 +2109,7 @@ class TestDataset(TestCase):
                            {'t': [0, 1]})
         actual = ds.copy()
         other = {'y': ('t', [5]), 't': [1]}
-        with self.assertRaisesRegexp(ValueError, 'conflicting sizes'):
+        with raises_regex(ValueError, 'conflicting sizes'):
             actual.update(other)
         actual.update(Dataset(other))
         self.assertDatasetIdentical(expected, actual)
@@ -2125,9 +2125,9 @@ class TestDataset(TestCase):
         data = create_test_data()
         self.assertIsInstance(data['var1'], DataArray)
         self.assertVariableEqual(data['var1'].variable, data.variables['var1'])
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             data['notfound']
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             data[['var1', 'notfound']]
 
         actual = data[['var1', 'var2']]
@@ -2151,7 +2151,7 @@ class TestDataset(TestCase):
         expected = data['var1'] + 1
         expected.name = (3, 4)
         self.assertDataArrayIdentical(expected, data[(3, 4)])
-        with self.assertRaisesRegexp(KeyError, "('var1', 'var2')"):
+        with raises_regex(KeyError, "('var1', 'var2')"):
             data[('var1', 'var2')]
 
     def test_virtual_variables_default_coords(self):
@@ -2238,7 +2238,7 @@ class TestDataset(TestCase):
         data2['B'] = dv
         self.assertDatasetIdentical(data1, data2)
         # can't assign an ND array without dimensions
-        with self.assertRaisesRegexp(ValueError,
+        with raises_regex(ValueError,
                                      'without explicit dimension names'):
             data2['C'] = var.values.reshape(2, 4)
         # but can assign a 1D array
@@ -2250,16 +2250,16 @@ class TestDataset(TestCase):
         data2['scalar'] = ([], 0)
         self.assertDatasetIdentical(data1, data2)
         # can't use the same dimension name as a scalar var
-        with self.assertRaisesRegexp(ValueError, 'already exists as a scalar'):
+        with raises_regex(ValueError, 'already exists as a scalar'):
             data1['newvar'] = ('scalar', [3, 4, 5])
         # can't resize a used dimension
-        with self.assertRaisesRegexp(ValueError, 'arguments without labels'):
+        with raises_regex(ValueError, 'arguments without labels'):
             data1['dim1'] = data1['dim1'][:5]
         # override an existing value
         data1['A'] = 3 * data2['A']
         self.assertVariableEqual(data1['A'], 3 * data2['A'])
 
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             data1[{'x': 0}] = 0
 
     def test_setitem_pandas(self):
@@ -2345,7 +2345,7 @@ class TestDataset(TestCase):
 
     def test_assign_multiindex_level(self):
         data = create_test_multiindex()
-        with self.assertRaisesRegexp(ValueError, 'conflicting MultiIndex'):
+        with raises_regex(ValueError, 'conflicting MultiIndex'):
             data.assign(level_1=range(4))
             data.assign_coords(level_1=range(4))
 
@@ -2380,7 +2380,7 @@ class TestDataset(TestCase):
 
     def test_setitem_multiindex_level(self):
         data = create_test_multiindex()
-        with self.assertRaisesRegexp(ValueError, 'conflicting MultiIndex'):
+        with raises_regex(ValueError, 'conflicting MultiIndex'):
             data['level_1'] = range(4)
 
     def test_delitem(self):
@@ -2403,7 +2403,7 @@ class TestDataset(TestCase):
             expected.set_coords(data.coords, inplace=True)
             self.assertDatasetIdentical(expected, data.squeeze(*args))
         # invalid squeeze
-        with self.assertRaisesRegexp(ValueError, 'cannot select a dimension'):
+        with raises_regex(ValueError, 'cannot select a dimension'):
             data.squeeze('y')
 
     def test_squeeze_drop(self):
@@ -2471,11 +2471,11 @@ class TestDataset(TestCase):
 
     def test_groupby_errors(self):
         data = create_test_data()
-        with self.assertRaisesRegexp(TypeError, '`group` must be'):
+        with raises_regex(TypeError, '`group` must be'):
             data.groupby(np.arange(10))
-        with self.assertRaisesRegexp(ValueError, 'length does not match'):
+        with raises_regex(ValueError, 'length does not match'):
             data.groupby(data['dim1'][:3])
-        with self.assertRaisesRegexp(TypeError, "`group` must be"):
+        with raises_regex(TypeError, "`group` must be"):
             data.groupby(data.coords['dim1'].to_index())
 
     def test_groupby_reduce(self):
@@ -2533,20 +2533,20 @@ class TestDataset(TestCase):
         actual = zeros + grouped
         self.assertDatasetEqual(expected, actual)
 
-        with self.assertRaisesRegexp(ValueError, 'incompat.* grouped binary'):
+        with raises_regex(ValueError, 'incompat.* grouped binary'):
             grouped + ds
-        with self.assertRaisesRegexp(ValueError, 'incompat.* grouped binary'):
+        with raises_regex(ValueError, 'incompat.* grouped binary'):
             ds + grouped
-        with self.assertRaisesRegexp(TypeError, 'only support binary ops'):
+        with raises_regex(TypeError, 'only support binary ops'):
             grouped + 1
-        with self.assertRaisesRegexp(TypeError, 'only support binary ops'):
+        with raises_regex(TypeError, 'only support binary ops'):
             grouped + grouped
-        with self.assertRaisesRegexp(TypeError, 'in-place operations'):
+        with raises_regex(TypeError, 'in-place operations'):
             ds += grouped
 
         ds = Dataset({'x': ('time', np.arange(100)),
                       'time': pd.date_range('2000-01-01', periods=100)})
-        with self.assertRaisesRegexp(ValueError, 'incompat.* grouped binary'):
+        with raises_regex(ValueError, 'incompat.* grouped binary'):
             ds + ds.groupby('time.month')
 
     def test_groupby_math_virtual(self):
@@ -2778,7 +2778,7 @@ class TestDataset(TestCase):
         # regression test for GH449
         df = pd.DataFrame(np.zeros((2, 2)))
         df.columns = ['foo', 'foo']
-        with self.assertRaisesRegexp(ValueError, 'non-unique columns'):
+        with raises_regex(ValueError, 'non-unique columns'):
             Dataset.from_dataframe(df)
 
     def test_convert_dataframe_with_many_types_and_multiindex(self):
@@ -2861,7 +2861,7 @@ class TestDataset(TestCase):
         d = {'a': {'data': x},
              't': {'data': t, 'dims': 't'},
              'b': {'dims': 't', 'data': y}}
-        with self.assertRaisesRegexp(ValueError, "cannot convert dict "
+        with raises_regex(ValueError, "cannot convert dict "
                                      "without the key 'dims'"):
             Dataset.from_dict(d)
 
@@ -2924,9 +2924,9 @@ class TestDataset(TestCase):
 
         for decode_cf in [True, False]:
             ds = open_dataset(store, decode_cf=decode_cf)
-            with self.assertRaises(UnexpectedDataAccess):
+            with pytest.raises(UnexpectedDataAccess):
                 ds.load()
-            with self.assertRaises(UnexpectedDataAccess):
+            with pytest.raises(UnexpectedDataAccess):
                 ds['var1'].values
 
             # these should not raise UnexpectedDataAccess:
@@ -2986,11 +2986,11 @@ class TestDataset(TestCase):
         expected = ds.isel(a=[1, 3])
         self.assertDatasetIdentical(actual, ds)
 
-        with self.assertRaisesRegexp(ValueError, 'a single dataset dimension'):
+        with raises_regex(ValueError, 'a single dataset dimension'):
             ds.dropna('foo')
-        with self.assertRaisesRegexp(ValueError, 'invalid how'):
+        with raises_regex(ValueError, 'invalid how'):
             ds.dropna('a', how='somehow')
-        with self.assertRaisesRegexp(TypeError, 'must specify how or thresh'):
+        with raises_regex(TypeError, 'must specify how or thresh'):
             ds.dropna('a', how=None)
 
     def test_fillna(self):
@@ -3035,7 +3035,7 @@ class TestDataset(TestCase):
         self.assertDatasetIdentical(expected, actual)
 
         # but new data variables is not okay
-        with self.assertRaisesRegexp(ValueError, 'must be contained'):
+        with raises_regex(ValueError, 'must be contained'):
             ds.fillna({'x': 0})
 
         # empty argument should be OK
@@ -3165,7 +3165,7 @@ class TestDataset(TestCase):
         actual = ds.where(ds.a > 1, drop=True)
         self.assertDatasetIdentical(expected, actual)
 
-        with self.assertRaisesRegexp(TypeError, 'must be a'):
+        with raises_regex(TypeError, 'must be a'):
             ds.where(np.arange(5) > 1, drop=True)
 
         # 1d with odd coordinates
@@ -3251,17 +3251,17 @@ class TestDataset(TestCase):
 
     def test_reduce_bad_dim(self):
         data = create_test_data()
-        with self.assertRaisesRegexp(ValueError, 'Dataset does not contain'):
+        with raises_regex(ValueError, 'Dataset does not contain'):
             ds = data.mean(dim='bad_dim')
 
     def test_reduce_cumsum_test_dims(self):
         data = create_test_data()
         for cumfunc in ['cumsum', 'cumprod']:
-            with self.assertRaisesRegexp(ValueError, "must supply either single 'dim' or 'axis'"):
+            with raises_regex(ValueError, "must supply either single 'dim' or 'axis'"):
                 ds = getattr(data, cumfunc)()
-            with self.assertRaisesRegexp(ValueError, "must supply either single 'dim' or 'axis'"):
+            with raises_regex(ValueError, "must supply either single 'dim' or 'axis'"):
                 ds = getattr(data, cumfunc)(dim=['dim1', 'dim2'])
-            with self.assertRaisesRegexp(ValueError, 'Dataset does not contain'):
+            with raises_regex(ValueError, 'Dataset does not contain'):
                 ds = getattr(data, cumfunc)(dim='bad_dim')
 
             # ensure dimensions are correct
@@ -3377,10 +3377,10 @@ class TestDataset(TestCase):
         actual = ds.reduce(mean_only_one_axis, 'y')
         self.assertDatasetIdentical(expected, actual)
 
-        with self.assertRaisesRegexp(TypeError, 'non-integer axis'):
+        with raises_regex(TypeError, 'non-integer axis'):
             ds.reduce(mean_only_one_axis)
 
-        with self.assertRaisesRegexp(TypeError, 'non-integer axis'):
+        with raises_regex(TypeError, 'non-integer axis'):
             ds.reduce(mean_only_one_axis, ['x', 'y'])
 
     def test_quantile(self):
@@ -3467,9 +3467,9 @@ class TestDataset(TestCase):
         self.assertDatasetIdentical(ds.isnull(), ~ds.notnull())
 
         # don't actually patch these methods in
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             ds.item
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             ds.searchsorted
 
     def test_dataset_array_math(self):
@@ -3552,11 +3552,11 @@ class TestDataset(TestCase):
     def test_dataset_math_errors(self):
         ds = self.make_example_math_dataset()
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             ds['foo'] += ds
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             ds['foo'].variable += ds
-        with self.assertRaisesRegexp(ValueError, 'must have the same'):
+        with raises_regex(ValueError, 'must have the same'):
             ds += ds[['bar']]
 
         # verify we can rollback in-place operations if something goes wrong
@@ -3564,7 +3564,7 @@ class TestDataset(TestCase):
         # but not floats thanks to numpy's inconsistent handling
         other = DataArray(np.datetime64('2000-01-01T12'), coords={'c': 2})
         actual = ds.copy(deep=True)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             actual += other
         self.assertDatasetIdentical(actual, ds)
 
@@ -3595,9 +3595,9 @@ class TestDataset(TestCase):
             expected_dims = tuple(d for d in new_order if d in ds[k].dims)
             self.assertEqual(actual[k].dims, expected_dims)
 
-        with self.assertRaisesRegexp(ValueError, 'arguments to transpose'):
+        with raises_regex(ValueError, 'arguments to transpose'):
             ds.transpose('dim1', 'dim2', 'dim3')
-        with self.assertRaisesRegexp(ValueError, 'arguments to transpose'):
+        with raises_regex(ValueError, 'arguments to transpose'):
             ds.transpose('dim1', 'dim2', 'dim3', 'time', 'extra_dim')
 
     def test_dataset_retains_period_index_on_transpose(self):
@@ -3657,12 +3657,12 @@ class TestDataset(TestCase):
 
     def test_dataset_diff_exception_n_neg(self):
         ds = create_test_data(seed=1)
-        with self.assertRaisesRegexp(ValueError, 'must be non-negative'):
+        with raises_regex(ValueError, 'must be non-negative'):
             ds.diff('dim2', n=-1)
 
     def test_dataset_diff_exception_label_str(self):
         ds = create_test_data(seed=1)
-        with self.assertRaisesRegexp(ValueError, '\'label\' argument has to'):
+        with raises_regex(ValueError, '\'label\' argument has to'):
             ds.diff('dim2', label='raise_me')
 
     def test_shift(self):
@@ -3673,7 +3673,7 @@ class TestDataset(TestCase):
         expected = Dataset({'foo': ('x', [np.nan, 1, 2])}, coords, attrs)
         self.assertDatasetIdentical(expected, actual)
 
-        with self.assertRaisesRegexp(ValueError, 'dimensions'):
+        with raises_regex(ValueError, 'dimensions'):
             ds.shift(foo=123)
 
     def test_roll(self):
@@ -3686,7 +3686,7 @@ class TestDataset(TestCase):
         expected = Dataset({'foo': ('x', [3, 1, 2])}, ex_coords, attrs)
         self.assertDatasetIdentical(expected, actual)
 
-        with self.assertRaisesRegexp(ValueError, 'dimensions'):
+        with raises_regex(ValueError, 'dimensions'):
             ds.roll(foo=123)
 
     def test_real_and_imag(self):
@@ -3701,11 +3701,11 @@ class TestDataset(TestCase):
 
     def test_setattr_raises(self):
         ds = Dataset({}, coords={'scalar': 1}, attrs={'foo': 'bar'})
-        with self.assertRaisesRegexp(AttributeError, 'cannot set attr'):
+        with raises_regex(AttributeError, 'cannot set attr'):
             ds.scalar = 2
-        with self.assertRaisesRegexp(AttributeError, 'cannot set attr'):
+        with raises_regex(AttributeError, 'cannot set attr'):
             ds.foo = 2
-        with self.assertRaisesRegexp(AttributeError, 'cannot set attr'):
+        with raises_regex(AttributeError, 'cannot set attr'):
             ds.other = 2
 
     def test_filter_by_attrs(self):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4106,3 +4106,9 @@ def test_rolling_reduce(ds, center, min_periods, window, name):
     # Make sure the dimension order is restored
     for key, src_var in ds.data_vars.items():
         assert src_var.dims == actual[key].dims
+
+
+def test_raise_no_warning_for_nan_in_binary_ops():
+    with pytest.warns(None) as record:
+        Dataset(data_vars={'x': ('y', [1, 2, np.NaN])}) > 0
+    assert len(record) == 0

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -8,7 +8,7 @@ from xarray.core.duck_array_ops import (
     first, last, count, mean, array_notnull_equiv,
 )
 
-from . import TestCase
+from . import TestCase, raises_regex
 
 
 class TestOps(TestCase):
@@ -42,7 +42,7 @@ class TestOps(TestCase):
         actual = first(self.x, axis=-1, skipna=False)
         self.assertArrayEqual(expected, actual)
 
-        with self.assertRaisesRegexp(IndexError, 'out of bounds'):
+        with raises_regex(IndexError, 'out of bounds'):
             first(self.x, 3)
 
     def test_last(self):
@@ -66,7 +66,7 @@ class TestOps(TestCase):
         actual = last(self.x, axis=-1, skipna=False)
         self.assertArrayEqual(expected, actual)
 
-        with self.assertRaisesRegexp(IndexError, 'out of bounds'):
+        with raises_regex(IndexError, 'out of bounds'):
             last(self.x, 3)
 
     def test_count(self):

--- a/xarray/tests/test_extensions.py
+++ b/xarray/tests/test_extensions.py
@@ -8,7 +8,7 @@ except ImportError:
 
 import xarray as xr
 
-from . import TestCase
+from . import TestCase, raises_regex
 
 
 @xr.register_dataset_accessor('example_accessor')
@@ -86,5 +86,5 @@ class TestAccessor(TestCase):
             def __init__(self, xarray_obj):
                 raise AttributeError('broken')
 
-        with self.assertRaisesRegexp(RuntimeError, 'error initializing'):
+        with raises_regex(RuntimeError, 'error initializing'):
             xr.Dataset().stupid_accessor

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -8,7 +8,7 @@ import pandas as pd
 from xarray.core import formatting
 from xarray.core.pycompat import PY3
 
-from . import TestCase
+from . import TestCase, raises_regex
 
 
 class TestFormatting(TestCase):
@@ -37,7 +37,7 @@ class TestFormatting(TestCase):
             expected = array.flat[:n]
             self.assertItemsEqual(expected, actual)
 
-        with self.assertRaisesRegexp(ValueError, 'at least one item'):
+        with raises_regex(ValueError, 'at least one item'):
             formatting.first_n_items(array, 0)
 
     def test_last_item(self):

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -53,7 +53,7 @@ def test_groupby_da_datetime():
     times = pd.date_range('2000-01-01', periods=4)
     foo = xr.DataArray([1,2,3,4], coords=dict(time=times), dims='time')
     # create test index
-    dd = times.to_datetime()
+    dd = times.to_pydatetime()
     reference_dates = [dd[0], dd[2]]
     labels = reference_dates[0:1]*2 + reference_dates[1:2]*2
     ind = xr.DataArray(labels, coords=dict(time=times), dims='time', name='reference_date')
@@ -70,5 +70,5 @@ def test_groupby_duplicate_coordinate_labels():
     actual = array.groupby('x').sum()
     assert expected.equals(actual)
 
-    
+
 # TODO: move other groupby tests from test_dataset and test_dataarray over here

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -24,7 +24,7 @@ from xarray.plot.utils import (_determine_cmap_params,
                                _build_discrete_cmap,
                                _color_palette, import_seaborn)
 
-from . import TestCase, requires_matplotlib, requires_seaborn
+from . import TestCase, requires_matplotlib, requires_seaborn, raises_regex
 
 
 @pytest.mark.flaky
@@ -153,10 +153,10 @@ class TestPlot(PlotTestCase):
         for ax in g.axes.flat:
             self.assertTrue(ax.has_data())
 
-        with self.assertRaisesRegexp(ValueError, '[Ff]acet'):
+        with raises_regex(ValueError, '[Ff]acet'):
             d.plot(x='x', y='y', col='z', ax=plt.gca())
 
-        with self.assertRaisesRegexp(ValueError, '[Ff]acet'):
+        with raises_regex(ValueError, '[Ff]acet'):
             d[0].plot(x='x', y='y', col='z', ax=plt.gca())
 
     @pytest.mark.slow
@@ -188,16 +188,16 @@ class TestPlot(PlotTestCase):
         self.darray.plot(size=5, aspect=2)
         assert tuple(plt.gcf().get_size_inches()) == (10, 5)
 
-        with self.assertRaisesRegexp(ValueError, 'cannot provide both'):
+        with raises_regex(ValueError, 'cannot provide both'):
             self.darray.plot(ax=plt.gca(), figsize=(3, 4))
 
-        with self.assertRaisesRegexp(ValueError, 'cannot provide both'):
+        with raises_regex(ValueError, 'cannot provide both'):
             self.darray.plot(size=5, figsize=(3, 4))
 
-        with self.assertRaisesRegexp(ValueError, 'cannot provide both'):
+        with raises_regex(ValueError, 'cannot provide both'):
             self.darray.plot(size=5, ax=plt.gca())
 
-        with self.assertRaisesRegexp(ValueError, 'cannot provide `aspect`'):
+        with raises_regex(ValueError, 'cannot provide `aspect`'):
             self.darray.plot(aspect=1)
 
     @pytest.mark.slow
@@ -210,7 +210,7 @@ class TestPlot(PlotTestCase):
         for ax in g.axes.flat:
             self.assertTrue(ax.has_data())
 
-        with self.assertRaisesRegexp(ValueError, '[Ff]acet'):
+        with raises_regex(ValueError, '[Ff]acet'):
             d.plot(x='x', y='y', col='columns', ax=plt.gca())
 
 
@@ -236,7 +236,7 @@ class TestPlot1D(PlotTestCase):
 
     def test_wrong_dims_raises_valueerror(self):
         twodims = DataArray(easy_array((2, 5)))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             twodims.plot.line()
 
     def test_format_string(self):
@@ -248,7 +248,7 @@ class TestPlot1D(PlotTestCase):
     def test_nonnumeric_index_raises_typeerror(self):
         a = DataArray([1, 2, 3], {'letter': ['a', 'b', 'c']},
                       dims='letter')
-        with self.assertRaisesRegexp(TypeError, r'[Pp]lot'):
+        with raises_regex(TypeError, r'[Pp]lot'):
             a.plot.line()
 
     def test_primitive_returned(self):
@@ -575,18 +575,18 @@ class Common2dMixin:
         self.assertEqual('y', plt.gca().get_ylabel())
 
     def test_1d_raises_valueerror(self):
-        with self.assertRaisesRegexp(ValueError, r'DataArray must be 2d'):
+        with raises_regex(ValueError, r'DataArray must be 2d'):
             self.plotfunc(self.darray[0, :])
 
     def test_3d_raises_valueerror(self):
         a = DataArray(easy_array((2, 3, 4)))
-        with self.assertRaisesRegexp(ValueError, r'DataArray must be 2d'):
+        with raises_regex(ValueError, r'DataArray must be 2d'):
             self.plotfunc(a)
 
     def test_nonnumeric_index_raises_typeerror(self):
         a = DataArray(easy_array((3, 2)),
                       coords=[['a', 'b', 'c'], ['d', 'e']])
-        with self.assertRaisesRegexp(TypeError, r'[Pp]lot'):
+        with raises_regex(TypeError, r'[Pp]lot'):
             self.plotfunc(a)
 
     def test_can_pass_in_axis(self):
@@ -659,13 +659,13 @@ class Common2dMixin:
         self.assertEqual('y', ax.get_ylabel())
 
     def test_bad_x_string_exception(self):
-        with self.assertRaisesRegexp(
+        with raises_regex(
                 ValueError, 'x and y must be coordinate variables'):
             self.plotmethod('not_a_real_dim', 'y')
-        with self.assertRaisesRegexp(
+        with raises_regex(
                 ValueError, 'x must be a dimension name if y is not supplied'):
             self.plotmethod(x='not_a_real_dim')
-        with self.assertRaisesRegexp(
+        with raises_regex(
                 ValueError, 'y must be a dimension name if x is not supplied'):
             self.plotmethod(y='not_a_real_dim')
         self.darray.coords['z'] = 100
@@ -755,7 +755,7 @@ class Common2dMixin:
         self.plotmethod(add_colorbar=False)
         self.assertNotIn('testvar', text_in_fig())
         # check that error is raised
-        self.assertRaises(ValueError, self.plotmethod,
+        pytest.raises(ValueError, self.plotmethod,
                           add_colorbar=False, cbar_kwargs= {'label':'label'})
 
     def test_verbose_facetgrid(self):
@@ -908,11 +908,11 @@ class TestContour(Common2dMixin, PlotTestCase):
             (0.0, 0.0, 1.0))
 
     def test_cmap_and_color_both(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.plotmethod(colors='k', cmap='RdBu')
 
     def list_of_colors_in_cmap_deprecated(self):
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             self.plotmethod(cmap=['k', 'b'])
 
     @pytest.mark.slow
@@ -984,7 +984,7 @@ class TestImshow(Common2dMixin, PlotTestCase):
     @pytest.mark.slow
     def test_cannot_change_mpl_aspect(self):
 
-        with self.assertRaisesRegexp(ValueError, 'not available in xarray'):
+        with raises_regex(ValueError, 'not available in xarray'):
             self.darray.plot.imshow(aspect='equal')
 
         # with numbers we fall back to fig control
@@ -1000,11 +1000,11 @@ class TestImshow(Common2dMixin, PlotTestCase):
     @pytest.mark.slow
     @requires_seaborn
     def test_seaborn_palette_needs_levels(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.plotmethod(cmap='husl')
 
     def test_2d_coord_names(self):
-        with self.assertRaisesRegexp(ValueError, 'requires 1D coordinates'):
+        with raises_regex(ValueError, 'requires 1D coordinates'):
             self.plotmethod(x='x2d', y='y2d')
 
 
@@ -1076,7 +1076,7 @@ class TestFacetGrid(PlotTestCase):
 
     @pytest.mark.slow
     def test_norow_nocol_error(self):
-        with self.assertRaisesRegexp(ValueError, r'[Rr]ow'):
+        with raises_regex(ValueError, r'[Rr]ow'):
             xplt.FacetGrid(self.darray)
 
     @pytest.mark.slow
@@ -1097,7 +1097,7 @@ class TestFacetGrid(PlotTestCase):
     @pytest.mark.slow
     def test_nonunique_index_error(self):
         self.darray.coords['z'] = [0.1, 0.2, 0.2]
-        with self.assertRaisesRegexp(ValueError, r'[Uu]nique'):
+        with raises_regex(ValueError, r'[Uu]nique'):
             xplt.FacetGrid(self.darray, col='z')
 
     @pytest.mark.slow
@@ -1156,10 +1156,10 @@ class TestFacetGrid(PlotTestCase):
         g = xplt.FacetGrid(self.darray, col='z', figsize=(9, 4))
         self.assertArrayEqual(g.fig.get_size_inches(), (9, 4))
 
-        with self.assertRaisesRegexp(ValueError, "cannot provide both"):
+        with raises_regex(ValueError, "cannot provide both"):
             g = xplt.plot(self.darray, row=2, col='z', figsize=(6, 4), size=6)
 
-        with self.assertRaisesRegexp(ValueError, "Can't use"):
+        with raises_regex(ValueError, "Can't use"):
             g = xplt.plot(self.darray, row=2, col='z', ax=plt.gca(), size=6)
 
     @pytest.mark.slow

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -165,7 +165,7 @@ class TestPlot(PlotTestCase):
         d = DataArray(a, dims=['y', 'x', 'z'])
         d.coords['z'] = list('abcd')
         g = d.plot(x='x', y='y', col='z', col_wrap=2, cmap='cool',
-                   subplot_kws=dict(axisbg='r'))
+                   subplot_kws=dict(facecolor='r'))
         for ax in g.axes.flat:
             try:
                 # mpl V2

--- a/xarray/tests/test_ufuncs.py
+++ b/xarray/tests/test_ufuncs.py
@@ -8,7 +8,7 @@ import numpy as np
 import xarray.ufuncs as xu
 import xarray as xr
 
-from . import TestCase
+from . import TestCase, raises_regex
 
 
 class TestOps(TestCase):
@@ -59,7 +59,7 @@ class TestOps(TestCase):
         self.assertIdentical(ds.a, xu.maximum(arr_grouped, group_mean.a))
         self.assertIdentical(ds.a, xu.maximum(group_mean.a, arr_grouped))
 
-        with self.assertRaisesRegexp(TypeError, 'only support binary ops'):
+        with raises_regex(TypeError, 'only support binary ops'):
             xu.maximum(ds.a.variable, ds_grouped)
 
     def test_pickle(self):

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -81,7 +81,7 @@ class TestDictionaries(TestCase):
         utils.update_safety_check(self.x, self.y)
 
     def test_unsafe(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             utils.update_safety_check(self.x, self.z)
 
     def test_ordered_dict_intersection(self):
@@ -116,11 +116,11 @@ class TestDictionaries(TestCase):
 
     def test_frozen(self):
         x = utils.Frozen(self.x)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             x['foo'] = 'bar'
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             del x['a']
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             x.update(self.y)
         self.assertEqual(x.mapping, self.x)
         self.assertIn(repr(x), ("Frozen({'a': 'A', 'b': 'B'})",

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1675,3 +1675,9 @@ class TestAsCompatibleData(TestCase):
                                      full_like(orig, 1))
         self.assertVariableIdentical(ones_like(orig, dtype=int),
                                      full_like(orig, 1, dtype=int))
+
+
+def test_raise_no_warning_for_nan_in_binary_ops():
+    with pytest.warns(None) as record:
+        Variable('x', [1, 2, np.NaN]) > 0
+    assert len(record) == 0

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -206,7 +206,7 @@ class VariableSubclassTestCases(object):
     def test_0d_time_data(self):
         # regression test for #105
         x = self.cls('time', pd.date_range('2000-01-01', periods=5))
-        expected = np.datetime64('2000-01-01T00Z', 'ns')
+        expected = np.datetime64('2000-01-01', 'ns')
         self.assertEqual(x[0].values, expected)
 
     def test_datetime64_conversion(self):
@@ -721,9 +721,9 @@ class TestVariable(TestCase, VariableSubclassTestCases):
         self.assertEqual(2, v.searchsorted(2))
 
     def test_datetime64_conversion_scalar(self):
-        expected = np.datetime64('2000-01-01T00:00:00Z', 'ns')
+        expected = np.datetime64('2000-01-01', 'ns')
         for values in [
-                 np.datetime64('2000-01-01T00Z'),
+                 np.datetime64('2000-01-01'),
                  pd.Timestamp('2000-01-01T00'),
                  datetime(2000, 1, 1),
                 ]:
@@ -756,7 +756,7 @@ class TestVariable(TestCase, VariableSubclassTestCases):
     def test_0d_datetime(self):
         v = Variable([], pd.Timestamp('2000-01-01'))
         self.assertEqual(v.dtype, np.dtype('datetime64[ns]'))
-        self.assertEqual(v.values, np.datetime64('2000-01-01T00Z', 'ns'))
+        self.assertEqual(v.values, np.datetime64('2000-01-01', 'ns'))
 
     def test_0d_timedelta(self):
         for td in [pd.to_timedelta('1s'), np.timedelta64(1, 's')]:
@@ -1592,26 +1592,26 @@ class TestAsCompatibleData(TestCase):
         self.assertEqual(np.dtype(float), actual.dtype)
 
     def test_datetime(self):
-        expected = np.datetime64('2000-01-01T00Z')
+        expected = np.datetime64('2000-01-01')
         actual = as_compatible_data(expected)
         self.assertEqual(expected, actual)
         self.assertEqual(np.ndarray, type(actual))
         self.assertEqual(np.dtype('datetime64[ns]'), actual.dtype)
 
-        expected = np.array([np.datetime64('2000-01-01T00Z')])
+        expected = np.array([np.datetime64('2000-01-01')])
         actual = as_compatible_data(expected)
         self.assertEqual(np.asarray(expected), actual)
         self.assertEqual(np.ndarray, type(actual))
         self.assertEqual(np.dtype('datetime64[ns]'), actual.dtype)
 
-        expected = np.array([np.datetime64('2000-01-01T00Z', 'ns')])
+        expected = np.array([np.datetime64('2000-01-01', 'ns')])
         actual = as_compatible_data(expected)
         self.assertEqual(np.asarray(expected), actual)
         self.assertEqual(np.ndarray, type(actual))
         self.assertEqual(np.dtype('datetime64[ns]'), actual.dtype)
         self.assertIs(expected, source_ndarray(np.asarray(actual)))
 
-        expected = np.datetime64('2000-01-01T00Z', 'ns')
+        expected = np.datetime64('2000-01-01', 'ns')
         actual = as_compatible_data(datetime(2000, 1, 1))
         self.assertEqual(np.asarray(expected), actual)
         self.assertEqual(np.ndarray, type(actual))


### PR DESCRIPTION
 - [x] Closes #1652
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

This first commit just includes the fixes for the warnings issued in our unit tests. I've temporarily added `-W error` to the travis builds so we can see the warnings/errors for all environments. Next step is to address the warnings in the xarray code itself. 