### PR TITLE
Numpy 1.18 support

### DIFF
--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -16,9 +16,9 @@ steps:
         --pre \
         --upgrade \
         matplotlib \
+        numpy \
         pandas \
         scipy
-        # numpy \  # FIXME https://github.com/pydata/xarray/issues/3409
     pip install \
         --no-deps \
         --upgrade \

--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -25,7 +25,7 @@ dependencies:
   - nc-time-axis
   - netcdf4
   - numba
-  - numpy<1.18  # FIXME https://github.com/pydata/xarray/issues/3409
+  - numpy
   - pandas
   - pint
   - pip

--- a/ci/requirements/py37.yml
+++ b/ci/requirements/py37.yml
@@ -25,7 +25,7 @@ dependencies:
   - nc-time-axis
   - netcdf4
   - numba
-  - numpy<1.18  # FIXME https://github.com/pydata/xarray/issues/3409
+  - numpy
   - pandas
   - pint
   - pip

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -115,8 +115,8 @@ Bug fixes
   (:issue:`3402`). By `Deepak Cherian <https://github.com/dcherian/>`_
 - Allow appending datetime and bool data variables to zarr stores.
   (:issue:`3480`). By `Akihiro Matsukawa <https://github.com/amatsukawa/>`_.
-- Add support for numpy >=1.18 (:issue:`3409`).
-  By `Guido Imperiale <https://github.com/crusaderky>`_.
+- Add support for numpy >=1.18 (); bugfix mean() on datetime64 arrays on dask backend
+  (:issue:`3409`, :pull:`3537`). By `Guido Imperiale <https://github.com/crusaderky>`_.
 - Add support for pandas >=0.26 (:issue:`3440`).
   By `Deepak Cherian <https://github.com/dcherian>`_.
 - Add support for pseudonetcdf >=3.1 (:pull:`3485`).

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -100,6 +100,12 @@ Bug fixes
   (:issue:`3402`). By `Deepak Cherian <https://github.com/dcherian/>`_
 - Allow appending datetime and bool data variables to zarr stores.
   (:issue:`3480`). By `Akihiro Matsukawa <https://github.com/amatsukawa/>`_.
+- Add support for numpy >=1.18 (:issue:`3409`).
+  By `Guido Imperiale <https://github.com/crusaderky>`_.
+- Add support for pandas >=0.26 (:issue:`3440`).
+  By `Deepak Cherian <https://github.com/dcherian>`_.
+- Add support for pseudonetcdf >=3.1 (:pull:`3485`).
+  By `Barron Henderson <https://github.com/barronh>`_.
 
 Documentation
 ~~~~~~~~~~~~~
@@ -118,7 +124,6 @@ Documentation
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-
 - Added integration tests against `pint <https://pint.readthedocs.io/>`_.
   (:pull:`3238`, :pull:`3447`, :pull:`3493`, :pull:`3508`)
   by `Justus Magin <https://github.com/keewis>`_.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5316,7 +5316,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 datetime_unit, _ = np.datetime_data(coord_var.dtype)
             elif datetime_unit is None:
                 datetime_unit = "s"  # Default to seconds for cftime objects
-            coord_var = datetime_to_numeric(coord_var, datetime_unit=datetime_unit)
+            coord_var = coord_var._replace(
+                data=datetime_to_numeric(coord_var.data, datetime_unit=datetime_unit)
+            )
 
         variables = {}
         coord_names = set()

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -10,7 +10,6 @@ from functools import partial
 
 import numpy as np
 import pandas as pd
-from distutils.version import LooseVersion
 
 from . import dask_array_ops, dtypes, npcompat, nputils
 from .nputils import nanfirst, nanlast

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -357,6 +357,7 @@ def _datetime_crude_nanmin(array):
 
     - can't accept an axis parameter
     - will return incorrect results if the array exclusively contains NaT
+    - doesn't work with dask!
     """
     if LooseVersion(np.__version__) < "1.18":
         # numpy.min < 1.18 incorrectly skips NaT - which we exploit here
@@ -371,10 +372,8 @@ def _datetime_crude_nanmin(array):
     array = array.ravel()
     array = array[~pandas_isnull(array)]
 
-    assert array.dtype.kind in "Mm"
     assert array.dtype.itemsize == 8
     initial = np.array(2 ** 63 - 1, dtype=array.dtype)
-
     return min(array, initial=initial, skipna=False)
 
 

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -360,12 +360,6 @@ def _datetime_nanmin(array):
     - numpy nanmin() don't work on datetime64 (all versions at the moment of writing)
     - dask min() does not work on datetime64 (all versions at the moment of writing)
     """
-    from .dataarray import DataArray
-    from .variable import Variable
-
-    if isinstance(array, (DataArray, Variable)):
-        array = array.data
-
     assert array.dtype.kind in "mM"
     dtype = array.dtype
     # (NaT).astype(float) does not produce NaN...

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5874,7 +5874,9 @@ def test_trapz_datetime(dask, which_datetime):
 
     actual = da.integrate("time", datetime_unit="D")
     expected_data = np.trapz(
-        da, duck_array_ops.datetime_to_numeric(da["time"], datetime_unit="D"), axis=0
+        da.data,
+        duck_array_ops.datetime_to_numeric(da["time"].data, datetime_unit="D"),
+        axis=0,
     )
     expected = xr.DataArray(
         expected_data,

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -274,14 +274,14 @@ def assert_dask_array(da, dask):
 
 
 @arm_xfail
-@pytest.mark.parametrize("dask", [False, True])
+@pytest.mark.parametrize("dask", [False, True] if has_dask else [False])
 def test_datetime_mean(dask):
     # Note: only testing numpy, as dask is broken upstream
     da = DataArray(
         np.array(["2010-01-01", "NaT", "2010-01-03", "NaT", "NaT"], dtype="M8"),
         dims=["time"],
     )
-    if dask and has_dask:
+    if dask:
         # Trigger use case where a chunk is full of NaT
         da = da.chunk({"time": 3})
 


### PR DESCRIPTION
Fix mean() and nanmean() for datetime64 arrays on numpy backend when upgrading from numpy 1.17 to 1.18.
All other nan-reductions on datetime64s were broken before and remain broken.
mean() on datetime64 and dask was broken before and remains broken.

 - [x] Closes #3409
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
