### PR TITLE
allow passing any iterable to drop when dropping variables

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -76,6 +76,9 @@ Bug fixes
   MultiIndex level names.
 - :py:meth:`Dataset.merge` no longer fails when passed a `DataArray` instead of a `Dataset` object.
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
+- Fix a regression in :py:meth:`Dataset.drop`: allow passing any
+  iterable to drop when dropping variables (:issue:`3552`, :pull:`3693`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -77,7 +77,7 @@ Bug fixes
 - :py:meth:`Dataset.merge` no longer fails when passed a `DataArray` instead of a `Dataset` object.
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - Fix a regression in :py:meth:`Dataset.drop`: allow passing any
-  iterable to drop when dropping variables (:issue:`3552`, :pull:`3693`)
+  iterable when dropping variables (:issue:`3552`, :pull:`3693`)
   By `Justus Magin <https://github.com/keewis>`_.
 
 Documentation

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -85,7 +85,6 @@ from .utils import (
     either_dict_or_kwargs,
     hashable,
     is_dict_like,
-    is_list_like,
     is_scalar,
     maybe_wrap_array,
 )
@@ -3690,7 +3689,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 raise ValueError("cannot specify dim and dict-like arguments.")
             labels = either_dict_or_kwargs(labels, labels_kwargs, "drop")
 
-        if dim is None and (is_list_like(labels) or is_scalar(labels)):
+        if dim is None and (is_scalar(labels) or isinstance(labels, Iterable)):
             warnings.warn(
                 "dropping variables using `drop` will be deprecated; using drop_vars is encouraged.",
                 PendingDeprecationWarning,

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2167,6 +2167,10 @@ class TestDataset:
             actual = data.drop(["time", "not_found_here"], errors="ignore")
         assert_identical(expected, actual)
 
+        with pytest.warns(PendingDeprecationWarning):
+            actual = data.drop({"time", "not_found_here"}, errors="ignore")
+        assert_identical(expected, actual)
+
     def test_drop_index_labels(self):
         data = Dataset({"A": (["x", "y"], np.random.randn(2, 3)), "x": ["a", "b"]})
 


### PR DESCRIPTION
This fixes a regression in the deprecated `drop` method.

 - [x] Closes #3552
 - [x] Tests added
 - [x] Passes `black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
