### PR TITLE
Add h5netcdf to the engine import hierarchy

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -40,9 +40,14 @@ def _get_default_engine(path, allow_remote=False):
             try:
                 import scipy.io.netcdf
                 engine = 'scipy'
-            except ImportError:
-                raise ValueError('cannot read or write netCDF files without '
-                                 'netCDF4-python or scipy installed')
+            except ImportError:  # pragma: no cover
+                try:
+                    import h5netcdf
+                    engine = 'h5netcdf'
+                except ImportError:
+                    raise ValueError(
+                        'cannot read or write netCDF files without '
+                        'netCDF4-python, h5netcdf, or scipy installed')
     return engine
 
 


### PR DESCRIPTION
h5netcdf is now part of the import statements in the `_get_default_engine()` function. The order is: netcdf4, scipy.io.netcdf, h5netcdf.

 - [ ] Closes #xxxx
 - [ ] Tests added / passed
 - [ ] Passes ``git diff upstream/master **/*py | flake8 --diff``
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API