### PR TITLE
Remove use of deprecated and unused keyword in cfgrib.open_file.

### DIFF
--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -46,7 +46,7 @@ class CfGribDataStore(AbstractDataStore):
             filter_by_keys_items = backend_kwargs['filter_by_keys'].items()
             backend_kwargs['filter_by_keys'] = tuple(filter_by_keys_items)
 
-        self.ds = cfgrib.open_file(filename, mode='r', **backend_kwargs)
+        self.ds = cfgrib.open_file(filename, **backend_kwargs)
 
     def open_store_variable(self, name, var):
         if isinstance(var.data, np.ndarray):


### PR DESCRIPTION
This is a trivial fix to remove the use of the `mode` keyword in the `cfgrib.open_file` call. The keyword has always be ignored and will be deprecated with the next version of *cfgrib*.

Better to have this fix in before the v0.11 release.