### PR TITLE
make text wrap width an argument in label_from_attrs

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,6 +36,7 @@ Breaking changes
 
 New Features
 ~~~~~~~~~~~~
+- 'wrap_amount' argument added to :py:func:'label_from_attrs' to specify text wrap amount for labels
 - Added :py:meth:`DataArray.polyfit` and :py:func:`xarray.polyval` for fitting polynomials. (:issue:`3349`)
   By `Pascal Bourgault <https://github.com/aulemahal>`_.
 - Control over attributes of result in :py:func:`merge`, :py:func:`concat`,

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -408,7 +408,7 @@ def get_axis(figsize, size, aspect, ax):
     return ax
 
 
-def label_from_attrs(da, extra=""):
+def label_from_attrs(da, extra="", wrap_width=30):
     """ Makes informative labels if variable metadata (attrs) follows
         CF conventions. """
 
@@ -426,7 +426,7 @@ def label_from_attrs(da, extra=""):
     else:
         units = ""
 
-    return "\n".join(textwrap.wrap(name + extra + units, 30))
+    return "\n".join(textwrap.wrap(name + extra + units, wrap_width))
 
 
 def _interval_to_mid_points(array):


### PR DESCRIPTION
label_from_attrs used textwrap.wrap with a default wrap width of 30,
this commit changes label_from_attrs to instead take an argument
wrap_width that specifies the wrap width.

context: I find the label_from_attrs function useful for plots that I make using pyplot, but needed to change the text wrap with. 

I am new to contributing to projects like this so bear with me.  I only had the mypy and flake8 linters and figured that was good enough for a minor change like this. And I didn't see label_from_attrs in the api document so just added a line to whats-new.rst

 - [x] Passes  mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst`
