### PR TITLE
xfail tests that append to netCDF files with scipy

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1404,23 +1404,23 @@ class ZarrDirectoryStoreTest(BaseZarrTest, TestCase):
             yield tmp
 
 
-class ScipyTest(CFEncodedDataTest, NetCDF3Only):
+class ScipyWriteTest(CFEncodedDataTest, NetCDF3Only):
 
     def test_append_write(self):
         import scipy
         if scipy.__version__ == '1.0.1':
             pytest.xfail('https://github.com/scipy/scipy/issues/8625')
-        super(ScipyTest, self).test_append_write()
+        super(ScipyWriteTest, self).test_append_write()
 
     def test_append_overwrite_values(self):
         import scipy
         if scipy.__version__ == '1.0.1':
             pytest.xfail('https://github.com/scipy/scipy/issues/8625')
-        super(ScipyTest, self).test_append_overwrite_values()
+        super(ScipyWriteTest, self).test_append_overwrite_values()
 
 
 @requires_scipy
-class ScipyInMemoryDataTest(ScipyTest, TestCase):
+class ScipyInMemoryDataTest(ScipyWriteTest, TestCase):
     engine = 'scipy'
 
     @contextlib.contextmanager
@@ -1446,7 +1446,7 @@ class ScipyInMemoryDataTestAutocloseTrue(ScipyInMemoryDataTest):
 
 
 @requires_scipy
-class ScipyFileObjectTest(ScipyTest, TestCase):
+class ScipyFileObjectTest(ScipyWriteTest, TestCase):
     engine = 'scipy'
 
     @contextlib.contextmanager
@@ -1474,7 +1474,7 @@ class ScipyFileObjectTest(ScipyTest, TestCase):
 
 
 @requires_scipy
-class ScipyFilePathTest(ScipyTest, TestCase):
+class ScipyFilePathTest(ScipyWriteTest, TestCase):
     engine = 'scipy'
 
     @contextlib.contextmanager
@@ -2183,7 +2183,7 @@ class PydapOnlineTest(PydapTest):
 
 @requires_scipy
 @requires_pynio
-class TestPyNio(CFEncodedDataTest, NetCDF3Only, TestCase):
+class PyNioTest(ScipyWriteTest, TestCase):
     def test_write_store(self):
         # pynio is read-only for now
         pass
@@ -2209,7 +2209,7 @@ class TestPyNio(CFEncodedDataTest, NetCDF3Only, TestCase):
             assert_identical(actual, expected)
 
 
-class TestPyNioAutocloseTrue(TestPyNio):
+class PyNioTestAutocloseTrue(PyNioTest):
     autoclose = True
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1404,8 +1404,23 @@ class ZarrDirectoryStoreTest(BaseZarrTest, TestCase):
             yield tmp
 
 
+class ScipyTest(CFEncodedDataTest, NetCDF3Only):
+
+    def test_append_write(self):
+        import scipy
+        if scipy.__version__ == '1.0.1':
+            pytest.xfail('https://github.com/scipy/scipy/issues/8625')
+        super(ScipyTest, self).test_append_write()
+
+    def test_append_overwrite_values(self):
+        import scipy
+        if scipy.__version__ == '1.0.1':
+            pytest.xfail('https://github.com/scipy/scipy/issues/8625')
+        super(ScipyTest, self).test_append_overwrite_values()
+
+
 @requires_scipy
-class ScipyInMemoryDataTest(CFEncodedDataTest, NetCDF3Only, TestCase):
+class ScipyInMemoryDataTest(ScipyTest, TestCase):
     engine = 'scipy'
 
     @contextlib.contextmanager
@@ -1431,7 +1446,7 @@ class ScipyInMemoryDataTestAutocloseTrue(ScipyInMemoryDataTest):
 
 
 @requires_scipy
-class ScipyFileObjectTest(CFEncodedDataTest, NetCDF3Only, TestCase):
+class ScipyFileObjectTest(ScipyTest, TestCase):
     engine = 'scipy'
 
     @contextlib.contextmanager
@@ -1459,7 +1474,7 @@ class ScipyFileObjectTest(CFEncodedDataTest, NetCDF3Only, TestCase):
 
 
 @requires_scipy
-class ScipyFilePathTest(CFEncodedDataTest, NetCDF3Only, TestCase):
+class ScipyFilePathTest(ScipyTest, TestCase):
     engine = 'scipy'
 
     @contextlib.contextmanager


### PR DESCRIPTION
These are broken by SciPy 1.0.1.

For details, see https://github.com/pydata/xarray/issues/2019

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
