### PR TITLE
added support for rasterio geotiff tags

### DIFF
--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -322,11 +322,14 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None, loc
         attrs["units"] = riods.units
 
     # Parse extra metadata from tags, if supported
-    parsers = {"ENVI": _parse_envi}
+    parsers = {"ENVI": _parse_envi, "GTiff": lambda m: m}
 
     driver = riods.driver
     if driver in parsers:
-        meta = parsers[driver](riods.tags(ns=driver))
+        if driver == "GTiff":
+            meta = parsers[driver](riods.tags())
+        else:
+            meta = parsers[driver](riods.tags(ns=driver))
 
         for k, v in meta.items():
             # Add values as coordinates if they match the band count,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3923,6 +3923,12 @@ class TestRasterio:
                 assert isinstance(rioda.attrs["map_info"], str)
                 assert isinstance(rioda.attrs["samples"], str)
 
+    def test_geotiff_tags(self):
+        # Create a geotiff file with some tags
+        with create_tmp_geotiff() as (tmp_file, _):
+            with xr.open_rasterio(tmp_file) as rioda:
+                assert isinstance(rioda.attrs["AREA_OR_POINT"], str)
+
     def test_no_mftime(self):
         # rasterio can accept "filename" urguments that are actually urls,
         # including paths to remote files.


### PR DESCRIPTION
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`

GeoTIFF and TIFF include tags that are useful in geo-processing. In particular the `AREA_OR_POINT` tag is commonly used. Although GDAL corrects the geo-referencing it is important to know which scheme is being used. An example of when this is useful is when aligning digital elevation models (which can be geotiff) with a raster data source.