### PR TITLE
Added suppport for geotiff colormap() colorinterp to be loaded into attrs

### DIFF
--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -313,12 +313,12 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None,
     if hasattr(riods, 'units') and any(riods.units):
         # A list of units string for each dataset band
         attrs['units'] = riods.units
-    if hasattr(riods, 'colormap') and any(riods.colormap):
+    if hasattr(riods, 'colormap'):
         # A dict containing the colormap for a band
         attrs['colormap'] = riods.colormap(1)
     if hasattr(riods, 'colorinterp') and any(riods.colorinterp):
         # A tuple of the band's colorinterp property
-        attrs['colorinterp'] = riods.colorinterpi
+        attrs['colorinterp'] = riods.colorinterp
 
     # Parse extra metadata from tags, if supported
     parsers = {'ENVI': _parse_envi}

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -313,6 +313,12 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None,
     if hasattr(riods, 'units') and any(riods.units):
         # A list of units string for each dataset band
         attrs['units'] = riods.units
+    if hasattr(riods, 'colormap') and any(riods.colormap):
+        # A dict containing the colormap for a band
+        attrs['colormap'] = riods.colormap(1)
+    if hasattr(riods, 'colorinterp') and any(riods.colorinterp):
+        # A tuple of the band's colorinterp property
+        attrs['colorinterp'] = riods.colorinterpi
 
     # Parse extra metadata from tags, if supported
     parsers = {'ENVI': _parse_envi}


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
This is tangentially related to the [`to_geotiff()` discussion](https://github.com/pydata/xarray/issues/2042).

We're using [intake-xarray](https://github.com/intake/intake-xarray) to read a year's worth of Sentinel-2 Scene Classification Layers into a DataArray, doing some processing, and then writing the output to a single band GeoTIFF. When writing the output, we'd like to preserve the colormap of the original underlying data. `xarray-intake` uses `xarray` to read the dataset, so thought it might be useful to add support in `open_rasterio()` to read and load `src.colormap(1)` and `src.colorinterp` into the attributes of the DataArray. My thinking is that if in the future the community ends up wanting to add a `to_geotiff()` method, reading the `src` colormap and colorinterp might be useful.

Before adding tests, I thought I'd submit the PR to see what others thought about adding this functionality. If there's support for this, I'm happy to add any needed tests or documentation.

 - [ ] Tests added
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
