### PR TITLE
Fix tests to new coordinate names in cfgrib>=0.9.2

### DIFF
--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -27,4 +27,4 @@ dependencies:
     - pytest-cov
     - pydap
     - lxml
-    - cfgrib
+    - cfgrib>=0.9.2

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2467,7 +2467,7 @@ class TestPyNio(ScipyWriteBase):
 class TestCfGrib(object):
 
     def test_read(self):
-        expected = {'number': 2, 'time': 3, 'air_pressure': 2, 'latitude': 3,
+        expected = {'number': 2, 'time': 3, 'isobaricInhPa': 2, 'latitude': 3,
                     'longitude': 4}
         with open_example_dataset('example.grib', engine='cfgrib') as ds:
             assert ds.dims == expected
@@ -2476,7 +2476,7 @@ class TestCfGrib(object):
 
     def test_read_filter_by_keys(self):
         kwargs = {'filter_by_keys': {'shortName': 't'}}
-        expected = {'number': 2, 'time': 3, 'air_pressure': 2, 'latitude': 3,
+        expected = {'number': 2, 'time': 3, 'isobaricInhPa': 2, 'latitude': 3,
                     'longitude': 4}
         with open_example_dataset('example.grib', engine='cfgrib',
                                   backend_kwargs=kwargs) as ds:


### PR DESCRIPTION
Fix `TestCfGrib` broken by a user-visible backward-incompatible change in *cfgrib>=0.9.2*.

No other user visible coordinate name change is expected so the test can remain like it is.

Sorry for the inconvenience!

 - [x] Noted in the discussion of #2500
 - [x] Tests added
 - ~~Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API~~
