### PR TITLE
Use literal syntax instead of function calls to create the data structure

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -146,6 +146,10 @@ Internal Changes
   ``all``, ``any``, ``enumerate``, ``sum``, ``tuple`` etc. can work directly with a
   generator expression. (:pull:`4026`)
   By `Prajjwal Nijhara <https://github.com/pnijhara>`_.
+- Use literal syntax instead of function calls to create the data structure
+  It is slower to call e.g. list() than using the empty literal, because the name list
+  must be looked up in the global scope in case it has been rebound. (:pull:`4038`)
+  By `Prajjwal Nijhara <https://github.com/pnijhara>`_.
 
 .. _whats-new.0.15.1:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -142,13 +142,7 @@ Internal Changes
 - Use ``async`` / ``await`` for the asynchronous distributed
   tests. (:issue:`3987`, :pull:`3989`)
   By `Justus Magin <https://github.com/keewis>`_.
-- Remove unnecessary comprehensions becuase the built-in functions like
-  ``all``, ``any``, ``enumerate``, ``sum``, ``tuple`` etc. can work directly with a
-  generator expression. (:pull:`4026`)
-  By `Prajjwal Nijhara <https://github.com/pnijhara>`_.
-- Use literal syntax instead of function calls to create the data structure
-  It is slower to call e.g. list() than using the empty literal, because the name list
-  must be looked up in the global scope in case it has been rebound. (:pull:`4038`)
+- Various internal code clean-ups (:pull:`4026`,  :pull:`4038`).
   By `Prajjwal Nijhara <https://github.com/pnijhara>`_.
 
 .. _whats-new.0.15.1:

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -841,7 +841,7 @@ def merge(
     from .dataarray import DataArray
     from .dataset import Dataset
 
-    dict_like_objects = list()
+    dict_like_objects = []
     for obj in objects:
         if not isinstance(obj, (DataArray, Dataset, dict)):
             raise TypeError(

--- a/xarray/util/print_versions.py
+++ b/xarray/util/print_versions.py
@@ -129,7 +129,7 @@ def show_versions(file=sys.stdout):
         ("sphinx", lambda mod: mod.__version__),
     ]
 
-    deps_blob = list()
+    deps_blob = []
     for (modname, ver_f) in deps:
         try:
             if modname in sys.modules:


### PR DESCRIPTION

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
---
It is slower to call e.g. `list()` than using the empty literal, because the name list must be looked up in the global scope in case it has been rebound. Same for the other two types like `dict()` and `tuple()`.