### PR TITLE
Reenable cross engine read write netCDF test

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1732,7 +1732,6 @@ class TestGenericNetCDFData(CFEncodedBase, NetCDF3Only):
         with raises_regex(ValueError, 'can only read'):
             open_dataset(BytesIO(netcdf_bytes), engine='foobar')
 
-    @pytest.mark.xfail(reason='https://github.com/pydata/xarray/issues/2050')
     def test_cross_engine_read_write_netcdf3(self):
         data = create_test_data()
         valid_engines = set()


### PR DESCRIPTION
Fixes https://github.com/pydata/xarray/issues/2050

I'm not quite sure what was going on, but it passes now.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2050
