### PR TITLE
Remove deprecated concat kwargs.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,7 +30,10 @@ Breaking changes
   By `Maximilian Roos <https://github.com/max-sixty>`_ 
 - The ``inplace`` kwarg for public methods now raises an error, having been deprecated
   since v0.11.0.
-  By `Maximilian Roos <https://github.com/max-sixty>`_ 
+  By `Maximilian Roos <https://github.com/max-sixty>`_
+- :py:func:`~xarray.concat` now requires the ``dim`` argument. Its ``indexers``, ``mode``
+  and ``concat_over`` kwargs have now been removed.
+  By `Deepak Cherian <https://github.com/dcherian>`_
 - Most xarray objects now define ``__slots__``. This reduces overall RAM usage by ~22%
   (not counting the underlying numpy buffers); on CPython 3.7/x64, a trivial DataArray
   has gone down from 1.9kB to 1.5kB.

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -1,4 +1,3 @@
-import warnings
 from collections import OrderedDict
 
 import pandas as pd
@@ -11,14 +10,11 @@ from .variable import concat as concat_vars
 
 def concat(
     objs,
-    dim=None,
+    dim,
     data_vars="all",
     coords="different",
     compat="equals",
     positions=None,
-    indexers=None,
-    mode=None,
-    concat_over=None,
     fill_value=dtypes.NA,
     join="outer",
 ):
@@ -110,38 +106,6 @@ def concat(
         first_obj, objs = utils.peek_at(objs)
     except StopIteration:
         raise ValueError("must supply at least one object to concatenate")
-
-    if dim is None:
-        warnings.warn(
-            "the `dim` argument to `concat` will be required "
-            "in a future version of xarray; for now, setting it to "
-            "the old default of 'concat_dim'",
-            FutureWarning,
-            stacklevel=2,
-        )
-        dim = "concat_dims"
-
-    if indexers is not None:  # pragma: no cover
-        warnings.warn(
-            "indexers has been renamed to positions; the alias "
-            "will be removed in a future version of xarray",
-            FutureWarning,
-            stacklevel=2,
-        )
-        positions = indexers
-
-    if mode is not None:
-        raise ValueError(
-            "`mode` is no longer a valid argument to "
-            "xarray.concat; it has been split into the "
-            "`data_vars` and `coords` arguments"
-        )
-    if concat_over is not None:
-        raise ValueError(
-            "`concat_over` is no longer a valid argument to "
-            "xarray.concat; it has been split into the "
-            "`data_vars` and `coords` arguments"
-        )
 
     if isinstance(first_obj, DataArray):
         f = _dataarray_concat

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -163,11 +163,6 @@ class TestConcatDataset:
         with raises_regex(ValueError, "coordinate in some datasets but not others"):
             concat([Dataset({"x": 0}), Dataset({}, {"x": 1})], dim="z")
 
-        with raises_regex(ValueError, "no longer a valid"):
-            concat([data, data], "new_dim", mode="different")
-        with raises_regex(ValueError, "no longer a valid"):
-            concat([data, data], "new_dim", concat_over="different")
-
     def test_concat_join_kwarg(self):
         ds1 = Dataset({"a": (("x", "y"), [[0]])}, coords={"x": [0], "y": [0]})
         ds2 = Dataset({"a": (("x", "y"), [[0]])}, coords={"x": [1], "y": [0.0001]})


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
