### PR TITLE
Improved default behavior when concatenating DataArrays

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,6 +40,9 @@ Enhancements
   `Spencer Clark <https://github.com/spencerkclark>`_.
 - Add ``data=False`` option to ``to_dict()`` methods. (:issue:`2656`)
   By `Ryan Abernathey <https://github.com/rabernat>`_
+- Use new dimension name and unique array names to create a new coordinate
+  when concatenating arrays, if no coordinates are given.
+  (:issue:`2775`). By `Zac Hatfield-Dodds <https://github.com/Zac-HD>`_.
 - :py:meth:`~xarray.DataArray.coarsen` and
   :py:meth:`~xarray.Dataset.coarsen` are newly added.
   See :ref:`comput.coarsen` for details.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -82,6 +82,10 @@ Bug fixes
 
 - Silenced warnings that appear when using pandas 0.24.
   By `Stephan Hoyer <https://github.com/shoyer>`_
+- Concatenating a sequence of :py:class:`~xarray.DataArray` with varying names
+  sets the name of the output array to ``None``, instead of the name of the
+  first input array.
+  (:issue:`2775`). By `Zac Hatfield-Dodds <https://github.com/Zac-HD>`_.
 - Interpolating via resample now internally specifies ``bounds_error=False``
   as an argument to ``scipy.interpolate.interp1d``, allowing for interpolation
   from higher frequencies to lower frequencies.  Datapoints outside the bounds

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from . import utils
 from .alignment import align
+from .computation import result_name
 from .merge import merge
 from .variable import IndexVariable, Variable, as_variable
 from .variable import concat as concat_vars
@@ -323,16 +324,10 @@ def _dataarray_concat(arrays, dim, data_vars, coords, compat,
         raise ValueError('data_vars is not a valid argument when '
                          'concatenating DataArray objects')
 
-    datasets = []
-    for n, arr in enumerate(arrays):
-        if n == 0:
-            name = arr.name
-        elif name != arr.name:
-            if compat == 'identical':
-                raise ValueError('array names not identical')
-            else:
-                arr = arr.rename(name)
-        datasets.append(arr._to_temp_dataset())
+    name = result_name(arrays)
+    if name is None and compat == 'identical':
+        raise ValueError('array names not identical')
+    datasets = [arr.rename(name)._to_temp_dataset() for arr in arrays]
 
     ds = _dataset_concat(datasets, dim, data_vars, coords, compat,
                          positions)

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -297,6 +297,16 @@ class TestConcatDataArray(object):
         assert combined.shape == (2, 3, 3)
         assert combined.dims == ('z', 'x', 'y')
 
+    def test_concat_names(self):
+        ds = Dataset({'foo': (['x', 'y'], np.random.random((2, 2))),
+                      'bar': (['x', 'y'], np.random.random((2, 2)))})
+        # Concat arrays with different names, new name is None
+        new = concat([ds.foo, ds.bar], dim='new')
+        assert new.name is None
+        # Concat arrays with same name, name is preserved
+        foobar = ds.foo.rename('bar')
+        assert concat([foobar, ds.bar], dim='new').name == 'bar'
+
 
 class TestAutoCombine(object):
 

--- a/xarray/tutorial.py
+++ b/xarray/tutorial.py
@@ -91,16 +91,17 @@ def open_dataset(name, cache=True, cache_dir=_default_cache_dir,
 
 def load_dataset(*args, **kwargs):
     """
-    `load_dataset` will be removed in version 0.12. The current behavior of
-    this function can be achived by using `tutorial.open_dataset(...).load()`.
+    `load_dataset` is deprecated and will be removed in a future version.
+    The current behavior of this function can be achived by using
+    `tutorial.open_dataset(...).load()`.
 
     See Also
     --------
     open_dataset
     """
     warnings.warn(
-        "load_dataset` will be removed in xarray version 0.12. The current "
-        "behavior of this function can be achived by using "
+        "load_dataset` will be removed in a future version of Xarray. "
+        "The current behavior of this function can be achived by using "
         "`tutorial.open_dataset(...).load()`.",
         DeprecationWarning, stacklevel=2)
     return open_dataset(*args, **kwargs).load()


### PR DESCRIPTION
 - [x] Closes #2775
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

This is really nice to have when producing faceted plots of satellite observations in various bands, and should be somewhere between useful and harmless in other cases.

Example code:

```python
ds = xr.Dataset({
    k: xr.DataArray(np.random.random((2, 2)), dims="x y".split(), name=k) 
    for k in "blue green red".split()
})
xr.concat([ds.blue, ds.green, ds.red], dim="band").plot.imshow(col="band")
```

Before - facets have an index, colorbar has misleading label: 

![image](https://user-images.githubusercontent.com/12229877/52989142-3276f780-3456-11e9-940a-dd97778736cb.png)

After - facets have meaningful labels, colorbar has no label:

![image](https://user-images.githubusercontent.com/12229877/52992574-31999200-3465-11e9-8244-5bf456bede1b.png)