### PR TITLE
Stop loading tutorial data by default

### DIFF
--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -411,7 +411,7 @@ can use indexing with ``.loc`` :
 
 .. ipython:: python
 
-    ds = xr.tutorial.load_dataset('air_temperature')
+    ds = xr.tutorial.open_dataset('air_temperature')
 
     #add an empty 2D dataarray
     ds['empty']= xr.full_like(ds.air.mean('time'),fill_value=0)

--- a/doc/interpolation.rst
+++ b/doc/interpolation.rst
@@ -262,7 +262,7 @@ Let's see how :py:meth:`~xarray.DataArray.interp` works on real data.
 .. ipython:: python
 
     # Raw data
-    ds = xr.tutorial.load_dataset('air_temperature').isel(time=0)
+    ds = xr.tutorial.open_dataset('air_temperature').isel(time=0)
     fig, axes = plt.subplots(ncols=2, figsize=(10, 4))
     ds.air.plot(ax=axes[0])
     axes[0].set_title('Raw data')

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -60,7 +60,7 @@ For these examples we'll use the North American air temperature dataset.
 
 .. ipython:: python
 
-    airtemps = xr.tutorial.load_dataset('air_temperature')
+    airtemps = xr.tutorial.open_dataset('air_temperature')
     airtemps
 
     # Convert to celsius
@@ -585,7 +585,7 @@ This script will plot the air temperature on a map.
 .. ipython:: python
 
     import cartopy.crs as ccrs
-    air = xr.tutorial.load_dataset('air_temperature').air
+    air = xr.tutorial.open_dataset('air_temperature').air
     ax = plt.axes(projection=ccrs.Orthographic(-80, 35))
     air.isel(time=0).plot.contourf(ax=ax, transform=ccrs.PlateCarree());
     @savefig plotting_maps_cartopy.png width=100%

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -70,6 +70,11 @@ Breaking changes
   should significantly improve performance when reading and writing
   netCDF files with Dask, especially when working with many files or using
   Dask Distributed. By `Stephan Hoyer <https://github.com/shoyer>`_
+- Tutorial data is now loaded lazily. Previous behavior of
+  :py:meth:`xarray.tutorial.load_dataset` would call `Dataset.load()` prior
+  to returning. This was changed in order to facilitate using this data with
+  dask.
+  By `Joe Hamman <https://github.com/jhamman>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/tests/test_tutorial.py
+++ b/xarray/tests/test_tutorial.py
@@ -26,3 +26,8 @@ class TestLoadDataset(object):
         ds = tutorial.open_dataset(self.testfile).load()
         tiny = DataArray(range(5), name='tiny').to_dataset()
         assert_identical(ds, tiny)
+
+    def test_download_from_github_load_without_cache(self):
+        ds_nocache = tutorial.open_dataset(self.testfile, cache=False).load()
+        ds_cache = tutorial.open_dataset(self.testfile).load()
+        assert_identical(ds_cache, ds_nocache)

--- a/xarray/tests/test_tutorial.py
+++ b/xarray/tests/test_tutorial.py
@@ -23,6 +23,6 @@ class TestLoadDataset(object):
             os.remove('{}.md5'.format(self.testfilepath))
 
     def test_download_from_github(self):
-        ds = tutorial.load_dataset(self.testfile).load()
+        ds = tutorial.open_dataset(self.testfile).load()
         tiny = DataArray(range(5), name='tiny').to_dataset()
         assert_identical(ds, tiny)

--- a/xarray/tests/test_tutorial.py
+++ b/xarray/tests/test_tutorial.py
@@ -23,6 +23,6 @@ class TestLoadDataset(object):
             os.remove('{}.md5'.format(self.testfilepath))
 
     def test_download_from_github(self):
-        ds = tutorial.load_dataset(self.testfile)
+        ds = tutorial.load_dataset(self.testfile).load()
         tiny = DataArray(range(5), name='tiny').to_dataset()
         assert_identical(ds, tiny)

--- a/xarray/tutorial.py
+++ b/xarray/tutorial.py
@@ -102,6 +102,6 @@ def load_dataset(*args, **kwargs):
     warnings.warn(
         "load_dataset` will be removed in version 0.12. The current behavior "
         "of this function can be achived by using "
-        "`tutorial.open_dataset(...).load()`."
+        "`tutorial.open_dataset(...).load()`.",
         FutureWarning, stacklevel=2)
     return open_dataset(*args, **kwargs).load()

--- a/xarray/tutorial.py
+++ b/xarray/tutorial.py
@@ -85,6 +85,7 @@ def open_dataset(name, cache=True, cache_dir=_default_cache_dir,
     ds = _open_dataset(localfile, **kws)
 
     if not cache:
+        ds = ds.load()
         _os.remove(localfile)
 
     return ds
@@ -100,8 +101,8 @@ def load_dataset(*args, **kwargs):
     open_dataset
     """
     warnings.warn(
-        "load_dataset` will be removed in version 0.12. The current behavior "
-        "of this function can be achived by using "
+        "load_dataset` will be removed in xarray version 0.12. The current "
+        "behavior of this function can be achived by using "
         "`tutorial.open_dataset(...).load()`.",
-        FutureWarning, stacklevel=2)
+        DeprecationWarning, stacklevel=2)
     return open_dataset(*args, **kwargs).load()

--- a/xarray/tutorial.py
+++ b/xarray/tutorial.py
@@ -77,7 +77,7 @@ def load_dataset(name, cache=True, cache_dir=_default_cache_dir,
             """
             raise IOError(msg)
 
-    ds = _open_dataset(localfile, **kws).load()
+    ds = _open_dataset(localfile, **kws)
 
     if not cache:
         _os.remove(localfile)

--- a/xarray/tutorial.py
+++ b/xarray/tutorial.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function
 
 import hashlib
 import os as _os
+import warnings
 
 from .backends.api import open_dataset as _open_dataset
 from .core.pycompat import urlretrieve as _urlretrieve
@@ -24,7 +25,7 @@ def file_md5_checksum(fname):
 
 
 # idea borrowed from Seaborn
-def load_dataset(name, cache=True, cache_dir=_default_cache_dir,
+def open_dataset(name, cache=True, cache_dir=_default_cache_dir,
                  github_url='https://github.com/pydata/xarray-data',
                  branch='master', **kws):
     """
@@ -47,6 +48,10 @@ def load_dataset(name, cache=True, cache_dir=_default_cache_dir,
         The git branch to download from
     kws : dict, optional
         Passed to xarray.open_dataset
+
+    See Also
+    --------
+    xarray.open_dataset
 
     """
     longdir = _os.path.expanduser(cache_dir)
@@ -83,3 +88,20 @@ def load_dataset(name, cache=True, cache_dir=_default_cache_dir,
         _os.remove(localfile)
 
     return ds
+
+
+def load_dataset(*args, **kwargs):
+    """
+    `load_dataset` will be removed in version 0.12. The current behavior of
+    this function can be achived by using `tutorial.open_dataset(...).load()`.
+
+    See Also
+    --------
+    open_dataset
+    """
+    warnings.warn(
+        "load_dataset` will be removed in version 0.12. The current behavior "
+        "of this function can be achived by using "
+        "`tutorial.open_dataset(...).load()`."
+        FutureWarning, stacklevel=2)
+    return open_dataset(*args, **kwargs).load()


### PR DESCRIPTION
 - [x] Tests added 
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API 

In working on an xarray/dask tutorial, I've come to realize we eagerly load the tutorial datasets in `xarray.tutorial.load_dataset`. I'm going to just say that I don't think we should do that but I could be missing some rational. I didn't open an issue so please feel free to share thoughts here.

One option would be to create a new function (`xr.tutorial.open_dataset`) that does what I'm suggesting and then slowly deprecate `tutorial.load_dataset`. Thoughts?

xref: https://github.com/dask/dask-examples/pull/51