### PR TITLE
Fix printing summaries of multiindex coords

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,6 +38,8 @@ Bug fixes
 
 - Compatibility fixes for the upcoming pandas 0.25 and NumPy 1.17 releases.
   By `Stephan Hoyer <https://github.com/shoyer>`_.
+- Fix summaries for multiindex coordinates (:issue:`3079`).
+  By `Jonas Hörsch <https://github.com/coroa>`_.
 
 .. _whats-new.0.12.2:
 

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -235,10 +235,9 @@ def _summarize_coord_multiindex(coord, col_width, marker):
 
 
 def _summarize_coord_levels(coord, col_width, marker='-'):
-    relevant_coord = coord[:30]
     return '\n'.join(
         [summarize_variable(lname,
-                            relevant_coord.get_level_variable(lname),
+                            coord.get_level_variable(lname),
                             col_width, marker=marker)
          for lname in coord.level_names])
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -64,6 +64,22 @@ class TestDataArray:
           - level_2  (x) int64 1 2 1 2""")
         assert expected == repr(self.mda)
 
+    def test_repr_multiindex_long(self):
+        mindex_long = pd.MultiIndex.from_product(
+            [['a', 'b', 'c', 'd'], [1, 2, 3, 4, 5, 6, 7, 8]],
+            names=('level_1', 'level_2'))
+        mda_long = DataArray(list(range(32)),
+                             coords={'x': mindex_long}, dims='x')
+        expected = dedent("""\
+        <xarray.DataArray (x: 32)>
+        array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17,
+               18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31])
+        Coordinates:
+          * x        (x) MultiIndex
+          - level_1  (x) object 'a' 'a' 'a' 'a' 'a' 'a' 'a' ... 'd' 'd' 'd' 'd' 'd' 'd'
+          - level_2  (x) int64 1 2 3 4 5 6 7 8 1 2 3 4 5 6 ... 4 5 6 7 8 1 2 3 4 5 6 7 8""")  # noqa: E501
+        assert expected == repr(mda_long)
+
     def test_properties(self):
         assert_equal(self.dv.variable, self.v)
         assert_array_equal(self.dv.values, self.v.values)


### PR DESCRIPTION
Since merging #2293 summarize_variable displays the first and last few entries,
so we have to pass all along.

MWE:
```python
import xarray as xr
import numpy as np
x = np.arange(0, 90, 0.5)
y = np.arange(0, 90, 0.5)
da = xr.DataArray(np.random.random((len(x), len(y))), [('x', x), ('y', y)])
da.stack(z=('x', 'y'))
```
gives on master:
```
<xarray.DataArray (z: 32400)>
array([0.497724, 0.793955, 0.140193, ..., 0.05734 , 0.884105, 0.479093])
Coordinates:
  * z        (z) MultiIndex
  - x        (z) float64 0.0 0.0 0.0 0.0 0.0 0.0 0.0 ... 0.0 0.0 0.0 0.0 0.0 0.0
  - y        (z) float64 0.0 0.5 1.0 1.5 2.0 2.5 ... 12.5 13.0 13.5 14.0 14.5
```
and on this branch
```
<xarray.DataArray (z: 32400)>
array([0.497724, 0.793955, 0.140193, ..., 0.05734 , 0.884105, 0.479093])
Coordinates:
  * z     (z) MultiIndex
  - x     (z) float64 0.0 0.0 0.0 0.0 0.0 0.0 ... 89.5 89.5 89.5 89.5 89.5 89.5
  - y     (z) float64 0.0 0.5 1.0 1.5 2.0 2.5 ... 87.0 87.5 88.0 88.5 89.0 89.5
```

 - [ ] Closes #xxxx
 - [x] Tests added
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
