### PR TITLE
Properly support user-provided norm.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -71,11 +71,17 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- ``xarray.plot()`` now properly accepts a ``norm`` argument and does not override
+  the norm's ``vmin`` and ``vmax``.
+  (:issue:`2381`)
+  By `Deepak Cherian <https://github.com/dcherian>`_.
+
 - Fixed ``DataArray.to_iris()`` failure while creating ``DimCoord`` by
   falling back to creating ``AuxCoord``. Fixed dependency on ``var_name``
   attribute being set.
   (:issue:`2201`)
   By `Thomas Voigt <https://github.com/tv3141>`_.
+
 - Fixed a bug in ``zarr`` backend which prevented use with datasets with
   invalid chunk size encoding after reading from an existing store
   (:issue:`2278`).

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -689,7 +689,7 @@ class TestDiscreteColorMap(TestCase):
 
     def test_colormap_pass_norm(self):
         norm = mpl.colors.LogNorm(0.1, 1e1)
-        primitive = self.darray.plot(norm=norm)
+        primitive = self.darray.plot(norm=norm, vmin=2, vmax=5)
         assert primitive.norm == norm
         assert primitive.norm.vmin == 0.1
         assert primitive.norm.vmax == 1e1

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -641,10 +641,10 @@ class TestDiscreteColorMap(TestCase):
 
     @pytest.mark.slow
     def test_discrete_colormap_list_of_levels(self):
-        for extend, levels in [('max', [-1, 2, 4, 8, 10]), ('both',
-                                                            [2, 5, 10, 11]),
-                               ('neither', [0, 5, 10, 15]), ('min',
-                                                             [2, 5, 10, 15])]:
+        for extend, levels in [('max', [-1, 2, 4, 8, 10]),
+                               ('both', [2, 5, 10, 11]),
+                               ('neither', [0, 5, 10, 15]),
+                               ('min', [2, 5, 10, 15])]:
             for kind in ['imshow', 'pcolormesh', 'contourf', 'contour']:
                 primitive = getattr(self.darray.plot, kind)(levels=levels)
                 assert_array_equal(levels, primitive.norm.boundaries)
@@ -658,10 +658,10 @@ class TestDiscreteColorMap(TestCase):
 
     @pytest.mark.slow
     def test_discrete_colormap_int_levels(self):
-        for extend, levels, vmin, vmax in [('neither', 7, None,
-                                            None), ('neither', 7, None, 20),
-                                           ('both', 7, 4, 8), ('min', 10, 4,
-                                                               15)]:
+        for extend, levels, vmin, vmax in [('neither', 7, None, None),
+                                           ('neither', 7, None, 20),
+                                           ('both', 7, 4, 8),
+                                           ('min', 10, 4, 15)]:
             for kind in ['imshow', 'pcolormesh', 'contourf', 'contour']:
                 primitive = getattr(self.darray.plot, kind)(
                     levels=levels, vmin=vmin, vmax=vmax)
@@ -686,6 +686,13 @@ class TestDiscreteColorMap(TestCase):
         primitive = self.darray.plot(levels=levels, vmin=-3, vmax=20)
         assert primitive.norm.vmax == max(levels)
         assert primitive.norm.vmin == min(levels)
+
+    def test_colormap_pass_norm(self):
+        norm = mpl.colors.LogNorm(0.1, 1e1)
+        primitive = self.darray.plot(norm=norm)
+        assert primitive.norm == norm
+        assert primitive.norm.vmin == 0.1
+        assert primitive.norm.vmax == 1e1
 
 
 class Common2dMixin:


### PR DESCRIPTION
 - [x] Closes #2381  (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
