### PR TITLE
Datasets more robust to non-string keys

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -46,6 +46,14 @@ Enhancements
   to manage its version strings. (:issue:`1300`).
   By `Joe Hamman <https://github.com/jhamman>`_.
 
+- :py:meth:`~DataArray.sel`, :py:meth:`~DataArray.isel` & :py:meth:`~DataArray.reindex`,
+  (and their :py:class:`Dataset` counterparts) now support supplying a ``dict``
+  as a first argument, as an alternative to the existing approach 
+  of supplying a set of `kwargs`. This allows for more robust behavior
+  of dimension names which conflict with other keyword names, or are 
+  not strings.
+  By `Maximilian Roos <https://github.com/maxim-lian>`_.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ testpaths=xarray/tests
 [flake8]
 max-line-length=79
 ignore=
+  W503
 exclude=
   doc/
 

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -9,7 +9,7 @@ from . import formatting, indexing
 from .merge import (
     expand_and_merge_variables, merge_coords, merge_coords_for_inplace_math)
 from .pycompat import OrderedDict
-from .utils import Frozen, ReprObject, combine_pos_and_kw_args
+from .utils import Frozen, ReprObject, either_dict_or_kwargs
 from .variable import Variable
 
 # Used as the key corresponding to a DataArray's variable when converting
@@ -345,7 +345,7 @@ def remap_label_indexers(obj, indexers=None, method=None, tolerance=None,
     new_indexes: mapping of new dimensional-coordinate.
     """
     from .dataarray import DataArray
-    indexers = combine_pos_and_kw_args(
+    indexers = either_dict_or_kwargs(
         indexers, indexers_kwargs, 'remap_label_indexers')
 
     v_indexers = {k: v.variable.data if isinstance(v, DataArray) else v

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -9,9 +9,8 @@ from . import formatting, indexing
 from .merge import (
     expand_and_merge_variables, merge_coords, merge_coords_for_inplace_math)
 from .pycompat import OrderedDict
-from .utils import Frozen, ReprObject
+from .utils import Frozen, ReprObject, combine_pos_and_kw_args
 from .variable import Variable
-
 
 # Used as the key corresponding to a DataArray's variable when converting
 # arbitrary DataArray objects to datasets
@@ -332,7 +331,8 @@ def assert_coordinate_consistent(obj, coords):
                     .format(k, obj[k], coords[k]))
 
 
-def remap_label_indexers(obj, method=None, tolerance=None, **indexers):
+def remap_label_indexers(obj, indexers=None, method=None, tolerance=None,
+                         **indexers_kwargs):
     """
     Remap **indexers from obj.coords.
     If indexer is an instance of DataArray and it has coordinate, then this
@@ -345,6 +345,8 @@ def remap_label_indexers(obj, method=None, tolerance=None, **indexers):
     new_indexes: mapping of new dimensional-coordinate.
     """
     from .dataarray import DataArray
+    indexers = combine_pos_and_kw_args(
+        indexers, indexers_kwargs, 'remap_label_indexers')
 
     v_indexers = {k: v.variable.data if isinstance(v, DataArray) else v
                   for k, v in indexers.items()}

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -785,7 +785,7 @@ class DataArray(AbstractArray, DataWithCoords):
             indexers=indexers, drop=drop, method=method, tolerance=tolerance)
         return self._from_temp_dataset(ds)
 
-    def isel_points(self, indexers=None, dim='points', **indexers_kwargs):
+    def isel_points(self, dim='points', **indexers):
         """Return a new DataArray whose dataset is given by pointwise integer
         indexing along the specified dimension(s).
 
@@ -793,13 +793,11 @@ class DataArray(AbstractArray, DataWithCoords):
         --------
         Dataset.isel_points
         """
-        indexers = combine_pos_and_kw_args(
-            indexers, indexers_kwargs, 'isel_points')
         ds = self._to_temp_dataset().isel_points(dim=dim, **indexers)
         return self._from_temp_dataset(ds)
 
-    def sel_points(self, indexers=None, dim='points', method=None,
-                   tolerance=None, **indexers_kwargs):
+    def sel_points(self, dim='points', method=None, tolerance=None,
+                   **indexers):
         """Return a new DataArray whose dataset is given by pointwise selection
         of index labels along the specified dimension(s).
 
@@ -807,8 +805,6 @@ class DataArray(AbstractArray, DataWithCoords):
         --------
         Dataset.sel_points
         """
-        indexers = combine_pos_and_kw_args(
-            indexers, indexers_kwargs, 'sel_points')
         ds = self._to_temp_dataset().sel_points(
             dim=dim, method=method, tolerance=tolerance, **indexers)
         return self._from_temp_dataset(ds)
@@ -860,12 +856,18 @@ class DataArray(AbstractArray, DataWithCoords):
         return self.reindex(method=method, tolerance=tolerance, copy=copy,
                             **indexers)
 
-    def reindex(self, method=None, tolerance=None, copy=True, **indexers):
+    def reindex(self, indexers=None, method=None, tolerance=None, copy=True,
+                **indexers_kwargs):
         """Conform this object onto a new set of indexes, filling in
         missing values with NaN.
 
         Parameters
         ----------
+        **indexers : dict
+            Dictionary with keys given by dimension names and values given by
+            arrays of coordinates tick labels. Any mis-matched coordinate
+            values will be filled in with NaN, and any mis-matched dimension
+            names will simply be ignored.
         copy : bool, optional
             If ``copy=True``, data in the return value is always copied. If
             ``copy=False`` and reindexing is unnecessary, or can be performed
@@ -883,11 +885,8 @@ class DataArray(AbstractArray, DataWithCoords):
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations most
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
-        **indexers : dict
-            Dictionary with keys given by dimension names and values given by
-            arrays of coordinates tick labels. Any mis-matched coordinate
-            values will be filled in with NaN, and any mis-matched dimension
-            names will simply be ignored.
+        **indexers_kwargs : {dim: indexer, ...}
+            The keyword arguments form of ``indexers``
 
         Returns
         -------
@@ -900,8 +899,10 @@ class DataArray(AbstractArray, DataWithCoords):
         DataArray.reindex_like
         align
         """
+        indexers = combine_pos_and_kw_args(
+            indexers, indexers_kwargs, 'reindex')
         ds = self._to_temp_dataset().reindex(
-            method=method, tolerance=tolerance, copy=copy, **indexers)
+            indexers=indexers, method=method, tolerance=tolerance, copy=copy)
         return self._from_temp_dataset(ds)
 
     def rename(self, new_name_or_name_dict):

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -886,7 +886,7 @@ class DataArray(AbstractArray, DataWithCoords):
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations most
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
-        **indexers_kwargs : {dim: indexer, ...}
+        **indexers_kwarg : {dim: indexer, ...}, optional
             The keyword arguments form of ``indexers``.
             One of indexers or indexers_kwargs must be provided.
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -466,7 +466,14 @@ class DataArray(AbstractArray, DataWithCoords):
         return self._replace_maybe_drop_dims(var, name=key)
 
     def __getitem__(self, key):
-        if isinstance(key, basestring):
+        try:
+            is_coord_key = key in set(self.dims).union(self.coords)
+        except TypeError:
+            # not hashable, but testing with collections.Hashable is not
+            # complete, since# tuples with slices inside will suggest
+            # they're hashable
+            is_coord_key = False
+        if is_coord_key:
             return self._getitem_coord(key)
         else:
             # xarray-style array indexing

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -472,7 +472,7 @@ class DataArray(AbstractArray, DataWithCoords):
             return self._getitem_coord(key)
         else:
             # xarray-style array indexing
-            return self.isel(indexer_dict=self._item_key_to_dict(key))
+            return self.isel(indexers=self._item_key_to_dict(key))
 
     def __setitem__(self, key, value):
         if isinstance(key, basestring):
@@ -754,10 +754,11 @@ class DataArray(AbstractArray, DataWithCoords):
         DataArray.sel
         """
         indexers = combine_pos_and_kw_args(indexers, indexers_kwargs, 'isel')
-        ds = self._to_temp_dataset().isel(drop=drop, indexer_dict=indexers)
+        ds = self._to_temp_dataset().isel(drop=drop, indexers=indexers)
         return self._from_temp_dataset(ds)
 
-    def sel(self, method=None, tolerance=None, drop=False, **indexers):
+    def sel(self, indexers=None, method=None, tolerance=None, drop=False,
+            **indexers_kwargs):
         """Return a new DataArray whose dataset is given by selecting
         index labels along the specified dimension(s).
 
@@ -779,11 +780,12 @@ class DataArray(AbstractArray, DataWithCoords):
         DataArray.isel
 
         """
-        ds = self._to_temp_dataset().sel(drop=drop, method=method,
-                                         tolerance=tolerance, **indexers)
+        indexers = combine_pos_and_kw_args(indexers, indexers_kwargs, 'sel')
+        ds = self._to_temp_dataset().sel(
+            indexers=indexers, drop=drop, method=method, tolerance=tolerance)
         return self._from_temp_dataset(ds)
 
-    def isel_points(self, dim='points', **indexers):
+    def isel_points(self, indexers=None, dim='points', **indexers_kwargs):
         """Return a new DataArray whose dataset is given by pointwise integer
         indexing along the specified dimension(s).
 
@@ -791,11 +793,13 @@ class DataArray(AbstractArray, DataWithCoords):
         --------
         Dataset.isel_points
         """
+        indexers = combine_pos_and_kw_args(
+            indexers, indexers_kwargs, 'isel_points')
         ds = self._to_temp_dataset().isel_points(dim=dim, **indexers)
         return self._from_temp_dataset(ds)
 
-    def sel_points(self, dim='points', method=None, tolerance=None,
-                   **indexers):
+    def sel_points(self, indexers=None, dim='points', method=None,
+                   tolerance=None, **indexers_kwargs):
         """Return a new DataArray whose dataset is given by pointwise selection
         of index labels along the specified dimension(s).
 
@@ -803,6 +807,8 @@ class DataArray(AbstractArray, DataWithCoords):
         --------
         Dataset.sel_points
         """
+        indexers = combine_pos_and_kw_args(
+            indexers, indexers_kwargs, 'sel_points')
         ds = self._to_temp_dataset().sel_points(
             dim=dim, method=method, tolerance=tolerance, **indexers)
         return self._from_temp_dataset(ds)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -467,7 +467,10 @@ class DataArray(AbstractArray, DataWithCoords):
 
     def __getitem__(self, key):
         try:
-            is_coord_key = key in set(self.dims).union(self.coords)
+            is_coord_key = any([
+                isinstance(key, basestring),
+                key in set(self.dims).union(self.coords)
+            ])
         except TypeError:
             # not hashable, but testing with collections.Hashable is not
             # complete, since# tuples with slices inside will suggest

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -863,11 +863,12 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Parameters
         ----------
-        **indexers : dict
+        indexers : dict, optional
             Dictionary with keys given by dimension names and values given by
             arrays of coordinates tick labels. Any mis-matched coordinate
             values will be filled in with NaN, and any mis-matched dimension
             names will simply be ignored.
+            One of indexers or indexers_kwargs must be provided.
         copy : bool, optional
             If ``copy=True``, data in the return value is always copied. If
             ``copy=False`` and reindexing is unnecessary, or can be performed
@@ -886,7 +887,8 @@ class DataArray(AbstractArray, DataWithCoords):
             matches. The values of the index at the matching locations most
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
         **indexers_kwargs : {dim: indexer, ...}
-            The keyword arguments form of ``indexers``
+            The keyword arguments form of ``indexers``.
+            One of indexers or indexers_kwargs must be provided.
 
         Returns
         -------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -19,7 +19,7 @@ from .formatting import format_item
 from .options import OPTIONS
 from .pycompat import OrderedDict, basestring, iteritems, range, zip
 from .utils import (
-    combine_pos_and_kw_args, decode_numpy_dict_values,
+    either_dict_or_kwargs, decode_numpy_dict_values,
     ensure_us_time_resolution)
 from .variable import (
     IndexVariable, Variable, as_compatible_data, as_variable,
@@ -753,7 +753,7 @@ class DataArray(AbstractArray, DataWithCoords):
         Dataset.isel
         DataArray.sel
         """
-        indexers = combine_pos_and_kw_args(indexers, indexers_kwargs, 'isel')
+        indexers = either_dict_or_kwargs(indexers, indexers_kwargs, 'isel')
         ds = self._to_temp_dataset().isel(drop=drop, indexers=indexers)
         return self._from_temp_dataset(ds)
 
@@ -780,7 +780,7 @@ class DataArray(AbstractArray, DataWithCoords):
         DataArray.isel
 
         """
-        indexers = combine_pos_and_kw_args(indexers, indexers_kwargs, 'sel')
+        indexers = either_dict_or_kwargs(indexers, indexers_kwargs, 'sel')
         ds = self._to_temp_dataset().sel(
             indexers=indexers, drop=drop, method=method, tolerance=tolerance)
         return self._from_temp_dataset(ds)
@@ -899,7 +899,7 @@ class DataArray(AbstractArray, DataWithCoords):
         DataArray.reindex_like
         align
         """
-        indexers = combine_pos_and_kw_args(
+        indexers = either_dict_or_kwargs(
             indexers, indexers_kwargs, 'reindex')
         ds = self._to_temp_dataset().reindex(
             indexers=indexers, method=method, tolerance=tolerance, copy=copy)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -18,7 +18,9 @@ from .dataset import Dataset, merge_indexes, split_indexes
 from .formatting import format_item
 from .options import OPTIONS
 from .pycompat import OrderedDict, basestring, iteritems, range, zip
-from .utils import decode_numpy_dict_values, ensure_us_time_resolution
+from .utils import (
+    combine_pos_and_kw_args, decode_numpy_dict_values,
+    ensure_us_time_resolution)
 from .variable import (
     IndexVariable, Variable, as_compatible_data, as_variable,
     assert_unique_multiindex_level_names)
@@ -742,7 +744,7 @@ class DataArray(AbstractArray, DataWithCoords):
                                            token=token, lock=lock)
         return self._from_temp_dataset(ds)
 
-    def isel(self, indexer_dict=None, drop=False, **indexers):
+    def isel(self, indexers=None, drop=False, **indexers_kwargs):
         """Return a new DataArray whose dataset is given by integer indexing
         along the specified dimension(s).
 
@@ -751,12 +753,7 @@ class DataArray(AbstractArray, DataWithCoords):
         Dataset.isel
         DataArray.sel
         """
-        if indexer_dict is not None:
-            if indexers:
-                # could combine them (easier syntax when we drop Py2)
-                raise ValueError("Both indexer_dict and indexers supplied. "
-                                 "Please only provide one")
-            indexers = indexer_dict
+        indexers = combine_pos_and_kw_args(indexers, indexers_kwargs, 'isel')
         ds = self._to_temp_dataset().isel(drop=drop, indexer_dict=indexers)
         return self._from_temp_dataset(ds)
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1368,7 +1368,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
                 attached_coords[k] = v
         return attached_coords
 
-    def isel(self, drop=False, **indexers):
+    def isel(self, indexer_dict=None, drop=False, **indexers):
         """Returns a new dataset with each array indexed along the specified
         dimension(s).
 
@@ -1404,12 +1404,19 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         Dataset.sel
         DataArray.isel
         """
+        if indexer_dict is not None:
+            if indexers:
+                raise ValueError("Both indexer_dict and indexers supplied. "
+                                 "Please only provide one")
+            indexers = indexer_dict
+        assert isinstance(drop, bool)
+
         indexers_list = self._validate_indexers(indexers)
 
         variables = OrderedDict()
         for name, var in iteritems(self._variables):
             var_indexers = {k: v for k, v in indexers_list if k in var.dims}
-            new_var = var.isel(**var_indexers)
+            new_var = var.isel(indexer_dict=var_indexers)
             if not (drop and name in var_indexers):
                 variables[name] = new_var
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1408,7 +1408,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         """
 
         indexers = either_dict_or_kwargs(indexers, indexers_kwargs, 'isel')
-        assert isinstance(drop, bool)
 
         indexers_list = self._validate_indexers(indexers)
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1384,11 +1384,13 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
             indexer can be a integer, slice, array-like or DataArray.
             If DataArrays are passed as indexers, xarray-style indexing will be
             carried out. See :ref:`indexing` for the details.
+            One of indexers or indexers_kwargs must be provided.
         drop : bool, optional
             If ``drop=True``, drop coordinates variables indexed by integers
             instead of making them scalar.
         **indexers_kwarg : {dim: indexer, ...}
-            The keyword arguments form of ``indexers``
+            The keyword arguments form of ``indexers``.
+            One of indexers or indexers_kwargs must be provided.
 
         Returns
         -------
@@ -1458,6 +1460,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
             matching index level names.
             If DataArrays are passed as indexers, xarray-style indexing will be
             carried out. See :ref:`indexing` for the details.
+            One of indexers or indexers_kwargs must be provided.
         method : {None, 'nearest', 'pad'/'ffill', 'backfill'/'bfill'}, optional
             Method to use for inexact matches (requires pandas>=0.16):
 
@@ -1474,7 +1477,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
             If ``drop=True``, drop coordinates variables in `indexers` instead
             of making them scalar.
         **indexers_kwargs : {dim: indexer, ...}
-            The keyword arguments form of ``indexers``
+            The keyword arguments form of ``indexers``.
+            One of indexers or indexers_kwargs must be provided.
 
         Returns
         -------
@@ -1755,6 +1759,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
             arrays of coordinates tick labels. Any mis-matched coordinate values
             will be filled in with NaN, and any mis-matched dimension names will
             simply be ignored.
+            One of indexers or indexers_kwargs must be provided.
         method : {None, 'nearest', 'pad'/'ffill', 'backfill'/'bfill'}, optional
             Method to use for filling index values in ``indexers`` not found in
             this dataset:
@@ -1773,8 +1778,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
             ``copy=False`` and reindexing is unnecessary, or can be performed
             with only slice operations, then the output may share memory with
             the input. In either case, a new xarray object is always returned.
-        **indexers_kwargs : optional
+        **indexers_kwargs : optional : {dim: indexer, ...}
             Keyword arguments in the same form as ``indexers``.
+            One of indexers or indexers_kwargs must be provided.
 
         Returns
         -------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1745,7 +1745,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
                             **indexers)
 
     def reindex(self, indexers=None, method=None, tolerance=None, copy=True,
-                **kw_indexers):
+                **indexers_kwargs):
         """Conform this object onto a new set of indexes, filling in
         missing values with NaN.
 
@@ -1774,7 +1774,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
             ``copy=False`` and reindexing is unnecessary, or can be performed
             with only slice operations, then the output may share memory with
             the input. In either case, a new xarray object is always returned.
-        **kw_indexers : optional
+        **indexers_kwargs : optional
             Keyword arguments in the same form as ``indexers``.
 
         Returns
@@ -1788,7 +1788,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         align
         pandas.Index.get_indexer
         """
-        indexers = utils.combine_pos_and_kw_args(indexers, kw_indexers,
+        indexers = utils.combine_pos_and_kw_args(indexers, indexers_kwargs,
                                                  'reindex')
 
         bad_dims = [d for d in indexers if d not in self.dims]

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1452,7 +1452,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
 
         Parameters
         ----------
-        ----------
         indexers : dict, optional
             A dict with keys matching dimensions and values given
             by scalars, slices or arrays of tick labels. For dimensions with

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -30,7 +30,7 @@ from .options import OPTIONS
 from .pycompat import (
     OrderedDict, basestring, dask_array_type, integer_types, iteritems, range)
 from .utils import (
-    Frozen, SortedKeysDict, combine_pos_and_kw_args, decode_numpy_dict_values,
+    Frozen, SortedKeysDict, either_dict_or_kwargs, decode_numpy_dict_values,
     ensure_us_time_resolution, hashable, maybe_wrap_array)
 from .variable import IndexVariable, Variable, as_variable, broadcast_variables
 
@@ -1407,7 +1407,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         DataArray.isel
         """
 
-        indexers = combine_pos_and_kw_args(indexers, indexers_kwargs, 'isel')
+        indexers = either_dict_or_kwargs(indexers, indexers_kwargs, 'isel')
         assert isinstance(drop, bool)
 
         indexers_list = self._validate_indexers(indexers)
@@ -1494,7 +1494,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         Dataset.isel
         DataArray.sel
         """
-        indexers = combine_pos_and_kw_args(indexers, indexers_kwargs, 'sel')
+        indexers = either_dict_or_kwargs(indexers, indexers_kwargs, 'sel')
         pos_indexers, new_indexes = remap_label_indexers(
             self, indexers=indexers, method=method, tolerance=tolerance)
         result = self.isel(indexers=pos_indexers, drop=drop)
@@ -1788,7 +1788,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         align
         pandas.Index.get_indexer
         """
-        indexers = utils.combine_pos_and_kw_args(indexers, indexers_kwargs,
+        indexers = utils.either_dict_or_kwargs(indexers, indexers_kwargs,
                                                  'reindex')
 
         bad_dims = [d for d in indexers if d not in self.dims]

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1388,7 +1388,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         drop : bool, optional
             If ``drop=True``, drop coordinates variables indexed by integers
             instead of making them scalar.
-        **indexers_kwarg : {dim: indexer, ...}
+        **indexers_kwarg : {dim: indexer, ...}, optional
             The keyword arguments form of ``indexers``.
             One of indexers or indexers_kwargs must be provided.
 
@@ -1476,7 +1476,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         drop : bool, optional
             If ``drop=True``, drop coordinates variables in `indexers` instead
             of making them scalar.
-        **indexers_kwargs : {dim: indexer, ...}
+        **indexers_kwarg : {dim: indexer, ...}, optional
             The keyword arguments form of ``indexers``.
             One of indexers or indexers_kwargs must be provided.
 
@@ -1778,7 +1778,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
             ``copy=False`` and reindexing is unnecessary, or can be performed
             with only slice operations, then the output may share memory with
             the input. In either case, a new xarray object is always returned.
-        **indexers_kwargs : optional : {dim: indexer, ...}
+        **indexers_kwarg : {dim: indexer, ...}, optional
             Keyword arguments in the same form as ``indexers``.
             One of indexers or indexers_kwargs must be provided.
 

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -183,7 +183,7 @@ def is_full_slice(value):
     return isinstance(value, slice) and value == slice(None)
 
 
-def combine_pos_and_kw_args(pos_kwargs, kw_kwargs, func_name):
+def either_dict_or_kwargs(pos_kwargs, kw_kwargs, func_name):
     if pos_kwargs is not None:
         if not is_dict_like(pos_kwargs):
             raise ValueError('the first argument to .%s must be a dictionary'

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -11,13 +11,13 @@ import pandas as pd
 import xarray as xr  # only for Dataset and DataArray
 
 from . import (
-    arithmetic, common, dtypes, duck_array_ops, indexing, nputils, ops, utils,)
+    arithmetic, common, dtypes, duck_array_ops, indexing, nputils, ops, utils)
 from .indexing import (
     BasicIndexer, OuterIndexer, PandasIndexAdapter, VectorizedIndexer,
     as_indexable)
 from .pycompat import (
     OrderedDict, basestring, dask_array_type, integer_types, zip)
-from .utils import OrderedSet
+from .utils import OrderedSet, combine_pos_and_kw_args
 
 try:
     import dask.array as da
@@ -824,7 +824,7 @@ class Variable(common.AbstractArray, arithmetic.SupportsArithmetic,
         return type(self)(self.dims, data, self._attrs, self._encoding,
                           fastpath=True)
 
-    def isel(self, indexer_dict=None, **indexers):
+    def isel(self, indexers=None, drop=False, **indexers_kwargs):
         """Return a new array indexed along the specified dimension(s).
 
         Parameters
@@ -841,11 +841,7 @@ class Variable(common.AbstractArray, arithmetic.SupportsArithmetic,
             unless numpy fancy indexing was triggered by using an array
             indexer, in which case the data will be a copy.
         """
-        if indexer_dict is not None:
-            if indexers:
-                raise ValueError("Both indexer_dict and indexers supplied. "
-                                 "Please only provide one")
-            indexers = indexer_dict
+        indexers = combine_pos_and_kw_args(indexers, indexers_kwargs, 'isel')
 
         invalid = [k for k in indexers if k not in self.dims]
         if invalid:

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -824,7 +824,7 @@ class Variable(common.AbstractArray, arithmetic.SupportsArithmetic,
         return type(self)(self.dims, data, self._attrs, self._encoding,
                           fastpath=True)
 
-    def isel(self, **indexers):
+    def isel(self, indexer_dict=None, **indexers):
         """Return a new array indexed along the specified dimension(s).
 
         Parameters
@@ -841,6 +841,12 @@ class Variable(common.AbstractArray, arithmetic.SupportsArithmetic,
             unless numpy fancy indexing was triggered by using an array
             indexer, in which case the data will be a copy.
         """
+        if indexer_dict is not None:
+            if indexers:
+                raise ValueError("Both indexer_dict and indexers supplied. "
+                                 "Please only provide one")
+            indexers = indexer_dict
+
         invalid = [k for k in indexers if k not in self.dims]
         if invalid:
             raise ValueError("dimensions %r do not exist" % invalid)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -17,7 +17,7 @@ from .indexing import (
     as_indexable)
 from .pycompat import (
     OrderedDict, basestring, dask_array_type, integer_types, zip)
-from .utils import OrderedSet, combine_pos_and_kw_args
+from .utils import OrderedSet, either_dict_or_kwargs
 
 try:
     import dask.array as da
@@ -841,7 +841,7 @@ class Variable(common.AbstractArray, arithmetic.SupportsArithmetic,
             unless numpy fancy indexing was triggered by using an array
             indexer, in which case the data will be a copy.
         """
-        indexers = combine_pos_and_kw_args(indexers, indexers_kwargs, 'isel')
+        indexers = either_dict_or_kwargs(indexers, indexers_kwargs, 'isel')
 
         invalid = [k for k in indexers if k not in self.dims]
         if invalid:

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -17,8 +17,8 @@ from xarray.core.common import full_like
 from xarray.core.pycompat import OrderedDict, iteritems
 from xarray.tests import (
     ReturnItem, TestCase, assert_allclose, assert_array_equal, assert_equal,
-    assert_identical, raises_regex, requires_bottleneck, requires_dask,
-    requires_scipy, source_ndarray, unittest, requires_cftime)
+    assert_identical, raises_regex, requires_bottleneck, requires_cftime,
+    requires_dask, requires_scipy, source_ndarray, unittest)
 
 
 class TestDataArray(TestCase):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1435,7 +1435,7 @@ class TestDataset(TestCase):
 
         with raises_regex(TypeError, '``method``'):
             # this should not pass silently
-            data.sel(data)
+            data.sel(method=data)
 
         # cannot pass method if there is no associated coordinate
         with raises_regex(ValueError, 'cannot supply'):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4181,6 +4181,12 @@ def test_dir_non_string(data_set):
     result = dir(data_set)
     assert not (5 in result)
 
+    # GH2172
+    sample_data = np.random.uniform(size=[2, 2000, 10000])
+    x = xr.Dataset({"sample_data": (sample_data.shape, sample_data)})
+    x2 = x["sample_data"]
+    dir(x2)
+
 
 def test_dir_unicode(data_set):
     data_set[u'unicode'] = 'uni'

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -1,17 +1,21 @@
 from __future__ import absolute_import, division, print_function
 
+from datetime import datetime
+
 import numpy as np
 import pandas as pd
 import pytest
 
-from datetime import datetime
 from xarray.coding.cftimeindex import CFTimeIndex
 from xarray.core import duck_array_ops, utils
 from xarray.core.options import set_options
 from xarray.core.pycompat import OrderedDict
+from xarray.core.utils import either_dict_or_kwargs
+
+from . import (
+    TestCase, assert_array_equal, has_cftime, has_cftime_or_netCDF4,
+    requires_dask)
 from .test_coding_times import _all_cftime_date_types
-from . import (TestCase, requires_dask, assert_array_equal,
-               has_cftime_or_netCDF4, has_cftime)
 
 
 class TestAlias(TestCase):
@@ -235,3 +239,17 @@ def test_hidden_key_dict():
         hkd[hidden_key]
     with pytest.raises(KeyError):
         del hkd[hidden_key]
+
+
+def test_either_dict_or_kwargs():
+
+    result = either_dict_or_kwargs(dict(a=1), None, 'foo')
+    expected = dict(a=1)
+    assert result == expected
+
+    result = either_dict_or_kwargs(None, dict(a=1), 'foo')
+    expected = dict(a=1)
+    assert result == expected
+
+    with pytest.raises(ValueError, match=r'foo'):
+        result = either_dict_or_kwargs(dict(a=1), dict(a=1), 'foo')


### PR DESCRIPTION
 - [x] Closes #2172 & #2173 
 - [x] Tests added 
 - [x] Tests passed 
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

I don't think this is the most efficient way of doing this, though it does work. Any ideas for a more efficient implementation?