### PR TITLE
Expand test environment for Python 3.7

### DIFF
--- a/ci/requirements-py37.yml
+++ b/ci/requirements-py37.yml
@@ -1,13 +1,30 @@
 name: test_env
 channels:
-  - defaults
+  - conda-forge
 dependencies:
   - python=3.7
+  - cftime
+  - dask
+  - distributed
+  - h5py
+  - h5netcdf
+  - matplotlib
+  - netcdf4
+  - pytest
+  - flake8
+  - numpy
+  - pandas
+  - scipy
+  - seaborn
+  - toolz
+  - rasterio
+  - bottleneck
+  - zarr
+  - pseudonetcdf>=3.0.1
+  - eccodes
   - pip:
-    - pytest
-    - flake8
-    - mock
-    - numpy
-    - pandas
     - coveralls
     - pytest-cov
+    - pydap
+    - lxml
+    - cfgrib>=0.9.2


### PR DESCRIPTION
Just adding a full environment for python 3.7.

 - [x] Extends #2271
 - [x] Tests added

