### PR TITLE
add spacing in the versions section of the issue report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,6 +28,8 @@ assignees: ''
 #### Versions
 
 <details><summary>Output of `xr.show_versions()`</summary>
+
 <!-- Paste the output here xr.show_versions() here -->
+
 
 </details>


### PR DESCRIPTION
This was causing new lines issues when reports were pasted without added line breaks.