### PR TITLE
Fix errors that appear after update to pandas 0.21

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -346,6 +346,10 @@ Bug fixes
 - Fix ``rasterio`` backend for Rasterio versions 1.0alpha10 and newer.
   (:issue:`1641`). By `Chris Holden <https://github.com/ceholden>`_.
 
+- Fix plotting with datetime64 axis labels under pandas 0.21 and newer
+  (:issue:`1661`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
+
 .. _whats-new.0.9.6:
 
 v0.9.6 (8 June 2017)

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -10,7 +10,8 @@ import functools
 import numpy as np
 
 from ..core.formatting import format_item
-from .utils import _determine_cmap_params, _infer_xy_labels
+from .utils import (_determine_cmap_params, _infer_xy_labels,
+                    import_matplotlib_pyplot)
 
 
 # Overrides axes.labelsize, xtick.major.size, ytick.major.size
@@ -101,7 +102,7 @@ class FacetGrid(object):
 
         """
 
-        import matplotlib.pyplot as plt
+        plt = import_matplotlib_pyplot()
 
         # Handle corner case of nonunique coordinates
         rep_col = col is not None and not data[col].to_index().is_unique
@@ -409,7 +410,7 @@ class FacetGrid(object):
         self : FacetGrid object
 
         """
-        import matplotlib.pyplot as plt
+        plt = import_matplotlib_pyplot()
 
         for ax, namedict in zip(self.axes.flat, self.name_dicts.flat):
             if namedict is not None:

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -15,7 +15,8 @@ import numpy as np
 import pandas as pd
 from datetime import datetime
 
-from .utils import _determine_cmap_params, _infer_xy_labels, get_axis
+from .utils import (_determine_cmap_params, _infer_xy_labels, get_axis,
+                    import_matplotlib_pyplot)
 from .facetgrid import FacetGrid
 from xarray.core.pycompat import basestring
 
@@ -179,7 +180,7 @@ def line(darray, *args, **kwargs):
         Additional arguments to matplotlib.pyplot.plot
 
     """
-    import matplotlib.pyplot as plt
+    plt = import_matplotlib_pyplot()
 
     ndims = len(darray.dims)
     if ndims != 1:
@@ -429,7 +430,7 @@ def _plot2d(plotfunc):
 
             return _easy_facetgrid(**allargs)
 
-        import matplotlib.pyplot as plt
+        plt = import_matplotlib_pyplot()
 
         # colors is mutually exclusive with cmap
         if cmap and colors:

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -40,6 +40,25 @@ def import_seaborn():
     return sns
 
 
+_registered = False
+
+
+def register_pandas_datetime_converter_if_needed():
+    # based on https://github.com/pandas-dev/pandas/pull/17710
+    global _registered
+    if not _registered:
+        from pandas.tseries import converter
+        converter.register()
+        _registered = True
+
+
+def import_matplotlib_pyplot():
+    """Import pyplot as register appropriate converters."""
+    register_pandas_datetime_converter_if_needed()
+    import matplotlib.pyplot as plt
+    return plt
+
+
 def _determine_extend(calc_data, vmin, vmax):
     extend_min = calc_data.min() < vmin
     extend_max = calc_data.max() > vmax

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -61,8 +61,10 @@ class TestIndexers(TestCase):
             indexing.convert_label_indexer(mindex, 0)
         with self.assertRaises(ValueError):
             indexing.convert_label_indexer(index, {'three': 0})
-        with self.assertRaisesRegexp(KeyError, 'index to be fully lexsorted'):
-            indexing.convert_label_indexer(mindex, (slice(None), 1, 'no_level'))
+        with self.assertRaises((KeyError, IndexError)):
+            # pandas 0.21 changed this from KeyError to IndexError
+            indexing.convert_label_indexer(
+                mindex, (slice(None), 1, 'no_level'))
 
     def test_convert_unsorted_datetime_index_raises(self):
         index = pd.to_datetime(['2001', '2000', '2002'])


### PR DESCRIPTION
Also fixes a test suite failure in test_indexing.py due to a changed pandas exception type.

 - [x] Fixes #1661 (datetime coordinates in matplotlib)
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
