### PR TITLE
Fix conversion of multiindexed pandas objects to sparse xarray objects

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -89,7 +89,7 @@ Bug fixes
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - Fix bug when converting multiindexed Pandas objects to sparse xarray objects. (:issue:`4019`)
   By `Deepak Cherian <https://github.com/dcherian>`_.
-- ``ValueError`` is raised when ``fill_value`` is not a scalar in :py:meth:`full_like`. (:issue`3977`)
+- ``ValueError`` is raised when ``fill_value`` is not a scalar in :py:meth:`full_like`. (:issue:`3977`)
   By `Huite Bootsma <https://github.com/huite>`_.
 - Fix wrong order in converting a ``pd.Series`` with a MultiIndex to ``DataArray``. (:issue:`3951`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -87,7 +87,6 @@ Bug fixes
 ~~~~~~~~~
 - Support dark mode in VS code (:issue:`4024`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
-- ``ValueError`` is raised when ``fill_value`` is not a scalar in :py:meth:`full_like`. (:issue:`3977`)
 - Fix bug when converting multiindexed Pandas objects to sparse xarray objects. (:issue:`4019`)
   By `Deepak Cherian <https://github.com/dcherian>`_.
 - ``ValueError`` is raised when ``fill_value`` is not a scalar in :py:meth:`full_like`. (:issue`3977`)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -88,6 +88,9 @@ Bug fixes
 - Support dark mode in VS code (:issue:`4024`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - ``ValueError`` is raised when ``fill_value`` is not a scalar in :py:meth:`full_like`. (:issue:`3977`)
+- Fix bug when converting multiindexed Pandas objects to sparse xarray objects. (:issue:`4019`)
+  By `Deepak Cherian <https://github.com/dcherian>`_.
+- ``ValueError`` is raised when ``fill_value`` is not a scalar in :py:meth:`full_like`. (:issue`3977`)
   By `Huite Bootsma <https://github.com/huite>`_.
 - Fix wrong order in converting a ``pd.Series`` with a MultiIndex to ``DataArray``. (:issue:`3951`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4534,7 +4534,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         idx = dataframe.index
         if isinstance(idx, pd.MultiIndex):
             coords = np.stack([np.asarray(code) for code in idx.codes], axis=0)
-            is_sorted = idx.is_lexsorted
+            is_sorted = idx.is_lexsorted()
             shape = tuple(lev.size for lev in idx.levels)
         else:
             coords = np.arange(idx.size).reshape(1, -1)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3532,6 +3532,26 @@ class TestDataArray:
         actual_sparse.data = actual_sparse.data.todense()
         assert_identical(actual_sparse, actual_dense)
 
+    @requires_sparse
+    def test_from_multiindex_series_sparse(self):
+        # regression test for GH4019
+        import sparse
+
+        idx = pd.MultiIndex.from_product([np.arange(3), np.arange(5)], names=["a", "b"])
+        series = pd.Series(np.random.RandomState(0).random(len(idx)), index=idx).sample(
+            n=5, random_state=3
+        )
+
+        actual_dense = DataArray.from_series(series, sparse=False)
+        actual_sparse = xr.DataArray.from_series(series, sparse=True)
+        actual_coords = actual_sparse.data.coords
+
+        np.testing.assert_equal(actual_sparse.data.todense(), actual_dense.values)
+        expected_coords = np.stack(
+            [np.asarray(code) for code in series.index.codes], axis=0
+        )
+        np.testing.assert_equal(actual_coords, expected_coords)
+
     def test_to_and_from_empty_series(self):
         # GH697
         expected = pd.Series([], dtype=np.float64)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3535,8 +3535,6 @@ class TestDataArray:
     @requires_sparse
     def test_from_multiindex_series_sparse(self):
         # regression test for GH4019
-        import sparse
-
         idx = pd.MultiIndex.from_product([np.arange(3), np.arange(5)], names=["a", "b"])
         series = pd.Series(np.random.RandomState(0).random(len(idx)), index=idx).sample(
             n=5, random_state=3

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3535,19 +3535,19 @@ class TestDataArray:
     @requires_sparse
     def test_from_multiindex_series_sparse(self):
         # regression test for GH4019
+        import sparse
+
         idx = pd.MultiIndex.from_product([np.arange(3), np.arange(5)], names=["a", "b"])
         series = pd.Series(np.random.RandomState(0).random(len(idx)), index=idx).sample(
             n=5, random_state=3
         )
 
-        actual_dense = DataArray.from_series(series, sparse=False)
+        dense = DataArray.from_series(series, sparse=False)
+        expected_coords = sparse.COO.from_numpy(dense.data, np.nan).coords
+
         actual_sparse = xr.DataArray.from_series(series, sparse=True)
         actual_coords = actual_sparse.data.coords
 
-        np.testing.assert_equal(actual_sparse.data.todense(), actual_dense.values)
-        expected_coords = np.stack(
-            [np.asarray(code) for code in series.index.codes], axis=0
-        )
         np.testing.assert_equal(actual_coords, expected_coords)
 
     def test_to_and_from_empty_series(self):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4019
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

~Doesn't have a proper test. Need some help here~. cc @bnaul 