### PR TITLE
Rename takes kwargs

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -49,9 +49,14 @@ Enhancements
 - :py:meth:`~DataArray.sel`, :py:meth:`~DataArray.isel` & :py:meth:`~DataArray.reindex`,
   (and their :py:class:`Dataset` counterparts) now support supplying a ``dict``
   as a first argument, as an alternative to the existing approach 
-  of supplying a set of `kwargs`. This allows for more robust behavior
+  of supplying `kwargs`. This allows for more robust behavior
   of dimension names which conflict with other keyword names, or are 
   not strings.
+  By `Maximilian Roos <https://github.com/maxim-lian>`_.
+
+- :py:meth:`~DataArray.rename` now supports supplying `kwargs`, as an
+  alternative to the existing approach of supplying a ``dict`` as the 
+  first argument.
   By `Maximilian Roos <https://github.com/maxim-lian>`_.
 
 Bug fixes

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -932,7 +932,7 @@ class DataArray(AbstractArray, DataWithCoords):
         Dataset.rename
         DataArray.swap_dims
         """
-        if utils.is_dict_like(new_name_or_name_dict):
+        if names or utils.is_dict_like(new_name_or_name_dict):
             name_dict = either_dict_or_kwargs(
                 new_name_or_name_dict, names, 'rename')
             dataset = self._to_temp_dataset().rename(name_dict)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -19,8 +19,7 @@ from .formatting import format_item
 from .options import OPTIONS
 from .pycompat import OrderedDict, basestring, iteritems, range, zip
 from .utils import (
-    either_dict_or_kwargs, decode_numpy_dict_values,
-    ensure_us_time_resolution)
+    decode_numpy_dict_values, either_dict_or_kwargs, ensure_us_time_resolution)
 from .variable import (
     IndexVariable, Variable, as_compatible_data, as_variable,
     assert_unique_multiindex_level_names)
@@ -907,16 +906,20 @@ class DataArray(AbstractArray, DataWithCoords):
             indexers=indexers, method=method, tolerance=tolerance, copy=copy)
         return self._from_temp_dataset(ds)
 
-    def rename(self, new_name_or_name_dict):
+    def rename(self, new_name_or_name_dict=None, **names):
         """Returns a new DataArray with renamed coordinates or a new name.
 
 
         Parameters
         ----------
-        new_name_or_name_dict : str or dict-like
+        new_name_or_name_dict : str or dict-like, optional
             If the argument is dict-like, it it used as a mapping from old
             names to new names for coordinates. Otherwise, use the argument
             as the new name for this array.
+        **names, optional
+            The keyword arguments form of a mapping from old names to
+            new names for coordinates.
+            One of new_name_or_name_dict or names must be provided.
 
 
         Returns
@@ -930,7 +933,9 @@ class DataArray(AbstractArray, DataWithCoords):
         DataArray.swap_dims
         """
         if utils.is_dict_like(new_name_or_name_dict):
-            dataset = self._to_temp_dataset().rename(new_name_or_name_dict)
+            name_dict = either_dict_or_kwargs(
+                new_name_or_name_dict, names, 'rename')
+            dataset = self._to_temp_dataset().rename(name_dict)
             return self._from_temp_dataset(dataset)
         else:
             return self._replace(name=new_name_or_name_dict)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1806,17 +1806,20 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         coord_names.update(indexers)
         return self._replace_vars_and_dims(variables, coord_names)
 
-    def rename(self, name_dict, inplace=False):
+    def rename(self, name_dict, inplace=False, **names):
         """Returns a new object with renamed variables and dimensions.
 
         Parameters
         ----------
-        name_dict : dict-like
+        name_dict : dict-like, optional
             Dictionary whose keys are current variable or dimension names and
             whose values are the desired names.
         inplace : bool, optional
             If True, rename variables and dimensions in-place. Otherwise,
             return a new dataset object.
+        **names, optional
+            Keyword form of ``name_dict``.
+            One of name_dict or names must be provided.
 
         Returns
         -------
@@ -1828,6 +1831,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         Dataset.swap_dims
         DataArray.rename
         """
+        name_dict = either_dict_or_kwargs(name_dict, names, 'rename')
         for k, v in name_dict.items():
             if k not in self and k not in self.dims:
                 raise ValueError("cannot rename %r because it is not a "

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1806,7 +1806,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         coord_names.update(indexers)
         return self._replace_vars_and_dims(variables, coord_names)
 
-    def rename(self, name_dict, inplace=False, **names):
+    def rename(self, name_dict=None, inplace=False, **names):
         """Returns a new object with renamed variables and dimensions.
 
         Parameters

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1270,6 +1270,9 @@ class TestDataArray(TestCase):
         assert renamed.name == 'z'
         assert renamed.dims == ('z',)
 
+        renamed_kwargs = self.dv.x.rename(x='z').rename('z')
+        assert_identical(renamed, renamed_kwargs)
+
     def test_swap_dims(self):
         array = DataArray(np.random.randn(3), {'y': ('x', list('abc'))}, 'x')
         expected = DataArray(array.values, {'y': list('abc')}, dims='y')

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1916,6 +1916,9 @@ class TestDataset(TestCase):
         with pytest.raises(UnexpectedDataAccess):
             renamed['renamed_var1'].values
 
+        renamed_kwargs = data.rename(**newnames)
+        assert_identical(renamed, renamed_kwargs)
+
     def test_rename_old_name(self):
         # regtest for GH1477
         data = create_test_data()


### PR DESCRIPTION
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
