### PR TITLE
Allow passing _FillValue=False in encoding for vlen str variables.

### DIFF
--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -170,6 +170,8 @@ class H5NetCDFStore(WritableCFDataStore):
             variable, raise_on_invalid_encoding=check_encoding)
 
         fillvalue = attrs.pop('_FillValue', None)
+        if dtype is str and fillvalue is False:
+            fillvalue = None
         if dtype is str and fillvalue is not None:
             raise NotImplementedError(
                 'h5netcdf does not yet support setting a fill value for '

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -433,7 +433,8 @@ class NetCDF4DataStore(WritableCFDataStore):
 
         fill_value = attrs.pop('_FillValue', None)
 
-        if datatype is str and fill_value is not None:
+        if ((datatype is str and fill_value is not None and
+             fill_value is not False)):
             raise NotImplementedError(
                 'netCDF4 does not yet support setting a fill value for '
                 'variable-length strings '

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1006,6 +1006,15 @@ class NetCDF4Base(CFEncodedBase):
                 assert actual['x'].encoding['dtype'] is str
                 assert_identical(actual, expected)
 
+    def test_string_explicit_no_fillvalue(self):
+        expected = Dataset(
+            dict(test=(('site',), [1, 1, 1, 1])),
+            coords=dict(site=['one', 'two', 'three', 'four']),
+        )
+        expected.coords['site'].encoding['_FillValue'] = False
+        with self.roundtrip(expected) as actual:
+            assert actual.coords['site'].encoding['dtype'] == str
+
     def test_roundtrip_string_with_fill_value_vlen(self):
         values = np.array(['ab', 'cdef', np.nan], dtype=object)
         expected = Dataset({'x': ('t', values)})


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
The documentation seems to imply that passing _FillValue=False in the encoding works to set no fill value for any value.  These changes to `netCDF4_.py` and `h5netcdf_.py` seem to allow this for variables that are vlen strings (dtype `str` rather than `"S1"`): I have used the code-path in `netCDF4_.py` in real code and know that it at least allows the save to complete.

Allowing _FillValue=False makes it easier to explicitly exclude `_FillValue` from being written for coordinate variables, which some CF-compliance checkers complain about.

 - [ ] Closes #xxxx
 - [X] Tests added
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
