### PR TITLE
ENH: enable `H5NetCDFStore` to work with already open h5netcdf.File a…

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,6 +25,11 @@ Breaking changes
 
 New Features
 ~~~~~~~~~~~~
+- Support using an existing, opened h5netcdf ``File`` with
+  :py:class:`~xarray.backends.H5NetCDFStore`. This permits creating an
+  :py:class:`~xarray.Dataset` from a h5netcdf ``File`` that has been opened
+  using other means (:issue:`3618`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - Implement :py:func:`median` and :py:func:`nanmedian` for dask arrays. This works by rechunking
   to a single chunk along all reduction axes. (:issue:`2999`).
   By `Deepak Cherian <https://github.com/dcherian>`_.

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -527,7 +527,7 @@ def open_dataset(
         if engine == "scipy":
             store = backends.ScipyDataStore(filename_or_obj, **backend_kwargs)
         elif engine == "h5netcdf":
-            store = backends.H5NetCDFStore(
+            store = backends.H5NetCDFStore.open(
                 filename_or_obj, group=group, lock=lock, **backend_kwargs
             )
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -503,7 +503,7 @@ def open_dataset(
         elif engine == "pydap":
             store = backends.PydapDataStore.open(filename_or_obj, **backend_kwargs)
         elif engine == "h5netcdf":
-            store = backends.H5NetCDFStore(
+            store = backends.H5NetCDFStore.open(
                 filename_or_obj, group=group, lock=lock, **backend_kwargs
             )
         elif engine == "pynio":
@@ -981,7 +981,7 @@ def open_mfdataset(
 WRITEABLE_STORES: Dict[str, Callable] = {
     "netcdf4": backends.NetCDF4DataStore.open,
     "scipy": backends.ScipyDataStore,
-    "h5netcdf": backends.H5NetCDFStore,
+    "h5netcdf": backends.H5NetCDFStore.open,
 }
 
 

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -34,7 +34,7 @@ def find_root_and_group(ds):
     """Find the root and group name of a netCDF4/h5netcdf dataset."""
     hierarchy = ()
     while ds.parent is not None:
-        hierarchy = (ds.name.split('/')[-1],) + hierarchy
+        hierarchy = (ds.name.split("/")[-1],) + hierarchy
         ds = ds.parent
     group = "/" + "/".join(hierarchy)
     return ds, group

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -34,7 +34,7 @@ def find_root_and_group(ds):
     """Find the root and group name of a netCDF4/h5netcdf dataset."""
     hierarchy = ()
     while ds.parent is not None:
-        hierarchy = (ds.name,) + hierarchy
+        hierarchy = (ds.name.split('/')[-1],) + hierarchy
         ds = ds.parent
     group = "/" + "/".join(hierarchy)
     return ds, group

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -80,9 +80,7 @@ class H5NetCDFStore(WritableCFDataStore):
         "_mode",
     )
 
-    def __init__(
-            self, manager, group=None, mode=None, lock=HDF5_LOCK, autoclose=False
-    ):
+    def __init__(self, manager, group=None, mode=None, lock=HDF5_LOCK, autoclose=False):
 
         import h5netcdf
 
@@ -126,9 +124,7 @@ class H5NetCDFStore(WritableCFDataStore):
             else:
                 lock = combine_locks([HDF5_LOCK, get_write_lock(filename)])
 
-        manager = CachingFileManager(
-            h5netcdf.File, filename, mode=mode, kwargs=kwargs
-        )
+        manager = CachingFileManager(h5netcdf.File, filename, mode=mode, kwargs=kwargs)
         return cls(manager, group=group, mode=mode, lock=lock, autoclose=autoclose)
 
     def _acquire(self, needs_lock=True):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2347,6 +2347,7 @@ class TestH5NetCDFData(NetCDF4Base):
 
     def test_already_open_dataset_group(self):
         import h5netcdf
+
         with create_tmp_file() as tmp_file:
             with nc4.Dataset(tmp_file, mode="w") as nc:
                 group = nc.createGroup("g")

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2182,7 +2182,7 @@ class TestH5NetCDFData(NetCDF4Base):
     @contextlib.contextmanager
     def create_store(self):
         with create_tmp_file() as tmp_file:
-            yield backends.H5NetCDFStore(tmp_file, "w")
+            yield backends.H5NetCDFStore.open(tmp_file, "w")
 
     @pytest.mark.filterwarnings("ignore:complex dtypes are supported by h5py")
     @pytest.mark.parametrize(
@@ -2344,6 +2344,26 @@ class TestH5NetCDFData(NetCDF4Base):
         with self.roundtrip(ds, save_kwargs=kwargs) as actual:
             assert actual.x.encoding["compression"] == "lzf"
             assert actual.x.encoding["compression_opts"] is None
+
+    def test_already_open_dataset_group(self):
+        import h5netcdf
+        with create_tmp_file() as tmp_file:
+            with nc4.Dataset(tmp_file, mode="w") as nc:
+                group = nc.createGroup("g")
+                v = group.createVariable("x", "int")
+                v[...] = 42
+
+            h5 = h5netcdf.File(tmp_file, mode="r")
+            store = backends.H5NetCDFStore(h5["g"])
+            with open_dataset(store) as ds:
+                expected = Dataset({"x": ((), 42)})
+                assert_identical(expected, ds)
+
+            h5 = h5netcdf.File(tmp_file, mode="r")
+            store = backends.H5NetCDFStore(h5, group="g")
+            with open_dataset(store) as ds:
+                expected = Dataset({"x": ((), 42)})
+                assert_identical(expected, ds)
 
 
 @requires_h5netcdf


### PR DESCRIPTION
enable `H5NetCDFStore` to work with open h5netcdf.File and h5netcdf.Group objects, add test

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
