### PR TITLE
Default initialize Variable._attrs to OrderedDict

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -263,7 +263,7 @@ class Variable(common.AbstractArray, arithmetic.SupportsArithmetic,
         """
         self._data = as_compatible_data(data, fastpath=fastpath)
         self._dims = self._parse_dimensions(dims)
-        self._attrs = None
+        self._attrs = OrderedDict()
         self._encoding = None
         if attrs is not None:
             self.attrs = attrs


### PR DESCRIPTION
When Variable is initialized with the default parameters, `_attr` is set to `None` by default. If `_attr` is none and the `attr` property is accessed, `_attr` is mutated to `OrderedDict()`. It is not good practice for a getter to be able to cause a mutation. This change initializes `_attr` to `OrderedDict()` by default instead.

This is an internal fix, so tests and documentation are omitted.