### PR TITLE
Escaping dtypes

### DIFF
--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -96,7 +96,7 @@ def summarize_variable(name, var, is_index=False, dtype=None, preview=None):
     cssclass_idx = " class='xr-has-index'" if is_index else ""
     dims_str = f"({', '.join(escape(dim) for dim in var.dims)})"
     name = escape(name)
-    dtype = dtype or var.dtype
+    dtype = dtype or escape(str(var.dtype))
 
     # "unique" ids required to expand/collapse subsections
     attrs_id = "attrs-" + str(uuid.uuid4())

--- a/xarray/tests/test_formatting_html.py
+++ b/xarray/tests/test_formatting_html.py
@@ -130,3 +130,5 @@ def test_repr_of_dataset(dataset):
     assert (
         formatted.count("class='xr-section-summary-in' type='checkbox'  checked>") == 3
     )
+    assert '&lt;U4' in formatted
+    assert '&lt;IA&gt;' in formatted

--- a/xarray/tests/test_formatting_html.py
+++ b/xarray/tests/test_formatting_html.py
@@ -130,5 +130,5 @@ def test_repr_of_dataset(dataset):
     assert (
         formatted.count("class='xr-section-summary-in' type='checkbox'  checked>") == 3
     )
-    assert '&lt;U4' in formatted
-    assert '&lt;IA&gt;' in formatted
+    assert "&lt;U4" in formatted
+    assert "&lt;IA&gt;" in formatted


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Follow-on to https://github.com/pydata/xarray/pull/3425 to make html_repr work with dtypes like '<U5'