### PR TITLE
Remove note about xray from docs index

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,12 +17,6 @@ pandas excels. Our approach adopts the `Common Data Model`_ for self-
 describing scientific data in widespread use in the Earth sciences:
 ``xarray.Dataset`` is an in-memory representation of a netCDF file.
 
-.. note::
-
-   xray is now xarray! See :ref:`the v0.7.0 release notes<whats-new.0.7.0>`
-   for more details. The preferred URL for these docs is now
-   http://xarray.pydata.org.
-
 .. _pandas: http://pandas.pydata.org
 .. _Common Data Model: http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/CDM
 .. _netCDF: http://www.unidata.ucar.edu/software/netcdf


### PR DESCRIPTION
We made this change several years ago now -- it's no longer timely news to
share with users.