### PR TITLE
Harmonize `FillValue` and `missing_value` during encoding and decoding steps

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -79,6 +79,8 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
+- Harmonize `_FillValue`, `missing_value` during encoding and decoding steps. (:pull:`3502`)
+  By `Anderson Banihirwe <https://github.com/andersy005>`_. 
 - Fix regression introduced in v0.14.0 that would cause a crash if dask is installed
   but cloudpickle isn't (:issue:`3401`) by `Rhys Doyle <https://github.com/rdoyle45>`_
 - Fix grouping over variables with NaNs. (:issue:`2383`, :pull:`3406`).

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -162,17 +162,15 @@ class CFMaskCoder(VariableCoder):
             )
 
         if fv is not None:
-            encoding["_FillValue"] = np.asarray(encoding["_FillValue"]).astype(
-                data.dtype
-            )
+            # Ensure _FillValue is cast to same dtype as data's
+            encoding["_FillValue"] = data.dtype.type(encoding["_FillValue"])
             fill_value = pop_to(encoding, attrs, "_FillValue", name=name)
             if not pd.isnull(fill_value):
                 data = duck_array_ops.fillna(data, fill_value)
 
         if mv is not None:
-            encoding["missing_value"] = np.asarray(encoding["missing_value"]).astype(
-                data.dtype
-            )
+            # Ensure missing_value is cast to same dtype as data's
+            encoding["missing_value"] = data.dtype.type(encoding["missing_value"])
             fill_value = pop_to(encoding, attrs, "missing_value", name=name)
             if not pd.isnull(fill_value) and fv is None:
                 data = duck_array_ops.fillna(data, fill_value)

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -162,13 +162,17 @@ class CFMaskCoder(VariableCoder):
             )
 
         if fv is not None:
-            # TODO: Cast _FillValue to the same dtype as the data
+            encoding["_FillValue"] = np.asarray(encoding["_FillValue"]).astype(
+                data.dtype
+            )
             fill_value = pop_to(encoding, attrs, "_FillValue", name=name)
             if not pd.isnull(fill_value):
                 data = duck_array_ops.fillna(data, fill_value)
 
         if mv is not None:
-            # TODO: Cast missing_value to the same dtype as the data
+            encoding["missing_value"] = np.asarray(encoding["missing_value"]).astype(
+                data.dtype
+            )
             fill_value = pop_to(encoding, attrs, "missing_value", name=name)
             if not pd.isnull(fill_value) and fv is None:
                 data = duck_array_ops.fillna(data, fill_value)

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -8,7 +8,6 @@ import pandas as pd
 
 from ..core import dtypes, duck_array_ops, indexing
 from ..core.pycompat import dask_array_type
-from ..core.utils import equivalent
 from ..core.variable import Variable
 
 
@@ -152,18 +151,24 @@ class CFMaskCoder(VariableCoder):
         fv = encoding.get("_FillValue")
         mv = encoding.get("missing_value")
 
-        if fv is not None and mv is not None and not equivalent(fv, mv):
+        if (
+            fv is not None
+            and mv is not None
+            and not duck_array_ops.allclose_or_equiv(fv, mv)
+        ):
             raise ValueError(
                 "Variable {!r} has multiple fill values {}. "
                 "Cannot encode data. ".format(name, [fv, mv])
             )
 
         if fv is not None:
+            # TODO: Cast _FillValue to the same dtype as the data
             fill_value = pop_to(encoding, attrs, "_FillValue", name=name)
             if not pd.isnull(fill_value):
                 data = duck_array_ops.fillna(data, fill_value)
 
         if mv is not None:
+            # TODO: Cast missing_value to the same dtype as the data
             fill_value = pop_to(encoding, attrs, "missing_value", name=name)
             if not pd.isnull(fill_value) and fv is None:
                 data = duck_array_ops.fillna(data, fill_value)

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -157,20 +157,19 @@ class CFMaskCoder(VariableCoder):
             and not duck_array_ops.allclose_or_equiv(fv, mv)
         ):
             raise ValueError(
-                "Variable {!r} has multiple fill values {}. "
-                "Cannot encode data. ".format(name, [fv, mv])
+                f"Variable {name!r} has conflicting _FillValue ({fv}) and missing_value ({mv}). Cannot encode data."
             )
 
         if fv is not None:
             # Ensure _FillValue is cast to same dtype as data's
-            encoding["_FillValue"] = data.dtype.type(encoding["_FillValue"])
+            encoding["_FillValue"] = data.dtype.type(fv)
             fill_value = pop_to(encoding, attrs, "_FillValue", name=name)
             if not pd.isnull(fill_value):
                 data = duck_array_ops.fillna(data, fill_value)
 
         if mv is not None:
             # Ensure missing_value is cast to same dtype as data's
-            encoding["missing_value"] = data.dtype.type(encoding["missing_value"])
+            encoding["missing_value"] = data.dtype.type(mv)
             fill_value = pop_to(encoding, attrs, "missing_value", name=name)
             if not pd.isnull(fill_value) and fv is None:
                 data = duck_array_ops.fillna(data, fill_value)

--- a/xarray/tests/test_coding.py
+++ b/xarray/tests/test_coding.py
@@ -31,7 +31,7 @@ def test_CFMaskCoder_encode_missing_fill_values_conflict():
 
     assert encoded.dtype == encoded.attrs["missing_value"].dtype
     assert encoded.dtype == encoded.attrs["_FillValue"].dtype
-    
+
     with pytest.warns(variables.SerializationWarning):
         roundtripped = coder.decode(coder.encode(original))
         assert_identical(roundtripped, original)

--- a/xarray/tests/test_coding.py
+++ b/xarray/tests/test_coding.py
@@ -20,6 +20,19 @@ def test_CFMaskCoder_decode():
     assert_identical(expected, encoded)
 
 
+def test_CFMaskCoder_encode_missing_fill_values_conflict():
+    original = xr.Variable(
+        ("x",),
+        [0.0, -1.0, 1.0],
+        encoding={"_FillValue": np.float32(1e20), "missing_value": np.float64(1e20)},
+    )
+    coder = variables.CFMaskCoder()
+    encoded = coder.encode(original)
+
+    assert encoded.dtype == encoded.attrs["missing_value"].dtype
+    assert encoded.dtype == encoded.attrs["_FillValue"].dtype
+
+
 def test_CFMaskCoder_missing_value():
     expected = xr.DataArray(
         np.array([[26915, 27755, -9999, 27705], [25595, -9999, 28315, -9999]]),

--- a/xarray/tests/test_coding.py
+++ b/xarray/tests/test_coding.py
@@ -32,6 +32,9 @@ def test_CFMaskCoder_encode_missing_fill_values_conflict():
     assert encoded.dtype == encoded.attrs["missing_value"].dtype
     assert encoded.dtype == encoded.attrs["_FillValue"].dtype
 
+    roundtripped = coder.decode(coder.encode(original))
+    assert_identical(roundtripped, original)
+
 
 def test_CFMaskCoder_missing_value():
     expected = xr.DataArray(

--- a/xarray/tests/test_coding.py
+++ b/xarray/tests/test_coding.py
@@ -31,9 +31,10 @@ def test_CFMaskCoder_encode_missing_fill_values_conflict():
 
     assert encoded.dtype == encoded.attrs["missing_value"].dtype
     assert encoded.dtype == encoded.attrs["_FillValue"].dtype
-
-    roundtripped = coder.decode(coder.encode(original))
-    assert_identical(roundtripped, original)
+    
+    with pytest.warns(variables.SerializationWarning):
+        roundtripped = coder.decode(coder.encode(original))
+        assert_identical(roundtripped, original)
 
 
 def test_CFMaskCoder_missing_value():


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

As pointed out in https://github.com/jbusecke/cmip6_preprocessing/issues/5, xarray appears to be very strict during the *encoding* and *decoding* steps even when there are (harmless) discrepancies between `missing_value` and `_FillValue`. For instance, when dtypes of `missing_value` and `_FillValue` are different, xarray gives up: 


```python
In [74]: from xarray.coding import variables                                                    

In [75]: import numpy as np                                                                     

In [76]: import xarray as xr                                                                    

In [77]: original = xr.Variable( 
    ...:         ("x",), 
    ...:         [0.0, -1.0, 1.0], 
    ...:         encoding={"_FillValue": np.float32(1e20), "missing_value": np.float64(1e20)}, 
    ...:     )                                                                                  

In [78]: coder = variables.CFMaskCoder()                                                        

In [79]: encoded = coder.encode(original)                                                       
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-79-9fbc3632e28b> in <module>
----> 1 encoded = coder.encode(original)

/glade/work/abanihi/devel/pangeo/xarray/xarray/coding/variables.py in encode(self, variable, name)
    156             raise ValueError(
    157                 "Variable {!r} has multiple fill values {}. "
--> 158                 "Cannot encode data. ".format(name, [fv, mv])
    159             )
    160 

ValueError: Variable None has multiple fill values [1e+20, 1e+20]. Cannot encode data. 
```

 - [ ] Closes #xxxx
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API




