### PR TITLE
Use encoding['dtype'] over data.dtype when possible within CFMaskCoder.encode

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -54,7 +54,7 @@ Bug fixes
 - Ensure :py:meth:`Dataset.quantile`, :py:meth:`DataArray.quantile` issue the correct error
   when ``q`` is out of bounds (:issue:`3634`) by `Mathias Hauser <https://github.com/mathause>`_.
 - Fix regression in xarray 0.14.1 that prevented encoding times with certain
-  ``dtype``, ``_FillValue``. and ``missing_value`` encodings (:issue:`3624`).
+  ``dtype``, ``_FillValue``, and ``missing_value`` encodings (:issue:`3624`).
   By `Spencer Clark <https://github.com/spencerkclark>`_
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -53,6 +53,9 @@ Bug fixes
   By `Tom Augspurger <https://github.com/TomAugspurger>`_.
 - Ensure :py:meth:`Dataset.quantile`, :py:meth:`DataArray.quantile` issue the correct error
   when ``q`` is out of bounds (:issue:`3634`) by `Mathias Hauser <https://github.com/mathause>`_.
+- Fix regression in xarray 0.14.1 that prevented encoding times with certain
+  ``dtype``, ``_FillValue``. and ``missing_value`` encodings (:issue:`3624`).
+  By `Spencer Clark <https://github.com/spencerkclark>`_
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -148,6 +148,7 @@ class CFMaskCoder(VariableCoder):
     def encode(self, variable, name=None):
         dims, data, attrs, encoding = unpack_for_encoding(variable)
 
+        dtype = np.dtype(encoding.get("dtype", data.dtype))
         fv = encoding.get("_FillValue")
         mv = encoding.get("missing_value")
 
@@ -162,14 +163,14 @@ class CFMaskCoder(VariableCoder):
 
         if fv is not None:
             # Ensure _FillValue is cast to same dtype as data's
-            encoding["_FillValue"] = data.dtype.type(fv)
+            encoding["_FillValue"] = dtype.type(fv)
             fill_value = pop_to(encoding, attrs, "_FillValue", name=name)
             if not pd.isnull(fill_value):
                 data = duck_array_ops.fillna(data, fill_value)
 
         if mv is not None:
             # Ensure missing_value is cast to same dtype as data's
-            encoding["missing_value"] = data.dtype.type(mv)
+            encoding["missing_value"] = dtype.type(mv)
             fill_value = pop_to(encoding, attrs, "missing_value", name=name)
             if not pd.isnull(fill_value) and fv is None:
                 data = duck_array_ops.fillna(data, fill_value)

--- a/xarray/tests/test_coding.py
+++ b/xarray/tests/test_coding.py
@@ -1,10 +1,12 @@
 from contextlib import suppress
 
 import numpy as np
+import pandas as pd
 import pytest
 
 import xarray as xr
 from xarray.coding import variables
+from xarray.conventions import decode_cf_variable, encode_cf_variable
 
 from . import assert_equal, assert_identical, requires_dask
 
@@ -20,20 +22,36 @@ def test_CFMaskCoder_decode():
     assert_identical(expected, encoded)
 
 
-def test_CFMaskCoder_encode_missing_fill_values_conflict():
-    original = xr.Variable(
-        ("x",),
-        [0.0, -1.0, 1.0],
-        encoding={"_FillValue": np.float32(1e20), "missing_value": np.float64(1e20)},
-    )
-    coder = variables.CFMaskCoder()
-    encoded = coder.encode(original)
+encoding_with_dtype = {
+    "dtype": np.dtype("float64"),
+    "_FillValue": np.float32(1e20),
+    "missing_value": np.float64(1e20),
+}
+encoding_without_dtype = {
+    "_FillValue": np.float32(1e20),
+    "missing_value": np.float64(1e20),
+}
+CFMASKCODER_ENCODE_DTYPE_CONFLICT_TESTS = {
+    "numeric-with-dtype": ([0.0, -1.0, 1.0], encoding_with_dtype),
+    "numeric-without-dtype": ([0.0, -1.0, 1.0], encoding_without_dtype),
+    "times-with-dtype": (pd.date_range("2000", periods=3), encoding_with_dtype),
+}
+
+
+@pytest.mark.parametrize(
+    ("data", "encoding"),
+    CFMASKCODER_ENCODE_DTYPE_CONFLICT_TESTS.values(),
+    ids=list(CFMASKCODER_ENCODE_DTYPE_CONFLICT_TESTS.keys()),
+)
+def test_CFMaskCoder_encode_missing_fill_values_conflict(data, encoding):
+    original = xr.Variable(("x",), data, encoding=encoding)
+    encoded = encode_cf_variable(original)
 
     assert encoded.dtype == encoded.attrs["missing_value"].dtype
     assert encoded.dtype == encoded.attrs["_FillValue"].dtype
 
     with pytest.warns(variables.SerializationWarning):
-        roundtripped = coder.decode(coder.encode(original))
+        roundtripped = decode_cf_variable("foo", encoded)
         assert_identical(roundtripped, original)
 
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
This uses `encoding['dtype']` over `data.dtype` when possible within `CFMaskCoder.encode` to decide what type to cast `encoding['missing_value']` or `encoding['_FillValue']` to; this is one way to fix #3624.  Another possible way would be to ensure the times have the proper `dtype` coming from `CFDatetimeCoder.encode`.  I'm not sure what is the preferred solution.

cc: @andersy005, @spencerahill

 - [x] Closes #3624
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
