### PR TITLE
remove xfail from test_cross_engine_read_write_netcdf4

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1801,7 +1801,6 @@ class TestH5NetCDFData(NetCDF4Base):
             with self.roundtrip(expected) as actual:
                 assert_equal(expected, actual)
 
-    @pytest.mark.xfail(reason='https://github.com/pydata/xarray/issues/535')
     def test_cross_engine_read_write_netcdf4(self):
         # Drop dim3, because its labels include strings. These appear to be
         # not properly read with python-netCDF4, which converts them into


### PR DESCRIPTION
This is passing in my local test environment. We'll see on CI...

 - [x] Closes #535
 - [x] Tests added
