### PR TITLE
One pytest config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = -p no:hypothesis

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ universal = 1
 
 [tool:pytest]
 python_files=test_*.py
+testpaths=xarray/tests
 
 [flake8]
 max-line-length=79


### PR DESCRIPTION
Currently our pytest settings in `setup.cfg` are ignored, because they're overridden by the presence of a `pytest.ini`

This restores pytest looking at `setup.cfg`, gives us a single place to put configs, and retains the 'no hypothesis by default'. Hypothesis is still run in travis, which specifically calls `pytest properties`