### PR TITLE
Change default flag for open_mfdataset.  Fixes Issue #2064

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -607,7 +607,7 @@ class _MultiFileCloser:
 
 def open_mfdataset(paths, chunks=None, concat_dim='_not_supplied',
                    compat='no_conflicts', preprocess=None, engine=None,
-                   lock=None, data_vars='all', coords='different',
+                   lock=None, data_vars='minimal', coords='different',
                    combine='_old_auto', autoclose=None, parallel=False,
                    **kwargs):
     """Open multiple files as a single dataset.


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2064
 - [ ] Tests added
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

I'm not sure I should add a test, because it's just changing the default behavior, and it requires a dataset file to be added.

I'm not sure it needs additional documentation, because Sphinx should update the default flag.  Should what-new.rst be updated?