### PR TITLE
Minor improvement of docstring for Dataset

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -343,7 +343,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         ----------
         data_vars : dict-like, optional
             A mapping from variable names to :py:class:`~xarray.DataArray`
-            objects, :py:class:`~xarray.Variable` objects or tuples of the
+            objects, :py:class:`~xarray.Variable` objects or to tuples of the
             form ``(dims, data[, attrs])`` which can be used as arguments to
             create a new ``Variable``. Each dimension must have the same length
             in all variables in which it appears.


### PR DESCRIPTION
This might help to avoid confusion. data_vars is always a mapping, not a
mapping, a variable or a tuple.

Passing just a tuple, does not work of course. But for xarray newbies, this might be less obvious and the error message is also not easy to interpret:
```
>>> xr.Dataset(('dim1', np.ones(5)))
...
TypeError: unhashable type: 'numpy.ndarray'
```

The correct version of the example above should be:
```
>>> xr.Dataset({'myvar': ('dim1', np.ones(5))})                                                                            
<xarray.Dataset>
Dimensions:  (dim1: 5)
Dimensions without coordinates: dim1
Data variables:
    myvar    (dim1) float64 1.0 1.0 1.0 1.0 1.0
```