### PR TITLE
Address multiplication DeprecationWarning in rasterio backend

### DIFF
--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -257,8 +257,8 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None, loc
         if parse:
             nx, ny = riods.width, riods.height
             # xarray coordinates are pixel centered
-            x, _ = (np.arange(nx) + 0.5, np.zeros(nx) + 0.5) * riods.transform
-            _, y = (np.zeros(ny) + 0.5, np.arange(ny) + 0.5) * riods.transform
+            x, _ = riods.transform * (np.arange(nx) + 0.5, np.zeros(nx) + 0.5)
+            _, y = riods.transform * (np.zeros(ny) + 0.5, np.arange(ny) + 0.5)
             coords["y"] = y
             coords["x"] = x
     else:


### PR DESCRIPTION
Very minor change to address this DeprecationWarning:

```
xarray\backends\rasterio_.py:260: DeprecationWarning: Right multiplication will be prohibited in version 3.0
    x, _ = (np.arange(nx) + 0.5, np.zeros(nx) + 0.5) * riods.transform
```