### PR TITLE
Support indexing with 0d-np.ndarray

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -106,6 +106,8 @@ Enhancements
 
 Bug fixes
 ~~~~~~~~~
+- Support indexing with a 0d-np.ndarray (:issue:`1921`).
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - Added warning in api.py of a netCDF4 bug that occurs when
   the filepath has 88 characters (:issue:`1745`).
   By `Liam Brannigan <https://github.com/braaannigan>`_.

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -463,9 +463,13 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         key = self._item_key_to_tuple(key)  # key is a tuple
         # key is a tuple of full size
         key = indexing.expanded_indexer(key, self.ndim)
-        # Convert a scalar Variable as an integer
+        # Convert a scalar Variable to an integer
         key = tuple(
             k.data.item() if isinstance(k, Variable) and k.ndim == 0 else k
+            for k in key)
+        # Convert a 0d-array to an integer
+        key = tuple(
+            k.item() if isinstance(k, np.ndarray) and k.ndim == 0 else k
             for k in key)
 
         if all(isinstance(k, BASIC_INDEXING_TYPES) for k in key):

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -627,6 +627,12 @@ class VariableSubclassTestCases(object):
         v_new = v[np.array([0])[0]]
         assert_array_equal(v_new, v_data[0])
 
+        v_new = v[np.array(0)]
+        assert_array_equal(v_new, v_data[0])
+
+        v_new = v[Variable((), np.array(0))]
+        assert_array_equal(v_new, v_data[0])
+
     def test_getitem_fancy(self):
         v = self.cls(['x', 'y'], [[0, 1, 2], [3, 4, 5]])
         v_data = v.compute().data


### PR DESCRIPTION
 - [x] Closes #1921 
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

Now Variable accepts 0d-np.ndarray indexer.