### PR TITLE
make facetgrid execute _finalize() only once

### DIFF
--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -188,6 +188,7 @@ class FacetGrid(object):
         self._y_var = None
         self._cmap_extend = None
         self._mappables = []
+        self._finalized = False
 
     @property
     def _left_axes(self):
@@ -308,13 +309,16 @@ class FacetGrid(object):
 
     def _finalize_grid(self, *axlabels):
         """Finalize the annotations and layout."""
-        self.set_axis_labels(*axlabels)
-        self.set_titles()
-        self.fig.tight_layout()
+        if not self._finalized:
+            self.set_axis_labels(*axlabels)
+            self.set_titles()
+            self.fig.tight_layout()
 
-        for ax, namedict in zip(self.axes.flat, self.name_dicts.flat):
-            if namedict is None:
-                ax.set_visible(False)
+            for ax, namedict in zip(self.axes.flat, self.name_dicts.flat):
+                if namedict is None:
+                    ax.set_visible(False)
+
+            self._finalized = True
 
     def add_legend(self, **kwargs):
         figlegend = self.fig.legend(

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1523,7 +1523,9 @@ class TestFacetGrid(PlotTestCase):
 
     @pytest.mark.slow
     def test_map(self):
+        assert self.g._finalized is False
         self.g.map(plt.contourf, 'x', 'y', Ellipsis)
+        assert self.g._finalized is True
         self.g.map(lambda: None)
 
     @pytest.mark.slow


### PR DESCRIPTION
 - [x] Closes #2024 
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)

Makes sure that `FacetGrid._finalize()` is only called once. This function sets axes labels and calls `tight_layout`. The user can do all that easily if they need to change the defaults.

See #2024 for example.