### PR TITLE
Resolve the version issues on RTD

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.7
   - bottleneck
   - cartopy
-  - eccodes
+  - cfgrib
   - h5netcdf
   - ipykernel
   - ipython
@@ -21,8 +21,5 @@ dependencies:
   - seaborn
   - sphinx
   - sphinx_rtd_theme
+  - xarray
   - zarr
-  - pip
-  - pip:
-    - cfgrib
-

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,9 +15,14 @@
 
 import datetime
 import os
+import pathlib
 import subprocess
 import sys
 from contextlib import suppress
+
+root = pathlib.Path(__file__).absolute().parent.parent
+os.environ["PYTHONPATH"] = str(root)
+sys.path.insert(0, str(root))
 
 import xarray
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 from contextlib import suppress
 
+# make sure the source version is preferred (#3567)
 root = pathlib.Path(__file__).absolute().parent.parent
 os.environ["PYTHONPATH"] = str(root)
 sys.path.insert(0, str(root))

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,5 +4,5 @@ conda:
     file: ci/requirements/doc.yml
 python:
     version: 3.7
-    setup_py_install: true
+    setup_py_install: false
 formats: []


### PR DESCRIPTION
The trick mentioned in https://github.com/pydata/xarray/issues/3567#issuecomment-561270215 works locally, but I don't know whether that's also the case for RTD. Since my own RTD setup cannot go past the environment creation stage: can someone with the appropriate rights on the official setup try this out for me?

Adding `xarray` to `doc.yml` is something temporary that has to be removed before the merge, but I think it is necessary to make sure the version collision occurs.

 - [x] Closes #3567 
 - [x] Passes `black . && mypy . && flake8`
