### PR TITLE
Add pytest markers to avoid warnings

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -83,6 +83,9 @@ Bug fixes
 - Replace incorrect usages of `message` in pytest assertions 
   with `match` (:issue:`3011`)
   By `Maximilian Roos <https://github.com/max-sixty>`_.
+- Add explicit pytest markers, now required by pytest
+  (:issue:`3032`).
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 .. _whats-new.0.12.1:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,10 @@ ignore=
     F401
 exclude=
     doc
+markers =
+    flaky: flaky tests
+    network: tests requiring a network connection
+    slow: slow tests
 
 [isort]
 default_section=THIRDPARTY

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -10,40 +10,20 @@ from textwrap import dedent
 import numpy as np
 import pandas as pd
 import pytest
+
 import xarray as xr
 from xarray import (
-    ALL_DIMS,
-    DataArray,
-    Dataset,
-    IndexVariable,
-    MergeError,
-    Variable,
-    align,
-    backends,
-    broadcast,
-    open_dataset,
-    set_options
-)
+    ALL_DIMS, DataArray, Dataset, IndexVariable, MergeError, Variable, align,
+    backends, broadcast, open_dataset, set_options)
 from xarray.core import dtypes, indexing, npcompat, utils
 from xarray.core.common import duck_array_ops, full_like
 from xarray.core.pycompat import integer_types
 
 from . import (
-    InaccessibleArray,
-    UnexpectedDataAccess,
-    assert_allclose,
-    assert_array_equal,
-    assert_equal,
-    assert_identical,
-    has_cftime,
-    has_dask,
-    raises_regex,
-    requires_bottleneck,
-    requires_cftime,
-    requires_dask,
-    requires_scipy,
-    source_ndarray
-)
+    InaccessibleArray, UnexpectedDataAccess, assert_allclose,
+    assert_array_equal, assert_equal, assert_identical, has_cftime, has_dask,
+    raises_regex, requires_bottleneck, requires_cftime, requires_dask,
+    requires_scipy, source_ndarray)
 
 try:
     import dask.array as da

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -10,20 +10,40 @@ from textwrap import dedent
 import numpy as np
 import pandas as pd
 import pytest
-
 import xarray as xr
 from xarray import (
-    ALL_DIMS, DataArray, Dataset, IndexVariable, MergeError, Variable, align,
-    backends, broadcast, open_dataset, set_options)
+    ALL_DIMS,
+    DataArray,
+    Dataset,
+    IndexVariable,
+    MergeError,
+    Variable,
+    align,
+    backends,
+    broadcast,
+    open_dataset,
+    set_options
+)
 from xarray.core import dtypes, indexing, npcompat, utils
 from xarray.core.common import duck_array_ops, full_like
 from xarray.core.pycompat import integer_types
 
 from . import (
-    InaccessibleArray, UnexpectedDataAccess, assert_allclose,
-    assert_array_equal, assert_equal, assert_identical, has_cftime, has_dask,
-    raises_regex, requires_bottleneck, requires_cftime, requires_dask,
-    requires_scipy, source_ndarray)
+    InaccessibleArray,
+    UnexpectedDataAccess,
+    assert_allclose,
+    assert_array_equal,
+    assert_equal,
+    assert_identical,
+    has_cftime,
+    has_dask,
+    raises_regex,
+    requires_bottleneck,
+    requires_cftime,
+    requires_dask,
+    requires_scipy,
+    source_ndarray
+)
 
 try:
     import dask.array as da
@@ -4625,7 +4645,7 @@ def test_error_message_on_set_supplied():
 def test_constructor_raises_with_invalid_coords(unaligned_coords):
 
     with pytest.raises(ValueError,
-                       message='not a subset of the DataArray dimensions'):
+                       match='not a subset of the DataArray dimensions'):
         xr.DataArray([1, 2, 3], dims=['x'], coords=unaligned_coords)
 
 


### PR DESCRIPTION
These are now required; I was getting warnings 

``` 
/usr/local/lib/python3.7/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: 
Unknown pytest.mark.network - is this a typo?  
You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html`
```