### PR TITLE
Improve where docstring

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -74,6 +74,8 @@ Documentation
 - Fix documentation of :py:class:`DataArray` removing the deprecated mention
   that when omitted, `dims` are inferred from a `coords`-dict. (:pull:`3821`)
   By `Sander van Rijn <https://github.com/sjvrijn>`_.
+- Improve the :py:func:`where` docstring.
+  By `Maximilian Roos <https://github.com/max-sixty>`_
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1225,14 +1225,18 @@ def where(cond, x, y):
     ----------
     cond : scalar, array, Variable, DataArray or Dataset with boolean dtype
         When True, return values from `x`, otherwise returns values from `y`.
-    x, y : scalar, array, Variable, DataArray or Dataset
-        Values from which to choose. All dimension coordinates on these objects
-        must be aligned with each other and with `cond`.
+    x : scalar, array, Variable, DataArray or Dataset
+        values to choose from where `cond` is True
+    y : scalar, array, Variable, DataArray or Dataset
+        values to choose from where `cond` is False
+
+    All dimension coordinates on these objects must be aligned with each
+    other and with `cond`.
 
     Returns
     -------
-    In priority order: Dataset, DataArray, Variable or array, whichever
-    type appears as an input argument.
+    Dataset, DataArray, Variable or array, whichever type appears as an input
+    argument.
 
     Examples
     --------
@@ -1246,13 +1250,13 @@ def where(cond, x, y):
     Coordinates:
     * lat      (lat) int64 0 1 2 3 4 5 6 7 8 9
 
-    >>> xr.where(x < 0.5, x,  100*x)
+    >>> xr.where(x < 0.5, x, x * 100)
     <xarray.DataArray 'sst' (lat: 10)>
     array([ 0. ,  0.1,  0.2,  0.3,  0.4, 50. , 60. , 70. , 80. , 90. ])
     Coordinates:
     * lat      (lat) int64 0 1 2 3 4 5 6 7 8 9
 
-    >>> >>> y = xr.DataArray(
+    >>> y = xr.DataArray(
     ...     0.1 * np.arange(9).reshape(3, 3),
     ...     dims=["lat", "lon"],
     ...     coords={"lat": np.arange(3), "lon": 10 + np.arange(3)},

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1234,8 +1234,8 @@ def where(cond, x, y):
 
     Returns
     -------
-    Dataset, DataArray, Variable or array, whichever type appears as an input
-    argument.
+    In priority order: Dataset, DataArray, Variable or array, whichever
+    type appears as an input argument.
 
     Examples
     --------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4362,8 +4362,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Examples
         --------
-        >>> import numpy as np
-        >>> import xarray as xr
         >>> x = xr.Dataset(
         ...     {
         ...         "temperature_c": (("lat", "lon"), 20 * np.random.rand(4).reshape(2, 2)),
@@ -4383,7 +4381,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Where the value is a callable, evaluated on dataset:
 
-        >>> x.assign(temperature_f = lambda x: x.temperature_c * 9 / 5 + 32)
+        >>> x.assign(temperature_f=lambda x: x.temperature_c * 9 / 5 + 32)
         <xarray.Dataset>
         Dimensions:        (lat: 2, lon: 2)
         Coordinates:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

The `x, y ` doesn't carry over to the online docs: http://xarray.pydata.org/en/stable/generated/xarray.where.html#xarray.where, lmk if there's a hack for representing that in a better way