### PR TITLE
Fix handling of abbreviated units like msec

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -80,7 +80,9 @@ Bug fixes
 - Fix bug causing :py:meth:`DataArray.interpolate_na` to always drop attributes,
   and added `keep_attrs` argument. (:issue:`3968`)
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
-
+- Fix bug in time parsing failing to fall back to cftime. This was causing time
+  variables with a time unit of `'msecs'` to fail to parse. (:pull:`3998`)
+  By `Ryan May <https://github.com/dopplershift>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -155,7 +155,7 @@ def decode_cf_datetime(num_dates, units, calendar=None, use_cftime=None):
     if use_cftime is None:
         try:
             dates = _decode_datetime_with_pandas(flat_num_dates, units, calendar)
-        except (OutOfBoundsDatetime, OverflowError):
+        except (KeyError, OutOfBoundsDatetime, OverflowError):
             dates = _decode_datetime_with_cftime(
                 flat_num_dates.astype(np.float), units, calendar
             )

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -432,6 +432,18 @@ def test_decode_360_day_calendar():
         assert_array_equal(actual, expected)
 
 
+@requires_cftime
+def test_decode_abbreviation():
+    """Test making sure we properly fall back to cftime on abbreviated units."""
+    import cftime
+
+    val = np.array([1586628000000.0])
+    units = "msecs since 1970-01-01T00:00:00Z"
+    actual = coding.times.decode_cf_datetime(val, units)
+    expected = coding.times.cftime_to_nptime(cftime.num2date(val, units))
+    assert_array_equal(actual, expected)
+
+
 @arm_xfail
 @requires_cftime
 @pytest.mark.parametrize(


### PR DESCRIPTION
By default, xarray tries to decode times with pandas and falls back to
cftime. This fixes the exception handler to fallback properly in the
cases an unhandled abbreviated unit is passed in.

An additional item here would be to add support for msec, etc. to xarray's handling, but I wasn't sure the best way to handle that. I'm happy just if things properly fall back to cftime.
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
