### PR TITLE
Fix precision drop when indexing a datetime64 arrays.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -41,6 +41,9 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- Fix the precision drop after indexing datetime64 arrays (:issue:`1932`).
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+
 .. _whats-new.0.10.1:
 
 v0.10.1 (25 February 2018)

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -891,7 +891,7 @@ class PandasIndexAdapter(ExplicitlyIndexedNDArrayMixin):
         key = indexer.tuple
         if isinstance(key, tuple) and len(key) == 1:
             # unpack key so it can index a pandas.Index object (pandas.Index
-            # objects don't like tuples)
+            # objects  don't like tuples)
             key, = key
 
         if getattr(key, 'ndim', 0) > 1:  # Return np-array if multidimensional
@@ -911,6 +911,10 @@ class PandasIndexAdapter(ExplicitlyIndexedNDArrayMixin):
                 result = np.datetime64('NaT', 'ns')
             elif isinstance(result, timedelta):
                 result = np.timedelta64(getattr(result, 'value', result), 'ns')
+            elif isinstance(result, pd.Timestamp):
+                # GH:1932 If a single item is indexed from DatetimeIndex,
+                # we need to convert it to np.datetime64
+                result = np.asarray(result.to_datetime64())
             elif self.dtype != object:
                 result = np.asarray(result, dtype=self.dtype)
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -912,8 +912,8 @@ class PandasIndexAdapter(ExplicitlyIndexedNDArrayMixin):
             elif isinstance(result, timedelta):
                 result = np.timedelta64(getattr(result, 'value', result), 'ns')
             elif isinstance(result, pd.Timestamp):
-                # GH:1932 If a single item is indexed from DatetimeIndex,
-                # we need to convert it to np.datetime64
+                # Work around for GH: pydata/xarray#1932 and numpy/numpy#10668
+                # numpy fails to convert pd.Timestamp to np.datetime64[ns]
                 result = np.asarray(result.to_datetime64())
             elif self.dtype != object:
                 result = np.asarray(result, dtype=self.dtype)

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -891,7 +891,7 @@ class PandasIndexAdapter(ExplicitlyIndexedNDArrayMixin):
         key = indexer.tuple
         if isinstance(key, tuple) and len(key) == 1:
             # unpack key so it can index a pandas.Index object (pandas.Index
-            # objects  don't like tuples)
+            # objects don't like tuples)
             key, = key
 
         if getattr(key, 'ndim', 0) > 1:  # Return np-array if multidimensional

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1719,6 +1719,13 @@ class TestIndexVariable(TestCase, VariableSubclassTestCases):
             x = Coordinate('x', [1, 2, 3])
         assert isinstance(x, IndexVariable)
 
+    def test_datetime64(self):
+        # GH:1932  Make sure indexing keeps precision
+        t = np.array([1518418799999986560, 1518418799999996560],
+                     dtype='datetime64[ns]')
+        v = IndexVariable('t', t)
+        assert v[0].data == t[0]
+
     # These tests make use of multi-dimensional variables, which are not valid
     # IndexVariable objects:
     @pytest.mark.xfail


### PR DESCRIPTION
 - [x] Closes #1932 
 - [x] Tests added
 - [x] Tests passed
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

This precision drop was caused when converting `pd.Timestamp` to `np.array`
```python
In [7]: ts = pd.Timestamp(np.datetime64('2018-02-12 06:59:59.999986560'))
In [11]: np.asarray(ts, 'datetime64[ns]')
Out[11]: array('2018-02-12T06:59:59.999986000', dtype='datetime64[ns]')
```

We need to call `to_datetime64` explicitly.
