### PR TITLE
Fix dtype=S1 encoding in to_netcdf()

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -62,9 +62,6 @@ Bug fixes
   bug where non-scalar data-variables that did not include the aggregation
   dimension were improperly skipped.
   By `Stephan Hoyer <https://github.com/shoyer>`_
-- Fixed a regression in 0.10.4, where specifying ``{'dtype': 'S1'}`` in
-  ``encoding`` with ``to_netcdf()`` raised an error.
-  `Stephan Hoyer <https://github.com/shoyer>`_
 
 - Selecting data indexed by a length-1 ``CFTimeIndex`` with a slice of strings
   now behaves as it does when using a length-1 ``DatetimeIndex`` (i.e. it no

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -49,6 +49,10 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- Fixed a regression in 0.10.4, where explicitly specifying ``dtype='S1'`` or
+  ``dtype=str`` in ``encoding`` with ``to_netcdf()`` raised an error
+  (:issue:`2149`).
+  `Stephan Hoyer <https://github.com/shoyer>`_
 - Fixed a bug where `to_netcdf(..., unlimited_dims='bar'` yielded NetCDF files
   with spurious 0-length dimensions (i.e. `b`, `a`, and `r`) (:issue:`2134`).
   By `Joe Hamman <https://github.com/jhamman>`_.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -58,6 +58,9 @@ Bug fixes
   bug where non-scalar data-variables that did not include the aggregation
   dimension were improperly skipped.
   By `Stephan Hoyer <https://github.com/shoyer>`_
+- Fixed a regression in 0.10.4, where specifying ``{'dtype': 'S1'}`` in
+  ``encoding`` with ``to_netcdf()`` raised an error.
+  `Stephan Hoyer <https://github.com/shoyer>`_
 
 - Selecting data indexed by a length-1 ``CFTimeIndex`` with a slice of strings
   now behaves as it does when using a length-1 ``DatetimeIndex`` (i.e. it no

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -184,8 +184,9 @@ class H5NetCDFStore(WritableCFDataStore, DataStorePickleMixin):
                 raise ValueError("'zlib' and 'compression' encodings mismatch")
             encoding.setdefault('compression', 'gzip')
 
-        if (check_encoding and encoding.get('complevel') not in
-                (None, encoding.get('compression_opts'))):
+        if (check_encoding and 
+                'complevel' in encoding and 'compression_opts' in encoding and
+                 encoding['complevel'] != encoding['compression_opts']):
             raise ValueError("'complevel' and 'compression_opts' encodings "
                              "mismatch")
         complevel = encoding.pop('complevel', 0)

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -184,9 +184,9 @@ class H5NetCDFStore(WritableCFDataStore, DataStorePickleMixin):
                 raise ValueError("'zlib' and 'compression' encodings mismatch")
             encoding.setdefault('compression', 'gzip')
 
-        if (check_encoding and 
+        if (check_encoding and
                 'complevel' in encoding and 'compression_opts' in encoding and
-                 encoding['complevel'] != encoding['compression_opts']):
+                encoding['complevel'] != encoding['compression_opts']):
             raise ValueError("'complevel' and 'compression_opts' encodings "
                              "mismatch")
         complevel = encoding.pop('complevel', 0)

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -115,12 +115,13 @@ class H5NetCDFStore(WritableCFDataStore, DataStorePickleMixin):
             # save source so __repr__ can detect if it's local or not
             encoding['source'] = self._filename
             encoding['original_shape'] = var.shape
+
             vlen_dtype = h5py.check_dtype(vlen=var.dtype)
-            if vlen_dtype is not None:
-                if vlen_dtype is not unicode_type:  # pragma: no cover
-                    raise NotImplementedError('unexpected vlen dtype: {!r}'
-                                              .format(vlen_dtype))
+            if vlen_dtype is unicode_type:
                 encoding['dtype'] = str
+            elif vlen_dtype is not None:  # pragma: no cover
+                # xarray doesn't support writing arbitrary vlen dtypes yet.
+                pass
             else:
                 encoding['dtype'] = var.dtype
 

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -89,16 +89,33 @@ def _encode_nc4_variable(var):
     return var
 
 
-def _get_datatype(var, nc_format='NETCDF4'):
+def _check_encoding_dtype_is_vlen_string(dtype):
+    if dtype is not str:
+        raise AssertionError(  # pragma: no cover
+            "unexpected dtype encoding %r. This shouldn't happen: please "
+            "file a bug report at github.com/pydata/xarray" % dtype)
+
+
+def _get_datatype(var, nc_format='NETCDF4', raise_on_invalid_encoding=False):
     if nc_format == 'NETCDF4':
         datatype = _nc4_dtype(var)
     else:
+        if 'dtype' in var.encoding:
+            encoded_dtype = var.encoding['dtype']
+            _check_encoding_dtype_is_vlen_string(encoded_dtype)
+            if raise_on_invalid_encoding:
+                raise ValueError(
+                    'encoding dtype=str for vlen strings is only supported '
+                    'with format=\'NETCDF4\'.')
         datatype = var.dtype
     return datatype
 
 
 def _nc4_dtype(var):
-    if coding.strings.is_unicode_dtype(var.dtype):
+    if 'dtype' in var.encoding:
+        dtype = var.encoding.pop('dtype')
+        _check_encoding_dtype_is_vlen_string(dtype)
+    elif coding.strings.is_unicode_dtype(var.dtype):
         dtype = str
     elif var.dtype.kind in ['i', 'u', 'f', 'c', 'S']:
         dtype = var.dtype
@@ -168,7 +185,7 @@ def _extract_nc4_variable_encoding(variable, raise_on_invalid=False,
 
     safe_to_drop = set(['source', 'original_shape'])
     valid_encodings = set(['zlib', 'complevel', 'fletcher32', 'contiguous',
-                           'chunksizes', 'shuffle', '_FillValue'])
+                           'chunksizes', 'shuffle', '_FillValue', 'dtype'])
     if lsd_okay:
         valid_encodings.add('least_significant_digit')
     if h5py_okay:
@@ -340,6 +357,7 @@ class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
             # save source so __repr__ can detect if it's local or not
             encoding['source'] = self._filename
             encoding['original_shape'] = var.shape
+            encoding['dtype'] = var.dtype
 
         return Variable(dimensions, data, attributes, encoding)
 
@@ -394,7 +412,8 @@ class NetCDF4DataStore(WritableCFDataStore, DataStorePickleMixin):
 
     def prepare_variable(self, name, variable, check_encoding=False,
                          unlimited_dims=None):
-        datatype = _get_datatype(variable, self.format)
+        datatype = _get_datatype(variable, self.format,
+                                 raise_on_invalid_encoding=check_encoding)
         attrs = variable.attrs.copy()
 
         fill_value = attrs.pop('_FillValue', None)

--- a/xarray/coding/strings.py
+++ b/xarray/coding/strings.py
@@ -45,10 +45,10 @@ class EncodedStringCoder(VariableCoder):
         contains_unicode = is_unicode_dtype(data.dtype)
         encode_as_char = encoding.get('dtype') == 'S1'
 
-        if contains_unicode and (encode_as_char or not self.allows_unicode):
-            if encode_as_char:
-                del encoding['dtype']  # no longer relevant
+        if encode_as_char:
+            del encoding['dtype']  # no longer relevant
 
+        if contains_unicode and (encode_as_char or not self.allows_unicode):
             if '_FillValue' in attrs:
                 raise NotImplementedError(
                     'variable {!r} has a _FillValue specified, but '

--- a/xarray/coding/strings.py
+++ b/xarray/coding/strings.py
@@ -43,9 +43,12 @@ class EncodedStringCoder(VariableCoder):
         dims, data, attrs, encoding = unpack_for_encoding(variable)
 
         contains_unicode = is_unicode_dtype(data.dtype)
-        encode_as_char = 'dtype' in encoding and encoding['dtype'] == 'S1'
+        encode_as_char = encoding.get('dtype') == 'S1'
 
         if contains_unicode and (encode_as_char or not self.allows_unicode):
+            if encode_as_char:
+                del encoding['dtype']  # no longer relevant
+
             if '_FillValue' in attrs:
                 raise NotImplementedError(
                     'variable {!r} has a _FillValue specified, but '

--- a/xarray/coding/strings.py
+++ b/xarray/coding/strings.py
@@ -103,7 +103,7 @@ class CharacterArrayCoder(VariableCoder):
         variable = ensure_fixed_length_bytes(variable)
 
         dims, data, attrs, encoding = unpack_for_encoding(variable)
-        if data.dtype.kind == 'S':
+        if data.dtype.kind == 'S' and encoding.get('dtype') is not str:
             data = bytes_to_char(data)
             dims = dims + ('string%s' % data.shape[-1],)
         return Variable(dims, data, attrs, encoding)

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -80,7 +80,8 @@ def _var_as_tuple(var):
 
 def maybe_encode_nonstring_dtype(var, name=None):
     if ('dtype' in var.encoding and
-            var.encoding['dtype'] not in {'S1', str}):
+            var.encoding['dtype'] != 'S1' and
+            var.encoding['dtype'] is not str):
         dims, data, attrs, encoding = _var_as_tuple(var)
         dtype = np.dtype(encoding.pop('dtype'))
         if dtype != var.dtype:

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -79,11 +79,8 @@ def _var_as_tuple(var):
 
 
 def maybe_encode_nonstring_dtype(var, name=None):
-    # can't use dtype in {'S1', str} because numpy dtypes have the wrong hash:
-    # https://github.com/numpy/numpy/issues/7242
     if ('dtype' in var.encoding and
-            var.encoding['dtype'] != 'S1' and
-            var.encoding['dtype'] is not str):
+            var.encoding['dtype'] not in ('S1', str)):
         dims, data, attrs, encoding = _var_as_tuple(var)
         dtype = np.dtype(encoding.pop('dtype'))
         if dtype != var.dtype:

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -79,6 +79,8 @@ def _var_as_tuple(var):
 
 
 def maybe_encode_nonstring_dtype(var, name=None):
+    # can't use dtype in {'S1', str} because numpy dtypes have the wrong hash:
+    # https://github.com/numpy/numpy/issues/7242
     if ('dtype' in var.encoding and
             var.encoding['dtype'] != 'S1' and
             var.encoding['dtype'] is not str):
@@ -309,8 +311,7 @@ def decode_cf_variable(name, var, concat_characters=True, mask_and_scale=True,
         data = NativeEndiannessArray(data)
         original_dtype = data.dtype
 
-    if 'dtype' not in encoding:
-        encoding['dtype'] = original_dtype
+    encoding.setdefault('dtype', original_dtype)
 
     if 'dtype' in attributes and attributes['dtype'] == 'bool':
         del attributes['dtype']

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -79,7 +79,8 @@ def _var_as_tuple(var):
 
 
 def maybe_encode_nonstring_dtype(var, name=None):
-    if 'dtype' in var.encoding and var.encoding['dtype'] != 'S1':
+    if ('dtype' in var.encoding and
+            var.encoding['dtype'] not in {'S1', str}):
         dims, data, attrs, encoding = _var_as_tuple(var)
         dtype = np.dtype(encoding.pop('dtype'))
         if dtype != var.dtype:
@@ -307,11 +308,7 @@ def decode_cf_variable(name, var, concat_characters=True, mask_and_scale=True,
         data = NativeEndiannessArray(data)
         original_dtype = data.dtype
 
-    if 'dtype' in encoding:
-        if original_dtype != encoding['dtype']:
-            warnings.warn("CF decoding is overwriting dtype on variable {!r}"
-                          .format(name))
-    else:
+    if 'dtype' not in encoding:
         encoding['dtype'] = original_dtype
 
     if 'dtype' in attributes and attributes['dtype'] == 'bool':

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -804,11 +804,15 @@ class CFEncodedDataTest(DatasetIOTestCases):
 
     def test_encoding_kwarg_string(self):
         # regression test for GH2149
-        ds = Dataset({'x': ['foo', 'bar', 'baz']})
-        kwargs = dict(encoding={'x': {'dtype': 'S1'}})
-        with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            self.assertEqual(actual['x'].encoding['dtype'], 'S1')
-            assert_identical(actual, ds)
+        for strings in [
+            [b'foo', b'bar', b'baz'],
+            [u'foo', u'bar', u'baz'],
+        ]:
+            ds = Dataset({'x': strings})
+            kwargs = dict(encoding={'x': {'dtype': 'S1'}})
+            with self.roundtrip(ds, save_kwargs=kwargs) as actual:
+                self.assertEqual(actual['x'].encoding['dtype'], 'S1')
+                assert_identical(actual, ds)
 
     def test_default_fill_value(self):
         # Test default encoding for float:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1622,7 +1622,7 @@ class NetCDF3ViaNetCDF4DataTest(CFEncodedDataTest, NetCDF3Only, TestCase):
         original = Dataset({'x': [u'foo', u'bar', u'baz']})
         kwargs = dict(encoding={'x': {'dtype': str}})
         with raises_regex(ValueError, 'encoding dtype=str for vlen'):
-            with self.roundtrip(original, save_kwargs=kwargs) as actual:
+            with self.roundtrip(original, save_kwargs=kwargs):
                 pass
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -748,11 +748,20 @@ class CFEncodedDataTest(DatasetIOTestCases):
             with self.roundtrip(ds, save_kwargs=kwargs) as actual:
                 pass
 
+    def test_encoding_kwarg_dates(self):
         ds = Dataset({'t': pd.date_range('2000-01-01', periods=3)})
         units = 'days since 1900-01-01'
         kwargs = dict(encoding={'t': {'units': units}})
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
             self.assertEqual(actual.t.encoding['units'], units)
+            assert_identical(actual, ds)
+
+    def test_encoding_kwarg_string(self):
+        # regression test for GH2149
+        ds = Dataset({'x': ['foo', 'bar', 'baz']})
+        kwargs = dict(encoding={'x': {'dtype': 'S1'}})
+        with self.roundtrip(ds, save_kwargs=kwargs) as actual:
+            self.assertEqual(actual['x'].encoding['dtype'], 'S1')
             assert_identical(actual, ds)
 
     def test_default_fill_value(self):
@@ -1401,6 +1410,10 @@ class BaseZarrTest(CFEncodedDataTest):
         with self.roundtrip(original, save_kwargs={'group': group},
                             open_kwargs={'group': group}) as actual:
             assert_identical(original, actual)
+
+    def test_encoding_kwarg_string(self):
+        # not relevant for zarr, since we don't use EncodedStringCoder
+        pass
 
     # TODO: someone who understand caching figure out whether chaching
     # makes sense for Zarr backend

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -748,52 +748,6 @@ class CFEncodedDataTest(DatasetIOTestCases):
             with self.roundtrip(ds, save_kwargs=kwargs) as actual:
                 pass
 
-    def test_encoding_kwarg_compression(self):
-        ds = Dataset({
-            'x': np.arange(10.0),
-            's1': ['foo', 'bar', 'baz'],
-            's2': ['foo', 'bar', 'baz'],
-        })
-        kwargs = dict(encoding={
-            'x': {'dtype': 'f4'},
-            's1': {'dtype': 'S1'},
-            's2': {'dtype': str},
-        })
-
-        can_compress = (
-            self.engine not in ('scipy', 'zarr') and
-            self.file_format not in ('NETCDF3_CLASSIC', 'netcdf3_64bit'))
-        if can_compress:
-            kwargs['encoding']['x'].update(dict(
-                zlib=True, complevel=9, fletcher32=True, chunksizes=(5, ),
-                shuffle=True))
-
-        if self.engine == 'zarr':
-            actual_s2_dtype = '<U3'
-        elif self.engine == 'scipy':
-            actual_s2_dtype = 'S1'
-        elif self.file_format in ('NETCDF3_CLASSIC', 'NETCDF4_CLASSIC',
-                                  'netcdf3_64bit'):
-            actual_s2_dtype = 'S1'
-        else:
-            actual_s2_dtype = object
-
-        with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            self.assertEqual(actual.x.encoding['dtype'], 'f4')
-            if can_compress:
-                self.assertEqual(actual.x.encoding['zlib'], True)
-                self.assertEqual(actual.x.encoding['complevel'], 9)
-                self.assertEqual(actual.x.encoding['fletcher32'], True)
-                self.assertEqual(actual.x.encoding['chunksizes'], (5, ))
-                self.assertEqual(actual.x.encoding['shuffle'], True)
-            if self.engine != 'zarr':
-                self.assertEqual(actual.s1.encoding['dtype'], 'S1')
-                self.assertEqual(actual.s2.encoding['dtype'], actual_s2_dtype)
-
-        self.assertEqual(ds.x.encoding, {})
-        self.assertEqual(ds.s1.encoding, {})
-        self.assertEqual(ds.s2.encoding, {})
-
     def test_encoding_kwarg_dates(self):
         ds = Dataset({'t': pd.date_range('2000-01-01', periods=3)})
         units = 'days since 1900-01-01'
@@ -932,6 +886,7 @@ def create_tmp_files(nfiles, suffix='.nc', allow_cleanup_failure=False):
 
 @requires_netCDF4
 class BaseNetCDF4Test(CFEncodedDataTest):
+    """Tests for both netCDF4-python and h5netcdf."""
 
     engine = 'netcdf4'
 
@@ -1104,6 +1059,23 @@ class BaseNetCDF4Test(CFEncodedDataTest):
         expected = data.isel(dim1=0)
         with self.roundtrip(expected) as actual:
             assert_equal(expected, actual)
+
+    def test_encoding_kwarg_compression(self):
+        ds = Dataset({'x': np.arange(10.0)})
+        encoding = dict(dtype='f4', zlib=True, complevel=9, fletcher32=True,
+                        chunksizes=(5,), shuffle=True)
+        kwargs = dict(encoding=dict(x=encoding))
+
+        with self.roundtrip(ds, save_kwargs=kwargs) as actual:
+            assert_equal(actual, ds)
+            self.assertEqual(actual.x.encoding['dtype'], 'f4')
+            self.assertEqual(actual.x.encoding['zlib'], True)
+            self.assertEqual(actual.x.encoding['complevel'], 9)
+            self.assertEqual(actual.x.encoding['fletcher32'], True)
+            self.assertEqual(actual.x.encoding['chunksizes'], (5,))
+            self.assertEqual(actual.x.encoding['shuffle'], True)
+
+        self.assertEqual(ds.x.encoding, {})
 
     def test_encoding_chunksizes_unlimited(self):
         # regression test for GH1225

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1256,7 +1256,6 @@ class NetCDF4ViaDaskDataTestAutocloseTrue(NetCDF4ViaDaskDataTest):
 @requires_zarr
 class BaseZarrTest(CFEncodedDataTest):
 
-    engine = 'zarr'
     DIMENSION_KEY = '_ARRAY_DIMENSIONS'
 
     @contextlib.contextmanager

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -748,6 +748,52 @@ class CFEncodedDataTest(DatasetIOTestCases):
             with self.roundtrip(ds, save_kwargs=kwargs) as actual:
                 pass
 
+    def test_encoding_kwarg_compression(self):
+        ds = Dataset({
+            'x': np.arange(10.0),
+            's1': ['foo', 'bar', 'baz'],
+            's2': ['foo', 'bar', 'baz'],
+        })
+        kwargs = dict(encoding={
+            'x': {'dtype': 'f4'},
+            's1': {'dtype': 'S1'},
+            's2': {'dtype': str},
+        })
+
+        can_compress = (
+            self.engine not in ('scipy', 'zarr') and
+            self.file_format not in ('NETCDF3_CLASSIC', 'netcdf3_64bit'))
+        if can_compress:
+            kwargs['encoding']['x'].update(dict(
+                zlib=True, complevel=9, fletcher32=True, chunksizes=(5, ),
+                shuffle=True))
+
+        if self.engine == 'zarr':
+            actual_s2_dtype = '<U3'
+        elif self.engine == 'scipy':
+            actual_s2_dtype = 'S1'
+        elif self.file_format in ('NETCDF3_CLASSIC', 'NETCDF4_CLASSIC',
+                                  'netcdf3_64bit'):
+            actual_s2_dtype = 'S1'
+        else:
+            actual_s2_dtype = object
+
+        with self.roundtrip(ds, save_kwargs=kwargs) as actual:
+            self.assertEqual(actual.x.encoding['dtype'], 'f4')
+            if can_compress:
+                self.assertEqual(actual.x.encoding['zlib'], True)
+                self.assertEqual(actual.x.encoding['complevel'], 9)
+                self.assertEqual(actual.x.encoding['fletcher32'], True)
+                self.assertEqual(actual.x.encoding['chunksizes'], (5, ))
+                self.assertEqual(actual.x.encoding['shuffle'], True)
+            if self.engine != 'zarr':
+                self.assertEqual(actual.s1.encoding['dtype'], 'S1')
+                self.assertEqual(actual.s2.encoding['dtype'], actual_s2_dtype)
+
+        self.assertEqual(ds.x.encoding, {})
+        self.assertEqual(ds.s1.encoding, {})
+        self.assertEqual(ds.s2.encoding, {})
+
     def test_encoding_kwarg_dates(self):
         ds = Dataset({'t': pd.date_range('2000-01-01', periods=3)})
         units = 'days since 1900-01-01'
@@ -1234,6 +1280,7 @@ class NetCDF4ViaDaskDataTestAutocloseTrue(NetCDF4ViaDaskDataTest):
 @requires_zarr
 class BaseZarrTest(CFEncodedDataTest):
 
+    engine = 'zarr'
     DIMENSION_KEY = '_ARRAY_DIMENSIONS'
 
     @contextlib.contextmanager

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -884,7 +884,6 @@ def create_tmp_files(nfiles, suffix='.nc', allow_cleanup_failure=False):
         yield files
 
 
-@requires_netCDF4
 class BaseNetCDF4Test(CFEncodedDataTest):
     """Tests for both netCDF4-python and h5netcdf."""
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -756,7 +756,7 @@ class CFEncodedDataTest(DatasetIOTestCases):
             self.assertEqual(actual.t.encoding['units'], units)
             assert_identical(actual, ds)
 
-    def test_encoding_kwarg_string(self):
+    def test_encoding_kwarg_fixed_width_string(self):
         # regression test for GH2149
         for strings in [
             [b'foo', b'bar', b'baz'],
@@ -948,17 +948,17 @@ class BaseNetCDF4Test(CFEncodedDataTest):
             with open_dataset(tmp_file, group='data/2') as actual2:
                 assert_identical(data2, actual2)
 
-    @pytest.mark.parametrize('input_strings', [
-        [b'foo', b'bar', b'baz'],
-        [u'foo', u'bar', u'baz'],
-    ])
-    def test_encoding_kwarg_vlen_string(self, input_strings):
-        original = Dataset({'x': input_strings})
-        expected = Dataset({'x': [u'foo', u'bar', u'baz']})
-        kwargs = dict(encoding={'x': {'dtype': str}})
-        with self.roundtrip(original, save_kwargs=kwargs) as actual:
-            assert actual['x'].encoding['dtype'] is str
-            assert_identical(actual, expected)
+    def test_encoding_kwarg_vlen_string(self):
+        for input_strings in [
+            [b'foo', b'bar', b'baz'],
+            [u'foo', u'bar', u'baz'],
+        ]:
+            original = Dataset({'x': input_strings})
+            expected = Dataset({'x': [u'foo', u'bar', u'baz']})
+            kwargs = dict(encoding={'x': {'dtype': str}})
+            with self.roundtrip(original, save_kwargs=kwargs) as actual:
+                assert actual['x'].encoding['dtype'] is str
+                assert_identical(actual, expected)
 
     def test_roundtrip_string_with_fill_value_vlen(self):
         values = np.array([u'ab', u'cdef', np.nan], dtype=object)
@@ -1445,7 +1445,7 @@ class BaseZarrTest(CFEncodedDataTest):
                             open_kwargs={'group': group}) as actual:
             assert_identical(original, actual)
 
-    def test_encoding_kwarg_string(self):
+    def test_encoding_kwarg_fixed_width_string(self):
         # not relevant for zarr, since we don't use EncodedStringCoder
         pass
 

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -274,3 +274,6 @@ class TestCFEncodedDataStore(CFEncodedDataTest, TestCase):
 
     def test_encoding_kwarg(self):
         pass
+
+    def test_encoding_kwarg_string(self):
+        pass

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -277,3 +277,6 @@ class TestCFEncodedDataStore(CFEncodedDataTest, TestCase):
 
     def test_encoding_kwarg_string(self):
         pass
+
+    def test_encoding_kwarg_compression(self):
+        pass

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -275,5 +275,5 @@ class TestCFEncodedDataStore(CFEncodedDataTest, TestCase):
     def test_encoding_kwarg(self):
         pass
 
-    def test_encoding_kwarg_string(self):
+    def test_encoding_kwarg_fixed_width_string(self):
         pass

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -273,6 +273,11 @@ class TestCFEncodedDataStore(CFEncodedDataTest, TestCase):
         # only relevant for on-disk file formats
         pass
 
+    def test_encoding_kwarg(self):
+        # we haven't bothered to raise errors yet for unexpected encodings in
+        # this test dummy
+        pass
+
     def test_encoding_kwarg_fixed_width_string(self):
         # CFEncodedInMemoryStore doesn't support explicit string encodings.
         pass

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -270,10 +270,9 @@ class TestCFEncodedDataStore(CFEncodedDataTest, TestCase):
                                 'CFEncodedInMemoryStore')
 
     def test_invalid_dataarray_names_raise(self):
-        pass
-
-    def test_encoding_kwarg(self):
+        # only relevant for on-disk file formats
         pass
 
     def test_encoding_kwarg_fixed_width_string(self):
+        # CFEncodedInMemoryStore doesn't support explicit string encodings.
         pass

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -277,6 +277,3 @@ class TestCFEncodedDataStore(CFEncodedDataTest, TestCase):
 
     def test_encoding_kwarg_string(self):
         pass
-
-    def test_encoding_kwarg_compression(self):
-        pass


### PR DESCRIPTION
 - [x] Closes #2149 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

@crusaderky please take a look. Testing here is not as thorough as in https://github.com/pydata/xarray/pull/2150 yet, but it does include a regression test.