### PR TITLE
Install cftime with pip on Windows

### DIFF
--- a/ci/requirements-py27-windows.yml
+++ b/ci/requirements-py27-windows.yml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - python=2.7
-  - cftime
   - dask
   - distributed
   - h5py
@@ -21,3 +20,5 @@ dependencies:
   - toolz
   - rasterio
   - zarr
+  - pip:
+    - cftime


### PR DESCRIPTION
This should fix our build failures on Appveyor.