### PR TITLE
Return slices when possible from CFTimeIndex.get_loc()

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,6 +36,10 @@ Breaking changes
 Enhancements
 ~~~~~~~~~~~~
 
+- :py:class:`CFTimeIndex` uses slicing for string indexing when possible (like
+  :py:class:`pandas.DatetimeIndex`), which avoids unnecessary copies.
+  By `Stephan Hoyer <https://github.com/shoyer>`_
+
 Bug fixes
 ~~~~~~~~~
 


### PR DESCRIPTION
This code, adapted from pandas.DatetimeIndex, makes string indexing with CFTimeIndex work in a pandas.MultiIndex.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

CC @spencerkclark for review