### PR TITLE
Plotting upgrades

### DIFF
--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -207,6 +207,16 @@ It is also possible to make line plots such that the data are on the x-axis and 
     @savefig plotting_example_xy_kwarg.png
     air.isel(time=10, lon=[10, 11]).plot.line(y='lat', hue='lon')
 
+Changing Axes Direction
+-----------------------
+
+The keyword arguments ``xincrease`` and ``yincrease`` let you control the axes direction.
+
+.. ipython:: python
+
+    @savefig plotting_example_xincrease_yincrease_kwarg.png
+    air.isel(time=10, lon=[10, 11]).plot.line(y='lat', hue='lon', xincrease=False, yincrease=False)
+
 Two Dimensions
 --------------
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -42,6 +42,10 @@ Bug fixes
 
 - Better error handling in ``open_mfdataset`` (:issue:`2077`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
+- ``plot.line()`` does not call ``autofmt_xdate()`` anymore. Instead it changes the rotation and horizontal alignment of labels without removing the x-axes of any other subplots in the figure (if any).
+  By `Deepak Cherian <https://github.com/dcherian>`_.
+- ``plot.line()`` learned new kwargs: ``xincrease``, ``yincrease`` that change the direction of the respective axes.
+  By `Deepak Cherian <https://github.com/dcherian>`_.
 
 .. _whats-new.0.10.3:
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -278,7 +278,10 @@ def line(darray, *args, **kwargs):
 
     # Rotate dates on xlabels
     if np.issubdtype(xplt.dtype, np.datetime64):
-        ax.get_figure().autofmt_xdate()
+        for xlabels in ax.get_xticklabels():
+            xlabels.set_rotation(30)
+            xlabels.set_ha('right')
+
     _update_axes_limits(ax, xincrease, yincrease)
 
     return primitive

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -184,10 +184,10 @@ def line(darray, *args, **kwargs):
         plot method is called.
     xincrease : None, True, or False, optional
         Should the values on the x axes be increasing from left to right?
-        if None, use the default for the matplotlib function
+        if None, use the default for the matplotlib function.
     yincrease : None, True, or False, optional
         Should the values on the y axes be increasing from top to bottom?
-        if None, use the default for the matplotlib function
+        if None, use the default for the matplotlib function.
     add_legend : boolean, optional
         Add legend with y axis coordinates (2D inputs only).
     *args, **kwargs : optional
@@ -277,6 +277,9 @@ def line(darray, *args, **kwargs):
                   title=huelabel)
 
     # Rotate dates on xlabels
+    # Do this without calling autofmt_xdate so that x-axes ticks
+    # on other subplots (if any) are not deleted.
+    # https://stackoverflow.com/questions/17430105/autofmt-xdate-deletes-x-axis-labels-of-all-subplots
     if np.issubdtype(xplt.dtype, np.datetime64):
         for xlabels in ax.get_xticklabels():
             xlabels.set_rotation(30)
@@ -441,10 +444,10 @@ def _plot2d(plotfunc):
         Use together with ``col`` to wrap faceted plots
     xincrease : None, True, or False, optional
         Should the values on the x axes be increasing from left to right?
-        if None, use the default for the matplotlib function
+        if None, use the default for the matplotlib function.
     yincrease : None, True, or False, optional
         Should the values on the y axes be increasing from top to bottom?
-        if None, use the default for the matplotlib function
+        if None, use the default for the matplotlib function.
     add_colorbar : Boolean, optional
         Adds colorbar to axis
     add_labels : Boolean, optional

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -182,6 +182,12 @@ def line(darray, *args, **kwargs):
         Coordinates for x, y axis. Only one of these may be specified.
         The other coordinate plots values from the DataArray on which this
         plot method is called.
+    xincrease : None, True, or False, optional
+        Should the values on the x axes be increasing from left to right?
+        if None, use the default for the matplotlib function
+    yincrease : None, True, or False, optional
+        Should the values on the y axes be increasing from top to bottom?
+        if None, use the default for the matplotlib function
     add_legend : boolean, optional
         Add legend with y axis coordinates (2D inputs only).
     *args, **kwargs : optional
@@ -203,6 +209,8 @@ def line(darray, *args, **kwargs):
     hue = kwargs.pop('hue', None)
     x = kwargs.pop('x', None)
     y = kwargs.pop('y', None)
+    xincrease = kwargs.pop('xincrease', True)
+    yincrease = kwargs.pop('yincrease', True)
     add_legend = kwargs.pop('add_legend', True)
 
     ax = get_axis(figsize, size, aspect, ax)
@@ -271,6 +279,7 @@ def line(darray, *args, **kwargs):
     # Rotate dates on xlabels
     if np.issubdtype(xplt.dtype, np.datetime64):
         ax.get_figure().autofmt_xdate()
+    _update_axes_limits(ax, xincrease, yincrease)
 
     return primitive
 

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -21,6 +21,7 @@ def _load_default_cmap(fname='default_colormap.csv'):
     # Not sure what the first arg here should be
     f = pkg_resources.resource_stream(__name__, fname)
     cm_data = pd.read_csv(f, header=None).values
+    f.close()
 
     return LinearSegmentedColormap.from_list('viridis', cm_data)
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -352,6 +352,13 @@ class TestPlot1D(PlotTestCase):
         rotation = plt.gca().get_xticklabels()[0].get_rotation()
         assert rotation != 0
 
+    def test_xyincrease_false_changes_axes(self):
+        self.darray.plot.line(xincrease=False, yincrease=False)
+        xlim = plt.gca().get_xlim()
+        ylim = plt.gca().get_ylim()
+        diffs = xlim[1] - xlim[0], ylim[1] - ylim[0]
+        assert all(x < 0 for x in diffs)
+
     def test_slice_in_title(self):
         self.darray.coords['d'] = 10
         self.darray.plot.line()


### PR DESCRIPTION
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

`plot.line()` now accepts `xincrease`, `yincrease` kwargs (see bottom panel of image).

Additionally, instead of calling `autofmt_xdate()` which deletes all subplot x-axes except the last one, I rotate and set alignment for the x-axes labels manually. This allows for creating figures where not all subplots have time on the x-axis.

![image](https://user-images.githubusercontent.com/2448579/39437175-f5500502-4c54-11e8-889f-e8823e6ff956.png)

