### PR TITLE
Proposal for better error message about in-place operation

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2666,12 +2666,12 @@ class DataArray(AbstractArray, DataWithCoords):
             try:
                 with self.coords._merge_inplace(other_coords):
                     f(self.variable, other_variable)
-            except MergeError:
-                raise ValueError(
+            except MergeError as exc:
+                raise MergeError(
                     "Automatic alignment is not supported for in-place operations.\n"
                     "Consider aligning the indices manually or using a not-in-place operation.\n"
                     "See https://github.com/pydata/xarray/issues/3910 for more explanations."
-                )
+                ) from exc
             return self
 
         return func

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -54,7 +54,7 @@ from .dataset import Dataset, split_indexes
 from .formatting import format_item
 from .indexes import Indexes, default_indexes, propagate_indexes
 from .indexing import is_fancy_indexer
-from .merge import PANDAS_TYPES, _extract_indexes_from_coords, MergeError
+from .merge import PANDAS_TYPES, MergeError, _extract_indexes_from_coords
 from .options import OPTIONS
 from .utils import Default, ReprObject, _check_inplace, _default, either_dict_or_kwargs
 from .variable import (

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1921,9 +1921,9 @@ class TestDataArray:
     def test_inplace_math_automatic_alignment(self):
         a = DataArray(range(5), [("x", range(5))])
         b = DataArray(range(1, 6), [("x", range(1, 6))])
-        with pytest.raises(xr.MergeError):
+        with pytest.raises(ValueError):
             a += b
-        with pytest.raises(xr.MergeError):
+        with pytest.raises(ValueError):
             b += a
 
     def test_math_name(self):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1921,9 +1921,9 @@ class TestDataArray:
     def test_inplace_math_automatic_alignment(self):
         a = DataArray(range(5), [("x", range(5))])
         b = DataArray(range(1, 6), [("x", range(1, 6))])
-        with pytest.raises(ValueError):
+        with pytest.raises(xr.MergeError, match="Automatic alignment is not supported"):
             a += b
-        with pytest.raises(ValueError):
+        with pytest.raises(xr.MergeError, match="Automatic alignment is not supported"):
             b += a
 
     def test_math_name(self):


### PR DESCRIPTION
Trying to make error message slightly more informative when the user might expect automatic alignment with in-place operation.

 - [X] Closes #3910
 - [ ] Tests added
 - [X] Passes `isort -rc . && black . && mypy . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
