### PR TITLE
Dataset.copy docstring matches behavior

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -727,7 +727,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         ----------
         deep : bool, optional
             Whether each component variable is loaded into memory and copied onto
-            the new object. Default is True.
+            the new object. Default is False.
         data : dict-like, optional
             Data to use in the new object. Each item in `data` must have same
             shape as corresponding data variable in original. When `data` is


### PR DESCRIPTION
 - [ ] Closes #2490

This makes the docstring of Dataset.copy match the actual behavior. 

However, I noticed that DataArray.copy has the opposite behavior for the deep keyword. Is this intentional, or are they supposed to behave the same way?
