### PR TITLE
ds.merge(da) bugfix

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -70,6 +70,8 @@ Bug fixes
   By `Justus Magin <https://github.com/keewis>`_.
 - :py:meth:`Dataset.rename`, :py:meth:`DataArray.rename` now check for conflicts with
   MultiIndex level names.
+- :py:meth:`Dataset.merge` no longer fails when passed a `DataArray` instead of a `Dataset` object.
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3604,6 +3604,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             If any variables conflict (see ``compat``).
         """
         _check_inplace(inplace)
+        other = other.to_dataset() if isinstance(other, xr.DataArray) else other
         merge_result = dataset_merge_method(
             self,
             other,

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -253,3 +253,9 @@ class TestMergeMethod:
         with pytest.raises(xr.MergeError):
             ds3 = xr.Dataset({"a": ("y", [2, 3]), "y": [1, 2]})
             ds1.merge(ds3, compat="no_conflicts")
+
+    def test_merge_dataarray(self):
+        ds = xr.Dataset({'a': 0})
+        da = xr.DataArray(data=1, name='b')
+
+        assert ds.merge(da).identical(xr.merge([ds, da]))

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -255,7 +255,7 @@ class TestMergeMethod:
             ds1.merge(ds3, compat="no_conflicts")
 
     def test_merge_dataarray(self):
-        ds = xr.Dataset({'a': 0})
-        da = xr.DataArray(data=1, name='b')
+        ds = xr.Dataset({"a": 0})
+        da = xr.DataArray(data=1, name="b")
 
         assert ds.merge(da).identical(xr.merge([ds, da]))

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -3,6 +3,7 @@ import pytest
 
 import xarray as xr
 from xarray.core import dtypes, merge
+from xarray.testing import assert_identical
 
 from . import raises_regex
 from .test_dataset import create_test_data
@@ -258,4 +259,4 @@ class TestMergeMethod:
         ds = xr.Dataset({"a": 0})
         da = xr.DataArray(data=1, name="b")
 
-        assert ds.merge(da).identical(xr.merge([ds, da]))
+        assert_identical(ds.merge(da), xr.merge([ds, da]))


### PR DESCRIPTION
 - [x] Closes #3676
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
