### PR TITLE
Fix recombination in groupby when changing size along the grouped dimension

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,6 +35,10 @@ New Features
 Bug fixes
 ~~~~~~~~~
 
+- Fix recombination of groups in :py:meth:`Dataset.groupby` and
+  :py:meth:`DataArray.groupby` when performing an operation that changes the
+  size of the groups along the grouped dimension. By `Eric Jansen
+  <https://github.com/ej81>`_.
 - Fix :py:meth:`Dataset.swap_dims` and :py:meth:`DataArray.swap_dims` producing
   index with name reflecting the previous dimension name instead of the new one
   (:issue:`3748`, :pull:`3752`). By `Joseph K Aicher

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -715,7 +715,7 @@ class GroupBy(SupportsArithmetic):
 def _maybe_reorder(xarray_obj, dim, positions):
     order = _inverse_permutation_indices(positions)
 
-    if order is None:
+    if order is None or len(order) != xarray_obj.sizes[dim]:
         return xarray_obj
     else:
         return xarray_obj[{dim: order}]
@@ -833,7 +833,7 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
         if isinstance(combined, type(self._obj)):
             # only restore dimension order for arrays
             combined = self._restore_dim_order(combined)
-        if coord is not None:
+        if coord is not None and applied_example.sizes.get(dim, 0) == 0:
             if shortcut:
                 coord_var = as_variable(coord)
                 combined._coords[coord.name] = coord_var
@@ -949,7 +949,7 @@ class DatasetGroupBy(GroupBy, ImplementsDatasetReduce):
         coord, dim, positions = self._infer_concat_args(applied_example)
         combined = concat(applied, dim)
         combined = _maybe_reorder(combined, dim, positions)
-        if coord is not None:
+        if coord is not None and applied_example.sizes.get(dim, 0) == 0:
             combined[coord.name] = coord
         combined = self._maybe_restore_empty_groups(combined)
         combined = self._maybe_unstack(combined)

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -838,7 +838,8 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
         if isinstance(combined, type(self._obj)):
             # only restore dimension order for arrays
             combined = self._restore_dim_order(combined)
-        if coord is not None and applied_example.sizes.get(dim, 0) == 0:
+        # assign coord when the applied function does not return that coord
+        if coord is not None and dim not in applied_example.dims:
             if shortcut:
                 coord_var = as_variable(coord)
                 combined._coords[coord.name] = coord_var
@@ -954,7 +955,8 @@ class DatasetGroupBy(GroupBy, ImplementsDatasetReduce):
         coord, dim, positions = self._infer_concat_args(applied_example)
         combined = concat(applied, dim)
         combined = _maybe_reorder(combined, dim, positions)
-        if coord is not None and applied_example.sizes.get(dim, 0) == 0:
+        # assign coord when the applied function does not return that coord
+        if coord is not None and dim not in applied_example.dims:
             combined[coord.name] = coord
         combined = self._maybe_restore_empty_groups(combined)
         combined = self._maybe_unstack(combined)

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -107,23 +107,27 @@ def test_groupby_input_mutation():
     assert_identical(array, array_copy)  # should not modify inputs
 
 
-def test_da_groupby_map_shrink_groups():
-    array = xr.DataArray([1, 2, 3, 4, 5, 6], [("x", [1, 1, 1, 2, 2, 2])])
-    expected = array.isel(x=[0, 1, 3, 4])
-    actual = array.groupby("x").map(lambda f: f.isel(x=[0, 1]))
+@pytest.mark.parametrize(
+    "obj",
+    [
+        xr.DataArray([1, 2, 3, 4, 5, 6], [("x", [1, 1, 1, 2, 2, 2])]),
+        xr.Dataset({"foo": ("x", [1, 2, 3, 4, 5, 6])}, {"x": [1, 1, 1, 2, 2, 2]}),
+    ],
+)
+def test_groupby_map_shrink_groups(obj):
+    expected = obj.isel(x=[0, 1, 3, 4])
+    actual = obj.groupby("x").map(lambda f: f.isel(x=[0, 1]))
     assert_identical(expected, actual)
 
 
-def test_ds_groupby_map_shrink_groups():
-    dataset = xr.Dataset({"foo": ("x", [1, 2, 3, 4, 5, 6])}, {"x": [1, 1, 1, 2, 2, 2]})
-    expected = dataset.isel(x=[0, 1, 3, 4])
-    actual = dataset.groupby("x").map(lambda f: f.isel(x=[0, 1]))
-    assert_identical(expected, actual)
-
-
-def test_da_groupby_map_change_group_size():
-    array = xr.DataArray([1, 2, 3], [("x", [1, 2, 2])])
-
+@pytest.mark.parametrize(
+    "obj",
+    [
+        xr.DataArray([1, 2, 3], [("x", [1, 2, 2])]),
+        xr.Dataset({"foo": ("x", [1, 2, 3])}, {"x": [1, 2, 2]}),
+    ],
+)
+def test_ds_groupby_map_change_group_size(obj):
     def func(group):
         if group.sizes["x"] == 1:
             result = group.isel(x=[0, 0])
@@ -131,23 +135,8 @@ def test_da_groupby_map_change_group_size():
             result = group.isel(x=[0])
         return result
 
-    expected = array.isel(x=[0, 0, 1])
-    actual = array.groupby("x").map(func)
-    assert_identical(expected, actual)
-
-
-def test_ds_groupby_map_change_group_size():
-    dataset = xr.Dataset({"foo": ("x", [1, 2, 3])}, {"x": [1, 2, 2]})
-
-    def func(group):
-        if group.sizes["x"] == 1:
-            result = group.isel(x=[0, 0])
-        else:
-            result = group.isel(x=[0])
-        return result
-
-    expected = dataset.isel(x=[0, 0, 1])
-    actual = dataset.groupby("x").map(func)
+    expected = obj.isel(x=[0, 0, 1])
+    actual = obj.groupby("x").map(func)
     assert_identical(expected, actual)
 
 

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -127,7 +127,7 @@ def test_groupby_map_shrink_groups(obj):
         xr.Dataset({"foo": ("x", [1, 2, 3])}, {"x": [1, 2, 2]}),
     ],
 )
-def test_ds_groupby_map_change_group_size(obj):
+def test_groupby_map_change_group_size(obj):
     def func(group):
         if group.sizes["x"] == 1:
             result = group.isel(x=[0, 0])


### PR DESCRIPTION
When a a Dataset or DataArray is recombined after a groupby operation, xarray tries to restore the original coordinate. This causes problems if the group operation changes the size of the groups along the grouped dimension (e.g. some filtering operation that removes entries).

Restoring the original coordinate appears to be necessary only if it was squeezed from the groups, otherwise it is already restored by concatenation of the groups. This fix: 
1. avoids reordering if the size of the dimension has changed;
2. avoids restoring a coordinate that has not been squeezed out.

 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
