### PR TITLE
Remove `complex.nc` from built docs

### DIFF
--- a/doc/io.rst
+++ b/doc/io.rst
@@ -516,6 +516,11 @@ and currently raises a warning unless ``invalid_netcdf=True`` is set:
     # Reading it back
     xr.open_dataarray("complex.nc", engine="h5netcdf")
 
+.. ipython:: python
+    :suppress:
+
+    import os
+    os.remove('complex.nc')
 
 .. warning::
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,6 +33,10 @@ Documentation
 - Add examples for :py:meth:`Dataset.swap_dims` and :py:meth:`DataArray.swap_dims`.
   By `Justus Magin <https://github.com/keewis>`_.
 
+- Fixed documentation to clean up an unwanted file created in ``ipython`` example
+  (:pull:`3353`).
+  By `Gregory Gundersen <https://github.com/gwgundersen/>`_.
+
 .. _whats-new.0.13.0:
 
 v0.13.0 (17 Sep 2019)


### PR DESCRIPTION
I assume this is related to https://github.com/pydata/xarray/issues/3297 or an associated issue. Basically, a file, `complex.nc`, is being added to `doc/` after running `make clean && make html`. Would be nice to suppress this.
