### PR TITLE
Add xpublish to related projects

### DIFF
--- a/doc/related-projects.rst
+++ b/doc/related-projects.rst
@@ -63,6 +63,7 @@ Extend xarray capabilities
 - `hypothesis-gufunc <https://hypothesis-gufunc.readthedocs.io/en/latest/>`_: Extension to hypothesis. Makes it easy to write unit tests with xarray objects as input.
 - `nxarray <https://github.com/nxarray/nxarray>`_: NeXus input/output capability for xarray.
 - `xarray_extras <https://github.com/crusaderky/xarray_extras>`_: Advanced algorithms for xarray objects (e.g. integrations/interpolations).
+- `xpublish <https://xpublish.readthedocs.io/>`_: Publish Xarray Datasets via a Zarr compatible REST API.
 - `xrft <https://github.com/rabernat/xrft>`_: Fourier transforms for xarray data.
 - `xr-scipy <https://xr-scipy.readthedocs.io>`_: A lightweight scipy wrapper for xarray.
 - `X-regression <https://github.com/kuchaale/X-regression>`_: Multiple linear regression from Statsmodels library coupled with Xarray library.


### PR DESCRIPTION
We've recently released [Xpublish](https://xpublish.readthedocs.io/en/latest/).  This PR adds the project to the _related-projects` page in the Xarray documentation. To find out more about Xpublish, check out the [docs](https://xpublish.readthedocs.io/en/latest/) or the [release announcement blogpost](https://medium.com/pangeo/xpublish-ff788f900bbf). 