### PR TITLE
Fixes to the resample docs

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -18,6 +18,13 @@ What's New
 v0.14.1 (unreleased)
 --------------------
 
+Documentation
+~~~~~~~~~~~~~
+
+- Fix the documentation of :py:meth:`DataArray.resample` and
+  :py:meth:`Dataset.resample` and explicitly state that a
+  datetime-like dimension is required. (:pull:`3400`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 .. _whats-new.0.14.0:
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -988,15 +988,15 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         Coordinates:
           * time     (time) datetime64[ns] 1999-12-15 1999-12-16 ... 2000-11-15
 
-        References
-        ----------
-
-        .. [1] http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
-
         See Also
         --------
         pandas.Series.resample
         pandas.DataFrame.resample
+
+        References
+        ----------
+
+        .. [1] http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
         """
         # TODO support non-string indexer after removing the old API.
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -914,8 +914,10 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
     ):
         """Returns a Resample object for performing resampling operations.
 
-        Handles both downsampling and upsampling. If any intervals contain no
-        values from the original object, they will be given the value ``NaN``.
+        Handles both downsampling and upsampling. The resampled
+        dimension must be a datetime-like coordinate. If any intervals
+        contain no values from the original object, they will be given
+        the value ``NaN``.
 
         Parameters
         ----------

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -991,7 +991,12 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         References
         ----------
 
-        .. [1] https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
+        .. [1] http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
+
+        See Also
+        --------
+        pandas.Series.resample
+        pandas.DataFrame.resample
         """
         # TODO support non-string indexer after removing the old API.
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -988,7 +988,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         References
         ----------
 
-        .. [1] http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
+        .. [1] https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
         """
         # TODO support non-string indexer after removing the old API.
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -920,7 +920,8 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         Parameters
         ----------
         indexer : {dim: freq}, optional
-            Mapping from the dimension name to resample frequency.
+            Mapping from the dimension name to resample frequency. The
+            dimension must be datetime-like.
         skipna : bool, optional
             Whether to skip missing values when aggregating in downsampling.
         closed : 'left' or 'right', optional

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -978,6 +978,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
           * time     (time) datetime64[ns] 1999-12-15 1999-12-16 1999-12-17 ...
 
         Limit scope of upsampling method
+
         >>> da.resample(time='1D').nearest(tolerance='1D')
         <xarray.DataArray (time: 337)>
         array([ 0.,  0., nan, ..., nan, 11., 11.])


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

The docs of `resample` fail to mention that resampling only works with datetime-like coords: the only part where one could get this from is the examples (the pandas docs are much more explicit). I'm not sure whether it would be good to also point this out in the function description. Thoughts?