### PR TITLE
Python 3.8 CI

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -2,7 +2,7 @@ name: xarray-examples
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.8
   - boto3
   - bottleneck
   - cartopy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.7
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -40,7 +40,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.6"],
+    "pythons": ["3.8"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,8 +45,8 @@ jobs:
 - job: Windows
   strategy:
     matrix:
-      py38:
-        conda_env: py38-windows
+      py37:
+        conda_env: py37-windows
   pool:
     vmImage: 'vs2017-win2016'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,11 +20,11 @@ jobs:
         conda_env: py37
       py38:
         conda_env: py38
-      py37-upstream-dev:
-        conda_env: py37
+      py38-upstream-dev:
+        conda_env: py38
         upstream_dev: true
-      py36-flaky:
-        conda_env: py36
+      py38-flaky:
+        conda_env: py38
         pytest_extra_flags: --run-flaky --run-network-tests
         allow_failure: true
   pool:
@@ -74,7 +74,7 @@ jobs:
 
 - job: TypeChecking
   variables:
-    conda_env: py37
+    conda_env: py38
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
@@ -86,7 +86,7 @@ jobs:
 
 - job: isort
   variables:
-    conda_env: py37
+    conda_env: py38
   pool:
     vmImage: 'ubuntu-16.04'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,8 +35,8 @@ jobs:
 - job: MacOSX
   strategy:
     matrix:
-      py36:
-        conda_env: py36
+      py38:
+        conda_env: py38
   pool:
     vmImage: 'macOS-10.13'
   steps:
@@ -45,8 +45,8 @@ jobs:
 - job: Windows
   strategy:
     matrix:
-      py37:
-        conda_env: py37-windows
+      py38:
+        conda_env: py38-windows
   pool:
     vmImage: 'vs2017-win2016'
   steps:

--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -3,7 +3,7 @@ channels:
   # Don't change to pkgs/main, as it causes random timeouts in readthedocs
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.8
   - bottleneck
   - cartopy
   - cfgrib

--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -3,7 +3,7 @@ channels:
   # Don't change to pkgs/main, as it causes random timeouts in readthedocs
   - conda-forge
 dependencies:
-  - python=3.8
+  - python=3.7
   - bottleneck
   - cartopy
   - cfgrib

--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -20,7 +20,7 @@ dependencies:
   - hypothesis
   - iris
   - isort
-  - lxml    # optional dep of pydap
+  - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.761  # Must match .pre-commit-config.yaml
   - nc-time-axis

--- a/ci/requirements/py37-windows.yml
+++ b/ci/requirements/py37-windows.yml
@@ -2,7 +2,7 @@ name: xarray-tests
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
+  - python=3.7
   - black
   - boto3
   - bottleneck

--- a/ci/requirements/py38-windows.yml
+++ b/ci/requirements/py38-windows.yml
@@ -2,7 +2,7 @@ name: xarray-tests
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.8
   - black
   - boto3
   - bottleneck
@@ -26,7 +26,7 @@ dependencies:
   - nc-time-axis
   - netcdf4
   - numba
-  - numpy<1.18  # FIXME https://github.com/pydata/xarray/issues/3409
+  - numpy
   - pandas
   - pint
   - pip

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -3,13 +3,44 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
+  - black
+  - boto3
+  - bottleneck
+  - cartopy
+  - cdms2
+  - cfgrib
+  - cftime
+  - coveralls
+  - dask
+  - distributed
+  - flake8
+  - h5netcdf
+  - h5py
+  - hdf5
+  - hypothesis
+  - iris
+  - isort
+  - lxml    # Optional dep of pydap
+  - matplotlib
+  - mypy=0.761  # Must match .pre-commit-config.yaml
+  - nc-time-axis
+  - netcdf4
+  - numba
+  - numpy
+  - pandas
+  - pint
   - pip
+  - pseudonetcdf
+  - pydap
+  - pynio
+  - pytest
+  - pytest-cov
+  - pytest-env
+  - rasterio
+  - scipy
+  - seaborn
+  - sparse
+  - toolz
+  - zarr
   - pip:
-      - coveralls
-      - dask
-      - distributed
-      - numpy
-      - pandas
-      - pytest
-      - pytest-cov
-      - pytest-env
+    - numbagg

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -7,7 +7,7 @@ conda:
     environment: ci/requirements/doc.yml
 
 python:
-    version: 3.7
+    version: 3.8
     install: []
 
 formats: []

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -7,7 +7,7 @@ conda:
     environment: ci/requirements/doc.yml
 
 python:
-    version: 3.8
+    version: 3.7
     install: []
 
 formats: []


### PR DESCRIPTION
- Run full-fat suite of tests for Python 3.8
- Move asv, MacOSX tests, readthedocs, binder, and more to Python 3.8
- Test windows against latest numpy version
- Windows tests remain on Python 3.7 because of a couple of Python 3.8 tests that fail exclusively in CI. Will investigate later.
