### PR TITLE
docs: add xyzpy to projects

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -211,6 +211,7 @@ Extend xarray capabilities
 - `xrft <https://github.com/rabernat/xrft>`_: Fourier transforms for xarray data.
 - `xr-scipy <https://xr-scipy.readthedocs.io>`_: A lightweight scipy wrapper for xarray.
 - `X-regression <https://github.com/kuchaale/X-regression>`_: Multiple linear regression from Statsmodels library coupled with Xarray library.
+- `xyzpy <http://xyzpy.readthedocs.io>`_: Easily generate high dimensional data, including parallelization.
 
 Visualization
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Justs adds [xyzpy](http://xyzpy.readthedocs.io) to the list of projects utilizing ``xarray``.