### PR TITLE
Switch enable_cftimeindex to True by default

### DIFF
--- a/doc/api-hidden.rst
+++ b/doc/api-hidden.rst
@@ -153,3 +153,4 @@
    plot.FacetGrid.map
 
    CFTimeIndex.shift
+   CFTimeIndex.to_datetimeindex

--- a/doc/time-series.rst
+++ b/doc/time-series.rst
@@ -325,16 +325,16 @@ For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
    - Resampling along the time dimension for data indexed by a
      :py:class:`~xarray.CFTimeIndex` (:issue:`2191`, :issue:`2458`)
    - Built-in plotting of data with :py:class:`cftime.datetime` coordinate axes
-     (:issue:`2164`).
-   
-   If at any time you would like to restore the old default behavior, which was
-   to attempt to decode datetimes into ``np.datetime64[ns]`` objects whenever
-   possible (regardless of calendar type), you can set ``enable_cftimeindex`` to
-   ``False`` within your context when opening a file (see
-   :py:func:`~xarray.set_options` for more information).  For some use-cases 
-   this behavior may still be useful (e.g. to allow the use of some forms
-   resample with non-standard calendars); however in this case one should use
-   caution to only perform operations which do not depend on differences
+     (:issue:`2164`).   
+
+   For some use-cases it may still be useful to convert from
+   :py:class:`cftime.datetime` objects to ``np.datetime64[ns]`` objects,
+   despite the difference in calendar types (e.g. to allow the use of some
+   forms resample with non-standard calendars).  The recommended way of doing
+   this is through...
+
+   However in this case one should
+   use caution to only perform operations which do not depend on differences
    between dates (e.g. differentiation, interpolation, or upsampling with
    resample), as these could introduce subtle and silent errors due to the
    difference in calendar types between the dates encoded in your data and the

--- a/doc/time-series.rst
+++ b/doc/time-series.rst
@@ -71,10 +71,11 @@ One unfortunate limitation of using ``datetime64[ns]`` is that it limits the
 native representation of dates to those that fall between the years 1678 and
 2262. When a netCDF file contains dates outside of these bounds, dates will be
 returned as arrays of :py:class:`cftime.datetime` objects and a :py:class:`~xarray.CFTimeIndex`
-can be used for indexing.  The :py:class:`~xarray.CFTimeIndex` enables only a subset of
-the indexing functionality of a :py:class:`pandas.DatetimeIndex` and is only enabled
-when using the standalone version of ``cftime`` (not the version packaged with
-earlier versions ``netCDF4``).  See :ref:`CFTimeIndex` for more information.
+will be used for indexing.  :py:class:`~xarray.CFTimeIndex` enables a subset of
+the indexing functionality of a :py:class:`pandas.DatetimeIndex` and is only
+fully compatible with the standalone version of ``cftime`` (not the version
+packaged with earlier versions ``netCDF4``).  See :ref:`CFTimeIndex` for more
+information. 
 
 Datetime indexing
 -----------------
@@ -223,16 +224,26 @@ Through the standalone ``cftime`` library and a custom subclass of
 functionality enabled through the standard :py:class:`pandas.DatetimeIndex` for
 dates from non-standard calendars or dates using a standard calendar, but
 outside the `Timestamp-valid range`_ (approximately between years 1678 and
-2262).  This behavior has not yet been turned on by default; to take advantage
-of this functionality, you must have the ``enable_cftimeindex`` option set to
-``True`` within your context (see :py:func:`~xarray.set_options` for more
-information).  It is expected that this will become the default behavior in
-xarray version 0.11.
+2262).  
 
-For instance, you can create a DataArray indexed by a time
-coordinate with a no-leap calendar within a context manager setting the
-``enable_cftimeindex`` option, and the time index will be cast to a
-:py:class:`~xarray.CFTimeIndex`:
+.. note::
+
+   As of xarray version 0.11, by default, :py:class:`cftime.datetime` objects
+   will be used to represent times (either in indexes, as a
+   :py:class:`~xarray.CFTimeIndex`, or in data arrays with dtype object) if 
+   any of the following are true: 
+
+   - The dates are from a non-standard calendar
+   - Any dates are outside the Timestamp-valid range.
+
+   Otherwise pandas-compatible dates from a standard calendar will be
+   represented with the ``np.datetime64[ns]`` data type, enabling the use of a
+   :py:class:`pandas.DatetimeIndex` or arrays with dtype ``np.datetime64[ns]``
+   and their full set of associated features.
+
+For example, you can create a DataArray indexed by a time
+coordinate with dates from a no-leap calendar and a
+:py:class:`~xarray.CFTimeIndex` will automatically be used:
 
 .. ipython:: python
 
@@ -241,27 +252,11 @@ coordinate with a no-leap calendar within a context manager setting the
    
    dates = [DatetimeNoLeap(year, month, 1) for year, month in
             product(range(1, 3), range(1, 13))]
-   with xr.set_options(enable_cftimeindex=True):
-       da = xr.DataArray(np.arange(24), coords=[dates], dims=['time'],
-                         name='foo')
+   da = xr.DataArray(np.arange(24), coords=[dates], dims=['time'], name='foo')
                          
-.. note::
-
-   With the ``enable_cftimeindex`` option activated, a :py:class:`~xarray.CFTimeIndex`
-   will be used for time indexing if any of the following are true:
-
-   - The dates are from a non-standard calendar
-   - Any dates are outside the Timestamp-valid range
-
-   Otherwise a :py:class:`pandas.DatetimeIndex` will be used.  In addition, if any
-   variable (not just an index variable) is encoded using a non-standard
-   calendar, its times will be decoded into :py:class:`cftime.datetime` objects,
-   regardless of whether or not they can be represented using
-   ``np.datetime64[ns]`` objects.
-
 xarray also includes a :py:func:`~xarray.cftime_range` function, which enables
-creating a :py:class:`~xarray.CFTimeIndex` with regularly-spaced dates.  For instance, we can
-create the same dates and DataArray we created above using:
+creating a :py:class:`~xarray.CFTimeIndex` with regularly-spaced dates.  For
+instance, we can create the same dates and DataArray we created above using:
 
 .. ipython:: python
 
@@ -317,13 +312,32 @@ For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
 
 .. ipython:: python
 
-   da.to_netcdf('example.nc')
-   xr.open_dataset('example.nc')
+   da.to_netcdf('example-no-leap.nc')
+   xr.open_dataset('example-no-leap.nc')
 
 .. note::
    
-   Currently resampling along the time dimension for data indexed by a
-   :py:class:`~xarray.CFTimeIndex` is not supported.
+   While much of the time series functionality that is possible for standard
+   dates has been implemented for dates from non-standard calendars, there are
+   still some remaining important features that have yet to be implemented,
+   for example:
+
+   - Resampling along the time dimension for data indexed by a
+     :py:class:`~xarray.CFTimeIndex`
+   - Built-in plotting of data with :py:class:`cftime.datetime` coordinate axes.
+   
+   If at any time you would like to restore the old default behavior, which was
+   to attempt to decode datetimes into ``np.datetime64[ns]`` objects whenever
+   possible (regardless of calendar type), you can set ``enable_cftimeindex`` to
+   ``False`` within your context when opening a file (see
+   :py:func:`~xarray.set_options` for more information).  For some use-cases 
+   this behavior may still be useful (e.g. to allow the use of some forms
+   resample with non-standard calendars); however in this case one should use
+   caution to only perform operations which do not depend on differences
+   between dates (e.g. differentiation, interpolation, or upsampling with
+   resample), as these could introduce subtle and silent errors due to the
+   difference in calendar types between the dates encoded in your data and the
+   dates stored in memory.  
   
 .. _Timestamp-valid range: https://pandas.pydata.org/pandas-docs/stable/timeseries.html#timestamp-limitations
 .. _ISO 8601-format: https://en.wikipedia.org/wiki/ISO_8601

--- a/doc/time-series.rst
+++ b/doc/time-series.rst
@@ -328,11 +328,21 @@ For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
      (:issue:`2164`).   
 
    For some use-cases it may still be useful to convert from
-   :py:class:`cftime.datetime` objects to ``np.datetime64[ns]`` objects,
+   a :py:class:`~xarray.CFTimeIndex` to a :py:class:`pandas.DatetimeIndex`,
    despite the difference in calendar types (e.g. to allow the use of some
    forms resample with non-standard calendars).  The recommended way of doing
-   this is through...
+   this is to use the built-in :py:meth:`~xarray.CFTimeIndex.to_datetimeindex`
+   method:
 
+   .. ipython:: python
+
+       modern_times = xr.cftime_range('2000', periods=24, freq='MS', calendar='noleap')
+       da = xr.DataArray(range(24), [('time', modern_times)])
+       da
+       datetimeindex = da.indexes['time'].to_datetimeindex()
+       da['time'] = datetimeindex
+       da.resample(time='Y').mean('time')
+   
    However in this case one should
    use caution to only perform operations which do not depend on differences
    between dates (e.g. differentiation, interpolation, or upsampling with

--- a/doc/time-series.rst
+++ b/doc/time-series.rst
@@ -323,8 +323,9 @@ For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
    for example:
 
    - Resampling along the time dimension for data indexed by a
-     :py:class:`~xarray.CFTimeIndex`
-   - Built-in plotting of data with :py:class:`cftime.datetime` coordinate axes.
+     :py:class:`~xarray.CFTimeIndex` (:issue:`2191`, :issue:`2458`)
+   - Built-in plotting of data with :py:class:`cftime.datetime` coordinate axes
+     (:issue:`2164`).
    
    If at any time you would like to restore the old default behavior, which was
    to attempt to decode datetimes into ``np.datetime64[ns]`` objects whenever

--- a/doc/time-series.rst
+++ b/doc/time-series.rst
@@ -222,9 +222,9 @@ Non-standard calendars and dates outside the Timestamp-valid range
 Through the standalone ``cftime`` library and a custom subclass of
 :py:class:`pandas.Index`, xarray supports a subset of the indexing
 functionality enabled through the standard :py:class:`pandas.DatetimeIndex` for
-dates from non-standard calendars or dates using a standard calendar, but
-outside the `Timestamp-valid range`_ (approximately between years 1678 and
-2262).  
+dates from non-standard calendars commonly used in climate science or dates
+using a standard calendar, but outside the `Timestamp-valid range`_
+(approximately between years 1678 and 2262).  
 
 .. note::
 

--- a/doc/time-series.rst
+++ b/doc/time-series.rst
@@ -330,9 +330,9 @@ For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
    For some use-cases it may still be useful to convert from
    a :py:class:`~xarray.CFTimeIndex` to a :py:class:`pandas.DatetimeIndex`,
    despite the difference in calendar types (e.g. to allow the use of some
-   forms resample with non-standard calendars).  The recommended way of doing
-   this is to use the built-in :py:meth:`~xarray.CFTimeIndex.to_datetimeindex`
-   method:
+   forms of resample with non-standard calendars).  The recommended way of
+   doing this is to use the built-in
+   :py:meth:`~xarray.CFTimeIndex.to_datetimeindex` method:
 
    .. ipython:: python
 

--- a/doc/time-series.rst
+++ b/doc/time-series.rst
@@ -343,12 +343,11 @@ For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
        da['time'] = datetimeindex
        da.resample(time='Y').mean('time')
    
-   However in this case one should
-   use caution to only perform operations which do not depend on differences
-   between dates (e.g. differentiation, interpolation, or upsampling with
-   resample), as these could introduce subtle and silent errors due to the
-   difference in calendar types between the dates encoded in your data and the
-   dates stored in memory.  
+   However in this case one should use caution to only perform operations which
+   do not depend on differences between dates (e.g. differentiation,
+   interpolation, or upsampling with resample), as these could introduce subtle
+   and silent errors due to the difference in calendar types between the dates
+   encoded in your data and the dates stored in memory.  
   
 .. _Timestamp-valid range: https://pandas.pydata.org/pandas-docs/stable/timeseries.html#timestamp-limitations
 .. _ISO 8601-format: https://en.wikipedia.org/wiki/ISO_8601

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,6 +33,12 @@ v0.11.0 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- The option ``enable_cftimeindex`` has now been set to ``True`` by default.
+  This means that by default any dates encoded using a non-standard calendar
+  will be decoded into objects of type :py:class:`cftime.datetime`, regardless
+  of whether or not it might be possible to coerce them into
+  ``np.datetime64[ns]`` objects.  One can explicitly set the option to
+  ``False`` to restore the old behavior.
 - ``Dataset.T`` has been removed as a shortcut for :py:meth:`Dataset.transpose`.
   Call :py:meth:`Dataset.transpose` directly instead.
 - Iterating over a ``Dataset`` now includes only data variables, not coordinates.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,11 +36,14 @@ Breaking changes
 - For non-standard calendars commonly used in climate science, xarray will now
   always use :py:class:`cftime.datetime` objects, rather than by default try to
   coerce them to ``np.datetime64[ns]`` objects.  A
-  :py:class:`~xarray.CFTimeIndex` will be used for indexing in these cases.
-  New public methods for converting :py:class:`cftime.datetime` dates to
-  ``np.datetime64[ns]`` objects have been added for use-cases where standard
-  datetimes are currently required.  Setting the ``enable_cftimeindex`` option
-  is now a no-op and emits a FutureWarning.
+  :py:class:`~xarray.CFTimeIndex` will be used for indexing along time
+  coordinates in these cases. A new method,
+  :py:meth:`~xarray.CFTimeIndex.to_datetimeindex`, has been added 
+  to aid in converting from a  :py:class:`~xarray.CFTimeIndex` to a
+  :py:class:`pandas.DatetimeIndex` for the remaining use-cases where
+  using a :py:class:`~xarray.CFTimeIndex` is still a limitation (e.g. for
+  resample or plotting).  Setting the ``enable_cftimeindex`` option is now a
+  no-op and emits a ``FutureWarning``. 
 - ``Dataset.T`` has been removed as a shortcut for :py:meth:`Dataset.transpose`.
   Call :py:meth:`Dataset.transpose` directly instead.
 - Iterating over a ``Dataset`` now includes only data variables, not coordinates.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,12 +33,14 @@ v0.11.0 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-- The option ``enable_cftimeindex`` has now been set to ``True`` by default.
-  This means that by default any dates encoded using a non-standard calendar
-  will be decoded into objects of type :py:class:`cftime.datetime`, regardless
-  of whether or not it might be possible to coerce them into
-  ``np.datetime64[ns]`` objects.  One can explicitly set the option to
-  ``False`` to restore the old behavior.
+- For non-standard calendars commonly used in climate science, xarray will now
+  always use :py:class:`cftime.datetime` objects, rather than by default try to
+  coerce them to ``np.datetime64[ns]`` objects.  A
+  :py:class:`~xarray.CFTimeIndex` will be used for indexing in these cases.
+  New public methods for converting :py:class:`cftime.datetime` dates to
+  ``np.datetime64[ns]`` objects have been added for use-cases where standard
+  datetimes are currently required.  Setting the ``enable_cftimeindex`` option
+  is now a no-op and emits a FutureWarning.
 - ``Dataset.T`` has been removed as a shortcut for :py:meth:`Dataset.transpose`.
   Call :py:meth:`Dataset.transpose` directly instead.
 - Iterating over a ``Dataset`` now includes only data variables, not coordinates.

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -384,8 +384,14 @@ class CFTimeIndex(pd.Index):
         # pandas.  No longer used as of pandas 0.23.
         return self + deltas
 
-    def to_datetimeindex(self):
+    def to_datetimeindex(self, unsafe=False):
         """If possible, convert this index to a pandas.DatetimeIndex.
+
+        Parameters
+        ----------
+        unsafe : bool
+            Flag to turn off warning when converting from a CFTimeIndex with
+            a non-standard calendar to a DatetimeIndex (default ``False``).
 
         Returns
         -------
@@ -419,7 +425,7 @@ class CFTimeIndex(pd.Index):
         """  # noqa: E501
         nptimes = cftime_to_nptime(self)
         calendar = infer_calendar_name(self)
-        if calendar not in _STANDARD_CALENDARS:
+        if calendar not in _STANDARD_CALENDARS and not unsafe:
             warnings.warn(
                 'Converting a CFTimeIndex with dates from a non-standard '
                 'calendar, {!r}, to a pandas.DatetimeIndex, which uses dates '

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -42,6 +42,7 @@
 from __future__ import absolute_import
 
 import re
+import warnings
 from datetime import timedelta
 
 import numpy as np
@@ -49,6 +50,8 @@ import pandas as pd
 
 from xarray.core import pycompat
 from xarray.core.utils import is_scalar
+
+from .times import cftime_to_nptime, infer_calendar_name, _STANDARD_CALENDARS
 
 
 def named(name, pattern):
@@ -380,6 +383,50 @@ class CFTimeIndex(pd.Index):
         # To support TimedeltaIndex + CFTimeIndex with older versions of
         # pandas.  No longer used as of pandas 0.23.
         return self + deltas
+
+    def to_datetimeindex(self):
+        """If possible, convert this index to a pandas.DatetimeIndex.
+
+        Returns
+        -------
+        pandas.DatetimeIndex
+
+        Raises
+        ------
+        ValueError
+            If the CFTimeIndex contains dates that are not possible in the
+            standard calendar or outside the pandas.Timestamp-valid range.
+
+        Warns
+        -----
+        RuntimeWarning
+            If converting from a non-standard calendar to a DatetimeIndex.
+
+        Warnings
+        --------
+        Note that for non-standard calendars, this will change the calendar
+        type of the index.  In that case the result of this method should be
+        used with caution.
+
+        Examples
+        --------
+        >>> import xarray as xr
+        >>> times = xr.cftime_range('2000', periods=2, calendar='gregorian')
+        >>> times
+        CFTimeIndex([2000-01-01 00:00:00, 2000-01-02 00:00:00], dtype='object')
+        >>> times.to_datetimeindex()
+        DatetimeIndex(['2000-01-01', '2000-01-02'], dtype='datetime64[ns]', freq=None)
+        """  # noqa: E501
+        nptimes = cftime_to_nptime(self)
+        calendar = infer_calendar_name(self)
+        if calendar not in _STANDARD_CALENDARS:
+            warnings.warn(
+                'Converting a CFTimeIndex with dates from a non-standard '
+                'calendar, {!r}, to a pandas.DatetimeIndex, which uses dates '
+                'from the standard calendar.  This may lead to subtle errors '
+                'in operations that depend on the length of time between '
+                'dates.'.format(calendar), RuntimeWarning)
+        return pd.DatetimeIndex(nptimes)
 
 
 def _parse_iso8601_without_reso(date_type, datetime_str):

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -285,7 +285,7 @@ def cftime_to_nptime(times):
             # 1678 to 2262 (this is not currently the case for
             # datetime.datetime).
             dt = pd.Timestamp(t.year, t.month, t.day, t.hour, t.minute,
-                              t.second)
+                              t.second, t.microsecond)
         except ValueError as e:
             raise ValueError('Cannot convert date {} to a date in the '
                              'standard calendar.  Reason: {}.'.format(t, e))

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -280,6 +280,10 @@ def cftime_to_nptime(times):
     new = np.empty(times.shape, dtype='M8[ns]')
     for i, t in np.ndenumerate(times):
         try:
+            # Use pandas.Timestamp in place of datetime.datetime, because
+            # NumPy casts it safely it np.datetime64[ns] for dates outside
+            # 1678 to 2262 (this is not currently the case for
+            # datetime.datetime).
             dt = pd.Timestamp(t.year, t.month, t.day, t.hour, t.minute,
                               t.second)
         except ValueError as e:

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -279,7 +279,12 @@ def cftime_to_nptime(times):
     times = np.asarray(times)
     new = np.empty(times.shape, dtype='M8[ns]')
     for i, t in np.ndenumerate(times):
-        dt = datetime(t.year, t.month, t.day, t.hour, t.minute, t.second)
+        try:
+            dt = pd.Timestamp(t.year, t.month, t.day, t.hour, t.minute,
+                              t.second)
+        except ValueError as e:
+            raise ValueError('Cannot convert date {} to a date in the '
+                             'standard calendar.  Reason: {}.'.format(t, e))
         new[i] = np.datetime64(dt)
     return new
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -12,7 +12,6 @@ import pandas as pd
 from ..core import indexing
 from ..core.common import contains_cftime_datetimes
 from ..core.formatting import first_n_items, format_timestamp, last_item
-from ..core.options import OPTIONS
 from ..core.pycompat import PY3
 from ..core.variable import Variable
 from .variables import (
@@ -61,8 +60,9 @@ def _require_standalone_cftime():
     try:
         import cftime  # noqa: F401
     except ImportError:
-        raise ImportError('Using a CFTimeIndex requires the standalone '
-                          'version of the cftime library.')
+        raise ImportError('Decoding times with non-standard calendars '
+                          'or outside the pandas.Timestamp-valid range '
+                          'requires the standalone cftime package.')
 
 
 def _netcdf_to_numpy_timeunit(units):
@@ -84,41 +84,32 @@ def _unpack_netcdf_time_units(units):
     return delta_units, ref_date
 
 
-def _decode_datetime_with_cftime(num_dates, units, calendar,
-                                 enable_cftimeindex):
+def _decode_datetime_with_cftime(num_dates, units, calendar):
     cftime = _import_cftime()
-    if enable_cftimeindex:
-        _require_standalone_cftime()
+
+    if cftime.__name__ == 'cftime':
         dates = np.asarray(cftime.num2date(num_dates, units, calendar,
                                            only_use_cftime_datetimes=True))
     else:
+        # Must be using num2date from an old version of netCDF4 which
+        # does not have the only_use_cftime_datetimes option.
         dates = np.asarray(cftime.num2date(num_dates, units, calendar))
 
     if (dates[np.nanargmin(num_dates)].year < 1678 or
             dates[np.nanargmax(num_dates)].year >= 2262):
-        if not enable_cftimeindex or calendar in _STANDARD_CALENDARS:
+        if calendar in _STANDARD_CALENDARS:
             warnings.warn(
                 'Unable to decode time axis into full '
                 'numpy.datetime64 objects, continuing using dummy '
                 'cftime.datetime objects instead, reason: dates out '
                 'of range', SerializationWarning, stacklevel=3)
     else:
-        if enable_cftimeindex:
-            if calendar in _STANDARD_CALENDARS:
-                dates = cftime_to_nptime(dates)
-        else:
-            try:
-                dates = cftime_to_nptime(dates)
-            except ValueError as e:
-                warnings.warn(
-                    'Unable to decode time axis into full '
-                    'numpy.datetime64 objects, continuing using '
-                    'dummy cftime.datetime objects instead, reason:'
-                    '{0}'.format(e), SerializationWarning, stacklevel=3)
+        if calendar in _STANDARD_CALENDARS:
+            dates = cftime_to_nptime(dates)
     return dates
 
 
-def _decode_cf_datetime_dtype(data, units, calendar, enable_cftimeindex):
+def _decode_cf_datetime_dtype(data, units, calendar):
     # Verify that at least the first and last date can be decoded
     # successfully. Otherwise, tracebacks end up swallowed by
     # Dataset.__repr__ when users try to view their lazily decoded array.
@@ -128,8 +119,7 @@ def _decode_cf_datetime_dtype(data, units, calendar, enable_cftimeindex):
                                     last_item(values) or [0]])
 
     try:
-        result = decode_cf_datetime(example_value, units, calendar,
-                                    enable_cftimeindex)
+        result = decode_cf_datetime(example_value, units, calendar)
     except Exception:
         calendar_msg = ('the default calendar' if calendar is None
                         else 'calendar %r' % calendar)
@@ -145,8 +135,7 @@ def _decode_cf_datetime_dtype(data, units, calendar, enable_cftimeindex):
     return dtype
 
 
-def decode_cf_datetime(num_dates, units, calendar=None,
-                       enable_cftimeindex=False):
+def decode_cf_datetime(num_dates, units, calendar=None):
     """Given an array of numeric dates in netCDF format, convert it into a
     numpy array of date time objects.
 
@@ -200,8 +189,7 @@ def decode_cf_datetime(num_dates, units, calendar=None,
 
     except (OutOfBoundsDatetime, OverflowError):
         dates = _decode_datetime_with_cftime(
-            flat_num_dates.astype(np.float), units, calendar,
-            enable_cftimeindex)
+            flat_num_dates.astype(np.float), units, calendar)
 
     return dates.reshape(num_dates.shape)
 
@@ -399,15 +387,12 @@ class CFDatetimeCoder(VariableCoder):
     def decode(self, variable, name=None):
         dims, data, attrs, encoding = unpack_for_decoding(variable)
 
-        enable_cftimeindex = OPTIONS['enable_cftimeindex']
         if 'units' in attrs and 'since' in attrs['units']:
             units = pop_to(attrs, encoding, 'units')
             calendar = pop_to(attrs, encoding, 'calendar')
-            dtype = _decode_cf_datetime_dtype(
-                data, units, calendar, enable_cftimeindex)
+            dtype = _decode_cf_datetime_dtype(data, units, calendar)
             transform = partial(
-                decode_cf_datetime, units=units, calendar=calendar,
-                enable_cftimeindex=enable_cftimeindex)
+                decode_cf_datetime, units=units, calendar=calendar)
             data = lazy_elemwise_func(data, transform, dtype)
 
         return Variable(dims, data, attrs, encoding)

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -686,7 +686,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
                             "was passed %r" % dim)
 
         if isinstance(self.indexes[dim_name], CFTimeIndex):
-            raise TypeError(
+            raise NotImplementedError(
                 'Resample is currently not supported along a dimension '
                 'indexed by a CFTimeIndex.  For certain kinds of downsampling '
                 'it may be possible to work around this by converting your '
@@ -723,7 +723,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
                       FutureWarning, stacklevel=3)
 
         if isinstance(self.indexes[dim], CFTimeIndex):
-            raise TypeError(
+            raise NotImplementedError(
                 'Resample is currently not supported along a dimension '
                 'indexed by a CFTimeIndex.  For certain kinds of downsampling '
                 'it may be possible to work around this by converting your '

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -658,6 +658,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         from .dataarray import DataArray
         from .resample import RESAMPLE_DIM
+        from ..coding.cftimeindex import CFTimeIndex
 
         if dim is not None:
             if how is None:
@@ -676,13 +677,27 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
                 "Resampling only supported along single dimensions."
             )
         dim, freq = indexer.popitem()
-
+        
         if isinstance(dim, basestring):
             dim_name = dim
             dim = self[dim]
         else:
             raise TypeError("Dimension name should be a string; "
                             "was passed %r" % dim)
+
+        if isinstance(self.indexes[dim_name], CFTimeIndex):
+            raise TypeError(
+                'Resample is currently not supported along a dimension '
+                'indexed by a CFTimeIndex.  For certain kinds of downsampling '
+                'it may be possible to work around this by converting your '
+                'time index to a DatetimeIndex using '
+                'CFTimeIndex.to_datetimeindex.  Use caution when doing this '
+                'however, because switching to a DatetimeIndex from a '
+                'CFTimeIndex with a non-standard calendar entails a change '
+                'in the calendar type, which could lead to subtle and silent '
+                'errors.'
+            )
+
         group = DataArray(dim, [(dim.dims, dim)], name=RESAMPLE_DIM)
         grouper = pd.Grouper(freq=freq, closed=closed, label=label, base=base)
         resampler = self._resample_cls(self, group=group, dim=dim_name,
@@ -696,6 +711,8 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         """Implement the original version of .resample() which immediately
         executes the desired resampling operation. """
         from .dataarray import DataArray
+        from ..coding.cftimeindex import CFTimeIndex
+
         RESAMPLE_DIM = '__resample_dim__'
 
         warnings.warn("\n.resample() has been modified to defer "
@@ -705,8 +722,22 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
                       dim=dim, freq=freq, how=how),
                       FutureWarning, stacklevel=3)
 
+        if isinstance(self.indexes[dim], CFTimeIndex):
+            raise TypeError(
+                'Resample is currently not supported along a dimension '
+                'indexed by a CFTimeIndex.  For certain kinds of downsampling '
+                'it may be possible to work around this by converting your '
+                'time index to a DatetimeIndex using '
+                'CFTimeIndex.to_datetimeindex.  Use caution when doing this '
+                'however, because switching to a DatetimeIndex from a '
+                'CFTimeIndex with a non-standard calendar entails a change '
+                'in the calendar type, which could lead to subtle and silent '
+                'errors.'
+            )
+        
         if isinstance(dim, basestring):
             dim = self[dim]
+
         group = DataArray(dim, [(dim.dims, dim)], name=RESAMPLE_DIM)
         grouper = pd.Grouper(freq=freq, how=how, closed=closed, label=label,
                              base=base)

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -677,7 +677,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
                 "Resampling only supported along single dimensions."
             )
         dim, freq = indexer.popitem()
-        
+
         if isinstance(dim, basestring):
             dim_name = dim
             dim = self[dim]
@@ -734,7 +734,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
                 'in the calendar type, which could lead to subtle and silent '
                 'errors.'
             )
-        
+
         if isinstance(dim, basestring):
             dim = self[dim]
 

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -38,8 +38,16 @@ def _set_file_cache_maxsize(value):
     FILE_CACHE.maxsize = value
 
 
+def _warn_on_setting_enable_cftimeindex(enable_cftimeindex):
+    warnings.warn(
+        'The enable_cftimeindex option is now a no-op '
+        'and will be removed in a future version of xarray.',
+        FutureWarning)
+
+
 _SETTERS = {
     FILE_CACHE_MAXSIZE: _set_file_cache_maxsize,
+    ENABLE_CFTIMEINDEX: _warn_on_setting_enable_cftimeindex
 }
 
 
@@ -52,9 +60,6 @@ class set_options(object):
       Default: ``80``.
     - ``arithmetic_join``: DataArray/Dataset alignment in binary operations.
       Default: ``'inner'``.
-    - ``enable_cftimeindex``: flag to enable using a ``CFTimeIndex``
-      for time indexes with non-standard calendars or dates outside the
-      Timestamp-valid range. Default: ``True``.
     - ``file_cache_maxsize``: maximum number of open files to hold in xarray's
       global least-recently-usage cached. This should be smaller than your
       system's per-process file descriptor limit, e.g., ``ulimit -n`` on Linux.
@@ -85,11 +90,6 @@ f    You can use ``set_options`` either as a context manager:
 
     def __init__(self, **kwargs):
         self.old = OPTIONS.copy()
-        if ENABLE_CFTIMEINDEX in kwargs:
-            warnings.warn(
-                'The enable_cftimeindex option is now a no-op '
-                'and will be removed in a future version of xarray.',
-                FutureWarning)
         for k, v in kwargs.items():
             if k not in OPTIONS:
                 raise ValueError(

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -10,7 +10,7 @@ CMAP_DIVERGENT = 'cmap_divergent'
 OPTIONS = {
     DISPLAY_WIDTH: 80,
     ARITHMETIC_JOIN: 'inner',
-    ENABLE_CFTIMEINDEX: False,
+    ENABLE_CFTIMEINDEX: True,
     FILE_CACHE_MAXSIZE: 128,
     CMAP_SEQUENTIAL: 'viridis',
     CMAP_DIVERGENT: 'RdBu_r',
@@ -52,7 +52,7 @@ class set_options(object):
       Default: ``'inner'``.
     - ``enable_cftimeindex``: flag to enable using a ``CFTimeIndex``
       for time indexes with non-standard calendars or dates outside the
-      Timestamp-valid range. Default: ``False``.
+      Timestamp-valid range. Default: ``True``.
     - ``file_cache_maxsize``: maximum number of open files to hold in xarray's
       global least-recently-usage cached. This should be smaller than your
       system's per-process file descriptor limit, e.g., ``ulimit -n`` on Linux.

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import warnings
+
 DISPLAY_WIDTH = 'display_width'
 ARITHMETIC_JOIN = 'arithmetic_join'
 ENABLE_CFTIMEINDEX = 'enable_cftimeindex'
@@ -83,6 +85,11 @@ f    You can use ``set_options`` either as a context manager:
 
     def __init__(self, **kwargs):
         self.old = OPTIONS.copy()
+        if ENABLE_CFTIMEINDEX in kwargs:
+            warnings.warn(
+                'The enable_cftimeindex option is now a no-op '
+                'and will be removed in a future version of xarray.',
+                FutureWarning)
         for k, v in kwargs.items():
             if k not in OPTIONS:
                 raise ValueError(

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -109,7 +109,7 @@ class set_options(object):
     """
 
     def __init__(self, **kwargs):
-        self.old = OPTIONS.copy()
+        self.old = {}
         for k, v in kwargs.items():
             if k not in OPTIONS:
                 raise ValueError(
@@ -118,6 +118,7 @@ class set_options(object):
             if k in _VALIDATORS and not _VALIDATORS[k](v):
                 raise ValueError(
                     'option %r given an invalid value: %r' % (k, v))
+            self.old[k] = OPTIONS[k]
         self._apply_update(kwargs)
 
     def _apply_update(self, options_dict):
@@ -130,5 +131,4 @@ class set_options(object):
         return
 
     def __exit__(self, type, value, traceback):
-        OPTIONS.clear()
         self._apply_update(self.old)

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -13,7 +13,6 @@ from collections import Iterable, Mapping, MutableMapping, MutableSet
 import numpy as np
 import pandas as pd
 
-from .options import OPTIONS
 from .pycompat import (
     OrderedDict, basestring, bytes_type, dask_array_type, iteritems)
 
@@ -41,16 +40,13 @@ def alias(obj, old_name):
 def _maybe_cast_to_cftimeindex(index):
     from ..coding.cftimeindex import CFTimeIndex
 
-    if not OPTIONS['enable_cftimeindex']:
-        return index
-    else:
-        if index.dtype == 'O':
-            try:
-                return CFTimeIndex(index)
-            except (ImportError, TypeError):
-                return index
-        else:
+    if index.dtype == 'O':
+        try:
+            return CFTimeIndex(index)
+        except (ImportError, TypeError):
             return index
+    else:
+        return index
 
 
 def safe_cast_to_index(array):

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -145,8 +145,13 @@ def plot(darray, row=None, col=None, col_wrap=None, ax=None, hue=None,
     darray = darray.squeeze()
 
     if contains_cftime_datetimes(darray):
-        raise NotImplementedError('Plotting arrays of cftime.datetime objects '
-                                  'is currently not possible.')
+        raise NotImplementedError(
+            'Built-in plotting of arrays of cftime.datetime objects or arrays '
+            'indexed by cftime.datetime objects is currently not implemented '
+            'within xarray. A possible workaround is to use the '
+            'nc-time-axis package '
+            '(https://github.com/SciTools/nc-time-axis) to convert the dates '
+            'to a plottable type and plot your data directly with matplotlib.')
 
     plot_dims = set(darray.dims)
     plot_dims.discard(row)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -356,7 +356,7 @@ class DatasetIOBase(object):
             assert actual.t0.encoding['units'] == 'days since 1950-01-01'
 
     @requires_cftime
-    def test_roundtrip_cftime_datetime_data_enable_cftimeindex(self):
+    def test_roundtrip_cftime_datetime_data(self):
         from .test_coding_times import _all_cftime_date_types
 
         date_types = _all_cftime_date_types()
@@ -373,21 +373,20 @@ class DatasetIOBase(object):
                     warnings.filterwarnings(
                         'ignore', 'Unable to decode time axis')
 
-                with xr.set_options(enable_cftimeindex=True):
-                    with self.roundtrip(expected, save_kwargs=kwds) as actual:
-                        abs_diff = abs(actual.t.values - expected_decoded_t)
-                        assert (abs_diff <= np.timedelta64(1, 's')).all()
-                        assert (actual.t.encoding['units'] ==
-                                'days since 0001-01-01 00:00:00.000000')
-                        assert (actual.t.encoding['calendar'] ==
-                                expected_calendar)
+                with self.roundtrip(expected, save_kwargs=kwds) as actual:
+                    abs_diff = abs(actual.t.values - expected_decoded_t)
+                    assert (abs_diff <= np.timedelta64(1, 's')).all()
+                    assert (actual.t.encoding['units'] ==
+                            'days since 0001-01-01 00:00:00.000000')
+                    assert (actual.t.encoding['calendar'] ==
+                            expected_calendar)
 
-                        abs_diff = abs(actual.t0.values - expected_decoded_t0)
-                        assert (abs_diff <= np.timedelta64(1, 's')).all()
-                        assert (actual.t0.encoding['units'] ==
-                                'days since 0001-01-01')
-                        assert (actual.t.encoding['calendar'] ==
-                                expected_calendar)
+                    abs_diff = abs(actual.t0.values - expected_decoded_t0)
+                    assert (abs_diff <= np.timedelta64(1, 's')).all()
+                    assert (actual.t0.encoding['units'] ==
+                            'days since 0001-01-01')
+                    assert (actual.t.encoding['calendar'] ==
+                            expected_calendar)
 
     def test_roundtrip_timedelta_data(self):
         time_deltas = pd.to_timedelta(['1h', '2h', 'NaT'])
@@ -2087,7 +2086,7 @@ class TestDask(DatasetIOBase):
         with self.roundtrip(expected) as actual:
             assert_identical(expected, actual)
 
-    def test_roundtrip_cftime_datetime_data_enable_cftimeindex(self):
+    def test_roundtrip_cftime_datetime_data(self):
         # Override method in DatasetIOBase - remove not applicable
         # save_kwds
         from .test_coding_times import _all_cftime_date_types
@@ -2099,33 +2098,12 @@ class TestDask(DatasetIOBase):
             expected_decoded_t = np.array(times)
             expected_decoded_t0 = np.array([date_type(1, 1, 1)])
 
-            with xr.set_options(enable_cftimeindex=True):
-                with self.roundtrip(expected) as actual:
-                    abs_diff = abs(actual.t.values - expected_decoded_t)
-                    assert (abs_diff <= np.timedelta64(1, 's')).all()
+            with self.roundtrip(expected) as actual:
+                abs_diff = abs(actual.t.values - expected_decoded_t)
+                assert (abs_diff <= np.timedelta64(1, 's')).all()
 
-                    abs_diff = abs(actual.t0.values - expected_decoded_t0)
-                    assert (abs_diff <= np.timedelta64(1, 's')).all()
-
-    def test_roundtrip_cftime_datetime_data_disable_cftimeindex(self):
-        # Override method in DatasetIOBase - remove not applicable
-        # save_kwds
-        from .test_coding_times import _all_cftime_date_types
-
-        date_types = _all_cftime_date_types()
-        for date_type in date_types.values():
-            times = [date_type(1, 1, 1), date_type(1, 1, 2)]
-            expected = Dataset({'t': ('t', times), 't0': times[0]})
-            expected_decoded_t = np.array(times)
-            expected_decoded_t0 = np.array([date_type(1, 1, 1)])
-
-            with xr.set_options(enable_cftimeindex=False):
-                with self.roundtrip(expected) as actual:
-                    abs_diff = abs(actual.t.values - expected_decoded_t)
-                    assert (abs_diff <= np.timedelta64(1, 's')).all()
-
-                    abs_diff = abs(actual.t0.values - expected_decoded_t0)
-                    assert (abs_diff <= np.timedelta64(1, 's')).all()
+                abs_diff = abs(actual.t0.values - expected_decoded_t0)
+                assert (abs_diff <= np.timedelta64(1, 's')).all()
 
     def test_write_store(self):
         # Override method in DatasetIOBase - not applicable to dask

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -361,7 +361,7 @@ def test_groupby(da):
 
 @pytest.mark.skipif(not has_cftime, reason='cftime not installed')
 def test_resample_error(da):
-    with pytest.raises(TypeError):
+    with pytest.raises(NotImplementedError, match='to_datetimeindex'):
         da.resample(time='Y')
 
 
@@ -749,11 +749,12 @@ def test_parse_array_of_cftime_strings():
 
 @pytest.mark.skipif(not has_cftime, reason='cftime not installed')
 @pytest.mark.parametrize('calendar', _ALL_CALENDARS)
-def test_to_datetimeindex(calendar):
+@pytest.mark.parametrize('unsafe', [False, True])
+def test_to_datetimeindex(calendar, unsafe):
     index = xr.cftime_range('2000', periods=5, calendar=calendar)
     expected = pd.date_range('2000', periods=5)
 
-    if calendar in _NON_STANDARD_CALENDARS:
+    if calendar in _NON_STANDARD_CALENDARS and not unsafe:
         with pytest.warns(RuntimeWarning, match='non-standard'):
             result = index.to_datetimeindex()
     else:

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -594,18 +594,16 @@ def test_indexing_in_dataframe_iloc(df, index):
 
 
 @pytest.mark.skipif(not has_cftime_or_netCDF4, reason='cftime not installed')
-@pytest.mark.parametrize('enable_cftimeindex', [False, True])
-def test_concat_cftimeindex(date_type, enable_cftimeindex):
-    with xr.set_options(enable_cftimeindex=enable_cftimeindex):
-        da1 = xr.DataArray(
-            [1., 2.], coords=[[date_type(1, 1, 1), date_type(1, 2, 1)]],
-            dims=['time'])
-        da2 = xr.DataArray(
-            [3., 4.], coords=[[date_type(1, 3, 1), date_type(1, 4, 1)]],
-            dims=['time'])
-        da = xr.concat([da1, da2], dim='time')
+def test_concat_cftimeindex(date_type):
+    da1 = xr.DataArray(
+        [1., 2.], coords=[[date_type(1, 1, 1), date_type(1, 2, 1)]],
+        dims=['time'])
+    da2 = xr.DataArray(
+        [3., 4.], coords=[[date_type(1, 3, 1), date_type(1, 4, 1)]],
+        dims=['time'])
+    da = xr.concat([da1, da2], dim='time')
 
-    if enable_cftimeindex and has_cftime:
+    if has_cftime:
         assert isinstance(da.indexes['time'], CFTimeIndex)
     else:
         assert isinstance(da.indexes['time'], pd.Index)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -157,7 +157,7 @@ def test_decode_cf_datetime_non_iso_strings():
              (np.arange(100), 'hours since 2000-01-01 0:00')]
     for num_dates, units in cases:
         actual = coding.times.decode_cf_datetime(num_dates, units)
-        abs_diff = abs(actual - expected)
+        abs_diff = abs(actual - expected.values)
         # once we no longer support versions of netCDF4 older than 1.1.5,
         # we could do this check with near microsecond accuracy:
         # https://github.com/Unidata/netcdf4-python/issues/355

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -89,7 +89,11 @@ def test_cf_datetime(num_dates, units, calendar):
         actual = coding.times.decode_cf_datetime(num_dates, units,
                                                  calendar)
 
-    assert_array_equal(expected, actual)
+    abs_diff = np.atleast_1d(abs(actual - expected)).astype(np.timedelta64)
+    # once we no longer support versions of netCDF4 older than 1.1.5,
+    # we could do this check with near microsecond accuracy:
+    # https://github.com/Unidata/netcdf4-python/issues/355
+    assert (abs_diff <= np.timedelta64(1, 's')).all()
     encoded, _, _ = coding.times.encode_cf_datetime(actual, units,
                                                     calendar)
     if '1-1-1' not in units:
@@ -151,7 +155,11 @@ def test_decode_cf_datetime_non_iso_strings():
              (np.arange(100), 'hours since 2000-01-01 0:00')]
     for num_dates, units in cases:
         actual = coding.times.decode_cf_datetime(num_dates, units)
-        assert_array_equal(actual, expected)
+        abs_diff = abs(actual - expected)
+        # once we no longer support versions of netCDF4 older than 1.1.5,
+        # we could do this check with near microsecond accuracy:
+        # https://github.com/Unidata/netcdf4-python/issues/355
+        assert (abs_diff <= np.timedelta64(1, 's')).all()
 
 
 @pytest.mark.skipif(not has_cftime_or_netCDF4, reason='cftime not installed')

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -47,7 +47,8 @@ _CF_DATETIME_NUM_DATES_UNITS = [
     ([0.5, 1.5], 'hours since 1900-01-01T00:00:00'),
     (0, 'milliseconds since 2000-01-01T00:00:00'),
     (0, 'microseconds since 2000-01-01T00:00:00'),
-    (np.int32(788961600), 'seconds since 1981-01-01')  # GH2002
+    (np.int32(788961600), 'seconds since 1981-01-01'),  # GH2002
+    (12300 + np.arange(5), 'hour since 1680-01-01 00:00:00.500000')
 ]
 _CF_DATETIME_TESTS = [num_dates_units + (calendar,) for num_dates_units,
                       calendar in product(_CF_DATETIME_NUM_DATES_UNITS,

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2281,9 +2281,7 @@ class TestDataArray(object):
                                 calendar='noleap')
         array = DataArray(np.arange(12), [('time', times)])
 
-        with raises_regex(TypeError,
-                          'Only valid with DatetimeIndex, '
-                          'TimedeltaIndex or PeriodIndex'):
+        with raises_regex(TypeError, 'to_datetimeindex'):
             array.resample(time='6H').mean()
 
     def test_resample_first(self):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2281,7 +2281,7 @@ class TestDataArray(object):
                                 calendar='noleap')
         array = DataArray(np.arange(12), [('time', times)])
 
-        with raises_regex(TypeError, 'to_datetimeindex'):
+        with raises_regex(NotImplementedError, 'to_datetimeindex'):
             array.resample(time='6H').mean()
 
     def test_resample_first(self):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2279,8 +2279,7 @@ class TestDataArray(object):
         cftime = _import_cftime()
         times = cftime.num2date(np.arange(12), units='hours since 0001-01-01',
                                 calendar='noleap')
-        with set_options(enable_cftimeindex=True):
-            array = DataArray(np.arange(12), [('time', times)])
+        array = DataArray(np.arange(12), [('time', times)])
 
         with raises_regex(TypeError,
                           'Only valid with DatetimeIndex, '

--- a/xarray/tests/test_options.py
+++ b/xarray/tests/test_options.py
@@ -33,6 +33,9 @@ def test_enable_cftimeindex():
         xarray.set_options(enable_cftimeindex=None)
     with xarray.set_options(enable_cftimeindex=True):
         assert OPTIONS['enable_cftimeindex']
+    with pytest.warns(FutureWarning):
+        with xarray.set_options(enable_cftimeindex=True):
+            pass
 
 
 def test_file_cache_maxsize():

--- a/xarray/tests/test_options.py
+++ b/xarray/tests/test_options.py
@@ -31,11 +31,9 @@ def test_arithmetic_join():
 def test_enable_cftimeindex():
     with pytest.raises(ValueError):
         xarray.set_options(enable_cftimeindex=None)
-    with xarray.set_options(enable_cftimeindex=True):
-        assert OPTIONS['enable_cftimeindex']
-    with pytest.warns(FutureWarning):
+    with pytest.warns(FutureWarning, match='no-op'):
         with xarray.set_options(enable_cftimeindex=True):
-            pass
+            assert OPTIONS['enable_cftimeindex']
 
 
 def test_file_cache_maxsize():

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -46,19 +46,17 @@ def test_safe_cast_to_index():
 
 
 @pytest.mark.skipif(not has_cftime_or_netCDF4, reason='cftime not installed')
-@pytest.mark.parametrize('enable_cftimeindex', [False, True])
-def test_safe_cast_to_index_cftimeindex(enable_cftimeindex):
+def test_safe_cast_to_index_cftimeindex():
     date_types = _all_cftime_date_types()
     for date_type in date_types.values():
         dates = [date_type(1, 1, day) for day in range(1, 20)]
 
-        if enable_cftimeindex and has_cftime:
+        if has_cftime:
             expected = CFTimeIndex(dates)
         else:
             expected = pd.Index(dates)
 
-        with set_options(enable_cftimeindex=enable_cftimeindex):
-            actual = utils.safe_cast_to_index(np.array(dates))
+        actual = utils.safe_cast_to_index(np.array(dates))
         assert_array_equal(expected, actual)
         assert expected.dtype == actual.dtype
         assert isinstance(actual, type(expected))
@@ -66,13 +64,11 @@ def test_safe_cast_to_index_cftimeindex(enable_cftimeindex):
 
 # Test that datetime.datetime objects are never used in a CFTimeIndex
 @pytest.mark.skipif(not has_cftime_or_netCDF4, reason='cftime not installed')
-@pytest.mark.parametrize('enable_cftimeindex', [False, True])
-def test_safe_cast_to_index_datetime_datetime(enable_cftimeindex):
+def test_safe_cast_to_index_datetime_datetime():
     dates = [datetime(1, 1, day) for day in range(1, 20)]
 
     expected = pd.Index(dates)
-    with set_options(enable_cftimeindex=enable_cftimeindex):
-        actual = utils.safe_cast_to_index(np.array(dates))
+    actual = utils.safe_cast_to_index(np.array(dates))
     assert_array_equal(expected, actual)
     assert isinstance(actual, pd.Index)
 


### PR DESCRIPTION
As discussed in #2437 and #2505, this sets the option `enable_cftimeindex` to `True` by default.

 - [x] Fully documented, including `whats-new.rst` for all changes.
