### PR TITLE
kwargs.pop() cleanup

### DIFF
--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -41,12 +41,12 @@ class PseudoNetCDFDataStore(AbstractDataStore):
     """Store for accessing datasets via PseudoNetCDF
     """
     @classmethod
-    def open(cls, filename, lock=None, **format_kwds):
+    def open(cls, filename, lock=None, **format_kwargs):
         from PseudoNetCDF import pncopen
 
-        keywords = dict(kwargs=format_kwds)
+        keywords = dict(kwargs=format_kwargs)
         # only include mode if explicitly passed
-        mode = format_kwds.pop('mode', None)
+        mode = format_kwargs.pop('mode', None)
         if mode is not None:
             keywords['mode'] = mode
 

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -41,12 +41,11 @@ class PseudoNetCDFDataStore(AbstractDataStore):
     """Store for accessing datasets via PseudoNetCDF
     """
     @classmethod
-    def open(cls, filename, lock=None, **format_kwargs):
+    def open(cls, filename, lock=None, mode=None, **format_kwargs):
         from PseudoNetCDF import pncopen
 
-        keywords = dict(kwargs=format_kwargs)
+        keywords = {'kwargs': format_kwargs}
         # only include mode if explicitly passed
-        mode = format_kwargs.pop('mode', None)
         if mode is not None:
             keywords['mode'] = mode
 

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -391,7 +391,7 @@ def reindex_variables(
     return reindexed, new_indexes
 
 
-def broadcast(*args, **kwargs):
+def broadcast(*args, exclude=None):
     """Explicitly broadcast any number of DataArray or Dataset objects against
     one another.
 
@@ -466,13 +466,8 @@ def broadcast(*args, **kwargs):
     from .dataarray import DataArray
     from .dataset import Dataset
 
-    exclude = kwargs.pop('exclude', None)
     if exclude is None:
         exclude = set()
-    if kwargs:
-        raise TypeError('broadcast() got unexpected keyword arguments: %s'
-                        % list(kwargs))
-
     args = align(*args, join='outer', copy=False, exclude=exclude)
 
     common_coords = OrderedDict()

--- a/xarray/core/dask_array_compat.py
+++ b/xarray/core/dask_array_compat.py
@@ -82,7 +82,7 @@ else:  # pragma: no cover
         grad = np.gradient(x, coord, axis=axis, **grad_kwargs)
         return grad
 
-    def gradient(f, *varargs, **kwargs):
+    def gradient(f, *varargs, axis=None, **kwargs):
         f = da.asarray(f)
 
         kwargs["edge_order"] = math.ceil(kwargs.get("edge_order", 1))
@@ -90,7 +90,6 @@ else:  # pragma: no cover
             raise ValueError("edge_order must be less than or equal to 2.")
 
         drop_result_list = False
-        axis = kwargs.pop("axis", None)
         if axis is None:
             axis = tuple(range(f.ndim))
         elif isinstance(axis, Integral):

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -726,7 +726,7 @@ ops.inject_binary_ops(DataArrayGroupBy)
 
 
 class DatasetGroupBy(GroupBy, ImplementsDatasetReduce):
-    def apply(self, func, args=(), **kwargs):
+    def apply(self, func, args=(), shortcut=None, **kwargs):
         """Apply a function over each Dataset in the group and concatenate them
         together into a new Dataset.
 
@@ -756,7 +756,7 @@ class DatasetGroupBy(GroupBy, ImplementsDatasetReduce):
         applied : Dataset or DataArray
             The result of splitting, applying and combining this dataset.
         """
-        kwargs.pop('shortcut', None)  # ignore shortcut if set (for now)
+        # ignore shortcut if set (for now)
         applied = (func(ds, *args, **kwargs) for ds in self._iter_grouped())
         return self._combine(applied)
 

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -1,7 +1,6 @@
 import warnings
-from collections.abc import Iterable
 from functools import partial
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Sequence
 
 import numpy as np
 import pandas as pd
@@ -15,9 +14,10 @@ from .variable import Variable, broadcast_variables
 
 
 class BaseInterpolator:
-    '''gerneric interpolator class for normalizing interpolation methods'''
-    cons_kwargs = {}  # type: Dict[str, Any]
-    call_kwargs = {}  # type: Dict[str, Any]
+    """Generic interpolator class for normalizing interpolation methods
+    """
+    cons_kwargs = None  # type: Dict[str, Any]
+    call_kwargs = None  # type: Dict[str, Any]
     f = None  # type: Callable
     method = None  # type: str
 
@@ -30,13 +30,12 @@ class BaseInterpolator:
 
 
 class NumpyInterpolator(BaseInterpolator):
-    '''One-dimensional linear interpolation.
+    """One-dimensional linear interpolation.
 
     See Also
     --------
     numpy.interp
-    '''
-
+    """
     def __init__(self, xi, yi, method='linear', fill_value=None, period=None):
 
         if method != 'linear':
@@ -53,7 +52,7 @@ class NumpyInterpolator(BaseInterpolator):
         if fill_value is None:
             self._left = np.nan
             self._right = np.nan
-        elif isinstance(fill_value, Iterable) and len(fill_value) == 2:
+        elif isinstance(fill_value, Sequence) and len(fill_value) == 2:
             self._left = fill_value[0]
             self._right = fill_value[1]
         elif is_scalar(fill_value):
@@ -68,15 +67,15 @@ class NumpyInterpolator(BaseInterpolator):
 
 
 class ScipyInterpolator(BaseInterpolator):
-    '''Interpolate a 1-D function using Scipy interp1d
+    """Interpolate a 1-D function using Scipy interp1d
 
     See Also
     --------
     scipy.interpolate.interp1d
-    '''
-
+    """
     def __init__(self, xi, yi, method=None, fill_value=None,
-                 assume_sorted=True, copy=False, bounds_error=False, **kwargs):
+                 assume_sorted=True, copy=False, bounds_error=False,
+                 order=None, **kwargs):
         from scipy.interpolate import interp1d
 
         if method is None:
@@ -84,9 +83,9 @@ class ScipyInterpolator(BaseInterpolator):
                              'valid scipy.inter1d method (kind)')
 
         if method == 'polynomial':
-            method = kwargs.pop('order', None)
-            if method is None:
+            if order is None:
                 raise ValueError('order is required when method=polynomial')
+            method = order
 
         self.method = method
 
@@ -94,7 +93,7 @@ class ScipyInterpolator(BaseInterpolator):
         self.call_kwargs = {}
 
         if fill_value is None and method == 'linear':
-            fill_value = kwargs.pop('fill_value', (np.nan, np.nan))
+            fill_value = np.nan, np.nan
         elif fill_value is None:
             fill_value = np.nan
 
@@ -104,15 +103,14 @@ class ScipyInterpolator(BaseInterpolator):
 
 
 class SplineInterpolator(BaseInterpolator):
-    '''One-dimensional smoothing spline fit to a given set of data points.
+    """One-dimensional smoothing spline fit to a given set of data points.
 
     See Also
     --------
     scipy.interpolate.UnivariateSpline
-    '''
-
+    """
     def __init__(self, xi, yi, method='spline', fill_value=None, order=3,
-                 **kwargs):
+                 nu=0, ext=None, **kwargs):
         from scipy.interpolate import UnivariateSpline
 
         if method != 'spline':
@@ -121,8 +119,7 @@ class SplineInterpolator(BaseInterpolator):
 
         self.method = method
         self.cons_kwargs = kwargs
-        self.call_kwargs['nu'] = kwargs.pop('nu', 0)
-        self.call_kwargs['ext'] = kwargs.pop('ext', None)
+        self.call_kwargs = {'nu': nu, 'ext': ext}
 
         if fill_value is not None:
             raise ValueError('SplineInterpolator does not support fill_value')
@@ -131,8 +128,8 @@ class SplineInterpolator(BaseInterpolator):
 
 
 def _apply_over_vars_with_dim(func, self, dim=None, **kwargs):
-    '''wrapper for datasets'''
-
+    """Wrapper for datasets
+    """
     ds = type(self)(coords=self.coords, attrs=self.attrs)
 
     for name, var in self.data_vars.items():
@@ -144,7 +141,7 @@ def _apply_over_vars_with_dim(func, self, dim=None, **kwargs):
     return ds
 
 
-def get_clean_interp_index(arr, dim, use_coordinate=True, **kwargs):
+def get_clean_interp_index(arr, dim, use_coordinate=True):
     '''get index to use for x values in interpolation.
 
     If use_coordinate is True, the coordinate that shares the name of the
@@ -184,8 +181,8 @@ def get_clean_interp_index(arr, dim, use_coordinate=True, **kwargs):
 
 def interp_na(self, dim=None, use_coordinate=True, method='linear', limit=None,
               **kwargs):
-    '''Interpolate values according to different methods.'''
-
+    """Interpolate values according to different methods.
+    """
     if dim is None:
         raise NotImplementedError('dim is a required argument')
 
@@ -193,8 +190,7 @@ def interp_na(self, dim=None, use_coordinate=True, method='linear', limit=None,
         valids = _get_valid_fill_mask(self, dim, limit)
 
     # method
-    index = get_clean_interp_index(self, dim, use_coordinate=use_coordinate,
-                                   **kwargs)
+    index = get_clean_interp_index(self, dim, use_coordinate=use_coordinate)
     interp_class, kwargs = _get_interpolator(method, **kwargs)
     interpolator = partial(func_interpolate_na, interp_class, **kwargs)
 

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -37,7 +37,7 @@ class NumpyInterpolator(BaseInterpolator):
     numpy.interp
     '''
 
-    def __init__(self, xi, yi, method='linear', fill_value=None, **kwargs):
+    def __init__(self, xi, yi, method='linear', fill_value=None, period=None):
 
         if method != 'linear':
             raise ValueError(
@@ -45,15 +45,10 @@ class NumpyInterpolator(BaseInterpolator):
 
         self.method = method
         self.f = np.interp
-        self.cons_kwargs = kwargs
-        self.call_kwargs = {'period': self.cons_kwargs.pop('period', None)}
+        self.call_kwargs = {'period': period}
 
         self._xi = xi
         self._yi = yi
-
-        if self.cons_kwargs:
-            raise ValueError(
-                'received invalid kwargs: %r' % self.cons_kwargs.keys())
 
         if fill_value is None:
             self._left = np.nan

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -44,6 +44,7 @@ class NumpyInterpolator(BaseInterpolator):
 
         self.method = method
         self.f = np.interp
+        self.cons_kwargs = {}
         self.call_kwargs = {'period': period}
 
         self._xi = xi

--- a/xarray/core/nanops.py
+++ b/xarray/core/nanops.py
@@ -133,7 +133,7 @@ def nansum(a, axis=None, dtype=None, out=None, min_count=None):
         return result
 
 
-def _nanmean_ddof_object(ddof, value, axis=None, **kwargs):
+def _nanmean_ddof_object(ddof, value, axis=None, dtype=None, **kwargs):
     """ In house nanmean. ddof argument will be used in _nanvar method """
     from .duck_array_ops import (count, fillna, _dask_or_eager_func,
                                  where_method)
@@ -142,7 +142,6 @@ def _nanmean_ddof_object(ddof, value, axis=None, **kwargs):
     value = fillna(value, 0)
     # As dtype inference is impossible for object dtype, we assume float
     # https://github.com/dask/dask/issues/3162
-    dtype = kwargs.pop('dtype', None)
     if dtype is None and value.dtype.kind == 'O':
         dtype = value.dtype if value.dtype.kind in ['cf'] else float
 
@@ -165,14 +164,12 @@ def nanmedian(a, axis=None, out=None):
     return _dask_or_eager_func('nanmedian', eager_module=nputils)(a, axis=axis)
 
 
-def _nanvar_object(value, axis=None, **kwargs):
-    ddof = kwargs.pop('ddof', 0)
-    kwargs_mean = kwargs.copy()
-    kwargs_mean.pop('keepdims', None)
+def _nanvar_object(value, axis=None, ddof=0, keepdims=False, **kwargs):
     value_mean = _nanmean_ddof_object(ddof=0, value=value, axis=axis,
-                                      keepdims=True, **kwargs_mean)
+                                      keepdims=True, **kwargs)
     squared = (value.astype(value_mean.dtype) - value_mean)**2
-    return _nanmean_ddof_object(ddof, squared, axis=axis, **kwargs)
+    return _nanmean_ddof_object(ddof, squared, axis=axis,
+                                keepdims=keepdims, **kwargs)
 
 
 def nanvar(a, axis=None, dtype=None, out=None, ddof=0):

--- a/xarray/core/npcompat.py
+++ b/xarray/core/npcompat.py
@@ -108,11 +108,13 @@ else:
             axes = (axes, )
         return tuple([N + a if a < 0 else a for a in axes])
 
-    def gradient(f, *varargs, **kwargs):
+    def gradient(f, *varargs, axis=None, edge_order=1):
         f = np.asanyarray(f)
         N = f.ndim  # number of dimensions
 
-        axes = kwargs.pop('axis', None)
+        axes = axis
+        del axis
+
         if axes is None:
             axes = tuple(range(N))
         else:
@@ -146,10 +148,6 @@ else:
         else:
             raise TypeError("invalid number of arguments")
 
-        edge_order = kwargs.pop('edge_order', 1)
-        if kwargs:
-            raise TypeError('"{}" are not valid keyword arguments.'.format(
-                '", "'.join(kwargs.keys())))
         if edge_order > 2:
             raise ValueError("'edge_order' greater than 2 not supported")
 

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -204,8 +204,8 @@ def _rolling_window(a, window, axis=-1):
 
 
 def _create_bottleneck_method(name, npmodule=np):
-    def f(values, axis=None, **kwds):
-        dtype = kwds.get('dtype', None)
+    def f(values, axis=None, **kwargs):
+        dtype = kwargs.get('dtype', None)
         bn_func = getattr(bn, name, None)
 
         if (_USE_BOTTLENECK and bn_func is not None and
@@ -214,10 +214,10 @@ def _create_bottleneck_method(name, npmodule=np):
                 values.dtype.isnative and
                 (dtype is None or np.dtype(dtype) == values.dtype)):
             # bottleneck does not take care dtype, min_count
-            kwds.pop('dtype', None)
-            result = bn_func(values, axis=axis, **kwds)
+            kwargs.pop('dtype', None)
+            result = bn_func(values, axis=axis, **kwargs)
         else:
-            result = getattr(npmodule, name)(values, axis=axis, **kwds)
+            result = getattr(npmodule, name)(values, axis=axis, **kwargs)
 
         return result
 

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -154,15 +154,15 @@ class DataArrayResample(DataArrayGroupBy, Resample):
     specified dimension
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, dim=None, resample_dim=None, **kwargs):
 
-        self._dim = kwargs.pop('dim', None)
-        self._resample_dim = kwargs.pop('resample_dim', None)
-
-        if self._dim == self._resample_dim:
+        if dim == resample_dim:
             raise ValueError("Proxy resampling dimension ('{}') "
                              "cannot have the same name as actual dimension "
-                             "('{}')! ".format(self._resample_dim, self._dim))
+                             "('{}')! ".format(resample_dim, dim))
+        self._dim = dim
+        self._resample_dim = resample_dim
+
         super(DataArrayResample, self).__init__(*args, **kwargs)
 
     def apply(self, func, shortcut=False, args=(), **kwargs):
@@ -227,18 +227,18 @@ class DatasetResample(DatasetGroupBy, Resample):
     """DatasetGroupBy object specialized to resampling a specified dimension
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, dim=None, resample_dim=None, **kwargs):
 
-        self._dim = kwargs.pop('dim', None)
-        self._resample_dim = kwargs.pop('resample_dim', None)
-
-        if self._dim == self._resample_dim:
+        if dim == resample_dim:
             raise ValueError("Proxy resampling dimension ('{}') "
                              "cannot have the same name as actual dimension "
-                             "('{}')! ".format(self._resample_dim, self._dim))
+                             "('{}')! ".format(resample_dim, dim))
+        self._dim = dim
+        self._resample_dim = resample_dim
+
         super(DatasetResample, self).__init__(*args, **kwargs)
 
-    def apply(self, func, args=(), **kwargs):
+    def apply(self, func, args=(), shortcut=None, **kwargs):
         """Apply a function over each Dataset in the groups generated for
         resampling  and concatenate them together into a new Dataset.
 
@@ -267,7 +267,7 @@ class DatasetResample(DatasetGroupBy, Resample):
         applied : Dataset or DataArray
             The result of splitting, applying and combining this dataset.
         """
-        kwargs.pop('shortcut', None)  # ignore shortcut if set (for now)
+        # ignore shortcut if set (for now)
         applied = (func(ds, *args, **kwargs) for ds in self._iter_grouped())
         combined = self._combine(applied)
 

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -368,7 +368,7 @@ class FacetGrid:
         return self
 
     def set_titles(self, template="{coord} = {value}", maxchar=30,
-                   **kwargs):
+                   size=None, **kwargs):
         """
         Draw titles either above each facet or on the grid margins.
 
@@ -388,7 +388,8 @@ class FacetGrid:
         """
         import matplotlib as mpl
 
-        kwargs["size"] = kwargs.pop("size", mpl.rcParams["axes.labelsize"])
+        if size is None:
+            size = mpl.rcParams["axes.labelsize"]
 
         nicetitle = functools.partial(_nicetitle, maxchar=maxchar,
                                       template=template)
@@ -399,7 +400,7 @@ class FacetGrid:
                 if d is not None:
                     coord, value = list(d.items()).pop()
                     title = nicetitle(coord, value, maxchar=maxchar)
-                    ax.set_title(title, **kwargs)
+                    ax.set_title(title, size=size, **kwargs)
         else:
             # The row titles on the right edge of the grid
             for ax, row_name in zip(self.axes[:, -1], self.row_names):
@@ -412,7 +413,7 @@ class FacetGrid:
             for ax, col_name in zip(self.axes[0, :], self.col_names):
                 title = nicetitle(coord=self._col_var, value=col_name,
                                   maxchar=maxchar)
-                ax.set_title(title, **kwargs)
+                ax.set_title(title, size=size, **kwargs)
 
         return self
 
@@ -492,14 +493,13 @@ class FacetGrid:
 
 def _easy_facetgrid(data, plotfunc, kind, x=None, y=None, row=None,
                     col=None, col_wrap=None, sharex=True, sharey=True,
-                    aspect=None, size=None, subplot_kws=None, **kwargs):
+                    aspect=None, size=None, subplot_kws=None, ax=None,
+                    figsize=None, **kwargs):
     """
     Convenience method to call xarray.plot.FacetGrid from 2d plotting methods
 
     kwargs are the arguments to 2d plotting method
     """
-    ax = kwargs.pop('ax', None)
-    figsize = kwargs.pop('figsize', None)
     if ax is not None:
         raise ValueError("Can't use axes when making faceted plots.")
     if aspect is None:

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -222,12 +222,15 @@ class FacetGrid:
             raise ValueError('cbar_ax not supported by FacetGrid.')
 
         cmap_params, cbar_kwargs = _process_cmap_cbar_kwargs(
-            func, kwargs, self.data.values)
+            func, self.data.values, **kwargs)
 
         self._cmap_extend = cmap_params.get('extend')
 
         # Order is important
-        func_kwargs = kwargs.copy()
+        func_kwargs = {
+            k: v for k, v in kwargs.items()
+            if k not in {'cmap', 'colors', 'cbar_kwargs', 'levels'}
+        }
         func_kwargs.update(cmap_params)
         func_kwargs.update({'add_colorbar': False, 'add_labels': False})
 

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -264,7 +264,7 @@ class FacetGrid:
                 subset = self.data.loc[d]
                 mappable = func(subset, x=x, y=y, ax=ax,
                                 hue=hue, add_legend=False, _labels=False,
-                **kwargs)
+                                **kwargs)
                 self._mappables.append(mappable)
 
         _, _, hueplt, xlabel, ylabel, huelabel = _infer_line_data(

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -251,24 +251,21 @@ class FacetGrid:
 
         return self
 
-    def map_dataarray_line(self, func, x, y, **kwargs):
+    def map_dataarray_line(self, func, x, y, hue, add_legend=True,
+                           _labels=None, **kwargs):
         from .plot import _infer_line_data
-
-        add_legend = kwargs.pop('add_legend', True)
-        kwargs['add_legend'] = False
-        func_kwargs = kwargs.copy()
-        func_kwargs['_labels'] = False
 
         for d, ax in zip(self.name_dicts.flat, self.axes.flat):
             # None is the sentinel value
             if d is not None:
                 subset = self.data.loc[d]
-                mappable = func(subset, x=x, y=y, ax=ax, **func_kwargs)
+                mappable = func(subset, x=x, y=y, ax=ax,
+                                hue=hue, add_legend=False, _labels=False,
+                **kwargs)
                 self._mappables.append(mappable)
 
         _, _, hueplt, xlabel, ylabel, huelabel = _infer_line_data(
-            darray=self.data.loc[self.name_dicts.flat[0]],
-            x=x, y=y, hue=func_kwargs['hue'])
+            darray=self.data.loc[self.name_dicts.flat[0]], x=x, y=y, hue=hue)
 
         self._hue_var = hueplt
         self._hue_label = huelabel

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -555,9 +555,9 @@ def _plot2d(plotfunc):
         # Handle facetgrids first
         if row or col:
             allargs = locals().copy()
-            allargs.pop('imshow_rgb')
+            del allargs['darray']
+            del allargs['imshow_rgb']
             allargs.update(allargs.pop('kwargs'))
-            allargs.pop('darray')
             # Need the decorated plotting function
             allargs['plotfunc'] = globals()[plotfunc.__name__]
             return _easy_facetgrid(darray, kind='dataarray', **allargs)

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -178,7 +178,10 @@ def plot(darray, row=None, col=None, col_wrap=None, ax=None, hue=None,
 
 # This function signature should not change so that it can use
 # matplotlib format strings
-def line(darray, *args, **kwargs):
+def line(darray, *args, row=None, col=None, figsize=None, aspect=None,
+         size=None, ax=None, hue=None, x=None, y=None, xincrease=None,
+         yincrease=None, xscale=None, yscale=None, xticks=None, yticks=None,
+         xlim=None, ylim=None, add_legend=True, _labels=True, **kwargs):
     """
     Line plot of DataArray index against values
 
@@ -222,12 +225,8 @@ def line(darray, *args, **kwargs):
         Add legend with y axis coordinates (2D inputs only).
     *args, **kwargs : optional
         Additional arguments to matplotlib.pyplot.plot
-
     """
-
     # Handle facetgrids first
-    row = kwargs.pop('row', None)
-    col = kwargs.pop('col', None)
     if row or col:
         allargs = locals().copy()
         allargs.update(allargs.pop('kwargs'))
@@ -241,23 +240,6 @@ def line(darray, *args, **kwargs):
                          'dimensions'.format(ndims=ndims))
 
     # Ensures consistency with .plot method
-    figsize = kwargs.pop('figsize', None)
-    aspect = kwargs.pop('aspect', None)
-    size = kwargs.pop('size', None)
-    ax = kwargs.pop('ax', None)
-    hue = kwargs.pop('hue', None)
-    x = kwargs.pop('x', None)
-    y = kwargs.pop('y', None)
-    xincrease = kwargs.pop('xincrease', None)  # default needs to be None
-    yincrease = kwargs.pop('yincrease', None)
-    xscale = kwargs.pop('xscale', None)  # default needs to be None
-    yscale = kwargs.pop('yscale', None)
-    xticks = kwargs.pop('xticks', None)
-    yticks = kwargs.pop('yticks', None)
-    xlim = kwargs.pop('xlim', None)
-    ylim = kwargs.pop('ylim', None)
-    add_legend = kwargs.pop('add_legend', True)
-    _labels = kwargs.pop('_labels', True)
     if args is ():
         args = kwargs.pop('args', ())
 
@@ -277,7 +259,7 @@ def line(darray, *args, **kwargs):
                                    .replace('steps-post', '')
                                    .replace('steps-mid', ''))
             if kwargs['linestyle'] == '':
-                kwargs.pop('linestyle')
+                del kwargs['linestyle']
         else:
             xplt_val = _interval_to_mid_points(xplt.values)
             yplt_val = yplt.values
@@ -319,7 +301,7 @@ def line(darray, *args, **kwargs):
     return primitive
 
 
-def step(darray, *args, **kwargs):
+def step(darray, *args, where='pre', linestyle=None, ls=None, **kwargs):
     """
     Step plot of DataArray index against values
 
@@ -343,20 +325,21 @@ def step(darray, *args, **kwargs):
 
     *args, **kwargs : optional
         Additional arguments following :py:func:`xarray.plot.line`
-
     """
-    if ('ls' in kwargs.keys()) and ('linestyle' not in kwargs.keys()):
-        kwargs['linestyle'] = kwargs.pop('ls')
-
-    where = kwargs.pop('where', 'pre')
-
-    if where not in ('pre', 'post', 'mid'):
+    if where not in {'pre', 'post', 'mid'}:
         raise ValueError("'where' argument to step must be "
                          "'pre', 'post' or 'mid'")
 
-    kwargs['linestyle'] = 'steps-' + where + kwargs.get('linestyle', '')
+    if ls is not None:
+        if linestyle is None:
+            linestyle = ls
+        else:
+            raise TypeError('ls and linestyle are mutually exclusive')
+    if linestyle is None:
+        linestyle = ''
+    linestyle = 'steps-' + where + linestyle
 
-    return line(darray, *args, **kwargs)
+    return line(darray, *args, linestyle=linestyle, **kwargs)
 
 
 def hist(darray, figsize=None, size=None, aspect=None, ax=None, **kwargs):

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -239,6 +239,10 @@ def line(darray, *args, row=None, col=None, figsize=None, aspect=None,
                          'Passed DataArray has {ndims} '
                          'dimensions'.format(ndims=ndims))
 
+    # Ensures consistency with .plot method
+    if args is ():
+        args = kwargs.pop('args', ())
+
     ax = get_axis(figsize, size, aspect, ax)
     xplt, yplt, hueplt, xlabel, ylabel, huelabel = \
         _infer_line_data(darray, x, y, hue)

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -615,7 +615,7 @@ def _plot2d(plotfunc):
         _ensure_plottable(xplt, yplt)
 
         cmap_params, cbar_kwargs = _process_cmap_cbar_kwargs(
-            plotfunc, locals(), zval.data)
+            plotfunc, zval.data, **locals())
 
         if 'contour' in plotfunc.__name__:
             # extend is a keyword argument only for contour and contourf, but
@@ -656,7 +656,7 @@ def _plot2d(plotfunc):
             cbar = _add_colorbar(primitive, ax, cbar_ax, cbar_kwargs,
                                  cmap_params)
 
-        elif (cbar_ax is not None or cbar_kwargs):
+        elif cbar_ax is not None or cbar_kwargs:
             # inform the user about keywords which aren't used
             raise ValueError("cbar_ax and cbar_kwargs can't be used with "
                              "add_colorbar=False.")

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -239,9 +239,11 @@ def line(darray, *args, row=None, col=None, figsize=None, aspect=None,
                          'Passed DataArray has {ndims} '
                          'dimensions'.format(ndims=ndims))
 
-    # Ensures consistency with .plot method
+    # The allargs dict passed to _easy_facetgrid above contains args
     if args is ():
         args = kwargs.pop('args', ())
+    else:
+        assert 'args' not in kwargs
 
     ax = get_axis(figsize, size, aspect, ax)
     xplt, yplt, hueplt, xlabel, ylabel, huelabel = \

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -342,7 +342,9 @@ def step(darray, *args, where='pre', linestyle=None, ls=None, **kwargs):
     return line(darray, *args, linestyle=linestyle, **kwargs)
 
 
-def hist(darray, figsize=None, size=None, aspect=None, ax=None, **kwargs):
+def hist(darray, figsize=None, size=None, aspect=None, ax=None,
+         xincrease=None, yincrease=None, xscale=None, yscale=None,
+         xticks=None, yticks=None, xlim=None, ylim=None, **kwargs):
     """
     Histogram of DataArray
 
@@ -371,15 +373,6 @@ def hist(darray, figsize=None, size=None, aspect=None, ax=None, **kwargs):
 
     """
     ax = get_axis(figsize, size, aspect, ax)
-
-    xincrease = kwargs.pop('xincrease', None)  # default needs to be None
-    yincrease = kwargs.pop('yincrease', None)
-    xscale = kwargs.pop('xscale', None)  # default needs to be None
-    yscale = kwargs.pop('yscale', None)
-    xticks = kwargs.pop('xticks', None)
-    yticks = kwargs.pop('yticks', None)
-    xlim = kwargs.pop('xlim', None)
-    ylim = kwargs.pop('ylim', None)
 
     no_nan = np.ravel(darray.values)
     no_nan = no_nan[pd.notnull(no_nan)]

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -239,10 +239,6 @@ def line(darray, *args, row=None, col=None, figsize=None, aspect=None,
                          'Passed DataArray has {ndims} '
                          'dimensions'.format(ndims=ndims))
 
-    # Ensures consistency with .plot method
-    if args is ():
-        args = kwargs.pop('args', ())
-
     ax = get_axis(figsize, size, aspect, ax)
     xplt, yplt, hueplt, xlabel, ylabel, huelabel = \
         _infer_line_data(darray, x, y, hue)

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -4,6 +4,7 @@ import warnings
 from datetime import datetime
 from distutils.version import LooseVersion
 from inspect import getfullargspec
+from typing import Any, Iterable, Mapping, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -648,13 +649,14 @@ def _infer_interval_breaks(coord, axis=0, check_monotonic=False):
     return np.concatenate([first, coord[trim_last] + deltas, last], axis=axis)
 
 
-def _process_cmap_cbar_kwargs(func, kwargs, data):
+def _process_cmap_cbar_kwargs(
+    func, data, cmap=None, colors=None,
+    cbar_kwargs: Union[Iterable[Tuple[str, Any]], Mapping[str, Any]]=None,
+    levels=None, **kwargs):
     """
     Parameters
     ==========
     func : plotting function
-    kwargs : dict,
-        Dictionary with arguments that need to be parsed
     data : ndarray,
         Data values
 
@@ -664,14 +666,8 @@ def _process_cmap_cbar_kwargs(func, kwargs, data):
 
     cbar_kwargs
     """
-
-    cmap = kwargs.pop('cmap', None)
-    colors = kwargs.pop('colors', None)
-
-    cbar_kwargs = kwargs.pop('cbar_kwargs', {})
     cbar_kwargs = {} if cbar_kwargs is None else dict(cbar_kwargs)
 
-    levels = kwargs.pop('levels', None)
     if 'contour' in func.__name__ and levels is None:
         levels = 7  # this is the matplotlib default
 

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -651,7 +651,8 @@ def _infer_interval_breaks(coord, axis=0, check_monotonic=False):
 
 def _process_cmap_cbar_kwargs(
         func, data, cmap=None, colors=None,
-        cbar_kwargs: Union[Iterable[Tuple[str, Any]], Mapping[str, Any]] = None,
+        cbar_kwargs: Union[Iterable[Tuple[str, Any]],
+                           Mapping[str, Any]] = None,
         levels=None, **kwargs):
     """
     Parameters

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -650,9 +650,9 @@ def _infer_interval_breaks(coord, axis=0, check_monotonic=False):
 
 
 def _process_cmap_cbar_kwargs(
-    func, data, cmap=None, colors=None,
-    cbar_kwargs: Union[Iterable[Tuple[str, Any]], Mapping[str, Any]]=None,
-    levels=None, **kwargs):
+        func, data, cmap=None, colors=None,
+        cbar_kwargs: Union[Iterable[Tuple[str, Any]], Mapping[str, Any]] = None,
+        levels=None, **kwargs):
     """
     Parameters
     ==========

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -399,8 +399,8 @@ class DatasetIOBase:
     def test_roundtrip_numpy_datetime_data(self):
         times = pd.to_datetime(['2000-01-01', '2000-01-02', 'NaT'])
         expected = Dataset({'t': ('t', times), 't0': times[0]})
-        kwds = {'encoding': {'t0': {'units': 'days since 1950-01-01'}}}
-        with self.roundtrip(expected, save_kwargs=kwds) as actual:
+        kwargs = {'encoding': {'t0': {'units': 'days since 1950-01-01'}}}
+        with self.roundtrip(expected, save_kwargs=kwargs) as actual:
             assert_identical(expected, actual)
             assert actual.t0.encoding['units'] == 'days since 1950-01-01'
 
@@ -412,7 +412,7 @@ class DatasetIOBase:
         for date_type in date_types.values():
             times = [date_type(1, 1, 1), date_type(1, 1, 2)]
             expected = Dataset({'t': ('t', times), 't0': times[0]})
-            kwds = {'encoding': {'t0': {'units': 'days since 0001-01-01'}}}
+            kwargs = {'encoding': {'t0': {'units': 'days since 0001-01-01'}}}
             expected_decoded_t = np.array(times)
             expected_decoded_t0 = np.array([date_type(1, 1, 1)])
             expected_calendar = times[0].calendar
@@ -422,7 +422,7 @@ class DatasetIOBase:
                     warnings.filterwarnings(
                         'ignore', 'Unable to decode time axis')
 
-                with self.roundtrip(expected, save_kwargs=kwds) as actual:
+                with self.roundtrip(expected, save_kwargs=kwargs) as actual:
                     abs_diff = abs(actual.t.values - expected_decoded_t)
                     assert (abs_diff <= np.timedelta64(1, 's')).all()
                     assert (actual.t.encoding['units']
@@ -2453,7 +2453,7 @@ class TestDask(DatasetIOBase):
 
     def test_roundtrip_numpy_datetime_data(self):
         # Override method in DatasetIOBase - remove not applicable
-        # save_kwds
+        # save_kwargs
         times = pd.to_datetime(['2000-01-01', '2000-01-02', 'NaT'])
         expected = Dataset({'t': ('t', times), 't0': times[0]})
         with self.roundtrip(expected) as actual:
@@ -2461,7 +2461,7 @@ class TestDask(DatasetIOBase):
 
     def test_roundtrip_cftime_datetime_data(self):
         # Override method in DatasetIOBase - remove not applicable
-        # save_kwds
+        # save_kwargs
         from .test_coding_times import _all_cftime_date_types
 
         date_types = _all_cftime_date_types()

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -12,7 +12,7 @@ from . import (
 from .test_dataset import create_test_data
 
 
-class TestConcatDataset(object):
+class TestConcatDataset:
     def test_concat(self):
         # TODO: simplify and split this test case
 
@@ -247,7 +247,7 @@ class TestConcatDataset(object):
         assert_identical(actual, expected)
 
 
-class TestConcatDataArray(object):
+class TestConcatDataArray:
     def test_concat(self):
         ds = Dataset({'foo': (['x', 'y'], np.random.random((2, 3))),
                       'bar': (['x', 'y'], np.random.random((2, 3)))},

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1036,7 +1036,7 @@ class Common2dMixin:
         alltxt = text_in_fig()
         assert 'MyLabel' in alltxt
         assert 'testvar' not in alltxt
-        # you can use mapping types as well
+        # you can use anything accepted by the dict constructor as well
         self.plotmethod(
             add_colorbar=True, cbar_kwargs=(('label', 'MyLabel'), ))
         alltxt = text_in_fig()

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1428,24 +1428,24 @@ class TestImshow(Common2dMixin, PlotTestCase):
             arr.plot.imshow(rgb='band')
 
     def test_normalize_rgb_imshow(self):
-        for kwds in (
+        for kwargs in (
             dict(vmin=-1), dict(vmax=2),
             dict(vmin=-1, vmax=1), dict(vmin=0, vmax=0),
             dict(vmin=0, robust=True), dict(vmax=-1, robust=True),
         ):
             da = DataArray(easy_array((5, 5, 3), start=-0.6, stop=1.4))
-            arr = da.plot.imshow(**kwds).get_array()
-            assert 0 <= arr.min() <= arr.max() <= 1, kwds
+            arr = da.plot.imshow(**kwargs).get_array()
+            assert 0 <= arr.min() <= arr.max() <= 1, kwargs
 
     def test_normalize_rgb_one_arg_error(self):
         da = DataArray(easy_array((5, 5, 3), start=-0.6, stop=1.4))
         # If passed one bound that implies all out of range, error:
-        for kwds in [dict(vmax=-1), dict(vmin=2)]:
+        for kwargs in [dict(vmax=-1), dict(vmin=2)]:
             with pytest.raises(ValueError):
-                da.plot.imshow(**kwds)
+                da.plot.imshow(**kwargs)
         # If passed two that's just moving the range, *not* an error:
-        for kwds in [dict(vmax=-1, vmin=-1.2), dict(vmin=2, vmax=2.1)]:
-            da.plot.imshow(**kwds)
+        for kwargs in [dict(vmax=-1, vmin=-1.2), dict(vmin=2, vmax=2.1)]:
+            da.plot.imshow(**kwargs)
 
     def test_imshow_rgb_values_in_valid_range(self):
         da = DataArray(np.arange(75, dtype='uint8').reshape((5, 5, 3)))


### PR DESCRIPTION
- Clean up everywhere the pattern
```
def my_func(*args, **kwargs):
    my_optional_arg = kwargs.pop('my_optional_arg', None)
```
which was inherited from not being able to put named keyword arguments after ``*args`` in Python 2.

- Fix bug in SplineInterpolator where the ``__init__`` method would write to the class attributes of BaseInterpolator.
- ``map_dataarray`` was unintentionally and subtly relying on ``_process_cmap_cbar_kwargs`` to modify the kwargs in place. ``_process_cmap_cbar_kwargs`` is now strictly read-only and the modifications in kwargs have been made explicit in the caller function.
- Rename all 'kwds' to 'kwargs' for sake of coherency