### PR TITLE
update the docstring of diff

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -46,6 +46,10 @@ Bug fixes
 
 Documentation
 ~~~~~~~~~~~~~
+- update the docstring of :py:method:`Dataset.diff` and
+  :py:method:`DataArray.diff` so it does document the ``dim``
+  parameter as required. (:issue:`1040`, :pull:`3909`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 
 Internal Changes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -46,8 +46,8 @@ Bug fixes
 
 Documentation
 ~~~~~~~~~~~~~
-- update the docstring of :py:method:`Dataset.diff` and
-  :py:method:`DataArray.diff` so it does document the ``dim``
+- update the docstring of :py:meth:`Dataset.diff` and
+  :py:meth:`DataArray.diff` so it does document the ``dim``
   parameter as required. (:issue:`1040`, :pull:`3909`)
   By `Justus Magin <https://github.com/keewis>`_.
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2696,7 +2696,7 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Parameters
         ----------
-        dim : hashable, optional
+        dim : hashable
             Dimension over which to calculate the finite difference.
         n : int, optional
             The number of times values are differenced.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4901,7 +4901,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Parameters
         ----------
-        dim : str, optional
+        dim : str
             Dimension over which to calculate the finite difference.
         n : int, optional
             The number of times values are differenced.


### PR DESCRIPTION
As per #1040, don't document the `dim` parameter of `Dataset.diff` and `DataArray.diff` as optional.

 - [x] Fixes #1040
 - [ ] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
