### PR TITLE
ignore h5py 2.10.0 warnings and fix invalid_netcdf warning test.

### DIFF
--- a/doc/computation.rst
+++ b/doc/computation.rst
@@ -94,7 +94,8 @@ for filling missing values via 1D interpolation.
 
 Note that xarray slightly diverges from the pandas ``interpolate`` syntax by
 providing the ``use_coordinate`` keyword which facilitates a clear specification
-of which values to use as the index in the interpolation.
+of which values to use as the index in the interpolation. xarray also provides the ``maxgap`` keyword argument to limit the interpolation to data gaps of length ``maxgap`` or smaller. See
+:py:meth:`~xarray.DataArray.interpolate_na` for more.
 
 Aggregation
 ===========

--- a/doc/computation.rst
+++ b/doc/computation.rst
@@ -94,8 +94,7 @@ for filling missing values via 1D interpolation.
 
 Note that xarray slightly diverges from the pandas ``interpolate`` syntax by
 providing the ``use_coordinate`` keyword which facilitates a clear specification
-of which values to use as the index in the interpolation. xarray also provides the ``maxgap`` keyword argument to limit the interpolation to data gaps of length ``maxgap`` or smaller. See
-:py:meth:`~xarray.DataArray.interpolate_na` for more.
+of which values to use as the index in the interpolation.
 
 Aggregation
 ===========

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2172,7 +2172,6 @@ class TestH5NetCDFData(NetCDF4Base):
         with create_tmp_file() as tmp_file:
             yield backends.H5NetCDFStore(tmp_file, "w")
 
-    # TODO: Reduce num_warns by 1 when h5netcdf is updated to not issue the make_scale warning
     @pytest.mark.filterwarnings("ignore:complex dtypes are supported by h5py")
     @pytest.mark.parametrize(
         "invalid_netcdf, warntype, num_warns",

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2175,7 +2175,7 @@ class TestH5NetCDFData(NetCDF4Base):
     # TODO: Reduce num_warns by 1 when h5netcdf is updated to not issue the make_scale warning
     @pytest.mark.filterwarnings("ignore:complex dtypes are supported by h5py")
     @pytest.mark.parametrize(
-        "invalid_netcdf, warns, num_warns",
+        "invalid_netcdf, warntype, num_warns",
         [(None, FutureWarning, 1), (False, FutureWarning, 1), (True, None, 0)],
     )
     def test_complex(self, invalid_netcdf, warntype, num_warns):
@@ -2188,7 +2188,9 @@ class TestH5NetCDFData(NetCDF4Base):
         recorded_num_warns = 0
         if warntype:
             for warning in record:
-                if issubclass(warning.category, warntype):
+                if issubclass(warning.category, warntype) and (
+                    "complex dtypes" in str(warning.message)
+                ):
                     recorded_num_warns += 1
 
         assert recorded_num_warns == num_warns

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2163,6 +2163,7 @@ class TestGenericNetCDFData(CFEncodedBase, NetCDF3Only):
 
 @requires_h5netcdf
 @requires_netCDF4
+@pytest.mark.filterwarnings("ignore:use make_scale(name) instead")
 class TestH5NetCDFData(NetCDF4Base):
     engine = "h5netcdf"
 
@@ -2171,10 +2172,11 @@ class TestH5NetCDFData(NetCDF4Base):
         with create_tmp_file() as tmp_file:
             yield backends.H5NetCDFStore(tmp_file, "w")
 
+    # TODO: Reduce num_warns by 1 when h5netcdf is updated to not issue the make_scale warning
     @pytest.mark.filterwarnings("ignore:complex dtypes are supported by h5py")
     @pytest.mark.parametrize(
         "invalid_netcdf, warns, num_warns",
-        [(None, FutureWarning, 1), (False, FutureWarning, 1), (True, None, 0)],
+        [(None, FutureWarning, 2), (False, FutureWarning, 2), (True, None, 1)],
     )
     def test_complex(self, invalid_netcdf, warns, num_warns):
         expected = Dataset({"x": ("y", np.ones(5) + 1j * np.ones(5))})
@@ -2451,6 +2453,7 @@ def skip_if_not_engine(engine):
 
 
 @requires_dask
+@pytest.mark.filterwarnings("ignore:use make_scale(name) instead")
 def test_open_mfdataset_manyfiles(
     readengine, nfiles, parallel, chunks, file_cache_maxsize
 ):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2176,15 +2176,22 @@ class TestH5NetCDFData(NetCDF4Base):
     @pytest.mark.filterwarnings("ignore:complex dtypes are supported by h5py")
     @pytest.mark.parametrize(
         "invalid_netcdf, warns, num_warns",
-        [(None, FutureWarning, 2), (False, FutureWarning, 2), (True, None, 1)],
+        [(None, FutureWarning, 1), (False, FutureWarning, 1), (True, None, 0)],
     )
-    def test_complex(self, invalid_netcdf, warns, num_warns):
+    def test_complex(self, invalid_netcdf, warntype, num_warns):
         expected = Dataset({"x": ("y", np.ones(5) + 1j * np.ones(5))})
         save_kwargs = {"invalid_netcdf": invalid_netcdf}
-        with pytest.warns(warns) as record:
+        with pytest.warns(warntype) as record:
             with self.roundtrip(expected, save_kwargs=save_kwargs) as actual:
                 assert_equal(expected, actual)
-        assert len(record) == num_warns
+
+        recorded_num_warns = 0
+        if warntype:
+            for warning in record:
+                if issubclass(warning.category, warntype):
+                    recorded_num_warns += 1
+
+        assert recorded_num_warns == num_warns
 
     def test_cross_engine_read_write_netcdf4(self):
         # Drop dim3, because its labels include strings. These appear to be


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #3300 
 - [x] Passes `black . && mypy . && flake8`

Just increased expected number of warnings by 1 till `h5netcdf` is fixed to not throw a warning (xref https://github.com/shoyer/h5netcdf/issues/62)
