### PR TITLE
Remove .T as shortcut for transpose()

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,6 +33,9 @@ v0.11.0 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- ``.T`` has been removed as a shortcut for :py:meth:`transpose()`.
+  Call :py:meth:`Dataset.transpose()` or :py:meth:`DataArray.transpose()` instead.
+
 - Xarray's storage backends now automatically open and close files when
   necessary, rather than requiring opening a file with ``autoclose=True``. A
   global least-recently-used cache is used to store open files; the default

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,7 +34,7 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 - ``Dataset.T`` has been removed as a shortcut for :py:meth:`Dataset.transpose`.
-  Call :py:meth:`Dataset.transpose()` instead.
+  Call :py:meth:`Dataset.transpose` directly instead.
 - Iterating over a ``Dataset`` now includes only data variables, not coordinates.
   Similarily, calling ``len`` and ``bool`` on a ``Dataset`` now  
   includes only data variables

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,8 +33,8 @@ v0.11.0 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-- ``.T`` has been removed as a shortcut for :py:meth:`transpose()`.
-  Call :py:meth:`Dataset.transpose()` or :py:meth:`DataArray.transpose()` instead.
+- ``Dataset.T`` has been removed as a shortcut for :py:meth:`transpose()`.
+  Call :py:meth:`Dataset.transpose()` instead.
 
 - Xarray's storage backends now automatically open and close files when
   necessary, rather than requiring opening a file with ``autoclose=True``. A

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,7 +33,7 @@ v0.11.0 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-- ``Dataset.T`` has been removed as a shortcut for :py:meth:`transpose()`.
+- ``Dataset.T`` has been removed as a shortcut for :py:meth:`Dataset.transpose`.
   Call :py:meth:`Dataset.transpose()` instead.
 - Iterating over a ``Dataset`` now includes only data variables, not coordinates.
   Similarily, calling ``len`` and ``bool`` on a ``Dataset`` now  

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -916,10 +916,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         return [self.data_vars, self.coords, {d: self[d] for d in self.dims},
                 LevelCoordinatesSource(self)]
 
-    def __dir__(self):
-        d = super(Dataset, self).__dir__()
-        return d
-
     def __contains__(self, key):
         """The 'in' operator will return true or false depending on whether
         'key' is an array in the dataset or not.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -917,10 +917,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
                 LevelCoordinatesSource(self)]
 
     def __dir__(self):
-        # In order to suppress a deprecation warning in Ipython autocompletion
-        # .T is explicitly removed from __dir__. GH: issue 1675
         d = super(Dataset, self).__dir__()
-        d.remove('T')
         return d
 
     def __contains__(self, key):
@@ -2665,13 +2662,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
             var_dims = tuple(dim for dim in dims if dim in var.dims)
             ds._variables[name] = var.transpose(*var_dims)
         return ds
-
-    @property
-    def T(self):
-        warnings.warn('xarray.Dataset.T has been deprecated as an alias for '
-                      '`.transpose()`. It will be removed in xarray v0.11.',
-                      FutureWarning, stacklevel=2)
-        return self.transpose()
 
     def dropna(self, dim, how='any', thresh=None, subset=None):
         """Returns a new dataset with dropped labels for missing values along

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3805,10 +3805,6 @@ class TestDataset(object):
         expected = ds.apply(lambda x: x.transpose())
         assert_identical(expected, actual)
 
-        with pytest.warns(FutureWarning):
-            actual = ds.T
-        assert_identical(expected, actual)
-
         actual = ds.transpose('x', 'y')
         expected = ds.apply(lambda x: x.transpose('x', 'y'))
         assert_identical(expected, actual)


### PR DESCRIPTION
 - [x] Closes #1232
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
