### PR TITLE
Add `axis_aspect` kwarg to set axis aspect ratio.

### DIFF
--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -232,7 +232,7 @@ The keyword arguments ``xincrease`` and ``yincrease`` let you control the axes d
     @savefig plotting_example_xincrease_yincrease_kwarg.png
     air.isel(time=10, lon=[10, 11]).plot.line(y='lat', hue='lon', xincrease=False, yincrease=False)
 
-In addition, one can use ``xscale, yscale`` to set axes scaling; ``xticks, yticks`` to set axes ticks and ``xlim, ylim`` to set axes limits. These accept the same values as the matplotlib methods ``Axes.set_(x,y)scale()``, ``Axes.set_(x,y)ticks()``, ``Axes.set_(x,y)lim()`` respectively.
+In addition, one can use ``axis_aspect`` to set the Axes aspect ratio, ``xscale, yscale`` to set axes scaling; ``xticks, yticks`` to set axes ticks and ``xlim, ylim`` to set axes limits. These accept the same values as the matplotlib methods ``Axes.set_aspect()``, ``Axes.set_(x,y)scale()``, ``Axes.set_(x,y)ticks()``, ``Axes.set_(x,y)lim()`` respectively.
 
 
 Two Dimensions

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -66,6 +66,9 @@ Enhancements
   (:issue:`2394`)
   By `Julius Busecke <https://github.com/jbusecke>`_.
 
+- :py:meth:`plot()` now accepts the kwarg ``axis_aspect`` to set the Axes aspect ratio.
+  By `Deepak Cherian <https://github.com/dcherian>`_. (:issue:`2406`)
+
 - min_count option is newly supported in :py:meth:`~xarray.DataArray.sum`,
   :py:meth:`~xarray.DataArray.prod` and :py:meth:`~xarray.Dataset.sum`, and
   :py:meth:`~xarray.Dataset.prod`.
@@ -80,6 +83,7 @@ Enhancements
   now displayed as `a b ... y z` rather than `a b c d ...`.
   (:issue:`1186`)
   By `Seth P <https://github.com/seth-p>`_.
+
 - A new CFTimeIndex-enabled :py:func:`cftime_range` function for use in
   generating dates from standard or non-standard calendars.  By `Spencer Clark
   <https://github.com/spencerkclark>`_.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,6 +36,9 @@ Enhancements
 - Added support for Python 3.7. (:issue:`2271`).
   By `Joe Hamman <https://github.com/jhamman>`_.
 
+- :py:meth:`plot()` now accepts the kwarg ``axis_aspect`` to set the Axes aspect ratio.
+  By `Deepak Cherian <https://github.com/dcherian>`_. (:issue:`2406`)
+
 Bug fixes
 ~~~~~~~~~
 
@@ -65,9 +68,6 @@ Enhancements
   :py:func:`~xarray.set_options()`
   (:issue:`2394`)
   By `Julius Busecke <https://github.com/jbusecke>`_.
-
-- :py:meth:`plot()` now accepts the kwarg ``axis_aspect`` to set the Axes aspect ratio.
-  By `Deepak Cherian <https://github.com/dcherian>`_. (:issue:`2406`)
 
 - min_count option is newly supported in :py:meth:`~xarray.DataArray.sum`,
   :py:meth:`~xarray.DataArray.prod` and :py:meth:`~xarray.Dataset.sum`, and

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -258,6 +258,8 @@ def line(darray, *args, **kwargs):
     aspect : scalar, optional
         Aspect ratio of plot, so that ``aspect * size`` gives the width in
         inches. Only used if a ``size`` is provided.
+    axis_aspect: optional
+        Aspect ratio of axis. This is passed to `matplotlib.Axis.set_aspect()`
     size : scalar, optional
         If provided, create a new figure for the plot with the given size.
         Height (in inches) of each plot. See also: ``aspect``.
@@ -318,6 +320,7 @@ def line(darray, *args, **kwargs):
     xlim = kwargs.pop('xlim', None)
     ylim = kwargs.pop('ylim', None)
     add_legend = kwargs.pop('add_legend', True)
+    axis_aspect = kwargs.pop('axis_aspect', 'auto')
     _labels = kwargs.pop('_labels', True)
     if args is ():
         args = kwargs.pop('args', ())
@@ -354,7 +357,7 @@ def line(darray, *args, **kwargs):
             xlabels.set_ha('right')
 
     _update_axes(ax, xincrease, yincrease, xscale, yscale,
-                 xticks, yticks, xlim, ylim)
+                 xticks, yticks, xlim, ylim, axis_aspect)
 
     return primitive
 
@@ -397,6 +400,7 @@ def hist(darray, figsize=None, size=None, aspect=None, ax=None, **kwargs):
     yticks = kwargs.pop('yticks', None)
     xlim = kwargs.pop('xlim', None)
     ylim = kwargs.pop('ylim', None)
+    axis_aspect = kwargs.pop('axis_aspect', 'auto')
 
     no_nan = np.ravel(darray.values)
     no_nan = no_nan[pd.notnull(no_nan)]
@@ -407,7 +411,7 @@ def hist(darray, figsize=None, size=None, aspect=None, ax=None, **kwargs):
     ax.set_xlabel(label_from_attrs(darray))
 
     _update_axes(ax, xincrease, yincrease, xscale, yscale,
-                 xticks, yticks, xlim, ylim)
+                 xticks, yticks, xlim, ylim, axis_aspect)
 
     return primitive
 
@@ -415,7 +419,8 @@ def hist(darray, figsize=None, size=None, aspect=None, ax=None, **kwargs):
 def _update_axes(ax, xincrease, yincrease,
                  xscale=None, yscale=None,
                  xticks=None, yticks=None,
-                 xlim=None, ylim=None):
+                 xlim=None, ylim=None,
+                 axis_aspect='auto'):
     """
     Update axes with provided parameters
     """
@@ -452,6 +457,8 @@ def _update_axes(ax, xincrease, yincrease,
         ax.set_xlim(xlim)
     if ylim is not None:
         ax.set_ylim(ylim)
+
+    ax.set_aspect(axis_aspect)
 
 
 # MUST run before any 2d plotting functions are defined since
@@ -562,6 +569,8 @@ def _plot2d(plotfunc):
         Adds colorbar to axis
     add_labels : Boolean, optional
         Use xarray metadata to label axes
+    axis_aspect: optional
+        Aspect ratio of axis. This is passed to `matplotlib.Axis.set_aspect()`
     vmin, vmax : floats, optional
         Values to anchor the colormap, otherwise they are inferred from the
         data and other keyword arguments. When a diverging dataset is inferred,
@@ -630,7 +639,7 @@ def _plot2d(plotfunc):
                     levels=None, infer_intervals=None, colors=None,
                     subplot_kws=None, cbar_ax=None, cbar_kwargs=None,
                     xscale=None, yscale=None, xticks=None, yticks=None,
-                    xlim=None, ylim=None, **kwargs):
+                    xlim=None, ylim=None, axis_aspect='auto', **kwargs):
         # All 2d plots in xarray share this function signature.
         # Method signature below should be consistent.
 
@@ -781,7 +790,7 @@ def _plot2d(plotfunc):
             yincrease = None
 
         _update_axes(ax, xincrease, yincrease, xscale, yscale,
-                     xticks, yticks, xlim, ylim)
+                     xticks, yticks, xlim, ylim, axis_aspect)
 
         # Rotate dates on xlabels
         # Do this without calling autofmt_xdate so that x-axes ticks
@@ -804,7 +813,7 @@ def _plot2d(plotfunc):
                    levels=None, infer_intervals=None, subplot_kws=None,
                    cbar_ax=None, cbar_kwargs=None,
                    xscale=None, yscale=None, xticks=None, yticks=None,
-                   xlim=None, ylim=None, **kwargs):
+                   xlim=None, ylim=None, axis_aspect='auto', **kwargs):
         """
         The method should have the same signature as the function.
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1804,3 +1804,9 @@ class TestAxesKwargs(object):
         da.plot(yticks=np.arange(5))
         expected = np.arange(5)
         assert np.all(plt.gca().get_yticks() == expected)
+
+    @pytest.mark.parametrize('da', test_da_list)
+    def test_axis_aspect_kwarg(self, da):
+        plt.clf()
+        da.plot(axis_aspect='equal')
+        assert plt.gca().get_aspect() == 'equal'


### PR DESCRIPTION
 - [x] Closes #2406
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

```
array = xr.DataArray(np.random.rand(20,5,2,1), dims=['a', 'b', 'c', 'd'])
array.plot(x='a', y='b', col='c', axis_aspect='equal')
```
![image](https://user-images.githubusercontent.com/2448579/45859384-fbb08e80-bd9c-11e8-8bf4-97a7415c4269.png)
