### PR TITLE
Add strftime() to datetime accessor

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -82,6 +82,10 @@ Enhancements
   currently only supported by the netCDF4 and zarr backends. (:issue:`1784`).
   By `Joe Hamman <https://github.com/jhamman>`_.
 
+- ``strftime`` method added to ``.dt`` accessor, making it simpler to hand
+  datetime ``DataArray`` to other code expecting to format dates and times.
+  (:issue:`2090`). By `Ryan May <https://github.com/dopplershift>`_.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -258,3 +258,24 @@ class DatetimeAccessor(object):
             Array-like of datetime fields accessed for each element in values
         '''
         return self._tslib_round_accessor("round", freq)
+
+    def strftime(self, date_format):
+        '''
+        Return an array of formatted strings specified by date_format, which
+        supports the same string format as the python standard library. Details
+        of the string format can be found in `python string format doc
+        <https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior>`__
+
+        Parameters
+        ----------
+        date_format : str
+            date format string (e.g. "%Y-%m-%d")
+
+        Returns
+        -------
+        ndarray of formatted strings
+        '''
+        values = self._obj.data
+        values_as_series = pd.Series(values.ravel())
+        strs = values_as_series.dt.strftime(date_format)
+        return strs.values.reshape(values.shape)

--- a/xarray/tests/test_accessors.py
+++ b/xarray/tests/test_accessors.py
@@ -43,6 +43,10 @@ class TestDatetimeAccessor(TestCase):
         assert_equal(days, self.data.time.dt.day)
         assert_equal(hours, self.data.time.dt.hour)
 
+    def test_strftime(self):
+        assert ('2000-01-01 01:00:00' ==
+                self.data.time.dt.strftime('%Y-%m-%d %H:%M:%S')[1])
+
     def test_not_datetime_type(self):
         nontime_data = self.data.copy()
         int_data = np.arange(len(self.data.time)).astype('int8')


### PR DESCRIPTION
This matches pandas and makes it possible to pass a datetime dataarray
to something expecting to be able to use strftime().

 - [x] Closes #2090 
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API