### PR TITLE
Remove the matplotlib=3.0 constraint from py36.yml

### DIFF
--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -8,9 +8,7 @@ dependencies:
   - distributed
   - h5py
   - h5netcdf
-  # pin matplotlib for now, to ensure that we have at least one CI job
-  # testing pseudonetcdf: https://github.com/barronh/pseudonetcdf/issues/69
-  - matplotlib=3.0
+  - matplotlib
   - netcdf4
   - pytest
   - pytest-cov


### PR DESCRIPTION
The upstream issue that required the constraint seems to have been fixed:
https://github.com/barronh/pseudonetcdf/issues/69

<!-- Feel free to remove check-list items aren't relevant to your change -->
