### PR TITLE
Updated list of core developers

### DIFF
--- a/doc/roadmap.rst
+++ b/doc/roadmap.rst
@@ -219,6 +219,11 @@ Current core developers
 -  Fabien Maussion
 -  Keisuke Fujii
 -  Maximilian Roos
+-  Deepak Cherian
+-  Spencer Clark
+-  Tom Nicholas
+-  Guido Imperiale
+-  Justus Magin
 
 NumFOCUS
 ~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -82,6 +82,8 @@ Documentation
   <examples/monthly-means>` example notebook to take advantage of the new
   ``days_in_month`` accessor for :py:class:`xarray.CFTimeIndex`
   (:pull:`3935`). By `Spencer Clark <https://github.com/spencerkclark>`_.
+- Updated the list of current core developers. (:issue:`3892`)
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Names listed in order of date added.

 - [x] Closes #3892
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API