### PR TITLE
Pytest capture uses match, not message

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -76,6 +76,9 @@ Bug fixes
   By `Maximilian Roos <https://github.com/max-sixty>`_.
 - Fixed performance issues with cftime installed (:issue:`3000`)
   By `0x0L <https://github.com/0x0L>`_.
+- Replace incorrect usages of `message` in pytest assertions 
+  with `match` (:issue:`3011`)
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 .. _whats-new.0.12.1:
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1177,7 +1177,7 @@ class TestDataArray:
                              dims=['x', 'y'], name='foo')
         assert_identical(actual, expected)
 
-        with pytest.warns(FutureWarning, message='The inplace argument'):
+        with pytest.warns(FutureWarning, match='The inplace argument'):
             with raises_regex(ValueError, 'cannot reset coord'):
                 data = data.reset_coords(inplace=True)
         with raises_regex(ValueError, 'cannot be found'):
@@ -1540,7 +1540,7 @@ class TestDataArray:
         obj = self.mda.reorder_levels(x=['level_2', 'level_1'])
         assert_identical(obj, expected)
 
-        with pytest.warns(FutureWarning, message='The inplace argument'):
+        with pytest.warns(FutureWarning, match='The inplace argument'):
             array = self.mda.copy()
             array.reorder_levels(x=['level_2', 'level_1'], inplace=True)
             assert_identical(array, expected)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4615,7 +4615,7 @@ def test_dataset_constructor_aligns_to_explicit_coords(
 
 
 def test_error_message_on_set_supplied():
-    with pytest.raises(TypeError, match='has invalid type set'):
+    with pytest.raises(TypeError, match="has invalid type <class 'set'>"):
         xr.Dataset(dict(date=[1, 2, 3], sec={4}))
 
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2258,7 +2258,7 @@ class TestDataset:
         obj = ds.set_index(x=mindex.names)
         assert_identical(obj, expected)
 
-        with pytest.warns(FutureWarning, message='The inplace argument'):
+        with pytest.warns(FutureWarning, match='The inplace argument'):
             ds.set_index(x=mindex.names, inplace=True)
             assert_identical(ds, expected)
 
@@ -2278,7 +2278,7 @@ class TestDataset:
         obj = ds.reset_index('x')
         assert_identical(obj, expected)
 
-        with pytest.warns(FutureWarning, message='The inplace argument'):
+        with pytest.warns(FutureWarning, match='The inplace argument'):
             ds.reset_index('x', inplace=True)
             assert_identical(ds, expected)
 
@@ -2291,7 +2291,7 @@ class TestDataset:
         reindexed = ds.reorder_levels(x=['level_2', 'level_1'])
         assert_identical(reindexed, expected)
 
-        with pytest.warns(FutureWarning, message='The inplace argument'):
+        with pytest.warns(FutureWarning, match='The inplace argument'):
             ds.reorder_levels(x=['level_2', 'level_1'], inplace=True)
             assert_identical(ds, expected)
 
@@ -2375,7 +2375,7 @@ class TestDataset:
         assert actual_result is actual
         assert_identical(expected, actual)
 
-        with pytest.warns(FutureWarning, message='The inplace argument'):
+        with pytest.warns(FutureWarning, match='The inplace argument'):
             actual = data.update(data, inplace=False)
             expected = data
             assert actual is not expected
@@ -4615,7 +4615,7 @@ def test_dataset_constructor_aligns_to_explicit_coords(
 
 
 def test_error_message_on_set_supplied():
-    with pytest.raises(TypeError, message='has invalid type set'):
+    with pytest.raises(TypeError, match='has invalid type set'):
         xr.Dataset(dict(date=[1, 2, 3], sec={4}))
 
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -210,7 +210,7 @@ class TestPlot(PlotTestCase):
         hdl = da.plot.line(x='lon', hue='y')
         assert len(hdl) == 4
 
-        with pytest.raises(ValueError, message='If x or y are 2D '):
+        with pytest.raises(ValueError, match='If x or y are 2D '):
             da.plot.line(x='lon', hue='lat')
 
     def test_2d_before_squeeze(self):

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -210,7 +210,8 @@ class TestPlot(PlotTestCase):
         hdl = da.plot.line(x='lon', hue='y')
         assert len(hdl) == 4
 
-        with pytest.raises(ValueError, match='If x or y are 2D '):
+        with pytest.raises(
+                ValueError, match="For 2D inputs, hue must be a dimension"):
             da.plot.line(x='lon', hue='lat')
 
     def test_2d_before_squeeze(self):


### PR DESCRIPTION
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

`message` was always going being ignored, and with the newer pytest version raises a warning that an unknown kwarg is supplied