### PR TITLE
Use cftime master for upstream-dev build

### DIFF
--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -25,8 +25,7 @@ steps:
         git+https://github.com/dask/dask \
         git+https://github.com/dask/distributed \
         git+https://github.com/zarr-developers/zarr \
-        git+https://github.com/Unidata/cftime.git@refs/pull/127/merge
-        # git+https://github.com/Unidata/cftime  # FIXME PR 127 not merged yet
+        git+https://github.com/Unidata/cftime
   condition: eq(variables['UPSTREAM_DEV'], 'true')
   displayName: Install upstream dev dependencies
 


### PR DESCRIPTION
Follow-up on #3436, needed now that https://github.com/Unidata/cftime/pull/127 has been merged.