### PR TITLE
Better error handling in open_mfdataset for wildcard remote URLs

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,6 +40,8 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- Better error handling in ``open_mfdataset`` (:issue:`2077`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 .. _whats-new.0.10.3:
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -556,6 +556,11 @@ def open_mfdataset(paths, chunks=None, concat_dim=_CONCAT_DIM_DEFAULT,
     .. [2] http://xarray.pydata.org/en/stable/dask.html#chunking-and-performance
     """
     if isinstance(paths, basestring):
+        if is_remote_uri(paths):
+            raise ValueError(
+                'cannot do wild-card matching for paths that are remote URLs: '
+                '{!r}. Instead, supply paths as an explicit list of strings.'
+                .format(paths))
         paths = sorted(glob(paths))
     else:
         paths = [str(p) if isinstance(p, path_type) else p for p in paths]

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1928,6 +1928,9 @@ class DaskTest(TestCase, DatasetIOTestCases):
         with raises_regex(IOError, 'no files to open'):
             open_mfdataset('foo-bar-baz-*.nc', autoclose=self.autoclose)
 
+        with raises_regex(ValueError, 'wild-card'):
+            open_mfdataset('http://some/remote/uri', autoclose=self.autoclose)
+
     @requires_pathlib
     def test_open_mfdataset_pathlib(self):
         original = Dataset({'foo': ('x', np.random.randn(10))})


### PR DESCRIPTION
 - [x] Closes #2077 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
