### PR TITLE
Fix to_iris conversion issues

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -59,6 +59,8 @@ Bug fixes
   By `Deepak Cherian <https://github.com/dcherian>`_.
 - ``plot.line()`` learned new kwargs: ``xincrease``, ``yincrease`` that change the direction of the respective axes.
   By `Deepak Cherian <https://github.com/dcherian>`_.
+- Fixed ``to_iris`` to maintain lazy dask array after conversion (:issue:`2046`).
+  By `Alex Hilson <https://github.com/AlexHilson>`_ and `Stephan Hoyer <https://github.com/shoyer>`_.
 
 .. _whats-new.0.10.3:
 

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -101,6 +101,9 @@ tensordot = _dask_or_eager_func('tensordot', array_args=slice(2))
 einsum = _dask_or_eager_func('einsum', array_args=slice(1, None),
                              requires_dask='0.17.3')
 
+masked_invalid = _dask_or_eager_func('masked_invalid', eager_module=np.ma,
+                                     dask_module=dask_array.ma)
+
 
 def asarray(data):
     return data if isinstance(data, dask_array_type) else np.asarray(data)

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -103,7 +103,7 @@ einsum = _dask_or_eager_func('einsum', array_args=slice(1, None),
 
 masked_invalid = _dask_or_eager_func(
     'masked_invalid', eager_module=np.ma,
-    dask_module=getattr(dask_array, 'ma', None)
+    dask_module=getattr(dask_array, 'ma', None))
 
 
 def asarray(data):

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -101,8 +101,9 @@ tensordot = _dask_or_eager_func('tensordot', array_args=slice(2))
 einsum = _dask_or_eager_func('einsum', array_args=slice(1, None),
                              requires_dask='0.17.3')
 
-masked_invalid = _dask_or_eager_func('masked_invalid', eager_module=np.ma,
-                                     dask_module=dask_array.ma)
+masked_invalid = _dask_or_eager_func(
+    'masked_invalid', eager_module=np.ma,
+    dask_module=getattr(dask_array, 'ma', None)
 
 
 def asarray(data):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3025,12 +3025,11 @@ class TestDataArray(TestCase):
         roundtripped = DataArray.from_iris(actual)
         assert_identical(original, roundtripped)
 
-        # If the Iris version supports it then we should get a dask array back
+        # If the Iris version supports it then we should have a dask array
+        # at each stage of the conversion
         if hasattr(actual, 'core_data'):
-            pass
-            # TODO This currently fails due to the decoding loading
-            # the data (#1372)
-            # self.assertEqual(type(original.data), type(roundtripped.data))
+            self.assertEqual(type(original.data), type(actual.core_data()))
+            self.assertEqual(type(original.data), type(roundtripped.data))
 
         actual.remove_coord('time')
         auto_time_dimension = DataArray.from_iris(actual)


### PR DESCRIPTION
- Add test for issue fixed in #2047 
- Add workaround for da.ma.masked_invalid setting a bad chunksize when given a DataArray rather than a Dask array. Tested manually but unsure how best to add a unit test for this.

 - [x] Closes #2046 
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)