### PR TITLE
Don't use deprecated np.asscalar()

### DIFF
--- a/xarray/convert.py
+++ b/xarray/convert.py
@@ -247,7 +247,7 @@ def from_iris(cube):
         if coord_dims:
             coords[_name(coord)] = (coord_dims, coord.points, coord_attrs)
         else:
-            coords[_name(coord)] = ((), np.asscalar(coord.points), coord_attrs)
+            coords[_name(coord)] = ((), coord.points.item(), coord_attrs)
 
     array_attrs = _iris_obj_to_attrs(cube)
     cell_methods = _iris_cell_methods_to_str(cube.cell_methods)

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -550,7 +550,7 @@ def decode_numpy_dict_values(attrs):
         if isinstance(v, np.ndarray):
             attrs[k] = v.tolist()
         elif isinstance(v, np.generic):
-            attrs[k] = np.asscalar(v)
+            attrs[k] = v.item()
     return attrs
 
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2963,7 +2963,7 @@ class TestDataArray(object):
                  'maintainer': 'bar'}
         da = DataArray(x, {'t': t, 'lat': lat}, dims=['t', 'lat'],
                        attrs=attrs)
-        expected_attrs = {'created': np.asscalar(attrs['created']),
+        expected_attrs = {'created': attrs['created'].item(),
                           'coords': attrs['coords'].tolist(),
                           'maintainer': 'bar'}
         actual = da.to_dict()

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3152,7 +3152,7 @@ class TestDataset(object):
         ds = Dataset(OrderedDict([('a', ('t', x, attrs)),
                                   ('b', ('t', y, attrs)),
                                   ('t', ('t', t))]))
-        expected_attrs = {'created': np.asscalar(attrs['created']),
+        expected_attrs = {'created': attrs['created'].item(),
                           'coords': attrs['coords'].tolist(),
                           'maintainer': 'bar'}
         actual = ds.to_dict()


### PR DESCRIPTION
It got deprecated in numpy 1.16 and throws a ton of warnings due to that.
All the function does is returning .item() anyway, which is why it got deprecated.

I checked that it worked that way at least all the way down to numpy 1.12, which is the minimum required version according to setup.py.
