### PR TITLE
Fix test_88_character_filename_segmentation_fault

### DIFF
--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -264,6 +264,7 @@ class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
         if (len(filename) == 88 and
                 LooseVersion(nc4.__version__) < "1.3.1"):
             warnings.warn(
+<<<<<<< Updated upstream
                 '\nA segmentation fault may occur when the\n'
                 'file path has exactly 88 characters as it does\n'
                 'in this case. The issue is known to occur with\n'
@@ -271,6 +272,15 @@ class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
                 'upgrading netCDF4 to at least version 1.3.1.\n'
                 'More details can be found here:\n'
                 'https://github.com/pydata/xarray/issues/1745  \n')
+=======
+                'A segmentation fault may occur when the '
+                'file path has exactly 88 characters as it does '
+                'in this case. The issue is known to occur with '
+                'version 1.2.4 of netCDF4 and can be addressed by '
+                'upgrading netCDF4 to at least version 1.3.1. '
+                'More details can be found here: '
+                'https://github.com/pydata/xarray/issues/1745')
+>>>>>>> Stashed changes
         if format is None:
             format = 'NETCDF4'
         opener = functools.partial(_open_netcdf4_group, filename, mode=mode,

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -264,15 +264,6 @@ class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
         if (len(filename) == 88 and
                 LooseVersion(nc4.__version__) < "1.3.1"):
             warnings.warn(
-<<<<<<< Updated upstream
-                '\nA segmentation fault may occur when the\n'
-                'file path has exactly 88 characters as it does\n'
-                'in this case. The issue is known to occur with\n'
-                'version 1.2.4 of netCDF4 and can be addressed by\n'
-                'upgrading netCDF4 to at least version 1.3.1.\n'
-                'More details can be found here:\n'
-                'https://github.com/pydata/xarray/issues/1745  \n')
-=======
                 'A segmentation fault may occur when the '
                 'file path has exactly 88 characters as it does '
                 'in this case. The issue is known to occur with '
@@ -280,7 +271,6 @@ class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
                 'upgrading netCDF4 to at least version 1.3.1. '
                 'More details can be found here: '
                 'https://github.com/pydata/xarray/issues/1745')
->>>>>>> Stashed changes
         if format is None:
             format = 'NETCDF4'
         opener = functools.partial(_open_netcdf4_group, filename, mode=mode,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1137,8 +1137,10 @@ class NetCDF4DataTest(BaseNetCDF4Test, TestCase):
         # should be fixed in netcdf4 v1.3.1
         with mock.patch('netCDF4.__version__', '1.2.4'):
             with warnings.catch_warnings():
-                warnings.simplefilter("error")
-                with raises_regex(Warning, 'segmentation fault'):
+                message = ('A segmentation fault may occur when the '
+                           'file path has exactly 88 characters')
+                warnings.filterwarnings('error', message)
+                with pytest.raises(Warning):
                     # Need to construct 88 character filepath
                     xr.Dataset().to_netcdf('a' * (88 - len(os.getcwd()) - 1))
 


### PR DESCRIPTION
This test was turning all warnings into errors. Now it's more robust, and only
converts the appropriate warning into an error.

 - [x] Closes #2025 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
