### PR TITLE
enable sphinx.ext.napoleon

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,6 +66,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.extlinks',
     'sphinx.ext.mathjax',
+    'sphinx.ext.napoleon',
     'numpydoc',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
@@ -83,6 +84,9 @@ sphinx_gallery_conf = {'examples_dirs': 'gallery',
                        }
 
 autosummary_generate = True
+
+napoleon_use_param = True
+napoleon_use_rtype = True   
 
 numpydoc_class_members_toctree = True
 numpydoc_show_class_members = False


### PR DESCRIPTION
Enables the napoleon extension in sphinx. This will interpret the numpydoc style parameters and types and convert them to sphinx `:param type name:` Note that `sphinx.ext.napoleon` must come before the `numpydoc` extension.

Eventually the numpydoc dependency might be able to be removed but currently removing it makes the wrapped `ufunc` documentation omit the "parameters" and "returns", see the attached screenshot for what one of these ufuncs looks like with `numpydoc` removed.

 - [ ] Closes #3056

<img width="700" alt="napoleon_no_numpydoc" src="https://user-images.githubusercontent.com/868027/62393929-8ebf6680-b520-11e9-85cf-485868536d3f.png">