### PR TITLE
Add NetCDF3 dtype coercion for unsigned integer types

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -59,6 +59,9 @@ New Features
   the :py:class:`~core.accessor_dt.DatetimeAccessor` (:pull:`3935`).  This
   feature requires cftime version 1.1.0 or greater.  By
   `Spencer Clark <https://github.com/spencerkclark>`_.
+- For the netCDF3 backend, added dtype coercions for unsigned integer types.
+  (:issue:`4014`, :pull:`4018`)
+  By `Yunus Sevinchan <https://github.com/blsqr>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/backends/netcdf3.py
+++ b/xarray/backends/netcdf3.py
@@ -28,7 +28,14 @@ _reserved_names = {
 
 # These data-types aren't supported by netCDF3, so they are automatically
 # coerced instead as indicated by the "coerce_nc3_dtype" function
-_nc3_dtype_coercions = {"int64": "int32", "bool": "int8"}
+_nc3_dtype_coercions = {
+    "int64": "int32",
+    "uint64": "int32",
+    "uint32": "int32",
+    "uint16": "int16",
+    "uint8": "int8",
+    "bool": "int8",
+}
 
 # encode all strings as UTF-8
 STRING_ENCODING = "utf-8"
@@ -37,12 +44,17 @@ STRING_ENCODING = "utf-8"
 def coerce_nc3_dtype(arr):
     """Coerce an array to a data type that can be stored in a netCDF-3 file
 
-    This function performs the following dtype conversions:
-        int64 -> int32
-        bool -> int8
+    This function performs the dtype conversions as specified by the
+    ``_nc3_dtype_coercions`` mapping:
+        int64  -> int32
+        uint64 -> int32
+        uint32 -> int32
+        uint16 -> int16
+        uint8  -> int8
+        bool   -> int8
 
-    Data is checked for equality, or equivalence (non-NaN values) with
-    `np.allclose` with the default keyword arguments.
+    Data is checked for equality, or equivalence (non-NaN values) using the
+    ``(cast_array == original_array).all()``.
     """
     dtype = str(arr.dtype)
     if dtype in _nc3_dtype_coercions:


### PR DESCRIPTION
This PR addresses #4014. 

 - [x] Closes #4014 
 - [x] Tests added or adjusted
   - [x] Adjusted a test case where `int64` coercion played a role
   - [x] Explicit test for failing coercion (seems to be missing currently -- should this be added?)
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented
 - [x] Adjusted `whats-new.rst` for all changes ~~and `api.rst` for new API~~