### PR TITLE
install most documentation requirements using pip

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -4,23 +4,25 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
-  - bottleneck
+  - pip
   - cartopy
-  - cfgrib
-  - h5netcdf
-  - ipykernel
-  - ipython
-  - iris
-  - jupyter_client
-  - nbsphinx
-  - netcdf4
-  - numba
-  - numpy
-  - numpydoc
-  - pandas
-  - rasterio
-  - seaborn
-  - setuptools
-  - sphinx
-  - sphinx_rtd_theme
-  - zarr
+  - pip:
+    - bottleneck
+    - cfgrib
+    - h5netcdf
+    - ipykernel
+    - ipython
+    - scitools-iris
+    - jupyter_client
+    - nbsphinx
+    - netcdf4
+    - numba
+    - numpy
+    - numpydoc
+    - pandas
+    - rasterio
+    - seaborn
+    - setuptools
+    - sphinx
+    - sphinx_rtd_theme
+    - zarr

--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -6,6 +6,7 @@ dependencies:
   - python=3.8
   - pip
   - cartopy
+  - cf-units
   - pip:
     - bottleneck
     - cfgrib

--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -7,9 +7,13 @@ dependencies:
   - pip
   - cartopy
   - cf-units
+  - eccodes
+  - hdf5
   - pip:
     - bottleneck
     - cfgrib
+    - dask
+    - fsspec
     - h5netcdf
     - ipykernel
     - ipython
@@ -26,4 +30,5 @@ dependencies:
     - setuptools
     - sphinx
     - sphinx_rtd_theme
+    - toolz
     - zarr


### PR DESCRIPTION
RTD seems to have quite a lot of memory issues. In theory, they could upgrade to allow up to 2GB of RAM per project, but since `conda-forge` will probably continue to grow in the future, that would only be a short-term fix. `pip` does not have this issue (at least not as much), but we cannot solely rely on it since we also depend on packages that either don't provide wheels (`cartopy` and `cf-units`) or are not available on PyPI (`hdf5`?).

At the moment, the builds still fail, we probably need to add non-python dependencies such as `hdf5`.

 - [x] Closes #3796
