### PR TITLE
Change an `==` to an `is`. Fix tests so that this won't happen again.

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -10,7 +10,8 @@ import numpy as np
 
 from .. import Dataset, backends, conventions
 from ..core import indexing
-from ..core.combine import _auto_combine, _infer_concat_order_from_positions
+from ..core.combine import (
+    _CONCAT_DIM_DEFAULT, _auto_combine, _infer_concat_order_from_positions)
 from ..core.pycompat import basestring, path_type
 from ..core.utils import close_on_error, is_grib_path, is_remote_uri
 from .common import ArrayWriter
@@ -481,9 +482,6 @@ class _MultiFileCloser(object):
     def close(self):
         for f in self.file_objs:
             f.close()
-
-
-_CONCAT_DIM_DEFAULT = '__infer_concat_dim__'
 
 
 def open_mfdataset(paths, chunks=None, concat_dim=_CONCAT_DIM_DEFAULT,

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -606,7 +606,7 @@ def open_mfdataset(paths, chunks=None, concat_dim=_CONCAT_DIM_DEFAULT,
     # Coerce 1D input into ND to maintain backwards-compatible API until API
     # for N-D combine decided
     # (see https://github.com/pydata/xarray/pull/2553/#issuecomment-445892746)
-    if concat_dim is None or concat_dim == _CONCAT_DIM_DEFAULT:
+    if concat_dim is None or concat_dim is _CONCAT_DIM_DEFAULT:
         concat_dims = concat_dim
     elif not isinstance(concat_dim, list):
         concat_dims = [concat_dim]

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -368,7 +368,7 @@ def _auto_concat(datasets, dim=None, data_vars='all', coords='different'):
         return concat(datasets, dim=dim, data_vars=data_vars, coords=coords)
 
 
-_CONCAT_DIM_DEFAULT = '__infer_concat_dim__'
+_CONCAT_DIM_DEFAULT = utils.ReprObject('<inferred>')
 
 
 def _infer_concat_order_from_positions(datasets, concat_dims):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2647
 - [x] Tests added

Also re-affirms #1988.