### PR TITLE
add some blurbs about numfocus sponsorship to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,14 +123,16 @@ History
 xarray is an evolution of an internal tool developed at `The Climate
 Corporation`__. It was originally written by Climate Corp researchers Stephan
 Hoyer, Alex Kleeman and Eugene Brevdo and was released as open source in
-May 2014. The project was renamed from "xray" in January 2016.
+May 2014. The project was renamed from "xray" in January 2016. Xarray became a
+fiscally sponsored project of NumFOCUS_ in August 2018.
 
 __ http://climate.com/
+.. _NumFOCUS: https://numfocus.org
 
 License
 -------
 
-Copyright 2014-2017, xarray Developers
+Copyright 2014-2018, xarray Developers
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,8 @@ xarray: N-D labeled arrays and datasets
   :target: https://zenodo.org/badge/latestdoi/13221727
 .. image:: http://img.shields.io/badge/benchmarked%20by-asv-green.svg?style=flat
   :target: http://pandas.pydata.org/speed/xarray/
+.. image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
+  :target: http://numfocus.org
 
 **xarray** (formerly **xray**) is an open source project and Python package that aims to bring the
 labeled data power of pandas_ to the physical sciences, by providing
@@ -102,6 +104,18 @@ Get in touch
 .. _StackOverFlow: http://stackoverflow.com/questions/tagged/python-xarray
 .. _mailing list: https://groups.google.com/forum/#!forum/xarray
 .. _on GitHub: http://github.com/pydata/xarray
+
+NumFOCUS
+--------
+
+.. image:: https://numfocus.org/wp-content/uploads/2017/07/NumFocus_LRG.png
+   :scale: 50 %
+
+Xarray is a fiscally sponsored project of NumFOCUS, a nonprofit dedicated
+to supporting the open source scientific computing community. If you like
+Xarray and want to support our mission, please consider making a
+[donation](https://www.flipcause.com/secure/cause_pdetails/MjE3OQ==)
+to support our efforts.
 
 History
 -------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -120,12 +120,17 @@ Get in touch
 .. _mailing list: https://groups.google.com/forum/#!forum/xarray
 .. _on GitHub: http://github.com/pydata/xarray
 
-License
--------
+NumFOCUS
+--------
 
-xarray is available under the open source `Apache License`__.
+.. image:: _static/numfocus_logo.png
+   :scale: 50 %
 
-__ http://www.apache.org/licenses/LICENSE-2.0.html
+Xarray is a fiscally sponsored project of NumFOCUS, a nonprofit dedicated
+to supporting the open source scientific computing community. If you like
+Xarray and want to support our mission, please consider making a
+[donation](https://www.flipcause.com/secure/cause_pdetails/MjE3OQ==)
+to support our efforts.
 
 History
 -------
@@ -136,3 +141,10 @@ Hoyer, Alex Kleeman and Eugene Brevdo and was released as open source in
 May 2014. The project was renamed from "xray" in January 2016.
 
 __ http://climate.com/
+
+License
+-------
+
+xarray is available under the open source `Apache License`__.
+
+__ http://www.apache.org/licenses/LICENSE-2.0.html

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -138,9 +138,11 @@ History
 xarray is an evolution of an internal tool developed at `The Climate
 Corporation`__. It was originally written by Climate Corp researchers Stephan
 Hoyer, Alex Kleeman and Eugene Brevdo and was released as open source in
-May 2014. The project was renamed from "xray" in January 2016.
+May 2014. The project was renamed from "xray" in January 2016. Xarray became a
+fiscally sponsored project of NumFOCUS_ in August 2018.
 
 __ http://climate.com/
+.. _NumFOCUS: https://numfocus.org
 
 License
 -------


### PR DESCRIPTION
Xarray is now a fiscally sponsored project of NumFOCUS. This PR adds a few blurbs of text highlighting that on the main readme and index page of the docs. 

TODO:
- Update flipcause to xarray specific donation page
