### PR TITLE
implement a more threadsafe call to colorbar

### DIFF
--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -581,14 +581,15 @@ def _is_numeric(arr):
 
 
 def _add_colorbar(primitive, ax, cbar_ax, cbar_kwargs, cmap_params):
-    plt = import_matplotlib_pyplot()
+
     cbar_kwargs.setdefault("extend", cmap_params["extend"])
     if cbar_ax is None:
         cbar_kwargs.setdefault("ax", ax)
     else:
         cbar_kwargs.setdefault("cax", cbar_ax)
 
-    cbar = plt.colorbar(primitive, **cbar_kwargs)
+    fig = ax.get_figure()
+    cbar = fig.colorbar(primitive, **cbar_kwargs)
 
     return cbar
 


### PR DESCRIPTION
 - [ ] Xref #1889 
 - [ ] Tests added
 - [ ] Passes `isort -rc . && black . && mypy . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

If you think this is relevant, I'll go ahead and start working on the items above, even though I'm not sure new tests are needed.