### PR TITLE
Fix DataArray.__dask_scheduler__ to point to dask.threaded.get

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,6 +30,8 @@ Bug fixes
 
 .. _whats-new.0.10.0:
 
+- Properly point DataArray.__dask_scheduler__ to dask.threaded.get
+
 v0.10.0 (20 November 2017)
 --------------------------
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -594,7 +594,7 @@ class DataArray(AbstractArray, BaseDataObject):
 
     @property
     def __dask_scheduler__(self):
-        return self._to_temp_dataset().__dask_optimize__
+        return self._to_temp_dataset().__dask_scheduler__
 
     def __dask_postcompute__(self):
         func, args = self._to_temp_dataset().__dask_postcompute__()

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -830,3 +830,16 @@ def test_dataarray_with_dask_coords():
     assert not dask.is_dask_collection(array2)
 
     assert all(isinstance(v._variable.data, np.ndarray) for v in array2.coords.values())
+
+
+def test_basic_compute():
+    ds = Dataset({'foo': ('x', range(5)),
+                  'bar': ('x', range(5))}).chunk({'x': 2})
+    for get in [dask.threaded.get,
+                dask.multiprocessing.get,
+                dask.local.get_sync,
+                None]:
+        with dask.set_options(get=get):
+            ds.compute()
+            ds.foo.compute()
+            ds.foo.variable.compute()


### PR DESCRIPTION
Previously this erroneously pointed to an optimize function, likely a
copy-paste error.

For testing this also redirects the .compute methods to use the
dask.compute function directly *if* dask.__version__ >= '0.16.0'.

Closes #1759

 - [x] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
