### PR TITLE
Fix typo in docstring

### DIFF
--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -884,7 +884,7 @@ def apply_ufunc(
     Plain scalars, numpy arrays and a mix of these with xarray objects is also
     supported:
 
-    >>> magnitude(4, 5)
+    >>> magnitude(3, 4)
     5.0
     >>> magnitude(3, np.array([0, 4]))
     array([3., 5.])


### PR DESCRIPTION
Fixes a typo in the docstring for `xr.apply_ufunc`

It should be sqrt(3^2 + 4^2) = 5