### PR TITLE
Add automatic chunking to open_rasterio

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1340,7 +1340,6 @@ class BaseZarrTest(CFEncodedDataTest):
                 print(k)
                 assert v.chunks == actual[k].chunks
 
-
     def test_chunk_encoding(self):
         # These datasets have no dask chunks. All chunking specified in
         # encoding
@@ -3008,6 +3007,15 @@ class TestRasterio(TestCase):
                 ac = actual.sel(band=1).mean(dim='x')
                 ex = expected.sel(band=1).mean(dim='x')
                 assert_allclose(ac, ex)
+
+    @requires_dask
+    def test_chunks_auto(self):
+        import dask
+        with dask.config.set({'array.chunk-size': '1kiB'}):
+            with create_tmp_geotiff(1024, 1024, 3) as (tmp_file, expected):
+                with xr.open_rasterio(tmp_file, chunks=True) as actual:
+                    assert actual.chunks
+                    # TODO: enhance create_tmp_geotiff to support tiled images
 
     def test_pickle_rasterio(self):
         # regression test for https://github.com/pydata/xarray/issues/2121


### PR DESCRIPTION
This uses the automatic chunking in dask 0.18+ to chunk rasterio
datasets in a nicely aligned way.

Currently this doesn't implement tests due to a difficulty in creating
chunked tiff images.

This also uncovered some inefficiencies in how Dask doesn't align rechunking to existing chunk schemes.

 - [x] Closes #2093 
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

I could use help on how the following:

-  How to create tiled TIFF files in the tests
-  The right way to merge different dtypes and block shapes in the tiff file.  Currently I'm assuming that they're uniform