### PR TITLE
resolve #2071: 'bebroadcast' in ValueError msg

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -679,7 +679,7 @@ class Variable(common.AbstractArray, arithmetic.SupportsArithmetic,
             value = as_compatible_data(value)
             if value.ndim > len(dims):
                 raise ValueError(
-                    'shape mismatch: value array of shape %s could not be'
+                    'shape mismatch: value array of shape %s could not be '
                     'broadcast to indexing result with %s dimensions'
                     % (value.shape, len(dims)))
             if value.ndim == 0:


### PR DESCRIPTION
Simple spelling correction.

Add space to end of line halfway through error message on line 682 to avoid 'bebroadcast' on string concatenation.

 - [x] Closes #2071
 - ~~Tests added (for all bug fixes or enhancements)~~
 - [ ] Tests passed (for all non-documentation changes)
 - ~~Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)~~
