### PR TITLE
Recursive tokenization

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -73,7 +73,7 @@ New Features
   for xarray objects. Note that xarray objects with a dask.array backend already used
   deterministic hashing in previous releases; this change implements it when whole
   xarray objects are embedded in a dask graph, e.g. when :meth:`DataArray.map` is
-  invoked. (:issue:`3378`, :pull:`3446`)
+  invoked. (:issue:`3378`, :pull:`3446`, :pull:`3515`)
   By `Deepak Cherian <https://github.com/dcherian>`_ and
   `Guido Imperiale <https://github.com/crusaderky>`_.
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -755,7 +755,9 @@ class DataArray(AbstractArray, DataWithCoords):
             return dataset
 
     def __dask_tokenize__(self):
-        return (type(self), self._variable, self._coords, self._name)
+        from dask.base import normalize_token
+
+        return normalize_token((type(self), self._variable, self._coords, self._name))
 
     def __dask_graph__(self):
         return self._to_temp_dataset().__dask_graph__()

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -654,9 +654,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
     def __dask_tokenize__(self):
         from dask.base import normalize_token
 
-        return normalize_token((
-            type(self), self._variables, self._coord_names, self._attrs
-        ))
+        return normalize_token(
+            (type(self), self._variables, self._coord_names, self._attrs)
+        )
 
     def __dask_graph__(self):
         graphs = {k: v.__dask_graph__() for k, v in self.variables.items()}

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -652,7 +652,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         return self
 
     def __dask_tokenize__(self):
-        return (type(self), self._variables, self._coord_names, self._attrs)
+        from dask.base import normalize_token
+
+        return normalize_token((
+            type(self), self._variables, self._coord_names, self._attrs
+        ))
 
     def __dask_graph__(self):
         graphs = {k: v.__dask_graph__() for k, v in self.variables.items()}

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -393,7 +393,9 @@ class Variable(
     def __dask_tokenize__(self):
         # Use v.data, instead of v._data, in order to cope with the wrappers
         # around NetCDF and the like
-        return type(self), self._dims, self.data, self._attrs
+        from dask.base import normalize_token
+
+        return normalize_token((type(self), self._dims, self.data, self._attrs))
 
     def __dask_graph__(self):
         if isinstance(self._data, dask_array_type):
@@ -1973,8 +1975,10 @@ class IndexVariable(Variable):
             self._data = PandasIndexAdapter(self._data)
 
     def __dask_tokenize__(self):
+        from dask.base import normalize_token
+
         # Don't waste time converting pd.Index to np.ndarray
-        return (type(self), self._dims, self._data.array, self._attrs)
+        return normalize_token((type(self), self._dims, self._data.array, self._attrs))
 
     def load(self):
         # data is already loaded into memory for IndexVariable

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1283,6 +1283,20 @@ def test_token_identical(obj, transform):
     )
 
 
+def test_recursive_token():
+    """Test that tokenization is invoked recursively, and doesn't just rely on the
+    output of str()
+    """
+    a = np.ones(10000)
+    b = np.ones(10000)
+    b[5000] = 2
+    assert str(a) == str(b)
+    assert dask.base.tokenize(a) != dask.base.tokenize(b)
+    xa = DataArray(a)
+    xb = DataArray(b)
+    assert dask.base.tokenize(xa) != dask.base.tokenize(xb)
+
+
 @requires_scipy_or_netCDF4
 def test_normalize_token_with_backend(map_ds):
     with create_tmp_file(allow_cleanup_failure=ON_WINDOWS) as tmp_file:

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1292,9 +1292,12 @@ def test_recursive_token():
     b[5000] = 2
     assert str(a) == str(b)
     assert dask.base.tokenize(a) != dask.base.tokenize(b)
-    xa = DataArray(a)
-    xb = DataArray(b)
-    assert dask.base.tokenize(xa) != dask.base.tokenize(xb)
+    da_a = DataArray(a)
+    da_b = DataArray(b)
+    assert dask.base.tokenize(da_a) != dask.base.tokenize(da_b)
+    ds_a = da_a.to_dataset(name="x")
+    ds_b = da_b.to_dataset(name="x")
+    assert dask.base.tokenize(ds_a) != dask.base.tokenize(ds_b)
 
 
 @requires_scipy_or_netCDF4

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1292,12 +1292,23 @@ def test_recursive_token():
     b[5000] = 2
     assert str(a) == str(b)
     assert dask.base.tokenize(a) != dask.base.tokenize(b)
+
+    # Test DataArray and Variable
     da_a = DataArray(a)
     da_b = DataArray(b)
+    assert str(da_a) == str(da_b)
     assert dask.base.tokenize(da_a) != dask.base.tokenize(da_b)
+
+    # Test Dataset
     ds_a = da_a.to_dataset(name="x")
     ds_b = da_b.to_dataset(name="x")
     assert dask.base.tokenize(ds_a) != dask.base.tokenize(ds_b)
+
+    # Test IndexVariable
+    da_a = DataArray(a, dims=["x"], coords={"x": a})
+    da_b = DataArray(a, dims=["x"], coords={"x": b})
+    assert str(da_a) == str(da_b)
+    assert dask.base.tokenize(da_a) != dask.base.tokenize(da_b)
 
 
 @requires_scipy_or_netCDF4

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1296,7 +1296,6 @@ def test_recursive_token():
     # Test DataArray and Variable
     da_a = DataArray(a)
     da_b = DataArray(b)
-    assert str(da_a) == str(da_b)
     assert dask.base.tokenize(da_a) != dask.base.tokenize(da_b)
 
     # Test Dataset
@@ -1307,7 +1306,6 @@ def test_recursive_token():
     # Test IndexVariable
     da_a = DataArray(a, dims=["x"], coords={"x": a})
     da_b = DataArray(a, dims=["x"], coords={"x": b})
-    assert str(da_a) == str(da_b)
     assert dask.base.tokenize(da_a) != dask.base.tokenize(da_b)
 
 

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -856,6 +856,10 @@ def test_dask_token():
     import dask
 
     s = sparse.COO.from_numpy(np.array([0, 0, 1, 2]))
+
+    # https://github.com/pydata/sparse/issues/300
+    s.__dask_tokenize__ = lambda: dask.base.normalize_token(s.__dict__)
+
     a = DataArray(s)
     t1 = dask.base.tokenize(a)
     t2 = dask.base.tokenize(a)


### PR DESCRIPTION
After misreading the dask documentation  <https://docs.dask.org/en/latest/custom-collections.html#deterministic-hashing>, I was under the impression that the output of ``__dask_tokenize__`` would be recursively parsed, like it happens for ``__getstate__`` or ``__reduce__``. That's not the case - the output of ``__dask_tokenize__`` is just fed into a str() function so it has to be made explicitly recursive!