### PR TITLE
Fix/rtd

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -6,20 +6,21 @@ dependencies:
   - python=3.7
   - bottleneck
   - cartopy
-  - cfgrib
-  - h5netcdf
+  - cfgrib>=0.9
+  - dask>=2.10
+  - h5netcdf>=0.7.4
   - ipykernel
   - ipython
-  - iris
+  - iris>=2.3
   - jupyter_client
   - nbsphinx
-  - netcdf4
+  - netcdf4>=1.5
   - numba
-  - numpy
+  - numpy>=1.17
   - numpydoc
-  - pandas
-  - rasterio
+  - pandas>=1.0
+  - rasterio>=1.1
   - seaborn
-  - sphinx
-  - sphinx_rtd_theme
-  - zarr
+  - sphinx>=2.3
+  - sphinx_rtd_theme>=0.4
+  - zarr>=2.4

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,8 +6,4 @@ build:
 conda:
     environment: ci/requirements/doc.yml
 
-python:
-    version: 3.7
-    install: []
-
 formats: []


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
1. python 3.8 is not allowed on RTD (yet)
2. I  pinned a few versions (based on the env solution obtained locally). This seems to have fixed the memory problem.
