### PR TITLE
Update where docstring to make return value type more clear

### DIFF
--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1069,7 +1069,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         Returns
         -------
-        Same type as caller.
+        Same xarray type as caller. Xarray.values returned as float64.
 
         Examples
         --------

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1069,7 +1069,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         Returns
         -------
-        Same xarray type as caller. Xarray.values returned as float64.
+        Same xarray type as caller, with dtype float64.
 
         Examples
         --------


### PR DESCRIPTION
The where docstring was a little confusing to me.  I misunderstood "Same type as caller' to mean the values in the xarray not the xarray itself.  I think this small change will clean it up for most users.  Thanks.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #3390
 - [x] Passes `black . && mypy . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
