### PR TITLE
Add map_blocks example to whats-new

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -89,6 +89,8 @@ Documentation
 - Added examples for :py:meth:`DataArray.quantile`, :py:meth:`Dataset.quantile` and
   ``GroupBy.quantile``. (:pull:`3576`)
   By `Justus Magin <https://github.com/keewis>`_.
+- Added example for :py:func:`~xarray.map_blocks`. (:pull:`3667`)
+  By `Riley X. Brady <https://github.com/bradyrx>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This simply adds the `map_blocks` example from https://github.com/pydata/xarray/pull/3667 to the changelog.