### PR TITLE
Hypothesis tests for roundtrip to & from pandas

### DIFF
--- a/properties/conftest.py
+++ b/properties/conftest.py
@@ -1,0 +1,5 @@
+from hypothesis import settings
+
+# Run for a while - arrays are a bigger search space than usual
+settings.register_profile("ci", deadline=None)
+settings.load_profile("ci")

--- a/properties/test_encode_decode.py
+++ b/properties/test_encode_decode.py
@@ -6,14 +6,9 @@ These ones pass, just as you'd hope!
 """
 import hypothesis.extra.numpy as npst
 import hypothesis.strategies as st
-from hypothesis import given, settings
+from hypothesis import given
 
 import xarray as xr
-
-# Run for a while - arrays are a bigger search space than usual
-settings.register_profile("ci", deadline=None)
-settings.load_profile("ci")
-
 
 an_array = npst.arrays(
     dtype=st.one_of(

--- a/properties/test_pandas_roundtrip.py
+++ b/properties/test_pandas_roundtrip.py
@@ -29,7 +29,7 @@ def datasets_1d_vars(draw):
     Suitable for converting to pandas dataframes.
     """
     n_vars = draw(st.integers(min_value=1, max_value=3))
-    n_entries = draw(st.integers(min_value=1, max_value=100))
+    n_entries = draw(st.integers(min_value=0, max_value=100))
     dims = ("rows",)
     vars = {}
     for _ in range(n_vars):

--- a/properties/test_pandas_roundtrip.py
+++ b/properties/test_pandas_roundtrip.py
@@ -33,7 +33,7 @@ def datasets_1d_vars(draw):
     dims = ("rows",)
     vars = {}
     for _ in range(n_vars):
-        name = draw(st.text(min_size=1))
+        name = draw(st.text(min_size=0))
         dt = draw(numeric_dtypes)
         arr = draw(npst.arrays(dtype=dt, shape=(n_entries,)))
         vars[name] = xr.Variable(dims, arr)

--- a/properties/test_pandas_roundtrip.py
+++ b/properties/test_pandas_roundtrip.py
@@ -34,10 +34,26 @@ def test_roundtrip_dataarray(data, arr):
     roundtripped = xr.DataArray(original.to_pandas())
     xr.testing.assert_identical(original, roundtripped)
 
+
 @given(numeric_series, st.text())
-def test_roundtrip_pandas_series(ser, name):
+def test_roundtrip_pandas_series(ser, ix_name):
     # Need to name the index, otherwise Xarray calls it 'dim_0'.
-    ser.index.name = name
+    ser.index.name = ix_name
     arr = xr.DataArray(ser)
     roundtripped = arr.to_pandas()
     pd.testing.assert_series_equal(ser, roundtripped)
+
+
+numeric_homogeneous_dataframe = numeric_dtypes.flatmap(
+    lambda dt: pdst.data_frames(columns=pdst.columns(["a", "b", "c"], dtype=dt))
+)
+
+
+@given(numeric_homogeneous_dataframe)
+def test_roundtrip_pandas_dataframe(df):
+    # Need to name the indexes, otherwise Xarray names them 'dim_0', 'dim_1'.
+    df.index.name = "rows"
+    df.columns.name = "cols"
+    arr = xr.DataArray(df)
+    roundtripped = arr.to_pandas()
+    pd.testing.assert_frame_equal(df, roundtripped)

--- a/properties/test_pandas_roundtrip.py
+++ b/properties/test_pandas_roundtrip.py
@@ -1,0 +1,29 @@
+"""
+Property-based tests for roundtripping between xarray and pandas objects.
+"""
+import hypothesis.extra.numpy as npst
+import hypothesis.strategies as st
+from hypothesis import given
+
+import numpy as np
+import xarray as xr
+
+an_array = npst.arrays(
+    dtype=st.one_of(
+        npst.unsigned_integer_dtypes(), npst.integer_dtypes(), npst.floating_dtypes()
+    ),
+    shape=npst.array_shapes(max_dims=2),  # can only convert 1D/2D to pandas
+)
+
+
+@given(st.data(), an_array)
+def test_roundtrip_dataarray(data, arr):
+    names = data.draw(
+        st.lists(st.text(), min_size=arr.ndim, max_size=arr.ndim, unique=True).map(
+            tuple
+        )
+    )
+    coords = {name: np.arange(n) for (name, n) in zip(names, arr.shape)}
+    original = xr.DataArray(arr, dims=names, coords=coords)
+    roundtripped = xr.DataArray(original.to_pandas())
+    xr.testing.assert_identical(original, roundtripped)


### PR DESCRIPTION
Part of #1846: test roundtripping between xarray DataArray & Dataset and pandas Series & DataFrame.

I haven't particularly tried to hunt down corner cases (e.g. dataframes with 0 columns), in favour of adding tests that currently pass. But these tests probably form a useful platform if you do want to ensure corner cases like that behave nicely - just modify the limits and see what fails.