### PR TITLE
Don't set box-forced in Cartopy example.

### DIFF
--- a/doc/gallery/plot_cartopy_facetgrid.py
+++ b/doc/gallery/plot_cartopy_facetgrid.py
@@ -41,6 +41,6 @@ for ax in p.axes.flat:
     ax.set_extent([-160, -30, 5, 75])
     # Without this aspect attributes the maps will look chaotic and the
     # "extent" attribute above will be ignored
-    ax.set_aspect("equal", "box-forced")
+    ax.set_aspect("equal")
 
 plt.show()


### PR DESCRIPTION
It is deprecated in Matplotlib 2.2, removed in 3.1, and appears to have no effect on the result.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #3219
 - [N/A] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [N/A] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
