### PR TITLE
Raise an informative error message when converting Dataset -> np.ndarray

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -47,6 +47,9 @@ Bug fixes
 - Fixed labeled indexing with slice bounds given by xarray objects with
   datetime64 or timedelta64 dtypes (:issue:`1240`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
+- Attempting to convert an xarray.Dataset into a numpy array now raises an
+  informative error message.
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 .. _whats-new.0.10.2:
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -849,6 +849,12 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
                       FutureWarning, stacklevel=2)
         return iter(self._variables)
 
+    def __array__(self, dtype=None):
+        raise TypeError('cannot directly convert an xarray.Dataset into a '
+                        'numpy array. Instead, create an xarray.DataArray '
+                        'first, either with indexing on the Dataset or by '
+                        'invoking the `to_array()` method.')
+
     @property
     def nbytes(self):
         return sum(v.nbytes for v in self.variables.values())

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -443,6 +443,11 @@ class TestDataset(TestCase):
         assert Dataset({'x': np.int64(1),
                         'y': np.float32([1, 2])}).nbytes == 16
 
+    def test_asarray(self):
+        ds = Dataset({'x': 0})
+        with raises_regex(TypeError, 'cannot directly convert'):
+            np.asarray(ds)
+
     def test_get_index(self):
         ds = Dataset({'foo': (('x', 'y'), np.zeros((2, 3)))},
                      coords={'x': ['a', 'b']})


### PR DESCRIPTION
Makes `np.asarray(dataset)` issue an informative error. Currently,
`np.asarray(xr.Dataset({'x': 0}))` raises `KeyError: 0`, which makes no sense.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
