### PR TITLE
Base classes in Python 3 don't need to subclass object

### DIFF
--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -19,7 +19,7 @@ except ImportError:
 os.environ['HDF5_USE_FILE_LOCKING'] = 'FALSE'
 
 
-class IOSingleNetCDF(object):
+class IOSingleNetCDF:
     """
     A few examples that benchmark reading/writing a single netCDF file with
     xarray
@@ -214,7 +214,7 @@ class IOReadSingleNetCDF3Dask(IOReadSingleNetCDF4Dask):
                             chunks=self.time_chunks).load()
 
 
-class IOMultipleNetCDF(object):
+class IOMultipleNetCDF:
     """
     A few examples that benchmark reading/writing multiple netCDF files with
     xarray
@@ -419,7 +419,7 @@ def create_delayed_write():
     return ds.to_netcdf('file.nc', engine='netcdf4', compute=False)
 
 
-class IOWriteNetCDFDask(object):
+class IOWriteNetCDFDask:
     timeout = 60
     repeat = 1
     number = 5
@@ -432,7 +432,7 @@ class IOWriteNetCDFDask(object):
         self.write.compute()
 
 
-class IOWriteNetCDFDaskDistributed(object):
+class IOWriteNetCDFDaskDistributed:
     def setup(self):
         try:
             import distributed

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -58,7 +58,7 @@ vectorized_assignment_values = {
 }
 
 
-class Base(object):
+class Base:
     def setup(self, key):
         self.ds = xr.Dataset(
             {'var1': (('x', 'y'), randn((nx, ny), frac_nan=0.1)),

--- a/asv_bench/benchmarks/interp.py
+++ b/asv_bench/benchmarks/interp.py
@@ -24,7 +24,7 @@ new_x_long = np.linspace(0.3 * nx, 0.7 * nx, 1000)
 new_y_long = np.linspace(0.1, 0.9, 1000)
 
 
-class Interpolation(object):
+class Interpolation:
     def setup(self, *args, **kwargs):
         self.ds = xr.Dataset(
             {'var1': (('x', 'y'), randn_xy),

--- a/asv_bench/benchmarks/reindexing.py
+++ b/asv_bench/benchmarks/reindexing.py
@@ -7,7 +7,7 @@ import xarray as xr
 from . import requires_dask
 
 
-class Reindex(object):
+class Reindex:
     def setup(self):
         data = np.random.RandomState(0).randn(1000, 100, 100)
         self.ds = xr.Dataset({'temperature': (('time', 'x', 'y'), data)},

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -19,7 +19,7 @@ randn_t = randn((nt, ))
 randn_long = randn((long_nx, ), frac_nan=0.1)
 
 
-class Rolling(object):
+class Rolling:
     def setup(self, *args, **kwargs):
         self.ds = xr.Dataset(
             {'var1': (('x', 'y'), randn_xy),

--- a/asv_bench/benchmarks/unstacking.py
+++ b/asv_bench/benchmarks/unstacking.py
@@ -7,7 +7,7 @@ import xarray as xr
 from . import requires_dask
 
 
-class Unstacking(object):
+class Unstacking:
     def setup(self):
         data = np.random.RandomState(0).randn(1, 1000, 500)
         self.ds = xr.DataArray(data).stack(flat_dim=['dim_1', 'dim_2'])

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -457,7 +457,7 @@ typically find tests wrapped in a class.
 
 .. code-block:: python
 
-    class TestReallyCoolFeature(object):
+    class TestReallyCoolFeature:
         ....
 
 Going forward, we are moving to a more *functional* style using the

--- a/doc/examples/_code/accessor_example.py
+++ b/doc/examples/_code/accessor_example.py
@@ -2,7 +2,7 @@ import xarray as xr
 
 
 @xr.register_dataset_accessor('geo')
-class GeoAccessor(object):
+class GeoAccessor:
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
         self._center = None

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,7 +27,9 @@ Enhancements
 - Character arrays' character dimension name decoding and encoding handled by
   ``var.encoding['char_dim_name']`` (:issue:`2895`)
   By `James McCreight <https://github.com/jmccreight>`_.
-   
+- Clean up Python 2 compatibility in code (:issue:`2950`)
+  By `Guido Imperiale <https://github.com/crusaderky>`_.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -529,7 +529,7 @@ def open_dataarray(filename_or_obj, group=None, decode_cf=True,
     return data_array
 
 
-class _MultiFileCloser(object):
+class _MultiFileCloser:
     def __init__(self, file_objs):
         self.file_objs = file_objs
 

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -154,7 +154,7 @@ class AbstractDataStore(Mapping):
         self.close()
 
 
-class ArrayWriter(object):
+class ArrayWriter:
     def __init__(self, lock=None):
         self.sources = []
         self.targets = []

--- a/xarray/backends/file_manager.py
+++ b/xarray/backends/file_manager.py
@@ -19,7 +19,7 @@ REF_COUNTS = {}  # type: Dict[Any, int]
 _DEFAULT_MODE = utils.ReprObject('<unused>')
 
 
-class FileManager(object):
+class FileManager:
     """Manager for acquiring and closing a file object.
 
     Use FileManager subclasses (CachingFileManager in particular) on backend
@@ -237,7 +237,7 @@ class CachingFileManager(FileManager):
             type(self).__name__, self._opener, args_string, self._kwargs)
 
 
-class _RefCounter(object):
+class _RefCounter:
     """Class for keeping track of reference counts."""
     def __init__(self, counts):
         self._counts = counts

--- a/xarray/backends/locks.py
+++ b/xarray/backends/locks.py
@@ -135,7 +135,7 @@ def acquire(lock, blocking=True):
         return lock.acquire(blocking)
 
 
-class CombinedLock(object):
+class CombinedLock:
     """A combination of multiple locks.
 
     Like a locked door, a CombinedLock is locked if any of its constituent
@@ -167,7 +167,7 @@ class CombinedLock(object):
         return "CombinedLock(%r)" % list(self.locks)
 
 
-class DummyLock(object):
+class DummyLock:
     """DummyLock provides the lock API without any actual locking."""
 
     def acquire(self, blocking=True):

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -228,7 +228,7 @@ def _extract_nc4_variable_encoding(variable, raise_on_invalid=False,
     return encoding
 
 
-class GroupWrapper(object):
+class GroupWrapper:
     """Wrap netCDF4.Group objects so closing them closes the root group."""
     def __init__(self, value):
         self.value = value

--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -77,7 +77,7 @@ def get_date_type(calendar):
         return calendars[calendar]
 
 
-class BaseCFTimeOffset(object):
+class BaseCFTimeOffset:
     _freq = None  # type: ClassVar[str]
     _day_option = None  # type: ClassVar[str]
 

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -15,7 +15,7 @@ class SerializationWarning(RuntimeWarning):
     """Warnings about encoding/decoding issues in serialization."""
 
 
-class VariableCoder(object):
+class VariableCoder:
     """Base class for encoding and decoding transformations on variables.
 
     We use coders for transforming variables between xarray's data model and

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -110,7 +110,7 @@ def _round_field(values, name, freq):
         return _round_series(values, name, freq)
 
 
-class DatetimeAccessor(object):
+class DatetimeAccessor:
     """Access datetime fields for DataArrays with datetime-like dtypes.
 
      Similar to pandas, fields can be accessed through the `.dt` attribute

--- a/xarray/core/arithmetic.py
+++ b/xarray/core/arithmetic.py
@@ -8,7 +8,7 @@ from .pycompat import dask_array_type
 from .utils import not_implemented
 
 
-class SupportsArithmetic(object):
+class SupportsArithmetic:
     """Base class for xarray types that support arithmetic.
 
     Used by Dataset, DataArray, Variable and GroupBy.

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -29,7 +29,7 @@ _DEFAULT_NAME = utils.ReprObject('<default-name>')
 _JOINS_WITHOUT_FILL_VALUES = frozenset({'inner', 'exact'})
 
 
-class _UFuncSignature(object):
+class _UFuncSignature:
     """Core dimensions signature for a given function.
 
     Based on the signature provided by generalized ufuncs in NumPy.

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -258,7 +258,7 @@ class DataArrayCoordinates(AbstractCoordinates):
         return self._data._ipython_key_completions_()
 
 
-class LevelCoordinatesSource(object):
+class LevelCoordinatesSource:
     """Iterator for MultiIndex level coordinates.
 
     Used for attribute style lookup with AttrAccessMixin. Not returned directly

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -92,7 +92,7 @@ def _infer_coords_and_dims(shape, coords, dims):
     return new_coords, dims
 
 
-class _LocIndexer(object):
+class _LocIndexer:
     def __init__(self, data_array):
         self.data_array = data_array
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -303,7 +303,7 @@ class DataVariables(Mapping):
                 if key not in self._dataset._coord_names]
 
 
-class _LocIndexer(object):
+class _LocIndexer:
     def __init__(self, dataset):
         self.dataset = dataset
 

--- a/xarray/core/dtypes.py
+++ b/xarray/core/dtypes.py
@@ -9,7 +9,7 @@ NA = utils.ReprObject('<NA>')
 
 
 @functools.total_ordering
-class AlwaysGreaterThan(object):
+class AlwaysGreaterThan:
     def __gt__(self, other):
         return True
 
@@ -18,7 +18,7 @@ class AlwaysGreaterThan(object):
 
 
 @functools.total_ordering
-class AlwaysLessThan(object):
+class AlwaysLessThan:
     def __lt__(self, other):
         return True
 

--- a/xarray/core/extensions.py
+++ b/xarray/core/extensions.py
@@ -8,7 +8,7 @@ class AccessorRegistrationWarning(Warning):
     """Warning for conflicts in accessor registration."""
 
 
-class _CachedAccessor(object):
+class _CachedAccessor:
     """Custom property-like object (descriptor) for caching accessors."""
 
     def __init__(self, name, accessor):
@@ -81,7 +81,7 @@ def register_dataset_accessor(name):
         import xarray as xr
 
         @xr.register_dataset_accessor('geo')
-        class GeoAccessor(object):
+        class GeoAccessor:
             def __init__(self, xarray_obj):
                 self._obj = xarray_obj
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -113,7 +113,7 @@ def _inverse_permutation_indices(positions):
     return indices
 
 
-class _DummyGroup(object):
+class _DummyGroup:
     """Class for keeping track of grouped dimensions without coordinates.
 
     Should not be user visible.

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -294,7 +294,7 @@ def _index_indexer_1d(old_indexer, applied_indexer, size):
     return indexer
 
 
-class ExplicitIndexer(object):
+class ExplicitIndexer:
     """Base class for explicit indexer objects.
 
     ExplicitIndexer objects wrap a tuple of values given by their ``tuple``
@@ -430,7 +430,7 @@ class VectorizedIndexer(ExplicitIndexer):
         super(VectorizedIndexer, self).__init__(new_key)
 
 
-class ExplicitlyIndexed(object):
+class ExplicitlyIndexed:
     """Mixin to mark support for Indexer subclasses in indexing."""
 
 
@@ -740,7 +740,7 @@ def _combine_indexers(old_key, shape, new_key):
                                    np.broadcast_arrays(*old_key.tuple)))
 
 
-class IndexingSupport(object):  # could inherit from enum.Enum on Python 3
+class IndexingSupport:  # could inherit from enum.Enum on Python 3
     # for backends that support only basic indexer
     BASIC = 'BASIC'
     # for backends that support basic / outer indexer

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -14,7 +14,7 @@ from .utils import OrderedSet, is_scalar
 from .variable import Variable, broadcast_variables
 
 
-class BaseInterpolator(object):
+class BaseInterpolator:
     '''gerneric interpolator class for normalizing interpolation methods'''
     cons_kwargs = {}  # type: Dict[str, Any]
     call_kwargs = {}  # type: Dict[str, Any]

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -120,7 +120,7 @@ def _advanced_indexer_subspaces(key):
     return mixed_positions, vindex_positions
 
 
-class NumpyVIndexAdapter(object):
+class NumpyVIndexAdapter:
     """Object that implements indexing like vindex on a np.ndarray.
 
     This is a pure Python implementation of (some of) the logic in this NumPy

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -69,7 +69,7 @@ def _get_keep_attrs(default):
             " True, False or 'default'.")
 
 
-class set_options(object):
+class set_options:
     """Set options for xarray in a controlled context.
 
     Currently supported options:

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -4,7 +4,7 @@ from .groupby import DEFAULT_DIMS, DataArrayGroupBy, DatasetGroupBy
 RESAMPLE_DIM = '__resample_dim__'
 
 
-class Resample(object):
+class Resample:
     """An object that extends the `GroupBy` object with additional logic
     for handling specialized re-sampling operations.
 

--- a/xarray/core/resample_cftime.py
+++ b/xarray/core/resample_cftime.py
@@ -45,7 +45,7 @@ import numpy as np
 import pandas as pd
 
 
-class CFTimeGrouper(object):
+class CFTimeGrouper:
     """This is a simple container for the grouping parameters that implements a
     single method, the only one required for resampling in xarray.  It cannot
     be used in a call to groupby like a pandas.Grouper object can."""

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -12,7 +12,7 @@ from .ops import (
 from .pycompat import dask_array_type
 
 
-class Rolling(object):
+class Rolling:
     """A object that implements the moving window pattern.
 
     See Also
@@ -435,7 +435,7 @@ class DatasetRolling(Rolling):
             **{self.dim: slice(None, None, stride)})
 
 
-class Coarsen(object):
+class Coarsen:
     """A object that implements the coarsen.
 
     See Also

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -30,7 +30,7 @@ def _nicetitle(coord, value, maxchar, template):
     return title
 
 
-class FacetGrid(object):
+class FacetGrid:
     """
     Initialize the matplotlib figure and FacetGrid object.
 

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -410,7 +410,7 @@ def hist(darray, figsize=None, size=None, aspect=None, ax=None, **kwargs):
 
 # MUST run before any 2d plotting functions are defined since
 # _plot2d decorator adds them as methods here.
-class _PlotMethods(object):
+class _PlotMethods:
     """
     Enables use of xarray.plot functions as attributes on a DataArray.
     For example, DataArray.plot.imshow

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -151,13 +151,13 @@ class InaccessibleArray(utils.NDArrayMixin, ExplicitlyIndexed):
         raise UnexpectedDataAccess("Tried accessing data")
 
 
-class ReturnItem(object):
+class ReturnItem:
 
     def __getitem__(self, key):
         return key
 
 
-class IndexerMaker(object):
+class IndexerMaker:
 
     def __init__(self, indexer_cls):
         self._indexer_cls = indexer_cls

--- a/xarray/tests/test_accessors.py
+++ b/xarray/tests/test_accessors.py
@@ -9,7 +9,7 @@ from . import (
     has_dask, raises_regex, requires_dask)
 
 
-class TestDatetimeAccessor(object):
+class TestDatetimeAccessor:
     @pytest.fixture(autouse=True)
     def setup(self):
         nt = 100

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -141,13 +141,13 @@ def create_boolean_data():
     return Dataset({'x': ('t', [True, False, False, True], attributes)})
 
 
-class TestCommon(object):
+class TestCommon:
     def test_robust_getitem(self):
 
         class UnreliableArrayFailure(Exception):
             pass
 
-        class UnreliableArray(object):
+        class UnreliableArray:
             def __init__(self, array, failures=1):
                 self.array = array
                 self.failures = failures
@@ -168,11 +168,11 @@ class TestCommon(object):
         assert actual == 0
 
 
-class NetCDF3Only(object):
+class NetCDF3Only:
     pass
 
 
-class DatasetIOBase(object):
+class DatasetIOBase:
     engine = None  # type: Optional[str]
     file_format = None  # type: Optional[str]
 
@@ -2196,7 +2196,7 @@ def test_open_mfdataset_manyfiles(readengine, nfiles, parallel, chunks,
 
 
 @requires_scipy_or_netCDF4
-class TestOpenMFDatasetWithDataVarsAndCoordsKw(object):
+class TestOpenMFDatasetWithDataVarsAndCoordsKw:
     coord_name = 'lon'
     var_name = 'v1'
 
@@ -2644,7 +2644,7 @@ class TestDask(DatasetIOBase):
 
 @requires_scipy_or_netCDF4
 @requires_pydap
-class TestPydap(object):
+class TestPydap:
     def convert_to_pydap_dataset(self, original):
         from pydap.model import GridType, BaseType, DatasetType
         ds = DatasetType('bears', **original.attrs)
@@ -2777,7 +2777,7 @@ class TestPyNio(ScipyWriteBase):
 
 
 @requires_cfgrib
-class TestCfGrib(object):
+class TestCfGrib:
 
     def test_read(self):
         expected = {'number': 2, 'time': 3, 'isobaricInhPa': 2, 'latitude': 3,
@@ -2800,7 +2800,7 @@ class TestCfGrib(object):
 
 @requires_pseudonetcdf
 @pytest.mark.filterwarnings('ignore:IOAPI_ISPH is assumed to be 6370000')
-class TestPseudoNetCDFFormat(object):
+class TestPseudoNetCDFFormat:
 
     def open(self, path, **kwargs):
         return open_dataset(path, engine='pseudonetcdf', **kwargs)
@@ -3063,7 +3063,7 @@ def create_tmp_geotiff(nx=4, ny=3, nz=3,
 
 
 @requires_rasterio
-class TestRasterio(object):
+class TestRasterio:
 
     @requires_scipy_or_netCDF4
     def test_serialization(self):
@@ -3492,7 +3492,7 @@ class TestRasterio(object):
                         assert_equal(expected_val, actual_val)
 
 
-class TestEncodingInvalid(object):
+class TestEncodingInvalid:
 
     def test_extract_nc4_variable_encoding(self):
         var = xr.Variable(('x',), [1, 2, 3], {}, {'foo': 'bar'})
@@ -3521,7 +3521,7 @@ class MiscObject:
 
 
 @requires_netCDF4
-class TestValidateAttrs(object):
+class TestValidateAttrs:
     def test_validating_attrs(self):
         def new_dataset():
             return Dataset({'data': ('y', np.arange(10.0))},
@@ -3611,7 +3611,7 @@ class TestValidateAttrs(object):
 
 
 @requires_scipy_or_netCDF4
-class TestDataArrayToNetCDF(object):
+class TestDataArrayToNetCDF:
 
     def test_dataarray_to_netcdf_no_name(self):
         original_da = DataArray(np.arange(12).reshape((3, 4)))

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -18,7 +18,7 @@ from . import (
 from .test_dataset import create_test_data
 
 
-class TestConcatDataset(object):
+class TestConcatDataset:
     def test_concat(self):
         # TODO: simplify and split this test case
 
@@ -238,7 +238,7 @@ class TestConcatDataset(object):
         assert isinstance(actual.x.to_index(), pd.MultiIndex)
 
 
-class TestConcatDataArray(object):
+class TestConcatDataArray:
     def test_concat(self):
         ds = Dataset({'foo': (['x', 'y'], np.random.random((2, 3))),
                       'bar': (['x', 'y'], np.random.random((2, 3)))},
@@ -307,7 +307,7 @@ class TestConcatDataArray(object):
         assert combined.dims == ('z', 'x', 'y')
 
 
-class TestAutoCombine(object):
+class TestAutoCombine:
 
     @pytest.mark.parametrize("combine", [_auto_combine_1d, auto_combine])
     @requires_dask  # only for toolz
@@ -425,7 +425,7 @@ def assert_combined_tile_ids_equal(dict1, dict2):
         assert_equal(dict1[k], dict2[k])
 
 
-class TestTileIDsFromNestedList(object):
+class TestTileIDsFromNestedList:
     def test_1d(self):
         ds = create_test_data
         input = [ds(0), ds(1)]
@@ -533,7 +533,7 @@ def _create_tile_ids(shape):
 
 
 @requires_dask  # only for toolz
-class TestCombineND(object):
+class TestCombineND:
     @pytest.mark.parametrize("old_id, new_id", [((3, 0, 1), (0, 1)),
                                                 ((0, 0), (0,)),
                                                 ((1,), ()),
@@ -598,7 +598,7 @@ class TestCombineND(object):
         assert_equal(result, expected)
 
 
-class TestCheckShapeTileIDs(object):
+class TestCheckShapeTileIDs:
     def test_check_depths(self):
         ds = create_test_data(0)
         combined_tile_ids = {(0,): ds, (0, 1): ds}
@@ -616,7 +616,7 @@ class TestCheckShapeTileIDs(object):
 
 
 @requires_dask  # only for toolz
-class TestAutoCombineND(object):
+class TestAutoCombineND:
     def test_single_dataset(self):
         objs = [Dataset({'x': [0]}), Dataset({'x': [1]})]
         actual = auto_combine(objs)
@@ -712,7 +712,7 @@ class TestAutoCombineND(object):
         assert_identical(expected, actual)
 
 
-class TestAutoCombineUsingCoords(object):
+class TestAutoCombineUsingCoords:
     def test_order_inferred_from_coords(self):
         data = create_test_data()
         objs = [data.isel(dim2=slice(4, 9)), data.isel(dim2=slice(4))]

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -42,7 +42,7 @@ def test_signature_properties():
 
 def test_result_name():
 
-    class Named(object):
+    class Named:
         def __init__(self, name=None):
             self.name = name
 

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -19,7 +19,7 @@ from . import (
 from .test_backends import CFEncodedBase
 
 
-class TestBoolTypeArray(object):
+class TestBoolTypeArray:
     def test_booltype_array(self):
         x = np.array([1, 0, 1, 1, 0], dtype='i1')
         bx = conventions.BoolTypeArray(x)
@@ -28,7 +28,7 @@ class TestBoolTypeArray(object):
                                         dtype=np.bool))
 
 
-class TestNativeEndiannessArray(object):
+class TestNativeEndiannessArray:
     def test(self):
         x = np.arange(5, dtype='>i8')
         expected = np.arange(5, dtype='int64')
@@ -67,7 +67,7 @@ def test_decode_cf_with_conflicting_fill_missing_value():
 
 
 @requires_cftime_or_netCDF4
-class TestEncodeCFVariable(object):
+class TestEncodeCFVariable:
     def test_incompatible_attributes(self):
         invalid_vars = [
             Variable(['t'], pd.date_range('2000-01-01', periods=3),
@@ -132,7 +132,7 @@ class TestEncodeCFVariable(object):
 
 
 @requires_cftime_or_netCDF4
-class TestDecodeCF(object):
+class TestDecodeCF:
     def test_dataset(self):
         original = Dataset({
             't': ('t', [0, 1, 2], {'units': 'days since 2000-01-01'}),

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -22,7 +22,7 @@ da = pytest.importorskip('dask.array')
 dd = pytest.importorskip('dask.dataframe')
 
 
-class DaskTestCase(object):
+class DaskTestCase:
     def assertLazyAnd(self, expected, actual, test):
 
         with (dask.config.set(scheduler='single-threaded')
@@ -586,7 +586,7 @@ class TestDataArrayAndDataset(DaskTestCase):
         self.assertLazyAndIdentical(self.lazy_array, a)
 
 
-class TestToDaskDataFrame(object):
+class TestToDaskDataFrame:
 
     def test_to_dask_dataframe(self):
         # Test conversion of Datasets to dask DataFrames

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -23,7 +23,7 @@ from xarray.tests import (
     requires_scipy, source_ndarray)
 
 
-class TestDataArray(object):
+class TestDataArray:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.attrs = {'attr1': 'value1', 'attr2': 2929}
@@ -3809,7 +3809,7 @@ def test_name_in_masking():
     assert da.where((da > 5).rename('YokoOno'), drop=True).name == name
 
 
-class TestIrisConversion(object):
+class TestIrisConversion:
     @requires_iris
     def test_to_and_from_iris(self):
         import iris

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -81,7 +81,7 @@ class InaccessibleVariableDataStore(backends.InMemoryDataStore):
                     k, v in self._variables.items())
 
 
-class TestDataset(object):
+class TestDataset:
     def test_repr(self):
         data = create_test_data(seed=123)
         data.attrs['foo'] = 'bar'
@@ -267,7 +267,7 @@ class TestDataset(object):
             actual = Dataset({'x': arg})
             assert_identical(expected, actual)
 
-        class Arbitrary(object):
+        class Arbitrary:
             pass
 
         d = pd.Timestamp('2000-01-01T12')

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -20,7 +20,7 @@ from . import (
     requires_dask)
 
 
-class TestOps(object):
+class TestOps:
 
     @pytest.fixture(autouse=True)
     def setUp(self):

--- a/xarray/tests/test_extensions.py
+++ b/xarray/tests/test_extensions.py
@@ -9,19 +9,19 @@ from . import raises_regex
 
 @xr.register_dataset_accessor('example_accessor')
 @xr.register_dataarray_accessor('example_accessor')
-class ExampleAccessor(object):
+class ExampleAccessor:
     """For the pickling tests below."""
 
     def __init__(self, xarray_obj):
         self.obj = xarray_obj
 
 
-class TestAccessor(object):
+class TestAccessor:
     def test_register(self):
 
         @xr.register_dataset_accessor('demo')
         @xr.register_dataarray_accessor('demo')
-        class DemoAccessor(object):
+        class DemoAccessor:
             """Demo accessor."""
 
             def __init__(self, xarray_obj):
@@ -52,7 +52,7 @@ class TestAccessor(object):
 
         with pytest.warns(Warning, match='overriding a preexisting attribute'):
             @xr.register_dataarray_accessor('demo')
-            class Foo(object):
+            class Foo:
                 pass
 
         # it didn't get registered again
@@ -80,7 +80,7 @@ class TestAccessor(object):
         # regression test for GH933
 
         @xr.register_dataset_accessor('stupid_accessor')
-        class BrokenAccessor(object):
+        class BrokenAccessor:
             def __init__(self, xarray_obj):
                 raise AttributeError('broken')
 

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -10,7 +10,7 @@ from xarray.core import formatting
 from . import raises_regex
 
 
-class TestFormatting(object):
+class TestFormatting:
 
     def test_get_indexer_at_least_n_items(self):
         cases = [

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -12,7 +12,7 @@ from . import IndexerMaker, ReturnItem, assert_array_equal, raises_regex
 B = IndexerMaker(indexing.BasicIndexer)
 
 
-class TestIndexers(object):
+class TestIndexers:
     def set_to_zero(self, x, i):
         x = x.copy()
         x[i] = 0
@@ -129,7 +129,7 @@ class TestIndexers(object):
                      pd.MultiIndex.from_product([[1, 2], [-1, -2]]))
 
 
-class TestLazyArray(object):
+class TestLazyArray:
     def test_slice_slice(self):
         I = ReturnItem()  # noqa: E741  # allow ambiguous name
         for size in [100, 99]:
@@ -244,7 +244,7 @@ class TestLazyArray(object):
         check_indexing(v_eager, v_lazy, indexers)
 
 
-class TestCopyOnWriteArray(object):
+class TestCopyOnWriteArray:
     def test_setitem(self):
         original = np.arange(10)
         wrapped = indexing.CopyOnWriteArray(original)
@@ -268,7 +268,7 @@ class TestCopyOnWriteArray(object):
         assert np.array(x[B[0]][B[()]]) == 'foo'
 
 
-class TestMemoryCachedArray(object):
+class TestMemoryCachedArray:
     def test_wrapper(self):
         original = indexing.LazilyOuterIndexedArray(np.arange(10))
         wrapped = indexing.MemoryCachedArray(original)
@@ -381,7 +381,7 @@ def test_vectorized_indexer():
                                     np.arange(5, dtype=np.int64)))
 
 
-class Test_vectorized_indexer(object):
+class Test_vectorized_indexer:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.data = indexing.NumpyIndexingAdapter(np.random.randn(10, 12, 13))

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -8,7 +8,7 @@ from . import raises_regex
 from .test_dataset import create_test_data
 
 
-class TestMergeInternals(object):
+class TestMergeInternals:
     def test_broadcast_dimension_size(self):
         actual = merge.broadcast_dimension_size(
             [xr.Variable('x', [1]), xr.Variable('y', [2, 1])])
@@ -19,11 +19,11 @@ class TestMergeInternals(object):
         assert actual == {'x': 1, 'y': 2}
 
         with pytest.raises(ValueError):
-            actual = merge.broadcast_dimension_size(
+            merge.broadcast_dimension_size(
                 [xr.Variable(('x', 'y'), [[1, 2]]), xr.Variable('y', [2])])
 
 
-class TestMergeFunction(object):
+class TestMergeFunction:
     def test_merge_arrays(self):
         data = create_test_data()
         actual = xr.merge([data.var1, data.var2])
@@ -128,7 +128,7 @@ class TestMergeFunction(object):
         assert expected.identical(actual)
 
 
-class TestMergeMethod(object):
+class TestMergeMethod:
 
     def test_merge(self):
         data = create_test_data()

--- a/xarray/tests/test_options.py
+++ b/xarray/tests/test_options.py
@@ -81,7 +81,7 @@ def create_test_dataarray_attrs(seed=0, var='var1'):
     return da
 
 
-class TestAttrRetention(object):
+class TestAttrRetention:
     def test_dataset_attr_retention(self):
         # Use .mean() for all tests: a typical reduction operation
         ds = create_test_dataset_attrs()

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -65,7 +65,7 @@ def easy_array(shape, start=0, stop=1):
 
 
 @requires_matplotlib
-class PlotTestCase(object):
+class PlotTestCase:
     @pytest.fixture(autouse=True)
     def setup(self):
         yield
@@ -512,7 +512,7 @@ class TestPlotHistogram(PlotTestCase):
 
 
 @requires_matplotlib
-class TestDetermineCmapParams(object):
+class TestDetermineCmapParams:
     @pytest.fixture(autouse=True)
     def setUp(self):
         self.data = np.linspace(0, 1, num=100)
@@ -706,7 +706,7 @@ class TestDetermineCmapParams(object):
 
 
 @requires_matplotlib
-class TestDiscreteColorMap(object):
+class TestDiscreteColorMap:
     @pytest.fixture(autouse=True)
     def setUp(self):
         x = np.arange(start=0, stop=10, step=2)
@@ -793,7 +793,7 @@ class TestDiscreteColorMap(object):
         np.testing.assert_allclose(primitive.levels, norm.boundaries)
 
 
-class Common2dMixin(object):
+class Common2dMixin:
     """
     Common tests for 2d plotting go here.
 
@@ -1907,7 +1907,7 @@ test_da_list = [DataArray(easy_array((10, ))),
 
 
 @requires_matplotlib
-class TestAxesKwargs(object):
+class TestAxesKwargs:
     @pytest.mark.parametrize('da', test_da_list)
     @pytest.mark.parametrize('xincrease', [True, False])
     def test_xincrease_kwarg(self, da, xincrease):

--- a/xarray/tests/test_tutorial.py
+++ b/xarray/tests/test_tutorial.py
@@ -9,7 +9,7 @@ from . import assert_identical, network
 
 
 @network
-class TestLoadDataset(object):
+class TestLoadDataset:
     @pytest.fixture(autouse=True)
     def setUp(self):
         self.testfile = 'tiny'

--- a/xarray/tests/test_ufuncs.py
+++ b/xarray/tests/test_ufuncs.py
@@ -107,7 +107,7 @@ def test_kwargs():
 @requires_np113
 def test_xarray_defers_to_unrecognized_type():
 
-    class Other(object):
+    class Other:
         def __array_ufunc__(self, *args, **kwargs):
             return 'other'
 

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -14,7 +14,7 @@ from . import (
 from .test_coding_times import _all_cftime_date_types
 
 
-class TestAlias(object):
+class TestAlias:
     def test(self):
         def new_method():
             pass
@@ -92,7 +92,7 @@ def test_multiindex_from_product_levels_non_unique():
     np.testing.assert_array_equal(result.levels[1], [1, 2])
 
 
-class TestArrayEquiv(object):
+class TestArrayEquiv:
     def test_0d(self):
         # verify our work around for pd.isnull not working for 0-dimensional
         # object arrays
@@ -102,7 +102,7 @@ class TestArrayEquiv(object):
         assert not duck_array_ops.array_equiv(0, np.array(1, dtype=object))
 
 
-class TestDictionaries(object):
+class TestDictionaries:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.x = {'a': 'A', 'b': 'B'}
@@ -197,7 +197,7 @@ def test_is_grib_path():
     assert utils.is_grib_path('example.grb2')
 
 
-class Test_is_uniform_and_sorted(object):
+class Test_is_uniform_and_sorted:
 
     def test_sorted_uniform(self):
         assert utils.is_uniform_spaced(np.arange(5))
@@ -218,7 +218,7 @@ class Test_is_uniform_and_sorted(object):
         assert utils.is_uniform_spaced([0, 0.97, 2], rtol=0.1)
 
 
-class Test_hashable(object):
+class Test_hashable:
 
     def test_hashable(self):
         for v in [False, 1, (2, ), (3, 4), 'four']:

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -26,7 +26,7 @@ from . import (
     raises_regex, requires_dask, source_ndarray)
 
 
-class VariableSubclassobjects(object):
+class VariableSubclassobjects:
     def test_properties(self):
         data = 0.5 * np.arange(10)
         v = self.cls(['time'], data, {'foo': 'bar'})
@@ -195,7 +195,7 @@ class VariableSubclassobjects(object):
 
     def test_index_0d_object(self):
 
-        class HashableItemWrapper(object):
+        class HashableItemWrapper:
             def __init__(self, item):
                 self.item = item
 
@@ -1892,7 +1892,7 @@ class TestIndexVariable(VariableSubclassobjects):
         super(TestIndexVariable, self).test_coarsen_2d()
 
 
-class TestAsCompatibleData(object):
+class TestAsCompatibleData:
     def test_unchanged_types(self):
         types = (np.asarray, PandasIndexAdapter, LazilyOuterIndexedArray)
         for t in types:
@@ -2033,7 +2033,7 @@ def test_raise_no_warning_for_nan_in_binary_ops():
     assert len(record) == 0
 
 
-class TestBackendIndexing(object):
+class TestBackendIndexing:
     """    Make sure all the array wrappers can be indexed. """
 
     @pytest.fixture(autouse=True)

--- a/xarray/ufuncs.py
+++ b/xarray/ufuncs.py
@@ -35,7 +35,7 @@ def _dispatch_priority(obj):
     return -1
 
 
-class _UFuncDispatcher(object):
+class _UFuncDispatcher:
     """Wrapper for dispatching ufuncs."""
 
     def __init__(self, name):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
