### PR TITLE
Allow nested dictionaries in the Zarr backend (#3517)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -96,6 +96,8 @@ Bug fixes
   (:issue:`3402`). By `Deepak Cherian <https://github.com/dcherian/>`_
 - Allow appending datetime and bool data variables to zarr stores.
   (:issue:`3480`). By `Akihiro Matsukawa <https://github.com/amatsukawa/>`_.
+- Allow nested dictionaries in zarr attributes.
+  (:issue:`3517`). By `Eduardo Gonzalez <https://github.com/eddienko>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -179,7 +179,7 @@ def _validate_dataset_names(dataset):
         check_name(k)
 
 
-def _validate_attrs(dataset):
+def _validate_attrs(dataset, backend="netCDF"):
     """`attrs` must have a string key and a value which is either: a number,
     a string, an ndarray or a list/tuple of numbers/strings.
     """
@@ -197,6 +197,9 @@ def _validate_attrs(dataset):
                 "Invalid name for attr: {} must be a string for "
                 "serialization to netCDF files".format(name)
             )
+
+        if isinstance(value, dict) and ("zarr" in backend):
+            value = [value]
 
         if not isinstance(value, (str, Number, np.ndarray, np.number, list, tuple)):
             raise TypeError(
@@ -1299,7 +1302,7 @@ def to_zarr(
 
     # validate Dataset keys, DataArray names, and attr keys/values
     _validate_dataset_names(dataset)
-    _validate_attrs(dataset)
+    _validate_attrs(dataset, backend="zarr")
 
     if mode == "a":
         _validate_datatypes_for_zarr_append(dataset)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1754,6 +1754,13 @@ class ZarrBase(CFEncodedBase):
     def test_dataset_caching(self):
         super().test_dataset_caching()
 
+    def test_nested_dictionary(self):
+        original = create_test_data()
+        original.attrs["foo"] = {"bar": {"baz": 3}}
+        with self.create_zarr_target() as store_target:
+            original.to_zarr(store_target, mode="w")
+            assert_identical(original, xr.open_zarr(store_target))
+
     def test_append_write(self):
         ds, ds_to_append, _ = create_append_test_data()
         with self.create_zarr_target() as store_target:


### PR DESCRIPTION
Closes #3517.

I have tried to touch the minimum code as possible while leaving the defaults as they are now. The code works now by redefining to value to save as a list containing the dictionary. However when writing to disk the the dictionary is saved correctly, without the list (I do not understand 100% how it works but it does so someone double check!).

```
$ cat test.zarr/.zattrs
{
    "foo": {
        "bar": {
            "val": 3
        }
    }
}
```
