### PR TITLE
DOC: avoid downloading .tif file

### DIFF
--- a/doc/gallery/plot_rasterio.py
+++ b/doc/gallery/plot_rasterio.py
@@ -16,9 +16,6 @@ likely be irregular in lon/lat. It is often recommended to work in the data's
 original map projection (see :ref:`recipes.rasterio_rgb`).
 """
 
-import os
-import urllib.request
-
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 import numpy as np
@@ -26,12 +23,8 @@ from rasterio.warp import transform
 
 import xarray as xr
 
-# Download the file from rasterio's repository
-url = 'https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif'
-urllib.request.urlretrieve(url, 'RGB.byte.tif')
-
 # Read the data
-da = xr.open_rasterio('RGB.byte.tif')
+da = xr.open_rasterio('https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif')
 
 # Compute the lon/lat coordinates with rasterio.warp.transform
 ny, nx = len(da['y']), len(da['x'])
@@ -54,6 +47,3 @@ greyscale.plot(ax=ax, x='lon', y='lat', transform=ccrs.PlateCarree(),
                cmap='Greys_r', add_colorbar=False)
 ax.coastlines('10m', color='r')
 plt.show()
-
-# Delete the file
-os.remove('RGB.byte.tif')

--- a/doc/gallery/plot_rasterio.py
+++ b/doc/gallery/plot_rasterio.py
@@ -24,7 +24,8 @@ from rasterio.warp import transform
 import xarray as xr
 
 # Read the data
-da = xr.open_rasterio('https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif')
+url = 'https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif'
+da = xr.open_rasterio(url)
 
 # Compute the lon/lat coordinates with rasterio.warp.transform
 ny, nx = len(da['y']), len(da['x'])

--- a/doc/gallery/plot_rasterio_rgb.py
+++ b/doc/gallery/plot_rasterio_rgb.py
@@ -13,20 +13,13 @@ original map projection instead of relying on pcolormesh and a map
 transformation.
 """
 
-import os
-import urllib.request
-
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 
 import xarray as xr
 
-# Download the file from rasterio's repository
-url = 'https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif'
-urllib.request.urlretrieve(url, 'RGB.byte.tif')
-
 # Read the data
-da = xr.open_rasterio('RGB.byte.tif')
+da = xr.open_rasterio('https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif')
 
 # The data is in UTM projection. We have to set it manually until
 # https://github.com/SciTools/cartopy/issues/813 is implemented
@@ -38,5 +31,3 @@ da.plot.imshow(ax=ax, rgb='band', transform=crs)
 ax.coastlines('10m', color='r')
 plt.show()
 
-# Delete the file
-os.remove('RGB.byte.tif')

--- a/doc/gallery/plot_rasterio_rgb.py
+++ b/doc/gallery/plot_rasterio_rgb.py
@@ -19,7 +19,8 @@ import matplotlib.pyplot as plt
 import xarray as xr
 
 # Read the data
-da = xr.open_rasterio('https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif')
+url = 'https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif'
+da = xr.open_rasterio(url)
 
 # The data is in UTM projection. We have to set it manually until
 # https://github.com/SciTools/cartopy/issues/813 is implemented
@@ -30,4 +31,3 @@ ax = plt.subplot(projection=crs)
 da.plot.imshow(ax=ax, rgb='band', transform=crs)
 ax.coastlines('10m', color='r')
 plt.show()
-


### PR DESCRIPTION
Simplify by using that rasterio can read directly from http. 

This also removes imports of requests and os.

