### PR TITLE
Amend documentation to clean up temporary files/directories in examples

### DIFF
--- a/doc/dask.rst
+++ b/doc/dask.rst
@@ -132,6 +132,13 @@ A dataset can also be converted to a Dask DataFrame using :py:meth:`~xarray.Data
 
 Dask DataFrames do not support multi-indexes so the coordinate variables from the dataset are included as columns in the Dask DataFrame.
 
+.. ipython:: python
+    :suppress:
+
+    import os
+    os.remove('example-data.nc')
+    os.remove('manipulated-example-data.nc')
+
 Using Dask with xarray
 ----------------------
 
@@ -372,12 +379,6 @@ A good rule of thumb is to create arrays with a minimum chunksize of at least
 one million elements (e.g., a 1000x1000 matrix). With large arrays (10+ GB), the
 cost of queueing up Dask operations can be noticeable, and you may need even
 larger chunksizes.
-
-.. ipython:: python
-    :suppress:
-
-    import os
-    os.remove('example-data.nc')
 
 Optimization Tips
 -----------------

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -718,6 +718,13 @@ be done directly from zarr, as described in the
 
 .. _io.cfgrib:
 
+.. ipython:: python
+   :suppress:
+
+    import shutil
+    shutil.rmtree('foo.zarr')
+    shutil.rmtree('path/to/directory.zarr')
+
 GRIB format via cfgrib
 ----------------------
 

--- a/doc/weather-climate.rst
+++ b/doc/weather-climate.rst
@@ -137,6 +137,12 @@ For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
    da.to_netcdf('example-no-leap.nc')
    xr.open_dataset('example-no-leap.nc')
 
+.. ipython:: python
+    :suppress:
+
+    import os
+    os.remove('example-no-leap.nc')
+
 - And resampling along the time dimension for data indexed by a :py:class:`~xarray.CFTimeIndex`:
 
 .. ipython:: python

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -109,6 +109,10 @@ Documentation
   or pushing new commits.
   By `Gregory Gundersen <https://github.com/gwgundersen>`_.
 
+- Fixed documentation to clean up unwanted files created in ``ipython`` examples
+  (:issue:`3227`).
+  By `Gregory Gundersen <https://github.com/gwgundersen/>`_.
+
 v0.12.3 (10 July 2019)
 ----------------------
 


### PR DESCRIPTION
 - [x] Closes #3227.
 - [x] No CI tests added, but I ran `make clean` and `make html` to confirm the temporary files are no longer permanently created.
 - [x] No need to pass `black . && mypy . && flake8`.
 - [x] Fully documented in `whats-new.rst`.
