### PR TITLE
fix bugs in is_scalar and as_variable for dask arrays

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,9 +22,12 @@ Bug fixes
 ~~~~~~~~~
 
 - Suppress warning in Ipython autocompletion, related to the deprecation
-  of ``.T`` attributes. (:issue:`1675`).
+  of ``.T`` attributes (:issue:`1675`).
   By `Keisuke Fujii <https://github.com/fujiisoup>`_
 
+- Fix two bugs that were preventing dask arrays from being specified as
+  coordinates in the DataArray constructor (:issue:`1684`).
+  By `Joe Hamman <https://github.com/jhamman>`_
 
 v0.10.0 rc1 (30 October 2017)
 -----------------------------

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -189,7 +189,7 @@ def is_scalar(value):
     return (
         getattr(value, 'ndim', None) == 0 or
         isinstance(value, (basestring, bytes_type)) or not
-        isinstance(value, (Iterable, dask_array_type)))
+        isinstance(value, (Iterable, ) + dask_array_type))
 
 
 def is_valid_numpy_dtype(dtype):

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -13,7 +13,8 @@ from collections import Mapping, MutableMapping, MutableSet, Iterable
 import numpy as np
 import pandas as pd
 
-from .pycompat import iteritems, OrderedDict, basestring, bytes_type
+from .pycompat import (iteritems, OrderedDict, basestring, bytes_type,
+                       dask_array_type)
 
 
 def alias_message(old_name, new_name):
@@ -188,7 +189,7 @@ def is_scalar(value):
     return (
         getattr(value, 'ndim', None) == 0 or
         isinstance(value, (basestring, bytes_type)) or not
-        isinstance(value, Iterable))
+        isinstance(value, (Iterable, dask_array_type)))
 
 
 def is_valid_numpy_dtype(dtype):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -94,8 +94,7 @@ def as_variable(obj, name=None):
                             '{}'.format(obj))
     elif utils.is_scalar(obj):
         obj = Variable([], obj)
-    elif (isinstance(obj, (pd.Index, IndexVariable)) and
-          getattr(obj, 'name', None) is not None):
+    elif (isinstance(obj, (pd.Index, IndexVariable)) and obj.name is not None):
         obj = Variable(obj.name, obj)
     elif name is not None:
         data = as_compatible_data(obj)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -94,8 +94,8 @@ def as_variable(obj, name=None):
                             '{}'.format(obj))
     elif utils.is_scalar(obj):
         obj = Variable([], obj)
-    elif (getattr(obj, 'name', None) is not None and not
-          isinstance(obj, dask_array_type)):
+    elif (isinstance(obj, (pd.Index, IndexVariable)) and
+          getattr(obj, 'name', None) is not None):
         obj = Variable(obj.name, obj)
     elif name is not None:
         data = as_compatible_data(obj)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -94,7 +94,8 @@ def as_variable(obj, name=None):
                             '{}'.format(obj))
     elif utils.is_scalar(obj):
         obj = Variable([], obj)
-    elif getattr(obj, 'name', None) is not None:
+    elif (getattr(obj, 'name', None) is not None and not
+          isinstance(obj, dask_array_type)):
         obj = Variable(obj.name, obj)
     elif name is not None:
         data = as_compatible_data(obj)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -348,6 +348,21 @@ class TestDataArray(TestCase):
         actual = DataArray(0)
         self.assertDataArrayIdentical(expected, actual)
 
+    @requires_dask
+    def test_constructor_dask_coords(self):
+        # regression test for GH1684
+        import dask.array as da
+
+        coord = da.arange(8, chunks=(4,))
+        data = da.random.random((8, 8), chunks=(4, 4)) + 1
+        actual = DataArray(data, coords={'x': coord, 'y': coord},
+                           dims=['x', 'y'])
+
+        ecoord = np.arange(8)
+        expected = DataArray(data, coords={'x': ecoord, 'y': ecoord},
+                             dims=['x', 'y'])
+        assert_equal(actual, expected)
+
     def test_equals_and_identical(self):
         orig = DataArray(np.arange(5.0), {'a': 42}, dims='x')
 

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from xarray.core import duck_array_ops, utils
 from xarray.core.pycompat import OrderedDict
-from . import TestCase
+from . import TestCase, requires_dask
 
 
 class TestAlias(TestCase):
@@ -180,3 +180,12 @@ class Test_hashable(TestCase):
             self.assertTrue(utils.hashable(v))
         for v in [[5, 6], ['seven', '8'], {9: 'ten'}]:
             self.assertFalse(utils.hashable(v))
+
+
+@requires_dask
+def test_dask_array_is_scalar():
+    # regression test for GH1684
+    import dask.array as da
+
+    y = da.arange(8, chunks=4)
+    assert not utils.is_scalar(y)


### PR DESCRIPTION
 - [x] Closes #1684
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

xref: #1674

cc @shoyer, @mrocklin 