### PR TITLE
isort

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -2,7 +2,7 @@ linters:
   flake8:
     max-line-length: 79
     fixer: true
-    ignore: I002
+    ignore: 
     exclude:
       - 'doc/'
   py3k:

--- a/asv_bench/benchmarks/dataarray_missing.py
+++ b/asv_bench/benchmarks/dataarray_missing.py
@@ -12,8 +12,6 @@ except ImportError:
     pass
 
 
-
-
 def make_bench_data(shape, frac_nan, chunks):
     vals = randn(shape, frac_nan)
     coords = {'time': pd.date_range('2000-01-01', freq='D',

--- a/asv_bench/benchmarks/dataarray_missing.py
+++ b/asv_bench/benchmarks/dataarray_missing.py
@@ -1,17 +1,17 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import pandas as pd
+
+import xarray as xr
+
+from . import randn, requires_dask
 
 try:
     import dask
 except ImportError:
     pass
 
-import xarray as xr
 
-from . import randn, requires_dask
 
 
 def make_bench_data(shape, frac_nan, chunks):

--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -14,8 +14,6 @@ except ImportError:
     pass
 
 
-
-
 class IOSingleNetCDF(object):
     """
     A few examples that benchmark reading/writing a single netCDF file with

--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -1,9 +1,11 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import pandas as pd
+
+import xarray as xr
+
+from . import randn, requires_dask
 
 try:
     import dask
@@ -11,9 +13,7 @@ try:
 except ImportError:
     pass
 
-import xarray as xr
 
-from . import randn, requires_dask
 
 
 class IOSingleNetCDF(object):

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -1,13 +1,11 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import pandas as pd
+
 import xarray as xr
 
-from . import randn, randint, requires_dask
-
+from . import randint, randn, requires_dask
 
 nx = 3000
 ny = 2000

--- a/asv_bench/benchmarks/reindexing.py
+++ b/asv_bench/benchmarks/reindexing.py
@@ -1,8 +1,7 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
+
 import xarray as xr
 
 from . import requires_dask

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,14 +11,14 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
-import sys
-import os
 import datetime
 import importlib
+import os
+import sys
+
+import xarray
 
 allowed_failures = []
 
@@ -40,7 +40,6 @@ for name in ('numpy scipy pandas matplotlib dask IPython seaborn '
                                 'gallery/plot_rasterio.py'
                                 ]
 
-import xarray
 print("xarray: %s, %s" % (xarray.__version__, xarray.__file__))
 
 # -- General configuration ------------------------------------------------

--- a/doc/examples/_code/accessor_example.py
+++ b/doc/examples/_code/accessor_example.py
@@ -1,5 +1,6 @@
 import xarray as xr
 
+
 @xr.register_dataset_accessor('geo')
 class GeoAccessor(object):
     def __init__(self, xarray_obj):

--- a/doc/examples/_code/weather_data_setup.py
+++ b/doc/examples/_code/weather_data_setup.py
@@ -1,7 +1,8 @@
-import xarray as xr
 import numpy as np
 import pandas as pd
-import seaborn as sns # pandas aware plotting library
+import seaborn as sns  # pandas aware plotting library
+
+import xarray as xr
 
 np.random.seed(123)
 

--- a/doc/examples/_code/weather_data_setup.py
+++ b/doc/examples/_code/weather_data_setup.py
@@ -3,7 +3,6 @@ import pandas as pd
 
 import xarray as xr
 
-
 np.random.seed(123)
 
 times = pd.date_range('2000-01-01', '2001-12-31', name='time')

--- a/doc/gallery/plot_cartopy_facetgrid.py
+++ b/doc/gallery/plot_cartopy_facetgrid.py
@@ -14,9 +14,10 @@ For more details see `this discussion`_ on github.
 .. _this discussion: https://github.com/pydata/xarray/issues/1397#issuecomment-299190567
 """
 
-import xarray as xr
-import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
+
+import cartopy.crs as ccrs
+import xarray as xr
 
 # Load the data
 ds = xr.tutorial.load_dataset('air_temperature')

--- a/doc/gallery/plot_cartopy_facetgrid.py
+++ b/doc/gallery/plot_cartopy_facetgrid.py
@@ -14,9 +14,9 @@ For more details see `this discussion`_ on github.
 .. _this discussion: https://github.com/pydata/xarray/issues/1397#issuecomment-299190567
 """
 
+import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 
-import cartopy.crs as ccrs
 import xarray as xr
 
 # Load the data

--- a/doc/gallery/plot_colorbar_center.py
+++ b/doc/gallery/plot_colorbar_center.py
@@ -8,8 +8,9 @@ xarray's automatic colormaps choice
 
 """
 
-import xarray as xr
 import matplotlib.pyplot as plt
+
+import xarray as xr
 
 # Load the data
 ds = xr.tutorial.load_dataset('air_temperature')

--- a/doc/gallery/plot_lines_from_2d.py
+++ b/doc/gallery/plot_lines_from_2d.py
@@ -12,8 +12,9 @@ See :ref:`plotting.multiplelines` for more details.
 
 """
 
-import xarray as xr
 import matplotlib.pyplot as plt
+
+import xarray as xr
 
 # Load the data
 ds = xr.tutorial.load_dataset('air_temperature')

--- a/doc/gallery/plot_rasterio.py
+++ b/doc/gallery/plot_rasterio.py
@@ -18,12 +18,13 @@ original map projection (see :ref:`recipes.rasterio_rgb`).
 
 import os
 import urllib.request
-import numpy as np
-import xarray as xr
-import cartopy.crs as ccrs
-import matplotlib.pyplot as plt
-from rasterio.warp import transform
 
+import matplotlib.pyplot as plt
+import numpy as np
+
+import cartopy.crs as ccrs
+import xarray as xr
+from rasterio.warp import transform
 
 # Download the file from rasterio's repository
 url = 'https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif'

--- a/doc/gallery/plot_rasterio.py
+++ b/doc/gallery/plot_rasterio.py
@@ -19,12 +19,12 @@ original map projection (see :ref:`recipes.rasterio_rgb`).
 import os
 import urllib.request
 
+import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 import numpy as np
-
-import cartopy.crs as ccrs
-import xarray as xr
 from rasterio.warp import transform
+
+import xarray as xr
 
 # Download the file from rasterio's repository
 url = 'https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif'

--- a/doc/gallery/plot_rasterio_rgb.py
+++ b/doc/gallery/plot_rasterio_rgb.py
@@ -15,9 +15,11 @@ transformation.
 
 import os
 import urllib.request
-import xarray as xr
-import cartopy.crs as ccrs
+
 import matplotlib.pyplot as plt
+
+import cartopy.crs as ccrs
+import xarray as xr
 
 # Download the file from rasterio's repository
 url = 'https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif'

--- a/doc/gallery/plot_rasterio_rgb.py
+++ b/doc/gallery/plot_rasterio_rgb.py
@@ -16,9 +16,9 @@ transformation.
 import os
 import urllib.request
 
+import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 
-import cartopy.crs as ccrs
 import xarray as xr
 
 # Download the file from rasterio's repository

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,6 @@ python_files=test_*.py
 max-line-length=79
 
 [isort]
-known_third_party=netCDF4,scipy,pydap,h5netcdf,pynio,bottleneck,cyordereddict,pytest
+default_section=THIRDPARTY
 known_first_party=xarray
 multi_line_output=4

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,8 @@ python_files=test_*.py
 
 [flake8]
 max-line-length=79
+
+[isort]
+known_third_party=netCDF4,scipy,pydap,h5netcdf,pynio,bottleneck,cyordereddict,pytest
+known_first_party=xarray
+multi_line_output=4

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,7 @@ import re
 import sys
 import warnings
 
-from setuptools import setup, find_packages
-from setuptools import Command
+from setuptools import Command, find_packages, setup
 
 MAJOR = 0
 MINOR = 10

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import re
 import sys
 import warnings
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 MAJOR = 0
 MINOR = 10

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1,20 +1,18 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import os.path
 from glob import glob
 from io import BytesIO
 from numbers import Number
 
-
 import numpy as np
 
-from .. import backends, conventions, Dataset
-from .common import ArrayWriter, GLOBAL_LOCK
+from .. import Dataset, backends, conventions
 from ..core import indexing
 from ..core.combine import auto_combine
-from ..core.utils import close_on_error, is_remote_uri
 from ..core.pycompat import basestring, path_type
+from ..core.utils import close_on_error, is_remote_uri
+from .common import GLOBAL_LOCK, ArrayWriter
 
 DATAARRAY_NAME = '__xarray_dataarray_name__'
 DATAARRAY_VARIABLE = '__xarray_dataarray_variable__'

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -1,18 +1,18 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-import numpy as np
+from __future__ import absolute_import, division, print_function
+
+import contextlib
 import logging
 import time
 import traceback
-import contextlib
-from collections import Mapping, OrderedDict
 import warnings
+from collections import Mapping, OrderedDict
+
+import numpy as np
 
 from ..conventions import cf_encoder
 from ..core import indexing
+from ..core.pycompat import dask_array_type, iteritems
 from ..core.utils import FrozenOrderedDict, NdimSizeLenMixin
-from ..core.pycompat import iteritems, dask_array_type
 
 try:
     from dask.utils import SerializableLock as Lock

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -1,18 +1,17 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import functools
 
 import numpy as np
 
 from .. import Variable
 from ..core import indexing
+from ..core.pycompat import OrderedDict, bytes_type, iteritems, unicode_type
 from ..core.utils import FrozenOrderedDict, close_on_error
-from ..core.pycompat import iteritems, bytes_type, unicode_type, OrderedDict
-
-from .common import WritableCFDataStore, DataStorePickleMixin, find_root
-from .netCDF4_ import (_nc4_group, _encode_nc4_variable, _get_datatype,
-                       _extract_nc4_variable_encoding, BaseNetCDF4Array)
+from .common import DataStorePickleMixin, WritableCFDataStore, find_root
+from .netCDF4_ import (
+    BaseNetCDF4Array, _encode_nc4_variable, _extract_nc4_variable_encoding,
+    _get_datatype, _nc4_group)
 
 
 class H5NetCDFArrayWrapper(BaseNetCDF4Array):

--- a/xarray/backends/memory.py
+++ b/xarray/backends/memory.py
@@ -1,13 +1,11 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import copy
 
 import numpy as np
 
-from ..core.variable import Variable
 from ..core.pycompat import OrderedDict
-
+from ..core.variable import Variable
 from .common import AbstractWritableDataStore
 
 

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import functools
 import operator
 import warnings
@@ -8,16 +7,15 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
-from .. import conventions
-from .. import Variable
+from .. import Variable, conventions
 from ..conventions import pop_to
 from ..core import indexing
-from ..core.utils import (FrozenOrderedDict, close_on_error, is_remote_uri)
-from ..core.pycompat import iteritems, basestring, OrderedDict, PY3, suppress
-
-from .common import (WritableCFDataStore, robust_getitem, BackendArray,
-                     DataStorePickleMixin, find_root)
-from .netcdf3 import (encode_nc3_attr_value, encode_nc3_variable)
+from ..core.pycompat import PY3, OrderedDict, basestring, iteritems, suppress
+from ..core.utils import FrozenOrderedDict, close_on_error, is_remote_uri
+from .common import (
+    BackendArray, DataStorePickleMixin, WritableCFDataStore, find_root,
+    robust_getitem)
+from .netcdf3 import encode_nc3_attr_value, encode_nc3_variable
 
 # This lookup table maps from dtype.byteorder to a readable endian
 # string used by netCDF4.

--- a/xarray/backends/netcdf3.py
+++ b/xarray/backends/netcdf3.py
@@ -1,13 +1,11 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import unicodedata
 
 import numpy as np
 
-from .. import conventions, Variable
-from ..core.pycompat import basestring, unicode_type, OrderedDict
-
+from .. import Variable, conventions
+from ..core.pycompat import OrderedDict, basestring, unicode_type
 
 # Special characters that are permitted in netCDF names except in the
 # 0th position of the string

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -1,13 +1,11 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 
 from .. import Variable
-from ..core.utils import FrozenOrderedDict, Frozen, is_dict_like
 from ..core import indexing
 from ..core.pycompat import integer_types
-
+from ..core.utils import Frozen, FrozenOrderedDict, is_dict_like
 from .common import AbstractDataStore, BackendArray, robust_getitem
 
 

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -1,16 +1,13 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import functools
 
 import numpy as np
 
 from .. import Variable
-from ..core.utils import (FrozenOrderedDict, Frozen)
 from ..core import indexing
-
-from .common import AbstractDataStore, DataStorePickleMixin, BackendArray
+from ..core.utils import Frozen, FrozenOrderedDict
+from .common import AbstractDataStore, BackendArray, DataStorePickleMixin
 
 
 class NioArrayWrapper(BackendArray):

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -2,12 +2,14 @@ import os
 import warnings
 from collections import OrderedDict
 from distutils.version import LooseVersion
+
 import numpy as np
 
 from .. import DataArray
-from ..core.utils import is_scalar
 from ..core import indexing
+from ..core.utils import is_scalar
 from .common import BackendArray
+
 try:
     from dask.utils import SerializableLock as Lock
 except ImportError:

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -1,20 +1,18 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import functools
+import warnings
 from io import BytesIO
 
 import numpy as np
-import warnings
 
 from .. import Variable
-from ..core.pycompat import iteritems, OrderedDict, basestring
-from ..core.utils import (Frozen, FrozenOrderedDict)
 from ..core.indexing import NumpyIndexingAdapter
-
-from .common import WritableCFDataStore, DataStorePickleMixin, BackendArray
-from .netcdf3 import (is_valid_nc3_name, encode_nc3_attr_value,
-                      encode_nc3_variable)
+from ..core.pycompat import OrderedDict, basestring, iteritems
+from ..core.utils import Frozen, FrozenOrderedDict
+from .common import BackendArray, DataStorePickleMixin, WritableCFDataStore
+from .netcdf3 import (
+    encode_nc3_attr_value, encode_nc3_variable, is_valid_nc3_name)
 
 
 def _decode_string(s):

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1,18 +1,15 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from itertools import product
+from __future__ import absolute_import, division, print_function
+
 from base64 import b64encode
+from itertools import product
 
 import numpy as np
 
-from .. import coding
-from .. import Variable
+from .. import Variable, coding, conventions
 from ..core import indexing
+from ..core.pycompat import OrderedDict, integer_types, iteritems
 from ..core.utils import FrozenOrderedDict, HiddenKeyDict
-from ..core.pycompat import iteritems, OrderedDict, integer_types
-from .common import AbstractWritableDataStore, BackendArray, ArrayWriter
-from .. import conventions
+from .common import AbstractWritableDataStore, ArrayWriter, BackendArray
 
 # need some special secret attributes to tell us the dimensions
 _DIMENSION_KEY = '_ARRAY_DIMENSIONS'

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -24,7 +24,6 @@ except ImportError:
     from pandas.tslib import OutOfBoundsDatetime
 
 
-
 # standard calendars recognized by netcdftime
 _STANDARD_CALENDARS = set(['standard', 'gregorian', 'proleptic_gregorian'])
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import re
 import traceback
@@ -9,21 +7,22 @@ from datetime import datetime
 from functools import partial
 
 import numpy as np
-
 import pandas as pd
+
+from ..core import indexing
+from ..core.formatting import first_n_items, format_timestamp, last_item
+from ..core.pycompat import PY3
+from ..core.variable import Variable
+from .variables import (
+    SerializationWarning, VariableCoder, lazy_elemwise_func, pop_to,
+    safe_setitem, unpack_for_decoding, unpack_for_encoding)
+
 try:
     from pandas.errors import OutOfBoundsDatetime
 except ImportError:
     # pandas < 0.20
     from pandas.tslib import OutOfBoundsDatetime
 
-from .variables import (SerializationWarning, VariableCoder,
-                        lazy_elemwise_func, pop_to, safe_setitem,
-                        unpack_for_decoding, unpack_for_encoding)
-from ..core import indexing
-from ..core.formatting import first_n_items, format_timestamp, last_item
-from ..core.pycompat import PY3
-from ..core.variable import Variable
 
 
 # standard calendars recognized by netcdftime

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -1,18 +1,13 @@
 """Coders for individual Variable objects."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-from functools import partial
 import warnings
+from functools import partial
 
 import numpy as np
 import pandas as pd
 
-from ..core import dtypes
-from ..core import duck_array_ops
-from ..core import indexing
-from ..core import utils
+from ..core import dtypes, duck_array_ops, indexing, utils
 from ..core.pycompat import dask_array_type
 from ..core.variable import Variable
 

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -1,16 +1,12 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import warnings
 from collections import defaultdict
 
 import numpy as np
-
 import pandas as pd
 
-from .coding import times
-from .coding import variables
+from .coding import times, variables
 from .coding.variables import SerializationWarning
 from .core import duck_array_ops, indexing
 from .core.pycompat import OrderedDict, basestring, iteritems

--- a/xarray/convert.py
+++ b/xarray/convert.py
@@ -1,16 +1,14 @@
 """Functions for converting to and from xarray objects
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
 from .coding.times import CFDatetimeCoder, CFTimedeltaCoder
-from .core.dataarray import DataArray
-from .core.pycompat import OrderedDict, range
-from .core.dtypes import get_fill_value
 from .conventions import decode_cf
+from .core.dataarray import DataArray
+from .core.dtypes import get_fill_value
+from .core.pycompat import OrderedDict, range
 
 cdms2_ignored_attrs = {'name', 'tileIndex'}
 iris_forbidden_keys = {'standard_name', 'long_name', 'units', 'bounds', 'axis',

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -1,12 +1,10 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-from .dtypes import is_datetime_like
-from .pycompat import dask_array_type
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import pandas as pd
+
+from .dtypes import is_datetime_like
+from .pycompat import dask_array_type
 
 
 def _season_from_months(months):

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -1,17 +1,16 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import functools
 import operator
-from collections import defaultdict
 import warnings
+from collections import defaultdict
 
 import numpy as np
 
 from . import utils
 from .indexing import get_indexer_nd
-from .pycompat import iteritems, OrderedDict, suppress
-from .utils import is_full_slice, is_dict_like
+from .pycompat import OrderedDict, iteritems, suppress
+from .utils import is_dict_like, is_full_slice
 from .variable import IndexVariable
 
 

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import warnings
 
 import pandas as pd
@@ -8,9 +7,9 @@ import pandas as pd
 from . import utils
 from .alignment import align
 from .merge import merge
-from .pycompat import iteritems, OrderedDict, basestring
-from .variable import Variable, as_variable, IndexVariable, \
-    concat as concat_vars
+from .pycompat import OrderedDict, basestring, iteritems
+from .variable import IndexVariable, Variable, as_variable
+from .variable import concat as concat_vars
 
 
 def concat(objs, dim=None, data_vars='all', coords='different',

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1,15 +1,13 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-import numpy as np
-import pandas as pd
+from __future__ import absolute_import, division, print_function
+
 import warnings
 
-from .pycompat import basestring, suppress, dask_array_type, OrderedDict
-from . import dtypes
-from . import formatting
-from . import ops
-from .utils import SortedKeysDict, not_implemented, Frozen
+import numpy as np
+import pandas as pd
+
+from . import dtypes, formatting, ops
+from .pycompat import OrderedDict, basestring, dask_array_type, suppress
+from .utils import Frozen, SortedKeysDict, not_implemented
 
 
 class ImplementsArrayReduce(object):

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -212,7 +212,7 @@ class AttrAccessMixin(object):
 def get_squeeze_dims(xarray_obj, dim, axis=None):
     """Get a list of dimensions to squeeze out.
     """
-    if not dim is None and not axis is None:
+    if dim is not None and axis is not None:
         raise ValueError('cannot use both parameters `axis` and `dim`')
 
     if dim is None and axis is None:

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -9,13 +9,11 @@ import operator
 
 import numpy as np
 
-from . import duck_array_ops
-from . import utils
+from . import duck_array_ops, utils
 from .alignment import deep_align
 from .merge import expand_and_merge_variables
 from .pycompat import OrderedDict, dask_array_type
 from .utils import is_dict_like
-
 
 _DEFAULT_FROZEN_SET = frozenset()
 _NO_FILL_VALUE = utils.ReprObject('<no-fill-value>')

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -1,15 +1,15 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 from collections import Mapping
 from contextlib import contextmanager
+
 import pandas as pd
 
 from . import formatting, indexing
-from .utils import Frozen
 from .merge import (
-    merge_coords, expand_and_merge_variables, merge_coords_for_inplace_math)
+    expand_and_merge_variables, merge_coords, merge_coords_for_inplace_math)
 from .pycompat import OrderedDict
+from .utils import Frozen
 from .variable import Variable
 
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1,35 +1,27 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import functools
 import warnings
 
 import numpy as np
 import pandas as pd
 
+from . import duck_array_ops, groupby, indexing, ops, resample, rolling, utils
 from ..plot.plot import _PlotMethods
-
-from . import duck_array_ops
-from . import indexing
-from . import groupby
-from . import resample
-from . import rolling
-from . import ops
-from . import utils
 from .accessors import DatetimeAccessor
 from .alignment import align, reindex_like_indexers
 from .common import AbstractArray, BaseDataObject
-from .coordinates import (DataArrayCoordinates, LevelCoordinatesSource,
-                          Indexes, assert_coordinate_consistent,
-                          remap_label_indexers)
+from .coordinates import (
+    DataArrayCoordinates, Indexes, LevelCoordinatesSource,
+    assert_coordinate_consistent, remap_label_indexers)
 from .dataset import Dataset, merge_indexes, split_indexes
-from .pycompat import iteritems, basestring, OrderedDict, zip, range
-from .variable import (as_variable, Variable, as_compatible_data,
-                       IndexVariable,
-                       assert_unique_multiindex_level_names)
 from .formatting import format_item
-from .utils import decode_numpy_dict_values, ensure_us_time_resolution
 from .options import OPTIONS
+from .pycompat import OrderedDict, basestring, iteritems, range, zip
+from .utils import decode_numpy_dict_values, ensure_us_time_resolution
+from .variable import (
+    IndexVariable, Variable, as_compatible_data, as_variable,
+    assert_unique_multiindex_level_names)
 
 
 def _infer_coords_and_dims(shape, coords, dims):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1,43 +1,37 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import functools
+import sys
+import warnings
 from collections import Mapping, defaultdict
 from distutils.version import LooseVersion
 from numbers import Number
-import warnings
-
-import sys
 
 import numpy as np
 import pandas as pd
 
-from . import ops
-from . import utils
-from . import groupby
-from . import resample
-from . import rolling
-from . import indexing
-from . import alignment
-from . import formatting
-from . import duck_array_ops
+import xarray as xr
+
+from . import (
+    alignment, duck_array_ops, formatting, groupby, indexing, ops, resample,
+    rolling, utils)
 from .. import conventions
 from .alignment import align
-from .coordinates import (DatasetCoordinates, LevelCoordinatesSource, Indexes,
-                          assert_coordinate_consistent, remap_label_indexers)
-from .common import ImplementsDatasetReduce, BaseDataObject
+from .common import BaseDataObject, ImplementsDatasetReduce
+from .coordinates import (
+    DatasetCoordinates, Indexes, LevelCoordinatesSource,
+    assert_coordinate_consistent, remap_label_indexers)
 from .dtypes import is_datetime_like
-from .merge import (dataset_update_method, dataset_merge_method,
-                    merge_data_and_coords, merge_variables)
-from .utils import (Frozen, SortedKeysDict, maybe_wrap_array, hashable,
-                    decode_numpy_dict_values, ensure_us_time_resolution)
-from .variable import (Variable, as_variable, IndexVariable,
-                       broadcast_variables)
-from .pycompat import (iteritems, basestring, OrderedDict,
-                       integer_types, dask_array_type, range)
+from .merge import (
+    dataset_merge_method, dataset_update_method, merge_data_and_coords,
+    merge_variables)
 from .options import OPTIONS
-
-import xarray as xr
+from .pycompat import (
+    OrderedDict, basestring, dask_array_type, integer_types, iteritems, range)
+from .utils import (
+    Frozen, SortedKeysDict, decode_numpy_dict_values,
+    ensure_us_time_resolution, hashable, maybe_wrap_array)
+from .variable import IndexVariable, Variable, as_variable, broadcast_variables
 
 # list of attributes of pd.DatetimeIndex that are ndarrays of time info
 _DATETIMEINDEX_COMPONENTS = ['year', 'month', 'day', 'hour', 'minute',

--- a/xarray/core/dtypes.py
+++ b/xarray/core/dtypes.py
@@ -1,8 +1,8 @@
-import numpy as np
 import functools
 
-from . import utils
+import numpy as np
 
+from . import utils
 
 # Use as a sentinel value to indicate a dtype appropriate NA value.
 NA = utils.ReprObject('<NA>')

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -3,22 +3,19 @@
 Currently, this means Dask or NumPy arrays. None of these functions should
 accept or return xarray objects.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-from functools import partial
 import contextlib
 import inspect
 import warnings
+from functools import partial
 
 import numpy as np
 import pandas as pd
 
-from . import npcompat
-from . import dtypes
-from .pycompat import dask_array_type
+from . import dtypes, npcompat
 from .nputils import nanfirst, nanlast
+from .pycompat import dask_array_type
 
 try:
     import bottleneck as bn

--- a/xarray/core/extensions.py
+++ b/xarray/core/extensions.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import traceback
 import warnings
 

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -4,23 +4,24 @@ For the sake of sanity, we only do internal formatting with unicode, which can
 be returned by the __unicode__ special method. We use ReprMixin to provide the
 __repr__ method so that things can work on Python 2.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import contextlib
-from datetime import datetime, timedelta
 import functools
+from datetime import datetime, timedelta
 
 import numpy as np
 import pandas as pd
+
+from .options import OPTIONS
+from .pycompat import PY2, bytes_type, dask_array_type, unicode_type
+
 try:
     from pandas.errors import OutOfBoundsDatetime
 except ImportError:
     # pandas < 0.20
     from pandas.tslib import OutOfBoundsDatetime
 
-from .options import OPTIONS
-from .pycompat import PY2, unicode_type, bytes_type, dask_array_type
 
 
 def pretty_print(x, numchars):

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -23,7 +23,6 @@ except ImportError:
     from pandas.tslib import OutOfBoundsDatetime
 
 
-
 def pretty_print(x, numchars):
     """Given an object `x`, call `str(x)` and format the returned string so
     that it is numchars long, padding with trailing spaces or truncating with

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -1,21 +1,16 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import functools
+
 import numpy as np
 import pandas as pd
 
-from . import dtypes
-from . import duck_array_ops
-from . import nputils
-from . import ops
+from . import dtypes, duck_array_ops, nputils, ops
 from .combine import concat
-from .common import (
-    ImplementsArrayReduce, ImplementsDatasetReduce,
-)
-from .pycompat import range, zip, integer_types
-from .utils import hashable, peek_at, maybe_wrap_array, safe_cast_to_index
-from .variable import as_variable, Variable, IndexVariable
+from .common import ImplementsArrayReduce, ImplementsDatasetReduce
+from .pycompat import integer_types, range, zip
+from .utils import hashable, maybe_wrap_array, peek_at, safe_cast_to_index
+from .variable import IndexVariable, Variable, as_variable
 
 
 def unique_value_groups(ar, sort=True):

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1,18 +1,16 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from datetime import timedelta
-from collections import defaultdict, Hashable
+from __future__ import absolute_import, division, print_function
+
 import functools
 import operator
+from collections import Hashable, defaultdict
+from datetime import timedelta
+
 import numpy as np
 import pandas as pd
 
-from . import nputils
-from . import utils
-from . import duck_array_ops
-from .pycompat import (iteritems, range, integer_types, dask_array_type,
-                       suppress)
+from . import duck_array_ops, nputils, utils
+from .pycompat import (
+    dask_array_type, integer_types, iteritems, range, suppress)
 from .utils import is_dict_like
 
 

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -1,13 +1,11 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import pandas as pd
 
 from .alignment import deep_align
 from .pycompat import OrderedDict, basestring
 from .utils import Frozen
 from .variable import as_variable, assert_unique_multiindex_level_names
-
 
 PANDAS_TYPES = (pd.Series, pd.DataFrame, pd.Panel)
 

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 from collections import Iterable
 from functools import partial
@@ -8,11 +6,10 @@ from functools import partial
 import numpy as np
 import pandas as pd
 
-
-from .pycompat import iteritems
 from .computation import apply_ufunc
-from .utils import is_scalar
 from .npcompat import flip
+from .pycompat import iteritems
+from .utils import is_scalar
 
 
 class BaseInterpolator(object):

--- a/xarray/core/npcompat.py
+++ b/xarray/core/npcompat.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 
 try:

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -1,9 +1,9 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
+import warnings
+
 import numpy as np
 import pandas as pd
-import warnings
 
 
 def _validate_axis(data, axis):

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -5,19 +5,16 @@ NumPy's __array_ufunc__ and mixin classes instead of the unintuitive "inject"
 functions.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import operator
 
 import numpy as np
 import pandas as pd
 
-from . import dtypes
-from . import duck_array_ops
-from .pycompat import PY3
+from . import dtypes, duck_array_ops
 from .nputils import array_eq, array_ne
+from .pycompat import PY3
 
 try:
     import bottleneck as bn

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -1,7 +1,4 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
+from __future__ import absolute_import, division, print_function
 
 OPTIONS = {
     'display_width': 80,

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -1,8 +1,7 @@
 # flake8: noqa
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import sys
 
 import numpy as np

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -1,10 +1,8 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 from . import ops
 from .groupby import DataArrayGroupBy, DatasetGroupBy
-from .pycompat import dask_array_type, OrderedDict
+from .pycompat import OrderedDict, dask_array_type
 
 RESAMPLE_DIM = '__resample_dim__'
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -1,16 +1,17 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-import numpy as np
+from __future__ import absolute_import, division, print_function
+
 import warnings
 from distutils.version import LooseVersion
 
-from .pycompat import OrderedDict, zip, dask_array_type
-from .common import full_like
+import numpy as np
+
 from .combine import concat
-from .ops import (inject_bottleneck_rolling_methods,
-                  inject_datasetrolling_methods, has_bottleneck, bn)
+from .common import full_like
 from .dask_array_ops import dask_rolling_wrapper
+from .ops import (
+    bn, has_bottleneck, inject_bottleneck_rolling_methods,
+    inject_datasetrolling_methods)
+from .pycompat import OrderedDict, dask_array_type, zip
 
 
 class Rolling(object):

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -1,20 +1,19 @@
 """Internal utilties; not for external use
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import contextlib
 import functools
 import itertools
 import re
 import warnings
-from collections import Mapping, MutableMapping, MutableSet, Iterable
+from collections import Iterable, Mapping, MutableMapping, MutableSet
 
 import numpy as np
 import pandas as pd
 
-from .pycompat import (iteritems, OrderedDict, basestring, bytes_type,
-                       dask_array_type)
+from .pycompat import (
+    OrderedDict, basestring, bytes_type, dask_array_type, iteritems)
 
 
 def alias_message(old_name, new_name):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1,28 +1,22 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from datetime import timedelta
-from collections import defaultdict
+from __future__ import absolute_import, division, print_function
+
 import functools
 import itertools
+from collections import defaultdict
+from datetime import timedelta
 
 import numpy as np
 import pandas as pd
 
-from . import common
-from . import duck_array_ops
-from . import dtypes
-from . import indexing
-from . import nputils
-from . import ops
-from . import utils
-from .pycompat import (basestring, OrderedDict, zip, integer_types,
-                       dask_array_type)
-from .indexing import (PandasIndexAdapter, as_indexable, BasicIndexer,
-                       OuterIndexer, VectorizedIndexer)
-from .utils import OrderedSet
-
 import xarray as xr  # only for Dataset and DataArray
+
+from . import common, dtypes, duck_array_ops, indexing, nputils, ops, utils
+from .indexing import (
+    BasicIndexer, OuterIndexer, PandasIndexAdapter, VectorizedIndexer,
+    as_indexable)
+from .pycompat import (
+    OrderedDict, basestring, dask_array_type, integer_types, zip)
+from .utils import OrderedSet
 
 try:
     import dask.array as da

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -1,18 +1,15 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-import warnings
-import itertools
 import functools
+import itertools
+import warnings
 
 import numpy as np
 
-from ..core.pycompat import getargspec
 from ..core.formatting import format_item
-from .utils import (_determine_cmap_params, _infer_xy_labels,
-                    import_matplotlib_pyplot)
-
+from ..core.pycompat import getargspec
+from .utils import (
+    _determine_cmap_params, _infer_xy_labels, import_matplotlib_pyplot)
 
 # Overrides axes.labelsize, xtick.major.size, ytick.major.size
 # from mpl.rcParams

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -5,20 +5,21 @@ Use this module directly:
 Or use the methods on a DataArray:
     DataArray.plot._____
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import functools
 import warnings
+from datetime import datetime
 
 import numpy as np
 import pandas as pd
-from datetime import datetime
 
-from .utils import (ROBUST_PERCENTILE, _determine_cmap_params,
-                    _infer_xy_labels, get_axis, import_matplotlib_pyplot)
-from .facetgrid import FacetGrid
 from xarray.core.pycompat import basestring
+
+from .facetgrid import FacetGrid
+from .utils import (
+    ROBUST_PERCENTILE, _determine_cmap_params, _infer_xy_labels, get_axis,
+    import_matplotlib_pyplot)
 
 
 def _valid_numpy_subdtype(x, numpy_types):

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -1,15 +1,13 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-import pkg_resources
+from __future__ import absolute_import, division, print_function
+
 import warnings
 
 import numpy as np
 import pandas as pd
+import pkg_resources
 
 from ..core.pycompat import basestring
 from ..core.utils import is_scalar
-
 
 ROBUST_PERCENTILE = 2.0
 

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -1,7 +1,5 @@
 """Testing functions exposed to the user API"""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 

--- a/xarray/tests/test_accessors.py
+++ b/xarray/tests/test_accessors.py
@@ -1,13 +1,12 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-import xarray as xr
 import numpy as np
 import pandas as pd
 
-from . import (TestCase, requires_dask, raises_regex, assert_equal,
-               assert_array_equal)
+import xarray as xr
+
+from . import (
+    TestCase, assert_array_equal, assert_equal, raises_regex, requires_dask)
 
 
 class TestDatetimeAccessor(TestCase):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1,41 +1,39 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from io import BytesIO
+from __future__ import absolute_import, division, print_function
+
 import contextlib
 import itertools
 import os.path
 import pickle
 import shutil
+import sys
 import tempfile
 import unittest
-import sys
 import warnings
+from io import BytesIO
 
 import numpy as np
 import pandas as pd
 import pytest
 
 import xarray as xr
-from xarray import (Dataset, DataArray, open_dataset, open_dataarray,
-                    open_mfdataset, backends, save_mfdataset)
+from xarray import (
+    DataArray, Dataset, backends, open_dataarray, open_dataset, open_mfdataset,
+    save_mfdataset)
 from xarray.backends.common import robust_getitem
 from xarray.backends.netCDF4_ import _extract_nc4_variable_encoding
 from xarray.backends.pydap_ import PydapDataStore
 from xarray.core import indexing
-from xarray.core.pycompat import (iteritems, PY2, ExitStack, basestring,
-                                  dask_array_type)
-
-from . import (TestCase, requires_scipy, requires_netCDF4, requires_pydap,
-               requires_scipy_or_netCDF4, requires_dask, requires_h5netcdf,
-               requires_pynio, requires_pathlib, requires_zarr,
-               requires_rasterio, has_netCDF4, has_scipy, assert_allclose,
-               flaky, network, assert_identical, raises_regex, assert_equal,
-               assert_array_equal)
-
-from .test_dataset import create_test_data
-
+from xarray.core.pycompat import (
+    PY2, ExitStack, basestring, dask_array_type, iteritems)
 from xarray.tests import mock
+
+from . import (
+    TestCase, assert_allclose, assert_array_equal, assert_equal,
+    assert_identical, flaky, has_netCDF4, has_scipy, network, raises_regex,
+    requires_dask, requires_h5netcdf, requires_netCDF4, requires_pathlib,
+    requires_pydap, requires_pynio, requires_rasterio, requires_scipy,
+    requires_scipy_or_netCDF4, requires_zarr)
+from .test_dataset import create_test_data
 
 try:
     import netCDF4 as nc4

--- a/xarray/tests/test_coding.py
+++ b/xarray/tests/test_coding.py
@@ -1,12 +1,11 @@
 import numpy as np
-
 import pytest
 
 import xarray as xr
-from xarray.core.pycompat import suppress
 from xarray.coding import variables
+from xarray.core.pycompat import suppress
 
-from . import requires_dask, assert_identical
+from . import assert_identical, requires_dask
 
 with suppress(ImportError):
     import dask.array as da

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -1,16 +1,14 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import warnings
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from xarray import Variable, coding
-from . import (
-    TestCase, requires_netCDF4, assert_array_equal)
-import pytest
+
+from . import TestCase, assert_array_equal, requires_netCDF4
 
 
 @np.vectorize

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -9,8 +9,7 @@ import pytest
 from xarray import Variable, coding
 from xarray.coding.times import _import_netcdftime
 
-from . import (
-    TestCase, assert_array_equal, requires_netCDF4, requires_netcdftime)
+from . import TestCase, assert_array_equal, requires_netcdftime
 
 
 @np.vectorize

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -1,18 +1,17 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from copy import deepcopy
+from __future__ import absolute_import, division, print_function
 
-import pytest
+from copy import deepcopy
 
 import numpy as np
 import pandas as pd
+import pytest
 
-from xarray import Dataset, DataArray, auto_combine, concat, Variable
-from xarray.core.pycompat import iteritems, OrderedDict
+from xarray import DataArray, Dataset, Variable, auto_combine, concat
+from xarray.core.pycompat import OrderedDict, iteritems
 
-from . import (TestCase, InaccessibleArray, requires_dask, raises_regex,
-               assert_equal, assert_identical, assert_array_equal)
+from . import (
+    InaccessibleArray, TestCase, assert_array_equal, assert_equal,
+    assert_identical, raises_regex, requires_dask)
 from .test_dataset import create_test_data
 
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -1,21 +1,20 @@
 import functools
 import operator
 from collections import OrderedDict
-
 from distutils.version import LooseVersion
-import numpy as np
-from numpy.testing import assert_array_equal
-import pandas as pd
 
+import numpy as np
+import pandas as pd
 import pytest
+from numpy.testing import assert_array_equal
 
 import xarray as xr
 from xarray.core.computation import (
-    _UFuncSignature, result_name, broadcast_compat_data, collect_dict_values,
-    join_dict_keys, ordered_set_intersection, ordered_set_union,
-    unified_dim_sizes, apply_ufunc)
+    _UFuncSignature, apply_ufunc, broadcast_compat_data, collect_dict_values,
+    join_dict_keys, ordered_set_intersection, ordered_set_union, result_name,
+    unified_dim_sizes)
 
-from . import requires_dask, raises_regex
+from . import raises_regex, requires_dask
 
 
 def assert_identical(a, b):

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -1,26 +1,25 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import contextlib
 import warnings
+
 import numpy as np
 import pandas as pd
 import pytest
 
-from xarray import conventions, Variable, Dataset, open_dataset
-from xarray.core import utils, indexing
-from xarray.testing import assert_identical
-from . import (
-    TestCase, requires_netCDF4, requires_netcdftime, unittest, raises_regex,
-    IndexerMaker, assert_array_equal)
-from .test_backends import CFEncodedDataTest
-from xarray.core.pycompat import iteritems
-from xarray.backends.memory import InMemoryDataStore
+from xarray import Dataset, Variable, conventions, open_dataset
 from xarray.backends.common import WritableCFDataStore
+from xarray.backends.memory import InMemoryDataStore
 from xarray.conventions import decode_cf
+from xarray.core import indexing, utils
+from xarray.core.pycompat import iteritems
+from xarray.testing import assert_identical
 
+from . import (
+    IndexerMaker, TestCase, assert_array_equal, raises_regex, requires_netCDF4,
+    requires_netcdftime, unittest)
+from .test_backends import CFEncodedDataTest
 
 B = IndexerMaker(indexing.BasicIndexer)
 V = IndexerMaker(indexing.VectorizedIndexer)

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -4,12 +4,12 @@ import pickle
 from distutils.version import LooseVersion
 from textwrap import dedent
 
+import dask.array as da  # noqa: E402  # allow importorskip call above this
+import dask.dataframe as dd  # noqa: E402
 import numpy as np
 import pandas as pd
 import pytest
 
-import dask.array as da  # noqa: E402  # allow importorskip call above this
-import dask.dataframe as dd  # noqa: E402
 import xarray as xr
 import xarray.ufuncs as xu
 from xarray import DataArray, Dataset, Variable

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -4,8 +4,6 @@ import pickle
 from distutils.version import LooseVersion
 from textwrap import dedent
 
-import dask.array as da  # noqa: E402  # allow importorskip call above this
-import dask.dataframe as dd  # noqa: E402
 import numpy as np
 import pandas as pd
 import pytest
@@ -21,6 +19,8 @@ from . import (
     assert_frame_equal, assert_identical, raises_regex)
 
 dask = pytest.importorskip('dask')
+da = pytest.importorskip('dask.array')
+dd = pytest.importorskip('dask.dataframe')
 
 
 class DaskTestCase(TestCase):

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1,28 +1,26 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import pickle
+from distutils.version import LooseVersion
 from textwrap import dedent
 
-from distutils.version import LooseVersion
 import numpy as np
 import pandas as pd
 import pytest
 
-import xarray as xr
-from xarray import Variable, DataArray, Dataset
-import xarray.ufuncs as xu
-from xarray.core.pycompat import suppress, OrderedDict
-from . import (
-    TestCase, assert_frame_equal, raises_regex, assert_equal, assert_identical,
-    assert_array_equal, assert_allclose)
-
-from xarray.tests import mock
-
-dask = pytest.importorskip('dask')
 import dask.array as da  # noqa: E402  # allow importorskip call above this
 import dask.dataframe as dd  # noqa: E402
+import xarray as xr
+import xarray.ufuncs as xu
+from xarray import DataArray, Dataset, Variable
+from xarray.core.pycompat import OrderedDict, suppress
+from xarray.tests import mock
+
+from . import (
+    TestCase, assert_allclose, assert_array_equal, assert_equal,
+    assert_frame_equal, assert_identical, raises_regex)
+
+dask = pytest.importorskip('dask')
 
 
 class DaskTestCase(TestCase):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1,25 +1,24 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
+import pickle
+from copy import deepcopy
+from distutils.version import LooseVersion
+from textwrap import dedent
+
 import numpy as np
 import pandas as pd
-import pickle
 import pytest
-from copy import deepcopy
-from textwrap import dedent
-from distutils.version import LooseVersion
 
 import xarray as xr
-
-from xarray import (align, broadcast, Dataset, DataArray,
-                    IndexVariable, Variable)
+from xarray import (
+    DataArray, Dataset, IndexVariable, Variable, align, broadcast)
 from xarray.coding.times import CFDatetimeCoder
-from xarray.core.pycompat import iteritems, OrderedDict
 from xarray.core.common import full_like
+from xarray.core.pycompat import OrderedDict, iteritems
 from xarray.tests import (
-    TestCase, ReturnItem, source_ndarray, unittest, requires_dask,
-    assert_identical, assert_equal, assert_allclose, assert_array_equal,
-    raises_regex, requires_scipy, requires_bottleneck)
+    ReturnItem, TestCase, assert_allclose, assert_array_equal, assert_equal,
+    assert_identical, raises_regex, requires_bottleneck, requires_dask,
+    requires_scipy, source_ndarray, unittest)
 
 
 class TestDataArray(TestCase):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -34,9 +34,6 @@ except ImportError:
     pass
 
 
-
-
-
 def create_test_data(seed=None):
     rs = np.random.RandomState(seed)
     _vars = {'var1': ['dim1', 'dim2'],

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1,9 +1,29 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 from copy import copy, deepcopy
+from distutils.version import LooseVersion
+from io import StringIO
 from textwrap import dedent
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import xarray as xr
+from xarray import (
+    DataArray, Dataset, IndexVariable, MergeError, Variable, align, backends,
+    broadcast, open_dataset, set_options)
+from xarray.core import indexing, utils
+from xarray.core.common import full_like
+from xarray.core.pycompat import (
+    OrderedDict, integer_types, iteritems, unicode_type)
+
+from . import (
+    InaccessibleArray, TestCase, UnexpectedDataAccess, assert_allclose,
+    assert_array_equal, assert_equal, assert_identical, raises_regex,
+    requires_bottleneck, requires_dask, requires_scipy, source_ndarray)
+
 try:
     import cPickle as pickle
 except ImportError:
@@ -12,25 +32,9 @@ try:
     import dask.array as da
 except ImportError:
     pass
-from io import StringIO
-from distutils.version import LooseVersion
 
-import numpy as np
-import pandas as pd
-import xarray as xr
-import pytest
 
-from xarray import (align, broadcast, backends, Dataset, DataArray, Variable,
-                    IndexVariable, open_dataset, set_options, MergeError)
-from xarray.core import indexing, utils
-from xarray.core.pycompat import (iteritems, OrderedDict, unicode_type,
-                                  integer_types)
-from xarray.core.common import full_like
 
-from . import (TestCase, raises_regex, InaccessibleArray, UnexpectedDataAccess,
-               requires_dask, source_ndarray, assert_array_equal, assert_equal,
-               assert_allclose, assert_identical, requires_bottleneck,
-               requires_scipy)
 
 
 def create_test_data(seed=None):

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -17,8 +17,6 @@ distributed = pytest.importorskip('distributed')
 da = pytest.importorskip('dask.array')
 
 
-
-
 ENGINES = []
 if has_scipy:
     ENGINES.append('scipy')

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -1,6 +1,16 @@
+""" isort:skip_file """
+
 import sys
 
 import pytest
+
+dask = pytest.importorskip('dask')  # isort:skip
+distributed = pytest.importorskip('distributed')  # isort:skip
+
+from dask import array
+from distributed.utils_test import cluster, gen_cluster
+from distributed.utils_test import loop  # flake8: noqa
+from distributed.client import futures_of
 
 import xarray as xr
 from xarray.tests.test_backends import ON_WINDOWS, create_tmp_file
@@ -12,14 +22,10 @@ from . import (
 # this is to stop isort throwing errors. May have been easier to just use
 # `isort:skip` in retrospect
 
-dask = pytest.importorskip('dask')
-distributed = pytest.importorskip('distributed')
+
+
 da = pytest.importorskip('dask.array')
 
-futures_of = distributed.client.futures_of
-loop = distributed.utils_test.loop
-cluster = distributed.utils_test.cluster
-gen_cluster = distributed.utils_test.gen_cluster
 
 ENGINES = []
 if has_scipy:

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -23,7 +23,6 @@ from . import (
 # `isort:skip` in retrospect
 
 
-
 da = pytest.importorskip('dask.array')
 
 

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -1,10 +1,6 @@
 import sys
 
-import dask
 import pytest
-from distributed.client import futures_of
-from distributed.utils_test import loop  # flake8: noqa
-from distributed.utils_test import cluster, gen_cluster
 
 import xarray as xr
 from xarray.tests.test_backends import ON_WINDOWS, create_tmp_file
@@ -13,9 +9,17 @@ from xarray.tests.test_dataset import create_test_data
 from . import (
     assert_allclose, has_h5netcdf, has_netCDF4, has_scipy, requires_zarr)
 
+# this is to stop isort throwing errors. May have been easier to just use
+# `isort:skip` in retrospect
+
+dask = pytest.importorskip('dask')
 distributed = pytest.importorskip('distributed')
 da = pytest.importorskip('dask.array')
 
+futures_of = distributed.client.futures_of
+loop = distributed.utils_test.loop
+cluster = distributed.utils_test.cluster
+gen_cluster = distributed.utils_test.gen_cluster
 
 ENGINES = []
 if has_scipy:

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -76,7 +76,7 @@ def test_async(c, s, a, b):
     assert dask.is_dask_collection(y.var2)
 
     z = y.persist()
-    assert str(z)©
+    assert str(z)
 
     assert dask.is_dask_collection(z)
     assert dask.is_dask_collection(z.var1)

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -1,20 +1,22 @@
 import sys
 
 import pytest
+
+import dask
 import xarray as xr
+from distributed.client import futures_of
+from distributed.utils_test import loop  # flake8: noqa
+from distributed.utils_test import cluster, gen_cluster
+from xarray.tests.test_backends import ON_WINDOWS, create_tmp_file
+from xarray.tests.test_dataset import create_test_data
+
+from . import (
+    assert_allclose, has_h5netcdf, has_netCDF4, has_scipy, requires_zarr)
 
 distributed = pytest.importorskip('distributed')
 da = pytest.importorskip('dask.array')
-import dask
-from distributed.utils_test import cluster, gen_cluster
-from distributed.utils_test import loop  # flake8: noqa
-from distributed.client import futures_of
 
-from xarray.tests.test_backends import create_tmp_file, ON_WINDOWS
-from xarray.tests.test_dataset import create_test_data
 
-from . import (assert_allclose, has_scipy, has_netCDF4, has_h5netcdf,
-               requires_zarr)
 
 
 ENGINES = []

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -1,12 +1,12 @@
 import sys
 
-import pytest
-
 import dask
-import xarray as xr
+import pytest
 from distributed.client import futures_of
 from distributed.utils_test import loop  # flake8: noqa
 from distributed.utils_test import cluster, gen_cluster
+
+import xarray as xr
 from xarray.tests.test_backends import ON_WINDOWS, create_tmp_file
 from xarray.tests.test_dataset import create_test_data
 

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -39,7 +39,8 @@ def test_dask_distributed_netcdf_integration_test(loop, engine):
             original = create_test_data()
             with create_tmp_file(allow_cleanup_failure=ON_WINDOWS) as filename:
                 original.to_netcdf(filename, engine=engine)
-                with xr.open_dataset(filename, chunks=3, engine=engine) as restored:
+                with xr.open_dataset(
+                        filename, chunks=3, engine=engine) as restored:
                     assert isinstance(restored.var1.data, da.Array)
                     computed = restored.compute()
                     assert_allclose(original, computed)
@@ -70,7 +71,7 @@ def test_async(c, s, a, b):
     assert dask.is_dask_collection(y.var2)
 
     z = y.persist()
-    assert str(z)
+    assert str(z)©
 
     assert dask.is_dask_collection(z)
     assert dask.is_dask_collection(z.var1)

--- a/xarray/tests/test_dtypes.py
+++ b/xarray/tests/test_dtypes.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import pytest

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -1,19 +1,17 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-import pytest
-import numpy as np
-from numpy import array, nan
-from distutils.version import LooseVersion
-from . import assert_array_equal
-from xarray.core.duck_array_ops import (
-    first, last, count, mean, array_notnull_equiv, where, stack, concatenate
-)
-from xarray import DataArray
-from xarray.testing import assert_allclose
-from xarray import concat
+from __future__ import absolute_import, division, print_function
 
-from . import TestCase, raises_regex, has_dask
+from distutils.version import LooseVersion
+
+import numpy as np
+import pytest
+from numpy import array, nan
+
+from xarray import DataArray, concat
+from xarray.core.duck_array_ops import (
+    array_notnull_equiv, concatenate, count, first, last, mean, stack, where)
+from xarray.testing import assert_allclose
+
+from . import TestCase, assert_array_equal, has_dask, raises_regex
 
 
 class TestOps(TestCase):

--- a/xarray/tests/test_extensions.py
+++ b/xarray/tests/test_extensions.py
@@ -1,15 +1,17 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+import xarray as xr
+
+from . import TestCase, raises_regex
+
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
 
-import xarray as xr
 
-from . import TestCase, raises_regex
-import pytest
 
 
 @xr.register_dataset_accessor('example_accessor')

--- a/xarray/tests/test_extensions.py
+++ b/xarray/tests/test_extensions.py
@@ -12,8 +12,6 @@ except ImportError:
     import pickle
 
 
-
-
 @xr.register_dataset_accessor('example_accessor')
 @xr.register_dataarray_accessor('example_accessor')
 class ExampleAccessor(object):

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 import pandas as pd
 

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -1,12 +1,11 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 import pandas as pd
+import pytest
+
 import xarray as xr
 from xarray.core.groupby import _consolidate_slices
-
-import pytest
 
 
 def test_consolidate_slices():

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -1,20 +1,17 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-import itertools
+from __future__ import absolute_import, division, print_function
 
-import pytest
+import itertools
 
 import numpy as np
 import pandas as pd
+import pytest
 
-from xarray import Dataset, DataArray, Variable
-from xarray.core import indexing
-from xarray.core import nputils
+from xarray import DataArray, Dataset, Variable
+from xarray.core import indexing, nputils
 from xarray.core.pycompat import native_int_types
-from . import (
-    TestCase, ReturnItem, raises_regex, IndexerMaker, assert_array_equal)
 
+from . import (
+    IndexerMaker, ReturnItem, TestCase, assert_array_equal, raises_regex)
 
 B = IndexerMaker(indexing.BasicIndexer)
 

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -1,15 +1,13 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-import numpy as np
-import xarray as xr
+from __future__ import absolute_import, division, print_function
 
+import numpy as np
 import pytest
+
+import xarray as xr
+from xarray.core import merge
 
 from . import TestCase, raises_regex
 from .test_dataset import create_test_data
-
-from xarray.core import merge
 
 
 class TestMergeInternals(TestCase):

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -1,20 +1,18 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
+import itertools
+
 import numpy as np
 import pandas as pd
 import pytest
-import itertools
 
 import xarray as xr
-
-from xarray.core.missing import (NumpyInterpolator, ScipyInterpolator,
-                                 SplineInterpolator)
+from xarray.core.missing import (
+    NumpyInterpolator, ScipyInterpolator, SplineInterpolator)
 from xarray.core.pycompat import dask_array_type
-
-from xarray.tests import (assert_equal, assert_array_equal, raises_regex,
-                          requires_scipy, requires_bottleneck, requires_dask,
-                          requires_np112)
+from xarray.tests import (
+    assert_array_equal, assert_equal, raises_regex, requires_bottleneck,
+    requires_dask, requires_np112, requires_scipy)
 
 
 @pytest.fixture

--- a/xarray/tests/test_nputils.py
+++ b/xarray/tests/test_nputils.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from xarray.core.nputils import _is_contiguous, NumpyVIndexAdapter
+from xarray.core.nputils import NumpyVIndexAdapter, _is_contiguous
 
 
 def test_is_contiguous():

--- a/xarray/tests/test_options.py
+++ b/xarray/tests/test_options.py
@@ -1,9 +1,8 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-import xarray
+from __future__ import absolute_import, division, print_function
+
 import pytest
 
+import xarray
 from xarray.core.options import OPTIONS
 
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1,6 +1,22 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
+import inspect
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import xarray.plot as xplt
+from xarray import DataArray
+from xarray.plot.plot import _infer_interval_breaks
+from xarray.plot.utils import (
+    _build_discrete_cmap, _color_palette, _determine_cmap_params,
+    import_seaborn)
+
+from . import (
+    TestCase, assert_array_equal, assert_equal, raises_regex,
+    requires_matplotlib, requires_seaborn)
 
 # import mpl and change the backend before other mpl imports
 try:
@@ -9,22 +25,10 @@ try:
 except ImportError:
     pass
 
-import inspect
 
-import numpy as np
-import pandas as pd
-from datetime import datetime
-import pytest
 
-from xarray import DataArray
 
-import xarray.plot as xplt
-from xarray.plot.plot import _infer_interval_breaks
-from xarray.plot.utils import (_determine_cmap_params, _build_discrete_cmap,
-                               _color_palette, import_seaborn)
 
-from . import (TestCase, requires_matplotlib, requires_seaborn, raises_regex,
-               assert_equal, assert_array_equal)
 
 
 @pytest.mark.flaky

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -26,11 +26,6 @@ except ImportError:
     pass
 
 
-
-
-
-
-
 @pytest.mark.flaky
 @pytest.mark.skip(reason='maybe flaky')
 def text_in_fig():

--- a/xarray/tests/test_testing.py
+++ b/xarray/tests/test_testing.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import xarray as xr
 

--- a/xarray/tests/test_tutorial.py
+++ b/xarray/tests/test_tutorial.py
@@ -1,13 +1,11 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 
-from xarray import tutorial, DataArray
+from xarray import DataArray, tutorial
 from xarray.core.pycompat import suppress
 
-from . import TestCase, network, assert_identical
+from . import TestCase, assert_identical, network
 
 
 @network

--- a/xarray/tests/test_ufuncs.py
+++ b/xarray/tests/test_ufuncs.py
@@ -1,15 +1,13 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import pickle
 
 import numpy as np
 
-import xarray.ufuncs as xu
 import xarray as xr
+import xarray.ufuncs as xu
 
-from . import (
-    TestCase, raises_regex, assert_identical, assert_array_equal)
+from . import TestCase, assert_array_equal, assert_identical, raises_regex
 
 
 class TestOps(TestCase):

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -1,14 +1,13 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-import pytest
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from xarray.core import duck_array_ops, utils
 from xarray.core.pycompat import OrderedDict
-from . import TestCase, requires_dask, assert_array_equal
+
+from . import TestCase, assert_array_equal, requires_dask
 
 
 class TestAlias(TestCase):

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1,35 +1,32 @@
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 from collections import namedtuple
 from copy import copy, deepcopy
 from datetime import datetime, timedelta
-from textwrap import dedent
-import pytest
-
 from distutils.version import LooseVersion
-import numpy as np
-import pytz
-import pandas as pd
+from textwrap import dedent
 
-from xarray import Variable, IndexVariable, Coordinate, Dataset
+import numpy as np
+import pandas as pd
+import pytest
+import pytz
+
+from xarray import Coordinate, Dataset, IndexVariable, Variable
 from xarray.core import indexing
-from xarray.core.variable import as_variable, as_compatible_data
-from xarray.core.indexing import (PandasIndexAdapter, LazilyIndexedArray,
-                                  BasicIndexer, OuterIndexer,
-                                  VectorizedIndexer, NumpyIndexingAdapter,
-                                  CopyOnWriteArray, MemoryCachedArray,
-                                  DaskIndexingAdapter)
+from xarray.core.common import full_like, ones_like, zeros_like
+from xarray.core.indexing import (
+    BasicIndexer, CopyOnWriteArray, DaskIndexingAdapter, LazilyIndexedArray,
+    MemoryCachedArray, NumpyIndexingAdapter, OuterIndexer, PandasIndexAdapter,
+    VectorizedIndexer)
 from xarray.core.pycompat import PY3, OrderedDict
-from xarray.core.common import full_like, zeros_like, ones_like
 from xarray.core.utils import NDArrayMixin
+from xarray.core.variable import as_compatible_data, as_variable
+from xarray.tests import requires_bottleneck
 
 from . import (
-    TestCase, source_ndarray, requires_dask, raises_regex, assert_identical,
-    assert_array_equal, assert_equal, assert_allclose)
-
-from xarray.tests import requires_bottleneck
+    TestCase, assert_allclose, assert_array_equal, assert_equal,
+    assert_identical, raises_regex, requires_dask, source_ndarray)
 
 
 class VariableSubclassTestCases(object):

--- a/xarray/tutorial.py
+++ b/xarray/tutorial.py
@@ -5,17 +5,13 @@ Useful for:
 * building tutorials in the documentation.
 
 '''
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import hashlib
-
 import os as _os
 
 from .backends.api import open_dataset as _open_dataset
 from .core.pycompat import urlretrieve as _urlretrieve
-
 
 _default_cache_dir = _os.sep.join(('~', '.xarray_tutorial_data'))
 

--- a/xarray/ufuncs.py
+++ b/xarray/ufuncs.py
@@ -13,20 +13,16 @@ priority order:
 Once NumPy 1.10 comes out with support for overriding ufuncs, this module will
 hopefully no longer be necessary.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import numpy as _np
 
-from .core.variable import Variable as _Variable
-from .core.dataset import Dataset as _Dataset
 from .core.dataarray import DataArray as _DataArray
-from .core.groupby import GroupBy as _GroupBy
-
-from .core.pycompat import dask_array_type as _dask_array_type
+from .core.dataset import Dataset as _Dataset
 from .core.duck_array_ops import _dask_or_eager_func
-
+from .core.groupby import GroupBy as _GroupBy
+from .core.pycompat import dask_array_type as _dask_array_type
+from .core.variable import Variable as _Variable
 
 _xarray_types = (_Variable, _DataArray, _Dataset, _GroupBy)
 _dispatch_order = (_np.ndarray, _dask_array_type) + _xarray_types

--- a/xarray/util/print_versions.py
+++ b/xarray/util/print_versions.py
@@ -2,14 +2,14 @@
 
 
 see pandas/pandas/util/_print_versions.py'''
+import codecs
+import importlib
+import locale
 import os
 import platform
-import sys
 import struct
 import subprocess
-import codecs
-import locale
-import importlib
+import sys
 
 
 def get_sys_info():

--- a/xarray/util/print_versions.py
+++ b/xarray/util/print_versions.py
@@ -2,6 +2,8 @@
 
 
 see pandas/pandas/util/_print_versions.py'''
+from __future__ import absolute_import
+
 import codecs
 import importlib
 import locale


### PR DESCRIPTION
Not sure if we want this?

Probably too strict to enforce on every commit, more permissible to do a one-time update, assuming it doesn't cause merge conflicts. 

You can get the same result by running `isort -y`