### PR TITLE
Update cftime version in doc environment

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - zarr=2.2.0
   - iris=2.1.0
   - flake8=3.5.0
-  - cftime=1.0.0
+  - cftime=1.0.3.4
   - bottleneck=1.2
   - sphinx=1.7.6
   - numpydoc=0.8.0


### PR DESCRIPTION
As mentioned in https://github.com/pydata/xarray/issues/2597#issuecomment-446151329, the `dayofyr` and `dayofwk` attributes of `cftime.datetime` objects do not always work in versions of cftime prior to 1.0.2.  This issue comes up in the [latest doc build](http://xarray.pydata.org/en/latest/time-series.html#non-standard-calendars-and-dates-outside-the-timestamp-valid-range):

<img width="796" alt="screen shot 2018-12-13 at 6 46 05 am" src="https://user-images.githubusercontent.com/6628425/49936817-f007cc00-fea2-11e8-80a6-3b62c3947c43.png">

This updates the documentation environment to use the most recent version (1.0.3.4), which should fix things.