### PR TITLE
WIP DataArray.plot() can now plot errorbars with kwargs xerr, yerr

### DIFF
--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -212,8 +212,6 @@ If required, the automatic legend can be turned off using ``add_legend=False``. 
 ``hue`` can be passed directly to :py:func:`xarray.plot` as `air.isel(lon=10, lat=[19,21,22]).plot(hue='lat')`.
 
 
-
-
 Dimension along y-axis
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -225,7 +223,7 @@ It is also possible to make line plots such that the data are on the x-axis and 
     air.isel(time=10, lon=[10, 11]).plot(y='lat', hue='lon')
 
 Changing Axes Direction
------------------------
+~~~~~~~~~~~~~~~~~~~~~~~
 
 The keyword arguments ``xincrease`` and ``yincrease`` let you control the axes direction.
 
@@ -233,6 +231,16 @@ The keyword arguments ``xincrease`` and ``yincrease`` let you control the axes d
 
     @savefig plotting_example_xincrease_yincrease_kwarg.png
     air.isel(time=10, lon=[10, 11]).plot.line(y='lat', hue='lon', xincrease=False, yincrease=False)
+
+Errorbars
+~~~~~~~~~
+
+If provided with the keyword arguments ``xerr`` and ``yerr``, errorbars will be added. Additional ``kwargs`` will be passed to matplotlib's ``errorbar()``. Currently this functionality is only supported for 1D DataArrays; i.e. the following would not work with ``air.isel(time=10, lon=[10, 11])``.
+
+.. ipython:: python
+
+    @savefig plotting_example_yerr_kwarg.png
+    air.isel(time=10, lon=10).plot.line(y='lat', xerr=3, yerr=1.5, ecolor='r')
 
 Two Dimensions
 --------------

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -41,6 +41,9 @@ Enhancements
   (:issue:`2218`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 
+- :py:meth:`~xarray.DataArray.plot()` will now plot errorbars if provided with kwargs ``xerr, yerr``.
+  By `Deepak Cherian <https://github.com/dcherian>`_.
+
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -270,6 +270,7 @@ def line(darray, *args, **kwargs):
         Coordinates for x, y axis. Only one of these may be specified.
         The other coordinate plots values from the DataArray on which this
         plot method is called.
+    xerr, yerr : Errorbar sizes (optional)
     xincrease : None, True, or False, optional
         Should the values on the x axes be increasing from left to right?
         if None, use the default for the matplotlib function.
@@ -308,6 +309,8 @@ def line(darray, *args, **kwargs):
     y = kwargs.pop('y', None)
     xincrease = kwargs.pop('xincrease', True)
     yincrease = kwargs.pop('yincrease', True)
+    xerr = kwargs.pop('xerr', None)
+    yerr = kwargs.pop('yerr', None)
     add_legend = kwargs.pop('add_legend', True)
     _labels = kwargs.pop('_labels', True)
 
@@ -317,7 +320,13 @@ def line(darray, *args, **kwargs):
 
     _ensure_plottable(xplt)
 
-    primitive = ax.plot(xplt, yplt, *args, **kwargs)
+    if xerr is None and yerr is None:
+        primitive = ax.plot(xplt, yplt, *args, **kwargs)
+    else:
+        if xplt.ndim > 1 or yplt.ndim > 1:
+            raise ValueError('xerr, yerr can only be used with 1D data.')
+
+        primitive = ax.errorbar(xplt, yplt, xerr=xerr, yerr=yerr, **kwargs)
 
     if _labels:
         if xlabel is not None:

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -148,6 +148,9 @@ class TestPlot(PlotTestCase):
         self.darray[:, :, 0].plot.line(x='dim_0', hue='dim_1')
         self.darray[:, :, 0].plot.line(y='dim_0', hue='dim_1')
 
+        with raises_regex(ValueError, 'xerr, yerr'):
+            self.darray[:, :, 0].plot.line(y='dim_0', hue='dim_1', xerr=1)
+
         with raises_regex(ValueError, 'cannot'):
             self.darray[:, :, 0].plot.line(x='dim_1', y='dim_0', hue='dim_1')
 
@@ -390,6 +393,12 @@ class TestPlot1D(PlotTestCase):
         self.darray.plot.line()
         title = plt.gca().get_title()
         assert 'd = 10' == title
+
+    def test_errorbars(self):
+        primitive = self.darray.plot(xerr=self.darray / 2,
+                                     yerr=self.darray / 2,
+                                     ecolor='r')
+        assert isinstance(primitive, mpl.container.ErrorbarContainer)
 
 
 class TestPlotHistogram(PlotTestCase):


### PR DESCRIPTION
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

Added support for errorbar plotting. This works by providing the kwargs `xerr` and/or `yerr` to `plot()` or `plot.line()`. It will only work for 1D data. 

Errorbars for plots that use`hue` argument require that we loop and plot each line individually. I'm happy to add this is you think it's a good idea.

Example from docs: 
`air.isel(time=10, lon=10).plot.line(y='lat', xerr=3, yerr=1.5, ecolor='r')`

![image](https://user-images.githubusercontent.com/2448579/42188123-e20cdde8-7e0f-11e8-97ae-d0405a2df9b4.png)
