### PR TITLE
Fix CRS being WKT instead of PROJ.4

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -79,6 +79,9 @@ Bug fixes
   :py:class:`CFTimeIndex` now results in a :py:class:`pandas.TimedeltaIndex`
   instead of raising a ``TypeError`` (:issue:`2671`).  By `Spencer Clark
   <https://github.com/spencerkclark>`_.
+- Fix ``open_rasterio`` creating a WKT CRS instead of PROJ.4 with
+  ``rasterio`` 1.0.14+ (:issue:`2715`).
+  By `David Hoese <https://github.com/djhoese`_.
 
 .. _whats-new.0.11.3:
 

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -282,10 +282,10 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None,
         # CRS is a dict-like object specific to rasterio
         # If CRS is not None, we convert it back to a PROJ4 string using
         # rasterio itself
-    try:
-        attrs['crs'] = riods.crs.to_proj4()
-    except AttributeError:
-        attrs['crs'] = riods.crs.to_string()
+        try:
+            attrs['crs'] = riods.crs.to_proj4()
+        except AttributeError:
+            attrs['crs'] = riods.crs.to_string()
     if hasattr(riods, 'res'):
         # (width, height) tuple of pixels in units of CRS
         attrs['res'] = riods.res

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -282,7 +282,10 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None,
         # CRS is a dict-like object specific to rasterio
         # If CRS is not None, we convert it back to a PROJ4 string using
         # rasterio itself
+    try:
         attrs['crs'] = riods.crs.to_proj4()
+    except AttributeError:
+        attrs['crs'] = riods.crs.to_string()
     if hasattr(riods, 'res'):
         # (width, height) tuple of pixels in units of CRS
         attrs['res'] = riods.res

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -282,7 +282,7 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None,
         # CRS is a dict-like object specific to rasterio
         # If CRS is not None, we convert it back to a PROJ4 string using
         # rasterio itself
-        attrs['crs'] = riods.crs.to_string()
+        attrs['crs'] = riods.crs.to_proj4()
     if hasattr(riods, 'res'):
         # (width, height) tuple of pixels in units of CRS
         attrs['res'] = riods.res


### PR DESCRIPTION
See https://github.com/mapbox/rasterio/blob/master/CHANGES.txt#L7 for the change in rasterio 1.0.14 and my conda-forge issue where I discovered this: https://github.com/conda-forge/gdal-feedstock/issues/262

This was put in a bugfix (micro version number) release of rasterio which made it harder to discover. @sgillies @snowman2 I saw that you brought this up and how it affected xarray (https://rasterio.groups.io/g/dev/message/68). If this pull request is a duplicate of a fix one of you made let me know.

To xarray devs, if I need to make any other changes (whats-new?) also let me know.

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
