### PR TITLE
support darkmode

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -64,7 +64,9 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
-- ``ValueError`` is raised when ``fill_value`` is not a scalar in :py:meth:`full_like`. (:issue`3977`)
+- Support dark mode in VS code (:issue:`4024`)
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+- ``ValueError`` is raised when ``fill_value`` is not a scalar in :py:meth:`full_like`. (:issue:`3977`)
   By `Huite Bootsma <https://github.com/huite>`_.
 - Fix wrong order in converting a ``pd.Series`` with a MultiIndex to ``DataArray``. (:issue:`3951`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.

--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -2,7 +2,7 @@
  *
  */
 
-:root {
+ :root {
   --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
   --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
   --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
@@ -11,6 +11,17 @@
   --xr-background-color: var(--jp-layout-color0, white);
   --xr-background-color-row-even: var(--jp-layout-color1, white);
   --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
+}
+
+body.vscode-dark {
+  --xr-font-color0: rgba(255, 255, 255, 1);
+  --xr-font-color2: rgba(255, 255, 255, 0.54);
+  --xr-font-color3: rgba(255, 255, 255, 0.38);
+  --xr-border-color: #1F1F1F;
+  --xr-disabled-color: #515151;
+  --xr-background-color: #111111;
+  --xr-background-color-row-even: #111111;
+  --xr-background-color-row-odd: #313131;
 }
 
 .xr-wrap {

--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -13,6 +13,7 @@
   --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
 }
 
+html[theme=dark],
 body.vscode-dark {
   --xr-font-color0: rgba(255, 255, 255, 1);
   --xr-font-color2: rgba(255, 255, 255, 0.54);

--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -2,7 +2,7 @@
  *
  */
 
- :root {
+:root {
   --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
   --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
   --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4024
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Now it looks like
![image](https://user-images.githubusercontent.com/6815844/81138965-e3f04300-8f9e-11ea-9e5d-7b5b680932d7.png)

I'm pretty sure that this workaround is not the best (maybe the second worst), as it only supports the dark mode of vscode but not other environments.

I couldn't find a good way to make a workaround for the general dark-mode.
Any advice is welcome.

