### PR TITLE
BUG: unnamed args in faceted line plots

### DIFF
--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -289,7 +289,6 @@ def line(darray, *args, **kwargs):
     if row or col:
         allargs = locals().copy()
         allargs.update(allargs.pop('kwargs'))
-        allargs.update(allargs.pop('args'))
         return _line_facetgrid(**allargs)
 
     ndims = len(darray.dims)
@@ -310,6 +309,8 @@ def line(darray, *args, **kwargs):
     yincrease = kwargs.pop('yincrease', True)
     add_legend = kwargs.pop('add_legend', True)
     _labels = kwargs.pop('_labels', True)
+    if args is ():
+        args = kwargs.pop('args', ())
 
     ax = get_axis(figsize, size, aspect, ax)
     xplt, yplt, hueplt, xlabel, ylabel, huelabel = \

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1546,7 +1546,7 @@ class TestFacetedLinePlots(PlotTestCase):
         g = self.darray.plot.line('o--', row='row', col='col', hue='hue')
         lines = [q for q in g.axes.flat[0].get_children()
                  if isinstance(q, mpl.lines.Line2D)]
-        # passing '.' as argument should set the marker
+        # passing 'o--' as argument should set marker and linestyle
         assert lines[0].get_marker() == 'o'
         assert lines[0].get_linestyle() == '--'
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1542,6 +1542,14 @@ class TestFacetedLinePlots(PlotTestCase):
         g = self.darray.plot(row='col', col='row', hue='hue')
         assert g.axes.shape == (len(self.darray.col), len(self.darray.row))
 
+    def test_unnamed_args(self):
+        g = self.darray.plot.line('o--', row='row', col='col', hue='hue')
+        lines = [q for q in g.axes.flat[0].get_children()
+                 if isinstance(q, mpl.lines.Line2D)]
+        # passing '.' as argument should set the marker
+        assert lines[0].get_marker() == 'o'
+        assert lines[0].get_linestyle() == '--'
+
     def test_default_labels(self):
         g = self.darray.plot(row='row', col='col', hue='hue')
         # Rightmost column should be labeled


### PR DESCRIPTION
- [x] Closes #2248 (remove if there is no corresponding issue, which should only be the case for minor changes)
- [x] Tests added (for all bug fixes or enhancements)
- [x] Tests passed (for all non-documentation changes)

Fixed a syntax inconsistency, allowing to pass unnamed arguments to faceted line plots. 

Example code:
```python
import xarray as xr
import numpy as np

np.random.seed(0)
da = xr.DataArray(np.random.randn(3, 3, 3, 3),
                 dims=['x', 'y', 'z',  'w'],
                 coords=[range(3),  [3.5, 4.9, 6.7], ['a','b','c'], ['foo', 'bar', 'foobar']],
                 name='arr_name')
da.plot.line('o--',row='y', col='w',hue='z')
```

![sdojn](https://user-images.githubusercontent.com/6164157/42094867-0cde3d8e-7b7f-11e8-91e5-a9a9156955f4.png)
