### PR TITLE
Add gallery example for multiple lines plot

### DIFF
--- a/doc/gallery/plot_lines_from_2d.py
+++ b/doc/gallery/plot_lines_from_2d.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""
+==================================
+Multiple lines from a 2d DataArray
+==================================
+
+
+Use :py:func:`xarray.plot.line` on a 2d DataArray to plot selections as
+multiple lines.
+
+See :ref:`plotting.multiplelines` for more details.
+
+"""
+
+import xarray as xr
+import matplotlib.pyplot as plt
+
+# Load the data
+ds = xr.tutorial.load_dataset('air_temperature')
+air = ds.air - 273.15  # to celsius
+
+# Prepare the figure
+f, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4), sharey=True)
+
+# Selected latitude indices
+isel_lats = [10, 15, 20]
+
+# Temperature vs longitude plot - illustrates the "hue" kwarg
+air.isel(time=0, lat=isel_lats).plot.line(ax=ax1, hue='lat')
+ax1.set_ylabel('°C')
+
+# Temperature vs time plot - illustrates the "x" and "add_legend" kwargs
+air.isel(lon=30, lat=isel_lats).plot.line(ax=ax2, x='time', add_legend=False)
+ax2.set_ylabel('')
+
+# Show
+plt.tight_layout()
+plt.show()

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -175,10 +175,12 @@ entire figure (as for matplotlib's ``figsize`` argument).
 .. _not equivalent to matplotlib's: https://github.com/mwaskom/seaborn/issues/746
 
 
+.. _plotting.multiplelines:
+
 Multiple lines showing variation along a dimension
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It is possible to make line plots of two-dimensional data by calling ``xarray.plot.line()``
+It is possible to make line plots of two-dimensional data by calling :py:func:`xarray.plot.line`
 with appropriate arguments. Consider the 3D variable ``air`` defined above. We can use line
 plots to check the variation of air temperature at three different latitudes along a longitude line:
 


### PR DESCRIPTION
Extends https://github.com/pydata/xarray/pull/1804 by adding some usage examples to the gallery.

Here is how the plot looks like:

![sphx_glr_plot_lines_from_2d_001](https://user-images.githubusercontent.com/10050469/34524787-12d5eb82-f09d-11e7-9bb0-62070a62f6e6.png)

cc @dcherian and @shoyer 

