### PR TITLE
Drop the hack needed by CachingFileManager in cfgrib_.py

### DIFF
--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -39,13 +39,6 @@ class CfGribDataStore(AbstractDataStore):
         if lock is None:
             lock = ECCODES_LOCK
         self.lock = ensure_lock(lock)
-
-        # NOTE: filter_by_keys is a dict, but CachingFileManager only accepts
-        #   hashable types.
-        if 'filter_by_keys' in backend_kwargs:
-            filter_by_keys_items = backend_kwargs['filter_by_keys'].items()
-            backend_kwargs['filter_by_keys'] = tuple(filter_by_keys_items)
-
         self.ds = cfgrib.open_file(filename, **backend_kwargs)
 
     def open_store_variable(self, name, var):


### PR DESCRIPTION
This is a minor cleanup of the `backend_kwargs` hack that was needed to support CachingFileManager and that I forgot to remove after I stopped using it.

I didn't include this bit in #2540 because I didn't want to pollute the important fix with cleanup noise.