### PR TITLE
facetgrid: unset cmap if colors is specified.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -43,6 +43,8 @@ Bug fixes
 
 - Fix the precision drop after indexing datetime64 arrays (:issue:`1932`).
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+- Fix kwarg `colors` clashing with auto-inferred `cmap` (:issue:`1461`)
+  By `Deepak Cherian <https://github.com/dcherian>`_.
 
 .. _whats-new.0.10.1:
 

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -221,6 +221,14 @@ class FacetGrid(object):
         self : FacetGrid object
 
         """
+
+        cmapkw = kwargs.get('cmap')
+        colorskw = kwargs.get('colors')
+
+        # colors is mutually exclusive with cmap
+        if cmapkw and colorskw:
+            raise ValueError("Can't specify both cmap and colors.")
+
         # These should be consistent with xarray.plot._plot2d
         cmap_kwargs = {'plot_data': self.data.values,
                        # MPL default
@@ -232,6 +240,9 @@ class FacetGrid(object):
         cmap_kwargs.update((a, kwargs[a]) for a in cmap_args if a in kwargs)
 
         cmap_params = _determine_cmap_params(**cmap_kwargs)
+
+        if colorskw is not None:
+            cmap_params['cmap'] = None
 
         # Order is important
         func_kwargs = kwargs.copy()

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -902,6 +902,10 @@ class Common2dMixin:
         # check that all colormaps are the same
         assert len(set(m.get_cmap().name for m in fg._mappables)) == 1
 
+    def test_cmap_and_color_both(self):
+        with pytest.raises(ValueError):
+            self.plotmethod(colors='k', cmap='RdBu')
+
 
 @pytest.mark.slow
 class TestContourf(Common2dMixin, PlotTestCase):


### PR DESCRIPTION
 - [x] Closes #1461 
 - [x] Tests added
 - [x] Tests passed
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

This seemed the cleanest way to fix this. If both `colors` and `cmap` are specified, raise an error. If `colors` is specified and `cmap` was None, I set the auto-inferred `cmap` to None.