### PR TITLE
Upgrade mypy & DataWithCoords check

### DIFF
--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -31,4 +31,4 @@ dependencies:
   - pydap
   - lxml
   - pip:
-    - mypy==0.660
+    - mypy==0.711

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -996,6 +996,10 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         self.close()
 
+    def __getitem__(self, value):
+        # implementations of this class should implement this method
+        raise NotImplementedError
+
 
 def full_like(other, fill_value, dtype: Optional[DTypeLike] = None):
     """Return a new object with the same shape and type as a given object.


### PR DESCRIPTION
Quicker than expected follow-up to the typing PR, but realized that a newer version of mypy catches https://github.com/pydata/xarray/blob/master/xarray/core/common.py#L831 as `__getitem__` isn't implemented