### PR TITLE
Clean up _parse_array_of_cftime_strings

### DIFF
--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -391,4 +391,3 @@ def _parse_array_of_cftime_strings(strings, date_type):
     """
     return np.array([_parse_iso8601_without_reso(date_type, s)
                      for s in strings.ravel()]).reshape(strings.shape)
-

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -389,8 +389,6 @@ def _parse_array_of_cftime_strings(strings, date_type):
     -------
     np.array
     """
-    if strings.ndim == 0:
-        return np.array(_parse_iso8601_without_reso(date_type, strings.item()))
-    else:
-        return np.array([_parse_iso8601_without_reso(date_type, s)
-                         for s in strings])
+    return np.array([_parse_iso8601_without_reso(date_type, s)
+                     for s in strings.ravel()]).reshape(strings.shape)
+

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -689,9 +689,11 @@ def test_cftimeindex_shift_invalid_freq():
 def test_parse_array_of_cftime_strings():
     from cftime import DatetimeNoLeap
 
-    strings = np.array(['2000-01-01', '2000-01-02'])
-    expected = np.array([DatetimeNoLeap(2000, 1, 1),
-                         DatetimeNoLeap(2000, 1, 2)])
+    strings = np.array([['2000-01-01', '2000-01-02'],
+                        ['2000-01-03', '2000-01-04']])
+    expected = np.array(
+        [[DatetimeNoLeap(2000, 1, 1), DatetimeNoLeap(2000, 1, 2)],
+         [DatetimeNoLeap(2000, 1, 3), DatetimeNoLeap(2000, 1, 4)]])
 
     result = _parse_array_of_cftime_strings(strings, DatetimeNoLeap)
     np.testing.assert_array_equal(result, expected)


### PR DESCRIPTION
Per @shoyer's comment, https://github.com/pydata/xarray/pull/2431#discussion_r221976257, this cleans up `_parse_array_of_cftime_strings`, making it robust to multi-dimensional arrays in the process.