### PR TITLE
Fix rasterio example in docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,6 +20,8 @@ import os
 import datetime
 import importlib
 
+allowed_failures = []
+
 print("python exec:", sys.executable)
 print("sys.path:", sys.path)
 for name in ('numpy scipy pandas matplotlib dask IPython seaborn '
@@ -32,6 +34,11 @@ for name in ('numpy scipy pandas matplotlib dask IPython seaborn '
         print("%s: %s, %s" % (name, module.__version__, fname))
     except ImportError:
         print("no %s" % name)
+        if name == 'rasterio':
+            # not having rasterio should not break the build process
+            allowed_failures = ['gallery/plot_rasterio_rgb.py',
+                                'gallery/plot_rasterio.py'
+                                ]
 
 import xarray
 print("xarray: %s, %s" % (xarray.__version__, xarray.__file__))
@@ -62,7 +69,8 @@ extlinks = {'issue': ('https://github.com/pydata/xarray/issues/%s', 'GH'),
 
 sphinx_gallery_conf = {'examples_dirs': 'gallery',
                        'gallery_dirs': 'auto_gallery',
-                       'backreferences_dir': False
+                       'backreferences_dir': False,
+                       'expected_failing_examples': allowed_failures
                        }
 
 autosummary_generate = True

--- a/doc/gallery/plot_rasterio.py
+++ b/doc/gallery/plot_rasterio.py
@@ -13,7 +13,7 @@ latitudes.
 These new coordinates might be handy for plotting and indexing, but it should
 be kept in mind that a grid which is regular in projection coordinates will
 likely be irregular in lon/lat. It is often recommended to work in the data's
-original map projection.
+original map projection (see :ref:`recipes.rasterio_rgb`).
 """
 
 import os
@@ -44,10 +44,13 @@ lat = np.asarray(lat).reshape((ny, nx))
 da.coords['lon'] = (('y', 'x'), lon)
 da.coords['lat'] = (('y', 'x'), lat)
 
+# Compute a greyscale out of the rgb image
+greyscale = da.mean(dim='band')
+
 # Plot on a map
 ax = plt.subplot(projection=ccrs.PlateCarree())
-da.plot.imshow(ax=ax, x='lon', y='lat', rgb='band',
-               transform=ccrs.PlateCarree())
+greyscale.plot(ax=ax, x='lon', y='lat', transform=ccrs.PlateCarree(),
+               cmap='Greys_r', add_colorbar=False)
 ax.coastlines('10m', color='r')
 plt.show()
 

--- a/doc/gallery/plot_rasterio_rgb.py
+++ b/doc/gallery/plot_rasterio_rgb.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""
+.. _recipes.rasterio_rgb:
+
+============================
+imshow() and map projections
+============================
+
+Using rasterio's projection information for more accurate plots.
+
+This example extends :ref:`recipes.rasterio` and plots the image in the
+original map projection instead of relying on pcolormesh and a map
+transformation.
+"""
+
+import os
+import urllib.request
+import xarray as xr
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+
+# Download the file from rasterio's repository
+url = 'https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif'
+urllib.request.urlretrieve(url, 'RGB.byte.tif')
+
+# Read the data
+da = xr.open_rasterio('RGB.byte.tif')
+
+# Normalize the image
+da = da / 255
+
+# The data is in UTM projection
+# Until https://github.com/SciTools/cartopy/issues/813 is implemented
+# we have to do this manually
+crs = ccrs.UTM('18N')
+
+# Plot on a map
+ax = plt.subplot(projection=crs)
+da.plot.imshow(ax=ax, transform=crs)
+ax.coastlines('10m', color='r')
+plt.show()
+
+# Delete the file
+os.remove('RGB.byte.tif')

--- a/doc/gallery/plot_rasterio_rgb.py
+++ b/doc/gallery/plot_rasterio_rgb.py
@@ -29,14 +29,13 @@ da = xr.open_rasterio('RGB.byte.tif')
 # Normalize the image
 da = da / 255
 
-# The data is in UTM projection
-# Until https://github.com/SciTools/cartopy/issues/813 is implemented
-# we have to do this manually
+# The data is in UTM projection. We have to set it manually until
+# https://github.com/SciTools/cartopy/issues/813 is implemented
 crs = ccrs.UTM('18N')
 
 # Plot on a map
 ax = plt.subplot(projection=crs)
-da.plot.imshow(ax=ax, transform=crs)
+da.plot.imshow(ax=ax, rgb='band', transform=crs)
 ax.coastlines('10m', color='r')
 plt.show()
 


### PR DESCRIPTION
https://github.com/pydata/xarray/pull/1796 introduced a bug in the doc gallery. This PR reverts the code to the previous greyscale example and adds a new case using imshow (the use case is different, as I tried to explain in the descriptions).

I also took care of https://github.com/pydata/xarray/issues/1789#issuecomment-356068358 : the docs should now build even when rasterio is not installed.

cc @Zac-HD , @shoyer 
