### PR TITLE
Provide better error message when dimension name matches argument

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1999,7 +1999,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         Dataset.isel
         DataArray.sel
         """
-        indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "sel")
+        func_args = set(locals().keys())
+        dims = set(self.dims)
+        indexers = either_dict_or_kwargs(
+            indexers, indexers_kwargs, "sel", func_args=func_args, dims=dims
+        )
         pos_indexers, new_indexes = remap_label_indexers(
             self, indexers=indexers, method=method, tolerance=tolerance
         )

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -249,7 +249,16 @@ def either_dict_or_kwargs(
     pos_kwargs: Optional[Mapping[Hashable, T]],
     kw_kwargs: Mapping[str, T],
     func_name: str,
+    func_args: Any = None,
+    dims: Any = None,
 ) -> Mapping[Hashable, T]:
+    if func_args is not None:
+        inter = func_args.intersection(dims)
+        if inter:
+            raise ValueError(
+                "the dimension name '%s' matches an argument "
+                "to .%s" % (inter.pop(), func_name)
+            )
     if pos_kwargs is not None:
         if not is_dict_like(pos_kwargs):
             raise ValueError(


### PR DESCRIPTION
WIP PR for https://github.com/pydata/xarray/issues/3324. Since `either_dict_or_kwargs` is called 57 times, I don't want to modify every function call without a preliminary review. My main question is if using `locals()` at the top of each function is considered acceptable. Of course, if `locals()` is called _after_ some local variables are created, this code could raise an error when no conflict exists. But explicitly passing in the function argument names in all 57 functions seems brittle. I'd appreciate any thoughts on the PR before I modify all the functions and write some tests.