### PR TITLE
Remove outdated code related to compatibility with netcdftime

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,7 +21,7 @@ v0.14.1 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-- Minimum cftime version is now 1.0.3. `Deepak Cherian <https://github.com/dcherian>`_.
+- Minimum cftime version is now 1.0.3. By `Deepak Cherian <https://github.com/dcherian>`_.
 - All support for netcdftime, the module in older versions of netCDF4 that
   eventually became the cftime package, has been removed.  By `Spencer Clark
   <https://github.com/spencerkclark>`_. 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,7 +21,10 @@ v0.14.1 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-- Minimum cftime version is now 1.0.3. By `Deepak Cherian <https://github.com/dcherian>`_.
+- Minimum cftime version is now 1.0.3. `Deepak Cherian <https://github.com/dcherian>`_.
+- All support for netcdftime, the module in older versions of netCDF4 that
+  eventually became the cftime package, has been removed.  By `Spencer Clark
+  <https://github.com/spencerkclark>`_. 
 
 New Features
 ~~~~~~~~~~~~

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -78,10 +78,6 @@ has_scipy_or_netCDF4 = has_scipy or has_netCDF4
 requires_scipy_or_netCDF4 = pytest.mark.skipif(
     not has_scipy_or_netCDF4, reason="requires scipy or netCDF4"
 )
-has_cftime_or_netCDF4 = has_cftime or has_netCDF4
-requires_cftime_or_netCDF4 = pytest.mark.skipif(
-    not has_cftime_or_netCDF4, reason="requires cftime or netCDF4"
-)
 try:
     import_seaborn()
     has_seaborn = True

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -7,10 +7,8 @@ import xarray as xr
 from . import (
     assert_array_equal,
     assert_equal,
-    has_cftime,
-    has_cftime_or_netCDF4,
-    has_dask,
     raises_regex,
+    requires_cftime,
     requires_dask,
 )
 
@@ -199,7 +197,7 @@ def times_3d(times):
     )
 
 
-@pytest.mark.skipif(not has_cftime, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize(
     "field", ["year", "month", "day", "hour", "dayofyear", "dayofweek"]
 )
@@ -217,7 +215,7 @@ def test_field_access(data, field):
     assert_equal(result, expected)
 
 
-@pytest.mark.skipif(not has_cftime, reason="cftime not installed")
+@requires_cftime
 def test_cftime_strftime_access(data):
     """ compare cftime formatting against datetime formatting """
     date_format = "%Y%m%d%H"
@@ -232,8 +230,8 @@ def test_cftime_strftime_access(data):
     assert_equal(result, expected)
 
 
-@pytest.mark.skipif(not has_dask, reason="dask not installed")
-@pytest.mark.skipif(not has_cftime, reason="cftime not installed")
+@requires_cftime
+@requires_dask
 @pytest.mark.parametrize(
     "field", ["year", "month", "day", "hour", "dayofyear", "dayofweek"]
 )
@@ -254,8 +252,8 @@ def test_dask_field_access_1d(data, field):
     assert_equal(result.compute(), expected)
 
 
-@pytest.mark.skipif(not has_dask, reason="dask not installed")
-@pytest.mark.skipif(not has_cftime, reason="cftime not installed")
+@requires_cftime
+@requires_dask
 @pytest.mark.parametrize(
     "field", ["year", "month", "day", "hour", "dayofyear", "dayofweek"]
 )
@@ -286,7 +284,7 @@ def cftime_date_type(calendar):
     return _all_cftime_date_types()[calendar]
 
 
-@pytest.mark.skipif(not has_cftime, reason="cftime not installed")
+@requires_cftime
 def test_seasons(cftime_date_type):
     dates = np.array([cftime_date_type(2000, month, 15) for month in range(1, 13)])
     dates = xr.DataArray(dates)
@@ -307,15 +305,3 @@ def test_seasons(cftime_date_type):
     seasons = xr.DataArray(seasons)
 
     assert_array_equal(seasons.values, dates.dt.season.values)
-
-
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime or netCDF4 not installed")
-def test_dt_accessor_error_netCDF4(cftime_date_type):
-    da = xr.DataArray(
-        [cftime_date_type(1, 1, 1), cftime_date_type(2, 1, 1)], dims=["time"]
-    )
-    if not has_cftime:
-        with pytest.raises(TypeError):
-            da.dt.month
-    else:
-        da.dt.month

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -15,11 +15,11 @@ from xarray.coding.cftimeindex import (
 )
 from xarray.tests import assert_array_equal, assert_identical
 
-from . import has_cftime, has_cftime_or_netCDF4, raises_regex, requires_cftime
+from . import raises_regex, requires_cftime
 from .test_coding_times import (
     _ALL_CALENDARS,
     _NON_STANDARD_CALENDARS,
-    _all_cftime_date_types,
+    _all_cftime_date_types
 )
 
 
@@ -653,7 +653,7 @@ def test_indexing_in_dataframe_iloc(df, index):
     assert result.equals(expected)
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 def test_concat_cftimeindex(date_type):
     da1 = xr.DataArray(
         [1.0, 2.0], coords=[[date_type(1, 1, 1), date_type(1, 2, 1)]], dims=["time"]
@@ -663,11 +663,7 @@ def test_concat_cftimeindex(date_type):
     )
     da = xr.concat([da1, da2], dim="time")
 
-    if has_cftime:
-        assert isinstance(da.indexes["time"], CFTimeIndex)
-    else:
-        assert isinstance(da.indexes["time"], pd.Index)
-        assert not isinstance(da.indexes["time"], CFTimeIndex)
+    assert isinstance(da.indexes["time"], CFTimeIndex)
 
 
 @requires_cftime

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -19,7 +19,7 @@ from . import raises_regex, requires_cftime
 from .test_coding_times import (
     _ALL_CALENDARS,
     _NON_STANDARD_CALENDARS,
-    _all_cftime_date_types
+    _all_cftime_date_types,
 )
 
 

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -8,7 +8,6 @@ from pandas.errors import OutOfBoundsDatetime
 
 from xarray import DataArray, Dataset, Variable, coding, decode_cf
 from xarray.coding.times import (
-    _import_cftime,
     cftime_to_nptime,
     decode_cf_datetime,
     encode_cf_datetime,
@@ -23,10 +22,8 @@ from . import (
     arm_xfail,
     assert_array_equal,
     has_cftime,
-    has_cftime_or_netCDF4,
-    has_dask,
     requires_cftime,
-    requires_cftime_or_netCDF4,
+    requires_dask
 )
 
 _NON_STANDARD_CALENDARS_SET = {
@@ -79,10 +76,8 @@ _CF_DATETIME_TESTS = [
 
 
 def _all_cftime_date_types():
-    try:
-        import cftime
-    except ImportError:
-        import netcdftime as cftime
+    import cftime
+
     return {
         "noleap": cftime.DatetimeNoLeap,
         "365_day": cftime.DatetimeNoLeap,
@@ -95,16 +90,12 @@ def _all_cftime_date_types():
     }
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize(["num_dates", "units", "calendar"], _CF_DATETIME_TESTS)
 def test_cf_datetime(num_dates, units, calendar):
-    cftime = _import_cftime()
-    if cftime.__name__ == "cftime":
-        expected = cftime.num2date(
-            num_dates, units, calendar, only_use_cftime_datetimes=True
-        )
-    else:
-        expected = cftime.num2date(num_dates, units, calendar)
+    import cftime
+
+    expected = cftime.num2date(num_dates, units, calendar, only_use_cftime_datetimes=True)
     min_y = np.ravel(np.atleast_1d(expected))[np.nanargmin(num_dates)].year
     max_y = np.ravel(np.atleast_1d(expected))[np.nanargmax(num_dates)].year
     if min_y >= 1678 and max_y < 2262:
@@ -138,15 +129,12 @@ def test_cf_datetime(num_dates, units, calendar):
             assert_array_equal(num_dates, np.around(encoded, 1))
 
 
-@requires_cftime_or_netCDF4
+@requires_cftime
 def test_decode_cf_datetime_overflow():
     # checks for
     # https://github.com/pydata/pandas/issues/14068
     # https://github.com/pydata/xarray/issues/975
-    try:
-        from cftime import DatetimeGregorian
-    except ImportError:
-        from netcdftime import DatetimeGregorian
+    from cftime import DatetimeGregorian
 
     datetime = DatetimeGregorian
     units = "days since 2000-01-01 00:00:00"
@@ -171,7 +159,7 @@ def test_decode_cf_datetime_non_standard_units():
     assert_array_equal(actual, expected)
 
 
-@requires_cftime_or_netCDF4
+@requires_cftime
 def test_decode_cf_datetime_non_iso_strings():
     # datetime strings that are _almost_ ISO compliant but not quite,
     # but which cftime.num2date can still parse correctly
@@ -190,10 +178,10 @@ def test_decode_cf_datetime_non_iso_strings():
         assert (abs_diff <= np.timedelta64(1, "s")).all()
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize("calendar", _STANDARD_CALENDARS)
 def test_decode_standard_calendar_inside_timestamp_range(calendar):
-    cftime = _import_cftime()
+    import cftime
 
     units = "days since 0001-01-01"
     times = pd.date_range("2001-04-01-00", end="2001-04-30-23", freq="H")
@@ -210,21 +198,17 @@ def test_decode_standard_calendar_inside_timestamp_range(calendar):
     assert (abs_diff <= np.timedelta64(1, "s")).all()
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize("calendar", _NON_STANDARD_CALENDARS)
 def test_decode_non_standard_calendar_inside_timestamp_range(calendar):
-    cftime = _import_cftime()
+    import cftime
     units = "days since 0001-01-01"
     times = pd.date_range("2001-04-01-00", end="2001-04-30-23", freq="H")
     non_standard_time = cftime.date2num(times.to_pydatetime(), units, calendar=calendar)
 
-    if cftime.__name__ == "cftime":
-        expected = cftime.num2date(
-            non_standard_time, units, calendar=calendar, only_use_cftime_datetimes=True
-        )
-    else:
-        expected = cftime.num2date(non_standard_time, units, calendar=calendar)
-
+    expected = cftime.num2date(
+        non_standard_time, units, calendar=calendar, only_use_cftime_datetimes=True
+    )
     expected_dtype = np.dtype("O")
 
     actual = coding.times.decode_cf_datetime(
@@ -238,24 +222,19 @@ def test_decode_non_standard_calendar_inside_timestamp_range(calendar):
     assert (abs_diff <= np.timedelta64(1, "s")).all()
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize("calendar", _ALL_CALENDARS)
 def test_decode_dates_outside_timestamp_range(calendar):
+    import cftime
     from datetime import datetime
-
-    cftime = _import_cftime()
 
     units = "days since 0001-01-01"
     times = [datetime(1, 4, 1, h) for h in range(1, 5)]
     time = cftime.date2num(times, units, calendar=calendar)
 
-    if cftime.__name__ == "cftime":
-        expected = cftime.num2date(
-            time, units, calendar=calendar, only_use_cftime_datetimes=True
-        )
-    else:
-        expected = cftime.num2date(time, units, calendar=calendar)
-
+    expected = cftime.num2date(
+        time, units, calendar=calendar, only_use_cftime_datetimes=True
+    )
     expected_date_type = type(expected[0])
 
     with warnings.catch_warnings():
@@ -269,7 +248,7 @@ def test_decode_dates_outside_timestamp_range(calendar):
     assert (abs_diff <= np.timedelta64(1, "s")).all()
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize("calendar", _STANDARD_CALENDARS)
 def test_decode_standard_calendar_single_element_inside_timestamp_range(calendar):
     units = "days since 0001-01-01"
@@ -280,7 +259,7 @@ def test_decode_standard_calendar_single_element_inside_timestamp_range(calendar
         assert actual.dtype == np.dtype("M8[ns]")
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize("calendar", _NON_STANDARD_CALENDARS)
 def test_decode_non_standard_calendar_single_element_inside_timestamp_range(calendar):
     units = "days since 0001-01-01"
@@ -291,10 +270,10 @@ def test_decode_non_standard_calendar_single_element_inside_timestamp_range(cale
         assert actual.dtype == np.dtype("O")
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize("calendar", _NON_STANDARD_CALENDARS)
 def test_decode_single_element_outside_timestamp_range(calendar):
-    cftime = _import_cftime()
+    import cftime
     units = "days since 0001-01-01"
     for days in [1, 1470376]:
         for num_time in [days, [days], [[days]]]:
@@ -304,20 +283,16 @@ def test_decode_single_element_outside_timestamp_range(calendar):
                     num_time, units, calendar=calendar
                 )
 
-            if cftime.__name__ == "cftime":
-                expected = cftime.num2date(
-                    days, units, calendar, only_use_cftime_datetimes=True
-                )
-            else:
-                expected = cftime.num2date(days, units, calendar)
-
+            expected = cftime.num2date(
+                days, units, calendar, only_use_cftime_datetimes=True
+            )
             assert isinstance(actual.item(), type(expected))
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize("calendar", _STANDARD_CALENDARS)
 def test_decode_standard_calendar_multidim_time_inside_timestamp_range(calendar):
-    cftime = _import_cftime()
+    import cftime
 
     units = "days since 0001-01-01"
     times1 = pd.date_range("2001-04-01", end="2001-04-05", freq="D")
@@ -343,10 +318,10 @@ def test_decode_standard_calendar_multidim_time_inside_timestamp_range(calendar)
     assert (abs_diff2 <= np.timedelta64(1, "s")).all()
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize("calendar", _NON_STANDARD_CALENDARS)
 def test_decode_nonstandard_calendar_multidim_time_inside_timestamp_range(calendar):
-    cftime = _import_cftime()
+    import cftime
 
     units = "days since 0001-01-01"
     times1 = pd.date_range("2001-04-01", end="2001-04-05", freq="D")
@@ -382,12 +357,11 @@ def test_decode_nonstandard_calendar_multidim_time_inside_timestamp_range(calend
     assert (abs_diff2 <= np.timedelta64(1, "s")).all()
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize("calendar", _ALL_CALENDARS)
 def test_decode_multidim_time_outside_timestamp_range(calendar):
+    import cftime
     from datetime import datetime
-
-    cftime = _import_cftime()
 
     units = "days since 0001-01-01"
     times1 = [datetime(1, 4, day) for day in range(1, 6)]
@@ -398,16 +372,8 @@ def test_decode_multidim_time_outside_timestamp_range(calendar):
     mdim_time[:, 0] = time1
     mdim_time[:, 1] = time2
 
-    if cftime.__name__ == "cftime":
-        expected1 = cftime.num2date(
-            time1, units, calendar, only_use_cftime_datetimes=True
-        )
-        expected2 = cftime.num2date(
-            time2, units, calendar, only_use_cftime_datetimes=True
-        )
-    else:
-        expected1 = cftime.num2date(time1, units, calendar)
-        expected2 = cftime.num2date(time2, units, calendar)
+    expected1 = cftime.num2date(time1, units, calendar, only_use_cftime_datetimes=True)
+    expected2 = cftime.num2date(time2, units, calendar, only_use_cftime_datetimes=True)
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", "Unable to decode time axis")
@@ -424,46 +390,34 @@ def test_decode_multidim_time_outside_timestamp_range(calendar):
     assert (abs_diff2 <= np.timedelta64(1, "s")).all()
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize("calendar", ["360_day", "all_leap", "366_day"])
 def test_decode_non_standard_calendar_single_element(calendar):
-    cftime = _import_cftime()
+    import cftime
     units = "days since 0001-01-01"
 
-    try:
-        dt = cftime.netcdftime.datetime(2001, 2, 29)
-    except AttributeError:
-        # Must be using the standalone cftime library
-        dt = cftime.datetime(2001, 2, 29)
+    dt = cftime.datetime(2001, 2, 29)
 
     num_time = cftime.date2num(dt, units, calendar)
     actual = coding.times.decode_cf_datetime(num_time, units, calendar=calendar)
 
-    if cftime.__name__ == "cftime":
-        expected = np.asarray(
-            cftime.num2date(num_time, units, calendar, only_use_cftime_datetimes=True)
-        )
-    else:
-        expected = np.asarray(cftime.num2date(num_time, units, calendar))
+    expected = np.asarray(
+        cftime.num2date(num_time, units, calendar, only_use_cftime_datetimes=True)
+    )
     assert actual.dtype == np.dtype("O")
     assert expected == actual
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 def test_decode_360_day_calendar():
-    cftime = _import_cftime()
+    import cftime
     calendar = "360_day"
     # ensure leap year doesn't matter
     for year in [2010, 2011, 2012, 2013, 2014]:
         units = f"days since {year}-01-01"
         num_times = np.arange(100)
 
-        if cftime.__name__ == "cftime":
-            expected = cftime.num2date(
-                num_times, units, calendar, only_use_cftime_datetimes=True
-            )
-        else:
-            expected = cftime.num2date(num_times, units, calendar)
+        expected = cftime.num2date(num_times, units, calendar, only_use_cftime_datetimes=True)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -477,7 +431,7 @@ def test_decode_360_day_calendar():
 
 
 @arm_xfail
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize(
     ["num_dates", "units", "expected_list"],
     [
@@ -499,7 +453,7 @@ def test_cf_datetime_nan(num_dates, units, expected_list):
     assert_array_equal(expected, actual)
 
 
-@requires_cftime_or_netCDF4
+@requires_cftime
 def test_decoded_cf_datetime_array_2d():
     # regression test for GH1229
     variable = Variable(
@@ -548,7 +502,7 @@ _CFTIME_DATETIME_UNITS_TESTS = [
 ]
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize(
     "calendar", _NON_STANDARD_CALENDARS + ["gregorian", "proleptic_gregorian"]
 )
@@ -622,7 +576,7 @@ def test_infer_timedelta_units(deltas, expected):
     assert expected == coding.times.infer_timedelta_units(deltas)
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize(
     ["date_args", "expected"],
     [
@@ -649,7 +603,7 @@ def test_decode_cf(calendar):
         ds[v].attrs["units"] = "days since 2001-01-01"
         ds[v].attrs["calendar"] = calendar
 
-    if not has_cftime_or_netCDF4 and calendar not in _STANDARD_CALENDARS:
+    if not has_cftime and calendar not in _STANDARD_CALENDARS:
         with pytest.raises(ValueError):
             ds = decode_cf(ds)
     else:
@@ -703,7 +657,7 @@ def test_decode_cf_time_bounds():
     _update_bounds_attributes(ds.variables)
 
 
-@requires_cftime_or_netCDF4
+@requires_cftime
 def test_encode_time_bounds():
 
     time = pd.date_range("2000-01-16", periods=1)
@@ -749,7 +703,7 @@ def calendar(request):
 
 @pytest.fixture()
 def times(calendar):
-    cftime = _import_cftime()
+    import cftime
 
     return cftime.num2date(
         np.arange(4),
@@ -779,24 +733,24 @@ def times_3d(times):
     )
 
 
-@pytest.mark.skipif(not has_cftime, reason="cftime not installed")
+@requires_cftime
 def test_contains_cftime_datetimes_1d(data):
     assert contains_cftime_datetimes(data.time)
 
 
-@pytest.mark.skipif(not has_dask, reason="dask not installed")
-@pytest.mark.skipif(not has_cftime, reason="cftime not installed")
+@requires_cftime
+@requires_dask
 def test_contains_cftime_datetimes_dask_1d(data):
     assert contains_cftime_datetimes(data.time.chunk())
 
 
-@pytest.mark.skipif(not has_cftime, reason="cftime not installed")
+@requires_cftime
 def test_contains_cftime_datetimes_3d(times_3d):
     assert contains_cftime_datetimes(times_3d)
 
 
-@pytest.mark.skipif(not has_dask, reason="dask not installed")
-@pytest.mark.skipif(not has_cftime, reason="cftime not installed")
+@requires_cftime
+@requires_dask
 def test_contains_cftime_datetimes_dask_3d(times_3d):
     assert contains_cftime_datetimes(times_3d.chunk())
 
@@ -806,13 +760,13 @@ def test_contains_cftime_datetimes_non_cftimes(non_cftime_data):
     assert not contains_cftime_datetimes(non_cftime_data)
 
 
-@pytest.mark.skipif(not has_dask, reason="dask not installed")
+@requires_dask
 @pytest.mark.parametrize("non_cftime_data", [DataArray([]), DataArray([1, 2])])
 def test_contains_cftime_datetimes_non_cftimes_dask(non_cftime_data):
     assert not contains_cftime_datetimes(non_cftime_data.chunk())
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 @pytest.mark.parametrize("shape", [(24,), (8, 3), (2, 4, 3)])
 def test_encode_cf_datetime_overflow(shape):
     # Test for fix to GH 2272
@@ -837,7 +791,7 @@ def test_encode_cf_datetime_pandas_min():
     assert calendar == expected_calendar
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 def test_time_units_with_timezone_roundtrip(calendar):
     # Regression test for GH 2649
     expected_units = "days since 2000-01-01T00:00:00-05:00"

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -18,13 +18,7 @@ from xarray.conventions import _update_bounds_attributes, cf_encoder
 from xarray.core.common import contains_cftime_datetimes
 from xarray.testing import assert_equal
 
-from . import (
-    arm_xfail,
-    assert_array_equal,
-    has_cftime,
-    requires_cftime,
-    requires_dask
-)
+from . import arm_xfail, assert_array_equal, has_cftime, requires_cftime, requires_dask
 
 _NON_STANDARD_CALENDARS_SET = {
     "noleap",
@@ -95,7 +89,9 @@ def _all_cftime_date_types():
 def test_cf_datetime(num_dates, units, calendar):
     import cftime
 
-    expected = cftime.num2date(num_dates, units, calendar, only_use_cftime_datetimes=True)
+    expected = cftime.num2date(
+        num_dates, units, calendar, only_use_cftime_datetimes=True
+    )
     min_y = np.ravel(np.atleast_1d(expected))[np.nanargmin(num_dates)].year
     max_y = np.ravel(np.atleast_1d(expected))[np.nanargmax(num_dates)].year
     if min_y >= 1678 and max_y < 2262:
@@ -202,6 +198,7 @@ def test_decode_standard_calendar_inside_timestamp_range(calendar):
 @pytest.mark.parametrize("calendar", _NON_STANDARD_CALENDARS)
 def test_decode_non_standard_calendar_inside_timestamp_range(calendar):
     import cftime
+
     units = "days since 0001-01-01"
     times = pd.date_range("2001-04-01-00", end="2001-04-30-23", freq="H")
     non_standard_time = cftime.date2num(times.to_pydatetime(), units, calendar=calendar)
@@ -274,6 +271,7 @@ def test_decode_non_standard_calendar_single_element_inside_timestamp_range(cale
 @pytest.mark.parametrize("calendar", _NON_STANDARD_CALENDARS)
 def test_decode_single_element_outside_timestamp_range(calendar):
     import cftime
+
     units = "days since 0001-01-01"
     for days in [1, 1470376]:
         for num_time in [days, [days], [[days]]]:
@@ -394,6 +392,7 @@ def test_decode_multidim_time_outside_timestamp_range(calendar):
 @pytest.mark.parametrize("calendar", ["360_day", "all_leap", "366_day"])
 def test_decode_non_standard_calendar_single_element(calendar):
     import cftime
+
     units = "days since 0001-01-01"
 
     dt = cftime.datetime(2001, 2, 29)
@@ -411,13 +410,16 @@ def test_decode_non_standard_calendar_single_element(calendar):
 @requires_cftime
 def test_decode_360_day_calendar():
     import cftime
+
     calendar = "360_day"
     # ensure leap year doesn't matter
     for year in [2010, 2011, 2012, 2013, 2014]:
         units = f"days since {year}-01-01"
         num_times = np.arange(100)
 
-        expected = cftime.num2date(num_times, units, calendar, only_use_cftime_datetimes=True)
+        expected = cftime.num2date(
+            num_times, units, calendar, only_use_cftime_datetimes=True
+        )
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -21,7 +21,7 @@ from xarray.testing import assert_identical
 from . import (
     assert_array_equal,
     raises_regex,
-    requires_cftime_or_netCDF4,
+    requires_cftime,
     requires_dask,
     requires_netCDF4,
 )
@@ -81,7 +81,7 @@ def test_decode_cf_with_conflicting_fill_missing_value():
     assert_identical(actual, expected)
 
 
-@requires_cftime_or_netCDF4
+@requires_cftime
 class TestEncodeCFVariable:
     def test_incompatible_attributes(self):
         invalid_vars = [
@@ -144,7 +144,7 @@ class TestEncodeCFVariable:
         assert_identical(original, encoded)
 
 
-@requires_cftime_or_netCDF4
+@requires_cftime
 class TestDecodeCF:
     def test_dataset(self):
         original = Dataset(
@@ -226,7 +226,7 @@ class TestDecodeCF:
         with raises_regex(ValueError, "unable to decode time"):
             decode_cf(ds)
 
-    @requires_cftime_or_netCDF4
+    @requires_cftime
     def test_dataset_repr_with_netcdf4_datetimes(self):
         # regression test for #347
         attrs = {"units": "days since 0001-01-01", "calendar": "noleap"}
@@ -239,7 +239,7 @@ class TestDecodeCF:
         ds = decode_cf(Dataset({"time": ("time", [0, 1], attrs)}))
         assert "(time) datetime64[ns]" in repr(ds)
 
-    @requires_cftime_or_netCDF4
+    @requires_cftime
     def test_decode_cf_datetime_transition_to_invalid(self):
         # manually create dataset with not-decoded date
         from datetime import datetime

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -9,7 +9,7 @@ from xarray.coding.cftimeindex import CFTimeIndex
 from xarray.core import duck_array_ops, utils
 from xarray.core.utils import either_dict_or_kwargs
 
-from . import assert_array_equal, has_cftime, has_cftime_or_netCDF4, requires_dask
+from . import assert_array_equal, requires_cftime, requires_dask
 from .test_coding_times import _all_cftime_date_types
 
 
@@ -39,17 +39,12 @@ def test_safe_cast_to_index():
         assert expected.dtype == actual.dtype
 
 
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 def test_safe_cast_to_index_cftimeindex():
     date_types = _all_cftime_date_types()
     for date_type in date_types.values():
         dates = [date_type(1, 1, day) for day in range(1, 20)]
-
-        if has_cftime:
-            expected = CFTimeIndex(dates)
-        else:
-            expected = pd.Index(dates)
-
+        expected = CFTimeIndex(dates)
         actual = utils.safe_cast_to_index(np.array(dates))
         assert_array_equal(expected, actual)
         assert expected.dtype == actual.dtype
@@ -57,7 +52,7 @@ def test_safe_cast_to_index_cftimeindex():
 
 
 # Test that datetime.datetime objects are never used in a CFTimeIndex
-@pytest.mark.skipif(not has_cftime_or_netCDF4, reason="cftime not installed")
+@requires_cftime
 def test_safe_cast_to_index_datetime_datetime():
     dates = [datetime(1, 1, day) for day in range(1, 20)]
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
Per https://github.com/pydata/xarray/pull/3431#discussion_r337620810, this removes outdated code leftover from the netcdftime -> cftime transition.  Currently the [minimum version of netCDF4 that xarray tests against](https://github.com/dcherian/xarray/blob/fa9b644dd3d41d5bedb4b040d71f101590e48d11/ci/requirements/py36-min-all-deps.yml#L30) is 1.4, which does not include netcdftime, and instead specifies cftime as a required dependency.

 - [ ] Passes `black . && mypy . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
