### PR TITLE
Zarr chunking (GH2300)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -136,6 +136,10 @@ Bug fixes
   the dates must be encoded using cftime rather than NumPy (:issue:`2272`).
   By `Spencer Clark <https://github.com/spencerkclark>`_.
 
+- Chunked datasets can now roundtrip to Zarr storage continually 
+  with `to_zarr` and ``open_zarr`` (:issue:`2300`).
+  By `Lily Wang <https://github.com/lilyminium>`_.
+
 .. _whats-new.0.10.9:
 
 v0.10.9 (21 September 2018)

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -80,13 +80,13 @@ def _determine_zarr_chunks(enc_chunks, var_chunks, ndim):
         if any(len(set(chunks[:-1])) > 1 for chunks in var_chunks):
             raise ValueError(
                 "Zarr requires uniform chunk sizes except for final chunk."
-                " Variable %r has incompatible chunks. Consider "
+                " Variable dask chunks %r are incompatible. Consider "
                 "rechunking using `chunk()`." % (var_chunks,))
         if any((chunks[0] < chunks[-1]) for chunks in var_chunks):
             raise ValueError(
-                "Final chunk of Zarr array must be smaller than first. "
-                "Variable %r has incompatible chunks. Consider rechunking "
-                "using `chunk()`." % var_chunks)
+                "Final chunk of Zarr array must be the same size or smaller "
+                "than the first. Variable Dask chunks %r are incompatible. "
+                "Consider rechunking using `chunk()`." % var_chunks)
         # return the first chunk for each dimension
         return tuple(chunk[0] for chunk in var_chunks)
 
@@ -136,9 +136,11 @@ def _determine_zarr_chunks(enc_chunks, var_chunks, ndim):
                         % (enc_chunks_tuple, var_chunks))
             if dchunks[-1] > zchunk:
                 raise ValueError(
-                    "Final chunk of Zarr array must be smaller than first. "
-                    "Variable %r has incompatible chunks. Consider rechunking "
-                    "using `chunk()`." % var_chunks)
+                    "Final chunk of Zarr array must be the same size or smaller "
+                    "than the first. The specified Zarr chunk encoding is %r, "
+                    "but %r in variable Dask chunks %r is incompatible. "
+                    "Consider rechunking using `chunk()`." 
+                    % (enc_chunks_tuple, dchunks, var_chunks))
         return enc_chunks_tuple
 
     raise AssertionError(

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -79,7 +79,7 @@ def _determine_zarr_chunks(enc_chunks, var_chunks, ndim):
     if var_chunks and enc_chunks is None:
         if any(len(set(chunks[:-1])) > 1 for chunks in var_chunks):
             raise ValueError(
-                "Zarr requires uniform chunk sizes excpet for final chunk."
+                "Zarr requires uniform chunk sizes except for final chunk."
                 " Variable %r has incompatible chunks. Consider "
                 "rechunking using `chunk()`." % (var_chunks,))
         if any((chunks[0] < chunks[-1]) for chunks in var_chunks):

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -136,10 +136,10 @@ def _determine_zarr_chunks(enc_chunks, var_chunks, ndim):
                         % (enc_chunks_tuple, var_chunks))
             if dchunks[-1] > zchunk:
                 raise ValueError(
-                    "Final chunk of Zarr array must be the same size or smaller "
-                    "than the first. The specified Zarr chunk encoding is %r, "
-                    "but %r in variable Dask chunks %r is incompatible. "
-                    "Consider rechunking using `chunk()`." 
+                    "Final chunk of Zarr array must be the same size or "
+                    "smaller than the first. The specified Zarr chunk "
+                    "encoding is %r, but %r in variable Dask chunks %r is "
+                    "incompatible. Consider rechunking using `chunk()`."
                     % (enc_chunks_tuple, dchunks, var_chunks))
         return enc_chunks_tuple
 

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -126,7 +126,7 @@ def _determine_zarr_chunks(enc_chunks, var_chunks, ndim):
     # threads
     if var_chunks and enc_chunks_tuple:
         for zchunk, dchunks in zip(enc_chunks_tuple, var_chunks):
-            for dchunk in dchunks:
+            for dchunk in dchunks[:-1]:
                 if dchunk % zchunk:
                     raise NotImplementedError(
                         "Specified zarr chunks %r would overlap multiple dask "
@@ -134,6 +134,11 @@ def _determine_zarr_chunks(enc_chunks, var_chunks, ndim):
                         " Consider rechunking the data using "
                         "`chunk()` or specifying different chunks in encoding."
                         % (enc_chunks_tuple, var_chunks))
+            if dchunks[-1] > zchunk:
+                raise ValueError(
+                    "Final chunk of Zarr array must be smaller than first. "
+                    "Variable %r has incompatible chunks. Consider rechunking "
+                    "using `chunk()`." % var_chunks)
         return enc_chunks_tuple
 
     raise AssertionError(

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1393,7 +1393,6 @@ class ZarrBase(CFEncodedBase):
         with self.roundtrip(ds_chunk_irreg) as original:
             with self.roundtrip(original) as actual:
                 assert_identical(original, actual)
-        
 
         # - encoding specified  -
         # specify compatible encodings
@@ -1401,8 +1400,6 @@ class ZarrBase(CFEncodedBase):
             ds_chunk4['var1'].encoding.update({'chunks': chunk_enc})
             with self.roundtrip(ds_chunk4) as actual:
                 assert (4,) == actual['var1'].encoding['chunks']
-        
-        
 
         # TODO: remove this failure once syncronized overlapping writes are
         # supported by xarray
@@ -1410,8 +1407,6 @@ class ZarrBase(CFEncodedBase):
         with pytest.raises(NotImplementedError):
             with self.roundtrip(ds_chunk4) as actual:
                 pass
-    
-        
 
     def test_hidden_zarr_keys(self):
         expected = create_test_data()

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1389,6 +1389,9 @@ class ZarrBase(CFEncodedBase):
         ds_chunk_irreg = ds.chunk({'x': (5, 5, 2)})
         with self.roundtrip(ds_chunk_irreg) as actual:
             assert (5,) == actual['var1'].encoding['chunks']
+        with self.roundtrip(actual) as actual_2:
+            assert actual['var1'].encoding == actual_2['var1'].encoding
+        
 
         # - encoding specified  -
         # specify compatible encodings
@@ -1396,6 +1399,8 @@ class ZarrBase(CFEncodedBase):
             ds_chunk4['var1'].encoding.update({'chunks': chunk_enc})
             with self.roundtrip(ds_chunk4) as actual:
                 assert (4,) == actual['var1'].encoding['chunks']
+        
+        
 
         # TODO: remove this failure once syncronized overlapping writes are
         # supported by xarray
@@ -1403,6 +1408,8 @@ class ZarrBase(CFEncodedBase):
         with pytest.raises(NotImplementedError):
             with self.roundtrip(ds_chunk4) as actual:
                 pass
+    
+        
 
     def test_hidden_zarr_keys(self):
         expected = create_test_data()

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1389,8 +1389,10 @@ class ZarrBase(CFEncodedBase):
         ds_chunk_irreg = ds.chunk({'x': (5, 5, 2)})
         with self.roundtrip(ds_chunk_irreg) as actual:
             assert (5,) == actual['var1'].encoding['chunks']
-        with self.roundtrip(actual) as actual_2:
-            assert actual['var1'].encoding == actual_2['var1'].encoding
+        # re-save Zarr arrays
+        with self.roundtrip(ds_chunk_irreg) as original:
+            with self.roundtrip(original) as actual:
+                assert_identical(original, actual)
         
 
         # - encoding specified  -


### PR DESCRIPTION
 - [x] Band-aid for #2300
 - [x] Test added to check that zarr-originating array can save
 - [x] Updated whats-new

I don't fully understand the ins-and-outs of Zarr, but it seems that if it can be serialised with a smaller end-chunk to begin with, then saving a Dataset constructed from Zarr should not have an issue with that either. 