### PR TITLE
np.AxisError was added in numpy 1.13

### DIFF
--- a/xarray/core/dask_array_compat.py
+++ b/xarray/core/dask_array_compat.py
@@ -44,7 +44,13 @@ else:  # pragma: no cover
     import math
     from numbers import Integral, Real
 
-    AxisError = np.AxisError
+    try:
+        AxisError = np.AxisError
+    except AttributeError:
+        try:
+            np.array([0]).sum(axis=5)
+        except Exception as e:
+            AxisError = type(e)
 
     def validate_axis(axis, ndim):
         """ Validate an input to axis= keywords """


### PR DESCRIPTION
https://github.com/pydata/xarray/blob/f9c4169150286fa1aac020ab965380ed21fe1148/xarray/core/dask_array_compat.py#L47

But AxisError was [added](https://github.com/numpy/numpy/commit/eb642f1b6533fcd92e366377f5859e4ea56d5eed) in 1.13.

The fix is copied from Dask code: https://github.com/dask/dask/blob/0fb0f876bb974cfca1458903540ac389e6f89019/dask/array/utils.py#L15