### PR TITLE
Use divergent colormap if lowest and highest level span 0

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -48,6 +48,8 @@ Bug fixes
 - Fix a regression where deleting a coordinate from a copied :py:class:`DataArray`
   can affect the original :py:class:`Dataarray`.  (:issue:`3899`, :pull:`3871`)
   By `Todd Jennings <https://github.com/toddrjen>`_
+- Use divergent colormap if ``levels`` spans 0. (:issue:`3524`)
+  By `Deepak Cherian <https://github.com/dcherian>`_
 
 
 Documentation

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -216,8 +216,13 @@ def _determine_cmap_params(
         vlim = abs(vmax - center)
 
     if possibly_divergent:
+        levels_are_divergent = (
+            isinstance(levels, Iterable) and levels[0] * levels[-1] < 0
+        )
         # kwargs not specific about divergent or not: infer defaults from data
-        divergent = ((vmin < 0) and (vmax > 0)) or not center_is_none
+        divergent = (
+            ((vmin < 0) and (vmax > 0)) or not center_is_none or levels_are_divergent
+        )
     else:
         divergent = False
 

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -169,6 +169,9 @@ def _determine_cmap_params(
     """
     import matplotlib as mpl
 
+    if levels is not None:
+        levels = sorted(levels)
+
     calc_data = np.ravel(plot_data[np.isfinite(plot_data)])
 
     # Handle all-NaN input data gracefully

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -169,7 +169,7 @@ def _determine_cmap_params(
     """
     import matplotlib as mpl
 
-    if levels is not None:
+    if isinstance(levels, Iterable):
         levels = sorted(levels)
 
     calc_data = np.ravel(plot_data[np.isfinite(plot_data)])

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -827,6 +827,12 @@ class TestDetermineCmapParams:
         assert cmap_params["vmax"] == 0.6
         assert cmap_params["cmap"] == "viridis"
 
+        # regression test for GH3524
+        # infer diverging colormap from divergent levels
+        cmap_params = _determine_cmap_params(pos, levels=[-0.1, 0, 1])
+        # specifying levels makes cmap a Colormap object
+        assert cmap_params["cmap"].name == "RdBu_r"
+
     def test_norm_sets_vmin_vmax(self):
         vmin = self.data.min()
         vmax = self.data.max()


### PR DESCRIPTION

 - [x] Closes #3524
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
