### PR TITLE
Raise on multiple string args to groupby

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,7 +30,11 @@ New Features
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - implement pint support. (:issue:`3594`, :pull:`3706`)
   By `Justus Magin <https://github.com/keewis>`_.
-
+- :py:meth:`Dataset.groupby` and :py:meth:`DataArray.groupby` now raise a 
+  `TypeError` on multiple string arguments. Receiving multiple string arguments
+  often means a user is attempting to pass multiple dimensions to group over
+  and should instead pass a list.
+  By `Maximilian Roos <https://github.com/max-sixty>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -660,6 +660,17 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         core.groupby.DataArrayGroupBy
         core.groupby.DatasetGroupBy
         """
+        # While we don't generally check the type of every arg, passing
+        # multiple dimensions as multiple arguments is common enough, and the
+        # consequences hidden enough (strings evaluate as true) to warrant
+        # checking here.
+        # A future version could make squeeze kwarg only, but would face
+        # backward-compat issues.
+        if not isinstance(squeeze, bool):
+            raise TypeError(
+                f"`squeeze` must be True or False, but {squeeze} was supplied"
+            )
+
         return self._groupby_cls(
             self, group, squeeze=squeeze, restore_coord_dims=restore_coord_dims
         )

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -483,6 +483,11 @@ def test_groupby_reduce_dimension_error(array):
     assert_allclose(array.mean(["x", "z"]), grouped.reduce(np.mean, ["x", "z"]))
 
 
+def test_groupby_multiple_string_args(array):
+    with pytest.raises(TypeError):
+        array.groupby("x", "y")
+
+
 def test_groupby_bins_timeseries():
     ds = xr.Dataset()
     ds["time"] = xr.DataArray(


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

From the comment:

While we don't generally check the type of every arg, passing
multiple dimensions as multiple arguments is common enough, and the
consequences hidden enough (strings evaluate as true) to warrant
checking here.
A future version could make squeeze kwarg only, but would face
backward-compat issues.