### PR TITLE
Fix string slice indexing for a length-1 CFTimeIndex

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -55,6 +55,12 @@ Bug fixes
   dimension were improperly skipped.
   By `Stephan Hoyer <https://github.com/shoyer>`_
 
+- Selecting data indexed by a length-1 ``CFTimeIndex`` with a slice of strings
+  now behaves as it does when using a length-1 ``DatetimeIndex`` (i.e. it no
+  longer falsely returns an empty array when the slice includes the value in
+  the index) (:issue:`2165`).
+  By `Spencer Clark <https://github.com/spencerkclark>`_.
+  
 .. _whats-new.0.10.4:
 
 v0.10.4 (May 16, 2018)

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -225,7 +225,7 @@ class CFTimeIndex(pd.Index):
                                                           label)
             start, end = _parsed_string_to_bounds(self.date_type, resolution,
                                                   parsed)
-            if self.is_monotonic_decreasing and len(self):
+            if self.is_monotonic_decreasing and len(self) > 1:
                 return end if side == 'left' else start
             return start if side == 'left' else end
         else:

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -80,6 +80,12 @@ def monotonic_decreasing_index(date_type):
 
 
 @pytest.fixture
+def length_one_index(date_type):
+    dates = [date_type(1, 1, 1)]
+    return CFTimeIndex(dates)
+
+
+@pytest.fixture
 def da(index):
     return xr.DataArray([1, 2, 3, 4], coords=[index],
                         dims=['time'])
@@ -278,6 +284,35 @@ def test_get_slice_bound_decreasing_index(
         date_type(1, 3, 1), 'right', kind)
     expected = 2
     assert result == expected
+
+
+@pytest.mark.skipif(not has_cftime, reason='cftime not installed')
+@pytest.mark.parametrize('kind', ['loc', 'getitem'])
+def test_get_slice_bound_length_one_index(
+        date_type, length_one_index, kind):
+    result = length_one_index.get_slice_bound('0001', 'left', kind)
+    expected = 0
+    assert result == expected
+
+    result = length_one_index.get_slice_bound('0001', 'right', kind)
+    expected = 1
+    assert result == expected
+
+    result = length_one_index.get_slice_bound(
+        date_type(1, 3, 1), 'left', kind)
+    expected = 1
+    assert result == expected
+
+    result = length_one_index.get_slice_bound(
+        date_type(1, 3, 1), 'right', kind)
+    expected = 1
+    assert result == expected
+
+
+def test_string_slice_length_one_index(length_one_index):
+    da = xr.DataArray([1], coords=[length_one_index], dims=['time'])
+    result = da.sel(time=slice('0001', '0001'))
+    assert_identical(result, da)
 
 
 @pytest.mark.skipif(not has_cftime, reason='cftime not installed')

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -309,6 +309,7 @@ def test_get_slice_bound_length_one_index(
     assert result == expected
 
 
+@pytest.mark.skipif(not has_cftime, reason='cftime not installed')
 def test_string_slice_length_one_index(length_one_index):
     da = xr.DataArray([1], coords=[length_one_index], dims=['time'])
     result = da.sel(time=slice('0001', '0001'))


### PR DESCRIPTION
 - [x] Closes #2165
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

The issue is that both `is_monotonic_decreasing` and `is_monotonic_increasing` return `True` for a length-1 index; therefore an additional check is needed to make sure the length of the index is greater than 1 in `CFTimeIndex._maybe_cast_slice_bound`.  This is similar to how things are done in [`DatetimeIndex._maybe_cast_slice_bound`](https://github.com/pandas-dev/pandas/blob/master/pandas/core/indexes/datetimes.py#L1666) in pandas.