### PR TITLE
Simplify some rasterio tests

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -129,6 +129,12 @@ Bug fixes
 - Fix indexing with lists for arrays loaded from netCDF files with
   ``engine='h5netcdf`` (:issue:`1864`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
+- Corrected a bug with incorrect coordinates for non-georeferenced geotiff
+  files (:issue:`1686`). Internally, we now use the rasterio coordinate
+  transform tool instead of doing the computations ourselves. A
+  ``parse_coordinates`` kwarg has beed added to :py:func:`~open_rasterio`
+  (set to ``True`` per default).
+  By `Fabien Maussion <https://github.com/fmaussion>`_.
 
 .. _whats-new.0.10.0:
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2271,7 +2271,7 @@ class TestRasterio(TestCase):
     def test_platecarree(self):
         with create_tmp_geotiff(8, 10, 1, transform_args=[1, 2, 0.5, 2.],
                                 crs='+proj=latlong',
-                                open_kwargs={'nodata':-9765}) \
+                                open_kwargs={'nodata': -9765}) \
                 as (tmp_file, expected):
             with xr.open_rasterio(tmp_file) as rioda:
                 assert_allclose(rioda, expected)


### PR DESCRIPTION
 - [x] Closes https://github.com/pydata/xarray/issues/1843
 - [x] Tests added
 - [x] Tests passed
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API 

This PR restores the tests that were incorrectly removed in https://github.com/pydata/xarray/pull/1817 and adds the what's new entry I forgot in https://github.com/pydata/xarray/pull/1712
