### PR TITLE
Fix DataArray.stack() with non-unique coordinates on pandas 0.23

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -59,6 +59,10 @@ Bug fixes
   dimension were improperly skipped.
   By `Stephan Hoyer <https://github.com/shoyer>`_
 
+- Fix :meth:`~DataArray.stack` with non-unique coordinates on pandas 0.23
+  (:issue:`2160`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_
+
 - Selecting data indexed by a length-1 ``CFTimeIndex`` with a slice of strings
   now behaves as it does when using a length-1 ``DatetimeIndex`` (i.e. it no
   longer falsely returns an empty array when the slice includes the value in

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1673,6 +1673,13 @@ class TestDataArray(TestCase):
         actual = DataArray(s, dims='z').unstack('z')
         assert_identical(expected, actual)
 
+    def test_stack_nonunique_consistency(self):
+        orig = DataArray([[0, 1], [2, 3]], dims=['x', 'y'],
+                         coords={'x': [0, 1], 'y': [0, 0]})
+        actual = orig.stack(z=['x', 'y'])
+        expected = DataArray(orig.to_pandas().stack(), dims='z')
+        assert_identical(expected, actual)
+
     def test_transpose(self):
         assert_equal(self.dv.variable.transpose(),
                      self.dv.transpose().variable)

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -72,7 +72,8 @@ def test_safe_cast_to_index_datetime_datetime(enable_cftimeindex):
 
 
 def test_multiindex_from_product_levels():
-    result = utils.multiindex_from_product_levels([['b', 'a'], [1, 3, 2]])
+    result = utils.multiindex_from_product_levels(
+        [pd.Index(['b', 'a']), pd.Index([1, 3, 2])])
     np.testing.assert_array_equal(
         result.labels, [[0, 0, 0, 1, 1, 1], [0, 1, 2, 0, 1, 2]])
     np.testing.assert_array_equal(result.levels[0], ['b', 'a'])
@@ -80,6 +81,15 @@ def test_multiindex_from_product_levels():
 
     other = pd.MultiIndex.from_product([['b', 'a'], [1, 3, 2]])
     np.testing.assert_array_equal(result.values, other.values)
+
+
+def test_multiindex_from_product_levels_non_unique():
+    result = utils.multiindex_from_product_levels(
+        [pd.Index(['b', 'a']), pd.Index([1, 1, 2])])
+    np.testing.assert_array_equal(
+        result.labels, [[0, 0, 0, 1, 1, 1], [0, 0, 1, 0, 0, 1]])
+    np.testing.assert_array_equal(result.levels[0], ['b', 'a'])
+    np.testing.assert_array_equal(result.levels[1], [1, 2])
 
 
 class TestArrayEquiv(TestCase):


### PR DESCRIPTION
 - [x] Closes #2160 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
