### PR TITLE
Prevent Inf from screwing colorbar scale.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -59,6 +59,8 @@ Bug fixes
   By `Deepak Cherian <https://github.com/dcherian>`_.
 - ``plot.line()`` learned new kwargs: ``xincrease``, ``yincrease`` that change the direction of the respective axes.
   By `Deepak Cherian <https://github.com/dcherian>`_.
+- Colorbar limits are now determined by excluding ±Infs too.
+  By `Deepak Cherian <https://github.com/dcherian>`_.
 
 .. _whats-new.0.10.3:
 

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -160,7 +160,7 @@ def _determine_cmap_params(plot_data, vmin=None, vmax=None, cmap=None,
     """
     import matplotlib as mpl
 
-    calc_data = np.ravel(plot_data[~pd.isnull(plot_data)])
+    calc_data = np.ravel(plot_data[np.isfinite(plot_data)])
 
     # Handle all-NaN input data gracefully
     if calc_data.size == 0:

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -426,6 +426,15 @@ class TestDetermineCmapParams(TestCase):
         assert cmap_params['levels'] is None
         assert cmap_params['norm'] is None
 
+    def test_nan_inf_are_ignored(self):
+        cmap_params1 = _determine_cmap_params(self.data)
+        data = self.data
+        data[50:55] = np.nan
+        data[56:60] = np.inf
+        cmap_params2 = _determine_cmap_params(data)
+        assert cmap_params1['vmin'] == cmap_params2['vmin']
+        assert cmap_params1['vmax'] == cmap_params2['vmax']
+
     @pytest.mark.slow
     def test_integer_levels(self):
         data = self.data + 1


### PR DESCRIPTION
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

The current version uses `pd.isnull` to remove invalid values from input data when making a colorbar. `pd.isnull([np.inf])` is False which means `_determine_cmap_params` returns Inf for colorbar limits which screws everything up. This PR changes `pd.isnull` to `np.isfinite`.