### PR TITLE
Add names for test failures

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -28,8 +28,10 @@ Bug fixes
 Testing
 ~~~~~~~
 
-- Add coordinate names to failure printout for
-  :py:func:`xarray.testing.assert_allclose`.
+- Add name parameter and extra formatting to
+  :py:func:`xarray.testing.assert_allclose`,
+  :py:func:`xarray.testing.assert_identical` and
+  :py:func:`xarray.testing.assert_equal` for nicer failure printouts.
   By `Matti Eskelinen <https://github.com/maaleske>`_
 
 v0.10.0 rc1 (30 October 2017)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,6 +25,11 @@ Bug fixes
   of ``.T`` attributes. (:issue:`1675`).
   By `Keisuke Fujii <https://github.com/fujiisoup>`_
 
+Testing
+~~~~~~~
+
+- Add coordinate names to failure printout for :py:func:`assert_allclose`.
+  By `Matti Eskelinen <https://github.com/maaleske>`_
 
 v0.10.0 rc1 (30 October 2017)
 -----------------------------

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -28,7 +28,8 @@ Bug fixes
 Testing
 ~~~~~~~
 
-- Add coordinate names to failure printout for :py:func:`assert_allclose`.
+- Add coordinate names to failure printout for
+  :py:func:`xarray.testing.assert_allclose`.
   By `Matti Eskelinen <https://github.com/maaleske>`_
 
 v0.10.0 rc1 (30 October 2017)

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -130,7 +130,7 @@ def assert_allclose(a, b, rtol=1e-05, atol=1e-08, decode_bytes=True, name=''):
         allclose = _data_allclose_or_equiv(a.values, b.values, **kwargs)
         assert allclose, '{}:{}\n{}'.format(name, a.values, b.values)
     elif isinstance(a, xr.DataArray):
-        assert_allclose(a.variable, b.variable, **kwargs)
+        assert_allclose(a.variable, b.variable, name=name, **kwargs)
         assert set(a.coords) == set(b.coords)
         for v in a.coords.variables:
             # can't recurse with this function as coord is sometimes a

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -130,8 +130,8 @@ def assert_allclose(a, b, rtol=1e-05, atol=1e-08, decode_bytes=True):
             allclose = _data_allclose_or_equiv(a.coords[v].values,
                                                b.coords[v].values, **kwargs)
             assert allclose, 'coord {}:{}\n{}'.format(a.coords[v].name,
-                                             a.coords[v].values,
-                                             b.coords[v].values)
+                                                      a.coords[v].values,
+                                                      b.coords[v].values)
     elif isinstance(a, xr.Dataset):
         assert set(a.data_vars) == set(b.data_vars)
         assert set(a.coords) == set(b.coords)

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -55,7 +55,7 @@ def assert_equal(a, b, name=''):
     assert type(a) == type(b)
     if isinstance(a, (xr.Variable, xr.DataArray, xr.Dataset)):
         assert a.equals(b), \
-               '{}:{}\n{}'.format(name, a, b) if name else '{}\n{}'.format(a, b)
+            '{}:{}\n{}'.format(name, a, b) if name else '{}\n{}'.format(a, b)
     else:
         raise TypeError('{} not supported by assertion comparison'
                         .format(type(a)))
@@ -88,7 +88,7 @@ def assert_identical(a, b, name=''):
         assert_identical(a._to_temp_dataset(), b._to_temp_dataset(), name=name)
     elif isinstance(a, (xr.Dataset, xr.Variable)):
         assert a.identical(b), \
-               '{}:{}\n{}'.format(name, a, b) if name else '{}\n{}'.format(a, b)
+            '{}:{}\n{}'.format(name, a, b) if name else '{}\n{}'.format(a, b)
     else:
         raise TypeError('{} not supported by assertion comparison'
                         .format(type(a)))

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -27,7 +27,7 @@ def _data_allclose_or_equiv(arr1, arr2, rtol=1e-05, atol=1e-08,
             arr1, arr2, rtol=rtol, atol=atol)
 
 
-def assert_equal(a, b, name=''):
+def assert_equal(a, b, name=None):
     """Like :py:func:`numpy.testing.assert_array_equal`, but for xarray
     objects.
 
@@ -61,7 +61,7 @@ def assert_equal(a, b, name=''):
                         .format(type(a)))
 
 
-def assert_identical(a, b, name=''):
+def assert_identical(a, b, name=None):
     """Like :py:func:`xarray.testing.assert_equal`, but also matches the
     objects' names and attributes.
 
@@ -94,7 +94,7 @@ def assert_identical(a, b, name=''):
                         .format(type(a)))
 
 
-def assert_allclose(a, b, rtol=1e-05, atol=1e-08, decode_bytes=True, name=''):
+def assert_allclose(a, b, rtol=1e-05, atol=1e-08, decode_bytes=True, name=None):
     """Like :py:func:`numpy.testing.assert_allclose`, but for xarray objects.
 
     Raises an AssertionError if two objects are not equal up to desired

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -129,7 +129,8 @@ def assert_allclose(a, b, rtol=1e-05, atol=1e-08, decode_bytes=True):
             # DataArray, so call into _data_allclose_or_equiv directly
             allclose = _data_allclose_or_equiv(a.coords[v].values,
                                                b.coords[v].values, **kwargs)
-            assert allclose, '{}\n{}'.format(a.coords[v].values,
+            assert allclose, 'coord {}:{}\n{}'.format(a.coords[v].name,
+                                             a.coords[v].values,
                                              b.coords[v].values)
     elif isinstance(a, xr.Dataset):
         assert set(a.data_vars) == set(b.data_vars)


### PR DESCRIPTION
This PR adds the coordinate name to the test failure printout in `assert_allclose()` when cycling through the coordinates . Specifying the coordinate makes test failures much easier to diagnose just based on the message.

 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
