### PR TITLE
restore ddof support in std

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -39,6 +39,9 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- ``xarray.DataArray.std()`` now correctly accepts ``ddof`` keyword argument.
+  (:issue:`2240`)
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 
 .. _whats-new.0.10.9:
 

--- a/xarray/core/nanops.py
+++ b/xarray/core/nanops.py
@@ -184,9 +184,9 @@ def nanvar(a, axis=None, dtype=None, out=None, ddof=0):
         a, axis=axis, dtype=dtype, ddof=ddof)
 
 
-def nanstd(a, axis=None, dtype=None, out=None):
+def nanstd(a, axis=None, dtype=None, out=None, ddof=0):
     return _dask_or_eager_func('nanstd', eager_module=nputils)(
-        a, axis=axis, dtype=dtype)
+        a, axis=axis, dtype=dtype, ddof=ddof)
 
 
 def nanprod(a, axis=None, dtype=None, out=None, min_count=None):

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -309,7 +309,7 @@ def test_reduce(dim_num, dtype, dask, func, skipna, aggdim):
         assert_allclose(actual, expected, rtol=rtol)
 
         # make sure the compatiblility with pandas' results.
-        if func == 'var':
+        if func in ['var', 'std']:
             expected = series_reduce(da, func, skipna=skipna, dim=aggdim,
                                      ddof=0)
             assert_allclose(actual, expected, rtol=rtol)


### PR DESCRIPTION
 - [x] Closes #2440
 - [x] Tests added
 - [x] Tests passed
 - [x] Fully documented, including `whats-new.rst` for all changes

It looks that I wrongly remove `ddof` option for `nanstd` in #2236.
This PR fixes this.
