### PR TITLE
Allow other tutorial filename extensions

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -25,6 +25,9 @@ dependencies:
   - sphinx_rtd_theme=0.4.2
   - mock=2.0.0
   - nbsphinx=0.4.2
+<<<<<<< HEAD
   - jupyter_client=5.3.1
   - ipykernel=5.1.1
+=======
+>>>>>>> switching out examples to use nbsphinx
   - pip

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -25,9 +25,6 @@ dependencies:
   - sphinx_rtd_theme=0.4.2
   - mock=2.0.0
   - nbsphinx=0.4.2
-<<<<<<< HEAD
   - jupyter_client=5.3.1
   - ipykernel=5.1.1
-=======
->>>>>>> switching out examples to use nbsphinx
   - pip

--- a/xarray/tutorial.py
+++ b/xarray/tutorial.py
@@ -33,8 +33,9 @@ def open_dataset(name, cache=True, cache_dir=_default_cache_dir,
     Parameters
     ----------
     name : str
-        Name of the netcdf file containing the dataset
-        ie. 'air_temperature'
+        Name of the file containing the dataset. If no suffix is given, assumed
+        to be netCDF ('.nc' is appended)
+        e.g. 'air_temperature'
     cache_dir : string, optional
         The directory in which to search for and write cached data.
     cache : boolean, optional
@@ -51,10 +52,13 @@ def open_dataset(name, cache=True, cache_dir=_default_cache_dir,
     xarray.open_dataset
 
     """
+    root, ext = _os.path.splitext(name)
+    if not ext:
+        ext = '.nc'
+    fullname = root + ext
     longdir = _os.path.expanduser(cache_dir)
-    fullname = name + '.nc'
     localfile = _os.sep.join((longdir, fullname))
-    md5name = name + '.md5'
+    md5name = fullname + '.md5'
     md5file = _os.sep.join((longdir, md5name))
 
     if not _os.path.exists(localfile):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #3118
 - [ ] Tests added
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Together with https://github.com/pydata/xarray-data/pull/15, this allows us to generalize out tutorial datasets to non netCDF files. But it is backwards compatible--if there is no file suffix, it will append `.nc`.