### PR TITLE
Improve the documentation of swap_dims

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,6 +25,10 @@ Bug fixes
   objects remain unaddressable by weakref in order to save memory.
   (:issue:`3317`) by `Guido Imperiale <https://github.com/crusaderky>`_.
 
+Documentation
+~~~~~~~~~~~~~
+- Add examples for :py:meth:`Dataset.swap_dims` and :py:meth:`DataArray.swap_dims`.
+  By `Justus Magin <https://github.com/keewis>`_.
 
 .. _whats-new.0.13.0:
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1453,8 +1453,25 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Returns
         -------
-        swapped : Dataset
+        swapped : DataArray
             DataArray with swapped dimensions.
+
+        Examples
+        --------
+        >>> arr = xr.DataArray(data=[0, 1], dims="x",
+                               coords={"x": ["a", "b"], "y": ("x", [0, 1])})
+        >>> arr
+        <xarray.DataArray (x: 2)>
+        array([0, 1])
+        Coordinates:
+          * x        (x) <U1 'a' 'b'
+            y        (x) int64 0 1
+        >>> arr.swap_dims({"x": "y"})
+        <xarray.DataArray (x2: 2)>
+        array([0, 1])
+        Coordinates:
+            x        (x2) <U1 'a' 'b'
+          * y        (x2) int64 0 1
 
         See Also
         --------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1467,11 +1467,11 @@ class DataArray(AbstractArray, DataWithCoords):
           * x        (x) <U1 'a' 'b'
             y        (x) int64 0 1
         >>> arr.swap_dims({"x": "y"})
-        <xarray.DataArray (x2: 2)>
+        <xarray.DataArray (y: 2)>
         array([0, 1])
         Coordinates:
-            x        (x2) <U1 'a' 'b'
-          * y        (x2) int64 0 1
+            x        (y) <U1 'a' 'b'
+          * y        (y) int64 0 1
 
         See Also
         --------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2702,7 +2702,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             a        (y) int64 5 7
             b        (y) float64 0.1 2.4
 
-
         See Also
         --------
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2679,6 +2679,30 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         swapped : Dataset
             Dataset with swapped dimensions.
 
+        Examples
+        --------
+        >>> ds = xr.Dataset(data_vars={"a": ("x", [5, 7]), "b": ("x", [0.1, 2.4])},
+                            coords={"x": ["a", "b"], "y": ("x", [0, 1])})
+        >>> ds
+        <xarray.Dataset>
+        Dimensions:  (x: 2)
+        Coordinates:
+          * x        (x) <U1 'a' 'b'
+            y        (x) int64 0 1
+        Data variables:
+            a        (x) int64 5 7
+            b        (x) float64 0.1 2.4
+        >>> ds.swap_dims({"x": "y"})
+        <xarray.Dataset>
+        Dimensions:  (y: 2)
+        Coordinates:
+            x        (y) <U1 'a' 'b'
+          * y        (y) int64 0 1
+        Data variables:
+            a        (y) int64 5 7
+            b        (y) float64 0.1 2.4
+
+
         See Also
         --------
 


### PR DESCRIPTION
This adds examples to both `Dataset.swap_dims` and `DataArray.swap_dims` (and fixes an oversight on my part in #3329).

From #2838, it seems that there was the intention to rename it, but as far as I can tell, that decision is not official yet (and `Dataset` even got its own new `rename_dims`).

 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
