### PR TITLE
Un-xfail test_dayofyear_after_cftime_range

### DIFF
--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -1176,7 +1176,6 @@ def test_dayofweek_after_cftime_range(freq):
     np.testing.assert_array_equal(result, expected)
 
 
-@pytest.mark.xfail(reason="See GH3885")
 @pytest.mark.parametrize("freq", ["A", "M", "D"])
 def test_dayofyear_after_cftime_range(freq):
     pytest.importorskip("cftime", minversion="1.0.2.1")


### PR DESCRIPTION
With Unidata/cftime#163 merged, this test, [which we temporarily xfailed in #3885](https://github.com/pydata/xarray/pull/3885#issuecomment-603406294), should pass with cftime master.