### PR TITLE
map_blocks: Allow passing dask-backed objects in args

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -70,6 +70,8 @@ New Features
 - :py:meth:`map_blocks` now accepts a ``template`` kwarg. This allows use cases
   where the result of a computation could not be inferred automatically.
   By `Deepak Cherian <https://github.com/dcherian>`_
+- :py:meth:`map_blocks` can now handle dask-backed xarray objects in ``args``. (:pull:`3818`)
+  By `Deepak Cherian <https://github.com/dcherian>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3270,9 +3270,8 @@ class DataArray(AbstractArray, DataWithCoords):
 
             This function cannot add a new chunked dimension.
         args: Sequence
-            Passed verbatim to func after unpacking, after the sliced DataArray. xarray
-            objects, if any, will not be split by chunks. Passing dask collections is
-            not allowed.
+            Passed verbatim to func after unpacking, after the sliced obj.
+            Any xarray objects will also be split by blocks and then passed on.
         kwargs: Mapping
             Passed verbatim to func after unpacking. xarray objects, if any, will not be
             split by chunks. Passing dask collections is not allowed.

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3262,44 +3262,93 @@ class DataArray(AbstractArray, DataWithCoords):
         ----------
         func: callable
             User-provided function that accepts a DataArray as its first
-            parameter. The function will receive a subset, i.e. one block, of this DataArray
-            (see below), corresponding to one chunk along each chunked dimension. ``func`` will be
-            executed as ``func(block_subset, *args, **kwargs)``.
+            parameter. The function will receive a subset or 'block' of this DataArray (see below),
+            corresponding to one chunk along each chunked dimension. ``func`` will be
+            executed as ``func(subset_dataarray, *subset_args, **kwargs)``.
 
             This function must return either a single DataArray or a single Dataset.
 
             This function cannot add a new chunked dimension.
+
+        obj: DataArray, Dataset
+            Passed to the function as its first argument, one block at a time.
         args: Sequence
-            Passed verbatim to func after unpacking, after the sliced obj.
-            Any xarray objects will also be split by blocks and then passed on.
+            Passed to func after unpacking and subsetting any xarray objects by blocks.
+            xarray objects in args must be aligned with obj, otherwise an error is raised.
         kwargs: Mapping
             Passed verbatim to func after unpacking. xarray objects, if any, will not be
-            split by chunks. Passing dask collections is not allowed.
+            subset to blocks. Passing dask collections in kwargs is not allowed.
         template: (optional) DataArray, Dataset
             xarray object representing the final result after compute is called. If not provided,
-            the function will be first run on mocked-up data, that looks like 'obj' but
+            the function will be first run on mocked-up data, that looks like ``obj`` but
             has sizes 0, to determine properties of the returned object such as dtype,
-            variable names, new dimensions and new indexes (if any).
-            'template' must be provided if the function changes the size of existing dimensions.
+            variable names, attributes, new dimensions and new indexes (if any).
+            ``template`` must be provided if the function changes the size of existing dimensions.
+            When provided, ``attrs`` on variables in `template` are copied over to the result. Any
+            ``attrs`` set by ``func`` will be ignored.
+
 
         Returns
         -------
-        A single DataArray or Dataset with dask backend, reassembled from the outputs of
-        the function.
+        A single DataArray or Dataset with dask backend, reassembled from the outputs of the
+        function.
 
         Notes
         -----
-        This method is designed for when one needs to manipulate a whole xarray object
-        within each chunk. In the more common case where one can work on numpy arrays,
-        it is recommended to use apply_ufunc.
+        This function is designed for when ``func`` needs to manipulate a whole xarray object
+        subset to each block. In the more common case where ``func`` can work on numpy arrays, it is
+        recommended to use ``apply_ufunc``.
 
-        If none of the variables in this DataArray is backed by dask, calling this
-        method is equivalent to calling ``func(self, *args, **kwargs)``.
+        If none of the variables in ``obj`` is backed by dask arrays, calling this function is
+        equivalent to calling ``func(obj, *args, **kwargs)``.
 
         See Also
         --------
-        dask.array.map_blocks, xarray.apply_ufunc, xarray.map_blocks,
-        xarray.Dataset.map_blocks
+        dask.array.map_blocks, xarray.apply_ufunc, xarray.Dataset.map_blocks,
+        xarray.DataArray.map_blocks
+
+        Examples
+        --------
+
+        Calculate an anomaly from climatology using ``.groupby()``. Using
+        ``xr.map_blocks()`` allows for parallel operations with knowledge of ``xarray``,
+        its indices, and its methods like ``.groupby()``.
+
+        >>> def calculate_anomaly(da, groupby_type="time.month"):
+        ...     # Necessary workaround to xarray's check with zero dimensions
+        ...     # https://github.com/pydata/xarray/issues/3575
+        ...     gb = da.groupby(groupby_type)
+        ...     clim = gb.mean(dim="time")
+        ...     return gb - clim
+        >>> time = xr.cftime_range("1990-01", "1992-01", freq="M")
+        >>> np.random.seed(123)
+        >>> array = xr.DataArray(
+        ...     np.random.rand(len(time)), dims="time", coords=[time]
+        ... ).chunk()
+        >>> array.map_blocks(calculate_anomaly, template=array).compute()
+        <xarray.DataArray (time: 24)>
+        array([ 0.12894847,  0.11323072, -0.0855964 , -0.09334032,  0.26848862,
+                0.12382735,  0.22460641,  0.07650108, -0.07673453, -0.22865714,
+               -0.19063865,  0.0590131 , -0.12894847, -0.11323072,  0.0855964 ,
+                0.09334032, -0.26848862, -0.12382735, -0.22460641, -0.07650108,
+                0.07673453,  0.22865714,  0.19063865, -0.0590131 ])
+        Coordinates:
+          * time     (time) object 1990-01-31 00:00:00 ... 1991-12-31 00:00:00
+
+        Note that one must explicitly use ``args=[]`` and ``kwargs={}`` to pass arguments
+        to the function being applied in ``xr.map_blocks()``:
+
+        >>> array.map_blocks(
+        ...     calculate_anomaly, kwargs={"groupby_type": "time.year"}, template=array,
+        ... )
+        <xarray.DataArray (time: 24)>
+        array([ 0.15361741, -0.25671244, -0.31600032,  0.008463  ,  0.1766172 ,
+               -0.11974531,  0.43791243,  0.14197797, -0.06191987, -0.15073425,
+               -0.19967375,  0.18619794, -0.05100474, -0.42989909, -0.09153273,
+                0.24841842, -0.30708526, -0.31412523,  0.04197439,  0.0422506 ,
+                0.14482397,  0.35985481,  0.23487834,  0.12144652])
+        Coordinates:
+            * time     (time) object 1990-01-31 00:00:00 ... 1991-12-31 00:00:00
         """
         from .parallel import map_blocks
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3315,8 +3315,6 @@ class DataArray(AbstractArray, DataWithCoords):
         its indices, and its methods like ``.groupby()``.
 
         >>> def calculate_anomaly(da, groupby_type="time.month"):
-        ...     # Necessary workaround to xarray's check with zero dimensions
-        ...     # https://github.com/pydata/xarray/issues/3575
         ...     gb = da.groupby(groupby_type)
         ...     clim = gb.mean(dim="time")
         ...     return gb - clim

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5717,48 +5717,98 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         .. warning::
             This method is experimental and its signature may change.
 
-        Parameters
+       Parameters
         ----------
         func: callable
             User-provided function that accepts a Dataset as its first
-            parameter. The function will receive a subset, i.e. one block, of this Dataset
-            (see below), corresponding to one chunk along each chunked dimension. ``func`` will be
-            executed as ``func(block_subset, *args, **kwargs)``.
+            parameter. The function will receive a subset or 'block' of this Dataset (see below),
+            corresponding to one chunk along each chunked dimension. ``func`` will be
+            executed as ``func(subset_dataset, *subset_args, **kwargs)``.
 
             This function must return either a single DataArray or a single Dataset.
 
             This function cannot add a new chunked dimension.
+
+        obj: DataArray, Dataset
+            Passed to the function as its first argument, one block at a time.
         args: Sequence
-            Passed verbatim to func after unpacking, after the sliced obj.
-            Any xarray objects will also be split by blocks and then passed on.
+            Passed to func after unpacking and subsetting any xarray objects by blocks.
+            xarray objects in args must be aligned with obj, otherwise an error is raised.
         kwargs: Mapping
             Passed verbatim to func after unpacking. xarray objects, if any, will not be
-            split by chunks. Passing dask collections is not allowed.
+            subset to blocks. Passing dask collections in kwargs is not allowed.
         template: (optional) DataArray, Dataset
             xarray object representing the final result after compute is called. If not provided,
-            the function will be first run on mocked-up data, that looks like 'obj' but
+            the function will be first run on mocked-up data, that looks like ``obj`` but
             has sizes 0, to determine properties of the returned object such as dtype,
-            variable names, new dimensions and new indexes (if any).
-            'template' must be provided if the function changes the size of existing dimensions.
+            variable names, attributes, new dimensions and new indexes (if any).
+            ``template`` must be provided if the function changes the size of existing dimensions.
+            When provided, ``attrs`` on variables in `template` are copied over to the result. Any
+            ``attrs`` set by ``func`` will be ignored.
+
 
         Returns
         -------
-        A single DataArray or Dataset with dask backend, reassembled from the outputs of
-        the function.
+        A single DataArray or Dataset with dask backend, reassembled from the outputs of the
+        function.
 
         Notes
         -----
-        This method is designed for when one needs to manipulate a whole xarray object
-        within each chunk. In the more common case where one can work on numpy arrays,
-        it is recommended to use apply_ufunc.
+        This function is designed for when ``func`` needs to manipulate a whole xarray object
+        subset to each block. In the more common case where ``func`` can work on numpy arrays, it is
+        recommended to use ``apply_ufunc``.
 
-        If none of the variables in this Dataset is backed by dask, calling this method
-        is equivalent to calling ``func(self, *args, **kwargs)``.
+        If none of the variables in ``obj`` is backed by dask arrays, calling this function is
+        equivalent to calling ``func(obj, *args, **kwargs)``.
 
         See Also
         --------
-        dask.array.map_blocks, xarray.apply_ufunc, xarray.map_blocks,
+        dask.array.map_blocks, xarray.apply_ufunc, xarray.Dataset.map_blocks,
         xarray.DataArray.map_blocks
+
+        Examples
+        --------
+
+        Calculate an anomaly from climatology using ``.groupby()``. Using
+        ``xr.map_blocks()`` allows for parallel operations with knowledge of ``xarray``,
+        its indices, and its methods like ``.groupby()``.
+
+        >>> def calculate_anomaly(da, groupby_type="time.month"):
+        ...     # Necessary workaround to xarray's check with zero dimensions
+        ...     # https://github.com/pydata/xarray/issues/3575
+        ...     gb = da.groupby(groupby_type)
+        ...     clim = gb.mean(dim="time")
+        ...     return gb - clim
+        >>> time = xr.cftime_range("1990-01", "1992-01", freq="M")
+        >>> np.random.seed(123)
+        >>> array = xr.DataArray(
+        ...     np.random.rand(len(time)), dims="time", coords=[time]
+        ... ).chunk()
+        >>> ds = xr.Dataset({"a": array})
+        >>> ds.map_blocks(calculate_anomaly, template=ds).compute()
+        <xarray.DataArray (time: 24)>
+        array([ 0.12894847,  0.11323072, -0.0855964 , -0.09334032,  0.26848862,
+                0.12382735,  0.22460641,  0.07650108, -0.07673453, -0.22865714,
+               -0.19063865,  0.0590131 , -0.12894847, -0.11323072,  0.0855964 ,
+                0.09334032, -0.26848862, -0.12382735, -0.22460641, -0.07650108,
+                0.07673453,  0.22865714,  0.19063865, -0.0590131 ])
+        Coordinates:
+          * time     (time) object 1990-01-31 00:00:00 ... 1991-12-31 00:00:00
+
+        Note that one must explicitly use ``args=[]`` and ``kwargs={}`` to pass arguments
+        to the function being applied in ``xr.map_blocks()``:
+
+        >>> ds.map_blocks(
+        ...     calculate_anomaly, kwargs={"groupby_type": "time.year"}, template=ds,
+        ... )
+        <xarray.DataArray (time: 24)>
+        array([ 0.15361741, -0.25671244, -0.31600032,  0.008463  ,  0.1766172 ,
+               -0.11974531,  0.43791243,  0.14197797, -0.06191987, -0.15073425,
+               -0.19967375,  0.18619794, -0.05100474, -0.42989909, -0.09153273,
+                0.24841842, -0.30708526, -0.31412523,  0.04197439,  0.0422506 ,
+                0.14482397,  0.35985481,  0.23487834,  0.12144652])
+        Coordinates:
+            * time     (time) object 1990-01-31 00:00:00 ... 1991-12-31 00:00:00
         """
         from .parallel import map_blocks
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5774,8 +5774,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         its indices, and its methods like ``.groupby()``.
 
         >>> def calculate_anomaly(da, groupby_type="time.month"):
-        ...     # Necessary workaround to xarray's check with zero dimensions
-        ...     # https://github.com/pydata/xarray/issues/3575
         ...     gb = da.groupby(groupby_type)
         ...     clim = gb.mean(dim="time")
         ...     return gb - clim

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5729,9 +5729,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
             This function cannot add a new chunked dimension.
         args: Sequence
-            Passed verbatim to func after unpacking, after the sliced DataArray. xarray
-            objects, if any, will not be split by chunks. Passing dask collections is
-            not allowed.
+            Passed verbatim to func after unpacking, after the sliced obj.
+            Any xarray objects will also be split by blocks and then passed on.
         kwargs: Mapping
             Passed verbatim to func after unpacking. xarray objects, if any, will not be
             split by chunks. Passing dask collections is not allowed.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5717,7 +5717,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         .. warning::
             This method is experimental and its signature may change.
 
-       Parameters
+        Parameters
         ----------
         func: callable
             User-provided function that accepts a Dataset as its first

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -541,6 +541,9 @@ def map_blocks(
         hlg.layers[gname_l] = layer
 
     result = Dataset(coords=indexes, attrs=template.attrs)
+    for index in result.indexes:
+        result[index].attrs = template[index].attrs
+
     for name, gname_l in var_key_map.items():
         dims = template[name].dims
         var_chunks = []

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -497,8 +497,7 @@ def map_blocks(
         expected["coords"] = set(template.coords.keys())  # type: ignore
         expected["indexes"] = {
             dim: indexes[dim][_get_chunk_slicer(dim, chunk_index, output_chunk_bounds)]
-            for dim in output_chunks
-            if dim in indexes
+            for dim in indexes
         }
 
         from_wrapper = (gname,) + chunk_tuple

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -428,8 +428,7 @@ def map_blocks(
 
     else:
         # template xarray object has been provided with proper sizes and chunk shapes
-        indexes = input_indexes
-        indexes.update(template.indexes)
+        indexes = dict(template.indexes)
         if isinstance(template, DataArray):
             output_chunks = dict(zip(template.dims, template.chunks))  # type: ignore
         else:
@@ -498,7 +497,8 @@ def map_blocks(
         expected["coords"] = set(template.coords.keys())  # type: ignore
         expected["indexes"] = {
             dim: indexes[dim][_get_chunk_slicer(dim, chunk_index, output_chunk_bounds)]
-            for dim in indexes
+            for dim in output_chunks
+            if dim in indexes
         }
 
         from_wrapper = (gname,) + chunk_tuple

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -543,6 +543,7 @@ def map_blocks(
     result = Dataset(coords=indexes, attrs=template.attrs)
     for index in result.indexes:
         result[index].attrs = template[index].attrs
+        result[index].encoding = template[index].encoding
 
     for name, gname_l in var_key_map.items():
         dims = template[name].dims

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -410,7 +410,7 @@ def map_blocks(
         if isinstance(template, DataArray):
             output_chunks = dict(zip(template.dims, template.chunks))  # type: ignore
         else:
-            output_chunks = template.chunks  # type: ignore
+            output_chunks = dict(template.chunks)
 
     for dim in output_chunks:
         if dim in input_chunks and len(input_chunks[dim]) != len(output_chunks[dim]):

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -430,7 +430,7 @@ def map_blocks(
 
         # this will become [[name1, variable1],
         #                   [name2, variable2],
-        #                    ...]
+        #                   ...]
         # which is passed to dict and then to Dataset
         data_vars = []
         coords = []

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -279,9 +279,6 @@ def map_blocks(
         passes these to the user function `func` and checks returned objects for expected shapes/sizes/etc.
         """
 
-        check_shapes = dict(args[0].dims)
-        check_shapes.update(expected["shapes"])
-
         converted_args = [
             dataset_to_dataarray(arg) if is_array else arg
             for is_array, arg in zip(arg_is_array, args)
@@ -298,10 +295,10 @@ def map_blocks(
 
         # check that index lengths and values are as expected
         for name, index in result.indexes.items():
-            if name in check_shapes:
-                if len(index) != check_shapes[name]:
+            if name in expected["shapes"]:
+                if len(index) != expected["shapes"][name]:
                     raise ValueError(
-                        f"Received dimension {name!r} of length {len(index)}. Expected length {check_shapes[name]}."
+                        f"Received dimension {name!r} of length {len(index)}. Expected length {expected['shapes'][name]}."
                     )
             if name in expected["indexes"]:
                 expected_index = expected["indexes"][name]

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -16,6 +16,8 @@ from typing import (
     DefaultDict,
     Dict,
     Hashable,
+    Iterable,
+    List,
     Mapping,
     Sequence,
     Tuple,
@@ -32,7 +34,7 @@ from .dataset import Dataset
 T_DSorDA = TypeVar("T_DSorDA", DataArray, Dataset)
 
 
-def get_index_vars(obj):
+def get_index_vars(obj: Union[DataArray, Dataset]) -> dict:
     return {dim: obj[dim] for dim in obj.indexes}
 
 
@@ -76,7 +78,9 @@ def check_result_variables(
         )
 
 
-def subset_dataset_to_block(graph, gname, dataset, input_chunks, chunk_tuple):
+def subset_dataset_to_block(
+    graph: dict, gname: str, dataset: Dataset, input_chunks: dict, chunk_tuple: tuple
+):
 
     # mapping from dimension name to chunk index
     input_chunk_index = dict(zip(input_chunks.keys(), chunk_tuple))
@@ -328,7 +332,13 @@ def map_blocks(
         * time     (time) object 1990-01-31 00:00:00 ... 1991-12-31 00:00:00
     """
 
-    def _wrapper(func, args, kwargs, arg_is_array, expected):
+    def _wrapper(
+        func: Callable,
+        args: List,
+        kwargs: dict,
+        arg_is_array: Iterable[bool],
+        expected: dict,
+    ):
         check_shapes = dict(args[0].dims)
         check_shapes.update(expected["shapes"])
 

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -233,8 +233,6 @@ def map_blocks(
     its indices, and its methods like ``.groupby()``.
 
     >>> def calculate_anomaly(da, groupby_type="time.month"):
-    ...     # Necessary workaround to xarray's check with zero dimensions
-    ...     # https://github.com/pydata/xarray/issues/3575
     ...     gb = da.groupby(groupby_type)
     ...     clim = gb.mean(dim="time")
     ...     return gb - clim

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1128,9 +1128,8 @@ def test_map_blocks_dask_args():
     with raises_regex(ValueError, "Chunk sizes along dimension 'x'"):
         xr.map_blocks(operator.add, da1, args=[da1.chunk({"x": 1})])
 
-    with raise_if_dask_computes():
-        mapped = xr.map_blocks(operator.add, da1, args=[da1.reindex(x=np.arange(20))])
-    xr.testing.assert_equal(da1 + da1, mapped)
+    with raises_regex(ValueError, "indexes along dimension 'x' are not equal"):
+        xr.map_blocks(operator.add, da1, args=[da1.reindex(x=np.arange(20))])
 
     # reduction
     da1 = da1.chunk({"x": -1})

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1121,6 +1121,9 @@ def test_map_blocks_dask_args():
         mapped = xr.map_blocks(operator.add, da1, args=[da2])
     xr.testing.assert_equal(da1 + da2, mapped)
 
+    with raises_regex(ValueError, "Chunk sizes along dimension 'x'"):
+        xr.map_blocks(operator.add, da1, args=[da1.chunk({"x": 1})])
+
 
 @pytest.mark.parametrize("obj", [make_da(), make_ds()])
 def test_map_blocks_add_attrs(obj):

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -972,6 +972,7 @@ def make_da():
         coords={"x": np.arange(10), "y": np.arange(100, 120)},
         name="a",
     ).chunk({"x": 4, "y": 5})
+    da.x.attrs["long_name"] = "x"
     da.attrs["test"] = "test"
     da.coords["c2"] = 0.5
     da.coords["ndcoord"] = da.x * 2
@@ -994,6 +995,9 @@ def make_ds():
     map_ds.coords["cx"].attrs["test2"] = "test2"
     map_ds.attrs["test"] = "test"
     map_ds.coords["xx"] = map_ds["a"] * map_ds.y
+
+    map_ds.x.attrs["long_name"] = "x"
+    map_ds.y.attrs["long_name"] = "y"
 
     return map_ds
 

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1132,6 +1132,22 @@ def test_map_blocks_dask_args():
         mapped = xr.map_blocks(operator.add, da1, args=[da1.reindex(x=np.arange(20))])
     xr.testing.assert_equal(da1 + da1, mapped)
 
+    # reduction
+    da1 = da1.chunk({"x": -1})
+    da2 = da1 + 1
+    with raise_if_dask_computes():
+        mapped = xr.map_blocks(lambda a, b: (a + b).sum("x"), da1, args=[da2])
+    xr.testing.assert_equal((da1 + da2).sum("x"), mapped)
+
+    # reduction with template
+    da1 = da1.chunk({"x": -1})
+    da2 = da1 + 1
+    with raise_if_dask_computes():
+        mapped = xr.map_blocks(
+            lambda a, b: (a + b).sum("x"), da1, args=[da2], template=da1.sum("x")
+        )
+    xr.testing.assert_equal((da1 + da2).sum("x"), mapped)
+
 
 @pytest.mark.parametrize("obj", [make_da(), make_ds()])
 def test_map_blocks_add_attrs(obj):

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1124,6 +1124,10 @@ def test_map_blocks_dask_args():
     with raises_regex(ValueError, "Chunk sizes along dimension 'x'"):
         xr.map_blocks(operator.add, da1, args=[da1.chunk({"x": 1})])
 
+    with raise_if_dask_computes():
+        mapped = xr.map_blocks(operator.add, da1, args=[da1.reindex(x=np.arange(20))])
+    xr.testing.assert_equal(da1 + da1, mapped)
+
 
 @pytest.mark.parametrize("obj", [make_da(), make_ds()])
 def test_map_blocks_add_attrs(obj):

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1067,9 +1067,6 @@ def test_map_blocks_error(map_da, map_ds):
         xr.map_blocks(bad_func, ds_copy)
 
     with raises_regex(TypeError, "Cannot pass dask collections"):
-        xr.map_blocks(bad_func, map_da, args=[map_da.chunk()])
-
-    with raises_regex(TypeError, "Cannot pass dask collections"):
         xr.map_blocks(bad_func, map_da, kwargs=dict(a=map_da.chunk()))
 
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

It parses `args` and breaks any xarray objects into appropriate blocks before passing them on to the user function.

e.g.
```python
da1 = xr.DataArray(
    np.ones((10, 20)), dims=["x", "y"], coords={"x": np.arange(10), "y": np.arange(20)}
).chunk({"x": 5, "y": 4})
da1

def sumda(da1, da2):
    #print(da1.shape)
    #print(da2.shape)
    return da1 - da2

da3 = (da1 + 1).isel(x=1, drop=True).rename({"y": "k"})
mapped = xr.map_blocks(sumda, da1, args=[da3])
xr.testing.assert_equal(da1-da3, mapped) # passes
```