### PR TITLE
Change name of testing conda environment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ jobs:
   steps:
   - template: ci/azure/install.yml
   - bash: |
-      source activate test_env
+      source activate xarray-tests
       mypy . || exit 0
     displayName: mypy type checks
 
@@ -76,7 +76,7 @@ jobs:
     parameters:
       env_file: doc/environment.yml
   - bash: |
-      source activate test_env
+      source activate xarray-tests
       cd doc
       sphinx-build -n -j auto -b html -d _build/doctrees . _build/html
     displayName: Build HTML docs
@@ -89,6 +89,6 @@ jobs:
   steps:
   - template: ci/azure/install.yml
   - bash: |
-      source activate test_env
+      source activate xarray-tests
       pytest properties
     displayName: Property based tests

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -6,11 +6,11 @@ steps:
 - template: add-conda-to-path.yml
 
 - bash: |
-    conda env create -n test_env --file ${{ parameters.env_file }}
+    conda env create -n xarray-tests --file ${{ parameters.env_file }}
   displayName: Install conda dependencies
 
 - bash: |
-    source activate test_env
+    source activate xarray-tests
     pip install -f https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com \
         --no-deps \
         --pre \
@@ -29,12 +29,12 @@ steps:
   displayName: Install upstream dev dependencies
 
 - bash: |
-    source activate test_env
+    source activate xarray-tests
     pip install --no-deps -e .
   displayName: Install xarray
 
 - bash: |
-    source activate test_env
+    source activate xarray-tests
     conda info -a
     conda list
     python xarray/util/print_versions.py

--- a/ci/azure/unit-tests.yml
+++ b/ci/azure/unit-tests.yml
@@ -3,14 +3,14 @@ steps:
 - template: install.yml
 
 - bash: |
-    source activate test_env
+    source activate xarray-tests
     python -OO -c "import xarray"
   displayName: Import xarray
 
 # Work around for allowed test failures:
 # https://github.com/microsoft/azure-pipelines-tasks/issues/9302
 - bash: |
-    source activate test_env
+    source activate xarray-tests
     pytest xarray \
     --junitxml=junit/test-results.xml \
     --cov=xarray \

--- a/ci/requirements/py35-min.yml
+++ b/ci/requirements/py35-min.yml
@@ -1,4 +1,4 @@
-name: test_env
+name: xarray-tests
 dependencies:
   - python=3.5.0
   - pytest

--- a/ci/requirements/py36-hypothesis.yml
+++ b/ci/requirements/py36-hypothesis.yml
@@ -1,4 +1,4 @@
-name: test_env
+name: xarray-tests
 channels:
   - conda-forge
 dependencies:

--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -1,4 +1,4 @@
-name: test_env
+name: xarray-tests
 channels:
   - conda-forge
 dependencies:

--- a/ci/requirements/py37-windows.yml
+++ b/ci/requirements/py37-windows.yml
@@ -1,4 +1,4 @@
-name: test_env
+name: xarray-tests
 channels:
   - conda-forge
 dependencies:

--- a/ci/requirements/py37.yml
+++ b/ci/requirements/py37.yml
@@ -1,4 +1,4 @@
-name: test_env
+name: xarray-tests
 channels:
   - conda-forge
 dependencies:

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -152,10 +152,10 @@ We'll now kick off a two-step process:
 
    # Create and activate the build environment
    conda env create -f ci/requirements/py36.yml
-   conda activate test_env
+   conda activate xarray-tests
 
    # or with older versions of Anaconda:
-   source activate test_env
+   source activate xarray-tests
 
    # Build and install xarray
    pip install -e .


### PR DESCRIPTION
This PR changes the test environment name from `test_env` to `xarray-tests` for clarity and to be consistent with the documentation environment name (`xarray-docs`).

 - [x] Closes #3107 
