### PR TITLE
Support Dask interface

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,6 +15,9 @@ What's New
 
 .. _whats-new.0.9.7:
 
+- Experimental support for the Dask collection interface (:issue:`1674`).
+  By `Matthew Rocklin <https://github.com/mrocklin>`_.
+
 v0.10.0 (unreleased)
 --------------------
 
@@ -27,7 +30,6 @@ backwards incompatible changes. Highlights include:
 - :py:func:`~xarray.apply_ufunc` facilitates wrapping and parallelizing
   functions written for NumPy arrays.
 - Performance improvements, particularly for dask and :py:func:`open_mfdataset`.
-- Support Dask collection interface
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,6 +27,7 @@ backwards incompatible changes. Highlights include:
 - :py:func:`~xarray.apply_ufunc` facilitates wrapping and parallelizing
   functions written for NumPy arrays.
 - Performance improvements, particularly for dask and :py:func:`open_mfdataset`.
+- Support Dask collection interface
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -592,11 +592,13 @@ class DataArray(AbstractArray, BaseDataObject):
 
     def __dask_postcompute__(self):
         variable_func, variable_args = self._variable.__dask_postcompute__()
-        return self._dask_finalize, (variable_func, variable_args, self._coords, self._name)
+        return self._dask_finalize, (variable_func, variable_args,
+                                     self._coords, self._name)
 
     def __dask_postpersist__(self):
         variable_func, variable_args = self._variable.__dask_postpersist__()
-        return self._dask_finalize, (variable_func, variable_args, self._coords, self._name)
+        return self._dask_finalize, (variable_func, variable_args,
+                                     self._coords, self._name)
 
     @staticmethod
     def _dask_finalize(results, variable_func, variable_args, coords, name):

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -576,10 +576,6 @@ class DataArray(AbstractArray, BaseDataObject):
             dataset[self.name] = self.variable
             return dataset
 
-    def visualize(self, **kwargs):
-        import dask
-        return dask.visualize(self, **kwargs)
-
     def __dask_graph__(self):
         return self._variable.__dask_graph__()
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -646,9 +646,8 @@ class DataArray(AbstractArray, BaseDataObject):
         --------
         dask.array.compute
         """
-        import dask
-        (result,) = dask.compute(self, **kwargs)
-        return result
+        new = self.copy(deep=False)
+        return new.load(**kwargs)
 
     def persist(self, **kwargs):
         """ Trigger computation in constituent dask arrays
@@ -666,9 +665,8 @@ class DataArray(AbstractArray, BaseDataObject):
         --------
         dask.persist
         """
-        import dask
-        (result,) = dask.persist(self, **kwargs)
-        return result
+        ds = self._to_temp_dataset().persist(**kwargs)
+        return self._from_temp_dataset(ds)
 
     def copy(self, deep=True):
         """Returns a copy of this array.

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -582,7 +582,6 @@ class DataArray(AbstractArray, BaseDataObject):
 
     def __dask_graph__(self):
         return self._variable.__dask_graph__()
-        # These fully describe a DataArray
 
     def __dask_keys__(self):
         return self._variable.__dask_keys__()
@@ -651,8 +650,9 @@ class DataArray(AbstractArray, BaseDataObject):
         --------
         dask.array.compute
         """
-        new = self.copy(deep=False)
-        return new.load(**kwargs)
+        import dask
+        (result,) = dask.compute(self, **kwargs)
+        return result
 
     def persist(self, **kwargs):
         """ Trigger computation in constituent dask arrays
@@ -670,8 +670,9 @@ class DataArray(AbstractArray, BaseDataObject):
         --------
         dask.persist
         """
-        ds = self._to_temp_dataset().persist(**kwargs)
-        return self._from_temp_dataset(ds)
+        import dask
+        (result,) = dask.persist(self, **kwargs)
+        return result
 
     def copy(self, deep=True):
         """Returns a copy of this array.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -618,9 +618,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         --------
         dask.persist
         """
-        import dask
-        (result,) = dask.persist(self, **kwargs)
-        return result
+        new = self.copy(deep=False)
+        return new._persist_inplace(**kwargs)
 
     @classmethod
     def _construct_direct(cls, variables, coord_names, dims=None, attrs=None,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -493,10 +493,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
 
         return self
 
-    def visualize(self, **kwargs):
-        import dask
-        return dask.visualize(self, **kwargs)
-
     def __dask_graph__(self):
         graphs = {k: v.__dask_graph__() for k, v in self.variables.items()}
         graphs = {k: v for k, v in graphs.items() if v is not None}

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -523,7 +523,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
                 if dask.is_dask_collection(v) else
                 (False, k, v) for k, v in self._variables.items()]
         return self._dask_postcompute, (info, self._coord_names, self._dims,
-                                     self._attrs, self._file_obj, self._encoding)
+                                        self._attrs, self._file_obj,
+                                        self._encoding)
 
     def __dask_postpersist__(self):
         import dask
@@ -531,7 +532,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
                 if dask.is_dask_collection(v) else
                 (False, k, v) for k, v in self._variables.items()]
         return self._dask_postpersist, (info, self._coord_names, self._dims,
-                                     self._attrs, self._file_obj, self._encoding)
+                                        self._attrs, self._file_obj,
+                                        self._encoding)
 
     @staticmethod
     def _dask_postcompute(results, info, *args):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -538,7 +538,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
     @staticmethod
     def _dask_postcompute(results, info, *args):
         variables = OrderedDict()
-        results2 = results[::-1]
+        results2 = list(results[::-1])
         for is_dask, k, v in info:
             if is_dask:
                 func, args2 = v

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -627,7 +627,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         """Shortcut around __init__ for internal use when we want to skip
         costly validation
         """
-        assert not callable(coord_names), (cls, variables, coord_names, dims, attrs)
         obj = object.__new__(cls)
         obj._variables = variables
         obj._coord_names = coord_names

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -364,10 +364,6 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         (result,) = dask.compute(self, **kwargs)
         return result
 
-    def visualize(self, **kwargs):
-        import dask
-        return dask.visualize(self, **kwargs)
-
     def __dask_graph__(self):
         if isinstance(self._data, dask_array_type):
             return self._data.__dask_graph__()

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -395,6 +395,9 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
 
     @staticmethod
     def _dask_finalize(results, array_func, array_args, dims, attrs, encoding):
+        if isinstance(results, dict):  # persist case
+            name = array_args[0]
+            results = {k: v for k, v in results.items() if k[0] == name}  # cull
         data = array_func(results, *array_args)
         return Variable(dims, data, attrs=attrs, encoding=encoding)
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -360,8 +360,13 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         --------
         dask.array.compute
         """
-        new = self.copy(deep=False)
-        return new.load(**kwargs)
+        import dask
+        (result,) = dask.compute(self, **kwargs)
+        return result
+
+    def visualize(self, **kwargs):
+        import dask
+        return dask.visualize(self, **kwargs)
 
     def __dask_graph__(self):
         if isinstance(self._data, dask_array_type):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -360,9 +360,8 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         --------
         dask.array.compute
         """
-        import dask
-        (result,) = dask.compute(self, **kwargs)
-        return result
+        new = self.copy(deep=False)
+        return new.load(**kwargs)
 
     def __dask_graph__(self):
         if isinstance(self._data, dask_array_type):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -382,11 +382,13 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
 
     def __dask_postcompute__(self):
         array_func, array_args = self._data.__dask_postcompute__()
-        return self._dask_finalize, (array_func, array_args, self._dims, self._attrs, self._encoding)
+        return self._dask_finalize, (array_func, array_args, self._dims,
+                                     self._attrs, self._encoding)
 
     def __dask_postpersist__(self):
         array_func, array_args = self._data.__dask_postpersist__()
-        return self._dask_finalize, (array_func, array_args, self._dims, self._attrs, self._encoding)
+        return self._dask_finalize, (array_func, array_args, self._dims,
+                                     self._attrs, self._encoding)
 
     @staticmethod
     def _dask_finalize(results, array_func, array_args, dims, attrs, encoding):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -363,6 +363,36 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         new = self.copy(deep=False)
         return new.load(**kwargs)
 
+    def __dask_graph__(self):
+        if isinstance(self._data, dask_array_type):
+            return self._data.__dask_graph__()
+        else:
+            return None
+
+    def __dask_keys__(self):
+        return self._data.__dask_keys__()
+
+    @property
+    def __dask_optimize__(self):
+        return self._data.__dask_optimize__
+
+    @property
+    def __dask_scheduler__(self):
+        return self._data.__dask_scheduler__
+
+    def __dask_postcompute__(self):
+        array_func, array_args = self._data.__dask_postcompute__()
+        return self._dask_finalize, (array_func, array_args, self._dims, self._attrs, self._encoding)
+
+    def __dask_postpersist__(self):
+        array_func, array_args = self._data.__dask_postpersist__()
+        return self._dask_finalize, (array_func, array_args, self._dims, self._attrs, self._encoding)
+
+    @staticmethod
+    def _dask_finalize(results, array_func, array_args, dims, attrs, encoding):
+        data = array_func(results, *array_args)
+        return Variable(dims, data, attrs=attrs, encoding=encoding)
+
     @property
     def values(self):
         """The variable's data as a numpy.ndarray"""

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -735,6 +735,8 @@ def build_dask_array(name):
         chunks=((1,),), dtype=np.int64)
 
 
+# test both the perist method and the dask.persist function
+# the dask.persist function requires a new version of dask
 @pytest.mark.parametrize('persist', [
     lambda x: x.persist(),
     pytest.mark.skipif(LooseVersion(dask.__version__) < '0.16',
@@ -751,6 +753,7 @@ def test_persist_Dataset(persist):
 
     assert len(ds2.foo.data.dask) == 1
     assert len(ds.foo.data.dask) == n  # doesn't mutate in place
+
 
 @pytest.mark.parametrize('persist', [
     lambda x: x.persist(),

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -206,8 +206,8 @@ class TestVariable(DaskTestCase):
         self.assertLazyAndAllClose(np.maximum(u, 0), xu.maximum(v, 0))
         self.assertLazyAndAllClose(np.maximum(u, 0), xu.maximum(0, v))
 
-    @pytest.mark.skipif(LooseVersion(dask.__version__) < '0.16',
-                        reason='Need dask 0.16+ for new interface')
+    @pytest.mark.skipif(LooseVersion(dask.__version__) <= '0.15.4',
+                        reason='Need dask 0.16 for new interface')
     def test_compute(self):
         u = self.eager_var
         v = self.lazy_var
@@ -218,8 +218,8 @@ class TestVariable(DaskTestCase):
 
         assert ((u + 1).data == v2.data).all()
 
-    @pytest.mark.skipif(LooseVersion(dask.__version__) < '0.16',
-                        reason='Need dask 0.16+ for new interface')
+    @pytest.mark.skipif(LooseVersion(dask.__version__) <= '0.15.4',
+                        reason='Need dask 0.16 for new interface')
     def test_persist(self):
         u = self.eager_var
         v = self.lazy_var + 1
@@ -279,8 +279,8 @@ class TestDataArrayAndDataset(DaskTestCase):
         actual = xr.concat([v[:2], v[2:]], 'x')
         self.assertLazyAndAllClose(u, actual)
 
-    @pytest.mark.skipif(LooseVersion(dask.__version__) < '0.16',
-                        reason='Need dask 0.16+ for new interface')
+    @pytest.mark.skipif(LooseVersion(dask.__version__) <= '0.15.4',
+                        reason='Need dask 0.16 for new interface')
     def test_compute(self):
         u = self.eager_array
         v = self.lazy_array
@@ -291,8 +291,8 @@ class TestDataArrayAndDataset(DaskTestCase):
 
         assert ((u + 1).data == v2.data).all()
 
-    @pytest.mark.skipif(LooseVersion(dask.__version__) < '0.16',
-                        reason='Need dask 0.16+ for new interface')
+    @pytest.mark.skipif(LooseVersion(dask.__version__) <= '0.15.4',
+                        reason='Need dask 0.16 for new interface')
     def test_persist(self):
         u = self.eager_array
         v = self.lazy_array + 1
@@ -739,9 +739,9 @@ def build_dask_array(name):
 # the dask.persist function requires a new version of dask
 @pytest.mark.parametrize('persist', [
     lambda x: x.persist(),
-    pytest.mark.skipif(LooseVersion(dask.__version__) < '0.16',
+    pytest.mark.skipif(LooseVersion(dask.__version__) <= '0.15.4',
                        lambda x: dask.persist(x)[0],
-                       reason='Need Dask 0.16+')
+                       reason='Need Dask 0.16')
 ])
 def test_persist_Dataset(persist):
     ds = Dataset({'foo': ('x', range(5)),
@@ -757,9 +757,9 @@ def test_persist_Dataset(persist):
 
 @pytest.mark.parametrize('persist', [
     lambda x: x.persist(),
-    pytest.mark.skipif(LooseVersion(dask.__version__) < '0.16',
+    pytest.mark.skipif(LooseVersion(dask.__version__) <= '0.15.4',
                        lambda x: dask.persist(x)[0],
-                       reason='Need Dask 0.16+')
+                       reason='Need Dask 0.16')
 ])
 def test_persist_DataArray(persist):
     x = da.arange(10, chunks=(5,))

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -676,7 +676,6 @@ class TestDataArrayAndDataset(DaskTestCase):
         assert_frame_equal(expected, actual.compute())
 
 
-@pytest.mark.xfail(reason="mock no longer targets the right method")
 @pytest.mark.parametrize("method", ['load', 'compute'])
 def test_dask_kwargs_variable(method):
     x = Variable('y', da.from_array(np.arange(3), chunks=(2,)))
@@ -687,7 +686,6 @@ def test_dask_kwargs_variable(method):
     mock_compute.assert_called_with(foo='bar')
 
 
-@pytest.mark.xfail(reason="mock no longer targets the right method")
 @pytest.mark.parametrize("method", ['load', 'compute', 'persist'])
 def test_dask_kwargs_dataarray(method):
     data = da.from_array(np.arange(3), chunks=(2,))
@@ -702,7 +700,6 @@ def test_dask_kwargs_dataarray(method):
     mock_func.assert_called_with(data, foo='bar')
 
 
-@pytest.mark.xfail(reason="mock no longer targets the right method")
 @pytest.mark.parametrize("method", ['load', 'compute', 'persist'])
 def test_dask_kwargs_dataset(method):
     data = da.from_array(np.arange(3), chunks=(2,))
@@ -738,10 +735,12 @@ def build_dask_array(name):
         chunks=((1,),), dtype=np.int64)
 
 
-@pytest.mark.skipif(LooseVersion(dask.__version__) < '0.16',
-                    reason='Need dask 0.16+ for new interface')
-@pytest.mark.parametrize('persist', [lambda x: x.persist(),
-                                     lambda x: dask.persist(x)[0]])
+@pytest.mark.parametrize('persist', [
+    lambda x: x.persist(),
+    pytest.mark.skipif(LooseVersion(dask.__version__) < '0.16',
+                       lambda x: dask.persist(x)[0],
+                       reason='Need Dask 0.16+')
+])
 def test_persist_Dataset(persist):
     ds = Dataset({'foo': ('x', range(5)),
                   'bar': ('x', range(5))}).chunk()

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -206,6 +206,8 @@ class TestVariable(DaskTestCase):
         self.assertLazyAndAllClose(np.maximum(u, 0), xu.maximum(v, 0))
         self.assertLazyAndAllClose(np.maximum(u, 0), xu.maximum(0, v))
 
+    @pytest.mark.skipif(LooseVersion(dask.__version__) < '0.16',
+                        reason='Need dask 0.16+ for new interface')
     def test_compute(self):
         u = self.eager_var
         v = self.lazy_var
@@ -216,6 +218,8 @@ class TestVariable(DaskTestCase):
 
         assert ((u + 1).data == v2.data).all()
 
+    @pytest.mark.skipif(LooseVersion(dask.__version__) < '0.16',
+                        reason='Need dask 0.16+ for new interface')
     def test_persist(self):
         u = self.eager_var
         v = self.lazy_var + 1
@@ -275,6 +279,8 @@ class TestDataArrayAndDataset(DaskTestCase):
         actual = xr.concat([v[:2], v[2:]], 'x')
         self.assertLazyAndAllClose(u, actual)
 
+    @pytest.mark.skipif(LooseVersion(dask.__version__) < '0.16',
+                        reason='Need dask 0.16+ for new interface')
     def test_compute(self):
         u = self.eager_array
         v = self.lazy_array
@@ -285,6 +291,8 @@ class TestDataArrayAndDataset(DaskTestCase):
 
         assert ((u + 1).data == v2.data).all()
 
+    @pytest.mark.skipif(LooseVersion(dask.__version__) < '0.16',
+                        reason='Need dask 0.16+ for new interface')
     def test_persist(self):
         u = self.eager_array
         v = self.lazy_array + 1
@@ -730,6 +738,8 @@ def build_dask_array(name):
         chunks=((1,),), dtype=np.int64)
 
 
+@pytest.mark.skipif(LooseVersion(dask.__version__) < '0.16',
+                    reason='Need dask 0.16+ for new interface')
 @pytest.mark.parametrize('persist', [lambda x: x.persist(),
                                      lambda x: dask.persist(x)[0]])
 def test_persist_Dataset(persist):
@@ -743,8 +753,12 @@ def test_persist_Dataset(persist):
     assert len(ds2.foo.data.dask) == 1
     assert len(ds.foo.data.dask) == n  # doesn't mutate in place
 
-@pytest.mark.parametrize('persist', [lambda x: x.persist(),
-                                     lambda x: dask.persist(x)[0]])
+@pytest.mark.parametrize('persist', [
+    lambda x: x.persist(),
+    pytest.mark.skipif(LooseVersion(dask.__version__) < '0.16',
+                       lambda x: dask.persist(x)[0],
+                       reason='Need Dask 0.16+')
+])
 def test_persist_DataArray(persist):
     x = da.arange(10, chunks=(5,))
     y = DataArray(x)

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -4,7 +4,9 @@ from xarray.core.pycompat import suppress
 
 distributed = pytest.importorskip('distributed')
 da = pytest.importorskip('dask.array')
-from distributed.utils_test import cluster, loop
+import dask
+from distributed.utils_test import cluster, loop, gen_cluster
+from distributed.client import futures_of, wait
 
 from xarray.tests.test_backends import create_tmp_file, ON_WINDOWS
 from xarray.tests.test_dataset import create_test_data
@@ -32,3 +34,34 @@ def test_dask_distributed_integration_test(loop, engine):
                     assert isinstance(restored.var1.data, da.Array)
                     computed = restored.compute()
                     assert_allclose(original, computed)
+
+
+@gen_cluster(client=True, timeout=None)
+def test_async(c, s, a, b):
+    x = create_test_data()
+    assert not dask.is_dask_collection(x)
+    y = x.chunk({'dim2': 4}) + 10
+    assert dask.is_dask_collection(y)
+    assert dask.is_dask_collection(y.var1)
+    assert dask.is_dask_collection(y.var2)
+    # assert not dask.is_dask_collection(y.var3)  # TODO: avoid chunking unnecessarily in dataset.py::maybe_chunk
+
+    z = y.persist()
+    assert str(z)
+
+    assert dask.is_dask_collection(z)
+    assert dask.is_dask_collection(z.var1)
+    assert dask.is_dask_collection(z.var2)
+    # assert not dask.is_dask_collection(z.var3)
+    assert len(y.__dask_graph__()) > len(z.__dask_graph__())
+
+    assert not futures_of(y)
+    assert futures_of(z)
+
+    future = c.compute(z)
+    w = yield future
+    assert not dask.is_dask_collection(w)
+    assert_allclose(x + 10, w)
+
+
+    assert s.task_state

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -53,7 +53,6 @@ def test_async(c, s, a, b):
     assert dask.is_dask_collection(z)
     assert dask.is_dask_collection(z.var1)
     assert dask.is_dask_collection(z.var2)
-    # assert not dask.is_dask_collection(z.var3)
     assert len(y.__dask_graph__()) > len(z.__dask_graph__())
 
     assert not futures_of(y)

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -46,7 +46,6 @@ def test_async(c, s, a, b):
     assert dask.is_dask_collection(y)
     assert dask.is_dask_collection(y.var1)
     assert dask.is_dask_collection(y.var2)
-    # assert not dask.is_dask_collection(y.var3)  # TODO: avoid chunking unnecessarily in dataset.py::maybe_chunk
 
     z = y.persist()
     assert str(z)

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -36,6 +36,8 @@ def test_dask_distributed_integration_test(loop, engine):
                     assert_allclose(original, computed)
 
 
+@pytest.mark.skipif(distributed.__version__ <= '1.19.3',
+                    reason='Need recent distributed version to clean up get')
 @gen_cluster(client=True, timeout=None)
 def test_async(c, s, a, b):
     x = create_test_data()
@@ -62,6 +64,5 @@ def test_async(c, s, a, b):
     w = yield future
     assert not dask.is_dask_collection(w)
     assert_allclose(x + 10, w)
-
 
     assert s.task_state


### PR DESCRIPTION
This integrates the new dask interface methods into XArray.  This will place XArray as a first-class dask collection and help in particular with newer dask.distributed features.

 - [x] Closes https://github.com/pangeo-data/pangeo/issues/5
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Builds on work from @jcrist here: https://github.com/dask/dask/pull/2748
Depends on https://github.com/dask/dask/pull/2847