### PR TITLE
Replace task_state with tasks in dask test

### DIFF
--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -81,4 +81,4 @@ def test_async(c, s, a, b):
     assert not dask.is_dask_collection(w)
     assert_allclose(x + 10, w)
 
-    assert s.task_state
+    assert s.tasks


### PR DESCRIPTION
This internal state was changed in the latest release

 - [x] Closes #1903 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [ ] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
