### PR TITLE
Remove setting of universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[wheel]
-universal = 1
-
 [tool:pytest]
 python_files=test_*.py
 testpaths=xarray/tests properties


### PR DESCRIPTION
Universal wheels indicate that one wheel supports Python 2 and 3. This
is no longer the case for xarray. This causes builds to generate files
with names like xarray-0.13.0-py2.py3-none-any.whl, which can cause
pip to incorrectly install the wheel on Python 2 when installing from a list of
wheel files.
