### PR TITLE
dask.ghost -> dask.overlap

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -56,12 +56,15 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
-- Fixed ``DataArray.to_iris()`` failure while creating ``DimCoord`` by 
+- Fixed ``DataArray.to_iris()`` failure while creating ``DimCoord`` by
   falling back to creating ``AuxCoord``. Fixed dependency on ``var_name``
   attribute being set.
   (:issue:`2201`)
   By `Thomas Voigt <https://github.com/tv3141>`_.
 - Tests can be run in parallel with pytest-xdist
+- Follow up the renamings in dask; from dask.ghost to dask.overlap
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+
 
 .. _whats-new.0.10.8:
 

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+from distutils.version import LooseVersion
 
 import numpy as np
 
@@ -6,7 +7,15 @@ from . import nputils
 from . import dtypes
 
 try:
+    import dask
     import dask.array as da
+    # Note: dask has used `ghost` before 0.18.2
+    if LooseVersion(dask.__version__) <= LooseVersion('0.18.2'):
+        overlap = da.ghost.ghost
+        trim_internal = da.ghost.trim_internal
+    else:
+        overlap = da.overlap.overlap
+        trim_internal = da.overlap.trim_internal
 except ImportError:
     pass
 
@@ -15,26 +24,25 @@ def dask_rolling_wrapper(moving_func, a, window, min_count=None, axis=-1):
     '''wrapper to apply bottleneck moving window funcs on dask arrays'''
     dtype, fill_value = dtypes.maybe_promote(a.dtype)
     a = a.astype(dtype)
-    # inputs for ghost
+    # inputs for overlap
     if axis < 0:
         axis = a.ndim + axis
     depth = {d: 0 for d in range(a.ndim)}
     depth[axis] = (window + 1) // 2
     boundary = {d: fill_value for d in range(a.ndim)}
-    # create ghosted arrays
-    ag = da.ghost.ghost(a, depth=depth, boundary=boundary)
+    # Create overlap array.
+    ag = overlap(a, depth=depth, boundary=boundary)
     # apply rolling func
     out = ag.map_blocks(moving_func, window, min_count=min_count,
                         axis=axis, dtype=a.dtype)
     # trim array
-    result = da.ghost.trim_internal(out, depth)
+    result = trim_internal(out, depth)
     return result
 
 
 def rolling_window(a, axis, window, center, fill_value):
     """ Dask's equivalence to np.utils.rolling_window """
     orig_shape = a.shape
-    # inputs for ghost
     if axis < 0:
         axis = a.ndim + axis
     depth = {d: 0 for d in range(a.ndim)}
@@ -50,7 +58,7 @@ def rolling_window(a, axis, window, center, fill_value):
             "more evenly divides the shape of your array." %
             (window, depth[axis], min(a.chunks[axis])))
 
-    # Although dask.ghost pads values to boundaries of the array,
+    # Although dask.overlap pads values to boundaries of the array,
     # the size of the generated array is smaller than what we want
     # if center == False.
     if center:
@@ -60,12 +68,12 @@ def rolling_window(a, axis, window, center, fill_value):
         start, end = window - 1, 0
     pad_size = max(start, end) + offset - depth[axis]
     drop_size = 0
-    # pad_size becomes more than 0 when the ghosted array is smaller than
+    # pad_size becomes more than 0 when the overlapped array is smaller than
     # needed. In this case, we need to enlarge the original array by padding
-    # before ghosting.
+    # before overlapping.
     if pad_size > 0:
         if pad_size < depth[axis]:
-            # Ghosting requires each chunk larger than depth. If pad_size is
+            # overlapping requires each chunk larger than depth. If pad_size is
             # smaller than the depth, we enlarge this and truncate it later.
             drop_size = depth[axis] - pad_size
             pad_size = depth[axis]
@@ -78,8 +86,8 @@ def rolling_window(a, axis, window, center, fill_value):
 
     boundary = {d: fill_value for d in range(a.ndim)}
 
-    # create ghosted arrays
-    ag = da.ghost.ghost(a, depth=depth, boundary=boundary)
+    # create overlap arrays
+    ag = overlap(a, depth=depth, boundary=boundary)
 
     # apply rolling func
     def func(x, window, axis=-1):


### PR DESCRIPTION
Dask renamed `dask.ghost` -> `dask.overlap` in dask/dask#3830.
This PR follows up this.