### PR TITLE
DOC: Update link to documentation of Rasterio

### DIFF
--- a/doc/io.rst
+++ b/doc/io.rst
@@ -534,7 +534,7 @@ longitudes and latitudes.
     considered as being experimental. Please report any bug you may find
     on xarray's github repository.
 
-.. _rasterio: https://mapbox.github.io/rasterio/
+.. _rasterio: https://rasterio.readthedocs.io/en/latest/
 .. _test files: https://github.com/mapbox/rasterio/blob/master/tests/data/RGB.byte.tif
 .. _pyproj: https://github.com/jswhit/pyproj
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -785,7 +785,7 @@ Enhancements
   By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 - New function :py:func:`~xarray.open_rasterio` for opening raster files with
-  the `rasterio <https://mapbox.github.io/rasterio/>`_ library.
+  the `rasterio <https://rasterio.readthedocs.io/en/latest/>`_ library.
   See :ref:`the docs <io.rasterio>` for details.
   By `Joe Hamman <https://github.com/jhamman>`_,
   `Nic Wayand <https://github.com/NicWayand>`_ and


### PR DESCRIPTION
The documentation of Rasterio used to be at https://mapbox.github.io/rasterio/, but now you'll get a 404 and a pointer to https://rasterio.readthedocs.io/en/latest/. I've updated the links in `io.rst` and `whats-new.rst`.

Don't think I need to check the boxes below. :)

 - [NA] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [NA] Tests added (for all bug fixes or enhancements)
 - [NA] Tests passed (for all non-documentation changes)
 - [NA] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
