### PR TITLE
Restore crashing CI tests on pseudonetcdf-3.1

### DIFF
--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -29,7 +29,7 @@ dependencies:
   - pandas
   - pint
   - pip
-  - pseudonetcdf
+  - pseudonetcdf<3.1  # FIXME https://github.com/pydata/xarray/issues/3409
   - pydap
   - pynio
   - pytest

--- a/ci/requirements/py37-windows.yml
+++ b/ci/requirements/py37-windows.yml
@@ -29,7 +29,7 @@ dependencies:
   - pandas
   - pint
   - pip
-  - pseudonetcdf
+  - pseudonetcdf<3.1  # FIXME https://github.com/pydata/xarray/issues/3409
   - pydap
   # - pynio  # Not available on Windows
   - pytest

--- a/ci/requirements/py37.yml
+++ b/ci/requirements/py37.yml
@@ -29,7 +29,7 @@ dependencies:
   - pandas
   - pint
   - pip
-  - pseudonetcdf
+  - pseudonetcdf<3.1  # FIXME https://github.com/pydata/xarray/issues/3409
   - pydap
   - pynio
   - pytest


### PR DESCRIPTION
Related to #3409 

The crashes caused by pseudonetcdf-3.1 are blocking all PRs.
Sorry I don't know anything about pseudonetcdf. This PR takes the issue out of the critical path so that whoever knows about the library can deal with it in due time.