### PR TITLE
Ability to force float64 instead of float32 issue #2304

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -24,7 +24,7 @@ Breaking changes
 - Remove support for Python 2. This is the first version of xarray that is
   Python 3 only. (:issue:`1876`).
   By `Joe Hamman <https://github.com/jhamman>`_.
-- The `compat` argument to `Dataset` and the `encoding` argument to 
+- The `compat` argument to `Dataset` and the `encoding` argument to
   `DataArray` are deprecated and will be removed in a future release.
   (:issue:`1188`)
   By `Maximilian Roos <https://github.com/max-sixty>`_.
@@ -62,6 +62,10 @@ Enhancements
 - :py:meth:`pandas.Series.dropna` is now supported for a
   :py:class:`pandas.Series` indexed by a :py:class:`~xarray.CFTimeIndex`
   (:issue:`2688`). By `Spencer Clark <https://github.com/spencerkclark>`_.
+- Ability to promote to float64 instead of float32 when dealing int type
+  variables with scale_factor added parameter force_promote_float64
+  to :py:meth:`~xarray.open_dataset` and :py:meth:`~xarray.open_dataarray`
+  that enables this behaviour. By `Daoud Jahdou <https://github.com/daoudjahdou>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -62,8 +62,9 @@ Enhancements
 - :py:meth:`pandas.Series.dropna` is now supported for a
   :py:class:`pandas.Series` indexed by a :py:class:`~xarray.CFTimeIndex`
   (:issue:`2688`). By `Spencer Clark <https://github.com/spencerkclark>`_.
-- Ability to promote to float64 instead of float32 when dealing int type
-  variables with scale_factor added parameter force_promote_float64
+- Ability to promote to float64 instead of float32 when dealing with int type
+  variables with scale_factor.
+  Added parameter force_promote_float64 (False by default)
   to :py:meth:`~xarray.open_dataset` and :py:meth:`~xarray.open_dataarray`
   that enables this behaviour. By `Daoud Jahdou <https://github.com/daoudjahdou>`_.
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -14,6 +14,7 @@ from ..core.combine import (
 from ..core.utils import close_on_error, is_grib_path, is_remote_uri
 from .common import ArrayWriter
 from .locks import _get_scheduler
+from ..core import dtypes
 
 DATAARRAY_NAME = '__xarray_dataarray_name__'
 DATAARRAY_VARIABLE = '__xarray_dataarray_variable__'
@@ -161,6 +162,7 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
                  mask_and_scale=None, decode_times=True, autoclose=None,
                  concat_characters=True, decode_coords=True, engine=None,
                  chunks=None, lock=None, cache=None, drop_variables=None,
+                 force_promote_float64=False,
                  backend_kwargs=None):
     """Load and decode a dataset from a file or file-like object.
 
@@ -227,6 +229,9 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or
         inconsistent values.
+    force_promote_float64: bool
+        If True force int variables to be promoted to float64 instead of
+        float32
     backend_kwargs: dictionary, optional
         A dictionary of keyword arguments to pass on to the backend. This
         may be useful when backend options would improve performance or
@@ -261,6 +266,8 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
 
     if cache is None:
         cache = chunks is None
+
+    dtypes.FORCE_PROMOTE_FLOAT64 = force_promote_float64
 
     if backend_kwargs is None:
         backend_kwargs = {}
@@ -360,7 +367,7 @@ def open_dataarray(filename_or_obj, group=None, decode_cf=True,
                    mask_and_scale=None, decode_times=True, autoclose=None,
                    concat_characters=True, decode_coords=True, engine=None,
                    chunks=None, lock=None, cache=None, drop_variables=None,
-                   backend_kwargs=None):
+                   force_promote_float64=False, backend_kwargs=None):
     """Open an DataArray from a netCDF file containing a single data variable.
 
     This is designed to read netCDF files with only one data variable. If
@@ -424,6 +431,9 @@ def open_dataarray(filename_or_obj, group=None, decode_cf=True,
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or
         inconsistent values.
+    force_promote_float64: bool
+        If True force int variables to be promoted to float64 instead of
+        float32
     backend_kwargs: dictionary, optional
         A dictionary of keyword arguments to pass on to the backend. This
         may be useful when backend options would improve performance or
@@ -450,6 +460,7 @@ def open_dataarray(filename_or_obj, group=None, decode_cf=True,
                            decode_coords=decode_coords, engine=engine,
                            chunks=chunks, lock=lock, cache=cache,
                            drop_variables=drop_variables,
+                           force_promote_float64=force_promote_float64,
                            backend_kwargs=backend_kwargs)
 
     if len(dataset.data_vars) != 1:

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -230,8 +230,8 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
         dataset. This may be useful to drop variables with problems or
         inconsistent values.
     force_promote_float64: bool
-        If True force int variables to be promoted to float64 instead of
-        float32
+        If True force int variables with scale factorto be promoted to
+        float64 instead of float32
     backend_kwargs: dictionary, optional
         A dictionary of keyword arguments to pass on to the backend. This
         may be useful when backend options would improve performance or
@@ -432,8 +432,8 @@ def open_dataarray(filename_or_obj, group=None, decode_cf=True,
         dataset. This may be useful to drop variables with problems or
         inconsistent values.
     force_promote_float64: bool
-        If True force int variables to be promoted to float64 instead of
-        float32
+        If True force int variables with scale factor to be promoted to
+        float64 instead of float32
     backend_kwargs: dictionary, optional
         A dictionary of keyword arguments to pass on to the backend. This
         may be useful when backend options would improve performance or

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -230,7 +230,7 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
         dataset. This may be useful to drop variables with problems or
         inconsistent values.
     force_promote_float64: bool
-        If True force int variables with scale factorto be promoted to
+        If True force int variables with scale factor to be promoted to
         float64 instead of float32
     backend_kwargs: dictionary, optional
         A dictionary of keyword arguments to pass on to the backend. This

--- a/xarray/core/dtypes.py
+++ b/xarray/core/dtypes.py
@@ -30,6 +30,11 @@ class AlwaysLessThan(object):
 INF = AlwaysGreaterThan()
 NINF = AlwaysLessThan()
 
+# Constant that indicates that we
+# must switch to float64 instead of
+# float32 even if dtype.itemsize <= 2
+FORCE_PROMOTE_FLOAT64 = False
+
 
 # Pairs of types that, if both found, should be promoted to object dtype
 # instead of following NumPy's own type-promotion rules. These type promotion
@@ -63,7 +68,7 @@ def maybe_promote(dtype):
         # Check np.timedelta64 before np.integer
         fill_value = np.timedelta64('NaT')
     elif np.issubdtype(dtype, np.integer):
-        if dtype.itemsize <= 2:
+        if dtype.itemsize <= 2 and not FORCE_PROMOTE_FLOAT64:
             dtype = np.float32
         else:
             dtype = np.float64

--- a/xarray/core/dtypes.py
+++ b/xarray/core/dtypes.py
@@ -30,8 +30,8 @@ class AlwaysLessThan(object):
 INF = AlwaysGreaterThan()
 NINF = AlwaysLessThan()
 
-# Constant that indicates that we
-# must switch to float64 instead of
+# Constant that indicates if we
+# want to promote to float64 instead of
 # float32 even if dtype.itemsize <= 2
 FORCE_PROMOTE_FLOAT64 = False
 


### PR DESCRIPTION
Ability to promote to float64 instead of float32 when dealing with int variables with scale_factor.
added parameter force_promote_float64 (False by default) to open_dataset and open_dataarray that enables this behaviour when True.

 - [x] Closes #2304 
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
