### PR TITLE
fix test suite warnings re `drop`

### DIFF
--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -440,7 +440,9 @@ def test_argmin_max(dim_num, dtype, contains_nan, dask, func, skipna, aggdim):
             **{aggdim: getattr(da, "arg" + func)(dim=aggdim, skipna=skipna).compute()}
         )
         expected = getattr(da, func)(dim=aggdim, skipna=skipna)
-        assert_allclose(actual.drop(actual.coords), expected.drop(expected.coords))
+        assert_allclose(
+            actual.drop(list(actual.coords)), expected.drop(list(expected.coords))
+        )
 
 
 def test_argmin_max_error():


### PR DESCRIPTION
Some more warnings silenced