### PR TITLE
Add hypothesis test for netCDF4 roundtrip

### DIFF
--- a/properties/README.md
+++ b/properties/README.md
@@ -8,6 +8,8 @@ They are stored in a separate directory because they tend to run more examples
 and thus take longer, and so that local development can run a test suite
 without needing to `pip install hypothesis`.
 
+To run these tests, run `pytest` in this directory.
+
 ## Hang on, "property-based" tests?
 
 Instead of making assertions about operations on a particular piece of

--- a/properties/test_netcdf_roundtrip.py
+++ b/properties/test_netcdf_roundtrip.py
@@ -14,34 +14,36 @@ settings.load_profile("ci")
 
 an_array = npst.arrays(
     dtype=st.one_of(
-        npst.unsigned_integer_dtypes(), npst.integer_dtypes(),
+        npst.unsigned_integer_dtypes(),
+        npst.integer_dtypes(),
         # NetCDF does not support float16
         # https://www.unidata.ucar.edu/software/netcdf/docs/data_type.html
-        npst.floating_dtypes(sizes=(32, 64))
+        npst.floating_dtypes(sizes=(32, 64)),
     ),
     shape=npst.array_shapes(max_side=3),  # max_side specified for performance
 )
 
 compatible_names = st.text(
     alphabet=st.characters(
-        whitelist_categories=('Ll', 'Lu', 'Nd'),
+        whitelist_categories=("Ll", "Lu", "Nd"),
         # It looks like netCDF should allow unicode names, but removing
         # this causes a failure with 'ά'
-        max_codepoint=255
+        max_codepoint=255,
     ),
-    min_size=1
+    min_size=1,
 )
+
 
 @given(st.data(), an_array)
 def test_netcdf_roundtrip(tmp_path, data, arr):
     names = data.draw(
-        st.lists(compatible_names, min_size=arr.ndim, max_size=arr.ndim, unique=True).map(
-            tuple
-        )
+        st.lists(
+            compatible_names, min_size=arr.ndim, max_size=arr.ndim, unique=True
+        ).map(tuple)
     )
     var = xr.Variable(names, arr)
-    original = xr.Dataset({'data': var})
-    original.to_netcdf(tmp_path / 'test.nc')
+    original = xr.Dataset({"data": var})
+    original.to_netcdf(tmp_path / "test.nc")
 
-    roundtripped = xr.open_dataset(tmp_path / 'test.nc')
+    roundtripped = xr.open_dataset(tmp_path / "test.nc")
     xr.testing.assert_identical(original, roundtripped)

--- a/properties/test_netcdf_roundtrip.py
+++ b/properties/test_netcdf_roundtrip.py
@@ -1,0 +1,47 @@
+"""
+Property-based tests for round-tripping data to netCDF
+"""
+import hypothesis.extra.numpy as npst
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
+import xarray as xr
+
+# Run for a while - arrays are a bigger search space than usual
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")
+
+
+an_array = npst.arrays(
+    dtype=st.one_of(
+        npst.unsigned_integer_dtypes(), npst.integer_dtypes(),
+        # NetCDF does not support float16
+        # https://www.unidata.ucar.edu/software/netcdf/docs/data_type.html
+        npst.floating_dtypes(sizes=(32, 64))
+    ),
+    shape=npst.array_shapes(max_side=3),  # max_side specified for performance
+)
+
+compatible_names = st.text(
+    alphabet=st.characters(
+        whitelist_categories=('Ll', 'Lu', 'Nd'),
+        # It looks like netCDF should allow unicode names, but removing
+        # this causes a failure with 'ά'
+        max_codepoint=255
+    ),
+    min_size=1
+)
+
+@given(st.data(), an_array)
+def test_netcdf_roundtrip(tmp_path, data, arr):
+    names = data.draw(
+        st.lists(compatible_names, min_size=arr.ndim, max_size=arr.ndim, unique=True).map(
+            tuple
+        )
+    )
+    var = xr.Variable(names, arr)
+    original = xr.Dataset({'data': var})
+    original.to_netcdf(tmp_path / 'test.nc')
+
+    roundtripped = xr.open_dataset(tmp_path / 'test.nc')
+    xr.testing.assert_identical(original, roundtripped)


### PR DESCRIPTION
Part of #1846: add a property-based test for reading & writing netCDF4 files.

This is the first time I've played with Hypothesis, but it seems to be working - e.g. I got an error with float16, and the [netCDF docs show](https://www.unidata.ucar.edu/software/netcdf/docs/data_type.html) that 16-bit floats are not a supported data type.

However:

- This currently only tests a dataset with a single variable - it could be extended to multiple variables if that's useful.
- It [looks like](https://www.unidata.ucar.edu/software/netcdf/docs/netcdf_data_set_components.html#Permitted) netCDF4 should support unicode characters, but it failed when I didn't have `max_codepoint=255` in there. I don't know if that's an expected limitation I'm not aware of, or a bug somewhere. But I thought I'd make the test pass for now.

