### PR TITLE
python 3.8 tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,8 @@ jobs:
         conda_env: py36
       py37:
         conda_env: py37
+      py38:
+        conda_env: py38
       py37-upstream-dev:
         conda_env: py37
         upstream_dev: true

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -1,0 +1,15 @@
+name: xarray-tests
+channels:
+  - conda-forge
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+      - coveralls
+      - dask
+      - distributed
+      - numpy
+      - pandas
+      - pytest
+      - pytest-cov
+      - pytest-env

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -105,7 +105,7 @@ Internal Changes
     ``pip install git+https://github.com/andrewgsavage/pint.git@refs/pull/6/head)``.
     Even with it, interaction with non-numpy array libraries, e.g. dask or sparse, is broken.
 
-- Use Python 3.6 idioms throughout the codebase. (:pull:3419)
+- Use Python 3.6 idioms throughout the codebase. (:pull:`3419`)
   By `Maximilian Roos <https://github.com/max-sixty>`_
 
 - Run basic CI tests on Python 3.8. (:pull:`3477`)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -78,7 +78,8 @@ Bug fixes
 
 Documentation
 ~~~~~~~~~~~~~
-- Fix leap year condition in example (http://xarray.pydata.org/en/stable/examples/monthly-means.html) by `Mickaël Lalande <https://github.com/mickaellalande>`_.
+- Fix leap year condition in example (http://xarray.pydata.org/en/stable/examples/monthly-means.html)
+  by `Mickaël Lalande <https://github.com/mickaellalande>`_.
 - Fix the documentation of :py:meth:`DataArray.resample` and
   :py:meth:`Dataset.resample` and explicitly state that a
   datetime-like dimension is required. (:pull:`3400`)
@@ -105,6 +106,9 @@ Internal Changes
     Even with it, interaction with non-numpy array libraries, e.g. dask or sparse, is broken.
 
 - Use Python 3.6 idioms throughout the codebase. (:pull:3419)
+  By `Maximilian Roos <https://github.com/max-sixty>`_
+
+- Run basic CI tests on Python 3.8. (:pull:3477)
   By `Maximilian Roos <https://github.com/max-sixty>`_
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -108,7 +108,7 @@ Internal Changes
 - Use Python 3.6 idioms throughout the codebase. (:pull:3419)
   By `Maximilian Roos <https://github.com/max-sixty>`_
 
-- Run basic CI tests on Python 3.8. (:pull:3477)
+- Run basic CI tests on Python 3.8. (:pull:`3477`)
   By `Maximilian Roos <https://github.com/max-sixty>`_
 
 


### PR DESCRIPTION
Adds some minimal Python 3.8 tests

Scipy doesn't seem to yet work, neither installing packages via conda. But at least we show we're compatible, and we can change the tests to align with our standard setup when available