### PR TITLE
fix pandas-dev tests

### DIFF
--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -16,7 +16,7 @@ steps:
         --pre \
         --upgrade \
         matplotlib \
-        pandas=0.26.0.dev0+628.g03c1a3db2 \  # FIXME https://github.com/pydata/xarray/issues/3440
+        pandas \
         scipy
         # numpy \  # FIXME https://github.com/pydata/xarray/issues/3409
     pip install \

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -52,6 +52,7 @@ from .coordinates import (
 from .dataset import Dataset, merge_indexes, split_indexes
 from .formatting import format_item
 from .indexes import Indexes, default_indexes
+from .merge import PANDAS_TYPES
 from .options import OPTIONS
 from .utils import Default, ReprObject, _default, _check_inplace, either_dict_or_kwargs
 from .variable import (
@@ -358,7 +359,7 @@ class DataArray(AbstractArray, DataWithCoords):
                 dims = getattr(data, "dims", getattr(coords, "dims", None))
             if name is None:
                 name = getattr(data, "name", None)
-            if attrs is None:
+            if attrs is None and not isinstance(data, PANDAS_TYPES):
                 attrs = getattr(data, "attrs", None)
             if encoding is None:
                 encoding = getattr(data, "encoding", None)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #3440

This PR makes `DataArray.__init__` ignore the pandas `attrs`. 

Not sure what we want to do about these attributes in the long term. One option would be to pop the `name` attribute, assign to `DataArray.name` and keep the rest as `DataArray.attrs`? But what if `name` clashes with the provided `name`?