### PR TITLE
WIP: 1d+2d coord plotting

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,6 +21,10 @@ v0.10.1 (unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
+- :py:func:`~plot.contourf()` learned to contour 2D variables that have both a 1D co-ordinate (e.g. time) and a 2D co-ordinate (e.g. depth as a function of time).
+  By `Deepak Cherian <https://github.com/dcherian>`_.
+
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -453,6 +453,13 @@ def _plot2d(plotfunc):
         yval = darray[ylab].values
         zval = darray.to_masked_array(copy=False)
 
+        # check if we need to broadcast one dimension
+        if xval.ndim < yval.ndim:
+            xval = np.broadcast_to(xval, yval.shape)
+
+        if yval.ndim < xval.ndim:
+            yval = np.broadcast_to(yval, xval.shape)
+
         # May need to transpose for correct x, y labels
         # xlab may be the name of a coord, we have to check for dim names
         if darray[xlab].dims[-1] == darray.dims[0]:

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -107,6 +107,15 @@ class TestPlot(PlotTestCase):
         a.coords['dim_1'] = [2, 1, 89]
         self.assertTrue(self.contourf_called(a.plot.contourf))
 
+    def test2d_1d_2d_coordinates_contourf(self):
+        sz = (20, 10)
+        depth = easy_array(sz)
+        a = DataArray(easy_array(sz), dims=['z', 'time'],
+                      coords={'depth': (['z', 'time'], depth),
+                              'time': np.linspace(0, 1, sz[1])})
+
+        a.plot.contourf(x='time', y='depth')
+
     def test3d(self):
         self.darray.plot()
 


### PR DESCRIPTION
 - [ ] Closes #xxxx
 - [x] Tests added / passed
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

This PR teaches `plot.contourf()` to contour variables with both a 1D co-ordinate (e.g. time) and a 2D co-ordinate (e.g. time-varying depth) `da`:
```
<xarray.DataArray 'S' (z: 5, time: 85646)>
array([[       nan,        nan,        nan, ...,        nan,        nan,
               nan],
       [ 35.02816 ,  34.729567,  34.779223, ...,  34.57513 ,  34.671975,
         34.334675],
       [ 35.206943,  35.163239,  34.938674, ...,  34.780728,  34.836331,
         34.70386 ],
       [       nan,  35.184057,  35.10592 , ...,  34.656925,  34.776915,
         34.429442],
       [ 34.85562 ,  34.81994 ,  35.00963 , ...,  35.014522,  34.9747  ,
         35.033848]])
Coordinates:
    depth    (z, time) float16 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 53.5 ...
  * time     (time) datetime64[ns] 2013-12-19T06:00:01 2013-12-19T06:10:01 ...
Dimensions without coordinates: z
```

Now we can do `da.plot(x='time', y='depth')`

Couple of questions:
1. I've added a test, but am not sure how to work in an assert statement.
2. How do I test that I haven't messed up the syntax in `whats-new.rst`




