### PR TITLE
Add missing_dims argument allowing isel() to ignore missing dimensions

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,10 +35,10 @@ New Features
   :py:func:`combine_by_coords` and :py:func:`combine_nested` using
   combine_attrs keyword argument. (:issue:`3865`, :pull:`3877`)
   By `John Omotani <https://github.com/johnomotani>`_
-- 'missing_dims' argument to :py:meth:`DataArray.isel` and
-  :py:meth:`Variable.isel` to allow replacing the exception when a dimension
-  passed to ``isel`` is not present with a warning, or just ignore the
-  dimension. (:issue:`3866`, :pull:`3923`)
+- 'missing_dims' argument to :py:meth:`Dataset.isel`,
+  `:py:meth:`DataArray.isel` and :py:meth:`Variable.isel` to allow replacing
+  the exception when a dimension passed to ``isel`` is not present with a
+  warning, or just ignore the dimension. (:issue:`3866`, :pull:`3923`)
   By `John Omotani <https://github.com/johnomotani>`_
 - Limited the length of array items with long string reprs to a
   reasonable width (:pull:`3900`)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -28,6 +28,11 @@ New Features
   :py:func:`combine_by_coords` and :py:func:`combine_nested` using
   combine_attrs keyword argument. (:issue:`3865`, :pull:`3877`)
   By `John Omotani <https://github.com/johnomotani>`_
+- 'missing_dims' argument to :py:meth:`DataArray.isel` and
+  :py:meth:`Variable.isel` to allow replacing the exception when a dimension
+  passed to ``isel`` is not present with a warning, or just ignore the
+  dimension. (:issue:`3866`, :pull:`3923`)
+  By `John Omotani <https://github.com/johnomotani>`_
 
 
 Bug fixes

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1007,7 +1007,7 @@ class DataArray(AbstractArray, DataWithCoords):
         self,
         indexers: Mapping[Hashable, Any] = None,
         drop: bool = False,
-        missing_dims: str = "exception",
+        missing_dims: str = "raise",
         **indexers_kwargs: Any,
     ) -> "DataArray":
         """Return a new DataArray whose data is given by integer indexing
@@ -1025,7 +1025,7 @@ class DataArray(AbstractArray, DataWithCoords):
         drop : bool, optional
             If ``drop=True``, drop coordinates variables indexed by integers
             instead of making them scalar.
-        missing_dims : {"exception", "warning", "ignore"}, default "exception"
+        missing_dims : {"raise", "warn", "ignore"}, default "raise"
             What to do if dimensions that should be selected from are not present in the
             DataArray:
             - "exception": raise an exception

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1768,7 +1768,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         return self._replace(variables)
 
     def _validate_indexers(
-        self, indexers: Mapping[Hashable, Any], missing_dims: str = "exception",
+        self, indexers: Mapping[Hashable, Any], missing_dims: str = "raise",
     ) -> Iterator[Tuple[Hashable, Union[int, slice, np.ndarray, Variable]]]:
         """ Here we make sure
         + indexer has a valid keys
@@ -1962,7 +1962,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         indexers: Mapping[Hashable, Any],
         *,
         drop: bool,
-        missing_dims: str = "exception",
+        missing_dims: str = "raise",
     ) -> "Dataset":
         # Note: we need to preserve the original indexers variable in order to merge the
         # coords below

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -751,10 +751,10 @@ def drop_dims_from_indexers(
     ----------
     indexers : dict
     dims : sequence
-    missing_dims : {"exception", "warning", "ignore"}
+    missing_dims : {"raise", "warn", "ignore"}
     """
 
-    if missing_dims == "exception":
+    if missing_dims == "raise":
         invalid = indexers.keys() - set(dims)
         if invalid:
             raise ValueError(
@@ -763,7 +763,7 @@ def drop_dims_from_indexers(
 
         return indexers
 
-    elif missing_dims == "warning":
+    elif missing_dims == "warn":
 
         # don't modify input
         indexers = dict(indexers)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1031,7 +1031,7 @@ class Variable(
     def isel(
         self: VariableType,
         indexers: Mapping[Hashable, Any] = None,
-        missing_dims: str = "exception",
+        missing_dims: str = "raise",
         **indexers_kwargs: Any,
     ) -> VariableType:
         """Return a new array indexed along the specified dimension(s).
@@ -1041,7 +1041,7 @@ class Variable(
         **indexers : {dim: indexer, ...}
             Keyword arguments with names matching dimensions and values given
             by integers, slice objects or arrays.
-        missing_dims : {"exception", "warning", "ignore"}, default "exception"
+        missing_dims : {"raise", "warn", "ignore"}, default "raise"
             What to do if dimensions that should be selected from are not present in the
             DataArray:
             - "exception": raise an exception

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -780,6 +780,19 @@ class TestDataArray:
         assert_identical(self.dv, self.dv.isel(x=slice(None)))
         assert_identical(self.dv[:3], self.dv.isel(x=slice(3)))
         assert_identical(self.dv[:3, :5], self.dv.isel(x=slice(3), y=slice(5)))
+        with raises_regex(
+            ValueError,
+            r"dimensions {'not_a_dim'} do not exist. Expected "
+            r"one or more of \('x', 'y'\)",
+        ):
+            self.dv.isel(not_a_dim=0)
+        with pytest.warns(
+            UserWarning,
+            match=r"dimensions {'not_a_dim'} do not exist. "
+            r"Expected one or more of \('x', 'y'\)",
+        ):
+            self.dv.isel(not_a_dim=0, missing_dims="warning")
+        assert_identical(self.dv, self.dv.isel(not_a_dim=0, missing_dims="ignore"))
 
     def test_isel_types(self):
         # regression test for #1405

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -792,7 +792,7 @@ class TestDataArray:
             match=r"dimensions {'not_a_dim'} do not exist. "
             r"Expected one or more of \('x', 'y'\)",
         ):
-            self.dv.isel(not_a_dim=0, missing_dims="warning")
+            self.dv.isel(not_a_dim=0, missing_dims="warn")
         assert_identical(self.dv, self.dv.isel(not_a_dim=0, missing_dims="ignore"))
 
     def test_isel_types(self):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1023,6 +1023,21 @@ class TestDataset:
 
         with pytest.raises(ValueError):
             data.isel(not_a_dim=slice(0, 2))
+        with raises_regex(
+            ValueError,
+            r"dimensions {'not_a_dim'} do not exist. Expected "
+            r"one or more of "
+            r"[\w\W]*'time'[\w\W]*'dim\d'[\w\W]*'dim\d'[\w\W]*'dim\d'[\w\W]*",
+        ):
+            data.isel(not_a_dim=slice(0, 2))
+        with pytest.warns(
+            UserWarning,
+            match=r"dimensions {'not_a_dim'} do not exist. "
+            r"Expected one or more of "
+            r"[\w\W]*'time'[\w\W]*'dim\d'[\w\W]*'dim\d'[\w\W]*'dim\d'[\w\W]*",
+        ):
+            data.isel(not_a_dim=slice(0, 2), missing_dims="warn")
+        assert_identical(data, data.isel(not_a_dim=slice(0, 2), missing_dims="ignore"))
 
         ret = data.isel(dim1=0)
         assert {"time": 20, "dim2": 9, "dim3": 10} == ret.dims

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1265,7 +1265,7 @@ class TestVariable(VariableSubclassobjects):
             match=r"dimensions {'not_a_dim'} do not exist. Expected one or more of "
             r"\('time', 'x'\)",
         ):
-            v.isel(not_a_dim=0, missing_dims="warning")
+            v.isel(not_a_dim=0, missing_dims="warn")
         assert_identical(v, v.isel(not_a_dim=0, missing_dims="ignore"))
 
     def test_index_0d_numpy_string(self):

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1254,8 +1254,19 @@ class TestVariable(VariableSubclassobjects):
         assert_identical(v.isel(x=0), v[:, 0])
         assert_identical(v.isel(x=[0, 2]), v[:, [0, 2]])
         assert_identical(v.isel(time=[]), v[[]])
-        with raises_regex(ValueError, "do not exist"):
-            v.isel(not_a_dim=0)
+        with raises_regex(
+            ValueError,
+            r"dimensions {'not_a_dim'} do not exist. Expected one or more of "
+            r"\('x', 'y'\)",
+        ):
+            self.dv.isel(not_a_dim=0)
+        with pytest.warns(
+            UserWarning,
+            match=r"dimensions {'not_a_dim'} do not exist. Expected one or more of "
+            r"\('x', 'y'\)",
+        ):
+            self.v.isel(not_a_dim=0, missing_dims="warning")
+        assert_identical(self.dv, self.dv.isel(not_a_dim=0, missing_dims="ignore"))
 
     def test_index_0d_numpy_string(self):
         # regression test to verify our work around for indexing 0d strings

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1257,16 +1257,16 @@ class TestVariable(VariableSubclassobjects):
         with raises_regex(
             ValueError,
             r"dimensions {'not_a_dim'} do not exist. Expected one or more of "
-            r"\('x', 'y'\)",
+            r"\('time', 'x'\)",
         ):
-            self.dv.isel(not_a_dim=0)
+            v.isel(not_a_dim=0)
         with pytest.warns(
             UserWarning,
             match=r"dimensions {'not_a_dim'} do not exist. Expected one or more of "
-            r"\('x', 'y'\)",
+            r"\('time', 'x'\)",
         ):
-            self.v.isel(not_a_dim=0, missing_dims="warning")
-        assert_identical(self.dv, self.dv.isel(not_a_dim=0, missing_dims="ignore"))
+            v.isel(not_a_dim=0, missing_dims="warning")
+        assert_identical(v, v.isel(not_a_dim=0, missing_dims="ignore"))
 
     def test_index_0d_numpy_string(self):
         # regression test to verify our work around for indexing 0d strings


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
Note: only added to `DataArray.isel()` and `Variable.isel()`. A `Dataset` should include all dimensions, so presumably it should always be an error to pass a non-existent dimension when slicing a `Dataset`?

 - [x] Closes #3866
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
