### PR TITLE
Ignore example.grib.0112.idx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ dask-worker-space/
 doc/_build
 doc/generated
 xarray/version.py
+xarray/tests/data/*.grib.*.idx
 
 # Sync tools
 Icon*


### PR DESCRIPTION
``open_dataset("<name>.grib", engine="cfgrib")`` creates a new file in the same directory called ``<name>.grib.<numbers>.idx``