### PR TITLE
uamiv test using only raw uamiv variables

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3405,8 +3405,8 @@ class TestPseudoNetCDFFormat:
             ("TSTEP",),
             data,
             dict(
-                long_name="TFLAG".ljust(16)
-                var_desc="TFLAG".ljust(80)
+                long_name="TFLAG".ljust(16),
+                var_desc="TFLAG".ljust(80),
                 units="DATE-TIME".ljust(16)
             ),
         )
@@ -3438,8 +3438,8 @@ class TestPseudoNetCDFFormat:
 
         data = np.array([[[2002154, 0]]], dtype='i').repeat(2, 0)
         attrs = dict(
-            long_name="TFLAG".ljust(16)
-            var_desc="TFLAG".ljust(80)
+            long_name="TFLAG".ljust(16),
+            var_desc="TFLAG".ljust(80),
             units="DATE-TIME".ljust(16)
         )
         expected = xr.Variable(("TSTEP",), data, attrs)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3402,7 +3402,7 @@ class TestPseudoNetCDFFormat:
 
         data = np.array([[[2002154, 0]]], dtype="i")
         expected = xr.Variable(
-            ("TSTEP",),
+            ("TSTEP", "VAR", "DATE-TIME"),
             data,
             dict(
                 long_name="TFLAG".ljust(16),
@@ -3442,7 +3442,8 @@ class TestPseudoNetCDFFormat:
             var_desc="TFLAG".ljust(80),
             units="DATE-TIME".ljust(16),
         )
-        expected = xr.Variable(("TSTEP",), data, attrs)
+        dims = ("TSTEP", "VAR", "DATE-TIME")
+        expected = xr.Variable(dims, data, attrs)
         actual = camxfile.variables["TFLAG"]
         assert_allclose(expected, actual)
         camxfile.close()

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3400,14 +3400,14 @@ class TestPseudoNetCDFFormat:
         actual = camxfile.variables["O3"]
         assert_allclose(expected, actual)
 
-        data = np.array([[[2002154, 0]]], dtype='i')
+        data = np.array([[[2002154, 0]]], dtype="i")
         expected = xr.Variable(
             ("TSTEP",),
             data,
             dict(
                 long_name="TFLAG".ljust(16),
                 var_desc="TFLAG".ljust(80),
-                units="DATE-TIME".ljust(16)
+                units="DATE-TIME".ljust(16),
             ),
         )
         actual = camxfile.variables["TFLAG"]
@@ -3436,11 +3436,11 @@ class TestPseudoNetCDFFormat:
         actual = camxfile.variables["O3"]
         assert_allclose(expected, actual)
 
-        data = np.array([[[2002154, 0]]], dtype='i').repeat(2, 0)
+        data = np.array([[[2002154, 0]]], dtype="i").repeat(2, 0)
         attrs = dict(
             long_name="TFLAG".ljust(16),
             var_desc="TFLAG".ljust(80),
-            units="DATE-TIME".ljust(16)
+            units="DATE-TIME".ljust(16),
         )
         expected = xr.Variable(("TSTEP",), data, attrs)
         actual = camxfile.variables["TFLAG"]

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3400,20 +3400,17 @@ class TestPseudoNetCDFFormat:
         actual = camxfile.variables["O3"]
         assert_allclose(expected, actual)
 
-        data = np.array(["2002-06-03"], "datetime64[ns]")
+        data = np.array([[[2002154, 0]]], dtype='i')
         expected = xr.Variable(
             ("TSTEP",),
             data,
             dict(
-                bounds="time_bounds",
-                long_name=(
-                    "synthesized time coordinate "
-                    + "from SDATE, STIME, STEP "
-                    + "global attributes"
-                ),
+                long_name="TFLAG".ljust(16)
+                var_desc="TFLAG".ljust(80)
+                units="DATE-TIME".ljust(16)
             ),
         )
-        actual = camxfile.variables["time"]
+        actual = camxfile.variables["TFLAG"]
         assert_allclose(expected, actual)
         camxfile.close()
 
@@ -3439,18 +3436,14 @@ class TestPseudoNetCDFFormat:
         actual = camxfile.variables["O3"]
         assert_allclose(expected, actual)
 
-        data1 = np.array(["2002-06-03"], "datetime64[ns]")
-        data = np.concatenate([data1] * 2, axis=0)
+        data = np.array([[[2002154, 0]]], dtype='i').repeat(2, 0)
         attrs = dict(
-            bounds="time_bounds",
-            long_name=(
-                "synthesized time coordinate "
-                + "from SDATE, STIME, STEP "
-                + "global attributes"
-            ),
+            long_name="TFLAG".ljust(16)
+            var_desc="TFLAG".ljust(80)
+            units="DATE-TIME".ljust(16)
         )
         expected = xr.Variable(("TSTEP",), data, attrs)
-        actual = camxfile.variables["time"]
+        actual = camxfile.variables["TFLAG"]
         assert_allclose(expected, actual)
         camxfile.close()
 


### PR DESCRIPTION
Previous test relied on CF generated metadata, but this test is more robust.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Addresses #3409 #3420 #3434
 - [x] Tests fixed

Development machine is missing python3.6 environment, using azure to check. This should help me get this fix in faster.