### PR TITLE
Make Indexer classes not inherit from tuple.

### DIFF
--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -10,7 +10,8 @@ from collections import Mapping
 from distutils.version import LooseVersion
 
 from ..conventions import cf_encoder
-from ..core.utils import FrozenOrderedDict
+from ..core import indexing
+from ..core.utils import FrozenOrderedDict, NdimSizeLenMixin
 from ..core.pycompat import iteritems, dask_array_type
 
 try:
@@ -74,6 +75,13 @@ def robust_getitem(array, key, catch=Exception, max_retries=6,
                    (next_delay, max_retries - n, traceback.format_exc()))
             logger.debug(msg)
             time.sleep(1e-3 * next_delay)
+
+
+class BackendArray(NdimSizeLenMixin, indexing.ExplicitlyIndexed):
+
+    def __array__(self, dtype=None):
+        key = indexing.BasicIndexer((slice(None),) * self.ndim)
+        return np.asarray(self[key], dtype=dtype)
 
 
 class AbstractDataStore(Mapping):

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -15,11 +15,8 @@ from .netCDF4_ import (_nc4_group, _nc4_values_and_dtype,
 
 class H5NetCDFArrayWrapper(BaseNetCDF4Array):
     def __getitem__(self, key):
-        if isinstance(key, indexing.VectorizedIndexer):
-            raise NotImplementedError(
-                 'Vectorized indexing for {} is not implemented. Load your '
-                 'data first with .load() or .compute().'.format(type(self)))
-        key = indexing.to_tuple(key)
+        key = indexing.unwrap_explicit_indexer(
+            key, self, allow=(indexing.BasicIndexer, indexing.OuterIndexer))
         with self.datastore.ensure_open(autoclose=True):
             return self.get_array()[key]
 

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -9,7 +9,6 @@ import numpy as np
 from .. import Variable
 from ..core.utils import (FrozenOrderedDict, Frozen)
 from ..core import indexing
-from ..core.pycompat import integer_types
 
 from .common import AbstractDataStore, DataStorePickleMixin, BackendArray
 

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -7,16 +7,14 @@ import functools
 import numpy as np
 
 from .. import Variable
-from ..core.utils import (FrozenOrderedDict, Frozen,
-                          NdimSizeLenMixin, DunderArrayMixin)
+from ..core.utils import (FrozenOrderedDict, Frozen)
 from ..core import indexing
 from ..core.pycompat import integer_types
 
-from .common import AbstractDataStore, DataStorePickleMixin
+from .common import AbstractDataStore, DataStorePickleMixin, BackendArray
 
 
-class NioArrayWrapper(NdimSizeLenMixin, DunderArrayMixin,
-                      indexing.NDArrayIndexable):
+class NioArrayWrapper(BackendArray):
 
     def __init__(self, variable_name, datastore):
         self.datastore = datastore
@@ -30,13 +28,9 @@ class NioArrayWrapper(NdimSizeLenMixin, DunderArrayMixin,
         return self.datastore.ds.variables[self.variable_name]
 
     def __getitem__(self, key):
-        if isinstance(key, (indexing.VectorizedIndexer,
-                            indexing.OuterIndexer)):
-            raise NotImplementedError(
-                'Nio backend does not support vectorized / outer indexing. '
-                'Load your data first with .load() or .compute(). '
-                'Given {}'.format(key))
-        key = indexing.to_tuple(key)
+        key = indexing.unwrap_explicit_indexer(
+            key, target=self, allow=indexing.BasicIndexer)
+
         with self.datastore.ensure_open(autoclose=True):
             array = self.get_array()
             if key == () and self.ndim == 0:

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -3,8 +3,9 @@ from collections import OrderedDict
 import numpy as np
 
 from .. import DataArray
-from ..core.utils import DunderArrayMixin, NdimSizeLenMixin, is_scalar
+from ..core.utils import is_scalar
 from ..core import indexing
+from .common import BackendArray
 try:
     from dask.utils import SerializableLock as Lock
 except ImportError:
@@ -17,8 +18,7 @@ _ERROR_MSG = ('The kind of indexing operation you are trying to do is not '
               'first.')
 
 
-class RasterioArrayWrapper(NdimSizeLenMixin, DunderArrayMixin,
-                           indexing.NDArrayIndexable):
+class RasterioArrayWrapper(BackendArray):
     """A wrapper around rasterio dataset objects"""
     def __init__(self, rasterio_ds):
         self.rasterio_ds = rasterio_ds
@@ -38,11 +38,9 @@ class RasterioArrayWrapper(NdimSizeLenMixin, DunderArrayMixin,
         return self._shape
 
     def __getitem__(self, key):
-        if isinstance(key, indexing.VectorizedIndexer):
-            raise NotImplementedError(
-             'Vectorized indexing for {} is not implemented. Load your '
-             'data first with .load() or .compute().'.format(type(self)))
-        key = indexing.to_tuple(key)
+        key = indexing.unwrap_explicit_indexer(
+            key, self, allow=(indexing.BasicIndexer, indexing.OuterIndexer))
+
         # bands cannot be windowed but they can be listed
         band_key = key[0]
         n_bands = self.shape[0]

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -9,11 +9,10 @@ import warnings
 
 from .. import Variable
 from ..core.pycompat import iteritems, OrderedDict, basestring
-from ..core.utils import (Frozen, FrozenOrderedDict, NdimSizeLenMixin,
-                          DunderArrayMixin)
-from ..core.indexing import NumpyIndexingAdapter, NDArrayIndexable
+from ..core.utils import (Frozen, FrozenOrderedDict)
+from ..core.indexing import NumpyIndexingAdapter
 
-from .common import WritableCFDataStore, DataStorePickleMixin
+from .common import WritableCFDataStore, DataStorePickleMixin, BackendArray
 from .netcdf3 import (is_valid_nc3_name, encode_nc3_attr_value,
                       encode_nc3_variable)
 
@@ -31,7 +30,7 @@ def _decode_attrs(d):
                        for (k, v) in iteritems(d))
 
 
-class ScipyArrayWrapper(NdimSizeLenMixin, DunderArrayMixin, NDArrayIndexable):
+class ScipyArrayWrapper(BackendArray):
 
     def __init__(self, variable_name, datastore):
         self.datastore = datastore

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -333,7 +333,7 @@ def encode_cf_timedelta(timedeltas, units=None):
     return (num, units)
 
 
-class MaskedAndScaledArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
+class MaskedAndScaledArray(indexing.ExplicitNDArrayMixin):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically scaled and masked according to
     CF conventions for packed and missing data values.
@@ -391,7 +391,7 @@ class MaskedAndScaledArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
                  self.scale_factor, self.add_offset, self._dtype))
 
 
-class DecodedCFDatetimeArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
+class DecodedCFDatetimeArray(indexing.ExplicitNDArrayMixin):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically converted into datetime objects
     using decode_cf_datetime.
@@ -404,8 +404,9 @@ class DecodedCFDatetimeArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
         # Verify that at least the first and last date can be decoded
         # successfully. Otherwise, tracebacks end up swallowed by
         # Dataset.__repr__ when users try to view their lazily decoded array.
-        example_value = np.concatenate([first_n_items(array, 1) or [0],
-                                        last_item(array) or [0]])
+        values = indexing.WrapImplicitIndexing(self.array)
+        example_value = np.concatenate([first_n_items(values, 1) or [0],
+                                        last_item(values) or [0]])
 
         try:
             result = decode_cf_datetime(example_value, units, calendar)
@@ -430,7 +431,7 @@ class DecodedCFDatetimeArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
                                   calendar=self.calendar)
 
 
-class DecodedCFTimedeltaArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
+class DecodedCFTimedeltaArray(indexing.ExplicitNDArrayMixin):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically converted into timedelta objects
     using decode_cf_timedelta.
@@ -447,7 +448,7 @@ class DecodedCFTimedeltaArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
         return decode_cf_timedelta(self.array[key], units=self.units)
 
 
-class StackedBytesArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
+class StackedBytesArray(indexing.ExplicitNDArrayMixin):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically stacked along the last dimension.
 
@@ -493,7 +494,7 @@ class StackedBytesArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
         return char_to_bytes(self.array[key])
 
 
-class BytesToStringArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
+class BytesToStringArray(indexing.ExplicitNDArrayMixin):
     """Wrapper that decodes bytes to unicode when values are read.
 
     >>> BytesToStringArray(np.array([b'abc']))[:]
@@ -532,7 +533,7 @@ class BytesToStringArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
         return decode_bytes_array(self.array[key], self.encoding)
 
 
-class NativeEndiannessArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
+class NativeEndiannessArray(indexing.ExplicitNDArrayMixin):
     """Decode arrays on the fly from non-native to native endianness
 
     This is useful for decoding arrays from netCDF3 files (which are all
@@ -561,7 +562,7 @@ class NativeEndiannessArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
         return np.asarray(self.array[key], dtype=self.dtype)
 
 
-class BoolTypeArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
+class BoolTypeArray(indexing.ExplicitNDArrayMixin):
     """Decode arrays on the fly from integer to boolean datatype
 
     This is useful for decoding boolean arrays from integer typed netCDF
@@ -589,7 +590,7 @@ class BoolTypeArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
         return np.asarray(self.array[key], dtype=self.dtype)
 
 
-class UnsignedIntTypeArray(utils.NDArrayMixin, indexing.ExplicitlyIndexed):
+class UnsignedIntTypeArray(indexing.ExplicitNDArrayMixin):
     """Decode arrays on the fly from signed integer to unsigned
     integer. Typically used when _Unsigned is set at as a netCDF
     attribute on a signed integer variable.

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -333,7 +333,7 @@ def encode_cf_timedelta(timedeltas, units=None):
     return (num, units)
 
 
-class MaskedAndScaledArray(indexing.ExplicitNDArrayMixin):
+class MaskedAndScaledArray(indexing.ExplicitlyIndexedNDArrayMixin):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically scaled and masked according to
     CF conventions for packed and missing data values.
@@ -391,7 +391,7 @@ class MaskedAndScaledArray(indexing.ExplicitNDArrayMixin):
                  self.scale_factor, self.add_offset, self._dtype))
 
 
-class DecodedCFDatetimeArray(indexing.ExplicitNDArrayMixin):
+class DecodedCFDatetimeArray(indexing.ExplicitlyIndexedNDArrayMixin):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically converted into datetime objects
     using decode_cf_datetime.
@@ -404,7 +404,7 @@ class DecodedCFDatetimeArray(indexing.ExplicitNDArrayMixin):
         # Verify that at least the first and last date can be decoded
         # successfully. Otherwise, tracebacks end up swallowed by
         # Dataset.__repr__ when users try to view their lazily decoded array.
-        values = indexing.WrapImplicitIndexing(self.array)
+        values = indexing.ImplicitToExplicitIndexingAdapter(self.array)
         example_value = np.concatenate([first_n_items(values, 1) or [0],
                                         last_item(values) or [0]])
 
@@ -431,7 +431,7 @@ class DecodedCFDatetimeArray(indexing.ExplicitNDArrayMixin):
                                   calendar=self.calendar)
 
 
-class DecodedCFTimedeltaArray(indexing.ExplicitNDArrayMixin):
+class DecodedCFTimedeltaArray(indexing.ExplicitlyIndexedNDArrayMixin):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically converted into timedelta objects
     using decode_cf_timedelta.
@@ -448,7 +448,7 @@ class DecodedCFTimedeltaArray(indexing.ExplicitNDArrayMixin):
         return decode_cf_timedelta(self.array[key], units=self.units)
 
 
-class StackedBytesArray(indexing.ExplicitNDArrayMixin):
+class StackedBytesArray(indexing.ExplicitlyIndexedNDArrayMixin):
     """Wrapper around array-like objects to create a new indexable object where
     values, when accessed, are automatically stacked along the last dimension.
 
@@ -494,7 +494,7 @@ class StackedBytesArray(indexing.ExplicitNDArrayMixin):
         return char_to_bytes(self.array[key])
 
 
-class BytesToStringArray(indexing.ExplicitNDArrayMixin):
+class BytesToStringArray(indexing.ExplicitlyIndexedNDArrayMixin):
     """Wrapper that decodes bytes to unicode when values are read.
 
     >>> BytesToStringArray(np.array([b'abc']))[:]
@@ -533,7 +533,7 @@ class BytesToStringArray(indexing.ExplicitNDArrayMixin):
         return decode_bytes_array(self.array[key], self.encoding)
 
 
-class NativeEndiannessArray(indexing.ExplicitNDArrayMixin):
+class NativeEndiannessArray(indexing.ExplicitlyIndexedNDArrayMixin):
     """Decode arrays on the fly from non-native to native endianness
 
     This is useful for decoding arrays from netCDF3 files (which are all
@@ -562,7 +562,7 @@ class NativeEndiannessArray(indexing.ExplicitNDArrayMixin):
         return np.asarray(self.array[key], dtype=self.dtype)
 
 
-class BoolTypeArray(indexing.ExplicitNDArrayMixin):
+class BoolTypeArray(indexing.ExplicitlyIndexedNDArrayMixin):
     """Decode arrays on the fly from integer to boolean datatype
 
     This is useful for decoding boolean arrays from integer typed netCDF
@@ -590,7 +590,7 @@ class BoolTypeArray(indexing.ExplicitNDArrayMixin):
         return np.asarray(self.array[key], dtype=self.dtype)
 
 
-class UnsignedIntTypeArray(indexing.ExplicitNDArrayMixin):
+class UnsignedIntTypeArray(indexing.ExplicitlyIndexedNDArrayMixin):
     """Decode arrays on the fly from signed integer to unsigned
     integer. Typically used when _Unsigned is set at as a netCDF
     attribute on a signed integer variable.

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -99,7 +99,7 @@ def last_item(x):
         # work around for https://github.com/numpy/numpy/issues/5195
         return []
 
-    indexer = (slice(-1, None),) * x.ndim
+    indexer = BasicIndexer((slice(-1, None),) * x.ndim)
     return np.ravel(x[indexer]).tolist()
 
 

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -69,38 +69,39 @@ def _get_indexer_at_least_n_items(shape, n_desired):
     cum_items = np.cumprod(shape[::-1])
     n_steps = np.argmax(cum_items >= n_desired)
     stop = int(np.ceil(float(n_desired) / np.r_[1, cum_items][n_steps]))
-    indexer = BasicIndexer((0, ) * (len(shape) - 1 - n_steps) + (slice(stop), )
-                           + (slice(None), ) * n_steps)
+    indexer = ((0,) * (len(shape) - 1 - n_steps) +
+               (slice(stop),) +
+               (slice(None),) * n_steps)
     return indexer
 
 
-def first_n_items(x, n_desired):
+def first_n_items(array, n_desired):
     """Returns the first n_desired items of an array"""
-    # Unfortunately, we can't just do x.flat[:n_desired] here because x might
-    # not be a numpy.ndarray. Moreover, access to elements of x could be very
-    # expensive (e.g. if it's only available over DAP), so go out of our way to
-    # get them in a single call to __getitem__ using only slices.
+    # Unfortunately, we can't just do array.flat[:n_desired] here because it
+    # might not be a numpy.ndarray. Moreover, access to elements of the array
+    # could be very expensive (e.g. if it's only available over DAP), so go out
+    # of our way to get them in a single call to __getitem__ using only slices.
     if n_desired < 1:
         raise ValueError('must request at least one item')
 
-    if x.size == 0:
+    if array.size == 0:
         # work around for https://github.com/numpy/numpy/issues/5195
         return []
 
-    if n_desired < x.size:
-        indexer = _get_indexer_at_least_n_items(x.shape, n_desired)
-        x = x[indexer]
-    return np.asarray(x).flat[:n_desired]
+    if n_desired < array.size:
+        indexer = _get_indexer_at_least_n_items(array.shape, n_desired)
+        array = array[indexer]
+    return np.asarray(array).flat[:n_desired]
 
 
-def last_item(x):
+def last_item(array):
     """Returns the last item of an array in a list or an empty list."""
-    if x.size == 0:
+    if array.size == 0:
         # work around for https://github.com/numpy/numpy/issues/5195
         return []
 
-    indexer = BasicIndexer((slice(-1, None),) * x.ndim)
-    return np.ravel(x[indexer]).tolist()
+    indexer = (slice(-1, None),) * array.ndim
+    return np.ravel(array[indexer]).tolist()
 
 
 def format_timestamp(t):
@@ -174,19 +175,18 @@ def format_items(x):
     return formatted
 
 
-def format_array_flat(items_ndarray, max_width):
+def format_array_flat(array, max_width):
     """Return a formatted string for as many items in the flattened version of
-    items_ndarray that will fit within max_width characters
+    array that will fit within max_width characters.
     """
     # every item will take up at least two characters, but we always want to
     # print at least one item
     max_possibly_relevant = max(int(np.ceil(max_width / 2.0)), 1)
-    relevant_items = first_n_items(items_ndarray, max_possibly_relevant)
+    relevant_items = first_n_items(array, max_possibly_relevant)
     pprint_items = format_items(relevant_items)
 
     cum_len = np.cumsum([len(s) + 1 for s in pprint_items]) - 1
-    if (max_possibly_relevant < items_ndarray.size or
-            (cum_len > max_width).any()):
+    if (max_possibly_relevant < array.size or (cum_len > max_width).any()):
         end_padding = u' ...'
         count = max(np.argmax((cum_len + len(end_padding)) > max_width), 1)
         pprint_items = pprint_items[:count]

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -302,7 +302,7 @@ class ExplicitIndexer(object):
 
 
 def as_integer_or_none(value):
-    return None if value is None operator.index(value)
+    return None if value is None else operator.index(value)
 
 
 def as_integer_slice(value):

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -302,7 +302,7 @@ class ExplicitIndexer(object):
 
 
 def as_integer_or_none(value):
-    return None if value is None else operator.index(value)
+    return None if value is None operator.index(value)
 
 
 def as_integer_slice(value):

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -12,7 +12,7 @@ if PY3:  # pragma: no cover
     basestring = str
     unicode_type = str
     bytes_type = bytes
-    integer_types = (int, np.integer)
+    native_int_types = (int,)
 
     def iteritems(d):
         return iter(d.items())
@@ -31,7 +31,7 @@ else:  # pragma: no cover
     basestring = basestring  # noqa
     unicode_type = unicode  # noqa
     bytes_type = str
-    integer_types = (int, long, np.integer)  # noqa
+    native_int_types = (int, long)  # noqa
 
     def iteritems(d):
         return d.iteritems()
@@ -45,6 +45,9 @@ else:  # pragma: no cover
     import __builtin__ as builtins
     from urllib import urlretrieve
     from inspect import getargspec
+
+integer_types = native_int_types + (np.integer,)
+
 try:
     from cyordereddict import OrderedDict
 except ImportError:  # pragma: no cover

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -437,12 +437,7 @@ class NdimSizeLenMixin(object):
             raise TypeError('len() of unsized object')
 
 
-class DunderArrayMixin(object):
-    def __array__(self, dtype=None):
-        return np.asarray(self[...], dtype=dtype)
-
-
-class NDArrayMixin(NdimSizeLenMixin, DunderArrayMixin):
+class NDArrayMixin(NdimSizeLenMixin):
     """Mixin class for making wrappers of N-dimensional arrays that conform to
     the ndarray interface required for the data argument to Variable objects.
 
@@ -459,6 +454,9 @@ class NDArrayMixin(NdimSizeLenMixin, DunderArrayMixin):
 
     def __getitem__(self, key):
         return self.array[key]
+
+    def __array__(self, dtype=None):
+        return np.asarray(self.array, dtype=dtype)
 
     def __repr__(self):
         return '%s(array=%r)' % (type(self).__name__, self.array)

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -455,9 +455,6 @@ class NDArrayMixin(NdimSizeLenMixin):
     def __getitem__(self, key):
         return self.array[key]
 
-    def __array__(self, dtype=None):
-        return np.asarray(self.array, dtype=dtype)
-
     def __repr__(self):
         return '%s(array=%r)' % (type(self).__name__, self.array)
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -769,7 +769,12 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
             if utils.is_dict_like(chunks):
                 chunks = tuple(chunks.get(n, s)
                                for n, s in enumerate(self.shape))
-            data = indexing.WrapImplicitIndexing(data, indexing.OuterIndexer)
+            # da.from_array works by using lazily indexing with a tuple of
+            # slices. Using OuterIndexer is a pragmatic choice: dask does not
+            # yet handle different indexing types in an explicit way:
+            # https://github.com/dask/dask/issues/2883
+            data = indexing.ImplicitToExplicitIndexingAdapter(
+                data, indexing.OuterIndexer)
             data = da.from_array(data, chunks, name=name, lock=lock)
 
         return type(self)(self.dims, data, self._attrs, self._encoding,

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1270,7 +1270,7 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
             return (self.dims == other.dims and
                     (self._data is other._data or
                      equiv(self.data, other.data)))
-        except (TypeError, AttributeError) as e:
+        except (TypeError, AttributeError):
             return False
 
     def broadcast_equals(self, other, equiv=duck_array_ops.array_equiv):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -32,7 +32,7 @@ except ImportError:
 
 
 NON_NUMPY_SUPPORTED_ARRAY_TYPES = (
-    indexing.NDArrayIndexable, pd.Index) + dask_array_type
+    indexing.ExplicitlyIndexed, pd.Index) + dask_array_type
 BASIC_INDEXING_TYPES = integer_types + (slice,)
 
 
@@ -766,6 +766,7 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
             if utils.is_dict_like(chunks):
                 chunks = tuple(chunks.get(n, s)
                                for n, s in enumerate(self.shape))
+            data = indexing.BasicToExplicitArray(indexing.as_indexable(data))
             data = da.from_array(data, chunks, name=name, lock=lock)
 
         return type(self)(self.dims, data, self._attrs, self._encoding,
@@ -1261,7 +1262,7 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
             return (self.dims == other.dims and
                     (self._data is other._data or
                      equiv(self.data, other.data)))
-        except (TypeError, AttributeError):
+        except (TypeError, AttributeError) as e:
             return False
 
     def broadcast_equals(self, other, equiv=duck_array_ops.array_equiv):

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -214,6 +214,17 @@ class ReturnItem(object):
         return key
 
 
+class IndexerMaker(object):
+
+    def __init__(self, indexer_cls):
+        self._indexer_cls = indexer_cls
+
+    def __getitem__(self, key):
+        if not isinstance(key, tuple):
+            key = (key,)
+        return self._indexer_cls(key)
+
+
 def source_ndarray(array):
     """Given an ndarray, return the base object which holds its memory, or the
     object itself.

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -14,7 +14,7 @@ import pytest
 
 from xarray.core import utils
 from xarray.core.pycompat import PY3
-from xarray.core.indexing import NDArrayIndexable
+from xarray.core.indexing import ExplicitlyIndexed
 from xarray.testing import assert_equal, assert_identical, assert_allclose
 from xarray.plot.utils import import_seaborn
 
@@ -199,7 +199,7 @@ class UnexpectedDataAccess(Exception):
     pass
 
 
-class InaccessibleArray(utils.NDArrayMixin, NDArrayIndexable):
+class InaccessibleArray(utils.NDArrayMixin, ExplicitlyIndexed):
 
     def __init__(self, array):
         self.array = array

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -436,7 +436,7 @@ class DatasetIOTestCases(object):
         def find_and_validate_array(obj):
             # recursively called function. obj: array or array wrapper.
             if hasattr(obj, 'array'):
-                if isinstance(obj.array, indexing.NDArrayIndexable):
+                if isinstance(obj.array, indexing.ExplicitlyIndexed):
                     find_and_validate_array(obj.array)
                 else:
                     if isinstance(obj.array, np.ndarray):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1768,11 +1768,11 @@ class TestPyNio(CFEncodedDataTest, NetCDF3Only, TestCase):
 
     def test_orthogonal_indexing(self):
         # pynio also does not support list-like indexing
-        with raises_regex(NotImplementedError, 'Nio backend does not '):
+        with raises_regex(NotImplementedError, 'Outer indexing'):
             super(TestPyNio, self).test_orthogonal_indexing()
 
     def test_isel_dataarray(self):
-        with raises_regex(NotImplementedError, 'Nio backend does not '):
+        with raises_regex(NotImplementedError, 'Outer indexing'):
             super(TestPyNio, self).test_isel_dataarray()
 
     def test_array_type_after_indexing(self):

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -321,7 +321,7 @@ class TestDatetime(TestCase):
             np.array([0, 1, 2]), 'days since 1900-01-01', 'standard')
         expected = pd.date_range('1900-01-01', periods=3).values
         self.assertEqual(actual.dtype, np.dtype('datetime64[ns]'))
-        self.assertArrayEqual(actual[O[np.array([0, 2]),]], expected[[0, 2]])
+        self.assertArrayEqual(actual[O[np.array([0, 2])]], expected[[0, 2]])
 
     def test_decode_cf_datetime_non_standard_units(self):
         expected = pd.date_range(periods=100, start='1970-01-01', freq='h')

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1556,7 +1556,8 @@ class TestDataset(TestCase):
         expected = Dataset({'x': ('time', np.random.randn(5))},
                            {'time': range(5)})
         time2 = DataArray(np.arange(5), dims="time2")
-        actual = expected.reindex(time=time2)
+        with pytest.warns(FutureWarning):
+            actual = expected.reindex(time=time2)
         self.assertDatasetIdentical(actual, expected)
 
         # another regression test

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -347,9 +347,9 @@ def test_unwrap_explicit_indexer():
             indexer.tuple, target, allow=indexing.OuterIndexer)
 
 
-def test_wrap_implicit_indexing():
+def test_implicit_indexing_adapter():
     array = np.arange(10)
-    implicit = indexing.WrapImplicitIndexing(
+    implicit = indexing.ImplicitToExplicitIndexingAdapter(
         indexing.NumpyIndexingAdapter(array), indexing.BasicIndexer)
     np.testing.assert_array_equal(array, np.asarray(implicit))
     np.testing.assert_array_equal(array, implicit[:])

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -12,7 +12,10 @@ from xarray import Dataset, DataArray, Variable
 from xarray.core import indexing
 from xarray.core import nputils
 from xarray.core.pycompat import integer_types
-from . import TestCase, ReturnItem, raises_regex
+from . import TestCase, ReturnItem, raises_regex, IndexerMaker
+
+
+B = IndexerMaker(indexing.BasicIndexer)
 
 
 class TestIndexers(TestCase):
@@ -173,7 +176,7 @@ class TestLazyArray(TestCase):
 
                         # make sure actual.key is appropriate type
                         if all(isinstance(k, integer_types + (slice, ))
-                               for k in v_lazy._data.key):
+                               for k in v_lazy._data.key.tuple):
                             assert isinstance(v_lazy._data.key,
                                               indexing.BasicIndexer)
                         else:
@@ -197,16 +200,16 @@ class TestCopyOnWriteArray(TestCase):
     def test_setitem(self):
         original = np.arange(10)
         wrapped = indexing.CopyOnWriteArray(original)
-        wrapped[:] = 0
+        wrapped[B[:]] = 0
         self.assertArrayEqual(original, np.arange(10))
         self.assertArrayEqual(wrapped, np.zeros(10))
 
     def test_sub_array(self):
         original = np.arange(10)
         wrapped = indexing.CopyOnWriteArray(original)
-        child = wrapped[:5]
+        child = wrapped[B[:5]]
         self.assertIsInstance(child, indexing.CopyOnWriteArray)
-        child[:] = 0
+        child[B[:]] = 0
         self.assertArrayEqual(original, np.arange(10))
         self.assertArrayEqual(wrapped, np.arange(10))
         self.assertArrayEqual(child, np.zeros(5))
@@ -214,7 +217,7 @@ class TestCopyOnWriteArray(TestCase):
     def test_index_scalar(self):
         # regression test for GH1374
         x = indexing.CopyOnWriteArray(np.array(['foo', 'bar']))
-        assert np.array(x[0][()]) == 'foo'
+        assert np.array(x[B[0]][B[()]]) == 'foo'
 
 
 class TestMemoryCachedArray(TestCase):
@@ -227,7 +230,7 @@ class TestMemoryCachedArray(TestCase):
     def test_sub_array(self):
         original = indexing.LazilyIndexedArray(np.arange(10))
         wrapped = indexing.MemoryCachedArray(original)
-        child = wrapped[:5]
+        child = wrapped[B[:5]]
         self.assertIsInstance(child, indexing.MemoryCachedArray)
         self.assertArrayEqual(child, np.arange(5))
         self.assertIsInstance(child.array, indexing.NumpyIndexingAdapter)
@@ -236,46 +239,149 @@ class TestMemoryCachedArray(TestCase):
     def test_setitem(self):
         original = np.arange(10)
         wrapped = indexing.MemoryCachedArray(original)
-        wrapped[:] = 0
+        wrapped[B[:]] = 0
         self.assertArrayEqual(original, np.zeros(10))
 
     def test_index_scalar(self):
         # regression test for GH1374
         x = indexing.MemoryCachedArray(np.array(['foo', 'bar']))
-        assert np.array(x[0][()]) == 'foo'
+        assert np.array(x[B[0]][B[()]]) == 'foo'
 
 
-class TestIndexerTuple(TestCase):
-    """ Make sure _outer_to_numpy_indexer gives similar result to
-    Variable._broadcast_indexes_vectorized
-    """
-    def test_outer_indexer(self):
-        def nonzero(x):
-            if isinstance(x, np.ndarray) and x.dtype.kind == 'b':
-                x = x.nonzero()[0]
-            return x
-        original = np.random.rand(10, 20, 30)
-        v = Variable(['i', 'j', 'k'], original)
-        I = ReturnItem()
-        # test orthogonally applied indexers
-        indexers = [I[:], 0, -2, I[:3], np.array([0, 1, 2, 3]), np.array([0]),
-                    np.arange(10) < 5]
-        for i, j, k in itertools.product(indexers, repeat=3):
+def test_base_explicit_indexer():
+    with pytest.raises(TypeError):
+        indexing.ExplicitIndexer(())
 
-            if isinstance(j, np.ndarray) and j.dtype.kind == 'b':  # match size
-                j = np.arange(20) < 4
-            if isinstance(k, np.ndarray) and k.dtype.kind == 'b':
-                k = np.arange(30) < 8
+    class Subclass(indexing.ExplicitIndexer):
+        pass
 
-            _, expected, new_order = v._broadcast_indexes_vectorized((i, j, k))
-            expected_data = nputils.NumpyVIndexAdapter(v.data)[expected]
-            if new_order:
-                old_order = range(len(new_order))
-                expected_data = np.moveaxis(expected_data, old_order,
-                                            new_order)
+    value = Subclass((1, 2, 3))
+    assert value.tuple == (1, 2, 3)
+    assert repr(value) == 'Subclass((1, 2, 3))'
 
-            outer_index = indexing.OuterIndexer(
-                (nonzero(i), nonzero(j), nonzero(k)))
-            actual = indexing._outer_to_numpy_indexer(outer_index, v.shape)
-            actual_data = v.data[actual]
-            self.assertArrayEqual(actual_data, expected_data)
+
+@pytest.mark.parametrize('indexer_cls', [indexing.BasicIndexer,
+                                         indexing.OuterIndexer,
+                                         indexing.VectorizedIndexer])
+def test_invalid_for_all(indexer_cls):
+    with pytest.raises(TypeError):
+        indexer_cls(None)
+    with pytest.raises(TypeError):
+        indexer_cls(([],))
+    with pytest.raises(TypeError):
+        indexer_cls((None,))
+    with pytest.raises(TypeError):
+        indexer_cls(('foo',))
+    with pytest.raises(TypeError):
+        indexer_cls((1.0,))
+    with pytest.raises(TypeError):
+        indexer_cls((slice('foo'),))
+    with pytest.raises(TypeError):
+        indexer_cls((np.array(['foo']),))
+
+
+def check_integer(indexer_cls):
+    value = indexer_cls((1, np.uint64(2),)).tuple
+    assert all(isinstance(v, int) for v in value)
+    assert value == (1, 2)
+
+
+def check_slice(indexer_cls):
+    (value,) = indexer_cls((slice(1, None, np.int64(2)),)).tuple
+    assert value == slice(1, None, 2)
+    assert isinstance(value.step, int)
+
+
+def check_array1d(indexer_cls):
+    (value,) = indexer_cls((np.arange(3, dtype=np.int32),)).tuple
+    assert value.dtype == np.int64
+    np.testing.assert_array_equal(value, [0, 1, 2])
+
+
+def check_array2d(indexer_cls):
+    array = np.array([[1, 2], [3, 4]], dtype=np.int64)
+    (value,) = indexer_cls((array,)).tuple
+    assert value.dtype == np.int64
+    np.testing.assert_array_equal(value, array)
+
+
+def test_basic_indexer():
+    check_integer(indexing.BasicIndexer)
+    check_slice(indexing.BasicIndexer)
+    with pytest.raises(TypeError):
+        check_array1d(indexing.BasicIndexer)
+    with pytest.raises(TypeError):
+        check_array2d(indexing.BasicIndexer)
+
+
+def test_outer_indexer():
+    check_integer(indexing.OuterIndexer)
+    check_slice(indexing.OuterIndexer)
+    check_array1d(indexing.OuterIndexer)
+    with pytest.raises(TypeError):
+        check_array2d(indexing.OuterIndexer)
+
+
+def test_vectorized_indexer():
+    with pytest.raises(TypeError):
+        check_integer(indexing.VectorizedIndexer)
+    check_slice(indexing.VectorizedIndexer)
+    check_array1d(indexing.VectorizedIndexer)
+    check_array2d(indexing.VectorizedIndexer)
+
+
+def test_unwrap_explicit_indexer():
+    indexer = indexing.BasicIndexer((1, 2))
+    target = None
+
+    unwrapped = indexing.unwrap_explicit_indexer(
+        indexer, target, allow=indexing.BasicIndexer)
+    assert unwrapped == (1, 2)
+
+    with raises_regex(NotImplementedError, 'Load your data'):
+        indexing.unwrap_explicit_indexer(
+            indexer, target, allow=indexing.OuterIndexer)
+
+    with raises_regex(TypeError, 'unexpected key type'):
+        indexing.unwrap_explicit_indexer(
+            indexer.tuple, target, allow=indexing.OuterIndexer)
+
+
+def test_wrap_implicit_indexing():
+    array = np.arange(10)
+    implicit = indexing.WrapImplicitIndexing(
+        indexing.NumpyIndexingAdapter(array), indexing.BasicIndexer)
+    np.testing.assert_array_equal(array, np.asarray(implicit))
+    np.testing.assert_array_equal(array, implicit[:])
+
+
+def test_outer_indexer_consistency_with_broadcast_indexes_vectorized():
+    def nonzero(x):
+        if isinstance(x, np.ndarray) and x.dtype.kind == 'b':
+            x = x.nonzero()[0]
+        return x
+
+    original = np.random.rand(10, 20, 30)
+    v = Variable(['i', 'j', 'k'], original)
+    I = ReturnItem()
+    # test orthogonally applied indexers
+    indexers = [I[:], 0, -2, I[:3], np.array([0, 1, 2, 3]), np.array([0]),
+                np.arange(10) < 5]
+    for i, j, k in itertools.product(indexers, repeat=3):
+
+        if isinstance(j, np.ndarray) and j.dtype.kind == 'b':  # match size
+            j = np.arange(20) < 4
+        if isinstance(k, np.ndarray) and k.dtype.kind == 'b':
+            k = np.arange(30) < 8
+
+        _, expected, new_order = v._broadcast_indexes_vectorized((i, j, k))
+        expected_data = nputils.NumpyVIndexAdapter(v.data)[expected.tuple]
+        if new_order:
+            old_order = range(len(new_order))
+            expected_data = np.moveaxis(expected_data, old_order,
+                                        new_order)
+
+        outer_index = (nonzero(i), nonzero(j), nonzero(k))
+        actual = indexing._outer_to_numpy_indexer(outer_index, v.shape)
+        actual_data = v.data[actual]
+        np.testing.assert_array_equal(actual_data, expected_data)

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -11,7 +11,7 @@ import pandas as pd
 from xarray import Dataset, DataArray, Variable
 from xarray.core import indexing
 from xarray.core import nputils
-from xarray.core.pycompat import integer_types
+from xarray.core.pycompat import native_int_types
 from . import TestCase, ReturnItem, raises_regex, IndexerMaker
 
 
@@ -175,7 +175,7 @@ class TestLazyArray(TestCase):
                                           indexing.LazilyIndexedArray)
 
                         # make sure actual.key is appropriate type
-                        if all(isinstance(k, integer_types + (slice, ))
+                        if all(isinstance(k, native_int_types + (slice, ))
                                for k in v_lazy._data.key.tuple):
                             assert isinstance(v_lazy._data.key,
                                               indexing.BasicIndexer)
@@ -289,7 +289,7 @@ def check_integer(indexer_cls):
 def check_slice(indexer_cls):
     (value,) = indexer_cls((slice(1, None, np.int64(2)),)).tuple
     assert value == slice(1, None, 2)
-    assert isinstance(value.step, int)
+    assert isinstance(value.step, native_int_types)
 
 
 def check_array1d(indexer_cls):

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -59,28 +59,29 @@ class VariableSubclassTestCases(object):
         self.assertVariableIdentical(expected, actual)
 
     def test_getitem_1d(self):
-        v = self.cls(['x'], [0, 1, 2])
+        data = np.array([0, 1, 2])
+        v = self.cls(['x'], data)
 
         v_new = v[dict(x=[0, 1])]
         assert v_new.dims == ('x', )
-        self.assertArrayEqual(v_new, v._data[[0, 1]])
+        self.assertArrayEqual(v_new, data[[0, 1]])
 
         v_new = v[dict(x=slice(None))]
         assert v_new.dims == ('x', )
-        self.assertArrayEqual(v_new, v._data)
+        self.assertArrayEqual(v_new, data)
 
         v_new = v[dict(x=Variable('a', [0, 1]))]
         assert v_new.dims == ('a', )
-        self.assertArrayEqual(v_new, v._data[[0, 1]])
+        self.assertArrayEqual(v_new, data[[0, 1]])
 
         v_new = v[dict(x=1)]
         assert v_new.dims == ()
-        self.assertArrayEqual(v_new, v._data[1])
+        self.assertArrayEqual(v_new, data[1])
 
         # tuple argument
         v_new = v[slice(None)]
         assert v_new.dims == ('x', )
-        self.assertArrayEqual(v_new, v._data)
+        self.assertArrayEqual(v_new, data)
 
     def test_getitem_1d_fancy(self):
         v = self.cls(['x'], [0, 1, 2])

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1723,7 +1723,7 @@ class TestAsCompatibleData(TestCase):
             def __init__(self, array):
                 self.array = array
 
-        class CustomIndexable(CustomArray, indexing.NDArrayIndexable):
+        class CustomIndexable(CustomArray, indexing.ExplicitlyIndexed):
             pass
 
         array = CustomArray(np.arange(3))


### PR DESCRIPTION
I'm not entirely sure this is a good idea. The advantage is that it ensures that
all our indexing code is entirely explicit: everything that reaches a backend
*must* be an ExplicitIndexer. The downside is that it removes a bit of
internal flexibility: we can't just use tuples in place of basic indexers
anymore. On the whole, I think this is probably worth it but I would appreciate
feedback.

@fujiisoup can you take a look?

 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff``
