### PR TITLE
Add indexing.explicit_indexing_adapter and refactor backends to use it.

### DIFF
--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -28,16 +28,13 @@ class PncArrayWrapper(BackendArray):
         return self.datastore.ds.variables[self.variable_name]
 
     def __getitem__(self, key):
-        key, np_inds = indexing.decompose_indexer(
-            key, self.shape, indexing.IndexingSupport.OUTER_1VECTOR)
+        return indexing.explicit_indexing_adapter(
+            key, self.shape, indexing.IndexingSupport.OUTER_1VECTOR,
+            self._getitem)
 
+    def _getitem(self, key):
         with self.datastore.ensure_open(autoclose=True):
-            array = self.get_array()[key.tuple]  # index backend array
-
-        if len(np_inds.tuple) > 0:
-            # index the loaded np.ndarray
-            array = indexing.NumpyIndexingAdapter(array)[np_inds]
-        return array
+            return self.get_array()[key]
 
 
 class PseudoNetCDFDataStore(AbstractDataStore, DataStorePickleMixin):

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -24,19 +24,16 @@ class NioArrayWrapper(BackendArray):
         return self.datastore.ds.variables[self.variable_name]
 
     def __getitem__(self, key):
-        key, np_inds = indexing.decompose_indexer(
-            key, self.shape, indexing.IndexingSupport.BASIC)
+        return indexing.explicit_indexing_adapter(
+            key, self.shape, indexing.IndexingSupport.BASIC, self._getitem)
 
+    def _getitem(self, key):
         with self.datastore.ensure_open(autoclose=True):
             array = self.get_array()
-            if key.tuple == () and self.ndim == 0:
+            if key == () and self.ndim == 0:
                 return array.get_value()
 
-            array = array[key.tuple]
-            if len(np_inds.tuple) > 0:
-                array = indexing.NumpyIndexingAdapter(array)[np_inds]
-
-            return array
+            return array[key]
 
 
 class NioDataStore(AbstractDataStore, DataStorePickleMixin):

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -47,7 +47,7 @@ class RasterioArrayWrapper(BackendArray):
 
         Parameter
         ---------
-        key: ExplicitIndexer
+        key: tuple of int
 
         Returns
         -------
@@ -60,13 +60,11 @@ class RasterioArrayWrapper(BackendArray):
         --------
         indexing.decompose_indexer
         """
-        key, np_inds = indexing.decompose_indexer(
-            key, self.shape, indexing.IndexingSupport.OUTER)
+        assert len(key) == 3, 'rasterio datasets should always be 3D'
 
         # bands cannot be windowed but they can be listed
-        band_key = key.tuple[0]
-        new_shape = []
-        np_inds2 = []
+        band_key = key[0]
+        np_inds = []
         # bands (axis=0) cannot be windowed but they can be listed
         if isinstance(band_key, slice):
             start, stop, step = band_key.indices(self.shape[0])
@@ -74,18 +72,16 @@ class RasterioArrayWrapper(BackendArray):
         # be sure we give out a list
         band_key = (np.asarray(band_key) + 1).tolist()
         if isinstance(band_key, list):  # if band_key is not a scalar
-            new_shape.append(len(band_key))
-            np_inds2.append(slice(None))
+            np_inds.append(slice(None))
 
         # but other dims can only be windowed
         window = []
         squeeze_axis = []
-        for i, (k, n) in enumerate(zip(key.tuple[1:], self.shape[1:])):
+        for i, (k, n) in enumerate(zip(key[1:], self.shape[1:])):
             if isinstance(k, slice):
                 # step is always positive. see indexing.decompose_indexer
                 start, stop, step = k.indices(n)
-                np_inds2.append(slice(None, None, step))
-                new_shape.append(stop - start)
+                np_inds.append(slice(None, None, step))
             elif is_scalar(k):
                 # windowed operations will always return an array
                 # we will have to squeeze it later
@@ -94,21 +90,33 @@ class RasterioArrayWrapper(BackendArray):
                 stop = k + 1
             else:
                 start, stop = np.min(k), np.max(k) + 1
-                np_inds2.append(k - start)
-                new_shape.append(stop - start)
+                np_inds.append(k - start)
             window.append((start, stop))
 
-        np_inds = indexing._combine_indexers(
-            indexing.OuterIndexer(tuple(np_inds2)), new_shape, np_inds)
-        return band_key, window, tuple(squeeze_axis), np_inds
+        if isinstance(key[1], np.ndarray) and isinstance(key[2], np.ndarray):
+            # do outer-style indexing
+            np_inds[1:] = np.ix_(*np_inds[1:])
 
-    def __getitem__(self, key):
+        return band_key, tuple(window), tuple(squeeze_axis), tuple(np_inds)
+
+    def _getitem(self, key):
         band_key, window, squeeze_axis, np_inds = self._get_indexer(key)
 
-        out = self.riods.value.read(band_key, window=tuple(window))
+        if not band_key or any(start == stop for (start, stop) in window):
+            # no need to do IO
+            shape = (len(band_key),) + tuple(
+                stop - start for (start, stop) in window)
+            out = np.zeros(shape, dtype=self.dtype)
+        else:
+            out = self.riods.value.read(band_key, window=window)
+
         if squeeze_axis:
             out = np.squeeze(out, axis=squeeze_axis)
-        return indexing.NumpyIndexingAdapter(out)[np_inds]
+        return out[np_inds]
+
+    def __getitem__(self, key):
+        return indexing.explicit_indexing_adapter(
+            key, self.shape, indexing.IndexingSupport.OUTER, self._getitem)
 
 
 def _parse_envi(meta):

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -63,7 +63,10 @@ class _ElementwiseFunctionArray(indexing.ExplicitlyIndexedNDArrayMixin):
         return np.dtype(self._dtype)
 
     def __getitem__(self, key):
-        return self.func(self.array[key])
+        return type(self)(self.array[key], self.func, self.dtype)
+
+    def __array__(self, dtype=None):
+        return self.func(self.array)
 
     def __repr__(self):
         return ("%s(%r, func=%r, dtype=%r)" %

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -11,7 +11,6 @@ from collections import Counter
 import numpy as np
 
 from . import duck_array_ops
-from . import indexing
 from . import utils
 from .alignment import deep_align
 from .merge import expand_and_merge_variables

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -10,7 +10,9 @@ from collections import Counter
 
 import numpy as np
 
-from . import duck_array_ops, utils
+from . import duck_array_ops
+from . import indexing
+from . import utils
 from .alignment import deep_align
 from .merge import expand_and_merge_variables
 from .pycompat import OrderedDict, dask_array_type, basestring

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2916,9 +2916,13 @@ class TestRasterio(TestCase):
                 assert_allclose(expected.isel(**ind), actual.isel(**ind))
                 assert not actual.variable._in_memory
 
-                # None is selected
+                # empty selection
                 ind = {'band': np.array([2, 1, 0]),
                        'x': 1, 'y': slice(2, 2, 1)}
+                assert_allclose(expected.isel(**ind), actual.isel(**ind))
+                assert not actual.variable._in_memory
+
+                ind = {'band': slice(0, 0), 'x': 1, 'y': 2}
                 assert_allclose(expected.isel(**ind), actual.isel(**ind))
                 assert not actual.variable._in_memory
 


### PR DESCRIPTION
No external API changes.

This simplifies the boilerplate for supporting explicit indexing in a backend
array class.

CC @fujiisoup @jhamman 