### PR TITLE
Added fill_value for unstack

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -39,6 +39,9 @@ Breaking changes
 New Features
 ~~~~~~~~~~~~
 
+- Added the ``fill_value`` option to :py:meth:`~xarray.DataArray.unstack` and
+  :py:meth:`~xarray.Dataset.unstack` (:issue:`3518`).
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - Added the ``max_gap`` kwarg to :py:meth:`~xarray.DataArray.interpolate_na` and
   :py:meth:`~xarray.Dataset.interpolate_na`. This controls the maximum size of the data
   gap that will be filled by interpolation. By `Deepak Cherian <https://github.com/dcherian>`_.

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1729,7 +1729,6 @@ class DataArray(AbstractArray, DataWithCoords):
         self,
         dim: Union[Hashable, Sequence[Hashable], None] = None,
         fill_value: Any = dtypes.NA,
-        sparse: bool = False,
     ) -> "DataArray":
         """
         Unstack existing dimensions corresponding to MultiIndexes into
@@ -1743,7 +1742,6 @@ class DataArray(AbstractArray, DataWithCoords):
             Dimension(s) over which to unstack. By default unstacks all
             MultiIndexes.
         fill_value: value to be filled. By default, np.nan
-        sparse: use sparse if True.
 
         Returns
         -------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1726,7 +1726,10 @@ class DataArray(AbstractArray, DataWithCoords):
         return self._from_temp_dataset(ds)
 
     def unstack(
-        self, dim: Union[Hashable, Sequence[Hashable], None] = None
+        self,
+        dim: Union[Hashable, Sequence[Hashable], None] = None,
+        fill_value: Any = dtypes.NA,
+        sparse: bool = False,
     ) -> "DataArray":
         """
         Unstack existing dimensions corresponding to MultiIndexes into
@@ -1739,6 +1742,8 @@ class DataArray(AbstractArray, DataWithCoords):
         dim : hashable or sequence of hashable, optional
             Dimension(s) over which to unstack. By default unstacks all
             MultiIndexes.
+        fill_value: value to be filled. By default, np.nan
+        sparse: use sparse if True.
 
         Returns
         -------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1773,7 +1773,7 @@ class DataArray(AbstractArray, DataWithCoords):
         --------
         DataArray.stack
         """
-        ds = self._to_temp_dataset().unstack(dim)
+        ds = self._to_temp_dataset().unstack(dim, fill_value)
         return self._from_temp_dataset(ds)
 
     def to_unstacked_dataset(self, dim, level=0):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3333,7 +3333,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         return data_array
 
-    def _unstack_once(self, dim: Hashable, fill_value, sparse: bool) -> "Dataset":
+    def _unstack_once(self, dim: Hashable, fill_value) -> "Dataset":
         index = self.get_index(dim)
         index = index.remove_unused_levels()
         full_idx = pd.MultiIndex.from_product(index.levels, names=index.names)
@@ -3372,7 +3372,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         self,
         dim: Union[Hashable, Iterable[Hashable]] = None,
         fill_value: Any = dtypes.NA,
-        sparse: bool = False,
     ) -> "Dataset":
         """
         Unstack existing dimensions corresponding to MultiIndexes into
@@ -3386,7 +3385,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             Dimension(s) over which to unstack. By default unstacks all
             MultiIndexes.
         fill_value: value to be filled. By default, np.nan
-        sparse: use sparse if True.
 
         Returns
         -------
@@ -3424,7 +3422,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         result = self.copy(deep=False)
         for dim in dims:
-            result = result._unstack_once(dim, fill_value, sparse)
+            result = result._unstack_once(dim, fill_value)
         return result
 
     def update(self, other: "CoercibleMapping", inplace: bool = None) -> "Dataset":

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1341,7 +1341,7 @@ class Variable(
 
     def stack(self, dimensions=None, **dimensions_kwargs):
         """
-        Stack any number of existing dimensions into a single new dimension.
+        Stack any nimber of existing dimensions into a single new dimension.
 
         New dimensions will be added at the end, and the order of the data
         along each new dimension will be in contiguous (C) order.

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1341,7 +1341,7 @@ class Variable(
 
     def stack(self, dimensions=None, **dimensions_kwargs):
         """
-        Stack any nimber of existing dimensions into a single new dimension.
+        Stack any number of existing dimensions into a single new dimension.
 
         New dimensions will be added at the end, and the order of the data
         along each new dimension will be in contiguous (C) order.

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2805,11 +2805,11 @@ class TestDataset:
         actual = ds.unstack("index", fill_value=-1)
         expected = ds.unstack("index").fillna(-1).astype(np.int)
         assert actual["var"].dtype == np.int
-        assert actual.equals(expected)
+        assert_equals(actual, expected)
 
         actual = ds["var"].unstack("index", fill_value=-1)
         expected = ds["var"].unstack("index").fillna(-1).astype(np.int)
-        assert actual.equals(expected)
+        assert_equals(actual, expected)
 
     def test_stack_unstack_fast(self):
         ds = Dataset(

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2805,11 +2805,11 @@ class TestDataset:
         actual = ds.unstack("index", fill_value=-1)
         expected = ds.unstack("index").fillna(-1).astype(np.int)
         assert actual["var"].dtype == np.int
-        assert_equals(actual, expected)
+        assert_equal(actual, expected)
 
         actual = ds["var"].unstack("index", fill_value=-1)
         expected = ds["var"].unstack("index").fillna(-1).astype(np.int)
-        assert_equals(actual, expected)
+        assert actual.equals(expected)
 
     def test_stack_unstack_fast(self):
         ds = Dataset(

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2794,6 +2794,23 @@ class TestDataset:
         with raises_regex(ValueError, "do not have a MultiIndex"):
             ds.unstack("x")
 
+    def test_unstack_fill_value(self):
+        ds = xr.Dataset(
+            {"var": (("x",), np.arange(6))},
+            coords={"x": [0, 1, 2] * 2, "y": (("x",), ["a"] * 3 + ["b"] * 3)},
+        )
+        # make ds incomplete
+        ds = ds.isel(x=[0, 2, 3, 4]).set_index(index=["x", "y"])
+        # test fill_value
+        actual = ds.unstack("index", fill_value=-1)
+        expected = ds.unstack("index").fillna(-1).astype(np.int)
+        assert actual["var"].dtype == np.int
+        assert actual.equals(expected)
+
+        actual = ds["var"].unstack("index", fill_value=-1)
+        expected = ds["var"].unstack("index").fillna(-1).astype(np.int)
+        assert actual.equals(expected)
+
     def test_stack_unstack_fast(self):
         ds = Dataset(
             {


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #3518
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Added an option `fill_value` for `unstack`.
I am trying to add `sparse` option too, but it may take longer.
Probably better to do in a separate PR?
