### PR TITLE
BUG: fix+test groupby on empty DataArray raises StopIteration

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -83,6 +83,8 @@ Bug fixes
 - Fix HDF5 error that could arise when reading multiple groups from a file at
   once (:issue:`2954`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
+- Better error when using groupby on an empty DataArray (:issue:`3037`).
+  By `Hasan Ahmad <https://github.com/HasanAhmadQ7>`_.
 
 .. _whats-new.0.12.2:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -83,7 +83,7 @@ Bug fixes
 - Fix HDF5 error that could arise when reading multiple groups from a file at
   once (:issue:`2954`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
-- Better error when using groupby on an empty DataArray (:issue:`3037`).
+- Better error message when using groupby on an empty DataArray (:issue:`3037`).
   By `Hasan Ahmad <https://github.com/HasanAhmadQ7>`_.
 
 .. _whats-new.0.12.2:

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -233,7 +233,7 @@ class GroupBy(SupportsArithmetic):
                                 'name of an xarray variable or dimension')
             group = obj[group]
             if len(group) == 0:
-                raise ValueError("Group must not be empty")
+                raise ValueError("{} must not be empty".format(group.name))
 
             if group.name not in obj.coords and group.name in obj.dims:
                 # DummyGroups should not appear on groupby results

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -232,6 +232,9 @@ class GroupBy(SupportsArithmetic):
                 raise TypeError('`group` must be an xarray.DataArray or the '
                                 'name of an xarray variable or dimension')
             group = obj[group]
+            if len(group) == 0:
+                raise ValueError("Group must not be empty")
+
             if group.name not in obj.coords and group.name in obj.dims:
                 # DummyGroups should not appear on groupby results
                 group = _DummyGroup(obj, group.name, group.coords)

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -105,6 +105,14 @@ def test_ds_groupby_apply_func_args():
     assert_identical(expected, actual)
 
 
+def test_da_groupby_empty():
+
+    empty_array = xr.DataArray([], dims='dim')
+
+    with pytest.raises(ValueError):
+        empty_array.groupby('dim')
+
+
 def test_da_groupby_quantile():
 
     array = xr.DataArray([1, 2, 3, 4, 5, 6],


### PR DESCRIPTION
Using groupby on an empty DataArray or Dataset raises StopIteration. It should raise a more meaningful error.
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #3037
 - [x] Tests added
