### PR TITLE
BUG: Added new names for pandas isna/notna unary functions

### DIFF
--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -42,6 +42,8 @@ NUMPY_SAME_METHODS = ['item', 'searchsorted']
 # wrapped in an Variable/DataArray
 NUMPY_UNARY_METHODS = ['astype', 'argsort', 'clip', 'conj', 'conjugate']
 PANDAS_UNARY_FUNCTIONS = ['isnull', 'notnull']
+if pd.__version__ >= "0.21":
+    PANDAS_UNARY_FUNCTIONS.extend(['isna', 'notna'])
 # methods which remove an axis
 REDUCE_METHODS = ['all', 'any']
 NAN_REDUCE_METHODS = ['argmax', 'argmin', 'max', 'min', 'mean', 'prod', 'sum',


### PR DESCRIPTION
In pandas commit
https://github.com/pandas-dev/pandas/commit/793020293ee1e5fa023f45c12943a4ac51cc23d
isna and notna were added as aliases for isnull and notnull.  Those need
to be added to PANDAS_UNARY_FUNCTIONS for xarray datasets notnull to work.
Closes #1663.

 - [ ] Closes #1663 

Note: I'm not sure how to test for this, as I think existing tests should be already failing due to this.  In fact, when I run `nosetests` on my system I get 123 skips, 29 errors and 2 failures, none of which are related to my addition, so there must be something wrong on my system.

I did not try the flake8 test and I think new documentation is exaggerated in this case.
