### PR TITLE
Use Hypothesis profile mechanism, not no-op mutation

### DIFF
--- a/properties/test_encode_decode.py
+++ b/properties/test_encode_decode.py
@@ -13,7 +13,8 @@ import hypothesis.extra.numpy as npst
 import xarray as xr
 
 # Run for a while - arrays are a bigger search space than usual
-settings.deadline = None
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
 
 
 an_array = npst.arrays(


### PR DESCRIPTION
Closes #2441 - [Hypothesis 3.72.0](https://hypothesis.readthedocs.io/en/latest/changes.html#v3-72-0) turned a common no-op into an explicit error.  Apparently this was *such* a common misunderstanding that I had done it too :disappointed: 

Anyway: while it hasn't been using the deadline at all until now, I've still translated it into the correct form rather than deleting it in order to avoid flaky tests if the Travis VM is slow.