### PR TITLE
Plot labels use CF convention information if available.

### DIFF
--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -66,6 +66,10 @@ For these examples we'll use the North American air temperature dataset.
     # Convert to celsius
     air = airtemps.air - 273.15
 
+    # copy attributes to get nice figure labels and change Kelvin to Celsius
+    air.attrs = airtemps.air.attrs
+    air.attrs['units'] = 'deg C'
+
 
 One Dimension
 -------------
@@ -73,7 +77,7 @@ One Dimension
 Simple Example
 ~~~~~~~~~~~~~~
 
-xarray uses the coordinate name to label the x axis.
+xarray uses the coordinate name along with any associated `CF-compliant metadata <http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/ch03s03.html>`_ (the `attrs` 'long_name', 'standard_name' and 'units') to label the axes.
 
 .. ipython:: python
 

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -89,7 +89,7 @@ The simplest way to make a plot is to call the :py:func:`xarray.DataArray.plot()
     @savefig plotting_1d_simple.png width=4in
     air1d.plot()
 
-xarray uses the coordinate name along with  metadata ``attrs.long_name``, ``attrs.standard_name``, ``DataArray.name`` and ``attrs.units`` (if available) to label the axes. The names ``long_name``, ``standard_name`` and ``units`` are defined by the `CF-conventions <http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/ch03s03.html>`_. When choosing names, the order of precedence is ``long_name``, ``standard_name`` and finally ``DataArray.name``. The y-axis label in the above plot was constructed from the ``long_name`` and ``units`` attributes of ``air1d``.
+xarray uses the coordinate name along with  metadata ``attrs.long_name``, ``attrs.standard_name``, ``DataArray.name`` and ``attrs.units`` (if available) to label the axes. The names ``long_name``, ``standard_name`` and ``units`` are copied from the `CF-conventions spec <http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/ch03s03.html>`_. When choosing names, the order of precedence is ``long_name``, ``standard_name`` and finally ``DataArray.name``. The y-axis label in the above plot was constructed from the ``long_name`` and ``units`` attributes of ``air1d``.
 
 .. ipython:: python
 

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -70,6 +70,9 @@ For these examples we'll use the North American air temperature dataset.
     air.attrs = airtemps.air.attrs
     air.attrs['units'] = 'deg C'
 
+.. note::
+   Until :issue:`1614` is solved, you might need to copy over the metadata in ``attrs`` to get informative figure labels (as was done above).
+
 
 One Dimension
 -------------
@@ -77,7 +80,7 @@ One Dimension
 Simple Example
 ~~~~~~~~~~~~~~
 
-xarray uses the coordinate name along with any associated `CF-compliant metadata <http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/ch03s03.html>`_ (the `attrs` 'long_name', 'standard_name' and 'units') to label the axes.
+The simplest way to make a plot is to call the :py:func:`xarray.DataArray.plot()` method.
 
 .. ipython:: python
 
@@ -85,6 +88,12 @@ xarray uses the coordinate name along with any associated `CF-compliant metadata
 
     @savefig plotting_1d_simple.png width=4in
     air1d.plot()
+
+xarray uses the coordinate name along with  metadata ``attrs.long_name``, ``attrs.standard_name``, ``DataArray.name`` and ``attrs.units`` (if available) to label the axes. The names ``long_name``, ``standard_name`` and ``units`` are defined by the `CF-conventions <http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/ch03s03.html>`_. When choosing names, the order of precedence is ``long_name``, ``standard_name`` and finally ``DataArray.name``. The y-axis label in the above plot was constructed from the ``long_name`` and ``units`` attributes of ``air1d``.
+
+.. ipython:: python
+
+    air1d.attrs
 
 Additional Arguments
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,6 +35,8 @@ Documentation
 
 Enhancements
 ~~~~~~~~~~~~
+- Plot labels now make use of metadata that follow CF conventions.
+  By `Deepak Cherian <https://github.com/dcherian>`_ and `Ryan Abernathey <https://github.com/rabernat>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -9,7 +9,8 @@ import numpy as np
 from ..core.formatting import format_item
 from ..core.pycompat import getargspec
 from .utils import (
-    _determine_cmap_params, _infer_xy_labels, import_matplotlib_pyplot)
+    _determine_cmap_params, _infer_xy_labels, import_matplotlib_pyplot,
+    label_from_attrs)
 
 # Overrides axes.labelsize, xtick.major.size, ytick.major.size
 # from mpl.rcParams
@@ -282,8 +283,8 @@ class FacetGrid(object):
         kwargs = kwargs.copy()
         if self._cmap_extend is not None:
             kwargs.setdefault('extend', self._cmap_extend)
-        if getattr(self.data, 'name', None) is not None:
-            kwargs.setdefault('label', self.data.name)
+        if 'label' not in kwargs:
+            kwargs.setdefault('label', label_from_attrs(self.data))
         self.cbar = self.fig.colorbar(self._mappables[-1],
                                       ax=list(self.axes.flat),
                                       **kwargs)
@@ -292,17 +293,25 @@ class FacetGrid(object):
     def set_axis_labels(self, x_var=None, y_var=None):
         """Set axis labels on the left column and bottom row of the grid."""
         if x_var is not None:
-            self._x_var = x_var
-            self.set_xlabels(x_var)
+            if x_var in self.data.coords:
+                self._x_var = x_var
+                self.set_xlabels(label_from_attrs(self.data[x_var]))
+            else:
+                # x_var is a string
+                self.set_xlabels(x_var)
+
         if y_var is not None:
-            self._y_var = y_var
-            self.set_ylabels(y_var)
+            if y_var in self.data.coords:
+                self._y_var = y_var
+                self.set_ylabels(label_from_attrs(self.data[y_var]))
+            else:
+                self.set_ylabels(y_var)
         return self
 
     def set_xlabels(self, label=None, **kwargs):
         """Label the x axis on the bottom row of the grid."""
         if label is None:
-            label = self._x_var
+            label = label_from_attrs(self.data[self._x_var])
         for ax in self._bottom_axes:
             ax.set_xlabel(label, **kwargs)
         return self
@@ -310,7 +319,7 @@ class FacetGrid(object):
     def set_ylabels(self, label=None, **kwargs):
         """Label the y axis on the left column of the grid."""
         if label is None:
-            label = self._y_var
+            label = label_from_attrs(self.data[self._y_var])
         for ax in self._left_axes:
             ax.set_ylabel(label, **kwargs)
         return self

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -361,22 +361,18 @@ def label_from_attrs(da):
     ''' Makes informative labels if variable metadata (attrs) follows
         CF conventions. '''
 
-    attrs = da.attrs
-
-    if 'long_name' in attrs:
-        name = attrs['long_name']
-    elif 'standard_name' in attrs:
-        name = attrs['standard_name']
+    if da.attrs.get('long_name'):
+        name = da.attrs['long_name']
+    elif da.attrs.get('standard_name'):
+        name = da.attrs['standard_name']
     elif da.name is not None:
         name = da.name
     else:
         name = ''
 
-    if 'units' in da.attrs:
+    if da.attrs.get('units'):
         units = ' [{}]'.format(da.attrs['units'])
     else:
         units = ''
 
-    label = '\n'.join(textwrap.wrap(name + units, 30))
-
-    return label
+    return '\n'.join(textwrap.wrap(name + units, 30))

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -5,6 +5,7 @@ import warnings
 import numpy as np
 import pandas as pd
 import pkg_resources
+import textwrap
 
 from ..core.pycompat import basestring
 from ..core.utils import is_scalar
@@ -354,3 +355,28 @@ def get_axis(figsize, size, aspect, ax):
         ax = plt.gca()
 
     return ax
+
+
+def label_from_attrs(da):
+    ''' Makes informative labels if variable metadata (attrs) follows
+        CF conventions. '''
+
+    attrs = da.attrs
+
+    if 'long_name' in attrs:
+        name = attrs['long_name']
+    elif 'standard_name' in attrs:
+        name = attrs['standard_name']
+    elif da.name is not None:
+        name = da.name
+    else:
+        name = ''
+
+    if 'units' in da.attrs:
+        units = ' [{}]'.format(da.attrs['units'])
+    else:
+        units = ''
+
+    label = '\n'.join(textwrap.wrap(name + units, 30))
+
+    return label

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -13,7 +13,7 @@ from xarray.coding.times import _import_cftime
 from xarray.plot.plot import _infer_interval_breaks
 from xarray.plot.utils import (
     _build_discrete_cmap, _color_palette, _determine_cmap_params,
-    import_seaborn)
+    import_seaborn, label_from_attrs)
 
 from . import (
     TestCase, assert_array_equal, assert_equal, raises_regex,
@@ -88,6 +88,20 @@ class PlotTestCase(TestCase):
 class TestPlot(PlotTestCase):
     def setUp(self):
         self.darray = DataArray(easy_array((2, 3, 4)))
+
+    def test_label_from_attrs(self):
+        da = self.darray
+        da.name = 'a'
+        da.attrs['units'] = 'a_units'
+        da.attrs['long_name'] = 'a_long_name'
+        da.attrs['standard_name'] = 'a_standard_name'
+        assert 'a_long_name [a_units]' == label_from_attrs(da)
+        da.attrs.pop('long_name')
+        assert 'a_standard_name [a_units]' == label_from_attrs(da)
+        da.attrs.pop('standard_name')
+        assert 'a [a_units]' == label_from_attrs(da)
+        da.attrs.pop('units')
+        assert 'a' == label_from_attrs(da)
 
     def test1d(self):
         self.darray[:, 0, 0].plot()
@@ -303,10 +317,11 @@ class TestPlot1D(PlotTestCase):
         d = [0, 1.1, 0, 2]
         self.darray = DataArray(
             d, coords={'period': range(len(d))}, dims='period')
+        self.darray.period.attrs['units'] = 's'
 
     def test_xlabel_is_index_name(self):
         self.darray.plot()
-        assert 'period' == plt.gca().get_xlabel()
+        assert 'period [s]' == plt.gca().get_xlabel()
 
     def test_no_label_name_on_x_axis(self):
         self.darray.plot(y='period')
@@ -318,13 +333,15 @@ class TestPlot1D(PlotTestCase):
 
     def test_ylabel_is_data_name(self):
         self.darray.name = 'temperature'
+        self.darray.attrs['units'] = 'degrees_Celsius'
         self.darray.plot()
-        assert self.darray.name == plt.gca().get_ylabel()
+        assert 'temperature [degrees_Celsius]' == plt.gca().get_ylabel()
 
     def test_xlabel_is_data_name(self):
         self.darray.name = 'temperature'
+        self.darray.attrs['units'] = 'degrees_Celsius'
         self.darray.plot(y='period')
-        self.assertEqual(self.darray.name, plt.gca().get_xlabel())
+        assert 'temperature [degrees_Celsius]' == plt.gca().get_xlabel()
 
     def test_format_string(self):
         self.darray.plot.line('ro')
@@ -374,18 +391,19 @@ class TestPlotHistogram(PlotTestCase):
     def test_3d_array(self):
         self.darray.plot.hist()
 
-    def test_title_no_name(self):
-        self.darray.plot.hist()
-        assert '' == plt.gca().get_title()
-
-    def test_title_uses_name(self):
+    def test_xlabel_uses_name(self):
         self.darray.name = 'testpoints'
+        self.darray.attrs['units'] = 'testunits'
         self.darray.plot.hist()
-        assert self.darray.name in plt.gca().get_title()
+        assert 'testpoints [testunits]' == plt.gca().get_xlabel()
 
     def test_ylabel_is_count(self):
         self.darray.plot.hist()
         assert 'Count' == plt.gca().get_ylabel()
+
+    def test_title_is_histogram(self):
+        self.darray.plot.hist()
+        assert 'Histogram' == plt.gca().get_title()
 
     def test_can_pass_in_kwargs(self):
         nbins = 5
@@ -654,7 +672,10 @@ class Common2dMixin:
     """
 
     def setUp(self):
-        da = DataArray(easy_array((10, 15), start=-1), dims=['y', 'x'])
+        da = DataArray(easy_array((10, 15), start=-1),
+                       dims=['y', 'x'],
+                       coords={'y': np.arange(10),
+                               'x': np.arange(15)})
         # add 2d coords
         ds = da.to_dataset(name='testvar')
         x, y = np.meshgrid(da.x.values, da.y.values)
@@ -663,12 +684,21 @@ class Common2dMixin:
         ds.set_coords(['x2d', 'y2d'], inplace=True)
         # set darray and plot method
         self.darray = ds.testvar
+
+        # Add CF-compliant metadata
+        self.darray.attrs['long_name'] = 'a_long_name'
+        self.darray.attrs['units'] = 'a_units'
+        self.darray.x.attrs['long_name'] = 'x_long_name'
+        self.darray.x.attrs['units'] = 'x_units'
+        self.darray.y.attrs['long_name'] = 'y_long_name'
+        self.darray.y.attrs['units'] = 'y_units'
+
         self.plotmethod = getattr(self.darray.plot, self.plotfunc.__name__)
 
     def test_label_names(self):
         self.plotmethod()
-        assert 'x' == plt.gca().get_xlabel()
-        assert 'y' == plt.gca().get_ylabel()
+        assert 'x_long_name [x_units]' == plt.gca().get_xlabel()
+        assert 'y_long_name [y_units]' == plt.gca().get_ylabel()
 
     def test_1d_raises_valueerror(self):
         with raises_regex(ValueError, r'DataArray must be 2d'):
@@ -761,19 +791,19 @@ class Common2dMixin:
     def test_xy_strings(self):
         self.plotmethod('y', 'x')
         ax = plt.gca()
-        assert 'y' == ax.get_xlabel()
-        assert 'x' == ax.get_ylabel()
+        assert 'y_long_name [y_units]' == ax.get_xlabel()
+        assert 'x_long_name [x_units]' == ax.get_ylabel()
 
     def test_positional_coord_string(self):
         self.plotmethod(y='x')
         ax = plt.gca()
-        assert 'x' == ax.get_ylabel()
-        assert 'y' == ax.get_xlabel()
+        assert 'x_long_name [x_units]' == ax.get_ylabel()
+        assert 'y_long_name [y_units]' == ax.get_xlabel()
 
         self.plotmethod(x='x')
         ax = plt.gca()
-        assert 'x' == ax.get_xlabel()
-        assert 'y' == ax.get_ylabel()
+        assert 'x_long_name [x_units]' == ax.get_xlabel()
+        assert 'y_long_name [y_units]' == ax.get_ylabel()
 
     def test_bad_x_string_exception(self):
         with raises_regex(ValueError, 'x and y must be coordinate variables'):
@@ -797,7 +827,7 @@ class Common2dMixin:
         # Normal case, without transpose
         self.plotfunc(self.darray, x='x', y='newy')
         ax = plt.gca()
-        assert 'x' == ax.get_xlabel()
+        assert 'x_long_name [x_units]' == ax.get_xlabel()
         assert 'newy' == ax.get_ylabel()
         # ax limits might change between plotfuncs
         # simply ensure that these high coords were passed over
@@ -812,7 +842,7 @@ class Common2dMixin:
         self.plotfunc(self.darray, x='newy', y='x')
         ax = plt.gca()
         assert 'newy' == ax.get_xlabel()
-        assert 'x' == ax.get_ylabel()
+        assert 'x_long_name [x_units]' == ax.get_ylabel()
         # ax limits might change between plotfuncs
         # simply ensure that these high coords were passed over
         assert np.min(ax.get_xlim()) > 100.
@@ -826,19 +856,29 @@ class Common2dMixin:
         assert 'c = 1, d = foo' == title or 'd = foo, c = 1' == title
 
     def test_colorbar_default_label(self):
-        self.darray.name = 'testvar'
         self.plotmethod(add_colorbar=True)
-        assert self.darray.name in text_in_fig()
+        assert ('a_long_name [a_units]' in text_in_fig())
 
     def test_no_labels(self):
         self.darray.name = 'testvar'
+        self.darray.attrs['units'] = 'test_units'
         self.plotmethod(add_labels=False)
         alltxt = text_in_fig()
-        for string in ['x', 'y', 'testvar']:
+        for string in ['x_long_name [x_units]',
+                       'y_long_name [y_units]',
+                       'testvar [test_units]']:
             assert string not in alltxt
 
     def test_colorbar_kwargs(self):
         # replace label
+        self.darray.attrs.pop('long_name')
+        self.darray.attrs['units'] = 'test_units'
+        # check default colorbar label
+        self.plotmethod(add_colorbar=True)
+        alltxt = text_in_fig()
+        assert 'testvar [test_units]' in alltxt
+        self.darray.attrs.pop('units')
+
         self.darray.name = 'testvar'
         self.plotmethod(add_colorbar=True, cbar_kwargs={'label': 'MyLabel'})
         alltxt = text_in_fig()

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -90,16 +90,24 @@ class TestPlot(PlotTestCase):
         self.darray = DataArray(easy_array((2, 3, 4)))
 
     def test_label_from_attrs(self):
-        da = self.darray
+        da = self.darray.copy()
+        assert '' == label_from_attrs(da)
+
         da.name = 'a'
         da.attrs['units'] = 'a_units'
         da.attrs['long_name'] = 'a_long_name'
         da.attrs['standard_name'] = 'a_standard_name'
         assert 'a_long_name [a_units]' == label_from_attrs(da)
+
         da.attrs.pop('long_name')
         assert 'a_standard_name [a_units]' == label_from_attrs(da)
+        da.attrs.pop('units')
+        assert 'a_standard_name' == label_from_attrs(da)
+
+        da.attrs['units'] = 'a_units'
         da.attrs.pop('standard_name')
         assert 'a [a_units]' == label_from_attrs(da)
+
         da.attrs.pop('units')
         assert 'a' == label_from_attrs(da)
 


### PR DESCRIPTION
Uses attrs long_name/standard_name, units if available.

 - [x] Closes #2135, #1630, #1787
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

This PR basically uses @rabernat's `label_from_attrs` in #2135. 

Examples:
![image](https://user-images.githubusercontent.com/2448579/40190529-668475e0-59bc-11e8-8e03-879193082ec1.png)

![image](https://user-images.githubusercontent.com/2448579/40190494-4fdf439c-59bc-11e8-8b78-2a19b64d1a06.png)

![image](https://user-images.githubusercontent.com/2448579/40190445-35385dd0-59bc-11e8-82c9-389e9143fc34.png)
![image](https://user-images.githubusercontent.com/2448579/40190462-3d6a902c-59bc-11e8-809b-c0763474664c.png)
![image](https://user-images.githubusercontent.com/2448579/40190487-49ce18fc-59bc-11e8-895a-e4b518ceadc5.png)


I also changed the way histograms are labelled
**Old:**
![image](https://user-images.githubusercontent.com/2448579/40191183-e97235d6-59bd-11e8-8817-6e30564c6670.png)


**New**:
![image](https://user-images.githubusercontent.com/2448579/40191190-ee9c1f04-59bd-11e8-81fb-54c4192f51b0.png)


