### PR TITLE
Fix for stack+groupby+apply w/ non-increasing coord

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -39,7 +39,9 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
-
+- Fix renaming of coords when one or more stacked coords is not in
+  sorted order during stack+groupby+apply operations. (:issue:`3287`,
+  :pull:`3906`) By `Spencer Hill <https://github.com/spencerahill>`_
 
 Documentation
 ~~~~~~~~~~~~~
@@ -83,13 +85,13 @@ New Features
 - Added support for :py:class:`pandas.DatetimeIndex`-style rounding of
   ``cftime.datetime`` objects directly via a :py:class:`CFTimeIndex` or via the
   :py:class:`~core.accessor_dt.DatetimeAccessor`.
-  By `Spencer Clark <https://github.com/spencerkclark>`_ 
+  By `Spencer Clark <https://github.com/spencerkclark>`_
 - Support new h5netcdf backend keyword `phony_dims` (available from h5netcdf
   v0.8.0 for :py:class:`~xarray.backends.H5NetCDFStore`.
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - Add partial support for unit aware arrays with pint. (:pull:`3706`, :pull:`3611`)
   By `Justus Magin <https://github.com/keewis>`_.
-- :py:meth:`Dataset.groupby` and :py:meth:`DataArray.groupby` now raise a 
+- :py:meth:`Dataset.groupby` and :py:meth:`DataArray.groupby` now raise a
   `TypeError` on multiple string arguments. Receiving multiple string arguments
   often means a user is attempting to pass multiple dimensions as separate
   arguments and should instead pass a single list of dimensions.
@@ -107,7 +109,7 @@ New Features
   By `Maximilian Roos <https://github.com/max-sixty>`_.
 - ``skipna`` is available in :py:meth:`Dataset.quantile`, :py:meth:`DataArray.quantile`,
   :py:meth:`core.groupby.DatasetGroupBy.quantile`, :py:meth:`core.groupby.DataArrayGroupBy.quantile`
-  (:issue:`3843`, :pull:`3844`) 
+  (:issue:`3843`, :pull:`3844`)
   By `Aaron Spring <https://github.com/aaronspring>`_.
 
 Bug fixes
@@ -801,7 +803,7 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
-- Created a `PR checklist <https://xarray.pydata.org/en/stable/contributing.html/contributing.html#pr-checklist>`_ 
+- Created a `PR checklist <https://xarray.pydata.org/en/stable/contributing.html/contributing.html#pr-checklist>`_
   as a quick reference for tasks before creating a new PR
   or pushing new commits.
   By `Gregory Gundersen <https://github.com/gwgundersen>`_.

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -371,9 +371,7 @@ class GroupBy(SupportsArithmetic):
 
             # look through group to find the unique values
             group_as_index = safe_cast_to_index(group)
-            sort = bins is None and (
-                not isinstance(group_as_index, pd.MultiIndex)
-            )
+            sort = bins is None and (not isinstance(group_as_index, pd.MultiIndex))
             unique_values, group_indices = unique_value_groups(
                 group_as_index, sort=sort
             )

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -370,10 +370,11 @@ class GroupBy(SupportsArithmetic):
                 group = group.dropna(group_dim)
 
             # look through group to find the unique values
-            all_sorted = all([safe_cast_to_index(c).is_monotonic_increasing
-                              for c in group.coords.values()])
+            sort = bins is None and (
+                not isinstance(safe_cast_to_index(group), pd.MultiIndex)
+            )
             unique_values, group_indices = unique_value_groups(
-                safe_cast_to_index(group), sort=(bins is None and all_sorted)
+                safe_cast_to_index(group), sort=sort
             )
             unique_coord = IndexVariable(group.name, unique_values)
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -370,11 +370,12 @@ class GroupBy(SupportsArithmetic):
                 group = group.dropna(group_dim)
 
             # look through group to find the unique values
+            group_as_index = safe_cast_to_index(group)
             sort = bins is None and (
-                not isinstance(safe_cast_to_index(group), pd.MultiIndex)
+                not isinstance(group_as_index, pd.MultiIndex)
             )
             unique_values, group_indices = unique_value_groups(
-                safe_cast_to_index(group), sort=sort
+                group_as_index, sort=sort
             )
             unique_coord = IndexVariable(group.name, unique_values)
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -370,8 +370,10 @@ class GroupBy(SupportsArithmetic):
                 group = group.dropna(group_dim)
 
             # look through group to find the unique values
+            all_sorted = all([safe_cast_to_index(c).is_monotonic_increasing
+                              for c in group.coords.values()])
             unique_values, group_indices = unique_value_groups(
-                safe_cast_to_index(group), sort=(bins is None)
+                safe_cast_to_index(group), sort=(bins is None and all_sorted)
             )
             unique_coord = IndexVariable(group.name, unique_values)
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1208,14 +1208,13 @@ class TestDataArray:
         dims = ["x", "y"]
         y_vals = [2, 3]
 
-        # "y" coord is in sorted order, and everything works
         arr = xr.DataArray(data, dims=dims, coords={"y": y_vals})
         actual1 = arr.stack(z=dims).groupby("z").first()
         midx1 = pd.MultiIndex.from_product([[0, 1], [2, 3]], names=dims)
         expected1 = xr.DataArray(data_flat, dims=["z"], coords={"z": midx1})
         xr.testing.assert_equal(actual1, expected1)
 
-        # Now "y" coord is NOT in sorted order, and the bug appears
+        # GH: 3287.  Note that y coord values are not in sorted order.
         arr = xr.DataArray(data, dims=dims, coords={"y": y_vals[::-1]})
         actual2 = arr.stack(z=dims).groupby("z").first()
         midx2 = pd.MultiIndex.from_product([[0, 1], [3, 2]], names=dims)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1202,6 +1202,26 @@ class TestDataArray:
         expected = data.isel(xy=[0, 1]).unstack("xy").squeeze("y").drop_vars("y")
         assert_equal(actual, expected)
 
+    def test_stack_groupby_unsorted_coord(self):
+        data = [[0, 1], [2, 3]]
+        data_flat = [0, 1, 2, 3]
+        dims = ["x", "y"]
+        y_vals = [2, 3]
+
+        # "y" coord is in sorted order, and everything works
+        arr = xr.DataArray(data, dims=dims, coords={"y": y_vals})
+        actual1 = arr.stack(z=dims).groupby("z").first()
+        midx1 = pd.MultiIndex.from_product([[0, 1], [2, 3]], names=dims)
+        expected1 = xr.DataArray(data_flat, dims=["z"], coords={"z": midx1})
+        xr.testing.assert_equal(actual1, expected1)
+
+        # Now "y" coord is NOT in sorted order, and the bug appears
+        arr = xr.DataArray(data, dims=dims, coords={"y": y_vals[::-1]})
+        actual2 = arr.stack(z=dims).groupby("z").first()
+        midx2 = pd.MultiIndex.from_product([[0, 1], [3, 2]], names=dims)
+        expected2 = xr.DataArray(data_flat, dims=["z"], coords={"z": midx2})
+        xr.testing.assert_equal(actual2, expected2)
+
     def test_virtual_default_coords(self):
         array = DataArray(np.zeros((5,)), dims="x")
         expected = DataArray(range(5), dims="x", name="x")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Fixes #3287
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

I've added a check within `groupby.__init__` for monotonicity of the coords, which makes my test pass, but it causes three existing tests to fail.  Getting the logic right that properly distinguishes among these different cases is escaping me for now, but it does seem like this call to `unique_value_groups` within `groupby.__init__` is where the re-sorting is occurring.  Feedback welcome.  TIA!
