### PR TITLE
parametrized accessor examples

### DIFF
--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -113,6 +113,44 @@ reasons:
    a DataArray from a Dataset (ex. ``ds[var_name]``), will have new
    accessors created.
 
+Parametrizing an accessor is possible, too, by defining ``__call__``:
+
+.. ipython:: python
+
+    @xr.register_dataarray_accessor("weighted")
+    class Weighted:
+        def __init__(self, xarray_obj):
+            self._obj = xarray_obj
+            self._weight = None
+
+        def __call__(self, weight):
+            self._weight = weight
+
+        def sum(self, dim):
+            return "weighted sum"
+
+If we need to require the parameter, the easiest way to do so is using
+a wrapper function:
+
+.. ipython:: python
+
+    class Weighted:
+        def __init__(self, obj, weight):
+            self._obj = obj
+            self._weight = weight
+
+        def sum(self, dim):
+            return f"weighted sum over {dim} and with weight {self._weight}"
+
+    @xr.register_dataarray_accessor("weighted")
+    def weighted(obj):
+        def wrapped(weight):
+            return Weighted(obj, weight)
+        return wrapped
+
+    da = xr.DataArray(data=range(5), dims="x")
+    da.weighted(5).sum(dim="x")
+
 Back in an interactive IPython session, we can use these properties:
 
 .. ipython:: python


### PR DESCRIPTION
This starts adding the parametrized accessor examples from #3829 to the accessor documentation as suggested by @jhamman. Since then the `weighted` methods have been added, though, so I'd like to use a different example instead (ideas welcome).

Also, this feature can be abused to add functions to the main `DataArray` / `Dataset` namespace (by registering a function with the `register_*_accessor` decorators, see the second example). Is this something we want to explicitly discourage?

(When trying to build the docs locally, sphinx keeps complaining about a code block without code. Not sure what that is about)

 - [x] Closes #3829
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
