### PR TITLE
Remove tests where results change in cftime 1.0.2.1

### DIFF
--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -576,28 +576,24 @@ def test_infer_datetime_units(dates, expected):
     assert expected == coding.times.infer_datetime_units(dates)
 
 
+_CFTIME_DATETIME_UNITS_TESTS = [
+    ([(1900, 1, 1), (1900, 1, 1)], 'days since 1900-01-01 00:00:00.000000'),
+    ([(1900, 1, 1), (1900, 1, 2), (1900, 1, 2, 0, 0, 1)],
+     'seconds since 1900-01-01 00:00:00.000000'),
+    ([(1900, 1, 1), (1900, 1, 8), (1900, 1, 16)],
+     'days since 1900-01-01 00:00:00.000000')
+]
+
+
 @pytest.mark.skipif(not has_cftime_or_netCDF4, reason='cftime not installed')
-def test_infer_cftime_datetime_units():
-    date_types = _all_cftime_date_types()
-    for date_type in date_types.values():
-        for dates, expected in [
-                ([date_type(1900, 1, 1),
-                  date_type(1900, 1, 2)],
-                 'days since 1900-01-01 00:00:00.000000'),
-                ([date_type(1900, 1, 1, 12),
-                  date_type(1900, 1, 1, 13)],
-                 'seconds since 1900-01-01 12:00:00.000000'),
-                ([date_type(1900, 1, 1),
-                  date_type(1900, 1, 2),
-                  date_type(1900, 1, 2, 0, 0, 1)],
-                 'seconds since 1900-01-01 00:00:00.000000'),
-                ([date_type(1900, 1, 1),
-                  date_type(1900, 1, 2, 0, 0, 0, 5)],
-                 'days since 1900-01-01 00:00:00.000000'),
-                ([date_type(1900, 1, 1), date_type(1900, 1, 8),
-                  date_type(1900, 1, 16)],
-                 'days since 1900-01-01 00:00:00.000000')]:
-            assert expected == coding.times.infer_datetime_units(dates)
+@pytest.mark.parametrize(
+    'calendar', _NON_STANDARD_CALENDARS + ['gregorian', 'proleptic_gregorian'])
+@pytest.mark.parametrize(('date_args', 'expected'),
+                         _CFTIME_DATETIME_UNITS_TESTS)
+def test_infer_cftime_datetime_units(calendar, date_args, expected):
+    date_type = _all_cftime_date_types()[calendar]
+    dates = [date_type(*args) for args in date_args]
+    assert expected == coding.times.infer_datetime_units(dates)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
 - [x] Closes #2521 (remove if there is no corresponding issue, which should only be the case for minor changes)

`cftime` version 1.0.2.1 (currently only installed on Windows, because it hasn't appeared on conda-forge yet) includes some changes that improve the precision of datetime arithmetic, which causes some results of `infer_datetime_units` to change.  These changes aren't really a concern, because it doesn't impact our ability to round-trip dates; it just changes the units dates are encoded with in some cases.  For that reason I've just deleted the tests where the answers change across versions.
