### PR TITLE
Remove syntax warning

### DIFF
--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -288,7 +288,7 @@ def line(
         )
 
     # The allargs dict passed to _easy_facetgrid above contains args
-    if args is ():
+    if args == ():
         args = kwargs.pop("args", ())
     else:
         assert "args" not in kwargs


### PR DESCRIPTION
Currently raises a `SyntaxWarning` (though I don't think causing any issues)

```
/home/vsts/work/1/s/xarray/plot/plot.py:291: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if args is ():
```