### PR TITLE
BUG: Fix #2864 by adding the missing vrt parameters

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,6 +33,8 @@ Bug fixes
   By `Andras Gefferth <https://github.com/kefirbandi>`_.
 - ``swap_dims`` would create incorrect ``indexes`` (:issue:`2842`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
+- open_rasterio() now supports rasterio.vrt.WarpedVRT with custom transform, width and height (:issue:`2864`).
+  By `Julien Michel <https://github.com/jmichel-otb>`_.
 
 .. _whats-new.0.12.0:
 

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -224,6 +224,9 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None,
                           src_nodata=vrt.src_nodata,
                           dst_nodata=vrt.dst_nodata,
                           tolerance=vrt.tolerance,
+                          transform=vrt.transform,
+                          width=vrt.width,
+                          height=vrt.height,
                           warp_extras=vrt.warp_extras)
 
     if lock is None:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3354,12 +3354,14 @@ class TestRasterio(object):
         # Test open_rasterio() support of WarpedVRT with transform, width and
         # height (issue #2864)
         import rasterio
+        from rasterio.warp import calculate_default_transform
+        from affine import Affine
         with create_tmp_geotiff() as (tmp_file, expected):
             with rasterio.open(tmp_file) as src:
                 # Estimate the transform, width and height
                 # for a change of resolution
                 # tmp_file initial res is (1000,2000) (default values)
-                trans, w, h = rasterio.warp.calculate_default_transform(
+                trans, w, h = calculate_default_transform(
                     src.crs, src.crs, src.width, src.height,
                     resolution=500, *src.bounds)
                 with rasterio.vrt.WarpedVRT(src, transform=trans,
@@ -3370,7 +3372,7 @@ class TestRasterio(object):
                     with xr.open_rasterio(vrt) as da:
                         actual_shape = (da.sizes['x'], da.sizes['y'])
                         actual_res = da.res
-                        actual_transform = da.transform
+                        actual_transform = Affine(*da.transform)
                         assert actual_res == expected_res
                         assert actual_shape == expected_shape
                         assert actual_transform == expected_transform

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3356,11 +3356,14 @@ class TestRasterio(object):
         import rasterio
         with create_tmp_geotiff() as (tmp_file, expected):
             with rasterio.open(tmp_file) as src:
-                # Estimate the transform, width and height for a change of resolution
+                # Estimate the transform, width and height
+                # for a change of resolution
                 # tmp_file initial res is (1000,2000) (default values)
-                transform, width, height = rasterio.warp.calculate_default_transform(
-                    src.crs, src.crs, src.width, src.height, resolution=500, *src.bounds)
-                with rasterio.vrt.WarpedVRT(src, transform=transform, width=width, height=height) as vrt:
+                trans, w, h = rasterio.warp.calculate_default_transform(
+                    src.crs, src.crs, src.width, src.height,
+                    resolution=500, *src.bounds)
+                with rasterio.vrt.WarpedVRT(src, transform=trans,
+                                            width=w, height=h) as vrt:
                     expected_shape = (vrt.width, vrt.height)
                     expected_res = vrt.res
                     expected_transform = vrt.transform


### PR DESCRIPTION
 - [x] Closes #2864 
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
