### PR TITLE
Add strftime() to datetime accessor with cftimeindex and dask support

### DIFF
--- a/doc/api-hidden.rst
+++ b/doc/api-hidden.rst
@@ -153,3 +153,4 @@
 
    CFTimeIndex.shift
    CFTimeIndex.to_datetimeindex
+   CFTimeIndex.strftime

--- a/doc/time-series.rst
+++ b/doc/time-series.rst
@@ -152,6 +152,15 @@ __ http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
 
     ds['time'].dt.floor('D')
 
+The ``.dt`` accessor can also be used to generate formatted datetime strings
+for arrays utilising the same formatting as the standard `datetime.strftime`_.
+
+.. _datetime.strftime: https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior
+
+.. ipython:: python
+
+    ds['time'].dt.strftime('%a, %b %d %H:%M')
+
 .. _resampling:
 
 Resampling and grouped operations

--- a/doc/weather-climate.rst
+++ b/doc/weather-climate.rst
@@ -71,6 +71,18 @@ instance, we can create the same dates and DataArray we created above using:
    dates = xr.cftime_range(start='0001', periods=24, freq='MS', calendar='noleap')
    da = xr.DataArray(np.arange(24), coords=[dates], dims=['time'], name='foo')
 
+With :py:meth:`~xarray.CFTimeIndex.strftime` we can also easily generate formatted strings from
+the datetime values of a :py:class:`~xarray.CFTimeIndex` directly or through the
+:py:meth:`~xarray.DataArray.dt` accessor for a :py:class:`~xarray.DataArray`
+using the same formatting as the standard `datetime.strftime`_ convention .
+
+.. _datetime.strftime: https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior
+
+.. ipython:: python
+
+    dates.strftime('%c')
+    da['time'].dt.strftime('%Y%m%d')
+
 For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
 
 - `Partial datetime string indexing`_ using strictly `ISO 8601-format`_ partial

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -42,6 +42,13 @@ Enhancements
   helpful for avoiding file-lock errors when trying to write to files opened
   using ``open_dataset()`` or ``open_dataarray()``. (:issue:`2887`)
   By `Dan Nowacki <https://github.com/dnowacki-usgs>`_.
+- Added `strftime`` method to ``.dt`` accessor, making it simpler to hand
+  datetime ``DataArray`` to other code expecting formatted dates and times.
+  (:issue:`2090`). By `Alan Brammer <https://github.com/abrammer>` and
+  `Ryan May <https://github.com/dopplershift>`_.
+- Like :py:class:`pandas.DatetimeIndex`, :py:class:`CFTimeIndex` now supports
+  `strftime` method to return an index of string formatted datetimes. By
+  `Alan Brammer <https://github.com/abrammer>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -44,11 +44,11 @@ Enhancements
   By `Dan Nowacki <https://github.com/dnowacki-usgs>`_.
 - Added `strftime`` method to ``.dt`` accessor, making it simpler to hand
   datetime ``DataArray`` to other code expecting formatted dates and times.
-  (:issue:`2090`). By `Alan Brammer <https://github.com/abrammer>` and
+  (:issue:`2090`). By `Alan Brammer <https://github.com/abrammer>`_ and
   `Ryan May <https://github.com/dopplershift>`_.
 - Like :py:class:`pandas.DatetimeIndex`, :py:class:`CFTimeIndex` now supports
-  `strftime` method to return an index of string formatted datetimes. By
-  `Alan Brammer <https://github.com/abrammer>`_.
+  :py:meth:`~xarray.CFTimeIndex.strftime` method to return an index of string
+  formatted datetimes. By `Alan Brammer <https://github.com/abrammer>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -42,7 +42,7 @@ Enhancements
   helpful for avoiding file-lock errors when trying to write to files opened
   using ``open_dataset()`` or ``open_dataarray()``. (:issue:`2887`)
   By `Dan Nowacki <https://github.com/dnowacki-usgs>`_.
-- Added `strftime`` method to ``.dt`` accessor, making it simpler to hand
+- Added ``strftime`` method to ``.dt`` accessor, making it simpler to hand a
   datetime ``DataArray`` to other code expecting formatted dates and times.
   (:issue:`2090`). By `Alan Brammer <https://github.com/abrammer>`_ and
   `Ryan May <https://github.com/dopplershift>`_.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -46,7 +46,7 @@ Enhancements
   datetime ``DataArray`` to other code expecting formatted dates and times.
   (:issue:`2090`). By `Alan Brammer <https://github.com/abrammer>`_ and
   `Ryan May <https://github.com/dopplershift>`_.
-- Like :py:class:`pandas.DatetimeIndex`, :py:class:`CFTimeIndex` now supports
+- Like :py:class:`pandas.DatetimeIndex`, :py:class:`CFTimeIndex` now supports a
   :py:meth:`~xarray.CFTimeIndex.strftime` method to return an index of string
   formatted datetimes. By `Alan Brammer <https://github.com/abrammer>`_.
 

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -478,7 +478,7 @@ class CFTimeIndex(pd.Index):
 
     def strftime(self, date_format):
         """
-        Return a pd.Index of formatted strings specified by date_format, which
+        Return a Index of formatted strings specified by date_format, which
         supports the same string format as the python standard library. Details
         of the string format can be found in `python string format doc
         <https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior>`__
@@ -486,11 +486,22 @@ class CFTimeIndex(pd.Index):
         Parameters
         ----------
         date_format : str
-            date format string (e.g. "%Y-%m-%d")
+            Date format string (e.g. "%Y-%m-%d")
 
         Returns
         -------
-        ndarray of formatted strings
+        Index
+            Index of formatted strings
+
+        Examples
+        --------
+        >>> rng = xr.cftime_range(start='2000', periods=6, freq='2MS',
+        ...                       calendar='noleap')
+        >>> rng.strftime('%B %d, %Y, %r')
+        Index(['January 01, 2000, 12:00:00 AM', 'March 01, 2000, 12:00:00 AM',
+               'May 01, 2000, 12:00:00 AM', 'July 01, 2000, 12:00:00 AM',
+               'September 01, 2000, 12:00:00 AM', 'November 01, 2000, 12:00:00 AM'],
+              dtype='object')
         """
         return pd.Index([date.strftime(date_format) for date in self._data])
 

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -478,7 +478,7 @@ class CFTimeIndex(pd.Index):
 
     def strftime(self, date_format):
         """
-        Return a Index of formatted strings specified by date_format, which
+        Return an Index of formatted strings specified by date_format, which
         supports the same string format as the python standard library. Details
         of the string format can be found in `python string format doc
         <https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior>`__

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -476,6 +476,24 @@ class CFTimeIndex(pd.Index):
                 'dates.'.format(calendar), RuntimeWarning, stacklevel=2)
         return pd.DatetimeIndex(nptimes)
 
+    def strftime(self, date_format):
+        """
+        Return a pd.Index of formatted strings specified by date_format, which
+        supports the same string format as the python standard library. Details
+        of the string format can be found in `python string format doc
+        <https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior>`__
+
+        Parameters
+        ----------
+        date_format : str
+            date format string (e.g. "%Y-%m-%d")
+
+        Returns
+        -------
+        ndarray of formatted strings
+        """
+        return pd.Index([date.strftime(date_format) for date in self._data])
+
 
 def _parse_iso8601_without_reso(date_type, datetime_str):
     date, _ = _parse_iso8601_with_reso(date_type, datetime_str)

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -481,7 +481,7 @@ class CFTimeIndex(pd.Index):
         Return a Index of formatted strings specified by date_format, which
         supports the same string format as the python standard library. Details
         of the string format can be found in `python string format doc
-        <https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior>`__
+        <https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior>`__
 
         Parameters
         ----------

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -495,12 +495,12 @@ class CFTimeIndex(pd.Index):
 
         Examples
         --------
-        >>> rng = xr.cftime_range(start='2000', periods=6, freq='2MS',
+        >>> rng = xr.cftime_range(start='2000', periods=5, freq='2MS',
         ...                       calendar='noleap')
         >>> rng.strftime('%B %d, %Y, %r')
         Index(['January 01, 2000, 12:00:00 AM', 'March 01, 2000, 12:00:00 AM',
                'May 01, 2000, 12:00:00 AM', 'July 01, 2000, 12:00:00 AM',
-               'September 01, 2000, 12:00:00 AM', 'November 01, 2000, 12:00:00 AM'],
+               'September 01, 2000, 12:00:00 AM'],
               dtype='object')
         """
         return pd.Index([date.strftime(date_format) for date in self._data])

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -294,7 +294,7 @@ class DatetimeAccessor:
         Return an array of formatted strings specified by date_format, which
         supports the same string format as the python standard library. Details
         of the string format can be found in `python string format doc
-        <https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior>`__
+        <https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior>`__
 
         Parameters
         ----------

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -117,6 +117,16 @@ def _strftime_through_array(values, date_format):
 
     return field_values.reshape(values.shape)
 
+def _strftime_through_cftimeindex(values, date_format):
+    """Coerce an array of datetime-like values to a CFTimeIndex
+    and access requested datetime component
+    """
+    from ..coding.cftimeindex import CFTimeIndex
+    values_as_cftimeindex = CFTimeIndex(values.ravel())
+
+    field_values = values_as_cftimeindex._strftime(date_format)
+    return field_values.reshape(values.shape)
+
 
 def _strftime_through_series(values, date_format):
     """Coerce an array of datetime-like values to a pandas Series and

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -120,7 +120,7 @@ def _strftime_through_array(values, date_format):
 
 
 def _strftime_through_cftimeindex(values, date_format):
-    """Coerce an array of datetime-like values to a CFTimeIndex
+    """Coerce an array of cftime-like values to a CFTimeIndex
     and access requested datetime component
     """
     from ..coding.cftimeindex import CFTimeIndex
@@ -312,7 +312,17 @@ class DatetimeAccessor:
 
         Returns
         -------
-        ndarray of formatted strings
+        formatted strings : same type as values
+            Array-like of strings formatted for each element in values
+
+        Examples
+        --------
+        >>> rng = xr.Dataset({'time': datetime.datetime(2000, 1, 1)})
+        >>> rng['time'].dt.strftime('%B %d, %Y, %r')
+        <xarray.DataArray 'strftime' ()>
+        array('January 01, 2000, 12:00:00 AM', dtype=object)
+        """
+
         '''
         values = self._obj.data
         obj_type = type(self._obj)

--- a/xarray/core/accessors.py
+++ b/xarray/core/accessors.py
@@ -113,9 +113,11 @@ def _round_field(values, name, freq):
 def _strftime_through_array(values, date_format):
     """ Return string formatted values for all items in array """
     values_unravelled = values.ravel()
-    field_values = np.array([date.strftime(date_format) for date in values_unravelled])
+    field_values = np.array([date.strftime(date_format)
+                             for date in values_unravelled])
 
     return field_values.reshape(values.shape)
+
 
 def _strftime_through_cftimeindex(values, date_format):
     """Coerce an array of datetime-like values to a CFTimeIndex

--- a/xarray/tests/test_accessors.py
+++ b/xarray/tests/test_accessors.py
@@ -183,14 +183,13 @@ def test_cftime_strftime_access(data):
     """ compare cftime formatting against datetime formatting """
     date_format = '%Y%m%d%H'
     result = data.time.dt.strftime(date_format)
-    
-    data_time_array = xr.DataArray(
+    datetime_array = xr.DataArray(
         xr.coding.cftimeindex.CFTimeIndex(
-        data.time.values).to_datetimeindex(),
+            data.time.values).to_datetimeindex(),
         name="stftime",
         coords=data.time.coords,
         dims=data.time.dims)
-    expected = data_time_array.dt.strftime(date_format)
+    expected = datetime_array.dt.strftime(date_format)
     assert_equal(result, expected)
 
 

--- a/xarray/tests/test_accessors.py
+++ b/xarray/tests/test_accessors.py
@@ -42,6 +42,10 @@ class TestDatetimeAccessor:
         assert_equal(days, self.data.time.dt.day)
         assert_equal(hours, self.data.time.dt.hour)
 
+    def test_strftime(self):
+        assert ('2000-01-01 01:00:00' == self.data.time.dt.strftime(
+            '%Y-%m-%d %H:%M:%S')[1])
+
     def test_not_datetime_type(self):
         nontime_data = self.data.copy()
         int_data = np.arange(len(self.data.time)).astype('int8')
@@ -60,6 +64,7 @@ class TestDatetimeAccessor:
         floor = self.times_data.dt.floor('D')
         ceil = self.times_data.dt.ceil('D')
         round = self.times_data.dt.round('D')
+        strftime = self.times_data.dt.strftime('%Y-%m-%d %H:%M:%S')
 
         dask_times_arr = da.from_array(self.times_arr, chunks=(5, 5, 50))
         dask_times_2d = xr.DataArray(dask_times_arr,
@@ -73,12 +78,14 @@ class TestDatetimeAccessor:
         dask_floor = dask_times_2d.dt.floor('D')
         dask_ceil = dask_times_2d.dt.ceil('D')
         dask_round = dask_times_2d.dt.round('D')
+        dask_strftime = dask_times_2d.dt.strftime('%Y-%m-%d %H:%M:%S')
 
         # Test that the data isn't eagerly evaluated
         assert isinstance(dask_year.data, da.Array)
         assert isinstance(dask_month.data, da.Array)
         assert isinstance(dask_day.data, da.Array)
         assert isinstance(dask_hour.data, da.Array)
+        assert isinstance(dask_strftime.data, da.Array)
 
         # Double check that outcome chunksize is unchanged
         dask_chunks = dask_times_2d.chunks
@@ -86,6 +93,7 @@ class TestDatetimeAccessor:
         assert dask_month.data.chunks == dask_chunks
         assert dask_day.data.chunks == dask_chunks
         assert dask_hour.data.chunks == dask_chunks
+        assert dask_strftime.data.chunks == dask_chunks
 
         # Check the actual output from the accessors
         assert_equal(years, dask_year.compute())
@@ -95,6 +103,7 @@ class TestDatetimeAccessor:
         assert_equal(floor, dask_floor.compute())
         assert_equal(ceil, dask_ceil.compute())
         assert_equal(round, dask_round.compute())
+        assert_equal(strftime, dask_strftime.compute())
 
     def test_seasons(self):
         dates = pd.date_range(start="2000/01/01", freq="M", periods=12)
@@ -166,6 +175,22 @@ def test_field_access(data, field):
         getattr(xr.coding.cftimeindex.CFTimeIndex(data.time.values), field),
         name=field, coords=data.time.coords, dims=data.time.dims)
 
+    assert_equal(result, expected)
+
+
+@pytest.mark.skipif(not has_cftime, reason='cftime not installed')
+def test_cftime_strftime_access(data):
+    """ compare cftime formatting against datetime formatting """
+    date_format = '%Y%m%d%H'
+    result = data.time.dt.strftime(date_format)
+    
+    data_time_array = xr.DataArray(
+        xr.coding.cftimeindex.CFTimeIndex(
+        data.time.values).to_datetimeindex(),
+        name="stftime",
+        coords=data.time.coords,
+        dims=data.time.dims)
+    expected = data_time_array.dt.strftime(date_format)
     assert_equal(result, expected)
 
 

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -784,6 +784,17 @@ def test_parse_array_of_cftime_strings():
     result = _parse_array_of_cftime_strings(strings, DatetimeNoLeap)
     np.testing.assert_array_equal(result, expected)
 
+@pytest.mark.skipif(not has_cftime, reason='cftime not installed')
+@pytest.mark.parametrize('calendar', _ALL_CALENDARS)
+@pytest.mark.parametrize('unsafe', [False, True])
+def test_strftime_of_cftime_array(calendar, unsafe):
+    date_format = '%Y%m%d%H%M'
+    cf_values = xr.cftime_range('2000', periods=5, calendar=calendar)
+    dt_values = pd.date_range('2000', periods=5)
+    expected = dt_values.strftime(date_format)
+    result = cf_values.strftime(date_format)
+    assert result.equals(expected)
+
 
 @pytest.mark.skipif(not has_cftime, reason='cftime not installed')
 @pytest.mark.parametrize('calendar', _ALL_CALENDARS)

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -787,8 +787,7 @@ def test_parse_array_of_cftime_strings():
 
 @pytest.mark.skipif(not has_cftime, reason='cftime not installed')
 @pytest.mark.parametrize('calendar', _ALL_CALENDARS)
-@pytest.mark.parametrize('unsafe', [False, True])
-def test_strftime_of_cftime_array(calendar, unsafe):
+def test_strftime_of_cftime_array(calendar):
     date_format = '%Y%m%d%H%M'
     cf_values = xr.cftime_range('2000', periods=5, calendar=calendar)
     dt_values = pd.date_range('2000', periods=5)

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -784,6 +784,7 @@ def test_parse_array_of_cftime_strings():
     result = _parse_array_of_cftime_strings(strings, DatetimeNoLeap)
     np.testing.assert_array_equal(result, expected)
 
+
 @pytest.mark.skipif(not has_cftime, reason='cftime not installed')
 @pytest.mark.parametrize('calendar', _ALL_CALENDARS)
 @pytest.mark.parametrize('unsafe', [False, True])


### PR DESCRIPTION
 - [x] Closes #2090
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
 - [x] Add further examples to User Guide Docs

Building on #2144, I added dask support and returning the appropriate object type.  

The two initial commits show alternate approach to handling cftime values.  Either adding strftime to `cftimeindex` and accessing that way (commit 
5de4db1)  or just rolling the loop within the datetime accessor and not touching `cftimeindex` at all (
51239c9). can revert commit  5de4db1 if its preferred to not touch `cftimeindex` for any reason.  

Can clean up docstrings and minor formatting after some input on the implementation details.  
Is there a vectorized or better method for the cftime values? List comprehension was the best I could come up with, borrowing from similar logic elsewhere in the code.

