### PR TITLE
Removed `.T` from __dir__ explicitly

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,6 +15,9 @@ What's New
 
 .. _whats-new.0.10.0:
 
+Changes since v0.10.0 rc1 (Unreleased)
+--------------------------------------
+
 Bug fixes
 ~~~~~~~~~
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,6 +15,14 @@ What's New
 
 .. _whats-new.0.10.0:
 
+Bug fixes
+~~~~~~~~~
+
+- Suppress warning in Ipython autocompletion, related to the deprecation
+  of ``.T`` attributes. (:issue:`1675`).
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_
+
+
 v0.10.0 rc1 (30 October 2017)
 -----------------------------
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -732,7 +732,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
                 LevelCoordinatesSource(self)]
 
     def __dir__(self):
-        # In order to suppress a deprecatin warning in Ipython autocompletion
+        # In order to suppress a deprecation warning in Ipython autocompletion
         # .T is explicitly removed from __dir__. GH: issue 1675
         d = super(Dataset, self).__dir__()
         d.remove('T')

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -731,6 +731,13 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
         return [self.data_vars, self.coords, {d: self[d] for d in self.dims},
                 LevelCoordinatesSource(self)]
 
+    def __dir__(self):
+        # In order to suppress a deprecatin warning in Ipython autocompletion
+        # .T is explicitly removed from __dir__. GH: issue 1675
+        d = super(Dataset, self).__dir__()
+        d.remove('T')
+        return d
+
     def __contains__(self, key):
         """The 'in' operator will return true or false depending on whether
         'key' is an array in the dataset or not.

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3971,6 +3971,10 @@ class TestDataset(TestCase):
             ds.data_vars[item]  # should not raise
         assert sorted(actual) == sorted(expected)
 
+    def test_dir(self):
+        ds = create_test_data(seed=1)
+        assert 'T' not in dir(ds)
+
 # Py.test tests
 
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3606,6 +3606,8 @@ class TestDataset(TestCase):
         with raises_regex(ValueError, 'arguments to transpose'):
             ds.transpose('dim1', 'dim2', 'dim3', 'time', 'extra_dim')
 
+        assert 'T' not in dir(ds)
+
     def test_dataset_retains_period_index_on_transpose(self):
 
         ds = create_test_data()
@@ -3970,10 +3972,6 @@ class TestDataset(TestCase):
         for item in actual:
             ds.data_vars[item]  # should not raise
         assert sorted(actual) == sorted(expected)
-
-    def test_dir(self):
-        ds = create_test_data(seed=1)
-        assert 'T' not in dir(ds)
 
 # Py.test tests
 


### PR DESCRIPTION
 - [x] Closes #1675
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Remved `T` from `xr.Dataset.__dir__` to suppress a deprecation warning in Ipython autocompletion.