### PR TITLE
Fix h5py version printing

### DIFF
--- a/xarray/util/print_versions.py
+++ b/xarray/util/print_versions.py
@@ -68,7 +68,7 @@ def netcdf_and_hdf5_versions():
     except ImportError:
         try:
             import h5py
-            libhdf5_version = h5py.__hdf5libversion__
+            libhdf5_version = h5py.version.hdf5_version
         except ImportError:
             pass
     return [('libhdf5', libhdf5_version), ('libnetcdf', libnetcdf_version)]
@@ -77,7 +77,10 @@ def netcdf_and_hdf5_versions():
 def show_versions(file=sys.stdout):
     sys_info = get_sys_info()
 
-    sys_info.extend(netcdf_and_hdf5_versions())
+    try:
+        sys_info.extend(netcdf_and_hdf5_versions())
+    except Exception as e:
+        print(f"Error collecting netcdf / hdf5 version: {e}")
 
     deps = [
         # (MODULE_NAME, f(mod) -> mod version)

--- a/xarray/util/print_versions.py
+++ b/xarray/util/print_versions.py
@@ -80,7 +80,7 @@ def show_versions(file=sys.stdout):
     try:
         sys_info.extend(netcdf_and_hdf5_versions())
     except Exception as e:
-        print(f"Error collecting netcdf / hdf5 version: {e}")
+        print("Error collecting netcdf / hdf5 version: {}".format(e))
 
     deps = [
         # (MODULE_NAME, f(mod) -> mod version)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes https://github.com/pydata/xarray/issues/3144

I surrounded the whole check for h5py & netcdf with a blanket try / except, consistent with the other modules (but maybe too broad?