### PR TITLE
Combining attrs of member DataArrays of Datasets

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -951,12 +951,18 @@ def open_mfdataset(
                 coords=coords,
                 ids=ids,
                 join=join,
+                combine_attrs="drop",
             )
         elif combine == "by_coords":
             # Redo ordering from coordinates, ignoring how they were ordered
             # previously
             combined = combine_by_coords(
-                datasets, compat=compat, data_vars=data_vars, coords=coords, join=join
+                datasets,
+                compat=compat,
+                data_vars=data_vars,
+                coords=coords,
+                join=join,
+                combine_attrs="drop",
             )
         else:
             raise ValueError(

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2654,7 +2654,7 @@ class TestOpenMFDatasetWithDataVarsAndCoordsKw:
 
     def test_open_mfdataset_dataset_attr_by_coords(self):
         """
-        Case when an attribute of type list differs across the multiple files
+        Case when an attribute differs across the multiple files
         """
         with self.setup_files_and_datasets() as (files, [ds1, ds2]):
             # Give the files an inconsistent attribute
@@ -2669,7 +2669,7 @@ class TestOpenMFDatasetWithDataVarsAndCoordsKw:
 
     def test_open_mfdataset_dataarray_attr_by_coords(self):
         """
-        Case when an attribute of type list differs across the multiple files
+        Case when an attribute of a member DataArray differs across the multiple files
         """
         with self.setup_files_and_datasets() as (files, [ds1, ds2]):
             # Give the files an inconsistent attribute


### PR DESCRIPTION
While looking at #4009, I noticed that the `combine_attrs` kwarg to `concat` or `merge` only affects the global attrs of the `Dataset`, not the attrs of `DataArray` or `Variable` members of the `Dataset`s being combined. I think this is a bug.

So far this PR adds tests that reproduce the issue in #4009, and the issue described above. Fixing should be fairly simple: for #4009 pass `combine_attrs="drop"` to `combine_by_coords` and `combine_nested` in `open_mfdataset`; for this issue insert the `combine_attrs` handling in an appropriate place - possibly in `merge.unique_variable`. I'll update with fixes when I get a chance.

 - [ ] Closes #4009
 - [x] Tests added
 - [ ] Passes `isort -rc . && black . && mypy . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
