### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+#### MCVE Code Sample
+
+In order for the maintainers to efficiently understand and prioritize issues, we ask you post a "Minimal, Complete and Verifiable Example" (MCVE): http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports
+
+```python
+# Your code here
+
+```
+
+#### Problem Description
+
+[this should explain **why** the current behavior is a problem and why the expected output is a better solution.]
+
+#### Expected Output
+
+#### Output of ``xr.show_versions()``
+
+<details>
+# Paste the output here xr.show_versions() here
+
+</details>


### PR DESCRIPTION
This: 
- Updates to the [newer GitHub format](https://help.github.com/en/articles/about-issue-and-pull-request-templates)
- Strengthens the language around MCVE. It doesn't say people *have* to, but makes it less of a suggestion
- Only contains 'Bug Report'. Should we have others? I don't immediately see how they'd be different

(I realize because I did this from the GH website, it created from this repo rather than my own fork. That's a mistake.)