### PR TITLE
Add note about accessor instance creation

### DIFF
--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -106,6 +106,13 @@ reasons:
    functionality that clearly identifies it as separate from built-in xarray
    methods.
 
+.. note::
+
+   Accessors are created once per DataArray and Dataset instance. New
+   instances, like those created from arithmetic operations or when accessing
+   a DataArray from a Dataset (ex. ``ds[var_name]``), will have new
+   accessors created.
+
 Back in an interactive IPython session, we can use these properties:
 
 .. ipython:: python


### PR DESCRIPTION
This is an attempt at clarifying accessor docs to help with the confusion I had in #3205. I'm not sure how many other xarray doc pages use `.. note::` but it seemed useable here. I'm not sure this is worth the explanation or if it is worded the best, but thought this could start the discussion.

 - [ ] Closes #3205 
 - [ ] Tests added
 - [ ] Passes `black . && mypy . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
