### PR TITLE
Updater to testing environment name

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -152,10 +152,10 @@ We'll now kick off a two-step process:
 
    # Create and activate the build environment
    conda env create -f ci/requirements/py36.yml
-   conda activate test_env
+   conda activate xarray-tests
 
    # or with older versions of Anaconda:
-   source activate test_env
+   source activate xarray-tests
 
    # Build and install xarray
    pip install -e .


### PR DESCRIPTION
The testing environment name has been updated to `xarray-tests` in the package and we should do this in the documentation as well.

