### PR TITLE
Add x,y kwargs for plot.line().

### DIFF
--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -197,10 +197,10 @@ It is required to explicitly specify either
 Thus, we could have made the previous plot by specifying ``hue='lat'`` instead of ``x='time'``.
 If required, the automatic legend can be turned off using ``add_legend=False``.
 
-Coordinate along y-axis
-~~~~~~~~~~~~~~~~~~~~~~~
+Dimension along y-axis
+~~~~~~~~~~~~~~~~~~~~~~
 
-It is also possible to make line plots such that the data are on the x-axis and a coordinate is on the y-axis. This can be done by specifying the ``x`` and ``y`` keyword arguments.
+It is also possible to make line plots such that the data are on the x-axis and a dimension is on the y-axis. This can be done by specifying the appropriate ``y`` keyword argument.
 
 .. ipython:: python
 

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -197,6 +197,16 @@ It is required to explicitly specify either
 Thus, we could have made the previous plot by specifying ``hue='lat'`` instead of ``x='time'``.
 If required, the automatic legend can be turned off using ``add_legend=False``.
 
+Data along x-axis
+~~~~~~~~~~~~~~~~~
+
+It is also possible to make line plots such that the data are on the x-axis and a co-ordinate is on the y-axis. This can be done by specifying the ``x`` and ``y`` keyword arguments.
+
+.. ipython:: python
+
+    @savefig plotting_example_xy_kwarg.png
+    air.isel(time=10, lon=[10, 11]).plot.line(y='lat', hue='lon')
+
 Two Dimensions
 --------------
 

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -197,10 +197,10 @@ It is required to explicitly specify either
 Thus, we could have made the previous plot by specifying ``hue='lat'`` instead of ``x='time'``.
 If required, the automatic legend can be turned off using ``add_legend=False``.
 
-Data along x-axis
-~~~~~~~~~~~~~~~~~
+Coordinate along y-axis
+~~~~~~~~~~~~~~~~~~~~~~~
 
-It is also possible to make line plots such that the data are on the x-axis and a co-ordinate is on the y-axis. This can be done by specifying the ``x`` and ``y`` keyword arguments.
+It is also possible to make line plots such that the data are on the x-axis and a coordinate is on the y-axis. This can be done by specifying the ``x`` and ``y`` keyword arguments.
 
 .. ipython:: python
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -141,6 +141,8 @@ Enhancements
   encoding/decoding of datetimes with non-standard calendars without the
   netCDF4 dependency (:issue:`1084`).
   By `Joe Hamman <https://github.com/jhamman>`_.
+- :py:func:`~plot.line()` learned to make plots with data on x-axis if so specified.
+  By `Deepak Cherian <https://github.com/dcherian>`_.
 
 .. _Zarr: http://zarr.readthedocs.io/
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -141,7 +141,7 @@ Enhancements
   encoding/decoding of datetimes with non-standard calendars without the
   netCDF4 dependency (:issue:`1084`).
   By `Joe Hamman <https://github.com/jhamman>`_.
-- :py:func:`~plot.line()` learned to make plots with data on x-axis if so specified.
+- :py:func:`~plot.line()` learned to make plots with data on x-axis if so specified. (:issue:`575`)
   By `Deepak Cherian <https://github.com/dcherian>`_.
 
 .. _Zarr: http://zarr.readthedocs.io/

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -46,6 +46,8 @@ Enhancements
   rolling, windowed rolling, ND-rolling, short-time FFT and convolution.
   (:issue:`1831`, :issue:`1142`, :issue:`819`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+- :py:func:`~plot.line()` learned to make plots with data on x-axis if so specified. (:issue:`575`)
+  By `Deepak Cherian <https://github.com/dcherian>`_.
 
 Bug fixes
 ~~~~~~~~~
@@ -141,8 +143,6 @@ Enhancements
   encoding/decoding of datetimes with non-standard calendars without the
   netCDF4 dependency (:issue:`1084`).
   By `Joe Hamman <https://github.com/jhamman>`_.
-- :py:func:`~plot.line()` learned to make plots with data on x-axis if so specified. (:issue:`575`)
-  By `Deepak Cherian <https://github.com/dcherian>`_.
 
 .. _Zarr: http://zarr.readthedocs.io/
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -206,7 +206,7 @@ def line(darray, *args, **kwargs):
     ax = get_axis(figsize, size, aspect, ax)
 
     error_msg = ('must be either None or one of ({0:s})'
-                 .format(', '.join(['\'' + dd + '\'' for dd in darray.dims])))
+                 .format(', '.join([repr(dd) for dd in darray.dims])))
 
     if x is not None and x not in darray.dims:
         raise ValueError('x ' + error_msg)
@@ -215,7 +215,8 @@ def line(darray, *args, **kwargs):
         raise ValueError('y ' + error_msg)
 
     if x is not None and y is not None:
-        raise ValueError('You cannot specify both x and y kwargs.')
+        raise ValueError('You cannot specify both x and y kwargs'
+                         'for line plots.')
 
     if ndims == 1:
         dim, = darray.dims  # get the only dimension name

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -180,6 +180,8 @@ def line(darray, *args, **kwargs):
         (2D DataArrays only).
     x, y : string, optional
         Coordinates for x, y axis. Only one of these may be specified.
+        The other coordinate plots values from the DataArray on which this
+        plot method is called.
     add_legend : boolean, optional
         Add legend with y axis coordinates (2D inputs only).
     *args, **kwargs : optional

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -178,11 +178,8 @@ def line(darray, *args, **kwargs):
     hue : string, optional
         Coordinate for which you want multiple lines plotted
         (2D DataArrays only).
-    x : string, optional
-        1D and 2D DataArrays: Coordinate for x axis.
-    y : string, optional
-        1D DataArray: Can be coordinate name or DataArray.name
-        2D DataArray: Coordinate for y axis.
+    x, y : string, optional
+        Coordinates for x, y axis. Only one of these may be specified.
     add_legend : boolean, optional
         Add legend with y axis coordinates (2D inputs only).
     *args, **kwargs : optional
@@ -208,29 +205,28 @@ def line(darray, *args, **kwargs):
 
     ax = get_axis(figsize, size, aspect, ax)
 
+    error_msg = ('must be either None or one of ({0:s})'
+                 .format(', '.join(['\'' + dd + '\'' for dd in darray.dims])))
+
+    if x is not None and x not in darray.dims:
+        raise ValueError('x ' + error_msg)
+
+    if y is not None and y not in darray.dims:
+        raise ValueError('y ' + error_msg)
+
+    if x is not None and y is not None:
+        raise ValueError('You cannot specify both x and y kwargs.')
+
     if ndims == 1:
         dim, = darray.dims  # get the only dimension name
 
-        error_msg = 'must be either None or %r' % dim
-        if darray.name:
-            error_msg += ' or %r.' % darray.name
-
-        if x not in [None, dim, darray.name]:
-            raise ValueError('x ' + error_msg)
-
-        if y not in [None, dim, darray.name]:
-            raise ValueError('y ' + error_msg)
-
-        if x is not None and y is not None and x == y:
-            raise ValueError('Cannot make a plot with x=%r and y=%r' % (x, y))
-
-        if (x is None and y is None) or x == dim or y == darray.name:
+        if (x is None and y is None) or x == dim:
             xplt = darray.coords[dim]
             yplt = darray
             xlabel = dim
             ylabel = darray.name
 
-        elif y == dim or x == darray.name:
+        else:
             yplt = darray.coords[dim]
             xplt = darray
             xlabel = darray.name
@@ -247,10 +243,6 @@ def line(darray, *args, **kwargs):
             yplt = darray.transpose(xlabel, huelabel)
 
         else:
-            if x is not None and x is not darray.name:
-                raise ValueError('Cannot make a plot with x=%r and y=%r '
-                                 % (x, y))
-
             ylabel, huelabel = _infer_xy_labels(darray=darray, x=y, y=hue)
             xlabel = darray.name
             xplt = darray.transpose(ylabel, huelabel)

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -224,13 +224,13 @@ def line(darray, *args, **kwargs):
         if x is not None and y is not None and x == y:
             raise ValueError('Cannot make a plot with x=%r and y=%r' % (x, y))
 
-        if (x is None and y is None) or x == dim or y is darray.name:
+        if (x is None and y is None) or x == dim or y == darray.name:
             xplt = darray.coords[dim]
             yplt = darray
             xlabel = dim
             ylabel = darray.name
 
-        elif y == dim or x is darray.name:
+        elif y == dim or x == darray.name:
             yplt = darray.coords[dim]
             xplt = darray
             xlabel = darray.name

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -91,14 +91,42 @@ class TestPlot(PlotTestCase):
     def test1d(self):
         self.darray[:, 0, 0].plot()
 
-        with raises_regex(ValueError, 'dimension'):
+        with raises_regex(ValueError, 'None'):
             self.darray[:, 0, 0].plot(x='dim_1')
+
+    def test_1d_x_y_kw(self):
+        z = np.arange(10)
+        da = DataArray(np.cos(z), dims=['z'], coords=[z], name='f')
+
+        xy = [[None, None],
+              [None, 'f'],
+              [None, 'z'],
+              ['f', None],
+              ['z', None],
+              ['z', 'f'],
+              ['f', 'z']]
+
+        f, ax = plt.subplots(2, 4)
+
+        for aa, (x, y) in enumerate(xy):
+            da.plot(x=x, y=y, ax=ax.flat[aa])
+            ax.flat[aa].set_title('x=' + str(x) + ' | '+'y='+str(y))
+
+        with raises_regex(ValueError, 'Cannot'):
+            da.plot(x='z', y='z')
 
     def test_2d_line(self):
         with raises_regex(ValueError, 'hue'):
             self.darray[:, :, 0].plot.line()
 
         self.darray[:, :, 0].plot.line(hue='dim_1')
+        self.darray[:, :, 0].plot.line(x='dim_1')
+        self.darray[:, :, 0].plot.line(y='dim_1')
+        self.darray[:, :, 0].plot.line(x='dim_0', hue='dim_1')
+        self.darray[:, :, 0].plot.line(y='dim_0', hue='dim_1')
+
+        with raises_regex(ValueError, 'Cannot'):
+            self.darray[:, :, 0].plot.line(x='dim_1', y='dim_0', hue='dim_1')
 
     def test_2d_line_accepts_legend_kw(self):
         self.darray[:, :, 0].plot.line(x='dim_0', add_legend=False)
@@ -279,6 +307,10 @@ class TestPlot1D(PlotTestCase):
         self.darray.plot()
         assert 'period' == plt.gca().get_xlabel()
 
+    def test_no_label_name_on_x_axis(self):
+        self.darray.plot(y='period')
+        self.assertEqual('', plt.gca().get_xlabel())
+
     def test_no_label_name_on_y_axis(self):
         self.darray.plot()
         assert '' == plt.gca().get_ylabel()
@@ -287,6 +319,11 @@ class TestPlot1D(PlotTestCase):
         self.darray.name = 'temperature'
         self.darray.plot()
         assert self.darray.name == plt.gca().get_ylabel()
+
+    def test_xlabel_is_data_name(self):
+        self.darray.name = 'temperature'
+        self.darray.plot(x=self.darray.name)
+        self.assertEqual(self.darray.name, plt.gca().get_xlabel())
 
     def test_format_string(self):
         self.darray.plot.line('ro')

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -102,11 +102,9 @@ class TestPlot(PlotTestCase):
               [None, 'z'],
               ['z', None]]
 
-        f, ax = plt.subplots(2, 4)
-
+        f, ax = plt.subplots(3, 1)
         for aa, (x, y) in enumerate(xy):
             da.plot(x=x, y=y, ax=ax.flat[aa])
-            ax.flat[aa].set_title('x=' + str(x) + ' | ' + 'y=' + str(y))
 
         with raises_regex(ValueError, 'cannot'):
             da.plot(x='z', y='z')

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -99,21 +99,23 @@ class TestPlot(PlotTestCase):
         da = DataArray(np.cos(z), dims=['z'], coords=[z], name='f')
 
         xy = [[None, None],
-              [None, 'f'],
               [None, 'z'],
-              ['f', None],
-              ['z', None],
-              ['z', 'f'],
-              ['f', 'z']]
+              ['z', None]]
 
         f, ax = plt.subplots(2, 4)
 
         for aa, (x, y) in enumerate(xy):
             da.plot(x=x, y=y, ax=ax.flat[aa])
-            ax.flat[aa].set_title('x=' + str(x) + ' | '+'y='+str(y))
+            ax.flat[aa].set_title('x=' + str(x) + ' | ' + 'y=' + str(y))
 
-        with raises_regex(ValueError, 'Cannot'):
+        with raises_regex(ValueError, 'cannot'):
             da.plot(x='z', y='z')
+
+        with raises_regex(ValueError, 'None'):
+            da.plot(x='f', y='z')
+
+        with raises_regex(ValueError, 'None'):
+            da.plot(x='z', y='f')
 
     def test_2d_line(self):
         with raises_regex(ValueError, 'hue'):
@@ -125,7 +127,7 @@ class TestPlot(PlotTestCase):
         self.darray[:, :, 0].plot.line(x='dim_0', hue='dim_1')
         self.darray[:, :, 0].plot.line(y='dim_0', hue='dim_1')
 
-        with raises_regex(ValueError, 'Cannot'):
+        with raises_regex(ValueError, 'cannot'):
             self.darray[:, :, 0].plot.line(x='dim_1', y='dim_0', hue='dim_1')
 
     def test_2d_line_accepts_legend_kw(self):
@@ -322,7 +324,7 @@ class TestPlot1D(PlotTestCase):
 
     def test_xlabel_is_data_name(self):
         self.darray.name = 'temperature'
-        self.darray.plot(x=self.darray.name)
+        self.darray.plot(y='period')
         self.assertEqual(self.darray.name, plt.gca().get_xlabel())
 
     def test_format_string(self):


### PR DESCRIPTION
 - [x] Partially closes #575 
 - [x] Tests added
 - [x] Tests passed
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

### Description
`plot.line` now supports both 1D and 2D DataArrays as input. I've changed  some variable names to make code clearer:
   1. set `xplt`, `yplt` to be values that are passed to `ax.plot()`
   2. `xlabel`, `ylabel` are axes labels
   3. `xdim`, `ydim` are dimension names

### Example
This code
```z = np.arange(10)
da = xr.DataArray(np.cos(z), dims=['z'], coords=[z], name='f')

xy = [[None, None],
     [None, 'f'],
     [None, 'z'],
     ['f', None],
      ['z', None],
      ['z', 'f'],
      ['f', 'z']]

f, ax = plt.subplots(2,4)

for aa, (x,y) in enumerate(xy):
    da.plot(x=x, y=y, ax=ax.flat[aa])
    ax.flat[aa].set_title('x='+str(x)+ ' | '+'y='+str(y))
```

yields

![image](https://user-images.githubusercontent.com/2448579/36409515-ca2d6d9e-15c0-11e8-9d04-c7c741ac3d5d.png)

### Feedback requested

Should I refactor out the kwarg checking? 