### PR TITLE
Ensure explicitly indexed arrays are preserved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
   - env:
     - CONDA_ENV=py36
     - EXTRA_FLAGS="--run-flaky --run-network-tests"
+  - env: CONDA_ENV=py36-dask-dev
   - env: CONDA_ENV=py36-pandas-dev
   - env: CONDA_ENV=py36-rasterio
   - env: CONDA_ENV=py36-zarr-dev
@@ -25,7 +26,6 @@ matrix:
   - env: CONDA_ENV=py36-hypothesis
 
   allow_failures:
-  - env: CONDA_ENV=py36-dask-dev
   - env:
     - CONDA_ENV=py36
     - EXTRA_FLAGS="--run-flaky --run-network-tests"

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -453,7 +453,13 @@ class ImplicitToExplicitIndexingAdapter(utils.NDArrayMixin):
 
     def __getitem__(self, key):
         key = expanded_indexer(key, self.ndim)
-        return self.array[self.indexer_cls(key)]
+        result = self.array[self.indexer_cls(key)]
+        if isinstance(result, ExplicitlyIndexed):
+            return type(self)(result, self.indexer_cls)
+        else:
+            # Sometimes explicitly indexed arrays return NumPy arrays or
+            # scalars.
+            return result
 
 
 class LazilyOuterIndexedArray(ExplicitlyIndexedNDArrayMixin):

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -505,11 +505,18 @@ def test_decompose_indexers(shape, indexer_mode, indexing_support):
 
 
 def test_implicit_indexing_adapter():
-    array = np.arange(10)
+    array = np.arange(10, dtype=np.int64)
     implicit = indexing.ImplicitToExplicitIndexingAdapter(
         indexing.NumpyIndexingAdapter(array), indexing.BasicIndexer)
     np.testing.assert_array_equal(array, np.asarray(implicit))
     np.testing.assert_array_equal(array, implicit[:])
+
+
+def test_implicit_indexing_adapter_copy_on_write():
+    array = np.arange(10, dtype=np.int64)
+    implicit = indexing.ImplicitToExplicitIndexingAdapter(
+        indexing.CopyOnWriteArray(array))
+    assert isinstance(implicit[:], indexing.ImplicitToExplicitIndexingAdapter)
 
 
 def test_outer_indexer_consistency_with_broadcast_indexes_vectorized():


### PR DESCRIPTION
Fixes https://github.com/pydata/xarray/issues/3009

Previously, indexing an ImplicitToExplicitIndexingAdapter object could directly return an ExplicitlyIndexed object, which could not be indexed normally, e.g., `x[index]` could result in an object that could not be indexed properly. This resulted in broken behavior with dask's new `_meta` attribute.

I'm pretty sure this fix is appropriate, but it does introduce two failing tests with xarray on dask master. In particular, there are now errors raised inside two tests from dask's `blockwise_meta` helper function:
```
>       return meta.astype(dtype)
E       AttributeError: 'ImplicitToExplicitIndexingAdapter' object has no attribute 'astype'
```

cc @mrocklin  @pentschev

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
