### PR TITLE
Add pyXpcm to Related Projects doc page

### DIFF
--- a/doc/related-projects.rst
+++ b/doc/related-projects.rst
@@ -22,6 +22,7 @@ Geosciences
 - `PyGDX <https://pygdx.readthedocs.io/en/latest/>`_: Python 3 package for
   accessing data stored in GAMS Data eXchange (GDX) files. Also uses a custom
   subclass.
+- `pyXpcm <https://pyxpcm.readthedocs.io>`_: xarray-based Profile Classification Modelling (PCM), mostly for ocean data.
 - `Regionmask <https://regionmask.readthedocs.io/>`_: plotting and creation of masks of spatial regions
 - `salem <https://salem.readthedocs.io>`_: Adds geolocalised subsetting, masking, and plotting operations to xarray's data structures via accessors.
 - `SatPy <https://satpy.readthedocs.io/>`_ : Library for reading and manipulating meteorological remote sensing data and writing it to various image and data file formats. 


### PR DESCRIPTION
As it says, this is just to add the https://github.com/obidam/pyxpcm xarray related project to the documentation page.

pyXpcm is a python package to create and work with ocean Profile Classification Model that consumes and produces Xarray objects.
