### PR TITLE
Add support for cftime.datetime coordinates with coarsen

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -45,6 +45,10 @@ Enhancements
   See :ref:`comput.coarsen` for details.
   (:issue:`2525`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+- Taking the mean of arrays of :py:class:`cftime.datetime` objects, and
+  by extension, use of :py:meth:`~xarray.DataArray.coarsen` with
+  :py:class:`cftime.datetime` coordinates is now possible. By `Spencer Clark
+  <https://github.com/spencerkclark>`_. 
 - Upsampling an array via interpolation with resample is now dask-compatible,
   as long as the array is not chunked along the resampling dimension.
   By `Spencer Clark <https://github.com/spencerkclark>`_.

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -997,15 +997,15 @@ def is_np_datetime_like(dtype):
             np.issubdtype(dtype, np.timedelta64))
 
 
-def contains_cftime_datetimes(var):
-    """Check if a variable contains cftime datetime objects"""
+def _contains_cftime_datetimes(array):
+    """Check if an array contains cftime.datetime objects"""
     try:
         from cftime import datetime as cftime_datetime
     except ImportError:
         return False
     else:
-        if var.dtype == np.dtype('O') and var.data.size > 0:
-            sample = var.data.ravel()[0]
+        if array.dtype == np.dtype('O') and array.size > 0:
+            sample = array.ravel()[0]
             if isinstance(sample, dask_array_type):
                 sample = sample.compute()
                 if isinstance(sample, np.ndarray):
@@ -1013,6 +1013,11 @@ def contains_cftime_datetimes(var):
             return isinstance(sample, cftime_datetime)
         else:
             return False
+
+
+def contains_cftime_datetimes(var):
+    """Check if an xarray.Variable contains cftime.datetime objects"""
+    return _contains_cftime_datetimes(var.data)
 
 
 def _contains_datetime_like_objects(var):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -23,7 +23,7 @@ from . import (
     InaccessibleArray, UnexpectedDataAccess, assert_allclose,
     assert_array_equal, assert_equal, assert_identical, has_cftime, has_dask,
     raises_regex, requires_bottleneck, requires_dask, requires_scipy,
-    source_ndarray)
+    source_ndarray, requires_cftime)
 
 try:
     import dask.array as da
@@ -4508,6 +4508,15 @@ def test_coarsen_coords(ds, dask):
         np.linspace(0, 365, num=364), dims='time',
         coords={'time': pd.date_range('15/12/1999', periods=364)})
     actual = da.coarsen(time=2).mean()
+
+
+@requires_cftime
+def test_coarsen_coords_cftime():
+    times = xr.cftime_range('2000', periods=6)
+    da = xr.DataArray(range(6), [('time', times)])
+    actual = da.coarsen(time=3).mean()
+    expected_times = xr.cftime_range('2000-01-02', freq='3D', periods=2)
+    np.testing.assert_array_equal(actual.time, expected_times)
 
 
 def test_rolling_properties(ds):

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -270,6 +270,31 @@ def test_datetime_reduce(dask):
     assert da['time'][0].mean() == da['time'][:1].mean()
 
 
+@requires_cftime
+def test_cftime_datetime_mean():
+    times = cftime_range('2000', periods=4)
+    da = DataArray(times, dims=['time'])
+
+    assert da.isel(time=0).mean() == da.isel(time=0)
+
+    expected = DataArray(times.date_type(2000, 1, 2, 12))
+    result = da.mean()
+    assert_equal(result, expected)
+
+    da_2d = DataArray(times.values.reshape(2, 2))
+    result = da_2d.mean()
+    assert_equal(result, expected)
+
+
+@requires_cftime
+@requires_dask
+def test_cftime_datetime_mean_dask_error():
+    times = cftime_range('2000', periods=4)
+    da = DataArray(times, dims=['time']).chunk()
+    with pytest.raises(NotImplementedError):
+        da.mean()
+
+
 @pytest.mark.parametrize('dim_num', [1, 2])
 @pytest.mark.parametrize('dtype', [float, int, np.float32, np.bool_])
 @pytest.mark.parametrize('dask', [False, True])


### PR DESCRIPTION
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

For now I've held off on making these changes dask-compatible (I could do it, but I'm not sure it is worth the extra complexity).