### PR TITLE
plot.line(): Draw multiple lines for 2D DataArrays.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,6 +33,9 @@ Enhancements
 - Experimental support for parsing ENVI metadata to coordinates and attributes
   in :py:func:`xarray.open_rasterio`.
   By `Matti Eskelinen <https://github.com/maaleske>`_.
+- :py:func:`~plot.line()` learned to draw multiple lines if provided with a
+  2D variable.
+  By `Deepak Cherian <https://github.com/dcherian>`_.
 
 .. _Zarr: http://zarr.readthedocs.io/
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -177,7 +177,7 @@ def line(darray, *args, **kwargs):
         Axis on which to plot this figure. By default, use the current axis.
         Mutually exclusive with ``size`` and ``figsize``.
     x : string, optional
-        Coordinate for x axis (2D inputs only). If None use darray.dims[1]
+        Coordinate for x axis (2D inputs only). If None use longer dimension.
     add_legend : boolean, optional
         Add legend with y axis coordinates (2D inputs only).
     *args, **kwargs : optional
@@ -207,6 +207,9 @@ def line(darray, *args, **kwargs):
         x = darray.coords[xlabel]
 
     else:
+        if x is None:
+            x = darray.dims[np.argmax(darray.shape)]
+
         xlabel, ylabel = _infer_xy_labels(darray=darray, x=x, y=None)
         x = darray.coords[xlabel]
         darray = darray.transpose(xlabel, ylabel)

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -208,7 +208,8 @@ def line(darray, *args, **kwargs):
     if ndims == 1:
         xlabel, = darray.dims
         if x is not None and xlabel != x:
-            raise ValueError('Input does not have specified dimension ' + x)
+            raise ValueError('Input does not have specified dimension'
+                             + ' {!r}'.format(x))
 
         x = darray.coords[xlabel]
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -176,8 +176,11 @@ def line(darray, *args, **kwargs):
     ax : matplotlib axes object, optional
         Axis on which to plot this figure. By default, use the current axis.
         Mutually exclusive with ``size`` and ``figsize``.
+    hue : string, optional
+        Coordinate for which you want multiple lines plotted (2D inputs only).
     x : string, optional
-        Coordinate for x axis (2D inputs only). If None use longer dimension.
+        Coordinate for x axis (2D inputs only). If both x and hue are None,
+        x is set to the longer dimension.
     add_legend : boolean, optional
         Add legend with y axis coordinates (2D inputs only).
     *args, **kwargs : optional
@@ -197,6 +200,7 @@ def line(darray, *args, **kwargs):
     aspect = kwargs.pop('aspect', None)
     size = kwargs.pop('size', None)
     ax = kwargs.pop('ax', None)
+    hue = kwargs.pop('hue', None)
     x = kwargs.pop('x', None)
     add_legend = kwargs.pop('add_legend', True)
 
@@ -207,12 +211,12 @@ def line(darray, *args, **kwargs):
         x = darray.coords[xlabel]
 
     else:
-        if x is None:
+        if x is None and hue is None:
             x = darray.dims[np.argmax(darray.shape)]
 
-        xlabel, ylabel = _infer_xy_labels(darray=darray, x=x, y=None)
+        xlabel, huelabel = _infer_xy_labels(darray=darray, x=x, y=hue)
         x = darray.coords[xlabel]
-        darray = darray.transpose(xlabel, ylabel)
+        darray = darray.transpose(xlabel, huelabel)
 
     _ensure_plottable(x)
 
@@ -225,7 +229,7 @@ def line(darray, *args, **kwargs):
         ax.set_ylabel(darray.name)
 
     if darray.ndim == 2 and add_legend:
-        ax.legend(darray.coords[ylabel].values, title=ylabel)
+        ax.legend(darray.coords[huelabel].values, title=huelabel)
 
     # Rotate dates on xlabels
     if np.issubdtype(x.dtype, np.datetime64):

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -229,7 +229,9 @@ def line(darray, *args, **kwargs):
         ax.set_ylabel(darray.name)
 
     if darray.ndim == 2 and add_legend:
-        ax.legend(darray.coords[huelabel].values, title=huelabel)
+        ax.legend(handles=primitive,
+                  labels=list(darray.coords[huelabel].values),
+                  title=huelabel)
 
     # Rotate dates on xlabels
     if np.issubdtype(x.dtype, np.datetime64):

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -179,8 +179,7 @@ def line(darray, *args, **kwargs):
     hue : string, optional
         Coordinate for which you want multiple lines plotted (2D inputs only).
     x : string, optional
-        Coordinate for x axis (2D inputs only). If both x and hue are None,
-        x is set to the longer dimension.
+        Coordinate for x axis.
     add_legend : boolean, optional
         Add legend with y axis coordinates (2D inputs only).
     *args, **kwargs : optional
@@ -208,11 +207,14 @@ def line(darray, *args, **kwargs):
 
     if ndims == 1:
         xlabel, = darray.dims
+        if x is not None and xlabel != x:
+            raise ValueError('Input does not have specified dimension ' + x)
+
         x = darray.coords[xlabel]
 
     else:
         if x is None and hue is None:
-            x = darray.dims[np.argmax(darray.shape)]
+            raise ValueError('For 2D inputs, please specify either hue or x.')
 
         xlabel, huelabel = _infer_xy_labels(darray=darray, x=x, y=hue)
         x = darray.coords[xlabel]

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -94,6 +94,9 @@ class TestPlot(PlotTestCase):
     def test1d(self):
         self.darray[:, 0, 0].plot()
 
+    def test2dline(self):
+        self.darray[:, :, 0].plot.line()
+
     def test_2d_before_squeeze(self):
         a = DataArray(easy_array((1, 5)))
         a.plot()
@@ -242,11 +245,6 @@ class TestPlot1D(PlotTestCase):
         self.darray.name = 'temperature'
         self.darray.plot()
         self.assertEqual(self.darray.name, plt.gca().get_ylabel())
-
-    def test_wrong_dims_raises_valueerror(self):
-        twodims = DataArray(easy_array((2, 5)))
-        with pytest.raises(ValueError):
-            twodims.plot.line()
 
     def test_format_string(self):
         self.darray.plot.line('ro')

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -94,19 +94,24 @@ class TestPlot(PlotTestCase):
     def test1d(self):
         self.darray[:, 0, 0].plot()
 
+        with raises_regex(ValueError, 'dimension'):
+            self.darray[:, 0, 0].plot(x='dim_1')
+
     def test_2d_line(self):
-        self.darray[:, :, 0].plot.line()
-        self.assertTrue(plt.gca().get_xlabel() == 'dim_1')
+        with raises_regex(ValueError, 'hue'):
+            self.darray[:, :, 0].plot.line()
+
+        self.darray[:, :, 0].plot.line(hue='dim_1')
 
     def test_2d_line_accepts_legend_kw(self):
-        self.darray[:, :, 0].plot.line(add_legend=False)
+        self.darray[:, :, 0].plot.line(x='dim_0', add_legend=False)
         self.assertFalse(plt.gca().get_legend())
         plt.cla()
-        self.darray[:, :, 0].plot.line(add_legend=True)
+        self.darray[:, :, 0].plot.line(x='dim_0', add_legend=True)
         self.assertTrue(plt.gca().get_legend())
         # check whether legend title is set
         self.assertTrue(plt.gca().get_legend().get_title().get_text()
-                        == 'dim_0')
+                        == 'dim_1')
 
     def test_2d_line_accepts_x_kw(self):
         self.darray[:, :, 0].plot.line(x='dim_0')

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -115,6 +115,15 @@ class TestPlot(PlotTestCase):
         self.darray[:, :, 0].plot.line(x='dim_1')
         self.assertTrue(plt.gca().get_xlabel() == 'dim_1')
 
+    def test_2d_line_accepts_hue_kw(self):
+        self.darray[:, :, 0].plot.line(hue='dim_0')
+        self.assertTrue(plt.gca().get_legend().get_title().get_text()
+                        == 'dim_0')
+        plt.cla()
+        self.darray[:, :, 0].plot.line(hue='dim_1')
+        self.assertTrue(plt.gca().get_legend().get_title().get_text()
+                        == 'dim_1')
+
     def test_2d_before_squeeze(self):
         a = DataArray(easy_array((1, 5)))
         a.plot()

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -96,6 +96,7 @@ class TestPlot(PlotTestCase):
 
     def test_2d_line(self):
         self.darray[:, :, 0].plot.line()
+        self.assertTrue(plt.gca().get_xlabel() == 'dim_1')
 
     def test_2d_line_accepts_legend_kw(self):
         self.darray[:, :, 0].plot.line(add_legend=False)

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -94,8 +94,25 @@ class TestPlot(PlotTestCase):
     def test1d(self):
         self.darray[:, 0, 0].plot()
 
-    def test2dline(self):
+    def test_2d_line(self):
         self.darray[:, :, 0].plot.line()
+
+    def test_2d_line_accepts_legend_kw(self):
+        self.darray[:, :, 0].plot.line(add_legend=False)
+        self.assertFalse(plt.gca().get_legend())
+        plt.cla()
+        self.darray[:, :, 0].plot.line(add_legend=True)
+        self.assertTrue(plt.gca().get_legend())
+        # check whether legend title is set
+        self.assertTrue(plt.gca().get_legend().get_title().get_text()
+                        == 'dim_0')
+
+    def test_2d_line_accepts_x_kw(self):
+        self.darray[:, :, 0].plot.line(x='dim_0')
+        self.assertTrue(plt.gca().get_xlabel() == 'dim_0')
+        plt.cla()
+        self.darray[:, :, 0].plot.line(x='dim_1')
+        self.assertTrue(plt.gca().get_xlabel() == 'dim_1')
 
     def test_2d_before_squeeze(self):
         a = DataArray(easy_array((1, 5)))


### PR DESCRIPTION
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

Adds support for plotting multiple lines if `plot.line()` is provided with a 2D dataarray.

kwarg `x` lets you specify co-ordinate for x-axis.

Example:


![xarray-multiple-line](https://user-images.githubusercontent.com/2448579/34031085-96dfbaee-e124-11e7-8578-e97586257b7a.png)
