### PR TITLE
Assign default group name in groupby if name=None (#158)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -100,6 +100,8 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
+- If groupby receives a ``DataArray`` with name=None, assign a default name (:issue:`158`)
+  By `Phil Butcher <https://github.com/pjbutcher>`_.
 - Support dark mode in VS code (:issue:`4024`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - Fix bug when converting multiindexed Pandas objects to sparse xarray objects. (:issue:`4019`)

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -321,7 +321,7 @@ class GroupBy(SupportsArithmetic):
                 group = _DummyGroup(obj, group.name, group.coords)
 
         if getattr(group, "name", None) is None:
-            raise ValueError("`group` must have a name")
+            group.name = "group"
 
         group, obj, stacked_dim, inserted_dims = _ensure_1d(group, obj)
         (group_dim,) = group.dims

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -546,7 +546,8 @@ def test_groupby_none_group_name():
     da = xr.DataArray(data)  # da.name = None
     key = xr.DataArray(np.floor_divide(data, 2))
 
-    da.groupby(key).mean()
+    mean = da.groupby(key).mean()
+    assert "group" in mean.dims
 
 
 # TODO: move other groupby tests from test_dataset and test_dataarray over here

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -538,4 +538,15 @@ def test_groupby_bins_timeseries():
     assert_identical(actual, expected)
 
 
+def test_groupby_none_group_name():
+    # GH158
+    # xarray should not fail if a DataArray's name attribute is None
+
+    data = np.arange(10) + 10
+    da = xr.DataArray(data)  # da.name = None
+    key = xr.DataArray(np.floor_divide(data, 2))
+
+    da.groupby(key).mean()
+
+
 # TODO: move other groupby tests from test_dataset and test_dataarray over here


### PR DESCRIPTION
Ran across the issue describe in #158 the other day and decided to implement Stephan's suggestion of assigning a default name of 'group' to the DataArray passed to groupby if name=None. Previously when name=None on the DataArray a ValueError: `group` must have a name was raised. 

This is my first pull request so let me know if I missed anything. Thanks!

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #158
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
