### PR TITLE
Update black instructions

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -389,14 +389,14 @@ each time you commit changes. You can skip these checks with
   conflicts. Because they have had limited testing, please reach out to the core devs
   on your pull request if you face any issues, and we'll help with the merge:
 
-  - Merge the commit on master prior to the `black` commit into your branch 
-    `git merge f172c673`. Any conflicts are real conflicts and require resolving
-  - Apply `black .` to your branch and commit
-    # TODO: insert after the black commit is on master
-  - Merge master at the `black` commit, resolving in favor of 'our' changes: 
-    `git merge [master-at-black-commit] -X ours`. You shouldn't have any merge conflicts
-  - Merge current master `git merge master`; any conflicts here are real and 
-    again require resolving
+  - Merge the commit on master prior to the ``black`` commit into your branch
+    ``git merge f172c673``. If you have conflicts here, resolve and commit.
+  - Apply ``black .`` to your branch and commit ``git commit -am "black"``
+  - Apply a patch of other changes we made on that commit: ``curl https://gist.githubusercontent.com/max-sixty/3cceb8472ed4ea806353999ca43aed52/raw/03cbee4e386156bddb61acaa250c0bfc726f596d/xarray%2520black%2520diff | git apply -``
+  - Commit (``git commit -am "black2"``)
+  - Merge master at the ``black`` commit, resolving in favor of 'our' changes:
+    ``git merge d089df38 -X ours``. You shouldn't have any merge conflicts
+  - Merge current master ``git merge master``; resolve and commit any conflicts
 
 Backwards Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This needed updating with the relevant commit post-black change

I also added a line to apply the patch of manual changes we made on top of the black changes. It makes the list of steps a bit burdensome. But I've tested them a couple of times and, where people have lots of code changes, it's still going to be much easier than resolving manually.

I generally wouldn't want to suggest people curl data from the internet (even if we trust the individual). I think it's probably OK in this instance: the address contains a hash of the contents, and it's only being fed into `git apply -`, not executed. But lmk if that's still a security concern.

I'll update the issue I opened on `black` with the above issue; we should have done one commit with only the `black` changes, and then another with any manual changes.