### PR TITLE
Backend env

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -451,7 +451,7 @@ def open_dataset(
     if backend_env:
         try:
             assert isinstance(backend_env, dict)
-        except:
+        except AssertionError:
             raise (
                 "Backend environmental settings must be given as a dictionary! You gave %s."
                 % type(backend_env)

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -456,8 +456,8 @@ def open_dataset(
                 "Backend environmental settings must be given as a dictionary! You gave %s."
                 % type(backend_env)
             )
+        old_env = os.environ.copy()
         for key, value in backend_env.items():
-            old_env = os.environ.copy()
             os.environ[key] = value
 
     def maybe_decode_store(store, lock=False):

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -22,7 +22,6 @@ from typing import (
 import numpy as np
 import pandas as pd
 
-from ..plot.plot import _PlotMethods
 from . import (
     computation,
     dtypes,
@@ -34,6 +33,7 @@ from . import (
     rolling,
     utils,
 )
+from ..plot.plot import _PlotMethods
 from .accessor_dt import CombinedDatetimelikeAccessor
 from .accessor_str import StringAccessor
 from .alignment import (

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -33,8 +33,6 @@ import pandas as pd
 
 import xarray as xr
 
-from ..coding.cftimeindex import _parse_array_of_cftime_strings
-from ..plot.dataset_plot import _Dataset_PlotMethods
 from . import (
     alignment,
     dtypes,
@@ -47,6 +45,8 @@ from . import (
     rolling,
     utils,
 )
+from ..coding.cftimeindex import _parse_array_of_cftime_strings
+from ..plot.dataset_plot import _Dataset_PlotMethods
 from .alignment import _broadcast_helper, _get_broadcast_dims_map_common_coords, align
 from .common import (
     DataWithCoords,

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -10,12 +10,7 @@ from xarray.core.dataset import Dataset
 from xarray.core.indexes import default_indexes
 from xarray.core.variable import IndexVariable, Variable
 
-__all__ = (
-    "assert_allclose",
-    "assert_chunks_equal",
-    "assert_equal",
-    "assert_identical",
-)
+__all__ = ("assert_allclose", "assert_chunks_equal", "assert_equal", "assert_identical")
 
 
 def _decode_string_data(data):

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -16,7 +16,6 @@ from xarray.core import duck_array_ops
 from xarray.testing import assert_chunks_equal
 from xarray.tests import mock
 
-from ..core.duck_array_ops import lazy_array_equiv
 from . import (
     assert_allclose,
     assert_array_equal,
@@ -26,6 +25,7 @@ from . import (
     raises_regex,
     requires_scipy_or_netCDF4,
 )
+from ..core.duck_array_ops import lazy_array_equiv
 from .test_backends import create_tmp_file
 
 dask = pytest.importorskip("dask")

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -5,8 +5,8 @@ import pytest
 import xarray as xr
 from xarray.tests import assert_allclose, assert_equal, requires_cftime, requires_scipy
 
-from ..coding.cftimeindex import _parse_array_of_cftime_strings
 from . import has_dask, has_scipy
+from ..coding.cftimeindex import _parse_array_of_cftime_strings
 from .test_dataset import create_test_data
 
 try:

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1643,7 +1643,7 @@ class TestVariable(VariableSubclassobjects):
             pytest.param(1, id="no_unit"),
             pytest.param(unit_registry.dimensionless, id="dimensionless"),
             pytest.param(unit_registry.s, id="incompatible_unit"),
-            pytest.param(unit_registry.cm, id="compatible_unit",),
+            pytest.param(unit_registry.cm, id="compatible_unit"),
             pytest.param(unit_registry.m, id="identical_unit"),
         ),
     )


### PR DESCRIPTION
This merge request allows the user to set a `backend_env` while opening a file. This should be a dictionary, and the key/value pairs are temporarily added to `os.enviorn` while opening the file. The old environment is restored later.


 - [x] Closes #3853
    Maybe -- I'm not sure if it is clever to actually close this issue at this point. I added the `backend_env` idea.
 - [ ] Tests added

   Here, I need some help: How should I actually design the tests? The environment is only temporarily modified, so as soon as the open_dataset function ends again, the environment is restored. I would have though temporarily adding an equivalent to  `$ export lala=tada` into the environment and checking for that would be an idea; but since I restore the environment right away, there is no way I can see to actually access the new `os.environ`
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

   I added a section to the relevant docstring. Not sure how much this needs to also be included in the other files.
