### PR TITLE
add warning stating that xarray will drop python 2 support at the end of 2018

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -6,6 +6,15 @@ Installation
 Required dependencies
 ---------------------
 
+.. warning::
+
+  Xarray is dropping support for Python 2 at the end of 2018. For more
+  information see the following references:
+
+  - `Xarray Github issue discussing dropping Python 2 <https://github.com/pydata/xarray/issues/1829>`__
+  - `Python 3 Statement <http://www.python3statement.org/>`__
+  - `Tips on porting to Python 3 <https://docs.python.org/3/howto/pyporting.html>`__
+
 - Python 2.7, 3.4, 3.5, or 3.6
 - `numpy <http://www.numpy.org/>`__ (1.11 or later)
 - `pandas <http://pandas.pydata.org/>`__ (0.18.0 or later)

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -97,8 +97,11 @@ To run these benchmark tests in a local machine, first install
 and run
 ``asv run  # this will install some conda environments in ./.asv/envs``
 
-.. [1] Xarray plans to drop support at the end of 2018. For more
-   information see the following references:
+.. [1] Xarray plans to drop support for python 2.7 at the end of 2018. This
+   means that new releases of xarray published after this date will only be
+   installable on python 3+ environments, but older versions of xarray will
+   always be available to python 2.7 users. For more information see the
+   following references:
 
       - `Xarray Github issue discussing dropping Python 2 <https://github.com/pydata/xarray/issues/1829>`__
       - `Python 3 Statement <http://www.python3statement.org/>`__

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -6,16 +6,7 @@ Installation
 Required dependencies
 ---------------------
 
-.. warning::
-
-  Xarray is dropping support for Python 2 at the end of 2018. For more
-  information see the following references:
-
-  - `Xarray Github issue discussing dropping Python 2 <https://github.com/pydata/xarray/issues/1829>`__
-  - `Python 3 Statement <http://www.python3statement.org/>`__
-  - `Tips on porting to Python 3 <https://docs.python.org/3/howto/pyporting.html>`__
-
-- Python 2.7, 3.4, 3.5, or 3.6
+- Python 2.7 [1]_, 3.4, 3.5, or 3.6
 - `numpy <http://www.numpy.org/>`__ (1.11 or later)
 - `pandas <http://pandas.pydata.org/>`__ (0.18.0 or later)
 
@@ -105,3 +96,10 @@ To run these benchmark tests in a local machine, first install
 
 and run
 ``asv run  # this will install some conda environments in ./.asv/envs``
+
+.. [1] Xarray plans to drop support at the end of 2018. For more
+   information see the following references:
+
+      - `Xarray Github issue discussing dropping Python 2 <https://github.com/pydata/xarray/issues/1829>`__
+      - `Python 3 Statement <http://www.python3statement.org/>`__
+      - `Tips on porting to Python 3 <https://docs.python.org/3/howto/pyporting.html>`__

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -13,6 +13,15 @@ What's New
     import xarray as xr
     np.random.seed(123456)
 
+.. warning::
+
+  Xarray is dropping support for Python 2 at the end of 2018. For more
+  information see the following references:
+
+  - `Xarray Github issue discussing dropping Python 2 <https://github.com/pydata/xarray/issues/1829>`__
+  - `Python 3 Statement <http://www.python3statement.org/>`__
+  - `Tips on porting to Python 3 <https://docs.python.org/3/howto/pyporting.html>`__
+
 .. _whats-new.0.10.1:
 
 v0.10.1 (unreleased)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,8 +15,11 @@ What's New
 
 .. warning::
 
-    Xarray plans to drop support at the end of 2018. For more information see
-    the following references
+    Xarray plans to drop support for python 2.7 at the end of 2018. This
+    means that new releases of xarray published after this date will only be
+    installable on python 3+ environments, but older versions of xarray will
+    always be available to python 2.7 users. For more information see the
+    following references
 
   - `Xarray Github issue discussing dropping Python 2 <https://github.com/pydata/xarray/issues/1829>`__
   - `Python 3 Statement <http://www.python3statement.org/>`__

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,8 +15,8 @@ What's New
 
 .. warning::
 
-  Xarray is dropping support for Python 2 at the end of 2018. For more
-  information see the following references:
+    Xarray plans to drop support at the end of 2018. For more information see
+    the following references
 
   - `Xarray Github issue discussing dropping Python 2 <https://github.com/pydata/xarray/issues/1829>`__
   - `Python 3 Statement <http://www.python3statement.org/>`__


### PR DESCRIPTION

 - [x] Closes #1830 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API 
