### PR TITLE
move auto_combine deprecation to 0.14

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -915,7 +915,7 @@ def open_mfdataset(
             # Remove this after deprecation cycle from #2616 is complete
             basic_msg = dedent(
                 """\
-            In xarray version 0.13 the default behaviour of `open_mfdataset`
+            In xarray version 0.14 the default behaviour of `open_mfdataset`
             will change. To retain the existing behavior, pass
             combine='nested'. To use future default behavior, pass
             combine='by_coords'. See

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -716,7 +716,7 @@ def auto_combine(
     if not from_openmfds:
         basic_msg = dedent(
             """\
-        In xarray version 0.13 `auto_combine` will be deprecated. See
+        In xarray version 0.14 `auto_combine` will be deprecated. See
         http://xarray.pydata.org/en/stable/combining.html#combining-multi"""
         )
         warnings.warn(basic_msg, FutureWarning, stacklevel=2)
@@ -758,7 +758,7 @@ def auto_combine(
         message += dedent(
             """\
         The datasets supplied require both concatenation and merging. From
-        xarray version 0.13 this will operation will require either using the
+        xarray version 0.14 this will operation will require either using the
         new `combine_nested` function (or the `combine='nested'` option to
         open_mfdataset), with a nested list structure such that you can combine
         along the dimensions {}. Alternatively if your datasets have global

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -714,7 +714,7 @@ class TestCombineAuto:
 
 
 @pytest.mark.filterwarnings(
-    "ignore:In xarray version 0.13 `auto_combine` " "will be deprecated"
+    "ignore:In xarray version 0.14 `auto_combine` " "will be deprecated"
 )
 @pytest.mark.filterwarnings("ignore:Also `open_mfdataset` will no longer")
 @pytest.mark.filterwarnings("ignore:The datasets supplied")


### PR DESCRIPTION
- [x] Closes #3280

This undoes the `auto_combine` deprecation until we figure out the best way to proceed.

(I am not very familiar with `auto_combine` so someone else should look over this. The tests all pass though...)