### PR TITLE
xfail tests due to #3751

### DIFF
--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -450,6 +450,7 @@ def test_sel_date_scalar(da, date_type, index):
     assert_identical(result, expected)
 
 
+@pytest.mark.xfail(reason="https://github.com/pydata/xarray/issues/3751")
 @requires_cftime
 @pytest.mark.parametrize(
     "sel_kwargs",
@@ -501,7 +502,12 @@ def test_sel_date_scalar_backfill(da, date_type, index, sel_kwargs):
     [
         {"method": "pad", "tolerance": timedelta(days=20)},
         {"method": "backfill", "tolerance": timedelta(days=20)},
-        {"method": "nearest", "tolerance": timedelta(days=20)},
+        pytest.param(
+            {"method": "nearest", "tolerance": timedelta(days=20)},
+            marks=pytest.mark.xfail(
+                reason="https://github.com/pydata/xarray/issues/3751"
+            ),
+        ),
     ],
 )
 def test_sel_date_scalar_tolerance_raises(da, date_type, sel_kwargs):
@@ -509,6 +515,7 @@ def test_sel_date_scalar_tolerance_raises(da, date_type, sel_kwargs):
         da.sel(time=date_type(1, 5, 1), **sel_kwargs)
 
 
+@pytest.mark.xfail(reason="https://github.com/pydata/xarray/issues/3751")
 @requires_cftime
 @pytest.mark.parametrize(
     "sel_kwargs",
@@ -556,7 +563,12 @@ def test_sel_date_list_backfill(da, date_type, index, sel_kwargs):
     [
         {"method": "pad", "tolerance": timedelta(days=20)},
         {"method": "backfill", "tolerance": timedelta(days=20)},
-        {"method": "nearest", "tolerance": timedelta(days=20)},
+        pytest.param(
+            {"method": "nearest", "tolerance": timedelta(days=20)},
+            marks=pytest.mark.xfail(
+                reason="https://github.com/pydata/xarray/issues/3751"
+            ),
+        ),
     ],
 )
 def test_sel_date_list_tolerance_raises(da, date_type, sel_kwargs):
@@ -591,6 +603,7 @@ def range_args(date_type):
     ]
 
 
+@pytest.mark.xfail(reason="https://github.com/pydata/xarray/issues/3751")
 @requires_cftime
 def test_indexing_in_series_getitem(series, index, scalar_args, range_args):
     for arg in scalar_args:

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -556,6 +556,7 @@ def test_datetime_single_string():
     assert_allclose(actual.drop_vars("time"), expected)
 
 
+@pytest.mark.xfail(reason="https://github.com/pydata/xarray/issues/3751")
 @requires_cftime
 @requires_scipy
 def test_cftime():
@@ -582,6 +583,7 @@ def test_cftime_type_error():
         da.interp(time=times_new)
 
 
+@pytest.mark.xfail(reason="https://github.com/pydata/xarray/issues/3751")
 @requires_cftime
 @requires_scipy
 def test_cftime_list_of_strings():
@@ -603,6 +605,7 @@ def test_cftime_list_of_strings():
     assert_allclose(actual, expected)
 
 
+@pytest.mark.xfail(reason="https://github.com/pydata/xarray/issues/3751")
 @requires_cftime
 @requires_scipy
 def test_cftime_single_string():
@@ -664,6 +667,7 @@ def test_datetime_interp_noerror():
     a.interp(x=xi, time=xi.time)  # should not raise an error
 
 
+@pytest.mark.xfail(reason="https://github.com/pydata/xarray/issues/3751")
 @requires_cftime
 def test_3641():
     times = xr.cftime_range("0001", periods=3, freq="500Y")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

@max-sixty @shoyer -- I agree we've let these linger far too long.  This should hopefully get things back to being green.

 - [x] Passes `isort -rc . && black . && mypy . && flake8`
