### PR TITLE
Fix docstring formatting for load().

### DIFF
--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -198,7 +198,7 @@ class AbstractDataStore(Mapping):
         A centralized loading function makes it easier to create
         data stores that do automatic encoding/decoding.
 
-        For example:
+        For example::
 
             class SuffixAppendingDataStore(AbstractDataStore):
 


### PR DESCRIPTION
Need '::' to introduce a code literal block. This was causing MetPy's
doc build to warn (since we inherit AbstractDataStore).


