### PR TITLE
XFAIL tests failing on ARM

### DIFF
--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -36,6 +36,7 @@ arm_xfail = pytest.mark.xfail(platform.machine() == 'aarch64' or
                               'arm' in platform.machine(),
                               reason='expected failure on ARM')
 
+
 def _importorskip(modname, minversion=None):
     try:
         mod = importlib.import_module(modname)

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -31,6 +31,10 @@ try:
 except ImportError:
     pass
 
+import platform
+arm_xfail = pytest.mark.xfail(platform.machine() == 'aarch64' or
+                              'arm' in platform.machine(),
+                              reason='expected failure on ARM')
 
 def _importorskip(modname, minversion=None):
     try:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -35,7 +35,7 @@ from . import (
     requires_cftime, requires_dask, requires_h5fileobj, requires_h5netcdf,
     requires_netCDF4, requires_pathlib, requires_pseudonetcdf, requires_pydap,
     requires_pynio, requires_rasterio, requires_scipy,
-    requires_scipy_or_netCDF4, requires_zarr)
+    requires_scipy_or_netCDF4, requires_zarr, arm_xfail)
 from .test_coding_times import (
     _ALL_CALENDARS, _NON_STANDARD_CALENDARS, _STANDARD_CALENDARS)
 from .test_dataset import create_test_data, create_append_test_data
@@ -400,6 +400,7 @@ class DatasetIOBase:
             assert_identical(expected, actual)
             assert actual['x'].encoding['_Encoding'] == 'ascii'
 
+    @arm_xfail
     def test_roundtrip_numpy_datetime_data(self):
         times = pd.to_datetime(['2000-01-01', '2000-01-02', 'NaT'])
         expected = Dataset({'t': ('t', times), 't0': times[0]})

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -16,7 +16,7 @@ from xarray.testing import assert_equal
 
 from . import (
     assert_array_equal, has_cftime, has_cftime_or_netCDF4, has_dask,
-    requires_cftime, requires_cftime_or_netCDF4)
+    requires_cftime, requires_cftime_or_netCDF4, arm_xfail)
 
 try:
     from pandas.errors import OutOfBoundsDatetime
@@ -470,6 +470,7 @@ def test_decode_360_day_calendar():
         assert_array_equal(actual, expected)
 
 
+@arm_xfail
 @pytest.mark.skipif(not has_cftime_or_netCDF4, reason='cftime not installed')
 @pytest.mark.parametrize(
     ['num_dates', 'units', 'expected_list'],

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -251,6 +251,7 @@ def assert_dask_array(da, dask):
     if dask and da.ndim > 0:
         assert isinstance(da.data, dask_array_type)
 
+
 @arm_xfail
 @pytest.mark.parametrize('dask', [False, True])
 def test_datetime_reduce(dask):

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -17,7 +17,7 @@ from xarray.testing import assert_allclose, assert_equal
 
 from . import (
     assert_array_equal, has_dask, has_np113, raises_regex, requires_cftime,
-    requires_dask)
+    requires_dask, arm_xfail)
 
 
 class TestOps:
@@ -251,7 +251,7 @@ def assert_dask_array(da, dask):
     if dask and da.ndim > 0:
         assert isinstance(da.data, dask_array_type)
 
-
+@arm_xfail
 @pytest.mark.parametrize('dask', [False, True])
 def test_datetime_reduce(dask):
     time = np.array(pd.date_range('15/12/1999', periods=11))


### PR DESCRIPTION
These tests are expected to fail on ARM due to the following issue in NumPy:
https://github.com/numpy/numpy/issues/8325

 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
