### PR TITLE
Use pip install -e in contributing docs

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -156,7 +156,7 @@ We'll now kick off a two-step process:
    source activate test_env
 
    # Build and install xarray
-   python setup.py develop
+   pip install -e .
 
 At this point you should be able to import xarray from your locally built version::
 


### PR DESCRIPTION
I think that pip install is the recommended way to install packages in dev mode (see also http://www.python3statement.org/practicalities/ )
