### PR TITLE
reactivate the macos CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,16 +32,15 @@ jobs:
   steps:
   - template: ci/azure/unit-tests.yml
 
-# excluded while waiting for https://github.com/conda-forge/libwebp-feedstock/issues/26
-# - job: MacOSX
-#   strategy:
-#     matrix:
-#       py38:
-#         conda_env: py38
-#   pool:
-#     vmImage: 'macOS-10.15'
-#   steps:
-#   - template: ci/azure/unit-tests.yml
+- job: MacOSX
+  strategy:
+    matrix:
+      py38:
+        conda_env: py38
+  pool:
+    vmImage: 'macOS-10.15'
+  steps:
+  - template: ci/azure/unit-tests.yml
 
 - job: Windows
   strategy:


### PR DESCRIPTION
the packaging issue has been closed, so this tries to reactivate the MacOS CI.

 - [x] Closes #3867
 - [ ] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
