### PR TITLE
Fix wrong error message in interp()

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1946,7 +1946,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
         """
         from . import missing
 
-        coords = either_dict_or_kwargs(coords, coords_kwargs, 'rename')
+        coords = either_dict_or_kwargs(coords, coords_kwargs, 'interp')
         indexers = OrderedDict(self._validate_indexers(coords))
 
         obj = self if assume_sorted else self.sortby([k for k in coords])


### PR DESCRIPTION
This is just a minor fix of a wrong error message. Please let me know if you think that this is worth testing in unit tests. 

Before:

```
>>> import xarray as xr
>>> d = xr.DataArray([1,2,3])
>>> d.interp(1)
...
ValueError: the first argument to .rename must be a dictionary
```

After:
```
>>> import xarray as xr
>>> d = xr.DataArray([1,2,3])
>>> d.interp(1)
...

ValueError: the first argument to .interp must be a dictionary
```