### PR TITLE
FIX Don't raise a deprecation warning for xarray.ufuncs.{angle,iscomplex}

### DIFF
--- a/xarray/tests/test_ufuncs.py
+++ b/xarray/tests/test_ufuncs.py
@@ -172,6 +172,41 @@ def test_xarray_ufuncs_deprecation():
     with pytest.warns(PendingDeprecationWarning, match='xarray.ufuncs'):
         xu.cos(xr.DataArray([0, 1]))
 
+    with pytest.warns(None) as record:
+        xu.angle(xr.DataArray([0, 1]))
+    record = [el.message for el in record
+              if el.category == PendingDeprecationWarning]
+    assert len(record) == 0
+
+
+@requires_np113
+@pytest.mark.filterwarnings('ignore::RuntimeWarning')
+@pytest.mark.parametrize(
+    'name',
+    [name for name in dir(xu)
+        if (not name.startswith('_') and hasattr(np, name)
+            and name not in ['print_function', 'absolute_import', 'division'])]
+)
+def test_numpy_ufuncs(name, request):
+    x = xr.DataArray([1, 1])
+
+    np_func = getattr(np, name)
+    if hasattr(np_func, 'nin') and np_func.nin == 2:
+        args = (x, x)
+    else:
+        args = (x,)
+
+    y = np_func(*args)
+
+    if name in ['angle', 'iscomplex']:
+        # these functions need to be handled with __array_function__ protocol
+        assert isinstance(y, np.ndarray)
+    elif name in ['frexp']:
+        # np.frexp returns a tuple
+        assert not isinstance(y, xr.DataArray)
+    else:
+        assert isinstance(y, xr.DataArray)
+
 
 def test_xarray_ufuncs_pickle():
     a = 1.0

--- a/xarray/ufuncs.py
+++ b/xarray/ufuncs.py
@@ -44,10 +44,12 @@ class _UFuncDispatcher(object):
         self._name = name
 
     def __call__(self, *args, **kwargs):
-        _warnings.warn(
-            'xarray.ufuncs will be deprecated when xarray no longer supports '
-            'versions of numpy older than v1.13. Instead, use numpy ufuncs '
-            'directly.', PendingDeprecationWarning, stacklevel=2)
+        if self._name not in ['angle', 'iscomplex']:
+            _warnings.warn(
+                'xarray.ufuncs will be deprecated when xarray no longer '
+                'supports versions of numpy older than v1.13. Instead, use '
+                'numpy ufuncs directly.',
+                PendingDeprecationWarning, stacklevel=2)
 
         new_args = args
         f = _dask_or_eager_func(self._name, array_args=slice(len(args)))

--- a/xarray/ufuncs.py
+++ b/xarray/ufuncs.py
@@ -47,7 +47,7 @@ class _UFuncDispatcher(object):
         if self._name not in ['angle', 'iscomplex']:
             _warnings.warn(
                 'xarray.ufuncs will be deprecated when xarray no longer '
-                'supports versions of numpy older than v1.13. Instead, use '
+                'supports versions of numpy older than v1.17. Instead, use '
                 'numpy ufuncs directly.',
                 PendingDeprecationWarning, stacklevel=2)
 


### PR DESCRIPTION
Closes https://github.com/pydata/xarray/issues/2609

This removes PendingDeprecationWarnings for `xarray.ufuncs.{angle,iscomplex}` which appear to not be proper ufuncs and cannot be just used from numpy for now (as discussed in the parent issue).

Also adds more generic tests that numpy ufuncs do preserve the DataArray dtype.