### PR TITLE
Make RTD builds faster

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,7 +26,7 @@ print("python exec:", sys.executable)
 print("sys.path:", sys.path)
 for name in ('numpy scipy pandas matplotlib dask IPython seaborn '
              'cartopy netCDF4 rasterio zarr iris flake8 '
-             'sphinx-gallery cftime').split():
+             'sphinx_gallery cftime').split():
     try:
         module = importlib.import_module(name)
         if name == 'matplotlib':

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,7 +25,8 @@ allowed_failures = set()
 print("python exec:", sys.executable)
 print("sys.path:", sys.path)
 for name in ('numpy scipy pandas matplotlib dask IPython seaborn '
-             'cartopy netCDF4 rasterio zarr').split():
+             'cartopy netCDF4 rasterio zarr iris flake8 '
+             'sphinx-gallery cftime').split():
     try:
         module = importlib.import_module(name)
         if name == 'matplotlib':

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -4,19 +4,19 @@ channels:
   - defaults
 dependencies:
   - python=3.6
-  - numpy=1.13
-  - pandas=0.21.0
-  - scipy=1.0
+  - numpy
+  - pandas
+  - scipy
   - bottleneck
-  - numpydoc=0.7.0
-  - matplotlib=2.1.2
-  - seaborn=0.8
-  - dask=0.16.0
-  - ipython=6.2.1
-  - sphinx=1.5
-  - netCDF4=1.3.1
-  - cartopy=0.15.1
-  - rasterio=0.36.0
+  - numpydoc
+  - matplotlib
+  - seaborn
+  - dask
+  - ipython
+  - sphinx
+  - netCDF4
+  - cartopy
+  - conda-forge/label/dev::rasterio
   - sphinx-gallery
   - zarr
   - iris

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,7 +1,6 @@
 name: xarray-docs
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python=3.6
   - numpy
@@ -16,7 +15,7 @@ dependencies:
   - sphinx
   - netCDF4
   - cartopy
-  - conda-forge/label/dev::rasterio
+  - rasterio
   - sphinx-gallery
   - zarr
   - iris

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,21 +3,21 @@ channels:
   - conda-forge
 dependencies:
   - python=3.6
-  - numpy
-  - pandas
-  - scipy
-  - bottleneck
-  - numpydoc
-  - matplotlib
-  - seaborn
-  - dask
-  - ipython
-  - sphinx
-  - netCDF4
-  - cartopy
-  - rasterio
-  - sphinx-gallery
-  - zarr
-  - iris
-  - flake8
-  - cftime
+  - numpy=1.14.5
+  - pandas=0.23.3
+  - scipy=1.1.0
+  - matplotlib=2.2.2
+  - seaborn=0.9.0
+  - dask=0.18.2
+  - ipython=6.4.0
+  - netCDF4=1.4.0
+  - cartopy=0.16.0
+  - rasterio=1.0.1
+  - zarr=2.2.0
+  - iris=2.1.0
+  - flake8=3.5.0
+  - cftime=1.0.0
+  - bottleneck=1.2
+  - sphinx=1.7.6
+  - numpydoc=0.8.0
+  - sphinx-gallery=0.2.0

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,8 @@
+build:
+    image: latest
 conda:
     file: doc/environment.yml
 python:
-   version: 3
-   setup_py_install: true
+    version: 3.6
+    setup_py_install: true
+formats: []


### PR DESCRIPTION
See https://github.com/pydata/xarray/issues/2306

This makes the builds a little bit faster. But we are still very close to the 900 s limit.

I tried to pin more packages this morning but this didn't work out. I'll merge this first (the latest build worked with this config, https://readthedocs.org/projects/xray/builds/) and try again at a later stage. 