### PR TITLE
fix Docstring of xr.Dataset.info() to avoid failures when updating to numpydoc>=0.9

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1381,7 +1381,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         See Also
         --------
         pandas.DataFrame.assign
-        netCDF's ncdump
+        ncdump: netCDF's ncdump
         """
 
         if buf is None:  # pragma: no cover


### PR DESCRIPTION
fix Docstring of xr.Dataset.info() to avoid failures when updating to numpydoc>=0.9
 - [ X ] Closes #2959
 - [ ] Tests added
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
