### PR TITLE
Fixes centerized rolling with bottleneck

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -49,6 +49,9 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- Fixed a bug in `rolling` with bottleneck. Also, fixed a bug in rolling an
+  integer dask array. (:issue:`21133`)
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - Fixed a bug where `keep_attrs=True` flag was neglected if
   :py:func:`apply_func` was used with :py:class:`Variable`. (:issue:`2114`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 
 from . import nputils
+from . import dtypes
 
 try:
     import dask.array as da
@@ -12,12 +13,14 @@ except ImportError:
 
 def dask_rolling_wrapper(moving_func, a, window, min_count=None, axis=-1):
     '''wrapper to apply bottleneck moving window funcs on dask arrays'''
+    dtype, fill_value = dtypes.maybe_promote(a.dtype)
+    a = a.astype(dtype)
     # inputs for ghost
     if axis < 0:
         axis = a.ndim + axis
     depth = {d: 0 for d in range(a.ndim)}
     depth[axis] = window - 1
-    boundary = {d: np.nan for d in range(a.ndim)}
+    boundary = {d: fill_value for d in range(a.ndim)}
     # create ghosted arrays
     ag = da.ghost.ghost(a, depth=depth, boundary=boundary)
     # apply rolling func

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -285,18 +285,26 @@ class DataArrayRolling(Rolling):
 
             padded = self.obj.variable
             if self.center:
-                shift = (-self.window // 2) + 1
-
                 if (LooseVersion(np.__version__) < LooseVersion('1.13') and
                         self.obj.dtype.kind == 'b'):
                     # with numpy < 1.13 bottleneck cannot handle np.nan-Boolean
                     # mixed array correctly. We cast boolean array to float.
                     padded = padded.astype(float)
+
+                if isinstance(padded.data, dask_array_type):
+                    # Workaround to make the padded chunk size is larger than
+                    # self.window-1
+                    shift = - (self.window - 1)
+                    offset = -shift - self.window // 2
+                    valid = (slice(None), ) * axis + (
+                        slice(offset, offset + self.obj.shape[axis]), )
+                else:
+                    shift = (-self.window // 2) + 1
+                    valid = (slice(None), ) * axis + (slice(-shift, None), )
                 padded = padded.pad_with_fill_value(**{self.dim: (0, -shift)})
-                valid = (slice(None), ) * axis + (slice(-shift, None), )
 
             if isinstance(padded.data, dask_array_type):
-                values = dask_rolling_wrapper(func, self.obj.data,
+                values = dask_rolling_wrapper(func, padded,
                                               window=self.window,
                                               min_count=min_count,
                                               axis=axis)


### PR DESCRIPTION
 - [x] Closes #2113
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Two bugs were found and fixed.

1. rolling a dask-array with center=True and bottleneck
2. rolling an integer dask-array with bottleneck