### PR TITLE
Deprecate decode timedelta

### DIFF
--- a/doc/io.rst
+++ b/doc/io.rst
@@ -335,6 +335,10 @@ like ``'days'`` for ``timedelta64`` data. ``calendar`` should be one of the cale
 supported by netCDF4-python: 'standard', 'gregorian', 'proleptic_gregorian' 'noleap',
 '365_day', '360_day', 'julian', 'all_leap', '366_day'.
 
+The automatic decoding of untis like ``'days'`` to ``timedelta64`` is deprecated and
+will be removed in xarray version 0.11. The default behavior will keep the same numeric
+type of the original data instead of converting to ``timedelta64``.
+
 By default, xarray uses the 'proleptic_gregorian' calendar and units of the smallest time
 difference between values, with a reference time of the first time value.
 

--- a/doc/time-series.rst
+++ b/doc/time-series.rst
@@ -41,8 +41,8 @@ converted automatically when used as arguments in xarray objects:
     import datetime
     xr.Dataset({'time': datetime.datetime(2000, 1, 1)})
 
-When reading or writing netCDF files, xarray automatically decodes datetime and
-timedelta arrays using `CF conventions`_ (that is, by using a ``units``
+When reading or writing netCDF files, xarray automatically decodes datetime
+arrays using `CF conventions`_ (that is, by using a ``units``
 attribute like ``'days since 2000-01-01'``).
 
 .. _CF conventions: http://cfconventions.org

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,6 +40,19 @@ Enhancements
   This greatly boosts speed and allows chunking on the core dims.
   The function now requires dask >= 0.17.3 to work on dask-backed data
   (:issue:`2074`). By `Guido Imperiale <https://github.com/crusaderky>`_.
+- Deprecate the automatic decoding of time data to timedelta64 (:issue:`1621`).
+
+  .. ipython:: python
+
+    In [1]: wave_periods = xr.Variable(['t'], [0, 1, 2])
+    In [2]: wave_periods.attrs.update({'units': 'seconds'})
+    In [3]: current_behavior = xr.conventions.decode_cf_variable('t', wave_periods)
+    In [4]: print(current_behavior.dtype)
+            timedelta64[ns]
+    In [5]: with xr.set_options(enable_future_time_unit_decoding=True):
+       ...:     new_behavior = xr.conventions.decode_cf_variable('t', wave_periods)
+    In [6]: print(new_behavior.dtype)
+            int64
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -180,6 +180,9 @@ def decode_cf_timedelta(num_timedeltas, units):
     """Given an array of numeric timedeltas in netCDF format, convert it into a
     numpy timedelta64[ns] array.
     """
+    warnings.warn('Decoding timedeltas been deprecated and '
+                  'will be removed in xarray v??.',
+                  FutureWarning, stacklevel=2)
     num_timedeltas = np.asarray(num_timedeltas)
     units = _netcdf_to_numpy_timeunit(units)
 
@@ -362,10 +365,12 @@ class CFTimedeltaCoder(VariableCoder):
             data, units = encode_cf_timedelta(
                 data, encoding.pop('units', None))
             safe_setitem(attrs, 'units', units, name=name)
-
         return Variable(dims, data, attrs, encoding)
 
     def decode(self, variable, name=None):
+        warnings.warn('Decoding timedeltas been deprecated and '
+                      'will be removed in xarray v??.',
+                      FutureWarning, stacklevel=2)
         dims, data, attrs, encoding = unpack_for_decoding(variable)
 
         if 'units' in attrs and attrs['units'] in TIME_UNITS:

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -180,9 +180,6 @@ def decode_cf_timedelta(num_timedeltas, units):
     """Given an array of numeric timedeltas in netCDF format, convert it into a
     numpy timedelta64[ns] array.
     """
-    warnings.warn('Decoding timedeltas been deprecated and '
-                  'will be removed in xarray v??.',
-                  FutureWarning, stacklevel=2)
     num_timedeltas = np.asarray(num_timedeltas)
     units = _netcdf_to_numpy_timeunit(units)
 
@@ -365,12 +362,10 @@ class CFTimedeltaCoder(VariableCoder):
             data, units = encode_cf_timedelta(
                 data, encoding.pop('units', None))
             safe_setitem(attrs, 'units', units, name=name)
+
         return Variable(dims, data, attrs, encoding)
 
     def decode(self, variable, name=None):
-        warnings.warn('Decoding timedeltas been deprecated and '
-                      'will be removed in xarray v??.',
-                      FutureWarning, stacklevel=2)
         dims, data, attrs, encoding = unpack_for_decoding(variable)
 
         if 'units' in attrs and attrs['units'] in TIME_UNITS:

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -294,12 +294,16 @@ def decode_cf_variable(name, var, concat_characters=True, mask_and_scale=True,
                       variables.CFScaleOffsetCoder()]:
             var = coder.decode(var, name=name)
 
-    enable_future_time_unit_decoding = OPTIONS['enable_future_time_unit_decoding']
+    enable_future_time_unit_decoding = OPTIONS[
+        'enable_future_time_unit_decoding']
     if decode_times:
         if enable_future_time_unit_decoding:
             coder = times.CFDatetimeCoder()
             var = coder.decode(var, name=name)
         else:
+            warnings.warn('Decoding timedeltas been deprecated and '
+                          'will be removed in xarray v0.11.',
+                          FutureWarning, stacklevel=2)
             for coder in [times.CFTimedeltaCoder(),
                           times.CFDatetimeCoder()]:
                 var = coder.decode(var, name=name)

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -9,6 +9,7 @@ import pandas as pd
 from .coding import times, strings, variables
 from .coding.variables import SerializationWarning
 from .core import duck_array_ops, indexing
+from .core.options import OPTIONS
 from .core.pycompat import (
     OrderedDict, basestring, bytes_type, iteritems, dask_array_type,
     unicode_type)
@@ -293,10 +294,15 @@ def decode_cf_variable(name, var, concat_characters=True, mask_and_scale=True,
                       variables.CFScaleOffsetCoder()]:
             var = coder.decode(var, name=name)
 
+    enable_future_time_unit_decoding = OPTIONS['enable_future_time_unit_decoding']
     if decode_times:
-        for coder in [times.CFTimedeltaCoder(),
-                      times.CFDatetimeCoder()]:
+        if enable_future_time_unit_decoding:
+            coder = times.CFDatetimeCoder()
             var = coder.decode(var, name=name)
+        else:
+            for coder in [times.CFTimedeltaCoder(),
+                          times.CFDatetimeCoder()]:
+                var = coder.decode(var, name=name)
 
     dimensions, data, attributes, encoding = (
         variables.unpack_for_decoding(var))

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 OPTIONS = {
     'display_width': 80,
     'arithmetic_join': 'inner',
+    'enable_future_time_unit_decoding': False,
 }
 
 


### PR DESCRIPTION
 - [X] Closes #1621 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [X] Tests added (for all bug fixes or enhancements)
 - [X] Tests passed (for all non-documentation changes)
 - [X] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

I'll add tests, docs, and the whats-new entry later if I'm on the right path here.

xref.: #843, #940, and #2085

See http://nbviewer.jupyter.org/gist/ocefpaf/e736c07faf3d4c9361ecf546a692c2cd