### PR TITLE
Bug fixes for Dataset.reduce() and n-dimensional cumsum/cumprod

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -37,9 +37,19 @@ Documentation
 Enhancements
 ~~~~~~~~~~~~
 
+- :py:meth:`~DataArray.cumsum` and :py:meth:`~DataArray.cumprod` now support
+  aggregation over multiple dimensions at the same time. This is the default
+  behavior when dimensions are not specified (previously this raised an error).
+  By `Stephan Hoyer <https://github.com/shoyer>`_
+
 Bug fixes
 ~~~~~~~~~
 
+- Aggregations with :py:meth:`Dataset.reduce` (including ``mean``, ``sum``,
+  etc) no longer drop unrelated coordinates (:issue:`1470`). Also fixed a
+  bug where non-scalar data-variables that did not include the aggregation
+  dimension were improperly skipped.
+  By `Stephan Hoyer <https://github.com/shoyer>`_
 
 .. _whats-new.0.10.4:
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2597,7 +2597,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
             if name in self.coords:
                 if not reduce_dims:
                     variables[name] = var
-                # drop other coordinates
             else:
                 if (not numeric_only or
                         np.issubdtype(var.dtype, np.number) or
@@ -2615,7 +2614,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
                                                  keep_attrs=keep_attrs,
                                                  allow_lazy=allow_lazy,
                                                  **kwargs)
-                # drop other data_vars
 
         coord_names = set(k for k in self.coords if k in variables)
         attrs = self.attrs if keep_attrs else None

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -281,8 +281,7 @@ _nan_object_funcs = {
 
 
 def _create_nan_agg_method(name, numeric_only=False, np_compat=False,
-                           no_bottleneck=False, coerce_strings=False,
-                           keep_dims=False):
+                           no_bottleneck=False, coerce_strings=False):
     def f(values, axis=None, skipna=None, **kwargs):
         if kwargs.pop('out', None) is not None:
             raise TypeError('`out` is not valid for {}'.format(name))
@@ -343,7 +342,6 @@ def _create_nan_agg_method(name, numeric_only=False, np_compat=False,
                            'or newer to use skipna=True or skipna=None' % name)
                 raise NotImplementedError(msg)
     f.numeric_only = numeric_only
-    f.keep_dims = keep_dims
     f.__name__ = name
     return f
 
@@ -358,10 +356,34 @@ std = _create_nan_agg_method('std', numeric_only=True)
 var = _create_nan_agg_method('var', numeric_only=True)
 median = _create_nan_agg_method('median', numeric_only=True)
 prod = _create_nan_agg_method('prod', numeric_only=True, no_bottleneck=True)
-cumprod = _create_nan_agg_method('cumprod', numeric_only=True, np_compat=True,
-                                 no_bottleneck=True, keep_dims=True)
-cumsum = _create_nan_agg_method('cumsum', numeric_only=True, np_compat=True,
-                                no_bottleneck=True, keep_dims=True)
+cumprod_1d = _create_nan_agg_method(
+    'cumprod', numeric_only=True, np_compat=True, no_bottleneck=True)
+cumsum_1d = _create_nan_agg_method(
+    'cumsum', numeric_only=True, np_compat=True, no_bottleneck=True)
+
+
+def _nd_cum_func(cum_func, array, axis, **kwargs):
+    array = asarray(array)
+    if axis is None:
+        axis = tuple(range(array.ndim))
+    if isinstance(axis, int):
+        axis = (axis,)
+
+    out = array
+    for ax in axis:
+        out = cum_func(out, axis=ax, **kwargs)
+    return out
+
+
+def cumprod(array, axis=None, **kwargs):
+    """N-dimensional version of cumprod."""
+    return _nd_cum_func(cumprod_1d, array, axis, **kwargs)
+
+
+def cumsum(array, axis=None, **kwargs):
+    """N-dimensional version of cumsum."""
+    return _nd_cum_func(cumsum_1d, array, axis, **kwargs)
+
 
 _fail_on_dask_array_input_skipna = partial(
     fail_on_dask_array_input,

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1256,11 +1256,6 @@ class Variable(common.AbstractArray, arithmetic.SupportsArithmetic,
         if dim is not None and axis is not None:
             raise ValueError("cannot supply both 'axis' and 'dim' arguments")
 
-        if getattr(func, 'keep_dims', False):
-            if dim is None and axis is None:
-                raise ValueError("must supply either single 'dim' or 'axis' "
-                                 "argument to %s" % (func.__name__))
-
         if dim is not None:
             axis = self.get_axis_num(dim)
         data = func(self.data if allow_lazy else self.values,

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1767,6 +1767,11 @@ class TestDataArray(TestCase):
         orig = DataArray([[-1, 0, 1], [-3, 0, 3]], coords,
                          dims=['x', 'y'])
 
+        actual = orig.cumsum()
+        expected = DataArray([[-1, -1, 0], [-4, -4, 0]], coords,
+                             dims=['x', 'y'])
+        assert_identical(expected, actual)
+
         actual = orig.cumsum('x')
         expected = DataArray([[-1, 0, 1], [-4, 0, 4]], coords,
                              dims=['x', 'y'])

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -8,6 +8,7 @@ from numpy import array, nan
 import warnings
 
 from xarray import DataArray, concat
+from xarray.core import duck_array_ops
 from xarray.core.duck_array_ops import (
     array_notnull_equiv, concatenate, count, first, last, mean, rolling_window,
     stack, where)
@@ -101,6 +102,53 @@ class TestOps(TestCase):
 
     def test_all_nan_arrays(self):
         assert np.isnan(mean([np.nan, np.nan]))
+
+
+def test_cumsum_1d():
+    inputs = np.array([0, 1, 2, 3])
+    expected = np.array([0, 1, 3, 6])
+    actual = duck_array_ops.cumsum(inputs)
+    assert_array_equal(expected, actual)
+
+    actual = duck_array_ops.cumsum(inputs, axis=0)
+    assert_array_equal(expected, actual)
+
+    actual = duck_array_ops.cumsum(inputs, axis=-1)
+    assert_array_equal(expected, actual)
+
+    actual = duck_array_ops.cumsum(inputs, axis=(0,))
+    assert_array_equal(expected, actual)
+
+    actual = duck_array_ops.cumsum(inputs, axis=())
+    assert_array_equal(inputs, actual)
+
+
+def test_cumsum_2d():
+    inputs = np.array([[1, 2], [3, 4]])
+
+    expected = np.array([[1, 3], [4, 10]])
+    actual = duck_array_ops.cumsum(inputs)
+    assert_array_equal(expected, actual)
+
+    actual = duck_array_ops.cumsum(inputs, axis=(0, 1))
+    assert_array_equal(expected, actual)
+
+    actual = duck_array_ops.cumsum(inputs, axis=())
+    assert_array_equal(inputs, actual)
+
+
+def test_cumprod_2d():
+    inputs = np.array([[1, 2], [3, 4]])
+
+    expected = np.array([[1, 2], [3, 2*3*4]])
+    actual = duck_array_ops.cumprod(inputs)
+    assert_array_equal(expected, actual)
+
+    actual = duck_array_ops.cumprod(inputs, axis=(0, 1))
+    assert_array_equal(expected, actual)
+
+    actual = duck_array_ops.cumprod(inputs, axis=())
+    assert_array_equal(inputs, actual)
 
 
 class TestArrayNotNullEquiv():

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -140,7 +140,7 @@ def test_cumsum_2d():
 def test_cumprod_2d():
     inputs = np.array([[1, 2], [3, 4]])
 
-    expected = np.array([[1, 2], [3, 2*3*4]])
+    expected = np.array([[1, 2], [3, 2 * 3 * 4]])
     actual = duck_array_ops.cumprod(inputs)
     assert_array_equal(expected, actual)
 


### PR DESCRIPTION
Fixes GH1470, "Dataset.mean drops coordinates"

Fixes a bug where non-scalar data-variables that did not include the
aggregated dimension were not properly reduced:

    Previously::

        >>> ds = Dataset({'x': ('a', [2, 2]), 'y': 2, 'z': ('b', [2])})
        >>> ds.var('a')
        <xarray.Dataset>
        Dimensions:  (b: 1)
        Dimensions without coordinates: b
        Data variables:
            x        float64 0.0
            y        float64 0.0
            z        (b) int64 2

    Now::

        >>> ds.var('a')
        <xarray.Dataset>
        Dimensions:  (b: 1)
        Dimensions without coordinates: b
        Data variables:
            x        int64 0
            y        int64 0
            z        (b) int64 0

Finally, adds support for n-dimensional cumsum() and cumprod(), reducing
over all dimensions of an array. (This was necessary as part of the above fix.)

 - [x] Closes #1470 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
