### PR TITLE
Allow plotting bool data

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -41,7 +41,8 @@ New Features
 - Implement :py:meth:`DataArray.idxmax`, :py:meth:`DataArray.idxmin`,
   :py:meth:`Dataset.idxmax`, :py:meth:`Dataset.idxmin`.  (:issue:`60`, :pull:`3871`)
   By `Todd Jennings <https://github.com/toddrjen>`_
-
+- Allow plotting of boolean arrays. (:pull:`3766`)
+  By `Marek Jacob <https://github.com/MeraX>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -689,7 +689,7 @@ def _plot2d(plotfunc):
         xplt, xlab_extra = _resolve_intervals_2dplot(xval, plotfunc.__name__)
         yplt, ylab_extra = _resolve_intervals_2dplot(yval, plotfunc.__name__)
 
-        _ensure_plottable(xplt, yplt)
+        _ensure_plottable(xplt, yplt, zval)
 
         cmap_params, cbar_kwargs = _process_cmap_cbar_kwargs(
             plotfunc, zval.data, **locals()

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -510,7 +510,7 @@ def _ensure_plottable(*args):
     Raise exception if there is anything in args that can't be plotted on an
     axis by matplotlib.
     """
-    numpy_types = [np.floating, np.integer, np.timedelta64, np.datetime64]
+    numpy_types = [np.floating, np.integer, np.timedelta64, np.datetime64, np.bool8]
     other_types = [datetime]
     try:
         import cftime

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -510,7 +510,7 @@ def _ensure_plottable(*args):
     Raise exception if there is anything in args that can't be plotted on an
     axis by matplotlib.
     """
-    numpy_types = [np.floating, np.integer, np.timedelta64, np.datetime64, np.bool8]
+    numpy_types = [np.floating, np.integer, np.timedelta64, np.datetime64, np.bool_]
     other_types = [datetime]
     try:
         import cftime
@@ -525,10 +525,10 @@ def _ensure_plottable(*args):
             or _valid_other_type(np.array(x), other_types)
         ):
             raise TypeError(
-                "Plotting requires coordinates to be numeric "
-                "or dates of type np.datetime64, "
+                "Plotting requires coordinates to be numeric, boolean, "
+                "or dates of type numpy.datetime64, "
                 "datetime.datetime, cftime.datetime or "
-                "pd.Interval."
+                f"pandas.Interval. Received data of type {np.array(x).dtype} instead."
             )
         if (
             _valid_other_type(np.array(x), cftime_datetime)

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -138,6 +138,12 @@ class TestPlot(PlotTestCase):
         with raises_regex(ValueError, "None"):
             self.darray[:, 0, 0].plot(x="dim_1")
 
+        with raises_regex(TypeError, "complex128"):
+            (self.darray[:, 0, 0] + 1j).plot()
+
+    def test_1d_bool(self):
+        xr.ones_like(self.darray[:, 0, 0], dtype=np.bool).plot()
+
     def test_1d_x_y_kw(self):
         z = np.arange(10)
         da = DataArray(np.cos(z), dims=["z"], coords=[z], name="f")
@@ -918,6 +924,13 @@ class Common2dMixin:
     def test_1d_raises_valueerror(self):
         with raises_regex(ValueError, r"DataArray must be 2d"):
             self.plotfunc(self.darray[0, :])
+
+    def test_bool(self):
+        xr.ones_like(self.darray, dtype=np.bool).plot()
+
+    def test_complex_raises_typeerror(self):
+        with raises_regex(TypeError, "complex128"):
+            (self.darray + 1j).plot()
 
     def test_3d_raises_valueerror(self):
         a = DataArray(easy_array((2, 3, 4)))


### PR DESCRIPTION
as @dcherian said:

> matplotlib can plot `bool` values so we should add that to the check in `_ensure_plottable`.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #3722 

