### PR TITLE
Add new h5netcdf backend phony_dims kwarg

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -24,6 +24,9 @@ Breaking changes
 
 New Features
 ~~~~~~~~~~~~
+- Support new h5netcdf backend keyword `phony_dims` (available from h5netcdf
+  v0.8.0 for :py:class:`~xarray.backends.H5NetCDFStore`.
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -1,4 +1,5 @@
 import functools
+from distutils.version import LooseVersion
 
 import numpy as np
 
@@ -117,6 +118,7 @@ class H5NetCDFStore(WritableCFDataStore):
         lock=None,
         autoclose=False,
         invalid_netcdf=None,
+        phony_dims=None,
     ):
         import h5netcdf
 
@@ -124,6 +126,14 @@ class H5NetCDFStore(WritableCFDataStore):
             raise ValueError("invalid format for h5netcdf backend")
 
         kwargs = {"invalid_netcdf": invalid_netcdf}
+        if phony_dims is not None:
+            if LooseVersion(h5netcdf.__version__) >= LooseVersion("0.8.0"):
+                kwargs["phony_dims"] = phony_dims
+            else:
+                raise (
+                    "h5netcdf backend keyword argument 'phony_dims' needs "
+                    "h5netcdf >= 0.8.0."
+                )
 
         if lock is None:
             if mode == "r":

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -130,7 +130,7 @@ class H5NetCDFStore(WritableCFDataStore):
             if LooseVersion(h5netcdf.__version__) >= LooseVersion("0.8.0"):
                 kwargs["phony_dims"] = phony_dims
             else:
-                raise (
+                raise ValueError(
                     "h5netcdf backend keyword argument 'phony_dims' needs "
                     "h5netcdf >= 0.8.0."
                 )


### PR DESCRIPTION
This adds support for the new `phony_dims` keyword for the h5netcdf backend which is available from `h5netcdf` version 0.8.0.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
