### PR TITLE
Fix using xarray's own times for slice indexing

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,6 +40,10 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- Fixed labeled indexing with slice bounds given by xarray objects with
+  datetime64 or timedelta64 dtypes (:issue:`1240`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
+
 .. _whats-new.0.10.2:
 
 v0.10.2 (13 March 2018)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -779,6 +779,22 @@ class TestDataArray(TestCase):
         assert 'new_dim' in actual.coords
         assert_equal(actual['new_dim'].drop('x'), ind['new_dim'])
 
+    def test_sel_invalid_slice(self):
+        array = DataArray(np.arange(10), [('x', np.arange(10))])
+        with raises_regex(ValueError, 'cannot use non-scalar arrays'):
+            array.sel(x=slice(array.x))
+
+    def test_sel_dataarray_datetime(self):
+        # regression test for GH1240
+        times = pd.date_range('2000-01-01', freq='D', periods=365)
+        array = DataArray(np.arange(365), [('time', times)])
+        result = array.sel(time=slice(array.time[0], array.time[-1]))
+        assert_equal(result, array)
+
+        array = DataArray(np.arange(365), [('delta', times - times[0])])
+        result = array.sel(delta=slice(array.delta[0], array.delta[-1]))
+        assert_equal(result, array)
+
     def test_sel_no_index(self):
         array = DataArray(np.arange(10), dims='x')
         assert_identical(array[0], array.sel(x=0))


### PR DESCRIPTION
 - [x] Closes #1240 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
