### PR TITLE
Remove Dataset.T from api-hidden.rst

### DIFF
--- a/doc/api-hidden.rst
+++ b/doc/api-hidden.rst
@@ -39,7 +39,6 @@
    Dataset.imag
    Dataset.round
    Dataset.real
-   Dataset.T
    Dataset.cumsum
    Dataset.cumprod
    Dataset.rank


### PR DESCRIPTION
Just a minor followup to #2509 to remove `Dataset.T` from the documentation.
