### PR TITLE
Enable resampling on PeriodIndex

### DIFF
--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -722,6 +722,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         # TODO support non-string indexer after removing the old API.
 
         from .dataarray import DataArray
+        from .variable import IndexVariable
         from .resample import RESAMPLE_DIM
         from ..coding.cftimeindex import CFTimeIndex
 
@@ -745,10 +746,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
             )
         dim, freq = indexer.popitem()
 
-        dim_name = dim
-        dim_coord = self[dim]
-
-        if isinstance(self.indexes[dim_name], CFTimeIndex):
+        if isinstance(self.indexes[dim], CFTimeIndex):
             raise NotImplementedError(
                 'Resample is currently not supported along a dimension '
                 'indexed by a CFTimeIndex.  For certain kinds of downsampling '
@@ -761,12 +759,12 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
                 'errors.'
             )
 
-        group = DataArray(dim_coord, coords=dim_coord.coords,
-                          dims=dim_coord.dims, name=RESAMPLE_DIM)
+        group = IndexVariable(
+            data=self.indexes[dim], dims=[dim], name=RESAMPLE_DIM)
         # TODO: to_offset() call required for pandas==0.19.2
         grouper = pd.Grouper(freq=freq, closed=closed, label=label, base=base,
                              loffset=pd.tseries.frequencies.to_offset(loffset))
-        resampler = self._resample_cls(self, group=group, dim=dim_name,
+        resampler = self._resample_cls(self, group=group, dim=dim,
                                        grouper=grouper,
                                        resample_dim=RESAMPLE_DIM)
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1789,12 +1789,17 @@ class IndexVariable(Variable):
     unless another name is given.
     """
 
-    def __init__(self, dims, data, attrs=None, encoding=None, fastpath=False):
+    def __init__(self, dims, data, attrs=None, encoding=None, fastpath=False, name=None):
         super(IndexVariable, self).__init__(dims, data, attrs, encoding,
                                             fastpath)
         if self.ndim != 1:
             raise ValueError('%s objects must be 1-dimensional' %
                              type(self).__name__)
+        
+        if name is None:
+            self._name = self.dims[0]
+        else:
+            self._name = name
 
         # Unlike in Variable, always eagerly load values into memory
         if not isinstance(self._data, PandasIndexAdapter):
@@ -1956,7 +1961,7 @@ class IndexVariable(Variable):
 
     @property
     def name(self):
-        return self.dims[0]
+        return self._name
 
     @name.setter
     def name(self, value):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2399,6 +2399,14 @@ class TestDataArray(object):
                              attrs=array.attrs)
         assert_identical(result, expected)
 
+    def test_resample_period_index(self):
+        times = pd.period_range('2000-01-01', freq='6H', periods=10)
+        array = DataArray(np.arange(10), [('time', times)])
+
+        actual = array.resample(time='24H').mean()
+        expected = DataArray(array.to_series().resample('24H').mean())
+        assert_identical(expected, actual)
+
     def test_resample_skipna(self):
         times = pd.date_range('2000-01-01', freq='6H', periods=10)
         array = DataArray(np.ones(10), [('time', times)])


### PR DESCRIPTION
This allows resampling with `PeriodIndex` objects by keeping the `group` as an index rather than coercing to a DataArray (which coerces any non-native types to objects)

I'm still getting one failure around the name of the IndexVariable still being `__resample_dim__` after resample, but wanted to socialize the approach of allowing a `name` argument to `IndexVariable` - is this reasonable?

 - [x] Closes https://github.com/pydata/xarray/issues/1270
 - [x] Tests added
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
