### PR TITLE
Add cftime to doc/environment.yml

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -21,3 +21,4 @@ dependencies:
   - zarr
   - iris
   - flake8
+  - cftime


### PR DESCRIPTION
cftime is now needed to build the documentation: http://xarray.pydata.org/en/latest/time-series.html#non-standard-calendars-and-dates-outside-the-timestamp-valid-range

Sorry I neglected this in #1252!
