### PR TITLE
Tests for module-level functions with units

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -104,7 +104,7 @@ Internal Changes
 ~~~~~~~~~~~~~~~~
 
 - Added integration tests against `pint <https://pint.readthedocs.io/>`_.
-  (:pull:`3238`, :pull:`3447`) by `Justus Magin <https://github.com/keewis>`_.
+  (:pull:`3238`, :pull:`3447`, :pull:`3493`) by `Justus Magin <https://github.com/keewis>`_.
 
   .. note::
 

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -469,10 +469,10 @@ def test_broadcast_dataset(dtype):
 
     ds = xr.Dataset(data_vars={"a": ("x", array1), "b": ("y", array2)})
 
-    expected, = tuple(
+    (expected,) = tuple(
         attach_units(elem, extract_units(ds)) for elem in xr.broadcast(strip_units(ds))
     )
-    result, = xr.broadcast(ds)
+    (result,) = xr.broadcast(ds)
 
     assert_equal_with_units(expected, result)
 

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -570,7 +570,7 @@ def test_broadcast_dataset(dtype):
         "coords",
     ),
 )
-def test_combine_by_coords_dataset(variant, unit, error, dtype):
+def test_combine_by_coords(variant, unit, error, dtype):
     original_unit = unit_registry.m
 
     variants = {

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -222,7 +222,9 @@ def convert_units(obj, to):
             if name != obj.name
         }
 
-        new_obj = xr.DataArray(name=name, data=data, coords=coords, attrs=obj.attrs)
+        new_obj = xr.DataArray(
+            name=name, data=data, coords=coords, attrs=obj.attrs, dims=obj.dims
+        )
     elif isinstance(obj, unit_registry.Quantity):
         units = to.get(None)
         new_obj = obj.to(units) if units is not None else obj

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -882,39 +882,20 @@ def test_merge_dataset(variant, unit, error, dtype):
             "z": ("x", np.arange(3, 6) * coord_unit),
         },
     )
-    ds4 = xr.Dataset(
-        data_vars={
-            "a": (("y", "x"), -1 * np.ones_like(array1) * data_unit),
-            "b": (("y", "x"), -1 * np.ones_like(array2) * data_unit),
-        },
-        coords={
-            "x": np.arange(6, 9) * dim_unit,
-            "y": np.arange(6, 8) * dim_unit,
-            "z": ("x", np.arange(6, 9) * coord_unit),
-        },
-    )
 
     func = function(xr.merge)
     if error is not None:
         with pytest.raises(error):
-            func([ds1, ds2, ds3, ds4])
+            func([ds1, ds2, ds3])
 
         return
 
     units = extract_units(ds1)
     convert_and_strip = lambda ds: strip_units(convert_units(ds, units))
     expected = attach_units(
-        func(
-            [
-                strip_units(ds1),
-                convert_and_strip(ds2),
-                convert_and_strip(ds3),
-                convert_and_strip(ds4),
-            ]
-        ),
-        units,
+        func([strip_units(ds1), convert_and_strip(ds2), convert_and_strip(ds3)]), units
     )
-    result = func([ds1, ds2, ds3, ds4])
+    result = func([ds1, ds2, ds3])
 
     assert_equal_with_units(expected, result)
 

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -768,7 +768,7 @@ def test_concat_dataarray(variant, unit, error, dtype):
     assert_equal_with_units(expected, result)
 
 
-@pytest.mark.xfail(False, reason="`concat` strips units")
+@pytest.mark.xfail(reason="`concat` strips units")
 @pytest.mark.parametrize(
     "unit,error",
     (
@@ -813,6 +813,108 @@ def test_concat_dataset(variant, unit, error, dtype):
         xr.concat([strip_units(ds1), strip_units(ds2)], dim="x"), extract_units(ds1)
     )
     result = xr.concat([ds1, ds2], dim="x")
+
+    assert_equal_with_units(expected, result)
+
+
+@pytest.mark.xfail(reason="blocked by `where`")
+@pytest.mark.parametrize(
+    "unit,error",
+    (
+        pytest.param(1, DimensionalityError, id="no_unit"),
+        pytest.param(
+            unit_registry.dimensionless, DimensionalityError, id="dimensionless"
+        ),
+        pytest.param(unit_registry.s, DimensionalityError, id="incompatible_unit"),
+        pytest.param(unit_registry.mm, None, id="compatible_unit"),
+        pytest.param(unit_registry.m, None, id="identical_unit"),
+    ),
+    ids=repr,
+)
+@pytest.mark.parametrize(
+    "variant",
+    (
+        "data",
+        pytest.param("dims", marks=pytest.mark.xfail(reason="indexes strip units")),
+        "coords",
+    ),
+)
+def test_merge_dataset(variant, unit, error, dtype):
+    original_unit = unit_registry.m
+
+    variants = {
+        "data": (unit, original_unit, original_unit),
+        "dims": (original_unit, unit, original_unit),
+        "coords": (original_unit, original_unit, unit),
+    }
+    data_unit, dim_unit, coord_unit = variants.get(variant)
+
+    array1 = np.zeros(shape=(2, 3), dtype=dtype) * original_unit
+    array2 = np.zeros(shape=(2, 3), dtype=dtype) * original_unit
+
+    x = np.arange(11, 14) * original_unit
+    y = np.arange(2) * original_unit
+    z = np.arange(3) * original_unit
+
+    ds1 = xr.Dataset(
+        data_vars={"a": (("y", "x"), array1), "b": (("y", "x"), array2)},
+        coords={"x": x, "y": y, "z": ("x", z)},
+    )
+    ds2 = xr.Dataset(
+        data_vars={
+            "a": (("y", "x"), np.ones_like(array1) * data_unit),
+            "b": (("y", "x"), np.ones_like(array2) * data_unit),
+        },
+        coords={
+            "x": np.arange(3) * dim_unit,
+            "y": np.arange(2, 4) * dim_unit,
+            "z": ("x", np.arange(-3, 0) * coord_unit),
+        },
+    )
+    ds3 = xr.Dataset(
+        data_vars={
+            "a": (("y", "x"), np.zeros_like(array1) * np.nan * data_unit),
+            "b": (("y", "x"), np.zeros_like(array2) * np.nan * data_unit),
+        },
+        coords={
+            "x": np.arange(3, 6) * dim_unit,
+            "y": np.arange(4, 6) * dim_unit,
+            "z": ("x", np.arange(3, 6) * coord_unit),
+        },
+    )
+    ds4 = xr.Dataset(
+        data_vars={
+            "a": (("y", "x"), -1 * np.ones_like(array1) * data_unit),
+            "b": (("y", "x"), -1 * np.ones_like(array2) * data_unit),
+        },
+        coords={
+            "x": np.arange(6, 9) * dim_unit,
+            "y": np.arange(6, 8) * dim_unit,
+            "z": ("x", np.arange(6, 9) * coord_unit),
+        },
+    )
+
+    func = function(xr.merge)
+    if error is not None:
+        with pytest.raises(error):
+            func([ds1, ds2, ds3, ds4])
+
+        return
+
+    units = extract_units(ds1)
+    convert_and_strip = lambda ds: strip_units(convert_units(ds, units))
+    expected = attach_units(
+        func(
+            [
+                strip_units(ds1),
+                convert_and_strip(ds2),
+                convert_and_strip(ds3),
+                convert_and_strip(ds4),
+            ]
+        ),
+        units,
+    )
+    result = func([ds1, ds2, ds3, ds4])
 
     assert_equal_with_units(expected, result)
 

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -306,7 +306,9 @@ def test_apply_ufunc_dataarray(dtype):
     assert_equal_with_units(expected, result)
 
 
-@pytest.mark.xfail(reason="pint does not implement `np.result_type`")
+@pytest.mark.xfail(
+    reason="pint does not implement `np.result_type` and align strips units"
+)
 @pytest.mark.parametrize(
     "unit,error",
     (
@@ -320,18 +322,36 @@ def test_apply_ufunc_dataarray(dtype):
     ),
     ids=repr,
 )
+@pytest.mark.parametrize("variant", ("data", "dims", "coords"))
 @pytest.mark.parametrize("fill_value", (np.float64(10), np.float64(np.nan)))
-def test_align_dataarray(fill_value, unit, error, dtype):
-    array1 = np.linspace(0, 10, 2 * 5).reshape(2, 5).astype(dtype) * unit_registry.m
-    array2 = np.linspace(0, 8, 2 * 5).reshape(2, 5).astype(dtype) * unit_registry.m
-    x = np.arange(2) * unit_registry.m
-    y = np.arange(5) * unit_registry.m
-    z = np.arange(2, 7) * unit_registry.m
+def test_align_dataarray(fill_value, variant, unit, error, dtype):
+    original_unit = unit_registry.m
 
-    data_array1 = xr.DataArray(data=array1, coords={"x": x, "y": y}, dims=("x", "y"))
-    data_array2 = xr.DataArray(data=array2, coords={"x": x, "y": z}, dims=("x", "y"))
+    variants = {
+        "data": (unit, original_unit, original_unit),
+        "dims": (original_unit, unit, original_unit),
+        "coords": (original_unit, original_unit, unit),
+    }
+    data_unit, dim_unit, coord_unit = variants.get(variant)
 
-    fill_value = fill_value * unit
+    array1 = np.linspace(0, 10, 2 * 5).reshape(2, 5).astype(dtype) * original_unit
+    array2 = np.linspace(0, 8, 2 * 5).reshape(2, 5).astype(dtype) * data_unit
+    x = np.arange(2) * original_unit
+    x_a1 = np.array([10, 5]) * original_unit
+    x_a2 = np.array([10, 5]) * coord_unit
+
+    y1 = np.arange(5) * original_unit
+    y2 = np.arange(2, 7) * dim_unit
+
+    data_array1 = xr.DataArray(
+        data=array1, coords={"x": x, "x_a": ("x", x_a1), "y": y1}, dims=("x", "y")
+    )
+    data_array2 = xr.DataArray(
+        data=array2, coords={"x": x, "x_a": ("x", x_a2), "y": y2}, dims=("x", "y")
+    )
+
+    # FIXME: convert x_a2 and y2 in data_array2, too
+    fill_value = fill_value * data_unit
     if isinstance(fill_value, unit_registry.Quantity) and fill_value.check(
         unit_registry.m
     ):
@@ -354,7 +374,9 @@ def test_align_dataarray(fill_value, unit, error, dtype):
     assert_equal_with_units(expected_b, result_b)
 
 
-@pytest.mark.xfail(reason="pint does not implement `np.result_type`")
+@pytest.mark.xfail(
+    reason="pint does not implement `np.result_type` and align strips units"
+)
 @pytest.mark.parametrize(
     "unit,error",
     (
@@ -368,18 +390,39 @@ def test_align_dataarray(fill_value, unit, error, dtype):
     ),
     ids=repr,
 )
+@pytest.mark.parametrize("variant", ("data", "dims", "coords"))
 @pytest.mark.parametrize("fill_value", (np.float64(10), np.float64(np.nan)))
-def test_align_dataset(fill_value, unit, error, dtype):
-    array1 = np.linspace(0, 10, 2 * 5).reshape(2, 5).astype(dtype) * unit_registry.m
-    array2 = np.linspace(0, 8, 2 * 5).reshape(2, 5).astype(dtype) * unit_registry.m
-    x = np.arange(2) * unit_registry.m
-    y = np.arange(5) * unit_registry.m
-    z = np.arange(2, 7) * unit_registry.m
+def test_align_dataset(fill_value, unit, variant, error, dtype):
+    original_unit = unit_registry.m
 
-    ds1 = xr.Dataset(data_vars={"a": (("x", "y"), array1)}, coords={"x": x, "y": y})
-    ds2 = xr.Dataset(data_vars={"a": (("x", "y"), array2)}, coords={"x": x, "y": z})
+    variants = {
+        "data": (unit, original_unit, original_unit),
+        "dims": (original_unit, unit, original_unit),
+        "coords": (original_unit, original_unit, unit),
+    }
+    data_unit, dim_unit, coord_unit = variants.get(variant)
 
-    fill_value = fill_value * unit
+    array1 = np.linspace(0, 10, 2 * 5).reshape(2, 5).astype(dtype) * original_unit
+    array2 = np.linspace(0, 10, 2 * 5).reshape(2, 5).astype(dtype) * data_unit
+
+    x = np.arange(2) * original_unit
+    x_a1 = np.array([10, 5]) * original_unit
+    x_a2 = np.array([10, 5]) * coord_unit
+
+    y1 = np.arange(5) * original_unit
+    y2 = np.arange(2, 7) * dim_unit
+
+    ds1 = xr.Dataset(
+        data_vars={"a": (("x", "y"), array1)},
+        coords={"x": x, "x_a": ("x", x_a1), "y": y1},
+    )
+    ds2 = xr.Dataset(
+        data_vars={"a": (("x", "y"), array2)},
+        coords={"x": x, "x_a": ("x", x_a2), "y": y2},
+    )
+
+    # FIXME: convert x_a2 and y2 in ds2, too
+    fill_value = fill_value * data_unit
     if isinstance(fill_value, unit_registry.Quantity) and fill_value.check(
         unit_registry.m
     ):
@@ -393,7 +436,10 @@ def test_align_dataset(fill_value, unit, error, dtype):
         return
 
     stripped_kwargs = {key: strip_units(value) for key, value in func.kwargs.items()}
-    expected_a, expected_b = func(strip_units(ds1), strip_units(ds2), **stripped_kwargs)
+    expected_a, expected_b = tuple(
+        attach_units(result, extract_units(ds1))
+        for result in func(strip_units(ds1), strip_units(ds2), **stripped_kwargs)
+    )
     result_a, result_b = func(ds1, ds2)
 
     assert_equal_with_units(expected_a, result_a)

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -392,6 +392,26 @@ def test_replication_full_like_dataset(unit, error, dtype):
     assert_equal_with_units(expected, result)
 
 
+@pytest.mark.xfail(reason="pint does not implement `np.einsum`")
+def test_dot_dataarray(dtype):
+    array1 = (
+        np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype)
+        * unit_registry.m
+        / unit_registry.s
+    )
+    array2 = (
+        np.linspace(10, 20, 10 * 20).reshape(10, 20).astype(dtype) * unit_registry.s
+    )
+
+    arr1 = xr.DataArray(data=array1, dims=("x", "y"))
+    arr2 = xr.DataArray(data=array2, dims=("y", "z"))
+
+    expected = array1.dot(array2)
+    result = xr.dot(arr1, arr2)
+
+    assert_equal_with_units(expected, result)
+
+
 class TestDataArray:
     @pytest.mark.filterwarnings("error:::pint[.*]")
     @pytest.mark.parametrize(

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -608,9 +608,11 @@ def test_combine_by_coords(variant, unit, error, dtype):
         return
 
     units = extract_units(ds)
-    # FIXME: convert other to `units` before `strip_units`
     expected = attach_units(
-        xr.combine_by_coords([strip_units(ds), strip_units(other)]), units
+        xr.combine_by_coords(
+            [strip_units(ds), strip_units(convert_units(other, units))]
+        ),
+        units,
     )
     result = xr.combine_by_coords([ds, other])
 

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -514,7 +514,7 @@ def test_replication_dataset(func, dtype):
 @pytest.mark.xfail(
     reason=(
         "pint is undecided on how `full_like` should work, so incorrect errors "
-        "may be thrown: hgrecco/pint#882"
+        "may be expected: hgrecco/pint#882"
     )
 )
 @pytest.mark.parametrize(
@@ -548,7 +548,7 @@ def test_replication_full_like_dataarray(unit, error, dtype):
 @pytest.mark.xfail(
     reason=(
         "pint is undecided on how `full_like` should work, so incorrect errors "
-        "may be thrown: hgrecco/pint#882"
+        "may be expected: hgrecco/pint#882"
     )
 )
 @pytest.mark.parametrize(

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -357,6 +357,7 @@ def test_replication_dataset(func, dtype):
         pytest.param(unit_registry.ms, None, id="compatible_unit"),
         pytest.param(unit_registry.s, None, id="identical_unit"),
     ),
+    ids=repr,
 )
 def test_replication_full_like_dataarray(unit, error, dtype):
     array = np.linspace(0, 5, 10) * unit_registry.s
@@ -390,6 +391,7 @@ def test_replication_full_like_dataarray(unit, error, dtype):
         pytest.param(unit_registry.ms, None, id="compatible_unit"),
         pytest.param(unit_registry.s, None, id="identical_unit"),
     ),
+    ids=repr,
 )
 def test_replication_full_like_dataset(unit, error, dtype):
     array1 = np.linspace(0, 10, 20).astype(dtype) * unit_registry.s

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -446,6 +446,37 @@ def test_align_dataset(fill_value, unit, variant, error, dtype):
     assert_equal_with_units(expected_b, result_b)
 
 
+def test_broadcast_dataarray(dtype):
+    array1 = np.linspace(0, 10, 2) * unit_registry.Pa
+    array2 = np.linspace(0, 10, 3) * unit_registry.Pa
+
+    a = xr.DataArray(data=array1, dims="x")
+    b = xr.DataArray(data=array2, dims="y")
+
+    expected_a, expected_b = tuple(
+        attach_units(elem, extract_units(a))
+        for elem in xr.broadcast(strip_units(a), strip_units(b))
+    )
+    result_a, result_b = xr.broadcast(a, b)
+
+    assert_equal_with_units(expected_a, result_a)
+    assert_equal_with_units(expected_b, result_b)
+
+
+def test_broadcast_dataset(dtype):
+    array1 = np.linspace(0, 10, 2) * unit_registry.Pa
+    array2 = np.linspace(0, 10, 3) * unit_registry.Pa
+
+    ds = xr.Dataset(data_vars={"a": ("x", array1), "b": ("y", array2)})
+
+    expected, = tuple(
+        attach_units(elem, extract_units(ds)) for elem in xr.broadcast(strip_units(ds))
+    )
+    result, = xr.broadcast(ds)
+
+    assert_equal_with_units(expected, result)
+
+
 @pytest.mark.parametrize("func", (xr.zeros_like, xr.ones_like))
 def test_replication_dataarray(func, dtype):
     array = np.linspace(0, 10, 20).astype(dtype) * unit_registry.s


### PR DESCRIPTION
This PR adds tests that cover the module level functions of the public API, similar to #3238 and #3447.
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

As a reference for myself, these are the functions listed by the docs:
* [x] `apply_ufunc`
* [x] `align`
* [x] `broadcast`
* [x] `concat`
* [x] `merge`
* [x] `combine_by_coords`
* [x] `combine_nested`
* [ ] <strike>`auto_combine` (deprecated)</strike>
* [x] masking / selecting: `where`
* [x] replication: `full_like`, `ones_like`, `zeros_like`
* [x] `dot`
* [ ] <strike>`map_blocks`</strike>

Functions not covered by this PR:
* `auto_combine` (deprecated)
* `map_blocks` (dask specific, should be the same as `apply_ufunc` without dask)
