### PR TITLE
Enable use of cftime.datetime coordinates with differentiate and interp

### DIFF
--- a/doc/interpolation.rst
+++ b/doc/interpolation.rst
@@ -63,6 +63,9 @@ by specifing the time periods required.
 
     da_dt64.interp(time=pd.date_range('1/1/2000', '1/3/2000', periods=3))
 
+Interpolation of data indexed by a :py:class:`~xarray.CFTimeIndex` is also
+allowed.  See :ref:`CFTimeIndex` for examples.
+    
 .. note::
 
   Currently, our interpolation only works for regular grids.

--- a/doc/time-series.rst
+++ b/doc/time-series.rst
@@ -70,9 +70,9 @@ You can manual decode arrays in this form by passing a dataset to
 One unfortunate limitation of using ``datetime64[ns]`` is that it limits the
 native representation of dates to those that fall between the years 1678 and
 2262. When a netCDF file contains dates outside of these bounds, dates will be
-returned as arrays of ``cftime.datetime`` objects and a ``CFTimeIndex``
-can be used for indexing.  The ``CFTimeIndex`` enables only a subset of
-the indexing functionality of a ``pandas.DatetimeIndex`` and is only enabled
+returned as arrays of :py:class:`cftime.datetime` objects and a :py:class:`~xarray.CFTimeIndex`
+can be used for indexing.  The :py:class:`~xarray.CFTimeIndex` enables only a subset of
+the indexing functionality of a :py:class:`pandas.DatetimeIndex` and is only enabled
 when using the standalone version of ``cftime`` (not the version packaged with
 earlier versions ``netCDF4``).  See :ref:`CFTimeIndex` for more information.
 
@@ -219,12 +219,12 @@ Non-standard calendars and dates outside the Timestamp-valid range
 ------------------------------------------------------------------
 
 Through the standalone ``cftime`` library and a custom subclass of
-``pandas.Index``, xarray supports a subset of the indexing functionality enabled
-through the standard ``pandas.DatetimeIndex`` for dates from non-standard
-calendars or dates using a standard calendar, but outside the
-`Timestamp-valid range`_ (approximately between years 1678 and 2262).  This
-behavior has not yet been turned on by default; to take advantage of this
-functionality, you must have the ``enable_cftimeindex`` option set to
+:py:class:`pandas.Index`, xarray supports a subset of the indexing
+functionality enabled through the standard :py:class:`pandas.DatetimeIndex` for
+dates from non-standard calendars or dates using a standard calendar, but
+outside the `Timestamp-valid range`_ (approximately between years 1678 and
+2262).  This behavior has not yet been turned on by default; to take advantage
+of this functionality, you must have the ``enable_cftimeindex`` option set to
 ``True`` within your context (see :py:func:`~xarray.set_options` for more
 information).  It is expected that this will become the default behavior in
 xarray version 0.11.
@@ -232,7 +232,7 @@ xarray version 0.11.
 For instance, you can create a DataArray indexed by a time
 coordinate with a no-leap calendar within a context manager setting the
 ``enable_cftimeindex`` option, and the time index will be cast to a
-``CFTimeIndex``:
+:py:class:`~xarray.CFTimeIndex`:
 
 .. ipython:: python
 
@@ -247,28 +247,28 @@ coordinate with a no-leap calendar within a context manager setting the
                          
 .. note::
 
-   With the ``enable_cftimeindex`` option activated, a ``CFTimeIndex``
+   With the ``enable_cftimeindex`` option activated, a :py:class:`~xarray.CFTimeIndex`
    will be used for time indexing if any of the following are true:
 
    - The dates are from a non-standard calendar
    - Any dates are outside the Timestamp-valid range
 
-   Otherwise a ``pandas.DatetimeIndex`` will be used.  In addition, if any
+   Otherwise a :py:class:`pandas.DatetimeIndex` will be used.  In addition, if any
    variable (not just an index variable) is encoded using a non-standard
-   calendar, its times will be decoded into ``cftime.datetime`` objects,
+   calendar, its times will be decoded into :py:class:`cftime.datetime` objects,
    regardless of whether or not they can be represented using
    ``np.datetime64[ns]`` objects.
 
-xarray also includes a :py:func:`cftime_range` function, which enables creating a
-``CFTimeIndex`` with regularly-spaced dates.  For instance, we can create the
-same dates and DataArray we created above using:
+xarray also includes a :py:func:`~xarray.cftime_range` function, which enables
+creating a :py:class:`~xarray.CFTimeIndex` with regularly-spaced dates.  For instance, we can
+create the same dates and DataArray we created above using:
 
 .. ipython:: python
 
    dates = xr.cftime_range(start='0001', periods=24, freq='MS', calendar='noleap')
    da = xr.DataArray(np.arange(24), coords=[dates], dims=['time'], name='foo')
    
-For data indexed by a ``CFTimeIndex`` xarray currently supports:
+For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
 
 - `Partial datetime string indexing`_ using strictly `ISO 8601-format`_ partial
   datetime strings:
@@ -294,7 +294,25 @@ For data indexed by a ``CFTimeIndex`` xarray currently supports:
 .. ipython:: python
 
    da.groupby('time.month').sum()
-   
+
+- Interpolation using :py:class:`cftime.datetime` objects:
+
+.. ipython:: python
+
+   da.interp(time=[DatetimeNoLeap(1, 1, 15), DatetimeNoLeap(1, 2, 15)])
+
+- Interpolation using datetime strings:
+
+.. ipython:: python
+
+   da.interp(time=['0001-01-15', '0001-02-15'])
+
+- Differentiation:
+
+.. ipython:: python
+
+   da.differentiate('time')
+
 - And serialization:
 
 .. ipython:: python
@@ -305,7 +323,7 @@ For data indexed by a ``CFTimeIndex`` xarray currently supports:
 .. note::
    
    Currently resampling along the time dimension for data indexed by a
-   ``CFTimeIndex`` is not supported.
+   :py:class:`~xarray.CFTimeIndex` is not supported.
   
 .. _Timestamp-valid range: https://pandas.pydata.org/pandas-docs/stable/timeseries.html#timestamp-limitations
 .. _ISO 8601-format: https://en.wikipedia.org/wiki/ISO_8601

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,6 +36,13 @@ Enhancements
 - Added support for Python 3.7. (:issue:`2271`).
   By `Joe Hamman <https://github.com/jhamman>`_.
 
+- Added support for using ``cftime.datetime`` coordinates with
+  :py:meth:`~xarray.DataArray.differentiate`,
+  :py:meth:`~xarray.Dataset.differentiate`,
+  :py:meth:`~xarray.DataArray.interp`, and
+  :py:meth:`~xarray.Dataset.interp`.
+  By `Spencer Clark <https://github.com/spencerkclark>`_
+  
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -314,3 +314,32 @@ class CFTimeIndex(pd.Index):
     def contains(self, key):
         """Needed for .loc based partial-string indexing"""
         return self.__contains__(key)
+
+
+def _parse_iso8601_without_reso(date_type, datetime_str):
+    date, _ = _parse_iso8601_with_reso(date_type, datetime_str)
+    return date
+
+
+def _parse_array_of_cftime_strings(strings, date_type):
+    """Create a numpy array from an array of strings.
+
+    For use in generating dates from strings for use with interp.  Assumes the
+    array is either 0-dimensional or 1-dimensional.
+
+    Parameters
+    ----------
+    strings : array of strings
+        Strings to convert to dates
+    date_type : cftime.datetime type
+        Calendar type to use for dates
+
+    Returns
+    -------
+    np.array
+    """
+    if strings.ndim == 0:
+        return np.array(_parse_iso8601_without_reso(date_type, strings.item()))
+    else:
+        return np.array([_parse_iso8601_without_reso(date_type, s)
+                         for s in strings])

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -31,7 +31,7 @@ from .pycompat import (
     OrderedDict, basestring, dask_array_type, integer_types, iteritems, range)
 from .utils import (
     Frozen, SortedKeysDict, either_dict_or_kwargs, decode_numpy_dict_values,
-    ensure_us_time_resolution, hashable, maybe_wrap_array, to_numeric)
+    ensure_us_time_resolution, hashable, maybe_wrap_array, datetime_to_numeric)
 from .variable import IndexVariable, Variable, as_variable, broadcast_variables
 
 from ..coding.cftimeindex import _parse_array_of_cftime_strings
@@ -3831,14 +3831,14 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
                 datetime_unit, _ = np.datetime_data(coord_var.dtype)
             elif datetime_unit is None:
                 datetime_unit = 's'  # Default to seconds for cftime objects
-            coord_var = to_numeric(coord_var, datetime_unit=datetime_unit)
+            coord_var = datetime_to_numeric(coord_var, datetime_unit=datetime_unit)
 
         variables = OrderedDict()
         for k, v in self.variables.items():
             if (k in self.data_vars and dim in v.dims and
                     k not in self.coords):
                 if _contains_datetime_like_objects(v):
-                    v = to_numeric(v, datetime_unit=datetime_unit)
+                    v = datetime_to_numeric(v, datetime_unit=datetime_unit)
                 grad = duck_array_ops.gradient(
                     v.data, coord_var, edge_order=edge_order,
                     axis=v.get_axis_num(dim))

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 from . import rolling
+from .common import _contains_datetime_like_objects
 from .computation import apply_ufunc
 from .pycompat import iteritems
 from .utils import is_scalar, OrderedSet, to_numeric
@@ -407,13 +408,13 @@ def _floatize_x(x, new_x):
     x = list(x)
     new_x = list(new_x)
     for i in range(len(x)):
-        if x[i].dtype.kind in 'Mm':
+        if _contains_datetime_like_objects(x[i]):
             # Scipy casts coordinates to np.float64, which is not accurate
             # enough for datetime64 (uses 64bit integer).
             # We assume that the most of the bits are used to represent the
             # offset (min(x)) and the variation (x - min(x)) can be
             # represented by float.
-            xmin = np.min(x[i])
+            xmin = x[i].min()
             x[i] = to_numeric(x[i], offset=xmin, dtype=np.float64)
             new_x[i] = to_numeric(new_x[i], offset=xmin, dtype=np.float64)
     return x, new_x

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -12,7 +12,7 @@ from . import rolling
 from .common import _contains_datetime_like_objects
 from .computation import apply_ufunc
 from .pycompat import iteritems
-from .utils import is_scalar, OrderedSet, to_numeric
+from .utils import is_scalar, OrderedSet, datetime_to_numeric
 from .variable import Variable, broadcast_variables
 from .duck_array_ops import dask_array_type
 
@@ -415,8 +415,9 @@ def _floatize_x(x, new_x):
             # offset (min(x)) and the variation (x - min(x)) can be
             # represented by float.
             xmin = x[i].min()
-            x[i] = to_numeric(x[i], offset=xmin, dtype=np.float64)
-            new_x[i] = to_numeric(new_x[i], offset=xmin, dtype=np.float64)
+            x[i] = datetime_to_numeric(x[i], offset=xmin, dtype=np.float64)
+            new_x[i] = datetime_to_numeric(
+                new_x[i], offset=xmin, dtype=np.float64)
     return x, new_x
 
 

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -593,7 +593,7 @@ class HiddenKeyDict(MutableMapping):
         return len(self._data) - num_hidden
 
 
-def to_numeric(array, offset=None, datetime_unit=None, dtype=float):
+def datetime_to_numeric(array, offset=None, datetime_unit=None, dtype=float):
     """Convert an array containing datetime-like data to an array of floats.
 
     Parameters

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -594,19 +594,24 @@ class HiddenKeyDict(MutableMapping):
 
 
 def to_numeric(array, offset=None, datetime_unit=None, dtype=float):
-    """
-    Make datetime array float
+    """Convert an array containing datetime-like data to an array of floats.
 
+    Parameters
+    ----------
+    da : array
+        Input data
     offset: Scalar with the same type of array or None
         If None, subtract minimum values to reduce round off error
     datetime_unit: None or any of {'Y', 'M', 'W', 'D', 'h', 'm', 's', 'ms',
         'us', 'ns', 'ps', 'fs', 'as'}
     dtype: target dtype
+
+    Returns
+    -------
+    array
     """
-    if array.dtype.kind not in ['m', 'M']:
-        return array.astype(dtype)
     if offset is None:
-        offset = np.min(array)
+        offset = array.min()
     array = array - offset
 
     if datetime_unit:

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -9,10 +9,11 @@ import xarray as xr
 from datetime import timedelta
 from xarray.coding.cftimeindex import (
     parse_iso8601, CFTimeIndex, assert_all_valid_date_type,
-    _parsed_string_to_bounds, _parse_iso8601_with_reso)
+    _parsed_string_to_bounds, _parse_iso8601_with_reso,
+    _parse_array_of_cftime_strings)
 from xarray.tests import assert_array_equal, assert_identical
 
-from . import has_cftime, has_cftime_or_netCDF4
+from . import has_cftime, has_cftime_or_netCDF4, requires_cftime
 from .test_coding_times import _all_cftime_date_types
 
 
@@ -616,3 +617,21 @@ def test_concat_cftimeindex(date_type, enable_cftimeindex):
 def test_empty_cftimeindex():
     index = CFTimeIndex([])
     assert index.date_type is None
+
+
+@requires_cftime
+def test_parse_array_of_cftime_strings():
+    from cftime import DatetimeNoLeap
+
+    strings = np.array(['2000-01-01', '2000-01-02'])
+    expected = np.array([DatetimeNoLeap(2000, 1, 1),
+                         DatetimeNoLeap(2000, 1, 2)])
+
+    result = _parse_array_of_cftime_strings(strings, DatetimeNoLeap)
+    np.testing.assert_array_equal(result, expected)
+
+    # Test scalar array case
+    strings = np.array('2000-01-01')
+    expected = np.array(DatetimeNoLeap(2000, 1, 1))
+    result = _parse_array_of_cftime_strings(strings, DatetimeNoLeap)
+    np.testing.assert_array_equal(result, expected)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4573,7 +4573,7 @@ def test_differentiate_datetime(dask):
     actual = da.differentiate('x', edge_order=1, datetime_unit='D')
     expected_x = xr.DataArray(
         npcompat.gradient(
-            da, utils.to_numeric(da['x'], datetime_unit='D'),
+            da, utils.datetime_to_numeric(da['x'], datetime_unit='D'),
             axis=0, edge_order=1), dims=da.dims, coords=da.coords)
     assert_equal(expected_x, actual)
 
@@ -4607,7 +4607,7 @@ def test_differentiate_cftime(dask):
 
     actual = da.differentiate('time', edge_order=1, datetime_unit='D')
     expected_data = npcompat.gradient(
-        da, utils.to_numeric(da['time'], datetime_unit='D'),
+        da, utils.datetime_to_numeric(da['time'], datetime_unit='D'),
         axis=0, edge_order=1)
     expected = xr.DataArray(expected_data, coords=da.coords, dims=da.dims)
     assert_equal(expected, actual)

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -555,3 +555,21 @@ def test_cftime_single_string():
     expected = xr.DataArray(0.5, coords={'time': times_new_array})
 
     assert_allclose(actual, expected)
+
+
+@requires_scipy
+def test_datetime_to_non_datetime_error():
+    da = xr.DataArray(np.arange(24), dims='time',
+                      coords={'time': pd.date_range('2000-01-01', periods=24)})
+    with pytest.raises(TypeError):
+        da.interp(time=0.5)
+
+
+@requires_cftime
+@requires_scipy
+def test_cftime_to_non_cftime_error():
+    times = xr.cftime_range('2000', periods=24, freq='D')
+    da = xr.DataArray(np.arange(24), coords=[times], dims='time')
+
+    with pytest.raises(TypeError):
+        da.interp(time=0.5)

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -267,40 +267,40 @@ def test_either_dict_or_kwargs():
         result = either_dict_or_kwargs(dict(a=1), dict(a=1), 'foo')
 
 
-def test_to_numeric_datetime64():
+def test_datetime_to_numeric_datetime64():
     times = pd.date_range('2000', periods=5, freq='7D')
     da = xr.DataArray(times, coords=[times], dims=['time'])
-    result = utils.to_numeric(da, datetime_unit='h')
+    result = utils.datetime_to_numeric(da, datetime_unit='h')
     expected = 24 * xr.DataArray(np.arange(0, 35, 7), coords=da.coords)
     assert_identical(result, expected)
 
     offset = da.isel(time=1)
-    result = utils.to_numeric(da, offset=offset, datetime_unit='h')
+    result = utils.datetime_to_numeric(da, offset=offset, datetime_unit='h')
     expected = 24 * xr.DataArray(np.arange(-7, 28, 7), coords=da.coords)
     assert_identical(result, expected)
 
     dtype = np.float32
-    result = utils.to_numeric(da, datetime_unit='h', dtype=dtype)
+    result = utils.datetime_to_numeric(da, datetime_unit='h', dtype=dtype)
     expected = 24 * xr.DataArray(
         np.arange(0, 35, 7), coords=da.coords).astype(dtype)
     assert_identical(result, expected)
 
 
 @requires_cftime
-def test_to_numeric_cftime():
+def test_datetime_to_numeric_cftime():
     times = xr.cftime_range('2000', periods=5, freq='7D')
     da = xr.DataArray(times, coords=[times], dims=['time'])
-    result = utils.to_numeric(da, datetime_unit='h')
+    result = utils.datetime_to_numeric(da, datetime_unit='h')
     expected = 24 * xr.DataArray(np.arange(0, 35, 7), coords=da.coords)
     assert_identical(result, expected)
 
     offset = da.isel(time=1)
-    result = utils.to_numeric(da, offset=offset, datetime_unit='h')
+    result = utils.datetime_to_numeric(da, offset=offset, datetime_unit='h')
     expected = 24 * xr.DataArray(np.arange(-7, 28, 7), coords=da.coords)
     assert_identical(result, expected)
 
     dtype = np.float32
-    result = utils.to_numeric(da, datetime_unit='h', dtype=dtype)
+    result = utils.datetime_to_numeric(da, datetime_unit='h', dtype=dtype)
     expected = 24 * xr.DataArray(
         np.arange(0, 35, 7), coords=da.coords).astype(dtype)
     assert_identical(result, expected)


### PR DESCRIPTION
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

As discussed in https://github.com/pydata/xarray/pull/2398#pullrequestreview-156804917, this enables the use of `differentiate` and `interp` on DataArrays/Datasets with `cftime.datetime` coordinates.