### PR TITLE
Fix html repr on non-str keys

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -88,6 +88,8 @@ Bug fixes
   
 - Fix :py:meth:`xarray.core.dataset.Dataset.to_zarr` when using `append_dim` and `group`
   simultaneously. (:issue:`3170`). By `Matthias Meyer <https://github.com/niowniow>`_.
+- Fix html repr on ``Dataset``s with non-string keys (:pull:`3807`).
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -88,7 +88,7 @@ Bug fixes
   
 - Fix :py:meth:`xarray.core.dataset.Dataset.to_zarr` when using `append_dim` and `group`
   simultaneously. (:issue:`3170`). By `Matthias Meyer <https://github.com/niowniow>`_.
-- Fix html repr on ``Dataset``s with non-string keys (:pull:`3807`).
+- Fix html repr on :py:class:`Dataset` with non-string keys (:pull:`3807`).
   By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 Documentation

--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -95,7 +95,7 @@ def summarize_variable(name, var, is_index=False, dtype=None, preview=None):
 
     cssclass_idx = " class='xr-has-index'" if is_index else ""
     dims_str = f"({', '.join(escape(dim) for dim in var.dims)})"
-    name = escape(name)
+    name = escape(str(name))
     dtype = dtype or escape(str(var.dtype))
 
     # "unique" ids required to expand/collapse subsections

--- a/xarray/tests/test_formatting_html.py
+++ b/xarray/tests/test_formatting_html.py
@@ -51,6 +51,11 @@ def test_short_data_repr_html(dataarray):
     assert data_repr.startswith("array")
 
 
+def test_short_data_repr_html_non_str_keys(dataset):
+    ds = dataset.assign({2: lambda x: x["tmin"]})
+    fh.dataset_repr(ds)
+
+
 def test_short_data_repr_html_dask(dask_dataarray):
     import dask
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes https://github.com/pydata/xarray/issues/3833
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
