### PR TITLE
Fix set_index when an existing dimension becomes a level

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -79,6 +79,8 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
+- Fix a bug in `set_index` in case that an existing dimension becomes a level variable of MultiIndex. (:pull:`3520`)
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - Harmonize `_FillValue`, `missing_value` during encoding and decoding steps. (:pull:`3502`)
   By `Anderson Banihirwe <https://github.com/andersy005>`_. 
 - Fix regression introduced in v0.14.0 that would cause a crash if dask is installed

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1601,8 +1601,9 @@ class DataArray(AbstractArray, DataWithCoords):
         --------
         DataArray.reset_index
         """
-        ds = self._to_temp_dataset().set_index(indexes, append=append,
-                                               inplace=inplace, **indexes_kwargs)
+        ds = self._to_temp_dataset().set_index(
+            indexes, append=append, inplace=inplace, **indexes_kwargs
+        )
         return self._from_temp_dataset(ds)
 
     def reset_index(

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -48,7 +48,7 @@ from .coordinates import (
     assert_coordinate_consistent,
     remap_label_indexers,
 )
-from .dataset import Dataset, merge_indexes, split_indexes
+from .dataset import Dataset, split_indexes
 from .formatting import format_item
 from .indexes import Indexes, default_indexes
 from .merge import PANDAS_TYPES

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1601,10 +1601,9 @@ class DataArray(AbstractArray, DataWithCoords):
         --------
         DataArray.reset_index
         """
-        _check_inplace(inplace)
-        indexes = either_dict_or_kwargs(indexes, indexes_kwargs, "set_index")
-        coords, _ = merge_indexes(indexes, self._coords, set(), append=append)
-        return self._replace(coords=coords)
+        ds = self._to_temp_dataset().set_index(indexes, append=append,
+                                               inplace=inplace, **indexes_kwargs)
+        return self._from_temp_dataset(ds)
 
     def reset_index(
         self,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -270,9 +270,7 @@ def merge_indexes(
     for k, v in new_variables.items():
         if any(d in dims_to_replace for d in v.dims):
             new_dims = [dims_to_replace.get(d, d) for d in v.dims]
-            new_variables[k] = type(v)(
-                new_dims, v.data, attrs=v.attrs, encoding=v.encoding, fastpath=True
-            )
+            new_variables[k] = v._replace(dims=new_dims)
     new_coord_names = coord_names | set(vars_to_replace)
     new_coord_names -= set(vars_to_remove)
     return new_variables, new_coord_names

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -204,7 +204,7 @@ def merge_indexes(
     """
     vars_to_replace: Dict[Hashable, Variable] = {}
     vars_to_remove: List[Hashable] = []
-    dims_to_replace: Dict[Hashable, Variable] = {}
+    dims_to_replace: Dict[Hashable, Hashable] = {}
     error_msg = "{} is not the name of an existing variable."
 
     for dim, var_names in indexes.items():
@@ -270,8 +270,9 @@ def merge_indexes(
     for k, v in new_variables.items():
         if any(d in dims_to_replace for d in v.dims):
             new_dims = [dims_to_replace.get(d, d) for d in v.dims]
-            new_variables[k] = type(v)(new_dims, v.data, attrs=v.attrs,
-                                       encoding=v.encoding, fastpath=True)
+            new_variables[k] = type(v)(
+                new_dims, v.data, attrs=v.attrs, encoding=v.encoding, fastpath=True
+            )
     new_coord_names = coord_names | set(vars_to_replace)
     new_coord_names -= set(vars_to_remove)
     return new_variables, new_coord_names

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1184,12 +1184,12 @@ class TestDataArray:
 
     def test_selection_multiindex_from_level(self):
         # GH: 3512
-        da = DataArray([0, 1], dims=['x'], coords={'x': [0, 1], 'y': 'a'})
-        db = DataArray([2, 3], dims=['x'], coords={'x': [0, 1], 'y': 'b'})
-        data = xr.concat([da, db], dim='x').set_index(xy=['x', 'y'])
-        assert data.dims == ('xy', )
-        actual = data.sel(y='a')
-        expected = data.isel(xy=[0, 1]).unstack('xy').squeeze('y').drop('y')
+        da = DataArray([0, 1], dims=["x"], coords={"x": [0, 1], "y": "a"})
+        db = DataArray([2, 3], dims=["x"], coords={"x": [0, 1], "y": "b"})
+        data = xr.concat([da, db], dim="x").set_index(xy=["x", "y"])
+        assert data.dims == ("xy",)
+        actual = data.sel(y="a")
+        expected = data.isel(xy=[0, 1]).unstack("xy").squeeze("y").drop("y")
         assert_equal(actual, expected)
 
     def test_virtual_default_coords(self):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1183,7 +1183,7 @@ class TestDataArray:
         assert_identical(expected, actual)
 
     def test_selection_multiindex_from_level(self):
-        #GH: 3512
+        # GH: 3512
         da = DataArray([0, 1], dims=['x'], coords={'x': [0, 1], 'y': 'a'})
         db = DataArray([2, 3], dims=['x'], coords={'x': [0, 1], 'y': 'b'})
         data = xr.concat([da, db], dim='x').set_index(xy=['x', 'y'])

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1182,6 +1182,15 @@ class TestDataArray:
         expected = expected.set_index(xy=["x", "y"]).unstack()
         assert_identical(expected, actual)
 
+    def test_selection_multiindex_from_level(self):
+        #GH: issue 3512
+        da = DataArray([0, 1], dims=['x'], coords={'x': [0, 1], 'y': 'a'})
+        db = DataArray([2, 3], dims=['x'], coords={'x': [0, 1], 'y': 'b'})
+        data = xr.concat([da, db], dim='x').set_index(xy=['x', 'y'])
+        actual = data.sel(y='a')
+        expected = data.isel(xy=[0, 1]).unstack('xy').drop('y')
+        assert_identical(actual, expected)
+
     def test_virtual_default_coords(self):
         array = DataArray(np.zeros((5,)), dims="x")
         expected = DataArray(range(5), dims="x", name="x")

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1183,13 +1183,14 @@ class TestDataArray:
         assert_identical(expected, actual)
 
     def test_selection_multiindex_from_level(self):
-        #GH: issue 3512
+        #GH: 3512
         da = DataArray([0, 1], dims=['x'], coords={'x': [0, 1], 'y': 'a'})
         db = DataArray([2, 3], dims=['x'], coords={'x': [0, 1], 'y': 'b'})
         data = xr.concat([da, db], dim='x').set_index(xy=['x', 'y'])
+        assert data.dims == ('xy', )
         actual = data.sel(y='a')
-        expected = data.isel(xy=[0, 1]).unstack('xy').drop('y')
-        assert_identical(actual, expected)
+        expected = data.isel(xy=[0, 1]).unstack('xy').squeeze('y').drop('y')
+        assert_equal(actual, expected)
 
     def test_virtual_default_coords(self):
         array = DataArray(np.zeros((5,)), dims="x")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #3512
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

There was a bug in `set_index`, where an old dimension was not updated if it becomes a level of MultiIndex.