### PR TITLE
isort

### DIFF
--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 import xarray as xr
 
-from . import randn, randint, requires_dask
+from . import randint, randn, requires_dask
 
 try:
     import dask

--- a/asv_bench/benchmarks/unstacking.py
+++ b/asv_bench/benchmarks/unstacking.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
+
 import xarray as xr
 
 from . import requires_dask

--- a/properties/test_encode_decode.py
+++ b/properties/test_encode_decode.py
@@ -6,9 +6,9 @@ These ones pass, just as you'd hope!
 """
 from __future__ import absolute_import, division, print_function
 
-from hypothesis import given, settings
-import hypothesis.strategies as st
 import hypothesis.extra.numpy as npst
+import hypothesis.strategies as st
+from hypothesis import given, settings
 
 import xarray as xr
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 import sys
 
-from setuptools import find_packages, setup
-
 import versioneer
-
+from setuptools import find_packages, setup
 
 DISTNAME = 'xarray'
 LICENSE = 'Apache'

--- a/versioneer.py
+++ b/versioneer.py
@@ -277,16 +277,18 @@ https://creativecommons.org/publicdomain/zero/1.0/ .
 """
 
 from __future__ import print_function
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
+
 import errno
 import json
 import os
 import re
 import subprocess
 import sys
+
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 
 
 class VersioneerConfig:

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -10,8 +10,7 @@ import numpy as np
 from .. import Variable, coding
 from ..coding.variables import pop_to
 from ..core import indexing
-from ..core.pycompat import (
-    PY3, OrderedDict, basestring, iteritems, suppress)
+from ..core.pycompat import PY3, OrderedDict, basestring, iteritems, suppress
 from ..core.utils import FrozenOrderedDict, close_on_error, is_remote_uri
 from .common import (
     HDF5_LOCK, BackendArray, DataStorePickleMixin, WritableCFDataStore,

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -1,17 +1,14 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import functools
 
 import numpy as np
 
 from .. import Variable
-from ..core.pycompat import OrderedDict
-from ..core.utils import (FrozenOrderedDict, Frozen)
 from ..core import indexing
-
-from .common import AbstractDataStore, DataStorePickleMixin, BackendArray
+from ..core.pycompat import OrderedDict
+from ..core.utils import Frozen, FrozenOrderedDict
+from .common import AbstractDataStore, BackendArray, DataStorePickleMixin
 
 
 class PncArrayWrapper(BackendArray):

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -1,7 +1,7 @@
 import os
+import warnings
 from collections import OrderedDict
 from distutils.version import LooseVersion
-import warnings
 
 import numpy as np
 

--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -41,15 +41,14 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import re
-
 from datetime import timedelta
 from functools import partial
 
 import numpy as np
 
-from .cftimeindex import _parse_iso8601_with_reso, CFTimeIndex
-from .times import format_cftime_datetime
 from ..core.pycompat import basestring
+from .cftimeindex import CFTimeIndex, _parse_iso8601_with_reso
+from .times import format_cftime_datetime
 
 
 def get_date_type(calendar):

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -40,6 +40,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import absolute_import
+
 import re
 from datetime import timedelta
 

--- a/xarray/coding/strings.py
+++ b/xarray/coding/strings.py
@@ -9,8 +9,8 @@ from ..core import indexing
 from ..core.pycompat import bytes_type, dask_array_type, unicode_type
 from ..core.variable import Variable
 from .variables import (
-    VariableCoder, lazy_elemwise_func, pop_to,
-    safe_setitem, unpack_for_decoding, unpack_for_encoding)
+    VariableCoder, lazy_elemwise_func, pop_to, safe_setitem,
+    unpack_for_decoding, unpack_for_encoding)
 
 
 def create_vlen_dtype(element_type):

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -9,8 +9,8 @@ from functools import partial
 import numpy as np
 import pandas as pd
 
-from ..core.common import contains_cftime_datetimes
 from ..core import indexing
+from ..core.common import contains_cftime_datetimes
 from ..core.formatting import first_n_items, format_timestamp, last_item
 from ..core.options import OPTIONS
 from ..core.pycompat import PY3

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -6,11 +6,11 @@ from collections import defaultdict
 import numpy as np
 import pandas as pd
 
-from .coding import times, strings, variables
+from .coding import strings, times, variables
 from .coding.variables import SerializationWarning
 from .core import duck_array_ops, indexing
 from .core.pycompat import (
-    OrderedDict, basestring, bytes_type, iteritems, dask_array_type,
+    OrderedDict, basestring, bytes_type, dask_array_type, iteritems,
     unicode_type)
 from .core.variable import IndexVariable, Variable, as_variable
 

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 import pandas as pd
 
-from .common import is_np_datetime_like, _contains_datetime_like_objects
+from .common import _contains_datetime_like_objects, is_np_datetime_like
 from .pycompat import dask_array_type
 
 

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -8,8 +8,8 @@ from . import utils
 from .alignment import align
 from .merge import merge
 from .pycompat import OrderedDict, basestring, iteritems
-from .variable import concat as concat_vars
 from .variable import IndexVariable, Variable, as_variable
+from .variable import concat as concat_vars
 
 
 def concat(objs, dim=None, data_vars='all', coords='different',

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -7,11 +7,10 @@ from textwrap import dedent
 import numpy as np
 import pandas as pd
 
-from . import duck_array_ops, dtypes, formatting, ops
+from . import dtypes, duck_array_ops, formatting, ops
 from .arithmetic import SupportsArithmetic
 from .pycompat import OrderedDict, basestring, dask_array_type, suppress
-from .utils import either_dict_or_kwargs, Frozen, SortedKeysDict, ReprObject
-
+from .utils import Frozen, ReprObject, SortedKeysDict, either_dict_or_kwargs
 
 # Used as a sentinel value to indicate a all dimensions
 ALL_DIMS = ReprObject('<all-dims>')

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -2,19 +2,19 @@
 Functions for applying functions that act on arrays to xarray's labeled data.
 """
 from __future__ import absolute_import, division, print_function
-from distutils.version import LooseVersion
+
 import functools
 import itertools
 import operator
 from collections import Counter
+from distutils.version import LooseVersion
 
 import numpy as np
 
-from . import duck_array_ops
-from . import utils
+from . import duck_array_ops, utils
 from .alignment import deep_align
 from .merge import expand_and_merge_variables
-from .pycompat import OrderedDict, dask_array_type, basestring
+from .pycompat import OrderedDict, basestring, dask_array_type
 from .utils import is_dict_like
 
 _DEFAULT_FROZEN_SET = frozenset()

--- a/xarray/core/dask_array_compat.py
+++ b/xarray/core/dask_array_compat.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 from distutils.version import LooseVersion
 
+import dask.array as da
 import numpy as np
 from dask import __version__ as dask_version
-import dask.array as da
 
 try:
     from dask.array import isin

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
+
 from distutils.version import LooseVersion
 
 import numpy as np
 
-from . import nputils
-from . import dtypes
+from . import dtypes, nputils
 
 try:
     import dask

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -16,6 +16,7 @@ from . import (
     alignment, computation, duck_array_ops, formatting, groupby, indexing, ops,
     resample, rolling, utils)
 from .. import conventions
+from ..coding.cftimeindex import _parse_array_of_cftime_strings
 from .alignment import align
 from .common import (
     ALL_DIMS, DataWithCoords, ImplementsDatasetReduce,
@@ -31,11 +32,10 @@ from .options import OPTIONS
 from .pycompat import (
     OrderedDict, basestring, dask_array_type, integer_types, iteritems, range)
 from .utils import (
-    Frozen, SortedKeysDict, either_dict_or_kwargs, decode_numpy_dict_values,
-    ensure_us_time_resolution, hashable, maybe_wrap_array, datetime_to_numeric)
+    Frozen, SortedKeysDict, datetime_to_numeric, decode_numpy_dict_values,
+    either_dict_or_kwargs, ensure_us_time_resolution, hashable,
+    maybe_wrap_array)
 from .variable import IndexVariable, Variable, as_variable, broadcast_variables
-
-from ..coding.cftimeindex import _parse_array_of_cftime_strings
 
 # list of attributes of pd.DatetimeIndex that are ndarrays of time info
 _DATETIMEINDEX_COMPONENTS = ['year', 'month', 'day', 'hour', 'minute',

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -15,8 +15,7 @@ import pandas as pd
 
 from .options import OPTIONS
 from .pycompat import (
-    PY2, bytes_type, dask_array_type, unicode_type, zip_longest,
-)
+    PY2, bytes_type, dask_array_type, unicode_type, zip_longest)
 
 try:
     from pandas.errors import OutOfBoundsDatetime

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
+import warnings
 from collections import Iterable
 from functools import partial
-
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -11,10 +10,10 @@ import pandas as pd
 from . import rolling
 from .common import _contains_datetime_like_objects
 from .computation import apply_ufunc
-from .pycompat import iteritems
-from .utils import is_scalar, OrderedSet, datetime_to_numeric
-from .variable import Variable, broadcast_variables
 from .duck_array_ops import dask_array_type
+from .pycompat import iteritems
+from .utils import OrderedSet, datetime_to_numeric, is_scalar
+from .variable import Variable, broadcast_variables
 
 
 class BaseInterpolator(object):

--- a/xarray/core/nanops.py
+++ b/xarray/core/nanops.py
@@ -2,11 +2,10 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from . import dtypes
+from . import dtypes, nputils
+from .duck_array_ops import (
+    _dask_or_eager_func, count, fillna, isnull, where_method)
 from .pycompat import dask_array_type
-from . duck_array_ops import (count, isnull, fillna, where_method,
-                              _dask_or_eager_func)
-from . import nputils
 
 try:
     import dask.array as dask_array

--- a/xarray/core/npcompat.py
+++ b/xarray/core/npcompat.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from distutils.version import LooseVersion
+
 import numpy as np
 
 try:

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from . import ops
-from .groupby import DataArrayGroupBy, DatasetGroupBy, DEFAULT_DIMS
+from .groupby import DEFAULT_DIMS, DataArrayGroupBy, DatasetGroupBy
 from .pycompat import OrderedDict, dask_array_type
 
 RESAMPLE_DIM = '__resample_dim__'

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -5,6 +5,7 @@ import itertools
 import warnings
 
 import numpy as np
+
 from ..core.formatting import format_item
 from ..core.pycompat import getargspec
 from .utils import (

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -8,7 +8,6 @@ import numpy as np
 from ..core.options import OPTIONS
 from ..core.pycompat import basestring
 from ..core.utils import is_scalar
-from ..core.options import OPTIONS
 
 ROBUST_PERCENTILE = 2.0
 

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -1,15 +1,13 @@
-import pytest
-
 from itertools import product
 
 import numpy as np
+import pytest
 
-from xarray.coding.cftime_offsets import (
-    BaseCFTimeOffset, YearBegin, YearEnd, MonthBegin, MonthEnd,
-    Day, Hour, Minute, Second, _days_in_month,
-    to_offset, get_date_type, _MONTH_ABBREVIATIONS, to_cftime_datetime,
-    cftime_range)
 from xarray import CFTimeIndex
+from xarray.coding.cftime_offsets import (
+    _MONTH_ABBREVIATIONS, BaseCFTimeOffset, Day, Hour, Minute, MonthBegin,
+    MonthEnd, Second, YearBegin, YearEnd, _days_in_month, cftime_range,
+    get_date_type, to_cftime_datetime, to_offset)
 
 cftime = pytest.importorskip('cftime')
 

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -1,16 +1,15 @@
 from __future__ import absolute_import
 
-import pytest
+from datetime import timedelta
 
 import numpy as np
 import pandas as pd
-import xarray as xr
+import pytest
 
-from datetime import timedelta
+import xarray as xr
 from xarray.coding.cftimeindex import (
-    parse_iso8601, CFTimeIndex, assert_all_valid_date_type,
-    _parsed_string_to_bounds, _parse_iso8601_with_reso,
-    _parse_array_of_cftime_strings)
+    CFTimeIndex, _parse_array_of_cftime_strings, _parse_iso8601_with_reso,
+    _parsed_string_to_bounds, assert_all_valid_date_type, parse_iso8601)
 from xarray.tests import assert_array_equal, assert_identical
 
 from . import has_cftime, has_cftime_or_netCDF4, requires_cftime

--- a/xarray/tests/test_coding_strings.py
+++ b/xarray/tests/test_coding_strings.py
@@ -5,13 +5,13 @@ import numpy as np
 import pytest
 
 from xarray import Variable
-from xarray.core.pycompat import bytes_type, unicode_type, suppress
 from xarray.coding import strings
 from xarray.core import indexing
+from xarray.core.pycompat import bytes_type, suppress, unicode_type
 
-from . import (IndexerMaker, assert_array_equal, assert_identical,
-               raises_regex, requires_dask)
-
+from . import (
+    IndexerMaker, assert_array_equal, assert_identical, raises_regex,
+    requires_dask)
 
 with suppress(ImportError):
     import dask.array as da

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -1,20 +1,20 @@
 from __future__ import absolute_import, division, print_function
 
-from itertools import product
 import warnings
+from itertools import product
 
 import numpy as np
 import pandas as pd
 import pytest
 
-from xarray import Variable, coding, set_options, DataArray, decode_cf
+from xarray import DataArray, Variable, coding, decode_cf, set_options
 from xarray.coding.times import _import_cftime
 from xarray.coding.variables import SerializationWarning
 from xarray.core.common import contains_cftime_datetimes
 
-from . import (assert_array_equal, has_cftime_or_netCDF4,
-               requires_cftime_or_netCDF4, has_cftime, has_dask)
-
+from . import (
+    assert_array_equal, has_cftime, has_cftime_or_netCDF4, has_dask,
+    requires_cftime_or_netCDF4)
 
 _NON_STANDARD_CALENDARS_SET = {'noleap', '365_day', '360_day',
                                'julian', 'all_leap', '366_day'}

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -15,7 +15,7 @@ from xarray.core.computation import (
     join_dict_keys, ordered_set_intersection, ordered_set_union, result_name,
     unified_dim_sizes)
 
-from . import raises_regex, requires_dask, has_dask
+from . import has_dask, raises_regex, requires_dask
 
 
 def assert_identical(a, b):

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -5,8 +5,9 @@ import pandas as pd
 import pytest
 
 import xarray as xr
-from . import assert_identical
 from xarray.core.groupby import _consolidate_slices
+
+from . import assert_identical
 
 
 def test_consolidate_slices():

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -5,12 +5,12 @@ import pandas as pd
 import pytest
 
 import xarray as xr
-from xarray.tests import (assert_allclose, assert_equal, requires_cftime,
-                          requires_scipy)
-from . import has_dask, has_scipy
-from .test_dataset import create_test_data
+from xarray.tests import (
+    assert_allclose, assert_equal, requires_cftime, requires_scipy)
 
+from . import has_dask, has_scipy
 from ..coding.cftimeindex import _parse_array_of_cftime_strings
+from .test_dataset import create_test_data
 
 try:
     import scipy

--- a/xarray/tests/test_ufuncs.py
+++ b/xarray/tests/test_ufuncs.py
@@ -8,9 +8,9 @@ import pytest
 import xarray as xr
 import xarray.ufuncs as xu
 
-from . import (
-    assert_array_equal, assert_identical as assert_identical_, mock,
-    raises_regex, requires_np113)
+from . import assert_array_equal
+from . import assert_identical as assert_identical_
+from . import mock, raises_regex, requires_np113
 
 
 def assert_identical(a, b):


### PR DESCRIPTION
Do we want to keep `isort` up to date? I think it's a balance between consistency vs. overhead