### PR TITLE
Return correct count for scalar datetime64 arrays

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -26,6 +26,8 @@ Bug fixes
 
 - indexing with an empty list creates an object with zero-length axis (:issue:`2882`)
   By `Mayeul d'Avezac <https://github.com/mdavezac>`_.
+- Return correct count for scalar datetime64 arrays (:issue:`2770`)
+  By `Dan Nowacki <https://github.com/dnowacki-usgs>`_.
 
 .. _whats-new.0.12.1:
 

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -185,7 +185,7 @@ def array_notnull_equiv(arr1, arr2):
 def count(data, axis=None):
     """Count the number of non-NA in this array along the given axis or axes
     """
-    return np.sum(~isnull(data), axis=axis)
+    return np.sum(np.logical_not(isnull(data)), axis=axis)
 
 
 def where(condition, x, y):

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -86,6 +86,8 @@ class TestOps(object):
         expected = array([[1, 2, 3], [3, 2, 1]])
         assert_array_equal(expected, count(self.x, axis=-1))
 
+        assert 1 == count(np.datetime64('2000-01-01'))
+
     def test_where_type_promotion(self):
         result = where([True, False], [1, 2], ['a', 'b'])
         assert_array_equal(result, np.array([1, 'b'], dtype=object))


### PR DESCRIPTION
BUG: Fix #2770 by changing ~ to np.logical_not()
TST: Add test for scalar datetime64 value
DOC: Add to whats-new.rst