### PR TITLE
Restrict pytest to 'unit' tests (i.e. not hypothesis)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
 python_files=test_*.py
-testpaths=xarray/tests properties
+testpaths=xarray/tests
 # Fixed upstream in https://github.com/kwgoodman/bottleneck/pull/199
 filterwarnings =
     ignore:Using a non-tuple sequence for multidimensional indexing is deprecated:FutureWarning


### PR DESCRIPTION
Currently Azure is running hypothesis tests in any test job that has hypothesis installed (found in https://github.com/pydata/xarray/pull/3285). This isn't required, since we have a separate job for hypothesis, and slows down the normal tests.

We can either exclude it in the test job or in the tests that pytest runs as specified in `setup.cfg`

I think adjusting pytest's test paths in `setup.cfg` is a more logical place: pytest is responsible for running normal / unit tests in `xarray/tests`, and hypothesis can run the tests in `properties`