### PR TITLE
More informative error when writing attrs to netCDF

### DIFF
--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -293,9 +293,13 @@ def _set_nc_attribute(obj, key, value):
     else:
         try:
             obj.setncattr(key, value)
-        except AttributeError as e:
-            msg = ('The following exception occurred when attempting to set '
-                   'attribute ({}, {}): "{}"'.format(key, value, e))
+        except AttributeError:
+            msg = ('Failed to write attribute {!r} with value '
+                   '{!r}'.format(key, value))
+            var_name = getattr(obj, 'name', None)
+            if var_name is not None:
+                msg += ' on variable {!r}'.format(var_name)
+            msg += ' in a NetCDF file.'
             raise AttributeError(msg)
 
 

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -291,8 +291,12 @@ def _set_nc_attribute(obj, key, value):
                    'upgrade to netCDF4-python 1.2.4 or greater.')
             raise AttributeError(msg)
     else:
-        obj.setncattr(key, value)
-
+        try:
+            obj.setncattr(key, value)
+        except AttributeError as e:
+            msg = ('The following exception occurred when attempting to set '
+                   'attribute ({}, {}): "{}"'.format(key, value, e))
+            raise AttributeError(msg)
 
 class NetCDF4DataStore(WritableCFDataStore):
     """Store for reading and writing data via the Python-NetCDF4 library.

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -298,6 +298,7 @@ def _set_nc_attribute(obj, key, value):
                    'attribute ({}, {}): "{}"'.format(key, value, e))
             raise AttributeError(msg)
 
+
 class NetCDF4DataStore(WritableCFDataStore):
     """Store for reading and writing data via the Python-NetCDF4 library.
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1291,10 +1291,13 @@ class TestNetCDF4Data(NetCDF4Base):
                 assert one_string == totest.attrs['baz']
 
     def test_setncattr_fails(self):
-        ds = Dataset({'x': ('y', [1, 2, 3], {'CLASS': 'foo'})})
+        ds = Dataset({'bar': ('y', [1, 2, 3], {'CLASS': 'foo'})})
         with create_tmp_file() as tmp_file:
-            with pytest.raises(AttributeError, message='(CLASS, foo)'):
+            with pytest.raises(AttributeError) as e:
                 ds.to_netcdf(tmp_file)
+            msg = ("Failed to write attribute 'CLASS' with value 'foo' on "
+                   "variable 'bar' in a NetCDF file.")
+            assert msg == str(e.value)
 
     def test_autoclose_future_warning(self):
         data = create_test_data()

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1290,6 +1290,13 @@ class TestNetCDF4Data(NetCDF4Base):
                                    totest.attrs['bar'])
                 assert one_string == totest.attrs['baz']
 
+    def test_setncattr_fails(self):
+        attrs = {'CLASS': 'foo'}
+        ds = Dataset({'x': ('y', [1, 2, 3], attrs)})
+        with create_tmp_file() as tmp_file:
+            with pytest.raises(AttributeError, message='(CLASS, foo)'):
+                ds.to_netcdf(tmp_file)
+
     def test_autoclose_future_warning(self):
         data = create_test_data()
         with create_tmp_file() as tmp_file:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1291,8 +1291,7 @@ class TestNetCDF4Data(NetCDF4Base):
                 assert one_string == totest.attrs['baz']
 
     def test_setncattr_fails(self):
-        attrs = {'CLASS': 'foo'}
-        ds = Dataset({'x': ('y', [1, 2, 3], attrs)})
+        ds = Dataset({'x': ('y', [1, 2, 3], {'CLASS': 'foo'})})
         with create_tmp_file() as tmp_file:
             with pytest.raises(AttributeError, message='(CLASS, foo)'):
                 ds.to_netcdf(tmp_file)


### PR DESCRIPTION
Closes #3080 

Some attribute names aren't valid netCDF4 keys. For example:

```python
 import xarray as xr 
 ds = xr.Dataset({'x': ('y', [1, 2, 3], {'CLASS': 'foo'})})
ds.to_netcdf('test.nc')
```

will fail with:

```NetCDF: String match to name in use```

This is hard to debug if you don't know which attribute is faulty. With this small change the error should be more informative:

```AttributeError: The following exception occurred when attempting to set attribute (CLASS, foo): "NetCDF: String match to name in use"```
