### PR TITLE
Apply blackdoc to the documentation

### DIFF
--- a/doc/combining.rst
+++ b/doc/combining.rst
@@ -4,11 +4,12 @@ Combining data
 --------------
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     import numpy as np
     import pandas as pd
     import xarray as xr
+
     np.random.seed(123456)
 
 * For combining datasets or data arrays along a single dimension, see concatenate_.
@@ -28,11 +29,10 @@ that dimension:
 
 .. ipython:: python
 
-    arr = xr.DataArray(np.random.randn(2, 3),
-                       [('x', ['a', 'b']), ('y', [10, 20, 30])])
+    arr = xr.DataArray(np.random.randn(2, 3), [("x", ["a", "b"]), ("y", [10, 20, 30])])
     arr[:, :1]
     # this resembles how you would use np.concatenate
-    xr.concat([arr[:, :1], arr[:, 1:]], dim='y')
+    xr.concat([arr[:, :1], arr[:, 1:]], dim="y")
 
 In addition to combining along an existing dimension, ``concat`` can create a
 new dimension by stacking lower dimensional arrays together:
@@ -41,7 +41,7 @@ new dimension by stacking lower dimensional arrays together:
 
     arr[0]
     # to combine these 1d arrays into a 2d array in numpy, you would use np.array
-    xr.concat([arr[0], arr[1]], 'x')
+    xr.concat([arr[0], arr[1]], "x")
 
 If the second argument to ``concat`` is a new dimension name, the arrays will
 be concatenated along that new dimension, which is always inserted as the first
@@ -49,7 +49,7 @@ dimension:
 
 .. ipython:: python
 
-    xr.concat([arr[0], arr[1]], 'new_dim')
+    xr.concat([arr[0], arr[1]], "new_dim")
 
 The second argument to ``concat`` can also be an :py:class:`~pandas.Index` or
 :py:class:`~xarray.DataArray` object as well as a string, in which case it is
@@ -57,14 +57,14 @@ used to label the values along the new dimension:
 
 .. ipython:: python
 
-    xr.concat([arr[0], arr[1]], pd.Index([-90, -100], name='new_dim'))
+    xr.concat([arr[0], arr[1]], pd.Index([-90, -100], name="new_dim"))
 
 Of course, ``concat`` also works on ``Dataset`` objects:
 
 .. ipython:: python
 
-    ds = arr.to_dataset(name='foo')
-    xr.concat([ds.sel(x='a'), ds.sel(x='b')], 'x')
+    ds = arr.to_dataset(name="foo")
+    xr.concat([ds.sel(x="a"), ds.sel(x="b")], "x")
 
 :py:func:`~xarray.concat` has a number of options which provide deeper control
 over which variables are concatenated and how it handles conflicting variables
@@ -84,8 +84,8 @@ To combine variables and coordinates between multiple ``DataArray`` and/or
 
 .. ipython:: python
 
-    xr.merge([ds, ds.rename({'foo': 'bar'})])
-    xr.merge([xr.DataArray(n, name='var%d' % n) for n in range(5)])
+    xr.merge([ds, ds.rename({"foo": "bar"})])
+    xr.merge([xr.DataArray(n, name="var%d" % n) for n in range(5)])
 
 If you merge another dataset (or a dictionary including data array objects), by
 default the resulting dataset will be aligned on the **union** of all index
@@ -93,7 +93,7 @@ coordinates:
 
 .. ipython:: python
 
-    other = xr.Dataset({'bar': ('x', [1, 2, 3, 4]), 'x': list('abcd')})
+    other = xr.Dataset({"bar": ("x", [1, 2, 3, 4]), "x": list("abcd")})
     xr.merge([ds, other])
 
 This ensures that ``merge`` is non-destructive. ``xarray.MergeError`` is raised
@@ -116,7 +116,7 @@ used in the :py:class:`~xarray.Dataset` constructor:
 
 .. ipython:: python
 
-    xr.Dataset({'a': arr[:-1], 'b': arr[1:]})
+    xr.Dataset({"a": arr[:-1], "b": arr[1:]})
 
 .. _combine:
 
@@ -131,8 +131,8 @@ are filled with ``NaN``. For example:
 
 .. ipython:: python
 
-    ar0 = xr.DataArray([[0, 0], [0, 0]], [('x', ['a', 'b']), ('y', [-1, 0])])
-    ar1 = xr.DataArray([[1, 1], [1, 1]], [('x', ['b', 'c']), ('y', [0, 1])])
+    ar0 = xr.DataArray([[0, 0], [0, 0]], [("x", ["a", "b"]), ("y", [-1, 0])])
+    ar1 = xr.DataArray([[1, 1], [1, 1]], [("x", ["b", "c"]), ("y", [0, 1])])
     ar0.combine_first(ar1)
     ar1.combine_first(ar0)
 
@@ -152,7 +152,7 @@ variables with new values:
 
 .. ipython:: python
 
-    ds.update({'space': ('space', [10.2, 9.4, 3.9])})
+    ds.update({"space": ("space", [10.2, 9.4, 3.9])})
 
 However, dimensions are still required to be consistent between different
 Dataset variables, so you cannot change the size of a dimension unless you
@@ -170,7 +170,7 @@ syntax:
 
 .. ipython:: python
 
-    ds['baz'] = xr.DataArray([9, 9, 9, 9, 9], coords=[('x', list('abcde'))])
+    ds["baz"] = xr.DataArray([9, 9, 9, 9, 9], coords=[("x", list("abcde"))])
     ds.baz
 
 Equals and identical
@@ -193,7 +193,7 @@ object:
 
 .. ipython:: python
 
-    arr.identical(arr.rename('bar'))
+    arr.identical(arr.rename("bar"))
 
 :py:attr:`~xarray.Dataset.broadcast_equals` does a more relaxed form of equality
 check that allows variables to have different dimensions, as long as values
@@ -201,8 +201,8 @@ are constant along those new dimensions:
 
 .. ipython:: python
 
-    left = xr.Dataset(coords={'x': 0})
-    right = xr.Dataset({'x': [0, 0, 0]})
+    left = xr.Dataset(coords={"x": 0})
+    right = xr.Dataset({"x": [0, 0, 0]})
     left.broadcast_equals(right)
 
 Like pandas objects, two xarray objects are still equal or identical if they have
@@ -231,9 +231,9 @@ coordinates as long as any non-missing values agree or are disjoint:
 
 .. ipython:: python
 
-    ds1 = xr.Dataset({'a': ('x', [10, 20, 30, np.nan])}, {'x': [1, 2, 3, 4]})
-    ds2 = xr.Dataset({'a': ('x', [np.nan, 30, 40, 50])}, {'x': [2, 3, 4, 5]})
-    xr.merge([ds1, ds2], compat='no_conflicts')
+    ds1 = xr.Dataset({"a": ("x", [10, 20, 30, np.nan])}, {"x": [1, 2, 3, 4]})
+    ds2 = xr.Dataset({"a": ("x", [np.nan, 30, 40, 50])}, {"x": [2, 3, 4, 5]})
+    xr.merge([ds1, ds2], compat="no_conflicts")
 
 Note that due to the underlying representation of missing values as floating
 point numbers (``NaN``), variable data type is not always preserved when merging
@@ -273,10 +273,12 @@ datasets into a doubly-nested list, e.g:
 
 .. ipython:: python
 
-    arr = xr.DataArray(name='temperature', data=np.random.randint(5, size=(2, 2)), dims=['x', 'y'])
+    arr = xr.DataArray(
+        name="temperature", data=np.random.randint(5, size=(2, 2)), dims=["x", "y"]
+    )
     arr
     ds_grid = [[arr, arr], [arr, arr]]
-    xr.combine_nested(ds_grid, concat_dim=['x', 'y'])
+    xr.combine_nested(ds_grid, concat_dim=["x", "y"])
 
 :py:func:`~xarray.combine_nested` can also be used to explicitly merge datasets
 with different variables. For example if we have 4 datasets, which are divided
@@ -286,10 +288,10 @@ we wish to use ``merge`` instead of ``concat``:
 
 .. ipython:: python
 
-    temp = xr.DataArray(name='temperature', data=np.random.randn(2), dims=['t'])
-    precip = xr.DataArray(name='precipitation', data=np.random.randn(2), dims=['t'])
+    temp = xr.DataArray(name="temperature", data=np.random.randn(2), dims=["t"])
+    precip = xr.DataArray(name="precipitation", data=np.random.randn(2), dims=["t"])
     ds_grid = [[temp, precip], [temp, precip]]
-    xr.combine_nested(ds_grid, concat_dim=['t', None])
+    xr.combine_nested(ds_grid, concat_dim=["t", None])
 
 :py:func:`~xarray.combine_by_coords` is for combining objects which have dimension
 coordinates which specify their relationship to and order relative to one
@@ -302,8 +304,8 @@ coordinates, not on their position in the list passed to ``combine_by_coords``.
 .. ipython:: python
     :okwarning:
 
-    x1 = xr.DataArray(name='foo', data=np.random.randn(3), coords=[('x', [0, 1, 2])])
-    x2 = xr.DataArray(name='foo', data=np.random.randn(3), coords=[('x', [3, 4, 5])])
+    x1 = xr.DataArray(name="foo", data=np.random.randn(3), coords=[("x", [0, 1, 2])])
+    x2 = xr.DataArray(name="foo", data=np.random.randn(3), coords=[("x", [3, 4, 5])])
     xr.combine_by_coords([x2, x1])
 
 These functions can be used by :py:func:`~xarray.open_mfdataset` to open many

--- a/doc/computation.rst
+++ b/doc/computation.rst
@@ -195,7 +195,8 @@ We can also manually iterate through ``Rolling`` objects:
 .. code:: python
 
    for label, arr_window in r:
-      # arr_window is a view of x
+       # arr_window is a view of x
+       ...
 
 .. _comput.rolling_exp:
 

--- a/doc/computation.rst
+++ b/doc/computation.rst
@@ -18,17 +18,19 @@ Arithmetic operations with a single DataArray automatically vectorize (like
 numpy) over all array values:
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     import numpy as np
     import pandas as pd
     import xarray as xr
+
     np.random.seed(123456)
 
 .. ipython:: python
 
-    arr = xr.DataArray(np.random.RandomState(0).randn(2, 3),
-                       [('x', ['a', 'b']), ('y', [10, 20, 30])])
+    arr = xr.DataArray(
+        np.random.RandomState(0).randn(2, 3), [("x", ["a", "b"]), ("y", [10, 20, 30])]
+    )
     arr - 3
     abs(arr)
 
@@ -45,7 +47,7 @@ Use :py:func:`~xarray.where` to conditionally switch between values:
 
 .. ipython:: python
 
-    xr.where(arr > 0, 'positive', 'negative')
+    xr.where(arr > 0, "positive", "negative")
 
 Use `@` to perform matrix multiplication:
 
@@ -73,14 +75,14 @@ methods for working with missing data from pandas:
 
 .. ipython:: python
 
-    x = xr.DataArray([0, 1, np.nan, np.nan, 2], dims=['x'])
+    x = xr.DataArray([0, 1, np.nan, np.nan, 2], dims=["x"])
     x.isnull()
     x.notnull()
     x.count()
-    x.dropna(dim='x')
+    x.dropna(dim="x")
     x.fillna(-1)
-    x.ffill('x')
-    x.bfill('x')
+    x.ffill("x")
+    x.bfill("x")
 
 Like pandas, xarray uses the float value ``np.nan`` (not-a-number) to represent
 missing values.
@@ -90,9 +92,12 @@ for filling missing values via 1D interpolation.
 
 .. ipython:: python
 
-    x = xr.DataArray([0, 1, np.nan, np.nan, 2], dims=['x'],
-                     coords={'xx': xr.Variable('x', [0, 1, 1.1, 1.9, 3])})
-    x.interpolate_na(dim='x', method='linear', use_coordinate='xx')
+    x = xr.DataArray(
+        [0, 1, np.nan, np.nan, 2],
+        dims=["x"],
+        coords={"xx": xr.Variable("x", [0, 1, 1.1, 1.9, 3])},
+    )
+    x.interpolate_na(dim="x", method="linear", use_coordinate="xx")
 
 Note that xarray slightly diverges from the pandas ``interpolate`` syntax by
 providing the ``use_coordinate`` keyword which facilitates a clear specification
@@ -110,8 +115,8 @@ applied along particular dimension(s):
 
 .. ipython:: python
 
-    arr.sum(dim='x')
-    arr.std(['x', 'y'])
+    arr.sum(dim="x")
+    arr.std(["x", "y"])
     arr.min()
 
 
@@ -121,7 +126,7 @@ for wrapping code designed to work with numpy arrays), you can use the
 
 .. ipython:: python
 
-    arr.get_axis_num('y')
+    arr.get_axis_num("y")
 
 These operations automatically skip missing values, like in pandas:
 
@@ -142,8 +147,7 @@ method supports rolling window aggregation:
 
 .. ipython:: python
 
-    arr = xr.DataArray(np.arange(0, 7.5, 0.5).reshape(3, 5),
-                       dims=('x', 'y'))
+    arr = xr.DataArray(np.arange(0, 7.5, 0.5).reshape(3, 5), dims=("x", "y"))
     arr
 
 :py:meth:`~xarray.DataArray.rolling` is applied along one dimension using the
@@ -194,9 +198,9 @@ We can also manually iterate through ``Rolling`` objects:
 
 .. code:: python
 
-   for label, arr_window in r:
-       # arr_window is a view of x
-       ...
+    for label, arr_window in r:
+        # arr_window is a view of x
+        ...
 
 .. _comput.rolling_exp:
 
@@ -223,9 +227,9 @@ windowed rolling, convolution, short-time FFT etc.
 .. ipython:: python
 
     # rolling with 2-point stride
-    rolling_da = r.construct('window_dim', stride=2)
+    rolling_da = r.construct("window_dim", stride=2)
     rolling_da
-    rolling_da.mean('window_dim', skipna=False)
+    rolling_da.mean("window_dim", skipna=False)
 
 Because the ``DataArray`` given by ``r.construct('window_dim')`` is a view
 of the original array, it is memory efficient.
@@ -233,8 +237,8 @@ You can also use ``construct`` to compute a weighted rolling sum:
 
 .. ipython:: python
 
-   weight = xr.DataArray([0.25, 0.5, 0.25], dims=['window'])
-   arr.rolling(y=3).construct('window').dot(weight)
+    weight = xr.DataArray([0.25, 0.5, 0.25], dims=["window"])
+    arr.rolling(y=3).construct("window").dot(weight)
 
 .. note::
   numpy's Nan-aggregation functions such as ``nansum`` copy the original array.
@@ -255,52 +259,52 @@ support weighted ``sum`` and weighted ``mean``.
 
 .. ipython:: python
 
-  coords = dict(month=('month', [1, 2, 3]))
+    coords = dict(month=("month", [1, 2, 3]))
 
-  prec = xr.DataArray([1.1, 1.0, 0.9], dims=('month', ), coords=coords)
-  weights = xr.DataArray([31, 28, 31], dims=('month', ), coords=coords)
+    prec = xr.DataArray([1.1, 1.0, 0.9], dims=("month",), coords=coords)
+    weights = xr.DataArray([31, 28, 31], dims=("month",), coords=coords)
 
 Create a weighted object:
 
 .. ipython:: python
 
-  weighted_prec = prec.weighted(weights)
-  weighted_prec
+    weighted_prec = prec.weighted(weights)
+    weighted_prec
 
 Calculate the weighted sum:
 
 .. ipython:: python
 
-  weighted_prec.sum()
+    weighted_prec.sum()
 
 Calculate the weighted mean:
 
 .. ipython:: python
 
-        weighted_prec.mean(dim="month")
+    weighted_prec.mean(dim="month")
 
 The weighted sum corresponds to:
 
 .. ipython:: python
 
-  weighted_sum = (prec * weights).sum()
-  weighted_sum
+    weighted_sum = (prec * weights).sum()
+    weighted_sum
 
 and the weighted mean to:
 
 .. ipython:: python
 
-  weighted_mean = weighted_sum / weights.sum()
-  weighted_mean
+    weighted_mean = weighted_sum / weights.sum()
+    weighted_mean
 
 However, the functions also take missing values in the data into account:
 
 .. ipython:: python
 
-  data = xr.DataArray([np.NaN, 2, 4])
-  weights = xr.DataArray([8, 1, 1])
+    data = xr.DataArray([np.NaN, 2, 4])
+    weights = xr.DataArray([8, 1, 1])
 
-  data.weighted(weights).mean()
+    data.weighted(weights).mean()
 
 Using ``(data * weights).sum() / weights.sum()`` would (incorrectly) result
 in 0.6.
@@ -310,16 +314,16 @@ If the weights add up to to 0, ``sum`` returns 0:
 
 .. ipython:: python
 
-  data = xr.DataArray([1.0, 1.0])
-  weights = xr.DataArray([-1.0, 1.0])
+    data = xr.DataArray([1.0, 1.0])
+    weights = xr.DataArray([-1.0, 1.0])
 
-  data.weighted(weights).sum()
+    data.weighted(weights).sum()
 
 and ``mean`` returns ``NaN``:
 
 .. ipython:: python
 
-  data.weighted(weights).mean()
+    data.weighted(weights).mean()
 
 
 .. note::
@@ -337,18 +341,21 @@ methods. This supports the block aggregation along multiple dimensions,
 
 .. ipython:: python
 
-  x = np.linspace(0, 10, 300)
-  t = pd.date_range('15/12/1999', periods=364)
-  da = xr.DataArray(np.sin(x) * np.cos(np.linspace(0, 1, 364)[:, np.newaxis]),
-                    dims=['time', 'x'], coords={'time': t, 'x': x})
-  da
+    x = np.linspace(0, 10, 300)
+    t = pd.date_range("15/12/1999", periods=364)
+    da = xr.DataArray(
+        np.sin(x) * np.cos(np.linspace(0, 1, 364)[:, np.newaxis]),
+        dims=["time", "x"],
+        coords={"time": t, "x": x},
+    )
+    da
 
 In order to take a block mean for every 7 days along ``time`` dimension and
 every 2 points along ``x`` dimension,
 
 .. ipython:: python
 
-  da.coarsen(time=7, x=2).mean()
+    da.coarsen(time=7, x=2).mean()
 
 :py:meth:`~xarray.DataArray.coarsen` raises an ``ValueError`` if the data
 length is not a multiple of the corresponding window size.
@@ -357,14 +364,14 @@ the excess entries or padding ``nan`` to insufficient entries,
 
 .. ipython:: python
 
-  da.coarsen(time=30, x=2, boundary='trim').mean()
+    da.coarsen(time=30, x=2, boundary="trim").mean()
 
 If you want to apply a specific function to coordinate, you can pass the
 function or method name to ``coord_func`` option,
 
 .. ipython:: python
 
-  da.coarsen(time=7, x=2, coord_func={'time': 'min'}).mean()
+    da.coarsen(time=7, x=2, coord_func={"time": "min"}).mean()
 
 
 .. _compute.using_coordinates:
@@ -378,24 +385,25 @@ central finite differences using their coordinates,
 
 .. ipython:: python
 
-    a = xr.DataArray([0, 1, 2, 3], dims=['x'], coords=[[0.1, 0.11, 0.2, 0.3]])
+    a = xr.DataArray([0, 1, 2, 3], dims=["x"], coords=[[0.1, 0.11, 0.2, 0.3]])
     a
-    a.differentiate('x')
+    a.differentiate("x")
 
 This method can be used also for multidimensional arrays,
 
 .. ipython:: python
 
-    a = xr.DataArray(np.arange(8).reshape(4, 2), dims=['x', 'y'],
-                     coords={'x': [0.1, 0.11, 0.2, 0.3]})
-    a.differentiate('x')
+    a = xr.DataArray(
+        np.arange(8).reshape(4, 2), dims=["x", "y"], coords={"x": [0.1, 0.11, 0.2, 0.3]}
+    )
+    a.differentiate("x")
 
 :py:meth:`~xarray.DataArray.integrate` computes integration based on
 trapezoidal rule using their coordinates,
 
 .. ipython:: python
 
-    a.integrate('x')
+    a.integrate("x")
 
 .. note::
     These methods are limited to simple cartesian geometry. Differentiation
@@ -413,9 +421,9 @@ best fitting coefficients along a given dimension and for a given order,
 
 .. ipython:: python
 
-    x = xr.DataArray(np.arange(10), dims=['x'], name='x')
-    a = xr.DataArray(3 + 4 * x, dims=['x'], coords={'x': x})
-    out = a.polyfit(dim='x', deg=1, full=True)
+    x = xr.DataArray(np.arange(10), dims=["x"], name="x")
+    a = xr.DataArray(3 + 4 * x, dims=["x"], coords={"x": x})
+    out = a.polyfit(dim="x", deg=1, full=True)
     out
 
 The method outputs a dataset containing the coefficients (and more if `full=True`).
@@ -444,9 +452,9 @@ arrays with different sizes aligned along different dimensions:
 
 .. ipython:: python
 
-    a = xr.DataArray([1, 2], [('x', ['a', 'b'])])
+    a = xr.DataArray([1, 2], [("x", ["a", "b"])])
     a
-    b = xr.DataArray([-1, -2, -3], [('y', [10, 20, 30])])
+    b = xr.DataArray([-1, -2, -3], [("y", [10, 20, 30])])
     b
 
 With xarray, we can apply binary mathematical operations to these arrays, and
@@ -461,7 +469,7 @@ appeared:
 
 .. ipython:: python
 
-    c = xr.DataArray(np.arange(6).reshape(3, 2), [b['y'], a['x']])
+    c = xr.DataArray(np.arange(6).reshape(3, 2), [b["y"], a["x"]])
     c
     a + c
 
@@ -495,7 +503,7 @@ operations. The default result of a binary operation is by the *intersection*
 
 .. ipython:: python
 
-    arr = xr.DataArray(np.arange(3), [('x', range(3))])
+    arr = xr.DataArray(np.arange(3), [("x", range(3))])
     arr + arr[:-1]
 
 If coordinate values for a dimension are missing on either argument, all
@@ -504,7 +512,7 @@ matching dimensions must have the same size:
 .. ipython::
     :verbatim:
 
-    In [1]: arr + xr.DataArray([1, 2], dims='x')
+    In [1]: arr + xr.DataArray([1, 2], dims="x")
     ValueError: arguments without labels along dimension 'x' cannot be aligned because they have different dimension size(s) {2} than the size of the aligned dimension labels: 3
 
 
@@ -563,16 +571,20 @@ variables:
 
 .. ipython:: python
 
-    ds = xr.Dataset({'x_and_y': (('x', 'y'), np.random.randn(3, 5)),
-                     'x_only': ('x', np.random.randn(3))},
-                     coords=arr.coords)
+    ds = xr.Dataset(
+        {
+            "x_and_y": (("x", "y"), np.random.randn(3, 5)),
+            "x_only": ("x", np.random.randn(3)),
+        },
+        coords=arr.coords,
+    )
     ds > 0
 
 Datasets support most of the same methods found on data arrays:
 
 .. ipython:: python
 
-    ds.mean(dim='x')
+    ds.mean(dim="x")
     abs(ds)
 
 Datasets also support NumPy ufuncs (requires NumPy v1.13 or newer), or
@@ -595,7 +607,7 @@ Arithmetic between two datasets matches data variables of the same name:
 
 .. ipython:: python
 
-    ds2 = xr.Dataset({'x_and_y': 0, 'x_only': 100})
+    ds2 = xr.Dataset({"x_and_y": 0, "x_only": 100})
     ds - ds2
 
 Similarly to index based alignment, the result has the intersection of all
@@ -639,7 +651,7 @@ any additional arguments:
 .. ipython:: python
 
     squared_error = lambda x, y: (x - y) ** 2
-    arr1 = xr.DataArray([0, 1, 2, 3], dims='x')
+    arr1 = xr.DataArray([0, 1, 2, 3], dims="x")
     xr.apply_ufunc(squared_error, arr1, 1)
 
 For using more complex operations that consider some array values collectively,
@@ -659,21 +671,21 @@ to set ``axis=-1``. As an example, here is how we would wrap
 .. code-block:: python
 
     def vector_norm(x, dim, ord=None):
-        return xr.apply_ufunc(np.linalg.norm, x,
-                              input_core_dims=[[dim]],
-                              kwargs={'ord': ord, 'axis': -1})
+        return xr.apply_ufunc(
+            np.linalg.norm, x, input_core_dims=[[dim]], kwargs={"ord": ord, "axis": -1}
+        )
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     def vector_norm(x, dim, ord=None):
-        return xr.apply_ufunc(np.linalg.norm, x,
-                              input_core_dims=[[dim]],
-                              kwargs={'ord': ord, 'axis': -1})
+        return xr.apply_ufunc(
+            np.linalg.norm, x, input_core_dims=[[dim]], kwargs={"ord": ord, "axis": -1}
+        )
 
 .. ipython:: python
 
-    vector_norm(arr1, dim='x')
+    vector_norm(arr1, dim="x")
 
 Because ``apply_ufunc`` follows a standard convention for ufuncs, it plays
 nicely with tools for building vectorized functions, like

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -467,7 +467,7 @@ typically find tests wrapped in a class.
 .. code-block:: python
 
     class TestReallyCoolFeature:
-        ....
+        ...
 
 Going forward, we are moving to a more *functional* style using the
 `pytest <http://doc.pytest.org/en/latest/>`__ framework, which offers a richer
@@ -477,7 +477,7 @@ writing test classes, we will write test functions like this:
 .. code-block:: python
 
     def test_really_cool_feature():
-        ....
+        ...
 
 Using ``pytest``
 ~~~~~~~~~~~~~~~~

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -261,13 +261,13 @@ Some other important things to know about the docs:
       .. ipython:: python
 
           x = 2
-          x**3
+          x ** 3
 
   will be rendered as::
 
       In [1]: x = 2
 
-      In [2]: x**3
+      In [2]: x ** 3
       Out[2]: 8
 
   Almost all code examples in the docs are run (and the output saved) during the
@@ -508,17 +508,23 @@ We would name this file ``test_cool_feature.py`` and put in an appropriate place
     from xarray.testing import assert_equal
 
 
-    @pytest.mark.parametrize('dtype', ['int8', 'int16', 'int32', 'int64'])
+    @pytest.mark.parametrize("dtype", ["int8", "int16", "int32", "int64"])
     def test_dtypes(dtype):
         assert str(np.dtype(dtype)) == dtype
 
 
-    @pytest.mark.parametrize('dtype', ['float32',
-                             pytest.param('int16', marks=pytest.mark.skip),
-                             pytest.param('int32', marks=pytest.mark.xfail(
-                                reason='to show how it works'))])
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            "float32",
+            pytest.param("int16", marks=pytest.mark.skip),
+            pytest.param(
+                "int32", marks=pytest.mark.xfail(reason="to show how it works")
+            ),
+        ],
+    )
     def test_mark(dtype):
-        assert str(np.dtype(dtype)) == 'float32'
+        assert str(np.dtype(dtype)) == "float32"
 
 
     @pytest.fixture
@@ -526,7 +532,7 @@ We would name this file ``test_cool_feature.py`` and put in an appropriate place
         return xr.DataArray([1, 2, 3])
 
 
-    @pytest.fixture(params=['int8', 'int16', 'int32', 'int64'])
+    @pytest.fixture(params=["int8", "int16", "int32", "int64"])
     def dtype(request):
         return request.param
 

--- a/doc/dask.rst
+++ b/doc/dask.rst
@@ -56,19 +56,26 @@ argument to :py:func:`~xarray.open_dataset` or using the
     import numpy as np
     import pandas as pd
     import xarray as xr
+
     np.random.seed(123456)
     np.set_printoptions(precision=3, linewidth=100, threshold=100, edgeitems=3)
 
-    ds = xr.Dataset({'temperature': (('time', 'latitude', 'longitude'),
-                                     np.random.randn(30, 180, 180)),
-                     'time': pd.date_range('2015-01-01', periods=30),
-                     'longitude': np.arange(180),
-                     'latitude': np.arange(89.5, -90.5, -1)})
-    ds.to_netcdf('example-data.nc')
+    ds = xr.Dataset(
+        {
+            "temperature": (
+                ("time", "latitude", "longitude"),
+                np.random.randn(30, 180, 180),
+            ),
+            "time": pd.date_range("2015-01-01", periods=30),
+            "longitude": np.arange(180),
+            "latitude": np.arange(89.5, -90.5, -1),
+        }
+    )
+    ds.to_netcdf("example-data.nc")
 
 .. ipython:: python
 
-    ds = xr.open_dataset('example-data.nc', chunks={'time': 10})
+    ds = xr.open_dataset("example-data.nc", chunks={"time": 10})
     ds
 
 In this example ``latitude`` and ``longitude`` do not appear in the ``chunks``
@@ -106,7 +113,7 @@ usual way.
 
 .. ipython:: python
 
-    ds.to_netcdf('manipulated-example-data.nc')
+    ds.to_netcdf("manipulated-example-data.nc")
 
 By setting the ``compute`` argument to ``False``, :py:meth:`~xarray.Dataset.to_netcdf`
 will return a ``dask.delayed`` object that can be computed later.
@@ -114,8 +121,9 @@ will return a ``dask.delayed`` object that can be computed later.
 .. ipython:: python
 
     from dask.diagnostics import ProgressBar
+
     # or distributed.progress when using the distributed scheduler
-    delayed_obj = ds.to_netcdf('manipulated-example-data.nc', compute=False)
+    delayed_obj = ds.to_netcdf("manipulated-example-data.nc", compute=False)
     with ProgressBar():
         results = delayed_obj.compute()
 
@@ -141,8 +149,9 @@ Dask DataFrames do not support multi-indexes so the coordinate variables from th
     :suppress:
 
     import os
-    os.remove('example-data.nc')
-    os.remove('manipulated-example-data.nc')
+
+    os.remove("example-data.nc")
+    os.remove("manipulated-example-data.nc")
 
 Using Dask with xarray
 ----------------------
@@ -199,7 +208,7 @@ Dask arrays using the :py:meth:`~xarray.Dataset.persist` method:
 
 .. ipython:: python
 
-   ds = ds.persist()
+    ds = ds.persist()
 
 :py:meth:`~xarray.Dataset.persist` is particularly useful when using a
 distributed cluster because the data will be loaded into distributed memory
@@ -224,11 +233,11 @@ sizes of Dask arrays is done with the :py:meth:`~xarray.Dataset.chunk` method:
 .. ipython:: python
     :suppress:
 
-    ds = ds.chunk({'time': 10})
+    ds = ds.chunk({"time": 10})
 
 .. ipython:: python
 
-    rechunked = ds.chunk({'latitude': 100, 'longitude': 100})
+    rechunked = ds.chunk({"latitude": 100, "longitude": 100})
 
 You can view the size of existing chunks on an array by viewing the
 :py:attr:`~xarray.Dataset.chunks` attribute:
@@ -256,6 +265,7 @@ lazy Dask arrays, in the :ref:`xarray.ufuncs <api.ufuncs>` module:
 .. ipython:: python
 
     import xarray.ufuncs as xu
+
     xu.sin(rechunked)
 
 To access Dask arrays directly, use the new
@@ -302,24 +312,32 @@ we use to calculate `Spearman's rank-correlation coefficient <https://en.wikiped
     import xarray as xr
     import bottleneck
 
+
     def covariance_gufunc(x, y):
-        return ((x - x.mean(axis=-1, keepdims=True))
-                * (y - y.mean(axis=-1, keepdims=True))).mean(axis=-1)
+        return (
+            (x - x.mean(axis=-1, keepdims=True)) * (y - y.mean(axis=-1, keepdims=True))
+        ).mean(axis=-1)
+
 
     def pearson_correlation_gufunc(x, y):
         return covariance_gufunc(x, y) / (x.std(axis=-1) * y.std(axis=-1))
+
 
     def spearman_correlation_gufunc(x, y):
         x_ranks = bottleneck.rankdata(x, axis=-1)
         y_ranks = bottleneck.rankdata(y, axis=-1)
         return pearson_correlation_gufunc(x_ranks, y_ranks)
 
+
     def spearman_correlation(x, y, dim):
         return xr.apply_ufunc(
-            spearman_correlation_gufunc, x, y,
+            spearman_correlation_gufunc,
+            x,
+            y,
             input_core_dims=[[dim], [dim]],
-            dask='parallelized',
-            output_dtypes=[float])
+            dask="parallelized",
+            output_dtypes=[float],
+        )
 
 The only aspect of this example that is different from standard usage of
 ``apply_ufunc()`` is that we needed to supply the ``output_dtypes`` arguments.
@@ -335,7 +353,7 @@ work as a streaming operation, when run on arrays loaded from disk:
 
     In [56]: rs = np.random.RandomState(0)
 
-    In [57]: array1 = xr.DataArray(rs.randn(1000, 100000), dims=['place', 'time'])  # 800MB
+    In [57]: array1 = xr.DataArray(rs.randn(1000, 100000), dims=["place", "time"])  # 800MB
 
     In [58]: array2 = array1 + 0.5 * rs.randn(1000, 100000)
 
@@ -344,12 +362,12 @@ work as a streaming operation, when run on arrays loaded from disk:
     CPU times: user 21.6 s, sys: 2.84 s, total: 24.5 s
     Wall time: 24.9 s
 
-    In [8]: chunked1 = array1.chunk({'place': 10})
+    In [8]: chunked1 = array1.chunk({"place": 10})
 
-    In [9]: chunked2 = array2.chunk({'place': 10})
+    In [9]: chunked2 = array2.chunk({"place": 10})
 
     # using all my laptop's cores, with Dask
-    In [63]: r = spearman_correlation(chunked1, chunked2, 'time').compute()
+    In [63]: r = spearman_correlation(chunked1, chunked2, "time").compute()
 
     In [64]: %time _ = r.compute()
     CPU times: user 30.9 s, sys: 1.74 s, total: 32.6 s
@@ -361,7 +379,7 @@ multiple chunks along a core dimension:
 .. ipython::
     :verbatim:
 
-    In [63]: spearman_correlation(chunked1, chunked2, 'place')
+    In [63]: spearman_correlation(chunked1, chunked2, "place")
     ValueError: dimension 'place' on 0th function argument to apply_ufunc with
     dask='parallelized' consists of multiple chunks, but is also a core
     dimension. To fix, rechunk into a single Dask array chunk along this

--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -4,11 +4,12 @@ Data Structures
 ===============
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     import numpy as np
     import pandas as pd
     import xarray as xr
+
     np.random.seed(123456)
     np.set_printoptions(threshold=10)
 
@@ -57,9 +58,9 @@ The :py:class:`~xarray.DataArray` constructor takes:
 .. ipython:: python
 
     data = np.random.rand(4, 3)
-    locs = ['IA', 'IL', 'IN']
-    times = pd.date_range('2000-01-01', periods=4)
-    foo = xr.DataArray(data, coords=[times, locs], dims=['time', 'space'])
+    locs = ["IA", "IL", "IN"]
+    times = pd.date_range("2000-01-01", periods=4)
+    foo = xr.DataArray(data, coords=[times, locs], dims=["time", "space"])
     foo
 
 Only ``data`` is required; all of other arguments will be filled
@@ -105,23 +106,37 @@ As a list of tuples:
 
 .. ipython:: python
 
-    xr.DataArray(data, coords=[('time', times), ('space', locs)])
+    xr.DataArray(data, coords=[("time", times), ("space", locs)])
 
 As a dictionary:
 
 .. ipython:: python
 
-    xr.DataArray(data, coords={'time': times, 'space': locs, 'const': 42,
-                               'ranking': ('space', [1, 2, 3])},
-                 dims=['time', 'space'])
+    xr.DataArray(
+        data,
+        coords={
+            "time": times,
+            "space": locs,
+            "const": 42,
+            "ranking": ("space", [1, 2, 3]),
+        },
+        dims=["time", "space"],
+    )
 
 As a dictionary with coords across multiple dimensions:
 
 .. ipython:: python
 
-    xr.DataArray(data, coords={'time': times, 'space': locs, 'const': 42,
-                               'ranking': (('time', 'space'), np.arange(12).reshape(4,3))},
-                 dims=['time', 'space'])
+    xr.DataArray(
+        data,
+        coords={
+            "time": times,
+            "space": locs,
+            "const": 42,
+            "ranking": (("time", "space"), np.arange(12).reshape(4, 3)),
+        },
+        dims=["time", "space"],
+    )
 
 If you create a ``DataArray`` by supplying a pandas
 :py:class:`~pandas.Series`, :py:class:`~pandas.DataFrame` or
@@ -130,9 +145,9 @@ If you create a ``DataArray`` by supplying a pandas
 
 .. ipython:: python
 
-    df = pd.DataFrame({'x': [0, 1], 'y': [2, 3]}, index=['a', 'b'])
-    df.index.name = 'abc'
-    df.columns.name = 'xyz'
+    df = pd.DataFrame({"x": [0, 1], "y": [2, 3]}, index=["a", "b"])
+    df.index.name = "abc"
+    df.columns.name = "xyz"
     df
     xr.DataArray(df)
 
@@ -153,7 +168,7 @@ You can modify ``values`` inplace:
 
 .. ipython:: python
 
-   foo.values = 1.0 * foo.values
+    foo.values = 1.0 * foo.values
 
 .. note::
 
@@ -166,8 +181,8 @@ Now fill in some of that missing metadata:
 
 .. ipython:: python
 
-    foo.name = 'foo'
-    foo.attrs['units'] = 'meters'
+    foo.name = "foo"
+    foo.attrs["units"] = "meters"
     foo
 
 The :py:meth:`~xarray.DataArray.rename` method is another option, returning a
@@ -175,7 +190,7 @@ new data array:
 
 .. ipython:: python
 
-   foo.rename('bar')
+    foo.rename("bar")
 
 DataArray Coordinates
 ~~~~~~~~~~~~~~~~~~~~~
@@ -186,8 +201,8 @@ itself:
 
 .. ipython:: python
 
-    foo.coords['time']
-    foo['time']
+    foo.coords["time"]
+    foo["time"]
 
 These are also :py:class:`~xarray.DataArray` objects, which contain tick-labels
 for each dimension.
@@ -196,9 +211,9 @@ Coordinates can also be set or removed by using the dictionary like syntax:
 
 .. ipython:: python
 
-    foo['ranking'] = ('space', [1, 2, 3])
+    foo["ranking"] = ("space", [1, 2, 3])
     foo.coords
-    del foo['ranking']
+    del foo["ranking"]
     foo.coords
 
 For more details, see :ref:`coordinates` below.
@@ -276,12 +291,18 @@ Let's create some fake data for the example we show above:
 
     # for real use cases, its good practice to supply array attributes such as
     # units, but we won't bother here for the sake of brevity
-    ds = xr.Dataset({'temperature': (['x', 'y', 'time'],  temp),
-                     'precipitation': (['x', 'y', 'time'], precip)},
-                    coords={'lon': (['x', 'y'], lon),
-                            'lat': (['x', 'y'], lat),
-                            'time': pd.date_range('2014-09-06', periods=3),
-                            'reference_time': pd.Timestamp('2014-09-05')})
+    ds = xr.Dataset(
+        {
+            "temperature": (["x", "y", "time"], temp),
+            "precipitation": (["x", "y", "time"], precip),
+        },
+        coords={
+            "lon": (["x", "y"], lon),
+            "lat": (["x", "y"], lat),
+            "time": pd.date_range("2014-09-06", periods=3),
+            "reference_time": pd.Timestamp("2014-09-05"),
+        },
+    )
     ds
 
 Here we pass :py:class:`xarray.DataArray` objects or a pandas object as values
@@ -289,12 +310,12 @@ in the dictionary:
 
 .. ipython:: python
 
-    xr.Dataset({'bar': foo})
+    xr.Dataset({"bar": foo})
 
 
 .. ipython:: python
 
-    xr.Dataset({'bar': foo.to_pandas()})
+    xr.Dataset({"bar": foo.to_pandas()})
 
 Where a pandas object is supplied as a value, the names of its indexes are used as dimension
 names, and its data is aligned to any existing dimensions.
@@ -315,8 +336,8 @@ values given by :py:class:`xarray.DataArray` objects:
 
 .. ipython:: python
 
-    'temperature' in ds
-    ds['temperature']
+    "temperature" in ds
+    ds["temperature"]
 
 Valid keys include each listed coordinate and data variable.
 
@@ -336,7 +357,7 @@ of `attributes`:
 
     ds.attrs
 
-    ds.attrs['title'] = 'example attribute'
+    ds.attrs["title"] = "example attribute"
     ds
 
 xarray does not enforce any restrictions on attributes, but serialization to
@@ -364,13 +385,13 @@ example, to create this example dataset from scratch, we could have written:
 .. ipython:: python
 
     ds = xr.Dataset()
-    ds['temperature'] = (('x', 'y', 'time'), temp)
-    ds['temperature_double'] = (('x', 'y', 'time'), temp * 2 )
-    ds['precipitation'] = (('x', 'y', 'time'), precip)
-    ds.coords['lat'] = (('x', 'y'), lat)
-    ds.coords['lon'] = (('x', 'y'), lon)
-    ds.coords['time'] = pd.date_range('2014-09-06', periods=3)
-    ds.coords['reference_time'] = pd.Timestamp('2014-09-05')
+    ds["temperature"] = (("x", "y", "time"), temp)
+    ds["temperature_double"] = (("x", "y", "time"), temp * 2)
+    ds["precipitation"] = (("x", "y", "time"), precip)
+    ds.coords["lat"] = (("x", "y"), lat)
+    ds.coords["lon"] = (("x", "y"), lon)
+    ds.coords["time"] = pd.date_range("2014-09-06", periods=3)
+    ds.coords["reference_time"] = pd.Timestamp("2014-09-05")
 
 To change the variables in a ``Dataset``, you can use all the standard dictionary
 methods, including ``values``, ``items``, ``__delitem__``, ``get`` and
@@ -400,16 +421,16 @@ operations keep around coordinates:
 
 .. ipython:: python
 
-    ds[['temperature']]
-    ds[['temperature', 'temperature_double']]
-    ds.drop_vars('temperature')
+    ds[["temperature"]]
+    ds[["temperature", "temperature_double"]]
+    ds.drop_vars("temperature")
 
 To remove a dimension, you can use :py:meth:`~xarray.Dataset.drop_dims` method.
 Any variables using that dimension are dropped:
 
 .. ipython:: python
 
-    ds.drop_dims('time')
+    ds.drop_dims("time")
 
 As an alternate to dictionary-like modifications, you can use
 :py:meth:`~xarray.Dataset.assign` and :py:meth:`~xarray.Dataset.assign_coords`.
@@ -417,7 +438,7 @@ These methods return a new dataset with additional (or replaced) values:
 
 .. ipython:: python
 
-    ds.assign(temperature2 = 2 * ds.temperature)
+    ds.assign(temperature2=2 * ds.temperature)
 
 There is also the :py:meth:`~xarray.Dataset.pipe` method that allows you to use
 a method call with an external function (e.g., ``ds.pipe(func)``) instead of
@@ -429,12 +450,8 @@ follow nested function calls:
 
     # these lines are equivalent, but with pipe we can make the logic flow
     # entirely from left to right
-    plt.plot((2 * ds.temperature.sel(x=0)).mean('y'))
-    (ds.temperature
-     .sel(x=0)
-     .pipe(lambda x: 2 * x)
-     .mean('y')
-     .pipe(plt.plot))
+    plt.plot((2 * ds.temperature.sel(x=0)).mean("y"))
+    (ds.temperature.sel(x=0).pipe(lambda x: 2 * x).mean("y").pipe(plt.plot))
 
 Both ``pipe`` and ``assign`` replicate the pandas methods of the same names
 (:py:meth:`DataFrame.pipe <pandas.DataFrame.pipe>` and
@@ -453,15 +470,15 @@ dataset variables:
 
 .. ipython:: python
 
-    ds.rename({'temperature': 'temp', 'precipitation': 'precip'})
+    ds.rename({"temperature": "temp", "precipitation": "precip"})
 
 The related :py:meth:`~xarray.Dataset.swap_dims` method allows you do to swap
 dimension and non-dimension variables:
 
 .. ipython:: python
 
-    ds.coords['day'] = ('time', [6, 7, 8])
-    ds.swap_dims({'time': 'day'})
+    ds.coords["day"] = ("time", [6, 7, 8])
+    ds.swap_dims({"time": "day"})
 
 .. _coordinates:
 
@@ -519,8 +536,8 @@ To convert back and forth between data and coordinates, you can use the
 .. ipython:: python
 
     ds.reset_coords()
-    ds.set_coords(['temperature', 'precipitation'])
-    ds['temperature'].reset_coords(drop=True)
+    ds.set_coords(["temperature", "precipitation"])
+    ds["temperature"].reset_coords(drop=True)
 
 Notice that these operations skip coordinates with names given by dimensions,
 as used for indexing. This mostly because we are not entirely sure how to
@@ -544,7 +561,7 @@ logic used for merging coordinates in arithmetic operations
 
 .. ipython:: python
 
-    alt = xr.Dataset(coords={'z': [10], 'lat': 0, 'lon': 0})
+    alt = xr.Dataset(coords={"z": [10], "lat": 0, "lon": 0})
     ds.coords.merge(alt.coords)
 
 The ``coords.merge`` method may be useful if you want to implement your own
@@ -560,7 +577,7 @@ To convert a coordinate (or any ``DataArray``) into an actual
 
 .. ipython:: python
 
-    ds['time'].to_index()
+    ds["time"].to_index()
 
 A useful shortcut is the ``indexes`` property (on both ``DataArray`` and
 ``Dataset``), which lazily constructs a dictionary whose keys are given by each
@@ -577,9 +594,10 @@ Xarray supports labeling coordinate values with a :py:class:`pandas.MultiIndex`:
 
 .. ipython:: python
 
-    midx = pd.MultiIndex.from_arrays([['R', 'R', 'V', 'V'], [.1, .2, .7, .9]],
-                                     names=('band', 'wn'))
-    mda = xr.DataArray(np.random.rand(4), coords={'spec': midx}, dims='spec')
+    midx = pd.MultiIndex.from_arrays(
+        [["R", "R", "V", "V"], [0.1, 0.2, 0.7, 0.9]], names=("band", "wn")
+    )
+    mda = xr.DataArray(np.random.rand(4), coords={"spec": midx}, dims="spec")
     mda
 
 For convenience multi-index levels are directly accessible as "virtual" or
@@ -587,8 +605,8 @@ For convenience multi-index levels are directly accessible as "virtual" or
 
 .. ipython:: python
 
-     mda['band']
-     mda.wn
+    mda["band"]
+    mda.wn
 
 Indexing with multi-index levels is also possible using the ``sel`` method
 (see :ref:`multi-level indexing`).

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -4,11 +4,12 @@ Frequently Asked Questions
 ==========================
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     import numpy as np
     import pandas as pd
     import xarray as xr
+
     np.random.seed(123456)
 
 
@@ -103,21 +104,21 @@ code fragment
 .. ipython:: python
 
     arr = xr.DataArray([1, 2, 3])
-    pd.Series({'x': arr[0], 'mean': arr.mean(), 'std': arr.std()})
+    pd.Series({"x": arr[0], "mean": arr.mean(), "std": arr.std()})
 
 does not yield the pandas DataFrame we expected. We need to specify the type
 conversion ourselves:
 
 .. ipython:: python
 
-    pd.Series({'x': arr[0], 'mean': arr.mean(), 'std': arr.std()}, dtype=float)
+    pd.Series({"x": arr[0], "mean": arr.mean(), "std": arr.std()}, dtype=float)
 
 Alternatively, we could use the ``item`` method or the ``float`` constructor to
 convert values one at a time
 
 .. ipython:: python
 
-    pd.Series({'x': arr[0].item(), 'mean': float(arr.mean())})
+    pd.Series({"x": arr[0].item(), "mean": float(arr.mean())})
 
 
 .. _approach to metadata:

--- a/doc/groupby.rst
+++ b/doc/groupby.rst
@@ -26,11 +26,12 @@ Split
 Let's create a simple example dataset:
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     import numpy as np
     import pandas as pd
     import xarray as xr
+
     np.random.seed(123456)
 
 .. ipython:: python
@@ -47,20 +48,20 @@ use a DataArray directly), we get back a ``GroupBy`` object:
 
 .. ipython:: python
 
-    ds.groupby('letters')
+    ds.groupby("letters")
 
 This object works very similarly to a pandas GroupBy object. You can view
 the group indices with the ``groups`` attribute:
 
 .. ipython:: python
 
-    ds.groupby('letters').groups
+    ds.groupby("letters").groups
 
 You can also iterate over groups in ``(label, group)`` pairs:
 
 .. ipython:: python
 
-    list(ds.groupby('letters'))
+    list(ds.groupby("letters"))
 
 Just like in pandas, creating a GroupBy object is cheap: it does not actually
 split the data until you access particular values.
@@ -75,8 +76,8 @@ a customized coordinate, but xarray facilitates this via the
 
 .. ipython:: python
 
-    x_bins = [0,25,50]
-    ds.groupby_bins('x', x_bins).groups
+    x_bins = [0, 25, 50]
+    ds.groupby_bins("x", x_bins).groups
 
 The binning is implemented via :func:`pandas.cut`, whose documentation details how
 the bins are assigned. As seen in the example above, by default, the bins are
@@ -86,8 +87,8 @@ choose `float` labels which identify the bin centers:
 
 .. ipython:: python
 
-    x_bin_labels = [12.5,37.5]
-    ds.groupby_bins('x', x_bins, labels=x_bin_labels).groups
+    x_bin_labels = [12.5, 37.5]
+    ds.groupby_bins("x", x_bins, labels=x_bin_labels).groups
 
 
 Apply
@@ -102,7 +103,8 @@ concatenated back together along the group axis:
     def standardize(x):
         return (x - x.mean()) / x.std()
 
-    arr.groupby('letters').map(standardize)
+
+    arr.groupby("letters").map(standardize)
 
 GroupBy objects also have a :py:meth:`~xarray.core.groupby.DatasetGroupBy.reduce` method and
 methods like :py:meth:`~xarray.core.groupby.DatasetGroupBy.mean` as shortcuts for applying an
@@ -110,14 +112,14 @@ aggregation function:
 
 .. ipython:: python
 
-    arr.groupby('letters').mean(dim='x')
+    arr.groupby("letters").mean(dim="x")
 
 Using a groupby is thus also a convenient shortcut for aggregating over all
 dimensions *other than* the provided one:
 
 .. ipython:: python
 
-    ds.groupby('x').std(...)
+    ds.groupby("x").std(...)
 
 .. note::
 
@@ -134,7 +136,7 @@ values for group along the grouped dimension:
 
 .. ipython:: python
 
-    ds.groupby('letters').first(...)
+    ds.groupby("letters").first(...)
 
 By default, they skip missing values (control this with ``skipna``).
 
@@ -149,9 +151,9 @@ coordinates. For example:
 
 .. ipython:: python
 
-    alt = arr.groupby('letters').mean(...)
+    alt = arr.groupby("letters").mean(...)
     alt
-    ds.groupby('letters') - alt
+    ds.groupby("letters") - alt
 
 This last line is roughly equivalent to the following::
 
@@ -169,11 +171,11 @@ the ``squeeze`` parameter:
 
 .. ipython:: python
 
-    next(iter(arr.groupby('x')))
+    next(iter(arr.groupby("x")))
 
 .. ipython:: python
 
-    next(iter(arr.groupby('x', squeeze=False)))
+    next(iter(arr.groupby("x", squeeze=False)))
 
 Although xarray will attempt to automatically
 :py:attr:`~xarray.DataArray.transpose` dimensions back into their original order
@@ -197,13 +199,17 @@ __ http://cfconventions.org/cf-conventions/v1.6.0/cf-conventions.html#_two_dimen
 
 .. ipython:: python
 
-    da = xr.DataArray([[0,1],[2,3]],
-        coords={'lon': (['ny','nx'], [[30,40],[40,50]] ),
-                'lat': (['ny','nx'], [[10,10],[20,20]] ),},
-        dims=['ny','nx'])
+    da = xr.DataArray(
+        [[0, 1], [2, 3]],
+        coords={
+            "lon": (["ny", "nx"], [[30, 40], [40, 50]]),
+            "lat": (["ny", "nx"], [[10, 10], [20, 20]]),
+        },
+        dims=["ny", "nx"],
+    )
     da
-    da.groupby('lon').sum(...)
-    da.groupby('lon').map(lambda x: x - x.mean(), shortcut=False)
+    da.groupby("lon").sum(...)
+    da.groupby("lon").map(lambda x: x - x.mean(), shortcut=False)
 
 Because multidimensional groups have the ability to generate a very large
 number of bins, coarse-binning via :py:meth:`~xarray.Dataset.groupby_bins`
@@ -211,7 +217,7 @@ may be desirable:
 
 .. ipython:: python
 
-    da.groupby_bins('lon', [0,45,50]).sum()
+    da.groupby_bins("lon", [0, 45, 50]).sum()
 
 These methods group by `lon` values. It is also possible to groupby each
 cell in a grid, regardless of value, by stacking multiple dimensions, 
@@ -219,5 +225,5 @@ applying your function, and then unstacking the result:
 
 .. ipython:: python
 
-   stacked = da.stack(gridcell=['ny', 'nx'])
-   stacked.groupby('gridcell').sum(...).unstack('gridcell')
+    stacked = da.stack(gridcell=["ny", "nx"])
+    stacked.groupby("gridcell").sum(...).unstack("gridcell")

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -4,11 +4,12 @@ Indexing and selecting data
 ===========================
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     import numpy as np
     import pandas as pd
     import xarray as xr
+
     np.random.seed(123456)
 
 xarray offers extremely flexible indexing routines that combine the best
@@ -60,9 +61,13 @@ DataArray:
 
 .. ipython:: python
 
-    da = xr.DataArray(np.random.rand(4, 3),
-                      [('time', pd.date_range('2000-01-01', periods=4)),
-                       ('space', ['IA', 'IL', 'IN'])])
+    da = xr.DataArray(
+        np.random.rand(4, 3),
+        [
+            ("time", pd.date_range("2000-01-01", periods=4)),
+            ("space", ["IA", "IL", "IN"]),
+        ],
+    )
     da[:2]
     da[0, 0]
     da[:, [2, 1]]
@@ -81,7 +86,7 @@ fast. To do label based indexing, use the :py:attr:`~xarray.DataArray.loc` attri
 
 .. ipython:: python
 
-    da.loc['2000-01-01':'2000-01-02', 'IA']
+    da.loc["2000-01-01":"2000-01-02", "IA"]
 
 In this example, the selected is a subpart of the array
 in the range '2000-01-01':'2000-01-02' along the first coordinate `time`
@@ -98,7 +103,7 @@ Setting values with label based indexing is also supported:
 
 .. ipython:: python
 
-    da.loc['2000-01-01', ['IL', 'IN']] = -10
+    da.loc["2000-01-01", ["IL", "IN"]] = -10
     da
 
 
@@ -117,7 +122,7 @@ use them explicitly to slice data. There are two ways to do this:
         da[dict(space=0, time=slice(None, 2))]
 
         # index by dimension coordinate labels
-        da.loc[dict(time=slice('2000-01-01', '2000-01-02'))]
+        da.loc[dict(time=slice("2000-01-01", "2000-01-02"))]
 
 2. Use the :py:meth:`~xarray.DataArray.sel` and :py:meth:`~xarray.DataArray.isel`
    convenience methods:
@@ -128,7 +133,7 @@ use them explicitly to slice data. There are two ways to do this:
         da.isel(space=0, time=slice(None, 2))
 
         # index by dimension coordinate labels
-        da.sel(time=slice('2000-01-01', '2000-01-02'))
+        da.sel(time=slice("2000-01-01", "2000-01-02"))
 
 The arguments to these methods can be any objects that could index the array
 along the dimension given by the keyword, e.g., labels for an individual value,
@@ -156,16 +161,16 @@ enabling nearest neighbor (inexact) lookups by use of the methods ``'pad'``,
 
 .. ipython:: python
 
-   da = xr.DataArray([1, 2, 3], [('x', [0, 1, 2])])
-   da.sel(x=[1.1, 1.9], method='nearest')
-   da.sel(x=0.1, method='backfill')
-   da.reindex(x=[0.5, 1, 1.5, 2, 2.5], method='pad')
+    da = xr.DataArray([1, 2, 3], [("x", [0, 1, 2])])
+    da.sel(x=[1.1, 1.9], method="nearest")
+    da.sel(x=0.1, method="backfill")
+    da.reindex(x=[0.5, 1, 1.5, 2, 2.5], method="pad")
 
 Tolerance limits the maximum distance for valid matches with an inexact lookup:
 
 .. ipython:: python
 
-   da.reindex(x=[1.1, 1.5], method='nearest', tolerance=0.2)
+    da.reindex(x=[1.1, 1.5], method="nearest", tolerance=0.2)
 
 The method parameter is not yet supported if any of the arguments
 to ``.sel()`` is a ``slice`` object:
@@ -173,7 +178,7 @@ to ``.sel()`` is a ``slice`` object:
 .. ipython::
    :verbatim:
 
-   In [1]: da.sel(x=slice(1, 3), method='nearest')
+   In [1]: da.sel(x=slice(1, 3), method="nearest")
    NotImplementedError
 
 However, you don't need to use ``method`` to do inexact slicing. Slicing
@@ -182,15 +187,15 @@ labels are monotonic increasing:
 
 .. ipython:: python
 
-   da.sel(x=slice(0.9, 3.1))
+    da.sel(x=slice(0.9, 3.1))
 
 Indexing axes with monotonic decreasing labels also works, as long as the
 ``slice`` or ``.loc`` arguments are also decreasing:
 
 .. ipython:: python
 
-   reversed_da = da[::-1]
-   reversed_da.loc[3.1:0.9]
+    reversed_da = da[::-1]
+    reversed_da.loc[3.1:0.9]
 
 
 .. note::
@@ -227,7 +232,7 @@ arrays). However, you can do normal indexing with dimension names:
 .. ipython:: python
 
     ds[dict(space=[0], time=[0])]
-    ds.loc[dict(time='2000-01-01')]
+    ds.loc[dict(time="2000-01-01")]
 
 Using indexing to *assign* values to a subset of dataset (e.g.,
 ``ds[dict(space=0)] = 1``) is not yet supported.
@@ -240,7 +245,7 @@ index labels along a dimension dropped:
 
 .. ipython:: python
 
-    ds.drop_sel(space=['IN', 'IL'])
+    ds.drop_sel(space=["IN", "IL"])
 
 ``drop_sel`` is both a ``Dataset`` and ``DataArray`` method.
 
@@ -249,7 +254,7 @@ Any variables with these dimensions are also dropped:
 
 .. ipython:: python
 
-    ds.drop_dims('time')
+    ds.drop_dims("time")
 
 .. _masking with where:
 
@@ -263,7 +268,7 @@ xarray, use :py:meth:`~xarray.DataArray.where`:
 
 .. ipython:: python
 
-    da = xr.DataArray(np.arange(16).reshape(4, 4), dims=['x', 'y'])
+    da = xr.DataArray(np.arange(16).reshape(4, 4), dims=["x", "y"])
     da.where(da.x + da.y < 4)
 
 This is particularly useful for ragged indexing of multi-dimensional data,
@@ -296,7 +301,7 @@ multiple values, use :py:meth:`~xarray.DataArray.isin`:
 
 .. ipython:: python
 
-    da = xr.DataArray([1, 2, 3, 4, 5], dims=['x'])
+    da = xr.DataArray([1, 2, 3, 4, 5], dims=["x"])
     da.isin([2, 4])
 
 :py:meth:`~xarray.DataArray.isin` works particularly well with
@@ -305,7 +310,7 @@ already labels of an array:
 
 .. ipython:: python
 
-    lookup = xr.DataArray([-1, -2, -3, -4, -5], dims=['x'])
+    lookup = xr.DataArray([-1, -2, -3, -4, -5], dims=["x"])
     da.where(lookup.isin([-2, -4]), drop=True)
 
 However, some caution is in order: when done repeatedly, this type of indexing
@@ -328,7 +333,6 @@ MATLAB, or after using the :py:func:`numpy.ix_` helper:
 
 .. ipython:: python
 
-
     da = xr.DataArray(
         np.arange(12).reshape((3, 4)),
         dims=["x", "y"],
@@ -344,8 +348,8 @@ dimensions:
 
 .. ipython:: python
 
-    ind_x = xr.DataArray([0, 1], dims=['x'])
-    ind_y = xr.DataArray([0, 1], dims=['y'])
+    ind_x = xr.DataArray([0, 1], dims=["x"])
+    ind_y = xr.DataArray([0, 1], dims=["y"])
     da[ind_x, ind_y]  # orthogonal indexing
     da[ind_x, ind_x]  # vectorized indexing
 
@@ -364,7 +368,7 @@ indexers' dimension:
 
 .. ipython:: python
 
-    ind = xr.DataArray([[0, 1], [0, 1]], dims=['a', 'b'])
+    ind = xr.DataArray([[0, 1], [0, 1]], dims=["a", "b"])
     da[ind]
 
 Similar to how NumPy's `advanced indexing`_ works, vectorized
@@ -378,18 +382,18 @@ Vectorized indexing also works with ``isel``, ``loc``, and ``sel``:
 
 .. ipython:: python
 
-    ind = xr.DataArray([[0, 1], [0, 1]], dims=['a', 'b'])
+    ind = xr.DataArray([[0, 1], [0, 1]], dims=["a", "b"])
     da.isel(y=ind)  # same as da[:, ind]
 
-    ind = xr.DataArray([['a', 'b'], ['b', 'a']], dims=['a', 'b'])
+    ind = xr.DataArray([["a", "b"], ["b", "a"]], dims=["a", "b"])
     da.loc[:, ind]  # same as da.sel(y=ind)
 
 These methods may also be applied to ``Dataset`` objects
 
 .. ipython:: python
 
-    ds = da.to_dataset(name='bar')
-    ds.isel(x=xr.DataArray([0, 1, 2], dims=['points']))
+    ds = da.to_dataset(name="bar")
+    ds.isel(x=xr.DataArray([0, 1, 2], dims=["points"]))
 
 .. tip::
 
@@ -476,8 +480,8 @@ Like ``numpy.ndarray``, value assignment sometimes works differently from what o
 
 .. ipython:: python
 
-    da = xr.DataArray([0, 1, 2, 3], dims=['x'])
-    ind = xr.DataArray([0, 0, 0], dims=['x'])
+    da = xr.DataArray([0, 1, 2, 3], dims=["x"])
+    ind = xr.DataArray([0, 0, 0], dims=["x"])
     da[ind] -= 1
     da
 
@@ -511,7 +515,7 @@ __ https://docs.scipy.org/doc/numpy/user/basics.indexing.html#assigning-values-t
 
   .. ipython:: python
 
-      da = xr.DataArray([0, 1, 2, 3], dims=['x'])
+      da = xr.DataArray([0, 1, 2, 3], dims=["x"])
       # DO NOT do this
       da.isel(x=[0, 1, 2])[1] = -1
       da
@@ -581,15 +585,15 @@ To reindex a particular dimension, use :py:meth:`~xarray.DataArray.reindex`:
 
 .. ipython:: python
 
-    da.reindex(space=['IA', 'CA'])
+    da.reindex(space=["IA", "CA"])
 
 The :py:meth:`~xarray.DataArray.reindex_like` method is a useful shortcut.
 To demonstrate, we will make a subset DataArray with new values:
 
 .. ipython:: python
 
-    foo = da.rename('foo')
-    baz = (10 * da[:2, :2]).rename('baz')
+    foo = da.rename("foo")
+    baz = (10 * da[:2, :2]).rename("baz")
     baz
 
 Reindexing ``foo`` with ``baz`` selects out the first two values along each
@@ -611,8 +615,8 @@ The :py:func:`~xarray.align` function lets us perform more flexible database-lik
 
 .. ipython:: python
 
-    xr.align(foo, baz, join='inner')
-    xr.align(foo, baz, join='outer')
+    xr.align(foo, baz, join="inner")
+    xr.align(foo, baz, join="outer")
 
 Both ``reindex_like`` and ``align`` work interchangeably between
 :py:class:`~xarray.DataArray` and :py:class:`~xarray.Dataset` objects, and with any number of matching dimension names:
@@ -621,7 +625,7 @@ Both ``reindex_like`` and ``align`` work interchangeably between
 
     ds
     ds.reindex_like(baz)
-    other = xr.DataArray(['a', 'b', 'c'], dims='other')
+    other = xr.DataArray(["a", "b", "c"], dims="other")
     # this is a no-op, because there are no shared dimension names
     ds.reindex_like(other)
 
@@ -636,7 +640,7 @@ integer-based indexing as a fallback for dimensions without a coordinate label:
 
 .. ipython:: python
 
-    da = xr.DataArray([1, 2, 3], dims='x')
+    da = xr.DataArray([1, 2, 3], dims="x")
     da.sel(x=[0, -1])
 
 Alignment between xarray objects where one or both do not have coordinate labels
@@ -675,9 +679,9 @@ labels:
 
 .. ipython:: python
 
-    da = xr.DataArray([1, 2, 3], dims='x')
+    da = xr.DataArray([1, 2, 3], dims="x")
     da
-    da.get_index('x')
+    da.get_index("x")
 
 
 .. _copies_vs_views:
@@ -721,7 +725,6 @@ pandas:
 
 .. ipython:: python
 
-
     midx = pd.MultiIndex.from_product([list("abc"), [0, 1]], names=("one", "two"))
     mda = xr.DataArray(np.random.rand(6, 3), [("x", midx), ("y", range(3))])
     mda
@@ -732,20 +735,20 @@ a slice of tuples:
 
 .. ipython:: python
 
-    mda.sel(x=[('a', 0), ('b', 1)])
+    mda.sel(x=[("a", 0), ("b", 1)])
 
 Additionally, xarray supports dictionaries:
 
 .. ipython:: python
 
-    mda.sel(x={'one': 'a', 'two': 0})
+    mda.sel(x={"one": "a", "two": 0})
 
 For convenience, ``sel`` also accepts multi-index levels directly
 as keyword arguments:
 
 .. ipython:: python
 
-    mda.sel(one='a', two=0)
+    mda.sel(one="a", two=0)
 
 Note that using ``sel`` it is not possible to mix a dimension
 indexer with level indexers for that dimension
@@ -757,7 +760,7 @@ multi-index is reduced to a single index.
 
 .. ipython:: python
 
-    mda.loc[{'one': 'a'}, ...]
+    mda.loc[{"one": "a"}, ...]
 
 Unlike pandas, xarray does not guess whether you provide index levels or
 dimensions when using ``loc`` in some ambiguous cases. For example, for

--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -46,11 +46,12 @@ Extending xarray
 ----------------
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     import numpy as np
     import pandas as pd
     import xarray as xr
+
     np.random.seed(123456)
 
 xarray is designed as a general purpose library, and hence tries to avoid
@@ -87,11 +88,12 @@ defined that returns an instance of your class:
 
 .. code-block:: python
 
-  class Dataset:
-      ...
-      @property
-      def geo(self):
-          return GeoAccessor(self)
+    class Dataset:
+        ...
+
+        @property
+        def geo(self):
+            return GeoAccessor(self)
 
 However, using the register accessor decorators is preferable to simply adding
 your own ad-hoc property (i.e., ``Dataset.geo = property(...)``), for several
@@ -116,14 +118,13 @@ reasons:
 Back in an interactive IPython session, we can use these properties:
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
-   exec(open("examples/_code/accessor_example.py").read())
+    exec(open("examples/_code/accessor_example.py").read())
 
 .. ipython:: python
 
-    ds = xr.Dataset({'longitude': np.linspace(0, 10),
-                     'latitude': np.linspace(0, 20)})
+    ds = xr.Dataset({"longitude": np.linspace(0, 10), "latitude": np.linspace(0, 20)})
     ds.geo.center
     ds.geo.plot()
 

--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -90,7 +90,7 @@ defined that returns an instance of your class:
   class Dataset:
       ...
       @property
-      def geo(self)
+      def geo(self):
           return GeoAccessor(self)
 
 However, using the register accessor decorators is preferable to simply adding

--- a/doc/interpolation.rst
+++ b/doc/interpolation.rst
@@ -4,11 +4,12 @@ Interpolating data
 ==================
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     import numpy as np
     import pandas as pd
     import xarray as xr
+
     np.random.seed(123456)
 
 xarray offers flexible interpolation routines, which have a similar interface
@@ -27,9 +28,10 @@ indexing of a :py:class:`~xarray.DataArray`,
 
 .. ipython:: python
 
-    da = xr.DataArray(np.sin(0.3 * np.arange(12).reshape(4, 3)),
-                      [('time', np.arange(4)),
-                       ('space', [0.1, 0.2, 0.3])])
+    da = xr.DataArray(
+        np.sin(0.3 * np.arange(12).reshape(4, 3)),
+        [("time", np.arange(4)), ("space", [0.1, 0.2, 0.3])],
+    )
     # label lookup
     da.sel(time=3)
 
@@ -52,16 +54,17 @@ To interpolate data with a :py:doc:`numpy.datetime64 <reference/arrays.datetime>
 
 .. ipython:: python
 
-    da_dt64 = xr.DataArray([1, 3],
-                           [('time', pd.date_range('1/1/2000', '1/3/2000', periods=2))])
-    da_dt64.interp(time='2000-01-02')
+    da_dt64 = xr.DataArray(
+        [1, 3], [("time", pd.date_range("1/1/2000", "1/3/2000", periods=2))]
+    )
+    da_dt64.interp(time="2000-01-02")
 
 The interpolated data can be merged into the original :py:class:`~xarray.DataArray`
 by specifying the time periods required.
 
 .. ipython:: python
 
-    da_dt64.interp(time=pd.date_range('1/1/2000', '1/3/2000', periods=3))
+    da_dt64.interp(time=pd.date_range("1/1/2000", "1/3/2000", periods=3))
 
 Interpolation of data indexed by a :py:class:`~xarray.CFTimeIndex` is also
 allowed.  See :ref:`CFTimeIndex` for examples.
@@ -108,9 +111,10 @@ different coordinates,
 
 .. ipython:: python
 
-  other = xr.DataArray(np.sin(0.4 * np.arange(9).reshape(3, 3)),
-                       [('time', [0.9, 1.9, 2.9]),
-                       ('space', [0.15, 0.25, 0.35])])
+    other = xr.DataArray(
+        np.sin(0.4 * np.arange(9).reshape(3, 3)),
+        [("time", [0.9, 1.9, 2.9]), ("space", [0.15, 0.25, 0.35])],
+    )
 
 it might be a good idea to first interpolate ``da`` so that it will stay on the
 same coordinates of ``other``, and then subtract it.
@@ -118,9 +122,9 @@ same coordinates of ``other``, and then subtract it.
 
 .. ipython:: python
 
-  # interpolate da along other's coordinates
-  interpolated = da.interp_like(other)
-  interpolated
+    # interpolate da along other's coordinates
+    interpolated = da.interp_like(other)
+    interpolated
 
 It is now possible to safely compute the difference ``other - interpolated``.
 
@@ -135,12 +139,15 @@ The interpolation method can be specified by the optional ``method`` argument.
 
 .. ipython:: python
 
-    da = xr.DataArray(np.sin(np.linspace(0, 2 * np.pi, 10)), dims='x',
-                      coords={'x': np.linspace(0, 1, 10)})
+    da = xr.DataArray(
+        np.sin(np.linspace(0, 2 * np.pi, 10)),
+        dims="x",
+        coords={"x": np.linspace(0, 1, 10)},
+    )
 
-    da.plot.line('o', label='original')
-    da.interp(x=np.linspace(0, 1, 100)).plot.line(label='linear (default)')
-    da.interp(x=np.linspace(0, 1, 100), method='cubic').plot.line(label='cubic')
+    da.plot.line("o", label="original")
+    da.interp(x=np.linspace(0, 1, 100)).plot.line(label="linear (default)")
+    da.interp(x=np.linspace(0, 1, 100), method="cubic").plot.line(label="cubic")
     @savefig interpolation_sample1.png width=4in
     plt.legend()
 
@@ -149,15 +156,16 @@ Additional keyword arguments can be passed to scipy's functions.
 .. ipython:: python
 
     # fill 0 for the outside of the original coordinates.
-    da.interp(x=np.linspace(-0.5, 1.5, 10), kwargs={'fill_value': 0.0})
+    da.interp(x=np.linspace(-0.5, 1.5, 10), kwargs={"fill_value": 0.0})
     # 1-dimensional extrapolation
-    da.interp(x=np.linspace(-0.5, 1.5, 10), kwargs={'fill_value': 'extrapolate'})
+    da.interp(x=np.linspace(-0.5, 1.5, 10), kwargs={"fill_value": "extrapolate"})
     # multi-dimensional extrapolation
-    da = xr.DataArray(np.sin(0.3 * np.arange(12).reshape(4, 3)),
-                      [('time', np.arange(4)),
-                       ('space', [0.1, 0.2, 0.3])])
+    da = xr.DataArray(
+        np.sin(0.3 * np.arange(12).reshape(4, 3)),
+        [("time", np.arange(4)), ("space", [0.1, 0.2, 0.3])],
+    )
 
-    da.interp(time=4, space=np.linspace(-0.1, 0.5, 10), kwargs={'fill_value': None})
+    da.interp(time=4, space=np.linspace(-0.1, 0.5, 10), kwargs={"fill_value": None})
 
 
 Advanced Interpolation
@@ -181,17 +189,18 @@ For example:
 
 .. ipython:: python
 
-    da = xr.DataArray(np.sin(0.3 * np.arange(20).reshape(5, 4)),
-                      [('x', np.arange(5)),
-                       ('y', [0.1, 0.2, 0.3, 0.4])])
+    da = xr.DataArray(
+        np.sin(0.3 * np.arange(20).reshape(5, 4)),
+        [("x", np.arange(5)), ("y", [0.1, 0.2, 0.3, 0.4])],
+    )
     # advanced indexing
-    x = xr.DataArray([0, 2, 4], dims='z')
-    y = xr.DataArray([0.1, 0.2, 0.3], dims='z')
+    x = xr.DataArray([0, 2, 4], dims="z")
+    y = xr.DataArray([0.1, 0.2, 0.3], dims="z")
     da.sel(x=x, y=y)
 
     # advanced interpolation
-    x = xr.DataArray([0.5, 1.5, 2.5], dims='z')
-    y = xr.DataArray([0.15, 0.25, 0.35], dims='z')
+    x = xr.DataArray([0.5, 1.5, 2.5], dims="z")
+    y = xr.DataArray([0.15, 0.25, 0.35], dims="z")
     da.interp(x=x, y=y)
 
 where values on the original coordinates
@@ -203,9 +212,8 @@ If you want to add a coordinate to the new dimension ``z``, you can supply
 
 .. ipython:: python
 
-    x = xr.DataArray([0.5, 1.5, 2.5], dims='z', coords={'z': ['a', 'b','c']})
-    y = xr.DataArray([0.15, 0.25, 0.35], dims='z',
-                     coords={'z': ['a', 'b','c']})
+    x = xr.DataArray([0.5, 1.5, 2.5], dims="z", coords={"z": ["a", "b", "c"]})
+    y = xr.DataArray([0.15, 0.25, 0.35], dims="z", coords={"z": ["a", "b", "c"]})
     da.interp(x=x, y=y)
 
 For the details of the advanced indexing,
@@ -224,19 +232,18 @@ while other methods such as ``cubic`` or ``quadratic`` return all NaN arrays.
 
 .. ipython:: python
 
-    da = xr.DataArray([0, 2, np.nan, 3, 3.25], dims='x',
-                      coords={'x': range(5)})
+    da = xr.DataArray([0, 2, np.nan, 3, 3.25], dims="x", coords={"x": range(5)})
     da.interp(x=[0.5, 1.5, 2.5])
-    da.interp(x=[0.5, 1.5, 2.5], method='cubic')
+    da.interp(x=[0.5, 1.5, 2.5], method="cubic")
 
 To avoid this, you can drop NaN by :py:meth:`~xarray.DataArray.dropna`, and
 then make the interpolation
 
 .. ipython:: python
 
-    dropped = da.dropna('x')
+    dropped = da.dropna("x")
     dropped
-    dropped.interp(x=[0.5, 1.5, 2.5], method='cubic')
+    dropped.interp(x=[0.5, 1.5, 2.5], method="cubic")
 
 If NaNs are distributed randomly in your multidimensional array,
 dropping all the columns containing more than one NaNs by
@@ -246,7 +253,7 @@ which is similar to :py:meth:`pandas.Series.interpolate`.
 
 .. ipython:: python
 
-    filled = da.interpolate_na(dim='x')
+    filled = da.interpolate_na(dim="x")
     filled
 
 This fills NaN by interpolating along the specified dimension.
@@ -254,7 +261,7 @@ After filling NaNs, you can interpolate:
 
 .. ipython:: python
 
-    filled.interp(x=[0.5, 1.5, 2.5], method='cubic')
+    filled.interp(x=[0.5, 1.5, 2.5], method="cubic")
 
 For the details of :py:meth:`~xarray.DataArray.interpolate_na`,
 see :ref:`Missing values <missing_values>`.
@@ -268,18 +275,18 @@ Let's see how :py:meth:`~xarray.DataArray.interp` works on real data.
 .. ipython:: python
 
     # Raw data
-    ds = xr.tutorial.open_dataset('air_temperature').isel(time=0)
+    ds = xr.tutorial.open_dataset("air_temperature").isel(time=0)
     fig, axes = plt.subplots(ncols=2, figsize=(10, 4))
     ds.air.plot(ax=axes[0])
-    axes[0].set_title('Raw data')
+    axes[0].set_title("Raw data")
 
     # Interpolated data
-    new_lon = np.linspace(ds.lon[0], ds.lon[-1], ds.dims['lon'] * 4)
-    new_lat = np.linspace(ds.lat[0], ds.lat[-1], ds.dims['lat'] * 4)
+    new_lon = np.linspace(ds.lon[0], ds.lon[-1], ds.dims["lon"] * 4)
+    new_lat = np.linspace(ds.lat[0], ds.lat[-1], ds.dims["lat"] * 4)
     dsi = ds.interp(lat=new_lat, lon=new_lon)
     dsi.air.plot(ax=axes[1])
     @savefig interpolation_sample3.png width=8in
-    axes[1].set_title('Interpolated data')
+    axes[1].set_title("Interpolated data")
 
 Our advanced interpolation can be used to remap the data to the new coordinate.
 Consider the new coordinates x and z on the two dimensional plane.
@@ -291,20 +298,23 @@ The remapping can be done as follows
     x = np.linspace(240, 300, 100)
     z = np.linspace(20, 70, 100)
     # relation between new and original coordinates
-    lat = xr.DataArray(z, dims=['z'], coords={'z': z})
-    lon = xr.DataArray((x[:, np.newaxis]-270)/np.cos(z*np.pi/180)+270,
-                       dims=['x', 'z'], coords={'x': x, 'z': z})
+    lat = xr.DataArray(z, dims=["z"], coords={"z": z})
+    lon = xr.DataArray(
+        (x[:, np.newaxis] - 270) / np.cos(z * np.pi / 180) + 270,
+        dims=["x", "z"],
+        coords={"x": x, "z": z},
+    )
 
     fig, axes = plt.subplots(ncols=2, figsize=(10, 4))
     ds.air.plot(ax=axes[0])
     # draw the new coordinate on the original coordinates.
     for idx in [0, 33, 66, 99]:
-        axes[0].plot(lon.isel(x=idx), lat, '--k')
+        axes[0].plot(lon.isel(x=idx), lat, "--k")
     for idx in [0, 33, 66, 99]:
-        axes[0].plot(*xr.broadcast(lon.isel(z=idx), lat.isel(z=idx)), '--k')
-    axes[0].set_title('Raw data')
+        axes[0].plot(*xr.broadcast(lon.isel(z=idx), lat.isel(z=idx)), "--k")
+    axes[0].set_title("Raw data")
 
     dsi = ds.interp(lon=lon, lat=lat)
     dsi.air.plot(ax=axes[1])
     @savefig interpolation_sample4.png width=8in
-    axes[1].set_title('Remapped data')
+    axes[1].set_title("Remapped data")

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -9,11 +9,12 @@ simple :ref:`io.pickle` files to the more flexible :ref:`io.netcdf`
 format (recommended).
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     import numpy as np
     import pandas as pd
     import xarray as xr
+
     np.random.seed(123456)
 
 .. _io.netcdf:
@@ -52,12 +53,16 @@ We can save a Dataset to disk using the
 
 .. ipython:: python
 
-    ds = xr.Dataset({'foo': (('x', 'y'), np.random.rand(4, 5))},
-                    coords={'x': [10, 20, 30, 40],
-                            'y': pd.date_range('2000-01-01', periods=5),
-                            'z': ('x', list('abcd'))})
+    ds = xr.Dataset(
+        {"foo": (("x", "y"), np.random.rand(4, 5))},
+        coords={
+            "x": [10, 20, 30, 40],
+            "y": pd.date_range("2000-01-01", periods=5),
+            "z": ("x", list("abcd")),
+        },
+    )
 
-    ds.to_netcdf('saved_on_disk.nc')
+    ds.to_netcdf("saved_on_disk.nc")
 
 By default, the file is saved as netCDF4 (assuming netCDF4-Python is
 installed). You can control the format and engine used to write the file with
@@ -76,7 +81,7 @@ We can load netCDF files to create a new Dataset using
 
 .. ipython:: python
 
-    ds_disk = xr.open_dataset('saved_on_disk.nc')
+    ds_disk = xr.open_dataset("saved_on_disk.nc")
     ds_disk
 
 Similarly, a DataArray can be saved to disk using the
@@ -117,7 +122,7 @@ netCDF file. However, it's often cleaner to use a ``with`` statement:
 .. ipython:: python
 
     # this automatically closes the dataset after use
-    with xr.open_dataset('saved_on_disk.nc') as ds:
+    with xr.open_dataset("saved_on_disk.nc") as ds:
         print(ds.keys())
 
 Although xarray provides reasonable support for incremental reads of files on
@@ -171,7 +176,7 @@ You can view this encoding information (among others) in the
 .. ipython::
     :verbatim:
 
-    In [1]: ds_disk['y'].encoding
+    In [1]: ds_disk["y"].encoding
     Out[1]:
     {'zlib': False,
      'shuffle': False,
@@ -469,7 +474,7 @@ and currently raises a warning unless ``invalid_netcdf=True`` is set:
     :okwarning:
 
     # Writing complex valued data
-    da = xr.DataArray([1.+1.j, 2.+2.j, 3.+3.j])
+    da = xr.DataArray([1.0 + 1.0j, 2.0 + 2.0j, 3.0 + 3.0j])
     da.to_netcdf("complex.nc", engine="h5netcdf", invalid_netcdf=True)
 
     # Reading it back
@@ -479,7 +484,8 @@ and currently raises a warning unless ``invalid_netcdf=True`` is set:
     :suppress:
 
     import os
-    os.remove('complex.nc')
+
+    os.remove("complex.nc")
 
 .. warning::
 
@@ -499,9 +505,11 @@ installed xarray can convert a ``DataArray`` into a ``Cube`` using
 
 .. ipython:: python
 
-    da = xr.DataArray(np.random.rand(4, 5), dims=['x', 'y'],
-                      coords=dict(x=[10, 20, 30, 40],
-                                  y=pd.date_range('2000-01-01', periods=5)))
+    da = xr.DataArray(
+        np.random.rand(4, 5),
+        dims=["x", "y"],
+        coords=dict(x=[10, 20, 30, 40], y=pd.date_range("2000-01-01", periods=5)),
+    )
 
     cube = da.to_iris()
     cube
@@ -548,8 +556,9 @@ __ http://iri.columbia.edu/
     :verbatim:
 
     In [3]: remote_data = xr.open_dataset(
-       ...:     'http://iridl.ldeo.columbia.edu/SOURCES/.OSU/.PRISM/.monthly/dods',
-       ...:     decode_times=False)
+       ...:     "http://iridl.ldeo.columbia.edu/SOURCES/.OSU/.PRISM/.monthly/dods",
+       ...:     decode_times=False,
+       ...: )
 
     In [4]: remote_data
     Out[4]:
@@ -587,7 +596,7 @@ over the network until we look at particular values:
 .. ipython::
     :verbatim:
 
-    In [4]: tmax = remote_data['tmax'][:500, ::3, ::3]
+    In [4]: tmax = remote_data["tmax"][:500, ::3, ::3]
 
     In [5]: tmax
     Out[5]:
@@ -715,7 +724,8 @@ search indices or other automated data discovery tools.
     :suppress:
 
     import os
-    os.remove('saved_on_disk.nc')
+
+    os.remove("saved_on_disk.nc")
 
 .. _io.rasterio:
 
@@ -729,7 +739,7 @@ rasterio is installed. Here is an example of how to use
 .. ipython::
     :verbatim:
 
-    In [7]: rio = xr.open_rasterio('RGB.byte.tif')
+    In [7]: rio = xr.open_rasterio("RGB.byte.tif")
 
     In [8]: rio
     Out[8]:
@@ -769,7 +779,7 @@ GDAL readable raster data using `rasterio`_ as well as for exporting to a geoTIF
 
     In [1]: import rioxarray
 
-    In [2]: rds = rioxarray.open_rasterio('RGB.byte.tif')
+    In [2]: rds = rioxarray.open_rasterio("RGB.byte.tif")
 
     In [3]: rds
     Out[3]:
@@ -799,7 +809,7 @@ GDAL readable raster data using `rasterio`_ as well as for exporting to a geoTIF
     In [6]: rds4326.rio.crs
     Out[6]: CRS.from_epsg(4326)
 
-    In [7]: rds4326.rio.to_raster('RGB.byte.4326.tif')
+    In [7]: rds4326.rio.to_raster("RGB.byte.4326.tif")
 
 
 .. _rasterio: https://rasterio.readthedocs.io/en/latest/
@@ -831,17 +841,21 @@ xarray. To write a dataset with zarr, we use the :py:attr:`Dataset.to_zarr` meth
 To write to a local directory, we pass a path to a directory
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     ! rm -rf path/to/directory.zarr
 
 .. ipython:: python
 
-    ds = xr.Dataset({'foo': (('x', 'y'), np.random.rand(4, 5))},
-                    coords={'x': [10, 20, 30, 40],
-                            'y': pd.date_range('2000-01-01', periods=5),
-                            'z': ('x', list('abcd'))})
-    ds.to_zarr('path/to/directory.zarr')
+    ds = xr.Dataset(
+        {"foo": (("x", "y"), np.random.rand(4, 5))},
+        coords={
+            "x": [10, 20, 30, 40],
+            "y": pd.date_range("2000-01-01", periods=5),
+            "z": ("x", list("abcd")),
+        },
+    )
+    ds.to_zarr("path/to/directory.zarr")
 
 (The suffix ``.zarr`` is optional--just a reminder that a zarr store lives
 there.) If the directory does not exist, it will be created. If a zarr
@@ -854,22 +868,30 @@ It is also possible to append to an existing store. For that, set
 can be omitted as it will internally be set to ``'a'``.
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     ! rm -rf path/to/directory.zarr
 
 .. ipython:: python
 
-    ds1 = xr.Dataset({'foo': (('x', 'y', 't'), np.random.rand(4, 5, 2))},
-                     coords={'x': [10, 20, 30, 40],
-                             'y': [1,2,3,4,5],
-                             't': pd.date_range('2001-01-01', periods=2)})
-    ds1.to_zarr('path/to/directory.zarr')
-    ds2 = xr.Dataset({'foo': (('x', 'y', 't'), np.random.rand(4, 5, 2))},
-                     coords={'x': [10, 20, 30, 40],
-                             'y': [1,2,3,4,5],
-                             't': pd.date_range('2001-01-03', periods=2)})
-    ds2.to_zarr('path/to/directory.zarr', append_dim='t')
+    ds1 = xr.Dataset(
+        {"foo": (("x", "y", "t"), np.random.rand(4, 5, 2))},
+        coords={
+            "x": [10, 20, 30, 40],
+            "y": [1, 2, 3, 4, 5],
+            "t": pd.date_range("2001-01-01", periods=2),
+        },
+    )
+    ds1.to_zarr("path/to/directory.zarr")
+    ds2 = xr.Dataset(
+        {"foo": (("x", "y", "t"), np.random.rand(4, 5, 2))},
+        coords={
+            "x": [10, 20, 30, 40],
+            "y": [1, 2, 3, 4, 5],
+            "t": pd.date_range("2001-01-03", periods=2),
+        },
+    )
+    ds2.to_zarr("path/to/directory.zarr", append_dim="t")
 
 To store variable length strings use ``dtype=object``.
 
@@ -878,7 +900,7 @@ To read back a zarr dataset that has been created this way, we use the
 
 .. ipython:: python
 
-    ds_zarr = xr.open_zarr('path/to/directory.zarr')
+    ds_zarr = xr.open_zarr("path/to/directory.zarr")
     ds_zarr
 
 Cloud Storage Buckets
@@ -912,15 +934,16 @@ These options can be passed to the ``to_zarr`` method as variable encoding.
 For example:
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     ! rm -rf foo.zarr
 
 .. ipython:: python
 
     import zarr
-    compressor = zarr.Blosc(cname='zstd', clevel=3, shuffle=2)
-    ds.to_zarr('foo.zarr', encoding={'foo': {'compressor': compressor}})
+
+    compressor = zarr.Blosc(cname="zstd", clevel=3, shuffle=2)
+    ds.to_zarr("foo.zarr", encoding={"foo": {"compressor": compressor}})
 
 .. note::
 
@@ -959,11 +982,12 @@ be done directly from zarr, as described in the
 .. _io.cfgrib:
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     import shutil
-    shutil.rmtree('foo.zarr')
-    shutil.rmtree('path/to/directory.zarr')
+
+    shutil.rmtree("foo.zarr")
+    shutil.rmtree("path/to/directory.zarr")
 
 GRIB format via cfgrib
 ----------------------
@@ -975,7 +999,7 @@ to :py:func:`open_dataset`:
 .. ipython::
     :verbatim:
 
-    In [1]: ds_grib = xr.open_dataset('example.grib', engine='cfgrib')
+    In [1]: ds_grib = xr.open_dataset("example.grib", engine="cfgrib")
 
 We recommend installing ecCodes via conda::
 

--- a/doc/pandas.rst
+++ b/doc/pandas.rst
@@ -20,6 +20,7 @@ __ http://seaborn.pydata.org/
     import numpy as np
     import pandas as pd
     import xarray as xr
+
     np.random.seed(123456)
 
 Hierarchical and tidy data
@@ -47,10 +48,15 @@ To convert any dataset to a ``DataFrame`` in tidy form, use the
 
 .. ipython:: python
 
-    ds = xr.Dataset({'foo': (('x', 'y'), np.random.randn(2, 3))},
-                     coords={'x': [10, 20], 'y': ['a', 'b', 'c'],
-                             'along_x': ('x', np.random.randn(2)),
-                             'scalar': 123})
+    ds = xr.Dataset(
+        {"foo": (("x", "y"), np.random.randn(2, 3))},
+        coords={
+            "x": [10, 20],
+            "y": ["a", "b", "c"],
+            "along_x": ("x", np.random.randn(2)),
+            "scalar": 123,
+        },
+    )
     ds
     df = ds.to_dataframe()
     df
@@ -91,7 +97,7 @@ DataFrames:
 
 .. ipython:: python
 
-    s = ds['foo'].to_series()
+    s = ds["foo"].to_series()
     s
     # or equivalently, with Series.to_xarray()
     xr.DataArray.from_series(s)
@@ -117,8 +123,9 @@ available in pandas (i.e., a 1D array is converted to a
 
 .. ipython:: python
 
-    arr = xr.DataArray(np.random.randn(2, 3),
-                       coords=[('x', [10, 20]), ('y', ['a', 'b', 'c'])])
+    arr = xr.DataArray(
+        np.random.randn(2, 3), coords=[("x", [10, 20]), ("y", ["a", "b", "c"])]
+    )
     df = arr.to_pandas()
     df
 
@@ -136,9 +143,10 @@ preserve all use of multi-indexes:
 
 .. ipython:: python
 
-    index = pd.MultiIndex.from_arrays([['a', 'a', 'b'], [0, 1, 2]],
-                                      names=['one', 'two'])
-    df = pd.DataFrame({'x': 1, 'y': 2}, index=index)
+    index = pd.MultiIndex.from_arrays(
+        [["a", "a", "b"], [0, 1, 2]], names=["one", "two"]
+    )
+    df = pd.DataFrame({"x": 1, "y": 2}, index=index)
     ds = xr.Dataset(df)
     ds
 
@@ -175,9 +183,9 @@ Let's take a look:
 .. ipython:: python
 
     data = np.random.RandomState(0).rand(2, 3, 4)
-    items = list('ab')
-    major_axis = list('mno')
-    minor_axis = pd.date_range(start='2000', periods=4, name='date')
+    items = list("ab")
+    major_axis = list("mno")
+    minor_axis = pd.date_range(start="2000", periods=4, name="date")
 
 With old versions of pandas (prior to 0.25), this could stored in a ``Panel``:
 
@@ -207,7 +215,7 @@ You can also easily convert this data into ``Dataset``:
 
 .. ipython:: python
 
-    array.to_dataset(dim='dim_0')
+    array.to_dataset(dim="dim_0")
 
 Here, there are two data variables, each representing a DataFrame on panel's
 ``items`` axis, and labeled as such. Each variable is a 2D array of the

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -568,7 +568,7 @@ Faceted plotting supports other arguments common to xarray 2d plots.
     @savefig plot_facet_robust.png
     g = hasoutliers.plot.pcolormesh('lon', 'lat', col='time', col_wrap=3,
                                     robust=True, cmap='viridis',
-				    cbar_kwargs={'label': 'this has outliers'})
+                                    cbar_kwargs={'label': 'this has outliers'})
 
 ===================
  FacetGrid Objects

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -56,6 +56,7 @@ Imports
 
     # Use defaults so we don't get gridlines in generated docs
     import matplotlib as mpl
+
     mpl.rcdefaults()
 
 The following imports are necessary for all of the examples.
@@ -71,7 +72,7 @@ For these examples we'll use the North American air temperature dataset.
 
 .. ipython:: python
 
-    airtemps = xr.tutorial.open_dataset('air_temperature')
+    airtemps = xr.tutorial.open_dataset("air_temperature")
     airtemps
 
     # Convert to celsius
@@ -79,7 +80,7 @@ For these examples we'll use the North American air temperature dataset.
 
     # copy attributes to get nice figure labels and change Kelvin to Celsius
     air.attrs = airtemps.air.attrs
-    air.attrs['units'] = 'deg C'
+    air.attrs["units"] = "deg C"
 
 .. note::
    Until :issue:`1614` is solved, you might need to copy over the metadata in ``attrs`` to get informative figure labels (as was done above).
@@ -126,7 +127,7 @@ can be used:
 .. ipython:: python
 
     @savefig plotting_1d_additional_args.png width=4in
-    air1d[:200].plot.line('b-^')
+    air1d[:200].plot.line("b-^")
 
 .. note::
     Not all xarray plotting methods support passing positional arguments
@@ -138,7 +139,7 @@ Keyword arguments work the same way, and are more explicit.
 .. ipython:: python
 
     @savefig plotting_example_sin3.png width=4in
-    air1d[:200].plot.line(color='purple', marker='o')
+    air1d[:200].plot.line(color="purple", marker="o")
 
 =========================
  Adding to Existing Axis
@@ -219,7 +220,7 @@ plots to check the variation of air temperature at three different latitudes alo
 .. ipython:: python
 
     @savefig plotting_example_multiple_lines_x_kwarg.png
-    air.isel(lon=10, lat=[19,21,22]).plot.line(x='time')
+    air.isel(lon=10, lat=[19, 21, 22]).plot.line(x="time")
 
 It is required to explicitly specify either
 
@@ -240,7 +241,7 @@ It is also possible to make line plots such that the data are on the x-axis and 
 .. ipython:: python
 
     @savefig plotting_example_xy_kwarg.png
-    air.isel(time=10, lon=[10, 11]).plot(y='lat', hue='lon')
+    air.isel(time=10, lon=[10, 11]).plot(y="lat", hue="lon")
 
 ============
  Step plots
@@ -253,7 +254,7 @@ made using 1D data.
     :okwarning:
 
     @savefig plotting_example_step.png width=4in
-    air1d[:20].plot.step(where='mid')
+    air1d[:20].plot.step(where="mid")
 
 The argument ``where`` defines where the steps should be placed, options are
 ``'pre'`` (default), ``'post'``, and ``'mid'``. This is particularly handy
@@ -261,15 +262,15 @@ when plotting data grouped with :py:meth:`Dataset.groupby_bins`.
 
 .. ipython:: python
 
-    air_grp = air.mean(['time','lon']).groupby_bins('lat',[0,23.5,66.5,90])
+    air_grp = air.mean(["time", "lon"]).groupby_bins("lat", [0, 23.5, 66.5, 90])
     air_mean = air_grp.mean()
     air_std = air_grp.std()
     air_mean.plot.step()
-    (air_mean + air_std).plot.step(ls=':')
-    (air_mean - air_std).plot.step(ls=':')
-    plt.ylim(-20,30)
+    (air_mean + air_std).plot.step(ls=":")
+    (air_mean - air_std).plot.step(ls=":")
+    plt.ylim(-20, 30)
     @savefig plotting_example_step_groupby.png width=4in
-    plt.title('Zonal mean temperature')
+    plt.title("Zonal mean temperature")
 
 In this case, the actual boundaries of the bins are used and the ``where`` argument
 is ignored.
@@ -284,7 +285,9 @@ The keyword arguments ``xincrease`` and ``yincrease`` let you control the axes d
 .. ipython:: python
 
     @savefig plotting_example_xincrease_yincrease_kwarg.png
-    air.isel(time=10, lon=[10, 11]).plot.line(y='lat', hue='lon', xincrease=False, yincrease=False)
+    air.isel(time=10, lon=[10, 11]).plot.line(
+        y="lat", hue="lon", xincrease=False, yincrease=False
+    )
 
 In addition, one can use ``xscale, yscale`` to set axes scaling; ``xticks, yticks`` to set axes ticks and ``xlim, ylim`` to set axes limits. These accept the same values as the matplotlib methods ``Axes.set_(x,y)scale()``, ``Axes.set_(x,y)ticks()``, ``Axes.set_(x,y)lim()`` respectively.
 
@@ -348,7 +351,7 @@ produce plots with nonuniform coordinates.
 
     b = air2d.copy()
     # Apply a nonlinear transformation to one of the coords
-    b.coords['lat'] = np.log(b.coords['lat'])
+    b.coords["lat"] = np.log(b.coords["lat"])
 
     @savefig plotting_nonuniform_coords.png width=4in
     b.plot()
@@ -363,9 +366,9 @@ matplotlib is available.
 .. ipython:: python
 
     air2d.plot(cmap=plt.cm.Blues)
-    plt.title('These colors prove North America\nhas fallen in the ocean')
-    plt.ylabel('latitude')
-    plt.xlabel('longitude')
+    plt.title("These colors prove North America\nhas fallen in the ocean")
+    plt.ylabel("latitude")
+    plt.xlabel("longitude")
     plt.tight_layout()
 
     @savefig plotting_2d_call_matplotlib.png width=4in
@@ -381,7 +384,7 @@ matplotlib is available.
 
     .. ipython:: python
 
-        plt.xlabel('Never gonna see this.')
+        plt.xlabel("Never gonna see this.")
         air2d.plot()
 
         @savefig plotting_2d_call_matplotlib2.png width=4in
@@ -473,10 +476,10 @@ if using ``imshow`` or ``pcolormesh`` (but not with ``contour`` or ``contourf``,
 since levels are chosen automatically).
 
 .. ipython:: python
-   :okwarning:
+    :okwarning:
 
     @savefig plotting_seaborn_palette.png width=4in
-    air2d.plot(levels=10, cmap='husl')
+    air2d.plot(levels=10, cmap="husl")
     plt.draw()
 
 .. _plotting.faceting:
@@ -520,14 +523,16 @@ arguments to the xarray plotting methods/functions. This returns a
 .. ipython:: python
 
     @savefig plot_facet_dataarray.png
-    g_simple = t.plot(x='lon', y='lat', col='time', col_wrap=3)
+    g_simple = t.plot(x="lon", y="lat", col="time", col_wrap=3)
 
 Faceting also works for line plots.
 
 .. ipython:: python
 
     @savefig plot_facet_dataarray_line.png
-    g_simple_line = t.isel(lat=slice(0,None,4)).plot(x='lon', hue='lat', col='time', col_wrap=3)
+    g_simple_line = t.isel(lat=slice(0, None, 4)).plot(
+        x="lon", hue="lat", col="time", col_wrap=3
+    )
 
 ===============
  4 dimensional
@@ -541,12 +546,12 @@ one were much hotter.
 .. ipython:: python
 
     t2 = t.isel(time=slice(0, 2))
-    t4d = xr.concat([t2, t2 + 40], pd.Index(['normal', 'hot'], name='fourth_dim'))
+    t4d = xr.concat([t2, t2 + 40], pd.Index(["normal", "hot"], name="fourth_dim"))
     # This is a 4d array
     t4d.coords
 
     @savefig plot_facet_4d.png
-    t4d.plot(x='lon', y='lat', col='time', row='fourth_dim')
+    t4d.plot(x="lon", y="lat", col="time", row="fourth_dim")
 
 ================
  Other features
@@ -555,9 +560,9 @@ one were much hotter.
 Faceted plotting supports other arguments common to xarray 2d plots.
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
-      plt.close('all')
+    plt.close("all")
 
 .. ipython:: python
 
@@ -566,9 +571,15 @@ Faceted plotting supports other arguments common to xarray 2d plots.
     hasoutliers[-1, -1, -1] = 400
 
     @savefig plot_facet_robust.png
-    g = hasoutliers.plot.pcolormesh('lon', 'lat', col='time', col_wrap=3,
-                                    robust=True, cmap='viridis',
-                                    cbar_kwargs={'label': 'this has outliers'})
+    g = hasoutliers.plot.pcolormesh(
+        "lon",
+        "lat",
+        col="time",
+        col_wrap=3,
+        robust=True,
+        cmap="viridis",
+        cbar_kwargs={"label": "this has outliers"},
+    )
 
 ===================
  FacetGrid Objects
@@ -594,20 +605,20 @@ It's possible to select the :py:class:`xarray.DataArray` or
 
 .. ipython:: python
 
-   g.data.loc[g.name_dicts[0, 0]]
+    g.data.loc[g.name_dicts[0, 0]]
 
 Here is an example of using the lower level API and then modifying the axes after
 they have been plotted.
 
 .. ipython:: python
 
-    g = t.plot.imshow('lon', 'lat', col='time', col_wrap=3, robust=True)
+    g = t.plot.imshow("lon", "lat", col="time", col_wrap=3, robust=True)
 
     for i, ax in enumerate(g.axes.flat):
-        ax.set_title('Air Temperature %d' % i)
+        ax.set_title("Air Temperature %d" % i)
 
     bottomright = g.axes[-1, -1]
-    bottomright.annotate('bottom right', (240, 40))
+    bottomright.annotate("bottom right", (240, 40))
 
     @savefig plot_facet_iterator.png
     plt.draw()
@@ -632,8 +643,8 @@ Consider this dataset
 
 .. ipython:: python
 
-   ds = xr.tutorial.scatter_example_dataset()
-   ds
+    ds = xr.tutorial.scatter_example_dataset()
+    ds
 
 
 Suppose we want to scatter ``A`` against ``B``
@@ -641,14 +652,14 @@ Suppose we want to scatter ``A`` against ``B``
 .. ipython:: python
 
     @savefig ds_simple_scatter.png
-    ds.plot.scatter(x='A', y='B')
+    ds.plot.scatter(x="A", y="B")
 
 The ``hue`` kwarg lets you vary the color by variable value
 
 .. ipython:: python
 
     @savefig ds_hue_scatter.png
-    ds.plot.scatter(x='A', y='B', hue='w')
+    ds.plot.scatter(x="A", y="B", hue="w")
 
 When ``hue`` is specified, a colorbar is added for numeric ``hue`` DataArrays by
 default and a legend is added for non-numeric ``hue`` DataArrays (as above).
@@ -659,21 +670,21 @@ Additionally, the boolean kwarg ``add_guide`` can be used to prevent the display
 
     ds = ds.assign(w=[1, 2, 3, 5])
     @savefig ds_discrete_legend_hue_scatter.png
-    ds.plot.scatter(x='A', y='B', hue='w', hue_style='discrete')
+    ds.plot.scatter(x="A", y="B", hue="w", hue_style="discrete")
 
 The ``markersize`` kwarg lets you vary the point's size by variable value. You can additionally pass ``size_norm`` to control how the variable's values are mapped to point sizes.
 
 .. ipython:: python
 
     @savefig ds_hue_size_scatter.png
-    ds.plot.scatter(x='A', y='B', hue='z', hue_style='discrete', markersize='z')
+    ds.plot.scatter(x="A", y="B", hue="z", hue_style="discrete", markersize="z")
 
 Faceting is also possible
 
 .. ipython:: python
 
     @savefig ds_facet_scatter.png
-    ds.plot.scatter(x='A', y='B', col='x', row='z', hue='w', hue_style='discrete')
+    ds.plot.scatter(x="A", y="B", col="x", row="z", hue="w", hue_style="discrete")
 
 
 For more advanced scatter plots, we recommend converting the relevant data variables to a pandas DataFrame and using the extensive plotting capabilities of ``seaborn``.
@@ -691,7 +702,8 @@ This script will plot the air temperature on a map.
 .. ipython:: python
 
     import cartopy.crs as ccrs
-    air = xr.tutorial.open_dataset('air_temperature').air
+
+    air = xr.tutorial.open_dataset("air_temperature").air
     ax = plt.axes(projection=ccrs.Orthographic(-80, 35))
     air.isel(time=0).plot.contourf(ax=ax, transform=ccrs.PlateCarree());
     @savefig plotting_maps_cartopy.png width=100%
@@ -703,8 +715,11 @@ by faceting are accessible in the object returned by ``plot``:
 
 .. ipython:: python
 
-    p = air.isel(time=[0, 4]).plot(transform=ccrs.PlateCarree(), col='time',
-                                   subplot_kws={'projection': ccrs.Orthographic(-80, 35)})
+    p = air.isel(time=[0, 4]).plot(
+        transform=ccrs.PlateCarree(),
+        col="time",
+        subplot_kws={"projection": ccrs.Orthographic(-80, 35)},
+    )
     for ax in p.axes.flat:
         ax.coastlines()
         ax.gridlines()
@@ -732,6 +747,7 @@ These are provided for user convenience; they all call the same code.
 .. ipython:: python
 
     import xarray.plot as xplt
+
     da = xr.DataArray(range(5))
     fig, axes = plt.subplots(ncols=2, nrows=2)
     da.plot(ax=axes[0, 0])
@@ -766,8 +782,7 @@ read on.
 
 .. ipython:: python
 
-    a0 = xr.DataArray(np.zeros((4, 3, 2)), dims=('y', 'x', 'z'),
-                      name='temperature')
+    a0 = xr.DataArray(np.zeros((4, 3, 2)), dims=("y", "x", "z"), name="temperature")
     a0[0, 0, 0] = 1
     a = a0.isel(z=0)
     a
@@ -801,11 +816,13 @@ instead of the default ones:
 .. ipython:: python
 
     lon, lat = np.meshgrid(np.linspace(-20, 20, 5), np.linspace(0, 30, 4))
-    lon += lat/10
-    lat += lon/10
-    da = xr.DataArray(np.arange(20).reshape(4, 5), dims=['y', 'x'],
-                      coords = {'lat': (('y', 'x'), lat),
-                                'lon': (('y', 'x'), lon)})
+    lon += lat / 10
+    lat += lon / 10
+    da = xr.DataArray(
+        np.arange(20).reshape(4, 5),
+        dims=["y", "x"],
+        coords={"lat": (("y", "x"), lat), "lon": (("y", "x"), lon)},
+    )
 
     @savefig plotting_example_2d_irreg.png width=4in
     da.plot.pcolormesh('lon', 'lat');

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -704,10 +704,13 @@ This script will plot the air temperature on a map.
     import cartopy.crs as ccrs
 
     air = xr.tutorial.open_dataset("air_temperature").air
+
     ax = plt.axes(projection=ccrs.Orthographic(-80, 35))
-    air.isel(time=0).plot.contourf(ax=ax, transform=ccrs.PlateCarree());
+    air.isel(time=0).plot.contourf(ax=ax, transform=ccrs.PlateCarree())
+    ax.set_global()
+
     @savefig plotting_maps_cartopy.png width=100%
-    ax.set_global(); ax.coastlines();
+    ax.coastlines()
 
 When faceting on maps, the projection can be transferred to the ``plot``
 function using the ``subplot_kws`` keyword. The axes for the subplots created
@@ -724,7 +727,7 @@ by faceting are accessible in the object returned by ``plot``:
         ax.coastlines()
         ax.gridlines()
     @savefig plotting_maps_cartopy_facetting.png width=100%
-    plt.draw();
+    plt.draw()
 
 
 Details
@@ -825,7 +828,7 @@ instead of the default ones:
     )
 
     @savefig plotting_example_2d_irreg.png width=4in
-    da.plot.pcolormesh('lon', 'lat');
+    da.plot.pcolormesh("lon", "lat")
 
 Note that in this case, xarray still follows the pixel centered convention.
 This might be undesirable in some cases, for example when your data is defined
@@ -835,22 +838,25 @@ this convention when plotting on a map:
 .. ipython:: python
 
     import cartopy.crs as ccrs
-    ax = plt.subplot(projection=ccrs.PlateCarree());
-    da.plot.pcolormesh('lon', 'lat', ax=ax);
-    ax.scatter(lon, lat, transform=ccrs.PlateCarree());
+
+    ax = plt.subplot(projection=ccrs.PlateCarree())
+    da.plot.pcolormesh("lon", "lat", ax=ax)
+    ax.scatter(lon, lat, transform=ccrs.PlateCarree())
+    ax.coastlines()
     @savefig plotting_example_2d_irreg_map.png width=4in
-    ax.coastlines(); ax.gridlines(draw_labels=True);
+    ax.gridlines(draw_labels=True)
 
 You can however decide to infer the cell boundaries and use the
 ``infer_intervals`` keyword:
 
 .. ipython:: python
 
-    ax = plt.subplot(projection=ccrs.PlateCarree());
-    da.plot.pcolormesh('lon', 'lat', ax=ax, infer_intervals=True);
-    ax.scatter(lon, lat, transform=ccrs.PlateCarree());
+    ax = plt.subplot(projection=ccrs.PlateCarree())
+    da.plot.pcolormesh("lon", "lat", ax=ax, infer_intervals=True)
+    ax.scatter(lon, lat, transform=ccrs.PlateCarree())
+    ax.coastlines()
     @savefig plotting_example_2d_irreg_map_infer.png width=4in
-    ax.coastlines(); ax.gridlines(draw_labels=True);
+    ax.gridlines(draw_labels=True)
 
 .. note::
     The data model of xarray does not support datasets with `cell boundaries`_
@@ -864,6 +870,6 @@ One can also make line plots with multidimensional coordinates. In this case, ``
 .. ipython:: python
 
     f, ax = plt.subplots(2, 1)
-    da.plot.line(x='lon', hue='y', ax=ax[0]);
+    da.plot.line(x="lon", hue="y", ax=ax[0])
     @savefig plotting_example_2d_hue_xy.png
-    da.plot.line(x='lon', hue='x', ax=ax[1]);
+    da.plot.line(x="lon", hue="x", ax=ax[1])

--- a/doc/quick-overview.rst
+++ b/doc/quick-overview.rst
@@ -22,16 +22,14 @@ array or list, with optional *dimensions* and *coordinates*:
 
 .. ipython:: python
 
-    data = xr.DataArray(np.random.randn(2, 3),
-                        dims=('x', 'y'),
-                        coords={'x': [10, 20]})
+    data = xr.DataArray(np.random.randn(2, 3), dims=("x", "y"), coords={"x": [10, 20]})
     data
 
 In this case, we have generated a 2D array, assigned the names *x* and *y* to the two dimensions respectively and associated two *coordinate labels* '10' and '20' with the two locations along the x dimension. If you supply a pandas :py:class:`~pandas.Series` or :py:class:`~pandas.DataFrame`, metadata is copied directly:
 
 .. ipython:: python
 
-    xr.DataArray(pd.Series(range(3), index=list('abc'), name='foo'))
+    xr.DataArray(pd.Series(range(3), index=list("abc"), name="foo"))
 
 Here are the key properties for a ``DataArray``:
 
@@ -75,13 +73,13 @@ While you're setting up your DataArray, it's often a good idea to set metadata a
 
 .. ipython:: python
 
-    data.attrs['long_name'] = 'random velocity'
-    data.attrs['units'] = 'metres/sec'
-    data.attrs['description'] = 'A random variable created as an example.'
-    data.attrs['random_attribute'] = 123
+    data.attrs["long_name"] = "random velocity"
+    data.attrs["units"] = "metres/sec"
+    data.attrs["description"] = "A random variable created as an example."
+    data.attrs["random_attribute"] = 123
     data.attrs
     # you can add metadata to coordinates too
-    data.x.attrs['units'] = 'x units'
+    data.x.attrs["units"] = "x units"
 
 
 Computation
@@ -102,15 +100,15 @@ numbers:
 
 .. ipython:: python
 
-    data.mean(dim='x')
+    data.mean(dim="x")
 
 Arithmetic operations broadcast based on dimension name. This means you don't
 need to insert dummy dimensions for alignment:
 
 .. ipython:: python
 
-    a = xr.DataArray(np.random.randn(3), [data.coords['y']])
-    b = xr.DataArray(np.random.randn(4), dims='z')
+    a = xr.DataArray(np.random.randn(3), [data.coords["y"]])
+    b = xr.DataArray(np.random.randn(4), dims="z")
 
     a
     b
@@ -139,9 +137,9 @@ xarray supports grouped operations using a very similar API to pandas (see :ref:
 
 .. ipython:: python
 
-    labels = xr.DataArray(['E', 'F', 'E'], [data.coords['y']], name='labels')
+    labels = xr.DataArray(["E", "F", "E"], [data.coords["y"]], name="labels")
     labels
-    data.groupby(labels).mean('y')
+    data.groupby(labels).mean("y")
     data.groupby(labels).map(lambda x: x - x.min())
 
 Plotting
@@ -178,7 +176,7 @@ objects. You can think of it as a multi-dimensional generalization of the
 
 .. ipython:: python
 
-    ds = xr.Dataset({'foo': data, 'bar': ('x', [1, 2]), 'baz': np.pi})
+    ds = xr.Dataset({"foo": data, "bar": ("x", [1, 2]), "baz": np.pi})
     ds
 
 
@@ -186,7 +184,7 @@ This creates a dataset with three DataArrays named ``foo``, ``bar`` and ``baz``.
 
 .. ipython:: python
 
-    ds['foo']
+    ds["foo"]
     ds.foo
 
 
@@ -216,14 +214,15 @@ You can directly read and write xarray objects to disk using :py:meth:`~xarray.D
 
 .. ipython:: python
 
-    ds.to_netcdf('example.nc')
-    xr.open_dataset('example.nc')
+    ds.to_netcdf("example.nc")
+    xr.open_dataset("example.nc")
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     import os
-    os.remove('example.nc')
+
+    os.remove("example.nc")
 
 
 It is common for datasets to be distributed across multiple files (commonly one file per timestep). xarray supports this use-case by providing the :py:meth:`~xarray.open_mfdataset` and the :py:meth:`~xarray.save_mfdataset` methods. For more, see :ref:`io`.

--- a/doc/reshaping.rst
+++ b/doc/reshaping.rst
@@ -7,11 +7,12 @@ Reshaping and reorganizing data
 These methods allow you to reorganize
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     import numpy as np
     import pandas as pd
     import xarray as xr
+
     np.random.seed(123456)
 
 Reordering dimensions
@@ -23,9 +24,9 @@ ellipsis (`...`) can be use to represent all other dimensions:
 
 .. ipython:: python
 
-    ds = xr.Dataset({'foo': (('x', 'y', 'z'), [[[42]]]), 'bar': (('y', 'z'), [[24]])})
-    ds.transpose('y', 'z', 'x')
-    ds.transpose(..., 'x')  # equivalent
+    ds = xr.Dataset({"foo": (("x", "y", "z"), [[[42]]]), "bar": (("y", "z"), [[24]])})
+    ds.transpose("y", "z", "x")
+    ds.transpose(..., "x")  # equivalent
     ds.transpose()  # reverses all dimensions
 
 Expand and squeeze dimensions
@@ -37,7 +38,7 @@ use :py:meth:`~xarray.DataArray.expand_dims`
 
 .. ipython:: python
 
-    expanded  = ds.expand_dims('w')
+    expanded = ds.expand_dims("w")
     expanded
 
 This method attaches a new dimension with size 1 to all data variables.
@@ -48,7 +49,7 @@ use :py:meth:`~xarray.DataArray.squeeze`
 
 .. ipython:: python
 
-    expanded.squeeze('w')
+    expanded.squeeze("w")
 
 Converting between datasets and arrays
 --------------------------------------
@@ -69,14 +70,14 @@ To convert back from a DataArray to a Dataset, use
 
 .. ipython:: python
 
-    arr.to_dataset(dim='variable')
+    arr.to_dataset(dim="variable")
 
 The broadcasting behavior of ``to_array`` means that the resulting array
 includes the union of data variable dimensions:
 
 .. ipython:: python
 
-    ds2 = xr.Dataset({'a': 0, 'b': ('x', [3, 4, 5])})
+    ds2 = xr.Dataset({"a": 0, "b": ("x", [3, 4, 5])})
 
     # the input dataset has 4 elements
     ds2
@@ -90,7 +91,7 @@ If you use ``to_dataset`` without supplying the ``dim`` argument, the DataArray 
 
 .. ipython:: python
 
-    arr.to_dataset(name='combined')
+    arr.to_dataset(name="combined")
 
 .. _reshape.stack:
 
@@ -103,11 +104,12 @@ implemented :py:meth:`~xarray.DataArray.stack` and
 
 .. ipython:: python
 
-    array = xr.DataArray(np.random.randn(2, 3),
-                         coords=[('x', ['a', 'b']), ('y', [0, 1, 2])])
-    stacked = array.stack(z=('x', 'y'))
+    array = xr.DataArray(
+        np.random.randn(2, 3), coords=[("x", ["a", "b"]), ("y", [0, 1, 2])]
+    )
+    stacked = array.stack(z=("x", "y"))
     stacked
-    stacked.unstack('z')
+    stacked.unstack("z")
 
 As elsewhere in xarray, an ellipsis (`...`) can be used to represent all unlisted dimensions:
 
@@ -128,15 +130,15 @@ possible levels. Missing levels are filled in with ``NaN`` in the resulting obje
 
     stacked2 = stacked[::2]
     stacked2
-    stacked2.unstack('z')
+    stacked2.unstack("z")
 
 However, xarray's ``stack`` has an important difference from pandas: unlike
 pandas, it does not automatically drop missing values. Compare:
 
 .. ipython:: python
 
-    array = xr.DataArray([[np.nan, 1], [2, 3]], dims=['x', 'y'])
-    array.stack(z=('x', 'y'))
+    array = xr.DataArray([[np.nan, 1], [2, 3]], dims=["x", "y"])
+    array.stack(z=("x", "y"))
     array.to_pandas().stack()
 
 We departed from pandas's behavior here because predictable shapes for new
@@ -166,16 +168,15 @@ like this:
 
 .. ipython:: python
 
-        data = xr.Dataset(
-            data_vars={'a': (('x', 'y'), [[0, 1, 2], [3, 4, 5]]),
-                      'b': ('x', [6, 7])},
-            coords={'y': ['u', 'v', 'w']}
-        )
-        data
-        stacked = data.to_stacked_array("z", sample_dims=['x'])
-        stacked
-        unstacked = stacked.to_unstacked_dataset("z")
-        unstacked
+    data = xr.Dataset(
+        data_vars={"a": (("x", "y"), [[0, 1, 2], [3, 4, 5]]), "b": ("x", [6, 7])},
+        coords={"y": ["u", "v", "w"]},
+    )
+    data
+    stacked = data.to_stacked_array("z", sample_dims=["x"])
+    stacked
+    unstacked = stacked.to_unstacked_dataset("z")
+    unstacked
 
 In this example, ``stacked`` is a two dimensional array that we can easily pass to a scikit-learn or another generic
 numerical method.
@@ -202,19 +203,23 @@ coordinates using :py:meth:`~xarray.DataArray.set_index`:
 
 .. ipython:: python
 
-     da = xr.DataArray(np.random.rand(4),
-                       coords={'band': ('x', ['a', 'a', 'b', 'b']),
-                               'wavenumber': ('x', np.linspace(200, 400, 4))},
-                       dims='x')
-     da
-     mda = da.set_index(x=['band', 'wavenumber'])
-     mda
+    da = xr.DataArray(
+        np.random.rand(4),
+        coords={
+            "band": ("x", ["a", "a", "b", "b"]),
+            "wavenumber": ("x", np.linspace(200, 400, 4)),
+        },
+        dims="x",
+    )
+    da
+    mda = da.set_index(x=["band", "wavenumber"])
+    mda
 
 These coordinates can now be used for indexing, e.g.,
 
 .. ipython:: python
 
-     mda.sel(band='a')
+    mda.sel(band="a")
 
 Conversely, you can use :py:meth:`~xarray.DataArray.reset_index`
 to extract multi-index levels as coordinates (this is mainly useful
@@ -222,14 +227,14 @@ for serialization):
 
 .. ipython:: python
 
-     mda.reset_index('x')
+    mda.reset_index("x")
 
 :py:meth:`~xarray.DataArray.reorder_levels` allows changing the order
 of multi-index levels:
 
 .. ipython:: python
 
-     mda.reorder_levels(x=['wavenumber', 'band'])
+    mda.reorder_levels(x=["wavenumber", "band"])
 
 As of xarray v0.9 coordinate labels for each dimension are optional.
 You can also  use ``.set_index`` / ``.reset_index`` to add / remove
@@ -237,12 +242,12 @@ labels for one or several dimensions:
 
 .. ipython:: python
 
-    array = xr.DataArray([1, 2, 3], dims='x')
+    array = xr.DataArray([1, 2, 3], dims="x")
     array
-    array['c'] = ('x', ['a', 'b', 'c'])
-    array.set_index(x='c')
-    array = array.set_index(x='c')
-    array = array.reset_index('x', drop=True)
+    array["c"] = ("x", ["a", "b", "c"])
+    array.set_index(x="c")
+    array = array.set_index(x="c")
+    array = array.reset_index("x", drop=True)
 
 .. _reshape.shift_and_roll:
 
@@ -254,9 +259,9 @@ To adjust coordinate labels, you can use the :py:meth:`~xarray.Dataset.shift` an
 
 .. ipython:: python
 
-	array = xr.DataArray([1, 2, 3, 4], dims='x')
-	array.shift(x=2)
-	array.roll(x=2, roll_coords=True)
+    array = xr.DataArray([1, 2, 3, 4], dims="x")
+    array.shift(x=2)
+    array.roll(x=2, roll_coords=True)
 
 .. _reshape.sort:
 
@@ -269,17 +274,18 @@ One may sort a DataArray/Dataset via :py:meth:`~xarray.DataArray.sortby` and
 
 .. ipython:: python
 
-  ds = xr.Dataset({'A': (('x', 'y'), [[1, 2], [3, 4]]),
-                   'B': (('x', 'y'), [[5, 6], [7, 8]])},
-                  coords={'x': ['b', 'a'], 'y': [1, 0]})
-  dax = xr.DataArray([100, 99], [('x', [0, 1])])
-  day = xr.DataArray([90, 80], [('y', [0, 1])])
-  ds.sortby([day, dax])
+    ds = xr.Dataset(
+        {"A": (("x", "y"), [[1, 2], [3, 4]]), "B": (("x", "y"), [[5, 6], [7, 8]])},
+        coords={"x": ["b", "a"], "y": [1, 0]},
+    )
+    dax = xr.DataArray([100, 99], [("x", [0, 1])])
+    day = xr.DataArray([90, 80], [("y", [0, 1])])
+    ds.sortby([day, dax])
 
 As a shortcut, you can refer to existing coordinates by name:
 
 .. ipython:: python
 
-  ds.sortby('x')
-  ds.sortby(['y', 'x'])
-  ds.sortby(['y', 'x'], ascending=False)
+    ds.sortby("x")
+    ds.sortby(["y", "x"])
+    ds.sortby(["y", "x"], ascending=False)

--- a/doc/time-series.rst
+++ b/doc/time-series.rst
@@ -10,11 +10,12 @@ data in pandas such a joy to xarray. In most cases, we rely on pandas for the
 core functionality.
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     import numpy as np
     import pandas as pd
     import xarray as xr
+
     np.random.seed(123456)
 
 Creating datetime64 data
@@ -29,8 +30,8 @@ using :py:func:`pandas.to_datetime` and :py:func:`pandas.date_range`:
 
 .. ipython:: python
 
-    pd.to_datetime(['2000-01-01', '2000-02-02'])
-    pd.date_range('2000-01-01', periods=365)
+    pd.to_datetime(["2000-01-01", "2000-02-02"])
+    pd.date_range("2000-01-01", periods=365)
 
 Alternatively, you can supply arrays of Python ``datetime`` objects. These get
 converted automatically when used as arguments in xarray objects:
@@ -38,7 +39,8 @@ converted automatically when used as arguments in xarray objects:
 .. ipython:: python
 
     import datetime
-    xr.Dataset({'time': datetime.datetime(2000, 1, 1)})
+
+    xr.Dataset({"time": datetime.datetime(2000, 1, 1)})
 
 When reading or writing netCDF files, xarray automatically decodes datetime and
 timedelta arrays using `CF conventions`_ (that is, by using a ``units``
@@ -62,8 +64,8 @@ You can manual decode arrays in this form by passing a dataset to
 
 .. ipython:: python
 
-    attrs = {'units': 'hours since 2000-01-01'}
-    ds = xr.Dataset({'time': ('time', [0, 1, 2, 3], attrs)})
+    attrs = {"units": "hours since 2000-01-01"}
+    ds = xr.Dataset({"time": ("time", [0, 1, 2, 3], attrs)})
     xr.decode_cf(ds)
 
 One unfortunate limitation of using ``datetime64[ns]`` is that it limits the
@@ -87,10 +89,10 @@ items and with the `slice` object:
 
 .. ipython:: python
 
-    time = pd.date_range('2000-01-01', freq='H', periods=365 * 24)
-    ds = xr.Dataset({'foo': ('time', np.arange(365 * 24)), 'time': time})
-    ds.sel(time='2000-01')
-    ds.sel(time=slice('2000-06-01', '2000-06-10'))
+    time = pd.date_range("2000-01-01", freq="H", periods=365 * 24)
+    ds = xr.Dataset({"foo": ("time", np.arange(365 * 24)), "time": time})
+    ds.sel(time="2000-01")
+    ds.sel(time=slice("2000-06-01", "2000-06-10"))
 
 You can also select a particular time by indexing with a
 :py:class:`datetime.time` object:
@@ -113,8 +115,8 @@ given ``DataArray`` can be quickly computed using a special ``.dt`` accessor.
 
 .. ipython:: python
 
-    time = pd.date_range('2000-01-01', freq='6H', periods=365 * 4)
-    ds = xr.Dataset({'foo': ('time', np.arange(365 * 4)), 'time': time})
+    time = pd.date_range("2000-01-01", freq="6H", periods=365 * 4)
+    ds = xr.Dataset({"foo": ("time", np.arange(365 * 4)), "time": time})
     ds.time.dt.hour
     ds.time.dt.dayofweek
 
@@ -130,16 +132,16 @@ __ http://pandas.pydata.org/pandas-docs/stable/api.html#time-date-components
 
 .. ipython:: python
 
-    ds['time.month']
-    ds['time.dayofyear']
+    ds["time.month"]
+    ds["time.dayofyear"]
 
 For use as a derived coordinate, xarray adds ``'season'`` to the list of
 datetime components supported by pandas:
 
 .. ipython:: python
 
-    ds['time.season']
-    ds['time'].dt.season
+    ds["time.season"]
+    ds["time"].dt.season
 
 The set of valid seasons consists of 'DJF', 'MAM', 'JJA' and 'SON', labeled by
 the first letters of the corresponding months.
@@ -152,7 +154,7 @@ __ http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
 
 .. ipython:: python
 
-    ds['time'].dt.floor('D')
+    ds["time"].dt.floor("D")
 
 The ``.dt`` accessor can also be used to generate formatted datetime strings
 for arrays utilising the same formatting as the standard `datetime.strftime`_.
@@ -161,7 +163,7 @@ for arrays utilising the same formatting as the standard `datetime.strftime`_.
 
 .. ipython:: python
 
-    ds['time'].dt.strftime('%a, %b %d %H:%M')
+    ds["time"].dt.strftime("%a, %b %d %H:%M")
 
 .. _resampling:
 
@@ -173,9 +175,9 @@ Datetime components couple particularly well with grouped operations (see
 calculate the mean by time of day:
 
 .. ipython:: python
-   :okwarning:
+    :okwarning:
 
-    ds.groupby('time.hour').mean()
+    ds.groupby("time.hour").mean()
 
 For upsampling or downsampling temporal resolutions, xarray offers a
 :py:meth:`~xarray.Dataset.resample` method building on the core functionality
@@ -187,25 +189,25 @@ same api as ``resample`` `in pandas`_.
 For example, we can downsample our dataset from hourly to 6-hourly:
 
 .. ipython:: python
-   :okwarning:
+    :okwarning:
 
-    ds.resample(time='6H')
+    ds.resample(time="6H")
 
 This will create a specialized ``Resample`` object which saves information
 necessary for resampling. All of the reduction methods which work with
 ``Resample`` objects can also be used for resampling:
 
 .. ipython:: python
-   :okwarning:
+    :okwarning:
 
-   ds.resample(time='6H').mean()
+    ds.resample(time="6H").mean()
 
 You can also supply an arbitrary reduction function to aggregate over each
 resampling group:
 
 .. ipython:: python
 
-   ds.resample(time='6H').reduce(np.mean)
+    ds.resample(time="6H").reduce(np.mean)
 
 For upsampling, xarray provides six methods: ``asfreq``, ``ffill``, ``bfill``, ``pad``,
 ``nearest`` and ``interpolate``. ``interpolate`` extends ``scipy.interpolate.interp1d``
@@ -218,7 +220,7 @@ Data that has indices outside of the given ``tolerance`` are set to ``NaN``.
 
 .. ipython:: python
 
-    ds.resample(time='1H').nearest(tolerance='1H')
+    ds.resample(time="1H").nearest(tolerance="1H")
 
 
 For more examples of using grouped operations on a time dimension, see

--- a/doc/weather-climate.rst
+++ b/doc/weather-climate.rst
@@ -4,7 +4,7 @@ Weather and climate data
 ========================
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     import xarray as xr
 
@@ -56,11 +56,14 @@ coordinate with dates from a no-leap calendar and a
 
 .. ipython:: python
 
-   from itertools import product
-   from cftime import DatetimeNoLeap
-   dates = [DatetimeNoLeap(year, month, 1) for year, month in
-            product(range(1, 3), range(1, 13))]
-   da = xr.DataArray(np.arange(24), coords=[dates], dims=['time'], name='foo')
+    from itertools import product
+    from cftime import DatetimeNoLeap
+
+    dates = [
+        DatetimeNoLeap(year, month, 1)
+        for year, month in product(range(1, 3), range(1, 13))
+    ]
+    da = xr.DataArray(np.arange(24), coords=[dates], dims=["time"], name="foo")
 
 xarray also includes a :py:func:`~xarray.cftime_range` function, which enables
 creating a :py:class:`~xarray.CFTimeIndex` with regularly-spaced dates.  For
@@ -68,8 +71,8 @@ instance, we can create the same dates and DataArray we created above using:
 
 .. ipython:: python
 
-   dates = xr.cftime_range(start='0001', periods=24, freq='MS', calendar='noleap')
-   da = xr.DataArray(np.arange(24), coords=[dates], dims=['time'], name='foo')
+    dates = xr.cftime_range(start="0001", periods=24, freq="MS", calendar="noleap")
+    da = xr.DataArray(np.arange(24), coords=[dates], dims=["time"], name="foo")
 
 With :py:meth:`~xarray.CFTimeIndex.strftime` we can also easily generate formatted strings from
 the datetime values of a :py:class:`~xarray.CFTimeIndex` directly or through the
@@ -80,8 +83,8 @@ using the same formatting as the standard `datetime.strftime`_ convention .
 
 .. ipython:: python
 
-    dates.strftime('%c')
-    da['time'].dt.strftime('%Y%m%d')
+    dates.strftime("%c")
+    da["time"].dt.strftime("%Y%m%d")
 
 For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
 
@@ -90,8 +93,8 @@ For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
 
 .. ipython:: python
 
-   da.sel(time='0001')
-   da.sel(time=slice('0001-05', '0002-02'))
+    da.sel(time="0001")
+    da.sel(time=slice("0001-05", "0002-02"))
 
 - Access of basic datetime components via the ``dt`` accessor (in this case
   just "year", "month", "day", "hour", "minute", "second", "microsecond",
@@ -99,64 +102,65 @@ For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
 
 .. ipython:: python
 
-   da.time.dt.year
-   da.time.dt.month
-   da.time.dt.season
-   da.time.dt.dayofyear
-   da.time.dt.dayofweek
-   da.time.dt.days_in_month
+    da.time.dt.year
+    da.time.dt.month
+    da.time.dt.season
+    da.time.dt.dayofyear
+    da.time.dt.dayofweek
+    da.time.dt.days_in_month
 
 - Rounding of datetimes to fixed frequencies via the ``dt`` accessor:
 
 .. ipython:: python
 
-   da.time.dt.ceil('3D')
-   da.time.dt.floor('5D')
-   da.time.dt.round('2D')
+    da.time.dt.ceil("3D")
+    da.time.dt.floor("5D")
+    da.time.dt.round("2D")
    
 - Group-by operations based on datetime accessor attributes (e.g. by month of
   the year):
 
 .. ipython:: python
 
-   da.groupby('time.month').sum()
+    da.groupby("time.month").sum()
 
 - Interpolation using :py:class:`cftime.datetime` objects:
 
 .. ipython:: python
 
-   da.interp(time=[DatetimeNoLeap(1, 1, 15), DatetimeNoLeap(1, 2, 15)])
+    da.interp(time=[DatetimeNoLeap(1, 1, 15), DatetimeNoLeap(1, 2, 15)])
 
 - Interpolation using datetime strings:
 
 .. ipython:: python
 
-   da.interp(time=['0001-01-15', '0001-02-15'])
+    da.interp(time=["0001-01-15", "0001-02-15"])
 
 - Differentiation:
 
 .. ipython:: python
 
-   da.differentiate('time')
+    da.differentiate("time")
 
 - Serialization:
 
 .. ipython:: python
 
-   da.to_netcdf('example-no-leap.nc')
-   xr.open_dataset('example-no-leap.nc')
+    da.to_netcdf("example-no-leap.nc")
+    xr.open_dataset("example-no-leap.nc")
 
 .. ipython:: python
     :suppress:
 
     import os
-    os.remove('example-no-leap.nc')
+
+    os.remove("example-no-leap.nc")
 
 - And resampling along the time dimension for data indexed by a :py:class:`~xarray.CFTimeIndex`:
 
 .. ipython:: python
 
-    da.resample(time='81T', closed='right', label='right', base=3).mean()
+    da.resample(time="81T", closed="right", label="right", base=3).mean()
 
 .. note::
 
@@ -168,13 +172,13 @@ For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
    method:
 
    .. ipython:: python
-      :okwarning:
+       :okwarning:
 
-       modern_times = xr.cftime_range('2000', periods=24, freq='MS', calendar='noleap')
-       da = xr.DataArray(range(24), [('time', modern_times)])
+       modern_times = xr.cftime_range("2000", periods=24, freq="MS", calendar="noleap")
+       da = xr.DataArray(range(24), [("time", modern_times)])
        da
-       datetimeindex = da.indexes['time'].to_datetimeindex()
-       da['time'] = datetimeindex
+       datetimeindex = da.indexes["time"].to_datetimeindex()
+       da["time"] = datetimeindex
 
    However in this case one should use caution to only perform operations which
    do not depend on differences between dates (e.g. differentiation,

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -107,6 +107,8 @@ Documentation
   of ``kwargs`` in :py:meth:`Dataset.interp` and :py:meth:`DataArray.interp`
   for 1-d and n-d interpolation (:pull:`3956`).
   By `Matthias Riße <https://github.com/risebell>`_.
+- Apply ``black`` to all the code in the documentation (:pull:`4012`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -3272,7 +3272,7 @@ Enhancements
     In [1]: import xarray as xr; import numpy as np
 
     In [2]: arr = xr.DataArray(np.arange(0, 7.5, 0.5).reshape(3, 5),
-                               dims=('x', 'y'))
+       ...:                    dims=('x', 'y'))
 
     In [3]: arr
     Out[3]:

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -4,13 +4,14 @@ What's New
 ==========
 
 .. ipython:: python
-   :suppress:
+    :suppress:
 
     import numpy as np
     import pandas as pd
     import xarray as xray
     import xarray
     import xarray as xr
+
     np.random.seed(123456)
 
 .. _whats-new.0.16.0:
@@ -1962,8 +1963,8 @@ Enhancements
 
   .. ipython:: python
 
-    ds = xr.Dataset({'a': 1})
-    np.sin(ds)
+      ds = xr.Dataset({"a": 1})
+      np.sin(ds)
 
   This obliviates the need for the ``xarray.ufuncs`` module, which will be
   deprecated in the future when xarray drops support for older versions of
@@ -2054,8 +2055,8 @@ Enhancements
 
   .. ipython:: python
 
-    da = xr.DataArray(np.array([True, False, np.nan], dtype=object), dims='x')
-    da.sum()
+      da = xr.DataArray(np.array([True, False, np.nan], dtype=object), dims="x")
+      da.sum()
 
   (:issue:`1866`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
@@ -2209,7 +2210,7 @@ Breaking changes
   .. ipython::
     :verbatim:
 
-    In [1]: ds.resample('24H', dim='time', how='max')
+    In [1]: ds.resample("24H", dim="time", how="max")
     Out[1]:
     <xarray.Dataset>
     [...]
@@ -2219,7 +2220,7 @@ Breaking changes
   .. ipython::
     :verbatim:
 
-    In [1]: ds.resample(time='24H').max()
+    In [1]: ds.resample(time="24H").max()
     Out[1]:
     <xarray.Dataset>
     [...]
@@ -2289,9 +2290,9 @@ Enhancements
 
     In [1]: import xarray as xr
 
-    In [2]: arr = xr.DataArray([[1, 2, 3], [4, 5, 6]], dims=('x', 'y'))
+    In [2]: arr = xr.DataArray([[1, 2, 3], [4, 5, 6]], dims=("x", "y"))
 
-    In [3]: xr.where(arr % 2, 'even', 'odd')
+    In [3]: xr.where(arr % 2, "even", "odd")
     Out[3]:
     <xarray.DataArray (x: 2, y: 3)>
     array([['even', 'odd', 'even'],
@@ -2812,7 +2813,7 @@ Breaking changes
   .. ipython::
     :verbatim:
 
-    In [1]: xr.Dataset({'foo': (('x', 'y'), [[1, 2]])})
+    In [1]: xr.Dataset({"foo": (("x", "y"), [[1, 2]])})
     Out[1]:
     <xarray.Dataset>
     Dimensions:  (x: 1, y: 2)
@@ -3269,10 +3270,10 @@ Enhancements
   .. ipython::
     :verbatim:
 
-    In [1]: import xarray as xr; import numpy as np
+    In [1]: import xarray as xr
+       ...: import numpy as np
 
-    In [2]: arr = xr.DataArray(np.arange(0, 7.5, 0.5).reshape(3, 5),
-       ...:                    dims=('x', 'y'))
+    In [2]: arr = xr.DataArray(np.arange(0, 7.5, 0.5).reshape(3, 5), dims=("x", "y"))
 
     In [3]: arr
     Out[3]:
@@ -3411,7 +3412,7 @@ Breaking changes
   .. ipython::
     :verbatim:
 
-    In [2]: xray.DataArray([4, 5, 6], dims='x', name='x')
+    In [2]: xray.DataArray([4, 5, 6], dims="x", name="x")
     Out[2]:
     <xray.DataArray 'x' (x: 3)>
     array([4, 5, 6])
@@ -3423,7 +3424,7 @@ Breaking changes
   .. ipython::
     :verbatim:
 
-    In [2]: xray.DataArray([4, 5, 6], dims='x', name='x')
+    In [2]: xray.DataArray([4, 5, 6], dims="x", name="x")
     Out[2]:
     <xray.DataArray 'x' (x: 3)>
     array([4, 5, 6])
@@ -3446,13 +3447,11 @@ Enhancements
   .. ipython::
     :verbatim:
 
-    In [7]: df = pd.DataFrame({'foo': range(3),
-       ...:                    'x': ['a', 'b', 'b'],
-       ...:                    'y': [0, 0, 1]})
+    In [7]: df = pd.DataFrame({"foo": range(3), "x": ["a", "b", "b"], "y": [0, 0, 1]})
 
-    In [8]: s = df.set_index(['x', 'y'])['foo']
+    In [8]: s = df.set_index(["x", "y"])["foo"]
 
-    In [12]: arr = xray.DataArray(s, dims='z')
+    In [12]: arr = xray.DataArray(s, dims="z")
 
     In [13]: arr
     Out[13]:
@@ -3461,13 +3460,13 @@ Enhancements
     Coordinates:
       * z        (z) object ('a', 0) ('b', 0) ('b', 1)
 
-    In [19]: arr.indexes['z']
+    In [19]: arr.indexes["z"]
     Out[19]:
     MultiIndex(levels=[[u'a', u'b'], [0, 1]],
                labels=[[0, 1, 1], [0, 0, 1]],
                names=[u'x', u'y'])
 
-    In [14]: arr.unstack('z')
+    In [14]: arr.unstack("z")
     Out[14]:
     <xray.DataArray 'foo' (x: 2, y: 2)>
     array([[  0.,  nan],
@@ -3476,7 +3475,7 @@ Enhancements
       * x        (x) object 'a' 'b'
       * y        (y) int64 0 1
 
-    In [26]: arr.unstack('z').stack(z=('x', 'y'))
+    In [26]: arr.unstack("z").stack(z=("x", "y"))
     Out[26]:
     <xray.DataArray 'foo' (z: 4)>
     array([  0.,  nan,   1.,   2.])
@@ -3504,9 +3503,9 @@ Enhancements
   for shifting/rotating datasets or arrays along a dimension:
 
   .. ipython:: python
-     :okwarning:
+      :okwarning:
 
-      array = xray.DataArray([5, 6, 7, 8], dims='x')
+      array = xray.DataArray([5, 6, 7, 8], dims="x")
       array.shift(x=2)
       array.roll(x=2)
 
@@ -3521,8 +3520,8 @@ Enhancements
 
   .. ipython:: python
 
-      a = xray.DataArray([1, 2, 3], dims='x')
-      b = xray.DataArray([5, 6], dims='y')
+      a = xray.DataArray([1, 2, 3], dims="x")
+      b = xray.DataArray([5, 6], dims="y")
       a
       b
       a2, b2 = xray.broadcast(a, b)
@@ -3592,9 +3591,9 @@ Enhancements
   .. ipython::
     :verbatim:
 
-    In [5]: array = xray.DataArray([1, 2, 3], dims='x')
+    In [5]: array = xray.DataArray([1, 2, 3], dims="x")
 
-    In [6]: array.reindex(x=[0.9, 1.5], method='nearest', tolerance=0.2)
+    In [6]: array.reindex(x=[0.9, 1.5], method="nearest", tolerance=0.2)
     Out[6]:
     <xray.DataArray (x: 2)>
     array([  2.,  nan])
@@ -3674,10 +3673,11 @@ Enhancements
   .. ipython::
     :verbatim:
 
-    In [1]: da = xray.DataArray(np.arange(56).reshape((7, 8)),
-       ...:                     coords={'x': list('abcdefg'),
-       ...:                             'y': 10 * np.arange(8)},
-       ...:                     dims=['x', 'y'])
+    In [1]: da = xray.DataArray(
+       ...:     np.arange(56).reshape((7, 8)),
+       ...:     coords={"x": list("abcdefg"), "y": 10 * np.arange(8)},
+       ...:     dims=["x", "y"],
+       ...: )
 
     In [2]: da
     Out[2]:
@@ -3694,7 +3694,7 @@ Enhancements
     * x        (x) |S1 'a' 'b' 'c' 'd' 'e' 'f' 'g'
 
     # we can index by position along each dimension
-    In [3]: da.isel_points(x=[0, 1, 6], y=[0, 1, 0], dim='points')
+    In [3]: da.isel_points(x=[0, 1, 6], y=[0, 1, 0], dim="points")
     Out[3]:
     <xray.DataArray (points: 3)>
     array([ 0,  9, 48])
@@ -3704,7 +3704,7 @@ Enhancements
       * points   (points) int64 0 1 2
 
     # or equivalently by label
-    In [9]: da.sel_points(x=['a', 'b', 'g'], y=[0, 10, 0], dim='points')
+    In [9]: da.sel_points(x=["a", "b", "g"], y=[0, 10, 0], dim="points")
     Out[9]:
     <xray.DataArray (points: 3)>
     array([ 0,  9, 48])
@@ -3718,11 +3718,11 @@ Enhancements
 
   .. ipython:: python
 
-    ds = xray.Dataset(coords={'x': range(100), 'y': range(100)})
-    ds['distance'] = np.sqrt(ds.x ** 2 + ds.y ** 2)
+      ds = xray.Dataset(coords={"x": range(100), "y": range(100)})
+      ds["distance"] = np.sqrt(ds.x ** 2 + ds.y ** 2)
 
-    @savefig where_example.png width=4in height=4in
-    ds.distance.where(ds.distance < 100).plot()
+      @savefig where_example.png width=4in height=4in
+      ds.distance.where(ds.distance < 100).plot()
 
 - Added new methods ``xray.DataArray.diff`` and ``xray.Dataset.diff``
   for finite difference calculations along a given axis.
@@ -3732,9 +3732,9 @@ Enhancements
 
   .. ipython:: python
 
-    da = xray.DataArray(np.random.random_sample(size=(5, 4)))
-    da.where(da < 0.5)
-    da.where(da < 0.5).to_masked_array(copy=True)
+      da = xray.DataArray(np.random.random_sample(size=(5, 4)))
+      da.where(da < 0.5)
+      da.where(da < 0.5).to_masked_array(copy=True)
 
 - Added new flag "drop_variables" to ``xray.open_dataset`` for
   excluding variables from being parsed. This may be useful to drop
@@ -3792,9 +3792,9 @@ Enhancements
   .. ipython::
     :verbatim:
 
-    In [1]: years, datasets = zip(*ds.groupby('time.year'))
+    In [1]: years, datasets = zip(*ds.groupby("time.year"))
 
-    In [2]: paths = ['%s.nc' % y for y in years]
+    In [2]: paths = ["%s.nc" % y for y in years]
 
     In [3]: xray.save_mfdataset(datasets, paths)
 
@@ -3867,9 +3867,9 @@ Backwards incompatible changes
   .. ipython::
     :verbatim:
 
-    In [1]: ds = xray.Dataset({'x': 0})
+    In [1]: ds = xray.Dataset({"x": 0})
 
-    In [2]: xray.concat([ds, ds], dim='y')
+    In [2]: xray.concat([ds, ds], dim="y")
     Out[2]:
     <xray.Dataset>
     Dimensions:  ()
@@ -3881,13 +3881,13 @@ Backwards incompatible changes
   Now, the default always concatenates data variables:
 
   .. ipython:: python
-    :suppress:
+      :suppress:
 
-    ds = xray.Dataset({'x': 0})
+      ds = xray.Dataset({"x": 0})
 
   .. ipython:: python
 
-    xray.concat([ds, ds], dim='y')
+      xray.concat([ds, ds], dim="y")
 
   To obtain the old behavior, supply the argument ``concat_over=[]``.
 
@@ -3900,17 +3900,20 @@ Enhancements
 
   .. ipython:: python
 
-      ds = xray.Dataset({'a': 1, 'b': ('x', [1, 2, 3])},
-                        coords={'c': 42}, attrs={'Conventions': 'None'})
+      ds = xray.Dataset(
+          {"a": 1, "b": ("x", [1, 2, 3])},
+          coords={"c": 42},
+          attrs={"Conventions": "None"},
+      )
       ds.to_array()
-      ds.to_array().to_dataset(dim='variable')
+      ds.to_array().to_dataset(dim="variable")
 
 - New ``xray.Dataset.fillna`` method to fill missing values, modeled
   off the pandas method of the same name:
 
   .. ipython:: python
 
-      array = xray.DataArray([np.nan, 1, np.nan, 3], dims='x')
+      array = xray.DataArray([np.nan, 1, np.nan, 3], dims="x")
       array.fillna(0)
 
   ``fillna`` works on both ``Dataset`` and ``DataArray`` objects, and uses
@@ -3923,9 +3926,9 @@ Enhancements
 
   .. ipython:: python
 
-      ds = xray.Dataset({'y': ('x', [1, 2, 3])})
-      ds.assign(z = lambda ds: ds.y ** 2)
-      ds.assign_coords(z = ('x', ['a', 'b', 'c']))
+      ds = xray.Dataset({"y": ("x", [1, 2, 3])})
+      ds.assign(z=lambda ds: ds.y ** 2)
+      ds.assign_coords(z=("x", ["a", "b", "c"]))
 
   These methods return a new Dataset (or DataArray) with updated data or
   coordinate variables.
@@ -3938,7 +3941,7 @@ Enhancements
   .. ipython::
       :verbatim:
 
-      In [12]: ds.sel(x=1.1, method='nearest')
+      In [12]: ds.sel(x=1.1, method="nearest")
       Out[12]:
       <xray.Dataset>
       Dimensions:  ()
@@ -3947,7 +3950,7 @@ Enhancements
       Data variables:
           y        int64 2
 
-      In [13]: ds.sel(x=[1.1, 2.1], method='pad')
+      In [13]: ds.sel(x=[1.1, 2.1], method="pad")
       Out[13]:
       <xray.Dataset>
       Dimensions:  (x: 2)
@@ -3973,7 +3976,7 @@ Enhancements
 
   .. ipython:: python
 
-      ds = xray.Dataset({'x': np.arange(1000)})
+      ds = xray.Dataset({"x": np.arange(1000)})
       with xray.set_options(display_width=40):
           print(ds)
 
@@ -4011,42 +4014,42 @@ Enhancements
   need to supply the time dimension explicitly:
 
   .. ipython:: python
-     :verbatim:
+      :verbatim:
 
-      time = pd.date_range('2000-01-01', freq='6H', periods=10)
-      array = xray.DataArray(np.arange(10), [('time', time)])
-      array.resample('1D', dim='time')
+      time = pd.date_range("2000-01-01", freq="6H", periods=10)
+      array = xray.DataArray(np.arange(10), [("time", time)])
+      array.resample("1D", dim="time")
 
   You can specify how to do the resampling with the ``how`` argument and other
   options such as ``closed`` and ``label`` let you control labeling:
 
   .. ipython:: python
-     :verbatim:
+      :verbatim:
 
-      array.resample('1D', dim='time', how='sum', label='right')
+      array.resample("1D", dim="time", how="sum", label="right")
 
   If the desired temporal resolution is higher than the original data
   (upsampling), xray will insert missing values:
 
   .. ipython:: python
-     :verbatim:
+      :verbatim:
 
-      array.resample('3H', 'time')
+      array.resample("3H", "time")
 
 - ``first`` and ``last`` methods on groupby objects let you take the first or
   last examples from each group along the grouped axis:
 
   .. ipython:: python
-     :verbatim:
+      :verbatim:
 
-      array.groupby('time.day').first()
+      array.groupby("time.day").first()
 
   These methods combine well with ``resample``:
 
   .. ipython:: python
-     :verbatim:
+      :verbatim:
 
-      array.resample('1D', dim='time', how='first')
+      array.resample("1D", dim="time", how="first")
 
 
 - ``xray.Dataset.swap_dims`` allows for easily swapping one dimension
@@ -4054,9 +4057,9 @@ Enhancements
 
   .. ipython:: python
 
-       ds = xray.Dataset({'x': range(3), 'y': ('x', list('abc'))})
-       ds
-       ds.swap_dims({'x': 'y'})
+      ds = xray.Dataset({"x": range(3), "y": ("x", list("abc"))})
+      ds
+      ds.swap_dims({"x": "y"})
 
   This was possible in earlier versions of xray, but required some contortions.
 - ``xray.open_dataset`` and ``xray.Dataset.to_netcdf`` now
@@ -4102,8 +4105,8 @@ Breaking changes
 
   .. ipython:: python
 
-      lhs = xray.DataArray([1, 2, 3], [('x', [0, 1, 2])])
-      rhs = xray.DataArray([2, 3, 4], [('x', [1, 2, 3])])
+      lhs = xray.DataArray([1, 2, 3], [("x", [0, 1, 2])])
+      rhs = xray.DataArray([2, 3, 4], [("x", [1, 2, 3])])
       lhs + rhs
 
   :ref:`For dataset construction and merging<merge>`, we align based on the
@@ -4111,14 +4114,14 @@ Breaking changes
 
   .. ipython:: python
 
-      xray.Dataset({'foo': lhs, 'bar': rhs})
+      xray.Dataset({"foo": lhs, "bar": rhs})
 
   :ref:`For update and __setitem__<update>`, we align based on the **original**
   object:
 
   .. ipython:: python
 
-      lhs.coords['rhs'] = rhs
+      lhs.coords["rhs"] = rhs
       lhs
 
 - Aggregations like ``mean`` or ``median`` now skip missing values by default:
@@ -4141,8 +4144,8 @@ Breaking changes
 
   .. ipython:: python
 
-      a = xray.DataArray([1, 2], coords={'c': 0}, dims='x')
-      b = xray.DataArray([1, 2], coords={'c': ('x', [0, 0])}, dims='x')
+      a = xray.DataArray([1, 2], coords={"c": 0}, dims="x")
+      b = xray.DataArray([1, 2], coords={"c": ("x", [0, 0])}, dims="x")
       (a + b).coords
 
   This functionality can be controlled through the ``compat`` option, which
@@ -4153,9 +4156,10 @@ Breaking changes
 
   .. ipython:: python
 
-      time = xray.DataArray(pd.date_range('2000-01-01', periods=365),
-                            dims='time', name='time')
-      counts = time.groupby('time.month').count()
+      time = xray.DataArray(
+          pd.date_range("2000-01-01", periods=365), dims="time", name="time"
+      )
+      counts = time.groupby("time.month").count()
       counts.sel(month=2)
 
   Previously, you would need to use something like
@@ -4165,8 +4169,8 @@ Breaking changes
 
   .. ipython:: python
 
-      ds = xray.Dataset({'t': pd.date_range('2000-01-01', periods=12, freq='M')})
-      ds['t.season']
+      ds = xray.Dataset({"t": pd.date_range("2000-01-01", periods=12, freq="M")})
+      ds["t.season"]
 
   Previously, it returned numbered seasons 1 through 4.
 - We have updated our use of the terms of "coordinates" and "variables". What
@@ -4189,8 +4193,8 @@ Enhancements
 
   .. ipython:: python
 
-      data = xray.DataArray([1, 2, 3], [('x', range(3))])
-      data.reindex(x=[0.5, 1, 1.5, 2, 2.5], method='pad')
+      data = xray.DataArray([1, 2, 3], [("x", range(3))])
+      data.reindex(x=[0.5, 1, 1.5, 2, 2.5], method="pad")
 
   This will be especially useful once pandas 0.16 is released, at which point
   xray will immediately support reindexing with
@@ -4209,15 +4213,15 @@ Enhancements
   makes it easy to drop explicitly listed variables or index labels:
 
   .. ipython:: python
-     :okwarning:
+      :okwarning:
 
       # drop variables
-      ds = xray.Dataset({'x': 0, 'y': 1})
-      ds.drop('x')
+      ds = xray.Dataset({"x": 0, "y": 1})
+      ds.drop("x")
 
       # drop index labels
-      arr = xray.DataArray([1, 2, 3], coords=[('x', list('abc'))])
-      arr.drop(['a', 'c'], dim='x')
+      arr = xray.DataArray([1, 2, 3], coords=[("x", list("abc"))])
+      arr.drop(["a", "c"], dim="x")
 
 - ``xray.Dataset.broadcast_equals`` has been added to correspond to
   the new ``compat`` option.
@@ -4285,7 +4289,8 @@ Backwards incompatible changes
   .. ipython:: python
 
       from datetime import datetime
-      xray.Dataset({'t': [datetime(2000, 1, 1)]})
+
+      xray.Dataset({"t": [datetime(2000, 1, 1)]})
 
 - xray now has support (including serialization to netCDF) for
   :py:class:`~pandas.TimedeltaIndex`. :py:class:`datetime.timedelta` objects
@@ -4301,8 +4306,8 @@ Enhancements
 
   .. ipython:: python
 
-     ds = xray.Dataset({'tmin': ([], 25, {'units': 'celsius'})})
-     ds.tmin.units
+      ds = xray.Dataset({"tmin": ([], 25, {"units": "celsius"})})
+      ds.tmin.units
 
   Tab-completion for these variables should work in editors such as IPython.
   However, setting variables or attributes in this fashion is not yet
@@ -4312,7 +4317,7 @@ Enhancements
 
   .. ipython:: python
 
-      array = xray.DataArray(np.zeros(5), dims=['x'])
+      array = xray.DataArray(np.zeros(5), dims=["x"])
       array[dict(x=slice(3))] = 1
       array
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -447,7 +447,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         New coordinate can also be attached to an existing dimension:
 
         >>> lon_2 = np.array([300, 289, 0, 1])
-        >>> da.assign_coords(lon_2=('lon', lon_2))
+        >>> da.assign_coords(lon_2=("lon", lon_2))
         <xarray.DataArray (lon: 4)>
         array([0.28298 , 0.667347, 0.657938, 0.177683])
         Coordinates:
@@ -456,7 +456,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         Note that the same result can also be obtained with a dict e.g.
 
-        >>> _ = da.assign_coords({"lon_2": ('lon', lon_2)})
+        >>> _ = da.assign_coords({"lon_2": ("lon", lon_2)})
 
         Notes
         -----

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3503,9 +3503,9 @@ class DataArray(AbstractArray, DataWithCoords):
           * x        (x) float64 nan 0.0 1.0 2.0 nan nan
 
         >>> da = xr.DataArray([[0,1,2,3], [10,11,12,13]],
-                              dims=["x", "y"],
-                              coords={"x": [0,1], "y": [10, 20 ,30, 40], "z": ("x", [100, 200])}
-            )
+        ...                   dims=["x", "y"],
+        ...                   coords={"x": [0,1], "y": [10, 20 ,30, 40], "z": ("x", [100, 200])}
+        ... )
         >>> da.pad(x=1)
         <xarray.DataArray (x: 4, y: 4)>
         array([[nan, nan, nan, nan],

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3495,16 +3495,17 @@ class DataArray(AbstractArray, DataWithCoords):
         Examples
         --------
 
-        >>> arr = xr.DataArray([5, 6, 7], coords=[("x", [0,1,2])])
-        >>> arr.pad(x=(1,2), constant_values=0)
+        >>> arr = xr.DataArray([5, 6, 7], coords=[("x", [0, 1, 2])])
+        >>> arr.pad(x=(1, 2), constant_values=0)
         <xarray.DataArray (x: 6)>
         array([0, 5, 6, 7, 0, 0])
         Coordinates:
           * x        (x) float64 nan 0.0 1.0 2.0 nan nan
 
-        >>> da = xr.DataArray([[0,1,2,3], [10,11,12,13]],
-        ...                   dims=["x", "y"],
-        ...                   coords={"x": [0,1], "y": [10, 20 ,30, 40], "z": ("x", [100, 200])}
+        >>> da = xr.DataArray(
+        ...     [[0, 1, 2, 3], [10, 11, 12, 13]],
+        ...     dims=["x", "y"],
+        ...     coords={"x": [0, 1], "y": [10, 20, 30, 40], "z": ("x", [100, 200])},
         ... )
         >>> da.pad(x=1)
         <xarray.DataArray (x: 4, y: 4)>
@@ -3592,8 +3593,9 @@ class DataArray(AbstractArray, DataWithCoords):
         Examples
         --------
 
-        >>> array = xr.DataArray([0, 2, 1, 0, -2], dims="x",
-        ...                      coords={"x": ['a', 'b', 'c', 'd', 'e']})
+        >>> array = xr.DataArray(
+        ...     [0, 2, 1, 0, -2], dims="x", coords={"x": ["a", "b", "c", "d", "e"]}
+        ... )
         >>> array.min()
         <xarray.DataArray ()>
         array(-2)
@@ -3604,13 +3606,15 @@ class DataArray(AbstractArray, DataWithCoords):
         <xarray.DataArray 'x' ()>
         array('e', dtype='<U1')
 
-        >>> array = xr.DataArray([[2.0, 1.0, 2.0, 0.0, -2.0],
-        ...                       [-4.0, np.NaN, 2.0, np.NaN, -2.0],
-        ...                       [np.NaN, np.NaN, 1., np.NaN, np.NaN]],
-        ...                      dims=["y", "x"],
-        ...                      coords={"y": [-1, 0, 1],
-        ...                              "x": np.arange(5.)**2}
-        ...                      )
+        >>> array = xr.DataArray(
+        ...     [
+        ...         [2.0, 1.0, 2.0, 0.0, -2.0],
+        ...         [-4.0, np.NaN, 2.0, np.NaN, -2.0],
+        ...         [np.NaN, np.NaN, 1.0, np.NaN, np.NaN],
+        ...     ],
+        ...     dims=["y", "x"],
+        ...     coords={"y": [-1, 0, 1], "x": np.arange(5.0) ** 2},
+        ... )
         >>> array.min(dim="x")
         <xarray.DataArray (y: 3)>
         array([-2., -4.,  1.])
@@ -3686,8 +3690,9 @@ class DataArray(AbstractArray, DataWithCoords):
         Examples
         --------
 
-        >>> array = xr.DataArray([0, 2, 1, 0, -2], dims="x",
-        ...                      coords={"x": ['a', 'b', 'c', 'd', 'e']})
+        >>> array = xr.DataArray(
+        ...     [0, 2, 1, 0, -2], dims="x", coords={"x": ["a", "b", "c", "d", "e"]}
+        ... )
         >>> array.max()
         <xarray.DataArray ()>
         array(2)
@@ -3698,13 +3703,15 @@ class DataArray(AbstractArray, DataWithCoords):
         <xarray.DataArray 'x' ()>
         array('b', dtype='<U1')
 
-        >>> array = xr.DataArray([[2.0, 1.0, 2.0, 0.0, -2.0],
-        ...                       [-4.0, np.NaN, 2.0, np.NaN, -2.0],
-        ...                       [np.NaN, np.NaN, 1., np.NaN, np.NaN]],
-        ...                      dims=["y", "x"],
-        ...                      coords={"y": [-1, 0, 1],
-        ...                              "x": np.arange(5.)**2}
-        ...                      )
+        >>> array = xr.DataArray(
+        ...     [
+        ...         [2.0, 1.0, 2.0, 0.0, -2.0],
+        ...         [-4.0, np.NaN, 2.0, np.NaN, -2.0],
+        ...         [np.NaN, np.NaN, 1.0, np.NaN, np.NaN],
+        ...     ],
+        ...     dims=["y", "x"],
+        ...     coords={"y": [-1, 0, 1], "x": np.arange(5.0) ** 2},
+        ... )
         >>> array.max(dim="x")
         <xarray.DataArray (y: 3)>
         array([2., 2., 1.])

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1055,9 +1055,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         structure of the original object, but with the new data. Original
         object is unaffected.
 
-        >>> ds.copy(
-        ...     data={"foo": np.arange(6).reshape(2, 3), "bar": ["a", "b"]}
-        ... )
+        >>> ds.copy(data={"foo": np.arange(6).reshape(2, 3), "bar": ["a", "b"]})
         <xarray.Dataset>
         Dimensions:  (dim_0: 2, dim_1: 3, x: 2)
         Coordinates:
@@ -6061,8 +6059,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         Examples
         --------
 
-        >>> ds = xr.Dataset({'foo': ('x', range(5))})
-        >>> ds.pad(x=(1,2))
+        >>> ds = xr.Dataset({"foo": ("x", range(5))})
+        >>> ds.pad(x=(1, 2))
         <xarray.Dataset>
         Dimensions:  (x: 8)
         Dimensions without coordinates: x
@@ -6156,17 +6154,20 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         Examples
         --------
 
-        >>> array1 = xr.DataArray([0, 2, 1, 0, -2], dims="x",
-        ...                       coords={"x": ['a', 'b', 'c', 'd', 'e']})
-        >>> array2 = xr.DataArray([[2.0, 1.0, 2.0, 0.0, -2.0],
-        ...                        [-4.0, np.NaN, 2.0, np.NaN, -2.0],
-        ...                        [np.NaN, np.NaN, 1., np.NaN, np.NaN]],
-        ...                       dims=["y", "x"],
-        ...                       coords={"y": [-1, 0, 1],
-        ...                               "x": ['a', 'b', 'c', 'd', 'e']}
-        ...                       )
-        >>> ds = xr.Dataset({'int': array1, 'float': array2})
-        >>> ds.min(dim='x')
+        >>> array1 = xr.DataArray(
+        ...     [0, 2, 1, 0, -2], dims="x", coords={"x": ["a", "b", "c", "d", "e"]}
+        ... )
+        >>> array2 = xr.DataArray(
+        ...     [
+        ...         [2.0, 1.0, 2.0, 0.0, -2.0],
+        ...         [-4.0, np.NaN, 2.0, np.NaN, -2.0],
+        ...         [np.NaN, np.NaN, 1.0, np.NaN, np.NaN],
+        ...     ],
+        ...     dims=["y", "x"],
+        ...     coords={"y": [-1, 0, 1], "x": ["a", "b", "c", "d", "e"]},
+        ... )
+        >>> ds = xr.Dataset({"int": array1, "float": array2})
+        >>> ds.min(dim="x")
         <xarray.Dataset>
         Dimensions:  (y: 3)
         Coordinates:
@@ -6174,7 +6175,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         Data variables:
             int      int64 -2
             float    (y) float64 -2.0 -4.0 1.0
-        >>> ds.argmin(dim='x')
+        >>> ds.argmin(dim="x")
         <xarray.Dataset>
         Dimensions:  (y: 3)
         Coordinates:
@@ -6182,7 +6183,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         Data variables:
             int      int64 4
             float    (y) int64 4 0 2
-        >>> ds.idxmin(dim='x')
+        >>> ds.idxmin(dim="x")
         <xarray.Dataset>
         Dimensions:  (y: 3)
         Coordinates:
@@ -6251,17 +6252,20 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         Examples
         --------
 
-        >>> array1 = xr.DataArray([0, 2, 1, 0, -2], dims="x",
-        ...                       coords={"x": ['a', 'b', 'c', 'd', 'e']})
-        >>> array2 = xr.DataArray([[2.0, 1.0, 2.0, 0.0, -2.0],
-        ...                        [-4.0, np.NaN, 2.0, np.NaN, -2.0],
-        ...                        [np.NaN, np.NaN, 1., np.NaN, np.NaN]],
-        ...                       dims=["y", "x"],
-        ...                       coords={"y": [-1, 0, 1],
-        ...                               "x": ['a', 'b', 'c', 'd', 'e']}
-        ...                       )
-        >>> ds = xr.Dataset({'int': array1, 'float': array2})
-        >>> ds.max(dim='x')
+        >>> array1 = xr.DataArray(
+        ...     [0, 2, 1, 0, -2], dims="x", coords={"x": ["a", "b", "c", "d", "e"]}
+        ... )
+        >>> array2 = xr.DataArray(
+        ...     [
+        ...         [2.0, 1.0, 2.0, 0.0, -2.0],
+        ...         [-4.0, np.NaN, 2.0, np.NaN, -2.0],
+        ...         [np.NaN, np.NaN, 1.0, np.NaN, np.NaN],
+        ...     ],
+        ...     dims=["y", "x"],
+        ...     coords={"y": [-1, 0, 1], "x": ["a", "b", "c", "d", "e"]},
+        ... )
+        >>> ds = xr.Dataset({"int": array1, "float": array2})
+        >>> ds.max(dim="x")
         <xarray.Dataset>
         Dimensions:  (y: 3)
         Coordinates:
@@ -6269,7 +6273,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         Data variables:
             int      int64 2
             float    (y) float64 2.0 2.0 1.0
-        >>> ds.argmax(dim='x')
+        >>> ds.argmax(dim="x")
         <xarray.Dataset>
         Dimensions:  (y: 3)
         Coordinates:
@@ -6277,7 +6281,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         Data variables:
             int      int64 1
             float    (y) int64 0 2 2
-        >>> ds.idxmax(dim='x')
+        >>> ds.idxmax(dim="x")
         <xarray.Dataset>
         Dimensions:  (y: 3)
         Coordinates:


### PR DESCRIPTION
This applies `black` to the code in the documentation using [`blackdoc`](https://github.com/keewis/blackdoc). The tool itself is not stable or released yet, but this demonstrate the upcoming support for `rst` code blocks, including the ipython sphinx directive. There are a few issues with the latter, e.g. the semi-colon to suppress output will be removed by `black`. In a few cases this changes the other outputs, mostly plots. I think we might fix/work around that by moving the line decorator to the last line that should be plotted (which is what I did), but we could also use the ipython syntax with cell decorators:
```python
@savefig ...
In [1]: # code
   ...: # with multiple lines
```

Also, while I checked the changes manually, please don't take my word for it: I'm really not sure I didn't miss anything. I know this is a rather large PR so I'm fine with waiting.

 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
