### PR TITLE
allow formatting the diff of ndarray attributes

### DIFF
--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -523,6 +523,10 @@ def _diff_mapping_repr(a_mapping, b_mapping, compat, title, summarizer, col_widt
         except AttributeError:
             # compare attribute value
             compatible = a_mapping[k] == b_mapping[k]
+            # allow comparing with numpy.arrays
+            if hasattr(compatible, "ndim") and hasattr(compatible, "shape"):
+                compatible = all(compatible)
+
             is_variable = False
 
         if not compatible:

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -500,6 +500,13 @@ def diff_dim_summary(a, b):
 
 
 def _diff_mapping_repr(a_mapping, b_mapping, compat, title, summarizer, col_width=None):
+    def is_array_like(value):
+        return (
+            hasattr(value, "ndim")
+            and hasattr(value, "shape")
+            and hasattr(value, "dtype")
+        )
+
     def extra_items_repr(extra_keys, mapping, ab_side):
         extra_repr = [summarizer(k, mapping[k], col_width) for k in extra_keys]
         if extra_repr:
@@ -522,10 +529,10 @@ def _diff_mapping_repr(a_mapping, b_mapping, compat, title, summarizer, col_widt
             is_variable = True
         except AttributeError:
             # compare attribute value
-            compatible = a_mapping[k] == b_mapping[k]
-            # allow comparing with numpy.arrays
-            if hasattr(compatible, "ndim") and hasattr(compatible, "shape"):
-                compatible = all(compatible)
+            if is_array_like(a_mapping[k]) or is_array_like(b_mapping[k]):
+                compatible = array_equiv(a_mapping[k], b_mapping[k])
+            else:
+                compatible = a_mapping[k] == b_mapping[k]
 
             is_variable = False
 

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 
 import numpy as np
 import pandas as pd
+import pytest
 
 import xarray as xr
 from xarray.core import formatting
@@ -274,6 +275,44 @@ class TestFormatting:
             assert actual == expected
         except AssertionError:
             assert actual == expected.replace(", dtype=int64", "")
+
+    @pytest.mark.filterwarnings("error")
+    def test_diff_attrs_repr_with_array(self):
+        attrs_a = {"attr": np.array([0, 1])}
+
+        attrs_b = {"attr": 1}
+        expected = dedent(
+            """\
+            Differing attributes:
+            L   attr: [0 1]
+            R   attr: 1
+            """
+        ).strip()
+        actual = formatting.diff_attrs_repr(attrs_a, attrs_b, "equals")
+        assert expected == actual
+
+        attrs_b = {"attr": np.array([-3, 5])}
+        expected = dedent(
+            """\
+            Differing attributes:
+            L   attr: [0 1]
+            R   attr: [-3  5]
+            """
+        ).strip()
+        actual = formatting.diff_attrs_repr(attrs_a, attrs_b, "equals")
+        assert expected == actual
+
+        # should not raise a warning
+        attrs_b = {"attr": np.array([0, 1, 2])}
+        expected = dedent(
+            """\
+            Differing attributes:
+            L   attr: [0 1]
+            R   attr: [0 1 2]
+            """
+        ).strip()
+        actual = formatting.diff_attrs_repr(attrs_a, attrs_b, "equals")
+        assert expected == actual
 
     def test_diff_dataset_repr(self):
         ds_a = xr.Dataset(


### PR DESCRIPTION
This allows to have `ndarray` instances in attributes, which is the case for the dataset from `xarray/tests/data/example.uamiv`. It won't fix the cause for the error of #3711, though, because that seems to non-deterministic.

 - [x] partial fix to #3711
 - [ ] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
