### PR TITLE
Fix 'to_masked_array' computing dask arrays twice

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1746,8 +1746,9 @@ class DataArray(AbstractArray, DataWithCoords):
         result : MaskedArray
             Masked where invalid values (nan or inf) occur.
         """
-        isnull = pd.isnull(self.values)
-        return np.ma.MaskedArray(data=self.values, mask=isnull, copy=copy)
+        values = self.values  # only compute lazy arrays once
+        isnull = pd.isnull(values)
+        return np.ma.MaskedArray(data=values, mask=isnull, copy=copy)
 
     def to_netcdf(self, *args, **kwargs):
         """Write DataArray contents to a netCDF file.


### PR DESCRIPTION
I ran in to this issue when using `imshow` on a dask-based `DataArray` and dask's `ProgressBar()` context manager. I noticed that when using `my_data_arr.plot.imshow` the dask array was being computed twice. This PR fixes that.

Suggestions for tests and documenting this fix are welcome.

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
