### PR TITLE
fix empty dataset from_dict

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -427,7 +427,7 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         if isinstance(dims, basestring):
             dims = (dims,)
         dims = tuple(dims)
-        if len(dims) != self.ndim:
+        if self.shape != (0,) and len(dims) != self.ndim:
             raise ValueError('dimensions %s must have the same length as the '
                              'number of data dimensions, ndim=%s'
                              % (dims, self.ndim))

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2871,6 +2871,26 @@ class TestDataset(TestCase):
                                      "without the key 'dims'"):
             Dataset.from_dict(d)
 
+    def test_to_and_from_dict_with_zero_dim(self):
+        ds = Dataset(OrderedDict([('a', ('t', np.array([], dtype='float64'))),
+                                  ('b', ('t', np.array([], dtype='float64'))),
+                                  ('t', ('t', np.array([], dtype='U1')))]))
+        expected = {'coords': {'t': {'dims': ('t',),
+                                     'data': [],
+                                     'attrs': {}}},
+                    'attrs': {},
+                    'dims': {'t': 0},
+                    'data_vars': {'a': {'dims': ('t',),
+                                        'data': [],
+                                        'attrs': {}},
+                                  'b': {'dims': ('t',),
+                                        'data': [],
+                                        'attrs': {}}}}
+
+        actual = ds.to_dict()
+        self.assertEqual(expected, actual)
+        self.assertDatasetIdentical(ds, Dataset.from_dict(actual))
+
     def test_to_and_from_dict_with_time_dim(self):
         x = np.random.randn(10, 3)
         y = np.random.randn(10, 3)


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff``
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Not sure if you want an issue or a whats-new entry for a small fix like this.

Also not sure how xarray tends to handle `np.array([])`. One option that I did not take was to provide ndims to `as_compatible_data` in some fashion and make sure the result comes back as having shape `(0,)*ndim` instead of just `(0,)`.