### PR TITLE
More doc fixes

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -8,7 +8,7 @@ This page provides an auto-generated summary of xarray's API. For more details
 and examples, refer to the relevant chapters in the main part of the
 documentation.
 
-See also: :ref:`public api`_.
+See also: :ref:`public api`
 
 Top-level functions
 ===================

--- a/doc/reshaping.rst
+++ b/doc/reshaping.rst
@@ -156,6 +156,7 @@ represented by a :py:class:`pandas.MultiIndex` object. These methods are used
 like this:
 
 .. ipython:: python
+
         data = xr.Dataset(
             data_vars={'a': (('x', 'y'), [[0, 1, 2], [3, 4, 5]]),
                       'b': ('x', [6, 7])},

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2558,10 +2558,12 @@ class DataArray(AbstractArray, DataWithCoords):
         >>> d = DataArray([[1, 2], [3, 4]])
 
         For convenience just call this directly
+
         >>> d.plot()
 
         Or use it as a namespace to use xarray.plot functions as
         DataArray methods
+
         >>> d.plot.imshow()  # equivalent to xarray.plot.imshow(d)
 
         """


### PR DESCRIPTION
While going through the docs, I noticed several issues:
* in `reshaping.rst`, a code block gets hidden because of a missing newline
* in `api.rst`, the section `What parts of xarray are considered public API?` is referenced (I think), but the link is broken.
* the code samples in `DataArray.plot` are not recognized as such because of missing newlines
* the documentation of `Dataset.plot.scatter` in the API reference is broken

This PR tries to fix all of those, but while the first three issues are easy to fix, I'm not sure whether my proposed fix for the one involving `scatter` is correct: I've added `plot.dataset_plot.scatter` to `plot.__all__` (exposing `xr.plot.scatter`) and changed `api.rst` to reference `plot.scatter` instead of `Dataset.plot.scatter`. It seems harmless to me, but the information that `scatter` only exists for `Dataset` is less visible. Is that the way to fix this?

 - [x] Passes `black . && mypy . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
