### PR TITLE
docs: Move quick overview one level up

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -4,7 +4,6 @@ Examples
 .. toctree::
     :maxdepth: 2
 
-    examples/quick-overview
     examples/weather-data
     examples/monthly-means
     examples/multidimensional-coords

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -29,6 +29,7 @@ Documentation
 
 * :doc:`why-xarray`
 * :doc:`faq`
+* :doc:`quick-overview`
 * :doc:`examples`
 * :doc:`installing`
 
@@ -39,6 +40,7 @@ Documentation
 
    why-xarray
    faq
+   quick-overview
    examples
    installing
 

--- a/doc/quick-overview.rst
+++ b/doc/quick-overview.rst
@@ -179,16 +179,28 @@ objects. You can think of it as a multi-dimensional generalization of the
     ds = xr.Dataset({'foo': data, 'bar': ('x', [1, 2]), 'baz': np.pi})
     ds
 
-Use dictionary indexing to pull out ``Dataset`` variables as ``DataArray``
-objects:
+
+This creates a dataset with three DataArrays named ``foo``, ``bar`` and ``baz``. Use dictionary or dot indexing to pull out ``Dataset`` variables as ``DataArray`` objects but note that assignment only works with dictionary indexing:
 
 .. ipython:: python
 
     ds['foo']
+    ds.foo
+
+
+When creating ``ds``, we told xarray that ``foo`` is identical to ``data`` created earlier, ``bar`` is one-dimensional with single dimension ``x`` and associated values '1' and '2', and ``baz`` is a scalar not associated with any dimension in ``ds``.
 
 Variables in datasets can have different ``dtype`` and even different
 dimensions, but all dimensions are assumed to refer to points in the same shared
-coordinate system.
+coordinate system i.e. if two variables have dimension ``x``, that dimension must be identical in both variables.
+
+For example, when creating ``ds`` xarray automatically *aligns* ``bar`` with ``DataArray`` ``foo`` i.e. they share the same coordinate system so that ``ds.bar['x'] == ds.foo['x'] == ds['x']``. Consequently, the following works without out explicitly specifying the coordinate ``x`` when creating ``ds['bar']``:
+
+.. ipython:: python
+
+    ds.bar.sel(x=10)
+
+
 
 You can do almost everything you can do with ``DataArray`` objects with
 ``Dataset`` objects (including indexing and arithmetic) if you prefer to work

--- a/doc/quick-overview.rst
+++ b/doc/quick-overview.rst
@@ -27,7 +27,7 @@ array or list, with optional *dimensions* and *coordinates*:
                         coords={'x': [10, 20]})
     data
 
-In this case, we have generated a 2D array, assigned the names *x* and *y* to the two dimensions respectively and associated two *coordinate labels* 'a' and 'b' with the two locations along the x dimension. If you supply a pandas :py:class:`~pandas.Series` or :py:class:`~pandas.DataFrame`, metadata is copied directly:
+In this case, we have generated a 2D array, assigned the names *x* and *y* to the two dimensions respectively and associated two *coordinate labels* '10' and '20' with the two locations along the x dimension. If you supply a pandas :py:class:`~pandas.Series` or :py:class:`~pandas.DataFrame`, metadata is copied directly:
 
 .. ipython:: python
 
@@ -65,7 +65,7 @@ xarray supports four kind of indexing. Since we have assigned coordinate labels 
     data.sel(x=[10, 20])
 
 
-Unlike positional indexing, label-based indexing frees us from having to know how our array is organized. All we need to know are the dimension name and the label you wish to index i.e. ``data.sel(x=10)`` works regardless of whether x is the first or second dimension of the array and regardless of whether ``10`` is the first or second element of ``x``. We have already told xarray that x is the first dimension when we created ``data``. xarray keeps track of this so you don't have to. These operations are just as fast as in pandas, because xarray borrows pandas' indexing machinery.
+Unlike positional indexing, label-based indexing frees us from having to know how our array is organized. All we need to know are the dimension name and the label we wish to index i.e. ``data.sel(x=10)`` works regardless of whether ``x`` is the first or second dimension of the array and regardless of whether ``10`` is the first or second element of ``x``. We have already told xarray that x is the first dimension when we created ``data``: xarray keeps track of this so we don't have to. These operations are just as fast as in pandas, because xarray borrows pandas' indexing machinery.
 
 
 Attributes

--- a/doc/quick-overview.rst
+++ b/doc/quick-overview.rst
@@ -190,11 +190,7 @@ This creates a dataset with three DataArrays named ``foo``, ``bar`` and ``baz``.
     ds.foo
 
 
-When creating ``ds``, we told xarray that ``foo`` is identical to ``data`` created earlier, ``bar`` is one-dimensional with single dimension ``x`` and associated values '1' and '2', and ``baz`` is a scalar not associated with any dimension in ``ds``.
-
-Variables in datasets can have different ``dtype`` and even different
-dimensions, but all dimensions are assumed to refer to points in the same shared
-coordinate system i.e. if two variables have dimension ``x``, that dimension must be identical in both variables.
+When creating ``ds``, we specified that ``foo`` is identical to ``data`` created earlier, ``bar`` is one-dimensional with single dimension ``x`` and associated values '1' and '2', and ``baz`` is a scalar not associated with any dimension in ``ds``. Variables in datasets can have different ``dtype`` and even different dimensions, but all dimensions are assumed to refer to points in the same shared coordinate system i.e. if two variables have dimension ``x``, that dimension must be identical in both variables.
 
 For example, when creating ``ds`` xarray automatically *aligns* ``bar`` with ``DataArray`` ``foo`` i.e. they share the same coordinate system so that ``ds.bar['x'] == ds.foo['x'] == ds['x']``. Consequently, the following works without out explicitly specifying the coordinate ``x`` when creating ``ds['bar']``:
 
@@ -230,4 +226,4 @@ You can directly read and write xarray objects to disk using :py:meth:`~xarray.D
     os.remove('example.nc')
 
 
-It is common for many datasets to be distributed across multiple files (commonly one file per timestep). xarray supports this use-case by providing the :py:meth:`~xarray.open_mfdataset` and the :py:meth:`~xarray.save_mfdataset` methods. For more, see :ref:`io`.
+It is common for datasets to be distributed across multiple files (commonly one file per timestep). xarray supports this use-case by providing the :py:meth:`~xarray.open_mfdataset` and the :py:meth:`~xarray.save_mfdataset` methods. For more, see :ref:`io`.

--- a/doc/quick-overview.rst
+++ b/doc/quick-overview.rst
@@ -65,7 +65,7 @@ xarray supports four kind of indexing. Since we have assigned coordinate labels 
     data.sel(x=[10, 20])
 
 
-Unlike positional indexing, label-based indexing frees us from having to know how our array is organized. All we need to know are the dimension name and the label we wish to index i.e. ``data.sel(x=10)`` works regardless of whether ``x`` is the first or second dimension of the array and regardless of whether ``10`` is the first or second element of ``x``. We have already told xarray that x is the first dimension when we created ``data``: xarray keeps track of this so we don't have to. These operations are just as fast as in pandas, because xarray borrows pandas' indexing machinery. For more, see :ref:`indexing`.
+Unlike positional indexing, label-based indexing frees us from having to know how our array is organized. All we need to know are the dimension name and the label we wish to index i.e. ``data.sel(x=10)`` works regardless of whether ``x`` is the first or second dimension of the array and regardless of whether ``10`` is the first or second element of ``x``. We have already told xarray that x is the first dimension when we created ``data``: xarray keeps track of this so we don't have to. For more, see :ref:`indexing`.
 
 
 Attributes
@@ -192,7 +192,7 @@ This creates a dataset with three DataArrays named ``foo``, ``bar`` and ``baz``.
 
 When creating ``ds``, we specified that ``foo`` is identical to ``data`` created earlier, ``bar`` is one-dimensional with single dimension ``x`` and associated values '1' and '2', and ``baz`` is a scalar not associated with any dimension in ``ds``. Variables in datasets can have different ``dtype`` and even different dimensions, but all dimensions are assumed to refer to points in the same shared coordinate system i.e. if two variables have dimension ``x``, that dimension must be identical in both variables.
 
-For example, when creating ``ds`` xarray automatically *aligns* ``bar`` with ``DataArray`` ``foo`` i.e. they share the same coordinate system so that ``ds.bar['x'] == ds.foo['x'] == ds['x']``. Consequently, the following works without out explicitly specifying the coordinate ``x`` when creating ``ds['bar']``:
+For example, when creating ``ds`` xarray automatically *aligns* ``bar`` with ``DataArray`` ``foo``, i.e., they share the same coordinate system so that ``ds.bar['x'] == ds.foo['x'] == ds['x']``. Consequently, the following works without explicitly specifying the coordinate ``x`` when creating ``ds['bar']``:
 
 .. ipython:: python
 

--- a/doc/quick-overview.rst
+++ b/doc/quick-overview.rst
@@ -22,12 +22,12 @@ array or list, with optional *dimensions* and *coordinates*:
 
 .. ipython:: python
 
-    xr.DataArray(np.random.randn(2, 3))
-    data = xr.DataArray(np.random.randn(2, 3), coords={'x': ['a', 'b']}, dims=('x', 'y'))
+    data = xr.DataArray(np.random.randn(2, 3),
+                        dims=('x', 'y'),
+                        coords={'x': [10, 20]})
     data
 
-If you supply a pandas :py:class:`~pandas.Series` or
-:py:class:`~pandas.DataFrame`, metadata is copied directly:
+In this case, we have generated a 2D array, assigned the names *x* and *y* to the two dimensions respectively and associated two *coordinate labels* 'a' and 'b' with the two locations along the x dimension. If you supply a pandas :py:class:`~pandas.Series` or :py:class:`~pandas.DataFrame`, metadata is copied directly:
 
 .. ipython:: python
 
@@ -44,11 +44,11 @@ Here are the key properties for a ``DataArray``:
     # you can use this dictionary to store arbitrary metadata
     data.attrs
 
+
 Indexing
 --------
 
-xarray supports four kind of indexing. These operations are just as fast as in
-pandas, because we borrow pandas' indexing machinery.
+xarray supports four kind of indexing. Since we have assigned coordinate labels to the x dimension we can use label-based indexing along that dimension just like pandas. The four examples below all yield the same result but at varying levels of convenience and intuitiveness.
 
 .. ipython:: python
 
@@ -56,13 +56,31 @@ pandas, because we borrow pandas' indexing machinery.
     data[[0, 1]]
 
     # positional and by coordinate label, like pandas
-    data.loc['a':'b']
+    data.loc[10:20]
 
     # by dimension name and integer label
     data.isel(x=slice(2))
 
     # by dimension name and coordinate label
-    data.sel(x=['a', 'b'])
+    data.sel(x=[10, 20])
+
+
+Unlike positional indexing, label-based indexing frees us from having to know how our array is organized. All we need to know are the dimension name and the label you wish to index i.e. ``data.sel(x=10)`` works regardless of whether x is the first or second dimension of the array and regardless of whether ``10`` is the first or second element of ``x``. We have already told xarray that x is the first dimension when we created ``data``. xarray keeps track of this so you don't have to. These operations are just as fast as in pandas, because xarray borrows pandas' indexing machinery.
+
+
+Attributes
+----------
+
+While you're setting up your DataArray, it's often a good idea to set metadata attributes. A useful choice is to set ``data.attrs['long_name']`` and ``data.attrs['units']`` since xarray will use these, if present, to automatically label your plots. These special names were chosen following the `NetCDF Climate and Forecast (CF) Metadata Conventions <http://cfconventions.org/cf-conventions/cf-conventions.html>`_. ``attrs`` is just a Python dictionary, so you can assign anything you wish.
+
+.. ipython:: python
+
+    data.attrs['long_name'] = 'random velocity'
+    data.attrs['units'] = 'metres/sec'
+    data.attrs['description'] = 'A random variable created as an example.'
+    data.attrs['random_attribute'] = 123
+    data.x.attrs['units'] = 'x units'
+
 
 Computation
 -----------
@@ -73,6 +91,7 @@ Data arrays work very similarly to numpy ndarrays:
 
     data + 10
     np.sin(data)
+    # transpose
     data.T
     data.sum()
 
@@ -121,10 +140,22 @@ xarray supports grouped operations using a very similar API to pandas:
     data.groupby(labels).mean('y')
     data.groupby(labels).apply(lambda x: x - x.min())
 
+Plotting
+--------
+
+Visualizing your datasets is quick and convenient:
+
+.. ipython:: python
+
+    @savefig plotting_quick_overview.png
+    data.plot()
+
+Note the automatic labeling with names and units. Our effort in adding metadata attributes has paid off!
+    
 pandas
 ------
 
-Xarray objects can be easily converted to and from pandas objects:
+Xarray objects can be easily converted to and from pandas objects using the :py:meth:`~xarray.DataArray.to_series`, :py:meth:`~xarray.DataArray.to_dataframe` and :py:meth:`~pandas.DataFrame.to_xarray` methods:
 
 .. ipython:: python
 
@@ -161,10 +192,10 @@ You can do almost everything you can do with ``DataArray`` objects with
 ``Dataset`` objects (including indexing and arithmetic) if you prefer to work
 with multiple variables at once.
 
-NetCDF
-------
+Read & write netCDF files
+-------------------------
 
-NetCDF is the recommended binary serialization format for xarray objects. Users
+NetCDF is the recommended file format for xarray objects. Users
 from the geosciences will recognize that the :py:class:`~xarray.Dataset` data
 model looks very similar to a netCDF file (which, in fact, inspired it).
 

--- a/doc/quick-overview.rst
+++ b/doc/quick-overview.rst
@@ -214,3 +214,6 @@ You can directly read and write xarray objects to disk using :py:meth:`~xarray.D
 
     import os
     os.remove('example.nc')
+
+
+It is common for many datasets to be distributed across multiple files (commonly one file per timestep). xarray supports this use-case by providing the :py:meth:`~xarray.open_mfdataset` and the :py:meth:`~xarray.save_mfdataset` methods.

--- a/doc/quick-overview.rst
+++ b/doc/quick-overview.rst
@@ -79,6 +79,8 @@ While you're setting up your DataArray, it's often a good idea to set metadata a
     data.attrs['units'] = 'metres/sec'
     data.attrs['description'] = 'A random variable created as an example.'
     data.attrs['random_attribute'] = 123
+    data.attrs
+    # you can add metadata to coordinates too
     data.x.attrs['units'] = 'x units'
 
 

--- a/doc/quick-overview.rst
+++ b/doc/quick-overview.rst
@@ -65,7 +65,7 @@ xarray supports four kind of indexing. Since we have assigned coordinate labels 
     data.sel(x=[10, 20])
 
 
-Unlike positional indexing, label-based indexing frees us from having to know how our array is organized. All we need to know are the dimension name and the label we wish to index i.e. ``data.sel(x=10)`` works regardless of whether ``x`` is the first or second dimension of the array and regardless of whether ``10`` is the first or second element of ``x``. We have already told xarray that x is the first dimension when we created ``data``: xarray keeps track of this so we don't have to. These operations are just as fast as in pandas, because xarray borrows pandas' indexing machinery.
+Unlike positional indexing, label-based indexing frees us from having to know how our array is organized. All we need to know are the dimension name and the label we wish to index i.e. ``data.sel(x=10)`` works regardless of whether ``x`` is the first or second dimension of the array and regardless of whether ``10`` is the first or second element of ``x``. We have already told xarray that x is the first dimension when we created ``data``: xarray keeps track of this so we don't have to. These operations are just as fast as in pandas, because xarray borrows pandas' indexing machinery. For more, see :ref:`indexing`.
 
 
 Attributes
@@ -130,10 +130,12 @@ Operations also align based on index labels:
 
     data[:-1] - data[:1]
 
+For more, see :ref:`comput`.
+
 GroupBy
 -------
 
-xarray supports grouped operations using a very similar API to pandas:
+xarray supports grouped operations using a very similar API to pandas (see :ref:`groupby`):
 
 .. ipython:: python
 
@@ -152,7 +154,7 @@ Visualizing your datasets is quick and convenient:
     @savefig plotting_quick_overview.png
     data.plot()
 
-Note the automatic labeling with names and units. Our effort in adding metadata attributes has paid off!
+Note the automatic labeling with names and units. Our effort in adding metadata attributes has paid off! Many aspects of these figures are customizable: see :ref:`plotting`.
     
 pandas
 ------
@@ -228,4 +230,4 @@ You can directly read and write xarray objects to disk using :py:meth:`~xarray.D
     os.remove('example.nc')
 
 
-It is common for many datasets to be distributed across multiple files (commonly one file per timestep). xarray supports this use-case by providing the :py:meth:`~xarray.open_mfdataset` and the :py:meth:`~xarray.save_mfdataset` methods.
+It is common for many datasets to be distributed across multiple files (commonly one file per timestep). xarray supports this use-case by providing the :py:meth:`~xarray.open_mfdataset` and the :py:meth:`~xarray.save_mfdataset` methods. For more, see :ref:`io`.


### PR DESCRIPTION
I thought it'd be a good idea to make the "quick overview" example more prominent.

This PR moves that section one level up; adds some more text; talks about plotting and adding metadata.

![image](https://user-images.githubusercontent.com/2448579/56072263-5407a780-5d52-11e9-8d87-05168084bbeb.png)
