### PR TITLE
Add hypothesis support to related projects

### DIFF
--- a/doc/related-projects.rst
+++ b/doc/related-projects.rst
@@ -11,7 +11,7 @@ Geosciences
 ~~~~~~~~~~~
 
 - `aospy <https://aospy.readthedocs.io>`_: Automated analysis and management of gridded climate data.
-- `climpred <https://climpred.readthedocs.io>`_: Analysis of ensemble forecast models for climate prediction. 
+- `climpred <https://climpred.readthedocs.io>`_: Analysis of ensemble forecast models for climate prediction.
 - `infinite-diff <https://github.com/spencerahill/infinite-diff>`_: xarray-based finite-differencing, focused on gridded climate/meterology data
 - `marc_analysis <https://github.com/darothen/marc_analysis>`_: Analysis package for CESM/MARC experiments and output.
 - `MetPy <https://unidata.github.io/MetPy/dev/index.html>`_: A collection of tools in Python for reading, visualizing, and performing calculations with weather data.
@@ -26,7 +26,7 @@ Geosciences
   subclass.
 - `Regionmask <https://regionmask.readthedocs.io/>`_: plotting and creation of masks of spatial regions
 - `salem <https://salem.readthedocs.io>`_: Adds geolocalised subsetting, masking, and plotting operations to xarray's data structures via accessors.
-- `SatPy <https://satpy.readthedocs.io/>`_ : Library for reading and manipulating meteorological remote sensing data and writing it to various image and data file formats. 
+- `SatPy <https://satpy.readthedocs.io/>`_ : Library for reading and manipulating meteorological remote sensing data and writing it to various image and data file formats.
 - `Spyfit <https://spyfit.readthedocs.io/en/master/>`_: FTIR spectroscopy of the atmosphere
 - `windspharm <https://ajdawson.github.io/windspharm/index.html>`_: Spherical
   harmonic wind analysis in Python.
@@ -62,6 +62,7 @@ Extend xarray capabilities
 - `X-regression <https://github.com/kuchaale/X-regression>`_: Multiple linear regression from Statsmodels library coupled with Xarray library.
 - `xskillscore <https://github.com/raybellwaves/xskillscore>`_: Metrics for verifying forecasts.
 - `xyzpy <http://xyzpy.readthedocs.io>`_: Easily generate high dimensional data, including parallelization.
+- `hypothesis-gufunc <https://pypi.org/project/hypothesis-gufunc/0.0.5rc2>`_: Extension to hypothesis, to unit test functions with xarray objects as input.
 
 Visualization
 ~~~~~~~~~~~~~

--- a/doc/related-projects.rst
+++ b/doc/related-projects.rst
@@ -56,7 +56,7 @@ Extend xarray capabilities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 - `Collocate <https://github.com/cistools/collocate>`_: Collocate xarray trajectories in arbitrary physical dimensions
 - `eofs <https://ajdawson.github.io/eofs/>`_: EOF analysis in Python.
-- `hypothesis-gufunc <https://pypi.org/project/hypothesis-gufunc/0.0.5rc2>`_: Extension to hypothesis, to unit test functions with xarray objects as input.
+- `hypothesis-gufunc <https://hypothesis-gufunc.readthedocs.io/en/latest/>`_: Extension to hypothesis. Makes it easy to write unit tests with xarray objects as input.
 - `xarray_extras <https://github.com/crusaderky/xarray_extras>`_: Advanced algorithms for xarray objects (e.g. integrations/interpolations).
 - `xrft <https://github.com/rabernat/xrft>`_: Fourier transforms for xarray data.
 - `xr-scipy <https://xr-scipy.readthedocs.io>`_: A lightweight scipy wrapper for xarray.

--- a/doc/related-projects.rst
+++ b/doc/related-projects.rst
@@ -56,13 +56,13 @@ Extend xarray capabilities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 - `Collocate <https://github.com/cistools/collocate>`_: Collocate xarray trajectories in arbitrary physical dimensions
 - `eofs <https://ajdawson.github.io/eofs/>`_: EOF analysis in Python.
+- `hypothesis-gufunc <https://pypi.org/project/hypothesis-gufunc/0.0.5rc2>`_: Extension to hypothesis, to unit test functions with xarray objects as input.
 - `xarray_extras <https://github.com/crusaderky/xarray_extras>`_: Advanced algorithms for xarray objects (e.g. integrations/interpolations).
 - `xrft <https://github.com/rabernat/xrft>`_: Fourier transforms for xarray data.
 - `xr-scipy <https://xr-scipy.readthedocs.io>`_: A lightweight scipy wrapper for xarray.
 - `X-regression <https://github.com/kuchaale/X-regression>`_: Multiple linear regression from Statsmodels library coupled with Xarray library.
 - `xskillscore <https://github.com/raybellwaves/xskillscore>`_: Metrics for verifying forecasts.
 - `xyzpy <http://xyzpy.readthedocs.io>`_: Easily generate high dimensional data, including parallelization.
-- `hypothesis-gufunc <https://pypi.org/project/hypothesis-gufunc/0.0.5rc2>`_: Extension to hypothesis, to unit test functions with xarray objects as input.
 
 Visualization
 ~~~~~~~~~~~~~


### PR DESCRIPTION
The [hypothesis-gufunc](https://pypi.org/project/hypothesis-gufunc/0.0.5rc2/) project recently added hypothesis strategies for generating xarray data structures in version 0.0.5rc2. This links to it in the related projects page.  It currently uses xarray as a package extra and must be installed as
```
pip install hypothesis-gufunc[xarray]==0.0.5rc2
```
The documentation is [here](https://hypothesis-gufunc.readthedocs.io/en/latest/).

 - [x] Closes #3289
