### PR TITLE
DOC: Added xclim to related projects

### DIFF
--- a/doc/related-projects.rst
+++ b/doc/related-projects.rst
@@ -33,7 +33,7 @@ Geosciences
 - `xarray-simlab <https://xarray-simlab.readthedocs.io>`_: xarray extension for computer model simulations.
 - `xarray-topo <https://gitext.gfz-potsdam.de/sec55-public/xarray-topo>`_: xarray extension for topographic analysis and modelling.
 - `xbpch <https://github.com/darothen/xbpch>`_: xarray interface for bpch files.
-- `xclim <https://xclim.readthedocs.io/>`_ : A library for calculating climate science indices with unit handling built from xarray and dask.
+- `xclim <https://xclim.readthedocs.io/>`_: A library for calculating climate science indices with unit handling built from xarray and dask.
 - `xESMF <https://xesmf.readthedocs.io>`_: Universal Regridder for Geospatial Data.
 - `xgcm <https://xgcm.readthedocs.io/>`_: Extends the xarray data model to understand finite volume grid cells (common in General Circulation Models) and provides interpolation and difference operations for such grids.
 - `xmitgcm <http://xgcm.readthedocs.io/>`_: a python package for reading `MITgcm <http://mitgcm.org/>`_ binary MDS files into xarray data structures.

--- a/doc/related-projects.rst
+++ b/doc/related-projects.rst
@@ -33,6 +33,7 @@ Geosciences
 - `xarray-simlab <https://xarray-simlab.readthedocs.io>`_: xarray extension for computer model simulations.
 - `xarray-topo <https://gitext.gfz-potsdam.de/sec55-public/xarray-topo>`_: xarray extension for topographic analysis and modelling.
 - `xbpch <https://github.com/darothen/xbpch>`_: xarray interface for bpch files.
+- `xclim <https://xclim.readthedocs.io/>`_ : A library for calculating climate science indices with unit handling built from xarray and dask.
 - `xESMF <https://xesmf.readthedocs.io>`_: Universal Regridder for Geospatial Data.
 - `xgcm <https://xgcm.readthedocs.io/>`_: Extends the xarray data model to understand finite volume grid cells (common in General Circulation Models) and provides interpolation and difference operations for such grids.
 - `xmitgcm <http://xgcm.readthedocs.io/>`_: a python package for reading `MITgcm <http://mitgcm.org/>`_ binary MDS files into xarray data structures.


### PR DESCRIPTION
This PR adds the [xclim](https://github.com/Ouranosinc/xclim) project to the list of related projects. Xclim is a reimplementation of ICCLIM indicators (and others) used in climate science research and leverages xarray, dask and pint to produce CF-Compliant climate indices in NetCDF4 format.

For more information, see: https://xclim.readthedocs.io/en/latest/

Cheers,