### PR TITLE
Raise an Error if a coordinate with wrong size is assigned to a dataarray

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -43,7 +43,7 @@ Enhancements
 - Allow for serialization of ``cftime.datetime`` objects (:issue:`789`,
   :issue:`1084`, :issue:`2008`, :issue:`1252`) using the standalone ``cftime``
          library. By `Spencer Clark
-         <https://github.com/spencerkclark>`_. 
+         <https://github.com/spencerkclark>`_.
 - Support writing lists of strings as netCDF attributes (:issue:`2044`).
   By `Dan Nowacki <https://github.com/dnowacki-usgs>`_.
 - :py:meth:`~xarray.Dataset.to_netcdf(engine='h5netcdf')` now accepts h5py
@@ -59,8 +59,11 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- Now raises an Error if a coordinate with wrong size is assigned to a
+  :py:class:`~xarray.DataArray`. (:issue:`2112`)
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - Fixed a bug in `rolling` with bottleneck. Also, fixed a bug in rolling an
-  integer dask array. (:issue:`21133`)
+  integer dask array. (:issue:`2113`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - Fixed a bug where `keep_attrs=True` flag was neglected if
   :py:func:`apply_func` was used with :py:class:`Variable`. (:issue:`2114`)

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -9,8 +9,13 @@ from . import formatting, indexing
 from .merge import (
     expand_and_merge_variables, merge_coords, merge_coords_for_inplace_math)
 from .pycompat import OrderedDict
-from .utils import Frozen
+from .utils import Frozen, ReprObject
 from .variable import Variable
+
+
+# Used as the key corresponding to a DataArray's variable when converting
+# arbitrary DataArray objects to datasets
+_THIS_ARRAY = ReprObject('<this-array>')
 
 
 class AbstractCoordinates(Mapping, formatting.ReprMixin):
@@ -225,7 +230,9 @@ class DataArrayCoordinates(AbstractCoordinates):
     def _update_coords(self, coords):
         from .dataset import calculate_dimensions
 
-        dims = calculate_dimensions(coords)
+        coords_plus_data = coords.copy()
+        coords_plus_data[_THIS_ARRAY] = self._data.variable
+        dims = calculate_dimensions(coords_plus_data)
         if not set(dims) <= set(self.dims):
             raise ValueError('cannot add coordinates with new dimensions to '
                              'a DataArray')

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -474,10 +474,7 @@ class DataArray(AbstractArray, DataWithCoords):
 
     def __setitem__(self, key, value):
         if isinstance(key, basestring):
-            # convert to dataset first to use merge.dataset_update_method
-            ds = self._to_temp_dataset()
-            ds[key] = value
-            self._coords[key] = ds[key].variable
+            self.coords[key] = value
         else:
             # Coordinates in key, value and self[key] should be consistent.
             # TODO Coordinate consistency in key is checked here, but it

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -474,7 +474,10 @@ class DataArray(AbstractArray, DataWithCoords):
 
     def __setitem__(self, key, value):
         if isinstance(key, basestring):
-            self.coords[key] = value
+            # convert to dataset first to use merge.dataset_update_method
+            ds = self._to_temp_dataset()
+            ds[key] = value
+            self._coords[key] = ds[key].variable
         else:
             # Coordinates in key, value and self[key] should be consistent.
             # TODO Coordinate consistency in key is checked here, but it

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1184,6 +1184,8 @@ class TestDataArray(TestCase):
         da = xr.DataArray([0, 1, 2], dims='x')
         with pytest.raises(ValueError):
             da['x'] = [0, 1, 2, 3]  # no error
+        with pytest.raises(ValueError):
+            da.coords['x'] = [0, 1, 2, 3]  # no error
 
     def test_coords_alignment(self):
         lhs = DataArray([1, 2, 3], [('x', [0, 1, 2])])

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1180,6 +1180,11 @@ class TestDataArray(TestCase):
         with raises_regex(ValueError, 'conflicting MultiIndex'):
             self.mda.assign_coords(level_1=range(4))
 
+        # GH: 2112
+        da = xr.DataArray([0, 1, 2], dims='x')
+        with pytest.raises(ValueError):
+            da['x'] = [0, 1, 2, 3]  # no error
+
     def test_coords_alignment(self):
         lhs = DataArray([1, 2, 3], [('x', [0, 1, 2])])
         rhs = DataArray([2, 3, 4], [('x', [1, 2, 3])])

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1183,9 +1183,9 @@ class TestDataArray(TestCase):
         # GH: 2112
         da = xr.DataArray([0, 1, 2], dims='x')
         with pytest.raises(ValueError):
-            da['x'] = [0, 1, 2, 3]  # no error
+            da['x'] = [0, 1, 2, 3]  # size conflict
         with pytest.raises(ValueError):
-            da.coords['x'] = [0, 1, 2, 3]  # no error
+            da.coords['x'] = [0, 1, 2, 3]  # size conflict
 
     def test_coords_alignment(self):
         lhs = DataArray([1, 2, 3], [('x', [0, 1, 2])])


### PR DESCRIPTION
 - [x] Closes #2112
 - [x] Tests added
 - [x] Tests passed
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API.

Now uses `dataset_merge_method` when a new coordinate is assigned to a xr.DataArray
