### PR TITLE
Contour labels kwarg

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,6 +33,10 @@ v0.11.0 (unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
+- :py:meth:`plot()` now accepts the kwargs ``labels, clabel_kwargs`` to add
+  labels to contours.
+  By `Deepak Cherian <https://github.com/dcherian>`_. (:issue:`2224`)
+
 Bug fixes
 ~~~~~~~~~
 
@@ -58,12 +62,13 @@ Enhancements
   :py:meth:`~xarray.Dataset.differentiate` are newly added.
   (:issue:`1332`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+
 - Default colormap for sequential and divergent data can now be set via
   :py:func:`~xarray.set_options()`
   (:issue:`2394`)
   By `Julius Busecke <https://github.com/jbusecke>`_.
 
-- min_count option is newly supported in :py:meth:`~xarray.DataArray.sum`,
+- ``min_count`` option is newly supported in :py:meth:`~xarray.DataArray.sum`,
   :py:meth:`~xarray.DataArray.prod` and :py:meth:`~xarray.Dataset.sum`, and
   :py:meth:`~xarray.Dataset.prod`.
   (:issue:`2230`)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,9 +33,10 @@ v0.11.0 (unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
-- :py:meth:`plot()` now accepts the kwargs ``labels, clabel_kwargs`` to add
+- :py:meth:`plot.contour()` now accepts the kwargs ``labels, clabel_kwargs`` to add
   labels to contours.
   By `Deepak Cherian <https://github.com/dcherian>`_. (:issue:`2224`)
+
 - Added support for Python 3.7. (:issue:`2271`).
   By `Joe Hamman <https://github.com/jhamman>`_.
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -608,6 +608,10 @@ def _plot2d(plotfunc):
         Axes in which to draw the colorbar.
     cbar_kwargs : dict, optional
         Dictionary of keyword arguments to pass to the colorbar.
+    labels : bool, optional
+        Only applies to contour or contourf. Add labels to contours?
+    clabel_kwargs : dict, optional
+        Keyword arguments passed on to contour or contourf.
     **kwargs : optional
         Additional arguments to wrapped matplotlib function
 
@@ -907,11 +911,13 @@ def contour(x, y, z, ax, **kwargs):
     Wraps :func:`matplotlib:matplotlib.pyplot.contour`
     """
     labels = kwargs.pop('labels', False)
+    clabel_kwargs = kwargs.pop('clabel_kwargs', None)
+    clabel_kwargs = {} if clabel_kwargs is None else dict(clabel_kwargs)
 
     primitive = ax.contour(x, y, z, **kwargs)
 
     if labels:
-        ax.clabel(primitive, primitive.levels)
+        ax.clabel(primitive, primitive.levels, **clabel_kwargs)
 
     return primitive
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -906,7 +906,13 @@ def contour(x, y, z, ax, **kwargs):
 
     Wraps :func:`matplotlib:matplotlib.pyplot.contour`
     """
+    labels = kwargs.pop('labels', False)
+
     primitive = ax.contour(x, y, z, **kwargs)
+
+    if labels:
+        ax.clabel(primitive, primitive.levels)
+
     return primitive
 
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -609,9 +609,9 @@ def _plot2d(plotfunc):
     cbar_kwargs : dict, optional
         Dictionary of keyword arguments to pass to the colorbar.
     labels : bool, optional
-        Only applies to contour or contourf. Add labels to contours?
+        Only applies to contour. Add contour labels?
     clabel_kwargs : dict, optional
-        Keyword arguments passed on to contour or contourf.
+        Keyword arguments passed on to ``Axes.clabel``.
     **kwargs : optional
         Additional arguments to wrapped matplotlib function
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1167,6 +1167,12 @@ class TestContour(Common2dMixin, PlotTestCase):
         self.plotmethod(levels=[0.1])
         self.plotmethod(levels=1)
 
+    def test_clabel(self):
+        primitive = self.plotmethod(labels=True,
+                                    clabel_kwargs={'fmt': '%.1f'})
+        assert primitive.labelLevelList != []
+        assert primitive.labelFmt == '%.1f'
+
 
 class TestPcolormesh(Common2dMixin, PlotTestCase):
 


### PR DESCRIPTION
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

Adds a `labels` boolean kwarg for `contour` that adds contour labels. Also adds `clabel_kwargs` that is passed on to `Axes.clabel()`

`air.isel(time=0).plot.contour(labels=True, colors='k', clabel_kwargs={'fmt': '%.1f'})`

![image](https://user-images.githubusercontent.com/2448579/45925039-913c5180-bf48-11e8-8626-805c117ab6f3.png)

