### PR TITLE
add tests for handling of empty pandas objects in constructors

### DIFF
--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2824,6 +2824,15 @@ class TestDataArray(object):
         assert_identical(
             expected_da,
             DataArray.from_series(actual).drop(['x', 'y']))
+    
+    def test_to_and_from_empty_series(self):
+        # GH697
+        expected = pd.Series([])
+        da = DataArray.from_series(expected)
+        assert len(da) == 0
+        actual = da.to_series()
+        assert len(actual) == 0
+        assert expected.equals(actual)
 
     def test_series_categorical_index(self):
         # regression test for GH700

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2824,7 +2824,7 @@ class TestDataArray(object):
         assert_identical(
             expected_da,
             DataArray.from_series(actual).drop(['x', 'y']))
-    
+
     def test_to_and_from_empty_series(self):
         # GH697
         expected = pd.Series([])

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2984,6 +2984,15 @@ class TestDataset(object):
         expected = pd.DataFrame([[]], index=idx)
         assert expected.equals(actual), (expected, actual)
 
+    def test_to_and_from_empty_dataframe(self):
+        # GH697
+        expected = pd.DataFrame({'foo' : []})
+        ds = Dataset.from_dataframe(expected)
+        assert len(ds['foo']) == 0
+        actual = ds.to_dataframe()
+        assert len(actual) == 0
+        assert expected.equals(actual)
+
     def test_from_dataframe_non_unique_columns(self):
         # regression test for GH449
         df = pd.DataFrame(np.zeros((2, 2)))

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2986,7 +2986,7 @@ class TestDataset(object):
 
     def test_to_and_from_empty_dataframe(self):
         # GH697
-        expected = pd.DataFrame({'foo' : []})
+        expected = pd.DataFrame({'foo': []})
         ds = Dataset.from_dataframe(expected)
         assert len(ds['foo']) == 0
         actual = ds.to_dataframe()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #697 
 - [x] Tests added
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
