### PR TITLE
BUG: ensure indexes are reset when coords are modified

### DIFF
--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -237,6 +237,7 @@ class DataArrayCoordinates(AbstractCoordinates):
             raise ValueError('cannot add coordinates with new dimensions to '
                              'a DataArray')
         self._data._coords = coords
+        self._data._indexes = None
 
     @property
     def variables(self):

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -10,7 +10,7 @@ import xarray as xr
 from xarray.coding.cftimeindex import (
     CFTimeIndex, _parse_array_of_cftime_strings, _parse_iso8601_with_reso,
     _parsed_string_to_bounds, assert_all_valid_date_type, parse_iso8601)
-from xarray.tests import assert_array_equal, assert_identical
+from xarray.tests import assert_array_equal, assert_allclose, assert_identical
 
 from . import (has_cftime, has_cftime_1_0_2_1, has_cftime_or_netCDF4,
                raises_regex, requires_cftime)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1222,6 +1222,11 @@ class TestDataArray(object):
                              dims='x')
         assert_identical(lhs, expected)
 
+    def test_set_coords_update_index(self):
+        actual = DataArray([1, 2, 3], [('x', [1, 2, 3])])
+        actual.coords['x'] = ['a', 'b', 'c']
+        assert actual.indexes['x'].equals(pd.Index(['a', 'b', 'c']))
+
     def test_coords_replacement_alignment(self):
         # regression test for GH725
         arr = DataArray([0, 1, 2], dims=['abc'])

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -589,6 +589,11 @@ class TestDataset(object):
         expected = data.merge({'c': 11}).set_coords('c')
         assert_identical(expected, actual)
 
+    def test_update_index(self):
+        actual = Dataset(coords={'x': [1, 2, 3]})
+        actual['x'] = ['a', 'b', 'c']
+        assert actual.indexes['x'].equals(pd.Index(['a', 'b', 'c']))
+
     def test_coords_setitem_with_new_dimension(self):
         actual = Dataset()
         actual.coords['foo'] = ('x', [1, 2, 3])


### PR DESCRIPTION
This was introduced by the recent indexes refactor, but never made it into a
release.
