### PR TITLE
Better error message for vectorize=True in apply_ufunc with old numpy

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -50,6 +50,9 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- Raise an informative error message when using ``apply_ufunc`` with numpy
+  v1.11 (:issue:`1956`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
 - Fix the precision drop after indexing datetime64 arrays (:issue:`1932`).
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -882,7 +882,7 @@ def apply_ufunc(func, *args, **kwargs):
         func = functools.partial(func, **kwargs_)
 
     if vectorize:
-        if signature.all_output_core_dims:
+        if signature.all_core_dims:
             # we need the signature argument
             if LooseVersion(np.__version__) < '1.12':  # pragma: no cover
                 raise NotImplementedError(

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1,8 +1,7 @@
 """
 Functions for applying functions that act on arrays to xarray's labeled data.
-
-NOT PUBLIC API.
 """
+from __future__ import absolute_import, division, print_function
 from distutils.version import LooseVersion
 import functools
 import itertools

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -896,7 +896,7 @@ def apply_ufunc(func, *args, **kwargs):
                                 excluded=set(kwargs))
         else:
             func = np.vectorize(func,
-                                otype=output_dtypes,
+                                otypes=output_dtypes,
                                 excluded=set(kwargs))
 
     variables_ufunc = functools.partial(apply_variable_ufunc, func,


### PR DESCRIPTION
 - [x] Closes #1956 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
