### PR TITLE
Raise when pcolormesh coordinate is not sorted

### DIFF
--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -779,7 +779,9 @@ def _infer_interval_breaks(coord, axis=0):
         raise ValueError("The input coordinate is not sorted in increasing "
                          "order along axis %d. This can lead to unexpected "
                          "results. Consider calling the `sortby` method on "
-                         "the input DataArray." % axis)
+                         "the input DataArray. To plot data with categorical "
+                         "axes, consider using the `heatmap` function from "
+                         "the `seaborn` statistical plotting library." % axis)
 
     deltas = 0.5 * np.diff(coord, axis=axis)
     if deltas.size == 0:

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -758,8 +758,10 @@ def _is_monotonic(coord, axis=0):
         return True
     else:
         n = coord.shape[axis]
-        delta_pos = coord.take(np.arange(1, n), axis=axis) >= coord.take(np.arange(0, n-1), axis=axis)
-        delta_neg = coord.take(np.arange(1, n), axis=axis) <= coord.take(np.arange(0, n-1), axis=axis)
+        delta_pos = (coord.take(np.arange(1, n), axis=axis)
+                     >= coord.take(np.arange(0, n-1), axis=axis))
+        delta_neg = (coord.take(np.arange(1, n), axis=axis)
+                     <= coord.take(np.arange(0, n-1), axis=axis))
         return np.all(delta_pos) or np.all(delta_neg)
 
 
@@ -774,10 +776,10 @@ def _infer_interval_breaks(coord, axis=0):
     coord = np.asarray(coord)
 
     if not _is_monotonic(coord, axis=axis):
-        warnings.warn("The input coordinate is not sorted in increasing order "
-                      "along axis %d. This can lead to unexpected results. "
-                      "Consider calling the `sortby` method on the input "
-                      "DataArray." % axis)
+        raise ValueError("The input coordinate is not sorted in increasing "
+                         "order along axis %d. This can lead to unexpected "
+                         "results. Consider calling the `sortby` method on "
+                         "the input DataArray." % axis)
 
     deltas = 0.5 * np.diff(coord, axis=axis)
     if deltas.size == 0:

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -759,7 +759,8 @@ def _is_monotonic(coord, axis=0):
     else:
         n = coord.shape[axis]
         delta_pos = coord.take(np.arange(1, n), axis=axis) >= coord.take(np.arange(0, n-1), axis=axis)
-        return np.all(delta_pos) or np.all(~delta_pos)
+        delta_neg = coord.take(np.arange(1, n), axis=axis) <= coord.take(np.arange(0, n-1), axis=axis)
+        return np.all(delta_pos) or np.all(delta_neg)
 
 
 def _infer_interval_breaks(coord, axis=0):

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -757,9 +757,9 @@ def _is_monotonic(coord, axis=0):
     if coord.shape[axis] < 3:
         return True
     else:
-        delta = np.diff(coord, axis=axis)
-        # This ensures all the deltas have the same sign
-        return np.abs(delta).sum() == np.abs(delta.sum())
+        n = coord.shape[axis]
+        delta_pos = coord.take(np.arange(1, n), axis=axis) >= coord.take(np.arange(0, n-1), axis=axis)
+        return np.all(delta_pos) or np.all(~delta_pos)
 
 
 def _infer_interval_breaks(coord, axis=0):

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -745,6 +745,23 @@ def contourf(x, y, z, ax, **kwargs):
     return primitive
 
 
+def _is_monotonic(coord, axis=0):
+    """
+    >>> _is_monotonic(np.array([0, 1, 2]))
+    True
+    >>> _is_monotonic(np.array([2, 1, 0]))
+    True
+    >>> _is_monotonic(np.array([0, 2, 1]))
+    False
+    """
+    if coord.shape[axis] < 3:
+        return True
+    else:
+        delta = np.diff(coord, axis=axis)
+        # This ensures all the deltas have the same sign
+        return np.abs(delta).sum() == np.abs(delta.sum())
+
+
 def _infer_interval_breaks(coord, axis=0):
     """
     >>> _infer_interval_breaks(np.arange(5))
@@ -755,10 +772,11 @@ def _infer_interval_breaks(coord, axis=0):
     """
     coord = np.asarray(coord)
 
-    if any(np.diff(coord, axis=axis) < 0):
-        warnings.warn("The input coordinate is not sorted in increasing order along axis %d. "
-                      "This can lead to unexpected results. Consider calling the "
-                      "`sortby` method on the input DataArray."%axis)
+    if not _is_monotonic(coord, axis=axis):
+        warnings.warn("The input coordinate is not sorted in increasing order "
+                      "along axis %d. This can lead to unexpected results. "
+                      "Consider calling the `sortby` method on the input "
+                      "DataArray."%axis)
 
     deltas = 0.5 * np.diff(coord, axis=axis)
     if deltas.size == 0:

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -758,10 +758,10 @@ def _is_monotonic(coord, axis=0):
         return True
     else:
         n = coord.shape[axis]
-        delta_pos = (coord.take(np.arange(1, n), axis=axis)
-                     >= coord.take(np.arange(0, n-1), axis=axis))
-        delta_neg = (coord.take(np.arange(1, n), axis=axis)
-                     <= coord.take(np.arange(0, n-1), axis=axis))
+        delta_pos = (coord.take(np.arange(1, n), axis=axis) >=
+                     coord.take(np.arange(0, n-1), axis=axis))
+        delta_neg = (coord.take(np.arange(1, n), axis=axis) <=
+                     coord.take(np.arange(0, n-1), axis=axis))
         return np.all(delta_pos) or np.all(delta_neg)
 
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -776,7 +776,7 @@ def _infer_interval_breaks(coord, axis=0):
         warnings.warn("The input coordinate is not sorted in increasing order "
                       "along axis %d. This can lead to unexpected results. "
                       "Consider calling the `sortby` method on the input "
-                      "DataArray."%axis)
+                      "DataArray." % axis)
 
     deltas = 0.5 * np.diff(coord, axis=axis)
     if deltas.size == 0:

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -754,6 +754,12 @@ def _infer_interval_breaks(coord, axis=0):
            [ 2.5,  3.5,  4.5]])
     """
     coord = np.asarray(coord)
+
+    if any(np.diff(coord, axis=axis) < 0):
+        warnings.warn("The input coordinate is not sorted in increasing order along axis %d. "
+                      "This can lead to unexpected results. Consider calling the "
+                      "`sortby` method on the input DataArray."%axis)
+
     deltas = 0.5 * np.diff(coord, axis=axis)
     if deltas.size == 0:
         deltas = np.array(0.0)

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -178,6 +178,10 @@ class TestPlot(PlotTestCase):
         np.testing.assert_allclose(xref, x)
         np.testing.assert_allclose(yref, y)
 
+        # test that warning is raised for non-monotonic inputs
+        with pytest.warns(UserWarning):
+            _infer_interval_breaks(np.array([0, 2, 1]))
+
     def test_datetime_dimension(self):
         nrow = 3
         ncol = 4

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -179,7 +179,7 @@ class TestPlot(PlotTestCase):
         np.testing.assert_allclose(yref, y)
 
         # test that warning is raised for non-monotonic inputs
-        with pytest.warns(UserWarning):
+        with pytest.raises(ValueError):
             _infer_interval_breaks(np.array([0, 2, 1]))
 
     def test_datetime_dimension(self):


### PR DESCRIPTION
 - [x] Closes #1852 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)

I added a simple warning to `_infer_interval_breaks` in `xarray/plot/plot.py`. The warning does not currently say the name of the coordinate, because that would requiring introducing a new function or potentially passing a name argument, which seems overly complicated for such a small dit. Hopefully, this isn't a problem because the user can easily figure out which coordinate is not sorted by process of elimination.