### PR TITLE
RasterioDeprecationWarning

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -73,6 +73,8 @@ Bug fixes
 - Fix bug where plotting line plots with 2D coordinates depended on dimension
   order. (:issue:`3933`)
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
+- Fix `RasterioDeprecationWarning` when using a `vrt` in `open_rasterio`. (:issue:`3964`)
+  By `Taher Chegini <https://github.com/cheginit>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -73,7 +73,7 @@ Bug fixes
 - Fix bug where plotting line plots with 2D coordinates depended on dimension
   order. (:issue:`3933`)
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
-- Fix `RasterioDeprecationWarning` when using a `vrt` in `open_rasterio`. (:issue:`3964`)
+- Fix ``RasterioDeprecationWarning`` when using a ``vrt`` in ``open_rasterio``. (:issue:`3964`)
   By `Taher Chegini <https://github.com/cheginit>`_.
 
 Documentation

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -224,7 +224,7 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None, loc
             crs=vrt.crs.to_string(),
             resampling=vrt.resampling,
             src_nodata=vrt.src_nodata,
-            dst_nodata=vrt.dst_nodata,
+            nodata=vrt.nodata,
             tolerance=vrt.tolerance,
             transform=vrt.transform,
             width=vrt.width,


### PR DESCRIPTION
When a `vrt` is opened, a deprecation warning will be shown:
```python
/home/taher/.local/apps/miniconda/envs/hydrodata/lib/python3.8/site-packages/xarray/backends/rasterio_.py:241: RasterioDeprecationWarning: dst_nodata will be removed in 1.1, use nodata
  riods = WarpedVRT(riods, **vrt_params)
/home/taher/.local/apps/miniconda/envs/hydrodata/lib/python3.8/site-packages/xarray/backends/rasterio_.py:35: RasterioDeprecationWarning: dst_nodata will be removed in 1.1, use nodata
  riods = WarpedVRT(riods, **vrt_params)
/home/taher/.local/apps/miniconda/envs/hydrodata/lib/python3.8/site-packages/xarray/backends/rasterio_.py:122: RasterioDeprecationWarning: dst_nodata will be removed in 1.1, use nodata
  riods = WarpedVRT(riods, **self.vrt_params)
```
This change can be confirmed in `rasterio`'s documentation where `dst_nodata` is replaced with nodata.
https://rasterio.readthedocs.io/en/latest/api/rasterio.vrt.html