### PR TITLE
Add dtype support for reduce methods.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,7 +27,9 @@ Documentation
 
 Enhancements
 ~~~~~~~~~~~~
-
+- reduce methods such as :py:func:`DataArray.sum()` now accepts ``dtype``
+  arguments. (:issue:`1838`)
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - :py:func:`~plot.contourf()` learned to contour 2D variables that have both a
   1D co-ordinate (e.g. time) and a 2D co-ordinate (e.g. depth as a function of
   time) (:issue:`1737`).

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -176,7 +176,7 @@ def _create_nan_agg_method(name, numeric_only=False, np_compat=False,
                            keep_dims=False):
     def f(values, axis=None, skipna=None, **kwargs):
         if kwargs.pop('out', None) is not None:
-            raise ValueError('`out` is not valid for {}'.format(name))
+            raise TypeError('`out` is not valid for {}'.format(name))
 
         # If dtype is supplied, we use numpy's method.
         dtype = kwargs.get('dtype', None)

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -175,12 +175,10 @@ def _create_nan_agg_method(name, numeric_only=False, np_compat=False,
                            no_bottleneck=False, coerce_strings=False,
                            keep_dims=False):
     def f(values, axis=None, skipna=None, **kwargs):
-        # ignore keyword args inserted by np.mean and other numpy aggregators
-        # automatically:
-
         if kwargs.pop('out', None) is not None:
             raise ValueError('`out` is not valid for {}'.format(name))
 
+        # If dtype is supplied, we use numpy's method.
         dtype = kwargs.get('dtype', None)
         values = asarray(values)
 

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -181,6 +181,7 @@ def _create_nan_agg_method(name, numeric_only=False, np_compat=False,
         if kwargs.pop('out', None) is not None:
             raise ValueError('`out` is not valid for {}'.format(name))
 
+        dtype = kwargs.get('dtype', None)
         values = asarray(values)
 
         if coerce_strings and values.dtype.kind in 'SU':
@@ -193,9 +194,10 @@ def _create_nan_agg_method(name, numeric_only=False, np_compat=False,
                     % (name, values.dtype))
             nanname = 'nan' + name
             if (isinstance(axis, tuple) or not values.dtype.isnative or
-                    no_bottleneck or kwargs.get('dtype', None) is not None):
+                    no_bottleneck or
+                    (dtype is not None and np.dtype(dtype) != values.dtype)):
                 # bottleneck can't handle multiple axis arguments or non-native
-                # endianness or dtype
+                # endianness
                 if np_compat:
                     eager_module = npcompat
                 else:

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -203,7 +203,7 @@ def _create_nan_agg_method(name, numeric_only=False, np_compat=False,
                 else:
                     eager_module = np
             else:
-                kwargs.get('dtype', None)
+                kwargs.pop('dtype', None)
                 eager_module = bn
             func = _dask_or_eager_func(nanname, eager_module)
             using_numpy_nan_func = (eager_module is np or

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1790,7 +1790,7 @@ class TestDataArray(TestCase):
                   'c': -999}
         orig = DataArray([[-1, 0, 1], [-3, 0, 3]], coords, dims=['x', 'y'])
 
-        for dtype in [np.float32, np.float64, np.float128]:
+        for dtype in [np.float16, np.float32, np.float64]:
             assert orig.astype(float).mean(dtype=dtype).dtype == dtype
 
     def test_reduce_out(self):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1799,7 +1799,7 @@ class TestDataArray(TestCase):
                   'c': -999}
         orig = DataArray([[-1, 0, 1], [-3, 0, 3]], coords, dims=['x', 'y'])
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             orig.mean(out=np.ones(orig.shape))
 
     # skip due to bug in older versions of numpy.nanpercentile

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1784,6 +1784,24 @@ class TestDataArray(TestCase):
                              dims=['x', 'y']).mean('x')
         assert_equal(actual, expected)
 
+    def test_reduce_dtype(self):
+        coords = {'x': [-1, -2], 'y': ['ab', 'cd', 'ef'],
+                  'lat': (['x', 'y'], [[1, 2, 3], [-1, -2, -3]]),
+                  'c': -999}
+        orig = DataArray([[-1, 0, 1], [-3, 0, 3]], coords, dims=['x', 'y'])
+
+        for dtype in [np.float32, np.float64, np.float128]:
+            assert orig.astype(float).mean(dtype=dtype).dtype == dtype
+
+    def test_reduce_out(self):
+        coords = {'x': [-1, -2], 'y': ['ab', 'cd', 'ef'],
+                  'lat': (['x', 'y'], [[1, 2, 3], [-1, -2, -3]]),
+                  'c': -999}
+        orig = DataArray([[-1, 0, 1], [-3, 0, 3]], coords, dims=['x', 'y'])
+
+        with pytest.raises(ValueError):
+            orig.mean(out=np.ones(orig.shape))
+
     # skip due to bug in older versions of numpy.nanpercentile
     def test_quantile(self):
         for q in [0.25, [0.50], [0.25, 0.75]]:


### PR DESCRIPTION
 - [x] Closes #1838changes)
 - [x] Tests added
 - [x] Tests passed
 - [x] Passes ``git diff upstream/master **/*py | flake8 --diff``
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Fixes #1838.
The new rule for reduce is 
+ If dtype is not None and different from array's dtype, use numpy's aggregation function instead of bottleneck's.
+ If out is not None, raise an error.

as suggested in [this comments](https://github.com/pydata/xarray/issues/1838#issuecomment-358851474).