### PR TITLE
Update whats-new.rst

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,7 +27,7 @@ What's New
 
 .. _whats-new.0.10.9:
 
-v0.10.9 (21 September 2019)
+v0.10.9 (21 September 2018)
 ---------------------------
 
 This minor release contains a number of backwards compatible enhancements.


### PR DESCRIPTION
The release year of v0.10.9 is corrected from 2019 to 2018 

- [x ] Tests added (for all bug fixes or enhancements)
 - [ x] Tests passed (for all non-documentation changes)
 - [x ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
