### PR TITLE
Remove broken test for Panel with to_pandas()

### DIFF
--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -17,6 +17,7 @@ from xarray.core.common import full_like
 from xarray.core.indexes import propagate_indexes
 from xarray.core.utils import is_scalar
 from xarray.tests import (
+    LooseVersion,
     ReturnItem,
     assert_allclose,
     assert_array_equal,

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -17,7 +17,6 @@ from xarray.core.common import full_like
 from xarray.core.indexes import propagate_indexes
 from xarray.core.utils import is_scalar
 from xarray.tests import (
-    LooseVersion,
     ReturnItem,
     assert_allclose,
     assert_array_equal,

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -32,7 +32,6 @@ from xarray.core.utils import is_scalar
 
 from . import (
     InaccessibleArray,
-    LooseVersion,
     UnexpectedDataAccess,
     assert_allclose,
     assert_array_equal,

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -496,16 +496,11 @@ class TestDataset:
             DataArray(np.random.rand(4, 3), dims=["a", "b"]),  # df
         ]
 
-        if LooseVersion(pd.__version__) < "0.25.0":
-            das.append(DataArray(np.random.rand(4, 3, 2), dims=["a", "b", "c"]))
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", r"\W*Panel is deprecated")
-            for a in das:
-                pandas_obj = a.to_pandas()
-                ds_based_on_pandas = Dataset(pandas_obj)
-                for dim in ds_based_on_pandas.data_vars:
-                    assert_array_equal(ds_based_on_pandas[dim], pandas_obj[dim])
+        for a in das:
+            pandas_obj = a.to_pandas()
+            ds_based_on_pandas = Dataset(pandas_obj)
+            for dim in ds_based_on_pandas.data_vars:
+                assert_array_equal(ds_based_on_pandas[dim], pandas_obj[dim])
 
     def test_constructor_compat(self):
         data = {"x": DataArray(0, coords={"y": 1}), "y": ("z", [1, 1, 1])}


### PR DESCRIPTION
We don't support creating a Panel with to_pandas() with *any* version of
pandas at present, so this test was previous broken if pandas < 0.25 was
installed.

<!-- Feel free to remove check-list items aren't relevant to your change -->
