### PR TITLE
Fix test_cf_datetime_nan under pandas master

### DIFF
--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -451,7 +451,7 @@ def test_cf_datetime_nan(num_dates, units, expected_list):
         warnings.filterwarnings("ignore", "All-NaN")
         actual = coding.times.decode_cf_datetime(num_dates, units)
     # use pandas because numpy will deprecate timezone-aware conversions
-    expected = pd.to_datetime(expected_list)
+    expected = pd.to_datetime(expected_list).to_numpy(dtype="datetime64[ns]")
     assert_array_equal(expected, actual)
 
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
This fixes `test_cf_datetime_nan` for upcoming releases of pandas.  See failure class (2) reported in #3673.

 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
