### PR TITLE
Remove deprecated behavior from dataset.drop docstring

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3536,7 +3536,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         ----------
         labels : hashable or iterable of hashables
             Name(s) of variables or index labels to drop.
-            If dim is not None, labels can be any array-like.
         dim : None or hashable, optional
             Dimension along which to drop index labels. By default (if
             ``dim is None``), drops variables rather than index labels.

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2118,25 +2118,31 @@ class TestDataset:
     def test_drop_index_labels(self):
         data = Dataset({"A": (["x", "y"], np.random.randn(2, 3)), "x": ["a", "b"]})
 
-        actual = data.drop(x=["a"])
+        with pytest.warns(DeprecationWarning):
+            actual = data.drop(["a"], "x")
         expected = data.isel(x=[1])
         assert_identical(expected, actual)
 
-        actual = data.drop(x=["a", "b"])
+        with pytest.warns(DeprecationWarning):
+            actual = data.drop(["a", "b"], "x")
         expected = data.isel(x=slice(0, 0))
         assert_identical(expected, actual)
 
         with pytest.raises(KeyError):
             # not contained in axis
-            data.drop(x=["c"])
+            with pytest.warns(DeprecationWarning):
+                data.drop(["c"], dim="x")
 
-        actual = data.drop(x=["c"], errors="ignore")
+        with pytest.warns(DeprecationWarning):
+            actual = data.drop(["c"], dim="x", errors="ignore")
         assert_identical(data, actual)
 
         with pytest.raises(ValueError):
-            data.drop(["c"], dim="x", errors="wrong_value")
+            with pytest.warns(DeprecationWarning):
+                data.drop(["c"], dim="x", errors="wrong_value")
 
-        actual = data.drop(x=["a", "b", "c"], errors="ignore")
+        with pytest.warns(DeprecationWarning):
+            actual = data.drop(["a", "b", "c"], "x", errors="ignore")
         expected = data.isel(x=slice(0, 0))
         assert_identical(expected, actual)
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2118,25 +2118,25 @@ class TestDataset:
     def test_drop_index_labels(self):
         data = Dataset({"A": (["x", "y"], np.random.randn(2, 3)), "x": ["a", "b"]})
 
-        actual = data.drop(["a"], "x")
+        actual = data.drop(x=["a"])
         expected = data.isel(x=[1])
         assert_identical(expected, actual)
 
-        actual = data.drop(["a", "b"], "x")
+        actual = data.drop(x=["a", "b"])
         expected = data.isel(x=slice(0, 0))
         assert_identical(expected, actual)
 
         with pytest.raises(KeyError):
             # not contained in axis
-            data.drop(["c"], dim="x")
+            data.drop(x=["c"])
 
-        actual = data.drop(["c"], dim="x", errors="ignore")
+        actual = data.drop(x=["c"], errors="ignore")
         assert_identical(data, actual)
 
         with pytest.raises(ValueError):
             data.drop(["c"], dim="x", errors="wrong_value")
 
-        actual = data.drop(["a", "b", "c"], "x", errors="ignore")
+        actual = data.drop(x=["a", "b", "c"], errors="ignore")
         expected = data.isel(x=slice(0, 0))
         assert_identical(expected, actual)
 


### PR DESCRIPTION
I'm less up to speed on this behavior, but IIUC this part of the docstring refers to [deprecated behavior](https://github.com/pydata/xarray/compare/master...max-sixty:drop-docstring?expand=1#diff-921db548d18a549f6381818ed08298c9R3586-R3592)—is that correct or am I missing something?

xref https://github.com/pydata/xarray/issues/3266 