### PR TITLE
Turn on html repr by default

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -42,6 +42,7 @@ New Features
 - The new ``Dataset._repr_html_`` and ``DataArray._repr_html_`` (introduced
   in 0.14.1) is now on by default. To disable, use
   ``xarray.set_options(display_style="text")``.
+  By `Julia Signell <https://github.com/jsignell>`_.
 
 
 Bug fixes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -39,6 +39,10 @@ New Features
   often means a user is attempting to pass multiple dimensions to group over
   and should instead pass a list.
   By `Maximilian Roos <https://github.com/max-sixty>`_
+- The new ``Dataset._repr_html_`` and ``DataArray._repr_html_`` (introduced
+  in 0.14.1) is now on by default. To disable, use
+  ``xarray.set_options(display_style="text")``.
+
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -20,7 +20,7 @@ OPTIONS = {
     CMAP_SEQUENTIAL: "viridis",
     CMAP_DIVERGENT: "RdBu_r",
     KEEP_ATTRS: "default",
-    DISPLAY_STYLE: "text",
+    DISPLAY_STYLE: "html",
 }
 
 _JOIN_OPTIONS = frozenset(["inner", "outer", "left", "right", "exact"])

--- a/xarray/tests/test_options.py
+++ b/xarray/tests/test_options.py
@@ -68,12 +68,12 @@ def test_nested_options():
 
 
 def test_display_style():
-    original = "text"
+    original = "html"
     assert OPTIONS["display_style"] == original
     with pytest.raises(ValueError):
         xarray.set_options(display_style="invalid_str")
-    with xarray.set_options(display_style="html"):
-        assert OPTIONS["display_style"] == "html"
+    with xarray.set_options(display_style="text"):
+        assert OPTIONS["display_style"] == "text"
     assert OPTIONS["display_style"] == original
 
 
@@ -177,10 +177,11 @@ class TestAttrRetention:
 
     def test_display_style_text(self):
         ds = create_test_dataset_attrs()
-        text = ds._repr_html_()
-        assert text.startswith("<pre>")
-        assert "&#x27;nested&#x27;" in text
-        assert "&lt;xarray.Dataset&gt;" in text
+        with xarray.set_options(display_style="text"):
+            text = ds._repr_html_()
+            assert text.startswith("<pre>")
+            assert "&#x27;nested&#x27;" in text
+            assert "&lt;xarray.Dataset&gt;" in text
 
     def test_display_style_html(self):
         ds = create_test_dataset_attrs()
@@ -191,9 +192,10 @@ class TestAttrRetention:
 
     def test_display_dataarray_style_text(self):
         da = create_test_dataarray_attrs()
-        text = da._repr_html_()
-        assert text.startswith("<pre>")
-        assert "&lt;xarray.DataArray &#x27;var1&#x27;" in text
+        with xarray.set_options(display_style="text"):
+            text = da._repr_html_()
+            assert text.startswith("<pre>")
+            assert "&lt;xarray.DataArray &#x27;var1&#x27;" in text
 
     def test_display_dataarray_style_html(self):
         da = create_test_dataarray_attrs()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #3806 
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
