### PR TITLE
Use DatetimeGregorian when calendar='standard' in cftime_range instead of DatetimeProlepticGregorian

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -94,6 +94,12 @@ Bug fixes
 - Masking data arrays with :py:meth:`xarray.DataArray.where` now returns an
   array with the name of the original masked array (:issue:`2748` and :issue:`2457`).
   By `Yohai Bar-Sinai <https://github.com/yohai>`_.
+- Per `CF conventions
+  <http://cfconventions.org/cf-conventions/cf-conventions.html#calendar>`_,
+  specifying ``'standard'`` as the calendar type in
+  :py:meth:`~xarray.cftime_range` now correctly refers to the ``'gregorian'``
+  calendar instead of the ``'proleptic_gregorian'`` calendar (:issue:`2761`).
+
 .. _whats-new.0.11.3:
 
 v0.11.3 (26 January 2019)

--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -68,7 +68,7 @@ def get_date_type(calendar):
             'proleptic_gregorian': cftime.DatetimeProlepticGregorian,
             'julian': cftime.DatetimeJulian,
             'all_leap': cftime.DatetimeAllLeap,
-            'standard': cftime.DatetimeProlepticGregorian
+            'standard': cftime.DatetimeGregorian
         }
         return calendars[calendar]
 
@@ -679,9 +679,9 @@ def cftime_range(start=None, end=None, periods=None, freq='D',
     +--------------------------------+---------------------------------------+
     | Alias                          | Date type                             |
     +================================+=======================================+
-    | standard, proleptic_gregorian  | ``cftime.DatetimeProlepticGregorian`` |
+    | standard, gregorian            | ``cftime.DatetimeGregorian``          |
     +--------------------------------+---------------------------------------+
-    | gregorian                      | ``cftime.DatetimeGregorian``          |
+    | proleptic_gregorian            | ``cftime.DatetimeProlepticGregorian`` |
     +--------------------------------+---------------------------------------+
     | noleap, 365_day                | ``cftime.DatetimeNoLeap``             |
     +--------------------------------+---------------------------------------+

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -814,3 +814,9 @@ def test_dayofyear_after_cftime_range(freq):
     result = cftime_range('2000-02-01', periods=3, freq=freq).dayofyear
     expected = pd.date_range('2000-02-01', periods=3, freq=freq).dayofyear
     np.testing.assert_array_equal(result, expected)
+
+
+def test_cftime_range_standard_calendar_refers_to_gregorian():
+    from cftime import DatetimeGregorian
+    result, = cftime_range('2000', periods=1)
+    assert isinstance(result, DatetimeGregorian)

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -523,7 +523,8 @@ def test_cftime_type_error():
 def test_cftime_list_of_strings():
     from cftime import DatetimeProlepticGregorian
 
-    times = xr.cftime_range('2000', periods=24, freq='D')
+    times = xr.cftime_range('2000', periods=24, freq='D',
+                            calendar='proleptic_gregorian')
     da = xr.DataArray(np.arange(24), coords=[times], dims='time')
 
     times_new = ['2000-01-01T12:00', '2000-01-02T12:00', '2000-01-03T12:00']
@@ -542,7 +543,8 @@ def test_cftime_list_of_strings():
 def test_cftime_single_string():
     from cftime import DatetimeProlepticGregorian
 
-    times = xr.cftime_range('2000', periods=24, freq='D')
+    times = xr.cftime_range('2000', periods=24, freq='D',
+                            calendar='proleptic_gregorian')
     da = xr.DataArray(np.arange(24), coords=[times], dims='time')
 
     times_new = '2000-01-01T12:00'


### PR DESCRIPTION
 - [x] Closes #2761
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
