### PR TITLE
Respect PEP 440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,9 @@ if not ISRELEASED:
         # Strip leading v from tags format "vx.y.z" to get th version string
         FULLVERSION = rev.lstrip('v')
 
+        # make sure we respect PEP 440
+        FULLVERSION = FULLVERSION.replace("-", "+dev", 1).replace("-", ".")
+
 else:
     FULLVERSION += QUALIFIER
 

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ if not ISRELEASED:
             # partial clone, manually construct version string
             # this is the format before we started using git-describe
             # to get an ordering on dev version strings.
-            rev = "v%s.dev-%s" % (VERSION, rev)
+            rev = "v%s+dev.%s" % (VERSION, rev)
 
         # Strip leading v from tags format "vx.y.z" to get th version string
         FULLVERSION = rev.lstrip('v')


### PR DESCRIPTION
Change unreleased version numbers as to respect PEP 440.  Rather than
`0.10.0-9-g89a1a98` we will have `0.10.0+dev9.g89a1a98`.  This means
automated setuptools requirements can be respected.  Closes #1300.

 - [x] Closes #1300  (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
