### PR TITLE
Add libnetcdf, libhdf5, pydap and cfgrib to xarray.show_versions()

### DIFF
--- a/xarray/util/print_versions.py
+++ b/xarray/util/print_versions.py
@@ -63,8 +63,26 @@ def get_sys_info():
     return blob
 
 
+def netcdf_and_hdf5_versions():
+    libhdf5_version = None
+    libnetcdf_version = None
+    try:
+        import netCDF4
+        libhdf5_version = netCDF4.__hdf5libversion__
+        libnetcdf_version = netCDF4.__netcdf4libversion__
+    except ImportError:
+        try:
+            import h5py
+            libhdf5_version = h5py.__hdf5libversion__
+        except ImportError:
+            pass
+    return [('libhdf5', libhdf5_version), ('libnetcdf', libnetcdf_version)]
+
+
 def show_versions(as_json=False):
     sys_info = get_sys_info()
+
+    sys_info.extend(netcdf_and_hdf5_versions())
 
     deps = [
         # (MODULE_NAME, f(mod) -> mod version)
@@ -74,7 +92,7 @@ def show_versions(as_json=False):
         ("scipy", lambda mod: mod.__version__),
         # xarray optionals
         ("netCDF4", lambda mod: mod.__version__),
-        # ("pydap", lambda mod: mod.version.version),
+        ("pydap", lambda mod: getattr(mod, '__version__', '<=3.2.2')),
         ("h5netcdf", lambda mod: mod.__version__),
         ("h5py", lambda mod: mod.__version__),
         ("Nio", lambda mod: mod.__version__),
@@ -82,6 +100,7 @@ def show_versions(as_json=False):
         ("cftime", lambda mod: mod.__version__),
         ("PseudonetCDF", lambda mod: mod.__version__),
         ("rasterio", lambda mod: mod.__version__),
+        ("cfgrib", lambda mod: mod.__version__),
         ("iris", lambda mod: mod.__version__),
         ("bottleneck", lambda mod: mod.__version__),
         ("cyordereddict", lambda mod: mod.__version__),

--- a/xarray/util/print_versions.py
+++ b/xarray/util/print_versions.py
@@ -92,7 +92,7 @@ def show_versions(as_json=False):
         ("scipy", lambda mod: mod.__version__),
         # xarray optionals
         ("netCDF4", lambda mod: mod.__version__),
-        ("pydap", lambda mod: getattr(mod, '__version__', '<=3.2.2')),
+        ("pydap", lambda mod: mod.__version__),
         ("h5netcdf", lambda mod: mod.__version__),
         ("h5py", lambda mod: mod.__version__),
         ("Nio", lambda mod: mod.__version__),
@@ -126,10 +126,14 @@ def show_versions(as_json=False):
                 mod = sys.modules[modname]
             else:
                 mod = importlib.import_module(modname)
-            ver = ver_f(mod)
-            deps_blob.append((modname, ver))
         except Exception:
             deps_blob.append((modname, None))
+        else:
+            try:
+                ver = ver_f(mod)
+                deps_blob.append((modname, ver))
+            except Exception:
+                deps_blob.append((modname, 'installed'))
 
     if (as_json):
         try:

--- a/xarray/util/print_versions.py
+++ b/xarray/util/print_versions.py
@@ -44,7 +44,7 @@ def get_sys_info():
         (sysname, nodename, release,
          version, machine, processor) = platform.uname()
         blob.extend([
-            ("python", "%d.%d.%d.%s.%s" % sys.version_info[:]),
+            ("python", sys.version),
             ("python-bits", struct.calcsize("P") * 8),
             ("OS", "%s" % (sysname)),
             ("OS-release", "%s" % (release)),


### PR DESCRIPTION
Example of what this looks like:
```
In [3]: xarray.show_versions()

INSTALLED VERSIONS
------------------
commit: ef0838812cb3715d86d9cf9630606c824f3d8efb
python: 3.6.5.final.0
python-bits: 64
OS: Darwin
OS-release: 17.7.0
machine: x86_64
processor: i386
byteorder: little
LC_ALL: None
LANG: en_US.UTF-8
LOCALE: en_US.UTF-8
libhdf5: 1.10.3
libnetcdf: 4.6.1

xarray: 0.11.0+2.gef083881.dirty
pandas: 0.23.3
numpy: 1.14.2
scipy: 1.1.0
netCDF4: 1.4.2
pydap: installed
h5netcdf: 0.6.2
h5py: 2.8.0
Nio: None
zarr: 2.2.0
cftime: 1.0.1
PseudonetCDF: None
rasterio: None
cfgrib: installed
iris: None
bottleneck: 1.2.1
cyordereddict: None
dask: 0.19.0+120.g86da308e
distributed: 1.22.0
matplotlib: 2.2.2
cartopy: 0.16.0
seaborn: 0.8.1
setuptools: 39.2.0
pip: 10.0.1
conda: None
pytest: 3.6.0
IPython: 6.2.1
sphinx: 1.7.0
```

Note that released versions of pydap and cfgrib currently don't set the `__version__` attribute, so they just show up as "installed".