### PR TITLE
Update filter_by_attrs to use 'variables' instead of 'data_vars'

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5139,7 +5139,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         """  # noqa
         selection = []
-        for var_name, variable in self.data_vars.items():
+        for var_name, variable in self.variables.items():
             has_value_flag = False
             for attr_name, pattern in kwargs.items():
                 attr_value = variable.attrs.get(attr_name)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4938,7 +4938,7 @@ class TestDataset:
         new_ds = ds.filter_by_attrs(long_name="time_in_seconds")
         assert new_ds["time"].long_name == "time_in_seconds"
         assert not bool(new_ds.data_vars)
- 
+
         # Test return more than one DataArray.
         new_ds = ds.filter_by_attrs(standard_name="air_potential_temperature")
         assert len(new_ds.data_vars) == 2

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4920,7 +4920,7 @@ class TestDataset:
                 "temperature_10": (["t"], [0], temp10),
                 "precipitation": (["t"], [0], precip),
             },
-            coords={"time": (["t"], [0], dict(axis="T"))},
+            coords={"time": (["t"], [0], dict(axis="T",standard_name="time_in_seconds"))},
         )
 
         # Test return empty Dataset.
@@ -4934,6 +4934,11 @@ class TestDataset:
 
         assert_equal(new_ds["precipitation"], ds["precipitation"])
 
+        #Test filter coordinates
+        new_ds = ds.filter_by_attrs(standard_name="time_in_seconds")
+        assert new_ds["time"].standard_name == "time_in_seconds"
+        assert not bool(new_ds.data_vars)
+        
         # Test return more than one DataArray.
         new_ds = ds.filter_by_attrs(standard_name="air_potential_temperature")
         assert len(new_ds.data_vars) == 2

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4920,7 +4920,7 @@ class TestDataset:
                 "temperature_10": (["t"], [0], temp10),
                 "precipitation": (["t"], [0], precip),
             },
-            coords={"time": (["t"], [0], dict(axis="T", standard_name="time_in_seconds"))},
+            coords={"time": (["t"], [0], dict(axis="T", long_name="time_in_seconds"))},
         )
 
         # Test return empty Dataset.
@@ -4935,8 +4935,8 @@ class TestDataset:
         assert_equal(new_ds["precipitation"], ds["precipitation"])
 
         # Test filter coordinates
-        new_ds = ds.filter_by_attrs(standard_name="time_in_seconds")
-        assert new_ds["time"].standard_name == "time_in_seconds"
+        new_ds = ds.filter_by_attrs(long_name="time_in_seconds")
+        assert new_ds["time"].long_name == "time_in_seconds"
         assert not bool(new_ds.data_vars)
  
         # Test return more than one DataArray.

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4920,7 +4920,7 @@ class TestDataset:
                 "temperature_10": (["t"], [0], temp10),
                 "precipitation": (["t"], [0], precip),
             },
-            coords={"time": (["t"], [0], dict(axis="T",standard_name="time_in_seconds"))},
+            coords={"time": (["t"], [0], dict(axis="T", standard_name="time_in_seconds"))},
         )
 
         # Test return empty Dataset.
@@ -4934,11 +4934,11 @@ class TestDataset:
 
         assert_equal(new_ds["precipitation"], ds["precipitation"])
 
-        #Test filter coordinates
+        # Test filter coordinates
         new_ds = ds.filter_by_attrs(standard_name="time_in_seconds")
         assert new_ds["time"].standard_name == "time_in_seconds"
         assert not bool(new_ds.data_vars)
-        
+ 
         # Test return more than one DataArray.
         new_ds = ds.filter_by_attrs(standard_name="air_potential_temperature")
         assert len(new_ds.data_vars) == 2


### PR DESCRIPTION
This will allow `filter_by_attrs` to filter coordinates as well as variables. @ocefpaf
