### PR TITLE
Support orthogonal indexing in MemoryCachedArray (Fix for #1429)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,6 +15,14 @@ What's New
 
 .. _whats-new.0.10.0:
 
+Bug fixes
+~~~~~~~~~
+
+- (Internal bug) MemoryCachedArray now supports the orthogonal indexing.
+  Also made some internal cleanups around array wrappers (:issue:`1429`).
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_
+
+
 v0.10.0 rc1 (30 October 2017)
 -----------------------------
 

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -15,6 +15,9 @@ from .netCDF4_ import (_nc4_group, _nc4_values_and_dtype,
 
 class H5NetCDFArrayWrapper(BaseNetCDF4Array):
     def __getitem__(self, key):
+        if isinstance(key, indexing.VectorizedIndexer):
+            raise NotImplementedError('{} does not support vectorized '
+                                      'indexing'.format(self.__class__))
         key = indexing.to_tuple(key)
         with self.datastore.ensure_open(autoclose=True):
             return self.get_array()[key]

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -16,8 +16,9 @@ from .netCDF4_ import (_nc4_group, _nc4_values_and_dtype,
 class H5NetCDFArrayWrapper(BaseNetCDF4Array):
     def __getitem__(self, key):
         if isinstance(key, indexing.VectorizedIndexer):
-            raise NotImplementedError('{} does not support vectorized '
-                                      'indexing'.format(self.__class__))
+            raise NotImplementedError(
+                 'Vectorized indexing for {} is not implemented. Load your '
+                 'data first with .load() or .compute().'.format(type(self)))
         key = indexing.to_tuple(key)
         with self.datastore.ensure_open(autoclose=True):
             return self.get_array()[key]

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -57,8 +57,10 @@ class BaseNetCDF4Array(indexing.NDArrayIndexable):
 class NetCDF4ArrayWrapper(BaseNetCDF4Array):
     def __getitem__(self, key):
         if isinstance(key, indexing.VectorizedIndexer):
-            raise NotImplementedError('{} does not support vectorized '
-                                      'indexing'.format(self.__class__))
+            raise NotImplementedError(
+             'Vectorized indexing for {} is not implemented. Load your '
+             'data first with .load() or .compute().'.format(type(self)))
+
         key = indexing.to_tuple(key)
 
         if self.datastore.is_remote:  # pragma: no cover

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -10,9 +10,7 @@ from .. import conventions
 from .. import Variable
 from ..conventions import pop_to
 from ..core import indexing
-from ..core.utils import (FrozenOrderedDict, NdimSizeLenMixin,
-                          DunderArrayMixin, close_on_error,
-                          is_remote_uri)
+from ..core.utils import FrozenOrderedDict, close_on_error, is_remote_uri
 from ..core.pycompat import iteritems, basestring, OrderedDict, PY3, suppress
 
 from .common import (WritableCFDataStore, robust_getitem,
@@ -27,13 +25,13 @@ _endian_lookup = {'=': 'native',
                   '|': 'native'}
 
 
-class BaseNetCDF4Array(NdimSizeLenMixin, DunderArrayMixin):
+class BaseNetCDF4Array(indexing.NDArrayIndexable):
     def __init__(self, variable_name, datastore):
         self.datastore = datastore
         self.variable_name = variable_name
 
         array = self.get_array()
-        self.shape = array.shape
+        self._shape = array.shape
 
         dtype = array.dtype
         if dtype is str:
@@ -41,7 +39,15 @@ class BaseNetCDF4Array(NdimSizeLenMixin, DunderArrayMixin):
             # represent variable length strings; it also prevents automatic
             # string concatenation via conventions.decode_cf_variable
             dtype = np.dtype('O')
-        self.dtype = dtype
+        self._dtype = dtype
+
+    @property
+    def shape(self):
+        return self._shape
+
+    @property
+    def dtype(self):
+        return self._dtype
 
     def get_array(self):
         self.datastore.assert_open()

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -56,6 +56,9 @@ class BaseNetCDF4Array(indexing.NDArrayIndexable):
 
 class NetCDF4ArrayWrapper(BaseNetCDF4Array):
     def __getitem__(self, key):
+        if isinstance(key, indexing.VectorizedIndexer):
+            raise NotImplementedError('{} does not support vectorized '
+                                      'indexing'.format(self.__class__))
         key = indexing.to_tuple(key)
 
         if self.datastore.is_remote:  # pragma: no cover

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -10,7 +10,9 @@ from .. import conventions
 from .. import Variable
 from ..conventions import pop_to
 from ..core import indexing
-from ..core.utils import FrozenOrderedDict, close_on_error, is_remote_uri
+from ..core.utils import (FrozenOrderedDict, NdimSizeLenMixin,
+                          DunderArrayMixin, close_on_error,
+                          is_remote_uri)
 from ..core.pycompat import iteritems, basestring, OrderedDict, PY3, suppress
 
 from .common import (WritableCFDataStore, robust_getitem,
@@ -25,13 +27,14 @@ _endian_lookup = {'=': 'native',
                   '|': 'native'}
 
 
-class BaseNetCDF4Array(indexing.NDArrayIndexable):
+class BaseNetCDF4Array(NdimSizeLenMixin, DunderArrayMixin,
+                       indexing.NDArrayIndexable):
     def __init__(self, variable_name, datastore):
         self.datastore = datastore
         self.variable_name = variable_name
 
         array = self.get_array()
-        self._shape = array.shape
+        self.shape = array.shape
 
         dtype = array.dtype
         if dtype is str:
@@ -39,15 +42,7 @@ class BaseNetCDF4Array(indexing.NDArrayIndexable):
             # represent variable length strings; it also prevents automatic
             # string concatenation via conventions.decode_cf_variable
             dtype = np.dtype('O')
-        self._dtype = dtype
-
-    @property
-    def shape(self):
-        return self._shape
-
-    @property
-    def dtype(self):
-        return self._dtype
+        self.dtype = dtype
 
     def get_array(self):
         self.datastore.assert_open()

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -27,6 +27,9 @@ class PydapArrayWrapper(NDArrayMixin):
             return np.dtype(t.typecode + str(t.size))
 
     def __getitem__(self, key):
+        if isinstance(key, indexing.VectorizedIndexer):
+            raise NotImplementedError('{} does not support vectorized '
+                                      'indexing'.format(self.__class__))
         key = indexing.to_tuple(key)
         if not isinstance(key, tuple):
             key = (key,)

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -11,7 +11,7 @@ from ..core.pycompat import integer_types
 from .common import AbstractDataStore, robust_getitem
 
 
-class PydapArrayWrapper(NDArrayMixin):
+class PydapArrayWrapper(NDArrayMixin, indexing.NDArrayIndexable):
     def __init__(self, array):
         self.array = array
 

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -28,8 +28,9 @@ class PydapArrayWrapper(NDArrayMixin):
 
     def __getitem__(self, key):
         if isinstance(key, indexing.VectorizedIndexer):
-            raise NotImplementedError('{} does not support vectorized '
-                                      'indexing'.format(self.__class__))
+            raise NotImplementedError(
+             'Vectorized indexing for {} is not implemented. Load your '
+             'data first with .load() or .compute().'.format(type(self)))
         key = indexing.to_tuple(key)
         if not isinstance(key, tuple):
             key = (key,)

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -14,14 +14,22 @@ from ..core import indexing
 from .common import AbstractDataStore, DataStorePickleMixin
 
 
-class NioArrayWrapper(NdimSizeLenMixin, DunderArrayMixin):
+class NioArrayWrapper(indexing.NDArrayIndexable):
 
     def __init__(self, variable_name, datastore):
         self.datastore = datastore
         self.variable_name = variable_name
         array = self.get_array()
-        self.shape = array.shape
-        self.dtype = np.dtype(array.typecode())
+        self._shape = array.shape
+        self._dtype = np.dtype(array.typecode())
+
+    @property
+    def shape(self):
+        return self._shape
+
+    @property
+    def dtype(self):
+        return self._dtype
 
     def get_array(self):
         self.datastore.assert_open()

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -36,6 +36,9 @@ class NioArrayWrapper(indexing.NDArrayIndexable):
         return self.datastore.ds.variables[self.variable_name]
 
     def __getitem__(self, key):
+        if isinstance(key, indexing.VectorizedIndexer):
+            raise NotImplementedError('{} does not support vectorized '
+                                      'indexing'.format(self.__class__))
         key = indexing.to_tuple(key)
         with self.datastore.ensure_open(autoclose=True):
             array = self.get_array()

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -14,22 +14,15 @@ from ..core import indexing
 from .common import AbstractDataStore, DataStorePickleMixin
 
 
-class NioArrayWrapper(indexing.NDArrayIndexable):
+class NioArrayWrapper(NdimSizeLenMixin, DunderArrayMixin,
+                      indexing.NDArrayIndexable):
 
     def __init__(self, variable_name, datastore):
         self.datastore = datastore
         self.variable_name = variable_name
         array = self.get_array()
-        self._shape = array.shape
-        self._dtype = np.dtype(array.typecode())
-
-    @property
-    def shape(self):
-        return self._shape
-
-    @property
-    def dtype(self):
-        return self._dtype
+        self.shape = array.shape
+        self.dtype = np.dtype(array.typecode())
 
     def get_array(self):
         self.datastore.assert_open()

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -37,8 +37,9 @@ class NioArrayWrapper(indexing.NDArrayIndexable):
 
     def __getitem__(self, key):
         if isinstance(key, indexing.VectorizedIndexer):
-            raise NotImplementedError('{} does not support vectorized '
-                                      'indexing'.format(self.__class__))
+            raise NotImplementedError(
+             'Vectorized indexing for {} is not implemented. Load your '
+             'data first with .load() or .compute().'.format(type(self)))
         key = indexing.to_tuple(key)
         with self.datastore.ensure_open(autoclose=True):
             array = self.get_array()

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -37,8 +37,10 @@ class RasterioArrayWrapper(indexing.NDArrayIndexable):
         return self._shape
 
     def __getitem__(self, key):
+        if isinstance(key, indexing.VectorizedIndexer):
+            raise NotImplementedError('{} does not support vectorized '
+                                      'indexing'.format(self.__class__))
         key = indexing.to_tuple(key)
-        # TODO make sure it is the xarray-indexable
         # bands cannot be windowed but they can be listed
         band_key = key[0]
         n_bands = self.shape[0]

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -38,8 +38,9 @@ class RasterioArrayWrapper(indexing.NDArrayIndexable):
 
     def __getitem__(self, key):
         if isinstance(key, indexing.VectorizedIndexer):
-            raise NotImplementedError('{} does not support vectorized '
-                                      'indexing'.format(self.__class__))
+            raise NotImplementedError(
+             'Vectorized indexing for {} is not implemented. Load your '
+             'data first with .load() or .compute().'.format(type(self)))
         key = indexing.to_tuple(key)
         # bands cannot be windowed but they can be listed
         band_key = key[0]

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -1,10 +1,9 @@
 import os
 from collections import OrderedDict
-from distutils.version import LooseVersion
 import numpy as np
 
 from .. import DataArray
-from ..core.utils import DunderArrayMixin, NdimSizeLenMixin, is_scalar
+from ..core.utils import is_scalar
 from ..core import indexing
 try:
     from dask.utils import SerializableLock as Lock
@@ -18,7 +17,7 @@ _ERROR_MSG = ('The kind of indexing operation you are trying to do is not '
               'first.')
 
 
-class RasterioArrayWrapper(NdimSizeLenMixin, DunderArrayMixin):
+class RasterioArrayWrapper(indexing.NDArrayIndexable):
     """A wrapper around rasterio dataset objects"""
     def __init__(self, rasterio_ds):
         self.rasterio_ds = rasterio_ds
@@ -39,7 +38,7 @@ class RasterioArrayWrapper(NdimSizeLenMixin, DunderArrayMixin):
 
     def __getitem__(self, key):
         key = indexing.to_tuple(key)
-
+        # TODO make sure it is the xarray-indexable
         # bands cannot be windowed but they can be listed
         band_key = key[0]
         n_bands = self.shape[0]

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import numpy as np
 
 from .. import DataArray
-from ..core.utils import is_scalar
+from ..core.utils import DunderArrayMixin, NdimSizeLenMixin, is_scalar
 from ..core import indexing
 try:
     from dask.utils import SerializableLock as Lock
@@ -17,7 +17,8 @@ _ERROR_MSG = ('The kind of indexing operation you are trying to do is not '
               'first.')
 
 
-class RasterioArrayWrapper(indexing.NDArrayIndexable):
+class RasterioArrayWrapper(NdimSizeLenMixin, DunderArrayMixin,
+                           indexing.NDArrayIndexable):
     """A wrapper around rasterio dataset objects"""
     def __init__(self, rasterio_ds):
         self.rasterio_ds = rasterio_ds

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -10,8 +10,7 @@ import warnings
 from .. import Variable
 from ..core.pycompat import iteritems, OrderedDict, basestring
 from ..core.utils import Frozen, FrozenOrderedDict
-from ..core.indexing import (NumpyIndexingAdapter, NDArrayIndexable,
-                             as_indexable)
+from ..core.indexing import NumpyIndexingAdapter, NDArrayIndexable
 
 from .common import WritableCFDataStore, DataStorePickleMixin
 from .netcdf3 import (is_valid_nc3_name, encode_nc3_attr_value,

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -9,9 +9,9 @@ import warnings
 
 from .. import Variable
 from ..core.pycompat import iteritems, OrderedDict, basestring
-from ..core.utils import (Frozen, FrozenOrderedDict, NdimSizeLenMixin,
-                          DunderArrayMixin)
-from ..core.indexing import NumpyIndexingAdapter
+from ..core.utils import Frozen, FrozenOrderedDict
+from ..core.indexing import (NumpyIndexingAdapter, NDArrayIndexable,
+                             as_indexable)
 
 from .common import WritableCFDataStore, DataStorePickleMixin
 from .netcdf3 import (is_valid_nc3_name, encode_nc3_attr_value,
@@ -31,15 +31,23 @@ def _decode_attrs(d):
                        for (k, v) in iteritems(d))
 
 
-class ScipyArrayWrapper(NdimSizeLenMixin, DunderArrayMixin):
+class ScipyArrayWrapper(NDArrayIndexable):
 
     def __init__(self, variable_name, datastore):
         self.datastore = datastore
         self.variable_name = variable_name
         array = self.get_array()
-        self.shape = array.shape
-        self.dtype = np.dtype(array.dtype.kind +
-                              str(array.dtype.itemsize))
+        self._shape = array.shape
+        self._dtype = np.dtype(array.dtype.kind +
+                               str(array.dtype.itemsize))
+
+    @property
+    def shape(self):
+        return self._shape
+
+    @property
+    def dtype(self):
+        return self._dtype
 
     def get_array(self):
         self.datastore.assert_open()

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -9,7 +9,8 @@ import warnings
 
 from .. import Variable
 from ..core.pycompat import iteritems, OrderedDict, basestring
-from ..core.utils import Frozen, FrozenOrderedDict
+from ..core.utils import (Frozen, FrozenOrderedDict, NdimSizeLenMixin,
+                          DunderArrayMixin)
 from ..core.indexing import NumpyIndexingAdapter, NDArrayIndexable
 
 from .common import WritableCFDataStore, DataStorePickleMixin
@@ -30,23 +31,15 @@ def _decode_attrs(d):
                        for (k, v) in iteritems(d))
 
 
-class ScipyArrayWrapper(NDArrayIndexable):
+class ScipyArrayWrapper(NdimSizeLenMixin, DunderArrayMixin, NDArrayIndexable):
 
     def __init__(self, variable_name, datastore):
         self.datastore = datastore
         self.variable_name = variable_name
         array = self.get_array()
-        self._shape = array.shape
-        self._dtype = np.dtype(array.dtype.kind +
-                               str(array.dtype.itemsize))
-
-    @property
-    def shape(self):
-        return self._shape
-
-    @property
-    def dtype(self):
-        return self._dtype
+        self.shape = array.shape
+        self.dtype = np.dtype(array.dtype.kind +
+                              str(array.dtype.itemsize))
 
     def get_array(self):
         self.datastore.assert_open()

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -333,7 +333,7 @@ def encode_cf_timedelta(timedeltas, units=None):
     return (num, units)
 
 
-class MaskedAndScaledArray(utils.NDArrayMixin):
+class MaskedAndScaledArray(indexing.NDArrayIndexable):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically scaled and masked according to
     CF conventions for packed and missing data values.
@@ -370,7 +370,7 @@ class MaskedAndScaledArray(utils.NDArrayMixin):
             After applying scale_factor, add this number to entries in the
             original array.
         """
-        self.array = array
+        self.array = indexing.as_indexable(array)
         self.fill_value = fill_value
         self.scale_factor = scale_factor
         self.add_offset = add_offset
@@ -391,13 +391,13 @@ class MaskedAndScaledArray(utils.NDArrayMixin):
                  self.scale_factor, self.add_offset, self._dtype))
 
 
-class DecodedCFDatetimeArray(utils.NDArrayMixin):
+class DecodedCFDatetimeArray(indexing.NDArrayIndexable):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically converted into datetime objects
     using decode_cf_datetime.
     """
     def __init__(self, array, units, calendar=None):
-        self.array = array
+        self.array = indexing.as_indexable(array)
         self.units = units
         self.calendar = calendar
 
@@ -430,13 +430,13 @@ class DecodedCFDatetimeArray(utils.NDArrayMixin):
                                   calendar=self.calendar)
 
 
-class DecodedCFTimedeltaArray(utils.NDArrayMixin):
+class DecodedCFTimedeltaArray(indexing.NDArrayIndexable):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically converted into timedelta objects
     using decode_cf_timedelta.
     """
     def __init__(self, array, units):
-        self.array = array
+        self.array = indexing.as_indexable(array)
         self.units = units
 
     @property
@@ -447,7 +447,7 @@ class DecodedCFTimedeltaArray(utils.NDArrayMixin):
         return decode_cf_timedelta(self.array[key], units=self.units)
 
 
-class StackedBytesArray(utils.NDArrayMixin):
+class StackedBytesArray(indexing.NDArrayIndexable):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically stacked along the last dimension.
 
@@ -465,7 +465,7 @@ class StackedBytesArray(utils.NDArrayMixin):
         if array.dtype != 'S1':
             raise ValueError(
                 "can only use StackedBytesArray if argument has dtype='S1'")
-        self.array = array
+        self.array = indexing.as_indexable(array)
 
     @property
     def dtype(self):
@@ -493,7 +493,7 @@ class StackedBytesArray(utils.NDArrayMixin):
         return char_to_bytes(self.array[key])
 
 
-class BytesToStringArray(utils.NDArrayMixin):
+class BytesToStringArray(indexing.NDArrayIndexable):
     """Wrapper that decodes bytes to unicode when values are read.
 
     >>> BytesToStringArray(np.array([b'abc']))[:]
@@ -509,7 +509,7 @@ class BytesToStringArray(utils.NDArrayMixin):
         encoding : str
             String encoding to use.
         """
-        self.array = array
+        self.array = indexing.as_indexable(array)
         self.encoding = encoding
 
     @property
@@ -532,7 +532,7 @@ class BytesToStringArray(utils.NDArrayMixin):
         return decode_bytes_array(self.array[key], self.encoding)
 
 
-class NativeEndiannessArray(utils.NDArrayMixin):
+class NativeEndiannessArray(indexing.NDArrayIndexable):
     """Decode arrays on the fly from non-native to native endianness
 
     This is useful for decoding arrays from netCDF3 files (which are all
@@ -551,7 +551,7 @@ class NativeEndiannessArray(utils.NDArrayMixin):
     dtype('int16')
     """
     def __init__(self, array):
-        self.array = array
+        self.array = indexing.as_indexable(array)
 
     @property
     def dtype(self):
@@ -561,7 +561,7 @@ class NativeEndiannessArray(utils.NDArrayMixin):
         return np.asarray(self.array[key], dtype=self.dtype)
 
 
-class BoolTypeArray(utils.NDArrayMixin):
+class BoolTypeArray(indexing.NDArrayIndexable):
     """Decode arrays on the fly from integer to boolean datatype
 
     This is useful for decoding boolean arrays from integer typed netCDF
@@ -579,7 +579,7 @@ class BoolTypeArray(utils.NDArrayMixin):
     dtype('bool')
     """
     def __init__(self, array):
-        self.array = array
+        self.array = indexing.as_indexable(array)
 
     @property
     def dtype(self):
@@ -589,7 +589,7 @@ class BoolTypeArray(utils.NDArrayMixin):
         return np.asarray(self.array[key], dtype=self.dtype)
 
 
-class UnsignedIntTypeArray(utils.NDArrayMixin):
+class UnsignedIntTypeArray(indexing.NDArrayIndexable):
     """Decode arrays on the fly from signed integer to unsigned
     integer. Typically used when _Unsigned is set at as a netCDF
     attribute on a signed integer variable.
@@ -606,7 +606,7 @@ class UnsignedIntTypeArray(utils.NDArrayMixin):
     array([  0,   1, 127, 128, 255], dtype=uint8)
     """
     def __init__(self, array):
-        self.array = array
+        self.array = indexing.as_indexable(array)
         self.unsigned_dtype = np.dtype('u%s' % array.dtype.itemsize)
 
     @property

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -333,7 +333,7 @@ def encode_cf_timedelta(timedeltas, units=None):
     return (num, units)
 
 
-class MaskedAndScaledArray(indexing.NDArrayIndexable):
+class MaskedAndScaledArray(utils.NDArrayMixin, indexing.NDArrayIndexable):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically scaled and masked according to
     CF conventions for packed and missing data values.
@@ -391,7 +391,7 @@ class MaskedAndScaledArray(indexing.NDArrayIndexable):
                  self.scale_factor, self.add_offset, self._dtype))
 
 
-class DecodedCFDatetimeArray(indexing.NDArrayIndexable):
+class DecodedCFDatetimeArray(utils.NDArrayMixin, indexing.NDArrayIndexable):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically converted into datetime objects
     using decode_cf_datetime.
@@ -430,7 +430,7 @@ class DecodedCFDatetimeArray(indexing.NDArrayIndexable):
                                   calendar=self.calendar)
 
 
-class DecodedCFTimedeltaArray(indexing.NDArrayIndexable):
+class DecodedCFTimedeltaArray(utils.NDArrayMixin, indexing.NDArrayIndexable):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically converted into timedelta objects
     using decode_cf_timedelta.
@@ -447,7 +447,7 @@ class DecodedCFTimedeltaArray(indexing.NDArrayIndexable):
         return decode_cf_timedelta(self.array[key], units=self.units)
 
 
-class StackedBytesArray(indexing.NDArrayIndexable):
+class StackedBytesArray(utils.NDArrayMixin, indexing.NDArrayIndexable):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically stacked along the last dimension.
 
@@ -493,7 +493,7 @@ class StackedBytesArray(indexing.NDArrayIndexable):
         return char_to_bytes(self.array[key])
 
 
-class BytesToStringArray(indexing.NDArrayIndexable):
+class BytesToStringArray(utils.NDArrayMixin, indexing.NDArrayIndexable):
     """Wrapper that decodes bytes to unicode when values are read.
 
     >>> BytesToStringArray(np.array([b'abc']))[:]
@@ -532,7 +532,7 @@ class BytesToStringArray(indexing.NDArrayIndexable):
         return decode_bytes_array(self.array[key], self.encoding)
 
 
-class NativeEndiannessArray(indexing.NDArrayIndexable):
+class NativeEndiannessArray(utils.NDArrayMixin, indexing.NDArrayIndexable):
     """Decode arrays on the fly from non-native to native endianness
 
     This is useful for decoding arrays from netCDF3 files (which are all
@@ -561,7 +561,7 @@ class NativeEndiannessArray(indexing.NDArrayIndexable):
         return np.asarray(self.array[key], dtype=self.dtype)
 
 
-class BoolTypeArray(indexing.NDArrayIndexable):
+class BoolTypeArray(utils.NDArrayMixin, indexing.NDArrayIndexable):
     """Decode arrays on the fly from integer to boolean datatype
 
     This is useful for decoding boolean arrays from integer typed netCDF
@@ -589,7 +589,7 @@ class BoolTypeArray(indexing.NDArrayIndexable):
         return np.asarray(self.array[key], dtype=self.dtype)
 
 
-class UnsignedIntTypeArray(indexing.NDArrayIndexable):
+class UnsignedIntTypeArray(utils.NDArrayMixin, indexing.NDArrayIndexable):
     """Decode arrays on the fly from signed integer to unsigned
     integer. Typically used when _Unsigned is set at as a netCDF
     attribute on a signed integer variable.

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -303,7 +303,11 @@ class VectorizedIndexer(IndexerTuple):
     """ Tuple for vectorized indexing """
 
 
-class LazilyIndexedArray(utils.NDArrayMixin):
+class NDArrayIndexable(utils.NDArrayMixin):
+    """ A base array wrapper to support vectorized indexing """
+
+
+class LazilyIndexedArray(NDArrayIndexable):
     """Wrap an array that handles orthogonal indexing to make indexing lazy
     """
     def __init__(self, array, key=None):
@@ -356,7 +360,7 @@ class LazilyIndexedArray(utils.NDArrayMixin):
         return tuple(shape)
 
     def __array__(self, dtype=None):
-        array = xarray_indexable(self.array)
+        array = as_indexable(self.array)
         return np.asarray(array[self.key], dtype=None)
 
     def __getitem__(self, key):
@@ -379,9 +383,9 @@ def _wrap_numpy_scalars(array):
         return array
 
 
-class CopyOnWriteArray(utils.NDArrayMixin):
+class CopyOnWriteArray(NDArrayIndexable):
     def __init__(self, array):
-        self.array = array
+        self.array = as_indexable(array)
         self._copied = False
 
     def _ensure_copied(self):
@@ -400,9 +404,9 @@ class CopyOnWriteArray(utils.NDArrayMixin):
         self.array[key] = value
 
 
-class MemoryCachedArray(utils.NDArrayMixin):
+class MemoryCachedArray(NDArrayIndexable):
     def __init__(self, array):
-        self.array = _wrap_numpy_scalars(array)
+        self.array = _wrap_numpy_scalars(as_indexable(array))
 
     def _ensure_cached(self):
         if not isinstance(self.array, np.ndarray):
@@ -419,14 +423,21 @@ class MemoryCachedArray(utils.NDArrayMixin):
         self.array[key] = value
 
 
-def xarray_indexable(array):
+def as_indexable(array):
+    """
+    This function always returns a NDArrayIndexable subclass,
+    so that the vectorized indexing is always possible with the returned
+    object.
+    """
+    if isinstance(array, NDArrayIndexable):
+        return array
     if isinstance(array, np.ndarray):
         return NumpyIndexingAdapter(array)
     if isinstance(array, pd.Index):
         return PandasIndexAdapter(array)
     if isinstance(array, dask_array_type):
         return DaskIndexingAdapter(array)
-    return array
+    raise TypeError('Invalid array type: {}'.format(type(array)))
 
 
 def _outer_to_numpy_indexer(key, shape):
@@ -467,10 +478,14 @@ def _outer_to_numpy_indexer(key, shape):
     return tuple(new_key)
 
 
-class NumpyIndexingAdapter(utils.NDArrayMixin):
+class NumpyIndexingAdapter(NDArrayIndexable):
     """Wrap a NumPy array to use broadcasted indexing
     """
     def __init__(self, array):
+        # In NumpyIndexingAdapter we only allow to store bare np.ndarray
+        if not isinstance(array, np.ndarray):
+            raise TypeError('NumpyIndexingAdapter only wraps np.ndarray. '
+                            'Trying to wrap {}'.format(type(array)))
         self.array = array
 
     def _ensure_ndarray(self, value):
@@ -502,7 +517,7 @@ class NumpyIndexingAdapter(utils.NDArrayMixin):
         array[key] = value
 
 
-class DaskIndexingAdapter(utils.NDArrayMixin):
+class DaskIndexingAdapter(NDArrayIndexable):
     """Wrap a dask array to support xarray-style indexing.
     """
     def __init__(self, array):
@@ -543,7 +558,7 @@ class DaskIndexingAdapter(utils.NDArrayMixin):
                         'method or accessing its .values attribute.')
 
 
-class PandasIndexAdapter(utils.NDArrayMixin):
+class PandasIndexAdapter(NDArrayIndexable):
     """Wrap a pandas.Index to be better about preserving dtypes and to handle
     indexing by length 1 tuples like numpy
     """

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -537,6 +537,8 @@ class DaskIndexingAdapter(NDArrayIndexable):
             return self.array[to_int_tuple(key)]
         elif isinstance(key, VectorizedIndexer):
             return self.array.vindex[to_int_tuple(tuple(key))]
+        elif key is Ellipsis:
+            return self.array
         else:
             assert isinstance(key, OuterIndexer)
             key = to_int_tuple(tuple(key))

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -303,11 +303,11 @@ class VectorizedIndexer(IndexerTuple):
     """ Tuple for vectorized indexing """
 
 
-class NDArrayIndexable(utils.NDArrayMixin):
-    """ A base array wrapper to support vectorized indexing """
+class NDArrayIndexable(object):
+    """ Mixin to mark support for IndexerTuple subclasses in indexing."""
 
 
-class LazilyIndexedArray(NDArrayIndexable):
+class LazilyIndexedArray(utils.NDArrayMixin, NDArrayIndexable):
     """Wrap an array that handles orthogonal indexing to make indexing lazy
     """
     def __init__(self, array, key=None):
@@ -383,7 +383,7 @@ def _wrap_numpy_scalars(array):
         return array
 
 
-class CopyOnWriteArray(NDArrayIndexable):
+class CopyOnWriteArray(utils.NDArrayMixin, NDArrayIndexable):
     def __init__(self, array):
         self.array = as_indexable(array)
         self._copied = False
@@ -404,7 +404,7 @@ class CopyOnWriteArray(NDArrayIndexable):
         self.array[key] = value
 
 
-class MemoryCachedArray(NDArrayIndexable):
+class MemoryCachedArray(utils.NDArrayMixin, NDArrayIndexable):
     def __init__(self, array):
         self.array = _wrap_numpy_scalars(as_indexable(array))
 
@@ -478,7 +478,7 @@ def _outer_to_numpy_indexer(key, shape):
     return tuple(new_key)
 
 
-class NumpyIndexingAdapter(NDArrayIndexable):
+class NumpyIndexingAdapter(utils.NDArrayMixin, NDArrayIndexable):
     """Wrap a NumPy array to use broadcasted indexing
     """
     def __init__(self, array):
@@ -517,7 +517,7 @@ class NumpyIndexingAdapter(NDArrayIndexable):
         array[key] = value
 
 
-class DaskIndexingAdapter(NDArrayIndexable):
+class DaskIndexingAdapter(utils.NDArrayMixin, NDArrayIndexable):
     """Wrap a dask array to support xarray-style indexing.
     """
     def __init__(self, array):
@@ -560,7 +560,7 @@ class DaskIndexingAdapter(NDArrayIndexable):
                         'method or accessing its .values attribute.')
 
 
-class PandasIndexAdapter(NDArrayIndexable):
+class PandasIndexAdapter(utils.NDArrayMixin, NDArrayIndexable):
     """Wrap a pandas.Index to be better about preserving dtypes and to handle
     indexing by length 1 tuples like numpy
     """

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -31,6 +31,7 @@ except ImportError:
     pass
 
 
+SUPPORT_ARRAY_TYPES = (indexing.NDArrayIndexable, np.ndarray, pd.Series)
 BASIC_INDEXING_TYPES = integer_types + (slice,)
 
 
@@ -177,14 +178,6 @@ def as_compatible_data(data, fastpath=False):
     if isinstance(data, timedelta):
         data = np.timedelta64(getattr(data, 'value', data), 'ns')
 
-    if (not hasattr(data, 'dtype') or not isinstance(data.dtype, np.dtype) or
-            not hasattr(data, 'shape') or
-            isinstance(data, (np.string_, np.unicode_,
-                              np.datetime64, np.timedelta64))):
-        # data must be ndarray-like
-        # don't allow non-numpy dtypes (e.g., categories)
-        data = np.asarray(data)
-
     # we don't want nested self-described arrays
     data = getattr(data, 'values', data)
 
@@ -196,6 +189,10 @@ def as_compatible_data(data, fastpath=False):
             data[mask] = fill_value
         else:
             data = np.asarray(data)
+
+    # validate whether the data is valid data types
+    if not isinstance(data, SUPPORT_ARRAY_TYPES):
+        data = np.asarray(data)
 
     if isinstance(data, np.ndarray):
         if data.dtype.kind == 'O':

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -31,7 +31,8 @@ except ImportError:
     pass
 
 
-SUPPORT_ARRAY_TYPES = (indexing.NDArrayIndexable, pd.Index) + dask_array_type
+NON_NUMPY_SUPPORTED_ARRAY_TYPES = (
+    indexing.NDArrayIndexable, pd.Index) + dask_array_type
 BASIC_INDEXING_TYPES = integer_types + (slice,)
 
 
@@ -160,7 +161,7 @@ def as_compatible_data(data, fastpath=False):
     if isinstance(data, Variable):
         return data.data
 
-    if isinstance(data, SUPPORT_ARRAY_TYPES):
+    if isinstance(data, NON_NUMPY_SUPPORTED_ARRAY_TYPES):
         return _maybe_wrap_data(data)
 
     if isinstance(data, tuple):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -19,7 +19,7 @@ from . import ops
 from . import utils
 from .pycompat import (basestring, OrderedDict, zip, integer_types,
                        dask_array_type)
-from .indexing import (PandasIndexAdapter, xarray_indexable, BasicIndexer,
+from .indexing import (PandasIndexAdapter, as_indexable, BasicIndexer,
                        OuterIndexer, VectorizedIndexer)
 from .utils import OrderedSet
 
@@ -317,7 +317,7 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
 
     @property
     def _indexable_data(self):
-        return xarray_indexable(self._data)
+        return as_indexable(self._data)
 
     def load(self, **kwargs):
         """Manually trigger loading of this variable's data from disk or a

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -31,7 +31,7 @@ except ImportError:
     pass
 
 
-SUPPORT_ARRAY_TYPES = (indexing.NDArrayIndexable, np.ndarray, pd.Series)
+SUPPORT_ARRAY_TYPES = (indexing.NDArrayIndexable, pd.Index) + dask_array_type
 BASIC_INDEXING_TYPES = integer_types + (slice,)
 
 
@@ -160,12 +160,7 @@ def as_compatible_data(data, fastpath=False):
     if isinstance(data, Variable):
         return data.data
 
-    # add a custom fast-path for dask.array to avoid expensive checks for the
-    # dtype attribute
-    if isinstance(data, dask_array_type):
-        return data
-
-    if isinstance(data, pd.Index):
+    if isinstance(data, SUPPORT_ARRAY_TYPES):
         return _maybe_wrap_data(data)
 
     if isinstance(data, tuple):
@@ -191,8 +186,7 @@ def as_compatible_data(data, fastpath=False):
             data = np.asarray(data)
 
     # validate whether the data is valid data types
-    if not isinstance(data, SUPPORT_ARRAY_TYPES):
-        data = np.asarray(data)
+    data = np.asarray(data)
 
     if isinstance(data, np.ndarray):
         if data.dtype.kind == 'O':

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -12,7 +12,6 @@ from numpy.testing import assert_array_equal
 from xarray.core.duck_array_ops import allclose_or_equiv
 import pytest
 
-from xarray.core import utils
 from xarray.core.pycompat import PY3
 from xarray.core.indexing import NDArrayIndexable
 from xarray.testing import assert_equal, assert_identical, assert_allclose

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -14,6 +14,7 @@ import pytest
 
 from xarray.core import utils
 from xarray.core.pycompat import PY3
+from xarray.core.indexing import NDArrayIndexable
 from xarray.testing import assert_equal, assert_identical, assert_allclose
 from xarray.plot.utils import import_seaborn
 
@@ -198,7 +199,7 @@ class UnexpectedDataAccess(Exception):
     pass
 
 
-class InaccessibleArray(utils.NDArrayMixin):
+class InaccessibleArray(NDArrayIndexable):
 
     def __init__(self, array):
         self.array = array

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -12,6 +12,7 @@ from numpy.testing import assert_array_equal
 from xarray.core.duck_array_ops import allclose_or_equiv
 import pytest
 
+from xarray.core import utils
 from xarray.core.pycompat import PY3
 from xarray.core.indexing import NDArrayIndexable
 from xarray.testing import assert_equal, assert_identical, assert_allclose
@@ -198,7 +199,7 @@ class UnexpectedDataAccess(Exception):
     pass
 
 
-class InaccessibleArray(NDArrayIndexable):
+class InaccessibleArray(utils.NDArrayMixin, NDArrayIndexable):
 
     def __init__(self, array):
         self.array = array

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1002,9 +1002,6 @@ class ScipyInMemoryDataTest(CFEncodedDataTest, NetCDF3Only, TestCase):
             unpickled = pickle.loads(pickle.dumps(ds))
             self.assertDatasetIdentical(unpickled, data)
 
-    def test_vectorized_indexing(self):
-        self._test_vectorized_indexing(vindex_support=True)
-
 
 class ScipyInMemoryDataTestAutocloseTrue(ScipyInMemoryDataTest):
     autoclose = True

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -399,6 +399,24 @@ class DatasetIOTestCases(object):
             actual = on_disk.isel(**indexers)
             self.assertDatasetIdentical(expected, actual)
 
+    def test_vectorized_indexing(self):
+        # Make sure vectorized_indexing works or at leaset raises
+        # NotImplementedError
+        in_memory = create_test_data()
+        with self.roundtrip(in_memory) as on_disk:
+            indexers = {'dim1': DataArray([0, 2, 0], dims='a'),
+                        'dim2': DataArray([0, 2, 3], dims='a')}
+            expected = in_memory.isel(**indexers)
+            try:
+                actual = on_disk.isel(**indexers)
+                self.assertDatasetIdentical(expected, actual)
+                # do it twice, to make sure we're switched from orthogonal -> numpy
+                # when we cached the values
+                actual = on_disk.isel(**indexers)
+                self.assertDatasetIdentical(expected, actual)
+            except NotImplementedError:
+                pass
+
 
 class CFEncodedDataTest(DatasetIOTestCases):
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -400,7 +400,7 @@ class DatasetIOTestCases(object):
             assert_identical(expected, actual)
 
     def _test_vectorized_indexing(self, vindex_support=True):
-        # Make sure vectorized_indexing works or at leaset raises
+        # Make sure vectorized_indexing works or at least raises
         # NotImplementedError
         in_memory = create_test_data()
         with self.roundtrip(in_memory) as on_disk:
@@ -1001,6 +1001,9 @@ class ScipyInMemoryDataTest(CFEncodedDataTest, NetCDF3Only, TestCase):
         with open_dataset(fobj, autoclose=self.autoclose) as ds:
             unpickled = pickle.loads(pickle.dumps(ds))
             self.assertDatasetIdentical(unpickled, data)
+
+    def test_vectorized_indexing(self):
+        self._test_vectorized_indexing(vindex_support=True)
 
 
 class ScipyInMemoryDataTestAutocloseTrue(ScipyInMemoryDataTest):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -31,7 +31,7 @@ from . import (TestCase, requires_scipy, requires_netCDF4, requires_pydap,
                assert_identical, raises_regex)
 from .test_dataset import create_test_data
 
-from xarray.tests import mock
+from xarray.tests import mock, assert_identical
 
 try:
     import netCDF4 as nc4
@@ -393,11 +393,11 @@ class DatasetIOTestCases(object):
                         'dim3': np.arange(5)}
             expected = in_memory.isel(**indexers)
             actual = on_disk.isel(**indexers)
-            self.assertDatasetIdentical(expected, actual)
+            assert_identical(expected, actual)
             # do it twice, to make sure we're switched from orthogonal -> numpy
             # when we cached the values
             actual = on_disk.isel(**indexers)
-            self.assertDatasetIdentical(expected, actual)
+            assert_identical(expected, actual)
 
     def test_vectorized_indexing(self):
         # Make sure vectorized_indexing works or at leaset raises
@@ -409,11 +409,11 @@ class DatasetIOTestCases(object):
             expected = in_memory.isel(**indexers)
             try:
                 actual = on_disk.isel(**indexers)
-                self.assertDatasetIdentical(expected, actual)
+                assert_identical(expected, actual)
                 # do it twice, to make sure we're switched from
                 # orthogonal -> numpy when we cached the values
                 actual = on_disk.isel(**indexers)
-                self.assertDatasetIdentical(expected, actual)
+                assert_identical(expected, actual)
             except NotImplementedError:
                 pass
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -399,7 +399,7 @@ class DatasetIOTestCases(object):
             actual = on_disk.isel(**indexers)
             assert_identical(expected, actual)
 
-    def test_vectorized_indexing(self):
+    def _test_vectorized_indexing(self, vindex_support=True):
         # Make sure vectorized_indexing works or at leaset raises
         # NotImplementedError
         in_memory = create_test_data()
@@ -407,15 +407,20 @@ class DatasetIOTestCases(object):
             indexers = {'dim1': DataArray([0, 2, 0], dims='a'),
                         'dim2': DataArray([0, 2, 3], dims='a')}
             expected = in_memory.isel(**indexers)
-            try:
+            if vindex_support:
                 actual = on_disk.isel(**indexers)
                 assert_identical(expected, actual)
                 # do it twice, to make sure we're switched from
                 # orthogonal -> numpy when we cached the values
                 actual = on_disk.isel(**indexers)
                 assert_identical(expected, actual)
-            except NotImplementedError:
-                pass
+            else:
+                with raises_regex(NotImplementedError, 'Vectorized indexing '):
+                    actual = on_disk.isel(**indexers)
+
+    def test_vectorized_indexing(self):
+        # This test should be overwritten if vindex is supported
+        self._test_vectorized_indexing(vindex_support=False)
 
 
 class CFEncodedDataTest(DatasetIOTestCases):
@@ -640,6 +645,9 @@ class CFEncodedDataTest(DatasetIOTestCases):
             self.save(data[['var2', 'var9']], tmp_file, mode='a')
             with self.open(tmp_file) as actual:
                 self.assertDatasetIdentical(data, actual)
+
+    def test_vectorized_indexing(self):
+        self._test_vectorized_indexing(vindex_support=False)
 
 
 _counter = itertools.count()
@@ -964,6 +972,9 @@ class NetCDF4ViaDaskDataTest(NetCDF4DataTest):
     def test_dataset_caching(self):
         # caching behavior differs for dask
         pass
+
+    def test_vectorized_indexing(self):
+        self._test_vectorized_indexing(vindex_support=True)
 
 
 class NetCDF4ViaDaskDataTestAutocloseTrue(NetCDF4ViaDaskDataTest):
@@ -1541,7 +1552,6 @@ class DaskTest(TestCase, DatasetIOTestCases):
         with raises_regex(TypeError, 'supports writing Dataset'):
             save_mfdataset([da], ['dataarray'])
 
-
     @requires_pathlib
     def test_save_mfdataset_pathlib_roundtrip(self):
         original = Dataset({'foo': ('x', np.random.randn(10))})
@@ -1625,6 +1635,9 @@ class DaskTest(TestCase, DatasetIOTestCases):
         self.assertFalse(actual._in_memory)
         self.assertTrue(computed._in_memory)
         self.assertDataArrayAllClose(actual, computed, decode_bytes=False)
+
+    def test_vectorized_indexing(self):
+        self._test_vectorized_indexing(vindex_support=True)
 
 
 class DaskTestAutocloseTrue(DaskTest):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -410,8 +410,8 @@ class DatasetIOTestCases(object):
             try:
                 actual = on_disk.isel(**indexers)
                 self.assertDatasetIdentical(expected, actual)
-                # do it twice, to make sure we're switched from orthogonal -> numpy
-                # when we cached the values
+                # do it twice, to make sure we're switched from
+                # orthogonal -> numpy when we cached the values
                 actual = on_disk.isel(**indexers)
                 self.assertDatasetIdentical(expected, actual)
             except NotImplementedError:

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -17,7 +17,7 @@ from xarray.core import indexing
 from xarray.core.variable import as_variable, as_compatible_data
 from xarray.core.indexing import (PandasIndexAdapter, LazilyIndexedArray,
                                   NumpyIndexingAdapter, CopyOnWriteArray,
-                                  MemoryCachedArray)
+                                  MemoryCachedArray, DaskIndexingAdapter)
 from xarray.core.pycompat import PY3, OrderedDict
 from xarray.core.common import full_like, zeros_like, ones_like
 
@@ -1745,5 +1745,13 @@ class TestBackendIndexing(TestCase):
 
     @requires_dask
     def test_DaskIndexingAdapter(self):
-        # TODO add da.array test
-        pass
+        import dask.array as da
+        da = da.asarray(self.d)
+        v = Variable(dims=('x', 'y'), data=DaskIndexingAdapter(da))
+        self.check_orthogonal_indexing(v)
+        self.check_vectorized_indexing(v)
+        # doubly wrapping
+        v = Variable(dims=('x', 'y'),
+                     data=CopyOnWriteArray(DaskIndexingAdapter(da)))
+        self.check_orthogonal_indexing(v)
+        self.check_vectorized_indexing(v)

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -15,7 +15,9 @@ import pandas as pd
 from xarray import Variable, IndexVariable, Coordinate, Dataset
 from xarray.core import indexing
 from xarray.core.variable import as_variable, as_compatible_data
-from xarray.core.indexing import PandasIndexAdapter, LazilyIndexedArray
+from xarray.core.indexing import (PandasIndexAdapter, LazilyIndexedArray,
+                                  NumpyIndexingAdapter, CopyOnWriteArray,
+                                  MemoryCachedArray)
 from xarray.core.pycompat import PY3, OrderedDict
 from xarray.core.common import full_like, zeros_like, ones_like
 
@@ -1681,3 +1683,67 @@ def test_raise_no_warning_for_nan_in_binary_ops():
     with pytest.warns(None) as record:
         Variable('x', [1, 2, np.NaN]) > 0
     assert len(record) == 0
+
+
+class TestBackendIndexing(TestCase):
+    """    Make sure all the array wrappers can be indexed. """
+    def setUp(self):
+        self.d = np.random.random((10, 3)).astype(np.float64)
+
+    def check_orthogonal_indexing(self, v):
+        assert np.allclose(v.isel(x=[8, 3], y=[2, 1]), self.d[[8, 3]][:, [2, 1]])
+
+    def check_vectorized_indexing(self, v):
+        ind_x = Variable('z', [0, 2])
+        ind_y = Variable('z', [2, 1])
+        assert np.allclose(v.isel(x=ind_x, y=ind_y), self.d[ind_x, ind_y])
+
+    def test_NumpyIndexingAdapter(self):
+        v = Variable(dims=('x', 'y'), data=NumpyIndexingAdapter(self.d))
+        self.check_orthogonal_indexing(v)
+        self.check_vectorized_indexing(v)
+        # could not doublly wrapping
+        with raises_regex(TypeError, 'NumpyIndexingAdapter only wraps '):
+            v = Variable(dims=('x', 'y'), data=NumpyIndexingAdapter(
+                                            NumpyIndexingAdapter(self.d)))
+
+    def test_LazilyIndexedArray(self):
+        v = Variable(dims=('x', 'y'), data=LazilyIndexedArray(self.d))
+        self.check_orthogonal_indexing(v)
+        with raises_regex(NotImplementedError, 'Vectorized indexing for '):
+            self.check_vectorized_indexing(v)
+        # doubly wrapping
+        v = Variable(dims=('x', 'y'),
+                     data=LazilyIndexedArray(LazilyIndexedArray(self.d)))
+        self.check_orthogonal_indexing(v)
+        # hierarchical wrapping
+        v = Variable(dims=('x', 'y'),
+                     data=LazilyIndexedArray(NumpyIndexingAdapter(self.d)))
+        self.check_orthogonal_indexing(v)
+
+    def test_CopyOnWriteArray(self):
+        v = Variable(dims=('x', 'y'), data=CopyOnWriteArray(self.d))
+        self.check_orthogonal_indexing(v)
+        self.check_vectorized_indexing(v)
+        # doubly wrapping
+        v = Variable(dims=('x', 'y'),
+                     data=CopyOnWriteArray(LazilyIndexedArray(self.d)))
+        self.check_orthogonal_indexing(v)
+        with raises_regex(NotImplementedError, 'Vectorized indexing for '):
+            self.check_vectorized_indexing(v)
+
+    def test_MemoryCachedArray(self):
+        v = Variable(dims=('x', 'y'), data=CopyOnWriteArray(self.d))
+        self.check_orthogonal_indexing(v)
+        self.check_vectorized_indexing(v)
+        # doubly wrapping
+        v = Variable(dims=('x', 'y'),
+                     data=CopyOnWriteArray(LazilyIndexedArray(self.d)))
+        self.check_orthogonal_indexing(v)
+        with raises_regex(NotImplementedError, 'Vectorized indexing for '):
+            self.check_vectorized_indexing(v)
+
+    @requires_dask
+    def test_DaskIndexingAdapter(self):
+        # TODO add da.array test
+        pass

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1691,7 +1691,8 @@ class TestBackendIndexing(TestCase):
         self.d = np.random.random((10, 3)).astype(np.float64)
 
     def check_orthogonal_indexing(self, v):
-        assert np.allclose(v.isel(x=[8, 3], y=[2, 1]), self.d[[8, 3]][:, [2, 1]])
+        assert np.allclose(v.isel(x=[8, 3], y=[2, 1]),
+                           self.d[[8, 3]][:, [2, 1]])
 
     def check_vectorized_indexing(self, v):
         ind_x = Variable('z', [0, 2])
@@ -1733,15 +1734,14 @@ class TestBackendIndexing(TestCase):
             self.check_vectorized_indexing(v)
 
     def test_MemoryCachedArray(self):
-        v = Variable(dims=('x', 'y'), data=CopyOnWriteArray(self.d))
+        v = Variable(dims=('x', 'y'), data=MemoryCachedArray(self.d))
         self.check_orthogonal_indexing(v)
         self.check_vectorized_indexing(v)
         # doubly wrapping
         v = Variable(dims=('x', 'y'),
-                     data=CopyOnWriteArray(LazilyIndexedArray(self.d)))
+                     data=CopyOnWriteArray(MemoryCachedArray(self.d)))
         self.check_orthogonal_indexing(v)
-        with raises_regex(NotImplementedError, 'Vectorized indexing for '):
-            self.check_vectorized_indexing(v)
+        self.check_vectorized_indexing(v)
 
     @requires_dask
     def test_DaskIndexingAdapter(self):

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1721,7 +1721,7 @@ class TestBackendIndexing(TestCase):
         v = Variable(dims=('x', 'y'), data=NumpyIndexingAdapter(self.d))
         self.check_orthogonal_indexing(v)
         self.check_vectorized_indexing(v)
-        # could not doublly wrapping
+        # could not doubly wrapping
         with raises_regex(TypeError, 'NumpyIndexingAdapter only wraps '):
             v = Variable(dims=('x', 'y'), data=NumpyIndexingAdapter(
                                             NumpyIndexingAdapter(self.d)))


### PR DESCRIPTION
 - [x] Closes #1429
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

This bug originates from the complicated structure around the array wrappers and their indexing,
i.e. different array wrappers support different indexing types, and moreover, some can store another array wrapper in it.

I made some cleanups.
+ Now every array wrapper is a subclass of `NDArrayIndexable`
+ Every array wrapper should implement its own `__getitem__` or just store another `NDArrayIndexable`.

I think I added enough test for it, but I am not yet fully accustomed with xarray's backend.
There might be many combinations of their hierarchical relation.

I would appreciate any comments.