### PR TITLE
Replace the last of unittest with pytest

### DIFF
--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -141,10 +141,6 @@ class TestCase(unittest.TestCase):
         __tracebackhide__ = True  # noqa: F841
         assert not v1.equals(v2)
 
-    def assertEqual(self, a1, a2):
-        __tracebackhide__ = True  # noqa: F841
-        assert a1 == a2 or (a1 != a1 and a2 != a2)
-
     def assertAllClose(self, a1, a2, rtol=1e-05, atol=1e-8):
         __tracebackhide__ = True  # noqa: F841
         assert allclose_or_equiv(a1, a2, rtol=rtol, atol=atol)

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -9,7 +9,7 @@ import importlib
 
 import numpy as np
 from numpy.testing import assert_array_equal  # noqa: F401
-from xarray.core.duck_array_ops import allclose_or_equiv
+from xarray.core.duck_array_ops import allclose_or_equiv  # noqa
 import pytest
 
 from xarray.core import utils
@@ -24,10 +24,6 @@ except ImportError:
     # old location, for pandas < 0.20
     from pandas.util.testing import assert_frame_equal  # noqa: F401
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
 
 try:
     from unittest import mock
@@ -114,29 +110,6 @@ network = pytest.mark.skipif(
     _SKIP_NETWORK_TESTS,
     reason="set --run-network-tests option to run tests requiring an "
     "internet connection")
-
-
-class TestCase(unittest.TestCase):
-    """
-    These functions are all deprecated. Instead, use functions in xr.testing
-    """
-
-    @contextmanager
-    def assertWarns(self, message):
-        __tracebackhide__ = True  # noqa: F841
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', message)
-            yield
-        assert len(w) > 0
-        assert any(message in str(wi.message) for wi in w)
-
-    def assertVariableNotEqual(self, v1, v2):
-        __tracebackhide__ = True  # noqa: F841
-        assert not v1.equals(v2)
-
-    def assertAllClose(self, a1, a2, rtol=1e-05, atol=1e-8):
-        __tracebackhide__ = True  # noqa: F841
-        assert allclose_or_equiv(a1, a2, rtol=rtol, atol=atol)
 
 
 @contextmanager

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -13,7 +13,6 @@ from xarray.core.duck_array_ops import allclose_or_equiv
 import pytest
 
 from xarray.core import utils
-from xarray.core.pycompat import PY3
 from xarray.core.indexing import ExplicitlyIndexed
 from xarray.testing import (assert_equal, assert_identical,  # noqa: F401
                             assert_allclose)
@@ -121,12 +120,6 @@ class TestCase(unittest.TestCase):
     """
     These functions are all deprecated. Instead, use functions in xr.testing
     """
-    if PY3:
-        # Python 3 assertCountEqual is roughly equivalent to Python 2
-        # assertItemsEqual
-        def assertItemsEqual(self, first, second, msg=None):
-            __tracebackhide__ = True  # noqa: F841
-            return self.assertCountEqual(first, second, msg)
 
     @contextmanager
     def assertWarns(self, message):

--- a/xarray/tests/test_accessors.py
+++ b/xarray/tests/test_accessors.py
@@ -7,12 +7,13 @@ import pytest
 import xarray as xr
 
 from . import (
-    TestCase, assert_array_equal, assert_equal, has_cftime,
-    has_cftime_or_netCDF4, has_dask, raises_regex, requires_dask)
+    assert_array_equal, assert_equal, has_cftime, has_cftime_or_netCDF4,
+    has_dask, raises_regex, requires_dask)
 
 
-class TestDatetimeAccessor(TestCase):
-    def setUp(self):
+class TestDatetimeAccessor(object):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         nt = 100
         data = np.random.rand(10, 10, nt)
         lons = np.linspace(0, 11, 10)

--- a/xarray/tests/test_accessors.py
+++ b/xarray/tests/test_accessors.py
@@ -7,8 +7,8 @@ import pytest
 import xarray as xr
 
 from . import (
-    TestCase, assert_array_equal, assert_equal, raises_regex, requires_dask,
-    has_cftime, has_dask, has_cftime_or_netCDF4)
+    TestCase, assert_array_equal, assert_equal, has_cftime,
+    has_cftime_or_netCDF4, has_dask, raises_regex, requires_dask)
 
 
 class TestDatetimeAccessor(TestCase):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2433,7 +2433,7 @@ class PydapTest(object):
             assert actual.attrs.keys() == expected.attrs.keys()
 
         with self.create_datasets() as (actual, expected):
-            assert_equal(actual.isel(l=2), expected.isel(l=2))  # noqa: E741
+            assert_equal(actual.isel(l=2), expected.isel(l=2))  # noqa
 
         with self.create_datasets() as (actual, expected):
             assert_equal(actual.isel(i=0, j=-1),

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -626,20 +626,20 @@ class CFEncodedDataTest(DatasetIOTestCases):
         encoded = create_encoded_unsigned_masked_scaled_data()
         with self.roundtrip(decoded) as actual:
             for k in decoded.variables:
-                assert decoded.variables[k].dtype == \
-                    actual.variables[k].dtype
+                assert (decoded.variables[k].dtype ==
+                        actual.variables[k].dtype)
             assert_allclose(decoded, actual, decode_bytes=False)
         with self.roundtrip(decoded,
                             open_kwargs=dict(decode_cf=False)) as actual:
             for k in encoded.variables:
-                assert encoded.variables[k].dtype == \
-                    actual.variables[k].dtype
+                assert (encoded.variables[k].dtype ==
+                        actual.variables[k].dtype)
             assert_allclose(encoded, actual, decode_bytes=False)
         with self.roundtrip(encoded,
                             open_kwargs=dict(decode_cf=False)) as actual:
             for k in encoded.variables:
-                assert encoded.variables[k].dtype == \
-                    actual.variables[k].dtype
+                assert (encoded.variables[k].dtype ==
+                        actual.variables[k].dtype)
             assert_allclose(encoded, actual, decode_bytes=False)
         # make sure roundtrip encoding didn't change the
         # original dataset.
@@ -1180,7 +1180,7 @@ class BaseNetCDF4Test(CFEncodedDataTest):
 
 
 @requires_netCDF4
-class NetCDF4DataTest(BaseNetCDF4Test, object):
+class NetCDF4DataTest(BaseNetCDF4Test):
     autoclose = False
 
     @contextlib.contextmanager
@@ -1529,14 +1529,14 @@ class BaseZarrTest(CFEncodedDataTest):
 
 
 @requires_zarr
-class ZarrDictStoreTest(BaseZarrTest, object):
+class ZarrDictStoreTest(BaseZarrTest):
     @contextlib.contextmanager
     def create_zarr_target(self):
         yield {}
 
 
 @requires_zarr
-class ZarrDirectoryStoreTest(BaseZarrTest, object):
+class ZarrDirectoryStoreTest(BaseZarrTest):
     @contextlib.contextmanager
     def create_zarr_target(self):
         with create_tmp_file(suffix='.zarr') as tmp:
@@ -1559,7 +1559,7 @@ class ScipyWriteTest(CFEncodedDataTest, NetCDF3Only):
 
 
 @requires_scipy
-class ScipyInMemoryDataTest(ScipyWriteTest, object):
+class ScipyInMemoryDataTest(ScipyWriteTest):
     engine = 'scipy'
 
     @contextlib.contextmanager
@@ -1585,7 +1585,7 @@ class ScipyInMemoryDataTestAutocloseTrue(ScipyInMemoryDataTest):
 
 
 @requires_scipy
-class ScipyFileObjectTest(ScipyWriteTest, object):
+class ScipyFileObjectTest(ScipyWriteTest):
     engine = 'scipy'
 
     @contextlib.contextmanager
@@ -1613,7 +1613,7 @@ class ScipyFileObjectTest(ScipyWriteTest, object):
 
 
 @requires_scipy
-class ScipyFilePathTest(ScipyWriteTest, object):
+class ScipyFilePathTest(ScipyWriteTest):
     engine = 'scipy'
 
     @contextlib.contextmanager
@@ -1654,7 +1654,7 @@ class ScipyFilePathTestAutocloseTrue(ScipyFilePathTest):
 
 
 @requires_netCDF4
-class NetCDF3ViaNetCDF4DataTest(CFEncodedDataTest, NetCDF3Only, object):
+class NetCDF3ViaNetCDF4DataTest(CFEncodedDataTest, NetCDF3Only):
     engine = 'netcdf4'
     file_format = 'NETCDF3_CLASSIC'
 
@@ -1697,7 +1697,7 @@ class NetCDF4ClassicViaNetCDF4DataTestAutocloseTrue(
 
 
 @requires_scipy_or_netCDF4
-class GenericNetCDFDataTest(CFEncodedDataTest, NetCDF3Only, object):
+class GenericNetCDFDataTest(CFEncodedDataTest, NetCDF3Only):
     # verify that we can read and write netCDF3 files as long as we have scipy
     # or netCDF4-python installed
     file_format = 'netcdf3_64bit'
@@ -1778,7 +1778,7 @@ class GenericNetCDFDataTestAutocloseTrue(GenericNetCDFDataTest):
 
 @requires_h5netcdf
 @requires_netCDF4
-class H5NetCDFDataTest(BaseNetCDF4Test, object):
+class H5NetCDFDataTest(BaseNetCDF4Test):
     engine = 'h5netcdf'
 
     @contextlib.contextmanager
@@ -2493,7 +2493,7 @@ class PydapOnlineTest(PydapTest):
 
 @requires_scipy
 @requires_pynio
-class PyNioTest(ScipyWriteTest, object):
+class PyNioTest(ScipyWriteTest):
     def test_write_store(self):
         # pynio is read-only for now
         pass
@@ -2833,7 +2833,8 @@ class TestRasterio(object):
                 assert len(rioda.attrs['transform']) == 6
 
             # See if a warning is raised if we force it
-            with pytest.warns(Warning, match="transformation isn't rectilinear"):
+            with pytest.warns(Warning,
+                              match="transformation isn't rectilinear"):
                 with xr.open_rasterio(tmp_file,
                                       parse_coordinates=True) as rioda:
                     assert 'x' not in rioda.coords

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -126,11 +126,11 @@ class TestCommon(TestCase):
         array = UnreliableArray([0])
         with pytest.raises(UnreliableArrayFailure):
             array[0]
-        self.assertEqual(array[0], 0)
+        assert array[0] == 0
 
         actual = robust_getitem(array, 0, catch=UnreliableArrayFailure,
                                 initial_delay=0)
-        self.assertEqual(actual, 0)
+        assert actual == 0
 
 
 class NetCDF3Only(object):
@@ -222,11 +222,11 @@ class DatasetIOTestCases(object):
             with self.roundtrip(expected) as actual:
                 for k, v in actual.variables.items():
                     # IndexVariables are eagerly loaded into memory
-                    self.assertEqual(v._in_memory, k in actual.dims)
+                    assert v._in_memory == (k in actual.dims)
                 yield actual
                 for k, v in actual.variables.items():
                     if k in vars:
-                        self.assertTrue(v._in_memory)
+                        assert v._in_memory
                 assert_identical(expected, actual)
 
         with pytest.raises(AssertionError):
@@ -252,14 +252,14 @@ class DatasetIOTestCases(object):
             # Test Dataset.compute()
             for k, v in actual.variables.items():
                 # IndexVariables are eagerly cached
-                self.assertEqual(v._in_memory, k in actual.dims)
+                assert v._in_memory == (k in actual.dims)
 
             computed = actual.compute()
 
             for k, v in actual.variables.items():
-                self.assertEqual(v._in_memory, k in actual.dims)
+                assert v._in_memory == (k in actual.dims)
             for v in computed.variables.values():
-                self.assertTrue(v._in_memory)
+                assert v._in_memory
 
             assert_identical(expected, actual)
             assert_identical(expected, computed)
@@ -343,12 +343,12 @@ class DatasetIOTestCases(object):
         expected['x'].encoding['dtype'] = 'S1'
         with self.roundtrip(expected) as actual:
             assert_identical(expected, actual)
-            self.assertEqual(actual['x'].encoding['_Encoding'], 'utf-8')
+            assert actual['x'].encoding['_Encoding'] == 'utf-8'
 
         expected['x'].encoding['_Encoding'] = 'ascii'
         with self.roundtrip(expected) as actual:
             assert_identical(expected, actual)
-            self.assertEqual(actual['x'].encoding['_Encoding'], 'ascii')
+            assert actual['x'].encoding['_Encoding'] == 'ascii'
 
     def test_roundtrip_numpy_datetime_data(self):
         times = pd.to_datetime(['2000-01-01', '2000-01-02', 'NaT'])
@@ -434,10 +434,10 @@ class DatasetIOTestCases(object):
 
     def test_roundtrip_boolean_dtype(self):
         original = create_boolean_data()
-        self.assertEqual(original['x'].dtype, 'bool')
+        assert original['x'].dtype == 'bool'
         with self.roundtrip(original) as actual:
             assert_identical(original, actual)
-            self.assertEqual(actual['x'].dtype, 'bool')
+            assert actual['x'].dtype == 'bool'
 
     def test_orthogonal_indexing(self):
         in_memory = create_test_data()
@@ -626,20 +626,20 @@ class CFEncodedDataTest(DatasetIOTestCases):
         encoded = create_encoded_unsigned_masked_scaled_data()
         with self.roundtrip(decoded) as actual:
             for k in decoded.variables:
-                self.assertEqual(decoded.variables[k].dtype,
-                                 actual.variables[k].dtype)
+                assert decoded.variables[k].dtype == \
+                                 actual.variables[k].dtype
             assert_allclose(decoded, actual, decode_bytes=False)
         with self.roundtrip(decoded,
                             open_kwargs=dict(decode_cf=False)) as actual:
             for k in encoded.variables:
-                self.assertEqual(encoded.variables[k].dtype,
-                                 actual.variables[k].dtype)
+                assert encoded.variables[k].dtype == \
+                                 actual.variables[k].dtype
             assert_allclose(encoded, actual, decode_bytes=False)
         with self.roundtrip(encoded,
                             open_kwargs=dict(decode_cf=False)) as actual:
             for k in encoded.variables:
-                self.assertEqual(encoded.variables[k].dtype,
-                                 actual.variables[k].dtype)
+                assert encoded.variables[k].dtype == \
+                                 actual.variables[k].dtype
             assert_allclose(encoded, actual, decode_bytes=False)
         # make sure roundtrip encoding didn't change the
         # original dataset.
@@ -647,14 +647,14 @@ class CFEncodedDataTest(DatasetIOTestCases):
             encoded, create_encoded_unsigned_masked_scaled_data())
         with self.roundtrip(encoded) as actual:
             for k in decoded.variables:
-                self.assertEqual(decoded.variables[k].dtype,
-                                 actual.variables[k].dtype)
+                assert decoded.variables[k].dtype == \
+                                 actual.variables[k].dtype
             assert_allclose(decoded, actual, decode_bytes=False)
         with self.roundtrip(encoded,
                             open_kwargs=dict(decode_cf=False)) as actual:
             for k in encoded.variables:
-                self.assertEqual(encoded.variables[k].dtype,
-                                 actual.variables[k].dtype)
+                assert encoded.variables[k].dtype == \
+                                 actual.variables[k].dtype
             assert_allclose(encoded, actual, decode_bytes=False)
 
     def test_roundtrip_mask_and_scale(self):
@@ -692,12 +692,11 @@ class CFEncodedDataTest(DatasetIOTestCases):
         with create_tmp_file() as tmp_file:
             original.to_netcdf(tmp_file)
             with open_dataset(tmp_file, decode_coords=False) as ds:
-                self.assertTrue(equals_latlon(ds['temp'].attrs['coordinates']))
-                self.assertTrue(
-                    equals_latlon(ds['precip'].attrs['coordinates']))
-                self.assertNotIn('coordinates', ds.attrs)
-                self.assertNotIn('coordinates', ds['lat'].attrs)
-                self.assertNotIn('coordinates', ds['lon'].attrs)
+                assert equals_latlon(ds['temp'].attrs['coordinates'])
+                assert equals_latlon(ds['precip'].attrs['coordinates'])
+                assert 'coordinates' not in ds.attrs
+                assert 'coordinates' not in ds['lat'].attrs
+                assert 'coordinates' not in ds['lon'].attrs
 
         modified = original.drop(['temp', 'precip'])
         with self.roundtrip(modified) as actual:
@@ -705,9 +704,9 @@ class CFEncodedDataTest(DatasetIOTestCases):
         with create_tmp_file() as tmp_file:
             modified.to_netcdf(tmp_file)
             with open_dataset(tmp_file, decode_coords=False) as ds:
-                self.assertTrue(equals_latlon(ds.attrs['coordinates']))
-                self.assertNotIn('coordinates', ds['lat'].attrs)
-                self.assertNotIn('coordinates', ds['lon'].attrs)
+                assert equals_latlon(ds.attrs['coordinates'])
+                assert 'coordinates' not in ds['lat'].attrs
+                assert 'coordinates' not in ds['lon'].attrs
 
     def test_roundtrip_endian(self):
         ds = Dataset({'x': np.arange(3, 10, dtype='>i2'),
@@ -743,8 +742,8 @@ class CFEncodedDataTest(DatasetIOTestCases):
         ds = Dataset({'x': ('y', np.arange(10.0))})
         kwargs = dict(encoding={'x': {'dtype': 'f4'}})
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            self.assertEqual(actual.x.encoding['dtype'], 'f4')
-        self.assertEqual(ds.x.encoding, {})
+            assert actual.x.encoding['dtype'] == 'f4'
+        assert ds.x.encoding == {}
 
         kwargs = dict(encoding={'x': {'foo': 'bar'}})
         with raises_regex(ValueError, 'unexpected encoding'):
@@ -766,7 +765,7 @@ class CFEncodedDataTest(DatasetIOTestCases):
         units = 'days since 1900-01-01'
         kwargs = dict(encoding={'t': {'units': units}})
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            self.assertEqual(actual.t.encoding['units'], units)
+            assert actual.t.encoding['units'] == units
             assert_identical(actual, ds)
 
     def test_encoding_kwarg_fixed_width_string(self):
@@ -778,7 +777,7 @@ class CFEncodedDataTest(DatasetIOTestCases):
             ds = Dataset({'x': strings})
             kwargs = dict(encoding={'x': {'dtype': 'S1'}})
             with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-                self.assertEqual(actual['x'].encoding['dtype'], 'S1')
+                assert actual['x'].encoding['dtype'] == 'S1'
                 assert_identical(actual, ds)
 
     def test_default_fill_value(self):
@@ -786,9 +785,9 @@ class CFEncodedDataTest(DatasetIOTestCases):
         ds = Dataset({'x': ('y', np.arange(10.0))})
         kwargs = dict(encoding={'x': {'dtype': 'f4'}})
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            self.assertEqual(actual.x.encoding['_FillValue'],
-                             np.nan)
-        self.assertEqual(ds.x.encoding, {})
+            assert actual.x.encoding['_FillValue'] == \
+                             np.nan
+        assert ds.x.encoding == {}
 
         # Test default encoding for int:
         ds = Dataset({'x': ('y', np.arange(10.0))})
@@ -797,14 +796,14 @@ class CFEncodedDataTest(DatasetIOTestCases):
             warnings.filterwarnings(
                 'ignore', '.*floating point data as an integer')
             with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-                self.assertTrue('_FillValue' not in actual.x.encoding)
-        self.assertEqual(ds.x.encoding, {})
+                assert '_FillValue' not in actual.x.encoding
+        assert ds.x.encoding == {}
 
         # Test default encoding for implicit int:
         ds = Dataset({'x': ('y', np.arange(10, dtype='int16'))})
         with self.roundtrip(ds) as actual:
-            self.assertTrue('_FillValue' not in actual.x.encoding)
-        self.assertEqual(ds.x.encoding, {})
+            assert '_FillValue' not in actual.x.encoding
+        assert ds.x.encoding == {}
 
     def test_explicitly_omit_fill_value(self):
         ds = Dataset({'x': ('y', [np.pi, -np.pi])})
@@ -817,7 +816,7 @@ class CFEncodedDataTest(DatasetIOTestCases):
         kwargs = dict(encoding={'x': {'_FillValue': None}})
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
             assert '_FillValue' not in actual.x.encoding
-        self.assertEqual(ds.y.encoding, {})
+        assert ds.y.encoding == {}
 
     def test_explicitly_omit_fill_value_in_coord(self):
         ds = Dataset({'x': ('y', [np.pi, -np.pi])}, coords={'y': [0.0, 1.0]})
@@ -830,14 +829,14 @@ class CFEncodedDataTest(DatasetIOTestCases):
         kwargs = dict(encoding={'y': {'_FillValue': None}})
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
             assert '_FillValue' not in actual.y.encoding
-        self.assertEqual(ds.y.encoding, {})
+        assert ds.y.encoding == {}
 
     def test_encoding_same_dtype(self):
         ds = Dataset({'x': ('y', np.arange(10.0, dtype='f4'))})
         kwargs = dict(encoding={'x': {'dtype': 'f4'}})
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            self.assertEqual(actual.x.encoding['dtype'], 'f4')
-        self.assertEqual(ds.x.encoding, {})
+            assert actual.x.encoding['dtype'] == 'f4'
+        assert ds.x.encoding == {}
 
     def test_append_write(self):
         # regression for GH1215
@@ -1015,7 +1014,7 @@ class BaseNetCDF4Test(CFEncodedDataTest):
         data = Dataset({'x': np.array(['foo', 'zzzz'], dtype='S')})
         with self.roundtrip(data) as actual:
             assert_identical(data, actual)
-            self.assertEqual(actual['x'].dtype, np.dtype('S4'))
+            assert actual['x'].dtype == np.dtype('S4')
 
     def test_open_encodings(self):
         # Create a netCDF file with explicit time units
@@ -1040,15 +1039,15 @@ class BaseNetCDF4Test(CFEncodedDataTest):
                 actual_encoding = dict((k, v) for k, v in
                                        iteritems(actual['time'].encoding)
                                        if k in expected['time'].encoding)
-                self.assertDictEqual(actual_encoding,
-                                     expected['time'].encoding)
+                assert actual_encoding == \
+                                     expected['time'].encoding
 
     def test_dump_encodings(self):
         # regression test for #709
         ds = Dataset({'x': ('y', np.arange(10.0))})
         kwargs = dict(encoding={'x': {'zlib': True}})
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            self.assertTrue(actual.x.encoding['zlib'])
+            assert actual.x.encoding['zlib']
 
     def test_dump_and_open_encodings(self):
         # Create a netCDF file with explicit time units
@@ -1066,8 +1065,7 @@ class BaseNetCDF4Test(CFEncodedDataTest):
                 with create_tmp_file() as tmp_file2:
                     xarray_dataset.to_netcdf(tmp_file2)
                     with nc4.Dataset(tmp_file2, 'r') as ds:
-                        self.assertEqual(
-                            ds.variables['time'].getncattr('units'), units)
+                        assert ds.variables['time'].getncattr('units') == units
                         assert_array_equal(
                             ds.variables['time'], np.arange(10) + 4)
 
@@ -1080,7 +1078,7 @@ class BaseNetCDF4Test(CFEncodedDataTest):
                                       'original_shape': data.var2.shape})
         with self.roundtrip(data) as actual:
             for k, v in iteritems(data['var2'].encoding):
-                self.assertEqual(v, actual['var2'].encoding[k])
+                assert v == actual['var2'].encoding[k]
 
         # regression test for #156
         expected = data.isel(dim1=0)
@@ -1095,14 +1093,14 @@ class BaseNetCDF4Test(CFEncodedDataTest):
 
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
             assert_equal(actual, ds)
-            self.assertEqual(actual.x.encoding['dtype'], 'f4')
-            self.assertEqual(actual.x.encoding['zlib'], True)
-            self.assertEqual(actual.x.encoding['complevel'], 9)
-            self.assertEqual(actual.x.encoding['fletcher32'], True)
-            self.assertEqual(actual.x.encoding['chunksizes'], (5,))
-            self.assertEqual(actual.x.encoding['shuffle'], True)
+            assert actual.x.encoding['dtype'] == 'f4'
+            assert actual.x.encoding['zlib'] == True
+            assert actual.x.encoding['complevel'] == 9
+            assert actual.x.encoding['fletcher32'] == True
+            assert actual.x.encoding['chunksizes'] == (5,)
+            assert actual.x.encoding['shuffle'] == True
 
-        self.assertEqual(ds.x.encoding, {})
+        assert ds.x.encoding == {}
 
     def test_encoding_chunksizes_unlimited(self):
         # regression test for GH1225
@@ -1201,7 +1199,7 @@ class NetCDF4DataTest(BaseNetCDF4Test, TestCase):
         ds.coords['c'] = 4
 
         with self.roundtrip(ds) as actual:
-            self.assertEqual(list(ds.variables), list(actual.variables))
+            assert list(ds.variables) == list(actual.variables)
 
     def test_unsorted_index_raises(self):
         # should be fixed in netcdf4 v1.2.1
@@ -1220,7 +1218,7 @@ class NetCDF4DataTest(BaseNetCDF4Test, TestCase):
             try:
                 ds2.randovar.values
             except IndexError as err:
-                self.assertIn('first by calling .load', str(err))
+                assert 'first by calling .load' in str(err)
 
     def test_88_character_filename_segmentation_fault(self):
         # should be fixed in netcdf4 v1.3.1
@@ -1335,17 +1333,17 @@ class BaseZarrTest(CFEncodedDataTest):
                 original, open_kwargs={'auto_chunk': False}) as actual:
             for k, v in actual.variables.items():
                 # only index variables should be in memory
-                self.assertEqual(v._in_memory, k in actual.dims)
+                assert v._in_memory == (k in actual.dims)
                 # there should be no chunks
-                self.assertEqual(v.chunks, None)
+                assert v.chunks == None
 
         with self.roundtrip(
                 original, open_kwargs={'auto_chunk': True}) as actual:
             for k, v in actual.variables.items():
                 # only index variables should be in memory
-                self.assertEqual(v._in_memory, k in actual.dims)
+                assert v._in_memory == (k in actual.dims)
                 # chunk size should be the same as original
-                self.assertEqual(v.chunks, original[k].chunks)
+                assert v.chunks == original[k].chunks
 
     def test_write_uneven_dask_chunks(self):
         # regression for GH#2225
@@ -1365,7 +1363,7 @@ class BaseZarrTest(CFEncodedDataTest):
         data['var2'].encoding.update({'chunks': chunks})
 
         with self.roundtrip(data) as actual:
-            self.assertEqual(chunks, actual['var2'].encoding['chunks'])
+            assert chunks == actual['var2'].encoding['chunks']
 
         # expect an error with non-integer chunks
         data['var2'].encoding.update({'chunks': (5, 4.5)})
@@ -1382,7 +1380,7 @@ class BaseZarrTest(CFEncodedDataTest):
         # zarr automatically gets chunk information from dask chunks
         ds_chunk4 = ds.chunk({'x': 4})
         with self.roundtrip(ds_chunk4) as actual:
-            self.assertEqual((4,), actual['var1'].encoding['chunks'])
+            assert (4,) == actual['var1'].encoding['chunks']
 
         # should fail if dask_chunks are irregular...
         ds_chunk_irreg = ds.chunk({'x': (5, 4, 3)})
@@ -1395,14 +1393,14 @@ class BaseZarrTest(CFEncodedDataTest):
         # ... except if the last chunk is smaller than the first
         ds_chunk_irreg = ds.chunk({'x': (5, 5, 2)})
         with self.roundtrip(ds_chunk_irreg) as actual:
-            self.assertEqual((5,), actual['var1'].encoding['chunks'])
+            assert (5,) == actual['var1'].encoding['chunks']
 
         # - encoding specified  -
         # specify compatible encodings
         for chunk_enc in 4, (4, ):
             ds_chunk4['var1'].encoding.update({'chunks': chunk_enc})
             with self.roundtrip(ds_chunk4) as actual:
-                self.assertEqual((4,), actual['var1'].encoding['chunks'])
+                assert (4,) == actual['var1'].encoding['chunks']
 
         # TODO: remove this failure once syncronized overlapping writes are
         # supported by xarray
@@ -1640,7 +1638,7 @@ class ScipyFilePathTest(ScipyWriteTest, TestCase):
         # regression test for GH416
         expected = open_example_dataset('bears.nc', engine='scipy')
         for var in expected.variables.values():
-            self.assertTrue(var.dtype.isnative)
+            assert var.dtype.isnative
 
     @requires_netCDF4
     def test_nc4_scipy(self):
@@ -1754,24 +1752,24 @@ class GenericNetCDFDataTest(CFEncodedDataTest, NetCDF3Only, TestCase):
         ds = Dataset({'x': ('y', np.arange(10.0))})
         with self.roundtrip(ds,
                             save_kwargs=dict(unlimited_dims=['y'])) as actual:
-            self.assertEqual(actual.encoding['unlimited_dims'], set('y'))
+            assert actual.encoding['unlimited_dims'] == set('y')
             assert_equal(ds, actual)
 
         # Regression test for https://github.com/pydata/xarray/issues/2134
         with self.roundtrip(ds,
                             save_kwargs=dict(unlimited_dims='y')) as actual:
-            self.assertEqual(actual.encoding['unlimited_dims'], set('y'))
+            assert actual.encoding['unlimited_dims'] == set('y')
             assert_equal(ds, actual)
 
         ds.encoding = {'unlimited_dims': ['y']}
         with self.roundtrip(ds) as actual:
-            self.assertEqual(actual.encoding['unlimited_dims'], set('y'))
+            assert actual.encoding['unlimited_dims'] == set('y')
             assert_equal(ds, actual)
 
         # Regression test for https://github.com/pydata/xarray/issues/2134
         ds.encoding = {'unlimited_dims': 'y'}
         with self.roundtrip(ds) as actual:
-            self.assertEqual(actual.encoding['unlimited_dims'], set('y'))
+            assert actual.encoding['unlimited_dims'] == set('y')
             assert_equal(ds, actual)
 
 
@@ -1822,11 +1820,11 @@ class H5NetCDFDataTest(BaseNetCDF4Test, TestCase):
         ds = Dataset({'x': ('y', np.arange(10.0))})
         with self.roundtrip(ds,
                             save_kwargs=dict(unlimited_dims=['y'])) as actual:
-            self.assertEqual(actual.encoding['unlimited_dims'], set('y'))
+            assert actual.encoding['unlimited_dims'] == set('y')
             assert_equal(ds, actual)
         ds.encoding = {'unlimited_dims': ['y']}
         with self.roundtrip(ds) as actual:
-            self.assertEqual(actual.encoding['unlimited_dims'], set('y'))
+            assert actual.encoding['unlimited_dims'] == set('y')
             assert_equal(ds, actual)
 
     def test_compression_encoding_h5py(self):
@@ -1857,7 +1855,7 @@ class H5NetCDFDataTest(BaseNetCDF4Test, TestCase):
             compr_out.update(compr_common)
             with self.roundtrip(data) as actual:
                 for k, v in compr_out.items():
-                    self.assertEqual(v, actual['var2'].encoding[k])
+                    assert v == actual['var2'].encoding[k]
 
     def test_compression_check_encoding_h5py(self):
         """When mismatched h5py and NetCDF4-Python encodings are expressed
@@ -1898,14 +1896,14 @@ class H5NetCDFDataTest(BaseNetCDF4Test, TestCase):
         kwargs = {'encoding': {'x': {
             'compression': 'gzip', 'compression_opts': 9}}}
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            self.assertEqual(actual.x.encoding['zlib'], True)
-            self.assertEqual(actual.x.encoding['complevel'], 9)
+            assert actual.x.encoding['zlib'] == True
+            assert actual.x.encoding['complevel'] == 9
 
         kwargs = {'encoding': {'x': {
             'compression': 'lzf', 'compression_opts': None}}}
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            self.assertEqual(actual.x.encoding['compression'], 'lzf')
-            self.assertEqual(actual.x.encoding['compression_opts'], None)
+            assert actual.x.encoding['compression'] == 'lzf'
+            assert actual.x.encoding['compression_opts'] == None
 
 
 # tests pending h5netcdf fix
@@ -2056,9 +2054,9 @@ class OpenMFDatasetWithDataVarsAndCoordsKwTest(TestCase):
 
                 var_shape = ds[self.var_name].shape
 
-                self.assertEqual(var_shape, coord_shape)
-                self.assertNotEqual(coord_shape1, coord_shape)
-                self.assertNotEqual(coord_shape2, coord_shape)
+                assert var_shape == coord_shape
+                assert coord_shape1 != coord_shape
+                assert coord_shape2 != coord_shape
 
     def test_common_coord_when_datavars_minimal(self):
         opt = 'minimal'
@@ -2073,9 +2071,9 @@ class OpenMFDatasetWithDataVarsAndCoordsKwTest(TestCase):
 
                 var_shape = ds[self.var_name].shape
 
-                self.assertNotEqual(var_shape, coord_shape)
-                self.assertEqual(coord_shape1, coord_shape)
-                self.assertEqual(coord_shape2, coord_shape)
+                assert var_shape != coord_shape
+                assert coord_shape1 == coord_shape
+                assert coord_shape2 == coord_shape
 
     def test_invalid_data_vars_value_should_fail(self):
 
@@ -2133,10 +2131,10 @@ class DaskTest(TestCase, DatasetIOTestCases):
             with xr.set_options(enable_cftimeindex=True):
                 with self.roundtrip(expected) as actual:
                     abs_diff = abs(actual.t.values - expected_decoded_t)
-                    self.assertTrue((abs_diff <= np.timedelta64(1, 's')).all())
+                    assert (abs_diff <= np.timedelta64(1, 's')).all()
 
                     abs_diff = abs(actual.t0.values - expected_decoded_t0)
-                    self.assertTrue((abs_diff <= np.timedelta64(1, 's')).all())
+                    assert (abs_diff <= np.timedelta64(1, 's')).all()
 
     def test_roundtrip_cftime_datetime_data_disable_cftimeindex(self):
         # Override method in DatasetIOTestCases - remove not applicable
@@ -2153,10 +2151,10 @@ class DaskTest(TestCase, DatasetIOTestCases):
             with xr.set_options(enable_cftimeindex=False):
                 with self.roundtrip(expected) as actual:
                     abs_diff = abs(actual.t.values - expected_decoded_t)
-                    self.assertTrue((abs_diff <= np.timedelta64(1, 's')).all())
+                    assert (abs_diff <= np.timedelta64(1, 's')).all()
 
                     abs_diff = abs(actual.t0.values - expected_decoded_t0)
-                    self.assertTrue((abs_diff <= np.timedelta64(1, 's')).all())
+                    assert (abs_diff <= np.timedelta64(1, 's')).all()
 
     def test_write_store(self):
         # Override method in DatasetIOTestCases - not applicable to dask
@@ -2177,14 +2175,14 @@ class DaskTest(TestCase, DatasetIOTestCases):
                 original.isel(x=slice(5, 10)).to_netcdf(tmp2)
                 with open_mfdataset([tmp1, tmp2],
                                     autoclose=self.autoclose) as actual:
-                    self.assertIsInstance(actual.foo.variable.data, da.Array)
-                    self.assertEqual(actual.foo.variable.data.chunks,
-                                     ((5, 5),))
+                    assert isinstance(actual.foo.variable.data, da.Array)
+                    assert actual.foo.variable.data.chunks == \
+                                     ((5, 5),)
                     assert_identical(original, actual)
                 with open_mfdataset([tmp1, tmp2], chunks={'x': 3},
                                     autoclose=self.autoclose) as actual:
-                    self.assertEqual(actual.foo.variable.data.chunks,
-                                     ((3, 2, 3, 2),))
+                    assert actual.foo.variable.data.chunks == \
+                                     ((3, 2, 3, 2),)
 
         with raises_regex(IOError, 'no files to open'):
             open_mfdataset('foo-bar-baz-*.nc', autoclose=self.autoclose)
@@ -2218,7 +2216,7 @@ class DaskTest(TestCase, DatasetIOTestCases):
                 with open_mfdataset([tmp1, tmp2]) as actual:
                     # presumes that attributes inherited from
                     # first dataset loaded
-                    self.assertEqual(actual.test1, ds1.test1)
+                    assert actual.test1 == ds1.test1
                     # attributes from ds2 are not retained, e.g.,
                     with raises_regex(AttributeError,
                                       'no attribute'):
@@ -2298,13 +2296,13 @@ class DaskTest(TestCase, DatasetIOTestCases):
         with create_tmp_file() as tmp:
             original.to_netcdf(tmp)
             with open_dataset(tmp, chunks={'x': 5}) as actual:
-                self.assertIsInstance(actual.foo.variable.data, da.Array)
-                self.assertEqual(actual.foo.variable.data.chunks, ((5, 5),))
+                assert isinstance(actual.foo.variable.data, da.Array)
+                assert actual.foo.variable.data.chunks == ((5, 5),)
                 assert_identical(original, actual)
             with open_dataset(tmp, chunks=5) as actual:
                 assert_identical(original, actual)
             with open_dataset(tmp) as actual:
-                self.assertIsInstance(actual.foo.variable.data, np.ndarray)
+                assert isinstance(actual.foo.variable.data, np.ndarray)
                 assert_identical(original, actual)
 
     def test_open_single_dataset(self):
@@ -2344,9 +2342,9 @@ class DaskTest(TestCase, DatasetIOTestCases):
                 repeat_names = dict((k, v.data.name)
                                     for k, v in ds.data_vars.items())
             for var_name, dask_name in original_names.items():
-                self.assertIn(var_name, dask_name)
-                self.assertEqual(dask_name[:13], 'open_dataset-')
-            self.assertEqual(original_names, repeat_names)
+                assert var_name in dask_name
+                assert dask_name[:13] == 'open_dataset-'
+            assert original_names == repeat_names
 
     def test_dataarray_compute(self):
         # Test DataArray.compute() on dask backend.
@@ -2354,8 +2352,8 @@ class DaskTest(TestCase, DatasetIOTestCases):
         # however dask is the only tested backend which supports DataArrays
         actual = DataArray([1, 2]).chunk()
         computed = actual.compute()
-        self.assertFalse(actual._in_memory)
-        self.assertTrue(computed._in_memory)
+        assert not actual._in_memory
+        assert computed._in_memory
         assert_allclose(actual, computed, decode_bytes=False)
 
     def test_to_netcdf_compute_false_roundtrip(self):
@@ -2427,8 +2425,8 @@ class PydapTest(TestCase):
             assert_equal(actual, expected)
 
             # global attributes should be global attributes on the dataset
-            self.assertNotIn('NC_GLOBAL', actual.attrs)
-            self.assertIn('history', actual.attrs)
+            assert 'NC_GLOBAL' not in actual.attrs
+            assert 'history' in actual.attrs
 
             # we don't check attributes exactly with assertDatasetIdentical()
             # because the test DAP server seems to insert some extra
@@ -2837,7 +2835,7 @@ class TestRasterio(TestCase):
                 assert len(rioda.attrs['transform']) == 6
 
             # See if a warning is raised if we force it
-            with self.assertWarns("transformation isn't rectilinear"):
+            with pytest.warns("transformation isn't rectilinear"):
                 with xr.open_rasterio(tmp_file,
                                       parse_coordinates=True) as rioda:
                     assert 'x' not in rioda.coords
@@ -3024,7 +3022,7 @@ class TestRasterio(TestCase):
             with xr.open_rasterio(tmp_file, chunks=(1, 2, 2)) as actual:
 
                 import dask.array as da
-                self.assertIsInstance(actual.data, da.Array)
+                assert isinstance(actual.data, da.Array)
                 assert 'open_rasterio' in actual.data.name
 
                 # do some arithmetic
@@ -3105,7 +3103,7 @@ class TestRasterio(TestCase):
             with mock.patch('os.path.getmtime', side_effect=OSError):
                 with xr.open_rasterio(tmp_file, chunks=(1, 2, 2)) as actual:
                     import dask.array as da
-                    self.assertIsInstance(actual.data, da.Array)
+                    assert isinstance(actual.data, da.Array)
                     assert_allclose(actual, expected)
 
     @network
@@ -3118,7 +3116,7 @@ class TestRasterio(TestCase):
         # make sure chunking works
         with xr.open_rasterio(url, chunks=(1, 256, 256)) as actual:
             import dask.array as da
-            self.assertIsInstance(actual.data, da.Array)
+            assert isinstance(actual.data, da.Array)
 
 
 class TestEncodingInvalid(TestCase):
@@ -3130,12 +3128,12 @@ class TestEncodingInvalid(TestCase):
 
         var = xr.Variable(('x',), [1, 2, 3], {}, {'chunking': (2, 1)})
         encoding = _extract_nc4_variable_encoding(var)
-        self.assertEqual({}, encoding)
+        assert {} == encoding
 
         # regression test
         var = xr.Variable(('x',), [1, 2, 3], {}, {'shuffle': True})
         encoding = _extract_nc4_variable_encoding(var, raise_on_invalid=True)
-        self.assertEqual({'shuffle': True}, encoding)
+        assert {'shuffle': True} == encoding
 
     def test_extract_h5nc_encoding(self):
         # not supported with h5netcdf (yet)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import contextlib
 import itertools
+import math
 import os.path
 import pickle
 import shutil
@@ -19,8 +20,8 @@ import xarray as xr
 from xarray import (
     DataArray, Dataset, backends, open_dataarray, open_dataset, open_mfdataset,
     save_mfdataset)
-from xarray.backends.common import (robust_getitem,
-                                    PickleByReconstructionWrapper)
+from xarray.backends.common import (
+    PickleByReconstructionWrapper, robust_getitem)
 from xarray.backends.netCDF4_ import _extract_nc4_variable_encoding
 from xarray.backends.pydap_ import PydapDataStore
 from xarray.core import indexing
@@ -31,10 +32,10 @@ from xarray.tests import mock
 from . import (
     TestCase, assert_allclose, assert_array_equal, assert_equal,
     assert_identical, has_dask, has_netCDF4, has_scipy, network, raises_regex,
-    requires_dask, requires_h5netcdf, requires_netCDF4, requires_pathlib,
-    requires_pydap, requires_pynio, requires_rasterio, requires_scipy,
-    requires_scipy_or_netCDF4, requires_zarr, requires_pseudonetcdf,
-    requires_cftime)
+    requires_cftime, requires_dask, requires_h5netcdf, requires_netCDF4,
+    requires_pathlib, requires_pseudonetcdf, requires_pydap, requires_pynio,
+    requires_rasterio, requires_scipy, requires_scipy_or_netCDF4,
+    requires_zarr)
 from .test_dataset import create_test_data
 
 try:
@@ -627,19 +628,19 @@ class CFEncodedDataTest(DatasetIOTestCases):
         with self.roundtrip(decoded) as actual:
             for k in decoded.variables:
                 assert decoded.variables[k].dtype == \
-                                 actual.variables[k].dtype
+                    actual.variables[k].dtype
             assert_allclose(decoded, actual, decode_bytes=False)
         with self.roundtrip(decoded,
                             open_kwargs=dict(decode_cf=False)) as actual:
             for k in encoded.variables:
                 assert encoded.variables[k].dtype == \
-                                 actual.variables[k].dtype
+                    actual.variables[k].dtype
             assert_allclose(encoded, actual, decode_bytes=False)
         with self.roundtrip(encoded,
                             open_kwargs=dict(decode_cf=False)) as actual:
             for k in encoded.variables:
                 assert encoded.variables[k].dtype == \
-                                 actual.variables[k].dtype
+                    actual.variables[k].dtype
             assert_allclose(encoded, actual, decode_bytes=False)
         # make sure roundtrip encoding didn't change the
         # original dataset.
@@ -648,13 +649,13 @@ class CFEncodedDataTest(DatasetIOTestCases):
         with self.roundtrip(encoded) as actual:
             for k in decoded.variables:
                 assert decoded.variables[k].dtype == \
-                                 actual.variables[k].dtype
+                    actual.variables[k].dtype
             assert_allclose(decoded, actual, decode_bytes=False)
         with self.roundtrip(encoded,
                             open_kwargs=dict(decode_cf=False)) as actual:
             for k in encoded.variables:
                 assert encoded.variables[k].dtype == \
-                                 actual.variables[k].dtype
+                    actual.variables[k].dtype
             assert_allclose(encoded, actual, decode_bytes=False)
 
     def test_roundtrip_mask_and_scale(self):
@@ -785,8 +786,7 @@ class CFEncodedDataTest(DatasetIOTestCases):
         ds = Dataset({'x': ('y', np.arange(10.0))})
         kwargs = dict(encoding={'x': {'dtype': 'f4'}})
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            assert actual.x.encoding['_FillValue'] == \
-                             np.nan
+            assert math.isnan(actual.x.encoding['_FillValue'])
         assert ds.x.encoding == {}
 
         # Test default encoding for int:
@@ -1040,7 +1040,7 @@ class BaseNetCDF4Test(CFEncodedDataTest):
                                        iteritems(actual['time'].encoding)
                                        if k in expected['time'].encoding)
                 assert actual_encoding == \
-                                     expected['time'].encoding
+                    expected['time'].encoding
 
     def test_dump_encodings(self):
         # regression test for #709
@@ -2177,12 +2177,12 @@ class DaskTest(TestCase, DatasetIOTestCases):
                                     autoclose=self.autoclose) as actual:
                     assert isinstance(actual.foo.variable.data, da.Array)
                     assert actual.foo.variable.data.chunks == \
-                                     ((5, 5),)
+                        ((5, 5),)
                     assert_identical(original, actual)
                 with open_mfdataset([tmp1, tmp2], chunks={'x': 3},
                                     autoclose=self.autoclose) as actual:
                     assert actual.foo.variable.data.chunks == \
-                                     ((3, 2, 3, 2),)
+                        ((3, 2, 3, 2),)
 
         with raises_regex(IOError, 'no files to open'):
             open_mfdataset('foo-bar-baz-*.nc', autoclose=self.autoclose)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -30,12 +30,11 @@ from xarray.core.pycompat import (
 from xarray.tests import mock
 
 from . import (
-    TestCase, assert_allclose, assert_array_equal, assert_equal,
-    assert_identical, has_dask, has_netCDF4, has_scipy, network, raises_regex,
-    requires_cftime, requires_dask, requires_h5netcdf, requires_netCDF4,
-    requires_pathlib, requires_pseudonetcdf, requires_pydap, requires_pynio,
-    requires_rasterio, requires_scipy, requires_scipy_or_netCDF4,
-    requires_zarr)
+    assert_allclose, assert_array_equal, assert_equal, assert_identical,
+    has_dask, has_netCDF4, has_scipy, network, raises_regex, requires_cftime,
+    requires_dask, requires_h5netcdf, requires_netCDF4, requires_pathlib,
+    requires_pseudonetcdf, requires_pydap, requires_pynio, requires_rasterio,
+    requires_scipy, requires_scipy_or_netCDF4, requires_zarr)
 from .test_dataset import create_test_data
 
 try:
@@ -107,7 +106,7 @@ def create_boolean_data():
     return Dataset({'x': ('t', [True, False, False, True], attributes)})
 
 
-class TestCommon(TestCase):
+class TestCommon(object):
     def test_robust_getitem(self):
 
         class UnreliableArrayFailure(Exception):
@@ -1094,11 +1093,11 @@ class BaseNetCDF4Test(CFEncodedDataTest):
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
             assert_equal(actual, ds)
             assert actual.x.encoding['dtype'] == 'f4'
-            assert actual.x.encoding['zlib'] == True
+            assert actual.x.encoding['zlib']
             assert actual.x.encoding['complevel'] == 9
-            assert actual.x.encoding['fletcher32'] == True
+            assert actual.x.encoding['fletcher32']
             assert actual.x.encoding['chunksizes'] == (5,)
-            assert actual.x.encoding['shuffle'] == True
+            assert actual.x.encoding['shuffle']
 
         assert ds.x.encoding == {}
 
@@ -1181,7 +1180,7 @@ class BaseNetCDF4Test(CFEncodedDataTest):
 
 
 @requires_netCDF4
-class NetCDF4DataTest(BaseNetCDF4Test, TestCase):
+class NetCDF4DataTest(BaseNetCDF4Test, object):
     autoclose = False
 
     @contextlib.contextmanager
@@ -1335,7 +1334,7 @@ class BaseZarrTest(CFEncodedDataTest):
                 # only index variables should be in memory
                 assert v._in_memory == (k in actual.dims)
                 # there should be no chunks
-                assert v.chunks == None
+                assert v.chunks is None
 
         with self.roundtrip(
                 original, open_kwargs={'auto_chunk': True}) as actual:
@@ -1530,14 +1529,14 @@ class BaseZarrTest(CFEncodedDataTest):
 
 
 @requires_zarr
-class ZarrDictStoreTest(BaseZarrTest, TestCase):
+class ZarrDictStoreTest(BaseZarrTest, object):
     @contextlib.contextmanager
     def create_zarr_target(self):
         yield {}
 
 
 @requires_zarr
-class ZarrDirectoryStoreTest(BaseZarrTest, TestCase):
+class ZarrDirectoryStoreTest(BaseZarrTest, object):
     @contextlib.contextmanager
     def create_zarr_target(self):
         with create_tmp_file(suffix='.zarr') as tmp:
@@ -1560,7 +1559,7 @@ class ScipyWriteTest(CFEncodedDataTest, NetCDF3Only):
 
 
 @requires_scipy
-class ScipyInMemoryDataTest(ScipyWriteTest, TestCase):
+class ScipyInMemoryDataTest(ScipyWriteTest, object):
     engine = 'scipy'
 
     @contextlib.contextmanager
@@ -1586,7 +1585,7 @@ class ScipyInMemoryDataTestAutocloseTrue(ScipyInMemoryDataTest):
 
 
 @requires_scipy
-class ScipyFileObjectTest(ScipyWriteTest, TestCase):
+class ScipyFileObjectTest(ScipyWriteTest, object):
     engine = 'scipy'
 
     @contextlib.contextmanager
@@ -1614,7 +1613,7 @@ class ScipyFileObjectTest(ScipyWriteTest, TestCase):
 
 
 @requires_scipy
-class ScipyFilePathTest(ScipyWriteTest, TestCase):
+class ScipyFilePathTest(ScipyWriteTest, object):
     engine = 'scipy'
 
     @contextlib.contextmanager
@@ -1655,7 +1654,7 @@ class ScipyFilePathTestAutocloseTrue(ScipyFilePathTest):
 
 
 @requires_netCDF4
-class NetCDF3ViaNetCDF4DataTest(CFEncodedDataTest, NetCDF3Only, TestCase):
+class NetCDF3ViaNetCDF4DataTest(CFEncodedDataTest, NetCDF3Only, object):
     engine = 'netcdf4'
     file_format = 'NETCDF3_CLASSIC'
 
@@ -1680,7 +1679,7 @@ class NetCDF3ViaNetCDF4DataTestAutocloseTrue(NetCDF3ViaNetCDF4DataTest):
 
 @requires_netCDF4
 class NetCDF4ClassicViaNetCDF4DataTest(CFEncodedDataTest, NetCDF3Only,
-                                       TestCase):
+                                       object):
     engine = 'netcdf4'
     file_format = 'NETCDF4_CLASSIC'
 
@@ -1698,7 +1697,7 @@ class NetCDF4ClassicViaNetCDF4DataTestAutocloseTrue(
 
 
 @requires_scipy_or_netCDF4
-class GenericNetCDFDataTest(CFEncodedDataTest, NetCDF3Only, TestCase):
+class GenericNetCDFDataTest(CFEncodedDataTest, NetCDF3Only, object):
     # verify that we can read and write netCDF3 files as long as we have scipy
     # or netCDF4-python installed
     file_format = 'netcdf3_64bit'
@@ -1779,7 +1778,7 @@ class GenericNetCDFDataTestAutocloseTrue(GenericNetCDFDataTest):
 
 @requires_h5netcdf
 @requires_netCDF4
-class H5NetCDFDataTest(BaseNetCDF4Test, TestCase):
+class H5NetCDFDataTest(BaseNetCDF4Test, object):
     engine = 'h5netcdf'
 
     @contextlib.contextmanager
@@ -1896,14 +1895,14 @@ class H5NetCDFDataTest(BaseNetCDF4Test, TestCase):
         kwargs = {'encoding': {'x': {
             'compression': 'gzip', 'compression_opts': 9}}}
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
-            assert actual.x.encoding['zlib'] == True
+            assert actual.x.encoding['zlib']
             assert actual.x.encoding['complevel'] == 9
 
         kwargs = {'encoding': {'x': {
             'compression': 'lzf', 'compression_opts': None}}}
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
             assert actual.x.encoding['compression'] == 'lzf'
-            assert actual.x.encoding['compression_opts'] == None
+            assert actual.x.encoding['compression_opts'] is None
 
 
 # tests pending h5netcdf fix
@@ -1983,7 +1982,7 @@ def test_open_mfdataset_manyfiles(readengine, nfiles, autoclose, parallel,
 
 
 @requires_scipy_or_netCDF4
-class OpenMFDatasetWithDataVarsAndCoordsKwTest(TestCase):
+class OpenMFDatasetWithDataVarsAndCoordsKwTest(object):
     coord_name = 'lon'
     var_name = 'v1'
 
@@ -2091,7 +2090,7 @@ class OpenMFDatasetWithDataVarsAndCoordsKwTest(TestCase):
 @requires_dask
 @requires_scipy
 @requires_netCDF4
-class DaskTest(TestCase, DatasetIOTestCases):
+class DaskTest(DatasetIOTestCases):
     @contextlib.contextmanager
     def create_store(self):
         yield Dataset()
@@ -2393,7 +2392,7 @@ class DaskTestAutocloseTrue(DaskTest):
 
 @requires_scipy_or_netCDF4
 @requires_pydap
-class PydapTest(TestCase):
+class PydapTest(object):
     def convert_to_pydap_dataset(self, original):
         from pydap.model import GridType, BaseType, DatasetType
         ds = DatasetType('bears', **original.attrs)
@@ -2495,7 +2494,7 @@ class PydapOnlineTest(PydapTest):
 
 @requires_scipy
 @requires_pynio
-class PyNioTest(ScipyWriteTest, TestCase):
+class PyNioTest(ScipyWriteTest, object):
     def test_write_store(self):
         # pynio is read-only for now
         pass
@@ -2527,7 +2526,7 @@ class PyNioTestAutocloseTrue(PyNioTest):
 
 @requires_pseudonetcdf
 @pytest.mark.filterwarnings('ignore:IOAPI_ISPH is assumed to be 6370000')
-class PseudoNetCDFFormatTest(TestCase):
+class PseudoNetCDFFormatTest(object):
     autoclose = True
 
     def open(self, path, **kwargs):
@@ -2790,7 +2789,7 @@ def create_tmp_geotiff(nx=4, ny=3, nz=3,
 
 
 @requires_rasterio
-class TestRasterio(TestCase):
+class TestRasterio(object):
 
     @requires_scipy_or_netCDF4
     def test_serialization(self):
@@ -3119,7 +3118,7 @@ class TestRasterio(TestCase):
             assert isinstance(actual.data, da.Array)
 
 
-class TestEncodingInvalid(TestCase):
+class TestEncodingInvalid(object):
 
     def test_extract_nc4_variable_encoding(self):
         var = xr.Variable(('x',), [1, 2, 3], {}, {'foo': 'bar'})
@@ -3148,7 +3147,7 @@ class MiscObject:
 
 
 @requires_netCDF4
-class TestValidateAttrs(TestCase):
+class TestValidateAttrs(object):
     def test_validating_attrs(self):
         def new_dataset():
             return Dataset({'data': ('y', np.arange(10.0))},
@@ -3248,7 +3247,7 @@ class TestValidateAttrs(TestCase):
 
 
 @requires_scipy_or_netCDF4
-class TestDataArrayToNetCDF(TestCase):
+class TestDataArrayToNetCDF(object):
 
     def test_dataarray_to_netcdf_no_name(self):
         original_da = DataArray(np.arange(12).reshape((3, 4)))

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2433,8 +2433,7 @@ class PydapTest(object):
             assert actual.attrs.keys() == expected.attrs.keys()
 
         with self.create_datasets() as (actual, expected):
-            assert_equal(
-                actual.isel(l=2), expected.isel(l=2))  # noqa: E741
+            assert_equal(actual.isel(l=2), expected.isel(l=2))  # noqa: E741
 
         with self.create_datasets() as (actual, expected):
             assert_equal(actual.isel(i=0, j=-1),

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2833,7 +2833,7 @@ class TestRasterio(object):
                 assert len(rioda.attrs['transform']) == 6
 
             # See if a warning is raised if we force it
-            with pytest.warns("transformation isn't rectilinear"):
+            with pytest.warns(Warning, match="transformation isn't rectilinear"):
                 with xr.open_rasterio(tmp_file,
                                       parse_coordinates=True) as rioda:
                     assert 'x' not in rioda.coords

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -10,12 +10,12 @@ from xarray import DataArray, Dataset, Variable, auto_combine, concat
 from xarray.core.pycompat import OrderedDict, iteritems
 
 from . import (
-    InaccessibleArray, TestCase, assert_array_equal, assert_equal,
-    assert_identical, raises_regex, requires_dask)
+    InaccessibleArray, assert_array_equal, assert_equal, assert_identical,
+    raises_regex, requires_dask)
 from .test_dataset import create_test_data
 
 
-class TestConcatDataset(TestCase):
+class TestConcatDataset(object):
     def test_concat(self):
         # TODO: simplify and split this test case
 
@@ -235,7 +235,7 @@ class TestConcatDataset(TestCase):
         assert isinstance(actual.x.to_index(), pd.MultiIndex)
 
 
-class TestConcatDataArray(TestCase):
+class TestConcatDataArray(object):
     def test_concat(self):
         ds = Dataset({'foo': (['x', 'y'], np.random.random((2, 3))),
                       'bar': (['x', 'y'], np.random.random((2, 3)))},
@@ -295,7 +295,7 @@ class TestConcatDataArray(TestCase):
         assert combined.dims == ('z', 'x', 'y')
 
 
-class TestAutoCombine(TestCase):
+class TestAutoCombine(object):
 
     @requires_dask  # only for toolz
     def test_auto_combine(self):

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -8,20 +8,20 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from xarray import (Dataset, Variable, SerializationWarning, coding,
-                    conventions, open_dataset)
+from xarray import (
+    Dataset, SerializationWarning, Variable, coding, conventions, open_dataset)
 from xarray.backends.common import WritableCFDataStore
 from xarray.backends.memory import InMemoryDataStore
 from xarray.conventions import decode_cf
 from xarray.testing import assert_identical
 
 from . import (
-    TestCase, assert_array_equal, raises_regex, requires_netCDF4,
-    requires_cftime_or_netCDF4, unittest, requires_dask)
+    assert_array_equal, raises_regex, requires_cftime_or_netCDF4,
+    requires_dask, requires_netCDF4, unittest)
 from .test_backends import CFEncodedDataTest
 
 
-class TestBoolTypeArray(TestCase):
+class TestBoolTypeArray(object):
     def test_booltype_array(self):
         x = np.array([1, 0, 1, 1, 0], dtype='i1')
         bx = conventions.BoolTypeArray(x)
@@ -30,7 +30,7 @@ class TestBoolTypeArray(TestCase):
                                         dtype=np.bool))
 
 
-class TestNativeEndiannessArray(TestCase):
+class TestNativeEndiannessArray(object):
     def test(self):
         x = np.arange(5, dtype='>i8')
         expected = np.arange(5, dtype='int64')
@@ -69,7 +69,7 @@ def test_decode_cf_with_conflicting_fill_missing_value():
 
 
 @requires_cftime_or_netCDF4
-class TestEncodeCFVariable(TestCase):
+class TestEncodeCFVariable(object):
     def test_incompatible_attributes(self):
         invalid_vars = [
             Variable(['t'], pd.date_range('2000-01-01', periods=3),
@@ -134,7 +134,7 @@ class TestEncodeCFVariable(TestCase):
 
 
 @requires_cftime_or_netCDF4
-class TestDecodeCF(TestCase):
+class TestDecodeCF(object):
     def test_dataset(self):
         original = Dataset({
             't': ('t', [0, 1, 2], {'units': 'days since 2000-01-01'}),
@@ -255,7 +255,7 @@ class CFEncodedInMemoryStore(WritableCFDataStore, InMemoryDataStore):
 
 
 @requires_netCDF4
-class TestCFEncodedDataStore(CFEncodedDataTest, TestCase):
+class TestCFEncodedDataStore(CFEncodedDataTest, object):
     @contextlib.contextmanager
     def create_store(self):
         yield CFEncodedInMemoryStore()

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -17,7 +17,7 @@ from xarray.testing import assert_identical
 
 from . import (
     assert_array_equal, raises_regex, requires_cftime_or_netCDF4,
-    requires_dask, requires_netCDF4, unittest)
+    requires_dask, requires_netCDF4)
 from .test_backends import CFEncodedDataTest
 
 
@@ -267,9 +267,10 @@ class TestCFEncodedDataStore(CFEncodedDataTest, object):
         data.dump_to_store(store, **save_kwargs)
         yield open_dataset(store, **open_kwargs)
 
+    @pytest.mark.skip('cannot roundtrip coordinates yet for '
+                      'CFEncodedInMemoryStore')
     def test_roundtrip_coordinates(self):
-        raise unittest.SkipTest('cannot roundtrip coordinates yet for '
-                                'CFEncodedInMemoryStore')
+        pass
 
     def test_invalid_dataarray_names_raise(self):
         # only relevant for on-disk file formats

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -255,7 +255,7 @@ class CFEncodedInMemoryStore(WritableCFDataStore, InMemoryDataStore):
 
 
 @requires_netCDF4
-class TestCFEncodedDataStore(CFEncodedDataTest, object):
+class TestCFEncodedDataStore(CFEncodedDataTest):
     @contextlib.contextmanager
     def create_store(self):
         yield CFEncodedInMemoryStore()

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 import pickle
-from textwrap import dedent
 from distutils.version import LooseVersion
+from textwrap import dedent
 
 import numpy as np
 import pandas as pd
@@ -15,15 +15,15 @@ from xarray.core.pycompat import OrderedDict, suppress
 from xarray.tests import mock
 
 from . import (
-    TestCase, assert_allclose, assert_array_equal, assert_equal,
-    assert_frame_equal, assert_identical, raises_regex)
+    assert_allclose, assert_array_equal, assert_equal, assert_frame_equal,
+    assert_identical, raises_regex)
 
 dask = pytest.importorskip('dask')
 da = pytest.importorskip('dask.array')
 dd = pytest.importorskip('dask.dataframe')
 
 
-class DaskTestCase(TestCase):
+class DaskTestCase(object):
     def assertLazyAnd(self, expected, actual, test):
 
         with (dask.config.set(get=dask.get)
@@ -57,6 +57,7 @@ class TestVariable(DaskTestCase):
     def assertLazyAndAllClose(self, expected, actual):
         self.assertLazyAnd(expected, actual, assert_allclose)
 
+    @pytest.fixture(autouse=True)
     def setUp(self):
         self.values = np.random.RandomState(0).randn(4, 6)
         self.data = da.from_array(self.values, chunks=(2, 2))
@@ -249,6 +250,7 @@ class TestDataArrayAndDataset(DaskTestCase):
     def assertLazyAndEqual(self, expected, actual):
         self.assertLazyAnd(expected, actual, assert_equal)
 
+    @pytest.fixture(autouse=True)
     def setUp(self):
         self.values = np.random.randn(4, 6)
         self.data = da.from_array(self.values, chunks=(2, 2))
@@ -581,7 +583,7 @@ class TestDataArrayAndDataset(DaskTestCase):
         self.assertLazyAndIdentical(self.lazy_array, a)
 
 
-class TestToDaskDataFrame(TestCase):
+class TestToDaskDataFrame(object):
 
     def test_to_dask_dataframe(self):
         # Test conversion of Datasets to dask DataFrames

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -18,7 +18,7 @@ from xarray.convert import from_cdms2
 from xarray.core.common import ALL_DIMS, full_like
 from xarray.core.pycompat import OrderedDict, iteritems
 from xarray.tests import (
-    ReturnItem, TestCase, assert_allclose, assert_array_equal, assert_equal,
+    ReturnItem,  assert_allclose, assert_array_equal, assert_equal,
     assert_identical, raises_regex, requires_bottleneck, requires_cftime,
     requires_dask, requires_iris, requires_np113, requires_scipy,
     source_ndarray, unittest)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -442,7 +442,7 @@ class TestDataArray(object):
         assert_identical(self.ds['x'], x)
         assert_identical(self.ds['y'], y)
 
-        I = ReturnItem()  # noqa: E741  # allow ambiguous name
+        I = ReturnItem()  # noqa
         for i in [I[:], I[...], I[x.values], I[x.variable], I[x], I[x, y],
                   I[x.values > -1], I[x.variable > -1], I[x > -1],
                   I[x > -1, y > -1]]:

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import pickle
 import warnings
 from copy import deepcopy
-from distutils.version import LooseVersion
 from textwrap import dedent
 
 import numpy as np
@@ -3015,7 +3014,7 @@ class TestDataArray(object):
 
         back = from_cdms2(actual)
         assert original.dims == back.dims
-        assert original.coords.keys() == back.coords.keys()
+        assert set(original.coords.keys()) == set(back.coords.keys())
         assert_array_equal(original.coords['lat'], back.coords['lat'])
         assert_array_equal(original.coords['lon'], back.coords['lon'])
 
@@ -3036,8 +3035,8 @@ class TestDataArray(object):
                            actual.getLatitude().getValue())
 
         back = from_cdms2(actual)
-        assert (original.dims == back.dims)
-        assert (original.coords.keys() == back.coords.keys())
+        assert set(original.dims) == set(back.dims)
+        assert set(original.coords.keys()) == set(back.coords.keys())
         assert_array_equal(original.coords['lat'], back.coords['lat'])
         assert_array_equal(original.coords['lon'], back.coords['lon'])
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2027,8 +2027,10 @@ class TestDataArray(object):
         with pytest.warns(FutureWarning):
             grouped.sum()
 
-    @pytest.mark.skipif(LooseVersion(xr.__version__) < LooseVersion('0.12'),
-                        reason="not to forget the behavior change")
+    # Currently disabled due to https://github.com/pydata/xarray/issues/2468
+    # @pytest.mark.skipif(LooseVersion(xr.__version__) < LooseVersion('0.12'),
+    #                     reason="not to forget the behavior change")
+    @pytest.mark.skip
     def test_groupby_sum_default(self):
         array = self.make_groupby_example_array()
         grouped = array.groupby('abc')

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -18,10 +18,10 @@ from xarray.convert import from_cdms2
 from xarray.core.common import ALL_DIMS, full_like
 from xarray.core.pycompat import OrderedDict, iteritems
 from xarray.tests import (
-    ReturnItem,  assert_allclose, assert_array_equal, assert_equal,
+    ReturnItem, assert_allclose, assert_array_equal, assert_equal,
     assert_identical, raises_regex, requires_bottleneck, requires_cftime,
     requires_dask, requires_iris, requires_np113, requires_scipy,
-    source_ndarray, unittest)
+    source_ndarray)
 
 
 class TestDataArray(object):
@@ -2051,7 +2051,7 @@ class TestDataArray(object):
         expected = DataArray([1, 1, 2], coords=[('cat', ['a', 'b', 'c'])])
         assert_identical(actual, expected)
 
-    @unittest.skip('needs to be fixed for shortcut=False, keep_attrs=False')
+    @pytest.mark.skip('needs to be fixed for shortcut=False, keep_attrs=False')
     def test_groupby_reduce_attrs(self):
         array = self.make_groupby_example_array()
         array.attrs['foo'] = 'bar'
@@ -2827,7 +2827,7 @@ class TestDataArray(object):
     def test_series_categorical_index(self):
         # regression test for GH700
         if not hasattr(pd, 'CategoricalIndex'):
-            raise unittest.SkipTest('requires pandas with CategoricalIndex')
+            pytest.skip('requires pandas with CategoricalIndex')
 
         s = pd.Series(np.arange(5), index=pd.CategoricalIndex(list('aabbc')))
         arr = DataArray(s)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2969,7 +2969,7 @@ class TestDataArray(object):
         actual = original.to_cdms2()
         assert_array_equal(actual.asma(), original)
         assert actual.id == original.name
-        assert actual.getAxisIds() == original.dims
+        assert tuple(actual.getAxisIds()) == original.dims
         for axis, coord in zip(actual.getAxisList(), expected_coords):
             assert axis.id == coord.name
             assert_array_equal(axis, coord.values)
@@ -3005,15 +3005,15 @@ class TestDataArray(object):
                              coords=OrderedDict(x=x, y=y, lon=lon, lat=lat),
                              name='sst')
         actual = original.to_cdms2()
-        assert (actual.getAxisIds() == original.dims)
+        assert tuple(actual.getAxisIds()) == original.dims
         assert_array_equal(original.coords['lon'],
                            actual.getLongitude().asma())
         assert_array_equal(original.coords['lat'],
                            actual.getLatitude().asma())
 
         back = from_cdms2(actual)
-        assert (original.dims == back.dims)
-        assert (original.coords.keys() == back.coords.keys())
+        assert original.dims == back.dims
+        assert original.coords.keys() == back.coords.keys()
         assert_array_equal(original.coords['lat'], back.coords['lat'])
         assert_array_equal(original.coords['lon'], back.coords['lon'])
 
@@ -3027,7 +3027,7 @@ class TestDataArray(object):
         original = DataArray(np.arange(5), dims=['cell'],
                              coords={'lon': lon, 'lat': lat, 'cell': cell})
         actual = original.to_cdms2()
-        assert (actual.getAxisIds() == original.dims)
+        assert tuple(actual.getAxisIds()) == original.dims
         assert_array_equal(original.coords['lon'],
                            actual.getLongitude().getValue())
         assert_array_equal(original.coords['lat'],

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -399,7 +399,7 @@ class TestDataset(TestCase):
 
         ds = Dataset({}, {'a': ('x', [1])})
         assert not ds.data_vars
-        self.assertItemsEqual(ds.coords.keys(), ['a'])
+        assert ds.coords.keys() == ['a']
 
         mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2]],
                                             names=('level_1', 'level_2'))
@@ -421,9 +421,9 @@ class TestDataset(TestCase):
         assert type(ds.dims.mapping.mapping) is dict  # noqa
 
         with pytest.warns(FutureWarning):
-            self.assertItemsEqual(ds, list(ds.variables))
+            assert ds == list(ds.variables)
         with pytest.warns(FutureWarning):
-            self.assertItemsEqual(ds.keys(), list(ds.variables))
+            assert ds.keys() == list(ds.variables)
         assert 'aasldfjalskdfj' not in ds.variables
         assert 'dim1' in repr(ds.variables)
         with pytest.warns(FutureWarning):
@@ -431,18 +431,18 @@ class TestDataset(TestCase):
         with pytest.warns(FutureWarning):
             assert bool(ds)
 
-        self.assertItemsEqual(ds.data_vars, ['var1', 'var2', 'var3'])
-        self.assertItemsEqual(ds.data_vars.keys(), ['var1', 'var2', 'var3'])
+        assert ds.data_vars == ['var1', 'var2', 'var3']
+        assert ds.data_vars.keys() == ['var1', 'var2', 'var3']
         assert 'var1' in ds.data_vars
         assert 'dim1' not in ds.data_vars
         assert 'numbers' not in ds.data_vars
         assert len(ds.data_vars) == 3
 
-        self.assertItemsEqual(ds.indexes, ['dim2', 'dim3', 'time'])
+        assert ds.indexes == ['dim2', 'dim3', 'time']
         assert len(ds.indexes) == 3
         assert 'dim2' in repr(ds.indexes)
 
-        self.assertItemsEqual(ds.coords, ['time', 'dim2', 'dim3', 'numbers'])
+        assert ds.coords == ['time', 'dim2', 'dim3', 'numbers']
         assert 'dim2' in ds.coords
         assert 'numbers' in ds.coords
         assert 'var1' not in ds.coords
@@ -535,7 +535,7 @@ class TestDataset(TestCase):
 
         assert 4 == len(data.coords)
 
-        self.assertItemsEqual(['x', 'y', 'a', 'b'], list(data.coords))
+        assert ['x', 'y', 'a', 'b'] == list(data.coords)
 
         assert_identical(data.coords['x'].variable, data['x'].variable)
         assert_identical(data.coords['y'].variable, data['y'].variable)
@@ -831,7 +831,7 @@ class TestDataset(TestCase):
         ret = data.isel(**slicers)
 
         # Verify that only the specified dimension was altered
-        self.assertItemsEqual(data.dims, ret.dims)
+        assert data.dims == ret.dims
         for d in data.dims:
             if d in slicers:
                 assert ret.dims[d] == \
@@ -857,21 +857,21 @@ class TestDataset(TestCase):
 
         ret = data.isel(dim1=0)
         assert {'time': 20, 'dim2': 9, 'dim3': 10} == ret.dims
-        self.assertItemsEqual(data.data_vars, ret.data_vars)
-        self.assertItemsEqual(data.coords, ret.coords)
-        self.assertItemsEqual(data.indexes, ret.indexes)
+        assert data.data_vars == ret.data_vars
+        assert data.coords == ret.coords
+        assert data.indexes == ret.indexes
 
         ret = data.isel(time=slice(2), dim1=0, dim2=slice(5))
         assert {'time': 2, 'dim2': 5, 'dim3': 10} == ret.dims
-        self.assertItemsEqual(data.data_vars, ret.data_vars)
-        self.assertItemsEqual(data.coords, ret.coords)
-        self.assertItemsEqual(data.indexes, ret.indexes)
+        assert data.data_vars == ret.data_vars
+        assert data.coords == ret.coords
+        assert data.indexes == ret.indexes
 
         ret = data.isel(time=0, dim1=0, dim2=slice(5))
-        self.assertItemsEqual({'dim2': 5, 'dim3': 10}, ret.dims)
-        self.assertItemsEqual(data.data_vars, ret.data_vars)
-        self.assertItemsEqual(data.coords, ret.coords)
-        self.assertItemsEqual(data.indexes, list(ret.indexes) + ['time'])
+        assert {'dim2': 5, 'dim3': 10} == ret.dims
+        assert data.data_vars == ret.data_vars
+        assert data.coords == ret.coords
+        assert data.indexes == list(ret.indexes) + ['time']
 
     def test_isel_fancy(self):
         # isel with fancy indexing.
@@ -2546,12 +2546,11 @@ class TestDataset(TestCase):
     def test_delitem(self):
         data = create_test_data()
         all_items = set(data.variables)
-        self.assertItemsEqual(data.variables, all_items)
+        assert data.variables == all_items
         del data['var1']
-        self.assertItemsEqual(data.variables, all_items - set(['var1']))
+        assert data.variables == all_items - set(['var1'])
         del data['numbers']
-        self.assertItemsEqual(data.variables,
-                              all_items - set(['var1', 'numbers']))
+        assert data.variables == all_items - set(['var1', 'numbers'])
         assert 'numbers' not in data.coords
 
     def test_squeeze(self):
@@ -3426,7 +3425,7 @@ class TestDataset(TestCase):
                                  (('dim2', 'time'), ['dim1', 'dim3']),
                                  ((), ['dim1', 'dim2', 'dim3', 'time'])]:
             actual = data.min(dim=reduct).dims
-            self.assertItemsEqual(actual, expected)
+            assert actual == expected
 
         assert_equal(data.mean(dim=[]), data)
 
@@ -3480,7 +3479,7 @@ class TestDataset(TestCase):
                 ('time', ['dim1', 'dim2', 'dim3'])
             ]:
                 actual = getattr(data, cumfunc)(dim=reduct).dims
-                self.assertItemsEqual(actual, expected)
+                assert actual == expected
 
     def test_reduce_non_numeric(self):
         data1 = create_test_data(seed=44)
@@ -3618,14 +3617,14 @@ class TestDataset(TestCase):
         ds = create_test_data(seed=1234)
         # only ds.var3 depends on dim3
         z = ds.rank('dim3')
-        self.assertItemsEqual(['var3'], list(z.data_vars))
+        assert ['var3'] == list(z.data_vars)
         # same as dataarray version
         x = z.var3
         y = ds.var3.rank('dim3')
         assert_equal(x, y)
         # coordinates stick
-        self.assertItemsEqual(list(z.coords), list(ds.coords))
-        self.assertItemsEqual(list(x.coords), list(y.coords))
+        assert list(z.coords) == list(ds.coords)
+        assert list(x.coords) == list(y.coords)
         # invalid dim
         with raises_regex(ValueError, 'does not contain'):
             x.rank('invalid_dim')

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
+import sys
+import warnings
 from copy import copy, deepcopy
 from io import StringIO
 from textwrap import dedent
-import warnings
-import sys
 
 import numpy as np
 import pandas as pd
@@ -13,8 +13,8 @@ import pytest
 
 import xarray as xr
 from xarray import (
-    DataArray, Dataset, IndexVariable, MergeError, Variable, align, backends,
-    broadcast, open_dataset, set_options, ALL_DIMS)
+    ALL_DIMS, DataArray, Dataset, IndexVariable, MergeError, Variable, align,
+    backends, broadcast, open_dataset, set_options)
 from xarray.core import indexing, npcompat, utils
 from xarray.core.common import full_like
 from xarray.core.pycompat import (
@@ -22,8 +22,8 @@ from xarray.core.pycompat import (
 
 from . import (
     InaccessibleArray, TestCase, UnexpectedDataAccess, assert_allclose,
-    assert_array_equal, assert_equal, assert_identical, has_cftime,
-    has_dask, raises_regex, requires_bottleneck, requires_dask, requires_scipy,
+    assert_array_equal, assert_equal, assert_identical, has_cftime, has_dask,
+    raises_regex, requires_bottleneck, requires_dask, requires_scipy,
     source_ndarray)
 
 try:
@@ -3948,10 +3948,10 @@ class TestDataset(TestCase):
     def test_roll_multidim(self):
         # regression test for 2445
         arr = xr.DataArray(
-            [[1, 2, 3],[4, 5, 6]], coords={'x': range(3), 'y': range(2)},
-            dims=('y','x'))
+            [[1, 2, 3], [4, 5, 6]], coords={'x': range(3), 'y': range(2)},
+            dims=('y', 'x'))
         actual = arr.roll(x=1, roll_coords=True)
-        expected = xr.DataArray([[3, 1, 2],[6, 4, 5]],
+        expected = xr.DataArray([[3, 1, 2], [6, 4, 5]],
                                 coords=[('y', [0, 1]), ('x', [2, 0, 1])])
         assert_identical(expected, actual)
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -399,7 +399,7 @@ class TestDataset(TestCase):
 
         ds = Dataset({}, {'a': ('x', [1])})
         assert not ds.data_vars
-        assert ds.coords.keys() == ['a']
+        assert list(ds.coords.keys()) == ['a']
 
         mindex = pd.MultiIndex.from_product([['a', 'b'], [1, 2]],
                                             names=('level_1', 'level_2'))
@@ -421,9 +421,9 @@ class TestDataset(TestCase):
         assert type(ds.dims.mapping.mapping) is dict  # noqa
 
         with pytest.warns(FutureWarning):
-            assert ds == list(ds.variables)
+            assert list(ds) == list(ds.variables)
         with pytest.warns(FutureWarning):
-            assert ds.keys() == list(ds.variables)
+            assert list(ds.keys()) == list(ds.variables)
         assert 'aasldfjalskdfj' not in ds.variables
         assert 'dim1' in repr(ds.variables)
         with pytest.warns(FutureWarning):
@@ -431,18 +431,18 @@ class TestDataset(TestCase):
         with pytest.warns(FutureWarning):
             assert bool(ds)
 
-        assert ds.data_vars == ['var1', 'var2', 'var3']
-        assert ds.data_vars.keys() == ['var1', 'var2', 'var3']
+        assert list(ds.data_vars) == ['var1', 'var2', 'var3']
+        assert list(ds.data_vars.keys()) == ['var1', 'var2', 'var3']
         assert 'var1' in ds.data_vars
         assert 'dim1' not in ds.data_vars
         assert 'numbers' not in ds.data_vars
         assert len(ds.data_vars) == 3
 
-        assert ds.indexes == ['dim2', 'dim3', 'time']
+        assert set(ds.indexes) == {'dim2', 'dim3', 'time'}
         assert len(ds.indexes) == 3
         assert 'dim2' in repr(ds.indexes)
 
-        assert ds.coords == ['time', 'dim2', 'dim3', 'numbers']
+        assert list ( ds.coords ) == ['time', 'dim2', 'dim3', 'numbers']
         assert 'dim2' in ds.coords
         assert 'numbers' in ds.coords
         assert 'var1' not in ds.coords
@@ -831,7 +831,7 @@ class TestDataset(TestCase):
         ret = data.isel(**slicers)
 
         # Verify that only the specified dimension was altered
-        assert data.dims == ret.dims
+        assert list(data.dims) == list(ret.dims)
         for d in data.dims:
             if d in slicers:
                 assert ret.dims[d] == \
@@ -857,21 +857,21 @@ class TestDataset(TestCase):
 
         ret = data.isel(dim1=0)
         assert {'time': 20, 'dim2': 9, 'dim3': 10} == ret.dims
-        assert data.data_vars == ret.data_vars
-        assert data.coords == ret.coords
-        assert data.indexes == ret.indexes
+        assert set(data.data_vars) == set(ret.data_vars)
+        assert set(data.coords) == set(ret.coords)
+        assert set(data.indexes) == set(ret.indexes)
 
         ret = data.isel(time=slice(2), dim1=0, dim2=slice(5))
         assert {'time': 2, 'dim2': 5, 'dim3': 10} == ret.dims
-        assert data.data_vars == ret.data_vars
-        assert data.coords == ret.coords
-        assert data.indexes == ret.indexes
+        assert set(data.data_vars) == set(ret.data_vars)
+        assert set(data.coords) == set(ret.coords)
+        assert set(data.indexes) == set(ret.indexes)
 
         ret = data.isel(time=0, dim1=0, dim2=slice(5))
         assert {'dim2': 5, 'dim3': 10} == ret.dims
-        assert data.data_vars == ret.data_vars
-        assert data.coords == ret.coords
-        assert data.indexes == list(ret.indexes) + ['time']
+        assert set(data.data_vars) == set(ret.data_vars)
+        assert set(data.coords) == set(ret.coords)
+        assert set(data.indexes) == set(list(ret.indexes) + ['time'])
 
     def test_isel_fancy(self):
         # isel with fancy indexing.
@@ -2546,11 +2546,11 @@ class TestDataset(TestCase):
     def test_delitem(self):
         data = create_test_data()
         all_items = set(data.variables)
-        assert data.variables == all_items
+        assert set(data.variables) == all_items
         del data['var1']
-        assert data.variables == all_items - set(['var1'])
+        assert set(data.variables) == all_items - set(['var1'])
         del data['numbers']
-        assert data.variables == all_items - set(['var1', 'numbers'])
+        assert set(data.variables) == all_items - set(['var1', 'numbers'])
         assert 'numbers' not in data.coords
 
     def test_squeeze(self):
@@ -3424,7 +3424,7 @@ class TestDataset(TestCase):
                                  (['dim2', 'time'], ['dim1', 'dim3']),
                                  (('dim2', 'time'), ['dim1', 'dim3']),
                                  ((), ['dim1', 'dim2', 'dim3', 'time'])]:
-            actual = data.min(dim=reduct).dims
+            actual = list(data.min(dim=reduct).dims)
             assert actual == expected
 
         assert_equal(data.mean(dim=[]), data)
@@ -3479,7 +3479,7 @@ class TestDataset(TestCase):
                 ('time', ['dim1', 'dim2', 'dim3'])
             ]:
                 actual = getattr(data, cumfunc)(dim=reduct).dims
-                assert actual == expected
+                assert list(actual) == expected
 
     def test_reduce_non_numeric(self):
         data1 = create_test_data(seed=44)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -21,7 +21,7 @@ from xarray.core.pycompat import (
     OrderedDict, integer_types, iteritems, unicode_type)
 
 from . import (
-    InaccessibleArray, TestCase, UnexpectedDataAccess, assert_allclose,
+    InaccessibleArray, UnexpectedDataAccess, assert_allclose,
     assert_array_equal, assert_equal, assert_identical, has_cftime, has_dask,
     raises_regex, requires_bottleneck, requires_dask, requires_scipy,
     source_ndarray)
@@ -86,7 +86,7 @@ class InaccessibleVariableDataStore(backends.InMemoryDataStore):
                     k, v in iteritems(self._variables))
 
 
-class TestDataset(TestCase):
+class TestDataset(object):
     def test_repr(self):
         data = create_test_data(seed=123)
         data.attrs['foo'] = 'bar'
@@ -442,7 +442,7 @@ class TestDataset(TestCase):
         assert len(ds.indexes) == 3
         assert 'dim2' in repr(ds.indexes)
 
-        assert list ( ds.coords ) == ['time', 'dim2', 'dim3', 'numbers']
+        assert list(ds.coords) == ['time', 'dim2', 'dim3', 'numbers']
         assert 'dim2' in ds.coords
         assert 'numbers' in ds.coords
         assert 'var1' not in ds.coords
@@ -1482,7 +1482,7 @@ class TestDataset(TestCase):
                     ds = ds.rename({renamed_dim: 'x'})
                 assert_identical(ds['var'].variable,
                                  expected_ds['var'].variable)
-                self.assertVariableNotEqual(ds['x'], expected_ds['x'])
+                assert not ds['x'].equals(expected_ds['x'])
 
         test_sel(('a', 1, -1), 0)
         test_sel(('b', 2, -2), -1)

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -1,16 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
+import warnings
 from distutils.version import LooseVersion
+from textwrap import dedent
 
 import numpy as np
 import pandas as pd
 import pytest
-from textwrap import dedent
 from numpy import array, nan
-import warnings
 
 from xarray import DataArray, Dataset, concat
-from xarray.core import duck_array_ops, dtypes
+from xarray.core import dtypes, duck_array_ops
 from xarray.core.duck_array_ops import (
     array_notnull_equiv, concatenate, count, first, gradient, last, mean,
     rolling_window, stack, where)
@@ -18,12 +18,12 @@ from xarray.core.pycompat import dask_array_type
 from xarray.testing import assert_allclose, assert_equal
 
 from . import (
-    TestCase, assert_array_equal, has_dask, has_np113, raises_regex,
-    requires_dask)
+    assert_array_equal, has_dask, has_np113, raises_regex, requires_dask)
 
 
-class TestOps(TestCase):
+class TestOps(object):
 
+    @pytest.fixture(autouse=True)
     def setUp(self):
         self.x = array([[[nan, nan, 2., nan],
                          [nan, 5., 6., nan],

--- a/xarray/tests/test_extensions.py
+++ b/xarray/tests/test_extensions.py
@@ -4,7 +4,7 @@ import pytest
 
 import xarray as xr
 
-from . import TestCase, raises_regex
+from . import raises_regex
 
 try:
     import cPickle as pickle
@@ -21,7 +21,7 @@ class ExampleAccessor(object):
         self.obj = xarray_obj
 
 
-class TestAccessor(TestCase):
+class TestAccessor(object):
     def test_register(self):
 
         @xr.register_dataset_accessor('demo')

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from xarray.core import formatting
 from xarray.core.pycompat import PY3
+from xarray.testing import assert_equal
 
 from . import TestCase, raises_regex
 
@@ -45,7 +46,7 @@ class TestFormatting(TestCase):
         for n in [3, 10, 13, 100, 200]:
             actual = formatting.first_n_items(array, n)
             expected = array.flat[:n]
-            assert expected == actual
+            assert (expected == actual).all()
 
         with raises_regex(ValueError, 'at least one item'):
             formatting.first_n_items(array, 0)
@@ -55,7 +56,7 @@ class TestFormatting(TestCase):
         for n in [3, 10, 13, 100, 200]:
             actual = formatting.last_n_items(array, n)
             expected = array.flat[-n:]
-            assert expected == actual
+            assert (expected == actual).all()
 
         with raises_regex(ValueError, 'at least one item'):
             formatting.first_n_items(array, 0)

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -6,12 +6,11 @@ import pandas as pd
 
 from xarray.core import formatting
 from xarray.core.pycompat import PY3
-from xarray.testing import assert_equal
 
-from . import TestCase, raises_regex
+from . import raises_regex
 
 
-class TestFormatting(TestCase):
+class TestFormatting(object):
 
     def test_get_indexer_at_least_n_items(self):
         cases = [

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -45,7 +45,7 @@ class TestFormatting(TestCase):
         for n in [3, 10, 13, 100, 200]:
             actual = formatting.first_n_items(array, n)
             expected = array.flat[:n]
-            self.assertItemsEqual(expected, actual)
+            assert expected == actual
 
         with raises_regex(ValueError, 'at least one item'):
             formatting.first_n_items(array, 0)
@@ -55,7 +55,7 @@ class TestFormatting(TestCase):
         for n in [3, 10, 13, 100, 200]:
             actual = formatting.last_n_items(array, n)
             expected = array.flat[-n:]
-            self.assertItemsEqual(expected, actual)
+            assert expected == actual
 
         with raises_regex(ValueError, 'at least one item'):
             formatting.first_n_items(array, 0)

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -10,13 +10,12 @@ from xarray import DataArray, Dataset, Variable
 from xarray.core import indexing, nputils
 from xarray.core.pycompat import native_int_types
 
-from . import (
-    IndexerMaker, ReturnItem, TestCase, assert_array_equal, raises_regex)
+from . import IndexerMaker, ReturnItem, assert_array_equal, raises_regex
 
 B = IndexerMaker(indexing.BasicIndexer)
 
 
-class TestIndexers(TestCase):
+class TestIndexers(object):
     def set_to_zero(self, x, i):
         x = x.copy()
         x[i] = 0
@@ -133,7 +132,7 @@ class TestIndexers(TestCase):
                      pd.MultiIndex.from_product([[1, 2], [-1, -2]]))
 
 
-class TestLazyArray(TestCase):
+class TestLazyArray(object):
     def test_slice_slice(self):
         I = ReturnItem()  # noqa: E741  # allow ambiguous name
         for size in [100, 99]:
@@ -248,7 +247,7 @@ class TestLazyArray(TestCase):
         check_indexing(v_eager, v_lazy, indexers)
 
 
-class TestCopyOnWriteArray(TestCase):
+class TestCopyOnWriteArray(object):
     def test_setitem(self):
         original = np.arange(10)
         wrapped = indexing.CopyOnWriteArray(original)
@@ -272,7 +271,7 @@ class TestCopyOnWriteArray(TestCase):
         assert np.array(x[B[0]][B[()]]) == 'foo'
 
 
-class TestMemoryCachedArray(TestCase):
+class TestMemoryCachedArray(object):
     def test_wrapper(self):
         original = indexing.LazilyOuterIndexedArray(np.arange(10))
         wrapped = indexing.MemoryCachedArray(original)
@@ -385,8 +384,9 @@ def test_vectorized_indexer():
                                     np.arange(5, dtype=np.int64)))
 
 
-class Test_vectorized_indexer(TestCase):
-    def setUp(self):
+class Test_vectorized_indexer(object):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         self.data = indexing.NumpyIndexingAdapter(np.random.randn(10, 12, 13))
         self.indexers = [np.array([[0, 3, 2], ]),
                          np.array([[0, 3, 3], [4, 6, 7]]),

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -24,7 +24,7 @@ class TestIndexers(object):
     def test_expanded_indexer(self):
         x = np.random.randn(10, 11, 12, 13, 14)
         y = np.arange(5)
-        I = ReturnItem()  # noqa: E741  # allow ambiguous name
+        I = ReturnItem()  # noqa
         for i in [I[:], I[...], I[0, :, 10], I[..., 10], I[:5, ..., 0],
                   I[..., 0, :], I[y], I[y, y], I[..., y, y],
                   I[..., 0, 1, 2, 3, 4]]:

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -195,7 +195,7 @@ class TestMergeMethod(object):
         with pytest.raises(xr.MergeError):
             ds1.merge(ds2, compat='identical')
 
-        with raises_regex(ValueError, 'compat=\S+ invalid'):
+        with raises_regex(ValueError, 'compat=.* invalid'):
             ds1.merge(ds2, compat='foobar')
 
     def test_merge_auto_align(self):

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -6,11 +6,11 @@ import pytest
 import xarray as xr
 from xarray.core import merge
 
-from . import TestCase, raises_regex
+from . import raises_regex
 from .test_dataset import create_test_data
 
 
-class TestMergeInternals(TestCase):
+class TestMergeInternals(object):
     def test_broadcast_dimension_size(self):
         actual = merge.broadcast_dimension_size(
             [xr.Variable('x', [1]), xr.Variable('y', [2, 1])])
@@ -25,7 +25,7 @@ class TestMergeInternals(TestCase):
                 [xr.Variable(('x', 'y'), [[1, 2]]), xr.Variable('y', [2])])
 
 
-class TestMergeFunction(TestCase):
+class TestMergeFunction(object):
     def test_merge_arrays(self):
         data = create_test_data()
         actual = xr.merge([data.var1, data.var2])
@@ -130,7 +130,7 @@ class TestMergeFunction(TestCase):
         assert expected.identical(actual)
 
 
-class TestMergeMethod(TestCase):
+class TestMergeMethod(object):
 
     def test_merge(self):
         data = create_test_data()

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -357,7 +357,7 @@ class TestPlot1D(PlotTestCase):
 
     def test_no_label_name_on_x_axis(self):
         self.darray.plot(y='period')
-        self.assertEqual('', plt.gca().get_xlabel())
+        assert '' == plt.gca().get_xlabel()
 
     def test_no_label_name_on_y_axis(self):
         self.darray.plot()

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -5,9 +5,9 @@ from datetime import datetime
 
 import numpy as np
 import pandas as pd
-import xarray as xr
 import pytest
 
+import xarray as xr
 import xarray.plot as xplt
 from xarray import DataArray
 from xarray.coding.times import _import_cftime
@@ -17,9 +17,8 @@ from xarray.plot.utils import (
     import_seaborn, label_from_attrs)
 
 from . import (
-    TestCase, assert_array_equal, assert_equal, raises_regex,
-    requires_matplotlib, requires_matplotlib2, requires_seaborn,
-    requires_cftime)
+    assert_array_equal, assert_equal, raises_regex, requires_cftime,
+    requires_matplotlib, requires_matplotlib2, requires_seaborn)
 
 # import mpl and change the backend before other mpl imports
 try:
@@ -27,6 +26,12 @@ try:
     import matplotlib.pyplot as plt
 except ImportError:
     pass
+
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 
 @pytest.mark.flaky
@@ -65,7 +70,7 @@ def easy_array(shape, start=0, stop=1):
 
 
 @requires_matplotlib
-class PlotTestCase(TestCase):
+class PlotTestCase(unittest.TestCase):
     def tearDown(self):
         # Remove all matplotlib figures
         plt.close('all')
@@ -452,7 +457,7 @@ class TestPlotHistogram(PlotTestCase):
 
 
 @requires_matplotlib
-class TestDetermineCmapParams(TestCase):
+class TestDetermineCmapParams(unittest.TestCase):
     def setUp(self):
         self.data = np.linspace(0, 1, num=100)
 
@@ -625,7 +630,7 @@ class TestDetermineCmapParams(TestCase):
 
 
 @requires_matplotlib
-class TestDiscreteColorMap(TestCase):
+class TestDiscreteColorMap(unittest.TestCase):
     def setUp(self):
         x = np.arange(start=0, stop=10, step=2)
         y = np.arange(start=9, stop=-7, step=-3)

--- a/xarray/tests/test_tutorial.py
+++ b/xarray/tests/test_tutorial.py
@@ -2,15 +2,17 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
+import pytest
+
 from xarray import DataArray, tutorial
 from xarray.core.pycompat import suppress
 
-from . import TestCase, assert_identical, network
+from . import assert_identical, network
 
 
 @network
-class TestLoadDataset(TestCase):
-
+class TestLoadDataset(object):
+    @pytest.fixture(autouse=True)
     def setUp(self):
         self.testfile = 'tiny'
         self.testfilepath = os.path.expanduser(os.sep.join(

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -5,8 +5,8 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 import pytest
-import xarray as xr
 
+import xarray as xr
 from xarray.coding.cftimeindex import CFTimeIndex
 from xarray.core import duck_array_ops, utils
 from xarray.core.options import set_options
@@ -16,7 +16,7 @@ from xarray.testing import assert_identical
 
 from . import (
     TestCase, assert_array_equal, has_cftime, has_cftime_or_netCDF4,
-    requires_dask, requires_cftime)
+    requires_cftime, requires_dask)
 from .test_coding_times import _all_cftime_date_types
 
 
@@ -176,7 +176,7 @@ class TestDictionaries(TestCase):
     def test_sorted_keys_dict(self):
         x = {'a': 1, 'b': 2, 'c': 3}
         y = utils.SortedKeysDict(x)
-        self.assertItemsEqual(y, ['a', 'b', 'c'])
+        assert y == ['a', 'b', 'c']
         assert repr(utils.SortedKeysDict()) == \
             "SortedKeysDict({})"
 
@@ -191,7 +191,7 @@ class TestDictionaries(TestCase):
         m['x'] = 100
         assert m['x'] == 100
         assert m.maps[0]['x'] == 100
-        self.assertItemsEqual(['x', 'y', 'z'], m)
+        assert ['x', 'y', 'z'] == m
 
 
 def test_repr_object():

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -192,7 +192,7 @@ class TestDictionaries(object):
         m['x'] = 100
         assert m['x'] == 100
         assert m.maps[0]['x'] == 100
-        assert list(m) == ['x', 'y', 'z']
+        assert set(m) == {'x', 'y', 'z'}
 
 
 def test_repr_object():

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -176,7 +176,7 @@ class TestDictionaries(TestCase):
     def test_sorted_keys_dict(self):
         x = {'a': 1, 'b': 2, 'c': 3}
         y = utils.SortedKeysDict(x)
-        assert y == ['a', 'b', 'c']
+        assert list(y) == ['a', 'b', 'c']
         assert repr(utils.SortedKeysDict()) == \
             "SortedKeysDict({})"
 
@@ -191,7 +191,7 @@ class TestDictionaries(TestCase):
         m['x'] = 100
         assert m['x'] == 100
         assert m.maps[0]['x'] == 100
-        assert ['x', 'y', 'z'] == m
+        assert list(m) == ['x', 'y', 'z']
 
 
 def test_repr_object():

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -15,12 +15,12 @@ from xarray.core.utils import either_dict_or_kwargs
 from xarray.testing import assert_identical
 
 from . import (
-    TestCase, assert_array_equal, has_cftime, has_cftime_or_netCDF4,
-    requires_cftime, requires_dask)
+    assert_array_equal, has_cftime, has_cftime_or_netCDF4, requires_cftime,
+    requires_dask)
 from .test_coding_times import _all_cftime_date_types
 
 
-class TestAlias(TestCase):
+class TestAlias(object):
     def test(self):
         def new_method():
             pass
@@ -98,7 +98,7 @@ def test_multiindex_from_product_levels_non_unique():
     np.testing.assert_array_equal(result.levels[1], [1, 2])
 
 
-class TestArrayEquiv(TestCase):
+class TestArrayEquiv(object):
     def test_0d(self):
         # verify our work around for pd.isnull not working for 0-dimensional
         # object arrays
@@ -108,8 +108,9 @@ class TestArrayEquiv(TestCase):
         assert not duck_array_ops.array_equiv(0, np.array(1, dtype=object))
 
 
-class TestDictionaries(TestCase):
-    def setUp(self):
+class TestDictionaries(object):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         self.x = {'a': 'A', 'b': 'B'}
         self.y = {'c': 'C', 'b': 'B'}
         self.z = {'a': 'Z'}
@@ -199,7 +200,7 @@ def test_repr_object():
     assert repr(obj) == 'foo'
 
 
-class Test_is_uniform_and_sorted(TestCase):
+class Test_is_uniform_and_sorted(object):
 
     def test_sorted_uniform(self):
         assert utils.is_uniform_spaced(np.arange(5))
@@ -220,7 +221,7 @@ class Test_is_uniform_and_sorted(TestCase):
         assert utils.is_uniform_spaced([0, 0.97, 2], rtol=0.1)
 
 
-class Test_hashable(TestCase):
+class Test_hashable(object):
 
     def test_hashable(self):
         for v in [False, 1, (2, ), (3, 4), 'four']:

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -479,20 +479,20 @@ class VariableSubclassobjects(object):
         assert_identical(expected, actual)
         assert actual.dtype == object
 
-    def test_copy(self):
+    @pytest.mark.parametrize('deep', [True, False])
+    def test_copy(self, deep):
         v = self.cls('x', 0.5 * np.arange(10), {'foo': 'bar'})
-        for deep in [True, False]:
-            w = v.copy(deep=deep)
-            assert type(v) is type(w)
-            assert_identical(v, w)
-            assert v.dtype == w.dtype
-            if self.cls is Variable:
-                if deep:
-                    assert source_ndarray(v.values) is not \
-                        source_ndarray(w.values)
-                else:
-                    assert source_ndarray(v.values) is \
-                        source_ndarray(w.values)
+        w = v.copy(deep=deep)
+        assert type(v) is type(w)
+        assert_identical(v, w)
+        assert v.dtype == w.dtype
+        if self.cls is Variable:
+            if deep:
+                assert (source_ndarray(v.values) is not
+                        source_ndarray(w.values))
+            else:
+                assert (source_ndarray(v.values) is
+                        source_ndarray(w.values))
         assert_identical(v, copy(v))
 
     def test_copy_index(self):

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1,11 +1,11 @@
 
 from __future__ import absolute_import, division, print_function
 
+import warnings
 from copy import copy, deepcopy
 from datetime import datetime, timedelta
 from distutils.version import LooseVersion
 from textwrap import dedent
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -25,11 +25,11 @@ from xarray.core.variable import as_compatible_data, as_variable
 from xarray.tests import requires_bottleneck
 
 from . import (
-    TestCase, assert_allclose, assert_array_equal, assert_equal,
-    assert_identical, raises_regex, requires_dask, source_ndarray)
+    assert_allclose, assert_array_equal, assert_equal, assert_identical,
+    raises_regex, requires_dask, source_ndarray)
 
 
-class VariableSubclassTestCases(object):
+class VariableSubclassobjects(object):
     def test_properties(self):
         data = 0.5 * np.arange(10)
         v = self.cls(['time'], data, {'foo': 'bar'})
@@ -814,10 +814,11 @@ class VariableSubclassTestCases(object):
                     v_loaded[0] = 1.0
 
 
-class TestVariable(TestCase, VariableSubclassTestCases):
+class TestVariable(VariableSubclassobjects):
     cls = staticmethod(Variable)
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         self.d = np.random.random((10, 3)).astype(np.float64)
 
     def test_data_and_values(self):
@@ -1651,7 +1652,7 @@ class TestVariable(TestCase, VariableSubclassTestCases):
 
 
 @requires_dask
-class TestVariableWithDask(TestCase, VariableSubclassTestCases):
+class TestVariableWithDask(VariableSubclassobjects):
     cls = staticmethod(lambda *args: Variable(*args).chunk())
 
     @pytest.mark.xfail
@@ -1691,7 +1692,7 @@ class TestVariableWithDask(TestCase, VariableSubclassTestCases):
                          self.cls(('x', 'y'), [[0, -1], [-1, 2]]))
 
 
-class TestIndexVariable(TestCase, VariableSubclassTestCases):
+class TestIndexVariable(VariableSubclassobjects):
     cls = staticmethod(IndexVariable)
 
     def test_init(self):
@@ -1804,7 +1805,7 @@ class TestIndexVariable(TestCase, VariableSubclassTestCases):
         super(TestIndexVariable, self).test_rolling_window()
 
 
-class TestAsCompatibleData(TestCase):
+class TestAsCompatibleData(object):
     def test_unchanged_types(self):
         types = (np.asarray, PandasIndexAdapter, LazilyOuterIndexedArray)
         for t in types:
@@ -1945,9 +1946,10 @@ def test_raise_no_warning_for_nan_in_binary_ops():
     assert len(record) == 0
 
 
-class TestBackendIndexing(TestCase):
+class TestBackendIndexing(object):
     """    Make sure all the array wrappers can be indexed. """
 
+    @pytest.fixture(autouse=True)
     def setUp(self):
         self.d = np.random.random((10, 3)).astype(np.float64)
 


### PR DESCRIPTION
This replaces (by-and-large) any remaining unittest implementations with pytest implementations. This allows us to use fixtures on any test; the existing implementation does not let us use them on `TestCase` instances. It also directs future contributors away from using the legacy methods.

Would be great to merge this fairly soon, as there's some chance of merge conflicts (which git may not catch - e.g. someone writing `self.assertEqual`). I'll try and chase down any test breaks as soon as possible.