### PR TITLE
Coarsen keep attrs 3376

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -48,6 +48,11 @@ Bug fixes
 - xarray now respects the over, under and bad colors if set on a provided colormap.
   (:issue:`3590`, :pull:`3601`)
   By `johnomotani <https://github.com/johnomotani>`_.
+- :py:func:`coarsen` now respects ``xr.set_options(keep_attrs=True)``
+  to preserve attributes. :py:meth:`Dataset.coarsen` accepts a keyword
+  argument ``keep_attrs`` to change this setting. (:issue:`3376`,
+  :pull:`3801`) By `Andrew Thomas <https://github.com/amcnicho>`_.
+  
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -848,6 +848,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         boundary: str = "exact",
         side: Union[str, Mapping[Hashable, str]] = "left",
         coord_func: str = "mean",
+        keep_attrs: bool = None,
         **window_kwargs: int,
     ):
         """
@@ -870,6 +871,10 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         side : 'left' or 'right' or mapping from dimension to 'left' or 'right'
         coord_func : function (name) that is applied to the coordintes,
             or a mapping from coordinate name to function (name).
+        keep_attrs : bool, optional
+            If True, the object's attributes (`attrs`) will be copied from
+            the original object to the new one.  If False (default), the new
+            object will be returned without attributes.
 
         Returns
         -------
@@ -904,6 +909,9 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         core.rolling.DataArrayCoarsen
         core.rolling.DatasetCoarsen
         """
+        if keep_attrs is None:
+            keep_attrs = _get_keep_attrs(default=False)
+
         dim = either_dict_or_kwargs(dim, window_kwargs, "coarsen")
         return self._coarsen_cls(
             self, dim, boundary=boundary, side=side, coord_func=coord_func

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -808,7 +808,9 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
             keep_attrs = _get_keep_attrs(default=False)
 
         dim = either_dict_or_kwargs(dim, window_kwargs, "rolling")
-        return self._rolling_cls(self, dim, min_periods=min_periods, center=center, keep_attrs=keep_attrs)
+        return self._rolling_cls(
+            self, dim, min_periods=min_periods, center=center, keep_attrs=keep_attrs
+        )
 
     def rolling_exp(
         self,
@@ -922,7 +924,12 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         dim = either_dict_or_kwargs(dim, window_kwargs, "coarsen")
         return self._coarsen_cls(
-            self, dim, boundary=boundary, side=side, coord_func=coord_func, keep_attrs=keep_attrs
+            self,
+            dim,
+            boundary=boundary,
+            side=side,
+            coord_func=coord_func,
+            keep_attrs=keep_attrs,
         )
 
     def resample(

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -742,6 +742,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         dim: Mapping[Hashable, int] = None,
         min_periods: int = None,
         center: bool = False,
+        keep_attrs: bool = None,
         **window_kwargs: int,
     ):
         """
@@ -758,6 +759,10 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
             setting min_periods equal to the size of the window.
         center : boolean, default False
             Set the labels at the center of the window.
+        keep_attrs : bool, optional
+            If True, the object's attributes (`attrs`) will be copied from
+            the original object to the new one.  If False (default), the new
+            object will be returned without attributes.
         **window_kwargs : optional
             The keyword arguments form of ``dim``.
             One of dim or window_kwargs must be provided.
@@ -799,8 +804,11 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         core.rolling.DataArrayRolling
         core.rolling.DatasetRolling
         """
+        if keep_attrs is None:
+            keep_attrs = _get_keep_attrs(default=False)
+
         dim = either_dict_or_kwargs(dim, window_kwargs, "rolling")
-        return self._rolling_cls(self, dim, min_periods=min_periods, center=center)
+        return self._rolling_cls(self, dim, min_periods=min_periods, center=center, keep_attrs=keep_attrs)
 
     def rolling_exp(
         self,
@@ -914,7 +922,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         dim = either_dict_or_kwargs(dim, window_kwargs, "coarsen")
         return self._coarsen_cls(
-            self, dim, boundary=boundary, side=side, coord_func=coord_func
+            self, dim, boundary=boundary, side=side, coord_func=coord_func, keep_attrs=keep_attrs
         )
 
     def resample(

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -869,7 +869,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
             multiple of the window size. If 'trim', the excess entries are
             dropped. If 'pad', NA will be padded.
         side : 'left' or 'right' or mapping from dimension to 'left' or 'right'
-        coord_func : function (name) that is applied to the coordintes,
+        coord_func : function (name) that is applied to the coordinates,
             or a mapping from coordinate name to function (name).
         keep_attrs : bool, optional
             If True, the object's attributes (`attrs`) will be copied from

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -649,7 +649,7 @@ class DatasetCoarsen(Coarsen):
         def wrapped_func(self, **kwargs):
             from .dataset import Dataset
 
-            if self.keep_attrs == True:
+            if self.keep_attrs:
                 _attrs = self.obj.attrs
             else:
                 attrs = {}

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -192,7 +192,9 @@ class DataArrayRolling(Rolling):
         """
         if keep_attrs is None:
             keep_attrs = _get_keep_attrs(default=False)
-        super().__init__(obj, windows, min_periods=min_periods, center=center, keep_attrs=keep_attrs)
+        super().__init__(
+            obj, windows, min_periods=min_periods, center=center, keep_attrs=keep_attrs
+        )
 
         self.window_labels = self.obj[self.dim]
 
@@ -435,7 +437,9 @@ class DatasetRolling(Rolling):
         for key, da in self.obj.data_vars.items():
             # keeps rollings only for the dataset depending on slf.dim
             if self.dim in da.dims:
-                self.rollings[key] = DataArrayRolling(da, windows, min_periods, center, keep_attrs)
+                self.rollings[key] = DataArrayRolling(
+                    da, windows, min_periods, center, keep_attrs
+                )
 
     def _dataset_implementation(self, func, **kwargs):
         from .dataset import Dataset
@@ -446,7 +450,7 @@ class DatasetRolling(Rolling):
                 reduced[key] = func(self.rollings[key], **kwargs)
             else:
                 reduced[key] = self.obj[key]
-        attrs = self.obj.attrs if self.keep_attrs else {}            
+        attrs = self.obj.attrs if self.keep_attrs else {}
         return Dataset(reduced, coords=self.obj.coords, attrs=attrs)
 
     def reduce(self, func, **kwargs):
@@ -532,7 +536,15 @@ class Coarsen:
     DataArray.coarsen
     """
 
-    __slots__ = ("obj", "boundary", "coord_func", "windows", "side", "trim_excess", "keep_attrs")
+    __slots__ = (
+        "obj",
+        "boundary",
+        "coord_func",
+        "windows",
+        "side",
+        "trim_excess",
+        "keep_attrs",
+    )
     _attributes = ("windows", "side", "trim_excess")
 
     def __init__(self, obj, windows, boundary, side, coord_func, keep_attrs):

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -563,6 +563,7 @@ class Coarsen:
         self.windows = windows
         self.side = side
         self.boundary = boundary
+        self.keep_attrs = keep_attrs
 
         absent_dims = [dim for dim in windows.keys() if dim not in self.obj.dims]
         if absent_dims:
@@ -608,7 +609,7 @@ class DataArrayCoarsen(Coarsen):
             from .dataarray import DataArray
 
             reduced = self.obj.variable.coarsen(
-                self.windows, func, self.boundary, self.side, **kwargs
+                self.windows, func, self.boundary, self.side, self.keep_attrs, **kwargs
             )
             coords = {}
             for c, v in self.obj.coords.items():
@@ -648,6 +649,11 @@ class DatasetCoarsen(Coarsen):
         def wrapped_func(self, **kwargs):
             from .dataset import Dataset
 
+            if self.keep_attrs == True:
+                _attrs = self.obj.attrs
+            else:
+                attrs = {}
+
             reduced = {}
             for key, da in self.obj.data_vars.items():
                 reduced[key] = da.variable.coarsen(
@@ -666,7 +672,7 @@ class DatasetCoarsen(Coarsen):
                     )
                 else:
                     coords[c] = v.variable
-            return Dataset(reduced, coords=coords)
+            return Dataset(reduced, coords=coords, attrs=attrs)
 
         return wrapped_func
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -446,7 +446,8 @@ class DatasetRolling(Rolling):
                 reduced[key] = func(self.rollings[key], **kwargs)
             else:
                 reduced[key] = self.obj[key]
-        return Dataset(reduced, coords=self.obj.coords)
+        attrs = self.obj.attrs if self.keep_attrs else {}            
+        return Dataset(reduced, coords=self.obj.coords, attrs=attrs)
 
     def reduce(self, func, **kwargs):
         """Reduce the items in this group by applying `func` along some

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -7,6 +7,7 @@ import numpy as np
 from . import dtypes, duck_array_ops, utils
 from .dask_array_ops import dask_rolling_wrapper
 from .ops import inject_reduce_methods
+from .options import _get_keep_attrs
 from .pycompat import dask_array_type
 
 try:
@@ -42,10 +43,10 @@ class Rolling:
     DataArray.rolling
     """
 
-    __slots__ = ("obj", "window", "min_periods", "center", "dim")
-    _attributes = ("window", "min_periods", "center", "dim")
+    __slots__ = ("obj", "window", "min_periods", "center", "dim", "keep_attrs")
+    _attributes = ("window", "min_periods", "center", "dim", "keep_attrs")
 
-    def __init__(self, obj, windows, min_periods=None, center=False):
+    def __init__(self, obj, windows, min_periods=None, center=False, keep_attrs=None):
         """
         Moving window object.
 
@@ -65,6 +66,10 @@ class Rolling:
             setting min_periods equal to the size of the window.
         center : boolean, default False
             Set the labels at the center of the window.
+        keep_attrs : bool, optional
+            If True, the object's attributes (`attrs`) will be copied from
+            the original object to the new one.  If False (default), the new
+            object will be returned without attributes.
 
         Returns
         -------
@@ -88,6 +93,10 @@ class Rolling:
 
         self.center = center
         self.dim = dim
+
+        if keep_attrs is None:
+            keep_attrs = _get_keep_attrs(default=False)
+        self.keep_attrs = keep_attrs
 
     @property
     def _min_periods(self):
@@ -143,7 +152,7 @@ class Rolling:
 class DataArrayRolling(Rolling):
     __slots__ = ("window_labels",)
 
-    def __init__(self, obj, windows, min_periods=None, center=False):
+    def __init__(self, obj, windows, min_periods=None, center=False, keep_attrs=None):
         """
         Moving window object for DataArray.
         You should use DataArray.rolling() method to construct this object
@@ -165,6 +174,10 @@ class DataArrayRolling(Rolling):
             setting min_periods equal to the size of the window.
         center : boolean, default False
             Set the labels at the center of the window.
+        keep_attrs : bool, optional
+            If True, the object's attributes (`attrs`) will be copied from
+            the original object to the new one.  If False (default), the new
+            object will be returned without attributes.
 
         Returns
         -------
@@ -177,7 +190,9 @@ class DataArrayRolling(Rolling):
         Dataset.rolling
         Dataset.groupby
         """
-        super().__init__(obj, windows, min_periods=min_periods, center=center)
+        if keep_attrs is None:
+            keep_attrs = _get_keep_attrs(default=False)
+        super().__init__(obj, windows, min_periods=min_periods, center=center, keep_attrs=keep_attrs)
 
         self.window_labels = self.obj[self.dim]
 
@@ -374,7 +389,7 @@ class DataArrayRolling(Rolling):
 class DatasetRolling(Rolling):
     __slots__ = ("rollings",)
 
-    def __init__(self, obj, windows, min_periods=None, center=False):
+    def __init__(self, obj, windows, min_periods=None, center=False, keep_attrs=None):
         """
         Moving window object for Dataset.
         You should use Dataset.rolling() method to construct this object
@@ -396,6 +411,10 @@ class DatasetRolling(Rolling):
             setting min_periods equal to the size of the window.
         center : boolean, default False
             Set the labels at the center of the window.
+        keep_attrs : bool, optional
+            If True, the object's attributes (`attrs`) will be copied from
+            the original object to the new one.  If False (default), the new
+            object will be returned without attributes.
 
         Returns
         -------
@@ -408,7 +427,7 @@ class DatasetRolling(Rolling):
         Dataset.groupby
         DataArray.groupby
         """
-        super().__init__(obj, windows, min_periods, center)
+        super().__init__(obj, windows, min_periods, center, keep_attrs)
         if self.dim not in self.obj.dims:
             raise KeyError(self.dim)
         # Keep each Rolling object as a dictionary
@@ -416,7 +435,7 @@ class DatasetRolling(Rolling):
         for key, da in self.obj.data_vars.items():
             # keeps rollings only for the dataset depending on slf.dim
             if self.dim in da.dims:
-                self.rollings[key] = DataArrayRolling(da, windows, min_periods, center)
+                self.rollings[key] = DataArrayRolling(da, windows, min_periods, center, keep_attrs)
 
     def _dataset_implementation(self, func, **kwargs):
         from .dataset import Dataset
@@ -466,7 +485,7 @@ class DatasetRolling(Rolling):
             **kwargs,
         )
 
-    def construct(self, window_dim, stride=1, fill_value=dtypes.NA):
+    def construct(self, window_dim, stride=1, fill_value=dtypes.NA, keep_attrs=None):
         """
         Convert this rolling object to xr.Dataset,
         where the window dimension is stacked as a new dimension
@@ -486,6 +505,9 @@ class DatasetRolling(Rolling):
         """
 
         from .dataset import Dataset
+
+        if keep_attrs is None:
+            keep_attrs = _get_keep_attrs(default=True)
 
         dataset = {}
         for key, da in self.obj.data_vars.items():
@@ -509,10 +531,10 @@ class Coarsen:
     DataArray.coarsen
     """
 
-    __slots__ = ("obj", "boundary", "coord_func", "windows", "side", "trim_excess")
+    __slots__ = ("obj", "boundary", "coord_func", "windows", "side", "trim_excess", "keep_attrs")
     _attributes = ("windows", "side", "trim_excess")
 
-    def __init__(self, obj, windows, boundary, side, coord_func):
+    def __init__(self, obj, windows, boundary, side, coord_func, keep_attrs):
         """
         Moving window object.
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -609,7 +609,7 @@ class DataArrayCoarsen(Coarsen):
             from .dataarray import DataArray
 
             reduced = self.obj.variable.coarsen(
-                self.windows, func, self.boundary, self.side, self.keep_attrs, **kwargs
+                self.windows, func, self.boundary, self.side, **kwargs
             )
             coords = {}
             for c, v in self.obj.coords.items():
@@ -650,7 +650,7 @@ class DatasetCoarsen(Coarsen):
             from .dataset import Dataset
 
             if self.keep_attrs:
-                _attrs = self.obj.attrs
+                attrs = self.obj.attrs
             else:
                 attrs = {}
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1950,8 +1950,6 @@ class Variable(
                 shape.append(variable.shape[i])
 
         keep_attrs = _get_keep_attrs(default=False)
-        if keep_attrs is None:
-            keep_attrs = _get_keep_attrs(default=False)
         variable.attrs = variable._attrs if keep_attrs else {}
 
         return variable.data.reshape(shape), tuple(axes)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1949,6 +1949,11 @@ class Variable(
             else:
                 shape.append(variable.shape[i])
 
+        keep_attrs = _get_keep_attrs(default=False)
+        if keep_attrs is None:
+            keep_attrs = _get_keep_attrs(default=False)
+        variable.attrs = variable._attrs if keep_attrs else {}
+
         return variable.data.reshape(shape), tuple(axes)
 
     @property

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5664,7 +5664,7 @@ def test_coarsen_keep_attrs():
     ds = Dataset(
         data_vars={"var1": ("coord", var1), "var2": ("coord", var2)},
         coords={"coord": coords},
-        attrs={'units':'test', 'long_name':'testing'}
+        attrs=_attrs
     )
 
     # Test dropped attrs
@@ -5675,13 +5675,36 @@ def test_coarsen_keep_attrs():
     dat = ds.coarsen(coord=5, keep_attrs=True).mean()
     assert dat.attrs == _attrs
 
-    # # Test kept attrs using wrapper function keyword
-    # dat = ds.coarsen(coord=5).mean(keep_attrs=True)
-    # assert dat.attrs == _attrs
-
     # Test kept attrs using global option
     with set_options(keep_attrs=True):
         dat = ds.coarsen(coord=5).mean()
+    assert dat.attrs == _attrs
+
+
+def test_rolling_keep_attrs():
+    _attrs = {"units": "test", "long_name": "testing"}
+
+    var1 = np.linspace(10, 15, 100)
+    var2 = np.linspace(5, 10, 100)
+    coords = np.linspace(1, 10, 100)
+
+    ds = Dataset(
+        data_vars={"var1": ("coord", var1), "var2": ("coord", var2)},
+        coords={"coord": coords},
+        attrs=_attrs
+    )
+
+    # Test dropped attrs
+    dat = ds.rolling(dim={'coord':5}, min_periods=None, center=False).mean()
+    assert dat.attrs == {}
+
+    # Test kept attrs using dataset keyword
+    dat = ds.rolling(dim={'coord':5}, min_periods=None, center=False, keep_attrs=True).mean()
+    assert dat.attrs == _attrs
+
+    # Test kept attrs using global option
+    with set_options(keep_attrs=True):
+            dat = ds.rolling(dim={'coord':5}, min_periods=None, center=False).mean()
     assert dat.attrs == _attrs
 
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5654,7 +5654,7 @@ def test_coarsen_coords_cftime():
     np.testing.assert_array_equal(actual.time, expected_times)
 
 
-def test_coarsen_keep_attrs(self):
+def test_coarsen_keep_attrs():
     _attrs = {"units": "test", "long_name": "testing"}
 
     var1 = np.linspace(10, 15, 100)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5673,7 +5673,7 @@ def test_coarsen_keep_attrs():
     assert dat.attrs == {}
 
     # Test kept attrs
-    dat = ds.coarsen(coord=5, keep_attrs=True).mean()
+    dat = ds.coarsen(coord=5).mean(keep_attrs=True)
     assert dat.attrs == _attrs
 
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5674,7 +5674,7 @@ def test_coarsen_keep_attrs():
     ds = Dataset(
         data_vars={"var1": ("coord", var1), "var2": ("coord", var2)},
         coords={"coord": coords},
-        attrs=_attrs
+        attrs=_attrs,
     )
 
     # Test dropped attrs
@@ -5701,20 +5701,22 @@ def test_rolling_keep_attrs():
     ds = Dataset(
         data_vars={"var1": ("coord", var1), "var2": ("coord", var2)},
         coords={"coord": coords},
-        attrs=_attrs
+        attrs=_attrs,
     )
 
     # Test dropped attrs
-    dat = ds.rolling(dim={'coord':5}, min_periods=None, center=False).mean()
+    dat = ds.rolling(dim={"coord": 5}, min_periods=None, center=False).mean()
     assert dat.attrs == {}
 
     # Test kept attrs using dataset keyword
-    dat = ds.rolling(dim={'coord':5}, min_periods=None, center=False, keep_attrs=True).mean()
+    dat = ds.rolling(
+        dim={"coord": 5}, min_periods=None, center=False, keep_attrs=True
+    ).mean()
     assert dat.attrs == _attrs
 
     # Test kept attrs using global option
     with set_options(keep_attrs=True):
-            dat = ds.rolling(dim={'coord':5}, min_periods=None, center=False).mean()
+        dat = ds.rolling(dim={"coord": 5}, min_periods=None, center=False).mean()
     assert dat.attrs == _attrs
 
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5664,9 +5664,8 @@ def test_coarsen_keep_attrs():
     ds = Dataset(
         data_vars={"var1": ("coord", var1), "var2": ("coord", var2)},
         coords={"coord": coords},
+        attrs={'units':'test', 'long_name':'testing'}
     )
-    ds.attrs["units"] = "test"
-    ds.attrs["long_name"] = "testing"
 
     # Test dropped attrs
     dat = ds.coarsen(coord=5).mean()

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5654,6 +5654,29 @@ def test_coarsen_coords_cftime():
     np.testing.assert_array_equal(actual.time, expected_times)
 
 
+def test_coarsen_keep_attrs(self):
+    _attrs = {"units": "test", "long_name": "testing"}
+    
+    var1 = np.linspace(10, 15, 100)
+    var2 = np.linspace(5, 10, 100)
+    coords = np.linspace(1, 10, 100)
+    
+    ds = Dataset(
+        data_vars={"var1": ("coord", var1), "var2": ("coord", var2)},
+        coords={"coord": coords},
+    )
+    ds.attrs["units"] = "test"
+    ds.attrs["long_name"] = "testing"
+    
+    # Test dropped attrs
+    dat = ds.coarsen(coord=5).mean()
+    assert dat.attrs == {}
+    
+    # Test kept attrs
+    dat = ds.coarsen(coord=5, keep_attrs=True).mean()
+    assert dat.attrs == _attrs
+
+
 def test_rolling_properties(ds):
     # catching invalid args
     with pytest.raises(ValueError, match="exactly one dim/window should"):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5656,22 +5656,22 @@ def test_coarsen_coords_cftime():
 
 def test_coarsen_keep_attrs(self):
     _attrs = {"units": "test", "long_name": "testing"}
-    
+
     var1 = np.linspace(10, 15, 100)
     var2 = np.linspace(5, 10, 100)
     coords = np.linspace(1, 10, 100)
-    
+
     ds = Dataset(
         data_vars={"var1": ("coord", var1), "var2": ("coord", var2)},
         coords={"coord": coords},
     )
     ds.attrs["units"] = "test"
     ds.attrs["long_name"] = "testing"
-    
+
     # Test dropped attrs
     dat = ds.coarsen(coord=5).mean()
     assert dat.attrs == {}
-    
+
     # Test kept attrs
     dat = ds.coarsen(coord=5, keep_attrs=True).mean()
     assert dat.attrs == _attrs

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5671,8 +5671,17 @@ def test_coarsen_keep_attrs():
     dat = ds.coarsen(coord=5).mean()
     assert dat.attrs == {}
 
-    # Test kept attrs
-    dat = ds.coarsen(coord=5).mean(keep_attrs=True)
+    # Test kept attrs using dataset keyword
+    dat = ds.coarsen(coord=5, keep_attrs=True).mean()
+    assert dat.attrs == _attrs
+
+    # # Test kept attrs using wrapper function keyword
+    # dat = ds.coarsen(coord=5).mean(keep_attrs=True)
+    # assert dat.attrs == _attrs
+
+    # Test kept attrs using global option
+    with set_options(keep_attrs=True):
+        dat = ds.coarsen(coord=5).mean()
     assert dat.attrs == _attrs
 
 

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -9,7 +9,7 @@ import pytest
 import pytz
 
 from xarray import Coordinate, Dataset, IndexVariable, Variable, set_options
-from xarray.core import dtypes, indexing
+from xarray.core import dtypes, indexing, duck_array_ops
 from xarray.core.common import full_like, ones_like, zeros_like
 from xarray.core.indexing import (
     BasicIndexer,
@@ -1878,6 +1878,27 @@ class TestVariable(VariableSubclassobjects):
         actual = v.coarsen(dict(x=2, y=2), func="sum", boundary="exact", skipna=True)
         expected = self.cls(("x", "y"), [[10, 18], [42, 35]])
         assert_equal(actual, expected)
+
+
+    # perhaps @pytest.mark.parametrize("operation", [f for f in duck_array_ops])
+    def test_coarsen_keep_attrs(self, operation="mean"):
+        _attrs = {"units": "test", "long_name": "testing"}
+
+        coord = Variable(["coord"], np.linspace(1, 10, 100), attrs=_attrs)
+
+        test_func = getattr(duck_array_ops, operation, None)
+
+        # Test dropped attrs
+        with set_options(keep_attrs=False):
+            new = coord.coarsen(windows={"coord": 1}, func=test_func, 
+                                boundary="exact", side="left")
+        assert new.attrs == {}
+
+        # Test kept attrs
+        with set_options(keep_attrs=True):
+            new = coord.coarsen(windows={"coord": 1}, func=test_func, 
+                                boundary="exact", side="left")
+        assert new.attrs == _attrs
 
 
 @requires_dask

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -9,7 +9,7 @@ import pytest
 import pytz
 
 from xarray import Coordinate, Dataset, IndexVariable, Variable, set_options
-from xarray.core import dtypes, indexing, duck_array_ops
+from xarray.core import dtypes, duck_array_ops, indexing
 from xarray.core.common import full_like, ones_like, zeros_like
 from xarray.core.indexing import (
     BasicIndexer,
@@ -1879,7 +1879,6 @@ class TestVariable(VariableSubclassobjects):
         expected = self.cls(("x", "y"), [[10, 18], [42, 35]])
         assert_equal(actual, expected)
 
-
     # perhaps @pytest.mark.parametrize("operation", [f for f in duck_array_ops])
     def test_coarsen_keep_attrs(self, operation="mean"):
         _attrs = {"units": "test", "long_name": "testing"}
@@ -1890,14 +1889,16 @@ class TestVariable(VariableSubclassobjects):
 
         # Test dropped attrs
         with set_options(keep_attrs=False):
-            new = coord.coarsen(windows={"coord": 1}, func=test_func, 
-                                boundary="exact", side="left")
+            new = coord.coarsen(
+                windows={"coord": 1}, func=test_func, boundary="exact", side="left"
+            )
         assert new.attrs == {}
 
         # Test kept attrs
         with set_options(keep_attrs=True):
-            new = coord.coarsen(windows={"coord": 1}, func=test_func, 
-                                boundary="exact", side="left")
+            new = coord.coarsen(
+                windows={"coord": 1}, func=test_func, boundary="exact", side="left"
+            )
         assert new.attrs == _attrs
 
 

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1883,23 +1883,20 @@ class TestVariable(VariableSubclassobjects):
     def test_coarsen_keep_attrs(self, operation="mean"):
         _attrs = {"units": "test", "long_name": "testing"}
 
-        coord = Variable(["coord"], np.linspace(1, 10, 100), attrs=_attrs)
-
         test_func = getattr(duck_array_ops, operation, None)
 
         # Test dropped attrs
         with set_options(keep_attrs=False):
-            new = coord.coarsen(
-                windows={"coord": 1}, func=test_func, boundary="exact", side="left"
-            )
+            new = (Variable(["coord"], np.linspace(1, 10, 100), attrs=_attrs)
+                   .coarsen(windows={"coord": 1}, func=test_func, boundary="exact", side="left"))
         assert new.attrs == {}
 
         # Test kept attrs
         with set_options(keep_attrs=True):
-            new = coord.coarsen(
-                windows={"coord": 1}, func=test_func, boundary="exact", side="left"
-            )
+            new = (Variable(["coord"], np.linspace(1, 10, 100), attrs=_attrs)
+                   .coarsen(windows={"coord": 1}, func=test_func, boundary="exact", side="left"))
         assert new.attrs == _attrs
+
 
 
 @requires_dask

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1887,16 +1887,17 @@ class TestVariable(VariableSubclassobjects):
 
         # Test dropped attrs
         with set_options(keep_attrs=False):
-            new = (Variable(["coord"], np.linspace(1, 10, 100), attrs=_attrs)
-                   .coarsen(windows={"coord": 1}, func=test_func, boundary="exact", side="left"))
+            new = Variable(["coord"], np.linspace(1, 10, 100), attrs=_attrs).coarsen(
+                windows={"coord": 1}, func=test_func, boundary="exact", side="left"
+            )
         assert new.attrs == {}
 
         # Test kept attrs
         with set_options(keep_attrs=True):
-            new = (Variable(["coord"], np.linspace(1, 10, 100), attrs=_attrs)
-                   .coarsen(windows={"coord": 1}, func=test_func, boundary="exact", side="left"))
+            new = Variable(["coord"], np.linspace(1, 10, 100), attrs=_attrs).coarsen(
+                windows={"coord": 1}, func=test_func, boundary="exact", side="left"
+            )
         assert new.attrs == _attrs
-
 
 
 @requires_dask


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #3376
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

I also noticed missing attributes when attempting certain operations, so I have created this pull request to attempt a fix. I modified code in `DataWithCoords.coarsen()` to try applying the same logic used for other methods since #2482 was successfully merged.

I added two new tests that adapt the bug reported by @jejjohnson. I believe they should pass when this is fixed. One uses `Dataset.coarsen()` and the other uses `Variable.coarsen`. Both tests currently fail.

xarray/tests/test_dataset.py::TestDataset::test_coarsen_keep_attrs 
- fails because my attempted fix does not retain the attributes.

xarray/tests/test_variable.py::TestVariable::test_coarsen_keep_attrs
- also fails, but unexpectedly this seems to be because the attributes are _not_ removed by default, or even when explicitly setting the global option to False. 