### PR TITLE
Refactor string coding and fix string support in zarr

### DIFF
--- a/xarray/backends/memory.py
+++ b/xarray/backends/memory.py
@@ -37,9 +37,6 @@ class InMemoryDataStore(AbstractWritableDataStore):
 
     def prepare_variable(self, k, v, *args, **kwargs):
         new_var = Variable(v.dims, np.empty_like(v), v.attrs)
-        # we copy the variable and stuff all encodings in the
-        # attributes to imitate what happens when writing to disk.
-        new_var.attrs.update(v.encoding)
         self._variables[k] = new_var
         return new_var, v.data
 

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -7,10 +7,11 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
-from .. import Variable, conventions
-from ..conventions import pop_to
+from .. import Variable, coding
+from ..coding.variables import pop_to
 from ..core import indexing
-from ..core.pycompat import PY3, OrderedDict, basestring, iteritems, suppress
+from ..core.pycompat import (
+    PY3, OrderedDict, basestring, iteritems, suppress)
 from ..core.utils import FrozenOrderedDict, close_on_error, is_remote_uri
 from .common import (
     HDF5_LOCK, BackendArray, DataStorePickleMixin, WritableCFDataStore,
@@ -82,8 +83,9 @@ class NetCDF4ArrayWrapper(BaseNetCDF4Array):
 
 
 def _encode_nc4_variable(var):
-    if var.dtype.kind == 'S':
-        var = conventions.maybe_encode_as_char_array(var)
+    for coder in [coding.strings.EncodedStringCoder(allows_unicode=True),
+                  coding.strings.CharacterArrayCoder()]:
+        var = coder.encode(var)
     return var
 
 
@@ -96,12 +98,13 @@ def _get_datatype(var, nc_format='NETCDF4'):
 
 
 def _nc4_dtype(var):
-    if var.dtype.kind == 'U':
+    if coding.strings.is_unicode_dtype(var.dtype):
         dtype = str
     elif var.dtype.kind in ['i', 'u', 'f', 'c', 'S']:
         dtype = var.dtype
     else:
-        raise ValueError('cannot infer dtype for netCDF4 variable')
+        raise ValueError('unsupported dtype for netCDF4 variable: {}'
+                         .format(var.dtype))
     return dtype
 
 

--- a/xarray/backends/netcdf3.py
+++ b/xarray/backends/netcdf3.py
@@ -4,7 +4,7 @@ import unicodedata
 
 import numpy as np
 
-from .. import Variable, conventions
+from .. import Variable, coding
 from ..core.pycompat import OrderedDict, basestring, unicode_type
 
 # Special characters that are permitted in netCDF names except in the
@@ -65,7 +65,9 @@ def encode_nc3_attrs(attrs):
 
 
 def encode_nc3_variable(var):
-    var = conventions.maybe_encode_as_char_array(var)
+    for coder in [coding.strings.EncodedStringCoder(allows_unicode=False),
+                  coding.strings.CharacterArrayCoder()]:
+        var = coder.encode(var)
     data = coerce_nc3_dtype(var.data)
     attrs = encode_nc3_attrs(var.attrs)
     return Variable(var.dims, data, attrs, var.encoding)

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -236,7 +236,13 @@ def encode_zarr_variable(var, needs_copy=True, name=None):
     var = conventions.maybe_default_fill_value(var)
     var = conventions.maybe_encode_bools(var)
     var = conventions.ensure_dtype_not_object(var, name=name)
-    var = conventions.maybe_encode_string_dtype(var, name=name)
+
+    # zarr allows unicode, but not variable-length strings, so it's both
+    # simpler and more compact to always encode as UTF-8 explicitly.
+    # TODO: allow toggling this explicitly via dtype in encoding.
+    coder = coding.strings.EncodedStringCoder(allows_unicode=False)
+    var = coder.encode(var, name=name)
+
     return var
 
 

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from base64 import b64encode
 from itertools import product
 from distutils.version import LooseVersion
 
@@ -25,21 +24,9 @@ def _encode_zarr_attr_value(value):
     # this checks if it's a scalar number
     elif isinstance(value, np.generic):
         encoded = value.item()
-        # np.string_('X').item() returns a type `bytes`
-        # zarr still doesn't like that
-        if type(encoded) is bytes:  # noqa
-            encoded = b64encode(encoded)
     else:
         encoded = value
     return encoded
-
-
-def _ensure_valid_fill_value(value, dtype):
-    if dtype.type == np.string_ and type(value) == bytes:  # noqa
-        valid = b64encode(value)
-    else:
-        valid = value
-    return _encode_zarr_attr_value(valid)
 
 
 class ZarrArrayWrapper(BackendArray):
@@ -221,27 +208,14 @@ def encode_zarr_variable(var, needs_copy=True, name=None):
         A variable which has been encoded as described above.
     """
 
-    if var.dtype.kind == 'O':
-        raise NotImplementedError("Variable `%s` is an object. Zarr "
-                                  "store can't yet encode objects." % name)
-
-    for coder in [coding.times.CFDatetimeCoder(),
-                  coding.times.CFTimedeltaCoder(),
-                  coding.variables.CFScaleOffsetCoder(),
-                  coding.variables.CFMaskCoder(),
-                  coding.variables.UnsignedIntegerCoder()]:
-        var = coder.encode(var, name=name)
-
-    var = conventions.maybe_encode_nonstring_dtype(var, name=name)
-    var = conventions.maybe_default_fill_value(var)
-    var = conventions.maybe_encode_bools(var)
-    var = conventions.ensure_dtype_not_object(var, name=name)
+    var = conventions.encode_cf_variable(var, name=name)
 
     # zarr allows unicode, but not variable-length strings, so it's both
     # simpler and more compact to always encode as UTF-8 explicitly.
     # TODO: allow toggling this explicitly via dtype in encoding.
     coder = coding.strings.EncodedStringCoder(allows_unicode=False)
     var = coder.encode(var, name=name)
+    var = coding.strings.ensure_fixed_length_bytes(var)
 
     return var
 
@@ -345,8 +319,7 @@ class ZarrStore(AbstractWritableDataStore):
         dtype = variable.dtype
         shape = variable.shape
 
-        fill_value = _ensure_valid_fill_value(attrs.pop('_FillValue', None),
-                                              dtype)
+        fill_value = attrs.pop('_FillValue', None)
         if variable.encoding == {'_FillValue': None} and fill_value is None:
             variable.encoding = {}
 

--- a/xarray/coding/strings.py
+++ b/xarray/coding/strings.py
@@ -49,7 +49,7 @@ class EncodedStringCoder(VariableCoder):
             if '_FillValue' in attrs:
                 raise NotImplementedError(
                     'variable {!r} has a _FillValue specified, but '
-                    '_FillValue is yet supported on unicode strings: '
+                    '_FillValue is not yet supported on unicode strings: '
                     'https://github.com/pydata/xarray/issues/1647'
                     .format(name))
 

--- a/xarray/coding/strings.py
+++ b/xarray/coding/strings.py
@@ -1,0 +1,214 @@
+"""Coders for strings."""
+from __future__ import absolute_import, division, print_function
+
+from functools import partial
+
+import numpy as np
+
+from ..core import indexing
+from ..core.pycompat import bytes_type, dask_array_type, unicode_type
+from ..core.variable import Variable
+from .variables import (
+    VariableCoder, lazy_elemwise_func, pop_to,
+    safe_setitem, unpack_for_decoding, unpack_for_encoding)
+
+
+def create_vlen_dtype(element_type):
+    # based on h5py.special_dtype
+    return np.dtype('O', metadata={'element_type': element_type})
+
+
+def check_vlen_dtype(dtype):
+    if dtype.kind != 'O' or dtype.metadata is None:
+        return None
+    else:
+        return dtype.metadata.get('element_type')
+
+
+def is_unicode_dtype(dtype):
+    return dtype.kind == 'U' or check_vlen_dtype(dtype) == unicode_type
+
+
+def is_bytes_dtype(dtype):
+    return dtype.kind == 'S' or check_vlen_dtype(dtype) == bytes_type
+
+
+class EncodedStringCoder(VariableCoder):
+    """Transforms between unicode strings and fixed-width UTF-8 bytes."""
+
+    def __init__(self, allows_unicode=True):
+        self.allows_unicode = allows_unicode
+
+    def encode(self, variable, name=None):
+        dims, data, attrs, encoding = unpack_for_encoding(variable)
+
+        contains_unicode = is_unicode_dtype(data.dtype)
+        encode_as_char = 'dtype' in encoding and encoding['dtype'] == 'S1'
+
+        if contains_unicode and (encode_as_char or not self.allows_unicode):
+            if '_FillValue' in attrs:
+                raise NotImplementedError(
+                    'variable {!r} has a _FillValue specified, but '
+                    '_FillValue is yet supported on unicode strings: '
+                    'https://github.com/pydata/xarray/issues/1647'
+                    .format(name))
+
+            string_encoding = encoding.pop('_Encoding', 'utf-8')
+            safe_setitem(attrs, '_Encoding', string_encoding, name=name)
+            # TODO: figure out how to handle this in a lazy way with dask
+            data = encode_string_array(data, string_encoding)
+
+        return Variable(dims, data, attrs, encoding)
+
+    def decode(self, variable, name=None):
+        dims, data, attrs, encoding = unpack_for_decoding(variable)
+
+        if '_Encoding' in attrs:
+            string_encoding = pop_to(attrs, encoding, '_Encoding')
+            func = partial(decode_bytes_array, encoding=string_encoding)
+            data = lazy_elemwise_func(data, func, np.dtype(object))
+
+        return Variable(dims, data, attrs, encoding)
+
+
+def decode_bytes_array(bytes_array, encoding='utf-8'):
+    # This is faster than using np.char.decode() or np.vectorize()
+    bytes_array = np.asarray(bytes_array)
+    decoded = [x.decode(encoding) for x in bytes_array.ravel()]
+    return np.array(decoded, dtype=object).reshape(bytes_array.shape)
+
+
+def encode_string_array(string_array, encoding='utf-8'):
+    string_array = np.asarray(string_array)
+    encoded = [x.encode(encoding) for x in string_array.ravel()]
+    return np.array(encoded, dtype=bytes).reshape(string_array.shape)
+
+
+class CharacterArrayCoder(VariableCoder):
+    """Transforms between arrays containing bytes and character arrays."""
+
+    def encode(self, variable, name=None):
+        dims, data, attrs, encoding = unpack_for_encoding(variable)
+
+        if check_vlen_dtype(data.dtype) == bytes_type:
+            # TODO: figure out how to handle this with dask
+            data = np.asarray(data, dtype=np.string_)
+
+        if data.dtype.kind == 'S':  # and data.dtype.itemsize > 1:
+            data = bytes_to_char(data)
+            dims = dims + ('string%s' % data.shape[-1],)
+
+        return Variable(dims, data, attrs, encoding)
+
+    def decode(self, variable, name=None):
+        dims, data, attrs, encoding = unpack_for_decoding(variable)
+
+        if data.dtype == 'S1' and dims:
+            dims = dims[:-1]
+            data = char_to_bytes(data)
+
+        return Variable(dims, data, attrs, encoding)
+
+
+def bytes_to_char(arr):
+    """Convert numpy/dask arrays from fixed width bytes to characters."""
+    if arr.dtype.kind != 'S':
+        raise ValueError('argument must have a fixed-width bytes dtype')
+
+    if isinstance(arr, dask_array_type):
+        import dask.array as da
+        return da.map_blocks(_numpy_bytes_to_char, arr,
+                             dtype='S1',
+                             chunks=arr.chunks + ((arr.dtype.itemsize,)),
+                             new_axis=[arr.ndim])
+    else:
+        return _numpy_bytes_to_char(arr)
+
+
+def _numpy_bytes_to_char(arr):
+    """Like netCDF4.stringtochar, but faster and more flexible.
+    """
+    # ensure the array is contiguous
+    arr = np.array(arr, copy=False, order='C', dtype=np.string_)
+    return arr.reshape(arr.shape + (1,)).view('S1')
+
+
+def char_to_bytes(arr):
+    """Convert numpy/dask arrays from characters to fixed width bytes."""
+    if arr.dtype != 'S1':
+        raise ValueError("argument must have dtype='S1'")
+
+    if not arr.ndim:
+        # no dimension to concatenate along
+        return arr
+
+    size = arr.shape[-1]
+
+    if not size:
+        # can't make an S0 dtype
+        return np.zeros(arr.shape[:-1], dtype=np.string_)
+
+    if isinstance(arr, dask_array_type):
+        import dask.array as da
+
+        if len(arr.chunks[-1]) > 1:
+            raise ValueError('cannot stacked dask character array with '
+                             'multiple chunks in the last dimension: {}'
+                             .format(arr))
+
+        dtype = np.dtype('S' + str(arr.shape[-1]))
+        return da.map_blocks(_numpy_char_to_bytes, arr,
+                             dtype=dtype,
+                             chunks=arr.chunks[:-1],
+                             drop_axis=[arr.ndim - 1])
+    else:
+        return StackedBytesArray(arr)
+
+
+def _numpy_char_to_bytes(arr):
+    """Like netCDF4.chartostring, but faster and more flexible.
+    """
+    # based on: http://stackoverflow.com/a/10984878/809705
+    arr = np.array(arr, copy=False, order='C')
+    dtype = 'S' + str(arr.shape[-1])
+    return arr.view(dtype).reshape(arr.shape[:-1])
+
+
+class StackedBytesArray(indexing.ExplicitlyIndexedNDArrayMixin):
+    """Wrapper around array-like objects to create a new indexable object where
+    values, when accessed, are automatically stacked along the last dimension.
+
+    >>> StackedBytesArray(np.array(['a', 'b', 'c']))[:]
+    array('abc',
+          dtype='|S3')
+    """
+
+    def __init__(self, array):
+        """
+        Parameters
+        ----------
+        array : array-like
+            Original array of values to wrap.
+        """
+        if array.dtype != 'S1':
+            raise ValueError(
+                "can only use StackedBytesArray if argument has dtype='S1'")
+        self.array = indexing.as_indexable(array)
+
+    @property
+    def dtype(self):
+        return np.dtype('S' + str(self.array.shape[-1]))
+
+    @property
+    def shape(self):
+        return self.array.shape[:-1]
+
+    def __repr__(self):
+        return ('%s(%r)' % (type(self).__name__, self.array))
+
+    def __getitem__(self, key):
+        # require slicing the last dimension completely
+        key = type(key)(indexing.expanded_indexer(key.tuple, self.array.ndim))
+        if key.tuple[-1] != slice(None):
+            raise IndexError('too many indices')
+        return _numpy_char_to_bytes(self.array[key])

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -129,10 +129,10 @@ def _apply_mask(data,  # type: np.ndarray
                 dtype,  # type: Any
                 ):  # type: np.ndarray
     """Mask all matching values in a NumPy arrays."""
+    data = np.asarray(data, dtype=dtype)
     condition = False
     for fv in encoded_fill_values:
         condition |= data == fv
-    data = np.asarray(data, dtype=dtype)
     return np.where(condition, decoded_fill_value, data)
 
 

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -292,6 +292,7 @@ def decode_cf_variable(name, var, concat_characters=True, mask_and_scale=True,
                       variables.CFMaskCoder(),
                       variables.CFScaleOffsetCoder()]:
             var = coder.decode(var, name=name)
+
     if decode_times:
         for coder in [times.CFTimedeltaCoder(),
                       times.CFDatetimeCoder()]:

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -6,98 +6,13 @@ from collections import defaultdict
 import numpy as np
 import pandas as pd
 
-from .coding import times, variables
+from .coding import times, strings, variables
 from .coding.variables import SerializationWarning
 from .core import duck_array_ops, indexing
-from .core.pycompat import OrderedDict, basestring, iteritems, dask_array_type
+from .core.pycompat import (
+    OrderedDict, basestring, bytes_type, iteritems, dask_array_type,
+    unicode_type)
 from .core.variable import IndexVariable, Variable, as_variable
-
-
-class StackedBytesArray(indexing.ExplicitlyIndexedNDArrayMixin):
-    """Wrapper around array-like objects to create a new indexable object where
-    values, when accessed, are automatically stacked along the last dimension.
-
-    >>> StackedBytesArray(np.array(['a', 'b', 'c']))[:]
-    array('abc',
-          dtype='|S3')
-    """
-
-    def __init__(self, array):
-        """
-        Parameters
-        ----------
-        array : array-like
-            Original array of values to wrap.
-        """
-        if array.dtype != 'S1':
-            raise ValueError(
-                "can only use StackedBytesArray if argument has dtype='S1'")
-        self.array = indexing.as_indexable(array)
-
-    @property
-    def dtype(self):
-        return np.dtype('S' + str(self.array.shape[-1]))
-
-    @property
-    def shape(self):
-        return self.array.shape[:-1]
-
-    def __str__(self):
-        # TODO(shoyer): figure out why we need this special case?
-        if self.ndim == 0:
-            return str(np.array(self).item())
-        else:
-            return repr(self)
-
-    def __repr__(self):
-        return ('%s(%r)' % (type(self).__name__, self.array))
-
-    def __getitem__(self, key):
-        # require slicing the last dimension completely
-        key = type(key)(indexing.expanded_indexer(key.tuple, self.array.ndim))
-        if key.tuple[-1] != slice(None):
-            raise IndexError('too many indices')
-        return char_to_bytes(self.array[key])
-
-
-class BytesToStringArray(indexing.ExplicitlyIndexedNDArrayMixin):
-    """Wrapper that decodes bytes to unicode when values are read.
-
-    >>> BytesToStringArray(np.array([b'abc']))[:]
-    array(['abc'],
-          dtype=object)
-    """
-
-    def __init__(self, array, encoding='utf-8'):
-        """
-        Parameters
-        ----------
-        array : array-like
-            Original array of values to wrap.
-        encoding : str
-            String encoding to use.
-        """
-        self.array = indexing.as_indexable(array)
-        self.encoding = encoding
-
-    @property
-    def dtype(self):
-        # variable length string
-        return np.dtype(object)
-
-    def __str__(self):
-        # TODO(shoyer): figure out why we need this special case?
-        if self.ndim == 0:
-            return str(np.array(self).item())
-        else:
-            return repr(self)
-
-    def __repr__(self):
-        return ('%s(%r, encoding=%r)'
-                % (type(self).__name__, self.array, self.encoding))
-
-    def __getitem__(self, key):
-        return decode_bytes_array(self.array[key], self.encoding)
 
 
 class NativeEndiannessArray(indexing.ExplicitlyIndexedNDArrayMixin):
@@ -159,110 +74,8 @@ class BoolTypeArray(indexing.ExplicitlyIndexedNDArrayMixin):
         return np.asarray(self.array[key], dtype=self.dtype)
 
 
-def bytes_to_char(arr):
-    """Like netCDF4.stringtochar, but faster and more flexible.
-    """
-    # ensure the array is contiguous
-    arr = np.array(arr, copy=False, order='C')
-    kind = arr.dtype.kind
-    if kind not in ['U', 'S']:
-        raise ValueError('argument must be a string array')
-    return arr.reshape(arr.shape + (1,)).view(kind + '1')
-
-
-def char_to_bytes(arr):
-    """Like netCDF4.chartostring, but faster and more flexible.
-    """
-    # based on: http://stackoverflow.com/a/10984878/809705
-    arr = np.array(arr, copy=False, order='C')
-
-    kind = arr.dtype.kind
-    if kind not in ['U', 'S']:
-        raise ValueError('argument must be a string array')
-
-    if not arr.ndim:
-        # no dimension to concatenate along
-        return arr
-
-    size = arr.shape[-1]
-    if not size:
-        # can't make an S0 dtype
-        return np.zeros(arr.shape[:-1], dtype=kind)
-
-    dtype = kind + str(size)
-    return arr.view(dtype).reshape(arr.shape[:-1])
-
-
-def decode_bytes_array(bytes_array, encoding='utf-8'):
-    # This is faster than using np.char.decode() or np.vectorize()
-    bytes_array = np.asarray(bytes_array)
-    decoded = [x.decode(encoding) for x in bytes_array.ravel()]
-    return np.array(decoded, dtype=object).reshape(bytes_array.shape)
-
-
-def encode_string_array(string_array, encoding='utf-8'):
-    string_array = np.asarray(string_array)
-    encoded = [x.encode(encoding) for x in string_array.ravel()]
-    return np.array(encoded, dtype=bytes).reshape(string_array.shape)
-
-
-def safe_setitem(dest, key, value, name=None):
-    if key in dest:
-        var_str = ' on variable {!r}'.format(name) if name else ''
-        raise ValueError(
-            'failed to prevent overwriting existing key {} in attrs{}. '
-            'This is probably an encoding field used by xarray to describe '
-            'how a variable is serialized. To proceed, remove this key from '
-            "the variable's attributes manually.".format(key, var_str))
-    dest[key] = value
-
-
-def pop_to(source, dest, key, name=None):
-    """
-    A convenience function which pops a key k from source to dest.
-    None values are not passed on.  If k already exists in dest an
-    error is raised.
-    """
-    value = source.pop(key, None)
-    if value is not None:
-        safe_setitem(dest, key, value, name=name)
-    return value
-
-
 def _var_as_tuple(var):
     return var.dims, var.data, var.attrs.copy(), var.encoding.copy()
-
-
-def maybe_encode_as_char_array(var, name=None):
-    if var.dtype.kind in {'S', 'U'}:
-        dims, data, attrs, encoding = _var_as_tuple(var)
-        if data.dtype.kind == 'U':
-            if '_FillValue' in attrs:
-                raise NotImplementedError(
-                    'variable {!r} has a _FillValue specified, but '
-                    '_FillValue is yet supported on unicode strings: '
-                    'https://github.com/pydata/xarray/issues/1647'
-                    .format(name))
-
-            string_encoding = encoding.pop('_Encoding', 'utf-8')
-            safe_setitem(attrs, '_Encoding', string_encoding, name=name)
-            data = encode_string_array(data, string_encoding)
-
-        if data.dtype.itemsize > 1:
-            data = bytes_to_char(data)
-            dims = dims + ('string%s' % data.shape[-1],)
-
-        var = Variable(dims, data, attrs, encoding)
-    return var
-
-
-def maybe_encode_string_dtype(var, name=None):
-    # need to apply after ensure_dtype_not_object()
-    if 'dtype' in var.encoding and var.encoding['dtype'] == 'S1':
-        assert var.dtype.kind in {'S', 'U'}
-        var = maybe_encode_as_char_array(var, name=name)
-        del var.encoding['dtype']
-    return var
 
 
 def maybe_encode_nonstring_dtype(var, name=None):
@@ -306,19 +119,23 @@ def _infer_dtype(array, name=None):
     """Given an object array with no missing values, infer its dtype from its
     first element
     """
+    if array.dtype.kind != 'O':
+        raise TypeError('infer_type must be called on a dtype=object array')
+
     if array.size == 0:
-        dtype = np.dtype(float)
-    else:
-        dtype = np.array(array[(0,) * array.ndim]).dtype
-        if dtype.kind in ['S', 'U']:
-            # don't just use inferred dtype to avoid truncating arrays to
-            # the length of their first element
-            dtype = np.dtype(dtype.kind)
-        elif dtype.kind == 'O':
-            raise ValueError('unable to infer dtype on variable {!r}; xarray '
-                             'cannot serialize arbitrary Python objects'
-                             .format(name))
-    return dtype
+        return np.dtype(float)
+
+    element = array[(0,) * array.ndim]
+    if isinstance(element, (bytes_type, unicode_type)):
+        return strings.create_vlen_dtype(type(element))
+
+    dtype = np.array(element).dtype
+    if dtype.kind != 'O':
+        return dtype
+
+    raise ValueError('unable to infer dtype on variable {!r}; xarray '
+                     'cannot serialize arbitrary Python objects'
+                     .format(name))
 
 
 def ensure_not_multiindex(var, name=None):
@@ -332,10 +149,32 @@ def ensure_not_multiindex(var, name=None):
             'variables instead.'.format(name))
 
 
+def _copy_with_dtype(data, dtype):
+    """Create a copy of an array with the given dtype.
+
+    We use this instead of np.array() to ensure that custom object dtypes end
+    up on the resulting array.
+    """
+    result = np.empty(data.shape, dtype)
+    result[...] = data
+    return result
+
+
 def ensure_dtype_not_object(var, name=None):
     # TODO: move this from conventions to backends? (it's not CF related)
     if var.dtype.kind == 'O':
         dims, data, attrs, encoding = _var_as_tuple(var)
+
+        if isinstance(data, dask_array_type):
+            warnings.warn(
+                'variable {} has data in the form of a dask array with '
+                'dtype=object, which means it is being loaded into memory '
+                'to determine a data type that can be safely stored on disk. '
+                'To avoid this, coerce this variable to a fixed-size dtype '
+                'with astype() before saving it.'.format(name),
+                SerializationWarning)
+            data = data.compute()
+
         missing = pd.isnull(data)
         if missing.any():
             # nb. this will fail for dask.array data
@@ -345,9 +184,9 @@ def ensure_dtype_not_object(var, name=None):
             # There is no safe bit-pattern for NA in typical binary string
             # formats, we so can't set a fill_value. Unfortunately, this means
             # we can't distinguish between missing values and empty strings.
-            if inferred_dtype.kind == 'S':
+            if strings.is_bytes_dtype(inferred_dtype):
                 fill_value = b''
-            elif inferred_dtype.kind == 'U':
+            elif strings.is_unicode_dtype(inferred_dtype):
                 fill_value = u''
             else:
                 # insist on using float for numeric values
@@ -355,10 +194,12 @@ def ensure_dtype_not_object(var, name=None):
                     inferred_dtype = np.dtype(float)
                 fill_value = inferred_dtype.type(np.nan)
 
-            data = np.array(data, dtype=inferred_dtype, copy=True)
+            data = _copy_with_dtype(data, dtype=inferred_dtype)
             data[missing] = fill_value
         else:
-            data = data.astype(dtype=_infer_dtype(data, name))
+            data = _copy_with_dtype(data, dtype=_infer_dtype(data, name))
+
+        assert data.dtype.kind != 'O' or data.dtype.metadata
         var = Variable(dims, data, attrs, encoding)
     return var
 
@@ -397,7 +238,6 @@ def encode_cf_variable(var, needs_copy=True, name=None):
     var = maybe_default_fill_value(var)
     var = maybe_encode_bools(var)
     var = ensure_dtype_not_object(var, name=name)
-    var = maybe_encode_string_dtype(var, name=name)
     return var
 
 
@@ -439,26 +279,13 @@ def decode_cf_variable(name, var, concat_characters=True, mask_and_scale=True,
     out : Variable
         A variable holding the decoded equivalent of var.
     """
-    # use _data instead of data so as not to trigger loading data
     var = as_variable(var)
-    data = var._data
-    dimensions = var.dims
-    attributes = var.attrs.copy()
-    encoding = var.encoding.copy()
+    original_dtype = var.dtype
 
-    original_dtype = data.dtype
-
-    if concat_characters and data.dtype.kind == 'S':
+    if concat_characters:
         if stack_char_dim:
-            dimensions = dimensions[:-1]
-            data = StackedBytesArray(data)
-
-        string_encoding = pop_to(attributes, encoding, '_Encoding')
-        if string_encoding is not None:
-            data = BytesToStringArray(data, string_encoding)
-
-    # TODO(shoyer): convert everything above to use coders
-    var = Variable(dimensions, data, attributes, encoding)
+            var = strings.CharacterArrayCoder().decode(var, name=name)
+        var = strings.EncodedStringCoder().decode(var)
 
     if mask_and_scale:
         for coder in [variables.UnsignedIntegerCoder(),
@@ -492,6 +319,7 @@ def decode_cf_variable(name, var, concat_characters=True, mask_and_scale=True,
 
     if not isinstance(data, dask_array_type):
         data = indexing.LazilyOuterIndexedArray(data)
+
     return Variable(dimensions, data, attributes, encoding=encoding)
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1354,24 +1354,6 @@ class BaseZarrTest(CFEncodedDataTest):
                             open_kwargs={'group': group}) as actual:
             assert_identical(original, actual)
 
-    # TODO: implement zarr object encoding and make these tests pass
-    @pytest.mark.xfail(reason="Zarr object encoding not implemented")
-    def test_multiindex_not_implemented(self):
-        super(CFEncodedDataTest, self).test_multiindex_not_implemented()
-
-    @pytest.mark.xfail(reason="Zarr object encoding not implemented")
-    def test_roundtrip_bytes_with_fill_value(self):
-        super(CFEncodedDataTest, self).test_roundtrip_bytes_with_fill_value()
-
-    @pytest.mark.xfail(reason="Zarr object encoding not implemented")
-    def test_roundtrip_object_dtype(self):
-        super(CFEncodedDataTest, self).test_roundtrip_object_dtype()
-
-    @pytest.mark.xfail(reason="Zarr object encoding not implemented")
-    def test_roundtrip_string_encoded_characters(self):
-        super(CFEncodedDataTest,
-              self).test_roundtrip_string_encoded_characters()
-
     # TODO: someone who understand caching figure out whether chaching
     # makes sense for Zarr backend
     @pytest.mark.xfail(reason="Zarr caching not implemented")

--- a/xarray/tests/test_coding_strings.py
+++ b/xarray/tests/test_coding_strings.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+import pytest
+
+from xarray import Variable
+from xarray.core.pycompat import bytes_type, unicode_type, suppress
+from xarray.coding import strings
+from xarray.core import indexing
+
+from . import (IndexerMaker, assert_array_equal, assert_identical,
+               raises_regex, requires_dask)
+
+
+with suppress(ImportError):
+    import dask.array as da
+
+
+def test_vlen_dtype():
+    dtype = strings.create_vlen_dtype(unicode_type)
+    assert dtype.metadata['element_type'] == unicode_type
+    assert strings.is_unicode_dtype(dtype)
+    assert not strings.is_bytes_dtype(dtype)
+    assert strings.check_vlen_dtype(dtype) is unicode_type
+
+    dtype = strings.create_vlen_dtype(bytes_type)
+    assert dtype.metadata['element_type'] == bytes_type
+    assert not strings.is_unicode_dtype(dtype)
+    assert strings.is_bytes_dtype(dtype)
+    assert strings.check_vlen_dtype(dtype) is bytes_type
+
+    assert strings.check_vlen_dtype(np.dtype(object)) is None
+
+
+def test_EncodedStringCoder_decode():
+    coder = strings.EncodedStringCoder()
+
+    raw_data = np.array([b'abc', u'ß∂µ∆'.encode('utf-8')])
+    raw = Variable(('x',), raw_data, {'_Encoding': 'utf-8'})
+    actual = coder.decode(raw)
+
+    expected = Variable(
+        ('x',), np.array([u'abc', u'ß∂µ∆'], dtype=object))
+    assert_identical(actual, expected)
+
+    assert_identical(coder.decode(actual[0]), expected[0])
+
+
+@requires_dask
+def test_EncodedStringCoder_decode_dask():
+    coder = strings.EncodedStringCoder()
+
+    raw_data = np.array([b'abc', u'ß∂µ∆'.encode('utf-8')])
+    raw = Variable(('x',), raw_data, {'_Encoding': 'utf-8'}).chunk()
+    actual = coder.decode(raw)
+    assert isinstance(actual.data, da.Array)
+
+    expected = Variable(
+        ('x',), np.array([u'abc', u'ß∂µ∆'], dtype=object)).chunk()
+    assert_identical(actual, expected)
+
+    actual_indexed = coder.decode(actual[0])
+    assert isinstance(actual_indexed.data, da.Array)
+    assert_identical(actual_indexed, expected[0])
+
+
+def test_EncodedStringCoder_encode():
+    dtype = strings.create_vlen_dtype(unicode_type)
+    raw_data = np.array([u'abc', u'ß∂µ∆'], dtype=dtype)
+    expected_data = np.array([r.encode('utf-8') for r in raw_data],
+                             dtype=object)
+
+    coder = strings.EncodedStringCoder(allows_unicode=True)
+    raw = Variable(('x',), raw_data, encoding={'dtype': 'S1'})
+    actual = coder.encode(raw)
+    expected = Variable(('x',), expected_data, attrs={'_Encoding': 'utf-8'})
+    assert_identical(actual, expected)
+
+    raw = Variable(('x',), raw_data)
+    assert_identical(coder.encode(raw), raw)
+
+    coder = strings.EncodedStringCoder(allows_unicode=False)
+    assert_identical(coder.encode(raw), expected)
+
+
+@pytest.mark.parametrize('original', [
+    Variable(('x',), [b'ab', b'cdef']),
+    Variable((), b'ab'),
+    Variable(('x',), [b'a', b'b']),
+    Variable((), b'a'),
+])
+def test_CharacterArrayCoder_roundtrip(original):
+    coder = strings.CharacterArrayCoder()
+    roundtripped = coder.decode(coder.encode(original))
+    assert_identical(original, roundtripped)
+
+
+@pytest.mark.parametrize('data', [
+    np.array([b'a', b'bc']),
+    np.array([b'a', b'bc'], dtype=strings.create_vlen_dtype(bytes_type)),
+])
+def test_CharacterArrayCoder_encode(data):
+    coder = strings.CharacterArrayCoder()
+    raw = Variable(('x',), data)
+    actual = coder.encode(raw)
+    expected = Variable(('x', 'string2'),
+                        np.array([[b'a', b''], [b'b', b'c']]))
+    assert_identical(actual, expected)
+
+
+def test_StackedBytesArray():
+    array = np.array([[b'a', b'b', b'c'], [b'd', b'e', b'f']], dtype='S')
+    actual = strings.StackedBytesArray(array)
+    expected = np.array([b'abc', b'def'], dtype='S')
+    assert actual.dtype == expected.dtype
+    assert actual.shape == expected.shape
+    assert actual.size == expected.size
+    assert actual.ndim == expected.ndim
+    assert len(actual) == len(expected)
+    assert_array_equal(expected, actual)
+
+    B = IndexerMaker(indexing.BasicIndexer)
+    assert_array_equal(expected[:1], actual[B[:1]])
+    with pytest.raises(IndexError):
+        actual[B[:, :2]]
+
+
+def test_StackedBytesArray_scalar():
+    array = np.array([b'a', b'b', b'c'], dtype='S')
+    actual = strings.StackedBytesArray(array)
+
+    expected = np.array(b'abc')
+    assert actual.dtype == expected.dtype
+    assert actual.shape == expected.shape
+    assert actual.size == expected.size
+    assert actual.ndim == expected.ndim
+    with pytest.raises(TypeError):
+        len(actual)
+    np.testing.assert_array_equal(expected, actual)
+
+    B = IndexerMaker(indexing.BasicIndexer)
+    with pytest.raises(IndexError):
+        actual[B[:2]]
+
+
+def test_StackedBytesArray_vectorized_indexing():
+    array = np.array([[b'a', b'b', b'c'], [b'd', b'e', b'f']], dtype='S')
+    stacked = strings.StackedBytesArray(array)
+    expected = np.array([[b'abc', b'def'], [b'def', b'abc']])
+
+    V = IndexerMaker(indexing.VectorizedIndexer)
+    indexer = V[np.array([[0, 1], [1, 0]])]
+    actual = stacked[indexer]
+    assert_array_equal(actual, expected)
+
+
+def test_char_to_bytes():
+    array = np.array([[b'a', b'b', b'c'], [b'd', b'e', b'f']])
+    expected = np.array([b'abc', b'def'])
+    actual = strings.char_to_bytes(array)
+    assert_array_equal(actual, expected)
+
+    expected = np.array([b'ad', b'be', b'cf'])
+    actual = strings.char_to_bytes(array.T)  # non-contiguous
+    assert_array_equal(actual, expected)
+
+
+def test_char_to_bytes_ndim_zero():
+    expected = np.array(b'a')
+    actual = strings.char_to_bytes(expected)
+    assert_array_equal(actual, expected)
+
+
+def test_char_to_bytes_size_zero():
+    array = np.zeros((3, 0), dtype='S1')
+    expected = np.array([b'', b'', b''])
+    actual = strings.char_to_bytes(array)
+    assert_array_equal(actual, expected)
+
+
+@requires_dask
+def test_char_to_bytes_dask():
+    numpy_array = np.array([[b'a', b'b', b'c'], [b'd', b'e', b'f']])
+    array = da.from_array(numpy_array, ((2,), (3,)))
+    expected = np.array([b'abc', b'def'])
+    actual = strings.char_to_bytes(array)
+    assert isinstance(actual, da.Array)
+    assert actual.chunks == ((2,),)
+    assert actual.dtype == 'S3'
+    assert_array_equal(np.array(actual), expected)
+
+    with raises_regex(ValueError, 'stacked dask character array'):
+        strings.char_to_bytes(array.rechunk(1))
+
+
+def test_bytes_to_char():
+    array = np.array([[b'ab', b'cd'], [b'ef', b'gh']])
+    expected = np.array([[[b'a', b'b'], [b'c', b'd']],
+                         [[b'e', b'f'], [b'g', b'h']]])
+    actual = strings.bytes_to_char(array)
+    assert_array_equal(actual, expected)
+
+    expected = np.array([[[b'a', b'b'], [b'e', b'f']],
+                         [[b'c', b'd'], [b'g', b'h']]])
+    actual = strings.bytes_to_char(array.T)  # non-contiguous
+    assert_array_equal(actual, expected)
+
+
+@requires_dask
+def test_bytes_to_char_dask():
+    numpy_array = np.array([b'ab', b'cd'])
+    array = da.from_array(numpy_array, ((1, 1),))
+    expected = np.array([[b'a', b'b'], [b'c', b'd']])
+    actual = strings.bytes_to_char(array)
+    assert isinstance(actual, da.Array)
+    assert actual.chunks == ((1, 1), ((2,)))
+    assert actual.dtype == 'S1'
+    assert_array_equal(np.array(actual), expected)

--- a/xarray/tests/test_coding_strings.py
+++ b/xarray/tests/test_coding_strings.py
@@ -56,8 +56,7 @@ def test_EncodedStringCoder_decode_dask():
     actual = coder.decode(raw)
     assert isinstance(actual.data, da.Array)
 
-    expected = Variable(
-        ('x',), np.array([u'abc', u'ß∂µ∆'], dtype=object)).chunk()
+    expected = Variable(('x',), np.array([u'abc', u'ß∂µ∆'], dtype=object))
     assert_identical(actual, expected)
 
     actual_indexed = coder.decode(actual[0])


### PR DESCRIPTION
Fixes #2057

This refactor will make it easier to use different coding for different backends. It also makes string decoding/encoding work properly with dask arrays, which I think was the issue responsible for #2057.

It includes using a special dtype with metadata (like h5py) to identify variable length strings. So in principle, we could now handle fixed width and variable length unicode differently.

I also took this opportunity to fix handling of strings in zarr. We now no longer convert into character arrays, but instead store as fixed length bytes (with UTF-8 encoding, if necessary). This wasn't really necessary, but it is a little cleaner, since zarr doesn't have the restriction of only supporting character arrays.

CC @rabernat @jhamman 