### PR TITLE
remove macos build while waiting for libwebp fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,15 +32,16 @@ jobs:
   steps:
   - template: ci/azure/unit-tests.yml
 
-- job: MacOSX
-  strategy:
-    matrix:
-      py38:
-        conda_env: py38
-  pool:
-    vmImage: 'macOS-10.15'
-  steps:
-  - template: ci/azure/unit-tests.yml
+# excluded while waiting for https://github.com/conda-forge/libwebp-feedstock/issues/26
+# - job: MacOSX
+#   strategy:
+#     matrix:
+#       py38:
+#         conda_env: py38
+#   pool:
+#     vmImage: 'macOS-10.15'
+#   steps:
+#   - template: ci/azure/unit-tests.yml
 
 - job: Windows
   strategy:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes https://github.com/pydata/xarray/issues/3867

I think fine to pause the macos build, given the relative cost of fixing vs chance of finding a bug only in macos