### PR TITLE
Add warning for netCDF4 bug

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -63,6 +63,9 @@ Enhancements
 
 Bug fixes
 ~~~~~~~~~
+- Added warning in api.py of a netCDF4 bug that occurs when
+  the filepath has 88 characters (:issue:`1745`).
+  By `Liam Brannigan <https://github.com/braaannigan>` _.
 - Fixed encoding of multi-dimensional coordinates in
   :py:meth:`~Dataset.to_netcdf` (:issue:`1763`).
   By `Mike Neish <https://github.com/neishm>`_.

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -5,7 +5,7 @@ import os.path
 from glob import glob
 from io import BytesIO
 from numbers import Number
-import warnings
+
 
 import numpy as np
 
@@ -281,14 +281,6 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
             engine = _get_default_engine(filename_or_obj,
                                          allow_remote=True)
         if engine == 'netcdf4':
-            import netCDF4
-            if len( filename_or_obj ) == 88 and float(netCDF4.__version__[:3]) < 1.3:
-                warnings.warn('\nA segmentation fault may occur when the   \n'
-                'file path has exactly 88 characters.  The issue is known  \n'
-                'to occur with version 1.2.4 of netCDF4 and can be  \n'
-                'addressed by upgrading netCDF4 to at least version 1.3.1.  \n'
-                'More details can be found here:  \n'
-                'https://github.com/pydata/xarray/issues/1745  \n')
             store = backends.NetCDF4DataStore.open(filename_or_obj,
                                                    group=group,
                                                    autoclose=autoclose)
@@ -321,7 +313,10 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
     return maybe_decode_store(store)
 
 
-def open_dataarray(*args, **kwargs):
+def open_dataarray(filename_or_obj, group=None, decode_cf=True,
+                   mask_and_scale=True, decode_times=True, autoclose=False,
+                   concat_characters=True, decode_coords=True, engine=None,
+                   chunks=None, lock=None, cache=None, drop_variables=None):
     """Open an DataArray from a netCDF file containing a single data variable.
 
     This is designed to read netCDF files with only one data variable. If
@@ -402,7 +397,13 @@ def open_dataarray(*args, **kwargs):
     --------
     open_dataset
     """
-    dataset = open_dataset(*args, **kwargs)
+    dataset = open_dataset(filename_or_obj, group=group, decode_cf=decode_cf,
+                           mask_and_scale=mask_and_scale,
+                           decode_times=decode_times, autoclose=autoclose,
+                           concat_characters=concat_characters,
+                           decode_coords=decode_coords, engine=engine,
+                           chunks=chunks, lock=lock, cache=cache,
+                           drop_variables=drop_variables)
 
     if len(dataset.data_vars) != 1:
         raise ValueError('Given file dataset contains more than one data '

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -5,7 +5,7 @@ import os.path
 from glob import glob
 from io import BytesIO
 from numbers import Number
-
+import warnings
 
 import numpy as np
 
@@ -281,6 +281,14 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
             engine = _get_default_engine(filename_or_obj,
                                          allow_remote=True)
         if engine == 'netcdf4':
+            import netCDF4
+            if len( filename_or_obj ) == 88 and float(netCDF4.__version__[:3]) < 1.3:
+                warnings.warn('\nA segmentation fault may occur when the   \n'
+                'file path has exactly 88 characters.  The issue is known  \n'
+                'to occur with version 1.2.4 of netCDF4 and can be  \n'
+                'addressed by upgrading netCDF4 to at least version 1.3.1.  \n'
+                'More details can be found here:  \n'
+                'https://github.com/pydata/xarray/issues/1745  \n')
             store = backends.NetCDF4DataStore.open(filename_or_obj,
                                                    group=group,
                                                    autoclose=autoclose)

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 import functools
 import operator
+import warnings
 
 import numpy as np
 
@@ -244,6 +245,16 @@ class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
     def open(cls, filename, mode='r', format='NETCDF4', group=None,
              writer=None, clobber=True, diskless=False, persist=False,
              autoclose=False):
+        import netCDF4 as nc4
+        from distutils.version import LooseVersion
+        if (len(filename) == 88 and
+                LooseVersion(nc4.__version__) < "1.3.1"):
+            warnings.warn('\nA segmentation fault may occur when the\n'
+            'file path has exactly 88 characters as it does in this case.\n'
+            'The issue is known to occur with version 1.2.4 of netCDF4 and\n'
+            'can be addressed by upgrading netCDF4 to at least version 1.3.1.\n'
+            'More details can be found here:\n'
+            'https://github.com/pydata/xarray/issues/1745  \n')
         if format is None:
             format = 'NETCDF4'
         opener = functools.partial(_open_netcdf4_group, filename, mode=mode,

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import functools
 import operator
 import warnings
+from distutils.version import LooseVersion
 
 import numpy as np
 
@@ -246,18 +247,16 @@ class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
              writer=None, clobber=True, diskless=False, persist=False,
              autoclose=False):
         import netCDF4 as nc4
-        from distutils.version import LooseVersion
         if (len(filename) == 88 and
                 LooseVersion(nc4.__version__) < "1.3.1"):
             warnings.warn(
-            '\nA segmentation fault may occur when the\n'
-            'file path has exactly 88 characters as it does in this case.\n'
-            'The issue is known to occur with version 1.2.4 of netCDF4 \n'
-            'and can be addressed by upgrading netCDF4 to at\n'
-            'least version 1.3.1.\n'
-            'More details can be found here:\n'
-            'https://github.com/pydata/xarray/issues/1745  \n'
-            )
+                '\nA segmentation fault may occur when the\n'
+                'file path has exactly 88 characters as it does.\n'
+                'in this case. The issue is known to occur with\n'
+                'version 1.2.4 of netCDF4 and can be addressed by\n'
+                'upgrading netCDF4 to at least version 1.3.1.\n'
+                'More details can be found here:\n'
+                'https://github.com/pydata/xarray/issues/1745  \n')
         if format is None:
             format = 'NETCDF4'
         opener = functools.partial(_open_netcdf4_group, filename, mode=mode,

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -249,12 +249,15 @@ class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
         from distutils.version import LooseVersion
         if (len(filename) == 88 and
                 LooseVersion(nc4.__version__) < "1.3.1"):
-            warnings.warn('\nA segmentation fault may occur when the\n'
+            warnings.warn(
+            '\nA segmentation fault may occur when the\n'
             'file path has exactly 88 characters as it does in this case.\n'
-            'The issue is known to occur with version 1.2.4 of netCDF4 and\n'
-            'can be addressed by upgrading netCDF4 to at least version 1.3.1.\n'
+            'The issue is known to occur with version 1.2.4 of netCDF4 \n'
+            'and can be addressed by upgrading netCDF4 to at\n'
+            'least version 1.3.1.\n'
             'More details can be found here:\n'
-            'https://github.com/pydata/xarray/issues/1745  \n')
+            'https://github.com/pydata/xarray/issues/1745  \n'
+            )
         if format is None:
             format = 'NETCDF4'
         opener = functools.partial(_open_netcdf4_group, filename, mode=mode,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1056,6 +1056,12 @@ class NetCDF4DataTest(BaseNetCDF4Test, TestCase):
             except IndexError as err:
                 self.assertIn('first by calling .load', str(err))
 
+    def test_88_character_filename_segmentation_fault(self):
+        # should be fixed in netcdf4 v1.3.1
+        with mock.patch('netCDF4.__version__', '1.2.4'):
+            with pytest.warns(Warning, match='segmentation fault'):
+                xr.Dataset().to_netcdf('a' * 88)
+
 
 class NetCDF4DataStoreAutocloseTrue(NetCDF4DataTest):
     autoclose = True

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -10,6 +10,7 @@ import shutil
 import tempfile
 import unittest
 import sys
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -1059,8 +1060,11 @@ class NetCDF4DataTest(BaseNetCDF4Test, TestCase):
     def test_88_character_filename_segmentation_fault(self):
         # should be fixed in netcdf4 v1.3.1
         with mock.patch('netCDF4.__version__', '1.2.4'):
-            with pytest.warns(Warning, match='segmentation fault'):
-                xr.Dataset().to_netcdf('a' * 88)
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                with raises_regex(Warning, 'segmentation fault'):
+                    # Need to construct 88 character filepath
+                    xr.Dataset().to_netcdf('a' * (88 - len(os.getcwd()) - 1))
 
 
 class NetCDF4DataStoreAutocloseTrue(NetCDF4DataTest):


### PR DESCRIPTION
Closes #1745 by adding a warning message for a bug in netCDF4.  The bug occurs when the filepath has 88 characters and the netCDF4 engine has been used with version less than 1.3.1.  

The warning message has been added at the first point where the length of the file path is known and the netcdf4 version number is known.  

I don't think there is any corresponding test, as the bug leads to a seg fault rather than a python output/exception.

Passes ``git diff upstream/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)

Updated  `whats-new.rst` 
