### PR TITLE
Fix DataArray api doc

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -282,9 +282,9 @@ Indexing
    DataArray.loc
    DataArray.isel
    DataArray.sel
-   Dataset.head
-   Dataset.tail
-   Dataset.thin
+   DataArray.head
+   DataArray.tail
+   DataArray.thin
    DataArray.squeeze
    DataArray.interp
    DataArray.interp_like


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
Seems like I forgot to point `head`, `tail` and `thin` to the right direction in the `DataArray` api documentation