### PR TITLE
Remove failing Appveyor Python 2.7 32-bit build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,6 @@ branches:
 environment:
 
   matrix:
-    - PYTHON: "C:\\Python27-conda32"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "32"
-      CONDA_ENV: "py27-windows"
-
     - PYTHON: "C:\\Python27-conda64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"


### PR DESCRIPTION
There seems to be some sort of dependency issue on Appveyor, but it's not
worth tracking down given how we'll be dropping Python 2.7 in the new year
anyways.

<!-- Feel free to remove check-list items aren't relevant to your change -->
