### PR TITLE
Allow invalid_netcdf=True in to_netcdf()

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - dask=1.1.0
   - ipython=7.2.0
   - netCDF4=1.4.2
+  - h5netcdf=0.7.4
   - cartopy=0.17.0
   - rasterio=1.0.24
   - zarr=2.2.0

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -366,6 +366,31 @@ supported by netCDF4-python: 'standard', 'gregorian', 'proleptic_gregorian' 'nol
 By default, xarray uses the 'proleptic_gregorian' calendar and units of the smallest time
 difference between values, with a reference time of the first time value.
 
+Invalid netCDF files
+~~~~~~~~~~~~~~~~~~~~
+
+The library ``h5netcdf`` allows writing some dtypes (booleans, complex, ...) that aren't 
+allowed in netCDF4 (see
+`h5netcdf documentation <https://github.com/shoyer/h5netcdf#invalid-netcdf-files)>`_.
+This feature is availabe through :py:func:`DataArray.to_netcdf` and
+:py:func:`Dataset.to_netcdf` when used with ``engine="h5netcdf"``
+and currently raises a warning unless ``invalid_netcdf=True`` is set:
+
+.. ipython:: python
+
+    # Writing complex valued data
+    da = xr.DataArray([1.+1.j, 2.+2.j, 3.+3.j])
+    da.to_netcdf("complex.nc", engine="h5netcdf", invalid_netcdf=True)
+
+    # Reading it back
+    xr.open_dataarray("complex.nc", engine="h5netcdf")
+
+
+.. warning::
+
+  Note that this produces a file that is likely to be not readable by other netCDF
+  libraries!
+
 .. _io.iris:
 
 Iris

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -60,6 +60,9 @@ Enhancements
 - In :py:meth:`~xarray.Dataset.to_zarr`, passing ``mode`` is not mandatory if
   ``append_dim`` is set, as it will automatically be set to ``'a'`` internally.
   By `David Brochart <https://github.com/davidbrochart>`_.
+- :py:func:`~xarray.Dataset.to_netcdf()` now supports the ``invalid_netcdf`` kwarg when used
+  with ``engine="h5netcdf"``. It is passed to :py:func:`h5netcdf.File`.
+  By `Ulrich Herter <https://github.com/ulijh>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -979,6 +979,7 @@ def to_netcdf(
     unlimited_dims: Iterable[Hashable] = None,
     compute: bool = True,
     multifile: bool = False,
+    invalid_netcdf: bool = False,
 ) -> Union[Tuple[ArrayWriter, AbstractDataStore], bytes, "Delayed", None]:
     """This function creates an appropriate datastore for writing a dataset to
     disk as a netCDF file
@@ -1040,6 +1041,8 @@ def to_netcdf(
 
     target = path_or_file if path_or_file is not None else BytesIO()
     kwargs = dict(autoclose=True) if autoclose else {}
+    if engine == 'h5netcdf' and invalid_netcdf:
+        kwargs['invalid_netcdf'] = invalid_netcdf
     store = store_open(target, mode, format, group, **kwargs)
 
     if unlimited_dims is None:

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1041,8 +1041,13 @@ def to_netcdf(
 
     target = path_or_file if path_or_file is not None else BytesIO()
     kwargs = dict(autoclose=True) if autoclose else {}
-    if engine == "h5netcdf" and invalid_netcdf:
-        kwargs["invalid_netcdf"] = invalid_netcdf
+    if invalid_netcdf:
+        if engine == "h5netcdf":
+            kwargs["invalid_netcdf"] = invalid_netcdf
+        else:
+            raise ValueError(
+                "unrecognized option 'invalid_netcdf' for engine %s" % engine
+            )
     store = store_open(target, mode, format, group, **kwargs)
 
     if unlimited_dims is None:

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1041,8 +1041,8 @@ def to_netcdf(
 
     target = path_or_file if path_or_file is not None else BytesIO()
     kwargs = dict(autoclose=True) if autoclose else {}
-    if engine == 'h5netcdf' and invalid_netcdf:
-        kwargs['invalid_netcdf'] = invalid_netcdf
+    if engine == "h5netcdf" and invalid_netcdf:
+        kwargs["invalid_netcdf"] = invalid_netcdf
     store = store_open(target, mode, format, group, **kwargs)
 
     if unlimited_dims is None:

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -78,12 +78,14 @@ class H5NetCDFStore(WritableCFDataStore):
         group=None,
         lock=None,
         autoclose=False,
-        **kwargs
+        invalid_netcdf=None,
     ):
         import h5netcdf
 
         if format not in [None, "NETCDF4"]:
             raise ValueError("invalid format for h5netcdf backend")
+
+        kwargs = {"invalid_netcdf": invalid_netcdf}
 
         self._manager = CachingFileManager(
             h5netcdf.File, filename, mode=mode, kwargs=kwargs

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -71,14 +71,14 @@ class H5NetCDFStore(WritableCFDataStore):
     """
 
     def __init__(
-        self, filename, mode="r", format=None, group=None, lock=None, autoclose=False
+        self, filename, mode="r", format=None, group=None, lock=None, autoclose=False, **kwargs,
     ):
         import h5netcdf
 
         if format not in [None, "NETCDF4"]:
             raise ValueError("invalid format for h5netcdf backend")
 
-        self._manager = CachingFileManager(h5netcdf.File, filename, mode=mode)
+        self._manager = CachingFileManager(h5netcdf.File, filename, mode=mode, kwargs=kwargs)
 
         if lock is None:
             if mode == "r":

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -71,14 +71,23 @@ class H5NetCDFStore(WritableCFDataStore):
     """
 
     def __init__(
-        self, filename, mode="r", format=None, group=None, lock=None, autoclose=False, **kwargs,
+        self,
+        filename,
+        mode="r",
+        format=None,
+        group=None,
+        lock=None,
+        autoclose=False,
+        **kwargs
     ):
         import h5netcdf
 
         if format not in [None, "NETCDF4"]:
             raise ValueError("invalid format for h5netcdf backend")
 
-        self._manager = CachingFileManager(h5netcdf.File, filename, mode=mode, kwargs=kwargs)
+        self._manager = CachingFileManager(
+            h5netcdf.File, filename, mode=mode, kwargs=kwargs
+        )
 
         if lock is None:
             if mode == "r":

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1435,6 +1435,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         encoding: Mapping = None,
         unlimited_dims: Iterable[Hashable] = None,
         compute: bool = True,
+        invalid_netcdf: bool = False,
     ) -> Union[bytes, "Delayed", None]:
         """Write dataset contents to a netCDF file.
 
@@ -1513,6 +1514,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             encoding=encoding,
             unlimited_dims=unlimited_dims,
             compute=compute,
+            invalid_netcdf=invalid_netcdf,
         )
 
     def to_zarr(

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1501,7 +1501,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             ``dask.delayed.Delayed`` object that can be computed later.
         invalid_netcdf: boolean
             Only valid along with engine='h5netcdf'. If True, allow writing
-            hdf5 files which are (not yet) valid netcdf as described in
+            hdf5 files which are valid netcdf as described in
             https://github.com/shoyer/h5netcdf. Default: False.
         """
         if encoding is None:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1499,6 +1499,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         compute: boolean
             If true compute immediately, otherwise return a
             ``dask.delayed.Delayed`` object that can be computed later.
+        invalid_netcdf: boolean
+            Only valid along with engine='h5netcdf'. If True, allow writing
+            hdf5 files which are (not yet) valid netcdf as described in
+            https://github.com/shoyer/h5netcdf. Default: False.
         """
         if encoding is None:
             encoding = {}

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4404,7 +4404,7 @@ def test_use_cftime_false_nonstandard_calendar(calendar, units_year):
             open_dataset(tmp_file, use_cftime=False)
 
 
-@pytest.mark.parametrize('engine', ['netcdf4', 'scipy'])
+@pytest.mark.parametrize("engine", ["netcdf4", "scipy"])
 def test_invalid_netcdf_raises(engine):
     data = create_test_data()
     with raises_regex(ValueError, "unrecognized option 'invalid_netcdf'"):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4402,3 +4402,10 @@ def test_use_cftime_false_nonstandard_calendar(calendar, units_year):
         original.to_netcdf(tmp_file)
         with pytest.raises((OutOfBoundsDatetime, ValueError)):
             open_dataset(tmp_file, use_cftime=False)
+
+
+@pytest.mark.parametrize('engine', ['netcdf4', 'scipy'])
+def test_invalid_netcdf_raises(engine):
+    data = create_test_data()
+    with raises_regex(ValueError, "unrecognized option 'invalid_netcdf'"):
+        data.to_netcdf("foo.nc", engine=engine, invalid_netcdf=True)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2173,16 +2173,16 @@ class TestH5NetCDFData(NetCDF4Base):
 
     @pytest.mark.filterwarnings("ignore:complex dtypes are supported by h5py")
     @pytest.mark.parametrize(
-        "invalid_netcdf, warns, n_warns",
+        "invalid_netcdf, warns, num_warns",
         [(None, FutureWarning, 1), (False, FutureWarning, 1), (True, None, 0)],
     )
-    def test_complex(self, invalid_netcdf, warns, n_warns):
+    def test_complex(self, invalid_netcdf, warns, num_warns):
         expected = Dataset({"x": ("y", np.ones(5) + 1j * np.ones(5))})
         save_kwargs = {"invalid_netcdf": invalid_netcdf}
         with pytest.warns(warns) as record:
             with self.roundtrip(expected, save_kwargs=save_kwargs) as actual:
                 assert_equal(expected, actual)
-        assert n_warns == len(record)
+        assert len(record) == num_warns
 
     def test_cross_engine_read_write_netcdf4(self):
         # Drop dim3, because its labels include strings. These appear to be

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2172,13 +2172,17 @@ class TestH5NetCDFData(NetCDF4Base):
             yield backends.H5NetCDFStore(tmp_file, "w")
 
     @pytest.mark.filterwarnings("ignore:complex dtypes are supported by h5py")
-    def test_complex(self):
+    def test_complex_warning(self):
         expected = Dataset({"x": ("y", np.ones(5) + 1j * np.ones(5))})
         with pytest.warns(FutureWarning):
-            # TODO: make it possible to write invalid netCDF files from xarray
-            # without a warning
             with self.roundtrip(expected) as actual:
                 assert_equal(expected, actual)
+
+    def test_complex(self):
+        expected = Dataset({"x": ("y", np.ones(5) + 1j * np.ones(5))})
+        save_kwargs = {"invalid_netcdf": True}
+        with self.roundtrip(expected, save_kwargs=save_kwargs) as actual:
+            assert_equal(expected, actual)
 
     def test_cross_engine_read_write_netcdf4(self):
         # Drop dim3, because its labels include strings. These appear to be

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2172,17 +2172,17 @@ class TestH5NetCDFData(NetCDF4Base):
             yield backends.H5NetCDFStore(tmp_file, "w")
 
     @pytest.mark.filterwarnings("ignore:complex dtypes are supported by h5py")
-    def test_complex_warning(self):
+    @pytest.mark.parametrize(
+        "invalid_netcdf, warns, n_warns",
+        [(None, FutureWarning, 1), (False, FutureWarning, 1), (True, None, 0)],
+    )
+    def test_complex(self, invalid_netcdf, warns, n_warns):
         expected = Dataset({"x": ("y", np.ones(5) + 1j * np.ones(5))})
-        with pytest.warns(FutureWarning):
-            with self.roundtrip(expected) as actual:
+        save_kwargs = {"invalid_netcdf": invalid_netcdf}
+        with pytest.warns(warns) as record:
+            with self.roundtrip(expected, save_kwargs=save_kwargs) as actual:
                 assert_equal(expected, actual)
-
-    def test_complex(self):
-        expected = Dataset({"x": ("y", np.ones(5) + 1j * np.ones(5))})
-        save_kwargs = {"invalid_netcdf": True}
-        with self.roundtrip(expected, save_kwargs=save_kwargs) as actual:
-            assert_equal(expected, actual)
+        assert n_warns == len(record)
 
     def test_cross_engine_read_write_netcdf4(self):
         # Drop dim3, because its labels include strings. These appear to be


### PR DESCRIPTION
Hi all,

I prepared a little PR which could close #2243 and would allow for a IMO clean way of writing data with complex dtypes (and others).

What do you think? 

TODOs:
----------
 - [X] Closes #2243
 - [X] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
