### PR TITLE
Fix backend test classes so they actually run

### DIFF
--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -5,7 +5,7 @@ import numpy as np
 from .. import Variable
 from ..core import indexing
 from ..core.pycompat import OrderedDict
-from ..core.utils import Frozen
+from ..core.utils import Frozen, FrozenOrderedDict
 from .common import AbstractDataStore, BackendArray
 from .file_manager import CachingFileManager
 from .locks import HDF5_LOCK, NETCDFC_LOCK, combine_locks, ensure_lock
@@ -73,8 +73,8 @@ class PseudoNetCDFDataStore(AbstractDataStore):
         return Variable(var.dimensions, data, attrs)
 
     def get_variables(self):
-        return ((k, self.open_store_variable(k, v))
-                for k, v in self.ds.variables.items())
+        return FrozenOrderedDict((k, self.open_store_variable(k, v))
+                                 for k, v in self.ds.variables.items())
 
     def get_attrs(self):
         return Frozen(dict([(k, getattr(self.ds, k))

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -18,7 +18,7 @@ from xarray.testing import assert_identical
 from . import (
     assert_array_equal, raises_regex, requires_cftime_or_netCDF4,
     requires_dask, requires_netCDF4)
-from .test_backends import CFEncodedDataTest
+from .test_backends import CFEncodedBase
 
 
 class TestBoolTypeArray(object):
@@ -255,7 +255,7 @@ class CFEncodedInMemoryStore(WritableCFDataStore, InMemoryDataStore):
 
 
 @requires_netCDF4
-class TestCFEncodedDataStore(CFEncodedDataTest):
+class TestCFEncodedDataStore(CFEncodedBase):
     @contextlib.contextmanager
     def create_store(self):
         yield CFEncodedInMemoryStore()


### PR DESCRIPTION
We accidentally stopped running many backend tests when we merged #2467,
because they no longer inherited from untitest.TestCase and didn't have a
name starting with "Test".

This PR renames the tests so they actually run. I also fixed a bug with the
pseudonetcdf backend that appears to have been introduced by a bad merge in
#2261. It wasn't caught because the tests weren't actually running.

cc @max-sixty 
