### PR TITLE
Raise error when assigning to IndexVariable.values & IndexVariable.data

### DIFF
--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -657,7 +657,7 @@ Additionally, the boolean kwarg ``add_guide`` can be used to prevent the display
 
 .. ipython:: python
 
-    ds.w.values = [1, 2, 3, 5]
+    ds = ds.assign(w=[1, 2, 3, 5])
     @savefig ds_discrete_legend_hue_scatter.png
     ds.plot.scatter(x='A', y='B', hue='w', hue_style='discrete')
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -24,7 +24,8 @@ Breaking changes
 
 - Raise an error when assigning to the ``.values`` or ``.data`` attribute of
   dimension coordinates i.e. ``IndexVariable`` objects. This has been broken since
-  v0.12.0. (:issue:`3470`, :pull:`3862`)
+  v0.12.0. Please use :py:meth:`DataArray.assign_coords` or :py:meth:`Dataset.assign_coords`
+  instead. (:issue:`3470`, :pull:`3862`)
   By `Deepak Cherian <https://github.com/dcherian>`_
 
 New Features

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,6 +22,11 @@ v0.15.1 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- Raise an error when assigning to the ``.values`` or ``.data`` attribute of
+  dimension coordinates i.e. ``IndexVariable`` objects. This has been broken since
+  v0.13.0. (:issue:`3470`)
+  By `Deepak Cherian <https://github.com/dcherian>`_
+
 New Features
 ~~~~~~~~~~~~
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -24,7 +24,7 @@ Breaking changes
 
 - Raise an error when assigning to the ``.values`` or ``.data`` attribute of
   dimension coordinates i.e. ``IndexVariable`` objects. This has been broken since
-  v0.13.0. (:issue:`3470`)
+  v0.12.0. (:issue:`3470`, :pull:`3862`)
   By `Deepak Cherian <https://github.com/dcherian>`_
 
 New Features

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2061,9 +2061,17 @@ class IndexVariable(Variable):
     # https://github.com/python/mypy/issues/1465
     @Variable.data.setter  # type: ignore
     def data(self, data):
-        Variable.data.fset(self, data)
-        if not isinstance(self._data, PandasIndexAdapter):
-            self._data = PandasIndexAdapter(self._data)
+        raise ValueError(
+            f"Cannot assign to the .data attribute of dimension coordinate a.k.a IndexVariable {self.name!r}. "
+            f"Please use DataArray.assign_coords, Dataset.assign_coords or Dataset.assign as appropriate."
+        )
+
+    @Variable.values.setter  # type: ignore
+    def values(self, values):
+        raise ValueError(
+            f"Cannot assign to the .values attribute of dimension coordinate a.k.a IndexVariable {self.name!r}. "
+            f"Please use DataArray.assign_coords, Dataset.assign_coords or Dataset.assign as appropriate."
+        )
 
     def chunk(self, chunks=None, name=None, lock=False):
         # Dummy - do not chunk. This method is invoked e.g. by Dataset.chunk()

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -80,7 +80,7 @@ class TestDatetimeAccessor:
     def test_not_datetime_type(self):
         nontime_data = self.data.copy()
         int_data = np.arange(len(self.data.time)).astype("int8")
-        nontime_data["time"].values = int_data
+        nontime_data = nontime_data.assign_coords(time=int_data)
         with raises_regex(TypeError, "dt"):
             nontime_data.time.dt
 
@@ -213,7 +213,7 @@ class TestTimedeltaAccessor:
     def test_not_datetime_type(self):
         nontime_data = self.data.copy()
         int_data = np.arange(len(self.data.time)).astype("int8")
-        nontime_data["time"].values = int_data
+        nontime_data = nontime_data.assign_coords(time=int_data)
         with raises_regex(TypeError, "dt"):
             nontime_data.time.dt
 

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1274,7 +1274,7 @@ def test_token_changes_when_data_changes(obj):
     assert t3 != t2
 
     # Change IndexVariable
-    obj.coords["x"] *= 2
+    obj = obj.assign_coords(x=obj.x * 2)
     with raise_if_dask_computes():
         t4 = dask.base.tokenize(obj)
     assert t4 != t3

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -538,6 +538,10 @@ class VariableSubclassobjects:
         new_data = np.arange(5, 20)
         with raises_regex(ValueError, "must match shape of object"):
             orig.copy(data=new_data)
+        with raises_regex(ValueError, "Cannot assign to the .data"):
+            orig.data = new_data
+        with raises_regex(ValueError, "Cannot assign to the .values"):
+            orig.values = new_data
 
     def test_replace(self):
         var = Variable(("x", "y"), [[1.5, 2.0], [3.1, 4.3]], {"foo": "bar"})

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -530,8 +530,7 @@ class VariableSubclassobjects:
         orig = IndexVariable("x", np.arange(5))
         new_data = np.arange(5, 10)
         actual = orig.copy(data=new_data)
-        expected = orig.copy()
-        expected.data = new_data
+        expected = IndexVariable("x", np.arange(5, 10))
         assert_identical(expected, actual)
 
     def test_copy_index_with_data_errors(self):


### PR DESCRIPTION
 - [x] Closes #3470
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
