### PR TITLE
__slots__

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -31,6 +31,24 @@ Breaking changes
 - The ``inplace`` kwarg for public methods now raises an error, having been deprecated
   since v0.11.0.
   By `Maximilian Roos <https://github.com/max-sixty>`_ 
+- Most xarray objects now define ``__slots__``. This reduces overall RAM usage by ~22%
+  (not counting the underlying numpy buffers); on CPython 3.7/x64, a trivial DataArray
+  has gone down from 1.9kB to 1.5kB.
+
+  Caveats:
+
+  - Pickle streams produced by older versions of xarray can't be loaded using this
+    release, and vice versa.
+  - Any user code that was accessing the ``__dict__`` attribute of
+    xarray objects will break. The best practice to attach custom metadata to xarray
+    objects is to use the ``attrs`` dictionary.
+  - Any user code that defines custom subclasses of xarray classes must now explicitly
+    define ``__slots__`` itself. Subclasses that don't add any attributes must state so
+    by defining ``__slots__ = ()`` right after the class header.
+    Omitting ``__slots__`` will now cause a ``FutureWarning`` to be logged, and a hard
+    crash in a later release.
+
+  (:issue:`3250`) by `Guido Imperiale <https://github.com/crusaderky>`_.
 
 New functions/methods
 ~~~~~~~~~~~~~~~~~~~~~

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -695,6 +695,8 @@ def open_dataarray(
 
 
 class _MultiFileCloser:
+    __slots__ = ("file_objs",)
+
     def __init__(self, file_objs):
         self.file_objs = file_objs
 

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -68,12 +68,16 @@ def robust_getitem(array, key, catch=Exception, max_retries=6, initial_delay=500
 
 
 class BackendArray(NdimSizeLenMixin, indexing.ExplicitlyIndexed):
+    __slots__ = ()
+
     def __array__(self, dtype=None):
         key = indexing.BasicIndexer((slice(None),) * self.ndim)
         return np.asarray(self[key], dtype=dtype)
 
 
 class AbstractDataStore(Mapping):
+    __slots__ = ()
+
     def __iter__(self):
         return iter(self.variables)
 
@@ -165,6 +169,8 @@ class AbstractDataStore(Mapping):
 
 
 class ArrayWriter:
+    __slots__ = ("sources", "targets", "regions", "lock")
+
     def __init__(self, lock=None):
         self.sources = []
         self.targets = []
@@ -205,6 +211,8 @@ class ArrayWriter:
 
 
 class AbstractWritableDataStore(AbstractDataStore):
+    __slots__ = ()
+
     def encode(self, variables, attributes):
         """
         Encode the variables and attributes in this store
@@ -371,6 +379,8 @@ class AbstractWritableDataStore(AbstractDataStore):
 
 
 class WritableCFDataStore(AbstractWritableDataStore):
+    __slots__ = ()
+
     def encode(self, variables, attributes):
         # All NetCDF files get CF encoded by default, without this attempting
         # to write times, for example, would fail.

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -30,6 +30,8 @@ NETCDF4_PYTHON_LOCK = combine_locks([NETCDFC_LOCK, HDF5_LOCK])
 
 
 class BaseNetCDF4Array(BackendArray):
+    __slots__ = ("datastore", "dtype", "shape", "variable_name")
+
     def __init__(self, variable_name, datastore):
         self.datastore = datastore
         self.variable_name = variable_name
@@ -52,8 +54,13 @@ class BaseNetCDF4Array(BackendArray):
             if self.datastore.autoclose:
                 self.datastore.close(needs_lock=False)
 
+    def get_array(self, needs_lock=True):
+        raise NotImplementedError("Virtual Method")
+
 
 class NetCDF4ArrayWrapper(BaseNetCDF4Array):
+    __slots__ = ()
+
     def get_array(self, needs_lock=True):
         ds = self.datastore._acquire(needs_lock)
         variable = ds.variables[self.variable_name]
@@ -293,6 +300,17 @@ class NetCDF4DataStore(WritableCFDataStore):
 
     This store supports NetCDF3, NetCDF4 and OpenDAP datasets.
     """
+
+    __slots__ = (
+        "autoclose",
+        "format",
+        "is_remote",
+        "lock",
+        "_filename",
+        "_group",
+        "_manager",
+        "_mode",
+    )
 
     def __init__(
         self, manager, group=None, mode=None, lock=NETCDF4_PYTHON_LOCK, autoclose=False

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -29,6 +29,8 @@ def _encode_zarr_attr_value(value):
 
 
 class ZarrArrayWrapper(BackendArray):
+    __slots__ = ("datastore", "dtype", "shape", "variable_name")
+
     def __init__(self, variable_name, datastore):
         self.datastore = datastore
         self.variable_name = variable_name
@@ -230,6 +232,15 @@ def encode_zarr_variable(var, needs_copy=True, name=None):
 class ZarrStore(AbstractWritableDataStore):
     """Store for reading and writing data via zarr
     """
+
+    __slots__ = (
+        "append_dim",
+        "ds",
+        "_consolidate_on_close",
+        "_group",
+        "_read_only",
+        "_synchronizer",
+    )
 
     @classmethod
     def open_group(

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -31,6 +31,8 @@ class NativeEndiannessArray(indexing.ExplicitlyIndexedNDArrayMixin):
     dtype('int16')
     """
 
+    __slots__ = ("array",)
+
     def __init__(self, array):
         self.array = indexing.as_indexable(array)
 
@@ -59,6 +61,8 @@ class BoolTypeArray(indexing.ExplicitlyIndexedNDArrayMixin):
     >>> BoolTypeArray(x)[:].dtype
     dtype('bool')
     """
+
+    __slots__ = ("array",)
 
     def __init__(self, array):
         self.array = indexing.as_indexable(array)

--- a/xarray/core/accessor_str.py
+++ b/xarray/core/accessor_str.py
@@ -75,6 +75,8 @@ class StringAccessor:
 
     """
 
+    __slots__ = ("_obj",)
+
     def __init__(self, obj):
         self._obj = obj
 

--- a/xarray/core/arithmetic.py
+++ b/xarray/core/arithmetic.py
@@ -14,6 +14,8 @@ class SupportsArithmetic:
     Used by Dataset, DataArray, Variable and GroupBy.
     """
 
+    __slots__ = ()
+
     # TODO: implement special methods for arithmetic here rather than injecting
     # them in xarray/core/ops.py. Ideally, do so by inheriting from
     # numpy.lib.mixins.NDArrayOperatorsMixin.

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -203,7 +203,7 @@ class AttrAccessMixin:
             cls.__setattr__ = cls._setattr_dict
             warnings.warn(
                 "xarray subclass %s should explicitly define __slots__" % cls.__name__,
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=2,
             )
 
@@ -247,7 +247,7 @@ class AttrAccessMixin:
                 "to suppress this warning for legitimate custom attributes and "
                 "raise an error when attempting variables assignments."
                 % (name, type(self).__name__),
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=2,
             )
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -196,10 +196,11 @@ class AttrAccessMixin:
         This check is only triggered in Python 3.6+.
         """
         if not hasattr(object.__new__(cls), "__dict__"):
-            return
-        if cls.__module__.startswith("xarray."):
+            cls.__setattr__ = cls._setattr_slots
+        elif cls.__module__.startswith("xarray."):
             raise AttributeError("%s must explicitly define __slots__" % cls.__name__)
         else:
+            cls.__setattr__ = cls._setattr_dict
             warnings.warn(
                 "xarray subclass %s should explicitly define __slots__" % cls.__name__,
                 DeprecationWarning,
@@ -229,25 +230,32 @@ class AttrAccessMixin:
             "%r object has no attribute %r" % (type(self).__name__, name)
         )
 
-    def __setattr__(self, name: str, value: Any) -> None:
+    # This complicated three-method design boosts overall performance of simple
+    # operations - particularly DataArray methods that perform a _to_temp_dataset()
+    # round-trip - by a whopping 8% compared to a single method that checks
+    # hasattr(self, "__dict__") at runtime before every single assignment (like
+    # _setattr_py35 does). All of this is just temporary until the DeprecationWarning
+    # can be changed into a hard crash.
+    def _setattr_dict(self, name: str, value: Any) -> None:
+        """Deprecated third party subclass (see __init_subclass__ above)
+        """
+        object.__setattr__(self, name, value)
+        if name in self.__dict__:
+            # Custom, non-slotted attr, or improperly assigned variable?
+            warnings.warn(
+                "Setting attribute %r on a %r object. Explicitly define __slots__ "
+                "to suppress this warning for legitimate custom attributes and "
+                "raise an error when attempting variables assignments."
+                % (name, type(self).__name__),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+    def _setattr_slots(self, name: str, value: Any) -> None:
         """Objects with ``__slots__`` raise AttributeError if you try setting an
         undeclared attribute. This is desirable, but the error message could use some
         improvement.
         """
-        if hasattr(self, "__dict__"):
-            # Deprecated third party subclass (see __init_subclass__ above)
-            object.__setattr__(self, name, value)
-            if name in self.__dict__:
-                # Custom, non-slotted attr, or improperly assigned variable?
-                warnings.warn(
-                    "Setting attribute %r on a %r object. Explicitly define __slots__ "
-                    "to suppress this warning for legitimate custom attributes and "
-                    "raise an error when attempting variables assignments."
-                    % (name, type(self).__name__)
-                )
-            return
-
-        # Subclass defines __slots__
         try:
             object.__setattr__(self, name, value)
         except AttributeError as e:
@@ -260,6 +268,14 @@ class AttrAccessMixin:
                 "assignment (e.g., `ds['name'] = ...`) instead of assigning variables."
                 % (name, type(self).__name__)
             ) from e
+
+    def _setattr_py35(self, name: str, value: Any) -> None:
+        if hasattr(self, "__dict__"):
+            return self._setattr_dict(name, value)
+        return self._setattr_slots(name, value)
+
+    # Overridden in Python >=3.6 by __init_subclass__
+    __setattr__ = _setattr_py35
 
     def __dir__(self) -> List[str]:
         """Provide method name lookup and completion. Only provide 'public'

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -191,7 +191,7 @@ class AttrAccessMixin:
 
     def __init_subclass__(cls):
         """Verify that all subclasses explicitly define ``__slots__``. If they don't,
-        raise error in the core xarray module and a DeprecationWarning in third-party
+        raise error in the core xarray module and a FutureWarning in third-party
         extensions.
         This check is only triggered in Python 3.6+.
         """
@@ -234,10 +234,10 @@ class AttrAccessMixin:
     # operations - particularly DataArray methods that perform a _to_temp_dataset()
     # round-trip - by a whopping 8% compared to a single method that checks
     # hasattr(self, "__dict__") at runtime before every single assignment (like
-    # _setattr_py35 does). All of this is just temporary until the DeprecationWarning
-    # can be changed into a hard crash.
+    # _setattr_py35 does). All of this is just temporary until the FutureWarning can be
+    # changed into a hard crash.
     def _setattr_dict(self, name: str, value: Any) -> None:
-        """Deprecated third party subclass (see __init_subclass__ above)
+        """Deprecated third party subclass (see ``__init_subclass__`` above)
         """
         object.__setattr__(self, name, value)
         if name in self.__dict__:

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -35,6 +35,8 @@ T = TypeVar("T")
 
 
 class ImplementsArrayReduce:
+    __slots__ = ()
+
     @classmethod
     def _reduce_method(cls, func: Callable, include_skipna: bool, numeric_only: bool):
         if include_skipna:
@@ -72,6 +74,8 @@ class ImplementsArrayReduce:
 
 
 class ImplementsDatasetReduce:
+    __slots__ = ()
+
     @classmethod
     def _reduce_method(cls, func: Callable, include_skipna: bool, numeric_only: bool):
         if include_skipna:
@@ -180,7 +184,7 @@ class AttrAccessMixin:
     """Mixin class that allows getting keys with attribute access
     """
 
-    _initialized = False
+    __slots__ = ("_initialized",)
 
     @property
     def _attr_sources(self) -> List[Mapping[Hashable, Any]]:
@@ -195,6 +199,8 @@ class AttrAccessMixin:
         return []
 
     def __getattr__(self, name: str) -> Any:
+        if name == "_initialized":
+            return False
         if name != "__setstate__":
             # this avoids an infinite loop when pickle looks for the
             # __setstate__ attribute before the xarray object is initialized

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -51,6 +51,14 @@ class _UFuncSignature:
         Core dimension names on each output variable.
     """
 
+    __slots__ = (
+        "input_core_dims",
+        "output_core_dims",
+        "_all_input_core_dims",
+        "_all_output_core_dims",
+        "_all_core_dims",
+    )
+
     def __init__(self, input_core_dims, output_core_dims=((),)):
         self.input_core_dims = tuple(tuple(a) for a in input_core_dims)
         self.output_core_dims = tuple(tuple(a) for a in output_core_dims)

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -35,7 +35,7 @@ _THIS_ARRAY = ReprObject("<this-array>")
 
 
 class AbstractCoordinates(Mapping[Hashable, "DataArray"]):
-    __slots__ = ("_data",)
+    __slots__ = ()
 
     def __getitem__(self, key: Hashable) -> "DataArray":
         raise NotImplementedError()
@@ -187,6 +187,8 @@ class DatasetCoordinates(AbstractCoordinates):
     objects.
     """
 
+    __slots__ = ("_data",)
+
     def __init__(self, dataset: "Dataset"):
         self._data = dataset
 
@@ -256,6 +258,8 @@ class DataArrayCoordinates(AbstractCoordinates):
     dimensions and the values given by corresponding DataArray objects.
     """
 
+    __slots__ = ("_data",)
+
     def __init__(self, dataarray: "DataArray"):
         self._data = dataarray
 
@@ -309,6 +313,8 @@ class LevelCoordinatesSource(Mapping[Hashable, Any]):
     Used for attribute style lookup with AttrAccessMixin. Not returned directly
     by any public methods.
     """
+
+    __slots__ = ("_data",)
 
     def __init__(self, data_object: "Union[DataArray, Dataset]"):
         self._data = data_object

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -35,7 +35,7 @@ _THIS_ARRAY = ReprObject("<this-array>")
 
 
 class AbstractCoordinates(Mapping[Hashable, "DataArray"]):
-    _data = None  # type: Union["DataArray", "Dataset"]
+    __slots__ = ("_data",)
 
     def __getitem__(self, key: Hashable) -> "DataArray":
         raise NotImplementedError()
@@ -53,7 +53,7 @@ class AbstractCoordinates(Mapping[Hashable, "DataArray"]):
 
     @property
     def indexes(self) -> Indexes:
-        return self._data.indexes
+        return self._data.indexes  # type: ignore
 
     @property
     def variables(self):
@@ -108,9 +108,9 @@ class AbstractCoordinates(Mapping[Hashable, "DataArray"]):
             raise ValueError("no valid index for a 0-dimensional object")
         elif len(ordered_dims) == 1:
             (dim,) = ordered_dims
-            return self._data.get_index(dim)
+            return self._data.get_index(dim)  # type: ignore
         else:
-            indexes = [self._data.get_index(k) for k in ordered_dims]
+            indexes = [self._data.get_index(k) for k in ordered_dims]  # type: ignore
             names = list(ordered_dims)
             return pd.MultiIndex.from_product(indexes, names=names)
 
@@ -187,8 +187,6 @@ class DatasetCoordinates(AbstractCoordinates):
     objects.
     """
 
-    _data = None  # type: Dataset
-
     def __init__(self, dataset: "Dataset"):
         self._data = dataset
 
@@ -257,8 +255,6 @@ class DataArrayCoordinates(AbstractCoordinates):
     Essentially an OrderedDict with keys given by the array's
     dimensions and the values given by corresponding DataArray objects.
     """
-
-    _data = None  # type: DataArray
 
     def __init__(self, dataarray: "DataArray"):
         self._data = dataarray

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -159,6 +159,8 @@ def _infer_coords_and_dims(
 
 
 class _LocIndexer:
+    __slots__ = ("data_array",)
+
     def __init__(self, data_array: "DataArray"):
         self.data_array = data_array
 
@@ -222,6 +224,8 @@ class DataArray(AbstractArray, DataWithCoords):
     attrs : OrderedDict
         Dictionary for holding arbitrary metadata.
     """
+
+    __slots__ = ("_coords", "_file_obj", "_name", "_indexes", "_variable")
 
     _groupby_cls = groupby.DataArrayGroupBy
     _rolling_cls = rolling.DataArrayRolling

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -343,8 +343,6 @@ class DataArray(AbstractArray, DataWithCoords):
 
         self._file_obj = None
 
-        self._initialized = True  # type: bool
-
     def _replace(
         self,
         variable: Variable = None,

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -225,7 +225,7 @@ class DataArray(AbstractArray, DataWithCoords):
         Dictionary for holding arbitrary metadata.
     """
 
-    __slots__ = ("_coords", "_file_obj", "_name", "_indexes", "_variable")
+    __slots__ = ("_accessors", "_coords", "_file_obj", "_name", "_indexes", "_variable")
 
     _groupby_cls = groupby.DataArrayGroupBy
     _rolling_cls = rolling.DataArrayRolling
@@ -336,6 +336,7 @@ class DataArray(AbstractArray, DataWithCoords):
         assert isinstance(coords, OrderedDict)
         self._coords = coords  # type: OrderedDict[Any, Variable]
         self._name = name  # type: Optional[Hashable]
+        self._accessors = None  # type: Optional[Dict[str, Any]]
 
         # TODO(shoyer): document this argument, once it becomes part of the
         # public interface.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -513,7 +513,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             self._attrs = OrderedDict(attrs)
 
         self._encoding = None  # type: Optional[Dict]
-        self._initialized = True
 
     def _set_init_vars_and_dims(self, data_vars, coords, compat):
         """Set the initial value of Dataset variables and dimensions
@@ -852,7 +851,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         obj._attrs = attrs
         obj._file_obj = file_obj
         obj._encoding = encoding
-        obj._initialized = True
         return obj
 
     __default = object()

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -411,6 +411,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
     """
 
     __slots__ = (
+        "_accessors",
         "_attrs",
         "_coord_names",
         "_dims",
@@ -498,6 +499,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         self._variables = OrderedDict()  # type: OrderedDict[Any, Variable]
         self._coord_names = set()  # type: Set[Hashable]
         self._dims = {}  # type: Dict[Any, int]
+        self._accessors = None  # type: Optional[Dict[str, Any]]
         self._attrs = None  # type: Optional[OrderedDict]
         self._file_obj = None
         if data_vars is None:
@@ -851,6 +853,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         obj._attrs = attrs
         obj._file_obj = file_obj
         obj._encoding = encoding
+        obj._accessors = None
         return obj
 
     __default = object()
@@ -871,6 +874,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         attrs: "Optional[OrderedDict]" = __default,
         indexes: "Optional[OrderedDict[Any, pd.Index]]" = __default,
         encoding: Optional[dict] = __default,
+        accessors: Optional[Dict[str, Any]] = None,
         inplace: bool = False,
     ) -> "Dataset":
         """Fastpath constructor for internal use.
@@ -894,6 +898,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 self._indexes = indexes
             if encoding is not self.__default:
                 self._encoding = encoding
+            if accessors is not None:
+                self._accessors = accessors
             obj = self
         else:
             if variables is None:
@@ -908,8 +914,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 indexes = copy.copy(self._indexes)
             if encoding is self.__default:
                 encoding = copy.copy(self._encoding)
+            if accessors is None and self._accessors is not None:
+                accessors = self._accessors.copy()
             obj = self._construct_direct(
-                variables, coord_names, dims, attrs, indexes, encoding
+                variables, coord_names, dims, attrs, indexes, encoding, accessors
             )
         return obj
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -344,6 +344,8 @@ def as_dataset(obj: Any) -> "Dataset":
 
 
 class DataVariables(Mapping[Hashable, "DataArray"]):
+    __slots__ = ("_dataset",)
+
     def __init__(self, dataset: "Dataset"):
         self._dataset = dataset
 
@@ -383,6 +385,8 @@ class DataVariables(Mapping[Hashable, "DataArray"]):
 
 
 class _LocIndexer:
+    __slots__ = ("dataset",)
+
     def __init__(self, dataset: "Dataset"):
         self.dataset = dataset
 
@@ -405,6 +409,16 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
     One dimensional variables with name equal to their dimension are index
     coordinates used for label based indexing.
     """
+
+    __slots__ = (
+        "_attrs",
+        "_coord_names",
+        "_dims",
+        "_encoding",
+        "_file_obj",
+        "_indexes",
+        "_variables",
+    )
 
     _groupby_cls = groupby.DatasetGroupBy
     _rolling_cls = rolling.DatasetRolling

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -875,7 +875,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         attrs: "Optional[OrderedDict]" = __default,
         indexes: "Optional[OrderedDict[Any, pd.Index]]" = __default,
         encoding: Optional[dict] = __default,
-        accessors: Optional[Dict[str, Any]] = None,
         inplace: bool = False,
     ) -> "Dataset":
         """Fastpath constructor for internal use.
@@ -899,8 +898,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 self._indexes = indexes
             if encoding is not self.__default:
                 self._encoding = encoding
-            if accessors is not None:
-                self._accessors = accessors
             obj = self
         else:
             if variables is None:
@@ -915,10 +912,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 indexes = copy.copy(self._indexes)
             if encoding is self.__default:
                 encoding = copy.copy(self._encoding)
-            if accessors is None and self._accessors is not None:
-                accessors = self._accessors.copy()
             obj = self._construct_direct(
-                variables, coord_names, dims, attrs, indexes, encoding, accessors
+                variables, coord_names, dims, attrs, indexes, encoding
             )
         return obj
 

--- a/xarray/core/extensions.py
+++ b/xarray/core/extensions.py
@@ -19,6 +19,14 @@ class _CachedAccessor:
         if obj is None:
             # we're accessing the attribute of the class, i.e., Dataset.geo
             return self._accessor
+
+        try:
+            return obj._accessors[self._name]
+        except TypeError:
+            obj._accessors = {}
+        except KeyError:
+            pass
+
         try:
             accessor_obj = self._accessor(obj)
         except AttributeError:
@@ -26,11 +34,8 @@ class _CachedAccessor:
             # raised when initializing the accessor, so we need to raise as
             # something else (GH933):
             raise RuntimeError("error initializing %r accessor." % self._name)
-        # Replace the property with the accessor object. Inspired by:
-        # http://www.pydanny.com/cached-property.html
-        # We need to use object.__setattr__ because we overwrite __setattr__ on
-        # AttrAccessMixin.
-        object.__setattr__(obj, self._name, accessor_obj)
+
+        obj._accessors[self._name] = accessor_obj
         return accessor_obj
 
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -133,13 +133,24 @@ class _DummyGroup:
     Should not be user visible.
     """
 
+    __slots__ = ("name", "coords", "size")
+
     def __init__(self, obj, name, coords):
         self.name = name
         self.coords = coords
-        self.dims = (name,)
-        self.ndim = 1
         self.size = obj.sizes[name]
-        self.values = range(self.size)
+
+    @property
+    def dims(self):
+        return (self.name,)
+
+    @property
+    def ndim(self):
+        return 1
+
+    @property
+    def values(self):
+        return range(self.size)
 
 
 def _ensure_1d(group, obj):
@@ -209,6 +220,19 @@ class GroupBy(SupportsArithmetic):
     Dataset.groupby
     DataArray.groupby
     """
+
+    __slots__ = (
+        "_full_index",
+        "_inserted_dims",
+        "_group",
+        "_group_dim",
+        "_group_indices",
+        "_groups",
+        "_obj",
+        "_restore_coord_dims",
+        "_stacked_dim",
+        "_unique_coord",
+    )
 
     def __init__(
         self,

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -11,6 +11,8 @@ from .variable import Variable
 class Indexes(collections.abc.Mapping):
     """Immutable proxy for Dataset or DataArrary indexes."""
 
+    __slots__ = ("_indexes",)
+
     def __init__(self, indexes):
         """Not for public consumption.
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -327,6 +327,8 @@ class ExplicitIndexer:
     sub-classes BasicIndexer, OuterIndexer or VectorizedIndexer.
     """
 
+    __slots__ = ("_key",)
+
     def __init__(self, key):
         if type(self) is ExplicitIndexer:  # noqa
             raise TypeError("cannot instantiate base ExplicitIndexer objects")
@@ -359,6 +361,8 @@ class BasicIndexer(ExplicitIndexer):
     indexed with an integer are dropped from the result.
     """
 
+    __slots__ = ()
+
     def __init__(self, key):
         if not isinstance(key, tuple):
             raise TypeError("key must be a tuple: {!r}".format(key))
@@ -388,6 +392,8 @@ class OuterIndexer(ExplicitIndexer):
     axes indexed with an integer are dropped from the result. This type of
     indexing works like MATLAB/Fortran.
     """
+
+    __slots__ = ()
 
     def __init__(self, key):
         if not isinstance(key, tuple):
@@ -432,6 +438,8 @@ class VectorizedIndexer(ExplicitIndexer):
     https://github.com/numpy/numpy/pull/6256
     """
 
+    __slots__ = ()
+
     def __init__(self, key):
         if not isinstance(key, tuple):
             raise TypeError("key must be a tuple: {!r}".format(key))
@@ -468,10 +476,15 @@ class VectorizedIndexer(ExplicitIndexer):
 
 
 class ExplicitlyIndexed:
-    """Mixin to mark support for Indexer subclasses in indexing."""
+    """Mixin to mark support for Indexer subclasses in indexing.
+    """
+
+    __slots__ = ()
 
 
 class ExplicitlyIndexedNDArrayMixin(utils.NDArrayMixin, ExplicitlyIndexed):
+    __slots__ = ()
+
     def __array__(self, dtype=None):
         key = BasicIndexer((slice(None),) * self.ndim)
         return np.asarray(self[key], dtype=dtype)
@@ -479,6 +492,8 @@ class ExplicitlyIndexedNDArrayMixin(utils.NDArrayMixin, ExplicitlyIndexed):
 
 class ImplicitToExplicitIndexingAdapter(utils.NDArrayMixin):
     """Wrap an array, converting tuples into the indicated explicit indexer."""
+
+    __slots__ = ("array", "indexer_cls")
 
     def __init__(self, array, indexer_cls=BasicIndexer):
         self.array = as_indexable(array)
@@ -501,6 +516,8 @@ class ImplicitToExplicitIndexingAdapter(utils.NDArrayMixin):
 class LazilyOuterIndexedArray(ExplicitlyIndexedNDArrayMixin):
     """Wrap an array to make basic and outer indexing lazy.
     """
+
+    __slots__ = ("array", "key")
 
     def __init__(self, array, key=None):
         """
@@ -577,6 +594,8 @@ class LazilyVectorizedIndexedArray(ExplicitlyIndexedNDArrayMixin):
     """Wrap an array to make vectorized indexing lazy.
     """
 
+    __slots__ = ("array", "key")
+
     def __init__(self, array, key):
         """
         Parameters
@@ -631,6 +650,8 @@ def _wrap_numpy_scalars(array):
 
 
 class CopyOnWriteArray(ExplicitlyIndexedNDArrayMixin):
+    __slots__ = ("array", "_copied")
+
     def __init__(self, array):
         self.array = as_indexable(array)
         self._copied = False
@@ -655,6 +676,8 @@ class CopyOnWriteArray(ExplicitlyIndexedNDArrayMixin):
 
 
 class MemoryCachedArray(ExplicitlyIndexedNDArrayMixin):
+    __slots__ = ("array",)
+
     def __init__(self, array):
         self.array = _wrap_numpy_scalars(as_indexable(array))
 
@@ -792,6 +815,9 @@ class IndexingSupport:  # could inherit from enum.Enum on Python 3
     OUTER_1VECTOR = "OUTER_1VECTOR"
     # for backends that support full vectorized indexer.
     VECTORIZED = "VECTORIZED"
+
+    def __new__(cls, *args, **kwargs):
+        raise TypeError("Static class")
 
 
 def explicit_indexing_adapter(key, shape, indexing_support, raw_indexing_method):
@@ -1189,6 +1215,8 @@ def posify_mask_indexer(indexer):
 class NumpyIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
     """Wrap a NumPy array to use explicit indexing."""
 
+    __slots__ = ("array",)
+
     def __init__(self, array):
         # In NumpyIndexingAdapter we only allow to store bare np.ndarray
         if not isinstance(array, np.ndarray):
@@ -1239,6 +1267,8 @@ class NumpyIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
 
 
 class NdArrayLikeIndexingAdapter(NumpyIndexingAdapter):
+    __slots__ = ("array",)
+
     def __init__(self, array):
         if not hasattr(array, "__array_function__"):
             raise TypeError(
@@ -1250,6 +1280,8 @@ class NdArrayLikeIndexingAdapter(NumpyIndexingAdapter):
 
 class DaskIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
     """Wrap a dask array to support explicit indexing."""
+
+    __slots__ = ("array",)
 
     def __init__(self, array):
         """ This adapter is created in Variable.__getitem__ in
@@ -1291,6 +1323,8 @@ class DaskIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
 class PandasIndexAdapter(ExplicitlyIndexedNDArrayMixin):
     """Wrap a pandas.Index to preserve dtypes and handle explicit indexing.
     """
+
+    __slots__ = ("array", "_dtype")
 
     def __init__(self, array: Any, dtype: DTypeLike = None):
         self.array = utils.safe_cast_to_index(array)

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -43,7 +43,8 @@ class Rolling:
     DataArray.rolling
     """
 
-    _attributes = ["window", "min_periods", "center", "dim"]
+    __slots__ = ("obj", "window", "min_periods", "center", "dim")
+    _attributes = ("window", "min_periods", "center", "dim")
 
     def __init__(self, obj, windows, min_periods=None, center=False):
         """
@@ -93,16 +94,16 @@ class Rolling:
 
         # attributes
         self.window = window
+        if min_periods is not None and min_periods <= 0:
+            raise ValueError("min_periods must be greater than zero or None")
         self.min_periods = min_periods
-        if min_periods is None:
-            self._min_periods = window
-        else:
-            if min_periods <= 0:
-                raise ValueError("min_periods must be greater than zero or None")
 
-            self._min_periods = min_periods
         self.center = center
         self.dim = dim
+
+    @property
+    def _min_periods(self):
+        return self.min_periods if self.min_periods is not None else self.window
 
     def __repr__(self):
         """provide a nice str repr of our rolling object"""
@@ -152,6 +153,8 @@ class Rolling:
 
 
 class DataArrayRolling(Rolling):
+    __slots__ = ("window_labels",)
+
     def __init__(self, obj, windows, min_periods=None, center=False):
         """
         Moving window object for DataArray.
@@ -381,6 +384,8 @@ class DataArrayRolling(Rolling):
 
 
 class DatasetRolling(Rolling):
+    __slots__ = ("rollings",)
+
     def __init__(self, obj, windows, min_periods=None, center=False):
         """
         Moving window object for Dataset.
@@ -516,7 +521,8 @@ class Coarsen:
     DataArray.coarsen
     """
 
-    _attributes = ["windows", "side", "trim_excess"]
+    __slots__ = ("obj", "boundary", "coord_func", "windows", "side", "trim_excess")
+    _attributes = ("windows", "side", "trim_excess")
 
     def __init__(self, obj, windows, boundary, side, coord_func):
         """
@@ -569,6 +575,8 @@ class Coarsen:
 
 
 class DataArrayCoarsen(Coarsen):
+    __slots__ = ()
+
     @classmethod
     def _reduce_method(cls, func):
         """
@@ -599,6 +607,8 @@ class DataArrayCoarsen(Coarsen):
 
 
 class DatasetCoarsen(Coarsen):
+    __slots__ = ()
+
     @classmethod
     def _reduce_method(cls, func):
         """

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -514,6 +514,8 @@ class NDArrayMixin(NdimSizeLenMixin):
     `dtype`, `shape` and `__getitem__`.
     """
 
+    __slots__ = ()
+
     @property
     def dtype(self: Any) -> np.dtype:
         return self.array.dtype

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -381,7 +381,7 @@ class Frozen(Mapping[K, V]):
     saved under the `mapping` attribute.
     """
 
-    __slots__ = ["mapping"]
+    __slots__ = ("mapping",)
 
     def __init__(self, mapping: Mapping[K, V]):
         self.mapping = mapping
@@ -412,7 +412,7 @@ class SortedKeysDict(MutableMapping[K, V]):
     mapping.
     """
 
-    __slots__ = ["mapping"]
+    __slots__ = ("mapping",)
 
     def __init__(self, mapping: MutableMapping[K, V] = None):
         self.mapping = {} if mapping is None else mapping
@@ -445,6 +445,8 @@ class OrderedSet(MutableSet[T]):
     The API matches the builtin set, but it preserves insertion order of
     elements, like an OrderedDict.
     """
+
+    __slots__ = ("_ordered_dict",)
 
     def __init__(self, values: AbstractSet[T] = None):
         self._ordered_dict = OrderedDict()  # type: MutableMapping[T, None]
@@ -485,6 +487,8 @@ class NdimSizeLenMixin:
     """Mixin class that extends a class that defines a ``shape`` property to
     one that also defines ``ndim``, ``size`` and ``__len__``.
     """
+
+    __slots__ = ()
 
     @property
     def ndim(self: Any) -> int:
@@ -622,6 +626,8 @@ def ensure_us_time_resolution(val):
 class HiddenKeyDict(MutableMapping[K, V]):
     """Acts like a normal dictionary, but hides certain keys.
     """
+
+    __slots__ = ("_data", "_hidden_keys")
 
     # ``__init__`` method required to create instance from class.
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -3,7 +3,7 @@ import itertools
 from collections import OrderedDict, defaultdict
 from datetime import timedelta
 from distutils.version import LooseVersion
-from typing import Any, Hashable, Mapping, MutableMapping, Union
+from typing import Any, Hashable, Mapping, Union
 
 import numpy as np
 import pandas as pd
@@ -266,6 +266,8 @@ class Variable(
     form of a Dataset or DataArray should almost always be preferred, because
     they can use more complete metadata in context of coordinate labels.
     """
+
+    __slots__ = ("_dims", "_data", "_attrs", "_encoding")
 
     def __init__(self, dims, data, attrs=None, encoding=None, fastpath=False):
         """

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1933,6 +1933,8 @@ class IndexVariable(Variable):
     unless another name is given.
     """
 
+    __slots__ = ()
+
     def __init__(self, dims, data, attrs=None, encoding=None, fastpath=False):
         super().__init__(dims, data, attrs, encoding, fastpath)
         if self.ndim != 1:

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -67,7 +67,6 @@ class FacetGrid:
         Contains dictionaries mapping coordinate names to values. None is
         used as a sentinel value for axes which should remain empty, ie.
         sometimes the bottom right grid
-
     """
 
     def __init__(

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -452,6 +452,8 @@ class _PlotMethods:
     For example, DataArray.plot.imshow
     """
 
+    __slots__ = ("_da",)
+
     def __init__(self, darray):
         self._da = darray
 

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -198,8 +198,6 @@ def _assert_dataarray_invariants(da: DataArray):
     if da._indexes is not None:
         _assert_indexes_invariants_checks(da._indexes, da._coords, da.dims)
 
-    assert da._initialized is True
-
 
 def _assert_dataset_invariants(ds: Dataset):
     assert isinstance(ds._variables, OrderedDict), type(ds._variables)
@@ -236,7 +234,6 @@ def _assert_dataset_invariants(ds: Dataset):
 
     assert isinstance(ds._encoding, (type(None), dict))
     assert isinstance(ds._attrs, (type(None), OrderedDict))
-    assert ds._initialized is True
 
 
 def _assert_internal_invariants(xarray_obj: Union[DataArray, Dataset, Variable],):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4616,3 +4616,25 @@ def test_rolling_exp(da, dim, window_type, window):
     )
 
     assert_allclose(expected.variable, result.variable)
+
+
+def test_no_dict():
+    d = DataArray()
+    with pytest.raises(AttributeError):
+        d.__dict__
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_subclass_slots():
+    """Test that DataArray subclasses must explicitly define ``__slots__``.
+
+    .. note::
+       As of 0.13.0, this is actually mitigated into a FutureWarning for any class
+       defined outside of the xarray package.
+    """
+    with pytest.raises(AttributeError) as e:
+
+        class MyArray(DataArray):
+            pass
+
+    assert str(e.value) == "MyArray must explicitly define __slots__"

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5706,3 +5706,25 @@ def test_trapz_datetime(dask, which_datetime):
 
     actual2 = da.integrate("time", datetime_unit="h")
     assert_allclose(actual, actual2 / 24.0)
+
+
+def test_no_dict():
+    d = Dataset()
+    with pytest.raises(AttributeError):
+        d.__dict__
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
+def test_subclass_slots():
+    """Test that Dataset subclasses must explicitly define ``__slots__``.
+
+    .. note::
+       As of 0.13.0, this is actually mitigated into a FutureWarning for any class
+       defined outside of the xarray package.
+    """
+    with pytest.raises(AttributeError) as e:
+
+        class MyDS(Dataset):
+            pass
+
+    assert str(e.value) == "MyDS must explicitly define __slots__"


### PR DESCRIPTION
What changes:
- Most classes now define ``__slots__``
- removed ``_initialized`` property
- Enforced checks that all subclasses must also define ``__slots__``. For third-party subclasses, this is for now a DeprecationWarning and should be changed into a hard crash later on.
- 22% reduction in RAM usage
- 5% performance speedup for a DataArray method that performs a ``_to_temp_dataset`` roundtrip 

**DISCUSS:** support for third party subclasses is very poor at the moment (#1097). Should we skip the deprecation altogether?

Performance benchmark:
```python
import timeit
import psutil
import xarray

a = xarray.DataArray([1, 2], dims=['x'], coords={'x': [10, 20]})
RUNS = 10000
t = timeit.timeit("a.roll(x=1, roll_coords=True)", globals=globals(), number=RUNS)
print("{:.0f} us".format(t / RUNS * 1e6))

p = psutil.Process()
N = 100000
rss0 = p.memory_info().rss
x = [
    xarray.DataArray([1, 2], dims=['x'], coords={'x': [10, 20]})
    for _ in range(N)
]
rss1 = p.memory_info().rss
print("{:.0f} bytes".format((rss1 - rss0) / N))
```
Output:

| test          | env | master     | slots      |
|:-------------:|:---:|:----------:| ----------:|
| DataArray.roll | py35-min | 332 us     | 360 us     |
|  DataArray.roll | py37 | 354 us     | 337 us     |
| RAM usage of a DataArray | py35-min     | 2755 bytes | 2074 bytes |
| RAM usage of a DataArray | py37     | 1970 bytes | 1532 bytes |

The performance degradation on Python 3.5 is caused by the deprecation mechanism - see changes to common.py.

I honestly never realised that xarray objects are measured in kilobytes (vs. 32 bytes of underlying buffers!)

