### PR TITLE
FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: numfocus
+custom: http://numfocus.org/donate-to-xarray


### PR DESCRIPTION
add NumFOCUS github sponsors button (recurring donations only)

This feature launched today at GitHub Universe!

Also add the custom link to point to the donation form for xarray.

cc @shoyer
