### PR TITLE
BUG: Fixes GH3215

### DIFF
--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -96,7 +96,7 @@ def last_item(array):
         return []
 
     indexer = (slice(-1, None),) * array.ndim
-    return np.ravel(array[indexer]).tolist()
+    return np.ravel(np.asarray(array[indexer])).tolist()
 
 
 def format_timestamp(t):


### PR DESCRIPTION
Explicit cast to numpy array to avoid np.ravel calling out to dask

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #3215 
