### PR TITLE
Remove deprecated pytest.config usages

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,7 @@
 """Configuration for pytest."""
 
+import pytest
+
 
 def pytest_addoption(parser):
     """Add command-line flags for pytest."""
@@ -7,3 +9,21 @@ def pytest_addoption(parser):
                      help="runs flaky tests")
     parser.addoption("--run-network-tests", action="store_true",
                      help="runs tests requiring a network connection")
+
+
+def pytest_collection_modifyitems(config, items):
+
+    if not config.getoption("--run-flaky"):
+        skip_flaky = pytest.mark.skip(
+            reason="set --run-flaky option to run flaky tests")
+        for item in items:
+            if "flaky" in item.keywords:
+                item.add_marker(skip_flaky)
+
+    if not config.getoption("--run-network-tests"):
+        skip_network = pytest.mark.skip(
+            reason="set --run-network-tests option to run tests requiring an"
+            "internet connection")
+        for item in items:
+            if "network" in item.keywords:
+                item.add_marker(skip_network)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -54,6 +54,8 @@ Bug fixes
   By `Deepak Cherian <https://github.com/dcherian`_.
 - A deep copy deep-copies the coords (:issue:`1463`)
   By `Martin Pletcher <https://github.com/pletchm>`_.
+- Removed usages of `pytest.config`, which is deprecated (:issue:`2988`:)
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 .. _whats-new.0.12.1:
 

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -108,23 +108,8 @@ if has_dask:
     else:
         dask.config.set(scheduler='single-threaded')
 
-# pytest config
-try:
-    _SKIP_FLAKY = not pytest.config.getoption("--run-flaky")
-    _SKIP_NETWORK_TESTS = not pytest.config.getoption("--run-network-tests")
-except (ValueError, AttributeError):
-    # Can't get config from pytest, e.g., because xarray is installed instead
-    # of being run from a development version (and hence conftests.py is not
-    # available). Don't run flaky tests.
-    _SKIP_FLAKY = True
-    _SKIP_NETWORK_TESTS = True
-
-flaky = pytest.mark.skipif(
-    _SKIP_FLAKY, reason="set --run-flaky option to run flaky tests")
-network = pytest.mark.skipif(
-    _SKIP_NETWORK_TESTS,
-    reason="set --run-network-tests option to run tests requiring an "
-    "internet connection")
+flaky = pytest.mark.flaky
+network = pytest.mark.network
 
 
 @contextmanager


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

I need to confirm whether this works with an installed version of xarray, because of https://github.com/pytest-dev/pytest/issues/1596. 
If pytest doesn't pick up this config, it will run all tests, because the default is to not skip.

I know I've generally been the point person for pytest - let me know if anyone has an immediate solution for this though