### PR TITLE
Finish deprecation cycle for DataArray.__contains__ checking array values

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,11 +33,14 @@ v0.11.0 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-- ``Dataset.T`` has been removed as a shortcut for :py:meth:`Dataset.transpose`.
-  Call :py:meth:`Dataset.transpose` directly instead.
-- Iterating over a ``Dataset`` now includes only data variables, not coordinates.
-  Similarily, calling ``len`` and ``bool`` on a ``Dataset`` now  
-  includes only data variables
+- Finished deprecation cycles:
+  - ``Dataset.T`` has been removed as a shortcut for :py:meth:`Dataset.transpose`.
+    Call :py:meth:`Dataset.transpose` directly instead.
+  - Iterating over a ``Dataset`` now includes only data variables, not coordinates.
+    Similarily, calling ``len`` and ``bool`` on a ``Dataset`` now  
+    includes only data variables.
+  - ``DataArray.__contains__`` (used by Python's ``in`` operator) now checks
+    array data, not coordinates. 
 - Xarray's storage backends now automatically open and close files when
   necessary, rather than requiring opening a file with ``autoclose=True``. A
   global least-recently-used cache is used to store open files; the default

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -503,11 +503,7 @@ class DataArray(AbstractArray, DataWithCoords):
                 LevelCoordinatesSource(self)]
 
     def __contains__(self, key):
-        warnings.warn(
-            'xarray.DataArray.__contains__ currently checks membership in '
-            'DataArray.coords, but in xarray v0.11 will change to check '
-            'membership in array values.', FutureWarning, stacklevel=2)
-        return key in self._coords
+        return key in self.data
 
     @property
     def loc(self):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -618,9 +618,9 @@ class TestDataArray(object):
         da[dict(x=ind)] = value  # should not raise
 
     def test_contains(self):
-        data_array = DataArray(1, coords={'x': 2})
-        with pytest.warns(FutureWarning):
-            assert 'x' in data_array
+        data_array = DataArray([1, 2])
+        assert 1 in data_array
+        assert 3 not in data_array
 
     def test_attr_sources_multiindex(self):
         # make sure attr-style access for multi-index levels
@@ -2533,6 +2533,7 @@ class TestDataArray(object):
         assert_allclose(actual, expected, rtol=1e-16)
 
     @requires_dask
+    @requires_scipy
     def test_upsample_interpolate_dask(self):
         import dask.array as da
 


### PR DESCRIPTION
 - [x] Closes #1267 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
