### PR TITLE
#1621 optional decode timedelta

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -60,6 +60,11 @@ New Features
   feature requires cftime version 1.1.0 or greater.  By
   `Spencer Clark <https://github.com/spencerkclark>`_.
 
+- Add keyword ``decode_timedelta`` to :py:func:`xarray.open_dataset`,
+  (:py:func:`xarray.open_dataarray`, :py:func:`xarray.open_dataarray`,
+  :py:func:`xarray.decode_cf`) that allows to disable/enable the decoding of timedeltas
+  independently of time decoding (:issue:`1621`)
+
 Bug fixes
 ~~~~~~~~~
 - ``ValueError`` is raised when ``fill_value`` is not a scalar in :py:meth:`full_like`. (:issue`3977`)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -64,6 +64,7 @@ New Features
   (:py:func:`xarray.open_dataarray`, :py:func:`xarray.open_dataarray`,
   :py:func:`xarray.decode_cf`) that allows to disable/enable the decoding of timedeltas
   independently of time decoding (:issue:`1621`)
+  `Aureliana Barghini <https://github.com/aurghs>`
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -303,6 +303,7 @@ def open_dataset(
     drop_variables=None,
     backend_kwargs=None,
     use_cftime=None,
+    decode_timedelta=None,
 ):
     """Open and decode a dataset from a file or file-like object.
 
@@ -383,6 +384,11 @@ def open_dataset(
         represented using ``np.datetime64[ns]`` objects.  If False, always
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error.
+    decode_timedelta : bool, optional
+        If True, decode variables and coordinates with time units in
+        {'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds'}
+        into timedelta objects. If False, leave them encoded as numbers.
+        If None (default), assume the same value of decode_time.
 
     Returns
     -------
@@ -435,12 +441,16 @@ def open_dataset(
         decode_times = False
         concat_characters = False
         decode_coords = False
+        decode_timedelta = False
 
     if cache is None:
         cache = chunks is None
 
     if backend_kwargs is None:
         backend_kwargs = {}
+
+    if decode_timedelta is None:
+        decode_timedelta = decode_times
 
     def maybe_decode_store(store, lock=False):
         ds = conventions.decode_cf(
@@ -451,6 +461,7 @@ def open_dataset(
             decode_coords=decode_coords,
             drop_variables=drop_variables,
             use_cftime=use_cftime,
+            decode_timedelta=decode_timedelta,
         )
 
         _protect_dataset_variables_inplace(ds, cache)
@@ -477,6 +488,7 @@ def open_dataset(
                 chunks,
                 drop_variables,
                 use_cftime,
+                decode_timedelta,
             )
             name_prefix = "open_dataset-%s" % token
             ds2 = ds.chunk(chunks, name_prefix=name_prefix, token=token)
@@ -561,6 +573,7 @@ def open_dataarray(
     drop_variables=None,
     backend_kwargs=None,
     use_cftime=None,
+    decode_timedelta=None,
 ):
     """Open an DataArray from a file or file-like object containing a single
     data variable.
@@ -640,6 +653,11 @@ def open_dataarray(
         represented using ``np.datetime64[ns]`` objects.  If False, always
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error.
+    decode_timedelta : bool, optional
+        If True, decode variables and coordinates with time units in
+        {'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds'}
+        into timedelta objects. If False, leave them encoded as numbers.
+        If None (default), assume the same value of decode_time.
 
     Notes
     -----
@@ -671,6 +689,7 @@ def open_dataarray(
         drop_variables=drop_variables,
         backend_kwargs=backend_kwargs,
         use_cftime=use_cftime,
+        decode_timedelta=decode_timedelta,
     )
 
     if len(dataset.data_vars) != 1:

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -449,9 +449,6 @@ def open_dataset(
     if backend_kwargs is None:
         backend_kwargs = {}
 
-    if decode_timedelta is None:
-        decode_timedelta = decode_times
-
     def maybe_decode_store(store, lock=False):
         ds = conventions.decode_cf(
             store,

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -496,6 +496,7 @@ def open_zarr(
     drop_variables=None,
     consolidated=False,
     overwrite_encoded_chunks=False,
+    decode_timedelta=None,
     **kwargs,
 ):
     """Load and decode a dataset from a Zarr store.
@@ -555,6 +556,11 @@ def open_zarr(
     consolidated : bool, optional
         Whether to open the store using zarr's consolidated metadata
         capability. Only works for stores that have already been consolidated.
+   decode_timedelta : bool, optional
+        If True, decode variables and coordinates with time units in
+        {'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds'}
+        into timedelta objects. If False, leave them encoded as numbers.
+        If None (default), assume the same value of decode_time.
 
     Returns
     -------
@@ -605,6 +611,7 @@ def open_zarr(
         decode_times = False
         concat_characters = False
         decode_coords = False
+        decode_timedelta = False
 
     def maybe_decode_store(store, lock=False):
         ds = conventions.decode_cf(
@@ -614,6 +621,7 @@ def open_zarr(
             concat_characters=concat_characters,
             decode_coords=decode_coords,
             drop_variables=drop_variables,
+            decode_timedelta=decode_timedelta,
         )
 
         # TODO: this is where we would apply caching

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -556,7 +556,7 @@ def open_zarr(
     consolidated : bool, optional
         Whether to open the store using zarr's consolidated metadata
         capability. Only works for stores that have already been consolidated.
-   decode_timedelta : bool, optional
+    decode_timedelta : bool, optional
         If True, decode variables and coordinates with time units in
         {'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds'}
         into timedelta objects. If False, leave them encoded as numbers.

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -316,12 +316,12 @@ class TestDecodeCF:
             {
                 "coords": {
                     "timedelta": {
-                        "data": [1, 2, 3],
+                        "data": np.array([1, 2, 3], dtype="int64"),
                         "dims": "timedelta",
                         "attrs": {"units": "days"},
                     },
                     "time": {
-                        "data": [1, 2, 3],
+                        "data": np.array([1, 2, 3], dtype="int64"),
                         "dims": "time",
                         "attrs": {"units": "days since 2000-01-01"},
                     },

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -328,7 +328,7 @@ class TestDecodeCF:
                 },
                 "dims": {"time": 3, "timedelta": 3},
                 "data_vars": {
-                    "a": {"dims": ("time", "timedelta"), "data": np.ones((3, 3)),},
+                    "a": {"dims": ("time", "timedelta"), "data": np.ones((3, 3))},
                 },
             }
         )


### PR DESCRIPTION
Releated to ticket #1621. Add `decode_timedelta` kwargs in open_dataset, `xr.open_datarray`, `xr.open_zarr`, `xr.decode_cf`. If not passed explicitly the behaviour is not changed.
 - [x] Tests added for `xr.decode_cf`. 
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API