### PR TITLE
Make datetime_to_numeric more robust to overflow errors

### DIFF
--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -669,10 +669,22 @@ def test_datetime_to_numeric_datetime64():
     expected = 24 * np.arange(0, 35, 7).astype(dtype)
     np.testing.assert_array_equal(result, expected)
 
+    # Test overflow. Need to convert to ms first otherwise we get garbage
+    # TODO: make datetime_to_numeric more robust to overflow errors.
+    offset = np.datetime64("0001-01-01")
+    ms = times.astype("datetime64[ms]")
+    result = duck_array_ops.datetime_to_numeric(
+        ms, offset=offset, datetime_unit="D", dtype=int
+    )
+    expected = 730119 + np.arange(0, 35, 7)
+    np.testing.assert_array_equal(result, expected)
+
 
 @requires_cftime
 def test_datetime_to_numeric_cftime():
-    times = cftime_range("2000", periods=5, freq="7D").values
+    import cftime
+
+    times = cftime_range("2000", periods=5, freq="7D", calendar="standard").values
     result = duck_array_ops.datetime_to_numeric(times, datetime_unit="h")
     expected = 24 * np.arange(0, 35, 7)
     np.testing.assert_array_equal(result, expected)
@@ -685,4 +697,12 @@ def test_datetime_to_numeric_cftime():
     dtype = np.float32
     result = duck_array_ops.datetime_to_numeric(times, datetime_unit="h", dtype=dtype)
     expected = 24 * np.arange(0, 35, 7).astype(dtype)
+    np.testing.assert_array_equal(result, expected)
+
+    # Test potential overflow (outputs are different from timedelta64. Expected ?)
+    offset = cftime.DatetimeGregorian(1, 1, 1)
+    result = duck_array_ops.datetime_to_numeric(
+        times, offset=offset, datetime_unit="D", dtype=int
+    )
+    expected = 730121 + np.arange(0, 35, 7)
     np.testing.assert_array_equal(result, expected)

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -662,3 +662,10 @@ def test_datetime_interp_noerror():
         coords={"time": pd.date_range("01-01-2001", periods=50, freq="H")},
     )
     a.interp(x=xi, time=xi.time)  # should not raise an error
+
+
+@requires_cftime
+def test_3641():
+    times = xr.cftime_range("0001", periods=3, freq="500Y")
+    da = xr.DataArray(range(3), dims=["time"], coords=[times])
+    da.interp(time=["0002-05-01"])


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #3641 
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

This is likely only safe with NumPy>=1.17 though. 