### PR TITLE
Allow appending datetime & boolean variables to zarr stores

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -84,6 +84,8 @@ Bug fixes
 - Fix :py:meth:`xarray.core.groupby.DataArrayGroupBy.reduce` and
   :py:meth:`xarray.core.groupby.DatasetGroupBy.reduce` when reducing over multiple dimensions.
   (:issue:`3402`). By `Deepak Cherian <https://github.com/dcherian/>`_
+- Allow appending datetime and bool data variables to zarr stores.
+  (:issue:`3480`). By `Akihiro Matsukawa <https://github.com/amatsukawa/>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1243,8 +1243,9 @@ def _validate_datatypes_for_zarr_append(dataset):
             raise ValueError(
                 "Invalid dtype for data variable: {} "
                 "dtype must be a subtype of number, "
-                "a fixed sized string, a fixed size "
-                "unicode string or an object".format(var)
+                "datetime, bool, a fixed sized string, "
+                "a fixed size unicode string or an "
+                "object".format(var)
             )
 
     for k in dataset.data_vars.values():

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1234,6 +1234,8 @@ def _validate_datatypes_for_zarr_append(dataset):
     def check_dtype(var):
         if (
             not np.issubdtype(var.dtype, np.number)
+            and not np.issubdtype(var.dtype, np.datetime64)
+            and not np.issubdtype(var.dtype, np.bool)
             and not coding.strings.is_unicode_dtype(var.dtype)
             and not var.dtype == object
         ):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -90,8 +90,12 @@ def create_append_test_data(seed=None):
     string_var = np.array(["ae", "bc", "df"], dtype=object)
     string_var_to_append = np.array(["asdf", "asdfg"], dtype=object)
     unicode_var = ["áó", "áó", "áó"]
-    datetime_var = np.array(['2019-01-01', '2019-01-02', '2019-01-03'], dtype='datetime64[s]')
-    datetime_var_to_append = np.array(['2019-01-04', '2019-01-05'], dtype='datetime64[s]')
+    datetime_var = np.array(
+        ["2019-01-01", "2019-01-02", "2019-01-03"], dtype="datetime64[s]"
+    )
+    datetime_var_to_append = np.array(
+        ["2019-01-04", "2019-01-05"], dtype="datetime64[s]"
+    )
     bool_var = np.array([True, False, True], dtype=np.bool)
     bool_var_to_append = np.array([False, True], dtype=np.bool)
 
@@ -127,9 +131,7 @@ def create_append_test_data(seed=None):
             "datetime_var": xr.DataArray(
                 datetime_var_to_append, coords=[time2], dims=["time"]
             ),
-            "bool_var": xr.DataArray(
-                bool_var_to_append, coords=[time2], dims=["time"]
-            ),
+            "bool_var": xr.DataArray(bool_var_to_append, coords=[time2], dims=["time"]),
         }
     )
 
@@ -139,7 +141,7 @@ def create_append_test_data(seed=None):
                 rs.rand(3, 3, nt1 + nt2),
                 coords=[lat, lon, time1.append(time2)],
                 dims=["lat", "lon", "time"],
-            ),
+            )
         }
     )
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -90,6 +90,10 @@ def create_append_test_data(seed=None):
     string_var = np.array(["ae", "bc", "df"], dtype=object)
     string_var_to_append = np.array(["asdf", "asdfg"], dtype=object)
     unicode_var = ["áó", "áó", "áó"]
+    datetime_var = np.array(['2019-01-01', '2019-01-02', '2019-01-03'], dtype='datetime64[s]')
+    datetime_var_to_append = np.array(['2019-01-04', '2019-01-05'], dtype='datetime64[s]')
+    bool_var = np.array([True, False, True], dtype=np.bool)
+    bool_var_to_append = np.array([False, True], dtype=np.bool)
 
     ds = xr.Dataset(
         data_vars={
@@ -102,6 +106,8 @@ def create_append_test_data(seed=None):
             "unicode_var": xr.DataArray(
                 unicode_var, coords=[time1], dims=["time"]
             ).astype(np.unicode_),
+            "datetime_var": xr.DataArray(datetime_var, coords=[time1], dims=["time"]),
+            "bool_var": xr.DataArray(bool_var, coords=[time1], dims=["time"]),
         }
     )
 
@@ -118,6 +124,12 @@ def create_append_test_data(seed=None):
             "unicode_var": xr.DataArray(
                 unicode_var[:nt2], coords=[time2], dims=["time"]
             ).astype(np.unicode_),
+            "datetime_var": xr.DataArray(
+                datetime_var_to_append, coords=[time2], dims=["time"]
+            ),
+            "bool_var": xr.DataArray(
+                bool_var_to_append, coords=[time2], dims=["time"]
+            ),
         }
     )
 
@@ -127,7 +139,7 @@ def create_append_test_data(seed=None):
                 rs.rand(3, 3, nt1 + nt2),
                 coords=[lat, lon, time1.append(time2)],
                 dims=["lat", "lon", "time"],
-            )
+            ),
         }
     )
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #3480
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

AFAICT, the type checking in the `_validate_datatypes_for_zarr_append` is simply too strict, and relaxing it seems to work fine. But this is my first time digging into the xarray source code, so please let me know if this issue is more complex.