### PR TITLE
Array formatting fixes for sparse and NEP-18 arrays.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,11 +15,12 @@ markers =
     slow: slow tests
 
 [flake8]
-max-line-length=88
 ignore=
     # whitespace before ':' - doesn't work well with black
     E203
     E402
+    # line too long - let black worry about that
+    E501
     # do not assign a lambda expression, use a def
     E731
     # line break before binary operator

--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -955,7 +955,7 @@ def cftime_range(
     See Also
     --------
     pandas.date_range
-    """  # noqa: E501
+    """
     # Adapted from pandas.core.indexes.datetimes._generate_range.
     if _count_not_none(start, end, periods, freq) != 3:
         raise ValueError(

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -480,7 +480,7 @@ class CFTimeIndex(pd.Index):
         CFTimeIndex([2000-01-01 00:00:00, 2000-01-02 00:00:00], dtype='object')
         >>> times.to_datetimeindex()
         DatetimeIndex(['2000-01-01', '2000-01-02'], dtype='datetime64[ns]', freq=None)
-        """  # noqa: E501
+        """
         nptimes = cftime_to_nptime(self)
         calendar = infer_calendar_name(self)
         if calendar not in _STANDARD_CALENDARS and not unsafe:

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -960,7 +960,7 @@ def apply_ufunc(
     .. [1] http://docs.scipy.org/doc/numpy/reference/ufuncs.html
     .. [2] http://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
     .. [3] http://xarray.pydata.org/en/stable/computation.html#wrapping-custom-computation
-    """  # noqa: E501  # don't error on that URL one line up
+    """
     from .groupby import GroupBy
     from .dataarray import DataArray
     from .variable import Variable

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -168,7 +168,7 @@ def format_items(x):
     return formatted
 
 
-def inline_ndarray_repr(array, max_width):
+def format_array_flat(array, max_width):
     """Return a formatted string for as many items in the flattened version of
     array that will fit within max_width characters.
     """
@@ -232,7 +232,7 @@ def inline_sparse_repr(array):
 def inline_variable_array_repr(var, max_width):
     """Build a one-line summary of a variable's data."""
     if var._in_memory:
-        return inline_ndarray_repr(var, max_width)
+        return format_array_flat(var, max_width)
     elif isinstance(var._data, dask_array_type):
         return inline_dask_repr(var.data)
     elif isinstance(var._data, sparse_array_type):

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -216,14 +216,14 @@ def inline_dask_repr(array):
     redundant information that's already printed by the repr
     function of the xarray wrapper.
     """
-    assert isinstance(array, dask_array_type)
+    assert isinstance(array, dask_array_type), array
     chunksize = tuple(c[0] for c in array.chunks)
     return "dask.array<shape={}, chunksize={}>".format(array.shape, chunksize)
 
 
 def inline_sparse_repr(array):
     """Similar to sparse.COO.__repr__, but without the redundant shape/dtype."""
-    assert isinstance(array, sparse_array_type)
+    assert isinstance(array, sparse_array_type), array
     return "<COO: shape={!s}, nnz={:d}, fill_value={!s}>".format(
         array.shape, array.nnz, array.fill_value
     )

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -416,7 +416,9 @@ def short_data_repr(array):
     internal_data = getattr(array, "variable", array)._data
     if isinstance(array, np.ndarray):
         return short_numpy_repr(array)
-    elif hasattr(internal_data, "__array_function__"):
+    elif hasattr(internal_data, "__array_function__") or isinstance(
+        internal_data, dask_array_type
+    ):
         return repr(array.data)
     elif array._in_memory or array.size < 1e5:
         return short_numpy_repr(array)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -317,7 +317,9 @@ class Variable(
 
     @property
     def data(self):
-        if hasattr(self._data, "__array_function__"):
+        if hasattr(self._data, "__array_function__") or isinstance(
+            self._data, dask_array_type
+        ):
             return self._data
         else:
             return self.values

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -149,8 +149,8 @@ class TestVariable(DaskTestCase):
     def test_repr(self):
         expected = dedent(
             """\
-        <xarray.Variable (x: 4, y: 6)>
-        dask.array<shape=(4, 6), dtype=float64, chunksize=(2, 2)>"""
+            <xarray.Variable (x: 4, y: 6)>
+            dask.array<array, shape=(4, 6), dtype=float64, chunksize=(2, 2)>"""
         )
         assert expected == repr(self.lazy_var)
 
@@ -499,11 +499,11 @@ class TestDataArrayAndDataset(DaskTestCase):
         a = DataArray(data, dims=["x"], coords={"y": ("x", nonindex_coord)})
         expected = dedent(
             """\
-        <xarray.DataArray 'data' (x: 1)>
-        dask.array<shape=(1,), dtype=int64, chunksize=(1,)>
-        Coordinates:
-            y        (x) int64 dask.array<shape=(1,), chunksize=(1,)>
-        Dimensions without coordinates: x"""
+            <xarray.DataArray 'data' (x: 1)>
+            dask.array<data, shape=(1,), dtype=int64, chunksize=(1,)>
+            Coordinates:
+                y        (x) int64 dask.array<shape=(1,), chunksize=(1,)>
+            Dimensions without coordinates: x"""
         )
         assert expected == repr(a)
         assert kernel_call_count == 0
@@ -516,13 +516,13 @@ class TestDataArrayAndDataset(DaskTestCase):
         ds = Dataset(data_vars={"a": ("x", data)}, coords={"y": ("x", nonindex_coord)})
         expected = dedent(
             """\
-        <xarray.Dataset>
-        Dimensions:  (x: 1)
-        Coordinates:
-            y        (x) int64 dask.array<shape=(1,), chunksize=(1,)>
-        Dimensions without coordinates: x
-        Data variables:
-            a        (x) int64 dask.array<shape=(1,), chunksize=(1,)>"""
+            <xarray.Dataset>
+            Dimensions:  (x: 1)
+            Coordinates:
+                y        (x) int64 dask.array<shape=(1,), chunksize=(1,)>
+            Dimensions without coordinates: x
+            Data variables:
+                a        (x) int64 dask.array<shape=(1,), chunksize=(1,)>"""
         )
         assert expected == repr(ds)
         assert kernel_call_count == 0

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -491,6 +491,7 @@ class TestDataArrayAndDataset(DaskTestCase):
         lazy = self.lazy_array.dot(self.lazy_array[0])
         self.assertLazyAndAllClose(eager, lazy)
 
+    @pytest.mark.skipif(LooseVersion(dask.__version__) < "2.0", reason="needs meta")
     def test_dataarray_repr(self):
         # Test that __repr__ converts the dask backend to numpy
         # in neither the data variable nor the non-index coords
@@ -502,12 +503,13 @@ class TestDataArrayAndDataset(DaskTestCase):
             <xarray.DataArray 'data' (x: 1)>
             dask.array<data, shape=(1,), dtype=int64, chunksize=(1,)>
             Coordinates:
-                y        (x) int64 dask.array<shape=(1,), chunksize=(1,)>
+                y        (x) int64 dask.array<chunksize=(1,), meta=np.ndarray>
             Dimensions without coordinates: x"""
         )
         assert expected == repr(a)
         assert kernel_call_count == 0
 
+    @pytest.mark.skipif(LooseVersion(dask.__version__) < "2.0", reason="needs meta")
     def test_dataset_repr(self):
         # Test that pickling/unpickling converts the dask backend
         # to numpy in neither the data variables nor the non-index coords
@@ -519,10 +521,10 @@ class TestDataArrayAndDataset(DaskTestCase):
             <xarray.Dataset>
             Dimensions:  (x: 1)
             Coordinates:
-                y        (x) int64 dask.array<shape=(1,), chunksize=(1,)>
+                y        (x) int64 dask.array<chunksize=(1,), meta=np.ndarray>
             Dimensions without coordinates: x
             Data variables:
-                a        (x) int64 dask.array<shape=(1,), chunksize=(1,)>"""
+                a        (x) int64 dask.array<chunksize=(1,), meta=np.ndarray>"""
         )
         assert expected == repr(ds)
         assert kernel_call_count == 0

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -81,6 +81,10 @@ class TestDataArray:
         )
         assert expected == repr(self.mda)
 
+    @pytest.mark.skipif(
+        LooseVersion(np.__version__) < "1.15",
+        reason="old versions of numpy have different printing behavior",
+    )
     def test_repr_multiindex_long(self):
         mindex_long = pd.MultiIndex.from_product(
             [["a", "b", "c", "d"], [1, 2, 3, 4, 5, 6, 7, 8]],

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -57,27 +57,27 @@ class TestDataArray:
         data_array = DataArray(v, coords, name="my_variable")
         expected = dedent(
             """\
-        <xarray.DataArray 'my_variable' (time: 2, x: 3)>
-        array([[1, 2, 3],
-               [4, 5, 6]])
-        Coordinates:
-          * x        (x) int64 0 1 2
-            other    int64 0
-        Dimensions without coordinates: time
-        Attributes:
-            foo:      bar"""
+            <xarray.DataArray 'my_variable' (time: 2, x: 3)>
+            array([[1, 2, 3],
+                   [4, 5, 6]])
+            Coordinates:
+              * x        (x) int64 0 1 2
+                other    int64 0
+            Dimensions without coordinates: time
+            Attributes:
+                foo:      bar"""
         )
         assert expected == repr(data_array)
 
     def test_repr_multiindex(self):
         expected = dedent(
             """\
-        <xarray.DataArray (x: 4)>
-        array([0, 1, 2, 3])
-        Coordinates:
-          * x        (x) MultiIndex
-          - level_1  (x) object 'a' 'a' 'b' 'b'
-          - level_2  (x) int64 1 2 1 2"""
+            <xarray.DataArray (x: 4)>
+            array([0, 1, 2, 3])
+            Coordinates:
+              * x        (x) MultiIndex
+              - level_1  (x) object 'a' 'a' 'b' 'b'
+              - level_2  (x) int64 1 2 1 2"""
         )
         assert expected == repr(self.mda)
 
@@ -89,13 +89,13 @@ class TestDataArray:
         mda_long = DataArray(list(range(32)), coords={"x": mindex_long}, dims="x")
         expected = dedent(
             """\
-        <xarray.DataArray (x: 32)>
-        array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17,
-               18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31])
-        Coordinates:
-          * x        (x) MultiIndex
-          - level_1  (x) object 'a' 'a' 'a' 'a' 'a' 'a' 'a' ... 'd' 'd' 'd' 'd' 'd' 'd'
-          - level_2  (x) int64 1 2 3 4 5 6 7 8 1 2 3 4 5 6 ... 4 5 6 7 8 1 2 3 4 5 6 7 8"""  # noqa: E501
+            <xarray.DataArray (x: 32)>
+            array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
+                   17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31])
+            Coordinates:
+              * x        (x) MultiIndex
+              - level_1  (x) object 'a' 'a' 'a' 'a' 'a' 'a' 'a' ... 'd' 'd' 'd' 'd' 'd' 'd'
+              - level_2  (x) int64 1 2 3 4 5 6 7 8 1 2 3 4 5 6 ... 4 5 6 7 8 1 2 3 4 5 6 7 8"""  # noqa: E501
         )
         assert expected == repr(mda_long)
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -95,7 +95,7 @@ class TestDataArray:
             Coordinates:
               * x        (x) MultiIndex
               - level_1  (x) object 'a' 'a' 'a' 'a' 'a' 'a' 'a' ... 'd' 'd' 'd' 'd' 'd' 'd'
-              - level_2  (x) int64 1 2 3 4 5 6 7 8 1 2 3 4 5 6 ... 4 5 6 7 8 1 2 3 4 5 6 7 8"""  # noqa: E501
+              - level_2  (x) int64 1 2 3 4 5 6 7 8 1 2 3 4 5 6 ... 4 5 6 7 8 1 2 3 4 5 6 7 8"""
         )
         assert expected == repr(mda_long)
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -196,7 +196,7 @@ class TestDataset:
             Attributes:
                 foo:      bar"""
             % data["dim3"].dtype
-        )  # noqa: E501
+        )
         actual = "\n".join(x.rstrip() for x in repr(data).split("\n"))
         print(actual)
         assert expected == actual

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -298,7 +298,7 @@ class TestDataset:
         actual = str(data)
         assert expected == actual
 
-    @pytest.mark.skipif(not IS_NEP18_ACTIVE, reason='requires __array_function__')
+    @pytest.mark.skipif(not IS_NEP18_ACTIVE, reason="requires __array_function__")
     def test_repr_nep18(self):
         class Array:
             def __init__(self):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -178,7 +178,7 @@ class TestDataset:
     def test_repr(self):
         data = create_test_data(seed=123)
         data.attrs["foo"] = "bar"
-        # need to insert str dtype at runtime to handle both Python 2 & 3
+        # need to insert str dtype at runtime to handle different endianness
         expected = dedent(
             """\
             <xarray.Dataset>

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -298,7 +298,7 @@ class TestDataset:
         actual = str(data)
         assert expected == actual
 
-    @pytest.skipif(not IS_NEP18_ACTIVE, reason='requires __array_function__')
+    @pytest.mark.skipif(not IS_NEP18_ACTIVE, reason='requires __array_function__')
     def test_repr_nep18(self):
         class Array:
             def __init__(self):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -27,6 +27,7 @@ from xarray import (
 )
 from xarray.core import dtypes, indexing, npcompat, utils
 from xarray.core.common import duck_array_ops, full_like
+from xarray.core.npcompat import IS_NEP18_ACTIVE
 from xarray.core.pycompat import integer_types
 
 from . import (
@@ -297,6 +298,7 @@ class TestDataset:
         actual = str(data)
         assert expected == actual
 
+    @pytest.skipif(not IS_NEP18_ACTIVE, reason='requires __array_function__')
     def test_repr_nep18(self):
         class Array:
             def __init__(self):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -178,24 +178,22 @@ class TestDataset:
         data = create_test_data(seed=123)
         data.attrs["foo"] = "bar"
         # need to insert str dtype at runtime to handle both Python 2 & 3
-        expected = (
-            dedent(
-                """\
-        <xarray.Dataset>
-        Dimensions:  (dim1: 8, dim2: 9, dim3: 10, time: 20)
-        Coordinates:
-          * time     (time) datetime64[ns] 2000-01-01 2000-01-02 ... 2000-01-20
-          * dim2     (dim2) float64 0.0 0.5 1.0 1.5 2.0 2.5 3.0 3.5 4.0
-          * dim3     (dim3) %s 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j'
-            numbers  (dim3) int64 0 1 2 0 0 1 1 2 2 3
-        Dimensions without coordinates: dim1
-        Data variables:
-            var1     (dim1, dim2) float64 -1.086 0.9973 0.283 ... 0.1995 0.4684 -0.8312
-            var2     (dim1, dim2) float64 1.162 -1.097 -2.123 ... 0.1302 1.267 0.3328
-            var3     (dim3, dim1) float64 0.5565 -0.2121 0.4563 ... -0.2452 -0.3616
-        Attributes:
-            foo:      bar"""
-            )
+        expected = dedent(
+            """\
+            <xarray.Dataset>
+            Dimensions:  (dim1: 8, dim2: 9, dim3: 10, time: 20)
+            Coordinates:
+              * time     (time) datetime64[ns] 2000-01-01 2000-01-02 ... 2000-01-20
+              * dim2     (dim2) float64 0.0 0.5 1.0 1.5 2.0 2.5 3.0 3.5 4.0
+              * dim3     (dim3) %s 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j'
+                numbers  (dim3) int64 0 1 2 0 0 1 1 2 2 3
+            Dimensions without coordinates: dim1
+            Data variables:
+                var1     (dim1, dim2) float64 -1.086 0.9973 0.283 ... 0.1995 0.4684 -0.8312
+                var2     (dim1, dim2) float64 1.162 -1.097 -2.123 ... 0.1302 1.267 0.3328
+                var3     (dim3, dim1) float64 0.5565 -0.2121 0.4563 ... -0.2452 -0.3616
+            Attributes:
+                foo:      bar"""
             % data["dim3"].dtype
         )  # noqa: E501
         actual = "\n".join(x.rstrip() for x in repr(data).split("\n"))
@@ -208,10 +206,10 @@ class TestDataset:
 
         expected = dedent(
             """\
-        <xarray.Dataset>
-        Dimensions:  ()
-        Data variables:
-            *empty*"""
+            <xarray.Dataset>
+            Dimensions:  ()
+            Data variables:
+                *empty*"""
         )
         actual = "\n".join(x.rstrip() for x in repr(Dataset()).split("\n"))
         print(actual)
@@ -221,10 +219,10 @@ class TestDataset:
         data = Dataset({"foo": ("x", np.ones(10))}).mean()
         expected = dedent(
             """\
-        <xarray.Dataset>
-        Dimensions:  ()
-        Data variables:
-            foo      float64 1.0"""
+            <xarray.Dataset>
+            Dimensions:  ()
+            Data variables:
+                foo      float64 1.0"""
         )
         actual = "\n".join(x.rstrip() for x in repr(data).split("\n"))
         print(actual)
@@ -238,14 +236,14 @@ class TestDataset:
         data = create_test_multiindex()
         expected = dedent(
             """\
-        <xarray.Dataset>
-        Dimensions:  (x: 4)
-        Coordinates:
-          * x        (x) MultiIndex
-          - level_1  (x) object 'a' 'a' 'b' 'b'
-          - level_2  (x) int64 1 2 1 2
-        Data variables:
-            *empty*"""
+            <xarray.Dataset>
+            Dimensions:  (x: 4)
+            Coordinates:
+              * x        (x) MultiIndex
+              - level_1  (x) object 'a' 'a' 'b' 'b'
+              - level_2  (x) int64 1 2 1 2
+            Data variables:
+                *empty*"""
         )
         actual = "\n".join(x.rstrip() for x in repr(data).split("\n"))
         print(actual)
@@ -258,14 +256,14 @@ class TestDataset:
         data = Dataset({}, {"x": mindex})
         expected = dedent(
             """\
-        <xarray.Dataset>
-        Dimensions:                  (x: 4)
-        Coordinates:
-          * x                        (x) MultiIndex
-          - a_quite_long_level_name  (x) object 'a' 'a' 'b' 'b'
-          - level_2                  (x) int64 1 2 1 2
-        Data variables:
-            *empty*"""
+            <xarray.Dataset>
+            Dimensions:                  (x: 4)
+            Coordinates:
+              * x                        (x) MultiIndex
+              - a_quite_long_level_name  (x) object 'a' 'a' 'b' 'b'
+              - level_2                  (x) int64 1 2 1 2
+            Data variables:
+                *empty*"""
         )
         actual = "\n".join(x.rstrip() for x in repr(data).split("\n"))
         print(actual)
@@ -286,18 +284,41 @@ class TestDataset:
         byteorder = "<" if sys.byteorder == "little" else ">"
         expected = dedent(
             """\
-        <xarray.Dataset>
-        Dimensions:  (foø: 1)
-        Coordinates:
-          * foø      (foø) %cU3 %r
-        Data variables:
-            *empty*
-        Attributes:
-            å:        ∑"""
+            <xarray.Dataset>
+            Dimensions:  (foø: 1)
+            Coordinates:
+              * foø      (foø) %cU3 %r
+            Data variables:
+                *empty*
+            Attributes:
+                å:        ∑"""
             % (byteorder, "ba®")
         )
         actual = str(data)
         assert expected == actual
+
+    def test_repr_nep18(self):
+        class Array:
+            def __init__(self):
+                self.shape = (2,)
+                self.dtype = np.dtype(np.float64)
+
+            def __array_function__(self, *args, **kwargs):
+                pass
+
+            def __repr__(self):
+                return "Custom\nArray"
+
+        dataset = Dataset({"foo": ("x", Array())})
+        expected = dedent(
+            """\
+            <xarray.Dataset>
+            Dimensions:  (x: 2)
+            Dimensions without coordinates: x
+            Data variables:
+                foo      (x) float64 Custom Array"""
+        )
+        assert expected == repr(dataset)
 
     def test_info(self):
         ds = create_test_data(seed=123)

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -350,7 +350,7 @@ def test_set_numpy_options():
     assert np.get_printoptions() == original_options
 
 
-def test_short_array_repr():
+def test_short_numpy_repr():
     cases = [
         np.random.randn(500),
         np.random.randn(20, 20),
@@ -359,7 +359,7 @@ def test_short_array_repr():
     ]
     # number of lines:
     # for default numpy repr: 167, 140, 254, 248
-    # for short_array_repr: 1, 7, 24, 19
+    # for short_numpy_repr: 1, 7, 24, 19
     for array in cases:
-        num_lines = formatting.short_array_repr(array).count("\n") + 1
+        num_lines = formatting.short_numpy_repr(array).count("\n") + 1
         assert num_lines < 30

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -292,8 +292,8 @@ class TestSparseVariable:
     def test_repr(self):
         expected = dedent(
             """\
-        <xarray.Variable (x: 4, y: 6)>
-        <COO: shape=(4, 6), dtype=float64, nnz=12, fill_value=0.0>"""
+            <xarray.Variable (x: 4, y: 6)>
+            <COO: shape=(4, 6), dtype=float64, nnz=12, fill_value=0.0>"""
         )
         assert expected == repr(self.var)
 
@@ -704,11 +704,11 @@ class TestSparseDataArrayAndDataset:
         )
         expected = dedent(
             """\
-        <xarray.DataArray (x: 4)>
-        <COO: shape=(4,), dtype=float64, nnz=4, fill_value=0.0>
-        Coordinates:
-            y        (x) int64 ...
-        Dimensions without coordinates: x"""
+            <xarray.DataArray (x: 4)>
+            <COO: shape=(4,), dtype=float64, nnz=4, fill_value=0.0>
+            Coordinates:
+                y        (x) int64 <COO: shape=(4,), nnz=3, fill_value=0>
+            Dimensions without coordinates: x"""
         )
         assert expected == repr(a)
 
@@ -719,13 +719,13 @@ class TestSparseDataArrayAndDataset:
         )
         expected = dedent(
             """\
-        <xarray.Dataset>
-        Dimensions:  (x: 4)
-        Coordinates:
-            y        (x) int64 ...
-        Dimensions without coordinates: x
-        Data variables:
-            a        (x) float64 ..."""
+            <xarray.Dataset>
+            Dimensions:  (x: 4)
+            Coordinates:
+                y        (x) int64 <COO: shape=(4,), nnz=3, fill_value=0>
+            Dimensions without coordinates: x
+            Data variables:
+                a        (x) float64 <COO: shape=(4,), nnz=4, fill_value=0.0>"""
         )
         assert expected == repr(ds)
 

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -8,7 +8,7 @@ from xarray.core.npcompat import IS_NEP18_ACTIVE
 import xarray as xr
 import xarray.ufuncs as xu
 
-from . import assert_equal, assert_identical, requires_dask
+from . import assert_equal, assert_identical
 
 import pytest
 
@@ -729,8 +729,8 @@ class TestSparseDataArrayAndDataset:
         )
         assert expected == repr(ds)
 
-    @requires_dask
     def test_sparse_dask_dataset_repr(self):
+        dask = pytest.importorskip('dask', minversion='2.0')
         ds = xr.Dataset(data_vars={"a": ("x", COO.from_numpy(np.ones(4)))}).chunk()
         expected = dedent(
             """\

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -8,7 +8,7 @@ from xarray.core.npcompat import IS_NEP18_ACTIVE
 import xarray as xr
 import xarray.ufuncs as xu
 
-from . import assert_equal, assert_identical
+from . import assert_equal, assert_identical, requires_dask
 
 import pytest
 
@@ -707,7 +707,7 @@ class TestSparseDataArrayAndDataset:
             <xarray.DataArray (x: 4)>
             <COO: shape=(4,), dtype=float64, nnz=4, fill_value=0.0>
             Coordinates:
-                y        (x) int64 <COO: shape=(4,), nnz=3, fill_value=0>
+                y        (x) int64 <COO: nnz=3, fill_value=0>
             Dimensions without coordinates: x"""
         )
         assert expected == repr(a)
@@ -722,10 +722,23 @@ class TestSparseDataArrayAndDataset:
             <xarray.Dataset>
             Dimensions:  (x: 4)
             Coordinates:
-                y        (x) int64 <COO: shape=(4,), nnz=3, fill_value=0>
+                y        (x) int64 <COO: nnz=3, fill_value=0>
             Dimensions without coordinates: x
             Data variables:
-                a        (x) float64 <COO: shape=(4,), nnz=4, fill_value=0.0>"""
+                a        (x) float64 <COO: nnz=4, fill_value=0.0>"""
+        )
+        assert expected == repr(ds)
+
+    @requires_dask
+    def test_sparse_dask_dataset_repr(self):
+        ds = xr.Dataset(data_vars={"a": ("x", COO.from_numpy(np.ones(4)))}).chunk()
+        expected = dedent(
+            """\
+            <xarray.Dataset>
+            Dimensions:  (x: 4)
+            Dimensions without coordinates: x
+            Data variables:
+                a        (x) float64 dask.array<chunksize=(4,), meta=sparse.COO>"""
         )
         assert expected == repr(ds)
 

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -8,7 +8,7 @@ from xarray.core.npcompat import IS_NEP18_ACTIVE
 import xarray as xr
 import xarray.ufuncs as xu
 
-from . import assert_equal, assert_identical
+from . import assert_equal, assert_identical, LooseVersion
 
 import pytest
 
@@ -730,7 +730,7 @@ class TestSparseDataArrayAndDataset:
         assert expected == repr(ds)
 
     def test_sparse_dask_dataset_repr(self):
-        dask = pytest.importorskip('dask', minversion='2.0')
+        pytest.importorskip("dask", minversion="2.0")
         ds = xr.Dataset(data_vars={"a": ("x", COO.from_numpy(np.ones(4)))}).chunk()
         expected = dedent(
             """\


### PR DESCRIPTION
I also did a bit of cleanup (e.g., renaming methods) in xarray.core.formatting.

Sparse arrays were previously not shown in the Dataset repr:

    <xarray.Dataset>
    Dimensions:  (x: 4)
    Coordinates:
        y        (x) int64 ...
    Dimensions without coordinates: x
    Data variables:
        a        (x) float64 ..."""

Now they are:

    <xarray.Dataset>
    Dimensions:  (x: 4)
    Coordinates:
        y        (x) int64 <COO: shape=(4,), nnz=3, fill_value=0>
    Dimensions without coordinates: x
    Data variables:
        a        (x) float64 <COO: shape=(4,), nnz=4, fill_value=0.0>"""

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
