### PR TITLE
WIP: Speed up isel in most cases

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -60,6 +60,7 @@ from .coordinates import (
 )
 from .duck_array_ops import datetime_to_numeric
 from .indexes import Indexes, default_indexes, isel_variable_and_index, roll_index
+from .indexing import is_fancy_indexer
 from .merge import (
     dataset_merge_method,
     dataset_update_method,
@@ -1907,6 +1908,51 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         DataArray.isel
         """
         indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "isel")
+        if any(is_fancy_indexer(idx) for idx in indexers.values()):
+            return self._isel_fancy(indexers, drop=drop)
+
+        # Much faster algorithm for when all indexers are ints, slices, one-dimensional
+        # lists, or zero or one-dimensional np.ndarray's
+        invalid = indexers.keys() - self.dims.keys()
+        if invalid:
+            raise ValueError("dimensions %r do not exist" % invalid)
+
+        variables = {}
+        dims = {}
+        coord_names = self._coord_names.copy()
+        indexes = self._indexes.copy() if self._indexes is not None else None
+
+        for var_name, var_value in self._variables.items():
+            var_indexers = {k: v for k, v in indexers.items() if k in var_value.dims}
+            if var_indexers:
+                var_value = var_value.isel(var_indexers)
+                if drop and var_value.ndim == 0 and var_name in coord_names:
+                    coord_names.remove(var_name)
+                    if indexes:
+                        indexes.pop(var_name, None)
+                    continue
+                if indexes and var_name in indexes:
+                    if var_value.ndim == 1:
+                        indexes[var_name] = var_value.to_index()
+                    else:
+                        del indexes[var_name]
+            variables[var_name] = var_value
+            dims.update(dict(zip(var_value.dims, var_value.shape)))
+
+        # Restore order
+        dims = {k: dims[k] for k, v in self._dims.items() if k in dims}
+
+        return self._construct_direct(
+            variables=variables,
+            coord_names=coord_names,
+            dims=dims,
+            attrs=self._attrs,
+            indexes=indexes,
+            encoding=self._encoding,
+            file_obj=self._file_obj,
+        )
+
+    def _isel_fancy(self, indexers: Mapping[Hashable, Any], *, drop: bool) -> "Dataset":
         # Note: we need to preserve the original indexers variable in order to merge the
         # coords below
         indexers_list = list(self._validate_indexers(indexers))

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1213,6 +1213,19 @@ def posify_mask_indexer(indexer):
     return type(indexer)(key)
 
 
+def is_fancy_indexer(indexer: Any) -> bool:
+    """Return False if indexer is a int, slice, a 1-dimensional list, or a 0 or
+    1-dimensional ndarray; in all other cases return True
+    """
+    if isinstance(indexer, (int, slice)):
+        return False
+    if isinstance(indexer, np.ndarray):
+        return indexer.ndim > 1
+    if isinstance(indexer, list):
+        return bool(indexer) and not isinstance(indexer[0], int)
+    return True
+
+
 class NumpyIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
     """Wrap a NumPy array to use explicit indexing."""
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -617,7 +617,10 @@ class Variable(
                 k = k.data
             if not isinstance(k, BASIC_INDEXING_TYPES):
                 k = np.asarray(k)
-                if k.dtype.kind == "b":
+                if k.size == 0:
+                    # Slice by empty list; numpy could not infer the dtype
+                    k = k.astype(int)
+                elif k.dtype.kind == "b":
                     (k,) = np.nonzero(k)
             new_key.append(k)
 

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1154,6 +1154,26 @@ class TestVariable(VariableSubclassobjects):
     def test_getitem_basic(self):
         v = self.cls(["x", "y"], [[0, 1, 2], [3, 4, 5]])
 
+        # int argument
+        v_new = v[0]
+        assert v_new.dims == ("y",)
+        assert_array_equal(v_new, v._data[0])
+
+        # slice argument
+        v_new = v[:2]
+        assert v_new.dims == ("x", "y")
+        assert_array_equal(v_new, v._data[:2])
+
+        # list arguments
+        v_new = v[[0]]
+        assert v_new.dims == ("x", "y")
+        assert_array_equal(v_new, v._data[[0]])
+
+        v_new = v[[]]
+        assert v_new.dims == ("x", "y")
+        assert_array_equal(v_new, v._data[[]])
+
+        # dict arguments
         v_new = v[dict(x=0)]
         assert v_new.dims == ("y",)
         assert_array_equal(v_new, v._data[0])
@@ -1194,6 +1214,8 @@ class TestVariable(VariableSubclassobjects):
         assert_identical(v.isel(time=0), v[0])
         assert_identical(v.isel(time=slice(0, 3)), v[:3])
         assert_identical(v.isel(x=0), v[:, 0])
+        assert_identical(v.isel(x=[0, 2]), v[:, [0, 2]])
+        assert_identical(v.isel(time=[]), v[[]])
         with raises_regex(ValueError, "do not exist"):
             v.isel(not_a_dim=0)
 


### PR DESCRIPTION
Yet another major improvement for #2799.

Achieve a 2x to 5x boost in isel performance when slicing by int, list of int, scalar ndarray, or 1-dimensional ndarray.

```python
import xarray

da = xarray.DataArray([[1, 2], [3, 4]], dims=['x', 'y'])
v = da.variable
a = da.variable.values
ds = da.to_dataset(name="d")

ds_with_idx = xarray.Dataset({'x': [10, 20], 'y': [100, 200], 'd': (('x', 'y'), [[1, 2], [3, 4]])})
da_with_idx = ds_with_idx.d

# before -> after
%timeit a[0] # 121 ns
%timeit v[0] # 7 µs
%timeit v.isel(x=0) # 10 µs
%timeit da[0]  # 65 µs -> 15 µs
%timeit da.isel(x=0)  # 63 µs -> 13 µs
%timeit ds.isel(x=0)  # 48 µs -> 24 µs
%timeit da_with_idx[0]  # 209 µs -> 82 µs
%timeit da_with_idx.isel(x=0, drop=False)  # 135 µs -> 34 µs
%timeit da_with_idx.isel(x=0, drop=True)  # 101 µs -> 34 µs
%timeit ds_with_idx.isel(x=0, drop=False)  # 90 µs -> 49 µs
%timeit ds_with_idx.isel(x=0, drop=True)  # 65 µs -> 49 µs
```

Marked as WIP because this commands running the asv suite to verify there are no regressions for large arrays.
(on a separate note, we really need to add the small size cases to asv - as discussed in #3382).

This profoundly alters one of the most important methods in xarray and I must confess it makes me nervous, particularly as I am unsure if the test coverage of  DataArray.isel() is as through as Dataset.isel().