### PR TITLE
Tests for variables with units

### DIFF
--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1552,7 +1552,7 @@ class TestVariable(VariableSubclassobjects):
 
         if error is not None:
             with pytest.raises(error):
-                print(variable.fillna(value=fill_value))
+                variable.fillna(value=fill_value)
 
             return
 

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -2030,7 +2030,7 @@ class TestVariable(VariableSubclassobjects):
         array = np.linspace(0, 5, 3 * 10).reshape(3, 10).astype(dtype) * unit_registry.m
         variable = xr.Variable(("x", "y"), array)
 
-        fill_value = np.array(-100) * unit
+        fill_value = -100 * unit
 
         func = method("pad_with_fill_value", x=(2, 3), y=(1, 4))
         if error is not None:

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -295,6 +295,16 @@ def dtype(request):
     return request.param
 
 
+def merge_args(default_args, new_args):
+    from itertools import zip_longest
+
+    fill_value = object()
+    return [
+        second if second is not fill_value else first
+        for first, second in zip_longest(default_args, new_args, fillvalue=fill_value)
+    ]
+
+
 class method:
     def __init__(self, name, *args, **kwargs):
         self.name = name
@@ -305,7 +315,7 @@ class method:
         from collections.abc import Callable
         from functools import partial
 
-        all_args = list(self.args) + list(args)
+        all_args = merge_args(self.args, args)
         all_kwargs = {**self.kwargs, **kwargs}
 
         func = getattr(obj, self.name, None)
@@ -347,7 +357,7 @@ class function:
         self.kwargs = kwargs
 
     def __call__(self, *args, **kwargs):
-        all_args = list(self.args) + list(args)
+        all_args = merge_args(self.args, args)
         all_kwargs = {**self.kwargs, **kwargs}
 
         return self.func(*all_args, **all_kwargs)

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1491,6 +1491,7 @@ class TestVariable(VariableSubclassobjects):
         expected = func(strip_units(variable))
         actual = func(variable)
 
+        assert extract_units(expected) == extract_units(actual)
         xr.testing.assert_identical(expected, actual)
 
     @pytest.mark.parametrize(

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1466,6 +1466,29 @@ class TestVariable(VariableSubclassobjects):
         assert extract_units(expected) == extract_units(actual)
         np.testing.assert_allclose(expected, actual)
 
+    @pytest.mark.parametrize(
+        "func", (method("isnull"), method("notnull"), method("count")), ids=repr
+    )
+    def test_missing_value_detection(self, func, dtype):
+        array = (
+            np.array(
+                [
+                    [1.4, 2.3, np.nan, 7.2],
+                    [np.nan, 9.7, np.nan, np.nan],
+                    [2.1, np.nan, np.nan, 4.6],
+                    [9.9, np.nan, 7.2, 9.1],
+                ]
+            ).astype(dtype)
+            * unit_registry.degK
+        )
+
+        variable = xr.Variable(("x", "y"), array)
+
+        expected = func(strip_units(variable))
+        actual = func(variable)
+
+        xr.testing.assert_identical(expected, actual)
+
 
 class TestDataArray:
     @pytest.mark.filterwarnings("error:::pint[.*]")

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1354,7 +1354,6 @@ class TestVariable(VariableSubclassobjects):
             method("astype", np.float32),
             method("conj"),
             method("conjugate"),
-            method("searchsorted", 5),
             method("clip", min=2, max=7),
         ),
         ids=repr,
@@ -1398,7 +1397,6 @@ class TestVariable(VariableSubclassobjects):
             for key, value in kwargs.items()
         }
 
-        print("running on:", func, args, kwargs)
         units = extract_units(func(array, *args, **kwargs))
         expected = attach_units(
             func(strip_units(variable), *converted_args, **converted_kwargs), units
@@ -1407,6 +1405,66 @@ class TestVariable(VariableSubclassobjects):
 
         assert extract_units(expected) == extract_units(actual)
         xr.testing.assert_allclose(expected, actual)
+
+    @pytest.mark.parametrize(
+        "func", (method("item", 5), method("searchsorted", 5)), ids=repr
+    )
+    @pytest.mark.parametrize(
+        "unit,error",
+        (
+            pytest.param(1, DimensionalityError, id="no_unit"),
+            pytest.param(
+                unit_registry.dimensionless, DimensionalityError, id="dimensionless"
+            ),
+            pytest.param(unit_registry.s, DimensionalityError, id="incompatible_unit"),
+            pytest.param(unit_registry.cm, None, id="compatible_unit"),
+            pytest.param(unit_registry.m, None, id="identical_unit"),
+        ),
+    )
+    def test_raw_numpy_methods(self, func, unit, error, dtype):
+        array = np.linspace(0, 1, 10).astype(dtype) * unit_registry.m
+        variable = xr.Variable("x", array)
+
+        args = [
+            item * unit
+            if isinstance(item, (int, float, list)) and func.name != "item"
+            else item
+            for item in func.args
+        ]
+        kwargs = {
+            key: value * unit
+            if isinstance(value, (int, float, list)) and func.name != "item"
+            else value
+            for key, value in func.kwargs.items()
+        }
+
+        if error is not None and func.name != "item":
+            with pytest.raises(error):
+                func(variable, *args, **kwargs)
+
+            return
+
+        converted_args = [
+            strip_units(convert_units(item, {None: unit_registry.m}))
+            if func.name != "item"
+            else item
+            for item in args
+        ]
+        converted_kwargs = {
+            key: strip_units(convert_units(value, {None: unit_registry.m}))
+            if func.name != "item"
+            else value
+            for key, value in kwargs.items()
+        }
+
+        units = extract_units(func(array, *args, **kwargs))
+        expected = attach_units(
+            func(strip_units(variable), *converted_args, **converted_kwargs), units
+        )
+        actual = func(variable, *args, **kwargs)
+
+        assert extract_units(expected) == extract_units(actual)
+        np.testing.assert_allclose(expected, actual)
 
 
 class TestDataArray:

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1823,12 +1823,16 @@ class TestVariable(VariableSubclassobjects):
             ),
             method("roll", {"x": 2}),
             pytest.param(
+                method("rolling_window", "x", 3, "window"),
+                marks=pytest.mark.xfail(reason="converts to ndarray"),
+            ),
+            method("round", 2),
+            pytest.param(
                 method("shift", {"x": -2}),
                 marks=pytest.mark.xfail(
                     reason="trying to concatenate ndarray to quantity"
                 ),
             ),
-            method("round", 2),
         ),
         ids=repr,
     )

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1823,11 +1823,12 @@ class TestVariable(VariableSubclassobjects):
         assert_units_equal(expected, actual)
         xr.testing.assert_identical(expected, actual)
 
-        for dim in names:
+        names = tuple(name for name, size in zip(names, shape) if shape == 1)
+        for name in names:
             expected = attach_units(
-                strip_units(variable).squeeze(), extract_units(variable)
+                strip_units(variable).squeeze(dim=name), extract_units(variable)
             )
-            actual = variable.squeeze()
+            actual = variable.squeeze(dim=name)
 
             assert_units_equal(expected, actual)
             xr.testing.assert_identical(expected, actual)

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -32,16 +32,15 @@ pytestmark = [
 
 
 def is_compatible(unit1, unit2):
-    def _valid_type(unit1):
-        return isinstance(unit1, (int, unit_registry.Unit, Quantity))
+    def dimensionality(obj):
+        if isinstance(obj, (unit_registry.Quantity, unit_registry.Unit)):
+            unit_like = obj
+        else:
+            unit_like = unit_registry.dimensionless
 
-    if not _valid_type(unit1) or not _valid_type(unit2):
-        raise ValueError("can only pass int, Unit or Quantity instances")
+        return unit_like.dimensionality
 
-    unit1 = unit_registry.dimensionless if isinstance(unit1, int) else unit1
-    unit2 = unit_registry.dimensionless if isinstance(unit2, int) else unit2
-
-    return unit1.dimensionality == unit2.dimensionality
+    return dimensionality(unit1) == dimensionality(unit2)
 
 
 def compatible_mappings(first, second):

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1302,6 +1302,106 @@ class TestVariable(VariableSubclassobjects):
             dims, unit_registry.Quantity(data, unit_registry.m), *args, **kwargs
         )
 
+    @pytest.mark.parametrize(
+        "func",
+        (
+            pytest.param(
+                method("all"), marks=pytest.mark.xfail(reason="not implemented by pint")
+            ),
+            pytest.param(
+                method("any"), marks=pytest.mark.xfail(reason="not implemented by pint")
+            ),
+            method("argmax"),
+            method("argmin"),
+            method("argsort"),
+            method("cumprod"),
+            method("cumsum"),
+            method("max"),
+            method("mean"),
+            method("median"),
+            method("min"),
+            pytest.param(
+                method("prod"),
+                marks=pytest.mark.xfail(reason="not implemented by pint"),
+            ),
+            method("std"),
+            method("sum"),
+            method("var"),
+        ),
+        ids=repr,
+    )
+    def test_aggregation(self, func, dtype):
+        array = np.linspace(0, 1, 10).astype(dtype) * (
+            unit_registry.m if func.name != "cumprod" else unit_registry.dimensionless
+        )
+        variable = xr.Variable("x", array)
+
+        units = extract_units(func(array))
+        expected = attach_units(func(strip_units(variable)), units)
+        actual = func(variable)
+
+        xr.testing.assert_identical(expected, actual)
+
+    @pytest.mark.parametrize(
+        "func",
+        (
+            method("astype", np.float32),
+            method("conj"),
+            method("conjugate"),
+            method("searchsorted", 5),
+            method("clip", min=2, max=7),
+        ),
+        ids=repr,
+    )
+    @pytest.mark.parametrize(
+        "unit,error",
+        (
+            pytest.param(1, DimensionalityError, id="no_unit"),
+            pytest.param(
+                unit_registry.dimensionless, DimensionalityError, id="dimensionless"
+            ),
+            pytest.param(unit_registry.s, DimensionalityError, id="incompatible_unit"),
+            pytest.param(unit_registry.cm, None, id="compatible_unit"),
+            pytest.param(unit_registry.m, None, id="identical_unit"),
+        ),
+    )
+    def test_numpy_methods(self, func, unit, error, dtype):
+        array = np.linspace(0, 1, 10).astype(dtype) * unit_registry.m
+        variable = xr.Variable("x", array)
+
+        args = [
+            item * unit if isinstance(item, (int, float, list)) else item
+            for item in func.args
+        ]
+        kwargs = {
+            key: value * unit if isinstance(value, (int, float, list)) else value
+            for key, value in func.kwargs.items()
+        }
+
+        if error is not None and func.name in ("searchsorted", "clip"):
+            with pytest.raises(error):
+                func(variable, *args, **kwargs)
+
+            return
+
+        converted_args = [
+            strip_units(convert_units(item, {None: unit_registry.m})) for item in args
+        ]
+        converted_kwargs = {
+            key: strip_units(convert_units(value, {None: unit_registry.m}))
+            for key, value in kwargs.items()
+        }
+
+        print("running on:", func, args, kwargs)
+        units = extract_units(func(array, *args, **kwargs))
+        expected = attach_units(
+            func(strip_units(variable), *converted_args, **converted_kwargs), units
+        )
+        actual = func(variable, *args, **kwargs)
+
+        assert extract_units(expected) == extract_units(actual)
+        xr.testing.assert_allclose(expected, actual)
+
 
 class TestDataArray:
     @pytest.mark.filterwarnings("error:::pint[.*]")

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -333,6 +333,11 @@ def merge_args(default_args, new_args):
 
 
 class method:
+    """ wrapper class to help with passing methods via parametrize
+
+    This is works a bit similar to using `partial(Class.method, arg, kwarg)`
+    """
+
     def __init__(self, name, *args, **kwargs):
         self.name = name
         self.args = args
@@ -351,7 +356,7 @@ class method:
             if not isinstance(obj, (xr.Variable, xr.DataArray, xr.Dataset)):
                 numpy_func = getattr(np, self.name)
                 func = partial(numpy_func, obj)
-                # remove typical xr args like "dim"
+                # remove typical xarray args like "dim"
                 exclude_kwargs = ("dim", "dims")
                 all_kwargs = {
                     key: value
@@ -368,6 +373,11 @@ class method:
 
 
 class function:
+    """ wrapper class for numpy functions
+
+    Same as method, but the name is used for referencing numpy functions
+    """
+
     def __init__(self, name_or_function, *args, function_label=None, **kwargs):
         if callable(name_or_function):
             self.name = (

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1499,7 +1499,13 @@ class TestVariable(VariableSubclassobjects):
             pytest.param(1, id="no_unit"),
             pytest.param(unit_registry.dimensionless, id="dimensionless"),
             pytest.param(unit_registry.s, id="incompatible_unit"),
-            pytest.param(unit_registry.cm, id="compatible_unit"),
+            pytest.param(
+                unit_registry.cm,
+                id="compatible_unit",
+                marks=pytest.mark.xfail(
+                    reason="checking for identical units does not work properly, yet"
+                ),
+            ),
             pytest.param(unit_registry.m, id="identical_unit"),
         ),
     )

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -7,12 +7,13 @@ import pytest
 import xarray as xr
 from xarray.core import formatting
 from xarray.core.npcompat import IS_NEP18_ACTIVE
+from .test_variable import VariableSubclassobjects
 
 pint = pytest.importorskip("pint")
 DimensionalityError = pint.errors.DimensionalityError
 
 
-unit_registry = pint.UnitRegistry()
+unit_registry = pint.UnitRegistry(force_ndarray=True)
 Quantity = unit_registry.Quantity
 
 pytestmark = [
@@ -1243,6 +1244,46 @@ def test_dot_dataarray(dtype):
     actual = xr.dot(data_array, other)
 
     assert_equal_with_units(expected, actual)
+
+
+def delete_attrs(*to_delete):
+    def wrapper(cls):
+        for item in to_delete:
+            setattr(cls, item, None)
+
+        return cls
+
+    return wrapper
+
+
+@delete_attrs(
+    "test_getitem_with_mask",
+    "test_getitem_with_mask_nd_indexer",
+    "test_index_0d_string",
+    "test_index_0d_datetime",
+    "test_index_0d_timedelta64",
+    "test_0d_time_data",
+    "test_datetime64_conversion",
+    "test_timedelta64_conversion",
+    "test_pandas_period_index",
+    "test_1d_math",
+    "test_1d_reduce",
+    "test_array_interface",
+    "test___array__",
+    "test_copy_index",
+    "test_concat",
+    "test_concat_number_strings",
+    "test_concat_fixed_len_str",
+    "test_concat_mixed_dtypes",
+    "test_pandas_datetime64_with_tz",
+    "test_multiindex",
+)
+class TestVariable(VariableSubclassobjects):
+    @staticmethod
+    def cls(dims, data, *args, **kwargs):
+        return xr.Variable(
+            dims, unit_registry.Quantity(data, unit_registry.m), *args, **kwargs
+        )
 
 
 class TestDataArray:

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -278,6 +278,10 @@ def convert_units(obj, to):
     return new_obj
 
 
+def assert_units_equal(a, b):
+    assert extract_units(a) == extract_units(b)
+
+
 def assert_equal_with_units(a, b):
     # works like xr.testing.assert_equal, but also explicitly checks units
     # so, it is more like assert_identical
@@ -1384,6 +1388,7 @@ class TestVariable(VariableSubclassobjects):
         expected = attach_units(func(strip_units(variable)), units)
         actual = func(variable)
 
+        assert_units_equal(expected, actual)
         xr.testing.assert_identical(expected, actual)
 
     @pytest.mark.parametrize(
@@ -1441,7 +1446,7 @@ class TestVariable(VariableSubclassobjects):
         )
         actual = func(variable, *args, **kwargs)
 
-        assert extract_units(expected) == extract_units(actual)
+        assert_units_equal(expected, actual)
         xr.testing.assert_allclose(expected, actual)
 
     @pytest.mark.parametrize(
@@ -1501,7 +1506,7 @@ class TestVariable(VariableSubclassobjects):
         )
         actual = func(variable, *args, **kwargs)
 
-        assert extract_units(expected) == extract_units(actual)
+        assert_units_equal(expected, actual)
         np.testing.assert_allclose(expected, actual)
 
     @pytest.mark.parametrize(
@@ -1524,7 +1529,7 @@ class TestVariable(VariableSubclassobjects):
         expected = func(strip_units(variable))
         actual = func(variable)
 
-        assert extract_units(expected) == extract_units(actual)
+        assert_units_equal(expected, actual)
         xr.testing.assert_identical(expected, actual)
 
     @pytest.mark.parametrize(
@@ -1580,7 +1585,7 @@ class TestVariable(VariableSubclassobjects):
         )
         actual = variable.fillna(value=fill_value)
 
-        assert extract_units(expected) == extract_units(actual)
+        assert_units_equal(expected, actual)
         xr.testing.assert_identical(expected, actual)
 
     @pytest.mark.parametrize(
@@ -1687,6 +1692,7 @@ class TestVariable(VariableSubclassobjects):
         )
         actual = variable.isel(x=indices)
 
+        assert_units_equal(expected, actual)
         xr.testing.assert_identical(expected, actual)
 
     @pytest.mark.parametrize(
@@ -1744,7 +1750,7 @@ class TestVariable(VariableSubclassobjects):
         )
         actual = func(variable, y)
 
-        assert extract_units(expected) == extract_units(actual)
+        assert_units_equal(expected, actual)
         xr.testing.assert_allclose(expected, actual)
 
     @pytest.mark.parametrize(
@@ -1800,7 +1806,7 @@ class TestVariable(VariableSubclassobjects):
         )
         actual = func(variable, cond, other)
 
-        assert extract_units(expected) == extract_units(actual)
+        assert_units_equal(expected, actual)
         xr.testing.assert_identical(expected, actual)
 
     def test_squeeze(self, dtype):
@@ -1814,7 +1820,7 @@ class TestVariable(VariableSubclassobjects):
         )
         actual = variable.squeeze()
 
-        assert extract_units(expected) == extract_units(actual)
+        assert_units_equal(expected, actual)
         xr.testing.assert_identical(expected, actual)
 
         for dim in names:
@@ -1823,7 +1829,7 @@ class TestVariable(VariableSubclassobjects):
             )
             actual = variable.squeeze()
 
-            assert extract_units(expected) == extract_units(actual)
+            assert_units_equal(expected, actual)
             xr.testing.assert_identical(expected, actual)
 
     @pytest.mark.parametrize(
@@ -1861,7 +1867,7 @@ class TestVariable(VariableSubclassobjects):
 
         actual = func(variable)
 
-        assert extract_units(expected) == extract_units(actual)
+        assert_units_equal(expected, actual)
         xr.testing.assert_identical(expected, actual)
 
     @pytest.mark.parametrize(
@@ -1895,7 +1901,7 @@ class TestVariable(VariableSubclassobjects):
 
         actual = variable.searchsorted(value)
 
-        assert extract_units(expected) == extract_units(actual)
+        assert_units_equal(expected, actual)
         np.testing.assert_allclose(expected, actual)
 
     def test_stack(self, dtype):
@@ -1907,7 +1913,7 @@ class TestVariable(VariableSubclassobjects):
         )
         actual = variable.stack(z=("x", "y"))
 
-        assert extract_units(expected) == extract_units(actual)
+        assert_units_equal(expected, actual)
         xr.testing.assert_identical(expected, actual)
 
     def test_unstack(self, dtype):
@@ -1919,7 +1925,7 @@ class TestVariable(VariableSubclassobjects):
         )
         actual = variable.unstack(z={"x": 3, "y": 10})
 
-        assert extract_units(expected) == extract_units(actual)
+        assert_units_equal(expected, actual)
         xr.testing.assert_identical(expected, actual)
 
     @pytest.mark.xfail(reason="ignores units")
@@ -1957,7 +1963,7 @@ class TestVariable(VariableSubclassobjects):
         )
         actual = variable.concat(other)
 
-        assert extract_units(expected) == extract_units(actual)
+        assert_units_equal(expected, actual)
         xr.testing.assert_identical(expected, actual)
 
     def test_set_dims(self, dtype):
@@ -1970,7 +1976,7 @@ class TestVariable(VariableSubclassobjects):
         )
         actual = variable.set_dims(dims)
 
-        assert extract_units(expected) == extract_units(actual)
+        assert_units_equal(expected, actual)
         xr.testing.assert_identical(expected, actual)
 
     def test_copy(self, dtype):
@@ -1983,7 +1989,7 @@ class TestVariable(VariableSubclassobjects):
         )
         actual = variable.copy(data=other)
 
-        assert extract_units(expected) == extract_units(actual)
+        assert_units_equal(expected, actual)
         xr.testing.assert_identical(expected, actual)
 
     @pytest.mark.parametrize(
@@ -2067,7 +2073,7 @@ class TestVariable(VariableSubclassobjects):
         )
         actual = func(variable, fill_value=fill_value)
 
-        assert extract_units(expected) == extract_units(actual)
+        assert_units_equal(expected, actual)
         xr.testing.assert_identical(expected, actual)
 
 

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1907,6 +1907,19 @@ class TestVariable(VariableSubclassobjects):
         assert extract_units(expected) == extract_units(actual)
         xr.testing.assert_identical(expected, actual)
 
+    def test_set_dims(self, dtype):
+        array = np.linspace(0, 5, 3 * 10).reshape(3, 10).astype(dtype) * unit_registry.m
+        variable = xr.Variable(("x", "y"), array)
+
+        dims = {"z": 6, "x": 3, "a": 1, "b": 4, "y": 10}
+        expected = attach_units(
+            strip_units(variable).set_dims(dims), extract_units(variable)
+        )
+        actual = variable.set_dims(dims)
+
+        assert extract_units(expected) == extract_units(actual)
+        xr.testing.assert_identical(expected, actual)
+
 
 class TestDataArray:
     @pytest.mark.filterwarnings("error:::pint[.*]")

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -207,12 +207,7 @@ def attach_units(obj, units):
             name=obj.name, data=data, coords=coords, attrs=attrs, dims=dims
         )
     else:
-        data_units = (
-            units.get(obj.name, None)
-            or units.get("data", None)
-            or units.get(None, None)
-            or 1
-        )
+        data_units = units.get("data", None) or units.get(None, None) or 1
 
         data = array_attach_units(obj.data, data_units)
         new_obj = obj.copy(data=data)

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1335,12 +1335,8 @@ class TestVariable(VariableSubclassobjects):
     @pytest.mark.parametrize(
         "func",
         (
-            pytest.param(
-                method("all"), marks=pytest.mark.xfail(reason="not implemented by pint")
-            ),
-            pytest.param(
-                method("any"), marks=pytest.mark.xfail(reason="not implemented by pint")
-            ),
+            method("all"),
+            method("any"),
             method("argmax"),
             method("argmin"),
             method("argsort"),

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1733,6 +1733,62 @@ class TestVariable(VariableSubclassobjects):
         assert extract_units(expected) == extract_units(actual)
         xr.testing.assert_allclose(expected, actual)
 
+    @pytest.mark.parametrize(
+        "unit,error",
+        (
+            pytest.param(1, DimensionalityError, id="no_unit"),
+            pytest.param(
+                unit_registry.dimensionless, DimensionalityError, id="dimensionless"
+            ),
+            pytest.param(unit_registry.s, DimensionalityError, id="incompatible_unit"),
+            pytest.param(
+                unit_registry.cm,
+                None,
+                id="compatible_unit",
+                marks=pytest.mark.xfail(
+                    reason="getitem_with_mask converts to the unit of other"
+                ),
+            ),
+            pytest.param(unit_registry.m, None, id="identical_unit"),
+        ),
+    )
+    @pytest.mark.parametrize(
+        "func", (method("where"), method("_getitem_with_mask")), ids=repr
+    )
+    def test_masking(self, func, unit, error, dtype):
+        base_unit = unit_registry.m
+        array = np.linspace(0, 5, 10).astype(dtype) * base_unit
+        variable = xr.Variable("x", array)
+        cond = np.array([True, False] * 5)
+
+        other = -1 * unit
+
+        if error is not None:
+            with pytest.raises(error):
+                func(variable, cond, other)
+
+            return
+
+        expected = attach_units(
+            func(
+                strip_units(variable),
+                cond,
+                strip_units(
+                    convert_units(
+                        other,
+                        {None: base_unit}
+                        if is_compatible(base_unit, unit)
+                        else {None: None},
+                    )
+                ),
+            ),
+            extract_units(variable),
+        )
+        actual = func(variable, cond, other)
+
+        assert extract_units(expected) == extract_units(actual)
+        xr.testing.assert_identical(expected, actual)
+
 
 class TestDataArray:
     @pytest.mark.filterwarnings("error:::pint[.*]")

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -168,7 +168,8 @@ def strip_units(obj):
 
 def attach_units(obj, units):
     if not isinstance(obj, (xr.DataArray, xr.Dataset, xr.Variable)):
-        return array_attach_units(obj, units.get("data", 1))
+        units = units.get("data", None) or units.get(None, None) or 1
+        return array_attach_units(obj, units)
 
     if isinstance(obj, xr.Dataset):
         data_vars = {

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -32,11 +32,16 @@ pytestmark = [
 
 
 def is_compatible(unit1, unit2):
-    return (
-        isinstance(unit1, unit_registry.Unit)
-        and isinstance(unit2, unit_registry.Unit)
-        and unit1.dimensionality == unit2.dimensionality
-    )
+    def _valid_type(unit1):
+        return isinstance(unit1, (int, unit_registry.Unit, Quantity))
+
+    if not _valid_type(unit1) or not _valid_type(unit2):
+        raise ValueError("can only pass int, Unit or Quantity instances")
+
+    unit1 = unit_registry.dimensionless if isinstance(unit1, int) else unit1
+    unit2 = unit_registry.dimensionless if isinstance(unit2, int) else unit2
+
+    return unit1.dimensionality == unit2.dimensionality
 
 
 def compatible_mappings(first, second):

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1789,6 +1789,29 @@ class TestVariable(VariableSubclassobjects):
         assert extract_units(expected) == extract_units(actual)
         xr.testing.assert_identical(expected, actual)
 
+    def test_squeeze(self, dtype):
+        shape = (2, 1, 3, 1, 1, 2)
+        names = list("abcdef")
+        array = np.ones(shape=shape) * unit_registry.m
+        variable = xr.Variable(names, array)
+
+        expected = attach_units(
+            strip_units(variable).squeeze(), extract_units(variable)
+        )
+        actual = variable.squeeze()
+
+        assert extract_units(expected) == extract_units(actual)
+        xr.testing.assert_identical(expected, actual)
+
+        for dim in names:
+            expected = attach_units(
+                strip_units(variable).squeeze(), extract_units(variable)
+            )
+            actual = variable.squeeze()
+
+            assert extract_units(expected) == extract_units(actual)
+            xr.testing.assert_identical(expected, actual)
+
 
 class TestDataArray:
     @pytest.mark.filterwarnings("error:::pint[.*]")

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -391,6 +391,7 @@ class function:
         return f"function_{self.name}"
 
 
+@pytest.mark.xfail(reason="test bug: apply_ufunc should not be called that way")
 def test_apply_ufunc_dataarray(dtype):
     func = function(
         xr.apply_ufunc, np.mean, input_core_dims=[["x"]], kwargs={"axis": -1}
@@ -406,6 +407,7 @@ def test_apply_ufunc_dataarray(dtype):
     assert_equal_with_units(expected, actual)
 
 
+@pytest.mark.xfail(reason="test bug: apply_ufunc should not be called that way")
 def test_apply_ufunc_dataset(dtype):
     func = function(
         xr.apply_ufunc, np.mean, input_core_dims=[["x"]], kwargs={"axis": -1}
@@ -4347,6 +4349,7 @@ class TestDataset:
 
         assert_equal_with_units(expected, actual)
 
+    @pytest.mark.xfail(reason="does not work with quantities yet")
     def test_to_stacked_array(self, dtype):
         labels = np.arange(5).astype(dtype) * unit_registry.s
         arrays = {name: np.linspace(0, 1, 10) * unit_registry.m for name in labels}

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -13,6 +13,8 @@ pint = pytest.importorskip("pint")
 DimensionalityError = pint.errors.DimensionalityError
 
 
+# make sure scalars are converted to 0d arrays so quantities can
+# always be treated like ndarrays
 unit_registry = pint.UnitRegistry(force_ndarray=True)
 Quantity = unit_registry.Quantity
 

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1474,7 +1474,7 @@ class TestVariable(VariableSubclassobjects):
     @pytest.mark.parametrize(
         "func", (method("isnull"), method("notnull"), method("count")), ids=repr
     )
-    def test_missing_value_detection(self, func, dtype):
+    def test_missing_value_detection(self, func):
         array = (
             np.array(
                 [
@@ -1483,10 +1483,9 @@ class TestVariable(VariableSubclassobjects):
                     [2.1, np.nan, np.nan, 4.6],
                     [9.9, np.nan, 7.2, 9.1],
                 ]
-            ).astype(dtype)
+            )
             * unit_registry.degK
         )
-
         variable = xr.Variable(("x", "y"), array)
 
         expected = func(strip_units(variable))

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1619,6 +1619,24 @@ class TestVariable(VariableSubclassobjects):
 
         assert expected == actual
 
+    @pytest.mark.parametrize(
+        "indices",
+        (
+            pytest.param(4, id="single index"),
+            pytest.param([5, 2, 9, 1], id="multiple indices"),
+        ),
+    )
+    def test_isel(self, indices, dtype):
+        array = np.linspace(0, 5, 10).astype(dtype) * unit_registry.s
+        variable = xr.Variable("x", array)
+
+        expected = attach_units(
+            strip_units(variable).isel(x=indices), extract_units(variable)
+        )
+        actual = variable.isel(x=indices)
+
+        xr.testing.assert_identical(expected, actual)
+
 
 class TestDataArray:
     @pytest.mark.filterwarnings("error:::pint[.*]")

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1883,6 +1883,30 @@ class TestVariable(VariableSubclassobjects):
         assert extract_units(expected) == extract_units(actual)
         np.testing.assert_allclose(expected, actual)
 
+    def test_stack(self, dtype):
+        array = np.linspace(0, 5, 3 * 10).reshape(3, 10).astype(dtype) * unit_registry.m
+        variable = xr.Variable(("x", "y"), array)
+
+        expected = attach_units(
+            strip_units(variable).stack(z=("x", "y")), extract_units(variable)
+        )
+        actual = variable.stack(z=("x", "y"))
+
+        assert extract_units(expected) == extract_units(actual)
+        xr.testing.assert_identical(expected, actual)
+
+    def test_unstack(self, dtype):
+        array = np.linspace(0, 5, 3 * 10).astype(dtype) * unit_registry.m
+        variable = xr.Variable("z", array)
+
+        expected = attach_units(
+            strip_units(variable).unstack(z={"x": 3, "y": 10}), extract_units(variable)
+        )
+        actual = variable.unstack(z={"x": 3, "y": 10})
+
+        assert extract_units(expected) == extract_units(actual)
+        xr.testing.assert_identical(expected, actual)
+
 
 class TestDataArray:
     @pytest.mark.filterwarnings("error:::pint[.*]")

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1826,6 +1826,7 @@ class TestVariable(VariableSubclassobjects):
                 method("rolling_window", "x", 3, "window"),
                 marks=pytest.mark.xfail(reason="converts to ndarray"),
             ),
+            method("reduce", np.std, "x"),
             method("round", 2),
             pytest.param(
                 method("shift", {"x": -2}),

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1815,7 +1815,7 @@ class TestVariable(VariableSubclassobjects):
     @pytest.mark.parametrize(
         "func",
         (
-            method("coarsen", windows={"x": 2}, func=np.mean),
+            method("coarsen", windows={"y": 2}, func=np.mean),
             method("quantile", q=[0.25, 0.75]),
             pytest.param(
                 method("rank", dim="x"),
@@ -1833,13 +1833,14 @@ class TestVariable(VariableSubclassobjects):
                     reason="trying to concatenate ndarray to quantity"
                 ),
             ),
+            method("transpose", "y", "x"),
         ),
         ids=repr,
     )
     def test_computation(self, func, dtype):
         base_unit = unit_registry.m
-        array = np.linspace(0, 5, 10).astype(dtype) * base_unit
-        variable = xr.Variable("x", array)
+        array = np.linspace(0, 5, 5 * 10).reshape(5, 10).astype(dtype) * base_unit
+        variable = xr.Variable(("x", "y"), array)
 
         expected = attach_units(func(strip_units(variable)), extract_units(variable))
 


### PR DESCRIPTION
As promised in #3493, this adds integration tests for units. I'm doing this now rather than later since I encountered a few cases in #3643 where a increased test coverage for variables would have been helpful.

 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
