### PR TITLE
weighted rolling mean -> weighted rolling sum

### DIFF
--- a/doc/computation.rst
+++ b/doc/computation.rst
@@ -185,7 +185,7 @@ windowed rolling, convolution, short-time FFT etc.
 
 Because the ``DataArray`` given by ``r.construct('window_dim')`` is a view
 of the original array, it is memory efficient.
-You can also use ``construct`` to compute a weighted rolling mean:
+You can also use ``construct`` to compute a weighted rolling sum:
 
 .. ipython:: python
 


### PR DESCRIPTION
An example of weighted rolling mean in doc is actually weighted rolling *sum*.
It is a little bit misleading [SO](https://stackoverflow.com/questions/50520835/xarray-simple-weighted-rolling-mean-example-using-construct/50524093#50524093), so I propose to change 

`weighted rolling mean` -> `weighted rolling sum`
