### PR TITLE
Delete associated indexes when deleting coordinate variables.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -65,7 +65,8 @@ Bug fixes
   to preserve attributes. :py:meth:`Dataset.coarsen` accepts a keyword
   argument ``keep_attrs`` to change this setting. (:issue:`3376`,
   :pull:`3801`) By `Andrew Thomas <https://github.com/amcnicho>`_.
-  
+- Delete associated indexes when deleting coordinate variables. (:issue:`3746`).
+  By `Deepak Cherian <https://github.com/dcherian>`_.
 - Fix :py:meth:`xarray.core.dataset.Dataset.to_zarr` when using `append_dim` and `group`
   simultaneously. (:issue:`3170`). By `Matthias Meyer <https://github.com/niowniow>`_.
 

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -246,8 +246,12 @@ class DatasetCoordinates(Coordinates):
     def __delitem__(self, key: Hashable) -> None:
         if key in self:
             del self._data[key]
+            if key in self._data.indexes:
+                indexes = dict(self._data.indexes)
+                indexes.pop(key)
+                self._data._indexes = indexes
         else:
-            raise KeyError(key)
+            raise KeyError(f"{key!r} is not a coordinate variable.")
 
     def _ipython_key_completions_(self):
         """Provide method for the key-autocompletions in IPython. """
@@ -291,7 +295,7 @@ class DataArrayCoordinates(Coordinates):
         dims = calculate_dimensions(coords_plus_data)
         if not set(dims) <= set(self.dims):
             raise ValueError(
-                "cannot add coordinates with new dimensions to " "a DataArray"
+                "cannot add coordinates with new dimensions to a DataArray"
             )
         self._data._coords = coords
 
@@ -312,7 +316,14 @@ class DataArrayCoordinates(Coordinates):
         return Dataset._construct_direct(coords, set(coords))
 
     def __delitem__(self, key: Hashable) -> None:
-        del self._data._coords[key]
+        if key in self:
+            del self._data._coords[key]
+            if key in self._data.indexes:
+                indexes = dict(self._data.indexes)
+                indexes.pop(key)
+                self._data._indexes = indexes
+        else:
+            raise KeyError(f"{key!r} is not a coordinate variable.")
 
     def _ipython_key_completions_(self):
         """Provide method for the key-autocompletions in IPython. """

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -314,7 +314,8 @@ class DataArrayCoordinates(Coordinates):
     def __delitem__(self, key: Hashable) -> None:
         if key in self:
             del self._data._coords[key]
-            del self._data._indexes[key]
+            if self._data._indexes is not None and key in self._data._indexes:
+                del self._data._indexes[key]
         else:
             raise KeyError(f"{key!r} is not a coordinate variable.")
 

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -246,10 +246,6 @@ class DatasetCoordinates(Coordinates):
     def __delitem__(self, key: Hashable) -> None:
         if key in self:
             del self._data[key]
-            if key in self._data.indexes:
-                indexes = dict(self._data.indexes)
-                indexes.pop(key)
-                self._data._indexes = indexes
         else:
             raise KeyError(f"{key!r} is not a coordinate variable.")
 
@@ -318,10 +314,7 @@ class DataArrayCoordinates(Coordinates):
     def __delitem__(self, key: Hashable) -> None:
         if key in self:
             del self._data._coords[key]
-            if key in self._data.indexes:
-                indexes = dict(self._data.indexes)
-                indexes.pop(key)
-                self._data._indexes = indexes
+            del self._data._indexes[key]
         else:
             raise KeyError(f"{key!r} is not a coordinate variable.")
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1412,6 +1412,12 @@ class TestDataArray:
         expected = DataArray(2, coords={1: 2}, name=1)
         assert_identical(actual, expected)
 
+    def test_coords_delitem_delete_indexes(self):
+        # regression test for GH3746
+        arr = DataArray(np.ones((2,)), dims="x", coords={"x": [0, 1]})
+        del arr.coords["x"]
+        assert "x" not in arr.indexes
+
     def test_broadcast_like(self):
         arr1 = DataArray(
             np.ones((2, 3)),

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -744,6 +744,10 @@ class TestDataset:
         expected = data.merge({"c": 11}).set_coords("c")
         assert_identical(expected, actual)
 
+        # regression test for GH3746
+        del actual.coords["x"]
+        assert "x" not in actual.indexes
+
     def test_update_index(self):
         actual = Dataset(coords={"x": [1, 2, 3]})
         actual["x"] = ["a", "b", "c"]


### PR DESCRIPTION

 - [x] Closes #3746
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

@shoyer do you think this is the right thing to do?