### PR TITLE
always use dask_array_type for isinstance calls

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,6 +27,9 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
+- Use ``dask_array_type`` instead of ``dask_array.Array`` for type
+  checking. (:issue:`3779`, :pull:`3787`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/dask_array_compat.py
+++ b/xarray/core/dask_array_compat.py
@@ -3,6 +3,8 @@ from typing import Iterable
 
 import numpy as np
 
+from .pycompat import dask_array_type
+
 try:
     import dask.array as da
     from dask import __version__ as dask_version
@@ -36,7 +38,7 @@ else:
         """
         # If using x._meta, x must be a Dask Array, some libraries (e.g. zarr)
         # implement a _meta attribute that are incompatible with Dask Array._meta
-        if hasattr(x, "_meta") and isinstance(x, da.Array):
+        if hasattr(x, "_meta") and isinstance(x, dask_array_type):
             x = x._meta
 
         if dtype is None and x is None:

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -37,7 +37,7 @@ def _dask_or_eager_func(
                 dispatch_args = args[0]
             else:
                 dispatch_args = args[array_args]
-            if any(isinstance(a, dask_array.Array) for a in dispatch_args):
+            if any(isinstance(a, dask_array_type) for a in dispatch_args):
                 try:
                     wrapped = getattr(dask_module, name)
                 except AttributeError as e:
@@ -189,8 +189,8 @@ def lazy_array_equiv(arr1, arr2):
         return False
     if (
         dask_array
-        and isinstance(arr1, dask_array.Array)
-        and isinstance(arr2, dask_array.Array)
+        and isinstance(arr1, dask_array_type)
+        and isinstance(arr2, dask_array_type)
     ):
         # GH3068
         if arr1.name == arr2.name:


### PR DESCRIPTION
This makes sure we use `dask_array_type` instead of `dask_array.Array` for `isinstance` calls.

 - [x] Closes #3779
 - [ ] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API