### PR TITLE
Drop keyword support: small fixes

### DIFF
--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -236,7 +236,6 @@ The :py:meth:`~xarray.Dataset.drop` method returns a new object with the listed
 index labels along a dimension dropped:
 
 .. ipython:: python
-    :okwarning:
 
     ds.drop(space=['IN', 'IL'])
 

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -238,7 +238,7 @@ index labels along a dimension dropped:
 .. ipython:: python
     :okwarning:
 
-    ds.drop(['IN', 'IL'], dim='space')
+    ds.drop(space=['IN', 'IL'])
 
 ``drop`` is both a ``Dataset`` and ``DataArray`` method.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -66,7 +66,9 @@ Enhancements
   By `David Brochart <https://github.com/davidbrochart>`_.
 
 - :py:meth:`~xarray.Dataset.drop` now supports keyword arguments; dropping index
-  labels by specifying both ``dim`` and ``labels`` is deprecated (:issue:`2910`).
+  labels by using both ``dim`` and ``labels`` or using a
+  :py:class:`~xarray.core.coordinates.DataArrayCoordinates` object are
+  deprecated (:issue:`2910`).
   By `Gregory Gundersen <https://github.com/gwgundersen/>`_.
 
 - Added examples of :py:meth:`Dataset.set_index` and

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -55,7 +55,6 @@ from .common import (
     _contains_datetime_like_objects,
 )
 from .coordinates import (
-    DataArrayCoordinates,
     DatasetCoordinates,
     LevelCoordinatesSource,
     assert_coordinate_consistent,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3551,9 +3551,16 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         if is_dict_like(labels) and not isinstance(labels, dict):
             warnings.warn(
-                "dropping coordinates using key values of dict-like labels "
-                "is deprecated; use drop_vars or a list of coordinates.",
+                "dropping coordinates using key values of dict-like labels is "
+                "deprecated; use drop_vars or a list of coordinates.",
                 FutureWarning,
+                stacklevel=2,
+            )
+        if dim is not None and is_list_like(labels):
+            warnings.warn(
+                "dropping dimensions using list-like labels is deprecated; use "
+                "dict-like arguments.",
+                DeprecationWarning,
                 stacklevel=2,
             )
 
@@ -3572,13 +3579,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 labels = set(labels)
             return self._drop_vars(labels, errors=errors)
         else:
-            if is_list_like(labels):
-                warnings.warn(
-                    "dropping dimensions using list-like labels is deprecated; "
-                    "use dict-like arguments.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
             return self._drop_labels(labels, dim, errors=errors)
 
     def _drop_labels(self, labels=None, dim=None, errors="raise"):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -54,7 +54,6 @@ from .common import (
 )
 from .coordinates import (
     DatasetCoordinates,
-    DataArrayCoordinates,
     LevelCoordinatesSource,
     assert_coordinate_consistent,
     remap_label_indexers,
@@ -77,6 +76,8 @@ from .utils import (
     either_dict_or_kwargs,
     hashable,
     maybe_wrap_array,
+    is_dict_like,
+    is_list_like,
 )
 from .variable import IndexVariable, Variable, as_variable, broadcast_variables
 from ..plot.dataset_plot import _Dataset_PlotMethods
@@ -3548,8 +3549,16 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         if errors not in ["raise", "ignore"]:
             raise ValueError('errors must be either "raise" or "ignore"')
 
+        if is_dict_like(labels) and not isinstance(labels, dict):
+            warnings.warn(
+                "dropping coordinates using key values of dict-like labels "
+                "is deprecated; use drop_vars or a list of coordinates.",
+                FutureWarning,
+                stacklevel=2,
+            )
+
         if labels_kwargs or isinstance(labels, dict):
-            labels_kwargs = utils.either_dict_or_kwargs(labels, labels_kwargs, "drop")
+            labels_kwargs = either_dict_or_kwargs(labels, labels_kwargs, "drop")
             if dim is not None:
                 raise ValueError("cannot specify dim and dict-like arguments.")
             ds = self
@@ -3557,20 +3566,13 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 ds = ds._drop_labels(labels, dim, errors=errors)
             return ds
         elif dim is None:
-            if isinstance(labels, DataArrayCoordinates):
-                warnings.warn(
-                    "dropping coordinates using a DataArrayCoordinates object "
-                    "is deprecated; use drop_vars or a list of coordinates",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
             if isinstance(labels, str) or not isinstance(labels, Iterable):
                 labels = {labels}
             else:
                 labels = set(labels)
             return self._drop_vars(labels, errors=errors)
         else:
-            if utils.is_list_like(labels):
+            if is_list_like(labels):
                 warnings.warn(
                     "dropping dimensions using list-like labels is deprecated; "
                     "use dict-like arguments.",

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3548,8 +3548,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         if errors not in ["raise", "ignore"]:
             raise ValueError('errors must be either "raise" or "ignore"')
 
-        labels_are_coords = isinstance(labels, DataArrayCoordinates)
-        if labels_kwargs or (utils.is_dict_like(labels) and not labels_are_coords):
+        if labels_kwargs or isinstance(labels, dict):
             labels_kwargs = utils.either_dict_or_kwargs(labels, labels_kwargs, "drop")
             if dim is not None:
                 raise ValueError("cannot specify dim and dict-like arguments.")
@@ -3558,6 +3557,13 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 ds = ds._drop_labels(labels, dim, errors=errors)
             return ds
         elif dim is None:
+            if isinstance(labels, DataArrayCoordinates):
+                warnings.warn(
+                    "dropping coordinates using a DataArrayCoordinates object "
+                    "is deprecated; use drop_vars or a list of coordinates",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             if isinstance(labels, str) or not isinstance(labels, Iterable):
                 labels = {labels}
             else:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -29,6 +29,7 @@ from xarray.core import dtypes, indexing, npcompat, utils
 from xarray.core.common import duck_array_ops, full_like
 from xarray.core.npcompat import IS_NEP18_ACTIVE
 from xarray.core.pycompat import integer_types
+from xarray.core.coordinates import DatasetCoordinates, DataArrayCoordinates
 
 from . import (
     LooseVersion,
@@ -2214,13 +2215,20 @@ class TestDataset:
         # Basic functionality.
         assert len(data.coords["x"]) == 2
 
-        # This API is allowed but deprecated.
+        # In the future, this will break.
         with pytest.warns(DeprecationWarning):
             ds1 = data.drop(["a"], dim="x")
         ds2 = data.drop(x="a")
         ds3 = data.drop(x=["a"])
         ds4 = data.drop(x=["a", "b"])
         ds5 = data.drop(x=["a", "b"], y=range(0, 6, 2))
+
+        # In the future, this will result in different behavior.
+        arr = DataArray(range(3), dims=["c"])
+        with pytest.warns(FutureWarning):
+            data.drop(arr.coords)
+        with pytest.warns(FutureWarning):
+            data.drop(arr.indexes)
 
         assert_array_equal(ds1.coords["x"], ["b"])
         assert_array_equal(ds2.coords["x"], ["b"])

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -29,7 +29,6 @@ from xarray.core import dtypes, indexing, npcompat, utils
 from xarray.core.common import duck_array_ops, full_like
 from xarray.core.npcompat import IS_NEP18_ACTIVE
 from xarray.core.pycompat import integer_types
-from xarray.core.coordinates import DatasetCoordinates, DataArrayCoordinates
 
 from . import (
     LooseVersion,


### PR DESCRIPTION
 - Addresses issue https://github.com/pydata/xarray/issues/2910 and completes PR https://github.com/pydata/xarray/pull/3128.
 - Passes `black .` and `flake8`.
 - Documented in `whats-new.rst` and `indexing.rst`.