### PR TITLE
Fix wrong order of coordinate converted from pd.series with MultiIndex

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -58,7 +58,7 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
-- Fix wrong order in converting pd.seris with MultiIndex. (:issue:`3951`)
+- Fix wrong order in converting a ``pd.Series`` with a MultiIndex to ``DataArray``. (:issue:`3951`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - Fix renaming of coords when one or more stacked coords is not in
   sorted order during stack+groupby+apply operations. (:issue:`3287`,

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -58,6 +58,8 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
+- Fix wrong order in converting pd.seris with MultiIndex. (:issue:`3951`)
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - Fix renaming of coords when one or more stacked coords is not in
   sorted order during stack+groupby+apply operations. (:issue:`3287`,
   :pull:`3906`) By `Spencer Hill <https://github.com/spencerahill>`_

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4603,9 +4603,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         if not dataframe.columns.is_unique:
             raise ValueError("cannot convert DataFrame with non-unique columns")
-
-        idx = remove_unused_levels_categories(dataframe.index)
-        dataframe = dataframe.set_index(idx)
+        
+        idx, dataframe = remove_unused_levels_categories(dataframe.index, dataframe)
         obj = cls()
 
         if isinstance(idx, pd.MultiIndex):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4603,7 +4603,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         if not dataframe.columns.is_unique:
             raise ValueError("cannot convert DataFrame with non-unique columns")
-        
+
         idx, dataframe = remove_unused_levels_categories(dataframe.index, dataframe)
         obj = cls()
 

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -9,7 +9,7 @@ from .utils import is_scalar
 from .variable import Variable
 
 
-def remove_unused_levels_categories(index):
+def remove_unused_levels_categories(index, dataframe=None):
     """
     Remove unused levels from MultiIndex and unused categories from CategoricalIndex
     """
@@ -28,7 +28,11 @@ def remove_unused_levels_categories(index):
             index = pd.MultiIndex.from_arrays(levels, names=index.names)
     elif isinstance(index, pd.CategoricalIndex):
         index = index.remove_unused_categories()
-    return index
+
+    if dataframe is None:
+        return index
+    dataframe = dataframe.set_index(index)
+    return dataframe.index, dataframe
 
 
 class Indexes(collections.abc.Mapping):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3517,8 +3517,8 @@ class TestDataArray:
 
     def test_from_series_multiindex(self):
         # GH:3951
-        df = pd.DataFrame({'B': [1, 2, 3], 'A': [4, 5, 6]}) 
-        df = df.rename_axis('num').rename_axis('alpha', axis=1) 
+        df = pd.DataFrame({'B': [1, 2, 3], 'A': [4, 5, 6]})
+        df = df.rename_axis('num').rename_axis('alpha', axis=1)
         actual = df.stack('alpha').to_xarray()
         assert (actual.sel(alpha='B') == [1, 2, 3]).all()
         assert (actual.sel(alpha='A') == [4, 5, 6]).all()

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3515,6 +3515,14 @@ class TestDataArray:
             expected_da, DataArray.from_series(actual).drop_vars(["x", "y"])
         )
 
+    def test_from_series_multiindex(self):
+        # GH:3951
+        df = pd.DataFrame({'B': [1, 2, 3], 'A': [4, 5, 6]}) 
+        df = df.rename_axis('num').rename_axis('alpha', axis=1) 
+        actual = df.stack('alpha').to_xarray()
+        assert (actual.sel(alpha='B') == [1, 2, 3]).all()
+        assert (actual.sel(alpha='A') == [4, 5, 6]).all()
+
     @requires_sparse
     def test_from_series_sparse(self):
         import sparse

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3517,11 +3517,11 @@ class TestDataArray:
 
     def test_from_series_multiindex(self):
         # GH:3951
-        df = pd.DataFrame({'B': [1, 2, 3], 'A': [4, 5, 6]})
-        df = df.rename_axis('num').rename_axis('alpha', axis=1)
-        actual = df.stack('alpha').to_xarray()
-        assert (actual.sel(alpha='B') == [1, 2, 3]).all()
-        assert (actual.sel(alpha='A') == [4, 5, 6]).all()
+        df = pd.DataFrame({"B": [1, 2, 3], "A": [4, 5, 6]})
+        df = df.rename_axis("num").rename_axis("alpha", axis=1)
+        actual = df.stack("alpha").to_xarray()
+        assert (actual.sel(alpha="B") == [1, 2, 3]).all()
+        assert (actual.sel(alpha="A") == [4, 5, 6]).all()
 
     @requires_sparse
     def test_from_series_sparse(self):
@@ -4532,7 +4532,7 @@ class TestReduce1D(TestReduce):
 
     def test_idxmin(self, x, minindex, maxindex, nanindex):
         ar0 = xr.DataArray(
-            x, dims=["x"], coords={"x": np.arange(x.size) * 4}, attrs=self.attrs,
+            x, dims=["x"], coords={"x": np.arange(x.size) * 4}, attrs=self.attrs
         )
 
         # dim doesn't exist
@@ -4628,7 +4628,7 @@ class TestReduce1D(TestReduce):
 
     def test_idxmax(self, x, minindex, maxindex, nanindex):
         ar0 = xr.DataArray(
-            x, dims=["x"], coords={"x": np.arange(x.size) * 4}, attrs=self.attrs,
+            x, dims=["x"], coords={"x": np.arange(x.size) * 4}, attrs=self.attrs
         )
 
         # dim doesn't exist


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #3951
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

It looks 
`dataframe.set_index(index).index == index` is not always true.

Added a workaround for this...