### PR TITLE
Fix name loss when masking

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -24,7 +24,7 @@ Breaking changes
 - Remove support for Python 2. This is the first version of xarray that is
   Python 3 only. (:issue:`1876`).
   By `Joe Hamman <https://github.com/jhamman>`_.
-- The `compat` argument to `Dataset` and the `encoding` argument to 
+- The `compat` argument to `Dataset` and the `encoding` argument to
   `DataArray` are deprecated and will be removed in a future release.
   (:issue:`1188`)
   By `Maximilian Roos <https://github.com/max-sixty>`_.
@@ -82,7 +82,9 @@ Bug fixes
 - Fix ``open_rasterio`` creating a WKT CRS instead of PROJ.4 with
   ``rasterio`` 1.0.14+ (:issue:`2715`).
   By `David Hoese <https://github.com/djhoese`_.
-
+- Masking data arrays with :py:meth:`xarray.DataArray.where` now returns an
+  array with the name of the original masked array (:issue:`2748` and :issue:`2457`).
+  By `Yohai Bar-Sinai <https://github.com/yohai>`_.
 .. _whats-new.0.11.3:
 
 v0.11.3 (26 January 2019)

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -856,11 +856,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
             self = self.isel(**indexers)
             cond = cond.isel(**indexers)
 
-        result = ops.where_method(self, cond, other)
-        if isinstance(self, DataArray):
-            result.name = self.name
-
-        return result
+        return ops.where_method(self, cond, other)
 
     def close(self):
         """Close any files linked to this object

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -859,7 +859,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         result = ops.where_method(self, cond, other)
         if isinstance(self, DataArray):
             result.name = self.name
-            
+
         return result
 
     def close(self):

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -856,7 +856,11 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
             self = self.isel(**indexers)
             cond = cond.isel(**indexers)
 
-        return ops.where_method(self, cond, other)
+        result = ops.where_method(self, cond, other)
+        if isinstance(self, DataArray):
+            result.name = self.name
+            
+        return result
 
     def close(self):
         """Close any files linked to this object

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -199,6 +199,7 @@ def apply_dataarray_ufunc(func, *args, **kwargs):
     signature = kwargs.pop('signature')
     join = kwargs.pop('join', 'inner')
     exclude_dims = kwargs.pop('exclude_dims', _DEFAULT_FROZEN_SET)
+    keep_attrs = kwargs.pop('keep_attrs', True)
     if kwargs:
         raise TypeError('apply_dataarray_ufunc() got unexpected keyword '
                         'arguments: %s' % list(kwargs))
@@ -207,7 +208,10 @@ def apply_dataarray_ufunc(func, *args, **kwargs):
         args = deep_align(args, join=join, copy=False, exclude=exclude_dims,
                           raise_on_invalid=False)
 
-    name = result_name(args)
+    if keep_attrs and hasattr(args[0], 'name'):
+        name = args[0].name
+    else:
+        name = result_name(args)
     result_coords = build_output_coords(args, signature, exclude_dims)
 
     data_vars = [getattr(a, 'variable', a) for a in args]
@@ -986,7 +990,8 @@ def apply_ufunc(func, *args, **kwargs):
         return apply_dataarray_ufunc(variables_ufunc, *args,
                                      signature=signature,
                                      join=join,
-                                     exclude_dims=exclude_dims)
+                                     exclude_dims=exclude_dims,
+                                     keep_attrs=keep_attrs)
     elif any(isinstance(a, Variable) for a in args):
         return variables_ufunc(*args)
     else:

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3694,6 +3694,15 @@ def test_raise_no_warning_for_nan_in_binary_ops():
     assert len(record) == 0
 
 
+def test_name_in_masking():
+    name = 'RingoStarr'
+    da = xr.DataArray(range(10), coords=[('x', range(10))], name=name)
+    assert da.where(da > 5).name == name
+    assert da.where((da > 5).rename('YokoOno')).name == name
+    assert da.where(da > 5, drop=True).name == name
+    assert da.where((da > 5).rename('YokoOno'), drop=True).name == name
+
+
 class TestIrisConversion(object):
     @requires_iris
     def test_to_and_from_iris(self):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2457 #2748
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

I took a simple-minded strategy to fix: just mask and then rename the result to `self.name`. This is a slight overkill since the renaming will be done on every masking, not just on the edge cases when it's needed, but this is really a very small computational cost and it's much easier and bulletproof.