### PR TITLE
update readthedocs.yml

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,8 +1,13 @@
+version: 2
+
 build:
     image: latest
+
 conda:
-    file: ci/requirements/doc.yml
+    environment: ci/requirements/doc.yml
+
 python:
     version: 3.7
-    setup_py_install: false
+    install: []
+
 formats: []


### PR DESCRIPTION
This uses the new version of the readthedocs configuration. As usual, my setup failed on the creation of the environment, so we should try to check that before a merge.

 - [x] Closes #3623