### PR TITLE
Fix concat bug when concatenating unlabeled dimensions.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,6 +27,8 @@ Bug fixes
 - Line plots with the ``x`` or ``y`` argument set to a 1D non-dimensional coord
   now plot the correct data for 2D DataArrays.
   (:issue:`3334`). By `Tom Nicholas <http://github.com/TomNicholas>`_.
+- Fix error in concatenating unlabeled dimensions (:pull:`3362`).
+  By `Deepak Cherian <https://github.com/dcherian/>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -177,8 +177,6 @@ def _calc_concat_over(datasets, dim, dim_names, data_vars, coords, compat):
             if dim not in ds.dims:
                 if dim in ds:
                     ds = ds.set_coords(dim)
-                else:
-                    raise ValueError("%r is not present in all datasets" % dim)
         concat_over.update(k for k, v in ds.variables.items() if dim in v.dims)
         concat_dim_lengths.append(ds.dims.get(dim, 1))
 

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -756,7 +756,7 @@ class TestAutoCombineOldAPI:
             auto_combine(objs)
 
         objs = [Dataset({"x": [0], "y": [0]}), Dataset({"x": [0]})]
-        with raises_regex(ValueError, "'y' is not present in all datasets"):
+        with raises_regex(KeyError, "'y'"):
             auto_combine(objs)
 
     def test_auto_combine_previously_failed(self):

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -756,7 +756,7 @@ class TestAutoCombineOldAPI:
             auto_combine(objs)
 
         objs = [Dataset({"x": [0], "y": [0]}), Dataset({"x": [0]})]
-        with raises_regex(KeyError, "'y'"):
+        with raises_regex(ValueError, "'y' is not present in all datasets"):
             auto_combine(objs)
 
     def test_auto_combine_previously_failed(self):

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -41,6 +41,9 @@ def test_concat_compat():
     for var in ["has_x", "no_x_y"]:
         assert "y" not in result[var]
 
+    with raises_regex(ValueError, "One or more of the specified variables"):
+        concat([ds1, ds2], dim="q")
+
 
 class TestConcatDataset:
     @pytest.fixture

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -41,8 +41,10 @@ def test_concat_compat():
     for var in ["has_x", "no_x_y"]:
         assert "y" not in result[var]
 
-    with raises_regex(ValueError, "One or more of the specified variables"):
+    with raises_regex(ValueError, "coordinates in some datasets but not others"):
         concat([ds1, ds2], dim="q")
+    with raises_regex(ValueError, "'q' is not present in all datasets"):
+        concat([ds2, ds1], dim="q")
 
 
 class TestConcatDataset:

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -41,9 +41,6 @@ def test_concat_compat():
     for var in ["has_x", "no_x_y"]:
         assert "y" not in result[var]
 
-    with raises_regex(ValueError, "'q' is not present in all datasets"):
-        concat([ds1, ds2], dim="q", data_vars="all", compat="broadcast_equals")
-
 
 class TestConcatDataset:
     @pytest.fixture
@@ -89,7 +86,11 @@ class TestConcatDataset:
             assert_equal(data["extra"], actual["extra"])
 
     def test_concat(self, data):
-        split_data = [data.isel(dim1=slice(3)), data.isel(dim1=slice(3, None))]
+        split_data = [
+            data.isel(dim1=slice(3)),
+            data.isel(dim1=3),
+            data.isel(dim1=slice(4, None)),
+        ]
         assert_identical(data, concat(split_data, "dim1"))
 
     def test_concat_dim_precedence(self, data):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This fixes the following behaviour. (downstream issue https://github.com/xgcm/xgcm/issues/154)

```
def test_concat(self, data):
        split_data = [
            data.isel(dim1=slice(3)),
            data.isel(dim1=3), # this wouldn't work on master
            data.isel(dim1=slice(4, None)),
        ]
        assert_identical(data, concat(split_data, "dim1"))
```