### PR TITLE
Fix multi-index with categorical values.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -55,6 +55,8 @@ New Features
 Bug fixes
 ~~~~~~~~~
 
+- Fix use of multi-index with categorical values (:issue:`3674`).
+  By `Matthieu Ancellin <https://github.com/mancellin>`_.
 - Fix :py:meth:`Dataset.swap_dims` and :py:meth:`DataArray.swap_dims` producing
   index with name reflecting the previous dimension name instead of the new one
   (:issue:`3748`, :pull:`3752`). By `Joseph K Aicher

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -22,6 +22,8 @@ def remove_unused_levels_categories(index):
             for i, level in enumerate(index.levels):
                 if isinstance(level, pd.CategoricalIndex):
                     level = level[index.codes[i]].remove_unused_categories()
+                else:
+                    level = level[index.codes[i]]
                 levels.append(level)
             index = pd.MultiIndex.from_arrays(levels, names=index.names)
     elif isinstance(index, pd.CategoricalIndex):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1467,7 +1467,6 @@ class TestDataset:
             ["i1", "i2"]
         )
         actual = df.to_xarray()
-        print(actual)
         assert actual["values"].shape == (1, 2)
 
     def test_sel_drop(self):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1458,6 +1458,16 @@ class TestDataset:
         actual = ds.reindex(cat=["foo"])["cat"].values
         assert (actual == np.array(["foo"])).all()
 
+    def test_categorical_multiindex(self):
+        i1 = pd.Series([0, 0])
+        cat = pd.CategoricalDtype(categories=['foo', 'baz', 'bar'])
+        i2 = pd.Series(['baz', 'bar'], dtype=cat)
+
+        df = pd.DataFrame({'i1': i1, 'i2': i2, 'values': [1, 2]}).set_index(['i1', 'i2'])
+        actual = df.to_xarray()
+        print(actual)
+        assert actual['values'].shape == (1, 2)
+
     def test_sel_drop(self):
         data = Dataset({"foo": ("x", [1, 2, 3])}, {"x": [0, 1, 2]})
         expected = Dataset({"foo": 1})

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1460,13 +1460,15 @@ class TestDataset:
 
     def test_categorical_multiindex(self):
         i1 = pd.Series([0, 0])
-        cat = pd.CategoricalDtype(categories=['foo', 'baz', 'bar'])
-        i2 = pd.Series(['baz', 'bar'], dtype=cat)
+        cat = pd.CategoricalDtype(categories=["foo", "baz", "bar"])
+        i2 = pd.Series(["baz", "bar"], dtype=cat)
 
-        df = pd.DataFrame({'i1': i1, 'i2': i2, 'values': [1, 2]}).set_index(['i1', 'i2'])
+        df = pd.DataFrame({"i1": i1, "i2": i2, "values": [1, 2]}).set_index(
+            ["i1", "i2"]
+        )
         actual = df.to_xarray()
         print(actual)
-        assert actual['values'].shape == (1, 2)
+        assert actual["values"].shape == (1, 2)
 
     def test_sel_drop(self):
         data = Dataset({"foo": ("x", [1, 2, 3])}, {"x": [0, 1, 2]})


### PR DESCRIPTION
@fujiisoup Would you mind reviewing this PR?
The bug was actually straightforward.

 - [X] Closes #3674 
 - [X] Tests added
 - [X] Passes `isort -rc . && black . && mypy . && flake8`
 - [X] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API