### PR TITLE
boundary options for rolling.construct

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,7 +25,10 @@ Breaking changes
 
 New Features
 ~~~~~~~~~~~~
-
+- Some boundary options ('edge' | 'reflect' | 'symmetric' | 'wrap') are 
+  newly supported in :py:meth:`~xarray.DataArray.rolling.construct`.
+  (:issue:`2007`)
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -501,12 +501,14 @@ def last(values, axis, skipna=None):
     return take(values, -1, axis=axis)
 
 
-def rolling_window(array, axis, window, center, fill_value):
+def rolling_window(array, axis, window, center, fill_value, mode):
     """
     Make an ndarray with a rolling window of axis-th dimension.
     The rolling dimension will be placed at the last dimension.
     """
     if isinstance(array, dask_array_type):
-        return dask_array_ops.rolling_window(array, axis, window, center, fill_value)
+        return dask_array_ops.rolling_window(
+            array, axis, window, center, fill_value, mode
+        )
     else:  # np.ndarray
-        return nputils.rolling_window(array, axis, window, center, fill_value)
+        return nputils.rolling_window(array, axis, window, center, fill_value, mode)

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -140,7 +140,7 @@ class NumpyVIndexAdapter:
         self._array[key] = np.moveaxis(value, vindex_positions, mixed_positions)
 
 
-def rolling_window(a, axis, window, center, fill_value):
+def rolling_window(a, axis, window, center, fill_value, mode):
     """ rolling window with padding. """
     pads = [(0, 0) for s in a.shape]
     if center:
@@ -149,7 +149,10 @@ def rolling_window(a, axis, window, center, fill_value):
         pads[axis] = (start, end)
     else:
         pads[axis] = (window - 1, 0)
-    a = np.pad(a, pads, mode="constant", constant_values=fill_value)
+    if mode is None:
+        a = np.pad(a, pads, mode="constant", constant_values=fill_value)
+    else:
+        a = np.pad(a, pads, mode=mode)
     return _rolling_window(a, window, axis)
 
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -193,7 +193,7 @@ class DataArrayRolling(Rolling):
 
             yield (label, window)
 
-    def construct(self, window_dim, stride=1, fill_value=dtypes.NA):
+    def construct(self, window_dim, stride=1, fill_value=dtypes.NA, mode=None):
         """
         Convert this rolling object to xr.DataArray,
         where the window dimension is stacked as a new dimension
@@ -206,6 +206,11 @@ class DataArrayRolling(Rolling):
             Size of stride for the rolling window.
         fill_value: optional. Default dtypes.NA
             Filling value to match the dimension size.
+        mode: optional. Default None
+            One of None | 'edge' | 'reflect' | 'symmetric' | 'wrap'
+            For the details of the mode, see
+            https://docs.scipy.org/doc/numpy/reference/generated/numpy.pad.html
+            If it is not None, fill_value is ignored.
 
         Returns
         -------
@@ -234,7 +239,12 @@ class DataArrayRolling(Rolling):
         from .dataarray import DataArray
 
         window = self.obj.variable.rolling_window(
-            self.dim, self.window, window_dim, self.center, fill_value=fill_value
+            self.dim,
+            self.window,
+            window_dim,
+            self.center,
+            fill_value=fill_value,
+            mode=mode,
         )
         result = DataArray(
             window, dims=self.obj.dims + (window_dim,), coords=self.obj.coords
@@ -466,7 +476,7 @@ class DatasetRolling(Rolling):
             **kwargs,
         )
 
-    def construct(self, window_dim, stride=1, fill_value=dtypes.NA):
+    def construct(self, window_dim, stride=1, fill_value=dtypes.NA, mode=None):
         """
         Convert this rolling object to xr.Dataset,
         where the window dimension is stacked as a new dimension
@@ -491,7 +501,7 @@ class DatasetRolling(Rolling):
         for key, da in self.obj.data_vars.items():
             if self.dim in da.dims:
                 dataset[key] = self.rollings[key].construct(
-                    window_dim, fill_value=fill_value
+                    window_dim, fill_value=fill_value, mode=mode
                 )
             else:
                 dataset[key] = da

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1801,7 +1801,7 @@ class Variable(
         return Variable(self.dims, ranked)
 
     def rolling_window(
-        self, dim, window, window_dim, center=False, fill_value=dtypes.NA
+        self, dim, window, window_dim, center=False, fill_value=dtypes.NA, mode=None
     ):
         """
         Make a rolling_window along dim and add a new_dim to the last place.
@@ -1819,6 +1819,9 @@ class Variable(
             of the axis.
         fill_value:
             value to be filled.
+        mode: optional. Default None
+            One of None | 'periodic' | 'reflect'
+            If it is not None, fill_value is ignored.
 
         Returns
         -------
@@ -1856,6 +1859,7 @@ class Variable(
                 window=window,
                 center=center,
                 fill_value=fill_value,
+                mode=mode,
             ),
         )
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4252,6 +4252,14 @@ def test_rolling_wrapped_dask_nochunk(center):
     assert_allclose(actual, expected)
 
 
+@pytest.mark.parametrize("da", (1, 2), indirect=True)
+@pytest.mark.parametrize("center", [True, False])
+@pytest.mark.parametrize("mode", ["edge", "symmetric", "reflect", "wrap"])
+def test_rolling_mode(da, center, mode):
+    # just a working test
+    da.rolling(time=7, center=center).construct("constructed", mode=mode)
+
+
 @pytest.mark.parametrize("center", (True, False))
 @pytest.mark.parametrize("min_periods", (None, 1, 2, 3))
 @pytest.mark.parametrize("window", (1, 2, 3, 4))

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -503,10 +503,10 @@ def test_dask_rolling(axis, window, center):
     dx = da.from_array(x, chunks=[(6, 30, 30, 20, 14), 8])
 
     expected = rolling_window(
-        x, axis=axis, window=window, center=center, fill_value=np.nan
+        x, axis=axis, window=window, center=center, fill_value=np.nan, mode=None
     )
     actual = rolling_window(
-        dx, axis=axis, window=window, center=center, fill_value=np.nan
+        dx, axis=axis, window=window, center=center, fill_value=np.nan, mode=None
     )
     assert isinstance(actual, da.Array)
     assert_array_equal(actual, expected)
@@ -515,7 +515,9 @@ def test_dask_rolling(axis, window, center):
     # we need to take care of window size if chunk size is small
     # window/2 should be smaller than the smallest chunk size.
     with pytest.raises(ValueError):
-        rolling_window(dx, axis=axis, window=100, center=center, fill_value=np.nan)
+        rolling_window(
+            dx, axis=axis, window=100, center=center, fill_value=np.nan, mode=None
+        )
 
 
 @pytest.mark.skipif(not has_dask, reason="This is for dask.")

--- a/xarray/tests/test_nputils.py
+++ b/xarray/tests/test_nputils.py
@@ -33,17 +33,35 @@ def test_vindex():
 def test_rolling():
     x = np.array([1, 2, 3, 4], dtype=float)
 
-    actual = rolling_window(x, axis=-1, window=3, center=True, fill_value=np.nan)
+    actual = rolling_window(
+        x, axis=-1, window=3, center=True, fill_value=np.nan, mode=None
+    )
     expected = np.array(
         [[np.nan, 1, 2], [1, 2, 3], [2, 3, 4], [3, 4, np.nan]], dtype=float
     )
     assert_array_equal(actual, expected)
 
-    actual = rolling_window(x, axis=-1, window=3, center=False, fill_value=0.0)
+    actual = rolling_window(
+        x, axis=-1, window=3, center=False, fill_value=0.0, mode=None
+    )
     expected = np.array([[0, 0, 1], [0, 1, 2], [1, 2, 3], [2, 3, 4]], dtype=float)
     assert_array_equal(actual, expected)
 
+    actual = rolling_window(
+        x, axis=-1, window=3, center=True, fill_value=None, mode="wrap"
+    )
+    expected = np.array([[4, 1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 1]], dtype=float)
+    assert_array_equal(actual, expected)
+
+    actual = rolling_window(
+        x, axis=-1, window=3, center=True, fill_value=None, mode="reflect"
+    )
+    expected = np.array([[2, 1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 3]], dtype=float)
+    assert_array_equal(actual, expected)
+
     x = np.stack([x, x * 1.1])
-    actual = rolling_window(x, axis=-1, window=3, center=False, fill_value=0.0)
+    actual = rolling_window(
+        x, axis=-1, window=3, center=True, fill_value=None, mode="reflect"
+    )
     expected = np.stack([expected, expected * 1.1], axis=0)
     assert_array_equal(actual, expected)

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -820,6 +820,10 @@ class VariableSubclassobjects:
             assert_array_equal(actual, expected)
 
     def test_rolling_window(self):
+        v = self.cls(["x", "y", "z"], np.arange(40 * 30 * 2).reshape(40, 30, 2))
+        self._test_rolling_window(v)
+
+    def _test_rolling_window(self, v):
         # Just a working test. See test_nputils for the algorithm validation
         v = self.cls(["x", "y", "z"], np.arange(40 * 30 * 2).reshape(40, 30, 2))
         for (d, w) in [("x", 3), ("y", 5)]:
@@ -833,6 +837,15 @@ class VariableSubclassobjects:
 
             # dask and numpy result should be the same
             v_loaded = v.load().rolling_window(d, w, d + "_window", center=True)
+            assert_array_equal(v_rolling, v_loaded)
+
+            # dask and numpy result should be the same
+            v_rolling = v.rolling_window(
+                d, w, d + "_window", center=True, mode="symmetric"
+            )
+            v_loaded = v.load().rolling_window(
+                d, w, d + "_window", center=True, mode="symmetric"
+            )
             assert_array_equal(v_rolling, v_loaded)
 
             # numpy backend should not be over-written
@@ -1861,6 +1874,11 @@ class TestVariableWithDask(VariableSubclassobjects):
             v._getitem_with_mask(indexer, fill_value=-1),
             self.cls(("x", "y"), [[0, -1], [-1, 2]]),
         )
+
+    def test_rolling_window(self):
+        v = self.cls(["x", "y", "z"], np.arange(40 * 30 * 2).reshape(40, 30, 2))
+        self._test_rolling_window(v)
+        self._test_rolling_window(v.chunk({"x": 4, "y": 5, "z": -1}))
 
 
 @requires_sparse


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2003, #2011
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Added some boundary options for rolling.construct.
Currently, the option names are inherited from `np.pad`, `['edge' | 'reflect' | 'symmetric' | 'wrap']`.
Do we want a more intuitive name, such as `periodic`?