### PR TITLE
Revert cmap fix

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -75,8 +75,6 @@ Bug fixes
   By `Mayeul d'Avezac <https://github.com/mdavezac>`_.
 - Return correct count for scalar datetime64 arrays (:issue:`2770`)
   By `Dan Nowacki <https://github.com/dnowacki-usgs>`_.
-- Fix facetgrid colormap bug when ``extend=True``. (:issue:`2932`)
-  By `Deepak Cherian <https://github.com/dcherian`_.
 - A deep copy deep-copies the coords (:issue:`1463`)
   By `Martin Pletcher <https://github.com/pletchm>`_.
 - Increased support for `missing_value` (:issue:`2871`)

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -264,8 +264,7 @@ def _determine_cmap_params(plot_data, vmin=None, vmax=None, cmap=None,
     if extend is None:
         extend = _determine_extend(calc_data, vmin, vmax)
 
-    if ((levels is not None or isinstance(norm, mpl.colors.BoundaryNorm))
-            and (not isinstance(cmap, mpl.colors.Colormap))):
+    if levels is not None or isinstance(norm, mpl.colors.BoundaryNorm):
         cmap, newnorm = _build_discrete_cmap(cmap, levels, extend, filled)
         norm = newnorm if norm is None else norm
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -4,7 +4,6 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 import pytest
-from numpy.testing import assert_array_equal
 
 import xarray as xr
 import xarray.plot as xplt

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -775,13 +775,14 @@ class TestDiscreteColorMap:
 
     @pytest.mark.slow
     def test_discrete_colormap_int_levels(self):
-        for extend, levels, vmin, vmax in [('neither', 7, None, None),
-                                           ('neither', 7, None, 20),
-                                           ('both', 7, 4, 8),
-                                           ('min', 10, 4, 15)]:
+        for extend, levels, vmin, vmax, cmap in [
+                ('neither', 7, None, None, None),
+                ('neither', 7, None, 20, mpl.cm.RdBu),
+                ('both', 7, 4, 8, None),
+                ('min', 10, 4, 15, None)]:
             for kind in ['imshow', 'pcolormesh', 'contourf', 'contour']:
                 primitive = getattr(self.darray.plot, kind)(
-                    levels=levels, vmin=vmin, vmax=vmax)
+                    levels=levels, vmin=vmin, vmax=vmax, cmap=cmap)
                 assert levels >= \
                     len(primitive.norm.boundaries) - 1
                 if vmax is None:

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -4,10 +4,12 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_equal
 
 import xarray as xr
 import xarray.plot as xplt
 from xarray import DataArray
+from xarray.coding.times import _import_cftime
 from xarray.plot.plot import _infer_interval_breaks
 from xarray.plot.utils import (
     _build_discrete_cmap, _color_palette, _determine_cmap_params,
@@ -536,25 +538,6 @@ class TestDetermineCmapParams:
         with xr.set_options(cmap_sequential='magma'):
             cmap_params = _determine_cmap_params(self.data)
             assert cmap_params['cmap'] == 'magma'
-
-    def test_do_nothing_if_provided_cmap(self):
-        cmap_list = [
-            mpl.colors.LinearSegmentedColormap.from_list('name', ['r', 'g']),
-            mpl.colors.ListedColormap(['r', 'g', 'b'])
-        ]
-
-        # can't parametrize with mpl objects when mpl is absent
-        for cmap in cmap_list:
-            cmap_params = _determine_cmap_params(self.data,
-                                                 cmap=cmap,
-                                                 levels=7)
-            assert cmap_params['cmap'] is cmap
-
-    def test_do_something_if_provided_str_cmap(self):
-        cmap = 'RdBu_r'
-        cmap_params = _determine_cmap_params(self.data, cmap=cmap, levels=7)
-        assert cmap_params['cmap'] is not cmap
-        assert isinstance(cmap_params['cmap'], mpl.colors.ListedColormap)
 
     def test_cmap_sequential_explicit_option(self):
         with xr.set_options(cmap_sequential=mpl.cm.magma):


### PR DESCRIPTION
Unfortunately my fix in #2935 broke some major functionality. A proper fix would involve some facetgrid refactoring I think; so that'll take some time. This reverts that commit and adds a test.

```
xr.DataArray(np.random.randn(10, 20)).plot(levels=10, cmap=mpl.cm.RdBu)
```

![image](https://user-images.githubusercontent.com/2448579/59955418-08f7c800-9458-11e9-9534-1042415ce6be.png)
