### PR TITLE
Rename ordered_dict_intersection -> compat_dict_intersection

### DIFF
--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -343,7 +343,7 @@ def dict_equiv(
     return True
 
 
-def ordered_dict_intersection(
+def compat_dict_intersection(
     first_dict: Mapping[K, V],
     second_dict: Mapping[K, V],
     compat: Callable[[V, V], bool] = equivalent,
@@ -360,9 +360,6 @@ def ordered_dict_intersection(
     compat : function, optional
         Binary operator to determine if two values are compatible. By default,
         checks for equivalence.
-
-    # TODO: Rename to compat_dict_intersection, as we do not use OrderedDicts
-    # any more.
 
     Returns
     -------

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -120,9 +120,9 @@ class TestDictionaries:
         with pytest.raises(ValueError):
             utils.update_safety_check(self.x, self.z)
 
-    def test_ordered_dict_intersection(self):
-        assert {"b": "B"} == utils.ordered_dict_intersection(self.x, self.y)
-        assert {} == utils.ordered_dict_intersection(self.x, self.z)
+    def test_compat_dict_intersection(self):
+        assert {"b": "B"} == utils.compat_dict_intersection(self.x, self.y)
+        assert {} == utils.compat_dict_intersection(self.x, self.z)
 
     def test_compat_dict_union(self):
         assert {"a": "A", "b": "B", "c": "C"} == utils.compat_dict_union(self.x, self.y)


### PR DESCRIPTION
`xarray` does not use `OrderedDicts` any more, so name did not make sense. As suggested here https://github.com/pydata/xarray/pull/3877#discussion_r396620551.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Test~~s~~ ~~added~~ updated
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst`
