### PR TITLE
links from docstrings to documentation for apply_ufunc and open_mfdataset

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -443,8 +443,8 @@ def open_mfdataset(paths, chunks=None, concat_dim=_CONCAT_DIM_DEFAULT,
                    lock=None, data_vars='all', coords='different', **kwargs):
     """Open multiple files as a single dataset.
 
-    Requires dask to be installed.  Attributes from the first dataset file
-    are used for the combined dataset.
+    Requires dask to be installed. See documentation for details on dask [1].  
+    Attributes from the first dataset file are used for the combined dataset.
 
     Parameters
     ----------
@@ -458,7 +458,7 @@ def open_mfdataset(paths, chunks=None, concat_dim=_CONCAT_DIM_DEFAULT,
         If int, chunk each dimension by ``chunks``.
         By default, chunks will be chosen to load entire input files into
         memory at once. This has a major impact on performance: please see the
-        full documentation for more details.
+        full documentation for more details [2].
     concat_dim : None, str, DataArray or Index, optional
         Dimension to concatenate files along. This argument is passed on to
         :py:func:`xarray.auto_combine` along with the dataset objects. You only
@@ -533,6 +533,11 @@ def open_mfdataset(paths, chunks=None, concat_dim=_CONCAT_DIM_DEFAULT,
     --------
     auto_combine
     open_dataset
+
+    References
+    ----------
+    .. [1] http://xarray.pydata.org/en/stable/dask.html
+    .. [2] http://xarray.pydata.org/en/stable/dask.html#chunking-and-performance
     """
     if isinstance(paths, basestring):
         paths = sorted(glob(paths))

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -836,7 +836,8 @@ def apply_ufunc(func, *args, **kwargs):
     Most of NumPy's builtin functions already broadcast their inputs
     appropriately for use in `apply`. You may find helper functions such as
     numpy.broadcast_arrays helpful in writing your function. `apply_ufunc` also
-    works well with numba's vectorize and guvectorize.
+    works well with numba's vectorize and guvectorize. Further explanation with
+    examples are provided in the xarray documentation [3].
 
     See also
     --------
@@ -848,6 +849,7 @@ def apply_ufunc(func, *args, **kwargs):
     ----------
     .. [1] http://docs.scipy.org/doc/numpy/reference/ufuncs.html
     .. [2] http://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
+    .. [3] http://xarray.pydata.org/en/stable/computation.html#wrapping-custom-computation
     """  # noqa: E501  # don't error on that URL one line up
     from .groupby import GroupBy
     from .dataarray import DataArray


### PR DESCRIPTION
Adds links and inline prose to docstrings referencing relevant sections of online documentation.

 - [x] Closes #1783 (remove if there is no corresponding issue, which should only be the case for minor changes)