### PR TITLE
replace duplicate method _from_vars_and_coord_names

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -50,6 +50,10 @@ Internal Changes
 ~~~~~~~~~~~~~~~~
 
 
+- Removed internal method ``Dataset._from_vars_and_coord_names``, 
+  which was dominated by ``Dataset._construct_direct``. (:pull:`3565`)
+  By `Maximilian Roos <https://github.com/max-sixty>`_
+
 
 v0.14.1 (19 Nov 2019)
 ---------------------

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -342,7 +342,7 @@ def _fast_dataset(
 
     variables.update(coord_variables)
     coord_names = set(coord_variables)
-    return Dataset._from_vars_and_coord_names(variables, coord_names)
+    return Dataset._construct_direct(variables, coord_names)
 
 
 def apply_dataset_vfunc(

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -309,7 +309,7 @@ class DataArrayCoordinates(Coordinates):
         from .dataset import Dataset
 
         coords = {k: v.copy(deep=False) for k, v in self._data._coords.items()}
-        return Dataset._from_vars_and_coord_names(coords, set(coords))
+        return Dataset._construct_direct(coords, set(coords))
 
     def __delitem__(self, key: Hashable) -> None:
         del self._data._coords[key]

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -466,7 +466,7 @@ class DataArray(AbstractArray, DataWithCoords):
         variables.update({k: v for k, v in self._coords.items() if k != dim})
         indexes = propagate_indexes(self._indexes, exclude=dim)
         coord_names = set(self._coords) - set([dim])
-        dataset = Dataset._from_vars_and_coord_names(
+        dataset = Dataset._construct_direct(
             variables, coord_names, indexes=indexes, attrs=self.attrs
         )
         return dataset
@@ -496,9 +496,7 @@ class DataArray(AbstractArray, DataWithCoords):
         indexes = self._indexes
 
         coord_names = set(self._coords)
-        dataset = Dataset._from_vars_and_coord_names(
-            variables, coord_names, indexes=indexes
-        )
+        dataset = Dataset._construct_direct(variables, coord_names, indexes=indexes)
         return dataset
 
     def to_dataset(self, dim: Hashable = None, *, name: Hashable = None) -> Dataset:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -877,14 +877,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         obj._encoding = encoding
         return obj
 
-    @classmethod
-    def _from_vars_and_coord_names(
-        cls, variables, coord_names, indexes=None, attrs=None
-    ):
-        return cls._construct_direct(
-            variables, coord_names, indexes=indexes, attrs=attrs
-        )
-
     def _replace(
         self,
         variables: Dict[Hashable, Variable] = None,

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1190,7 +1190,7 @@ class TestDataArray:
         data = xr.concat([da, db], dim="x").set_index(xy=["x", "y"])
         assert data.dims == ("xy",)
         actual = data.sel(y="a")
-        expected = data.isel(xy=[0, 1]).unstack("xy").squeeze("y").drop("y")
+        expected = data.isel(xy=[0, 1]).unstack("xy").squeeze("y").drop_vars("y")
         assert_equal(actual, expected)
 
     def test_virtual_default_coords(self):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

From a recent PR review, noticed we have a method that's strictly dominated by another

 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
