### PR TITLE
Update pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,8 @@ repos:
     rev: stable
     hooks:
       - id: black
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     rev: 4.3.21-2
     hooks:
       - id: isort
+        files: .+\.py$
   # https://github.com/python/black#version-control-integration
   - repo: https://github.com/python/black
     rev: stable

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -53,6 +53,9 @@ Internal Changes
 - Use ``Fixes`` rather than ``Closes`` in GitHub Pull Request template, allowing
   linking to issues.
   By `Maximilian Roos <https://github.com/max-sixty>`_
+- Run the ``isort`` pre-commit hook only on python source files
+  and update the ``flake8`` version. (:issue:`3750`, :pull:`3711`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 
 .. _whats-new.0.15.1:


### PR DESCRIPTION
This limits the `pre-commit` `isort` hook to python files and updates the used `flake8` version.

 - [x] Closes #3750
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
