### PR TITLE
Support dot with older dask

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,7 +38,7 @@ Enhancements
 ~~~~~~~~~~~~
 
 - `:py:meth:`~DataArray.dot` and :py:func:`~dot` are partly supported with older
-  dask<01.7.4. (related to :issue:`2203`)
+  dask<0.17.4. (related to :issue:`2203`)
   By `Keisuke Fujii <https://github.com/fujiisoup`_.
 
 - :py:meth:`~DataArray.cumsum` and :py:meth:`~DataArray.cumprod` now support

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -37,6 +37,10 @@ Documentation
 Enhancements
 ~~~~~~~~~~~~
 
+- `:py:meth:`~DataArray.dot` and :py:func:`~dot` are partly supported with older
+  dask<01.7.4. (related to :issue:`2203`)
+  By `Keisuke Fujii <https://github.com/fujiisoup`_.
+
 - :py:meth:`~DataArray.cumsum` and :py:meth:`~DataArray.cumprod` now support
   aggregation over multiple dimensions at the same time. This is the default
   behavior when dimensions are not specified (previously this raised an error).
@@ -53,14 +57,14 @@ Enhancements
 
 - :py:meth:`~DataArray.sel`, :py:meth:`~DataArray.isel` & :py:meth:`~DataArray.reindex`,
   (and their :py:class:`Dataset` counterparts) now support supplying a ``dict``
-  as a first argument, as an alternative to the existing approach 
+  as a first argument, as an alternative to the existing approach
   of supplying `kwargs`. This allows for more robust behavior
-  of dimension names which conflict with other keyword names, or are 
+  of dimension names which conflict with other keyword names, or are
   not strings.
   By `Maximilian Roos <https://github.com/maxim-lian>`_.
 
 - :py:meth:`~DataArray.rename` now supports supplying `kwargs`, as an
-  alternative to the existing approach of supplying a ``dict`` as the 
+  alternative to the existing approach of supplying a ``dict`` as the
   first argument.
   By `Maximilian Roos <https://github.com/maxim-lian>`_.
 
@@ -96,7 +100,7 @@ Bug fixes
   when grouping over dimension coordinates with duplicated entries
   (:issue:`2153`).
   By `Stephan Hoyer <https://github.com/shoyer>`_
-  
+
 - Fix Dataset.to_netcdf() cannot create group with engine="h5netcdf"
   (:issue:`2177`).
   By `Stephan Hoyer <https://github.com/shoyer>`_

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1015,6 +1015,19 @@ def dot(*arrays, **kwargs):
     output_core_dims = [tuple(d for d in all_dims if d not in
                               dims + broadcast_dims)]
 
+    # older dask than 0.17.4, we use tensordot if possible.
+    if isinstance(arr.data, dask_array_type):
+        import dask
+        if LooseVersion(dask.__version__) < LooseVersion('0.17.4'):
+            if len(broadcast_dims) == 0 and len(arrays) == 2:
+                axes = [[arr.get_axis_num(d) for d in arr.dims if d in dims]
+                        for arr in arrays]
+                return apply_ufunc(duck_array_ops.tensordot, *arrays,
+                                   dask='allowed',
+                                   input_core_dims=input_core_dims,
+                                   output_core_dims=output_core_dims,
+                                   kwargs={'axes': axes})
+
     # construct einsum subscripts, such as '...abc,...ab->...c'
     # Note: input_core_dims are always moved to the last position
     subscripts_list = ['...' + ''.join([dim_map[d] for d in ds]) for ds

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -781,9 +781,10 @@ def test_dot(use_dask):
     assert (actual.data == np.einsum('ij,ijk->k', a, b)).all()
     assert isinstance(actual.variable.data, type(da_a.variable.data))
 
-    import dask
-    if LooseVersion(dask.__version__) < LooseVersion('0.17.3'):
-        pytest.skip("needs dask.array.einsum")
+    if use_dask:
+        import dask
+        if LooseVersion(dask.__version__) < LooseVersion('0.17.3'):
+            pytest.skip("needs dask.array.einsum")
 
     # for only a single array is passed without dims argument, just return
     # as is

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -757,9 +757,6 @@ def test_dot(use_dask):
     if use_dask:
         if not has_dask:
             pytest.skip('test for dask.')
-        import dask
-        if LooseVersion(dask.__version__) < LooseVersion('0.17.3'):
-            pytest.skip("needs dask.array.einsum")
 
     a = np.arange(30 * 4).reshape(30, 4)
     b = np.arange(30 * 4 * 5).reshape(30, 4, 5)
@@ -783,6 +780,10 @@ def test_dot(use_dask):
     assert actual.dims == ('c', )
     assert (actual.data == np.einsum('ij,ijk->k', a, b)).all()
     assert isinstance(actual.variable.data, type(da_a.variable.data))
+
+    import dask
+    if LooseVersion(dask.__version__) < LooseVersion('0.17.3'):
+        pytest.skip("needs dask.array.einsum")
 
     # for only a single array is passed without dims argument, just return
     # as is


### PR DESCRIPTION
 - [x] Related with #2203 
 - [x] Tests added
 - [x] Tests passed
 - [x] Fully documented

Related with #2203, I think it is better if `xr.DataArray.dot()` is working even with older dask, at least in the simpler case (as this is a very primary operation).

The cost is a slight complication of the code.
Any comments are welcome.
