### PR TITLE
Warning for coordinate names with spaces in to_netcdf

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -487,6 +487,7 @@ Exceptions
    :toctree: generated/
 
    MergeError
+   SerializationWarning
 
 Advanced API
 ============

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -46,6 +46,10 @@ Bug fixes
 - Fix importing xarray when running Python with ``-OO`` (:issue:`1706`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
 
+- Saving a netCDF file with a coordinates with a spaces in its names now raises
+  an appropriate warnings (:issue:`1689`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
+
 - Fix two bugs that were preventing dask arrays from being specified as
   coordinates in the DataArray constructor (:issue:`1684`).
   By `Joe Hamman <https://github.com/jhamman>`_

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -47,7 +47,7 @@ Bug fixes
   By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 - Saving a netCDF file with a coordinates with a spaces in its names now raises
-  an appropriate warnings (:issue:`1689`).
+  an appropriate warning (:issue:`1689`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 - Fix two bugs that were preventing dask arrays from being specified as

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -19,7 +19,7 @@ from .backends.api import (open_dataset, open_dataarray, open_mfdataset,
                            save_mfdataset)
 from .backends.rasterio_ import open_rasterio
 
-from .conventions import decode_cf
+from .conventions import decode_cf, SerializationWarning
 
 try:
     from .version import version as __version__

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -376,9 +376,17 @@ class DatasetIOTestCases(object):
         with self.roundtrip(original) as actual:
             self.assertDatasetIdentical(original, actual)
 
-        expected = original.drop('foo')
-        with self.roundtrip(expected) as actual:
-            self.assertDatasetIdentical(expected, actual)
+    def test_roundtrip_global_coordinates(self):
+        original = Dataset({'x': [2, 3], 'y': ('a', [42]), 'z': ('x', [4, 5])})
+        with self.roundtrip(original) as actual:
+            self.assertDatasetIdentical(original, actual)
+
+    def test_roundtrip_coordinates_with_space(self):
+        original = Dataset(coords={'x': 0, 'y z': 1})
+        expected = Dataset({'y z': 1}, {'x': 0})
+        with pytest.warns(xr.SerializationWarning):
+            with self.roundtrip(original) as actual:
+                self.assertDatasetIdentical(expected, actual)
 
     def test_roundtrip_boolean_dtype(self):
         original = create_boolean_data()
@@ -1506,8 +1514,11 @@ class DaskTest(TestCase, DatasetIOTestCases):
                   allow_cleanup_failure=False):
         yield data.chunk()
 
+    # Override methods in DatasetIOTestCases - not applicable to dask
     def test_roundtrip_string_encoded_characters(self):
-        # Override method in DatasetIOTestCases - not applicable to dask
+        pass
+
+    def test_roundtrip_coordinates_with_space(self):
         pass
 
     def test_roundtrip_datetime_data(self):


### PR DESCRIPTION
 - [x] xref #1689
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
