### PR TITLE
Fix integrate docs

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -74,6 +74,10 @@ Documentation
   By `Justus Magin <https://github.com/keewis>`_.
 - Update the terminology page to address multidimensional coordinates. (:pull:`3410`)
   By `Jon Thielen <https://github.com/jthielen>`_.
+- Fix the documentation of :py:meth:`Dataset.integrate` and
+  :py:meth:`DataArray.integrate` and add an example to
+  :py:meth:`Dataset.integrate`. (:pull:`3469`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2995,7 +2995,7 @@ class DataArray(AbstractArray, DataWithCoords):
         """ integrate the array with the trapezoidal rule.
 
         .. note::
-            This feature is limited to simple cartesian geometry, i.e. coord
+            This feature is limited to simple cartesian geometry, i.e. dim
             must be one dimensional.
 
         Parameters

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5185,20 +5185,20 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         --------
         >>> ds = xr.Dataset(
         ...     data_vars={"a": ("x", [5, 5, 6, 6]), "b": ("x", [1, 2, 1, 0])},
-        ...     coords={"x": [0, 1, 2, 3], "y": ("x", [10, 11, 12, 13])},
+        ...     coords={"x": [0, 1, 2, 3], "y": ("x", [1, 7, 3, 5])},
         ... )
         >>> ds.integrate("x")
         <xarray.Dataset>
         Dimensions:  ()
         Data variables:
-            a        float64 19.5
+            a        float64 16.5
             b        float64 3.5
         >>> ds.integrate("y")
         <xarray.Dataset>
         Dimensions:  ()
         Data variables:
-            a        float64 19.5
-            b        float64 3.5
+            a        float64 20.0
+            b        float64 4.0
         """
         if not isinstance(coord, (list, tuple)):
             coord = (coord,)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5187,6 +5187,15 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         ...     data_vars={"a": ("x", [5, 5, 6, 6]), "b": ("x", [1, 2, 1, 0])},
         ...     coords={"x": [0, 1, 2, 3], "y": ("x", [1, 7, 3, 5])},
         ... )
+        >>> ds
+        <xarray.Dataset>
+        Dimensions:  (x: 4)
+        Coordinates:
+          * x        (x) int64 0 1 2 3
+            y        (x) int64 1 7 3 5
+        Data variables:
+            a        (x) int64 5 5 6 6
+            b        (x) int64 1 2 1 0
         >>> ds.integrate("x")
         <xarray.Dataset>
         Dimensions:  ()

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5180,6 +5180,25 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         --------
         DataArray.integrate
         numpy.trapz: corresponding numpy function
+
+        Examples
+        --------
+        >>> ds = xr.Dataset(
+        ...     data_vars={"a": ("x", [5, 5, 6, 6]), "b": ("x", [1, 2, 1, 0])},
+        ...     coords={"x": [0, 1, 2, 3], "y": ("x", [10, 11, 12, 13])},
+        ... )
+        >>> ds.integrate("x")
+        <xarray.Dataset>
+        Dimensions:  ()
+        Data variables:
+            a        float64 19.5
+            b        float64 3.5
+        >>> ds.integrate("y")
+        <xarray.Dataset>
+        Dimensions:  ()
+        Data variables:
+            a        float64 19.5
+            b        float64 3.5
         """
         if not isinstance(coord, (list, tuple)):
             coord = (coord,)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5165,7 +5165,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Parameters
         ----------
-        dim: str, or a sequence of str
+        coord: str, or a sequence of str
             Coordinate(s) used for the integration.
         datetime_unit
             Can be specify the unit if datetime coordinate is used. One of


### PR DESCRIPTION
 - [ ] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

This updates the name in the parameter list of `Dataset.integrate` and adds an example. Also, the note in `DataArray.integrate` referred to `coord` which does not exist. I guess in the end to make it match `Dataset.integrate` it would be better to rename that parameter from `dim` to `coord`, but that would mean changing the API.