### PR TITLE
Push back finalizing deprecations for 0.12

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -262,8 +262,8 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
         warnings.warn(
             'The autoclose argument is no longer used by '
             'xarray.open_dataset() and is now ignored; it will be removed in '
-            'xarray v0.12. If necessary, you can control the maximum number '
-            'of simultaneous open files with '
+            'a future version of xarray. If necessary, you can control the '
+            'maximum number of simultaneous open files with '
             'xarray.set_options(file_cache_maxsize=...).',
             FutureWarning, stacklevel=2)
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -616,8 +616,9 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
             if self._obj.ndim > 1:
                 warnings.warn(
                     "Default reduction dimension will be changed to the "
-                    "grouped dimension after xarray 0.12. To silence this "
-                    "warning, pass dim=xarray.ALL_DIMS explicitly.",
+                    "grouped dimension in a future version of xarray. To "
+                    "silence this warning, pass dim=xarray.ALL_DIMS "
+                    "explicitly.",
                     FutureWarning, stacklevel=2)
 
         if keep_attrs is None:
@@ -731,8 +732,9 @@ class DatasetGroupBy(GroupBy, ImplementsDatasetReduce):
             # the deprecation process. Do not forget to remove _reduce_method
             warnings.warn(
                 "Default reduction dimension will be changed to the "
-                "grouped dimension after xarray 0.12. To silence this "
-                "warning, pass dim=xarray.ALL_DIMS explicitly.",
+                "grouped dimension in a future version of xarray. To "
+                "silence this warning, pass dim=xarray.ALL_DIMS "
+                "explicitly.",
                 FutureWarning, stacklevel=2)
         elif dim is None:
             dim = self._group_dim

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -20,7 +20,8 @@ def _check_inplace(inplace, default=False):
         inplace = default
     else:
         warnings.warn('The inplace argument has been deprecated and will be '
-                      'removed in xarray 0.12.0.', FutureWarning, stacklevel=3)
+                      'removed in a future version of xarray.',
+                      FutureWarning, stacklevel=3)
 
     return inplace
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2037,7 +2037,7 @@ class TestDataArray(object):
         with pytest.warns(FutureWarning):
             grouped.sum()
 
-    @pytest.mark.skipif(LooseVersion(xr.__version__) < LooseVersion('0.12'),
+    @pytest.mark.skipif(LooseVersion(xr.__version__) < LooseVersion('0.13'),
                         reason="not to forget the behavior change")
     def test_groupby_sum_default(self):
         array = self.make_groupby_example_array()

--- a/xarray/tutorial.py
+++ b/xarray/tutorial.py
@@ -91,16 +91,17 @@ def open_dataset(name, cache=True, cache_dir=_default_cache_dir,
 
 def load_dataset(*args, **kwargs):
     """
-    `load_dataset` will be removed in version 0.12. The current behavior of
-    this function can be achived by using `tutorial.open_dataset(...).load()`.
+    `load_dataset` will be removed a future version of xarray. The current
+    behavior of this function can be achived by using
+    `tutorial.open_dataset(...).load()`.
 
     See Also
     --------
     open_dataset
     """
     warnings.warn(
-        "load_dataset` will be removed in xarray version 0.12. The current "
-        "behavior of this function can be achived by using "
+        "load_dataset` will be removed in a future version of xarray. The "
+        "current behavior of this function can be achived by using "
         "`tutorial.open_dataset(...).load()`.",
         DeprecationWarning, stacklevel=2)
     return open_dataset(*args, **kwargs).load()


### PR DESCRIPTION
0.12 will already have a big change in dropping Python 2.7 support. I'd rather
wait a bit longer to finalize these deprecations to minimize the impact on
users.

xref https://github.com/pydata/xarray/issues/2776

<!-- Feel free to remove check-list items aren't relevant to your change -->