### PR TITLE
Add 'to_iris' and 'from_iris' to methods Dataset

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -465,6 +465,8 @@ Dataset methods
    Dataset.to_dataframe
    Dataset.to_dask_dataframe
    Dataset.to_dict
+   DataSet.to_iris
+   DataSet.from_iris
    Dataset.from_dataframe
    Dataset.from_dict
    Dataset.close

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -52,7 +52,12 @@ Enhancements
   :py:meth:`~xarray.DataArray.interp`, and
   :py:meth:`~xarray.Dataset.interp`.
   By `Spencer Clark <https://github.com/spencerkclark>`_
-  
+
+- Added :py:meth:`DataSet.to_iris` and
+  :py:meth:`DataSet.from_iris` for
+  converting data sets to and from Iris_ CubeLists with the same data and coordinates.
+  By `Jacob Tomlinson <https://github.com/jacobtomlinson>`_.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/convert.py
+++ b/xarray/convert.py
@@ -11,7 +11,7 @@ from .coding.times import CFDatetimeCoder, CFTimedeltaCoder
 from .conventions import decode_cf
 from .core import duck_array_ops
 from .core.dataarray import DataArray
-from .core.dataset import DataSet
+from .core.dataset import Dataset
 from .core.dtypes import get_fill_value
 from .core.pycompat import OrderedDict, range
 
@@ -277,13 +277,13 @@ def datarray_from_iris(cube):
 
 
 def dataset_to_iris(dataset):
-    """ Convert a DataSet into an Iris CubeList.
+    """ Convert a Dataset into an Iris CubeList.
     """
     from iris.cube import CubeList
     return CubeList([dataset[variable].to_iris() for variable in list(dataset.data_vars)])
 
 
 def dataset_from_iris(cubelist):
-    """ Convert an Iris CubeList into a DataSet.
+    """ Convert an Iris CubeList into a Dataset.
     """
     return Dataset({cube.var_name: DataArray.from_iris(cube) for cube in cubelist})

--- a/xarray/convert.py
+++ b/xarray/convert.py
@@ -11,6 +11,7 @@ from .coding.times import CFDatetimeCoder, CFTimedeltaCoder
 from .conventions import decode_cf
 from .core import duck_array_ops
 from .core.dataarray import DataArray
+from .core.dataset import Dataset
 from .core.dtypes import get_fill_value
 from .core.pycompat import OrderedDict, range
 
@@ -139,7 +140,7 @@ def _get_iris_args(attrs):
 
 
 # TODO: Add converting bounds from xarray to Iris and back
-def to_iris(dataarray):
+def datarray_to_iris(dataarray):
     """ Convert a DataArray into a Iris Cube
     """
     # Iris not a hard dependency
@@ -221,7 +222,7 @@ def _name(iris_obj, default='unknown'):
             iris_obj.long_name or default)
 
 
-def from_iris(cube):
+def datarray_from_iris(cube):
     """ Convert a Iris cube into an DataArray
     """
     import iris.exceptions
@@ -273,3 +274,16 @@ def from_iris(cube):
                           attrs=array_attrs, dims=dims)
     decoded_ds = decode_cf(dataarray._to_temp_dataset())
     return dataarray._from_temp_dataset(decoded_ds)
+
+
+def dataset_to_iris(dataset):
+    """ Convert a DataSet into an Iris CubeList.
+    """
+    from iris.cube import CubeList
+    return CubeList([dataset[variable].to_iris() for variable in list(dataset.data_vars)])
+
+
+def dataset_from_iris(cubelist):
+    """ Convert an Iris CubeList into a DataSet.
+    """
+    return Dataset({cube.var_name: DataArray.from_iris(cube) for cube in cubelist})

--- a/xarray/convert.py
+++ b/xarray/convert.py
@@ -11,7 +11,7 @@ from .coding.times import CFDatetimeCoder, CFTimedeltaCoder
 from .conventions import decode_cf
 from .core import duck_array_ops
 from .core.dataarray import DataArray
-from .core.dataset import Dataset
+from .core.dataset import DataSet
 from .core.dtypes import get_fill_value
 from .core.pycompat import OrderedDict, range
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1855,15 +1855,15 @@ class DataArray(AbstractArray, DataWithCoords):
     def to_iris(self):
         """Convert this array into a iris.cube.Cube
         """
-        from ..convert import to_iris
-        return to_iris(self)
+        from ..convert import datarray_to_iris
+        return datarray_to_iris(self)
 
     @classmethod
     def from_iris(cls, cube):
         """Convert a iris.cube.Cube into an xarray.DataArray
         """
-        from ..convert import from_iris
-        return from_iris(cube)
+        from ..convert import datarray_from_iris
+        return datarray_from_iris(cube)
 
     def _all_compat(self, other, compat_str):
         """Helper function for equals and identical"""

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1293,6 +1293,19 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         return to_zarr(self, store=store, mode=mode, synchronizer=synchronizer,
                        group=group, encoding=encoding, compute=compute)
 
+    def to_iris(self):
+        """Convert this dataset into an iris.cube.CubeList.
+        """
+        from ..convert import dataset_to_iris
+        return dataset_to_iris(self)
+
+    @classmethod
+    def from_iris(cls, cubelist):
+        """Convert an iris.cube.CubeList into a dataset.
+        """
+        from ..convert import dataset_from_iris
+        return dataset_from_iris(cubelist)
+
     def __unicode__(self):
         return formatting.dataset_repr(self)
 
@@ -1415,7 +1428,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         """ Here we make sure
         + indexer has a valid keys
         + indexer is in a valid data type
-        + string indexers are cast to the appropriate date type if the 
+        + string indexers are cast to the appropriate date type if the
           associated index is a DatetimeIndex or CFTimeIndex
         """
         from .dataarray import DataArray
@@ -1998,7 +2011,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
                                'Instead got\n{}'.format(new_x))
             else:
                 return (x, new_x)
-            
+
         variables = OrderedDict()
         for name, var in iteritems(obj._variables):
             if name not in indexers:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4661,7 +4661,7 @@ class TestIrisConversion(object):
         original = Dataset({'Temperature': array})
         actual = original.to_iris()
 
-        assert_array_equal(actual.extract(iris.Constraint(name='Temperature')).data,
+        assert_array_equal(actual.extract(iris.Constraint(name='Temperature'))[0].data,
                            original['Temperature'].data)
 
         assert len(list(original.data_vars)) == len(actual)


### PR DESCRIPTION
This PR adds `to_iris` and `from_iris` methods to DataSet. I've added this because I frequently find myself writing little list and dictionary comprehensions to pack and unpack both DataSets from DataArrays and Iris CubeLists from Cubes.

 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API 
