### PR TITLE
Fix FutureWarning resulting from CFTimeIndex.date_type

### DIFF
--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -157,7 +157,7 @@ def _field_accessor(name, docstring=None):
 
 
 def get_date_type(self):
-    if self.data:
+    if self._data.size:
         return type(self._data[0])
     else:
         return None


### PR DESCRIPTION
With the latest version of pandas, checking the `date_type` of a CFTimeIndex produces a FutureWarning:
```
In [1]: import xarray as xr

In [2]: times = xr.cftime_range('2000', periods=5)

In [3]: times.date_type
/Users/spencerclark/xarray-dev/xarray/xarray/coding/cftimeindex.py:161: FutureWarning: CFTimeIndex.data is deprecated and will be removed in a future version
  if self.data:
Out[3]: cftime._cftime.DatetimeProlepticGregorian
```
I think it was a typo to begin with to use `self.data` in `cftimeindex.get_date_type` (my mistake).  Here I switch to using `self._data`, which is used elsewhere when internally referencing values of the index.