### PR TITLE
Adds wrapping to tables in docs for improved readability.

### DIFF
--- a/doc/_static/theme_overrides.css
+++ b/doc/_static/theme_overrides.css
@@ -1,0 +1,13 @@
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      /* !important prevents the common CSS stylesheets from overriding
+         this as on RTD they are loaded after this stylesheet */
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      overflow: visible !important;
+   }
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -179,6 +179,12 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_context = {
+    'css_files': [
+        '_static/theme_overrides.css',  # override wide tables in RTD theme
+        ],
+     }
+
 # Sometimes the savefig directory doesn't exist and needs to be created
 # https://github.com/ipython/ipython/issues/8733
 # becomes obsolete when we can pin ipython>=5.2; see doc/environment.yml

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -16,5 +16,6 @@ dependencies:
   - hdf4=4.2.12  # temporary install to get netCD4 working (GH1106)
   - cartopy=0.15.1
   - rasterio=0.36.0
+  - sphinx_rtd_theme=0.2.4
   - pip:
     - sphinx-gallery


### PR DESCRIPTION
I've also added a dependency on `sphinx_rtd_theme` in the `environment.yml` file as
the docs wouldn't build without it.

 - [X] Closes #1728 
 - [X] Tests added / passed
 - [X] Passes ``git diff upstream/master **/*py | flake8 --diff``
 - [X] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

(I've ticked the last checkbox but I'm not sure if I'm supposed to document anything additional here...)