### PR TITLE
Fix DataArray.groupby().reduce() mutating input array

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -64,6 +64,11 @@ Bug fixes
   longer falsely returns an empty array when the slice includes the value in
   the index) (:issue:`2165`).
   By `Spencer Clark <https://github.com/spencerkclark>`_.
+
+- Fix ``DataArray.groupby().reduce()`` mutating coordinates on the input array
+  when grouping over dimension coordinates with duplicated entries
+  (:issue:`2153`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_
   
 .. _whats-new.0.10.4:
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -251,7 +251,7 @@ class DataArray(AbstractArray, DataWithCoords):
 
     def _replace_maybe_drop_dims(self, variable, name=__default):
         if variable.dims == self.dims:
-            coords = None
+            coords = self._coords.copy()
         else:
             allowed_dims = set(variable.dims)
             coords = OrderedDict((k, v) for k, v in self._coords.items()

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -553,7 +553,7 @@ def test_apply_dask():
     array = da.ones((2,), chunks=2)
     variable = xr.Variable('x', array)
     coords = xr.DataArray(variable).coords.variables
-    data_array = xr.DataArray(variable, coords, fastpath=True)
+    data_array = xr.DataArray(variable, dims=['x'], coords=coords)
     dataset = xr.Dataset({'y': variable})
 
     # encountered dask array, but did not set dask='allowed'

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 import xarray as xr
+from . import assert_identical
 from xarray.core.groupby import _consolidate_slices
 
 
@@ -71,6 +72,16 @@ def test_groupby_duplicate_coordinate_labels():
     expected = xr.DataArray([3, 3], [('x', [1, 2])])
     actual = array.groupby('x').sum()
     assert expected.equals(actual)
+
+
+def test_groupby_input_mutation():
+    # regression test for GH2153
+    array = xr.DataArray([1, 2, 3], [('x', [2, 2, 1])])
+    array_copy = array.copy()
+    expected = xr.DataArray([3, 3], [('x', [1, 2])])
+    actual = array.groupby('x').sum()
+    assert_identical(expected, actual)
+    assert_identical(array, array_copy)  # should not modify inputs
 
 
 # TODO: move other groupby tests from test_dataset and test_dataarray over here


### PR DESCRIPTION
Fixes GH2153

 - [x] Closes #2153 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
