### PR TITLE
Allow binned coordinates on 1D plots y-axis.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -97,6 +97,9 @@ Bug fixes
   By `Justus Magin <https://github.com/keewis>`_.
 - Fixed errors emitted by ``mypy --strict`` in modules that import xarray.
   (:issue:`3695`) by `Guido Imperiale <https://github.com/crusaderky>`_.
+- Fix plotting of binned coordinates on the y axis in :py:meth:`DataArray.plot`
+  (line) and :py:meth:`DataArray.plot.step` plots (:issue:`#3571`,
+  :pull:`3685`) by `Julien Seguinot <https://github.com/juseg>_`.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -297,7 +297,12 @@ def line(
     xplt, yplt, hueplt, xlabel, ylabel, hue_label = _infer_line_data(darray, x, y, hue)
 
     # Remove pd.Intervals if contained in xplt.values.
-    if _valid_other_type(xplt.values, [pd.Interval]):
+    if any(
+        [
+            _valid_other_type(xplt.values, [pd.Interval]),
+            _valid_other_type(yplt.values, [pd.Interval]),
+        ]
+    ):
         # Is it a step plot? (see matplotlib.Axes.step)
         if kwargs.get("linestyle", "").startswith("steps-"):
             xplt_val, yplt_val = _interval_to_double_bound_points(
@@ -313,8 +318,14 @@ def line(
             if kwargs["linestyle"] == "":
                 del kwargs["linestyle"]
         else:
-            xplt_val = _interval_to_mid_points(xplt.values)
-            yplt_val = yplt.values
+            if _valid_other_type(xplt.values, [pd.Interval]):
+                xplt_val = _interval_to_mid_points(xplt.values)
+            else:
+                xplt_val = xplt.values
+            if _valid_other_type(yplt.values, [pd.Interval]):
+                yplt_val = _interval_to_mid_points(yplt.values)
+            else:
+                yplt_val = yplt.values
             xlabel += "_center"
     else:
         xplt_val = xplt.values

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -346,7 +346,7 @@ def step(darray, *args, where="pre", linestyle=None, ls=None, **kwargs):
           every *x* position, i.e. the interval ``[x[i], x[i+1])`` has the
           value ``y[i]``.
         - 'mid': Steps occur half-way between the *x* positions.
-        Note that this parameter is ignored if the x coordinate consists of
+        Note that this parameter is ignored if one coordinate consists of
         :py:func:`pandas.Interval` values, e.g. as a result of
         :py:func:`xarray.Dataset.groupby_bins`. In this case, the actual
         boundaries of the interval are used.

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -472,14 +472,7 @@ def _resolve_intervals_1dplot(xval, yval, xlabel, ylabel, kwargs):
             yval, xval = _interval_to_double_bound_points(yval, xval)
 
         # Remove steps-* to be sure that matplotlib is not confused
-        kwargs["linestyle"] = (
-            kwargs["linestyle"]
-            .replace("steps-pre", "")
-            .replace("steps-post", "")
-            .replace("steps-mid", "")
-        )
-        if kwargs["linestyle"] == "":
-            del kwargs["linestyle"]
+        del kwargs["linestyle"]
 
     # Is it another kind of plot?
     else:

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -426,8 +426,24 @@ class TestPlot(PlotTestCase):
             d.plot(x="x", y="y", col="columns", ax=plt.gca())
 
     def test_coord_with_interval(self):
+        """Test line plot with intervals."""
         bins = [-1, 0, 1, 2]
         self.darray.groupby_bins("dim_0", bins).mean(...).plot()
+
+    def test_coord_with_interval_x(self):
+        """Test line plot with intervals explicitly on x axis."""
+        bins = [-1, 0, 1, 2]
+        self.darray.groupby_bins("dim_0", bins).mean(...).plot(x="dim_0_bins")
+
+    def test_coord_with_interval_y(self):
+        """Test line plot with intervals explicitly on y axis."""
+        bins = [-1, 0, 1, 2]
+        self.darray.groupby_bins("dim_0", bins).mean(...).plot(y="dim_0_bins")
+
+    def test_coord_with_interval_xy(self):
+        """Test line plot with intervals on both x and y axes."""
+        bins = [-1, 0, 1, 2]
+        self.darray.groupby_bins("dim_0", bins).mean(...).dim_0_bins.plot()
 
 
 class TestPlot1D(PlotTestCase):

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -527,8 +527,21 @@ class TestPlotStep(PlotTestCase):
         self.darray[0, 0].plot.step()
 
     def test_coord_with_interval_step(self):
+        """Test step plot with intervals."""
         bins = [-1, 0, 1, 2]
         self.darray.groupby_bins("dim_0", bins).mean(...).plot.step()
+        assert len(plt.gca().lines[0].get_xdata()) == ((len(bins) - 1) * 2)
+
+    def test_coord_with_interval_step_x(self):
+        """Test step plot with intervals explicitly on x axis."""
+        bins = [-1, 0, 1, 2]
+        self.darray.groupby_bins("dim_0", bins).mean(...).plot.step(x="dim_0_bins")
+        assert len(plt.gca().lines[0].get_xdata()) == ((len(bins) - 1) * 2)
+
+    def test_coord_with_interval_step_y(self):
+        """Test step plot with intervals explicitly on y axis."""
+        bins = [-1, 0, 1, 2]
+        self.darray.groupby_bins("dim_0", bins).mean(...).plot.step(y="dim_0_bins")
         assert len(plt.gca().lines[0].get_xdata()) == ((len(bins) - 1) * 2)
 
 


### PR DESCRIPTION
Currently 1D plot functions only allow binned coordinates (of `pd.Interval` type, produced with `groupby_bins`) on the y-axis (issue #3571). This pull request enables plotting intervals on either or both axes of 1D plots.

 - [x] Closes #3571
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API