### PR TITLE
plot.contour: Don't make cmap if colors is a single color.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -63,6 +63,10 @@ Bug fixes
 - ``xarray.DataArray.std()`` now correctly accepts ``ddof`` keyword argument.
   (:issue:`2240`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+- Restore matplotlib's default of plotting dashed negative contours when
+  a single color is passed to ``DataArray.contour()`` e.g. ``colors='k'``.
+  By `Deepak Cherian <https://github.com/dcherian>`_.
+
 
 .. _whats-new.0.10.9:
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -737,6 +737,11 @@ def _plot2d(plotfunc):
             # pcolormesh
             kwargs['extend'] = cmap_params['extend']
             kwargs['levels'] = cmap_params['levels']
+            # if colors == a single color, matplotlib draws dashed negative
+            # contours. we lose this feature if we pass cmap and not colors
+            if isinstance(colors, basestring):
+                cmap_params['cmap'] = None
+                kwargs['colors'] = colors
 
         if 'pcolormesh' == plotfunc.__name__:
             kwargs['infer_intervals'] = infer_intervals

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1140,9 +1140,9 @@ class TestContour(Common2dMixin, PlotTestCase):
         def _color_as_tuple(c):
             return tuple(c[:3])
 
+        # with single color, we don't want rgb array
         artist = self.plotmethod(colors='k')
-        assert _color_as_tuple(artist.cmap.colors[0]) == \
-            (0.0, 0.0, 0.0)
+        assert artist.cmap.colors[0] == 'k'
 
         artist = self.plotmethod(colors=['k', 'b'])
         assert _color_as_tuple(artist.cmap.colors[1]) == \


### PR DESCRIPTION
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

By default, matplotlib draws dashed negative contours when a single color is passed to `Axes.contour`. We lost this feature by manually specifying cmap everytime.

Currently on master:
```
delta = 0.025
x = np.arange(-3.0, 3.0, delta)
y = np.arange(-2.0, 2.0, delta)
X, Y = np.meshgrid(x, y)
Z1 = np.exp(-X**2 - Y**2)
Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
Z = xr.DataArray((Z1 - Z2) * 2, dims=['y', 'x'], coords={'x': x, 'y': y})

f, ax = plt.subplots(1, 2)
hdl = ax[0].contour(Z, colors='k')
hdlx = Z.plot.contour(ax=ax[1], colors='k')
```
![image](https://user-images.githubusercontent.com/2448579/46335584-e7a14280-c662-11e8-91e2-e1fedebf81dc.png)


 