### PR TITLE
sparse=True option for from_dataframe and from_series

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -32,6 +32,12 @@ New functions/methods
   By `Nezar Abdennur <https://github.com/nvictus>`_
   and `Guido Imperiale <https://github.com/crusaderky>`_.
 
+- :py:meth:`~Dataset.from_dataframe` and :py:meth:`~DataArray.from_series` now
+  support ``sparse=True`` for converting pandas objects into xarray objects
+  wrapping sparse arrays. This is particularly useful with sparsely populated
+  hierarchical indexes. (:issue:`3206`)
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
+
 - The xarray package is now discoverable by mypy (although typing hints coverage is not
   complete yet). mypy type checking is now enforced by CI. Libraries that depend on
   xarray and use mypy can now remove from their setup.cfg the lines::

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2295,7 +2295,7 @@ class DataArray(AbstractArray, DataWithCoords):
         return obj
 
     @classmethod
-    def from_series(cls, series: pd.Series) -> "DataArray":
+    def from_series(cls, series: pd.Series, sparse: bool = False) -> "DataArray":
         """Convert a pandas.Series into an xarray.DataArray.
 
         If the series's index is a MultiIndex, it will be expanded into a
@@ -2303,10 +2303,10 @@ class DataArray(AbstractArray, DataWithCoords):
         values with NaN). Thus this operation should be the inverse of the
         `to_series` method.
         """
-        # TODO: add a 'name' parameter
+        # TODO: add a 'name' parameter?
         name = series.name
         df = pd.DataFrame({name: series})
-        ds = Dataset.from_dataframe(df)
+        ds = Dataset.from_dataframe(df, sparse=sparse)
         return ds[name]
 
     def to_cdms2(self) -> "cdms2_Variable":

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2307,7 +2307,7 @@ class DataArray(AbstractArray, DataWithCoords):
         name = series.name
         df = pd.DataFrame({name: series})
         ds = Dataset.from_dataframe(df, sparse=sparse)
-        return ds[name]
+        return ds[name]  # type: ignore
 
     def to_cdms2(self) -> "cdms2_Variable":
         """Convert this array into a cdms2.Variable

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2302,12 +2302,19 @@ class DataArray(AbstractArray, DataWithCoords):
         tensor product of one-dimensional coordinates (filling in missing
         values with NaN). Thus this operation should be the inverse of the
         `to_series` method.
+
+        If sparse=True, creates a sparse array instead of a dense NumPy array.
+        Requires the pydata/sparse package.
+
+        See also
+        --------
+        xarray.Dataset.from_dataframe
         """
-        # TODO: add a 'name' parameter?
-        name = series.name
-        df = pd.DataFrame({name: series})
+        df = pd.DataFrame({_THIS_ARRAY: series})
         ds = Dataset.from_dataframe(df, sparse=sparse)
-        return ds[name]  # type: ignore
+        result = cast(DataArray, ds[_THIS_ARRAY])
+        result.name = series.name
+        return result
 
     def to_cdms2(self) -> "cdms2_Variable":
         """Convert this array into a cdms2.Variable

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -727,7 +727,7 @@ class DataArray(AbstractArray, DataWithCoords):
         else:
             if self.name is None:
                 raise ValueError(
-                    "cannot reset_coords with drop=False " "on an unnamed DataArrray"
+                    "cannot reset_coords with drop=False on an unnamed DataArrray"
                 )
             dataset[self.name] = self.variable
             return dataset
@@ -1468,9 +1468,7 @@ class DataArray(AbstractArray, DataWithCoords):
             This object, but with an additional dimension(s).
         """
         if isinstance(dim, int):
-            raise TypeError(
-                "dim should be hashable or sequence/mapping of " "hashables"
-            )
+            raise TypeError("dim should be hashable or sequence/mapping of hashables")
         elif isinstance(dim, Sequence) and not isinstance(dim, str):
             if len(dim) != len(set(dim)):
                 raise ValueError("dims should not contain duplicate values.")
@@ -2310,9 +2308,10 @@ class DataArray(AbstractArray, DataWithCoords):
         --------
         xarray.Dataset.from_dataframe
         """
-        df = pd.DataFrame({_THIS_ARRAY: series})
+        temp_name = "__temporary_name"
+        df = pd.DataFrame({temp_name: series})
         ds = Dataset.from_dataframe(df, sparse=sparse)
-        result = cast(DataArray, ds[_THIS_ARRAY])
+        result = cast(DataArray, ds[temp_name])
         result.name = series.name
         return result
 
@@ -2729,7 +2728,7 @@ class DataArray(AbstractArray, DataWithCoords):
         """
         if isinstance(other, Dataset):
             raise NotImplementedError(
-                "dot products are not yet supported " "with Dataset objects."
+                "dot products are not yet supported with Dataset objects."
             )
         if not isinstance(other, DataArray):
             raise TypeError("dot only operates on DataArrays.")

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -84,6 +84,7 @@ has_np113, requires_np113 = _importorskip("numpy", minversion="1.13.0")
 has_iris, requires_iris = _importorskip("iris")
 has_cfgrib, requires_cfgrib = _importorskip("cfgrib")
 has_numbagg, requires_numbagg = _importorskip("numbagg")
+has_sparse, requires_sparse = _importorskip("sparse")
 
 # some special cases
 has_h5netcdf07, requires_h5netcdf07 = _importorskip("h5netcdf", minversion="0.7")

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -30,6 +30,7 @@ from xarray.tests import (
     requires_np113,
     requires_numbagg,
     requires_scipy,
+    requires_sparse,
     source_ndarray,
 )
 
@@ -3374,13 +3375,14 @@ class TestDataArray:
         expected_da = self.dv.rename(None)
         assert_identical(expected_da, DataArray.from_series(actual).drop(["x", "y"]))
 
+    @requires_sparse
     def test_from_series_sparse(self):
-        sparse = pytest.importorskip("sparse")
+        import sparse
 
         series = pd.Series([1, 2], index=[("a", 1), ("b", 2)])
 
         actual_sparse = DataArray.from_series(series, sparse=True)
-        actual_dense = DataArray.from_series(series, sparse=True)
+        actual_dense = DataArray.from_series(series, sparse=False)
 
         assert isinstance(actual_sparse.data, sparse.COO)
         actual_sparse.data = actual_sparse.data.todense()

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3374,6 +3374,18 @@ class TestDataArray:
         expected_da = self.dv.rename(None)
         assert_identical(expected_da, DataArray.from_series(actual).drop(["x", "y"]))
 
+    def test_from_series_sparse(self):
+        sparse = pytest.importorskip("sparse")
+
+        series = pd.Series([1, 2], index=[("a", 1), ("b", 2)])
+
+        actual_sparse = DataArray.from_series(series, sparse=True)
+        actual_dense = DataArray.from_series(series, sparse=True)
+
+        assert isinstance(actual_sparse.data, sparse.COO)
+        actual_sparse.data = actual_sparse.data.todense()
+        assert_identical(actual_sparse, actual_dense)
+
     def test_to_and_from_empty_series(self):
         # GH697
         expected = pd.Series([])

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -45,6 +45,7 @@ from . import (
     requires_dask,
     requires_numbagg,
     requires_scipy,
+    requires_sparse,
     source_ndarray,
 )
 
@@ -3674,8 +3675,9 @@ class TestDataset:
         expected = pd.DataFrame([[]], index=idx)
         assert expected.equals(actual), (expected, actual)
 
+    @requires_sparse
     def test_from_dataframe_sparse(self):
-        sparse = pytest.importorskip("sparse")
+        import sparse
 
         df_base = pd.DataFrame(
             {"x": range(10), "y": list("abcdefghij"), "z": np.arange(0, 100, 10)}

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -245,9 +245,9 @@ def construct_dataarray(dim_num, dtype, contains_nan, dask):
 
 
 def from_series_or_scalar(se):
-    try:
+    if isinstance(se, pd.Series):
         return DataArray.from_series(se)
-    except AttributeError:  # scalar case
+    else:  # scalar case
         return DataArray(se)
 
 


### PR DESCRIPTION
Fixes https://github.com/pydata/xarray/issues/3206

Example usage:

    In [3]: import pandas as pd
       ...: import numpy as np
       ...: import xarray
       ...: df = pd.DataFrame({
       ...:     'w': range(10),
       ...:     'x': list('abcdefghij'),
       ...:     'y': np.arange(0, 100, 10),
       ...:     'z': np.ones(10),
       ...: }).set_index(['w', 'x', 'y'])
       ...:

    In [4]: ds = xarray.Dataset.from_dataframe(df, sparse=True)

    In [5]: ds.z.data
    Out[5]: <COO: shape=(10, 10, 10), dtype=float64, nnz=10, fill_value=nan>

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #3206, Closes #2139
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
