### PR TITLE
sparse option to reindex and unstack

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -39,6 +39,9 @@ Breaking changes
 New Features
 ~~~~~~~~~~~~
 
+- Added the ``fill_value`` option to :py:meth:`~xarray.DataArray.unstack` and
+  :py:meth:`~xarray.Dataset.unstack` (:issue:`3518`).
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - Added the ``max_gap`` kwarg to :py:meth:`~xarray.DataArray.interpolate_na` and
   :py:meth:`~xarray.Dataset.interpolate_na`. This controls the maximum size of the data
   gap that will be filled by interpolation. By `Deepak Cherian <https://github.com/dcherian>`_.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,7 +38,10 @@ Breaking changes
 
 New Features
 ~~~~~~~~~~~~
-
+- Added the ``sparse`` option to :py:meth:`~xarray.DataArray.unstack`, 
+  :py:meth:`~xarray.Dataset.unstack`, :py:meth:`~xarray.DataArray.reindex`, 
+  :py:meth:`~xarray.Dataset.reindex` (:issue:`3518`).
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - Added the ``fill_value`` option to :py:meth:`~xarray.DataArray.unstack` and
   :py:meth:`~xarray.Dataset.unstack` (:issue:`3518`).
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -466,6 +466,7 @@ def reindex_variables(
     tolerance: Any = None,
     copy: bool = True,
     fill_value: Optional[Any] = dtypes.NA,
+    sparse: bool = False,
 ) -> Tuple[Dict[Hashable, Variable], Dict[Hashable, pd.Index]]:
     """Conform a dictionary of aligned variables onto a new set of variables,
     filling in missing values with NaN.
@@ -503,6 +504,8 @@ def reindex_variables(
         the input. In either case, new xarray objects are always returned.
     fill_value : scalar, optional
         Value to use for newly missing values
+    sparse: bool, optional
+        Use an sparse-array
 
     Returns
     -------
@@ -571,6 +574,8 @@ def reindex_variables(
 
     for name, var in variables.items():
         if name not in indexers:
+            if sparse:
+                var = var._as_sparse(fill_value=fill_value)
             key = tuple(
                 slice(None) if d in unchanged_dims else int_indexers.get(d, slice(None))
                 for d in var.dims

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1729,6 +1729,7 @@ class DataArray(AbstractArray, DataWithCoords):
         self,
         dim: Union[Hashable, Sequence[Hashable], None] = None,
         fill_value: Any = dtypes.NA,
+        sparse: bool = False,
     ) -> "DataArray":
         """
         Unstack existing dimensions corresponding to MultiIndexes into
@@ -1742,6 +1743,7 @@ class DataArray(AbstractArray, DataWithCoords):
             Dimension(s) over which to unstack. By default unstacks all
             MultiIndexes.
         fill_value: value to be filled. By default, np.nan
+        sparse: use sparse-array if True
 
         Returns
         -------
@@ -1773,7 +1775,7 @@ class DataArray(AbstractArray, DataWithCoords):
         --------
         DataArray.stack
         """
-        ds = self._to_temp_dataset().unstack(dim, fill_value)
+        ds = self._to_temp_dataset().unstack(dim, fill_value, sparse)
         return self._from_temp_dataset(ds)
 
     def to_unstacked_dataset(self, dim, level=0):

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1729,7 +1729,6 @@ class DataArray(AbstractArray, DataWithCoords):
         self,
         dim: Union[Hashable, Sequence[Hashable], None] = None,
         fill_value: Any = dtypes.NA,
-        sparse: bool = False,
     ) -> "DataArray":
         """
         Unstack existing dimensions corresponding to MultiIndexes into
@@ -1743,7 +1742,6 @@ class DataArray(AbstractArray, DataWithCoords):
             Dimension(s) over which to unstack. By default unstacks all
             MultiIndexes.
         fill_value: value to be filled. By default, np.nan
-        sparse: use sparse if True.
 
         Returns
         -------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1726,7 +1726,10 @@ class DataArray(AbstractArray, DataWithCoords):
         return self._from_temp_dataset(ds)
 
     def unstack(
-        self, dim: Union[Hashable, Sequence[Hashable], None] = None
+        self,
+        dim: Union[Hashable, Sequence[Hashable], None] = None,
+        fill_value: Any = dtypes.NA,
+        sparse: bool = False,
     ) -> "DataArray":
         """
         Unstack existing dimensions corresponding to MultiIndexes into
@@ -1739,6 +1742,8 @@ class DataArray(AbstractArray, DataWithCoords):
         dim : hashable or sequence of hashable, optional
             Dimension(s) over which to unstack. By default unstacks all
             MultiIndexes.
+        fill_value: value to be filled. By default, np.nan
+        sparse: use sparse if True.
 
         Returns
         -------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1773,7 +1773,7 @@ class DataArray(AbstractArray, DataWithCoords):
         --------
         DataArray.stack
         """
-        ds = self._to_temp_dataset().unstack(dim)
+        ds = self._to_temp_dataset().unstack(dim, fill_value)
         return self._from_temp_dataset(ds)
 
     def to_unstacked_dataset(self, dim, level=0):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2254,7 +2254,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         tolerance: Number = None,
         copy: bool = True,
         fill_value: Any = dtypes.NA,
-        sparse: bool = False,
         **indexers_kwargs: Any,
     ) -> "Dataset":
         """Conform this object onto a new set of indexes, filling in
@@ -2430,6 +2429,29 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         the original and desired indexes. If you do want to fill in the `NaN` values present in the
         original dataset, use the :py:meth:`~Dataset.fillna()` method.
 
+        """
+        return self._reindex(
+            indexers,
+            method,
+            tolerance,
+            copy,
+            fill_value,
+            sparse=False,
+            **indexers_kwargs,
+        )
+
+    def _reindex(
+        self,
+        indexers: Mapping[Hashable, Any] = None,
+        method: str = None,
+        tolerance: Number = None,
+        copy: bool = True,
+        fill_value: Any = dtypes.NA,
+        sparse: bool = False,
+        **indexers_kwargs: Any,
+    ) -> "Dataset":
+        """
+        same to _reindex but support sparse option
         """
         indexers = utils.either_dict_or_kwargs(indexers, indexers_kwargs, "reindex")
 
@@ -3345,7 +3367,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         if index.equals(full_idx):
             obj = self
         else:
-            obj = self.reindex(
+            obj = self._reindex(
                 {dim: full_idx}, copy=False, fill_value=fill_value, sparse=sparse
             )
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3333,7 +3333,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         return data_array
 
-    def _unstack_once(self, dim: Hashable, fill_value, sparse: bool) -> "Dataset":
+    def _unstack_once(self, dim: Hashable, fill_value) -> "Dataset":
         index = self.get_index(dim)
         index = index.remove_unused_levels()
         full_idx = pd.MultiIndex.from_product(index.levels, names=index.names)
@@ -3372,7 +3372,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         self,
         dim: Union[Hashable, Iterable[Hashable]] = None,
         fill_value: Any = dtypes.NA,
-        sparse: bool = False,
     ) -> "Dataset":
         """
         Unstack existing dimensions corresponding to MultiIndexes into
@@ -3386,7 +3385,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             Dimension(s) over which to unstack. By default unstacks all
             MultiIndexes.
         fill_value: value to be filled. By default, np.nan
-        sparse: use sparse if True.
 
         Returns
         -------
@@ -3424,7 +3422,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         result = self.copy(deep=False)
         for dim in dims:
-            result = result._unstack_once(dim, fill_value, sparse)
+            result = result._unstack_once(dim, fill_value)
         return result
 
     def update(self, other: "CoercibleMapping", inplace: bool = None) -> "Dataset":

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2446,7 +2446,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             tolerance,
             copy=copy,
             fill_value=fill_value,
-            sparse=sparse
+            sparse=sparse,
         )
         coord_names = set(self._coord_names)
         coord_names.update(indexers)
@@ -3377,7 +3377,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         self,
         dim: Union[Hashable, Iterable[Hashable]] = None,
         fill_value: Any = dtypes.NA,
-        sparse: bool = False
+        sparse: bool = False,
     ) -> "Dataset":
         """
         Unstack existing dimensions corresponding to MultiIndexes into

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -13,7 +13,7 @@ import pandas as pd
 
 from . import dask_array_ops, dtypes, npcompat, nputils
 from .nputils import nanfirst, nanlast
-from .pycompat import dask_array_type, sparse_array_type
+from .pycompat import dask_array_type
 
 try:
     import dask.array as dask_array

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -17,9 +17,12 @@ from .pycompat import dask_array_type, sparse_array_type
 
 try:
     import dask.array as dask_array
-    import sparse
 except ImportError:
     dask_array = None  # type: ignore
+
+try:
+    import sparse
+except ImportError:
     sparse = None  # type: ignore
 
 
@@ -253,7 +256,8 @@ def count(data, axis=None):
 
 def where(condition, x, y):
     """Three argument where() with better dtype promotion rules."""
-    # sparse support
+    # TODO sparse is not working with np.result_type and x.astype(copy=False)
+    # The following two lines may be removed after they are supported.
     if isinstance(x, sparse_array_type) or isinstance(y, sparse_array_type):
         return sparse.where(condition, x, y)
     return _where(condition, *as_shared_dtype([x, y]))

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -13,12 +13,14 @@ import pandas as pd
 
 from . import dask_array_ops, dtypes, npcompat, nputils
 from .nputils import nanfirst, nanlast
-from .pycompat import dask_array_type
+from .pycompat import dask_array_type, sparse_array_type
 
 try:
     import dask.array as dask_array
+    import sparse
 except ImportError:
     dask_array = None  # type: ignore
+    sparse = None  # type: ignore
 
 
 def _dask_or_eager_func(
@@ -251,6 +253,9 @@ def count(data, axis=None):
 
 def where(condition, x, y):
     """Three argument where() with better dtype promotion rules."""
+    # sparse support
+    if isinstance(x, sparse_array_type) or isinstance(y, sparse_array_type):
+        return sparse.where(condition, x, y)
     return _where(condition, *as_shared_dtype([x, y]))
 
 

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -20,11 +20,6 @@ try:
 except ImportError:
     dask_array = None  # type: ignore
 
-try:
-    import sparse
-except ImportError:
-    sparse = None  # type: ignore
-
 
 def _dask_or_eager_func(
     name,
@@ -256,10 +251,6 @@ def count(data, axis=None):
 
 def where(condition, x, y):
     """Three argument where() with better dtype promotion rules."""
-    # TODO sparse is not working with np.result_type and x.astype(copy=False)
-    # The following two lines may be removed after they are supported.
-    if isinstance(x, sparse_array_type) or isinstance(y, sparse_array_type):
-        return sparse.where(condition, x, y)
     return _where(condition, *as_shared_dtype([x, y]))
 
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -998,6 +998,7 @@ class Variable(
         use sparse-array as backend.
         """
         import sparse
+
         # TODO  what to do if dask-backended?
         if fill_value is dtypes.NA:
             dtype, fill_value = dtypes.maybe_promote(self.dtype)
@@ -1005,8 +1006,8 @@ class Variable(
             dtype = self.dtype
 
         if sparse_format is _default:
-            sparse_format = 'coo'
-        as_sparse = getattr(sparse, 'as_{}'.format(sparse_format.lower()))
+            sparse_format = "coo"
+        as_sparse = getattr(sparse, "as_{}".format(sparse_format.lower()))
         data = as_sparse(self.data.astype(dtype), fill_value=fill_value)
         return self._replace(data=data)
 
@@ -1014,7 +1015,7 @@ class Variable(
         """
         Change backend from sparse to np.array
         """
-        if hasattr(self._data, 'todense'):
+        if hasattr(self._data, "todense"):
             return self._replace(data=self._data.todense())
         return self.copy(deep=False)
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1003,11 +1003,15 @@ class Variable(
         if fill_value is dtypes.NA:
             dtype, fill_value = dtypes.maybe_promote(self.dtype)
         else:
-            dtype = self.dtype
+            dtype = dtypes.result_type(self.dtype, fill_value)
 
         if sparse_format is _default:
             sparse_format = "coo"
-        as_sparse = getattr(sparse, "as_{}".format(sparse_format.lower()))
+        try:
+            as_sparse = getattr(sparse, "as_{}".format(sparse_format.lower()))
+        except AttributeError:
+            raise ValueError("{} is not a valid sparse format".format(sparse_format))
+
         data = as_sparse(self.data.astype(dtype), fill_value=fill_value)
         return self._replace(data=data)
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1341,7 +1341,7 @@ class Variable(
 
     def stack(self, dimensions=None, **dimensions_kwargs):
         """
-        Stack any number of existing dimensions into a single new dimension.
+        Stack any nimber of existing dimensions into a single new dimension.
 
         New dimensions will be added at the end, and the order of the data
         along each new dimension will be in contiguous (C) order.

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1341,7 +1341,7 @@ class Variable(
 
     def stack(self, dimensions=None, **dimensions_kwargs):
         """
-        Stack any nimber of existing dimensions into a single new dimension.
+        Stack any number of existing dimensions into a single new dimension.
 
         New dimensions will be added at the end, and the order of the data
         along each new dimension will be in contiguous (C) order.

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1756,12 +1756,14 @@ class TestDataset:
         expected = data.reindex(dim3=dim3, sparse=False)
         for k, v in data.data_vars.items():
             np.testing.assert_equal(actual[k].data.todense(), expected[k].data)
+        assert actual['var3'].data.density < 1.0
 
         data["var3"] = data["var3"].astype(int)
         actual = data.reindex(dim3=dim3, sparse=True, fill_value=-10)
         expected = data.reindex(dim3=dim3, sparse=False, fill_value=-10)
         for k, v in data.data_vars.items():
             np.testing.assert_equal(actual[k].data.todense(), expected[k].data)
+        assert actual['var3'].data.density < 1.0
 
     def test_reindex_warning(self):
         data = create_test_data()
@@ -2827,7 +2829,7 @@ class TestDataset:
         assert actual.equals(expected)
 
     @requires_sparse
-    def test_unstack_fill_value(self):
+    def test_unstack_sparse(self):
         ds = xr.Dataset(
             {"var": (("x",), np.arange(6))},
             coords={"x": [0, 1, 2] * 2, "y": (("x",), ["a"] * 3 + ["b"] * 3)},
@@ -2838,10 +2840,12 @@ class TestDataset:
         actual = ds.unstack("index", sparse=True)
         expected = ds.unstack("index")
         assert actual["var"].variable._to_dense().equals(expected["var"].variable)
+        assert actual["var"].data.density < 1.0
 
         actual = ds["var"].unstack("index", sparse=True)
         expected = ds["var"].unstack("index")
         assert actual.variable._to_dense().equals(expected.variable)
+        assert actual.data.density < 1.0
 
     def test_stack_unstack_fast(self):
         ds = Dataset(

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2794,6 +2794,23 @@ class TestDataset:
         with raises_regex(ValueError, "do not have a MultiIndex"):
             ds.unstack("x")
 
+    def test_unstack_fill_value(self):
+        ds = xr.Dataset(
+            {"var": (("x",), np.arange(6))},
+            coords={"x": [0, 1, 2] * 2, "y": (("x",), ["a"] * 3 + ["b"] * 3)},
+        )
+        # make ds incomplete
+        ds = ds.isel(x=[0, 2, 3, 4]).set_index(index=["x", "y"])
+        # test fill_value
+        actual = ds.unstack("index", fill_value=-1)
+        expected = ds.unstack("index").fillna(-1).astype(np.int)
+        assert actual["var"].dtype == np.int
+        assert actual.equals(expected)
+
+        actual = ds["var"].unstack("index", fill_value=-1)
+        expected = ds["var"].unstack("index").fillna(-1).astype(np.int)
+        assert actual.equals(expected)
+
     def test_stack_unstack_fast(self):
         ds = Dataset(
             {

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1756,14 +1756,14 @@ class TestDataset:
         expected = data.reindex(dim3=dim3, sparse=False)
         for k, v in data.data_vars.items():
             np.testing.assert_equal(actual[k].data.todense(), expected[k].data)
-        assert actual['var3'].data.density < 1.0
+        assert actual["var3"].data.density < 1.0
 
         data["var3"] = data["var3"].astype(int)
         actual = data.reindex(dim3=dim3, sparse=True, fill_value=-10)
         expected = data.reindex(dim3=dim3, sparse=False, fill_value=-10)
         for k, v in data.data_vars.items():
             np.testing.assert_equal(actual[k].data.todense(), expected[k].data)
-        assert actual['var3'].data.density < 1.0
+        assert actual["var3"].data.density < 1.0
 
     def test_reindex_warning(self):
         data = create_test_data()

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1748,23 +1748,6 @@ class TestDataset:
         actual = ds.reindex(x=[0, 1, 3], y=[0, 1])
         assert_identical(expected, actual)
 
-    @requires_sparse
-    def test_reindex_sparse(self):
-        data = create_test_data()
-        dim3 = list("abdeghijk")
-        actual = data.reindex(dim3=dim3, sparse=True)
-        expected = data.reindex(dim3=dim3, sparse=False)
-        for k, v in data.data_vars.items():
-            np.testing.assert_equal(actual[k].data.todense(), expected[k].data)
-        assert actual["var3"].data.density < 1.0
-
-        data["var3"] = data["var3"].astype(int)
-        actual = data.reindex(dim3=dim3, sparse=True, fill_value=-10)
-        expected = data.reindex(dim3=dim3, sparse=False, fill_value=-10)
-        for k, v in data.data_vars.items():
-            np.testing.assert_equal(actual[k].data.todense(), expected[k].data)
-        assert actual["var3"].data.density < 1.0
-
     def test_reindex_warning(self):
         data = create_test_data()
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1755,17 +1755,13 @@ class TestDataset:
         actual = data.reindex(dim3=dim3, sparse=True)
         expected = data.reindex(dim3=dim3, sparse=False)
         for k, v in data.data_vars.items():
-            np.testing.assert_equal(
-                actual[k].data.todense(), expected[k].data
-            )
+            np.testing.assert_equal(actual[k].data.todense(), expected[k].data)
 
-        data['var3'] = data['var3'].astype(int)
+        data["var3"] = data["var3"].astype(int)
         actual = data.reindex(dim3=dim3, sparse=True, fill_value=-10)
         expected = data.reindex(dim3=dim3, sparse=False, fill_value=-10)
         for k, v in data.data_vars.items():
-            np.testing.assert_equal(
-                actual[k].data.todense(), expected[k].data
-            )
+            np.testing.assert_equal(actual[k].data.todense(), expected[k].data)
 
     def test_reindex_warning(self):
         data = create_test_data()
@@ -2841,8 +2837,7 @@ class TestDataset:
         # test fill_value
         actual = ds.unstack("index", sparse=True)
         expected = ds.unstack("index")
-        assert actual['var'].variable._to_dense().equals(
-            expected['var'].variable)
+        assert actual["var"].variable._to_dense().equals(expected["var"].variable)
 
         actual = ds["var"].unstack("index", sparse=True)
         expected = ds["var"].unstack("index")

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -33,6 +33,7 @@ from . import (
     assert_identical,
     raises_regex,
     requires_dask,
+    requires_sparse,
     source_ndarray,
 )
 
@@ -1860,6 +1861,17 @@ class TestVariableWithDask(VariableSubclassobjects):
             v._getitem_with_mask(indexer, fill_value=-1),
             self.cls(("x", "y"), [[0, -1], [-1, 2]]),
         )
+
+
+@requires_sparse
+class TestVariableWithSparse():
+    # TODO inherit VariableSubclassobjects to cover more tests
+
+    def test_as_sparse(self):
+        data = np.arange(12).reshape(3, 4)
+        var = Variable(('x', 'y'), data)._as_sparse(fill_value=-1)
+        actual = var._to_dense()
+        assert_identical(var, actual)
 
 
 class TestIndexVariable(VariableSubclassobjects):

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1864,12 +1864,12 @@ class TestVariableWithDask(VariableSubclassobjects):
 
 
 @requires_sparse
-class TestVariableWithSparse():
+class TestVariableWithSparse:
     # TODO inherit VariableSubclassobjects to cover more tests
 
     def test_as_sparse(self):
         data = np.arange(12).reshape(3, 4)
-        var = Variable(('x', 'y'), data)._as_sparse(fill_value=-1)
+        var = Variable(("x", "y"), data)._as_sparse(fill_value=-1)
         actual = var._to_dense()
         assert_identical(var, actual)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #3518
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Added `sparse` option to `reindex` and `unstack`.
I just added a minimal set of codes necessary to `unstack` and `reindex`.

There is still a lot of space to complete the sparse support as discussed in #3245.
