### PR TITLE
fix the failing flake8 CI

### DIFF
--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -241,7 +241,7 @@ class AbstractWritableDataStore(AbstractDataStore):
         """encode one attribute"""
         return a
 
-    def set_dimension(self, d, l):  # pragma: no cover
+    def set_dimension(self, dim, length):  # pragma: no cover
         raise NotImplementedError()
 
     def set_attribute(self, k, v):  # pragma: no cover

--- a/xarray/backends/memory.py
+++ b/xarray/backends/memory.py
@@ -40,6 +40,6 @@ class InMemoryDataStore(AbstractWritableDataStore):
         # copy to imitate writing to disk.
         self._attributes[k] = copy.deepcopy(v)
 
-    def set_dimension(self, d, l, unlimited_dims=None):
+    def set_dimension(self, dim, length, unlimited_dims=None):
         # in this model, dimensions are accounted for in the variables
         pass


### PR DESCRIPTION
With its recent release, `pycodestyle` introduced `E741` which flags parameters named `l` (lowercase `L`) since that tends to be confused with `1` (the digit) or maybe even `(` or `)` depending on the font. The names actually don't matter in both cases since the first method is abstract and the second method is a dummy.

 - [x] Closes #4056
 - [x] Passes `isort -rc . && black . && mypy . && flake8`

