### PR TITLE
Bugfix plot 2d coords transpose

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -59,6 +59,9 @@ Bug fixes
   By `Todd Jennings <https://github.com/toddrjen>`_
 - Fix ``FacetGrid`` when ``vmin == vmax``. (:issue:`3734`)
   By `Deepak Cherian <https://github.com/dcherian>`_
+- Fix bug where plotting line plots with 2D coordinates depended on dimension
+  order. (:issue:`3933`)
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -92,7 +92,9 @@ def _infer_line_data(darray, x, y, hue):
                 if huename in darray.dims:
                     otherindex = 1 if darray.dims.index(huename) == 0 else 0
                     otherdim = darray.dims[otherindex]
-                    xplt = darray.transpose(otherdim, huename, transpose_coords=False)
+                    xplt = darray.transpose(otherdim, huename,
+                                            transpose_coords=False)
+                    yplt = yplt.transpose(otherdim, huename, transpose_coords=False)
                 else:
                     raise ValueError(
                         "For 2D inputs, hue must be a dimension"

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -92,8 +92,7 @@ def _infer_line_data(darray, x, y, hue):
                 if huename in darray.dims:
                     otherindex = 1 if darray.dims.index(huename) == 0 else 0
                     otherdim = darray.dims[otherindex]
-                    xplt = darray.transpose(otherdim, huename,
-                                            transpose_coords=False)
+                    xplt = darray.transpose(otherdim, huename, transpose_coords=False)
                     yplt = yplt.transpose(otherdim, huename, transpose_coords=False)
                 else:
                     raise ValueError(

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -261,12 +261,12 @@ class TestPlot(PlotTestCase):
         # checks for bug reported in GH #3933
         x = np.arange(10)
         y = np.arange(20)
-        ds = xr.Dataset(coords={'x': x, 'y': y})
+        ds = xr.Dataset(coords={"x": x, "y": y})
 
         for z in [ds.y + ds.x, ds.x + ds.y]:
             ds = ds.assign_coords(z=z)
-            ds['v'] = (ds.x + ds.y)
-            ds['v'].plot.line(y='z', hue='x')
+            ds["v"] = ds.x + ds.y
+            ds["v"].plot.line(y="z", hue="x")
 
     def test_2d_before_squeeze(self):
         a = DataArray(easy_array((1, 5)))

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -257,6 +257,17 @@ class TestPlot(PlotTestCase):
         with pytest.raises(ValueError, match="For 2D inputs, hue must be a dimension"):
             da.plot.line(x="lon", hue="lat")
 
+    def test_2d_coord_line_plot_coords_transpose_invariant(self):
+        # checks for bug reported in GH #3933
+        x = np.arange(10)
+        y = np.arange(20)
+        ds = xr.Dataset(coords={'x': x, 'y': y})
+
+        for z in [ds.y + ds.x, ds.x + ds.y]:
+            ds = ds.assign_coords(z=z)
+            ds['v'] = (ds.x + ds.y)
+            ds['v'].plot.line(y='z', hue='x')
+
     def test_2d_before_squeeze(self):
         a = DataArray(easy_array((1, 5)))
         a.plot()


### PR DESCRIPTION
Simple fix for #3933 - just required transposing y data before passing to matplotlib.

 - [x] Closes #3933
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API