### PR TITLE
Reduce pad size in rolling

### DIFF
--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -35,7 +35,7 @@ class Rolling(object):
     @parameterized(['func', 'center'],
                    (['mean', 'count'], [True, False]))
     def time_rolling(self, func, center):
-        getattr(self.ds.rolling(x=window, center=center), func)()
+        getattr(self.ds.rolling(x=window, center=center), func)().load()
 
     @parameterized(['func', 'pandas'],
                    (['mean', 'count'], [True, False]))
@@ -44,19 +44,20 @@ class Rolling(object):
             se = self.da_long.to_series()
             getattr(se.rolling(window=window), func)()
         else:
-            getattr(self.da_long.rolling(x=window), func)()
+            getattr(self.da_long.rolling(x=window), func)().load()
 
     @parameterized(['window_', 'min_periods'],
                    ([20, 40], [5, None]))
     def time_rolling_np(self, window_, min_periods):
         self.ds.rolling(x=window_, center=False,
-                        min_periods=min_periods).reduce(getattr(np, 'nanmean'))
+                        min_periods=min_periods).reduce(
+                            getattr(np, 'nanmean')).load()
 
     @parameterized(['center', 'stride'],
                    ([True, False], [1, 200]))
     def time_rolling_construct(self, center, stride):
         self.ds.rolling(x=window, center=center).construct(
-            'window_dim', stride=stride).mean(dim='window_dim')
+            'window_dim', stride=stride).mean(dim='window_dim').load()
 
 
 class RollingDask(Rolling):

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,6 +34,9 @@ v0.10.4 (unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
+- Slight modification in `rolling` with dask.array and bottleneck. Also, fixed a bug in rolling an
+  integer dask array.
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - Add an option for using a ``CFTimeIndex`` for indexing times with
   non-standard calendars and/or outside the Timestamp-valid range; this index
   enables a subset of the functionality of a standard
@@ -43,7 +46,7 @@ Enhancements
 - Allow for serialization of ``cftime.datetime`` objects (:issue:`789`,
   :issue:`1084`, :issue:`2008`, :issue:`1252`) using the standalone ``cftime``
          library. By `Spencer Clark
-         <https://github.com/spencerkclark>`_. 
+         <https://github.com/spencerkclark>`_.
 - Support writing lists of strings as netCDF attributes (:issue:`2044`).
   By `Dan Nowacki <https://github.com/dnowacki-usgs>`_.
 - :py:meth:`~xarray.Dataset.to_netcdf(engine='h5netcdf')` now accepts h5py

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -19,7 +19,7 @@ def dask_rolling_wrapper(moving_func, a, window, min_count=None, axis=-1):
     if axis < 0:
         axis = a.ndim + axis
     depth = {d: 0 for d in range(a.ndim)}
-    depth[axis] = window - 1
+    depth[axis] = (window + 1) // 2
     boundary = {d: fill_value for d in range(a.ndim)}
     # create ghosted arrays
     ag = da.ghost.ghost(a, depth=depth, boundary=boundary)

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -294,8 +294,8 @@ class DataArrayRolling(Rolling):
                 if isinstance(padded.data, dask_array_type):
                     # Workaround to make the padded chunk size is larger than
                     # self.window-1
-                    shift = - (self.window - 1)
-                    offset = -shift - self.window // 2
+                    shift = - (self.window + 1) // 2
+                    offset = (self.window - 1) // 2
                     valid = (slice(None), ) * axis + (
                         slice(offset, offset + self.obj.shape[axis]), )
                 else:


### PR DESCRIPTION
 - [ ] Closes #N.A.
 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Tests N.A.
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

I noticed `rolling` with dask array and with bottleneck can be slightly improved by reducing the padding depth in `da.ghost.ghost(a, depth=depth, boundary=boundary)`.

@jhamman , can you kindly review this?