### PR TITLE
Raise proper error for scalar array when coords is a dict

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -113,6 +113,11 @@ def _infer_coords_and_dims(
                 coord = as_variable(coord, name=dims[n]).to_index_variable()
                 dims[n] = coord.name
         dims = tuple(dims)
+    elif len(dims) != len(shape):
+        raise ValueError(
+            "different number of dimensions on data "
+            "and dims: %s vs %s" % (len(shape), len(dims))
+        )
     else:
         for d in dims:
             if not isinstance(d, str):
@@ -123,8 +128,6 @@ def _infer_coords_and_dims(
     if utils.is_dict_like(coords):
         for k, v in coords.items():
             new_coords[k] = as_variable(v, name=k)
-        if shape == () and dims != ():
-            shape = (0,)
     elif coords is not None:
         for dim, coord in zip(dims, coords):
             var = as_variable(coord, name=dim)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -123,6 +123,8 @@ def _infer_coords_and_dims(
     if utils.is_dict_like(coords):
         for k, v in coords.items():
             new_coords[k] = as_variable(v, name=k)
+        if shape == () and dims != ():
+            shape = (0,)
     elif coords is not None:
         for dim, coord in zip(dims, coords):
             var = as_variable(coord, name=dim)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1468,7 +1468,7 @@ class TestDataArray:
         actual = DataArray(coords=[("x", np.arange(10)), ("y", ["a", "b"])])
         assert_identical(expected, actual)
 
-        with pytest.raises(KeyError):
+        with raises_regex(ValueError, "length 0 on the data"):
             DataArray(np.array(1), coords={"x": np.arange(10)}, dims=["x"])
         with raises_regex(ValueError, "does not match the 0 dim"):
             DataArray(np.array(1), coords=[("x", np.arange(10))])

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1468,7 +1468,7 @@ class TestDataArray:
         actual = DataArray(coords=[("x", np.arange(10)), ("y", ["a", "b"])])
         assert_identical(expected, actual)
 
-        with raises_regex(ValueError, "length 0 on the data"):
+        with raises_regex(ValueError, "different number of dim"):
             DataArray(np.array(1), coords={"x": np.arange(10)}, dims=["x"])
         with raises_regex(ValueError, "does not match the 0 dim"):
             DataArray(np.array(1), coords=[("x", np.arange(10))])


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
As explained here https://github.com/pydata/xarray/pull/3159#discussion_r316230281 , when a user uses a scalar array to build a `DataArray` with `coords` given as a dictionary the error is not self explanatory.
```python
>>> xr.DataArray(np.array(1), coords={'x': np.arange(4), 'y': 'a'}, dims=['x'])
...
KeyError: 'x'
```

This PR makes sure that when `data` is a scalar array and `dims` is not empty, it sets the shape to `(0,)` to make it fail with the proper raise message 

```python
>>> xr.DataArray(np.array(1), coords={'x': np.arange(4), 'y': 'a'}, dims=['x'])
...
ValueError: conflicting sizes for dimension 'x': length 0 on the data but length 4 on coordinate 'x'
```

 - [x] Test updated
 - [x] Passes `black . && mypy . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API (is this needed for a change like this?)
