### PR TITLE
Testing deprecations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ pip-log.txt
 .tox
 nosetests.xml
 .cache
+.ropeproject/
 
 # Translations
 *.mo
@@ -50,5 +51,8 @@ nosetests.xml
 doc/_build
 doc/generated
 xarray/version.py
+
+# Sync tools
+Icon*
 
 .ipynb_checkpoints

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -351,7 +351,7 @@ def ensure_dtype_not_object(var, name=None):
                 fill_value = u''
             else:
                 # insist on using float for numeric values
-                if not np.issubdtype(inferred_dtype, float):
+                if not np.issubdtype(inferred_dtype, np.floating):
                     inferred_dtype = np.dtype(float)
                 fill_value = inferred_dtype.type(np.nan)
 

--- a/xarray/core/dtypes.py
+++ b/xarray/core/dtypes.py
@@ -20,13 +20,13 @@ def maybe_promote(dtype):
     fill_value : Valid missing value for the promoted dtype.
     """
     # N.B. these casting rules should match pandas
-    if np.issubdtype(dtype, float):
+    if np.issubdtype(dtype, np.floating):
         fill_value = np.nan
-    elif np.issubdtype(dtype, int):
+    elif np.issubdtype(dtype, np.signedinteger):
         # convert to floating point so NaN is valid
         dtype = float
         fill_value = np.nan
-    elif np.issubdtype(dtype, complex):
+    elif np.issubdtype(dtype, np.complexfloating):
         fill_value = np.nan + np.nan * 1j
     elif np.issubdtype(dtype, np.datetime64):
         fill_value = np.datetime64('NaT')

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -874,7 +874,7 @@ class PandasIndexAdapter(ExplicitlyIndexedNDArrayMixin):
         if isinstance(array, pd.PeriodIndex):
             with suppress(AttributeError):
                 # this might not be public API
-                array = array.asobject
+                array = array.astype('object')
         return np.asarray(array.values, dtype=dtype)
 
     @property

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -45,6 +45,12 @@ except ImportError:
 
 
 def _importorskip(modname, minversion=None):
+    """
+    This is deprecated - instead use pytest.importorskip. For example:
+
+    matplotlib = pytest.importorskip('matplotlib', minversion='1.9.0')
+
+    """
     try:
         mod = importlib.import_module(modname)
         has = True
@@ -109,6 +115,9 @@ network = pytest.mark.skipif(
 
 
 class TestCase(unittest.TestCase):
+    """
+    These functions are all deprecated. Instead, use functions in xr.testing
+    """
     if PY3:
         # Python 3 assertCountEqual is roughly equivalent to Python 2
         # assertItemsEqual


### PR DESCRIPTION
Re comment here: https://github.com/pydata/xarray/pull/1640#discussion_r158384496

The `TestCase` functions I think we should deprecate 
`_importorskip` I'm less sure about - there are some reasons to keep them if we need flexibility in the future (and it doesn't matter much)