### PR TITLE
Add fill_value for concat and auto_combine

### DIFF
--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -66,6 +66,8 @@ def concat(objs, dim=None, data_vars='all', coords='different',
         List of integer arrays which specifies the integer positions to which
         to assign each dataset along the concatenated dimension. If not
         supplied, objects are concatenated in the provided order.
+    fill_value : scalar, optional
+        Value to use for newly missing values
     indexers, mode, concat_over : deprecated
 
     Returns
@@ -607,6 +609,8 @@ def auto_combine(datasets, concat_dim=_CONCAT_DIM_DEFAULT,
         Details are in the documentation of concat
     coords : {'minimal', 'different', 'all' or list of str}, optional
         Details are in the documentation of conca
+    fill_value : scalar, optional
+        Value to use for newly missing values
 
     Returns
     -------

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -457,6 +457,7 @@ class TestAutoCombine:
                                   [[fill_value, 2, 3], [1, 2, fill_value]])},
                            {'x': [0, 1, 2]})
         actual = auto_combine(datasets, concat_dim='t', fill_value=fill_value)
+        assert_identical(expected, actual)
 
 
 def assert_combined_tile_ids_equal(dict1, dict2):

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 from xarray import DataArray, Dataset, Variable, auto_combine, concat
+from xarray.core import dtypes
 from xarray.core.combine import (
     _auto_combine, _auto_combine_1d, _auto_combine_all_along_first_dim,
     _check_shape_tile_ids, _combine_nd, _infer_concat_order_from_positions,
@@ -237,6 +238,20 @@ class TestConcatDataset:
         assert expected.equals(actual)
         assert isinstance(actual.x.to_index(), pd.MultiIndex)
 
+    @pytest.mark.parametrize('fill_value', [dtypes.NA, 2, 2.0])
+    def test_concat_fill_value(self, fill_value):
+        datasets = [Dataset({'a': ('x', [2, 3]), 'x': [1, 2]}),
+                    Dataset({'a': ('x', [1, 2]), 'x': [0, 1]})]
+        if fill_value == dtypes.NA:
+            # if we supply the default, we expect the missing value for a
+            # float array
+            fill_value = np.nan
+        expected = Dataset({'a': (('t', 'x'),
+                                  [[fill_value, 2, 3], [1, 2, fill_value]])},
+                           {'x': [0, 1, 2]})
+        actual = concat(datasets, dim='t', fill_value=fill_value)
+        assert_identical(actual, expected)
+
 
 class TestConcatDataArray:
     def test_concat(self):
@@ -305,6 +320,19 @@ class TestConcatDataArray:
         combined = concat(arrays, dim='z')
         assert combined.shape == (2, 3, 3)
         assert combined.dims == ('z', 'x', 'y')
+    
+    @pytest.mark.parametrize('fill_value', [dtypes.NA, 2, 2.0])
+    def test_concat_fill_value(self, fill_value):
+        foo = DataArray([1, 2], coords=[('x', [1, 2])])
+        bar = DataArray([1, 2], coords=[('x', [1, 3])])
+        if fill_value == dtypes.NA:
+            # if we supply the default, we expect the missing value for a
+            # float array
+            fill_value = np.nan
+        expected = DataArray([[1, 2, fill_value], [1, fill_value, 2]],
+                             dims=['y', 'x'], coords={'x': [1, 2, 3]})
+        actual = concat((foo, bar), dim='y', fill_value=fill_value)
+        assert_identical(actual, expected)
 
 
 class TestAutoCombine:
@@ -416,6 +444,19 @@ class TestAutoCombine:
                             'y': (('baz', 'z'), [[1, 2]])},
                            {'baz': [100]})
         assert_identical(expected, actual)
+
+    @pytest.mark.parametrize('fill_value', [dtypes.NA, 2, 2.0])
+    def test_auto_combine_fill_value(self, fill_value):
+        datasets = [Dataset({'a': ('x', [2, 3]), 'x': [1, 2]}),
+                    Dataset({'a': ('x', [1, 2]), 'x': [0, 1]})]
+        if fill_value == dtypes.NA:
+            # if we supply the default, we expect the missing value for a
+            # float array
+            fill_value = np.nan
+        expected = Dataset({'a': (('t', 'x'),
+                                  [[fill_value, 2, 3], [1, 2, fill_value]])},
+                           {'x': [0, 1, 2]})
+        actual = auto_combine(datasets, concat_dim='t', fill_value=fill_value)
 
 
 def assert_combined_tile_ids_equal(dict1, dict2):

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -320,7 +320,7 @@ class TestConcatDataArray:
         combined = concat(arrays, dim='z')
         assert combined.shape == (2, 3, 3)
         assert combined.dims == ('z', 'x', 'y')
-    
+
     @pytest.mark.parametrize('fill_value', [dtypes.NA, 2, 2.0])
     def test_concat_fill_value(self, fill_value):
         foo = DataArray([1, 2], coords=[('x', [1, 2])])


### PR DESCRIPTION
This PR adds the optional `fill_value` parameter to `concat()` and `auto_combine()` in `xarray.core.combine`, plus the associated underlying functions in the module.  This builds on the previous PR #2920 in addressing issue #2876, and gives users the option to avoid type-changing to `float` for arrays with missing values when using these functions as discussed in issue #2870.

 - [x] Closes #2870
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
