### PR TITLE
Make `dim` optional on unstack

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -68,6 +68,9 @@ Enhancements
   (:issue:`1875`)
   By `Andrew Huang <https://github.com/ahuang11>`_.
 
+- You can now call ``unstack`` without arguments to unstack every MultiIndex in a DataArray or Dataset.
+  By `Julia Signell <https://github.com/jsignell>`_.
+
 Bug fixes
 ~~~~~~~~~
 
@@ -84,7 +87,7 @@ Bug fixes
 - Tests can be run in parallel with pytest-xdist
   By `Tony Tung <https://github.com/ttung>`_.
 
-- Follow up the renamings in dask; from dask.ghost to dask.overlap 
+- Follow up the renamings in dask; from dask.ghost to dask.overlap
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 
 - Now raises a ValueError when there is a conflict between dimension names and

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1247,7 +1247,7 @@ class DataArray(AbstractArray, DataWithCoords):
         ds = self._to_temp_dataset().stack(dimensions, **dimensions_kwargs)
         return self._from_temp_dataset(ds)
 
-    def unstack(self, *dims):
+    def unstack(self, dim=None):
         """
         Unstack existing dimensions corresponding to MultiIndexes into
         multiple new dimensions.
@@ -1256,9 +1256,9 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Parameters
         ----------
-        *dims : str, optional
-            Names of the existing dimensions to unstack. By default (if
-            no dims provided), unstacks all MultiIndexes.
+        dim : str or sequence of str, optional
+            Dimension(s) over which to unstack. By default unstacks all
+            MultiIndexes.
 
         Returns
         -------
@@ -1285,7 +1285,7 @@ class DataArray(AbstractArray, DataWithCoords):
         --------
         DataArray.stack
         """
-        ds = self._to_temp_dataset().unstack(*dims)
+        ds = self._to_temp_dataset().unstack(dim)
         return self._from_temp_dataset(ds)
 
     def transpose(self, *dims):

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1247,18 +1247,18 @@ class DataArray(AbstractArray, DataWithCoords):
         ds = self._to_temp_dataset().stack(dimensions, **dimensions_kwargs)
         return self._from_temp_dataset(ds)
 
-    def unstack(self, dim=None):
+    def unstack(self, *dims):
         """
-        Unstack an existing dimension corresponding to a MultiIndex into
+        Unstack existing dimensions corresponding to MultiIndexes into
         multiple new dimensions.
 
         New dimensions will be added at the end.
 
         Parameters
         ----------
-        dim : str
-            Name of the existing dimension to unstack.By default (if
-            ``dim is None``), unstacks first MultiIndex in dims.
+        *dims : str, optional
+            Names of the existing dimensions to unstack. By default (if
+            no dims provided), unstacks all MultiIndexes.
 
         Returns
         -------
@@ -1285,7 +1285,7 @@ class DataArray(AbstractArray, DataWithCoords):
         --------
         DataArray.stack
         """
-        ds = self._to_temp_dataset().unstack(dim)
+        ds = self._to_temp_dataset().unstack(*dims)
         return self._from_temp_dataset(ds)
 
     def transpose(self, *dims):

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1247,7 +1247,7 @@ class DataArray(AbstractArray, DataWithCoords):
         ds = self._to_temp_dataset().stack(dimensions, **dimensions_kwargs)
         return self._from_temp_dataset(ds)
 
-    def unstack(self, dim):
+    def unstack(self, dim=None):
         """
         Unstack an existing dimension corresponding to a MultiIndex into
         multiple new dimensions.
@@ -1257,7 +1257,8 @@ class DataArray(AbstractArray, DataWithCoords):
         Parameters
         ----------
         dim : str
-            Name of the existing dimension to unstack.
+            Name of the existing dimension to unstack.By default (if
+            ``dim is None``), unstacks first dim.
 
         Returns
         -------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1258,12 +1258,28 @@ class DataArray(AbstractArray, DataWithCoords):
         ----------
         dim : str
             Name of the existing dimension to unstack.By default (if
-            ``dim is None``), unstacks first dim.
+            ``dim is None``), unstacks first MultiIndex in dims.
 
         Returns
         -------
         unstacked : DataArray
             Array with unstacked data.
+
+        Examples
+        --------
+
+        >>> arr = DataArray(np.arange(6).reshape(2, 3),
+        ...                 coords=[('x', ['a', 'b']), ('y', [0, 1, 2])])
+        >>> arr
+        <xarray.DataArray (x: 2, y: 3)>
+        array([[0, 1, 2],
+               [3, 4, 5]])
+        Coordinates:
+          * x        (x) |S1 'a' 'b'
+          * y        (y) int64 0 1 2
+        >>> roundtripped = arr.stack(z=('x', 'y')).unstack()
+        >>> arr.identical(roundtripped)
+        True
 
         See also
         --------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1277,7 +1277,12 @@ class DataArray(AbstractArray, DataWithCoords):
         Coordinates:
           * x        (x) |S1 'a' 'b'
           * y        (y) int64 0 1 2
-        >>> roundtripped = arr.stack(z=('x', 'y')).unstack()
+        >>> stacked = arr.stack(z=('x', 'y'))
+        >>> stacked.indexes['z']
+        MultiIndex(levels=[[u'a', u'b'], [0, 1, 2]],
+                   labels=[[0, 0, 0, 1, 1, 1], [0, 1, 2, 0, 1, 2]],
+                   names=[u'x', u'y'])
+        >>> roundtripped = stacked.unstack()
         >>> arr.identical(roundtripped)
         True
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2361,33 +2361,23 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         --------
         Dataset.stack
         """
-        dim_from_kwarg = dim is not None
-
         if isinstance(dim, basestring):
-            dims = set([dim])
+            dims = [dim]
         elif dim is None:
-            dims = set(self.dims)
+            dims = self.dims
         else:
-            dims = set(dim)
+            dims = dim
 
-        missing_dims = [dim for dim in dims if dim not in self.dims]
+        missing_dims = [d for d in dims if d not in self.dims]
         if missing_dims:
             raise ValueError('Dataset does not contain the dimensions: %s'
                              % missing_dims)
 
-        non_multi_dims = [dim for dim in dims
-                          if not isinstance(self.get_index(dim), pd.MultiIndex)]
-        if non_multi_dims and dim_from_kwarg:
-            raise ValueError('cannot unstack dimensions that do not '
-                             'have a MultiIndex: %s' % non_multi_dims)
-
-        dims = dims - set(non_multi_dims)
-        if len(dims) == 0:
-            raise ValueError('cannot unstack an object that does not have '
-                             'MultiIndex dimensions')
+        multi_dims = [d for d in dims if isinstance(self.get_index(d),
+                                                    pd.MultiIndex)]
 
         result = self
-        for dim in dims:
+        for dim in multi_dims:
             result = result._unstack_once(dim)
         return result
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2310,7 +2310,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
             result = result._stack_once(dims, new_dim)
         return result
 
-    def unstack(self, dim):
+    def unstack(self, dim=None):
         """
         Unstack an existing dimension corresponding to a MultiIndex into
         multiple new dimensions.
@@ -2319,8 +2319,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
 
         Parameters
         ----------
-        dim : str
-            Name of the existing dimension to unstack.
+        dim : str, optional
+            Name of the existing dimension to unstack. By default (if
+            ``dim is None``), unstacks first dim.
 
         Returns
         -------
@@ -2331,6 +2332,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         --------
         Dataset.stack
         """
+        if dim is None:
+            dim = next(iter(self.dims.keys()))
         if dim not in self.dims:
             raise ValueError('invalid dimension: %s' % dim)
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2376,7 +2376,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         multi_dims = [d for d in dims if isinstance(self.get_index(d),
                                                     pd.MultiIndex)]
 
-        result = self
+        result = self.copy(deep=False)
         for dim in multi_dims:
             result = result._unstack_once(dim)
         return result

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2361,27 +2361,26 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         --------
         Dataset.stack
         """
-        if isinstance(dim, basestring):
-            dims = [dim]
-        elif dim is None:
-            dims = self.dims
+
+        if dim is None:
+            dims = [d for d in self.dims if isinstance(self.get_index(d),
+                                                       pd.MultiIndex)]
         else:
-            dims = dim
+            dims = [dim] if isinstance(dim, basestring) else dim
 
-        missing_dims = [d for d in dims if d not in self.dims]
-        if missing_dims:
-            raise ValueError('Dataset does not contain the dimensions: %s'
-                             % missing_dims)
+            missing_dims = [d for d in dims if d not in self.dims]
+            if missing_dims:
+                raise ValueError('Dataset does not contain the dimensions: %s'
+                                 % missing_dims)
 
-        multi_dims = [d for d in dims if isinstance(self.get_index(d),
-                                                    pd.MultiIndex)]
-        non_multi_dims = set(dims) - set(multi_dims)
-        if dim and non_multi_dims:
-            raise ValueError('cannot unstack dimensions that do not '
-                             'have a MultiIndex: %s' % non_multi_dims)
+            non_multi_dims = [d for d in dims if not
+                              isinstance(self.get_index(d), pd.MultiIndex)]
+            if non_multi_dims:
+                raise ValueError('cannot unstack dimensions that do not '
+                                 'have a MultiIndex: %s' % non_multi_dims)
 
         result = self.copy(deep=False)
-        for dim in multi_dims:
+        for dim in dims:
             result = result._unstack_once(dim)
         return result
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2375,6 +2375,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
 
         multi_dims = [d for d in dims if isinstance(self.get_index(d),
                                                     pd.MultiIndex)]
+        non_multi_dims = set(dims) - set(multi_dims)
+        if dim and non_multi_dims:
+            raise ValueError('cannot unstack dimensions that do not '
+                             'have a MultiIndex: %s' % non_multi_dims)
 
         result = self.copy(deep=False)
         for dim in multi_dims:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2321,7 +2321,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         ----------
         dim : str, optional
             Name of the existing dimension to unstack. By default (if
-            ``dim is None``), unstacks first dim.
+            ``dim is None``), unstacks first MultiIndex in dims.
 
         Returns
         -------
@@ -2332,13 +2332,26 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         --------
         Dataset.stack
         """
-        if dim is None:
-            dim = next(iter(self.dims.keys()))
-        if dim not in self.dims:
-            raise ValueError('invalid dimension: %s' % dim)
+        dims = []
 
-        index = self.get_index(dim)
-        if not isinstance(index, pd.MultiIndex):
+        if dim is None:
+            dims = list(self.dims)
+            if len(dims) == 0:
+                raise ValueError('cannot unstack an object without dimensions')
+        elif dim not in self.dims:
+            raise ValueError('invalid dimension: %s' % dim)
+        else:
+            dims = [dim]
+
+        # set dim to first MultiIndex in dims or None
+        dim = None
+        for d in dims:
+            index = self.get_index(d)
+            if isinstance(index, pd.MultiIndex):
+                dim = d
+                break
+
+        if dim is None:
             raise ValueError('cannot unstack a dimension that does not have '
                              'a MultiIndex')
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1665,7 +1665,8 @@ class TestDataArray(TestCase):
 
     def test_stack_unstack_with_no_dim_kwarg(self):
         data = np.random.rand(1, 2, 3, 2)
-        orig = xr.DataArray(data, dims=['a', 'b', 'c', 'd'])
+        dims = ['a', 'b', 'c', 'd']
+        orig = xr.DataArray(data, dims=dims)
         stacked = orig.stack(ab=['a', 'b'], cd=['c', 'd']).expand_dims('e', 2)
 
         unstacked_ab = stacked.unstack()
@@ -1674,7 +1675,7 @@ class TestDataArray(TestCase):
         unstacked = unstacked_ab.unstack()
         assert unstacked.dims == ('e', 'a', 'b', 'c', 'd')
 
-        roundtripped = unstacked.squeeze('e', drop=True).drop(['a', 'b', 'c', 'd'])
+        roundtripped = unstacked.squeeze('e', drop=True).drop(dims)
         assert_identical(orig, roundtripped)
 
     def test_stack_unstack_decreasing_coordinate(self):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1660,18 +1660,21 @@ class TestDataArray(TestCase):
 
     def test_stack_unstack(self):
         orig = DataArray([[0, 1], [2, 3]], dims=['x', 'y'], attrs={'foo': 2})
+        assert_identical(orig, orig.unstack())
+
         actual = orig.stack(z=['x', 'y']).unstack('z').drop(['x', 'y'])
         assert_identical(orig, actual)
 
-    def test_stack_unstack_with_no_dim_kwarg(self):
-        data = np.random.rand(1, 2, 3, 2, 1)
         dims = ['a', 'b', 'c', 'd', 'e']
-        orig = xr.DataArray(data, dims=dims)
+        orig = xr.DataArray(np.random.rand(1, 2, 3, 2, 1), dims=dims)
         stacked = orig.stack(ab=['a', 'b'], cd=['c', 'd'])
 
-        unstacked = stacked.unstack()
-        roundtripped = unstacked.drop(['a', 'b', 'c', 'd']).transpose(*dims)
-        assert_identical(orig, roundtripped)
+        for dim in (None, ['ab', 'cd'], ['ab', 'cd', 'e']):
+            unstacked = stacked.unstack(dim=dim)
+            roundtripped = unstacked\
+                .drop(['a', 'b', 'c', 'd'])\
+                .transpose(*dims)
+            assert_identical(orig, roundtripped)
 
     def test_stack_unstack_decreasing_coordinate(self):
         # regression test for GH980

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1671,9 +1671,9 @@ class TestDataArray(TestCase):
 
         for dim in (None, ['ab', 'cd'], ['ab', 'cd', 'e']):
             unstacked = stacked.unstack(dim=dim)
-            roundtripped = unstacked\
-                .drop(['a', 'b', 'c', 'd'])\
-                .transpose(*dims)
+            roundtripped = (unstacked
+                .drop(['a', 'b', 'c', 'd'])
+                .transpose(*dims))
             assert_identical(orig, roundtripped)
 
     def test_stack_unstack_decreasing_coordinate(self):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1664,18 +1664,13 @@ class TestDataArray(TestCase):
         assert_identical(orig, actual)
 
     def test_stack_unstack_with_no_dim_kwarg(self):
-        data = np.random.rand(1, 2, 3, 2)
-        dims = ['a', 'b', 'c', 'd']
+        data = np.random.rand(1, 2, 3, 2, 1)
+        dims = ['a', 'b', 'c', 'd', 'e']
         orig = xr.DataArray(data, dims=dims)
-        stacked = orig.stack(ab=['a', 'b'], cd=['c', 'd']).expand_dims('e', 2)
+        stacked = orig.stack(ab=['a', 'b'], cd=['c', 'd'])
 
-        unstacked_ab = stacked.unstack()
-        assert unstacked_ab.dims == ('cd', 'e', 'a', 'b')
-
-        unstacked = unstacked_ab.unstack()
-        assert unstacked.dims == ('e', 'a', 'b', 'c', 'd')
-
-        roundtripped = unstacked.squeeze('e', drop=True).drop(dims)
+        unstacked = stacked.unstack()
+        roundtripped = unstacked.drop(['a', 'b', 'c', 'd']).transpose(*dims)
         assert_identical(orig, roundtripped)
 
     def test_stack_unstack_decreasing_coordinate(self):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1663,6 +1663,11 @@ class TestDataArray(TestCase):
         actual = orig.stack(z=['x', 'y']).unstack('z').drop(['x', 'y'])
         assert_identical(orig, actual)
 
+    def test_stack_unstack_with_no_dim_kwarg(self):
+        orig = DataArray([[0, 1], [2, 3]], dims=['x', 'y'], attrs={'foo': 2})
+        actual = orig.stack(z=['x', 'y']).unstack().drop(['x', 'y'])
+        assert_identical(orig, actual)
+
     def test_stack_unstack_decreasing_coordinate(self):
         # regression test for GH980
         orig = DataArray(np.random.rand(3, 4), dims=('y', 'x'),

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1669,12 +1669,13 @@ class TestDataArray(TestCase):
         orig = xr.DataArray(np.random.rand(1, 2, 3, 2, 1), dims=dims)
         stacked = orig.stack(ab=['a', 'b'], cd=['c', 'd'])
 
-        for dim in (None, ['ab', 'cd'], ['ab', 'cd', 'e']):
-            unstacked = stacked.unstack(dim=dim)
-            roundtripped = (unstacked
-                            .drop(['a', 'b', 'c', 'd'])
-                            .transpose(*dims))
-            assert_identical(orig, roundtripped)
+        unstacked = stacked.unstack(['ab', 'cd'])
+        roundtripped = unstacked.drop(['a', 'b', 'c', 'd']).transpose(*dims)
+        assert_identical(orig, roundtripped)
+
+        unstacked = stacked.unstack()
+        roundtripped = unstacked.drop(['a', 'b', 'c', 'd']).transpose(*dims)
+        assert_identical(orig, roundtripped)
 
     def test_stack_unstack_decreasing_coordinate(self):
         # regression test for GH980

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1672,8 +1672,8 @@ class TestDataArray(TestCase):
         for dim in (None, ['ab', 'cd'], ['ab', 'cd', 'e']):
             unstacked = stacked.unstack(dim=dim)
             roundtripped = (unstacked
-                .drop(['a', 'b', 'c', 'd'])
-                .transpose(*dims))
+                            .drop(['a', 'b', 'c', 'd'])
+                            .transpose(*dims))
             assert_identical(orig, roundtripped)
 
     def test_stack_unstack_decreasing_coordinate(self):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1664,9 +1664,18 @@ class TestDataArray(TestCase):
         assert_identical(orig, actual)
 
     def test_stack_unstack_with_no_dim_kwarg(self):
-        orig = DataArray([[0, 1], [2, 3]], dims=['x', 'y'], attrs={'foo': 2})
-        actual = orig.stack(z=['x', 'y']).unstack().drop(['x', 'y'])
-        assert_identical(orig, actual)
+        data = np.random.rand(1, 2, 3, 2)
+        orig = xr.DataArray(data, dims=['a', 'b', 'c', 'd'])
+        stacked = orig.stack(ab=['a', 'b'], cd=['c', 'd']).expand_dims('e', 2)
+
+        unstacked_ab = stacked.unstack()
+        assert unstacked_ab.dims == ('cd', 'e', 'a', 'b')
+
+        unstacked = unstacked_ab.unstack()
+        assert unstacked.dims == ('e', 'a', 'b', 'c', 'd')
+
+        roundtripped = unstacked.squeeze('e', drop=True).drop(['a', 'b', 'c', 'd'])
+        assert_identical(orig, roundtripped)
 
     def test_stack_unstack_decreasing_coordinate(self):
         # regression test for GH980

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2111,6 +2111,8 @@ class TestDataset(TestCase):
         ds = Dataset({'x': [1, 2, 3]})
         with raises_regex(ValueError, 'does not contain the dimensions'):
             ds.unstack('foo')
+        with raises_regex(ValueError, 'do not have a MultiIndex'):
+            ds.unstack('x')
 
     def test_stack_unstack_fast(self):
         ds = Dataset({'a': ('x', [0, 1]),

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2117,6 +2117,9 @@ class TestDataset(TestCase):
         assert_identical(actual, expected)
 
     def test_unstack_errors(self):
+        with raises_regex(ValueError, 'object without dimensions'):
+            Dataset().unstack()
+
         ds = Dataset({'x': [1, 2, 3]})
         with raises_regex(ValueError, 'invalid dimension'):
             ds.unstack('foo')

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2117,7 +2117,7 @@ class TestDataset(TestCase):
         assert_identical(actual, expected)
 
     def test_unstack_errors(self):
-        with raises_regex(ValueError, 'object without dimensions'):
+        with raises_regex(ValueError, 'does not have MultiIndex dimensions'):
             Dataset().unstack()
 
         ds = Dataset({'x': [1, 2, 3]})

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2108,14 +2108,9 @@ class TestDataset(TestCase):
             assert_identical(actual, expected)
 
     def test_unstack_errors(self):
-        with raises_regex(ValueError, 'does not have MultiIndex dimensions'):
-            Dataset().unstack()
-
         ds = Dataset({'x': [1, 2, 3]})
         with raises_regex(ValueError, 'does not contain the dimensions'):
             ds.unstack('foo')
-        with raises_regex(ValueError, 'do not have a MultiIndex'):
-            ds.unstack('x')
 
     def test_stack_unstack_fast(self):
         ds = Dataset({'a': ('x', [0, 1]),

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2106,6 +2106,16 @@ class TestDataset(TestCase):
         actual = ds.unstack('z')
         assert_identical(actual, expected)
 
+    def test_unstack_with_no_dim_kwarg(self):
+        index = pd.MultiIndex.from_product([[0, 1], ['a', 'b']],
+                                           names=['x', 'y'])
+        ds = Dataset({'b': ('z', [0, 1, 2, 3]), 'z': index})
+        expected = Dataset({'b': (('x', 'y'), [[0, 1], [2, 3]]),
+                            'x': [0, 1],
+                            'y': ['a', 'b']})
+        actual = ds.unstack()
+        assert_identical(actual, expected)
+
     def test_unstack_errors(self):
         ds = Dataset({'x': [1, 2, 3]})
         with raises_regex(ValueError, 'invalid dimension'):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2103,27 +2103,18 @@ class TestDataset(TestCase):
         expected = Dataset({'b': (('x', 'y'), [[0, 1], [2, 3]]),
                             'x': [0, 1],
                             'y': ['a', 'b']})
-        actual = ds.unstack('z')
-        assert_identical(actual, expected)
-
-    def test_unstack_with_no_dim_kwarg(self):
-        index = pd.MultiIndex.from_product([[0, 1], ['a', 'b']],
-                                           names=['x', 'y'])
-        ds = Dataset({'b': ('z', [0, 1, 2, 3]), 'z': index})
-        expected = Dataset({'b': (('x', 'y'), [[0, 1], [2, 3]]),
-                            'x': [0, 1],
-                            'y': ['a', 'b']})
-        actual = ds.unstack()
-        assert_identical(actual, expected)
+        for dim in ['z', ['z'], None]:
+            actual = ds.unstack(dim)
+            assert_identical(actual, expected)
 
     def test_unstack_errors(self):
         with raises_regex(ValueError, 'does not have MultiIndex dimensions'):
             Dataset().unstack()
 
         ds = Dataset({'x': [1, 2, 3]})
-        with raises_regex(ValueError, 'invalid dimension'):
+        with raises_regex(ValueError, 'does not contain the dimensions'):
             ds.unstack('foo')
-        with raises_regex(ValueError, 'does not have a MultiIndex'):
+        with raises_regex(ValueError, 'do not have a MultiIndex'):
             ds.unstack('x')
 
     def test_stack_unstack_fast(self):


### PR DESCRIPTION
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)


Not sure if this is a desirable change but I thought it could be easily discussed as a PR. Just for context I was looking at flattening spatial data for machine learning pipelines and then reshaping after the output had been acquired. 

I have a NxM array called `b` and am flattening it like:

```python
flat_input = b.stack(z=('y', 'x'))
```

Then I use that flat_input in my ML pipeline and get back an `np.array` (called `output`) which I want to unstack using all the metadata that went into stacking my original NxM array b.

```python
xr.full_like(flat_input, output).unstack(dim='z')
```

This PR just makes the `dim` argument optional in unstack so that we can use 

```python
xr.full_like(flat_input, output).unstack()
```

As a follow on PR I was thinking of making a function called `xr.unstack_like(other: xr.DataArray|xr.Dataset, data: array_like)` to encompass this functionality. A couple questions:

1) Would something like `xr.unstack_like` be desirable?
2) Should we be using `xr.full_like` in this way? The documentation in xarray and numpy only mentions scalars, but arrays work fine in both. If this is a supported behavior I could add docs, and if not perhaps a copy and overwrite is a better approach?

Here is a gist of the workflow using a tweaked datashader example and datashader example data https://gist.github.com/jsignell/79a6cf2da5c1458211d9dcf34d4417df