### PR TITLE
ENH: Add dt.date accessor.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,6 +21,9 @@ v0.10.1 (unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
+- `DatetimeAccessor` learned to return `date` i.e. `'2014-01-01T01:00:00.000000000'` is transformed to `'2014-01-01T00:00:00.000000000'`.
+  By `Deepak Cherian <https://github.com/dcherian>`_.
+
 - :py:func:`~plot.contourf()` learned to contour 2D variables that have both a 1D co-ordinate (e.g. time) and a 2D co-ordinate (e.g. depth as a function of time).
   By `Deepak Cherian <https://github.com/dcherian>`_.
 

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -26,8 +26,11 @@ def _access_through_series(values, name):
     if name == "season":
         months = values_as_series.dt.month.values
         field_values = _season_from_months(months)
+    elif name == "date":
+        field_values = values_as_series.dt.floor('1D').values
     else:
         field_values = getattr(values_as_series.dt, name).values
+
     return field_values.reshape(values.shape)
 
 
@@ -145,4 +148,8 @@ class DatetimeAccessor(object):
 
     time = _tslib_field_accessor(
         "time", "Timestamps corresponding to datetimes", object
+    )
+
+    date = _tslib_field_accessor(
+        "date", "Date with hours, minutes etc. dropped", object
     )

--- a/xarray/tests/test_accessors.py
+++ b/xarray/tests/test_accessors.py
@@ -35,11 +35,15 @@ class TestDatetimeAccessor(TestCase):
                             coords=[self.times, ], dims=['time', ])
         hours = xr.DataArray(self.times.hour, name='hour',
                              coords=[self.times, ], dims=['time', ])
+        dates = xr.DataArray((pd.to_datetime(self.times).floor('1D')),
+                             name='date', coords=[self.times, ],
+                             dims=['time', ])
 
         self.assertDataArrayEqual(years, self.data.time.dt.year)
         self.assertDataArrayEqual(months, self.data.time.dt.month)
         self.assertDataArrayEqual(days, self.data.time.dt.day)
         self.assertDataArrayEqual(hours, self.data.time.dt.hour)
+        self.assertDataArrayEqual(dates, self.data.time.dt.date)
 
     def test_not_datetime_type(self):
         nontime_data = self.data.copy()


### PR DESCRIPTION
This PR lets us access `dt.date` thereby removing all higher frequency time information. 

*Use case:* Just like `dayofyear` but easier to interpret when only looking at 1 year of data. 

*Example:* Start with `da.time`
```
<xarray.DataArray 'time' (time: 8737)>
  array(['2014-01-01T00:00:00.000000000', '2014-01-01T01:00:00.000000000',
         '2014-01-01T02:00:00.000000000', ..., '2014-12-30T22:00:00.000000000',
         '2014-12-30T23:00:00.000000000', '2014-12-31T00:00:00.000000000'], dtype='datetime64[ns]')
  Coordinates:
    * time     (time) datetime64[ns] 2014-01-01 2014-01-01T01:00:00 ...
```

then `da.time.dt.date` yields
```
<xarray.DataArray 'date' (time: 8737)>
  array(['2014-01-01T00:00:00.000000000', '2014-01-01T00:00:00.000000000',
         '2014-01-01T00:00:00.000000000', ..., '2014-12-30T00:00:00.000000000',
         '2014-12-30T00:00:00.000000000', '2014-12-31T00:00:00.000000000'], dtype='datetime64[ns]')
  Coordinates:
    * time     (time) datetime64[ns] 2014-01-01 2014-01-01T01:00:00 ...
```

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)