### PR TITLE
Add python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,5 +69,6 @@ setup(name=DISTNAME,
       install_requires=INSTALL_REQUIRES,
       tests_require=TESTS_REQUIRE,
       url=URL,
+      python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
       packages=find_packages(),
       package_data={'xarray': ['tests/data/*']})


### PR DESCRIPTION
This should assist users using PyPI/pip to install xarray when xarray drops python 2.7 support. The `python_requires` argument is described here:

https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

Basically, it says what versions of python your package supports. When xarray drops python 2 support and this kwarg gets update it should stop people on python 2 from getting the wrong package.

 - [x] Tests passed (for all non-documentation changes)

