### PR TITLE
Indexing with an empty array

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -24,6 +24,9 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- indexing with an empty list creates an object with zero-length axis (:issue:`2882`)
+  By `Mayeul d'Avezac <https://github.com/mdavezac>`_.
+
 .. _whats-new.0.12.1:
 
 v0.12.1 (4 April 2019)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 from distutils.version import LooseVersion
 from numbers import Number
 from typing import (
-    Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar, Union)
+    Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar, Union, Sequence)
 
 import numpy as np
 import pandas as pd
@@ -1516,6 +1516,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 v = as_variable(v)
             elif isinstance(v, Dataset):
                 raise TypeError('cannot use a Dataset as an indexer')
+            elif isinstance(v, Sequence) and len(v) == 0:
+                v = IndexVariable((k, ), np.asarray(v, dtype='int64'))
             else:
                 v = np.asarray(v)
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1517,7 +1517,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             elif isinstance(v, Dataset):
                 raise TypeError('cannot use a Dataset as an indexer')
             elif isinstance(v, Sequence) and len(v) == 0:
-                v = IndexVariable((k, ), np.asarray(v, dtype='int64'))
+                v = IndexVariable((k, ), np.zeros((0,), dtype='int64'))
             else:
                 v = np.asarray(v)
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -503,15 +503,11 @@ class TestDataArray(object):
 
     def test_getitem_empty_index(self):
         da = DataArray(np.arange(12).reshape((3, 4)), dims=['x', 'y'])
-        assert da[{'x': []}].size == 0
-        assert da[{'x': []}].x.size == 0
-        assert da[{'x': []}].y.size == da.y.size
-
-        assert da.loc[{'x': []}].size == 0
-        assert da.loc[{'x': []}].x.size == 0
-        assert da.loc[{'x': []}].y.size == da.y.size
-
-        assert da[[]].shape == da.values[[]].shape
+        assert_identical(da[{'x': []}],
+                         DataArray(np.zeros((0, 4)), dims=['x', 'y']))
+        assert_identical(da.loc[{'y': []}],
+                         DataArray(np.zeros((3, 0)), dims=['x', 'y']))
+        assert_identical(da[[]], DataArray(np.zeros((0, 4)), dims=['x', 'y']))
 
     def test_setitem(self):
         # basic indexing should work as numpy's indexing

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -501,6 +501,18 @@ class TestDataArray(object):
         assert_equal(da[ind], da[[0, 1]])
         assert_equal(da[ind], da[ind.values])
 
+    def test_getitem_empty_index(self):
+        da = DataArray(np.arange(12).reshape((3, 4)), dims=['x', 'y'])
+        assert da[{'x': []}].size == 0
+        assert da[{'x': []}].x.size == 0
+        assert da[{'x': []}].y.size == da.y.size
+
+        assert da.loc[{'x': []}].size == 0
+        assert da.loc[{'x': []}].x.size == 0
+        assert da.loc[{'x': []}].y.size == da.y.size
+
+        assert da[[]].shape == da.values[[]].shape
+
     def test_setitem(self):
         # basic indexing should work as numpy's indexing
         tuples = [(0, 0), (0, slice(None, None)),


### PR DESCRIPTION
Adds indexing over empty lists, e.g. `da[[]]`.
 
- [x] Closes #2882
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
