### PR TITLE
FutureWarning: creation of DataArrays w/ coords Dataset

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -60,8 +60,13 @@ def _infer_coords_and_dims(shape, coords, dims):
     new_coords = OrderedDict()
 
     if utils.is_dict_like(coords):
-        for k, v in coords.items():
-            new_coords[k] = as_variable(v, name=k)
+        if isinstance(coords, Dataset):
+            for k in coords.variables:
+                v = coords.variables[k]
+                new_coords[k] = as_variable(v, name=k)
+        else:
+            for k, v in coords.items():
+                new_coords[k] = as_variable(v, name=k)
     elif coords is not None:
         for dim, coord in zip(dims, coords):
             var = as_variable(coord, name=dim)

--- a/xarray/tests/test_creation.py
+++ b/xarray/tests/test_creation.py
@@ -2,10 +2,11 @@ import xarray as xr
 import numpy as np
 import warnings
 
+
 def test_coords_are_dataset():
     # Setup an array with coordinates
     n = np.zeros(3)
-    coords={'x': np.arange(3)}
+    coords = {'x': np.arange(3)}
     c = xr.Dataset(coords=coords)
     with warnings.catch_warnings():
         warnings.filterwarnings("error", "iteration over an xarray.Dataset")

--- a/xarray/tests/test_creation.py
+++ b/xarray/tests/test_creation.py
@@ -9,4 +9,4 @@ def test_coords_are_dataset():
     c = xr.Dataset(coords=coords)
     with warnings.catch_warnings():
         warnings.filterwarnings("error", "iteration over an xarray.Dataset")
-        a = xr.DataArray(n, dims=['x'], coords=c)
+        xr.DataArray(n, dims=['x'], coords=c)

--- a/xarray/tests/test_creation.py
+++ b/xarray/tests/test_creation.py
@@ -1,0 +1,12 @@
+import xarray as xr
+import numpy as np
+import warnings
+
+def test_coords_are_dataset():
+    # Setup an array with coordinates
+    n = np.zeros(3)
+    coords={'x': np.arange(3)}
+    c = xr.Dataset(coords=coords)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", "iteration over an xarray.Dataset")
+        a = xr.DataArray(n, dims=['x'], coords=c)


### PR DESCRIPTION
Previously, this would raise a:

FutureWarning:
iteration over an xarray.Dataset will change in xarray v0.11 to
only include data variables, not coordinates. Iterate over the
Dataset.variables property instead to preserve existing behavior
in a forwards compatible manner.

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
