### PR TITLE
drop_vars; deprecate drop for variables

### DIFF
--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -393,7 +393,7 @@ methods (like pandas) for transforming datasets into new objects.
 
 For removing variables, you can select and drop an explicit list of
 variables by indexing with a list of names or using the
-:py:meth:`~xarray.Dataset.drop` methods to return a new ``Dataset``. These
+:py:meth:`~xarray.Dataset.drop_vars` methods to return a new ``Dataset``. These
 operations keep around coordinates:
 
 .. ipython:: python

--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -400,7 +400,7 @@ operations keep around coordinates:
 
     ds[['temperature']]
     ds[['temperature', 'temperature_double']]
-    ds.drop('temperature')
+    ds.drop_vars('temperature')
 
 To remove a dimension, you can use :py:meth:`~xarray.Dataset.drop_dims` method.
 Any variables using that dimension are dropped:

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -237,7 +237,7 @@ index labels along a dimension dropped:
 
 .. ipython:: python
 
-    ds.drop(space=['IN', 'IL'])
+    ds.drop_sel(space=['IN', 'IL'])
 
 ``drop`` is both a ``Dataset`` and ``DataArray`` method.
 

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -232,14 +232,14 @@ Using indexing to *assign* values to a subset of dataset (e.g.,
 Dropping labels and dimensions
 ------------------------------
 
-The :py:meth:`~xarray.Dataset.drop` method returns a new object with the listed
+The :py:meth:`~xarray.Dataset.drop_sel` method returns a new object with the listed
 index labels along a dimension dropped:
 
 .. ipython:: python
 
     ds.drop_sel(space=['IN', 'IL'])
 
-``drop`` is both a ``Dataset`` and ``DataArray`` method.
+``drop_sel`` is both a ``Dataset`` and ``DataArray`` method.
 
 Use :py:meth:`~xarray.Dataset.drop_dims` to drop a full dimension from a Dataset.
 Any variables with these dimensions are also dropped:

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,8 +38,8 @@ Breaking changes
 
 New Features
 ~~~~~~~~~~~~
-- :py:meth:`Dataset.drop_sel` & :py:meth:`DataArray.drop_sel' have been added for dropping labels.
-  :py:meth:`Dataset.drop_vars` & :py:meth:`DataArray.drop_vars' have been added for 
+- :py:meth:`Dataset.drop_sel` & :py:meth:`DataArray.drop_sel` have been added for dropping labels.
+  :py:meth:`Dataset.drop_vars` & :py:meth:`DataArray.drop_vars` have been added for 
   dropping variables (including coordinates). The ``drop`` methods remain as a backward compatible 
   option for dropping either lables or variables, but using the more specific methods is encouraged.
   By `Maximilian Roos <https://github.com/max-sixty>`_

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,10 +21,6 @@ v0.14.1 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-- Using :py:meth:`Dataset.drop` & :py:meth:`DataArray.drop' to drop variables is deprecated in favor of
-  :py:meth:`Dataset.drop_vars` & :py:meth:`DataArray.drop_vars'. The ``drop`` methods are now exclusively
-  for dropping values by labels.
-  By `Maximilian Roos <https://github.com/max-sixty>`_
 - Broken compatibility with cftime < 1.0.3.
   By `Deepak Cherian <https://github.com/dcherian>`_.
 
@@ -42,6 +38,11 @@ Breaking changes
 
 New Features
 ~~~~~~~~~~~~
+- :py:meth:`Dataset.drop_sel` & :py:meth:`DataArray.drop_sel' have been added for dropping labels.
+  :py:meth:`Dataset.drop_vars` & :py:meth:`DataArray.drop_vars' have been added for 
+  dropping variables (including coordinates). The ``drop`` methods remain as a backward compatible 
+  option for dropping either lables or variables, but using the more specific methods is encouraged.
+  By `Maximilian Roos <https://github.com/max-sixty>`_
 - :py:meth:`Dataset.transpose` and :py:meth:`DataArray.transpose` now support an ellipsis (`...`)
   to represent all 'other' dimensions. For example, to move one dimension to the front,
   use `.transpose('x', ...)`. (:pull:`3421`)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,7 +25,6 @@ Breaking changes
   :py:meth:`Dataset.drop_vars` & :py:meth:`DataArray.drop_vars'. The ``drop`` methods are now exclusively
   for dropping values by labels.
   By `Maximilian Roos <https://github.com/max-sixty>`_
-- Minimum cftime version is now 1.0.3. By `Deepak Cherian <https://github.com/dcherian>`_.
 - Broken compatibility with cftime < 1.0.3.
   By `Deepak Cherian <https://github.com/dcherian>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -3760,11 +3760,11 @@ Enhancements
 
       # drop variables
       ds = xray.Dataset({'x': 0, 'y': 1})
-      ds.drop('x')
+      ds.drop_sel('x')
 
       # drop index labels
       arr = xray.DataArray([1, 2, 3], coords=[('x', list('abc'))])
-      arr.drop(['a', 'c'], dim='x')
+      arr.drop_sel(['a', 'c'], dim='x')
 
 - :py:meth:`~xray.Dataset.broadcast_equals` has been added to correspond to
   the new ``compat`` option.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -3749,6 +3749,7 @@ Enhancements
   explicitly listed variables or index labels:
 
   .. ipython:: python
+     :okwarning:
 
       # drop variables
       ds = xray.Dataset({'x': 0, 'y': 1})

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,8 +40,9 @@ New Features
 ~~~~~~~~~~~~
 - :py:meth:`Dataset.drop_sel` & :py:meth:`DataArray.drop_sel` have been added for dropping labels.
   :py:meth:`Dataset.drop_vars` & :py:meth:`DataArray.drop_vars` have been added for 
-  dropping variables (including coordinates). The ``drop`` methods remain as a backward compatible 
+  dropping variables (including coordinates). The existing ``drop`` methods remain as a backward compatible 
   option for dropping either lables or variables, but using the more specific methods is encouraged.
+  (:pull:`3475`)
   By `Maximilian Roos <https://github.com/max-sixty>`_
 - :py:meth:`Dataset.transpose` and :py:meth:`DataArray.transpose` now support an ellipsis (`...`)
   to represent all 'other' dimensions. For example, to move one dimension to the front,

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -3761,11 +3761,11 @@ Enhancements
 
       # drop variables
       ds = xray.Dataset({'x': 0, 'y': 1})
-      ds.drop_sel('x')
+      ds.drop('x')
 
       # drop index labels
       arr = xray.DataArray([1, 2, 3], coords=[('x', list('abc'))])
-      arr.drop_sel(['a', 'c'], dim='x')
+      arr.drop(['a', 'c'], dim='x')
 
 - :py:meth:`~xray.Dataset.broadcast_equals` has been added to correspond to
   the new ``compat`` option.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,6 +21,10 @@ v0.14.1 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- Using :py:meth:`Dataset.drop` & :py:meth:`DataArray.drop' to drop variables is deprecated in favor of
+  :py:meth:`Dataset.drop_vars` & :py:meth:`DataArray.drop_vars'. The ``drop`` methods are now exclusively
+  for dropping values by labels.
+  By `Maximilian Roos <https://github.com/max-sixty>`_
 - Minimum cftime version is now 1.0.3. By `Deepak Cherian <https://github.com/dcherian>`_.
 
   .. note::

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -370,7 +370,7 @@ def _dataset_concat(
     result = result.set_coords(coord_names)
     result.encoding = result_encoding
 
-    result = result.drop(unlabeled_dims, errors="ignore")
+    result = result.drop_vars(unlabeled_dims, errors="ignore")
 
     if coord is not None:
         # add concat dimension last to ensure that its in the final Dataset

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1896,12 +1896,12 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Parameters
         ----------
-        labels : hashable or iterable of hashables
+        names : hashable or iterable of hashables
             Name(s) of variables to drop.
         errors: {'raise', 'ignore'}, optional
             If 'raise' (default), raises a ValueError error if any of the variable
             passed are not in the dataset. If 'ignore', any given names that are in the
-            dataset are dropped and no error is raised.
+            DataArray are dropped and no error is raised.
 
         Returns
         -------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3538,7 +3538,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         dropped : Dataset
 
         """
-        if isinstance(names, str) or not isinstance(names, Iterable):
+        # the Iterable check is required for mypy
+        if is_scalar(names) or not isinstance(names, Iterable):
             names = {names}
         else:
             names = set(names)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3589,6 +3589,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             )
             return self.drop_sel({dim: labels}, errors=errors, **labels_kwargs)
 
+        warnings.warn(
+            "dropping labels using `drop` will be deprecated; using drop_sel is encouraged.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
         return self.drop_sel(labels, errors=errors)
 
     def drop_sel(self, labels=None, *, errors="raise", **labels_kwargs):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -79,6 +79,7 @@ from .utils import (
     hashable,
     is_dict_like,
     is_list_like,
+    is_scalar,
     maybe_wrap_array,
 )
 from .variable import IndexVariable, Variable, as_variable, broadcast_variables
@@ -3608,7 +3609,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 raise ValueError("cannot specify dim and dict-like arguments.")
             labels = either_dict_or_kwargs(labels, labels_kwargs, "drop")
 
-        if dim is None and is_list_like(labels):
+        if dim is None and (is_list_like(labels) or is_scalar(labels)):
             warnings.warn(
                 "dropping variables using `drop` is deprecated; use drop_vars.",
                 FutureWarning,

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -774,7 +774,7 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
         )
 
         if np.asarray(q, dtype=np.float64).ndim == 0:
-            out = out.drop("quantile")
+            out = out.drop_vars("quantile")
         return out
 
     def reduce(

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -850,6 +850,6 @@ def dataset_update_method(
                     if c not in value.dims and c in dataset.coords
                 ]
                 if coord_names:
-                    other[key] = value.drop(coord_names)
+                    other[key] = value.drop_vars(coord_names)
 
     return merge_core([dataset, other], priority_arg=1, indexes=dataset.indexes)

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -47,7 +47,7 @@ class Resample:
             if k == self._dim:
                 continue
             if self._dim in v.dims:
-                self._obj = self._obj.drop(k)
+                self._obj = self._obj.drop_vars(k)
 
         if method == "asfreq":
             return self.mean(self._dim)
@@ -146,7 +146,7 @@ class Resample:
         dummy = self._obj.copy()
         for k, v in self._obj.coords.items():
             if k != self._dim and self._dim in v.dims:
-                dummy = dummy.drop(k)
+                dummy = dummy.drop_vars(k)
         return dummy.interp(
             assume_sorted=True,
             method=kind,
@@ -218,7 +218,7 @@ class DataArrayResample(DataArrayGroupBy, Resample):
         # dimension, then we need to do so before we can rename the proxy
         # dimension we used.
         if self._dim in combined.coords:
-            combined = combined.drop(self._dim)
+            combined = combined.drop_vars(self._dim)
 
         if self._resample_dim in combined.dims:
             combined = combined.rename({self._resample_dim: self._dim})

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -800,7 +800,7 @@ class CFEncodedBase(DatasetIOBase):
                 assert "coordinates" not in ds["lat"].attrs
                 assert "coordinates" not in ds["lon"].attrs
 
-        modified = original.drop(["temp", "precip"])
+        modified = original.drop_vars(["temp", "precip"])
         with self.roundtrip(modified) as actual:
             assert_identical(actual, modified)
         with create_tmp_file() as tmp_file:
@@ -2177,7 +2177,7 @@ class TestH5NetCDFData(NetCDF4Base):
         # Drop dim3, because its labels include strings. These appear to be
         # not properly read with python-netCDF4, which converts them into
         # unicode instead of leaving them as bytes.
-        data = create_test_data().drop("dim3")
+        data = create_test_data().drop_vars("dim3")
         data.attrs["foo"] = "bar"
         valid_engines = ["netcdf4", "h5netcdf"]
         for write_engine in valid_engines:
@@ -2344,7 +2344,7 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
 
     def test_open_fileobj(self):
         # open in-memory datasets instead of local file paths
-        expected = create_test_data().drop("dim3")
+        expected = create_test_data().drop_vars("dim3")
         expected.attrs["foo"] = "bar"
         with create_tmp_file() as tmp_file:
             expected.to_netcdf(tmp_file, engine="h5netcdf")
@@ -4196,7 +4196,7 @@ class TestDataArrayToNetCDF:
         with create_tmp_file() as tmp:
             data.to_netcdf(tmp)
 
-            expected = data.drop("y")
+            expected = data.drop_vars("y")
             with open_dataarray(tmp, drop_variables=["y"]) as loaded:
                 assert_identical(expected, loaded)
 

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1077,11 +1077,11 @@ def test_map_blocks_to_array(map_ds):
     [
         lambda x: x,
         lambda x: x.to_dataset(),
-        lambda x: x.drop("x"),
+        lambda x: x.drop_vars("x"),
         lambda x: x.expand_dims(k=[1, 2, 3]),
         lambda x: x.assign_coords(new_coord=("y", x.y * 2)),
         lambda x: x.astype(np.int32),
-        # TODO: [lambda x: x.isel(x=1).drop("x"), map_da],
+        # TODO: [lambda x: x.isel(x=1).drop_vars("x"), map_da],
     ],
 )
 def test_map_blocks_da_transformations(func, map_da):
@@ -1095,9 +1095,9 @@ def test_map_blocks_da_transformations(func, map_da):
     "func",
     [
         lambda x: x,
-        lambda x: x.drop("cxy"),
-        lambda x: x.drop("a"),
-        lambda x: x.drop("x"),
+        lambda x: x.drop_vars("cxy"),
+        lambda x: x.drop_vars("a"),
+        lambda x: x.drop_vars("x"),
         lambda x: x.expand_dims(k=[1, 2, 3]),
         lambda x: x.rename({"a": "new1", "b": "new2"}),
         # TODO: [lambda x: x.isel(x=1)],

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2133,14 +2133,14 @@ class TestDataArray:
 
     def test_drop_index_labels(self):
         arr = DataArray(np.random.randn(2, 3), coords={"y": [0, 1, 2]}, dims=["x", "y"])
-        actual = arr.drop(y=[0, 1])
+        actual = arr.drop_sel(y=[0, 1])
         expected = arr[:, 2:]
         assert_identical(actual, expected)
 
         with raises_regex((KeyError, ValueError), "not .* in axis"):
-            actual = arr.drop([0, 1, 3], dim="y")
+            actual = arr.drop_sel(y=[0, 1, 3])
 
-        actual = arr.drop(y=[0, 1, 3], errors="ignore")
+        actual = arr.drop_sel(y=[0, 1, 3], errors="ignore")
         assert_identical(actual, expected)
 
         with pytest.warns(DeprecationWarning):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2120,6 +2120,20 @@ class TestDataset:
         actual = data.drop_vars(["time", "not_found_here"], errors="ignore")
         assert_identical(expected, actual)
 
+        # deprecated approach with `drop` works (straight copy paste from above)
+
+        with pytest.warns(FutureWarning):
+            actual = data.drop("not_found_here", errors="ignore")
+        assert_identical(data, actual)
+
+        with pytest.warns(FutureWarning):
+            actual = data.drop(["not_found_here"], errors="ignore")
+        assert_identical(data, actual)
+
+        with pytest.warns(FutureWarning):
+            actual = data.drop(["time", "not_found_here"], errors="ignore")
+        assert_identical(expected, actual)
+
     def test_drop_index_labels(self):
         data = Dataset({"A": (["x", "y"], np.random.randn(2, 3)), "x": ["a", "b"]})
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -322,7 +322,7 @@ class TestDataset:
 
     def test_info(self):
         ds = create_test_data(seed=123)
-        ds = ds.drop("dim3")  # string type prints differently in PY2 vs PY3
+        ds = ds.drop_vars("dim3")  # string type prints differently in PY2 vs PY3
         ds.attrs["unicode_attr"] = "ba®"
         ds.attrs["string_attr"] = "bar"
 
@@ -509,7 +509,9 @@ class TestDataset:
             {"c": (("x", "y"), np.zeros((2, 3))), "x": [0, 1]},
         )
 
-        actual = Dataset({"a": original["a"][:, 0], "b": original["a"][0].drop("x")})
+        actual = Dataset(
+            {"a": original["a"][:, 0], "b": original["a"][0].drop_vars("x")}
+        )
         assert_identical(expected, actual)
 
         data = {"x": DataArray(0, coords={"y": 3}), "y": ("z", [1, 1, 1])}
@@ -775,9 +777,9 @@ class TestDataset:
             one_coord.reset_coords("x")
 
         actual = all_coords.reset_coords("zzz", drop=True)
-        expected = all_coords.drop("zzz")
+        expected = all_coords.drop_vars("zzz")
         assert_identical(expected, actual)
-        expected = two_coords.drop("zzz")
+        expected = two_coords.drop_vars("zzz")
         assert_identical(expected, actual)
 
     def test_coords_to_dataset(self):
@@ -954,7 +956,7 @@ class TestDataset:
         ds.fillna(0)
         ds.rename({"dim1": "foobar"})
         ds.set_coords("var1")
-        ds.drop("var1")
+        ds.drop_vars("var1")
 
     def test_isel(self):
         data = create_test_data()
@@ -1097,7 +1099,7 @@ class TestDataset:
         actual = data.isel(dim1=stations["dim1s"], dim2=stations["dim2s"])
         assert "station" in actual.coords
         assert "station" in actual.dims
-        assert_identical(actual["station"].drop(["dim2"]), stations["station"])
+        assert_identical(actual["station"].drop_vars(["dim2"]), stations["station"])
 
         with raises_regex(ValueError, "conflicting values for "):
             data.isel(
@@ -1123,7 +1125,7 @@ class TestDataset:
         assert "dim2" in actual.coords
         assert "a" in actual["dim2"].dims
 
-        assert_identical(actual["a"].drop(["dim2"]), stations["a"])
+        assert_identical(actual["a"].drop_vars(["dim2"]), stations["a"])
         assert_identical(actual["b"], stations["b"])
         expected_var1 = data["var1"].variable[
             stations["dim1s"].variable, stations["dim2s"].variable
@@ -1132,7 +1134,7 @@ class TestDataset:
             stations["dim1s"].variable, stations["dim2s"].variable
         ]
         expected_var3 = data["var3"].variable[slice(None), stations["dim1s"].variable]
-        assert_equal(actual["a"].drop("dim2"), stations["a"])
+        assert_equal(actual["a"].drop_vars("dim2"), stations["a"])
         assert_array_equal(actual["var1"], expected_var1)
         assert_array_equal(actual["var2"], expected_var2)
         assert_array_equal(actual["var3"], expected_var3)
@@ -1200,7 +1202,7 @@ class TestDataset:
         indexing_da = indexing_da < 3
         actual = data.isel(dim2=indexing_da)
         assert_identical(
-            actual["dim2"].drop("non_dim").drop("non_dim2"), data["dim2"][:2]
+            actual["dim2"].drop_vars("non_dim").drop_vars("non_dim2"), data["dim2"][:2]
         )
         assert_identical(actual["non_dim"], indexing_da["non_dim"][:2])
         assert_identical(actual["non_dim2"], indexing_da["non_dim2"])
@@ -1286,8 +1288,10 @@ class TestDataset:
         expected = data.isel(dim2=[0, 1, 2]).rename({"dim2": "new_dim"})
         assert "new_dim" in actual.dims
         assert "new_dim" in actual.coords
-        assert_equal(actual.drop("new_dim").drop("dim2"), expected.drop("new_dim"))
-        assert_equal(actual["new_dim"].drop("dim2"), ind["new_dim"])
+        assert_equal(
+            actual.drop_vars("new_dim").drop_vars("dim2"), expected.drop_vars("new_dim")
+        )
+        assert_equal(actual["new_dim"].drop_vars("dim2"), ind["new_dim"])
 
         # with conflicted coordinate (silently ignored)
         ind = DataArray(
@@ -1304,10 +1308,12 @@ class TestDataset:
             coords={"new_dim": ["a", "b", "c"], "dim2": 3},
         )
         actual = data.sel(dim2=ind)
-        assert_equal(actual["new_dim"].drop("dim2"), ind["new_dim"].drop("dim2"))
+        assert_equal(
+            actual["new_dim"].drop_vars("dim2"), ind["new_dim"].drop_vars("dim2")
+        )
         expected = data.isel(dim2=[0, 1, 2])
         expected["dim2"] = (("new_dim"), expected["dim2"].values)
-        assert_equal(actual["dim2"].drop("new_dim"), expected["dim2"])
+        assert_equal(actual["dim2"].drop_vars("new_dim"), expected["dim2"])
         assert actual["var1"].dims == ("dim1", "new_dim")
 
         # with non-dimensional coordinate
@@ -1322,7 +1328,7 @@ class TestDataset:
         )
         actual = data.sel(dim2=ind)
         expected = data.isel(dim2=[0, 1, 2])
-        assert_equal(actual.drop("new_dim"), expected)
+        assert_equal(actual.drop_vars("new_dim"), expected)
         assert np.allclose(actual["new_dim"].values, ind["new_dim"].values)
 
     def test_sel_dataarray_mindex(self):
@@ -1554,8 +1560,8 @@ class TestDataset:
         expected_ary = data["foo"][[0, 1, 2], [0, 2, 1]]
         actual = data.sel(x=idx_x, y=idx_y)
         assert_array_equal(expected_ary, actual["foo"])
-        assert_identical(actual["a"].drop("x"), idx_x["a"])
-        assert_identical(actual["b"].drop("y"), idx_y["b"])
+        assert_identical(actual["a"].drop_vars("x"), idx_x["a"])
+        assert_identical(actual["b"].drop_vars("y"), idx_y["b"])
 
         with pytest.raises(KeyError):
             data.sel(x=[2.5], y=[2.0], method="pad", tolerance=1e-3)
@@ -2094,36 +2100,36 @@ class TestDataset:
     def test_drop_variables(self):
         data = create_test_data()
 
-        assert_identical(data, data.drop([]))
+        assert_identical(data, data.drop_vars([]))
 
         expected = Dataset({k: data[k] for k in data.variables if k != "time"})
-        actual = data.drop("time")
+        actual = data.drop_vars("time")
         assert_identical(expected, actual)
-        actual = data.drop(["time"])
+        actual = data.drop_vars(["time"])
         assert_identical(expected, actual)
 
         with raises_regex(ValueError, "cannot be found"):
-            data.drop("not_found_here")
+            data.drop_vars("not_found_here")
 
-        actual = data.drop("not_found_here", errors="ignore")
+        actual = data.drop_vars("not_found_here", errors="ignore")
         assert_identical(data, actual)
 
-        actual = data.drop(["not_found_here"], errors="ignore")
+        actual = data.drop_vars(["not_found_here"], errors="ignore")
         assert_identical(data, actual)
 
-        actual = data.drop(["time", "not_found_here"], errors="ignore")
+        actual = data.drop_vars(["time", "not_found_here"], errors="ignore")
         assert_identical(expected, actual)
 
     def test_drop_index_labels(self):
         data = Dataset({"A": (["x", "y"], np.random.randn(2, 3)), "x": ["a", "b"]})
 
         with pytest.warns(DeprecationWarning):
-            actual = data.drop(["a"], "x")
+            actual = data.drop(["a"], dim="x")
         expected = data.isel(x=[1])
         assert_identical(expected, actual)
 
         with pytest.warns(DeprecationWarning):
-            actual = data.drop(["a", "b"], "x")
+            actual = data.drop(["a", "b"], dim="x")
         expected = data.isel(x=slice(0, 0))
         assert_identical(expected, actual)
 
@@ -2147,15 +2153,17 @@ class TestDataset:
 
         # DataArrays as labels are a nasty corner case as they are not
         # Iterable[Hashable] - DataArray.__iter__ yields scalar DataArrays.
-        actual = data.drop(DataArray(["a", "b", "c"]), "x", errors="ignore")
+        actual = data.drop(x=DataArray(["a", "b", "c"]), errors="ignore")
         expected = data.isel(x=slice(0, 0))
+        assert_identical(expected, actual)
+        with pytest.warns(DeprecationWarning):
+            data.drop(DataArray(["a", "b", "c"]), dim="x", errors="ignore")
         assert_identical(expected, actual)
 
         with raises_regex(ValueError, "does not have coordinate labels"):
-            data.drop(1, "y")
+            data.drop(y=1)
 
     def test_drop_labels_by_keyword(self):
-        # Tests for #2910: Support for a additional `drop()` API.
         data = Dataset(
             {"A": (["x", "y"], np.random.randn(2, 6)), "x": ["a", "b"], "y": range(6)}
         )
@@ -2188,9 +2196,10 @@ class TestDataset:
         with pytest.raises(ValueError):
             data.drop(labels=["a"], x="a")
         with pytest.raises(ValueError):
-            data.drop(dim="x", x="a")
-        with pytest.raises(ValueError):
             data.drop(labels=["a"], dim="x", x="a")
+        warnings.filterwarnings("ignore", r"\W*drop")
+        with pytest.raises(ValueError):
+            data.drop(dim="x", x="a")
 
     def test_drop_dims(self):
         data = xr.Dataset(
@@ -2203,15 +2212,15 @@ class TestDataset:
         )
 
         actual = data.drop_dims("x")
-        expected = data.drop(["A", "B", "x"])
+        expected = data.drop_vars(["A", "B", "x"])
         assert_identical(expected, actual)
 
         actual = data.drop_dims("y")
-        expected = data.drop("A")
+        expected = data.drop_vars("A")
         assert_identical(expected, actual)
 
         actual = data.drop_dims(["x", "y"])
-        expected = data.drop(["A", "B", "x"])
+        expected = data.drop_vars(["A", "B", "x"])
         assert_identical(expected, actual)
 
         with pytest.raises((ValueError, KeyError)):
@@ -2230,7 +2239,7 @@ class TestDataset:
             actual = data.drop_dims("z", errors="wrong_value")
 
         actual = data.drop_dims(["x", "y", "z"], errors="ignore")
-        expected = data.drop(["A", "B", "x"])
+        expected = data.drop_vars(["A", "B", "x"])
         assert_identical(expected, actual)
 
     def test_copy(self):
@@ -2571,7 +2580,7 @@ class TestDataset:
                     original["x"].values * np.ones([4, 3, 3]),
                     coords=dict(d=range(4), e=["l", "m", "n"], a=np.linspace(0, 1, 3)),
                     dims=["d", "e", "a"],
-                ).drop("d"),
+                ).drop_vars("d"),
                 "y": xr.DataArray(
                     original["y"].values * np.ones([4, 3, 4, 3]),
                     coords=dict(
@@ -2581,7 +2590,7 @@ class TestDataset:
                         a=np.linspace(0, 1, 3),
                     ),
                     dims=["d", "e", "b", "a"],
-                ).drop("d"),
+                ).drop_vars("d"),
             },
             coords={"c": np.linspace(0, 1, 5)},
         )
@@ -3059,7 +3068,7 @@ class TestDataset:
             np.arange(10), dims="dim3", coords={"numbers": ("dim3", np.arange(10))}
         )
         expected = ds.copy()
-        expected["var3"] = other.drop("numbers")
+        expected["var3"] = other.drop_vars("numbers")
         actual = ds.copy()
         actual["var3"] = other
         assert_identical(expected, actual)
@@ -4504,7 +4513,9 @@ class TestDataset:
         actual = data.apply(lambda x: x.mean(keep_attrs=True), keep_attrs=True)
         assert_identical(expected, actual)
 
-        assert_identical(data.apply(lambda x: x, keep_attrs=True), data.drop("time"))
+        assert_identical(
+            data.apply(lambda x: x, keep_attrs=True), data.drop_vars("time")
+        )
 
         def scale(x, multiple=1):
             return multiple * x
@@ -4514,7 +4525,7 @@ class TestDataset:
         assert_identical(actual["numbers"], data["numbers"])
 
         actual = data.apply(np.asarray)
-        expected = data.drop("time")  # time is not used on a data var
+        expected = data.drop_vars("time")  # time is not used on a data var
         assert_equal(expected, actual)
 
     def make_example_math_dataset(self):
@@ -4616,7 +4627,7 @@ class TestDataset:
         assert_identical(expected, actual)
 
         actual = ds.isel(y=slice(1)) + ds.isel(y=slice(1, None))
-        expected = 2 * ds.drop(ds.y, dim="y")
+        expected = 2 * ds.drop(y=ds.y)
         assert_equal(actual, expected)
 
         actual = ds + ds[["bar"]]

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2122,15 +2122,15 @@ class TestDataset:
 
         # deprecated approach with `drop` works (straight copy paste from above)
 
-        with pytest.warns(FutureWarning):
+        with pytest.warns(PendingDeprecationWarning):
             actual = data.drop("not_found_here", errors="ignore")
         assert_identical(data, actual)
 
-        with pytest.warns(FutureWarning):
+        with pytest.warns(PendingDeprecationWarning):
             actual = data.drop(["not_found_here"], errors="ignore")
         assert_identical(data, actual)
 
-        with pytest.warns(FutureWarning):
+        with pytest.warns(PendingDeprecationWarning):
             actual = data.drop(["time", "not_found_here"], errors="ignore")
         assert_identical(expected, actual)
 
@@ -2167,7 +2167,7 @@ class TestDataset:
 
         # DataArrays as labels are a nasty corner case as they are not
         # Iterable[Hashable] - DataArray.__iter__ yields scalar DataArrays.
-        actual = data.drop(x=DataArray(["a", "b", "c"]), errors="ignore")
+        actual = data.drop_sel(x=DataArray(["a", "b", "c"]), errors="ignore")
         expected = data.isel(x=slice(0, 0))
         assert_identical(expected, actual)
         with pytest.warns(DeprecationWarning):
@@ -2175,7 +2175,7 @@ class TestDataset:
         assert_identical(expected, actual)
 
         with raises_regex(ValueError, "does not have coordinate labels"):
-            data.drop(y=1)
+            data.drop_sel(y=1)
 
     def test_drop_labels_by_keyword(self):
         data = Dataset(
@@ -2184,15 +2184,13 @@ class TestDataset:
         # Basic functionality.
         assert len(data.coords["x"]) == 2
 
-        # In the future, this will break.
         with pytest.warns(DeprecationWarning):
             ds1 = data.drop(["a"], dim="x")
-        ds2 = data.drop(x="a")
-        ds3 = data.drop(x=["a"])
-        ds4 = data.drop(x=["a", "b"])
-        ds5 = data.drop(x=["a", "b"], y=range(0, 6, 2))
+        ds2 = data.drop_sel(x="a")
+        ds3 = data.drop_sel(x=["a"])
+        ds4 = data.drop_sel(x=["a", "b"])
+        ds5 = data.drop_sel(x=["a", "b"], y=range(0, 6, 2))
 
-        # In the future, this will result in different behavior.
         arr = DataArray(range(3), dims=["c"])
         with pytest.warns(FutureWarning):
             data.drop(arr.coords)
@@ -4641,7 +4639,7 @@ class TestDataset:
         assert_identical(expected, actual)
 
         actual = ds.isel(y=slice(1)) + ds.isel(y=slice(1, None))
-        expected = 2 * ds.drop(y=ds.y)
+        expected = 2 * ds.drop_sel(y=ds.y)
         assert_equal(actual, expected)
 
         actual = ds + ds[["bar"]]

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -441,7 +441,8 @@ def test_argmin_max(dim_num, dtype, contains_nan, dask, func, skipna, aggdim):
         )
         expected = getattr(da, func)(dim=aggdim, skipna=skipna)
         assert_allclose(
-            actual.drop(list(actual.coords)), expected.drop(list(expected.coords))
+            actual.drop_vars(list(actual.coords)),
+            expected.drop_vars(list(expected.coords)),
         )
 
 

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -553,7 +553,7 @@ def test_datetime_single_string():
     actual = da.interp(time="2000-01-01T12:00")
     expected = xr.DataArray(0.5)
 
-    assert_allclose(actual.drop("time"), expected)
+    assert_allclose(actual.drop_vars("time"), expected)
 
 
 @requires_cftime

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1837,7 +1837,11 @@ class TestFacetedLinePlots(PlotTestCase):
             assert substring_in_axes(self.darray.name, ax)
 
     def test_test_empty_cell(self):
-        g = self.darray.isel(row=1).drop("row").plot(col="col", hue="hue", col_wrap=2)
+        g = (
+            self.darray.isel(row=1)
+            .drop_vars("row")
+            .plot(col="col", hue="hue", col_wrap=2)
+        )
         bottomright = g.axes[-1, -1]
         assert not bottomright.has_data()
         assert not bottomright.get_visible()

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1093,7 +1093,7 @@ class TestDataArray:
         "func",
         (
             pytest.param(
-                method("drop", labels=np.array([1, 5]), dim="x"),
+                method("drop_sel", labels=dict(x=np.array([1, 5]))),
                 marks=pytest.mark.xfail(
                     reason="selecting using incompatible units does not raise"
                 ),
@@ -1128,9 +1128,9 @@ class TestDataArray:
 
         expected = attach_units(
             func(strip_units(data_array), **stripped_kwargs),
-            {"data": quantity.units if func.name == "drop" else unit, "x": x.units},
+            {"data": quantity.units if func.name == "drop_sel" else unit, "x": x.units},
         )
-        if error is not None and func.name == "drop":
+        if error is not None and func.name == "drop_sel":
             with pytest.raises(error):
                 func(data_array, **kwargs)
         else:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Introduces `drop_vars`, and deprecates using `drop` for variables. `drop` is widely used for the deprecated case, so this is a fairly wide blast radius.

It's more churn than is ideal, but I do think it's a much better API.

This is ready for review, though I'm sure I'm missed references in the docs etc (took my peak regex skills to find/replace only the deprecated usages!)

Originally discussed [here](https://github.com/pydata/xarray/pull/3460)

 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
