### PR TITLE
Add defaults during concat 508

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -101,7 +101,7 @@ Bug fixes
 - Allow appending datetime and bool data variables to zarr stores.
   (:issue:`3480`). By `Akihiro Matsukawa <https://github.com/amatsukawa/>`_.
 - Make :py:func:`~xarray.concat` more robust when concatenating variables present in some datasets but
-  not others (:issue:`508`). By `Scott Chamberlin <http://github.com/scottcha>`_.
+  not others (:issue:`508`). By `Scott Chamberlin <https://github.com/scottcha>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -100,6 +100,8 @@ Bug fixes
   (:issue:`3402`). By `Deepak Cherian <https://github.com/dcherian/>`_
 - Allow appending datetime and bool data variables to zarr stores.
   (:issue:`3480`). By `Akihiro Matsukawa <https://github.com/amatsukawa/>`_.
+- Make :py:func:`~xarray.concat` more robust when merging variables present in some datasets but
+  not others (:issue:`508`). By `Scott Chamberlin <http://github.com/scottcha>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import numpy as np
 
 from . import dtypes, utils
 from .alignment import align
@@ -379,9 +378,16 @@ def _dataset_concat(
                 if k not in ds.variables:
                     for ds in datasets:
                         if k in ds.variables:
-                            # found one to use as a fill value, fill with np.nan
+                            # found one to use as a fill value, fill with fill_value
+                            if fill_value is dtypes.NA:
+                                dtype, fill_value = dtypes.maybe_promote(
+                                    ds.variables[k].dtype
+                                )
+                            else:
+                                dtype = ds.variables[k].dtype
+
                             filled = full_like(
-                                ds.variables[k], fill_value=np.nan, dtype=np.double
+                                ds.variables[k], fill_value=fill_value, dtype=dtype
                             )
                             break
                     variables.append(filled)

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -78,7 +78,8 @@ def concat(
         to assign each dataset along the concatenated dimension. If not
         supplied, objects are concatenated in the provided order.
     fill_value : scalar, optional
-        Value to use for newly missing values
+        Value to use for newly missing values as well as to fill values where the
+        variable is not present in all datasets.
     join : {'outer', 'inner', 'left', 'right', 'exact'}, optional
         String indicating how to combine differing indexes
         (excluding dim) in objects

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -457,26 +457,6 @@ def _dataset_concat(
     return result
 
 
-def _find_ordering_inplace(l, union):
-    # this logic maintains the order of the variable list and runs in
-    # O(n^2) where n is number of variables in the uncommon worst case
-    # where there are no missing variables this will be O(n)
-    # could potentially be refactored to a more generic function to determine
-    # a consistent ordering of variables if proper consideration were
-    # given both to the runtime as well as to the user scenarios
-    for i in range(0, len(l)):
-        if l[i] not in union:
-            # need to determine the correct place
-            # first add the new item which will be at the end
-            union[l[i]] = None
-            union.move_to_end(l[i])
-            # move any items after this in the variables list to the end
-            # this will only happen for missing variables
-            for j in range(i + 1, len(l)):
-                if l[j] in union:
-                    union.move_to_end(l[j])
-
-
 def _dataarray_concat(
     arrays,
     dim,

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -429,10 +429,9 @@ def _dataset_concat(
                 continue
 
             v_fill_value = fill_value
-            if fill_value is dtypes.NA:
-                dtype, v_fill_value = dtypes.maybe_promote(ds[variable_key].dtype)
-            else:
-                dtype = ds[variable_key].dtype
+            dtype, v_fill_value = dtypes.get_fill_value_for_variable(
+                ds[variable_key], fill_value
+            )
 
             union_of_variables[variable_key] = full_like(
                 ds[variable_key], fill_value=v_fill_value, dtype=dtype

--- a/xarray/core/dtypes.py
+++ b/xarray/core/dtypes.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from . import utils
 
+
 # Use as a sentinel value to indicate a dtype appropriate NA value.
 NA = utils.ReprObject("<NA>")
 
@@ -94,6 +95,37 @@ def get_fill_value(dtype):
     """
     _, fill_value = maybe_promote(dtype)
     return fill_value
+
+
+def get_fill_value_for_variable(variable, fill_value=NA):
+    """Return an appropriate fill value for this variable
+
+    Parameters
+    ----------
+    variables : DataSet or DataArray
+    fill_value : a suggested fill value to evaluate and promote if necessary
+
+    Returns
+    -------
+    dtype : Promoted dtype for fill value.
+    new_fill_value : Missing value corresponding to this dtype.
+    """
+    from .dataset import Dataset
+    from .dataarray import DataArray
+
+    if not (isinstance(variable, DataArray) or isinstance(variable, Dataset)):
+        raise TypeError(
+            "can only get fill value for xarray Dataset and DataArray "
+            "objects, got %s" % type(variable)
+        )
+
+    new_fill_value = fill_value
+    if fill_value is NA:
+        dtype, new_fill_value = maybe_promote(variable.dtype)
+    else:
+        dtype = variable.dtype
+
+    return dtype, new_fill_value
 
 
 def get_pos_infinity(dtype):

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -742,14 +742,8 @@ class TestAutoCombineOldAPI:
             Dataset({"x": ("a", [0]), "y": ("a", [0])}),
             Dataset({"y": ("a", [1]), "x": ("a", [1])}),
         ]
-
         actual = auto_combine(objs)
         expected = Dataset({"x": ("a", [0, 1]), "y": ("a", [0, 1])})
-        assert_identical(expected, actual)
-
-        objs = [Dataset({"x": [0], "y": [0]}), Dataset({"x": [0]})]
-        actual = auto_combine(objs)
-        expected = Dataset({"x": [0], "y": [0, np.nan]})
         assert_identical(expected, actual)
 
         objs = [Dataset({"x": [0], "y": [0]}), Dataset({"y": [1], "x": [1]})]
@@ -758,6 +752,10 @@ class TestAutoCombineOldAPI:
 
         objs = [Dataset({"x": 0}), Dataset({"x": 1})]
         with raises_regex(ValueError, "cannot infer dimension"):
+            auto_combine(objs)
+
+        objs = [Dataset({"x": [0], "y": [0]}), Dataset({"x": [0]})]
+        with raises_regex(ValueError, "'y' is not present in all datasets"):
             auto_combine(objs)
 
     def test_auto_combine_previously_failed(self):

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -742,8 +742,14 @@ class TestAutoCombineOldAPI:
             Dataset({"x": ("a", [0]), "y": ("a", [0])}),
             Dataset({"y": ("a", [1]), "x": ("a", [1])}),
         ]
+
         actual = auto_combine(objs)
         expected = Dataset({"x": ("a", [0, 1]), "y": ("a", [0, 1])})
+        assert_identical(expected, actual)
+
+        objs = [Dataset({"x": [0], "y": [0]}), Dataset({"x": [0]})]
+        actual = auto_combine(objs)
+        expected = Dataset({"x": [0], "y": [0, np.nan]})
         assert_identical(expected, actual)
 
         objs = [Dataset({"x": [0], "y": [0]}), Dataset({"y": [1], "x": [1]})]
@@ -752,10 +758,6 @@ class TestAutoCombineOldAPI:
 
         objs = [Dataset({"x": 0}), Dataset({"x": 1})]
         with raises_regex(ValueError, "cannot infer dimension"):
-            auto_combine(objs)
-
-        objs = [Dataset({"x": [0], "y": [0]}), Dataset({"x": [0]})]
-        with raises_regex(ValueError, "'y' is not present in all datasets"):
             auto_combine(objs)
 
     def test_auto_combine_previously_failed(self):

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -755,7 +755,9 @@ class TestAutoCombineOldAPI:
             auto_combine(objs)
 
         objs = [Dataset({"x": [0], "y": [0]}), Dataset({"x": [0]})]
-        with raises_regex(ValueError, "'y' is not present in all datasets"):
+        with raises_regex(
+            ValueError, ".* are coordinates in some datasets but not others"
+        ):
             auto_combine(objs)
 
     def test_auto_combine_previously_failed(self):

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -291,6 +291,7 @@ def test_multiple_missing_variables():
     assert_equal(result, ds_result)
 
 
+@pytest.mark.xfail(strict=True)
 def test_concat_multiple_datasets_missing_vars_and_new_dim():
     vars_to_drop = [
         "temperature",
@@ -329,6 +330,7 @@ def test_concat_multiple_datasets_missing_vars_and_new_dim():
                         (result_vars[vars_to_drop[i]], np.full([1, 4], np.nan)), axis=1,
                     )
     # TODO: this test still has two unexpected errors:
+
     # 1: concat throws a mergeerror expecting the temperature values to be the same, this doesn't seem to be correct in this case
     #   as we are concating on new dims
     # 2: if the values are the same for a variable (working around #1) then it will likely not correct add the new dim to the first variable
@@ -354,7 +356,6 @@ def test_concat_multiple_datasets_missing_vars_and_new_dim():
     # )
 
     # result = concat(datasets, dim="day")
-
     # r1 = list(result.data_vars.keys())
     # r2 = list(ds_result.data_vars.keys())
     # assert r1 == r2  # check the variables orders are the same

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -338,16 +338,28 @@ class TestConcatDataset:
             Dataset({"a": ("x", [2, 3]), "x": [1, 2]}),
             Dataset({"a": ("x", [1, 2]), "x": [0, 1]}),
         ]
+
         if fill_value == dtypes.NA:
             # if we supply the default, we expect the missing value for a
             # float array
-            fill_value = np.nan
+            fill_value_expected = np.nan
+        else:
+            fill_value_expected = fill_value
+
         expected = Dataset(
-            {"a": (("t", "x"), [[fill_value, 2, 3], [1, 2, fill_value]])},
+            {
+                "a": (
+                    ("t", "x"),
+                    [[fill_value_expected, 2, 3], [1, 2, fill_value_expected]],
+                )
+            },
             {"x": [0, 1, 2]},
         )
         actual = concat(datasets, dim="t", fill_value=fill_value)
         assert_identical(actual, expected)
+
+        # check that the dtype is as expected
+        assert expected.a.dtype == type(fill_value_expected)
 
 
 class TestConcatDataArray:

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -35,17 +35,28 @@ def test_concat_compat():
         },
         coords={"x": [0, 1], "y": [1], "z": [-1, -2], "q": [0]},
     )
-
+    ds_concat = Dataset(
+        {
+            "has_x_y": (
+                ("q", "y", "x"),
+                [[[np.nan, np.nan], [3, 4]], [[1, 2], [np.nan, np.nan]]],
+            ),
+            "has_x": (("q", "x"), [[1, 2], [1, 2]]),
+            "no_x_y": (("q", "z"), [[1, 2], [1, 2]]),
+        },
+        coords={"x": [0, 1], "y": [0, 1], "z": [-1, -2], "q": [0, np.nan]},
+    )
     result = concat([ds1, ds2], dim="y", data_vars="minimal", compat="broadcast_equals")
     assert_equal(ds2.no_x_y, result.no_x_y.transpose())
 
     for var in ["has_x", "no_x_y"]:
         assert "y" not in result[var]
 
+    result2 = concat([ds2, ds1], dim="q")
+    assert_equal(ds_concat, result2)
+
     with raises_regex(ValueError, "coordinates in some datasets but not others"):
         concat([ds1, ds2], dim="q")
-    with raises_regex(ValueError, "'q' is not present in all datasets"):
-        concat([ds2, ds1], dim="q")
 
 
 class TestConcatDataset:

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 import numpy as np
 import pandas as pd
 import pytest
+import random
 
 from xarray import DataArray, Dataset, Variable, concat
 from xarray.core import dtypes, merge
@@ -16,6 +17,71 @@ from . import (
     requires_dask,
 )
 from .test_dataset import create_test_data
+
+
+# helper method to create multiple tests datasets to concat
+def create_concat_datasets(num_datasets=2, seed=None):
+    random.seed(seed)
+    result = []
+    lat = np.random.randn(1, 4)
+    lon = np.random.randn(1, 4)
+    for i in range(num_datasets):
+        result.append(
+            Dataset(
+                data_vars={
+                    "temperature": (["x", "y", "day"], np.random.randn(1, 4, 2)),
+                    "pressure": (["x", "y", "day"], np.random.randn(1, 4, 2)),
+                    "humidity": (["x", "y", "day"], np.random.randn(1, 4, 2)),
+                    "precipitation": (["x", "y", "day"], np.random.randn(1, 4, 2)),
+                    "cloud cover": (["x", "y", "day"], np.random.randn(1, 4, 2)),
+                },
+                coords={
+                    "lat": (["x", "y"], lat),
+                    "lon": (["x", "y"], lon),
+                    "day": ["day" + str(i * 2 + 1), "day" + str(i * 2 + 2)],
+                },
+            )
+        )
+    return result
+
+
+# helper method to create multiple tests datasets to concat with specific types
+def create_typed_datasets(num_datasets=2, seed=None):
+    random.seed(seed)
+    var_strings = ["a", "b", "c", "d", "e", "f", "g", "h"]
+    result = []
+    lat = np.random.randn(1, 4)
+    lon = np.random.randn(1, 4)
+    for i in range(num_datasets):
+        result.append(
+            Dataset(
+                data_vars={
+                    "float": (["x", "y", "day"], np.random.randn(1, 4, 2)),
+                    "float2": (["x", "y", "day"], np.random.randn(1, 4, 2)),
+                    "string": (
+                        ["x", "y", "day"],
+                        np.random.choice(var_strings, (1, 4, 2)),
+                    ),
+                    "int": (["x", "y", "day"], np.random.randint(0, 10, (1, 4, 2))),
+                    "datetime64": (
+                        ["x", "y", "day"],
+                        np.arange(
+                            np.datetime64("2017-01-01"), np.datetime64("2017-01-09")
+                        ).reshape(1, 4, 2),
+                    ),
+                    "timedelta64": (
+                        ["x", "y", "day"],
+                        np.reshape([pd.Timedelta(days=i) for i in range(8)], [1, 4, 2]),
+                    ),
+                },
+                coords={
+                    "lat": (["x", "y"], lat),
+                    "lon": (["x", "y"], lon),
+                    "day": ["day" + str(i * 2 + 1), "day" + str(i * 2 + 2)],
+                },
+            )
+        )
+    return result
 
 
 def test_concat_compat():
@@ -35,28 +101,357 @@ def test_concat_compat():
         },
         coords={"x": [0, 1], "y": [1], "z": [-1, -2], "q": [0]},
     )
-    ds_concat = Dataset(
-        {
-            "has_x_y": (
-                ("q", "y", "x"),
-                [[[np.nan, np.nan], [3, 4]], [[1, 2], [np.nan, np.nan]]],
-            ),
-            "has_x": (("q", "x"), [[1, 2], [1, 2]]),
-            "no_x_y": (("q", "z"), [[1, 2], [1, 2]]),
-        },
-        coords={"x": [0, 1], "y": [0, 1], "z": [-1, -2], "q": [0, np.nan]},
-    )
+
     result = concat([ds1, ds2], dim="y", data_vars="minimal", compat="broadcast_equals")
     assert_equal(ds2.no_x_y, result.no_x_y.transpose())
 
     for var in ["has_x", "no_x_y"]:
         assert "y" not in result[var]
 
-    result2 = concat([ds2, ds1], dim="q")
-    assert_equal(ds_concat, result2)
-
     with raises_regex(ValueError, "coordinates in some datasets but not others"):
         concat([ds1, ds2], dim="q")
+
+    with raises_regex(ValueError, "coordinates in some datasets but not others"):
+        concat([ds2, ds1], dim="q")
+
+
+def test_concat_missing_var():
+    datasets = create_concat_datasets(2, 123)
+    vars_to_drop = ["humidity", "precipitation", "cloud cover"]
+    datasets[0] = datasets[0].drop_vars(vars_to_drop)
+    datasets[1] = datasets[1].drop_vars(vars_to_drop + ["pressure"])
+
+    temperature_result = np.concatenate(
+        (datasets[0].temperature.values, datasets[1].temperature.values), axis=2
+    )
+    pressure_result = np.concatenate(
+        (datasets[0].pressure.values, np.full([1, 4, 2], np.nan)), axis=2
+    )
+    ds_result = Dataset(
+        data_vars={
+            "temperature": (["x", "y", "day"], temperature_result),
+            "pressure": (["x", "y", "day"], pressure_result),
+        },
+        coords={
+            "lat": (["x", "y"], datasets[0].lat.values),
+            "lon": (["x", "y"], datasets[0].lon.values),
+            "day": ["day1", "day2", "day3", "day4"],
+        },
+    )
+    result = concat(datasets, dim="day")
+
+    assert_equal(result, ds_result)
+
+
+def test_concat_all_empty():
+    ds1 = Dataset()
+    ds2 = Dataset()
+    result = concat([ds1, ds2], dim="new_dim")
+
+    assert_equal(result, Dataset())
+
+
+def test_concat_second_empty():
+    ds1 = Dataset(data_vars={"a": ("y", [0.1])}, coords={"x": 0.1})
+    ds2 = Dataset(coords={"x": 0.1})
+
+    ds_result = Dataset(data_vars={"a": ("y", [0.1, np.nan])}, coords={"x": 0.1})
+    result = concat([ds1, ds2], dim="y")
+
+    assert_equal(result, ds_result)
+
+
+def test_multiple_missing_variables():
+    datasets = create_concat_datasets(2, 123)
+    vars_to_drop = ["pressure", "cloud cover"]
+    datasets[1] = datasets[1].drop_vars(vars_to_drop)
+
+    temperature_result = np.concatenate(
+        (datasets[0].temperature.values, datasets[1].temperature.values), axis=2
+    )
+    pressure_result = np.concatenate(
+        (datasets[0].pressure.values, np.full([1, 4, 2], np.nan)), axis=2
+    )
+    humidity_result = np.concatenate(
+        (datasets[0].humidity.values, datasets[1].humidity.values), axis=2
+    )
+    precipitation_result = np.concatenate(
+        (datasets[0].precipitation.values, datasets[1].precipitation.values), axis=2
+    )
+    cloudcover_result = np.concatenate(
+        (datasets[0]["cloud cover"].values, np.full([1, 4, 2], np.nan)), axis=2
+    )
+    ds_result = Dataset(
+        data_vars={
+            "temperature": (["x", "y", "day"], temperature_result),
+            "pressure": (["x", "y", "day"], pressure_result),
+            "humidity": (["x", "y", "day"], humidity_result),
+            "precipitation": (["x", "y", "day"], precipitation_result),
+            "cloud cover": (["x", "y", "day"], cloudcover_result),
+        },
+        coords={
+            "lat": (["x", "y"], datasets[0].lat.values),
+            "lon": (["x", "y"], datasets[0].lon.values),
+            "day": ["day1", "day2", "day3", "day4"],
+        },
+    )
+    result = concat(datasets, dim="day")
+
+    assert_equal(result, ds_result)
+
+
+def test_multiple_datasets_with_missing_variables():
+    vars_to_drop = [
+        "temperature",
+        "pressure",
+        "humidity",
+        "precipitation",
+        "cloud cover",
+    ]
+    datasets = create_concat_datasets(len(vars_to_drop), 123)
+    # set up the test data
+    datasets = [datasets[i].drop_vars(vars_to_drop[i]) for i in range(len(datasets))]
+
+    # set up the validation data
+    # the below code just drops one var per dataset depending on the location of the
+    # dataset in the list and allows us to quickly catch any boundaries cases across
+    # the three equivalence classes of beginning, middle and end of the concat list
+    result_vars = dict.fromkeys(vars_to_drop)
+    for i in range(len(vars_to_drop)):
+        for d in range(len(datasets)):
+            if d != i:
+                if result_vars[vars_to_drop[i]] is None:
+                    result_vars[vars_to_drop[i]] = datasets[d][vars_to_drop[i]].values
+                else:
+                    result_vars[vars_to_drop[i]] = np.concatenate(
+                        (
+                            result_vars[vars_to_drop[i]],
+                            datasets[d][vars_to_drop[i]].values,
+                        ),
+                        axis=2,
+                    )
+            else:
+                if result_vars[vars_to_drop[i]] is None:
+                    result_vars[vars_to_drop[i]] = np.full([1, 4, 2], np.nan)
+                else:
+                    result_vars[vars_to_drop[i]] = np.concatenate(
+                        (result_vars[vars_to_drop[i]], np.full([1, 4, 2], np.nan)),
+                        axis=2,
+                    )
+
+    ds_result = Dataset(
+        data_vars={
+            "temperature": (["x", "y", "day"], result_vars["temperature"]),
+            "pressure": (["x", "y", "day"], result_vars["pressure"]),
+            "humidity": (["x", "y", "day"], result_vars["humidity"]),
+            "precipitation": (["x", "y", "day"], result_vars["precipitation"]),
+            "cloud cover": (["x", "y", "day"], result_vars["cloud cover"]),
+        },
+        coords={
+            "lat": (["x", "y"], datasets[0].lat.values),
+            "lon": (["x", "y"], datasets[0].lon.values),
+            "day": ["day" + str(d + 1) for d in range(2 * len(vars_to_drop))],
+        },
+    )
+    result = concat(datasets, dim="day")
+
+    assert_equal(result, ds_result)
+
+
+def test_multiple_datasets_with_multiple_missing_variables():
+    vars_to_drop_in_first = ["temperature", "pressure"]
+    vars_to_drop_in_second = ["humidity", "precipitation", "cloud cover"]
+    datasets = create_concat_datasets(2, 123)
+    # set up the test data
+    datasets[0] = datasets[0].drop_vars(vars_to_drop_in_first)
+    datasets[1] = datasets[1].drop_vars(vars_to_drop_in_second)
+
+    temperature_result = np.concatenate(
+        (np.full([1, 4, 2], np.nan), datasets[1].temperature.values), axis=2
+    )
+    pressure_result = np.concatenate(
+        (np.full([1, 4, 2], np.nan), datasets[1].pressure.values), axis=2
+    )
+    humidity_result = np.concatenate(
+        (datasets[0].humidity.values, np.full([1, 4, 2], np.nan)), axis=2
+    )
+    precipitation_result = np.concatenate(
+        (datasets[0].precipitation.values, np.full([1, 4, 2], np.nan)), axis=2
+    )
+    cloudcover_result = np.concatenate(
+        (datasets[0]["cloud cover"].values, np.full([1, 4, 2], np.nan)), axis=2
+    )
+    ds_result = Dataset(
+        data_vars={
+            "temperature": (["x", "y", "day"], temperature_result),
+            "pressure": (["x", "y", "day"], pressure_result),
+            "humidity": (["x", "y", "day"], humidity_result),
+            "precipitation": (["x", "y", "day"], precipitation_result),
+            "cloud cover": (["x", "y", "day"], cloudcover_result),
+        },
+        coords={
+            "lat": (["x", "y"], datasets[0].lat.values),
+            "lon": (["x", "y"], datasets[0].lon.values),
+            "day": ["day1", "day2", "day3", "day4"],
+        },
+    )
+    result = concat(datasets, dim="day")
+
+    assert_equal(result, ds_result)
+
+
+def test_type_of_missing_fill():
+    datasets = create_typed_datasets(2, 123)
+
+    vars = ["float", "float2", "string", "int", "datetime64", "timedelta64"]
+
+    # set up the test data
+    datasets[1] = datasets[1].drop_vars(vars[1:])
+
+    float_result = np.concatenate(
+        (datasets[0].float.values, datasets[1].float.values), axis=2
+    )
+    float2_result = np.concatenate(
+        (datasets[0].float2.values, np.full([1, 4, 2], np.nan)), axis=2
+    )
+    # to correctly create the expected dataset we need to ensure we promote the string array to
+    # object type before filling as it will be promoted to that in the concat case.
+    # this matches the behavior of pandas
+    string_values = datasets[0].string.values
+    string_values = string_values.astype(object)
+    string_result = np.concatenate((string_values, np.full([1, 4, 2], np.nan)), axis=2)
+    datetime_result = np.concatenate(
+        (datasets[0].datetime64.values, np.full([1, 4, 2], np.datetime64("NaT"))),
+        axis=2,
+    )
+    timedelta_result = np.concatenate(
+        (datasets[0].timedelta64.values, np.full([1, 4, 2], np.timedelta64("NaT"))),
+        axis=2,
+    )
+    # string_result = string_result.astype(object)
+    int_result = np.concatenate(
+        (datasets[0].int.values, np.full([1, 4, 2], np.nan)), axis=2
+    )
+    ds_result = Dataset(
+        data_vars={
+            "float": (["x", "y", "day"], float_result),
+            "float2": (["x", "y", "day"], float2_result),
+            "string": (["x", "y", "day"], string_result),
+            "int": (["x", "y", "day"], int_result),
+            "datetime64": (["x", "y", "day"], datetime_result),
+            "timedelta64": (["x", "y", "day"], timedelta_result),
+        },
+        coords={
+            "lat": (["x", "y"], datasets[0].lat.values),
+            "lon": (["x", "y"], datasets[0].lon.values),
+            "day": ["day1", "day2", "day3", "day4"],
+        },
+    )
+    result = concat(datasets, dim="day", fill_value=dtypes.NA)
+
+    assert_equal(result, ds_result)
+
+    # test in the reverse order
+    float_result_rev = np.concatenate(
+        (datasets[1].float.values, datasets[0].float.values), axis=2
+    )
+    float2_result_rev = np.concatenate(
+        (np.full([1, 4, 2], np.nan), datasets[0].float2.values), axis=2
+    )
+    string_result_rev = np.concatenate(
+        (np.full([1, 4, 2], np.nan), string_values), axis=2
+    )
+    datetime_result_rev = np.concatenate(
+        (np.full([1, 4, 2], np.datetime64("NaT")), datasets[0].datetime64.values),
+        axis=2,
+    )
+    timedelta_result_rev = np.concatenate(
+        (np.full([1, 4, 2], np.timedelta64("NaT")), datasets[0].timedelta64.values),
+        axis=2,
+    )
+    int_result_rev = np.concatenate(
+        (np.full([1, 4, 2], np.nan), datasets[0].int.values), axis=2
+    )
+    ds_result_rev = Dataset(
+        data_vars={
+            "float": (["x", "y", "day"], float_result_rev),
+            "float2": (["x", "y", "day"], float2_result_rev),
+            "string": (["x", "y", "day"], string_result_rev),
+            "int": (["x", "y", "day"], int_result_rev),
+            "datetime64": (["x", "y", "day"], datetime_result_rev),
+            "timedelta64": (["x", "y", "day"], timedelta_result_rev),
+        },
+        coords={
+            "lat": (["x", "y"], datasets[0].lat.values),
+            "lon": (["x", "y"], datasets[0].lon.values),
+            "day": ["day3", "day4", "day1", "day2"],
+        },
+    )
+    result_rev = concat(datasets[::-1], dim="day", fill_value=dtypes.NA)
+
+    assert_equal(result_rev, ds_result_rev)
+
+
+def test_order_when_filling_missing():
+    vars_to_drop_in_first = []
+    # drop middle
+    vars_to_drop_in_second = ["humidity"]
+    datasets = create_concat_datasets(2, 123)
+    # set up the test data
+    datasets[0] = datasets[0].drop_vars(vars_to_drop_in_first)
+    datasets[1] = datasets[1].drop_vars(vars_to_drop_in_second)
+
+    temperature_result = np.concatenate(
+        (datasets[0].temperature.values, datasets[1].temperature.values), axis=2
+    )
+    pressure_result = np.concatenate(
+        (datasets[0].pressure.values, datasets[1].pressure.values), axis=2
+    )
+    humidity_result = np.concatenate(
+        (datasets[0].humidity.values, np.full([1, 4, 2], np.nan)), axis=2
+    )
+    precipitation_result = np.concatenate(
+        (datasets[0].precipitation.values, datasets[1].precipitation.values), axis=2
+    )
+    cloudcover_result = np.concatenate(
+        (datasets[0]["cloud cover"].values, datasets[1]["cloud cover"].values), axis=2
+    )
+    ds_result = Dataset(
+        data_vars={
+            "temperature": (["x", "y", "day"], temperature_result),
+            "pressure": (["x", "y", "day"], pressure_result),
+            "humidity": (["x", "y", "day"], humidity_result),
+            "precipitation": (["x", "y", "day"], precipitation_result),
+            "cloud cover": (["x", "y", "day"], cloudcover_result),
+        },
+        coords={
+            "lat": (["x", "y"], datasets[0].lat.values),
+            "lon": (["x", "y"], datasets[0].lon.values),
+            "day": ["day1", "day2", "day3", "day4"],
+        },
+    )
+    result = concat(datasets, dim="day")
+
+    assert_equal(result, ds_result)
+
+    result_keys = [
+        "temperature",
+        "pressure",
+        "humidity",
+        "precipitation",
+        "cloud cover",
+    ]
+    result_index = 0
+    for k in result.data_vars.keys():
+        assert k == result_keys[result_index]
+        result_index += 1
+
+    # test order when concat in reversed order
+    rev_result = concat(datasets[::-1], dim="day")
+    result_index = 0
+    for k in rev_result.data_vars.keys():
+        assert k == result_keys[result_index]
+        result_index += 1
 
 
 class TestConcatDataset:
@@ -332,6 +727,7 @@ class TestConcatDataset:
         assert expected.equals(actual)
         assert isinstance(actual.x.to_index(), pd.MultiIndex)
 
+    # TODO add parameter for missing var
     @pytest.mark.parametrize("fill_value", [dtypes.NA, 2, 2.0])
     def test_concat_fill_value(self, fill_value):
         datasets = [
@@ -394,6 +790,8 @@ class TestConcatDataArray:
         expected = foo[:2].rename({"x": "concat_dim"})
         assert_identical(expected, actual)
 
+        # TODO: is it really correct to expect the new dim to be concat_dim in this case
+        # I propose its likely better to throw an exception
         actual = concat([foo[0], foo[1]], [0, 1]).reset_coords(drop=True)
         expected = foo[:2].rename({"x": "concat_dim"})
         assert_identical(expected, actual)

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1969,7 +1969,7 @@ class TestDataArray:
                 dim={"z": np.linspace(10, 20, 12) * unit_registry.s},
                 axis=1,
             ),
-            method("drop", labels="x"),
+            method("drop_sel", labels="x"),
             method("reset_coords", names="x2"),
             method("copy"),
             pytest.param(
@@ -4045,7 +4045,7 @@ class TestDataset:
                 marks=pytest.mark.xfail(reason="strips units"),
             ),
             pytest.param(
-                method("apply", np.fabs),
+                method("map", np.fabs),
                 marks=pytest.mark.xfail(reason="fabs strips units"),
             ),
         ),
@@ -4220,7 +4220,7 @@ class TestDataset:
             method("rename_dims", x="offset_x"),
             method("swap_dims", {"x": "x2"}),
             method("expand_dims", v=np.linspace(10, 20, 12) * unit_registry.s, axis=1),
-            method("drop", labels="x"),
+            method("drop_sel", labels="x"),
             method("drop_dims", "z"),
             method("set_coords", names="c"),
             method("reset_coords", names="x2"),


### PR DESCRIPTION

 - [x] Closes #508 
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Contined on issue #508 by removing exception when concat two datasets with disjoint variables and instead add the missing variable with np.nan.
