### PR TITLE
bump rasterio to 1.0.24 in doc building environment

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - ipython=7.2.0
   - netCDF4=1.4.2
   - cartopy=0.17.0
-  - rasterio=1.0.13
+  - rasterio=1.0.24
   - zarr=2.2.0
   - iris=2.2.0
   - flake8=3.6.0


### PR DESCRIPTION
This is hopefully a fix for #3182 but I wasn't sure how to really test this on read the docs (RTD) itself.

There may be a few things going on:
* Local testing showed removing the "auto_gallery" dir would cause the failing gallery examples to actually be recognized as failing (i.e. bust the cache)
* https://github.com/conda-forge/rasterio-feedstock/issues/118 and some examining of the `conda list` output on RTD for led me to think this was a deeper problem. Local testing with a bumped version of rasterio resulted in conda-forge being the channel source (rather than pip?), it also fixed the failing builds which relied on rasterio.