### PR TITLE
Fix outer indexing on datasets loaded with h5netcdf

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -112,6 +112,9 @@ Bug fixes
 - Compatibility fixes to plotting module for Numpy 1.14 and Pandas 0.22
   (:issue:`1813`).
   By `Joe Hamman <https://github.com/jhamman>`_.
+- Fix indexing with lists for arrays loaded from netCDF files with
+  ``engine='h5netcdf`` (:issue:`1864`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 .. _whats-new.0.10.0:
 

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import print_function
 import functools
 
+import numpy as np
+
 from .. import Variable
 from ..core import indexing
 from ..core.utils import FrozenOrderedDict, close_on_error
@@ -17,6 +19,11 @@ class H5NetCDFArrayWrapper(BaseNetCDF4Array):
     def __getitem__(self, key):
         key = indexing.unwrap_explicit_indexer(
             key, self, allow=(indexing.BasicIndexer, indexing.OuterIndexer))
+        # h5py requires using lists for fancy indexing:
+        # https://github.com/h5py/h5py/issues/992
+        # OuterIndexer only holds 1D integer ndarrays, so it's safe to convert
+        # them to lists.
+        key = tuple(list(k) if isinstance(k, np.ndarray) else k for k in key)
         with self.datastore.ensure_open(autoclose=True):
             return self.get_array()[key]
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1572,11 +1572,16 @@ class H5NetCDFDataTest(BaseNetCDF4Test, TestCase):
             yield backends.H5NetCDFStore(tmp_file, 'w')
 
     def test_orthogonal_indexing(self):
-        # doesn't work for h5py (without using dask as an intermediate layer)
-        pass
+        # simplified version for h5netcdf
+        in_memory = create_test_data()
+        with self.roundtrip(in_memory) as on_disk:
+            indexers = {'dim3': np.arange(5)}
+            expected = in_memory.isel(**indexers)
+            actual = on_disk.isel(**indexers)
+            assert_identical(expected, actual.load())
 
     def test_array_type_after_indexing(self):
-        # pynio also does not support list-like indexing
+        # h5netcdf does not support multiple list-like indexers
         pass
 
     def test_complex(self):


### PR DESCRIPTION
 - [x] Closes #1864
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
