### PR TITLE
[DOC] Be more explicit about netCDF groups and xarray.Dataset relationship.

### DIFF
--- a/doc/io.rst
+++ b/doc/io.rst
@@ -147,13 +147,18 @@ convert the ``DataArray`` to a ``Dataset`` before saving, and then convert back
 when loading, ensuring that the ``DataArray`` that is loaded is always exactly
 the same as the one that was saved.
 
-A dataset can also be loaded or written to a specific group within a netCDF
-file. To load from a group, pass a ``group`` keyword argument to the
+NetCDF groups are not supported as part of the
+:py:class:`~xarray.Dataset` data model.  Instead, groups can be loaded
+individually as Dataset objects.
+To do so, pass a ``group`` keyword argument to the
 ``open_dataset`` function. The group can be specified as a path-like
 string, e.g., to access subgroup 'bar' within group 'foo' pass
-'/foo/bar' as the ``group`` argument. When writing multiple groups in one file,
-pass ``mode='a'`` to ``to_netcdf`` to ensure that each call does not delete the
-file.
+'/foo/bar' as the ``group`` argument.
+In a similar way, the ``group`` keyword argument can be given to the
+:py:meth:`~xarray.Dataset.to_netcdf` method to write to a group
+in a netCDF file.
+When writing multiple groups in one file, pass ``mode='a'`` to ``to_netcdf``
+to ensure that each call does not delete the file.
 
 Data is always loaded lazily from netCDF files. You can manipulate, slice and subset
 Dataset and DataArray objects, and no array values are loaded into memory until


### PR DESCRIPTION
This PR is related to the discussion in #2916.  In https://xarray.pydata.org/en/stable/io.html#netcdf there are statements like

>  netCDF files on disk directly correspond to Dataset objects.

This is useful conceptually but can be confusing when working with netCDF groups which are not supported as part of the data model.  I thought it would be clearer if the description of how to work with groups explicitly said this.