### PR TITLE
DOC: refresh whats-new for 0.11.3 / 0.12.0

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -13,9 +13,9 @@ What's New
     import xarray as xr
     np.random.seed(123456)
 
-.. _whats-new.0.11.3:
+.. _whats-new.0.12.0:
 
-v0.11.3 (unreleased)
+v0.12.0 (unreleased)
 --------------------
 
 Breaking changes
@@ -52,9 +52,23 @@ Bug fixes
   from higher frequencies to lower frequencies.  Datapoints outside the bounds
   of the original time coordinate are now filled with NaN (:issue:`2197`). By
   `Spencer Clark <https://github.com/spencerkclark>`_.
+
+.. _whats-new.0.11.3:
+
+v0.11.3 (26 January 2019)
+-------------------------
+
+Bug fixes
+~~~~~~~~~
+
 - Saving files with times encoded with reference dates with timezones
   (e.g. '2000-01-01T00:00:00-05:00') no longer raises an error
   (:issue:`2649`).  By `Spencer Clark <https://github.com/spencerkclark>`_.
+- Fixed performance regression with ``open_mfdataset`` (:issue:`2662`).
+  By `Tom Nicholas <http://github.com/TomNicholas>`_.
+- Fixed supplying an explicit dimension in the ``concat_dim`` argument to
+  to ``open_mfdataset`` (:issue:`2647`).
+  By `Ben Root <https://github.com/WeatherGod>`_.
 
 .. _whats-new.0.11.2:
 


### PR DESCRIPTION
I just pushed the 0.11.3 bug-fix release to pypi.