### PR TITLE
Flat iteration over DataArray

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2686,6 +2686,13 @@ class DataArray(AbstractArray, DataWithCoords):
         ds = self._to_temp_dataset().integrate(dim, datetime_unit)
         return self._from_temp_dataset(ds)
 
+    @property
+    def flat(self):
+        import itertools
+        gen = itertools.product(*(range(n) for n in self.shape))
+        for indices in gen:
+            yield self.__getitem__(indices)
+
     # this needs to be at the end, or mypy will confuse with `str`
     # https://mypy.readthedocs.io/en/latest/common_issues.html#dealing-with-conflicting-names  # noqa
     str = property(StringAccessor)


### PR DESCRIPTION
 - [ ] Tests added
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

A very simple way to iterate over `DataArray`s, imitating numpy's flat iterator. 

For a DataArray `da`, I implemented a flat iterator that works exactly like `da.values.flat`, but returns a singelton `DataArray` that has all the coordinates and meta data and whatnot.

I wrote it because I needed it for something and thought it would be useful for others too. I'd love to hear your opinions - if you think it's useful I'll write up some unittests. 