### PR TITLE
Allow non-unique and non-monotonic coordinates in get_clean_interp_index and polyfit

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -49,7 +49,7 @@ New Features
   By `Andrew Williams <https://github.com/AndrewWilliams3142>`_ 
 - Added :py:func:`xarray.cov` and :py:func:`xarray.corr` (:issue:`3784`, :pull:`3550`, :pull:`4089`).
   By `Andrew Williams <https://github.com/AndrewWilliams3142>`_ and `Robin Beer <https://github.com/r-beer>`_.
-- Added :py:meth:`DataArray.polyfit` and :py:func:`xarray.polyval` for fitting polynomials. (:issue:`3349`)
+- Added :py:meth:`DataArray.polyfit` and :py:func:`xarray.polyval` for fitting polynomials. (:issue:`3349`, :pull:`3733`, :pull:`4099`)
   By `Pascal Bourgault <https://github.com/aulemahal>`_.
 - Control over attributes of result in :py:func:`merge`, :py:func:`concat`,
   :py:func:`combine_by_coords` and :py:func:`combine_nested` using

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1506,7 +1506,7 @@ def polyval(coord, coeffs, degree_dim="degree"):
     from .dataarray import DataArray
     from .missing import get_clean_interp_index
 
-    x = get_clean_interp_index(coord, coord.name)
+    x = get_clean_interp_index(coord, coord.name, strict=False)
 
     deg_coord = coeffs[degree_dim]
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5839,7 +5839,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         variables = {}
         skipna_da = skipna
 
-        x = get_clean_interp_index(self, dim)
+        x = get_clean_interp_index(self, dim, strict=False)
         xname = "{}_".format(self[dim].name)
         order = int(deg) + 1
         lhs = np.vander(x, order)

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -208,7 +208,7 @@ def _apply_over_vars_with_dim(func, self, dim=None, **kwargs):
     return ds
 
 
-def get_clean_interp_index(arr, dim: Hashable, use_coordinate: Union[str, bool] = True):
+def get_clean_interp_index(arr, dim: Hashable, use_coordinate: Union[str, bool] = True, strict: bool = True):
     """Return index to use for x values in interpolation or curve fitting.
 
     Parameters
@@ -221,6 +221,8 @@ def get_clean_interp_index(arr, dim: Hashable, use_coordinate: Union[str, bool] 
       If use_coordinate is True, the coordinate that shares the name of the
       dimension along which interpolation is being performed will be used as the
       x values. If False, the x values are set as an equally spaced sequence.
+    strict : bool
+      Whether to raise errors if the index is either non-unique or non-monotonic (default).
 
     Returns
     -------
@@ -257,11 +259,12 @@ def get_clean_interp_index(arr, dim: Hashable, use_coordinate: Union[str, bool] 
     if isinstance(index, pd.MultiIndex):
         index.name = dim
 
-    if not index.is_monotonic:
-        raise ValueError(f"Index {index.name!r} must be monotonically increasing")
+    if strict:
+        if not index.is_monotonic:
+            raise ValueError(f"Index {index.name!r} must be monotonically increasing")
 
-    if not index.is_unique:
-        raise ValueError(f"Index {index.name!r} has duplicate values")
+        if not index.is_unique:
+            raise ValueError(f"Index {index.name!r} has duplicate values")
 
     # Special case for non-standard calendar indexes
     # Numerical datetime values are defined with respect to 1970-01-01T00:00:00 in units of nanoseconds
@@ -282,7 +285,7 @@ def get_clean_interp_index(arr, dim: Hashable, use_coordinate: Union[str, bool] 
         # xarray/numpy raise a ValueError
         raise TypeError(
             f"Index {index.name!r} must be castable to float64 to support "
-            f"interpolation, got {type(index).__name__}."
+            f"interpolation or curve fitting, got {type(index).__name__}."
         )
 
     return index

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -208,7 +208,9 @@ def _apply_over_vars_with_dim(func, self, dim=None, **kwargs):
     return ds
 
 
-def get_clean_interp_index(arr, dim: Hashable, use_coordinate: Union[str, bool] = True, strict: bool = True):
+def get_clean_interp_index(
+    arr, dim: Hashable, use_coordinate: Union[str, bool] = True, strict: bool = True
+):
     """Return index to use for x values in interpolation or curve fitting.
 
     Parameters

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -541,7 +541,9 @@ def test_get_clean_interp_index_strict(index):
     with pytest.raises(ValueError):
         get_clean_interp_index(da, "x")
 
-    get_clean_interp_index(da, "x", strict=False)
+    clean = get_clean_interp_index(da, "x", strict=False)
+    np.testing.assert_array_equal(index, clean)
+    assert clean.dtype == np.float64
 
 
 @pytest.fixture

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -534,6 +534,16 @@ def test_get_clean_interp_index_potential_overflow():
     get_clean_interp_index(da, "time")
 
 
+@pytest.mark.parametrize("index", ([0, 2, 1], [0, 1, 1]))
+def test_get_clean_interp_index_strict(index):
+    da = xr.DataArray([0, 1, 2], dims=("x",), coords={"x": index})
+
+    with pytest.raises(ValueError):
+        get_clean_interp_index(da, "x")
+
+    get_clean_interp_index(da, "x", strict=False)
+
+
 @pytest.fixture
 def da_time():
     return xr.DataArray(


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

 Pull #3733 added `da.polyfit` and `xr.polyval` and is using `xr.core.missing.get_clean_interp_index` in order to get the fitting coordinate. However, this method is stricter than what polyfit needs: as in `numpy.polyfit`, non-unique and non-monotonic indexes are acceptable. This PR adds a `strict` keyword argument to `get_clean_interp_index` so we can skip the uniqueness and monotony tests.

`ds.polyfit` and  `xr.polyval` were modified to use that keyword. I only added tests for  `get_clean_interp_index`, could add more for `polyfit` if requested.