### PR TITLE
add missing pint integration tests

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -111,7 +111,7 @@ Internal Changes
 ~~~~~~~~~~~~~~~~
 
 - Added integration tests against `pint <https://pint.readthedocs.io/>`_.
-  (:pull:`3238`, :pull:`3447`) by `Justus Magin <https://github.com/keewis>`_.
+  (:pull:`3238`, :pull:`3447`, :pull:`3508`) by `Justus Magin <https://github.com/keewis>`_.
 
   .. note::
 


### PR DESCRIPTION
This adds the tests that were missed by #3238 and #3447.

 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

This should be ready to merge, but I'm almost certain that while going through #3238 and #3447 and trying to fix obvious mistakes I will find more missing tests.

Missing tests:
* [x] `Dataset.broadcast_like` and `DataArray.broadcast_like`
* [x] `DataArray.head`, `DataArray.tail` and `DataArray.thin`