### PR TITLE
Make constructing slices lazily.

### DIFF
--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -8,26 +8,39 @@ import xarray as xr
 from . import parameterized, randn, requires_dask
 
 nx = 3000
+long_nx = 30000200
 ny = 2000
 nt = 1000
 window = 20
+
+randn_xy = randn((nx, ny), frac_nan=0.1)
+randn_xt = randn((nx, nt))
+randn_t = randn((nt, ))
+randn_long = randn((long_nx, ), frac_nan=0.1)
 
 
 class Rolling(object):
     def setup(self, *args, **kwargs):
         self.ds = xr.Dataset(
-            {'var1': (('x', 'y'), randn((nx, ny), frac_nan=0.1)),
-             'var2': (('x', 't'), randn((nx, nt))),
-             'var3': (('t', ), randn(nt))},
+            {'var1': (('x', 'y'), randn_xy),
+             'var2': (('x', 't'), randn_xt),
+             'var3': (('t', ), randn_t)},
             coords={'x': np.arange(nx),
                     'y': np.linspace(0, 1, ny),
                     't': pd.date_range('1970-01-01', periods=nt, freq='D'),
                     'x_coords': ('x', np.linspace(1.1, 2.1, nx))})
+        self.da_long = xr.DataArray(randn_long, dims='x',
+                                    coords={'x': np.arange(long_nx) * 0.1})
 
     @parameterized(['func', 'center'],
                    (['mean', 'count'], [True, False]))
     def time_rolling(self, func, center):
         getattr(self.ds.rolling(x=window, center=center), func)()
+
+    @parameterized(['func', 'center'],
+                   (['mean', 'count'], [True, False]))
+    def time_rolling_long(self, func, center):
+        getattr(self.da_long.rolling(x=window, center=center), func)()
 
     @parameterized(['window_', 'min_periods'],
                    ([20, 40], [5, None]))
@@ -47,3 +60,4 @@ class RollingDask(Rolling):
         requires_dask()
         super(RollingDask, self).setup(**kwargs)
         self.ds = self.ds.chunk({'x': 100, 'y': 50, 't': 50})
+        self.da_long = self.da_long.chunk({'x': 100, 'y': 50, 't': 50})

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -8,7 +8,7 @@ import xarray as xr
 from . import parameterized, randn, requires_dask
 
 nx = 3000
-long_nx = 30000200
+long_nx = 30000000
 ny = 2000
 nt = 1000
 window = 20
@@ -37,10 +37,14 @@ class Rolling(object):
     def time_rolling(self, func, center):
         getattr(self.ds.rolling(x=window, center=center), func)()
 
-    @parameterized(['func', 'center'],
+    @parameterized(['func', 'pandas'],
                    (['mean', 'count'], [True, False]))
-    def time_rolling_long(self, func, center):
-        getattr(self.da_long.rolling(x=window, center=center), func)()
+    def time_rolling_long(self, func, pandas):
+        if pandas:
+            se = self.da_long.to_series()
+            getattr(se.rolling(window=window), func)()
+        else:
+            getattr(self.da_long.rolling(x=window), func)()
 
     @parameterized(['window_', 'min_periods'],
                    ([20, 40], [5, None]))
@@ -60,4 +64,4 @@ class RollingDask(Rolling):
         requires_dask()
         super(RollingDask, self).setup(**kwargs)
         self.ds = self.ds.chunk({'x': 100, 'y': 50, 't': 50})
-        self.da_long = self.da_long.chunk({'x': 100, 'y': 50, 't': 50})
+        self.da_long = self.da_long.chunk({'x': 10000})

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -37,6 +37,10 @@ Documentation
 Enhancements
 ~~~~~~~~~~~~
 
+ - Some speed improvement to construct :py:class:`~xarray.DataArrayRolling`
+ object (:issue:`1993`)
+ By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -153,13 +153,12 @@ class DataArrayRolling(Rolling):
                                                center=center, **windows)
 
         self.window_labels = self.obj[self.dim]
-        self._stops = np.arange(1, len(self.window_labels) + 1)
-        self._starts = self._stops - int(self.window)
-        self._starts[:int(self.window)] = 0
 
     def __iter__(self):
-        for (label, start, stop) in zip(self.window_labels, self._starts,
-                                        self._stops):
+        _stops = np.arange(1, len(self.window_labels) + 1)
+        _starts = _stops - int(self.window)
+        _starts[:int(self.window)] = 0
+        for (label, start, stop) in zip(self.window_labels, _starts, _stops):
             window = self.obj.isel(**{self.dim: slice(start, stop)})
 
             counts = window.count(dim=self.dim)

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -155,10 +155,10 @@ class DataArrayRolling(Rolling):
         self.window_labels = self.obj[self.dim]
 
     def __iter__(self):
-        _stops = np.arange(1, len(self.window_labels) + 1)
-        _starts = _stops - int(self.window)
-        _starts[:int(self.window)] = 0
-        for (label, start, stop) in zip(self.window_labels, _starts, _stops):
+        stops = np.arange(1, len(self.window_labels) + 1)
+        starts = stops - int(self.window)
+        starts[:int(self.window)] = 0
+        for (label, start, stop) in zip(self.window_labels, starts, stops):
             window = self.obj.isel(**{self.dim: slice(start, stop)})
 
             counts = window.count(dim=self.dim)

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -153,8 +153,9 @@ class DataArrayRolling(Rolling):
                                                center=center, **windows)
 
         self.window_labels = self.obj[self.dim]
-        self._stops = np.arange(len(self.window_labels)) + 1
-        self._starts = np.maximum(self._stops - int(self.window), 0)
+        self._stops = np.arange(1, len(self.window_labels) + 1)
+        self._starts = self._stops - int(self.window)
+        self._starts[:int(self.window)] = 0
 
     def __iter__(self):
         for (label, start, stop) in zip(self.window_labels, self._starts,


### PR DESCRIPTION
 - [x] Closes #1993 
 - [x] Tests passed
 - [x] Fully documented, including `whats-new.rst` for all changes.

Quick fix of #1993.

With this fix, the script shown in #1993 runs
Bottleneck:  0.08317923545837402 s
Pandas:  1.3338768482208252 s
Xarray:  1.1349339485168457 s