### PR TITLE
implement interp_like

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -111,6 +111,7 @@ Indexing
    Dataset.sel
    Dataset.squeeze
    Dataset.interp
+   Dataset.interp_like
    Dataset.reindex
    Dataset.reindex_like
    Dataset.set_index
@@ -265,6 +266,7 @@ Indexing
    DataArray.sel
    DataArray.squeeze
    DataArray.interp
+   DataArray.interp_like
    DataArray.reindex
    DataArray.reindex_like
    DataArray.set_index

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -193,6 +193,14 @@ Indexing axes with monotonic decreasing labels also works, as long as the
    reversed_da.loc[3.1:0.9]
 
 
+.. note::
+
+  If you want to interpolate along coordinates rather than looking up the
+  nearest neighbors, use :py:meth:`~xarray.Dataset.interp` and
+  :py:meth:`~xarray.Dataset.interp_like`.
+  See :ref:`interpolation <interp>` for the details.
+
+
 Dataset indexing
 ----------------
 

--- a/doc/interpolation.rst
+++ b/doc/interpolation.rst
@@ -34,7 +34,7 @@ indexing of a :py:class:`~xarray.DataArray`,
     da.sel(time=3)
 
     # interpolation
-    da.interp(time=3.5)
+    da.interp(time=2.5)
 
 
 Similar to the indexing, :py:meth:`~xarray.DataArray.interp` also accepts an
@@ -80,6 +80,31 @@ Array-like coordinates are also accepted:
 
     # interpolation
     da.interp(time=[1.5, 2.5], space=[0.15, 0.25])
+
+
+:py:meth:`~xarray.DataArray.interp_like` method is a useful shortcut. This
+method interpolates an xarray object onto the coordinates of another xarray
+object. For example, if we want to compute the difference between
+two :py:class:`~xarray.DataArray` s (``da`` and ``other``) staying on slightly
+different coordinates,
+
+.. ipython:: python
+
+  other = xr.DataArray(np.sin(0.4 * np.arange(9).reshape(3, 3)),
+                       [('time', [0.9, 1.9, 2.9]),
+                       ('space', [0.15, 0.25, 0.35])])
+
+it might be a good idea to first interpolate ``da`` so that it will stay on the
+same coordinates of ``other``, and then subtract it.
+:py:meth:`~xarray.DataArray.interp_like` can be used for such a case,
+
+.. ipython:: python
+
+  # interpolate da along other's coordinates
+  interpolated = da.interp_like(other)
+  interpolated
+
+It is now possible to safely compute the difference ``other - interpolated``.
 
 
 Interpolation methods

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,6 +36,12 @@ Documentation
 Enhancements
 ~~~~~~~~~~~~
 
+- :py:meth:`~xarray.DataArray.interp_like` and
+  :py:meth:`~xarray.Dataset.interp_like` methods are newly added.
+  (:issue:`2218`)
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+
+
 Bug fixes
 ~~~~~~~~~
 
@@ -60,7 +66,7 @@ Enhancements
   See :ref:`interpolating values with interp` for the detail.
   (:issue:`2079`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
-  
+
 Bug fixes
 ~~~~~~~~~
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,6 +25,20 @@ What's New
   - `Python 3 Statement <http://www.python3statement.org/>`__
   - `Tips on porting to Python 3 <https://docs.python.org/3/howto/pyporting.html>`__
 
+.. _whats-new.0.10.8:
+
+v0.10.8 (unreleased)
+--------------------
+
+Documentation
+~~~~~~~~~~~~~
+
+Enhancements
+~~~~~~~~~~~~
+
+Bug fixes
+~~~~~~~~~
+
 .. _whats-new.0.10.7:
 
 v0.10.7 (7 June 2018)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -951,6 +951,52 @@ class DataArray(AbstractArray, DataWithCoords):
             **coords_kwargs)
         return self._from_temp_dataset(ds)
 
+    def interp_like(self, other, method='linear', assume_sorted=False,
+                    kwargs={}):
+        """Interpolate this object onto the coordinates of another object,
+        filling out of range values with NaN.
+
+        Parameters
+        ----------
+        other : Dataset or DataArray
+            Object with an 'indexes' attribute giving a mapping from dimension
+            names to an 1d array-like, which provides coordinates upon
+            which to index the variables in this dataset.
+        method: string, optional.
+            {'linear', 'nearest'} for multidimensional array,
+            {'linear', 'nearest', 'zero', 'slinear', 'quadratic', 'cubic'}
+            for 1-dimensional array. 'linear' is used by default.
+        assume_sorted: boolean, optional
+            If False, values of coordinates that are interpolated over can be
+            in any order and they are sorted first. If True, interpolated
+            coordinates are assumed to be an array of monotonically increasing
+            values.
+        kwargs: dictionary, optional
+            Additional keyword passed to scipy's interpolator.
+
+        Returns
+        -------
+        interpolated: xr.DataArray
+            Another dataarray by interpolating this dataarray's data along the
+            coordinates of the other object.
+
+        Note
+        ----
+        scipy is required.
+
+        See Also
+        --------
+        DataArray.interp
+        DataArray.reindex_like
+        """
+        if self.dtype.kind not in 'uifc':
+            raise TypeError('interp only works for a numeric type array. '
+                            'Given {}.'.format(self.dtype))
+
+        ds = self._to_temp_dataset().interp_like(
+            other, method=method, kwargs=kwargs, assume_sorted=assume_sorted)
+        return self._from_temp_dataset(ds)
+
     def rename(self, new_name_or_name_dict=None, **names):
         """Returns a new DataArray with renamed coordinates or a new name.
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -983,6 +983,8 @@ class DataArray(AbstractArray, DataWithCoords):
         Note
         ----
         scipy is required.
+        If the dataarray has object-type coordinates, reindex is used for these
+        coordinates instead of the interpolation.
 
         See Also
         --------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1925,6 +1925,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         Note
         ----
         scipy is required.
+        If the dataset has object-type coordinates, reindex is used for these
+        coordinates instead of the interpolation.
 
         See Also
         --------
@@ -1940,9 +1942,12 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
                 numeric_coords[k] = v
             else:
                 object_coords[k] = v
-        # We do not support interpolation along object coordinate.
-        # reindex instead.
-        ds = self.reindex(object_coords)
+
+        ds = self
+        if object_coords:
+            # We do not support interpolation along object coordinate.
+            # reindex instead.
+            ds = self.reindex(object_coords)
         return ds.interp(numeric_coords, method, assume_sorted, kwargs)
 
     def rename(self, name_dict=None, inplace=False, **names):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1934,7 +1934,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         coords = alignment.reindex_like_indexers(self, other)
 
         for k, v in coords.items():
-            if v.dtype.kind not in 'uifc':
+            if v.dtype.kind not in 'uifcMm':
                 raise TypeError('Interpolation along non-numeric coordinate '
                                 '{} (dtype: {}) is not supported.'.format(
                                     k, v.dtype))

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1893,6 +1893,53 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
                        .union(coord_vars))
         return obj._replace_vars_and_dims(variables, coord_names=coord_names)
 
+    def interp_like(self, other, method='linear', assume_sorted=False,
+                    kwargs={}):
+        """Interpolate this object onto the coordinates of another object,
+        filling the out of range values with NaN.
+
+        Parameters
+        ----------
+        other : Dataset or DataArray
+            Object with an 'indexes' attribute giving a mapping from dimension
+            names to an 1d array-like, which provides coordinates upon
+            which to index the variables in this dataset.
+        method: string, optional.
+            {'linear', 'nearest'} for multidimensional array,
+            {'linear', 'nearest', 'zero', 'slinear', 'quadratic', 'cubic'}
+            for 1-dimensional array. 'linear' is used by default.
+        assume_sorted: boolean, optional
+            If False, values of coordinates that are interpolated over can be
+            in any order and they are sorted first. If True, interpolated
+            coordinates are assumed to be an array of monotonically increasing
+            values.
+        kwargs: dictionary, optional
+            Additional keyword passed to scipy's interpolator.
+
+        Returns
+        -------
+        interpolated: xr.Dataset
+            Another dataset by interpolating this dataset's data along the
+            coordinates of the other object.
+
+        Note
+        ----
+        scipy is required.
+
+        See Also
+        --------
+        Dataset.interp
+        Dataset.reindex_like
+        """
+        coords = alignment.reindex_like_indexers(self, other)
+
+        for k, v in coords.items():
+            if v.dtype.kind not in 'uifc':
+                raise TypeError('Interpolation along non-numeric coordinate '
+                                '{} (dtype: {}) is not supported.'.format(
+                                    k, v.dtype))
+        return self.interp(coords, method, assume_sorted, kwargs)
+
     def rename(self, name_dict=None, inplace=False, **names):
         """Returns a new object with renamed variables and dimensions.
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1933,12 +1933,17 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         """
         coords = alignment.reindex_like_indexers(self, other)
 
+        numeric_coords = OrderedDict()
+        object_coords = OrderedDict()
         for k, v in coords.items():
-            if v.dtype.kind not in 'uifcMm':
-                raise TypeError('Interpolation along non-numeric coordinate '
-                                '{} (dtype: {}) is not supported.'.format(
-                                    k, v.dtype))
-        return self.interp(coords, method, assume_sorted, kwargs)
+            if v.dtype.kind in 'uifcMm':
+                numeric_coords[k] = v
+            else:
+                object_coords[k] = v
+        # We do not support interpolation along object coordinate.
+        # reindex instead.
+        ds = self.reindex(object_coords)
+        return ds.interp(numeric_coords, method, assume_sorted, kwargs)
 
     def rename(self, name_dict=None, inplace=False, **names):
         """Returns a new object with renamed variables and dimensions.

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -396,15 +396,19 @@ def _localize(var, indexes_coords):
 
 
 def _floatize_x(x, new_x):
-    """ Make x and new_x float. This is particulary useful for datetime dtype.
+    """ Make x and new_x float.
+    This is particulary useful for datetime dtype.
     x, new_x: tuple of np.ndarray
     """
     x = list(x)
     new_x = list(new_x)
     for i in range(len(x)):
         if x[i].dtype.kind in 'Mm':
+            # Scipy cast np.float_ for coordinate, but 64bit float is not
+            # sufficient for datetime64 (uses 64bit integer).
+            # We assumes x - min(x) can be well presented by 64bit float.
             xmin = np.min(x[i])
-            x[i] = (x[i] - xmin).astype(float)
+            x[i] = (x[i] - xmin).astype(np.float_)
             new_x[i] = (new_x[i] - xmin).astype(float)
     return x, new_x
 

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -404,12 +404,14 @@ def _floatize_x(x, new_x):
     new_x = list(new_x)
     for i in range(len(x)):
         if x[i].dtype.kind in 'Mm':
-            # Scipy cast np.float_ for coordinate, but 64bit float is not
-            # sufficient for datetime64 (uses 64bit integer).
-            # We assumes x - min(x) can be well presented by 64bit float.
+            # Scipy casts coordinates to np.float64, which is not accurate
+            # enough for datetime64 (uses 64bit integer).
+            # We assume that the most of the bits are used to represent the
+            # offset (min(x)) and the variation (x - min(x)) can be
+            # represented by float.
             xmin = np.min(x[i])
-            x[i] = (x[i] - xmin).astype(np.float_)
-            new_x[i] = (new_x[i] - xmin).astype(float)
+            x[i] = (x[i] - xmin).astype(np.float64)
+            new_x[i] = (new_x[i] - xmin).astype(np.float64)
     return x, new_x
 
 

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
-import pandas as pd
 import pytest
 
 import xarray as xr

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -456,8 +456,9 @@ def test_interp_like():
     other = xr.DataArray(np.random.randn(3), dims=['dim3'],
                          coords={'dim3': ['a', 'b', 'c']})
 
-    with pytest.raises(TypeError):
-        ds.interp_like(other)
+    actual = ds.interp_like(other)
+    expected = ds.reindex_like(other)
+    assert_allclose(actual, expected)
 
 
 @requires_scipy


### PR DESCRIPTION
 - [x] Closes #2218
 - [x] Tests added
 - [x] Tests passed
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API.

This adds `interp_like`, that behaves like `reindex_like` but using interpolation.
