### PR TITLE
Tell codecov that Azure is a CI provider

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,9 @@
+codecov:
+  ci:
+    # by default, codecov doesn't recognize azure as a CI provider
+    - dev.azure.com
+  require_ci_to_pass: yes
+
 coverage:
   status:
     project:


### PR DESCRIPTION
In theory, this should make codecov wait until reports from Azure are back (and require that all Azure checks pass) before posting its comment.
