### PR TITLE
Fix isel performance regression

### DIFF
--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -125,3 +125,16 @@ class IndexingDask(Indexing):
         requires_dask()
         super().setup(key)
         self.ds = self.ds.chunk({"x": 100, "y": 50, "t": 50})
+
+
+class BooleanIndexing:
+    # https://github.com/pydata/xarray/issues/2227
+    def setup(self):
+        self.ds = xr.Dataset(
+            {"a": ("time", np.arange(10_000_000))},
+            coords={"time": np.arange(10_000_000)},
+        )
+        self.time_filter = self.ds.time > 50_000
+
+    def time_indexing(self):
+        self.ds.isel(time=self.time_filter)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2364,7 +2364,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             kwargs = {}
         coords = either_dict_or_kwargs(coords, coords_kwargs, "interp")
         indexers = OrderedDict(
-            (k, v.to_index_variable() if v.ndim == 1 else v)
+            (k, v.to_index_variable() if isinstance(v, Variable) and v.ndim == 1 else v)
             for k, v in self._validate_indexers(coords)
         )
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1780,7 +1780,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             elif isinstance(v, Dataset):
                 raise TypeError("cannot use a Dataset as an indexer")
             elif isinstance(v, Sequence) and len(v) == 0:
-                v = IndexVariable((k,), np.zeros((0,), dtype="int64"))
+                v = Variable((k,), np.zeros((0,), dtype="int64"))
             else:
                 v = np.asarray(v)
 
@@ -1794,15 +1794,12 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 if v.ndim == 0:
                     v = Variable((), v)
                 elif v.ndim == 1:
-                    v = IndexVariable((k,), v)
+                    v = Variable((k,), v)
                 else:
                     raise IndexError(
                         "Unlabeled multi-dimensional array cannot be "
                         "used for indexing: {}".format(k)
                     )
-
-            if v.ndim == 1:
-                v = v.to_index_variable()
 
             indexers_list.append((k, v))
 
@@ -2366,7 +2363,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         if kwargs is None:
             kwargs = {}
         coords = either_dict_or_kwargs(coords, coords_kwargs, "interp")
-        indexers = OrderedDict(self._validate_indexers(coords))
+        indexers = OrderedDict(
+            (k, v.to_index_variable() if v.ndim == 1 else v)
+            for k, v in self._validate_indexers(coords)
+        )
 
         obj = self if assume_sorted else self.sortby([k for k in coords])
 


### PR DESCRIPTION
xref #2227

Before:
    indexing.BooleanIndexing.time_indexing      898±0ms

After
    indexing.BooleanIndexing.time_indexing      401±0ms

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `black . && mypy . && flake8`
