### PR TITLE
Tweak codecov.io configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        # Require 1% coverage, i.e., always succeed
+        target: 1
+    patch: false
+    changes: false
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no

--- a/ci/.coveragerc
+++ b/ci/.coveragerc
@@ -1,3 +1,4 @@
 [report]
 omit =
     xarray/tests/*
+    xarray/_version.py


### PR DESCRIPTION
- Exclude `_version.py` from coverage, since it was generated from versioneer.
- Remove the "reach" graph from comments.
- Don't give PRs a failing status if they decrease coverage.
