### PR TITLE
try no rasterio in py36 env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
   - python --version
   - python -OO -c "import xarray"
   - if [[ "$CONDA_ENV" == "docs" ]]; then
-      conda install -c conda-forge sphinx sphinx_rtd_theme sphinx-gallery numpydoc;
+      conda install -c conda-forge --override-channels sphinx sphinx_rtd_theme sphinx-gallery numpydoc "gdal>2.2.4";
       sphinx-build -n -j auto -b html -d _build/doctrees doc _build/html;
     elif [[ "$CONDA_ENV" == "lint" ]]; then
       pycodestyle xarray ;

--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -20,7 +20,7 @@ dependencies:
   - scipy
   - seaborn
   - toolz
-  - rasterio
+  # - rasterio  # xref #2683
   - bottleneck
   - zarr
   - pseudonetcdf>=3.0.1

--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -26,8 +26,8 @@ dependencies:
   - pseudonetcdf>=3.0.1
   - eccodes
   - cdms2
-  - pynio
-  - iris>=1.10
+  # - pynio  # xref #2683
+  # - iris>=1.10    # xref #2683
   - pydap
   - lxml
   - pip:


### PR DESCRIPTION
As described in #2683, our test suite is failing on Travis with an unfortunate segfault. For now, I've just taken `rasterio` (and therefore GDAL) out of the offending environment. I'll use this PR to test a few other options.

cc @max-sixty 

 - [x] Closes #2683
 - [ ] Tests added
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
