### PR TITLE
setuptools-scm and isort tweaks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,7 @@ classifiers =
 
 [options]
 packages = xarray
-zip_safe = True
+zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
 include_package_data = True
 python_requires = >=3.6
 install_requires =
@@ -91,8 +91,8 @@ xarray =
     static/html/*
 
 [tool:pytest]
-python_files=test_*.py
-testpaths=xarray/tests properties
+python_files = test_*.py
+testpaths = xarray/tests properties
 # Fixed upstream in https://github.com/pydata/bottleneck/pull/199
 filterwarnings =
     ignore:Using a non-tuple sequence for multidimensional indexing is deprecated:FutureWarning
@@ -104,7 +104,7 @@ markers =
     slow: slow tests
 
 [flake8]
-ignore=
+ignore =
     # whitespace before ':' - doesn't work well with black
     E203
     E402
@@ -119,13 +119,13 @@ exclude=
     doc
 
 [isort]
-default_section=THIRDPARTY
-known_first_party=xarray
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
+default_section = THIRDPARTY
+known_first_party = xarray
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+line_length = 88
 
 # Most of the numerical computing stack doesn't have type annotations yet.
 [mypy-affine.*]

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -1,13 +1,3 @@
-""" isort:skip_file """
-
-import pkg_resources
-
-try:
-    __version__ = pkg_resources.get_distribution("xarray").version
-except Exception:
-    # Local copy, not installed with setuptools
-    __version__ = "unknown"
-
 from .core.alignment import align, broadcast
 from .core.common import full_like, zeros_like, ones_like
 from .core.concat import concat
@@ -44,6 +34,13 @@ from . import ufuncs
 from . import testing
 
 from .core.common import ALL_DIMS
+
+try:
+    import pkg_resources
+    __version__ = pkg_resources.get_distribution("xarray").version
+except Exception:
+    # Local copy, not installed with setuptools, or setuptools is not available
+    __version__ = "unknown"
 
 # A hardcoded __all__ variable is necessary to appease
 # `mypy --strict` running in projects that import xarray.

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -28,6 +28,7 @@ from .util.print_versions import show_versions
 
 try:
     import pkg_resources
+
     __version__ = pkg_resources.get_distribution("xarray").version
 except Exception:
     # Local copy, not installed with setuptools, or setuptools is not available.

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -1,46 +1,38 @@
-from .core.alignment import align, broadcast
-from .core.common import full_like, zeros_like, ones_like
-from .core.concat import concat
-from .core.combine import combine_by_coords, combine_nested, auto_combine
-from .core.computation import apply_ufunc, dot, where
-from .core.extensions import register_dataarray_accessor, register_dataset_accessor
-from .core.variable import as_variable, Variable, IndexVariable, Coordinate
-from .core.dataset import Dataset
-from .core.dataarray import DataArray
-from .core.merge import merge, MergeError
-from .core.options import set_options
-from .core.parallel import map_blocks
-
+from . import testing, tutorial, ufuncs
 from .backends.api import (
-    open_dataset,
+    load_dataarray,
+    load_dataset,
     open_dataarray,
+    open_dataset,
     open_mfdataset,
     save_mfdataset,
-    load_dataset,
-    load_dataarray,
 )
 from .backends.rasterio_ import open_rasterio
 from .backends.zarr import open_zarr
-
-from .conventions import decode_cf, SerializationWarning
-
 from .coding.cftime_offsets import cftime_range
 from .coding.cftimeindex import CFTimeIndex
-
+from .conventions import SerializationWarning, decode_cf
+from .core.alignment import align, broadcast
+from .core.combine import auto_combine, combine_by_coords, combine_nested
+from .core.common import ALL_DIMS, full_like, ones_like, zeros_like
+from .core.computation import apply_ufunc, dot, where
+from .core.concat import concat
+from .core.dataarray import DataArray
+from .core.dataset import Dataset
+from .core.extensions import register_dataarray_accessor, register_dataset_accessor
+from .core.merge import MergeError, merge
+from .core.options import set_options
+from .core.parallel import map_blocks
+from .core.variable import Coordinate, IndexVariable, Variable, as_variable
 from .util.print_versions import show_versions
-
-from . import tutorial
-from . import ufuncs
-from . import testing
-
-from .core.common import ALL_DIMS
 
 try:
     import pkg_resources
     __version__ = pkg_resources.get_distribution("xarray").version
 except Exception:
-    # Local copy, not installed with setuptools, or setuptools is not available
-    __version__ = "unknown"
+    # Local copy, not installed with setuptools, or setuptools is not available.
+    # Disable minimum version checks on downstream libraries.
+    __version__ = "999"
 
 # A hardcoded __all__ variable is necessary to appease
 # `mypy --strict` running in projects that import xarray.

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -18,13 +18,16 @@ from typing import (
 
 import numpy as np
 
-from .. import DataArray, Dataset, auto_combine, backends, coding, conventions
+from .. import backends, coding, conventions
 from ..core import indexing
 from ..core.combine import (
     _infer_concat_order_from_positions,
     _nested_combine,
+    auto_combine,
     combine_by_coords,
 )
+from ..core.dataarray import DataArray
+from ..core.dataset import Dataset
 from ..core.utils import close_on_error, is_grib_path, is_remote_uri
 from .common import AbstractDataStore, ArrayWriter
 from .locks import _get_scheduler

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-from .. import Variable
 from ..core import indexing
 from ..core.utils import Frozen, FrozenDict
+from ..core.variable import Variable
 from .common import AbstractDataStore, BackendArray
 from .locks import SerializableLock, ensure_lock
 

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -2,9 +2,9 @@ import functools
 
 import numpy as np
 
-from .. import Variable
 from ..core import indexing
 from ..core.utils import FrozenDict, is_remote_uri
+from ..core.variable import Variable
 from .common import WritableCFDataStore, find_root_and_group
 from .file_manager import CachingFileManager, DummyFileManager
 from .locks import HDF5_LOCK, combine_locks, ensure_lock, get_write_lock

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -4,10 +4,11 @@ from contextlib import suppress
 
 import numpy as np
 
-from .. import Variable, coding
+from .. import coding
 from ..coding.variables import pop_to
 from ..core import indexing
 from ..core.utils import FrozenDict, is_remote_uri
+from ..core.variable import Variable
 from .common import (
     BackendArray,
     WritableCFDataStore,

--- a/xarray/backends/netcdf3.py
+++ b/xarray/backends/netcdf3.py
@@ -2,7 +2,8 @@ import unicodedata
 
 import numpy as np
 
-from .. import Variable, coding
+from .. import coding
+from ..core.variable import Variable
 
 # Special characters that are permitted in netCDF names except in the
 # 0th position of the string

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-from .. import Variable
 from ..core import indexing
 from ..core.utils import Frozen, FrozenDict
+from ..core.variable import Variable
 from .common import AbstractDataStore, BackendArray
 from .file_manager import CachingFileManager
 from .locks import HDF5_LOCK, NETCDFC_LOCK, combine_locks, ensure_lock

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from .. import Variable
 from ..core import indexing
 from ..core.pycompat import integer_types
 from ..core.utils import Frozen, FrozenDict, is_dict_like
+from ..core.variable import Variable
 from .common import AbstractDataStore, BackendArray, robust_getitem
 
 

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-from .. import Variable
 from ..core import indexing
 from ..core.utils import Frozen, FrozenDict
+from ..core.variable import Variable
 from .common import AbstractDataStore, BackendArray
 from .file_manager import CachingFileManager
 from .locks import HDF5_LOCK, NETCDFC_LOCK, SerializableLock, combine_locks, ensure_lock

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -3,8 +3,8 @@ import warnings
 
 import numpy as np
 
-from .. import DataArray
 from ..core import indexing
+from ..core.dataarray import DataArray
 from ..core.utils import is_scalar
 from .common import BackendArray
 from .file_manager import CachingFileManager

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -2,9 +2,9 @@ from io import BytesIO
 
 import numpy as np
 
-from .. import Variable
 from ..core.indexing import NumpyIndexingAdapter
 from ..core.utils import Frozen, FrozenDict
+from ..core.variable import Variable
 from .common import BackendArray, WritableCFDataStore
 from .file_manager import CachingFileManager, DummyFileManager
 from .locks import ensure_lock, get_write_lock

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -2,10 +2,11 @@ import warnings
 
 import numpy as np
 
-from .. import Variable, coding, conventions
+from .. import coding, conventions
 from ..core import indexing
 from ..core.pycompat import integer_types
 from ..core.utils import FrozenDict, HiddenKeyDict
+from ..core.variable import Variable
 from .common import AbstractWritableDataStore, BackendArray, _encode_variable_name
 
 # need some special secret attributes to tell us the dimensions


### PR DESCRIPTION
Follow-up on https://github.com/pydata/xarray/pull/3714

- Fix regression in mypy if pip creates a zipped archive
- Avoid breakage in the extremely unlikely event that setuptools is not installed
- Guarantee ``xarray.__version__`` to be always PEP440-compatible. This prevents a breakage if you run pandas without xarray installed and with the xarray sources folder in PYTHONPATH.
- Apply isort to ``xarray.__init__``
