### PR TITLE
Fix failure in time encoding for pandas < 0.21.1

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -83,7 +83,9 @@ Bug fixes
   By `Martin Raspaud <https://github.com/mraspaud>`_.
 - Fix parsing of ``_Unsigned`` attribute set by OPENDAP servers. (:issue:`2583`).
   By `Deepak Cherian <https://github.com/dcherian>`_
-
+- Fix failure in time encoding when exporting to netCDF with versions of pandas
+  less than 0.21.1 (:issue:`2623`).  By `Spencer Clark
+  <https://github.com/spencerkclark>`_.
 
 .. _whats-new.0.11.0:
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -357,7 +357,7 @@ def encode_cf_datetime(dates, units=None, calendar=None):
 
         delta_units = _netcdf_to_numpy_timeunit(delta)
         time_delta = np.timedelta64(1, delta_units).astype('timedelta64[ns]')
-        ref_date = np.datetime64(pd.Timestamp(ref_date))
+        ref_date = pd.Timestamp(ref_date)
 
         # Wrap the dates in a DatetimeIndex to do the subtraction to ensure
         # an OverflowError is raised if the ref_date is too far away from

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -737,3 +737,16 @@ def test_encode_cf_datetime_overflow(shape):
     num, _, _ = encode_cf_datetime(dates, units, calendar)
     roundtrip = decode_cf_datetime(num, units, calendar)
     np.testing.assert_array_equal(dates, roundtrip)
+
+
+def test_encode_cf_datetime_pandas_min():
+    # Test that encode_cf_datetime does not fail for versions
+    # of pandas < 0.21.1 (GH 2623).
+    dates = pd.date_range('2000', periods=3)
+    num, units, calendar = encode_cf_datetime(dates)
+    expected_num = np.array([0., 1., 2.])
+    expected_units = 'days since 2000-01-01 00:00:00'
+    expected_calendar = 'proleptic_gregorian'
+    np.testing.assert_array_equal(num, expected_num)
+    assert units == expected_units
+    assert calendar == expected_calendar


### PR DESCRIPTION
 - [x] Closes #2623 
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

This is related to a bug fixed in https://github.com/pandas-dev/pandas/pull/18020#issuecomment-340477318 (this should return a `TimedeltaIndex`):
```
In [2]: times = pd.date_range('2000', periods=3)

In [3]: times - np.datetime64('2000-01-01')
Out[3]: DatetimeIndex(['1970-01-01', '1970-01-02', '1970-01-03'], dtype='datetime64[ns]', freq='D')
```
Subtracting a `Timestamp` object seems to work in all versions:
```
In [4]: times - pd.Timestamp('2000-01-01')
Out[4]: TimedeltaIndex(['0 days', '1 days', '2 days'], dtype='timedelta64[ns]', freq=None)
```