### PR TITLE
Use pycodestyle for lint checks.

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,12 +1,15 @@
 # File : .pep8speaks.yml
 
+# This should be kept in sync with the duplicate config in the [pycodestyle]
+# block of setup.cfg.
+
 scanner:
     diff_only: True  # If True, errors caused by only the patch are shown
 
 pycodestyle:
     max-line-length: 79
     ignore:  # Errors and warnings to ignore
-        - E402,  # module level import not at top of file
-        - E731,  # do not assign a lambda expression, use a def
-        - W503   # line break before binary operator
-        - W504   # line break after binary operator
+        - E402  # module level import not at top of file
+        - E731  # do not assign a lambda expression, use a def
+        - W503  # line break before binary operator
+        - W504  # line break after binary operator

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -4,7 +4,7 @@
 # block of setup.cfg.
 
 scanner:
-    diff_only: True  # If True, errors caused by only the patch are shown
+    diff_only: False  # If True, errors caused by only the patch are shown
 
 pycodestyle:
     max-line-length: 79

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -11,5 +11,6 @@ pycodestyle:
     ignore:  # Errors and warnings to ignore
         - E402  # module level import not at top of file
         - E731  # do not assign a lambda expression, use a def
+        - E741  # ambiguous variable name
         - W503  # line break before binary operator
         - W504  # line break after binary operator

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
   - env: CONDA_ENV=py36-rasterio
   - env: CONDA_ENV=py36-zarr-dev
   - env: CONDA_ENV=docs
-  - env: CONDA_ENV=flake8
+  - env: CONDA_ENV=lint
   - env: CONDA_ENV=py36-hypothesis
 
   allow_failures:
@@ -62,7 +62,7 @@ before_install:
 install:
   - if [[ "$CONDA_ENV" == "docs" ]]; then
       conda env create -n test_env --file doc/environment.yml;
-    elif [[ "$CONDA_ENV" == "flake8" ]]; then
+    elif [[ "$CONDA_ENV" == "lint" ]]; then
       conda env create -n test_env --file ci/requirements-py37.yml;
     else
       conda env create -n test_env --file ci/requirements-$CONDA_ENV.yml;
@@ -79,8 +79,8 @@ script:
   - if [[ "$CONDA_ENV" == "docs" ]]; then
       conda install -c conda-forge sphinx sphinx_rtd_theme sphinx-gallery numpydoc;
       sphinx-build -n -j auto -b html -d _build/doctrees doc _build/html;
-    elif [[ "$CONDA_ENV" == "flake8" ]]; then
-      flake8 xarray ;
+    elif [[ "$CONDA_ENV" == "lint" ]]; then
+      pycodestyle xarray ;
     elif [[ "$CONDA_ENV" == "py36-hypothesis" ]]; then
       pytest properties ;
     else

--- a/ci/requirements-py37.yml
+++ b/ci/requirements-py37.yml
@@ -14,7 +14,7 @@ dependencies:
   - pytest-cov
   - pytest-env
   - coveralls
-  - flake8
+  - pycodestyle
   - numpy
   - pandas
   - scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,15 +10,13 @@ filterwarnings =
 env =
     UVCDAT_ANONYMOUS_LOG=no
 
-[flake8]
+[pycodestyle]
 max-line-length=79
 ignore=
   E402  # module level import not at top of file
   E731  # do not assign a lambda expression, use a def
   W503  # line break before binary operator
   W504  # line break after binary operator
-exclude=
-  doc/
 
 [isort]
 default_section=THIRDPARTY

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ env =
 # This should be kept in sync with .pep8speaks.yml
 [pycodestyle]
 max-line-length=79
-ignore=E402,E731,W503,W504
+ignore=E402,E731,E741,W503,W504
 
 [isort]
 default_section=THIRDPARTY

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,13 +10,10 @@ filterwarnings =
 env =
     UVCDAT_ANONYMOUS_LOG=no
 
+# This should be kept in sync with .pep8speaks.yml
 [pycodestyle]
 max-line-length=79
-ignore=
-  E402  # module level import not at top of file
-  E731  # do not assign a lambda expression, use a def
-  W503  # line break before binary operator
-  W504  # line break after binary operator
+ignore=E402,E731,W503,W504
 
 [isort]
 default_section=THIRDPARTY

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -806,7 +806,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         self._file_obj = None
 
     def isin(self, test_elements):
-        """Tests each value in the array for whether it is in the supplied list.
+        """Tests each value in the array for whether it is in test elements.
 
         Parameters
         ----------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1077,7 +1077,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
 
     @property
     def data_vars(self):
-        """Dictionary of xarray.DataArray objects corresponding to data variables
+        """Dictionary of DataArray objects corresponding to data variables
         """
         return DataVariables(self)
 
@@ -2171,8 +2171,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
                                            inplace=inplace)
 
     def expand_dims(self, dim, axis=None):
-        """Return a new object with an additional axis (or axes) inserted at the
-        corresponding position in the array shape.
+        """Return a new object with an additional axis (or axes) inserted at
+        the corresponding position in the array shape.
 
         If dim is already a scalar coordinate, it will be promoted to a 1D
         coordinate consisting of a single value.
@@ -2256,8 +2256,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords,
 
     def set_index(self, indexes=None, append=False, inplace=None,
                   **indexes_kwargs):
-        """Set Dataset (multi-)indexes using one or more existing coordinates or
-        variables.
+        """Set Dataset (multi-)indexes using one or more existing coordinates
+        or variables.
 
         Parameters
         ----------

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -128,22 +128,12 @@ except ImportError:
     # Inspired by discussions on http://bugs.python.org/issue13585
     class ExitStack(object):
         """Context manager for dynamic management of a stack of exit callbacks
-
-        For example:
-
-            with ExitStack() as stack:
-                files = [stack.enter_context(open(fname)) for fname in filenames]
-                # All opened files will automatically be closed at the end of
-                # the with statement, even if attempts to open files later
-                # in the list raise an exception
-
         """
 
         def __init__(self):
             self._exit_callbacks = deque()
 
         def pop_all(self):
-            """Preserve the context stack by transferring it to a new instance"""
             new_stack = type(self)()
             new_stack._exit_callbacks = self._exit_callbacks
             self._exit_callbacks = deque()

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2463,7 +2463,7 @@ class TestPydap(object):
             assert actual.attrs.keys() == expected.attrs.keys()
 
         with self.create_datasets() as (actual, expected):
-            assert_equal(actual.isel(l=2), expected.isel(l=2))  # noqa
+            assert_equal(actual[{'l': 2}], expected[{'l': 2}])
 
         with self.create_datasets() as (actual, expected):
             assert_equal(actual.isel(i=0, j=-1),

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -13,6 +13,7 @@ from xarray.core.pycompat import native_int_types
 from . import IndexerMaker, ReturnItem, assert_array_equal, raises_regex
 
 B = IndexerMaker(indexing.BasicIndexer)
+I = ReturnItem()  # noqa: E741  # allow ambiguous name
 
 
 class TestIndexers(object):
@@ -24,7 +25,6 @@ class TestIndexers(object):
     def test_expanded_indexer(self):
         x = np.random.randn(10, 11, 12, 13, 14)
         y = np.arange(5)
-        I = ReturnItem()  # noqa
         for i in [I[:], I[...], I[0, :, 10], I[..., 10], I[:5, ..., 0],
                   I[..., 0, :], I[y], I[y, y], I[..., y, y],
                   I[..., 0, 1, 2, 3, 4]]:
@@ -134,7 +134,6 @@ class TestIndexers(object):
 
 class TestLazyArray(object):
     def test_slice_slice(self):
-        I = ReturnItem()  # noqa: E741  # allow ambiguous name
         for size in [100, 99]:
             # We test even/odd size cases
             x = np.arange(size)
@@ -154,7 +153,6 @@ class TestLazyArray(object):
         v = Variable(['i', 'j', 'k'], original)
         lazy = indexing.LazilyOuterIndexedArray(x)
         v_lazy = Variable(['i', 'j', 'k'], lazy)
-        I = ReturnItem()  # noqa: E741  # allow ambiguous name
         # test orthogonally applied indexers
         indexers = [I[:], 0, -2, I[:3], [0, 1, 2, 3], [0], np.arange(10) < 5]
         for i in indexers:
@@ -211,7 +209,6 @@ class TestLazyArray(object):
         v_eager = Variable(['i', 'j', 'k'], x)
         lazy = indexing.LazilyOuterIndexedArray(x)
         v_lazy = Variable(['i', 'j', 'k'], lazy)
-        I = ReturnItem()  # noqa: E741  # allow ambiguous name
 
         def check_indexing(v_eager, v_lazy, indexers):
             for indexer in indexers:
@@ -523,7 +520,6 @@ def test_outer_indexer_consistency_with_broadcast_indexes_vectorized():
 
     original = np.random.rand(10, 20, 30)
     v = Variable(['i', 'j', 'k'], original)
-    I = ReturnItem()  # noqa: E741  # allow ambiguous name
     # test orthogonally applied indexers
     indexers = [I[:], 0, -2, I[:3], np.array([0, 1, 2, 3]), np.array([0]),
                 np.arange(10) < 5]

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -13,7 +13,7 @@ from xarray.core.pycompat import native_int_types
 from . import IndexerMaker, ReturnItem, assert_array_equal, raises_regex
 
 B = IndexerMaker(indexing.BasicIndexer)
-I = ReturnItem()  # noqa: E741  # allow ambiguous name
+I = ReturnItem()  # noqa: E741
 
 
 class TestIndexers(object):

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -13,7 +13,7 @@ from xarray.core.pycompat import native_int_types
 from . import IndexerMaker, ReturnItem, assert_array_equal, raises_regex
 
 B = IndexerMaker(indexing.BasicIndexer)
-I = ReturnItem()  # noqa: E741
+I = ReturnItem()  # noqa
 
 
 class TestIndexers(object):

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -13,7 +13,6 @@ from xarray.core.pycompat import native_int_types
 from . import IndexerMaker, ReturnItem, assert_array_equal, raises_regex
 
 B = IndexerMaker(indexing.BasicIndexer)
-I = ReturnItem()  # noqa
 
 
 class TestIndexers(object):
@@ -25,6 +24,7 @@ class TestIndexers(object):
     def test_expanded_indexer(self):
         x = np.random.randn(10, 11, 12, 13, 14)
         y = np.arange(5)
+        I = ReturnItem()  # noqa
         for i in [I[:], I[...], I[0, :, 10], I[..., 10], I[:5, ..., 0],
                   I[..., 0, :], I[y], I[y, y], I[..., y, y],
                   I[..., 0, 1, 2, 3, 4]]:
@@ -134,6 +134,7 @@ class TestIndexers(object):
 
 class TestLazyArray(object):
     def test_slice_slice(self):
+        I = ReturnItem()  # noqa: E741  # allow ambiguous name
         for size in [100, 99]:
             # We test even/odd size cases
             x = np.arange(size)
@@ -153,6 +154,7 @@ class TestLazyArray(object):
         v = Variable(['i', 'j', 'k'], original)
         lazy = indexing.LazilyOuterIndexedArray(x)
         v_lazy = Variable(['i', 'j', 'k'], lazy)
+        I = ReturnItem()  # noqa: E741  # allow ambiguous name
         # test orthogonally applied indexers
         indexers = [I[:], 0, -2, I[:3], [0, 1, 2, 3], [0], np.arange(10) < 5]
         for i in indexers:
@@ -209,6 +211,7 @@ class TestLazyArray(object):
         v_eager = Variable(['i', 'j', 'k'], x)
         lazy = indexing.LazilyOuterIndexedArray(x)
         v_lazy = Variable(['i', 'j', 'k'], lazy)
+        I = ReturnItem()  # noqa: E741  # allow ambiguous name
 
         def check_indexing(v_eager, v_lazy, indexers):
             for indexer in indexers:
@@ -520,6 +523,7 @@ def test_outer_indexer_consistency_with_broadcast_indexes_vectorized():
 
     original = np.random.rand(10, 20, 30)
     v = Variable(['i', 'j', 'k'], original)
+    I = ReturnItem()  # noqa: E741  # allow ambiguous name
     # test orthogonally applied indexers
     indexers = [I[:], 0, -2, I[:3], np.array([0, 1, 2, 3]), np.array([0]),
                 np.arange(10) < 5]


### PR DESCRIPTION
flake8 includes a few more useful checks, but it's annoying to only see it's
output in Travis-CI results.

This keeps Travis-CI and pep8speaks in sync.
