### PR TITLE
Fix datetime.timedelta casting bug in coding.times.infer_datetime_units

### DIFF
--- a/ci/requirements-py27-windows.yml
+++ b/ci/requirements-py27-windows.yml
@@ -8,7 +8,6 @@ dependencies:
   - h5py
   - h5netcdf
   - matplotlib
-  - netcdf4
   - pathlib2
   - pytest
   - flake8
@@ -21,4 +20,4 @@ dependencies:
   - rasterio
   - zarr
   - pip:
-    - cftime
+    - netcdf4

--- a/doc/time-series.rst
+++ b/doc/time-series.rst
@@ -73,7 +73,7 @@ native representation of dates to those that fall between the years 1678 and
 returned as arrays of ``cftime.datetime`` objects and a ``CFTimeIndex``
 can be used for indexing.  The ``CFTimeIndex`` enables only a subset of
 the indexing functionality of a ``pandas.DatetimeIndex`` and is only enabled
-when using standalone version of ``cftime`` (not the version packaged with
+when using the standalone version of ``cftime`` (not the version packaged with
 earlier versions ``netCDF4``).  See :ref:`CFTimeIndex` for more information.
 
 Datetime indexing

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -257,7 +257,7 @@ def infer_datetime_units(dates):
     if unique_timedeltas.dtype == np.dtype('O'):
         # Convert to np.timedelta64 objects using pandas to work around a
         # NumPy casting bug: https://github.com/numpy/numpy/issues/11096
-        unique_timedeltas = pd.to_timedelta(unique_timedeltas).values
+        unique_timedeltas = pd.to_timedelta(unique_timedeltas, box=False)
     units = _infer_time_units_from_diff(unique_timedeltas)
     return '%s since %s' % (units, reference_date)
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -255,10 +255,9 @@ def infer_datetime_units(dates):
         reference_date = format_cftime_datetime(reference_date)
     unique_timedeltas = np.unique(np.diff(dates))
     if unique_timedeltas.dtype == np.dtype('O'):
-        # Convert to np.timedelta64 objects one at a time to work around a
-        # NumPy casting bug (GH 2127)
-        unique_timedeltas = np.array([np.timedelta64(delta, 'ns')
-                                      for delta in unique_timedeltas])
+        # Convert to np.timedelta64 objects using pandas to work around a
+        # NumPy casting bug: https://github.com/numpy/numpy/issues/11096
+        unique_timedeltas = pd.to_timedelta(unique_timedeltas).values
     units = _infer_time_units_from_diff(unique_timedeltas)
     return '%s since %s' % (units, reference_date)
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -253,7 +253,12 @@ def infer_datetime_units(dates):
     else:
         reference_date = dates[0] if len(dates) > 0 else '1970-01-01'
         reference_date = format_cftime_datetime(reference_date)
-    unique_timedeltas = np.unique(np.diff(dates)).astype('timedelta64[ns]')
+    unique_timedeltas = np.unique(np.diff(dates))
+    if unique_timedeltas.dtype == np.dtype('O'):
+        # Convert to np.timedelta64 objects one at a time to work around a
+        # NumPy casting bug (GH 2127)
+        unique_timedeltas = np.array([np.timedelta64(delta, 'ns')
+                                      for delta in unique_timedeltas])
     units = _infer_time_units_from_diff(unique_timedeltas)
     return '%s since %s' % (units, reference_date)
 

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -587,6 +587,9 @@ def test_infer_cftime_datetime_units():
                  'seconds since 1900-01-01 00:00:00.000000'),
                 ([date_type(1900, 1, 1),
                   date_type(1900, 1, 2, 0, 0, 0, 5)],
+                 'days since 1900-01-01 00:00:00.000000'),
+                ([date_type(1900, 1, 1), date_type(1900, 1, 8),
+                  date_type(1900, 1, 16)],
                  'days since 1900-01-01 00:00:00.000000')]:
             assert expected == coding.times.infer_datetime_units(dates)
 


### PR DESCRIPTION
 - [x] Closes #2127
 - [x] Tests added
 - [x] Tests passed

I can confirm the docs now build properly locally:

<img width="665" alt="screen shot 2018-05-14 at 9 13 10 am" src="https://user-images.githubusercontent.com/6628425/39999510-3fa1e65e-5757-11e8-9c42-5852e6c52a2f.png">