### PR TITLE
Leave empty slot when not using accessors

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -249,14 +249,14 @@ class DataArray(AbstractArray, DataWithCoords):
         Dictionary for holding arbitrary metadata.
     """
 
-    _accessors: Optional[Dict[str, Any]]  # noqa
+    _cache: Dict[str, Any]
     _coords: Dict[Any, Variable]
     _indexes: Optional[Dict[Hashable, pd.Index]]
     _name: Optional[Hashable]
     _variable: Variable
 
     __slots__ = (
-        "_accessors",
+        "_cache",
         "_coords",
         "_file_obj",
         "_indexes",
@@ -373,7 +373,6 @@ class DataArray(AbstractArray, DataWithCoords):
         assert isinstance(coords, dict)
         self._coords = coords
         self._name = name
-        self._accessors = None
 
         # TODO(shoyer): document this argument, once it becomes part of the
         # public interface.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -411,8 +411,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
     coordinates used for label based indexing.
     """
 
-    _accessors: Optional[Dict[str, Any]]
     _attrs: Optional[Dict[Hashable, Any]]
+    _cache: Dict[str, Any]
     _coord_names: Set[Hashable]
     _dims: Dict[Hashable, int]
     _encoding: Optional[Dict[Hashable, Any]]
@@ -420,8 +420,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
     _variables: Dict[Hashable, Variable]
 
     __slots__ = (
-        "_accessors",
         "_attrs",
+        "_cache",
         "_coord_names",
         "_dims",
         "_encoding",
@@ -527,7 +527,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             data_vars, coords, compat=compat
         )
 
-        self._accessors = None
         self._attrs = dict(attrs) if attrs is not None else None
         self._file_obj = None
         self._encoding = None
@@ -862,7 +861,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         obj._attrs = attrs
         obj._file_obj = file_obj
         obj._encoding = encoding
-        obj._accessors = None
         return obj
 
     @classmethod

--- a/xarray/core/extensions.py
+++ b/xarray/core/extensions.py
@@ -20,10 +20,15 @@ class _CachedAccessor:
             # we're accessing the attribute of the class, i.e., Dataset.geo
             return self._accessor
 
+        # Use the same dict as @pandas.util.cache_readonly.
+        # It must be explicitly declared in obj.__slots__.
         try:
-            return obj._accessors[self._name]
-        except TypeError:
-            obj._accessors = {}
+            cache = obj._cache
+        except AttributeError:
+            cache = obj._cache = {}
+
+        try:
+            return cache[self._name]
         except KeyError:
             pass
 
@@ -35,7 +40,7 @@ class _CachedAccessor:
             # something else (GH933):
             raise RuntimeError("error initializing %r accessor." % self._name)
 
-        obj._accessors[self._name] = accessor_obj
+        cache[self._name] = accessor_obj
         return accessor_obj
 
 


### PR DESCRIPTION
Save a few bytes and nanoseconds for the overwhelming majority of the users that don't use accessors.
Lay the groundwork for potential future use of ``@pandas.utils.cache_readonly``.

xref https://github.com/pydata/xarray/issues/3514