### PR TITLE
remove datetime tests with pint

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -37,6 +37,8 @@ Internal Changes
 - Removed the internal ``import_seaborn`` function which handled the deprecation of
   the ``seaborn.apionly`` entry point (:issue:`3747`).
   By `Mathias Hauser <https://github.com/mathause>`_.
+- Don't test pint integration in combination with datetime objects. (:issue:`3778`, :pull:`3788`)
+  By `Justus Magin <https://github.com/keewis>`_.
 - Changed test_open_mfdataset_list_attr to only run with dask installed
   (:issue:`3777`, :pull:`3780`).
   By `Bruno Pagani <https://github.com/ArchangeGabriel>`_.

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -71,14 +71,7 @@ around = _dask_or_eager_func("around")
 isclose = _dask_or_eager_func("isclose")
 
 
-if hasattr(np, "isnat") and (
-    dask_array_type == () or hasattr(dask_array_type[0], "__array_ufunc__")
-):
-    # np.isnat is available since NumPy 1.13, so __array_ufunc__ is always
-    # supported.
-    isnat = np.isnat
-else:
-    isnat = _dask_or_eager_func("isnull", eager_module=pd)
+isnat = _dask_or_eager_func("isnat")
 isnan = _dask_or_eager_func("isnan")
 zeros_like = _dask_or_eager_func("zeros_like")
 

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -71,7 +71,7 @@ around = _dask_or_eager_func("around")
 isclose = _dask_or_eager_func("isclose")
 
 
-isnat = _dask_or_eager_func("isnat")
+isnat = np.isnat
 isnan = _dask_or_eager_func("isnan")
 zeros_like = _dask_or_eager_func("zeros_like")
 

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -72,7 +72,7 @@ isclose = _dask_or_eager_func("isclose")
 
 
 if hasattr(np, "isnat") and (
-    dask_array is None or hasattr(dask_array_type, "__array_ufunc__")
+    dask_array_type == () or hasattr(dask_array_type[0], "__array_ufunc__")
 ):
     # np.isnat is available since NumPy 1.13, so __array_ufunc__ is always
     # supported.

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1333,6 +1333,7 @@ def delete_attrs(*to_delete):
     "test_index_0d_datetime",
     "test_index_0d_timedelta64",
     "test_0d_time_data",
+    "test_index_0d_not_a_time",
     "test_datetime64_conversion",
     "test_timedelta64_conversion",
     "test_pandas_period_index",
@@ -1354,6 +1355,15 @@ class TestVariable(VariableSubclassobjects):
         return xr.Variable(
             dims, unit_registry.Quantity(data, unit_registry.m), *args, **kwargs
         )
+
+    def example_1d_objects(self):
+        for data in [
+            range(3),
+            0.5 * np.arange(3),
+            0.5 * np.arange(3, dtype=np.float32),
+            np.array(["a", "b", "c"], dtype=object),
+        ]:
+            yield (self.cls("x", data), data)
 
     @pytest.mark.parametrize(
         "func",


### PR DESCRIPTION
Since it does not make sense to try to wrap `datetime` objects in `pint`, I'm removing those tests. They still exposed a bug in the compatibility code of `isnat`: if `dask` is installed, the code would always use `pd.isnull`.

 - [x] Closes #3778
 - [ ] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
