### PR TITLE
DOC: add interp example

### DIFF
--- a/doc/interpolation.rst
+++ b/doc/interpolation.rst
@@ -58,12 +58,12 @@ wrap it explicitly in a :py:func:`numpy.datetime64` object.
                            [('time', pd.date_range('1/1/2000', '1/3/2000', periods=2))])
     da_dt64.interp(time=np.datetime64('2000-01-02'))
 
-The interpolated data can be merged into the original :py:class:`~xarray.DataArray`
-using :py:meth:`~xarray.concat`.
+The interpolated data can be merged into the original :py:class:`~xarray.DataArray` 
+by specifing the time periods required.
 
 .. ipython:: python
 
-    xr.concat([da_dt64, da_dt64.interp(time=np.datetime64('2000-01-02'))], dim='time')
+    da_dt64.interp(time=pd.date_range('1/1/2000', '1/3/2000', periods=3))
 
 .. note::
 

--- a/doc/interpolation.rst
+++ b/doc/interpolation.rst
@@ -48,6 +48,23 @@ array-like, which gives the interpolated result as an array.
     # interpolation
     da.interp(time=[2.5, 3.5])
 
+
+To interpolate data with a :py:func:`numpy.datetime64` coordinate you have to 
+wrap it explicitly in a :py:func:`numpy.datetime64` object.
+
+.. ipython:: python
+
+    da_dt64 = xr.DataArray([1, 3],
+                           [('time', pd.date_range('1/1/2000', '1/3/2000', periods=2))])
+    da_dt64.interp(time=np.datetime64('2000-01-02'))
+
+The interpolated data can be merged into the original :py:class:`~xarray.DataArray`
+using :py:meth:`~xarray.concat`.
+
+.. ipython:: python
+
+    xr.concat([da_dt64, da_dt64.interp(time=np.datetime64('2000-01-02'))], dim='time')
+
 .. note::
 
   Currently, our interpolation only works for regular grids.

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -941,6 +941,15 @@ class DataArray(AbstractArray, DataWithCoords):
         --------
         scipy.interpolate.interp1d
         scipy.interpolate.interpn
+
+        Examples
+        -------
+        >>> da = xr.DataArray([1, 3], [('x', np.arange(2))])
+        >>> da.interp(x=0.5)
+        <xarray.DataArray ()>
+        array(2.0)
+        Coordinates:
+            x        float64 0.5
         """
         if self.dtype.kind not in 'uifc':
             raise TypeError('interp only works for a numeric type array. '


### PR DESCRIPTION
 - [NA] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [NA] Tests added (for all bug fixes or enhancements)
 - [NA] Tests passed (for all non-documentation changes)
 - [NA] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

I wanted to add an example as googling 'xarray interp' takes me to http://xarray.pydata.org/en/stable/generated/xarray.Dataset.interp.html.

However, there lots of great examples in http://xarray.pydata.org/en/stable/interpolation.html
Perhaps I should edit it to:
```
Examples
--------
See http://xarray.pydata.org/en/stable/interpolation.html
```

I was also thinking about adding a note about interpolating time as it came up in https://github.com/pydata/xarray/issues/2284 but not sure what would be the best way to do so.
