### PR TITLE
Small fix: use == to compare strings

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1597,7 +1597,7 @@ class Variable(common.AbstractArray, arithmetic.SupportsArithmetic,
                             "prior to calling this method.")
 
         axis = self.get_axis_num(dim)
-        func = bn.nanrankdata if self.dtype.kind is 'f' else bn.rankdata
+        func = bn.nanrankdata if self.dtype.kind == 'f' else bn.rankdata
         ranked = func(self.data, axis=axis)
         if pct:
             count = np.sum(~np.isnan(self.data), axis=axis, keepdims=True)


### PR DESCRIPTION
`is` relies on interning, which is almost always OK for small strings, but reliant on language implementations

(unless there's something I'm missing about `.kind`?)