### PR TITLE
Convert ref_date to UTC in encode_cf_datetime

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -39,7 +39,10 @@ Bug fixes
   as an argument to ``scipy.interpolate.interp1d``, allowing for interpolation
   from higher frequencies to lower frequencies.  Datapoints outside the bounds
   of the original time coordinate are now filled with NaN (:issue:`2197`). By
-  `Spencer Clark <https://github.com/spencerkclark>`_. 
+  `Spencer Clark <https://github.com/spencerkclark>`_.
+- Saving files with times encoded with reference dates with timezones
+  (e.g. '2000-01-01T00:00:00-05:00') no longer raises an error
+  (:issue:`2649`).  By `Spencer Clark <https://github.com/spencerkclark>`_.
 
 .. _whats-new.0.11.2:
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -357,7 +357,7 @@ def encode_cf_datetime(dates, units=None, calendar=None):
 
         delta_units = _netcdf_to_numpy_timeunit(delta)
         time_delta = np.timedelta64(1, delta_units).astype('timedelta64[ns]')
-        ref_date = pd.Timestamp(ref_date)
+        ref_date = pd.Timestamp(ref_date).tz_convert(None)
 
         # Wrap the dates in a DatetimeIndex to do the subtraction to ensure
         # an OverflowError is raised if the ref_date is too far away from

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -357,7 +357,12 @@ def encode_cf_datetime(dates, units=None, calendar=None):
 
         delta_units = _netcdf_to_numpy_timeunit(delta)
         time_delta = np.timedelta64(1, delta_units).astype('timedelta64[ns]')
-        ref_date = pd.Timestamp(ref_date).tz_convert(None)
+        ref_date = pd.Timestamp(ref_date)
+
+        # If the ref_date Timestamp is timezone-aware, convert to UTC and
+        # make it timezone-naive (GH 2649).
+        if ref_date.tz is not None:
+            ref_date = ref_date.tz_convert(None)
 
         # Wrap the dates in a DatetimeIndex to do the subtraction to ensure
         # an OverflowError is raised if the ref_date is too far away from

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -750,3 +750,19 @@ def test_encode_cf_datetime_pandas_min():
     np.testing.assert_array_equal(num, expected_num)
     assert units == expected_units
     assert calendar == expected_calendar
+
+
+def test_encode_cf_datetime_units_with_tz():
+    # Regression test for GH 2649
+    units = 'days since 2000-01-01T00:00:00-05:00'
+    calendar = 'proleptic_gregorian'
+    dates = pd.date_range('2000', periods=3, tz='US/Eastern').values
+    num, units, calendar = encode_cf_datetime(dates,
+                                              units=units,
+                                              calendar=calendar)
+    expected_num = np.array([0, 1, 2])
+    expected_units = 'days since 2000-01-01T00:00:00-05:00'
+    expected_calendar = 'proleptic_gregorian'
+    np.testing.assert_array_equal(num, expected_num)
+    assert units == expected_units
+    assert calendar == expected_calendar


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2649 
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

I *think* this should be an appropriate fix for #2649, but I'd appreciate input from those who are more experienced dealing with timezones in NumPy/pandas.

My understanding is that NumPy dates are stored as UTC and do not carry any timezone information. Therefore converting the `ref_date` with `tz_convert(None)` here, which converts it to UTC and removes the timezone information, should be appropriate for encoding.