### PR TITLE
Remove reference to tensors in description of N-dimensional arrays

### DIFF
--- a/doc/why-xarray.rst
+++ b/doc/why-xarray.rst
@@ -8,8 +8,7 @@ and less error-prone developer experience.
 What labels enable
 ------------------
 
-Multi-dimensional (a.k.a. N-dimensional, ND) arrays (sometimes called
-"tensors") are an essential part of computational science.
+Multi-dimensional (a.k.a. N-dimensional, ND) arrays are an essential part of computational science.
 They are encountered in a wide range of fields, including physics, astronomy,
 geoscience, bioinformatics, engineering, finance, and deep learning.
 In Python, NumPy_ provides the fundamental data structure and API for


### PR DESCRIPTION
Don't mean to be pedantic, but although tensors are often represented by N-dimensional arrays, not all N-dimensional arrays are tensors. Tensors conform to a set of tests on coordinate system rotations that, in general, N-dimensional arrays will not pass. I suggest that we remove the reference to tensors in this description. Thank you for Xarray!
