### PR TITLE
Add PR checklist to contributing docs

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -847,24 +847,17 @@ The branch will still exist on GitHub, so to delete it there do::
 PR checklist
 ------------
 
-- **Use a helpful title for your pull request** by summarizing the main contributions rather than using the latest commit message. If this addresses an `issue <https://github.com/pydata/xarray/issues>`_, please reference it.
-- **Properly comment and document your code.** See `"Documenting your code" <https://xarray.pydata.org/en/stable/contributing.html#documenting-your-code>`_ for details.
-- **Test that the documentation builds correctly** by typing ``make html`` in the ``doc`` directory. This is not strictly necessary, but this may be easier than waiting for CI to catch a mistake. See `"Contributing to the documentation" <https://xarray.pydata.org/en/stable/contributing.html#contributing-to-the-documentation>`_ for details.
+- **Properly comment and document your code.** See `"Documenting your code" <https://xarray.pydata.org/en/stable/contributing.html#documenting-your-code>`_.
+- **Test that the documentation builds correctly** by typing ``make html`` in the ``doc`` directory. This is not strictly necessary, but this may be easier than waiting for CI to catch a mistake. See `"Contributing to the documentation" <https://xarray.pydata.org/en/stable/contributing.html#contributing-to-the-documentation>`_.
 - **Test your code**.
 
-    - Write tests if needed. See the section `"Test-driven development/code writing" <https://xarray.pydata.org/en/stable/contributing.html#test-driven-development-code-writing>`_ for details.
-    - Use |pytest|_. Running all tests (type ``pytest`` in the root directory) takes a while, so feel free to only run the tests you think are needed based on your PR (example: ``pytest xarray/tests/test_dataarray.py``). CI will catch any failing tests.
+    - Write new tests if needed. See `"Test-driven development/code writing" <https://xarray.pydata.org/en/stable/contributing.html#test-driven-development-code-writing>`_.
+    - Test the code using `Pytest <http://doc.pytest.org/en/latest/>`_. Running all tests (type ``pytest`` in the root directory) takes a while, so feel free to only run the tests you think are needed based on your PR (example: ``pytest xarray/tests/test_dataarray.py``). CI will catch any failing tests.
 
-- **Properly format your code** and verify that it passes the formatting guidelines set by |black|_ and |flake8|_. See `"Code formatting" <https://xarray.pydata.org/en/stable/contributing.html#code-formatting>`_ for details.
+- **Properly format your code** and verify that it passes the formatting guidelines set by `Black <https://black.readthedocs.io/en/stable/>`_ and `Flake8 <http://flake8.pycqa.org/en/latest/>`_. See `"Code formatting" <https://xarray.pydata.org/en/stablcontributing.html#code-formatting>`_.
 
     - Run ``black .`` in the root directory. This may modify some files. Confirm and commit any formatting changes.
     - Run ``flake8`` in the root directory. If this fails, it will log an error message.
 
-.. |pytest| replace:: ``pytest``
-.. pytest: http://doc.pytest.org/en/latest/
-.. |black| replace:: ``black``
-.. black: https://black.readthedocs.io/en/stable/
-.. |flake8| replace:: ``flake8``
-.. flake8: http://flake8.pycqa.org/en/latest/
-
-
+- **Push your code and** `create a PR on GitHub <https://help.github.com/en/articles/creating-a-pull-request>`_.
+- **Use a helpful title for your pull request** by summarizing the main contributions rather than using the latest commit message. If this addresses an `issue <https://github.com/pydata/xarray/issues>`_, please `reference it <https://help.github.com/en/articles/autolinked-references-and-urls>`_.

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -842,3 +842,29 @@ branch has not actually been merged.
 The branch will still exist on GitHub, so to delete it there do::
 
     git push origin --delete shiny-new-feature
+
+
+PR checklist
+------------
+
+- **Use a helpful title for your pull request** by summarizing the main contributions rather than using the latest commit message. If this addresses an `issue <https://github.com/pydata/xarray/issues>`_, please reference it.
+- **Properly comment and document your code.** See `"Documenting your code" <https://xarray.pydata.org/en/stable/contributing.html#documenting-your-code>`_ for details.
+- **Test that the documentation builds correctly** by typing ``make html`` in the ``doc`` directory. This is not strictly necessary, but this may be easier than waiting for CI to catch a mistake. See `"Contributing to the documentation" <https://xarray.pydata.org/en/stable/contributing.html#contributing-to-the-documentation>`_ for details.
+- **Test your code**.
+
+    - Write tests if needed. See the section `"Test-driven development/code writing" <https://xarray.pydata.org/en/stable/contributing.html#test-driven-development-code-writing>`_ for details.
+    - Use |pytest|_. Running all tests (type ``pytest`` in the root directory) takes a while, so feel free to only run the tests you think are needed based on your PR (example: ``pytest xarray/tests/test_dataarray.py``). CI will catch any failing tests.
+
+- **Properly format your code** and verify that it passes the formatting guidelines set by |black|_ and |flake8|_. See `"Code formatting" <https://xarray.pydata.org/en/stable/contributing.html#code-formatting>`_ for details.
+
+    - Run ``black .`` in the root directory. This may modify some files. Confirm and commit any formatting changes.
+    - Run ``flake8`` in the root directory. If this fails, it will log an error message.
+
+.. |pytest| replace:: ``pytest``
+.. pytest: http://doc.pytest.org/en/latest/
+.. |black| replace:: ``black``
+.. black: https://black.readthedocs.io/en/stable/
+.. |flake8| replace:: ``flake8``
+.. flake8: http://flake8.pycqa.org/en/latest/
+
+

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -91,6 +91,13 @@ Bug fixes
                                
 .. _whats-new.0.12.3:
 
+Documentation
+~~~~~~~~~~~~~
+
+- Created a `PR checklist <https://xarray.pydata.org/en/stable/contributing.html/contributing.html#pr-checklist>`_ as a quick reference for tasks before creating a new PR
+  or pushing new commits.
+  By `Gregory Gundersen <https://github.com/gwgundersen>`_.
+
 v0.12.3 (10 July 2019)
 ----------------------
 


### PR DESCRIPTION
I'm a new contributor working on a couple PRs for Xarray and wished I had a short checklist of things to do before pushing a commit. First, I think such an overview list is useful per se. Second, CI takes a while, and it's much faster to just run `black .` or to build the docs manually than it is easy wait for CI to fail.

Inspired by [Scikit-learn's checklist](https://scikit-learn.org/stable/developers/contributing.html#pull-request-checklist). This is just a first draft; happy for suggestions or to add anything I'm missing.