### PR TITLE
xfail cftimeindex multiindex test

### DIFF
--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -799,6 +799,7 @@ def test_to_datetimeindex_feb_29(calendar):
 
 
 @pytest.mark.skipif(not has_cftime, reason='cftime not installed')
+@pytest.mark.xfail(reason='https://github.com/pandas-dev/pandas/issues/24263')
 def test_multiindex():
     index = xr.cftime_range('2001-01-01', periods=100, calendar='360_day')
     mindex = pd.MultiIndex.from_arrays([index])


### PR DESCRIPTION
It was a nice idea to support CFTimeIndex in a pandas.MultiIndex, but pandas
seems to have inadvertently broken this, see
https://github.com/pandas-dev/pandas/issues/24263

(This should fix our failing CI tests with pandas 0.24 rc)
<!-- Feel free to remove check-list items aren't relevant to your change -->
