### PR TITLE
Normalisation for RGB imshow

### DIFF
--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -305,6 +305,8 @@ example, consider the original data in Kelvins rather than Celsius:
 The Celsius data contain 0, so a diverging color map was used. The
 Kelvins do not have 0, so the default color map was used.
 
+.. _robust-plotting:
+
 Robust
 ~~~~~~
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -41,6 +41,7 @@ Enhancements
 - Support for using `Zarr`_ as storage layer for xarray.
   By `Ryan Abernathey <https://github.com/rabernat>`_.
 - :func:`xarray.plot.imshow` now handles RGB and RGBA images.
+  Saturation can be adjusted with ``vmin`` and ``vmax``, or with ``robust=True``.
   By `Zac Hatfield-Dodds <https://github.com/Zac-HD>`_.
 - Experimental support for parsing ENVI metadata to coordinates and attributes
   in :py:func:`xarray.open_rasterio`.

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -11,6 +11,9 @@ from ..core.pycompat import basestring
 from ..core.utils import is_scalar
 
 
+ROBUST_PERCENTILE = 2.0
+
+
 def _load_default_cmap(fname='default_colormap.csv'):
     """
     Returns viridis color map
@@ -165,7 +168,6 @@ def _determine_cmap_params(plot_data, vmin=None, vmax=None, cmap=None,
     cmap_params : dict
         Use depends on the type of the plotting function
     """
-    ROBUST_PERCENTILE = 2.0
     import matplotlib as mpl
 
     calc_data = np.ravel(plot_data[~pd.isnull(plot_data)])

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1126,6 +1126,16 @@ class TestImshow(Common2dMixin, PlotTestCase):
         with pytest.raises(ValueError):
             arr.plot.imshow(rgb='band')
 
+    def test_normalize_rgb_imshow(self):
+        for kwds in (
+            dict(vmin=-1), dict(vmax=2),
+            dict(vmin=-1, vmax=1), dict(vmin=0, vmax=0),
+            dict(vmin=0, robust=True), dict(vmax=-1, robust=True),
+        ):
+            da = DataArray(easy_array((5, 5, 3), start=-0.6, stop=1.4))
+            arr = da.plot.imshow(**kwds).get_array()
+            assert 0 <= arr.min() <= arr.max() <= 1, kwds
+
 
 class TestFacetGrid(PlotTestCase):
     def setUp(self):

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1136,6 +1136,16 @@ class TestImshow(Common2dMixin, PlotTestCase):
             arr = da.plot.imshow(**kwds).get_array()
             assert 0 <= arr.min() <= arr.max() <= 1, kwds
 
+    def test_normalize_rgb_one_arg_error(self):
+        da = DataArray(easy_array((5, 5, 3), start=-0.6, stop=1.4))
+        # If passed one bound that implies all out of range, error:
+        for kwds in [dict(vmax=-1), dict(vmin=2)]:
+            with pytest.raises(ValueError):
+                da.plot.imshow(**kwds)
+        # If passed two that's just moving the range, *not* an error:
+        for kwds in [dict(vmax=-1, vmin=-1.2), dict(vmin=2, vmax=2.1)]:
+            da.plot.imshow(**kwds)
+
 
 class TestFacetGrid(PlotTestCase):
     def setUp(self):


### PR DESCRIPTION
Follow-up to #1796, where normalisation and clipping of RGB[A] values were deferred so that we could match any upstream API.  matplotlib/matplotlib#10220 implements clipping to the valid range, but a strong consensus *against* RGB normalisation in matplotlib has emerged.

This pull therefore implements normalisation, and clips values only where our normalisation has pushed them out of range.