### PR TITLE
Drop failing tests writing multi-dimensional arrays as attributes

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3445,22 +3445,12 @@ class TestValidateAttrs(object):
                 ds.to_netcdf(tmp_file)
 
             ds, attrs = new_dataset_and_attrs()
-            attrs['test'] = np.arange(12).reshape(3, 4)
-            with create_tmp_file() as tmp_file:
-                ds.to_netcdf(tmp_file)
-
-            ds, attrs = new_dataset_and_attrs()
             attrs['test'] = 'This is a string'
             with create_tmp_file() as tmp_file:
                 ds.to_netcdf(tmp_file)
 
             ds, attrs = new_dataset_and_attrs()
             attrs['test'] = ''
-            with create_tmp_file() as tmp_file:
-                ds.to_netcdf(tmp_file)
-
-            ds, attrs = new_dataset_and_attrs()
-            attrs['test'] = np.arange(12).reshape(3, 4)
             with create_tmp_file() as tmp_file:
                 ds.to_netcdf(tmp_file)
 


### PR DESCRIPTION
These aren't valid for netCDF files.

Fixes #2803

<!-- Feel free to remove check-list items aren't relevant to your change -->
