### PR TITLE
Remove py37 collections.abc deprecation warning from lru_cache module.

### DIFF
--- a/xarray/backends/lru_cache.py
+++ b/xarray/backends/lru_cache.py
@@ -1,8 +1,9 @@
 import collections
+import collections.abc
 import threading
 
 
-class LRUCache(collections.MutableMapping):
+class LRUCache(collections.abc.MutableMapping):
     """Thread-safe LRUCache based on an OrderedDict.
 
     All dict operations (__getitem__, __setitem__, __contains__) update the


### PR DESCRIPTION
Looks like this occurrence was missing in #2574.
