### PR TITLE
[WIP] Fix problem with wrong chunksizes when using rolling_window on dask.array

### DIFF
--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3497,7 +3497,7 @@ def test_rolling_wrapped_dask(da_dask, name, center, min_periods, window):
 @pytest.mark.parametrize('window', (7, 70))
 def test_rolling_wrapped_dask_chunksizes(da_dask, name, center, min_periods,
                                          window):
-    # check if chunksize is preserved GH: 2514
+    # check if chunksizes are preserved (GH: 2514)
     t = pd.date_range(start='2018-01-01', end='2018-02-01', freq='H')
     bar = np.sin(np.arange(len(t)))
     baz = np.cos(np.arange(len(t)))

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -247,6 +247,19 @@ def test_interpolate_limits():
     assert_equal(actual, expected)
 
 
+@requires_dask
+def test_interpolate_limits_chunksize():
+    # GH: 2514
+    da = xr.DataArray(np.array([1, 2, np.nan, np.nan, np.nan, 6],
+                               dtype=np.float64), dims='x').chunk({'x': 6})
+
+    actual = da.interpolate_na(dim='x', limit=None)
+    assert actual.chunks == (6,)
+
+    actual = da.interpolate_na(dim='x', limit=2)
+    assert actual.chunks == (6,)
+
+
 @requires_scipy
 def test_interpolate_methods():
     for method in ['linear', 'nearest', 'zero', 'slinear', 'quadratic',


### PR DESCRIPTION
 - [ ] Closes #2514
 - [ ] Closes #2531
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Fully documented, including `whats-new.rst` for all changes

## Short summary
The two rolling-window functions for `dask.array`
 * [dask_rolling_wrapper](https://github.com/pydata/xarray/blob/b622c5e7da928524ef949d9e389f6c7f38644494/xarray/core/dask_array_ops.py#L23)
 * [rolling_window](https://github.com/pydata/xarray/blob/b622c5e7da928524ef949d9e389f6c7f38644494/xarray/core/dask_array_ops.py#L43)

will be fixed to preserve `dask.array` chunksizes.

## Long summary

The specific initial problem with chunksizes and `interpolate_na()` in #2514 is caused by the padding done in

https://github.com/pydata/xarray/blob/5940100761478604080523ebb1291ecff90e779e/xarray/core/dask_array_ops.py#L74-L85

which adds a small array with a small chunk to the initial array.

There is another related problem where `DataArray.rolling()` changes the size and distribution of `dask.array` chunks which stems from this code

https://github.com/pydata/xarray/blob/b622c5e7da928524ef949d9e389f6c7f38644494/xarray/core/dask_array_ops.py#L23

For some (historic) reason there are these two rolling-window functions for `dask`. Both need to be fixed to preserve chunksize of a `dask.array` in all cases.
