### PR TITLE
Expose use_cftime option in open_zarr #2886

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -63,6 +63,9 @@ New Features
   dimensions order (:issue:`4331`, :pull:`4333`).
   By `Thomas Zilio <https://github.com/thomas-z>`_.
 
+- Expose ``use_cftime`` option in :py:func:`~xarray.open_zarr` (:issue:`2886`, :pull:`3229`)
+  By `Samnan Rahee <https://github.com/Geektrovert>`_ and `Anderson Banihirwe <https://github.com/andersy005>`_.
+
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -62,7 +62,6 @@ New Features
   now accept a ``dim_order`` parameter allowing to specify the resulting dataframe's
   dimensions order (:issue:`4331`, :pull:`4333`).
   By `Thomas Zilio <https://github.com/thomas-z>`_.
-
 - Expose ``use_cftime`` option in :py:func:`~xarray.open_zarr` (:issue:`2886`, :pull:`3229`)
   By `Samnan Rahee <https://github.com/Geektrovert>`_ and `Anderson Banihirwe <https://github.com/andersy005>`_.
 

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -506,6 +506,7 @@ def open_zarr(
     consolidated=False,
     overwrite_encoded_chunks=False,
     decode_timedelta=None,
+    use_cftime=None,
     **kwargs,
 ):
     """Load and decode a dataset from a Zarr store.
@@ -570,6 +571,16 @@ def open_zarr(
         {'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds'}
         into timedelta objects. If False, leave them encoded as numbers.
         If None (default), assume the same value of decode_time.
+    use_cftime: bool, optional
+        Only relevant if encoded dates come from a standard calendar
+        (e.g. "gregorian", "proleptic_gregorian", "standard", or not
+        specified).  If None (default), attempt to decode times to
+        ``np.datetime64[ns]`` objects; if this is not possible, decode times to
+        ``cftime.datetime`` objects. If True, always decode times to
+        ``cftime.datetime`` objects, regardless of whether or not they can be
+        represented using ``np.datetime64[ns]`` objects.  If False, always
+        decode times to ``np.datetime64[ns]`` objects; if this is not possible
+        raise an error.
 
     Returns
     -------
@@ -631,6 +642,7 @@ def open_zarr(
             decode_coords=decode_coords,
             drop_variables=drop_variables,
             decode_timedelta=decode_timedelta,
+            use_cftime=use_cftime
         )
 
         # TODO: this is where we would apply caching

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -642,7 +642,7 @@ def open_zarr(
             decode_coords=decode_coords,
             drop_variables=drop_variables,
             decode_timedelta=decode_timedelta,
-            use_cftime=use_cftime
+            use_cftime=use_cftime,
         )
 
         # TODO: this is where we would apply caching

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2016,6 +2016,16 @@ class ZarrBase(CFEncodedBase):
         ) as ds1:
             assert_equal(ds1, original)
 
+    @requires_cftime
+    def test_open_zarr_use_cftime(self):
+        ds = create_test_data()
+        with self.create_zarr_target() as store_target:
+            ds.to_zarr(store_target, consolidated=True)
+            ds_a = xr.open_zarr(store_target, consolidated=True)
+            assert_identical(ds, ds_a)
+            ds_b = xr.open_zarr(store_target, consolidated=True, use_cftime=True)
+            assert xr.coding.times.contains_cftime_datetimes(ds_b.time)
+
 
 @requires_zarr
 class TestZarrDictStore(ZarrBase):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2886 
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
