### PR TITLE
Fix docstring for combine_first: returns a Dataset

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4152,7 +4152,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Returns
         -------
-        DataArray
+        Dataset
         """
         out = ops.fillna(self, other, join="outer", dataset_join="outer")
         return out


### PR DESCRIPTION
The return type in the docstring should be a Dataset, not a DataArray.