### PR TITLE
Zarr consolidated

### DIFF
--- a/ci/requirements-py36-zarr-dev.yml
+++ b/ci/requirements-py36-zarr-dev.yml
@@ -18,4 +18,4 @@ dependencies:
   - pip:
     - coveralls
     - pytest-cov
-    - git+https://github.com/alimanfoo/zarr.git
+    - git+https://github.com/zarr-developers/zarr.git

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -650,10 +650,10 @@ opening the store. (For more information on this feature, consult the
 
 If you have zarr version 2.3 or greater, xarray can write and read stores
 with consolidated metadata. To write consolidated metadata, pass the
-``consolidate=True`` option to the
+``consolidated=True`` option to the
 :py:attr:`Dataset.to_zarr <xarray.Dataset.to_zarr>` method::
 
-    ds.to_zarr('foo.zarr', consolidate=True)
+    ds.to_zarr('foo.zarr', consolidated=True)
 
 To read a consolidated store, pass the ``consolidated=True`` option to
 :py:func:`~xarray.open_zarr`::

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -641,10 +641,10 @@ Consolidated Metadata
 Xarray needs to read all of the zarr metadata when it opens a dataset.
 In some storage mediums, such as with cloud object storage (e.g. amazon S3),
 this can introduce significant overhead, because two separate HTTP calls to the
-object store for each variable in the dataset.
-With version 2.3, zarr will support an feature called *consolidated metadata*,
+object store must be made for each variable in the dataset.
+With version 2.3, zarr will support a feature called *consolidated metadata*,
 which allows all metadata for the entire dataset to be stored with a single
-key (by default called ``.zmetadata``). This can drastically reduce the latency
+key (by default called ``.zmetadata``). This can drastically speed up
 opening the store. (For more information on this feature, consult the
 `zarr docs <https://zarr.readthedocs.io/en/latest/tutorial.html#consolidating-metadata>`_.)
 

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -635,6 +635,31 @@ For example:
     Not all native zarr compression and filtering options have been tested with
     xarray.
 
+Consolidated Metadata
+~~~~~~~~~~~~~~~~~~~~~
+
+Xarray needs to read all of the zarr metadata when it opens a dataset.
+In some storage mediums, such as with cloud object storage (e.g. amazon S3),
+this can introduce significant overhead, because two separate HTTP calls to the
+object store for each variable in the dataset.
+With version 2.3, zarr will support an feature called *consolidated metadata*,
+which allows all metadata for the entire dataset to be stored with a single
+key (by default called ``.zmetadata``). This can drastically reduce the latency
+opening the store. (For more information on this feature, consult the
+`zarr docs <https://zarr.readthedocs.io/en/latest/tutorial.html#consolidating-metadata>`_.)
+
+If you have zarr version 2.3 or greater, xarray can write and read stores
+with consolidated metadata. To write consolidated metadata, pass the
+``consolidate=True`` option to the
+:py:attr:`Dataset.to_zarr <xarray.Dataset.to_zarr>` method::
+
+    ds.to_zarr('foo.zarr', consolidate=True)
+
+To read a consolidated store, pass the ``consolidated=True`` option to
+:py:func:`~xarray.open_zarr`::
+
+    ds = xr.open_zarr('foo.zarr', consolidated=True)
+
 .. _io.cfgrib:
 
 GRIB format via cfgrib
@@ -678,7 +703,7 @@ Formats supported by PseudoNetCDF
 ---------------------------------
 
 xarray can also read CAMx, BPCH, ARL PACKED BIT, and many other file
-formats supported by PseudoNetCDF_, if PseudoNetCDF is installed. 
+formats supported by PseudoNetCDF_, if PseudoNetCDF is installed.
 PseudoNetCDF can also provide Climate Forecasting Conventions to
 CMAQ files. In addition, PseudoNetCDF can automatically register custom
 readers that subclass PseudoNetCDF.PseudoNetCDFFile. PseudoNetCDF can

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -659,6 +659,10 @@ To read a consolidated store, pass the ``consolidated=True`` option to
 :py:func:`~xarray.open_zarr`::
 
     ds = xr.open_zarr('foo.zarr', consolidated=True)
+    
+Xarray can't perform consolidation on pre-existing zarr datasets. This should
+be done directly from zarr, as described in the
+`zarr docs <https://zarr.readthedocs.io/en/latest/tutorial.html#consolidating-metadata>`_.
 
 .. _io.cfgrib:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,7 +36,7 @@ Breaking changes
 Enhancements
 ~~~~~~~~~~~~
 
-- Ability to read and write consolidated metadata in zarr stores.
+- Ability to read and write consolidated metadata in zarr stores (:issue:`2558`).
   By `Ryan Abernathey <https://github.com/rabernat>`_.
 - :py:class:`CFTimeIndex` uses slicing for string indexing when possible (like
   :py:class:`pandas.DatetimeIndex`), which avoids unnecessary copies.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,6 +36,9 @@ Breaking changes
 Enhancements
 ~~~~~~~~~~~~
 
+- Ability to read and write consolidated metadata in zarr stores.
+  By `Ryan Abernathey <https://github.com/rabernat>`_.
+
 Bug fixes
 ~~~~~~~~~
 
@@ -52,15 +55,15 @@ Breaking changes
   - ``Dataset.T`` has been removed as a shortcut for :py:meth:`Dataset.transpose`.
     Call :py:meth:`Dataset.transpose` directly instead.
   - Iterating over a ``Dataset`` now includes only data variables, not coordinates.
-    Similarily, calling ``len`` and ``bool`` on a ``Dataset`` now  
+    Similarily, calling ``len`` and ``bool`` on a ``Dataset`` now
     includes only data variables.
   - ``DataArray.__contains__`` (used by Python's ``in`` operator) now checks
-    array data, not coordinates. 
+    array data, not coordinates.
   - The old resample syntax from before xarray 0.10, e.g.,
     ``data.resample('1D', dim='time', how='mean')``, is no longer supported will
     raise an error in most cases. You need to use the new resample syntax
     instead, e.g., ``data.resample(time='1D').mean()`` or
-    ``data.resample({'time': '1D'}).mean()``. 
+    ``data.resample({'time': '1D'}).mean()``.
 
 
 - New deprecations (behavior will be changed in xarray 0.12):
@@ -97,13 +100,13 @@ Breaking changes
     than by default trying to coerce them into ``np.datetime64[ns]`` objects.
     A :py:class:`~xarray.CFTimeIndex` will be used for indexing along time
     coordinates in these cases.
-  - A new method :py:meth:`~xarray.CFTimeIndex.to_datetimeindex` has been added 
+  - A new method :py:meth:`~xarray.CFTimeIndex.to_datetimeindex` has been added
     to aid in converting from a  :py:class:`~xarray.CFTimeIndex` to a
     :py:class:`pandas.DatetimeIndex` for the remaining use-cases where
     using a :py:class:`~xarray.CFTimeIndex` is still a limitation (e.g. for
     resample or plotting).
   - Setting the ``enable_cftimeindex`` option is now a no-op and emits a
-    ``FutureWarning``. 
+    ``FutureWarning``.
 
 Enhancements
 ~~~~~~~~~~~~
@@ -190,7 +193,7 @@ Bug fixes
   the dates must be encoded using cftime rather than NumPy (:issue:`2272`).
   By `Spencer Clark <https://github.com/spencerkclark>`_.
 
-- Chunked datasets can now roundtrip to Zarr storage continually 
+- Chunked datasets can now roundtrip to Zarr storage continually
   with `to_zarr` and ``open_zarr`` (:issue:`2300`).
   By `Lily Wang <https://github.com/lilyminium>`_.
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -861,7 +861,7 @@ def save_mfdataset(datasets, paths, mode='w', format=None, groups=None,
 
 
 def to_zarr(dataset, store=None, mode='w-', synchronizer=None, group=None,
-            encoding=None, compute=True, consolidate=False):
+            encoding=None, compute=True, consolidated=False):
     """This function creates an appropriate datastore for writing a dataset to
     a zarr ztore
 
@@ -879,7 +879,7 @@ def to_zarr(dataset, store=None, mode='w-', synchronizer=None, group=None,
     zstore = backends.ZarrStore.open_group(store=store, mode=mode,
                                            synchronizer=synchronizer,
                                            group=group,
-                                           consolidate_on_close=consolidate)
+                                           consolidate_on_close=consolidated)
 
     writer = ArrayWriter()
     # TODO: figure out how to properly handle unlimited_dims

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -861,7 +861,7 @@ def save_mfdataset(datasets, paths, mode='w', format=None, groups=None,
 
 
 def to_zarr(dataset, store=None, mode='w-', synchronizer=None, group=None,
-            encoding=None, compute=True):
+            encoding=None, compute=True, consolidate=False):
     """This function creates an appropriate datastore for writing a dataset to
     a zarr ztore
 
@@ -876,16 +876,23 @@ def to_zarr(dataset, store=None, mode='w-', synchronizer=None, group=None,
     _validate_dataset_names(dataset)
     _validate_attrs(dataset)
 
-    store = backends.ZarrStore.open_group(store=store, mode=mode,
+    zstore = backends.ZarrStore.open_group(store=store, mode=mode,
                                           synchronizer=synchronizer,
                                           group=group)
 
     writer = ArrayWriter()
     # TODO: figure out how to properly handle unlimited_dims
-    dump_to_store(dataset, store, writer, encoding=encoding)
+    dump_to_store(dataset, zstore, writer, encoding=encoding)
     writes = writer.sync(compute=compute)
 
     if not compute:
         import dask
-        return dask.delayed(_finalize_store)(writes, store)
-    return store
+        return dask.delayed(_finalize_store)(writes, zstore)
+        # TODO: handle consolidation for delayed case
+
+    if consolidate:
+        import zarr
+        zarr.consolidate_metadata(store)
+        # do we need to reload ztore now that we have consolidated?
+
+    return zstore

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -877,9 +877,9 @@ def to_zarr(dataset, store=None, mode='w-', synchronizer=None, group=None,
     _validate_attrs(dataset)
 
     zstore = backends.ZarrStore.open_group(store=store, mode=mode,
-                                          synchronizer=synchronizer,
-                                          group=group,
-                                          consolidate_on_close=consolidate)
+                                           synchronizer=synchronizer,
+                                           group=group,
+                                           consolidate_on_close=consolidate)
 
     writer = ArrayWriter()
     # TODO: figure out how to properly handle unlimited_dims
@@ -891,5 +891,5 @@ def to_zarr(dataset, store=None, mode='w-', synchronizer=None, group=None,
     else:
         import dask
         return dask.delayed(_finalize_store)(writes, zstore)
-        
+
     return zstore

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -878,21 +878,18 @@ def to_zarr(dataset, store=None, mode='w-', synchronizer=None, group=None,
 
     zstore = backends.ZarrStore.open_group(store=store, mode=mode,
                                           synchronizer=synchronizer,
-                                          group=group)
+                                          group=group,
+                                          consolidate_on_close=consolidate)
 
     writer = ArrayWriter()
     # TODO: figure out how to properly handle unlimited_dims
     dump_to_store(dataset, zstore, writer, encoding=encoding)
     writes = writer.sync(compute=compute)
 
-    if not compute:
+    if compute:
+        _finalize_store(writes, zstore)
+    else:
         import dask
         return dask.delayed(_finalize_store)(writes, zstore)
-        # TODO: handle consolidation for delayed case
-
-    if consolidate:
-        import zarr
-        zarr.consolidate_metadata(store)
-        # do we need to reload ztore now that we have consolidated?
-
+        
     return zstore

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -237,7 +237,7 @@ class ZarrStore(AbstractWritableDataStore):
                                       "#installation" % min_zarr)
 
         if consolidated or consolidate_on_close:
-            if LooseVersion(zarr.__version__) <= '2.2': # pragma: no cover
+            if LooseVersion(zarr.__version__) <= '2.2':  # pragma: no cover
                 raise NotImplementedError("Zarr version 2.3 or greater is "
                                           "required by for consolidated "
                                           "metadata.")

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -237,9 +237,9 @@ class ZarrStore(AbstractWritableDataStore):
                                       "#installation" % min_zarr)
 
         if consolidated or consolidate_on_close:
-            if LooseVersion(zarr.__version__) <= '2.2':  # pragma: no cover
-                raise NotImplementedError("Zarr version 2.3 or greater is "
-                                          "required by for consolidated "
+            if LooseVersion(zarr.__version__) <= '2.2.1.dev2':  # pragma: no cover
+                raise NotImplementedError("Zarr version 2.2.1.dev2 or greater "
+                                          "is required by for consolidated "
                                           "metadata.")
 
         open_kwargs = dict(mode=mode, synchronizer=synchronizer, path=group)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1222,7 +1222,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
                          compute=compute)
 
     def to_zarr(self, store=None, mode='w-', synchronizer=None, group=None,
-                encoding=None, compute=True, consolidate=False):
+                encoding=None, compute=True, consolidated=False):
         """Write dataset contents to a zarr group.
 
         .. note:: Experimental
@@ -1247,7 +1247,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         compute: bool, optional
             If True compute immediately, otherwise return a
             ``dask.delayed.Delayed`` object that can be computed later.
-        consolidate: bool, optional
+        consolidated: bool, optional
             If True, apply zarr's `consolidate_metadata` function to the store
             after writing.
 
@@ -1264,7 +1264,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         from ..backends.api import to_zarr
         return to_zarr(self, store=store, mode=mode, synchronizer=synchronizer,
                        group=group, encoding=encoding, compute=compute,
-                       consolidate=consolidate)
+                       consolidated=consolidated)
 
     def __unicode__(self):
         return formatting.dataset_repr(self)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1222,7 +1222,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
                          compute=compute)
 
     def to_zarr(self, store=None, mode='w-', synchronizer=None, group=None,
-                encoding=None, compute=True):
+                encoding=None, compute=True, consolidate=False):
         """Write dataset contents to a zarr group.
 
         .. note:: Experimental
@@ -1244,9 +1244,16 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
             Nested dictionary with variable names as keys and dictionaries of
             variable specific encodings as values, e.g.,
             ``{'my_variable': {'dtype': 'int16', 'scale_factor': 0.1,}, ...}``
-        compute: boolean
-            If true compute immediately, otherwise return a
+        compute: bool, optional
+            If True compute immediately, otherwise return a
             ``dask.delayed.Delayed`` object that can be computed later.
+        consolidate: bool, optional
+            If True, apply zarr's `consolidate_metadata` function to the store
+            after writing.
+
+        References
+        ----------
+        https://zarr.readthedocs.io/
         """
         if encoding is None:
             encoding = {}
@@ -1256,7 +1263,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
                              "and 'w-'.")
         from ..backends.api import to_zarr
         return to_zarr(self, store=store, mode=mode, synchronizer=synchronizer,
-                       group=group, encoding=encoding, compute=compute)
+                       group=group, encoding=encoding, compute=compute,
+                       consolidate=consolidate)
 
     def __unicode__(self):
         return formatting.dataset_repr(self)
@@ -1380,7 +1388,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         """ Here we make sure
         + indexer has a valid keys
         + indexer is in a valid data type
-        + string indexers are cast to the appropriate date type if the 
+        + string indexers are cast to the appropriate date type if the
           associated index is a DatetimeIndex or CFTimeIndex
         """
         from .dataarray import DataArray
@@ -1963,7 +1971,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
                                'Instead got\n{}'.format(new_x))
             else:
                 return (x, new_x)
-            
+
         variables = OrderedDict()
         for name, var in iteritems(obj._variables):
             if name not in indexers:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1320,6 +1320,14 @@ class ZarrBase(CFEncodedBase):
                          allow_cleanup_failure=False):
         pytest.skip("zarr backend does not support appending")
 
+    def test_roundtrip_consolidated(self):
+        expected = create_test_data()
+        with self.roundtrip(expected,
+                            save_kwargs={'consolidate': True},
+                            open_kwargs={'consolidated': True}) as actual:
+            self.check_dtypes_roundtripped(expected, actual)
+            assert_identical(expected, actual)
+
     def test_auto_chunk(self):
         original = create_test_data().chunk()
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1321,7 +1321,6 @@ class ZarrBase(CFEncodedBase):
                          allow_cleanup_failure=False):
         pytest.skip("zarr backend does not support appending")
 
-
     def test_roundtrip_consolidated(self):
         # my understanding is that pytest.mark.skipif is broken here
         import zarr

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import contextlib
-from distutils.version import LooseVersion
 import itertools
 import math
 import os.path
@@ -1322,10 +1321,7 @@ class ZarrBase(CFEncodedBase):
         pytest.skip("zarr backend does not support appending")
 
     def test_roundtrip_consolidated(self):
-        # my understanding is that pytest.mark.skipif is broken here
-        import zarr
-        if LooseVersion(zarr.__version__) <= '2.2':
-            pytest.skip('zarr version 2.3 or greater needed for consolidated')
+        zarr = pytest.importorskip('zarr', minversion="2.2.1.dev2")
         expected = create_test_data()
         with self.roundtrip(expected,
                             save_kwargs={'consolidate': True},

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1324,7 +1324,7 @@ class ZarrBase(CFEncodedBase):
         zarr = pytest.importorskip('zarr', minversion="2.2.1.dev2")
         expected = create_test_data()
         with self.roundtrip(expected,
-                            save_kwargs={'consolidate': True},
+                            save_kwargs={'consolidated': True},
                             open_kwargs={'consolidated': True}) as actual:
             self.check_dtypes_roundtripped(expected, actual)
             assert_identical(expected, actual)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import contextlib
+from distutils.version import LooseVersion
 import itertools
 import math
 import os.path
@@ -1320,7 +1321,12 @@ class ZarrBase(CFEncodedBase):
                          allow_cleanup_failure=False):
         pytest.skip("zarr backend does not support appending")
 
+
     def test_roundtrip_consolidated(self):
+        # my understanding is that pytest.mark.skipif is broken here
+        import zarr
+        if LooseVersion(zarr.__version__) <= '2.2':
+            pytest.skip('zarr version 2.3 or greater needed for consolidated')
         expected = create_test_data()
         with self.roundtrip(expected,
                             save_kwargs={'consolidate': True},

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -130,6 +130,16 @@ def test_dask_distributed_zarr_integration_test(loop):
                     assert isinstance(restored.var1.data, da.Array)
                     computed = restored.compute()
                     assert_allclose(original, computed)
+            # repeat with consolidated metadata and delayed compute
+            with create_tmp_file(allow_cleanup_failure=ON_WINDOWS,
+                                 suffix='.zarrc') as filename:
+                futures = original.to_zarr(filename, consolidate=True,
+                                           compute=False)
+                futures.compute()
+                with xr.open_zarr(filename, consolidated=True) as restored:
+                    assert isinstance(restored.var1.data, da.Array)
+                    computed = restored.compute()
+                    assert_allclose(original, computed)
 
 
 @requires_rasterio

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -1,5 +1,6 @@
 """ isort:skip_file """
 from __future__ import absolute_import, division, print_function
+from distutils.version import LooseVersion
 import os
 import sys
 import pickle
@@ -131,6 +132,9 @@ def test_dask_distributed_zarr_integration_test(loop):
                     computed = restored.compute()
                     assert_allclose(original, computed)
             # repeat with consolidated metadata and delayed compute
+            import zarr
+            if LooseVersion(zarr.__version__) <= '2.2':
+                return
             with create_tmp_file(allow_cleanup_failure=ON_WINDOWS,
                                  suffix='.zarrc') as filename:
                 futures = original.to_zarr(filename, consolidate=True,

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -124,7 +124,7 @@ def test_dask_distributed_read_netcdf_integration_test(
 def test_dask_distributed_zarr_integration_test(loop, consolidated, compute):
     if consolidated:
         zarr = pytest.importorskip('zarr', minversion="2.2.1.dev2")
-        write_kwargs = dict(consolidate=True)
+        write_kwargs = dict(consolidated=True)
         read_kwargs = dict(consolidated=True)
     else:
         write_kwargs = read_kwargs = {}


### PR DESCRIPTION
This PR adds support for reading and writing of [consolidated metadata](https://zarr.readthedocs.io/en/latest/tutorial.html#consolidating-metadata) in zarr stores.

 - [x] Closes #2558 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)