### PR TITLE
Fix/misc fixes

### DIFF
--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -503,9 +503,10 @@ class FacetGrid(object):
                 plt.sca(ax)
                 innerargs = [data[a].values for a in args]
                 maybe_mappable = func(*innerargs, **kwargs)
-                # TODO: is there a better way to verify that an artist is mappable?
+                # TODO: better way to verify that an artist is mappable?
                 # https://stackoverflow.com/questions/33023036/is-it-possible-to-detect-if-a-matplotlib-artist-is-a-mappable-suitable-for-use-w#33023522
-                if maybe_mappable and hasattr(maybe_mappable, 'autoscale_None'):
+                if (maybe_mappable and
+                   hasattr(maybe_mappable, 'autoscale_None')):
                     self._mappables.append(maybe_mappable)
 
         self._finalize_grid(*args[:2])

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -502,9 +502,11 @@ class FacetGrid(object):
                 data = self.data.loc[namedict]
                 plt.sca(ax)
                 innerargs = [data[a].values for a in args]
-                # TODO: is it possible to verify that an artist is mappable?
-                mappable = func(*innerargs, **kwargs)
-                self._mappables.append(mappable)
+                maybe_mappable = func(*innerargs, **kwargs)
+                # TODO: is there a better way to verify that an artist is mappable?
+                # https://stackoverflow.com/questions/33023036/is-it-possible-to-detect-if-a-matplotlib-artist-is-a-mappable-suitable-for-use-w#33023522
+                if maybe_mappable and hasattr(maybe_mappable, 'autoscale_None'):
+                    self._mappables.append(maybe_mappable)
 
         self._finalize_grid(*args[:2])
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -770,7 +770,7 @@ def _plot2d(plotfunc):
                 cbar_kwargs.setdefault('cax', cbar_ax)
             cbar = plt.colorbar(primitive, **cbar_kwargs)
             if add_labels and 'label' not in cbar_kwargs:
-                cbar.set_label(label_from_attrs(darray), rotation=90)
+                cbar.set_label(label_from_attrs(darray))
         elif cbar_ax is not None or cbar_kwargs is not None:
             # inform the user about keywords which aren't used
             raise ValueError("cbar_ax and cbar_kwargs can't be used with "

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
+import textwrap
 import warnings
 
 import numpy as np
-import textwrap
 
+from ..core.options import OPTIONS
 from ..core.pycompat import basestring
 from ..core.utils import is_scalar
 from ..core.options import OPTIONS

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1033,6 +1033,19 @@ class Common2dMixin:
         for ax in g.axes.flat:
             assert ax.has_data()
 
+    @pytest.mark.filterwarnings('ignore:This figure includes')
+    def test_facetgrid_map_only_appends_mappables(self):
+        a = easy_array((10, 15, 2, 3))
+        d = DataArray(a, dims=['y', 'x', 'columns', 'rows'])
+        g = self.plotfunc(d, x='x', y='y', col='columns', row='rows')
+
+        expected = g._mappables
+
+        g.map(lambda: plt.plot(1, 1))
+        actual = g._mappables
+
+        assert expected == actual
+
     def test_facetgrid_cmap(self):
         # Regression test for GH592
         data = (np.random.random(size=(20, 25, 12)) + np.linspace(-3, 3, 12))


### PR DESCRIPTION
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)

Some minor fixes.
1. Don't explicitly set rotation on colorbar label. matplotlib automatically does the right thing for horizontal and vertical colorbars.

2. Adds a test for whether an object is mappable before adding it to `FacetGrid._mappables`. 