### PR TITLE
TST: silence warnings from bottleneck

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,9 @@ universal = 1
 [tool:pytest]
 python_files=test_*.py
 testpaths=xarray/tests
+# Fixed upstream in https://github.com/kwgoodman/bottleneck/pull/199
+filterwarnings =
+    ignore:Using a non-tuple sequence for multidimensional indexing is deprecated:FutureWarning
 
 [flake8]
 max-line-length=79


### PR DESCRIPTION
These were adding a lot of noise to the output of our test suite -- something like 500 lines of useless warnings!