### PR TITLE
remove type annotations from autodoc method signatures

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,6 +83,7 @@ sphinx_gallery_conf = {'examples_dirs': 'gallery',
                        }
 
 autosummary_generate = True
+autodoc_typehints = 'none'
 
 numpydoc_class_members_toctree = True
 numpydoc_show_class_members = False


### PR DESCRIPTION
This PR removes all the type hints from method signatures generated by sphinx.ext.autodoc. See http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_typehints

The sphinx documentation doesn't say which version this was added in, but I imagine it is quite recent.

 - [ ] Closes #3178