### PR TITLE
remove seaborn.apionly compatibility

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -59,7 +59,7 @@ For plotting
 
 - `matplotlib <http://matplotlib.org/>`__: required for :ref:`plotting`
 - `cartopy <http://scitools.org.uk/cartopy/>`__: recommended for :ref:`plot-maps`
-- `seaborn <https://stanford.edu/~mwaskom/software/seaborn/>`__: for better
+- `seaborn <http://seaborn.pydata.org/>`__: for better
   color palettes
 - `nc-time-axis <https://github.com/SciTools/nc-time-axis>`__: for plotting
   cftime.datetime objects

--- a/doc/pandas.rst
+++ b/doc/pandas.rst
@@ -12,7 +12,7 @@ using the visualization `built in to pandas itself`__ or provided by the pandas
 aware libraries such as `Seaborn`__.
 
 __ http://pandas.pydata.org/pandas-docs/stable/visualization.html
-__ http://stanford.edu/~mwaskom/software/seaborn/
+__ http://seaborn.pydata.org/
 
 .. ipython:: python
     :suppress:

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,6 +34,10 @@ Documentation
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Removed the internal ``import_seaborn`` function which handled the deprecation of
+  the ``seaborn.apionly`` entry point (:issue:`3747`).
+  By `Mathias Hauser <https://github.com/mathause>`_.
+
 .. _whats-new.0.15.0:
 
 

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -21,26 +21,6 @@ except ImportError:
 ROBUST_PERCENTILE = 2.0
 
 
-def import_seaborn():
-    """import seaborn and handle deprecation of apionly module"""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        try:
-            import seaborn.apionly as sns
-
-            if (
-                w
-                and issubclass(w[-1].category, UserWarning)
-                and ("seaborn.apionly module" in str(w[-1].message))
-            ):
-                raise ImportError
-        except ImportError:
-            import seaborn as sns
-        finally:
-            warnings.resetwarnings()
-    return sns
-
-
 _registered = False
 
 
@@ -119,7 +99,7 @@ def _color_palette(cmap, n_colors):
         except ValueError:
             # ValueError happens when mpl doesn't like a colormap, try seaborn
             try:
-                from seaborn.apionly import color_palette
+                from seaborn import color_palette
 
                 pal = color_palette(cmap, n_colors=n_colors)
             except (ValueError, ImportError):

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -16,7 +16,6 @@ from xarray.core import utils
 from xarray.core.duck_array_ops import allclose_or_equiv  # noqa: F401
 from xarray.core.indexing import ExplicitlyIndexed
 from xarray.core.options import set_options
-from xarray.plot.utils import import_seaborn
 
 # import mpl and change the backend before other mpl imports
 try:
@@ -71,6 +70,7 @@ has_zarr, requires_zarr = _importorskip("zarr")
 has_iris, requires_iris = _importorskip("iris")
 has_cfgrib, requires_cfgrib = _importorskip("cfgrib")
 has_numbagg, requires_numbagg = _importorskip("numbagg")
+has_seaborn, requires_seaborn = _importorskip("seaborn")
 has_sparse, requires_sparse = _importorskip("sparse")
 
 # some special cases
@@ -78,12 +78,6 @@ has_scipy_or_netCDF4 = has_scipy or has_netCDF4
 requires_scipy_or_netCDF4 = pytest.mark.skipif(
     not has_scipy_or_netCDF4, reason="requires scipy or netCDF4"
 )
-try:
-    import_seaborn()
-    has_seaborn = True
-except ImportError:
-    has_seaborn = False
-requires_seaborn = pytest.mark.skipif(not has_seaborn, reason="requires seaborn")
 
 # change some global options for tests
 set_options(warn_for_unclosed_files=True)

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -14,7 +14,6 @@ from xarray.plot.utils import (
     _build_discrete_cmap,
     _color_palette,
     _determine_cmap_params,
-    import_seaborn,
     label_from_attrs,
 )
 
@@ -2116,22 +2115,6 @@ class TestNcAxisNotInstalled(PlotTestCase):
     def test_ncaxis_notinstalled_line_plot(self):
         with raises_regex(ImportError, "optional `nc-time-axis`"):
             self.darray.plot.line()
-
-
-@requires_seaborn
-def test_import_seaborn_no_warning():
-    # GH1633
-    with pytest.warns(None) as record:
-        import_seaborn()
-    assert len(record) == 0
-
-
-@requires_matplotlib
-def test_plot_seaborn_no_import_warning():
-    # GH1633
-    with pytest.warns(None) as record:
-        _color_palette("Blues", 4)
-    assert len(record) == 0
 
 
 test_da_list = [


### PR DESCRIPTION

 - [x] Closes #3747
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
