### PR TITLE
Provide shape info in shape mismatch error.

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -346,7 +346,10 @@ class Variable(
     def data(self, data):
         data = as_compatible_data(data)
         if data.shape != self.shape:
-            raise ValueError("replacement data must match the Variable's shape")
+            raise ValueError(
+                f"replacement data must match the Variable's shape. "
+                f"data.shape is {data.shape}; Variable.shape is {self.shape}"
+            )
         self._data = data
 
     def load(self, **kwargs):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -348,7 +348,7 @@ class Variable(
         if data.shape != self.shape:
             raise ValueError(
                 f"replacement data must match the Variable's shape. "
-                f"data.shape is {data.shape}; Variable.shape is {self.shape}"
+                f"replacement data has shape {data.shape}; Variable has shape {self.shape}"
             )
         self._data = data
 


### PR DESCRIPTION
While it is easy enough to obtain this info from `%debug`, putting it
in the error messages is helpful when those messages come from user
reports (e.g. emails).

I am guessing that this change does not call for a new test or a
documentation update, but I'm happy to add one if asked.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `black . && mypy . && flake8`