### PR TITLE
Small error in open_zarr docs

### DIFF
--- a/doc/io.rst
+++ b/doc/io.rst
@@ -603,7 +603,7 @@ pass to xarray::
     # write to the bucket
     ds.to_zarr(store=gcsmap)
     # read it back
-    ds_gcs = xr.open_zarr(gcsmap, mode='r')
+    ds_gcs = xr.open_zarr(gcsmap)
 
 .. _Zarr: http://zarr.readthedocs.io/
 .. _Amazon S3: https://aws.amazon.com/s3/


### PR DESCRIPTION
I tried setting this up on GCS as an experiment, and found there's no `mode` kwarg to `open_zarr`. I'm not sure whether there are broader issues but thought I'd put this in regardless

(also - if anyone has any experience in deploying xarray over https://github.com/dask/dask-kubernetes and GCS, I'd be interested in your experience. We're currently working with either a) BigQuery for big data or b) in-memory xarray for small data, and I was interested whether there's a way of retaining the xarray model for bigger data without too much overhead)