### PR TITLE
Plotting: restore xyincrease kwarg default to True

### DIFF
--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -624,7 +624,7 @@ def _plot2d(plotfunc):
     @functools.wraps(plotfunc)
     def newplotfunc(darray, x=None, y=None, figsize=None, size=None,
                     aspect=None, ax=None, row=None, col=None,
-                    col_wrap=None, xincrease=None, yincrease=None,
+                    col_wrap=None, xincrease=True, yincrease=True,
                     add_colorbar=None, add_labels=True, vmin=None, vmax=None,
                     cmap=None, center=None, robust=False, extend=None,
                     levels=None, infer_intervals=None, colors=None,
@@ -776,6 +776,10 @@ def _plot2d(plotfunc):
             raise ValueError("cbar_ax and cbar_kwargs can't be used with "
                              "add_colorbar=False.")
 
+        # origin kwarg overrides yincrease
+        if 'origin' in kwargs:
+            yincrease = None
+
         _update_axes(ax, xincrease, yincrease, xscale, yscale,
                      xticks, yticks, xlim, ylim)
 
@@ -794,7 +798,7 @@ def _plot2d(plotfunc):
     @functools.wraps(newplotfunc)
     def plotmethod(_PlotMethods_obj, x=None, y=None, figsize=None, size=None,
                    aspect=None, ax=None, row=None, col=None, col_wrap=None,
-                   xincrease=None, yincrease=None, add_colorbar=None,
+                   xincrease=True, yincrease=True, add_colorbar=None,
                    add_labels=True, vmin=None, vmax=None, cmap=None,
                    colors=None, center=None, robust=False, extend=None,
                    levels=None, infer_intervals=None, subplot_kws=None,

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -762,6 +762,24 @@ class Common2dMixin:
     def test_can_pass_in_axis(self):
         self.pass_in_axis(self.plotmethod)
 
+    def test_xyincrease_defaults(self):
+
+        # With default settings the axis must be ordered regardless
+        # of the coords order.
+        self.plotfunc(DataArray(easy_array((3, 2)), coords=[[1, 2, 3],
+                                                            [1, 2]]))
+        bounds = plt.gca().get_ylim()
+        assert bounds[0] < bounds[1]
+        bounds = plt.gca().get_xlim()
+        assert bounds[0] < bounds[1]
+        # Inverted coords
+        self.plotfunc(DataArray(easy_array((3, 2)), coords=[[3, 2, 1],
+                                                            [2, 1]]))
+        bounds = plt.gca().get_ylim()
+        assert bounds[0] < bounds[1]
+        bounds = plt.gca().get_xlim()
+        assert bounds[0] < bounds[1]
+
     def test_xyincrease_false_changes_axes(self):
         self.plotmethod(xincrease=False, yincrease=False)
         xlim = plt.gca().get_xlim()
@@ -1308,8 +1326,8 @@ class TestImshow(Common2dMixin, PlotTestCase):
         da = DataArray(easy_array((1, 3, 3), start=0.0, stop=1.0))
         da.plot.imshow()
 
-    def test_imshow_origin_kwarg(self):
-        da = DataArray(easy_array((5, 5, 3), start=-0.6, stop=1.4))
+    def test_origin_overrides_xyincrease(self):
+        da = DataArray(easy_array((3, 2)), coords=[[-2, 0, 2], [-1, 1]])
         da.plot.imshow(origin='upper')
         assert plt.xlim()[0] < 0
         assert plt.ylim()[1] < 0


### PR DESCRIPTION
 - [x] Closes https://github.com/pydata/xarray/issues/2422
 - [x] Tests added 
 - [x] Tests passed 
 - [x] Fully documented, including `whats-new.rst` 

https://github.com/pydata/xarray/pull/2294 introduced the new ``xincrease`` and ``yincrease`` kwargs and a behavior documented as:

```
    xincrease : None, True, or False, optional
        Should the values on the x axes be increasing from left to right?
        if None, use the default for the matplotlib function.
```

The default was ``None``, I suggest to set it to ``True``: it was the default before https://github.com/pydata/xarray/pull/2294 and I think it is what most users expect.
