### PR TITLE
GroupBy plotting

### DIFF
--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -23,6 +23,8 @@ from .utils import (
 )
 from .variable import IndexVariable, Variable, as_variable
 
+from ..plot.plot import _PlotMethods as _DataArray_PlotMethods
+
 
 def check_reduce_dims(reduce_dims, dimensions):
 
@@ -263,6 +265,7 @@ class GroupBy(SupportsArithmetic):
         "_stacked_dim",
         "_unique_coord",
         "_dims",
+        "_coords",
     )
 
     def __init__(
@@ -404,6 +407,7 @@ class GroupBy(SupportsArithmetic):
         self._obj = obj
         self._group = group
         self._group_dim = group_dim
+        self._group_coord = obj[group_dim]
         self._group_indices = group_indices
         self._unique_coord = unique_coord
         self._stacked_dim = stacked_dim
@@ -411,9 +415,30 @@ class GroupBy(SupportsArithmetic):
         self._full_index = full_index
         self._restore_coord_dims = restore_coord_dims
 
+        # make groupby object mimic underlying object
+        self.attrs = obj.attrs
+        self.name = obj.name if hasattr(obj, "name") else None
+
         # cached attributes
         self._groups = None
         self._dims = None
+        self._coords = None
+
+    @property
+    def coords(self):
+        # TODO: implement drop_vars for Coordinates?
+        if self._coords is None:
+            self._coords = (
+                self._obj.isel(**{self._group_dim: self._group_indices[0]})
+                .coords.to_dataset()
+                .drop_vars([self._group.name, self._group_dim], errors="ignore")
+                .coords
+            )
+        return self._coords
+
+    @property
+    def ndim(self):
+        return len(self.dims)
 
     @property
     def dims(self):
@@ -444,6 +469,23 @@ class GroupBy(SupportsArithmetic):
             self._unique_coord.size,
             ", ".join(format_array_flat(self._unique_coord, 30).split()),
         )
+
+    def __getitem__(self, key):
+        # TODO: this may need to be better
+        if (
+            key != self._unique_coord.name
+            and key not in self.coords
+            and key not in self.dims
+        ):
+            raise ValueError(
+                f"Expected one of dimension {self._group_dim}, dimensions {self._obj.dims} "
+                f"or coordinates {self.coords._coord_names}. Received {key}."
+            )
+
+        if key == self._unique_coord.name:
+            return self._unique_coord
+        else:
+            return self._obj[key]
 
     def _get_index_and_items(self, index, grouper):
         from .resample_cftime import CFTimeGrouper
@@ -886,6 +928,10 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
         check_reduce_dims(dim, self.dims)
 
         return self.map(reduce_array, shortcut=shortcut)
+
+    @property
+    def plot(self):
+        return _DataArray_PlotMethods(self)
 
 
 ops.inject_reduce_methods(DataArrayGroupBy)

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -4,6 +4,7 @@ import warnings
 
 import numpy as np
 
+
 from ..core.formatting import format_item
 from .utils import (
     _infer_xy_labels,
@@ -30,6 +31,24 @@ def _nicetitle(coord, value, maxchar, template):
         title = title[: (maxchar - 3)] + "..."
 
     return title
+
+
+def parse_sharex_sharey(data, sharex, sharey):
+
+    from ..core.groupby import GroupBy
+
+    if sharex is None:
+        if isinstance(data, GroupBy):
+            sharex = False
+        else:
+            sharex = True
+    if sharey is None:
+        if isinstance(data, GroupBy):
+            sharey = False
+        else:
+            sharey = True
+
+    return sharex, sharey
 
 
 class FacetGrid:
@@ -79,8 +98,8 @@ class FacetGrid:
         col=None,
         row=None,
         col_wrap=None,
-        sharex=True,
-        sharey=True,
+        sharex=None,
+        sharey=None,
         figsize=None,
         aspect=1,
         size=3,
@@ -161,6 +180,7 @@ class FacetGrid:
             cbar_space = 1
             figsize = (ncol * size * aspect + cbar_space, nrow * size)
 
+        sharex, sharey = parse_sharex_sharey(data, sharex, sharey)
         fig, axes = plt.subplots(
             nrow,
             ncol,
@@ -360,6 +380,87 @@ class FacetGrid:
                 self.add_legend()
             elif meta_data["add_colorbar"]:
                 self.add_colorbar(label=self._hue_label, **cbar_kwargs)
+
+        return self
+
+    def map_groupby(
+        self, func, x=None, y=None, hue=None, hue_style=None, add_guide=None, **kwargs
+    ):
+
+        if kwargs.get("cbar_ax", None) is not None:
+            raise ValueError("cbar_ax not supported by FacetGrid.")
+
+        cmap_params, cbar_kwargs = _process_cmap_cbar_kwargs(
+            func, self.data._obj.values, **kwargs
+        )
+
+        self._cmap_extend = cmap_params.get("extend")
+
+        # Order is important
+        func_kwargs = {
+            k: v
+            for k, v in kwargs.items()
+            if k not in {"cmap", "colors", "cbar_kwargs", "levels"}
+        }
+        func_kwargs.update(cmap_params)
+        func_kwargs.update({"add_colorbar": False, "add_labels": False})
+
+        # Get x, y labels for the first subplot
+        grouped = self.data
+        first_group = grouped._obj.isel(
+            **{grouped._group_dim: grouped._group_indices[0]}
+        ).squeeze()
+        x, y = _infer_xy_labels(
+            darray=first_group,
+            x=x,
+            y=y,
+            imshow=func.__name__ == "imshow",
+            rgb=kwargs.get("rgb", None),
+        )
+
+        for (_, subset), ax in zip(self.data, self.axes.flat):
+            mappable = func(subset, x=x, y=y, ax=ax, **func_kwargs)
+            self._mappables.append(mappable)
+
+        self._finalize_grid(x, y)
+
+        if kwargs.get("add_colorbar", True):
+            self.add_colorbar(**cbar_kwargs)
+
+        return self
+
+    def map_groupby_line(
+        self, func, x, y, hue, add_legend=True, _labels=None, **kwargs
+    ):
+        from .plot import _infer_line_data
+
+        grouped = self.data
+        first_group = grouped._obj.isel(
+            **{grouped._group_dim: grouped._group_indices[0]}
+        ).squeeze()
+        _, _, hueplt, xlabel, ylabel, huelabel = _infer_line_data(
+            darray=first_group, x=x, y=y, hue=hue
+        )
+
+        for (_, subset), ax in zip(self.data, self.axes.flat):
+            mappable = func(
+                subset.squeeze(),
+                x=x,
+                y=y,
+                ax=ax,
+                hue=hue,
+                add_legend=False,
+                _labels=False,
+                **kwargs
+            )
+            self._mappables.append(mappable)
+
+        self._hue_var = hueplt
+        self._hue_label = huelabel
+        self._finalize_grid(xlabel, ylabel)
+
+        if add_legend and hueplt is not None and huelabel is not None:
+            self.add_legend()
 
         return self
 
@@ -599,8 +700,8 @@ def _easy_facetgrid(
     row=None,
     col=None,
     col_wrap=None,
-    sharex=True,
-    sharey=True,
+    sharex=None,
+    sharey=None,
     aspect=None,
     size=None,
     subplot_kws=None,
@@ -643,3 +744,9 @@ def _easy_facetgrid(
 
     if kind == "dataset":
         return g.map_dataset(plotfunc, x, y, **kwargs)
+
+    if kind == "groupby":
+        return g.map_groupby(plotfunc, x, y, **kwargs)
+
+    if kind == "groupby_line":
+        return g.map_groupby_line(plotfunc, x, y, **kwargs)

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -163,19 +163,26 @@ def plot(
         Additional keyword arguments to matplotlib
 
     """
-    darray = darray.squeeze().compute()
+    from ..core.groupby import GroupBy
+
+    if isinstance(darray, GroupBy):
+        if row is None and col is None:
+            raise ValueError(
+                f"Both 'row' and 'col' are None. Expected one of 'row' or 'col' to be '{darray._unique_coord.name}'"
+            )
 
     plot_dims = set(darray.dims)
     plot_dims.discard(row)
     plot_dims.discard(col)
     plot_dims.discard(hue)
 
-    ndims = len(plot_dims)
+    # if we are grouping over a 1D uniquely valued coordinate, then plotting should work.
+    if isinstance(darray, GroupBy) and darray._unique_coord.equals(
+        darray._obj.coords[darray._group_dim]
+    ):
+        plot_dims.discard(darray._group_dim)
 
-    error_msg = (
-        "Only 1d and 2d plots are supported for facets in xarray. "
-        "See the package `Seaborn` for more options."
-    )
+    ndims = len(plot_dims)
 
     if ndims in [1, 2]:
         if row or col:
@@ -194,12 +201,26 @@ def plot(
                 plotfunc = pcolormesh
     else:
         if row or col or hue:
-            raise ValueError(error_msg)
+            raise ValueError(
+                f"Only 1d and 2d plots are supported for facets in xarray. "
+                f"Provided DataArray has {ndims} dimension(s). "
+                f"See the package `Seaborn` for more options."
+            )
         plotfunc = hist
 
     kwargs["ax"] = ax
 
     return plotfunc(darray, **kwargs)
+
+
+def _sanity_check_groupby_row_col(grouped, row, col):
+    grouped_name = grouped._unique_coord.name
+    row_or_col = row if row is not None else col
+    if row_or_col != grouped_name:
+        raise ValueError(
+            "Expected grouped variable %r for 'row' or 'col', received %r instead."
+            % (grouped_name, row_or_col)
+        )
 
 
 # This function signature should not change so that it can use
@@ -272,12 +293,27 @@ def line(
     ``*args``, ``**kwargs`` : optional
         Additional arguments to matplotlib.pyplot.plot
     """
+
+    from ..core.groupby import GroupBy
+
+    if isinstance(darray, GroupBy):
+        if row is None and col is None:
+            raise ValueError(
+                f"Both 'row' and 'col' are None. Expected one of 'row' or 'col' to be '{darray._unique_coord.name}'"
+            )
+
     # Handle facetgrids first
     if row or col:
         allargs = locals().copy()
         allargs.update(allargs.pop("kwargs"))
-        allargs.pop("darray")
-        return _easy_facetgrid(darray, line, kind="line", **allargs)
+        del allargs["darray"]
+        del allargs["GroupBy"]
+
+        if not isinstance(darray, GroupBy):
+            return _easy_facetgrid(darray, line, kind="line", **allargs)
+        else:
+            _sanity_check_groupby_row_col(darray, row, col)
+            return _easy_facetgrid(darray, line, kind="groupby_line", **allargs)
 
     ndims = len(darray.dims)
     if ndims > 2:
@@ -295,6 +331,9 @@ def line(
 
     ax = get_axis(figsize, size, aspect, ax)
     xplt, yplt, hueplt, xlabel, ylabel, hue_label = _infer_line_data(darray, x, y, hue)
+
+    if not isinstance(darray, GroupBy):
+        darray = darray.squeeze().compute()
 
     # Remove pd.Intervals if contained in xplt.values.
     if _valid_other_type(xplt.values, [pd.Interval]):
@@ -649,7 +688,13 @@ def _plot2d(plotfunc):
             allargs.update(allargs.pop("kwargs"))
             # Need the decorated plotting function
             allargs["plotfunc"] = globals()[plotfunc.__name__]
-            return _easy_facetgrid(darray, kind="dataarray", **allargs)
+            from ..core.groupby import GroupBy
+
+            if not isinstance(darray, GroupBy):
+                return _easy_facetgrid(darray, kind="dataarray", **allargs)
+            else:
+                _sanity_check_groupby_row_col(darray, row, col)
+                return _easy_facetgrid(darray, kind="groupby", **allargs)
 
         plt = import_matplotlib_pyplot()
 
@@ -662,9 +707,13 @@ def _plot2d(plotfunc):
                 "with a three-dimensional array (per facet)"
             )
 
+        darray = darray.squeeze()
+
         xlab, ylab = _infer_xy_labels(
             darray=darray, x=x, y=y, imshow=imshow_rgb, rgb=rgb
         )
+
+        darray = darray.compute()
 
         # better to pass the ndarrays directly to plotting functions
         xval = darray[xlab].values

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -500,3 +500,5 @@ def test_groupby_bins_timeseries():
 
 
 # TODO: move other groupby tests from test_dataset and test_dataarray over here
+# TODO: add tests for groupby.coords
+# TODO: add tests for groupby.__getitem__

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -36,6 +36,11 @@ try:
 except ImportError:
     pass
 
+try:
+    import cftime
+except ImportError:
+    pass
+
 
 @pytest.mark.flaky
 @pytest.mark.skip(reason="maybe flaky")
@@ -2199,3 +2204,61 @@ def test_plot_transposes_properly(plotfunc):
     # pcolormesh returns 1D array but imshow returns a 2D array so it is necessary
     # to ravel() on the LHS
     assert np.all(hdl.get_array().ravel() == da.to_masked_array().ravel())
+
+
+class TestDataArrayGroupByPlot:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.ds = Dataset(
+            {
+                "variable": (
+                    ("lat", "lon", "time"),
+                    np.arange(60.0).reshape((4, 3, 5)),
+                ),
+                "id": (("lat", "lon"), np.arange(12.0).reshape((4, 3))),
+            },
+            coords={
+                "lat": np.arange(4),
+                "lon": np.arange(3),
+                "time": pd.date_range(start="2001-01-01", freq="D", periods=5),
+            },
+        )
+
+    @requires_cftime
+    @requires_nc_time_axis
+    @pytest.mark.parametrize(
+        "time",
+        [
+            cftime.num2date(
+                np.arange(0, 730), "days since 0001-01-01 00:00:00", calendar="noleap"
+            ),
+            pd.date_range("2001-01-01", freq="12H", periods=730),
+        ],
+    )
+    def test_time_grouping(self, time):
+        # create spatial coordinate
+        lev = np.arange(100)
+
+        # Create sample Dataset
+        ds = Dataset(
+            {
+                "sample_data": (["time", "lev"], np.random.rand(time.size, lev.size)),
+                "independent_data": (["lev"], np.random.rand(lev.size)),
+            },
+            coords={"time": (["time"], time), "lev": (["lev"], lev)},
+        )
+
+        ds.sample_data.groupby("time.month").plot(
+            col="month", col_wrap=4, x="time", sharey=True
+        )
+
+    def test_stacked_groupby_line_plot(self):
+        self.ds.variable.groupby(self.ds.id).plot.line(col="id", col_wrap=2)
+
+    def test_stacked_groupby_2d_plot(self):
+        id2 = self.ds.id.isel(lon=0)
+        self.ds.variable.groupby(id2).plot(col="id", col_wrap=2)
+
+    def test_groupby_plot_errors(self):
+        with raises_regex(ValueError, "Expected one of 'row' or 'col' to be 'id'"):
+            self.ds.variable.groupby(self.ds.id).plot.line()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Tests added
 - [ ] Passes `black . && mypy . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

This adds plotting methods to GroupBy objects so that it's easy to plot each group as a facet. I'm finding this super helpful in my current research project. 

It's pretty self-contained, mostly just adding `map_groupby*` methods to `FacetGrid`. But that's because I make `GroupBy` mimic the underlying `DataArray` by adding `coords`, `attrs` and `__getitem__`. This still needs more tests but I was wondering what people thought of the feature and the implementation.

## Example

``` python
import numpy as np
import xarray as xr

time = np.arange(80)
da = xr.DataArray(5 * np.sin(2*np.pi*time/10), coords={"time": time}, dims="time")
da["period"] = da.time.where((time % 10) == 0).ffill("time")/10
da.plot()
```
![image](https://user-images.githubusercontent.com/2448579/71194665-49f45c00-2284-11ea-96e5-9a5daec1b3a9.png)

``` python
da.groupby("period").plot(col="period", col_wrap=4)
```
![image](https://user-images.githubusercontent.com/2448579/71194694-51b40080-2284-11ea-9534-b5f7c6014b0f.png)

``` python
da = da.expand_dims(y=10)
da.groupby("period").plot(col="period", col_wrap=4, sharey=True, robust=True)
```
![image](https://user-images.githubusercontent.com/2448579/71194716-5c6e9580-2284-11ea-832a-c4e7d9296390.png)

