### PR TITLE
rolling: periodic

### DIFF
--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -146,7 +146,12 @@ def rolling_window(a, axis, window, center, fill_value):
         pads[axis] = (start, end)
     else:
         pads[axis] = (window - 1, 0)
-    a = np.pad(a, pads, mode='constant', constant_values=fill_value)
+
+    if fill_value == 'periodic':
+        a = np.pad(a, pads, mode='wrap')
+    else:
+        a = np.pad(a, pads, mode='constant', constant_values=fill_value)
+
     return _rolling_window(a, window, axis)
 
 

--- a/xarray/tests/test_nputils.py
+++ b/xarray/tests/test_nputils.py
@@ -53,3 +53,20 @@ def test_rolling():
     actual = rolling_window(x, axis=-1, window=3, center=False, fill_value=0.0)
     expected = np.stack([expected, expected * 1.1], axis=0)
     assert_array_equal(actual, expected)
+
+    x = np.array([1, 2, 3, 4], dtype=float)
+    actual = rolling_window(x, axis=-1, window=3, center=True,
+                            fill_value='periodic')
+    expected = np.array([[4, 1, 2],
+                         [1, 2, 3],
+                         [2, 3, 4],
+                         [3, 4, 1]], dtype=float)
+    assert_array_equal(actual, expected)
+
+    actual = rolling_window(x, axis=-1, window=3, center=False,
+                            fill_value='periodic')
+    expected = np.array([[3, 4, 1],
+                         [4, 1, 2],
+                         [1, 2, 3],
+                         [2, 3, 4]], dtype=float)
+    assert_array_equal(actual, expected)


### PR DESCRIPTION
 - [x] Closes #2007
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

---

Ok, this was easier to do than initially thought, we can use `np.pad(a, pads, mode='wrap')` in `nputils.rolling_window`. However, I'm not sure if that is enough already<sup>*</sup>.

I added an initial test, but could use some pointers where else you want this to be tested.

Questions:
* is `fill_value='periodic'` a good api?
* should the `fill_value` keyvalue be ported to `rolling`?
* should this also be mentioned in the docs for `rolling`  (I only learned about `rolling.construct` yesterday)

---
<sup>*</sup>`rolling` is present in`core/dataset.py`, `core/dataarray.py`, `core/variable.py`, `core/rolling.py`, `core/dask_array_ops.py`, `core/nputils.py`, `core/ops.py`, `core/common.py`, `core/missing.py`, and `core/duck_array_ops.py` that can be a bit daunting...

