### PR TITLE
Skipping variables in datasets that don't have the core dim

### DIFF
--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -314,6 +314,11 @@ def apply_dict_of_variables_ufunc(func, *args, **kwargs):
 
     result_vars = OrderedDict()
     for name, variable_args in zip(names, grouped_by_name):
+        if len(variable_args) == 1 and signature.all_input_core_dims:
+            variable_arg, = variable_args
+            if not set(variable_arg.dims) & signature.all_core_dims:
+                result_vars[name] = variable_arg
+                continue
         result_vars[name] = func(*variable_args)
 
     if signature.num_outputs > 1:

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -3,6 +3,7 @@ import operator
 import pickle
 from collections import OrderedDict
 from distutils.version import LooseVersion
+from functools import partial
 
 import numpy as np
 import pandas as pd
@@ -848,6 +849,17 @@ def test_output_wrong_dim_size():
                      apply_truncate_x_x_valid(data_array))
     assert_identical(xr.Dataset({'y': ('x', array[:5])}),
                      apply_truncate_x_x_valid(dataset))
+
+
+def test_ignore_variables_without_dim():
+
+    ds = xr.Dataset(dict(
+        a=xr.DataArray(np.random.rand(2, 3), dims=list('xy')),
+        b=xr.DataArray(np.random.rand(3, 4), dims=list('yz'))
+    ))
+    result = apply_ufunc(partial(np.nansum, axis=-1),
+                         ds, input_core_dims=[['x']])
+    assert set(result.dims) == set('yz')
 
 
 @pytest.mark.parametrize('use_dask', [True, False])


### PR DESCRIPTION
ref https://github.com/pydata/xarray/pull/2650#issuecomment-454164295

This seems an ugly way of accomplishing the goal; any ideas for a better way of doing this? 

And stepping back, do others think a) it's helpful to skip variables in a dataset, and b) `apply_ufunc` should do this?
