### PR TITLE
Fix DataArray.to_netcdf type annotation

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2227,7 +2227,7 @@ class DataArray(AbstractArray, DataWithCoords):
         isnull = pd.isnull(values)
         return np.ma.MaskedArray(data=values, mask=isnull, copy=copy)
 
-    def to_netcdf(self, *args, **kwargs) -> Optional["Delayed"]:
+    def to_netcdf(self, *args, **kwargs) -> Union[bytes, "Delayed", None]:
         """Write DataArray contents to a netCDF file.
 
         All parameters are passed directly to `xarray.Dataset.to_netcdf`.


### PR DESCRIPTION
It calls DataSet.to_netcdf, which returns Union[bytes, "Delayed", None].  So this should as well.