### PR TITLE
concat now handles non-dim coordinates only present in one dataset

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -28,6 +28,10 @@ New Features
 Bug fixes
 ~~~~~~~~~
 
+- :py:func:`concat` can now handle coordinate variables only present in one of
+  the objects to be concatenated when ``coords="different"``.
+  By `Deepak Cherian <https://github.com/dcherian>`_.
+
 Documentation
 ~~~~~~~~~~~~~
 

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -201,6 +201,8 @@ def _calc_concat_over(datasets, dim, dim_names, data_vars, coords, compat):
                                 variables.append(ds.variables[k])
 
                         if len(variables) == 1:
+                            # coords="different" doesn't make sense when only one object
+                            # contains a particular variable.
                             break
                         elif len(variables) != len(datasets) and opt == "different":
                             raise ValueError(

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -204,8 +204,8 @@ def _calc_concat_over(datasets, dim, dim_names, data_vars, coords, compat):
                             break
                         elif len(variables) != len(datasets) and opt == "different":
                             raise ValueError(
-                                f"{k} not present in all datasets and coords='different'. "
-                                f"Either add {k} to datasets where it is missing or "
+                                f"{k!r} not present in all datasets and coords='different'. "
+                                f"Either add {k!r} to datasets where it is missing or "
                                 "specify coords='minimal'."
                             )
 

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -194,7 +194,21 @@ def _calc_concat_over(datasets, dim, dim_names, data_vars, coords, compat):
                 for k in getattr(datasets[0], subset):
                     if k not in concat_over:
                         equals[k] = None
-                        variables = [ds.variables[k] for ds in datasets]
+
+                        variables = []
+                        for ds in datasets:
+                            if k in ds.variables:
+                                variables.append(ds.variables[k])
+
+                        if len(variables) == 1:
+                            break
+                        elif len(variables) != len(datasets) and opt == "different":
+                            raise ValueError(
+                                f"{k} not present in all datasets and coords='different'. "
+                                f"Either add {k} to datasets where it is missing or "
+                                "specify coords='minimal'."
+                            )
+
                         # first check without comparing values i.e. no computes
                         for var in variables[1:]:
                             equals[k] = getattr(variables[0], compat)(

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -365,9 +365,9 @@ class TestNestedCombine:
         expected = Dataset({"x": ("a", [0, 1]), "y": ("a", [0, 1])})
         assert_identical(expected, actual)
 
-        objs = [Dataset({"x": [0], "y": [0]}), Dataset({"x": [0]})]
+        objs = [Dataset({"x": [0], "y": [0]}), Dataset({"x": [1]})]
         actual = combine_nested(objs, concat_dim="x")
-        expected = Dataset({"x": [0, 0], "y": [0]})
+        expected = Dataset({"x": [0, 1], "y": [0]})
         assert_identical(expected, actual)
 
     @pytest.mark.parametrize(

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -366,8 +366,9 @@ class TestNestedCombine:
         assert_identical(expected, actual)
 
         objs = [Dataset({"x": [0], "y": [0]}), Dataset({"x": [0]})]
-        with pytest.raises(KeyError):
-            combine_nested(objs, concat_dim="x")
+        actual = combine_nested(objs, concat_dim="x")
+        expected = Dataset({"x": [0, 0], "y": [0]})
+        assert_identical(expected, actual)
 
     @pytest.mark.parametrize(
         "join, expected",

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -494,5 +494,5 @@ def test_concat_merge_single_non_dim_coord():
     da2 = DataArray([4, 5, 6], dims="x", coords={"x": [4, 5, 6]})
     da3 = DataArray([7, 8, 9], dims="x", coords={"x": [7, 8, 9], "y": 1})
     for coords in ["different", "all"]:
-        with raises_regex(ValueError, "'y' not present in all datasets."):
+        with raises_regex(ValueError, "'y' not present in all datasets"):
             concat([da1, da2, da3], dim="x")

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -475,3 +475,24 @@ def test_concat_attrs_first_variable(attr1, attr2):
 
     concat_attrs = concat(arrs, "y").attrs
     assert concat_attrs == attr1
+
+
+def test_concat_merge_single_non_dim_coord():
+    da1 = DataArray([1, 2, 3], dims="x", coords={"x": [1, 2, 3], "y": 1})
+    da2 = DataArray([4, 5, 6], dims="x", coords={"x": [4, 5, 6]})
+
+    expected = DataArray(range(1, 7), dims="x", coords={"x": range(1, 7), "y": 1})
+
+    for coords in ["different", "minimal"]:
+        actual = concat([da1, da2], "x", coords=coords)
+        assert_identical(actual, expected)
+
+    with raises_regex(ValueError, "'y' is not present in all datasets."):
+        concat([da1, da2], dim="x", coords="all")
+
+    da1 = DataArray([1, 2, 3], dims="x", coords={"x": [1, 2, 3], "y": 1})
+    da2 = DataArray([4, 5, 6], dims="x", coords={"x": [4, 5, 6]})
+    da3 = DataArray([7, 8, 9], dims="x", coords={"x": [7, 8, 9], "y": 1})
+    for coords in ["different", "all"]:
+        with raises_regex(ValueError, "'y' not present in all datasets."):
+            concat([da1, da2, da3], dim="x")


### PR DESCRIPTION

 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API


```
da1 = xr.DataArray([1, 2, 3], dims="x", coords={"x": [1, 2, 3], "y": 1})
da2 = xr.DataArray([4, 5, 6], dims="x", coords={"x": [4, 5, 6]})
xr.concat([da1, da2], dim="x")
```
This use case is quite common since you can get `da1` from something like `bigger_da1.sel(y=1)`

On master this raises an uninformative  `KeyError` because `'y'` is not present in all datasets. This is because `coords="different"` by default which means that we are checking for equality. However `coords='different'`(and the equality check) is meaningless when the variable is only present in one of the objects to be concatenated.

This PR skips equality checking when a variable is only present in one dataset and raises a nicer error message when it is present in more than one but not all datasets.
