### PR TITLE
Fix h5netcdf saving scalars with filters or chunks

### DIFF
--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -208,10 +208,12 @@ class H5NetCDFStore(WritableCFDataStore):
 
         encoding['chunks'] = encoding.pop('chunksizes', None)
 
-        for key in ['compression', 'compression_opts', 'shuffle',
-                    'chunks', 'fletcher32']:
-            if key in encoding:
-                kwargs[key] = encoding[key]
+        # Do not apply compression, filters or chunking to scalars.
+        if variable.shape:
+            for key in ['compression', 'compression_opts', 'shuffle',
+                        'chunks', 'fletcher32']:
+                if key in encoding:
+                    kwargs[key] = encoding[key]
         if name not in self.ds:
             nc4_var = self.ds.create_variable(
                 name, dtype=dtype, dimensions=variable.dims,

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -41,7 +41,7 @@ def create_test_data(seed=None):
     _vars = {'var1': ['dim1', 'dim2'],
              'var2': ['dim1', 'dim2'],
              'var3': ['dim3', 'dim1']}
-    _dims = {'dim1': 8, 'dim2': 9, 'dim3': 10}
+    _dims = {'dim1': 8, 'dim2': 9, 'dim3': 10, 'scalar_dim': 1}
 
     obj = Dataset()
     obj['time'] = ('time', pd.date_range('2000-01-01', periods=20))
@@ -50,6 +50,8 @@ def create_test_data(seed=None):
     for v, dims in sorted(_vars.items()):
         data = rs.normal(size=tuple(_dims[d] for d in dims))
         obj[v] = (dims, data, {'foo': 'variable'})
+    obj['scalar'] = ('scalar_dim', np.array([2.0]))
+    obj['scalar'] = obj['scalar'][0]
     obj.coords['numbers'] = ('dim3', np.array([0, 1, 2, 0, 0, 1, 1, 2, 2, 3],
                                               dtype='int64'))
     obj.encoding = {'foo': 'bar'}


### PR DESCRIPTION
 - [x] Closes #2563
 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

This PR also adds a scalar to the `create_test_data` test function.