### PR TITLE
Enable pandas-style rounding of cftime.datetime objects

### DIFF
--- a/doc/weather-climate.rst
+++ b/doc/weather-climate.rst
@@ -105,6 +105,14 @@ For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
    da.time.dt.dayofyear
    da.time.dt.dayofweek
 
+- Rounding of datetimes to fixed frequencies via the ``dt`` accessor:
+
+.. ipython:: python
+
+   da.time.dt.ceil('3D')
+   da.time.dt.floor('5D')
+   da.time.dt.round('2D')
+   
 - Group-by operations based on datetime accessor attributes (e.g. by month of
   the year):
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -28,7 +28,7 @@ New Features
 - Added support for :py:class:`pandas.DatetimeIndex`-style rounding of
   ``cftime.datetime`` objects directly via a :py:class:`CFTimeIndex` or via the
   :py:class:`~core.accessor_dt.DatetimeAccessor`.
-  By `Spencer Clark <https://github.com/spencerkclark>>`_ 
+  By `Spencer Clark <https://github.com/spencerkclark>`_ 
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,6 +25,11 @@ Breaking changes
 New Features
 ~~~~~~~~~~~~
 
+- Added support for :py:class:`pandas.DatetimeIndex`-style rounding of
+  ``cftime.datetime`` objects directly via a :py:class:`CFTimeIndex` or via the
+  :py:class:`~core.accessor_dt.DatetimeAccessor`.
+  By `Spencer Clark <https://github.com/spencerkclark>>`_ 
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -666,7 +666,7 @@ def _total_microseconds(delta):
     -------
     int
     """
-    return int(delta.total_seconds() * 1e6)
+    return delta / timedelta(microseconds=1)
 
 
 def _floor_int(values, unit):

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -528,6 +528,45 @@ class CFTimeIndex(pd.Index):
         """
         return pd.Index([date.strftime(date_format) for date in self._data])
 
+    @property
+    def asi8(self):
+        """Convert to integers with units of microseconds since 1970-01-01"""
+        from ..core.resample_cftime import exact_cftime_datetime_difference
+
+        epoch = self.date_type(1970, 1, 1)
+        return np.array(
+            [
+                _total_microseconds(exact_cftime_datetime_difference(epoch, date)) for date
+                in self.values
+            ]
+        )
+
+    def _round(self, freq, method):
+        from .cftime_offsets import CFTIME_TICKS, to_offset
+
+        offset = to_offset(freq)
+        if not isinstance(offset, CFTIME_TICKS):
+            raise ValueError(
+                f"{offset} is a non-fixed frequency"
+            )
+
+        unit = _total_microseconds(offset.as_timedelta())
+        values = self.asi8
+        rounded = method(values, unit)
+        return _cftimeindex_from_i8(rounded, self.date_type, self.name)
+
+    def floor(self, freq):
+        """Round dates down to fixed frequency"""
+        return self._round(freq, _floor_int)
+
+    def ceil(self, freq):
+        """Round dates up to fixed frequency"""
+        return self._round(freq, _ceil_int)
+
+    def round(self, freq):
+        """Round dates to a fixed frequency"""
+        return self._round(freq, _round_to_nearest_half_even)
+
 
 def _parse_iso8601_without_reso(date_type, datetime_str):
     date, _ = _parse_iso8601_with_reso(date_type, datetime_str)
@@ -554,3 +593,33 @@ def _parse_array_of_cftime_strings(strings, date_type):
     return np.array(
         [_parse_iso8601_without_reso(date_type, s) for s in strings.ravel()]
     ).reshape(strings.shape)
+
+
+def _cftimeindex_from_i8(values, date_type, name):
+    epoch = date_type(1970, 1, 1)
+    dates = np.array([epoch + timedelta(microseconds=int(value)) for value in values])
+    return CFTimeIndex(dates, name=name)
+
+
+def _total_microseconds(delta):
+    return int(delta.total_seconds() * 1e6)
+
+
+def _floor_int(values, unit):
+    return values - np.remainder(values, unit)
+
+
+def _ceil_int(values, unit):
+    return values + np.remainder(-values, unit)
+
+
+def _round_to_nearest_half_even(values, unit):
+    if unit % 2:
+        return _ceil_int(values - unit // 2, unit)
+    quotient, remainder = np.divmod(values, unit)
+    mask = np.logical_or(
+        remainder > (unit // 2),
+        np.logical_and(remainder == (unit // 2), quotient % 2)
+    )
+    quotient[mask] += 1
+    return quotient * unit

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -634,7 +634,7 @@ def _parse_array_of_cftime_strings(strings, date_type):
 
 
 def _cftimeindex_from_i8(values, date_type, name):
-    """Construct a CFTimeIndex from an array of integers
+    """Construct a CFTimeIndex from an array of integers.
 
     Parameters
     ----------
@@ -670,17 +670,17 @@ def _total_microseconds(delta):
 
 
 def _floor_int(values, unit):
-    """Adapted from pandas."""
+    """Copied from pandas."""
     return values - np.remainder(values, unit)
 
 
 def _ceil_int(values, unit):
-    """Adapted from pandas."""
+    """Copied from pandas."""
     return values + np.remainder(-values, unit)
 
 
 def _round_to_nearest_half_even(values, unit):
-    """Adapted from pandas."""
+    """Copied from pandas."""
     if unit % 2:
         return _ceil_int(values - unit // 2, unit)
     quotient, remainder = np.divmod(values, unit)

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -530,25 +530,24 @@ class CFTimeIndex(pd.Index):
 
     @property
     def asi8(self):
-        """Convert to integers with units of microseconds since 1970-01-01"""
+        """Convert to integers with units of microseconds since 1970-01-01."""
         from ..core.resample_cftime import exact_cftime_datetime_difference
 
         epoch = self.date_type(1970, 1, 1)
         return np.array(
             [
-                _total_microseconds(exact_cftime_datetime_difference(epoch, date)) for date
-                in self.values
+                _total_microseconds(exact_cftime_datetime_difference(epoch, date))
+                for date in self.values
             ]
         )
 
-    def _round(self, freq, method):
+    def _round_via_method(self, freq, method):
+        """Round dates using a specified method."""
         from .cftime_offsets import CFTIME_TICKS, to_offset
 
         offset = to_offset(freq)
         if not isinstance(offset, CFTIME_TICKS):
-            raise ValueError(
-                f"{offset} is a non-fixed frequency"
-            )
+            raise ValueError(f"{offset} is a non-fixed frequency")
 
         unit = _total_microseconds(offset.as_timedelta())
         values = self.asi8
@@ -556,16 +555,55 @@ class CFTimeIndex(pd.Index):
         return _cftimeindex_from_i8(rounded, self.date_type, self.name)
 
     def floor(self, freq):
-        """Round dates down to fixed frequency"""
-        return self._round(freq, _floor_int)
+        """Round dates down to fixed frequency.
+
+        Parameters
+        ----------
+        freq : str or CFTimeOffset
+            The frequency level to round the index to.  Must be a fixed
+            frequency like 'S' (second) not 'ME' (month end).  See `frequency
+            aliases <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`_
+            for a list of possible values.
+
+        Returns
+        -------
+        CFTimeIndex
+        """
+        return self._round_via_method(freq, _floor_int)
 
     def ceil(self, freq):
-        """Round dates up to fixed frequency"""
-        return self._round(freq, _ceil_int)
+        """Round dates up to fixed frequency.
+
+        Parameters
+        ----------
+        freq : str or CFTimeOffset
+            The frequency level to round the index to.  Must be a fixed
+            frequency like 'S' (second) not 'ME' (month end).  See `frequency
+            aliases <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`_
+            for a list of possible values.
+
+        Returns
+        -------
+        CFTimeIndex
+        """
+        return self._round_via_method(freq, _ceil_int)
 
     def round(self, freq):
-        """Round dates to a fixed frequency"""
-        return self._round(freq, _round_to_nearest_half_even)
+        """Round dates to a fixed frequency.
+
+        Parameters
+        ----------
+        freq : str or CFTimeOffset
+            The frequency level to round the index to.  Must be a fixed
+            frequency like 'S' (second) not 'ME' (month end).  See `frequency
+            aliases <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`_
+            for a list of possible values.
+
+        Returns
+        -------
+        CFTimeIndex
+        """
+        return self._round_via_method(freq, _round_to_nearest_half_even)
 
 
 def _parse_iso8601_without_reso(date_type, datetime_str):
@@ -596,30 +634,58 @@ def _parse_array_of_cftime_strings(strings, date_type):
 
 
 def _cftimeindex_from_i8(values, date_type, name):
+    """Construct a CFTimeIndex from an array of integers
+
+    Parameters
+    ----------
+    values : np.array
+        Integers representing microseconds since 1970-01-01.
+    date_type : cftime.datetime
+        Type of date for the index.
+    name : str
+        Name of the index.
+
+    Returns
+    -------
+    CFTimeIndex
+    """
     epoch = date_type(1970, 1, 1)
     dates = np.array([epoch + timedelta(microseconds=int(value)) for value in values])
     return CFTimeIndex(dates, name=name)
 
 
 def _total_microseconds(delta):
+    """Compute the total number of microseconds of a datetime.timedelta.
+
+    Parameters
+    ----------
+    delta : datetime.timedelta
+        Input timedelta.
+
+    Returns
+    -------
+    int
+    """
     return int(delta.total_seconds() * 1e6)
 
 
 def _floor_int(values, unit):
+    """Adapted from pandas."""
     return values - np.remainder(values, unit)
 
 
 def _ceil_int(values, unit):
+    """Adapted from pandas."""
     return values + np.remainder(-values, unit)
 
 
 def _round_to_nearest_half_even(values, unit):
+    """Adapted from pandas."""
     if unit % 2:
         return _ceil_int(values - unit // 2, unit)
     quotient, remainder = np.divmod(values, unit)
     mask = np.logical_or(
-        remainder > (unit // 2),
-        np.logical_and(remainder == (unit // 2), quotient % 2)
+        remainder > (unit // 2), np.logical_and(remainder == (unit // 2), quotient % 2)
     )
     quotient[mask] += 1
     return quotient * unit

--- a/xarray/core/accessor_dt.py
+++ b/xarray/core/accessor_dt.py
@@ -117,8 +117,9 @@ def _round_field(values, name, freq):
     if isinstance(values, dask_array_type):
         from dask.array import map_blocks
 
+        dtype = np.datetime64 if is_np_datetime_like(values.dtype) else np.dtype("O")
         return map_blocks(
-            _round_through_series_or_index, values, name, freq=freq, dtype=np.datetime64
+            _round_through_series_or_index, values, name, freq=freq, dtype=dtype
         )
     else:
         return _round_through_series_or_index(values, name, freq)

--- a/xarray/core/accessor_dt.py
+++ b/xarray/core/accessor_dt.py
@@ -117,7 +117,9 @@ def _round_field(values, name, freq):
     if isinstance(values, dask_array_type):
         from dask.array import map_blocks
 
-        return map_blocks(_round_through_series_or_index, values, name, freq=freq, dtype=np.datetime64)
+        return map_blocks(
+            _round_through_series_or_index, values, name, freq=freq, dtype=np.datetime64
+        )
     else:
         return _round_through_series_or_index(values, name, freq)
 

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -7,6 +7,7 @@ import xarray as xr
 from . import (
     assert_array_equal,
     assert_equal,
+    assert_identical,
     raises_regex,
     requires_cftime,
     requires_dask,
@@ -435,3 +436,94 @@ def test_seasons(cftime_date_type):
     seasons = xr.DataArray(seasons)
 
     assert_array_equal(seasons.values, dates.dt.season.values)
+
+
+@pytest.fixture
+def cftime_rounding_dataarray(cftime_date_type):
+    return xr.DataArray(
+        [
+            [cftime_date_type(1, 1, 1, 1), cftime_date_type(1, 1, 1, 15)],
+            [cftime_date_type(1, 1, 1, 23), cftime_date_type(1, 1, 2, 1)],
+        ]
+    )
+
+
+@requires_cftime
+@requires_dask
+@pytest.mark.parametrize("use_dask", [False, True])
+def test_cftime_floor_accessor(cftime_rounding_dataarray, cftime_date_type, use_dask):
+    import dask.array as da
+
+    freq = "D"
+    expected = xr.DataArray(
+        [
+            [cftime_date_type(1, 1, 1, 0), cftime_date_type(1, 1, 1, 0)],
+            [cftime_date_type(1, 1, 1, 0), cftime_date_type(1, 1, 2, 0)],
+        ],
+        name="floor",
+    )
+
+    if use_dask:
+        chunks = {"dim_0": 1}
+        result = cftime_rounding_dataarray.chunk(chunks).dt.floor(freq)
+        expected = expected.chunk(chunks)
+        assert isinstance(result.data, da.Array)
+        assert result.chunks == expected.chunks
+    else:
+        result = cftime_rounding_dataarray.dt.floor(freq)
+
+    assert_identical(result, expected)
+
+
+@requires_cftime
+@requires_dask
+@pytest.mark.parametrize("use_dask", [False, True])
+def test_cftime_ceil_accessor(cftime_rounding_dataarray, cftime_date_type, use_dask):
+    import dask.array as da
+
+    freq = "D"
+    expected = xr.DataArray(
+        [
+            [cftime_date_type(1, 1, 2, 0), cftime_date_type(1, 1, 2, 0)],
+            [cftime_date_type(1, 1, 2, 0), cftime_date_type(1, 1, 3, 0)],
+        ],
+        name="ceil",
+    )
+
+    if use_dask:
+        chunks = {"dim_0": 1}
+        result = cftime_rounding_dataarray.chunk(chunks).dt.ceil(freq)
+        expected = expected.chunk(chunks)
+        assert isinstance(result.data, da.Array)
+        assert result.chunks == expected.chunks
+    else:
+        result = cftime_rounding_dataarray.dt.ceil(freq)
+
+    assert_identical(result, expected)
+
+
+@requires_cftime
+@requires_dask
+@pytest.mark.parametrize("use_dask", [False, True])
+def test_cftime_round_accessor(cftime_rounding_dataarray, cftime_date_type, use_dask):
+    import dask.array as da
+
+    freq = "D"
+    expected = xr.DataArray(
+        [
+            [cftime_date_type(1, 1, 1, 0), cftime_date_type(1, 1, 2, 0)],
+            [cftime_date_type(1, 1, 2, 0), cftime_date_type(1, 1, 2, 0)],
+        ],
+        name="round",
+    )
+
+    if use_dask:
+        chunks = {"dim_0": 1}
+        result = cftime_rounding_dataarray.chunk(chunks).dt.round(freq)
+        expected = expected.chunk(chunks)
+        assert isinstance(result.data, da.Array)
+        assert result.chunks == expected.chunks
+    else:
+        result = cftime_rounding_dataarray.dt.round(freq)
+
+    assert_identical(result, expected)

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -465,7 +465,11 @@ def test_cftime_floor_accessor(cftime_rounding_dataarray, cftime_date_type, use_
 
     if use_dask:
         chunks = {"dim_0": 1}
-        result = cftime_rounding_dataarray.chunk(chunks).dt.floor(freq)
+        # Currently a compute is done to inspect a single value of the array
+        # if it is of object dtype to check if it is a cftime.datetime (if not
+        # we raise an error when using the dt accessor).
+        with raise_if_dask_computes(max_computes=1):
+            result = cftime_rounding_dataarray.chunk(chunks).dt.floor(freq)
         expected = expected.chunk(chunks)
         assert isinstance(result.data, da.Array)
         assert result.chunks == expected.chunks
@@ -492,7 +496,11 @@ def test_cftime_ceil_accessor(cftime_rounding_dataarray, cftime_date_type, use_d
 
     if use_dask:
         chunks = {"dim_0": 1}
-        result = cftime_rounding_dataarray.chunk(chunks).dt.ceil(freq)
+        # Currently a compute is done to inspect a single value of the array
+        # if it is of object dtype to check if it is a cftime.datetime (if not
+        # we raise an error when using the dt accessor).
+        with raise_if_dask_computes(max_computes=1):
+            result = cftime_rounding_dataarray.chunk(chunks).dt.ceil(freq)
         expected = expected.chunk(chunks)
         assert isinstance(result.data, da.Array)
         assert result.chunks == expected.chunks
@@ -519,7 +527,11 @@ def test_cftime_round_accessor(cftime_rounding_dataarray, cftime_date_type, use_
 
     if use_dask:
         chunks = {"dim_0": 1}
-        result = cftime_rounding_dataarray.chunk(chunks).dt.round(freq)
+        # Currently a compute is done to inspect a single value of the array
+        # if it is of object dtype to check if it is a cftime.datetime (if not
+        # we raise an error when using the dt accessor).
+        with raise_if_dask_computes(max_computes=1):
+            result = cftime_rounding_dataarray.chunk(chunks).dt.round(freq)
         expected = expected.chunk(chunks)
         assert isinstance(result.data, da.Array)
         assert result.chunks == expected.chunks

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -974,6 +974,7 @@ def test_asi8(date_type):
 def test_asi8_distant_date():
     """Test that asi8 conversion is truly exact."""
     import cftime
+
     date_type = cftime.DatetimeProlepticGregorian
     index = xr.CFTimeIndex([date_type(10731, 4, 22, 3, 25, 45, 123456)])
     result = index.asi8

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -904,6 +904,14 @@ def test_rounding_methods_against_datetimeindex(freq, method):
     assert result.equals(expected)
 
 
+@requires_cftime
+@pytest.mark.parametrize("method", ["floor", "ceil", "round"])
+def test_rounding_methods_invalid_freq(method):
+    index = xr.cftime_range("2000-01-02T01:03:51", periods=10, freq="1777S")
+    with pytest.raises(ValueError, match="fixed"):
+        getattr(index, method)("MS")
+
+
 @pytest.fixture
 def rounding_index(date_type):
     return xr.CFTimeIndex(

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -894,40 +894,61 @@ def test_multiindex():
 
 
 @requires_cftime
-@pytest.mark.parametrize('freq', ['3663S', '33T', '2H'])
-def test_floor(freq):
-    expected = pd.date_range('2000-01-02T01:03:51', periods=10, freq='1777S')
-    expected = expected.floor(freq)
-    result = xr.cftime_range('2000-01-02T01:03:51', periods=10, freq='1777S')
-    result = result.floor(freq).to_datetimeindex()
+@pytest.mark.parametrize("freq", ["3663S", "33T", "2H"])
+@pytest.mark.parametrize("method", ["floor", "ceil", "round"])
+def test_rounding_methods_against_datetimeindex(freq, method):
+    expected = pd.date_range("2000-01-02T01:03:51", periods=10, freq="1777S")
+    expected = getattr(expected, method)(freq)
+    result = xr.cftime_range("2000-01-02T01:03:51", periods=10, freq="1777S")
+    result = getattr(result, method)(freq).to_datetimeindex()
+    assert result.equals(expected)
+
+
+@pytest.fixture
+def rounding_index(date_type):
+    return xr.CFTimeIndex(
+        [
+            date_type(1, 1, 1, 1, 59, 59, 999512),
+            date_type(1, 1, 1, 3, 0, 1, 500001),
+            date_type(1, 1, 1, 7, 0, 6, 499999),
+        ]
+    )
+
+
+@requires_cftime
+def test_ceil(rounding_index, date_type):
+    result = rounding_index.ceil("S")
+    expected = xr.CFTimeIndex(
+        [
+            date_type(1, 1, 1, 2, 0, 0, 0),
+            date_type(1, 1, 1, 3, 0, 2, 0),
+            date_type(1, 1, 1, 7, 0, 7, 0),
+        ]
+    )
     assert result.equals(expected)
 
 
 @requires_cftime
-@pytest.mark.parametrize('freq', ['3663S', '33T', '2H'])
-def test_ceil(freq):
-    expected = pd.date_range('2000-01-02T01:03:51', periods=10, freq='1777S')
-    expected = expected.ceil(freq)
-    result = xr.cftime_range('2000-01-02T01:03:51', periods=10, freq='1777S')
-    result = result.ceil(freq).to_datetimeindex()
+def test_floor(rounding_index, date_type):
+    result = rounding_index.floor("S")
+    expected = xr.CFTimeIndex(
+        [
+            date_type(1, 1, 1, 1, 59, 59, 0),
+            date_type(1, 1, 1, 3, 0, 1, 0),
+            date_type(1, 1, 1, 7, 0, 6, 0),
+        ]
+    )
     assert result.equals(expected)
 
 
 @requires_cftime
-@pytest.mark.parametrize('freq', ['3663S', '33T', '2H'])
-def test_round(freq):
-    expected = pd.date_range('2000-01-02T01:03:51', periods=10, freq='1777S')
-    expected = expected.round(freq)
-    result = xr.cftime_range('2000-01-02T01:03:51', periods=10, freq='1777S')
-    result = result.round(freq).to_datetimeindex()
-    assert result.equals(expected)
-
-
-@requires_cftime
-@pytest.mark.parametrize('freq', ['H', '3H', '7H'])
-def test_round2(freq):
-    expected = pd.date_range('2000-01-02T01:03:51', periods=21, freq='59T')
-    expected = expected.round(freq)
-    result = xr.cftime_range('2000-01-02T01:03:51', periods=21, freq='59T')
-    result = result.round(freq).to_datetimeindex()
+def test_round(rounding_index, date_type):
+    result = rounding_index.round("S")
+    expected = xr.CFTimeIndex(
+        [
+            date_type(1, 1, 1, 2, 0, 0, 0),
+            date_type(1, 1, 1, 3, 0, 2, 0),
+            date_type(1, 1, 1, 7, 0, 6, 0),
+        ]
+    )
     assert result.equals(expected)

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -891,3 +891,43 @@ def test_multiindex():
     index = xr.cftime_range("2001-01-01", periods=100, calendar="360_day")
     mindex = pd.MultiIndex.from_arrays([index])
     assert mindex.get_loc("2001-01") == slice(0, 30)
+
+
+@requires_cftime
+@pytest.mark.parametrize('freq', ['3663S', '33T', '2H'])
+def test_floor(freq):
+    expected = pd.date_range('2000-01-02T01:03:51', periods=10, freq='1777S')
+    expected = expected.floor(freq)
+    result = xr.cftime_range('2000-01-02T01:03:51', periods=10, freq='1777S')
+    result = result.floor(freq).to_datetimeindex()
+    assert result.equals(expected)
+
+
+@requires_cftime
+@pytest.mark.parametrize('freq', ['3663S', '33T', '2H'])
+def test_ceil(freq):
+    expected = pd.date_range('2000-01-02T01:03:51', periods=10, freq='1777S')
+    expected = expected.ceil(freq)
+    result = xr.cftime_range('2000-01-02T01:03:51', periods=10, freq='1777S')
+    result = result.ceil(freq).to_datetimeindex()
+    assert result.equals(expected)
+
+
+@requires_cftime
+@pytest.mark.parametrize('freq', ['3663S', '33T', '2H'])
+def test_round(freq):
+    expected = pd.date_range('2000-01-02T01:03:51', periods=10, freq='1777S')
+    expected = expected.round(freq)
+    result = xr.cftime_range('2000-01-02T01:03:51', periods=10, freq='1777S')
+    result = result.round(freq).to_datetimeindex()
+    assert result.equals(expected)
+
+
+@requires_cftime
+@pytest.mark.parametrize('freq', ['H', '3H', '7H'])
+def test_round2(freq):
+    expected = pd.date_range('2000-01-02T01:03:51', periods=21, freq='59T')
+    expected = expected.round(freq)
+    result = xr.cftime_range('2000-01-02T01:03:51', periods=21, freq='59T')
+    result = result.round(freq).to_datetimeindex()
+    assert result.equals(expected)

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -960,3 +960,22 @@ def test_round(rounding_index, date_type):
         ]
     )
     assert result.equals(expected)
+
+
+@requires_cftime
+def test_asi8(date_type):
+    index = xr.CFTimeIndex([date_type(1970, 1, 1), date_type(1970, 1, 2)])
+    result = index.asi8
+    expected = 1000000 * 86400 * np.array([0, 1])
+    np.testing.assert_array_equal(result, expected)
+
+
+@requires_cftime
+def test_asi8_distant_date():
+    """Test that asi8 conversion is truly exact."""
+    import cftime
+    date_type = cftime.DatetimeProlepticGregorian
+    index = xr.CFTimeIndex([date_type(10731, 4, 22, 3, 25, 45, 123456)])
+    result = index.asi8
+    expected = np.array([1000000 * 86400 * 400 * 8000 + 12345 * 1000000 + 123456])
+    np.testing.assert_array_equal(result, expected)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

This is particularly useful for removing microsecond noise that can sometimes be added from decoding times via `cftime.num2date`, though also applies more generally.  The methods used here for rounding dates in the integer domain are copied from pandas.

On a somewhat more internal note, this adds an `asi8` property to `CFTimeIndex`, which encodes the dates as integer values representing microseconds since 1970-01-01; this encoding is made exact via the `exact_cftime_datetime_difference` function.  It's possible this could be useful in other contexts.

Some examples:

```
In [1]: import xarray as xr

In [2]: times = xr.cftime_range("2000", periods=5, freq="17D")

In [3]: time = xr.DataArray(times, dims=["time"], name="time")

In [4]: time.dt.floor("11D")
Out[4]:
<xarray.DataArray 'floor' (time: 5)>
array([cftime.DatetimeGregorian(1999-12-31 00:00:00),
       cftime.DatetimeGregorian(2000-01-11 00:00:00),
       cftime.DatetimeGregorian(2000-02-02 00:00:00),
       cftime.DatetimeGregorian(2000-02-13 00:00:00),
       cftime.DatetimeGregorian(2000-03-06 00:00:00)], dtype=object)
Coordinates:
  * time     (time) object 2000-01-01 00:00:00 ... 2000-03-09 00:00:00

In [5]: time.dt.ceil("11D")
Out[5]:
<xarray.DataArray 'ceil' (time: 5)>
array([cftime.DatetimeGregorian(2000-01-11 00:00:00),
       cftime.DatetimeGregorian(2000-01-22 00:00:00),
       cftime.DatetimeGregorian(2000-02-13 00:00:00),
       cftime.DatetimeGregorian(2000-02-24 00:00:00),
       cftime.DatetimeGregorian(2000-03-17 00:00:00)], dtype=object)
Coordinates:
  * time     (time) object 2000-01-01 00:00:00 ... 2000-03-09 00:00:00

In [6]: time.dt.round("11D")
Out[6]:
<xarray.DataArray 'round' (time: 5)>
array([cftime.DatetimeGregorian(1999-12-31 00:00:00),
       cftime.DatetimeGregorian(2000-01-22 00:00:00),
       cftime.DatetimeGregorian(2000-02-02 00:00:00),
       cftime.DatetimeGregorian(2000-02-24 00:00:00),
       cftime.DatetimeGregorian(2000-03-06 00:00:00)], dtype=object)
Coordinates:
  * time     (time) object 2000-01-01 00:00:00 ... 2000-03-09 00:00:00
```