### PR TITLE
Remove flake8 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,6 @@ install:
   - python xarray/util/print_versions.py
 
 script:
-  - flake8 -j auto xarray
   - python -OO -c "import xarray"
   - if [[ "$CONDA_ENV" == "docs" ]]; then
       conda install -c conda-forge sphinx_rtd_theme;


### PR DESCRIPTION
 - [x] Closes #1912 
 
The removal of flake8 from travis would increase the clearer separation between style-issue and test failure.