### PR TITLE
Support RGB[A] arrays in plot.imshow()

### DIFF
--- a/doc/gallery/plot_rasterio.py
+++ b/doc/gallery/plot_rasterio.py
@@ -44,13 +44,10 @@ lat = np.asarray(lat).reshape((ny, nx))
 da.coords['lon'] = (('y', 'x'), lon)
 da.coords['lat'] = (('y', 'x'), lat)
 
-# Compute a greyscale out of the rgb image
-greyscale = da.mean(dim='band')
-
 # Plot on a map
 ax = plt.subplot(projection=ccrs.PlateCarree())
-greyscale.plot(ax=ax, x='lon', y='lat', transform=ccrs.PlateCarree(),
-               cmap='Greys_r', add_colorbar=False)
+da.plot.imshow(ax=ax, x='lon', y='lat', rgb='band',
+               transform=ccrs.PlateCarree())
 ax.coastlines('10m', color='r')
 plt.show()
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,6 +33,8 @@ Enhancements
   By `Joe Hamman <https://github.com/jhamman>`_.
 - Support for using `Zarr`_ as storage layer for xarray.
   By `Ryan Abernathey <https://github.com/rabernat>`_.
+- :func:`xarray.plot.imshow` now handles RGB and RGBA images.
+  By `Zac Hatfield-Dodds <https://github.com/Zac-HD>`_.
 - Experimental support for parsing ENVI metadata to coordinates and attributes
   in :py:func:`xarray.open_rasterio`.
   By `Matti Eskelinen <https://github.com/maaleske>`_.

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -240,7 +240,7 @@ class FacetGrid(object):
 
         # Get x, y labels for the first subplot
         x, y = _infer_xy_labels(darray=self.data.loc[self.name_dicts.flat[0]],
-                                x=x, y=y)
+                                x=x, y=y, imshow=func.__name__ == 'imshow')
 
         for d, ax in zip(self.name_dicts.flat, self.axes.flat):
             # None is the sentinel value

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -239,8 +239,9 @@ class FacetGrid(object):
         func_kwargs.update({'add_colorbar': False, 'add_labels': False})
 
         # Get x, y labels for the first subplot
-        x, y = _infer_xy_labels(darray=self.data.loc[self.name_dicts.flat[0]],
-                                x=x, y=y, imshow=func.__name__ == 'imshow')
+        x, y = _infer_xy_labels(
+            darray=self.data.loc[self.name_dicts.flat[0]], x=x, y=y,
+            imshow=func.__name__ == 'imshow', rgb=kwargs.get('rgb', None))
 
         for d, ax in zip(self.name_dicts.flat, self.axes.flat):
             # None is the sentinel value

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -258,17 +258,21 @@ def _determine_cmap_params(plot_data, vmin=None, vmax=None, cmap=None,
                 levels=levels, norm=norm)
 
 
-def _infer_xy_labels(darray, x, y):
+def _infer_xy_labels(darray, x, y, imshow=False):
     """
     Determine x and y labels. For use in _plot2d
 
-    darray must be a 2 dimensional data array.
+    darray must be a 2 dimensional data array, or 3d for imshow only.
     """
 
     if x is None and y is None:
         if darray.ndim != 2:
-            raise ValueError('DataArray must be 2d')
-        y, x = darray.dims
+            if not imshow:
+                raise ValueError('DataArray must be 2d')
+            elif darray.ndim != 3 or darray.shape[2] not in (3, 4):
+                raise ValueError('DataArray for imshow must be 2d, MxNx3 for '
+                                 'RGB image, or MxNx4 for RGBA image.')
+        y, x, *_ = darray.dims
     elif x is None:
         if y not in darray.dims:
             raise ValueError('y must be a dimension name if x is not supplied')

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -258,21 +258,70 @@ def _determine_cmap_params(plot_data, vmin=None, vmax=None, cmap=None,
                 levels=levels, norm=norm)
 
 
-def _infer_xy_labels(darray, x, y, imshow=False):
+def _infer_xy_labels_3d(darray, x, y, rgb):
+    """
+    Determine x and y labels for showing RGB images.
+
+    Attempts to infer which dimension is RGB/RGBA by size and order of dims.
+
+    """
+    assert rgb is None or rgb != x
+    assert rgb is None or rgb != y
+    # Start by detecting and reporting invalid combinations of arguments
+    assert darray.ndim == 3
+    not_none = [a for a in (x, y, rgb) if a is not None]
+    if len(set(not_none)) < len(not_none):
+        raise ValueError(
+            'Dimension names must be None or unique strings, but imshow was '
+            'passed x=%r, y=%r, and rgb=%r.' % (x, y, rgb))
+    for label in not_none:
+        if label not in darray.dims:
+            raise ValueError('%r is not a dimension' % (label,))
+
+    # Then calculate rgb dimension if certain and check validity
+    could_be_color = [label for label in darray.dims
+                      if darray[label].size in (3, 4) and label not in (x, y)]
+    if rgb is None and not could_be_color:
+        raise ValueError(
+            'A 3-dimensional array was passed to imshow(), but there is no '
+            'dimension that could be color.  At least one dimension must be '
+            'of size 3 (RGB) or 4 (RGBA), and not given as x or y.')
+    if rgb is None and len(could_be_color) == 1:
+        rgb = could_be_color[0]
+    if rgb is not None and darray[rgb].size not in (3, 4):
+        raise ValueError('Cannot interpret dim %r of size %s as RGB or RGBA.'
+                         % (rgb, darray[rgb].size))
+
+    # If rgb dimension is still unknown, there must be two or three dimensions
+    # in could_be_color.  We therefore warn, and use a heuristic to break ties.
+    if rgb is None:
+        assert len(could_be_color) in (2, 3)
+        rgb = could_be_color[-1]
+        warnings.warn(
+            'Several dimensions of this array could be colors.  Xarray '
+            'will use the last possible dimension (%r) to match '
+            'matplotlib.pyplot.imshow.  You can pass names of x, y, '
+            'and/or rgb dimensions to override this guess.' % rgb)
+    assert rgb is not None
+
+    # Finally, we pick out the red slice and delegate to the 2D version:
+    return _infer_xy_labels(darray.isel(**{rgb: 0}).squeeze(), x, y)
+
+
+def _infer_xy_labels(darray, x, y, imshow=False, rgb=None):
     """
     Determine x and y labels. For use in _plot2d
 
     darray must be a 2 dimensional data array, or 3d for imshow only.
     """
+    assert x is None or x != y
+    if imshow and darray.ndim == 3:
+        return _infer_xy_labels_3d(darray, x, y, rgb)
 
     if x is None and y is None:
         if darray.ndim != 2:
-            if not imshow:
-                raise ValueError('DataArray must be 2d')
-            elif darray.ndim != 3 or darray.shape[2] not in (3, 4):
-                raise ValueError('DataArray for imshow must be 2d, MxNx3 for '
-                                 'RGB image, or MxNx4 for RGBA image.')
-        y, x, *_ = darray.dims
+            raise ValueError('DataArray must be 2d')
+        y, x = darray.dims
     elif x is None:
         if y not in darray.dims:
             raise ValueError('y must be a dimension name if x is not supplied')

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -619,6 +619,8 @@ class Common2dMixin:
 
     def test_3d_raises_valueerror(self):
         a = DataArray(easy_array((2, 3, 4)))
+        if self.plotfunc.__name__ == 'imshow':
+            pytest.skip()
         with raises_regex(ValueError, r'DataArray must be 2d'):
             self.plotfunc(a)
 
@@ -1061,6 +1063,20 @@ class TestImshow(Common2dMixin, PlotTestCase):
     def test_2d_coord_names(self):
         with raises_regex(ValueError, 'requires 1D coordinates'):
             self.plotmethod(x='x2d', y='y2d')
+
+    def test_plot_rgb_image(self):
+        DataArray(
+            easy_array((10, 15, 3), start=0),
+            dims=['y', 'x', 'band'],
+        ).plot.imshow()
+        self.assertEqual(0, len(find_possible_colorbars()))
+
+    def test_plot_rgb_faceted(self):
+        DataArray(
+            easy_array((2, 2, 10, 15, 3), start=0),
+            dims=['a', 'b', 'y', 'x', 'band'],
+        ).plot.imshow(row='a', col='b')
+        self.assertEqual(0, len(find_possible_colorbars()))
 
 
 class TestFacetGrid(PlotTestCase):


### PR DESCRIPTION
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes

This patch brings `xarray.plot.imshow` up to parity with `matplotlib.pyplot.imshow`:

- As well as 2D images (greyscale / luminance, using a colormap), it now supports a third dimension for RGB or RGBA channels.  For consistency with 2D arrays, missing data is plotted as transparent pixels
- Being Xarray, users need not care about the order of their dimensions - we infer the right one for color, and warn if it's ambiguous.
- ~~Using `robust=True` for easy saturation is really nice.  Having it adjust each channel and facet in the same way is essential for this to work, which it does.~~
- ~~Matplotlib wraps out-of-range colors, leading to crazy maps and serious interpretation problems if it's only a small region.  Xarray clips (ie saturates) to the valid range instead.~~

*I'm going to implement clip-to-range and color normalization upstream in matplotlib, then open a second PR here so that Xarray can use the same interface.*

And that's the commit log!  It's not really a big feature, but each of the parts can be fiddly so I've broken
 the commits up logically 😄 

Finally, a motivating example: visible-light Landsat data before, during (top-right), and after a fire at Sampson's Flat, Australia:

    arr = ds['red green blue'.split()].to_array(dim='band') / (2 ** 12)
    arr.plot.imshow(col='time', col_wrap=5, robust=True)

![image](https://user-images.githubusercontent.com/12229877/34209509-8c8b7800-e5e6-11e7-8276-2f4bbe92f325.png)
  