### PR TITLE
use cftime's intersphinx

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -351,4 +351,5 @@ intersphinx_mapping = {
     "numba": ("https://numba.pydata.org/numba-doc/latest", None),
     "matplotlib": ("https://matplotlib.org", None),
     "dask": ("https://docs.dask.org/en/latest", None),
+    "cftime": ("https://unidata.github.io/cftime", None),
 }


### PR DESCRIPTION
Now that Unidata/cftime#133 is merged, we can link to the `cftime` documentation using intersphinx (silencing a few more sphinx warnings).

 - [x] Passes `black . && mypy . && flake8`
