### PR TITLE
chunk sparse arrays

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -16,13 +16,21 @@ What's New
 .. _whats-new.0.12.4:
 
 v0.12.4 (unreleased)
--------------------
+--------------------
 
 This release increases the minimum required Python version from 3.5.0 to 3.5.3
 (:issue:`3089`). By `Guido Imperiale <https://github.com/crusaderky>`_.
 
 New functions/methods
 ~~~~~~~~~~~~~~~~~~~~~
+
+- xarray can now wrap around any
+  `NEP18 <https://www.numpy.org/neps/nep-0018-array-function-protocol.html>`_ compliant
+  numpy-like library (important: read notes about NUMPY_EXPERIMENTAL_ARRAY_FUNCTION in
+  the above link). Added explicit test coverage for
+  `sparse <https://github.com/pydata/sparse>`_. (:issue:`3117`, :issue:`3202`)
+  By `Nezar Abdennur <https://github.com/nvictus>`_
+  and `Guido Imperiale <https://github.com/crusaderky>`_.
 
 - Added :py:meth:`DataArray.broadcast_like` and :py:meth:`Dataset.broadcast_like`.
   By `Deepak Cherian <https://github.com/dcherian>`_ and `David Mertz 
@@ -37,7 +45,7 @@ New functions/methods
 
    By `Guido Imperiale <https://github.com/crusaderky>`_
 
-- Dataset plotting API for visualizing dependences between two `DataArray`s!
+- Dataset plotting API for visualizing dependencies between two `DataArray`s!
   Currently only :py:meth:`Dataset.plot.scatter` is implemented.
   By `Yohai Bar Sinai <https://github.com/yohai>`_ and `Deepak Cherian <https://github.com/dcherian>`_
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -13,9 +13,9 @@ What's New
     import xarray as xr
     np.random.seed(123456)
 
-.. _whats-new.0.12.4:
+.. _whats-new.0.13.0:
 
-v0.12.4 (unreleased)
+v0.13.0 (unreleased)
 --------------------
 
 This release increases the minimum required Python version from 3.5.0 to 3.5.3
@@ -32,18 +32,21 @@ New functions/methods
   By `Nezar Abdennur <https://github.com/nvictus>`_
   and `Guido Imperiale <https://github.com/crusaderky>`_.
 
-- Added :py:meth:`DataArray.broadcast_like` and :py:meth:`Dataset.broadcast_like`.
-  By `Deepak Cherian <https://github.com/dcherian>`_ and `David Mertz 
-  <http://github.com/DavidMertz>`_.
-
-- The xarray package is now discoverably by mypy (although typing hints
-  coverage is not complete yet). mypy type checking is now enforced by CI.
-  Libraries that depend on xarray and use mypy can now remove from their setup.cfg the lines::
+- The xarray package is now discoverable by mypy (although typing hints coverage is not
+  complete yet). mypy type checking is now enforced by CI. Libraries that depend on
+  xarray and use mypy can now remove from their setup.cfg the lines::
 
     [mypy-xarray]
     ignore_missing_imports = True
 
-   By `Guido Imperiale <https://github.com/crusaderky>`_
+  (:issue:`2877`, :issue:`3088`, :issue:`3090`, :issue:`3112`, :issue:`3117`,
+  :issue:`3207`)
+  By `Guido Imperiale <https://github.com/crusaderky>`_
+  and `Maximilian Roos <https://github.com/max-sixty>`_.
+
+- Added :py:meth:`DataArray.broadcast_like` and :py:meth:`Dataset.broadcast_like`.
+  By `Deepak Cherian <https://github.com/dcherian>`_ and `David Mertz 
+  <http://github.com/DavidMertz>`_.
 
 - Dataset plotting API for visualizing dependencies between two `DataArray`s!
   Currently only :py:meth:`Dataset.plot.scatter` is implemented.

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -186,7 +186,12 @@ def as_like_arrays(*data):
     elif any(isinstance(d, sparse_array_type) for d in data):
         from sparse import COO
 
-        return tuple(COO(d) for d in data)
+        out = []
+        for d in data:
+            if isinstance(d, dask_array_type):
+                d = d.compute()
+            out.append(COO(d))
+        return tuple(out)
     else:
         return tuple(np.asarray(d) for d in data)
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -941,7 +941,7 @@ class Variable(
                 if LooseVersion(dask.__version__) < "2.0.0":
                     kwargs = {}
                 else:
-                    # All of our lazily loaded backend array classes) should use NumPy
+                    # All of our lazily loaded backend array classes should use NumPy
                     # array operations.
                     kwargs = {"meta": np.ndarray}
             else:

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -136,7 +136,6 @@ def test_variable_property(prop):
             True,
             marks=xfail(reason="'COO' object has no attribute 'argsort'"),
         ),
-        param(do("chunk", chunks=(5, 5)), True, marks=xfail),
         param(
             do(
                 "concat",
@@ -403,9 +402,6 @@ def test_dataarray_property(prop):
             do("bfill", dim="x"),
             False,
             marks=xfail(reason="Missing implementation for np.flip"),
-        ),
-        param(
-            do("chunk", chunks=(5, 5)), False, marks=xfail(reason="Coercion to dense")
         ),
         param(
             do("combine_first", make_xrarray({"x": 10, "y": 5})),
@@ -861,3 +857,17 @@ class TestSparseCoords:
             dims=["x"],
             coords={"x": COO.from_numpy([1, 2, 3, 4])},
         )
+
+
+def test_chunk():
+    s = sparse.COO.from_numpy(np.array([0, 0, 1, 2]))
+    a = DataArray(s)
+    ac = a.chunk(2)
+    assert ac.chunks == ((2, 2),)
+    assert isinstance(ac.data._meta, sparse.COO)
+    assert_identical(a, ac)
+
+    ds = a.to_dataset("a")
+    dsc = ds.chunk(2)
+    assert dsc.chunks == {"dim_0": (2, 2)}
+    assert_identical(ds, dsc)

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -867,7 +867,7 @@ def test_chunk():
     assert isinstance(ac.data._meta, sparse.COO)
     assert_identical(a, ac)
 
-    ds = a.to_dataset("a")
+    ds = a.to_dataset(name="a")
     dsc = ds.chunk(2)
     assert dsc.chunks == {"dim_0": (2, 2)}
     assert_identical(ds, dsc)

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -1,25 +1,14 @@
-from collections import OrderedDict
-from contextlib import suppress
-from distutils.version import LooseVersion
 from textwrap import dedent
 import pickle
 import numpy as np
 import pandas as pd
 
-from xarray import DataArray, Dataset, Variable
-from xarray.tests import mock
+from xarray import DataArray, Variable
 from xarray.core.npcompat import IS_NEP18_ACTIVE
 import xarray as xr
 import xarray.ufuncs as xu
 
-from . import (
-    assert_allclose,
-    assert_array_equal,
-    assert_equal,
-    assert_frame_equal,
-    assert_identical,
-    raises_regex,
-)
+from . import assert_equal, assert_identical
 
 import pytest
 
@@ -883,9 +872,9 @@ def test_chunk():
     ac = a.chunk(2)
     assert ac.chunks == ((2, 2),)
     assert isinstance(ac.data._meta, sparse.COO)
-    assert_identical(a, ac)
+    assert_identical(ac, a)
 
     ds = a.to_dataset(name="a")
     dsc = ds.chunk(2)
     assert dsc.chunks == {"dim_0": (2, 2)}
-    assert_identical(ds, dsc)
+    assert_identical(dsc, ds)


### PR DESCRIPTION
Closes #3191

@shoyer I completely disabled wrapping in ImplicitToExplicitIndexingAdapter for sparse arrays, cupy arrays, etc.
I'm not sure if it's desirable; the chief problem is that I don't think I understand the purpose of ImplicitToExplicitIndexingAdapter to begin with... some enlightenment would be appreciated.