### PR TITLE
Simplify conda envs: cfgrib is now part of conda-forge

### DIFF
--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -24,12 +24,11 @@ dependencies:
   - bottleneck
   - zarr
   - pseudonetcdf>=3.0.1
-  - eccodes
+  - cfgrib>=0.9.2
   - cdms2
   - pynio
   - iris>=1.10
   - pydap
   - lxml
   - pip:
-    - cfgrib>=0.9.2
     - mypy==0.660

--- a/ci/requirements-py37.yml
+++ b/ci/requirements-py37.yml
@@ -25,9 +25,8 @@ dependencies:
   - bottleneck
   - zarr
   - pseudonetcdf>=3.0.1
+  - cfgrib>=0.9.2
   - lxml
-  - eccodes
   - pydap
   - pip:
-    - cfgrib>=0.9.2
     - mypy==0.650


### PR DESCRIPTION
This is a minor cleanup of the conda environment creation files:
 * no direct reference to *ecCodes*
 * conda-only dependency resolution
