### PR TITLE
Allow DataArray.to_series() without invoking sparse.COO.todense()

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -56,6 +56,7 @@ from .indexes import Indexes, default_indexes, propagate_indexes
 from .indexing import is_fancy_indexer
 from .merge import PANDAS_TYPES, _extract_indexes_from_coords
 from .options import OPTIONS
+from .pycompat import sparse_array_type
 from .utils import Default, ReprObject, _check_inplace, _default, either_dict_or_kwargs
 from .variable import (
     IndexVariable,
@@ -2357,8 +2358,20 @@ class DataArray(AbstractArray, DataWithCoords):
         The Series is indexed by the Cartesian product of index coordinates
         (in the form of a :py:class:`pandas.MultiIndex`).
         """
-        index = self.coords.to_index()
-        return pd.Series(self.values.reshape(-1), index=index, name=self.name)
+        if isinstance(self.data, sparse_array_type):
+            # Use sparse.COO.coords and .data (each already 1-D) to avoid a
+            # .todense() call, which could raise MemoryError.
+            # FIXME other subclasses of sparse_array_type, e.g. DOK, may lack
+            #       these attrs
+            index = pd.MultiIndex.from_arrays(
+                self.data.coords, names=self.dims
+            ).set_levels([self.coords[d].values for d in self.dims])
+            data = self.data.data
+        else:
+            index = self.coords.to_index()
+            data = self.values.reshape(-1)
+
+        return pd.Series(data, index=index, name=self.name)
 
     def to_masked_array(self, copy: bool = True) -> np.ma.MaskedArray:
         """Convert this array into a numpy.ma.MaskedArray


### PR DESCRIPTION
**Superseded by #11528**

This adds some code (from iiasa/ixmp#317) that allows DataArray.to_series() to be called without invoking sparse.COO.todense() when that is the backing data type.

I'm aware this needs some improvement to meet the standard of the existing codebase, so I hope I could ask for some guidance on how to address the following points (including whom to ask about them):
- [ ] Make the same improvement in {DataArray,Dataset}.to_dataframe().
- [ ] Possibly move the code out of dataarray.py to a more appropriate location (where?).
- [ ] Possibly check for sparse.COO explicitly instead of xarray.core.pycompat.sparse_array_type. Other SparseArray subclasses, e.g. DOK, may not have the same attributes.

Standard items:
 - [ ] Tests added.
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
   (Sort of: these wanted to modify 7 files beyond the one I touched; didn't commit these changes.)
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API.