### PR TITLE
Empty line missing for DataArray.assign_coords doc

### DIFF
--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -455,6 +455,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
             lon_2    (lon) int64 300 289 0 1
 
         Note that the same result can also be obtained with a dict e.g.
+
         >>> _ = da.assign_coords({"lon_2": ('lon', lon_2)})
 
         Notes


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Related to #3958 an empty is probably missing for the [example section](http://xarray.pydata.org/en/latest/generated/xarray.Dataset.assign_coords.html#xarray.Dataset.assign_coords)

 - [ ] Passes `isort -rc . && black . && mypy . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
