### PR TITLE
Coordinates passed to interp have nan values

### DIFF
--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -549,8 +549,8 @@ def _localize(var, indexes_coords):
     indexes = {}
     for dim, [x, new_x] in indexes_coords.items():
         index = x.to_index()
-        imin = index.get_loc(np.min(new_x.values), method="nearest")
-        imax = index.get_loc(np.max(new_x.values), method="nearest")
+        imin = index.get_loc(np.nanmin(new_x.values), method="nearest")
+        imax = index.get_loc(np.nanmax(new_x.values), method="nearest")
 
         indexes[dim] = slice(max(imin - 2, 0), imax + 2)
         indexes_coords[dim] = (x[indexes[dim]], new_x)


### PR DESCRIPTION
## Problem
`Keyerror` when the coordinates passed to `interp` have nan value.

### Example
```
import numpy as np
import xarray as xr

da = xr.DataArray(np.sin(0.3 * np.arange(20).reshape(5, 4)),
                  [('x', np.arange(5)),
                   ('y', [0.1, 0.2, 0.3, 0.4])])

x = xr.DataArray([[0.5, np.nan], [1.5, 2.5]], dims=['z1', 'z2'])
y = xr.DataArray([[0.15, 0.2], [np.nan, 0.35]], dims=['z1', 'z2'])
da_nan = da.interp(x=x, y=y)
```

### Output
```
E:\miniconda3\envs\satpy\lib\site-packages\pandas\core\indexes\base.py:2826: RuntimeWarning: invalid value encountered in less
  op(left_distances, right_distances) | (right_indexer == -1),
Traceback (most recent call last):
  File "C:\Users\Xin\Desktop\test_none.py", line 10, in <module>
    da_nan = da.interp(x=x, y=y)
  File "E:\miniconda3\envs\satpy\lib\site-packages\xarray\core\dataarray.py", line 1365, in interp
    **coords_kwargs,
  File "E:\miniconda3\envs\satpy\lib\site-packages\xarray\core\dataset.py", line 2610, in interp
    variables[name] = missing.interp(var, var_indexers, method, **kwargs)
  File "E:\miniconda3\envs\satpy\lib\site-packages\xarray\core\missing.py", line 611, in interp
    var, indexes_coords = _localize(var, indexes_coords)
  File "E:\miniconda3\envs\satpy\lib\site-packages\xarray\core\missing.py", line 552, in _localize
    imin = index.get_loc(np.min(new_x.values), method="nearest")
  File "E:\miniconda3\envs\satpy\lib\site-packages\pandas\core\indexes\base.py", line 2654, in get_loc
    raise KeyError(key)
KeyError: nan
```

## Solution
Use `np.nanmin` and `np.nanmax` in `index.get_loc()`

## Test
### Code
```
import numpy as np
import xarray as xr

da = xr.DataArray(np.sin(0.3 * np.arange(20).reshape(5, 4)),
                  [('x', np.arange(5)),
                   ('y', [0.1, 0.2, 0.3, 0.4])])

x = xr.DataArray([[0.5, np.nan], [1.5, 2.5]], dims=['z1', 'z2'])
y = xr.DataArray([[0.15, 0.2], [np.nan, 0.35]], dims=['z1', 'z2'])
da_nan = da.interp(x=x, y=y)

x = xr.DataArray([[0.5, 1], [1.5, 2.5]], dims=['z1', 'z2'])
y = xr.DataArray([[0.15, 0.2], [0.25, 0.35]], dims=['z1', 'z2'])
da_nonan = da.interp(x=x, y=y)

print('da_nan \n', da_nan)
print('da_nonan \n', da_nonan)
```

### Output
```
E:\miniconda3\envs\satpy\lib\site-packages\scipy\interpolate\interpolate.py:2539: RuntimeWarning: invalid value encountered in less
  out_of_bounds += x < grid[0]
E:\miniconda3\envs\satpy\lib\site-packages\scipy\interpolate\interpolate.py:2540: RuntimeWarning: invalid value encountered in greater
  out_of_bounds += x > grid[-1]
da_nan 
 <xarray.DataArray (z1: 2, z2: 2)>
array([[ 0.55626357,         nan],
       [        nan, -0.46643289]])
Coordinates:
    x        (z1, z2) float64 0.5 nan 1.5 2.5
    y        (z1, z2) float64 0.15 0.2 nan 0.35
Dimensions without coordinates: z1, z2
da_nonan 
 <xarray.DataArray (z1: 2, z2: 2)>
array([[ 0.55626357,  0.99749499],
       [ 0.63496063, -0.46643289]])
Coordinates:
    x        (z1, z2) float64 0.5 1.0 1.5 2.5
    y        (z1, z2) float64 0.15 0.2 0.25 0.35
Dimensions without coordinates: z1, z2
```