### PR TITLE
unpin pseudonetcdf

### DIFF
--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -29,7 +29,7 @@ dependencies:
   - pandas
   - pint
   - pip
-  - pseudonetcdf<3.1  # FIXME https://github.com/pydata/xarray/issues/3409
+  - pseudonetcdf
   - pydap
   - pynio
   - pytest

--- a/ci/requirements/py37-windows.yml
+++ b/ci/requirements/py37-windows.yml
@@ -29,7 +29,7 @@ dependencies:
   - pandas
   - pint
   - pip
-  - pseudonetcdf<3.1  # FIXME https://github.com/pydata/xarray/issues/3409
+  - pseudonetcdf
   - pydap
   # - pynio  # Not available on Windows
   - pytest

--- a/ci/requirements/py37.yml
+++ b/ci/requirements/py37.yml
@@ -29,7 +29,7 @@ dependencies:
   - pandas
   - pint
   - pip
-  - pseudonetcdf<3.1  # FIXME https://github.com/pydata/xarray/issues/3409
+  - pseudonetcdf
   - pydap
   - pynio
   - pytest


### PR DESCRIPTION
It should be possible to run the tests with pseudonetcdf 3.1.0 again. 

xref #3434, #3409, #3485

thanks @barronh 

