### PR TITLE
remove the backslash escapes and typehint fragments in the API docs

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -17,7 +17,6 @@ dependencies:
   - netcdf4>=1.5
   - numba
   - numpy>=1.17
-  - numpydoc
   - pandas>=1.0
   - rasterio>=1.1
   - seaborn

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -79,7 +79,6 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
-    "numpydoc",
     "IPython.sphinxext.ipython_directive",
     "IPython.sphinxext.ipython_console_highlighting",
     "nbsphinx",


### PR DESCRIPTION
The reason for those fragments is that `napoleon` and `numpydoc` somehow conflict with each other. From a quick glance I couldn't find anything that breaks without `numpydoc`, but I might be missing something.

For reference, here's the new [API page](https://xarray-keewis.readthedocs.io/en/fix-signature-escapes/api.html).
 - [x] Closes #3178
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
