### PR TITLE
ENH: Preserve monotonic descending index order when merging

### DIFF
--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -123,6 +123,14 @@ def align(*objects, join='inner', copy=True, indexes=None, exclude=frozenset(),
                         'indexes along dimension {!r} are not equal'
                         .format(dim))
                 index = joiner(matching_indexes)
+                # Pandas.Index.union gets called for an outer join, and the index
+                # is sorted in ascending order. When all indexes are monotonic
+                # descending, it's desirable to keep maintain descending order.
+                # The ascending sort doesn't happen if only one index is joined.
+                if join == 'outer' and len(matching_indexes) > 1:
+                    if all((matching_index.is_monotonic_decreasing
+                            for matching_index in matching_indexes)):
+                        index = index[::-1]
                 joined_indexes[dim] = index
             else:
                 index = matching_indexes[0]

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1851,13 +1851,13 @@ class TestDataset:
                                       coords={'y': [1, 2], 'x': [10, -3]})})
         x2, y2 = broadcast(x, y)
         expected_x2 = Dataset(
-            {'foo': DataArray([[3, 3], [2, 2], [1, 1], [np.nan, np.nan]],
+            {'foo': DataArray([[np.nan, np.nan], [1, 1], [2, 2], [3, 3]],
                               dims=['x', 'y'],
-                              coords={'y': [1, 2], 'x': [-3, -2, -1, 10]})})
+                              coords={'y': [1, 2], 'x': [10, -1, -2, -3]})})
         expected_y2 = Dataset(
             {'bar': DataArray(
-                [[2, 4], [np.nan, np.nan], [np.nan, np.nan], [1, 3]],
-                dims=['x', 'y'], coords={'y': [1, 2], 'x': [-3, -2, -1, 10]})})
+                [[1, 3], [np.nan, np.nan], [np.nan, np.nan], [2, 4]],
+                dims=['x', 'y'], coords={'y': [1, 2], 'x': [10, -1, -2, -3]})})
         assert_identical(expected_x2, x2)
         assert_identical(expected_y2, y2)
 

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -67,6 +67,13 @@ class TestMergeFunction:
         with raises_regex(ValueError, 'indexes .* not equal'):
             xr.merge([ds, other], join='exact')
 
+    def test_merge_monotonic_descending_indexes(self):
+        ds = xr.Dataset(coords={'x': [2, 1]})
+        other = xr.Dataset(coords={'x': [3, 2]})
+        actual = xr.merge([ds, other])
+        expected = xr.Dataset(coords={'x': [3, 2, 1]})
+        assert expected.identical(actual)
+
     def test_merge_no_conflicts_single_var(self):
         ds1 = xr.Dataset({'a': ('x', [1, 2]), 'x': [0, 1]})
         ds2 = xr.Dataset({'a': ('x', [2, 3]), 'x': [1, 2]})


### PR DESCRIPTION
* Addresses GH2947

* When indexes were joined in a dataset merge, they would always get sorted in ascending order. This is awkward for geospatial grids, which are nearly always descending in the "y" coordinate.

* This also caused an inconsistency: when a merge is called on datasets with identical descending indexes, the resulting index is descending. When a merge is called with non-identical descending indexes, the resulting index is ascending.

* When indexes are mixed ascending and descending, or non-monotonic, the resulting index is still sorted in ascending order.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2947
 - [x] Tests added
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

## Comments
I was doing some work and I kept running into the issue described at #2947, so I had a try at a fix. It was somewhat of a hassle to understand the issue because I kept running into seeming inconsistencies. This is caused by the fact that the joiner doesn't sort with a single index:

```python
def _get_joiner(join):
    if join == 'outer':
        return functools.partial(functools.reduce, operator.or_)
```
That makes sense, since I'm guessing `pandas.Index.union` isn't get called at all. (I still find the workings of  `functools` a little hard to infer.)

I also noticed that an outer join gets called with e.g. an `.isel` operation, even though there's only one index (so there's not really anything to join). However, skipping the join completely in that case makes several tests fail since dimension labels end up missing (I guess the `joiner` call takes care of it). 

It's just checking for the specific case now, but it feels like an very specific issue anyway...

The merge behavior is slightly different now, which is reflected in the updated test outcomes in `test_dataset.py`. These tests were turning monotonic decreasing indexes into an increasing index; now the decreasing order is maintained.