### PR TITLE
Fix rolling operation with dask and bottleneck

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,10 +27,13 @@ Enhancements
 - Character arrays' character dimension name decoding and encoding handled by
   ``var.encoding['char_dim_name']`` (:issue:`2895`)
   By `James McCreight <https://github.com/jmccreight>`_.
-   
+
 Bug fixes
 ~~~~~~~~~
 
+- a bug fix in rolling with dask and bottleneck
+  (:issue:`2940`)
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - indexing with an empty list creates an object with zero-length axis (:issue:`2882`)
   By `Mayeul d'Avezac <https://github.com/mdavezac>`_.
 - Return correct count for scalar datetime64 arrays (:issue:`2770`)
@@ -147,9 +150,9 @@ Other enhancements
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - Added :py:meth:`~xarray.Dataset.drop_dims` (:issue:`1949`).
   By `Kevin Squire <https://github.com/kmsquire>`_.
-- ``xr.open_zarr`` now accepts manually specified chunks with the ``chunks=`` 
-  parameter. ``auto_chunk=True`` is equivalent to ``chunks='auto'`` for 
-  backwards compatibility. The ``overwrite_encoded_chunks`` parameter is 
+- ``xr.open_zarr`` now accepts manually specified chunks with the ``chunks=``
+  parameter. ``auto_chunk=True`` is equivalent to ``chunks='auto'`` for
+  backwards compatibility. The ``overwrite_encoded_chunks`` parameter is
   added to remove the original zarr chunk encoding.
   By `Lily Wang <https://github.com/lilyminium>`_.
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -275,7 +275,7 @@ class DataArrayRolling(Rolling):
                 if isinstance(padded.data, dask_array_type):
                     # Workaround to make the padded chunk size is larger than
                     # self.window-1
-                    shift = - (self.window + 1) // 2
+                    shift = - (self.window - 1)
                     offset = (self.window - 1) // 2
                     valid = (slice(None), ) * axis + (
                         slice(offset, offset + self.obj.shape[axis]), )
@@ -285,7 +285,7 @@ class DataArrayRolling(Rolling):
                 padded = padded.pad_with_fill_value({self.dim: (0, -shift)})
 
             if isinstance(padded.data, dask_array_type):
-                values = dask_rolling_wrapper(func, padded,
+                values = dask_rolling_wrapper(func, padded.data,
                                               window=self.window,
                                               min_count=min_count,
                                               axis=axis)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3618,7 +3618,6 @@ def test_rolling_wrapped_bottleneck(da, name, center, min_periods):
 @pytest.mark.parametrize('center', (True, False, None))
 @pytest.mark.parametrize('min_periods', (1, None))
 @pytest.mark.parametrize('window', (7, 8))
-@pytest.mark.xfail(reason='https://github.com/pydata/xarray/issues/2940')
 def test_rolling_wrapped_dask(da_dask, name, center, min_periods, window):
     pytest.importorskip('dask.array')
     # dask version


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2940
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Fix for #2940 
It looks that there was a bug in the previous logic, but I am not sure why it was working...