### PR TITLE
Match mypy version between CI and pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.720
+    rev: v0.720  # Must match ci/requirements/*.yml
     hooks:
       - id: mypy
   # run these occasionally, ref discussion https://github.com/pydata/xarray/pull/3194

--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -15,6 +15,7 @@ dependencies:
   - pytest-env
   - coveralls
   - flake8
+  - mypy==0.720  # Must match .pre-commit-config.yaml
   - numpy>=1.12
   - pandas>=0.19
   - pip
@@ -34,5 +35,4 @@ dependencies:
   - iris>=1.10
   - pydap
   - lxml
-  - pip:
-    - mypy==0.711
+

--- a/ci/requirements/py37.yml
+++ b/ci/requirements/py37.yml
@@ -16,6 +16,7 @@ dependencies:
   - pytest-env
   - coveralls
   - flake8
+  - mypy==0.720  # Must match .pre-commit-config.yaml
   - numpy>=1.12
   - pandas>=0.19
   - pip
@@ -32,5 +33,4 @@ dependencies:
   - lxml
   - pydap
   - pip:
-    - mypy==0.650
     - numbagg

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -489,7 +489,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         self._indexes = None  # type: Optional[OrderedDict[Any, pd.Index]]
 
         if attrs is not None:
-            self.attrs = attrs
+            self._attrs = OrderedDict(attrs)
+
         self._encoding = None  # type: Optional[Dict]
         self._initialized = True
 


### PR DESCRIPTION
Pre-commit hook is currently failing because of an issue detected by mypy 0.720 but not by mypy 0.650