### PR TITLE
silence a couple of warnings in tests

### DIFF
--- a/xarray/tests/test_ufuncs.py
+++ b/xarray/tests/test_ufuncs.py
@@ -206,6 +206,7 @@ def test_numpy_ufuncs(name, request):
         assert isinstance(y, xr.DataArray)
 
 
+@pytest.mark.filterwarnings("ignore:xarray.ufuncs")
 def test_xarray_ufuncs_pickle():
     a = 1.0
     cos_pickled = pickle.loads(pickle.dumps(xu.cos))


### PR DESCRIPTION
The only other warning is:

```

xarray/tests/test_dataset.py::TestDataset::test_convert_dataframe_with_many_types_and_multiindex
  /Users/maximilian/workspace/xarray/xarray/core/dataset.py:3146: FutureWarning: Converting timezone-aware DatetimeArray to timezone-naive ndarray with 'datetime64[ns]' dtype. In the future, this will return an ndarray with 'object' dtype where each element is a 'pandas.Timestamp' with the correct 'tz'.
  	To accept the future behavior, pass 'dtype=object'.
  	To keep the old behavior, pass 'dtype="datetime64[ns]"'.
    data = np.asarray(series).reshape(shape)
  /usr/local/lib/python3.7/site-packages/pandas/core/apply.py:286: FutureWarning: Converting timezone-aware DatetimeArray to timezone-naive ndarray with 'datetime64[ns]' dtype. In the future, this will return an ndarray with 'object' dtype where each element is a 'pandas.Timestamp' with the correct 'tz'.
  	To accept the future behavior, pass 'dtype=object'.
  	To keep the old behavior, pass 'dtype="datetime64[ns]"'.
    results[i] = self.f(v)
```

I'm not sure what we want to do here - potentially we should make a choice between:
- the worse behavior of `object`
- accepting the coercing to naive datetimes
- supporting pandas extension arrays