### PR TITLE
Remove tz argument in cftime_range

### DIFF
--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -553,7 +553,7 @@ def _count_not_none(*args):
 
 
 def cftime_range(start=None, end=None, periods=None, freq='D',
-                 tz=None, normalize=False, name=None, closed=None,
+                 normalize=False, name=None, closed=None,
                  calendar='standard'):
     """Return a fixed frequency CFTimeIndex.
 


### PR DESCRIPTION
This was caught by @jwenfai in #2593.  I hope no one was inadvertently trying to use this argument before.

Should this need a what's new entry?