### PR TITLE
Use flake8 rather than pycodestyle

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -5,6 +5,7 @@
 
 scanner:
     diff_only: False  # If True, errors caused by only the patch are shown
+    linter: flake8
 
 pycodestyle:
     max-line-length: 79
@@ -14,3 +15,4 @@ pycodestyle:
         - E741  # ambiguous variable name
         - W503  # line break before binary operator
         - W504  # line break after binary operator
+        - F401  # Unused imports; TODO: Allow typing to work without triggering errors

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,18 +1,6 @@
-# File : .pep8speaks.yml
-
-# This should be kept in sync with the duplicate config in the [pycodestyle]
-# block of setup.cfg.
+# https://github.com/OrkoHunter/pep8speaks for more info
+# pep8speaks will use the flake8 configs in `setup.cfg`
 
 scanner:
-    diff_only: False  # If True, errors caused by only the patch are shown
+    diff_only: False
     linter: flake8
-
-pycodestyle:
-    max-line-length: 79
-    ignore:  # Errors and warnings to ignore
-        - E402  # module level import not at top of file
-        - E731  # do not assign a lambda expression, use a def
-        - E741  # ambiguous variable name
-        - W503  # line break before binary operator
-        - W504  # line break after binary operator
-        - F401  # Unused imports; TODO: Allow typing to work without triggering errors

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
       cd doc;
       sphinx-build -n -j auto -b html -d _build/doctrees . _build/html;
     elif [[ "$CONDA_ENV" == "lint" ]]; then
-      pycodestyle xarray ;
+      flake8 ;
     elif [[ "$CONDA_ENV" == "py36-hypothesis" ]]; then
       pytest properties ;
     else

--- a/asv_bench/benchmarks/__init__.py
+++ b/asv_bench/benchmarks/__init__.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import itertools
 
 import numpy as np

--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -14,7 +14,7 @@ dependencies:
   - pytest-cov
   - pytest-env
   - coveralls
-  - pycodestyle
+  - flake8
   - numpy>=1.12
   - pandas>=0.19
   - scipy

--- a/ci/requirements-py37.yml
+++ b/ci/requirements-py37.yml
@@ -15,7 +15,7 @@ dependencies:
   - pytest-cov
   - pytest-env
   - coveralls
-  - pycodestyle
+  - flake8
   - numpy>=1.12
   - pandas>=0.19
   - scipy

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,11 +13,11 @@
 # serve to show the default.
 from __future__ import absolute_import, division, print_function
 
-from contextlib import suppress
 import datetime
 import os
 import subprocess
 import sys
+from contextlib import suppress
 
 import xarray
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -351,11 +351,11 @@ the more common ``PEP8`` issues:
   - passing arguments should have spaces after commas, e.g. ``foo(arg1, arg2, kw1='bar')``
 
 :ref:`Continuous Integration <contributing.ci>` will run
-the `pycodestyle <http://pypi.python.org/pypi/pycodestyle>`_ tool
+the `flake8 <http://flake8.pycqa.org/en/latest/>`_ tool
 and report any stylistic errors in your code. Therefore, it is helpful before
-submitting code to run the check yourself::
+submitting code to run the check yourself:
 
-   pycodestyle xarray
+   flake8
 
 Other recommended but optional tools for checking code quality (not currently
 enforced in CI):
@@ -363,8 +363,6 @@ enforced in CI):
 - `mypy <http://mypy-lang.org/>`_ performs static type checking, which can
   make it easier to catch bugs. Please run ``mypy xarray`` if you annotate any
   code with `type hints <https://docs.python.org/3/library/typing.html>`_.
-- `flake8 <http://pypi.python.org/pypi/flake8>`_ includes a few more automated
-  checks than those enforced by pycodestyle.
 - `isort <https://github.com/timothycrosley/isort>`_ will highlight
   incorrectly sorted imports. ``isort -y`` will automatically fix them. See
   also `flake8-isort <https://github.com/gforcada/flake8-isort>`_.

--- a/doc/examples/_code/weather_data_setup.py
+++ b/doc/examples/_code/weather_data_setup.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-import seaborn as sns  # pandas aware plotting library
+import seaborn as sns  # noqa, pandas aware plotting library
 
 import xarray as xr
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,18 @@ env =
     UVCDAT_ANONYMOUS_LOG=no
 
 # This should be kept in sync with .pep8speaks.yml
-[pycodestyle]
+[flake8]
 max-line-length=79
-ignore=E402,E731,E741,W503,W504
+ignore=
+    E402
+    E731
+    E741
+    W503
+    W504
+    # Unused imports; TODO: Allow typing to work without triggering errors
+    F401
+exclude=
+    doc
 
 [isort]
 default_section=THIRDPARTY

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -1,35 +1,27 @@
 # flake8: noqa
 
+from . import testing, tutorial, ufuncs
 from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions
-
-from .core.alignment import align, broadcast, broadcast_arrays
-from .core.common import full_like, zeros_like, ones_like
-from .core.combine import concat, auto_combine
-from .core.computation import apply_ufunc, dot, where
-from .core.extensions import (register_dataarray_accessor,
-                              register_dataset_accessor)
-from .core.variable import as_variable, Variable, IndexVariable, Coordinate
-from .core.dataset import Dataset
-from .core.dataarray import DataArray
-from .core.merge import merge, MergeError
-from .core.options import set_options
-
-from .backends.api import (open_dataset, open_dataarray, open_mfdataset,
-                           save_mfdataset, load_dataset, load_dataarray)
+from .backends.api import (
+    load_dataarray, load_dataset, open_dataarray, open_dataset, open_mfdataset,
+    save_mfdataset)
 from .backends.rasterio_ import open_rasterio
 from .backends.zarr import open_zarr
-
-from .conventions import decode_cf, SerializationWarning
-
 from .coding.cftime_offsets import cftime_range
 from .coding.cftimeindex import CFTimeIndex
-
+from .conventions import SerializationWarning, decode_cf
+from .core.alignment import align, broadcast, broadcast_arrays
+from .core.combine import auto_combine, concat
+from .core.common import ALL_DIMS, full_like, ones_like, zeros_like
+from .core.computation import apply_ufunc, dot, where
+from .core.dataarray import DataArray
+from .core.dataset import Dataset
+from .core.extensions import (
+    register_dataarray_accessor, register_dataset_accessor)
+from .core.merge import MergeError, merge
+from .core.options import set_options
+from .core.variable import Coordinate, IndexVariable, Variable, as_variable
 from .util.print_versions import show_versions
 
-from . import tutorial
-from . import ufuncs
-from . import testing
-
-from .core.common import ALL_DIMS
+__version__ = get_versions()['version']
+del get_versions

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -1,27 +1,36 @@
+""" isort:skip_file """
 # flake8: noqa
 
-from . import testing, tutorial, ufuncs
 from ._version import get_versions
-from .backends.api import (
-    load_dataarray, load_dataset, open_dataarray, open_dataset, open_mfdataset,
-    save_mfdataset)
-from .backends.rasterio_ import open_rasterio
-from .backends.zarr import open_zarr
-from .coding.cftime_offsets import cftime_range
-from .coding.cftimeindex import CFTimeIndex
-from .conventions import SerializationWarning, decode_cf
-from .core.alignment import align, broadcast, broadcast_arrays
-from .core.combine import auto_combine, concat
-from .core.common import ALL_DIMS, full_like, ones_like, zeros_like
-from .core.computation import apply_ufunc, dot, where
-from .core.dataarray import DataArray
-from .core.dataset import Dataset
-from .core.extensions import (
-    register_dataarray_accessor, register_dataset_accessor)
-from .core.merge import MergeError, merge
-from .core.options import set_options
-from .core.variable import Coordinate, IndexVariable, Variable, as_variable
-from .util.print_versions import show_versions
-
 __version__ = get_versions()['version']
 del get_versions
+
+from .core.alignment import align, broadcast, broadcast_arrays
+from .core.common import full_like, zeros_like, ones_like
+from .core.combine import concat, auto_combine
+from .core.computation import apply_ufunc, dot, where
+from .core.extensions import (register_dataarray_accessor,
+                              register_dataset_accessor)
+from .core.variable import as_variable, Variable, IndexVariable, Coordinate
+from .core.dataset import Dataset
+from .core.dataarray import DataArray
+from .core.merge import merge, MergeError
+from .core.options import set_options
+
+from .backends.api import (open_dataset, open_dataarray, open_mfdataset,
+                           save_mfdataset, load_dataset, load_dataarray)
+from .backends.rasterio_ import open_rasterio
+from .backends.zarr import open_zarr
+
+from .conventions import decode_cf, SerializationWarning
+
+from .coding.cftime_offsets import cftime_range
+from .coding.cftimeindex import CFTimeIndex
+
+from .util.print_versions import show_versions
+
+from . import tutorial
+from . import ufuncs
+from . import testing
+
+from .core.common import ALL_DIMS

--- a/xarray/backends/__init__.py
+++ b/xarray/backends/__init__.py
@@ -3,16 +3,16 @@
 DataStores provide a uniform interface for saving and loading data in different
 formats. They should not be used directly, but rather through Dataset objects.
 """
-from .common import AbstractDataStore
-from .file_manager import FileManager, CachingFileManager, DummyFileManager
 from .cfgrib_ import CfGribDataStore
+from .common import AbstractDataStore
+from .file_manager import CachingFileManager, DummyFileManager, FileManager
+from .h5netcdf_ import H5NetCDFStore
 from .memory import InMemoryDataStore
 from .netCDF4_ import NetCDF4DataStore
+from .pseudonetcdf_ import PseudoNetCDFDataStore
 from .pydap_ import PydapDataStore
 from .pynio_ import NioDataStore
 from .scipy_ import ScipyDataStore
-from .h5netcdf_ import H5NetCDFStore
-from .pseudonetcdf_ import PseudoNetCDFDataStore
 from .zarr import ZarrStore
 
 __all__ = [

--- a/xarray/backends/file_manager.py
+++ b/xarray/backends/file_manager.py
@@ -1,7 +1,7 @@
 import contextlib
 import threading
-from typing import Any, Dict
 import warnings
+from typing import Any, Dict
 
 from ..core import utils
 from ..core.options import OPTIONS

--- a/xarray/backends/locks.py
+++ b/xarray/backends/locks.py
@@ -1,7 +1,7 @@
 import multiprocessing
 import threading
-from typing import Any, MutableMapping
 import weakref
+from typing import Any, MutableMapping
 
 try:
     from dask.utils import SerializableLock

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -174,7 +174,7 @@ def _force_native_endianness(var):
         # if endian exists, remove it from the encoding.
         var.encoding.pop('endian', None)
     # check to see if encoding has a value for endian its 'native'
-    if not var.encoding.get('endian', 'native') is 'native':
+    if not var.encoding.get('endian', 'native') == 'native':
         raise NotImplementedError("Attempt to write non-native endian type, "
                                   "this is not supported by the netCDF4 "
                                   "python library.")
@@ -237,6 +237,7 @@ def _extract_nc4_variable_encoding(variable, raise_on_invalid=False,
 
 class GroupWrapper:
     """Wrap netCDF4.Group objects so closing them closes the root group."""
+
     def __init__(self, value):
         self.value = value
 

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -1,7 +1,7 @@
 """Coders for individual Variable objects."""
-from typing import Any
 import warnings
 from functools import partial
+from typing import Any
 
 import numpy as np
 import pandas as pd

--- a/xarray/core/accessor_str.py
+++ b/xarray/core/accessor_str.py
@@ -45,7 +45,6 @@ import numpy as np
 
 from .computation import apply_ufunc
 
-
 _cpython_optimized_encoders = (
     "utf-8", "utf8", "latin-1", "latin1", "iso-8859-1", "mbcs", "ascii"
 )

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -8,7 +8,7 @@ from typing import Any, Mapping, Optional, Tuple
 import numpy as np
 import pandas as pd
 
-from . import utils, dtypes
+from . import dtypes, utils
 from .indexing import get_indexer_nd
 from .utils import is_dict_like, is_full_slice
 from .variable import IndexVariable, Variable

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -4,12 +4,12 @@ from collections import Counter, OrderedDict
 
 import pandas as pd
 
-from . import utils, dtypes
+from . import dtypes, utils
 from .alignment import align
+from .computation import result_name
 from .merge import merge
 from .variable import IndexVariable, Variable, as_variable
 from .variable import concat as concat_vars
-from .computation import result_name
 
 
 def concat(objs, dim=None, data_vars='all', coords='different',

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1,8 +1,9 @@
 from collections import OrderedDict
 from contextlib import suppress
 from textwrap import dedent
-from typing import (Any, Callable, Hashable, Iterable, Iterator, List, Mapping,
-                    MutableMapping, Optional, Tuple, TypeVar, Union)
+from typing import (
+    Any, Callable, Hashable, Iterable, Iterator, List, Mapping, MutableMapping,
+    Optional, Tuple, TypeVar, Union)
 
 import numpy as np
 import pandas as pd
@@ -12,7 +13,6 @@ from .arithmetic import SupportsArithmetic
 from .options import _get_keep_attrs
 from .pycompat import dask_array_type
 from .utils import Frozen, ReprObject, SortedKeysDict, either_dict_or_kwargs
-
 
 # Used as a sentinel value to indicate a all dimensions
 ALL_DIMS = ReprObject('<all-dims>')

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -35,8 +35,7 @@ from .options import OPTIONS, _get_keep_attrs
 from .pycompat import TYPE_CHECKING, dask_array_type
 from .utils import (
     Frozen, SortedKeysDict, _check_inplace, decode_numpy_dict_values,
-    either_dict_or_kwargs, ensure_us_time_resolution, hashable, is_dict_like,
-    maybe_wrap_array)
+    either_dict_or_kwargs, hashable, maybe_wrap_array)
 from .variable import IndexVariable, Variable, as_variable, broadcast_variables
 
 if TYPE_CHECKING:
@@ -4145,7 +4144,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         from .variable import Variable
 
         if coord not in self.variables and coord not in self.dims:
-            raise ValueError('Coordinate {} does not exist.'.format(dim))
+            raise ValueError('Coordinate {} does not exist.'.format(coord))
 
         coord_var = self[coord].variable
         if coord_var.ndim != 1:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 from distutils.version import LooseVersion
 from numbers import Number
 from typing import (
-    Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar, Union, Sequence)
+    Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, TypeVar, Union)
 
 import numpy as np
 import pandas as pd

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -4,9 +4,9 @@ Currently, this means Dask or NumPy arrays. None of these functions should
 accept or return xarray objects.
 """
 import contextlib
-from functools import partial
 import inspect
 import warnings
+from functools import partial
 
 import numpy as np
 import pandas as pd

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -9,7 +9,7 @@ import pandas as pd
 from . import utils
 from .common import _contains_datetime_like_objects
 from .computation import apply_ufunc
-from .duck_array_ops import dask_array_type, datetime_to_numeric
+from .duck_array_ops import dask_array_type
 from .utils import OrderedSet, is_scalar
 from .variable import Variable, broadcast_variables
 

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -59,7 +59,7 @@ _SETTERS = {
 def _get_keep_attrs(default):
     global_choice = OPTIONS['keep_attrs']
 
-    if global_choice is 'default':
+    if global_choice == 'default':
         return default
     elif global_choice in [True, False]:
         return global_choice

--- a/xarray/core/resample_cftime.py
+++ b/xarray/core/resample_cftime.py
@@ -36,13 +36,15 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from ..coding.cftimeindex import CFTimeIndex
-from ..coding.cftime_offsets import (cftime_range, normalize_date,
-                                     Day, MonthEnd, QuarterEnd, YearEnd,
-                                     CFTIME_TICKS, to_offset)
 import datetime
+
 import numpy as np
 import pandas as pd
+
+from ..coding.cftime_offsets import (
+    CFTIME_TICKS, Day, MonthEnd, QuarterEnd, YearEnd, cftime_range,
+    normalize_date, to_offset)
+from ..coding.cftimeindex import CFTimeIndex
 
 
 class CFTimeGrouper:

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -7,8 +7,8 @@ import numpy as np
 from . import dtypes, duck_array_ops, utils
 from .dask_array_ops import dask_rolling_wrapper
 from .ops import (
-    bn, has_bottleneck, inject_coarsen_methods,
-    inject_bottleneck_rolling_methods, inject_datasetrolling_methods)
+    bn, has_bottleneck, inject_bottleneck_rolling_methods,
+    inject_coarsen_methods, inject_datasetrolling_methods)
 from .pycompat import dask_array_type
 
 

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -7,16 +7,16 @@ import os.path
 import re
 import warnings
 from collections import OrderedDict
-from typing import (AbstractSet, Any, Callable, Container, Dict, Hashable,
-                    Iterable, Iterator, Optional, Sequence,
-                    Tuple, TypeVar, cast)
+from typing import (
+    AbstractSet, Any, Callable, Container, Dict, Hashable, Iterable, Iterator,
+    Mapping, MutableMapping, MutableSet, Optional, Sequence, Tuple, TypeVar,
+    cast)
 
 import numpy as np
 import pandas as pd
 
 from .pycompat import dask_array_type
 
-from typing import Mapping, MutableMapping, MutableSet
 try:  # Fix typed collections in Python 3.5.0~3.5.2
     from .pycompat import Mapping, MutableMapping, MutableSet  # noqa: F811
 except ImportError:

--- a/xarray/plot/__init__.py
+++ b/xarray/plot/__init__.py
@@ -1,7 +1,5 @@
-from .plot import (plot, line, step, contourf, contour,
-                   hist, imshow, pcolormesh)
-
 from .facetgrid import FacetGrid
+from .plot import contour, contourf, hist, imshow, line, pcolormesh, plot, step
 
 __all__ = [
     'plot',

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -7,8 +7,8 @@ import numpy as np
 
 from ..core.formatting import format_item
 from .utils import (
-    _infer_xy_labels, _process_cmap_cbar_kwargs,
-    import_matplotlib_pyplot, label_from_attrs)
+    _infer_xy_labels, _process_cmap_cbar_kwargs, import_matplotlib_pyplot,
+    label_from_attrs)
 
 # Overrides axes.labelsize, xtick.major.size, ytick.major.size
 # from mpl.rcParams

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -1,7 +1,6 @@
 import functools
 import itertools
 import warnings
-from inspect import getfullargspec
 
 import numpy as np
 
@@ -483,7 +482,7 @@ class FacetGrid:
                 # TODO: better way to verify that an artist is mappable?
                 # https://stackoverflow.com/questions/33023036/is-it-possible-to-detect-if-a-matplotlib-artist-is-a-mappable-suitable-for-use-w#33023522
                 if (maybe_mappable and
-                   hasattr(maybe_mappable, 'autoscale_None')):
+                        hasattr(maybe_mappable, 'autoscale_None')):
                     self._mappables.append(maybe_mappable)
 
         self._finalize_grid(*args[:2])

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -2,15 +2,14 @@ import itertools
 import textwrap
 import warnings
 from datetime import datetime
+from distutils.version import LooseVersion
+from inspect import getfullargspec
 
 import numpy as np
 import pandas as pd
 
-from inspect import getfullargspec
-
 from ..core.options import OPTIONS
 from ..core.utils import is_scalar
-from distutils.version import LooseVersion
 
 try:
     import nc_time_axis

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -4,8 +4,7 @@ from collections import OrderedDict
 import numpy as np
 import pandas as pd
 
-from xarray.core import duck_array_ops
-from xarray.core import formatting
+from xarray.core import duck_array_ops, formatting
 from xarray.core.indexes import default_indexes
 
 

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -3,7 +3,6 @@ import re
 import warnings
 from contextlib import contextmanager
 from distutils import version
-from unittest import mock
 
 import numpy as np
 import pytest

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -1,19 +1,19 @@
+import importlib
+import re
 import warnings
 from contextlib import contextmanager
 from distutils import version
-import re
-import importlib
 from unittest import mock
 
 import numpy as np
-from numpy.testing import assert_array_equal  # noqa: F401
-from xarray.core.duck_array_ops import allclose_or_equiv  # noqa
 import pytest
+from numpy.testing import assert_array_equal  # noqa: F401
 
-from xarray.core import utils
-from xarray.core.options import set_options
-from xarray.core.indexing import ExplicitlyIndexed
 import xarray.testing
+from xarray.core import utils
+from xarray.core.duck_array_ops import allclose_or_equiv  # noqa
+from xarray.core.indexing import ExplicitlyIndexed
+from xarray.core.options import set_options
 from xarray.plot.utils import import_seaborn
 
 try:

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -3,6 +3,7 @@ import re
 import warnings
 from contextlib import contextmanager
 from distutils import version
+from unittest import mock  # noqa
 
 import numpy as np
 import pytest

--- a/xarray/tests/test_accessor_str.py
+++ b/xarray/tests/test_accessor_str.py
@@ -138,14 +138,14 @@ def test_replace(dtype):
 def test_replace_callable():
     values = xr.DataArray(['fooBAD__barBAD'])
     # test with callable
-    repl = lambda m: m.group(0).swapcase()
+    repl = lambda m: m.group(0).swapcase()  # noqa
     result = values.str.replace('[a-z][A-Z]{2}', repl, n=2)
     exp = xr.DataArray(['foObaD__baRbaD'])
     assert_equal(result, exp)
     # test regex named groups
     values = xr.DataArray(['Foo Bar Baz'])
     pat = r"(?P<first>\w+) (?P<middle>\w+) (?P<last>\w+)"
-    repl = lambda m: m.group('middle').swapcase()
+    repl = lambda m: m.group('middle').swapcase()  # noqa
     result = values.str.replace(pat, repl)
     exp = xr.DataArray(['bAR'])
     assert_equal(result, exp)

--- a/xarray/tests/test_accessor_str.py
+++ b/xarray/tests/test_accessor_str.py
@@ -44,8 +44,7 @@ import pytest
 
 import xarray as xr
 
-from . import (
-    assert_array_equal, assert_equal, has_dask, raises_regex, requires_dask)
+from . import assert_equal, requires_dask
 
 
 @pytest.fixture(params=[np.str_, np.bytes_])

--- a/xarray/tests/test_accessor_str.py
+++ b/xarray/tests/test_accessor_str.py
@@ -39,8 +39,9 @@
 
 import re
 
-import pytest
 import numpy as np
+import pytest
+
 import xarray as xr
 
 from . import (

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2,15 +2,15 @@ import contextlib
 import itertools
 import math
 import os.path
-from pathlib import Path
 import pickle
 import shutil
 import sys
 import tempfile
-from typing import Optional
 import warnings
 from contextlib import ExitStack
 from io import BytesIO
+from pathlib import Path
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -18,26 +18,26 @@ import pytest
 
 import xarray as xr
 from xarray import (
-    DataArray, Dataset, backends, open_dataarray, open_dataset, open_mfdataset,
-    save_mfdataset, load_dataset, load_dataarray)
+    DataArray, Dataset, backends, load_dataarray, load_dataset, open_dataarray,
+    open_dataset, open_mfdataset, save_mfdataset)
 from xarray.backends.common import robust_getitem
 from xarray.backends.netCDF4_ import _extract_nc4_variable_encoding
 from xarray.backends.pydap_ import PydapDataStore
+from xarray.coding.variables import SerializationWarning
 from xarray.core import indexing
 from xarray.core.options import set_options
 from xarray.core.pycompat import dask_array_type
 from xarray.tests import mock
-from xarray.coding.variables import SerializationWarning
 
 from . import (
     assert_allclose, assert_array_equal, assert_equal, assert_identical,
     has_dask, has_netCDF4, has_scipy, network, raises_regex, requires_cfgrib,
-    requires_cftime, requires_dask, requires_h5netcdf, requires_netCDF4,
-    requires_pathlib, requires_pseudonetcdf, requires_pydap, requires_pynio,
-    requires_rasterio, requires_scipy, requires_scipy_or_netCDF4,
-    requires_zarr, requires_h5fileobj)
-from .test_coding_times import (_STANDARD_CALENDARS, _NON_STANDARD_CALENDARS,
-                                _ALL_CALENDARS)
+    requires_cftime, requires_dask, requires_h5fileobj, requires_h5netcdf,
+    requires_netCDF4, requires_pathlib, requires_pseudonetcdf, requires_pydap,
+    requires_pynio, requires_rasterio, requires_scipy,
+    requires_scipy_or_netCDF4, requires_zarr)
+from .test_coding_times import (
+    _ALL_CALENDARS, _NON_STANDARD_CALENDARS, _STANDARD_CALENDARS)
 from .test_dataset import create_test_data
 
 try:

--- a/xarray/tests/test_backends_lru_cache.py
+++ b/xarray/tests/test_backends_lru_cache.py
@@ -1,4 +1,5 @@
 from unittest import mock
+
 import pytest
 
 from xarray.backends.lru_cache import LRUCache

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -6,8 +6,8 @@ import pytest
 
 from xarray import CFTimeIndex
 from xarray.coding.cftime_offsets import (
-    _MONTH_ABBREVIATIONS, BaseCFTimeOffset, Day, Hour, Minute, Second,
-    MonthBegin, MonthEnd, YearBegin, YearEnd, QuarterBegin, QuarterEnd,
+    _MONTH_ABBREVIATIONS, BaseCFTimeOffset, Day, Hour, Minute, MonthBegin,
+    MonthEnd, QuarterBegin, QuarterEnd, Second, YearBegin, YearEnd,
     _days_in_month, cftime_range, get_date_type, to_cftime_datetime, to_offset)
 
 cftime = pytest.importorskip('cftime')

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -8,7 +8,7 @@ import xarray as xr
 from xarray.coding.cftimeindex import (
     CFTimeIndex, _parse_array_of_cftime_strings, _parse_iso8601_with_reso,
     _parsed_string_to_bounds, assert_all_valid_date_type, parse_iso8601)
-from xarray.tests import assert_array_equal, assert_allclose, assert_identical
+from xarray.tests import assert_allclose, assert_array_equal, assert_identical
 
 from . import (
     has_cftime, has_cftime_1_0_2_1, has_cftime_or_netCDF4, raises_regex,

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -8,7 +8,7 @@ import xarray as xr
 from xarray.coding.cftimeindex import (
     CFTimeIndex, _parse_array_of_cftime_strings, _parse_iso8601_with_reso,
     _parsed_string_to_bounds, assert_all_valid_date_type, parse_iso8601)
-from xarray.tests import assert_allclose, assert_array_equal, assert_identical
+from xarray.tests import assert_array_equal, assert_identical
 
 from . import (
     has_cftime, has_cftime_1_0_2_1, has_cftime_or_netCDF4, raises_regex,

--- a/xarray/tests/test_cftimeindex_resample.py
+++ b/xarray/tests/test_cftimeindex_resample.py
@@ -1,11 +1,11 @@
-import pytest
-
 import datetime
+
 import numpy as np
 import pandas as pd
+import pytest
+
 import xarray as xr
 from xarray.core.resample_cftime import CFTimeGrouper
-
 
 pytest.importorskip('cftime')
 pytest.importorskip('pandas', minversion='0.24')

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -15,7 +15,7 @@ from xarray.testing import assert_equal
 
 from . import (
     assert_array_equal, has_cftime, has_cftime_or_netCDF4, has_dask,
-    requires_cftime_or_netCDF4, requires_cftime)
+    requires_cftime, requires_cftime_or_netCDF4)
 
 try:
     from pandas.errors import OutOfBoundsDatetime

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -14,8 +14,8 @@ from xarray.core.combine import (
     _infer_tile_ids_from_nested_list, _new_tile_id)
 
 from . import (
-    InaccessibleArray, assert_array_equal,
-    assert_equal, assert_identical, raises_regex, requires_dask)
+    InaccessibleArray, assert_array_equal, assert_equal, assert_identical,
+    raises_regex, requires_dask)
 from .test_dataset import create_test_data
 
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1,9 +1,9 @@
 import pickle
+import sys
 import warnings
 from collections import OrderedDict
 from copy import deepcopy
 from textwrap import dedent
-import sys
 
 import numpy as np
 import pandas as pd

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1259,18 +1259,6 @@ class TestDataArray:
                 ValueError, 'different size for unlabeled'):
             foo.reindex_like(bar)
 
-    @pytest.mark.parametrize('fill_value', [dtypes.NA, 2, 2.0])
-    def test_reindex_fill_value(self, fill_value):
-        foo = DataArray([10, 20], dims='y', coords={'y': [0, 1]})
-        bar = DataArray([10, 20, 30], dims='y', coords={'y': [0, 1, 2]})
-        if fill_value == dtypes.NA:
-            # if we supply the default, we expect the missing value for a
-            # float array
-            fill_value = np.nan
-        actual = x.reindex_like(bar, fill_value=fill_value)
-        expected = DataArray([10, 20, fill_value], coords=[('y', [0, 1, 2])])
-        assert_identical(expected, actual)
-
     @pytest.mark.filterwarnings('ignore:Indexer has dimensions')
     def test_reindex_regressions(self):
         # regression test for #279

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -12,7 +12,7 @@ import pytest
 import xarray as xr
 from xarray import (
     DataArray, Dataset, IndexVariable, Variable, align, broadcast)
-from xarray.coding.times import CFDatetimeCoder, _import_cftime
+from xarray.coding.times import CFDatetimeCoder
 from xarray.convert import from_cdms2
 from xarray.core import dtypes
 from xarray.core.common import ALL_DIMS, full_like
@@ -1632,8 +1632,8 @@ class TestDataArray:
         assert (a + a.rename(None)).name is None
         assert (a + a.rename('bar')).name is None
         assert (a + a).name == 'foo'
-        assert (+a['x']).name is 'x'
-        assert (a['x'] + 0).name is 'x'
+        assert (+a['x']).name == 'x'
+        assert (a['x'] + 0).name == 'x'
         assert (a + a['x']).name is None
 
     def test_math_with_coords(self):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4756,9 +4756,9 @@ def test_rolling_wrapped_bottleneck(ds, name, center, min_periods, key):
 
     func_name = 'move_{0}'.format(name)
     actual = getattr(rolling_obj, name)()
-    if key is 'z1':  # z1 does not depend on 'Time' axis. Stored as it is.
+    if key == 'z1':  # z1 does not depend on 'Time' axis. Stored as it is.
         expected = ds[key]
-    elif key is 'z2':
+    elif key == 'z2':
         expected = getattr(bn, func_name)(ds[key].values, window=7, axis=0,
                                           min_count=min_periods)
     assert_array_equal(actual[key].values, expected)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -22,8 +22,8 @@ from xarray.core.pycompat import integer_types
 from . import (
     InaccessibleArray, UnexpectedDataAccess, assert_allclose,
     assert_array_equal, assert_equal, assert_identical, has_cftime, has_dask,
-    raises_regex, requires_bottleneck, requires_dask, requires_scipy,
-    source_ndarray, requires_cftime)
+    raises_regex, requires_bottleneck, requires_cftime, requires_dask,
+    requires_scipy, source_ndarray)
 
 try:
     import dask.array as da

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -1,4 +1,4 @@
-# """ isort:skip_file """
+""" isort:skip_file """
 # flake8: noqa: E402 - ignore linters re order of imports
 import pickle
 

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -1,4 +1,5 @@
-""" isort:skip_file """
+# """ isort:skip_file """
+# flake8: noqa: E402 - ignore linters re order of imports
 import pickle
 
 import pytest
@@ -28,6 +29,7 @@ from . import (
 
 
 da = pytest.importorskip('dask.array')
+loop = loop  # loop is an imported fixture, which flake8 has issues ack-ing
 
 
 @pytest.fixture

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -13,7 +13,7 @@ from xarray.core.duck_array_ops import (
     array_notnull_equiv, concatenate, count, first, gradient, last, mean,
     rolling_window, stack, where)
 from xarray.core.pycompat import dask_array_type
-from xarray.testing import assert_allclose, assert_equal, assert_identical
+from xarray.testing import assert_allclose, assert_equal
 
 from . import (
     assert_array_equal, has_dask, has_np113, raises_regex, requires_cftime,

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 from numpy import array, nan
 
-from xarray import DataArray, Dataset, concat, cftime_range
+from xarray import DataArray, Dataset, cftime_range, concat
 from xarray.core import dtypes, duck_array_ops
 from xarray.core.duck_array_ops import (
     array_notnull_equiv, concatenate, count, first, gradient, last, mean,

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -6,8 +6,8 @@ import xarray as xr
 from xarray.tests import (
     assert_allclose, assert_equal, requires_cftime, requires_scipy)
 
-from . import has_dask, has_scipy
 from ..coding.cftimeindex import _parse_array_of_cftime_strings
+from . import has_dask, has_scipy
 from .test_dataset import create_test_data
 
 try:

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import xarray as xr
-from xarray.core import merge, dtypes
+from xarray.core import dtypes, merge
 
 from . import raises_regex
 from .test_dataset import create_test_data

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -14,10 +14,9 @@ from xarray.plot.utils import (
     import_seaborn, label_from_attrs)
 
 from . import (
-    assert_array_equal, assert_equal, raises_regex, requires_cftime,
-    requires_matplotlib, requires_matplotlib2, requires_seaborn,
-    requires_nc_time_axis)
-from . import has_nc_time_axis
+    assert_array_equal, assert_equal, has_nc_time_axis, raises_regex,
+    requires_cftime, requires_matplotlib, requires_matplotlib2,
+    requires_nc_time_axis, requires_seaborn)
 
 # import mpl and change the backend before other mpl imports
 try:

--- a/xarray/tutorial.py
+++ b/xarray/tutorial.py
@@ -7,7 +7,6 @@ Useful for:
 '''
 import hashlib
 import os as _os
-import warnings
 from urllib.request import urlretrieve
 
 from .backends.api import open_dataset as _open_dataset


### PR DESCRIPTION
 - [x] Closes https://github.com/pydata/xarray/issues/2990
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

I also ran `isort`, which created more changes that I would have hoped. Lmk if that's OK. 
We could also enable `isort` by default. It's a balance: it reduces the chance of merge conflicts and adds automatic consistency, but at the cost of making first-time contributions a bit more difficult.
