### PR TITLE
apply_ufunc now raises a ValueError when the size of input_core_dims is inconsistent with number of argument

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -56,11 +56,16 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
-- Fixed ``DataArray.to_iris()`` failure while creating ``DimCoord`` by 
+- Fixed ``DataArray.to_iris()`` failure while creating ``DimCoord`` by
   falling back to creating ``AuxCoord``. Fixed dependency on ``var_name``
   attribute being set.
   (:issue:`2201`)
   By `Thomas Voigt <https://github.com/tv3141>`_.
+
+- Now :py:func:`xr.apply_ufunc` raises a ValueError when the size of
+``input_core_dims`` is inconsistent with the number of arguments.
+  (:issue:`2341`)
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 
 .. _whats-new.0.10.8:
 

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -920,6 +920,11 @@ def apply_ufunc(func, *args, **kwargs):
 
     if input_core_dims is None:
         input_core_dims = ((),) * (len(args))
+    if len(input_core_dims) != len(args):
+        raise ValueError(
+            'input_core_dims must be None or a tuple with the length same to '
+            'the number of arguments. Given input_core_dims: {}, '
+            'number of args: {}.'.format(input_core_dims, len(args)))
 
     signature = _UFuncSignature(input_core_dims, output_core_dims)
 

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -920,7 +920,7 @@ def apply_ufunc(func, *args, **kwargs):
 
     if input_core_dims is None:
         input_core_dims = ((),) * (len(args))
-    if len(input_core_dims) != len(args):
+    elif len(input_core_dims) != len(args):
         raise ValueError(
             'input_core_dims must be None or a tuple with the length same to '
             'the number of arguments. Given input_core_dims: {}, '

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -274,16 +274,20 @@ def test_apply_input_core_dimension():
     assert_identical(expected_dataset_x,
                      first_element(dataset.groupby('y'), 'x'))
 
+    def multiply(*args):
+        val = args[0]
+        for arg in args[1:]:
+            val = val * arg
+        return val
+
     # regression test for GH:2341
     with pytest.raises(ValueError):
-        apply_ufunc(np.gradient, data_array, data_array['y'].values,
-                    kwargs={'axis': -1}, input_core_dims=[['y']],
-                    output_core_dims=[['y']])
-    expected = xr.DataArray(np.gradient(data_array, data_array['y'], axis=-1),
+        apply_ufunc(multiply, data_array, data_array['y'].values,
+                    input_core_dims=[['y']], output_core_dims=[['y']])
+    expected = xr.DataArray(multiply(data_array, data_array['y']),
                             dims=['x', 'y'], coords=data_array.coords)
-    actual = apply_ufunc(np.gradient, data_array, data_array['y'].values,
-                         kwargs={'axis': -1}, input_core_dims=[['y'], []],
-                         output_core_dims=[['y']])
+    actual = apply_ufunc(multiply, data_array, data_array['y'].values,
+                         input_core_dims=[['y'], []], output_core_dims=[['y']])
     assert_identical(expected, actual)
 
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -274,6 +274,18 @@ def test_apply_input_core_dimension():
     assert_identical(expected_dataset_x,
                      first_element(dataset.groupby('y'), 'x'))
 
+    # regression test for GH:2341
+    with pytest.raises(ValueError):
+        apply_ufunc(np.gradient, data_array, data_array['y'].values,
+                    kwargs={'axis': -1}, input_core_dims=[['y']],
+                    output_core_dims=[['y']])
+    expected = xr.DataArray(np.gradient(data_array, data_array['y'], axis=-1),
+                            dims=['x', 'y'], coords=data_array.coords)
+    actual = apply_ufunc(np.gradient, data_array, data_array['y'].values,
+                         kwargs={'axis': -1}, input_core_dims=[['y'], []],
+                         output_core_dims=[['y']])
+    assert_identical(expected, actual)
+
 
 def test_apply_output_core_dimension():
 


### PR DESCRIPTION
 - [x] Closes #2341
 - [x] Tests added
 - [x] Tests passed
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Now raises a ValueError when the size of input_core_dims is inconsistent with number of argument.
