### PR TITLE
keep attrs in reset_index

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,17 +36,19 @@ Breaking changes
 
 Enhancements
 ~~~~~~~~~~~~
-- Performance improvement of :py:meth:`DataArray.interp` and :py:func:`Dataset.interp` 
-  For orthogonal linear- and nearest-neighbor interpolation, we do 1d-interpolation sequentially 
+- Performance improvement of :py:meth:`DataArray.interp` and :py:func:`Dataset.interp`
+  For orthogonal linear- and nearest-neighbor interpolation, we do 1d-interpolation sequentially
   rather than interpolating in multidimensional space. (:issue:`2223`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+- :py:meth:`DataArray.reset_index` and :py:meth:`Dataset.reset_index` now keep
+  coordinate attributes (:pull:`4103`). By `Oriol Abril <https://github.com/OriolAbril>`_.
 
 New Features
 ~~~~~~~~~~~~
 
 - ``chunks='auto'`` is now supported in the ``chunks`` argument of
   :py:meth:`Dataset.chunk`. (:issue:`4055`)
-  By `Andrew Williams <https://github.com/AndrewWilliams3142>`_ 
+  By `Andrew Williams <https://github.com/AndrewWilliams3142>`_
 - Added :py:func:`xarray.cov` and :py:func:`xarray.corr` (:issue:`3784`, :pull:`3550`, :pull:`4089`).
   By `Andrew Williams <https://github.com/AndrewWilliams3142>`_ and `Robin Beer <https://github.com/r-beer>`_.
 - Added :py:meth:`DataArray.polyfit` and :py:func:`xarray.polyval` for fitting polynomials. (:issue:`3349`)
@@ -76,7 +78,7 @@ New Features
   By `Stephan Hoyer <https://github.com/shoyer>`_.
 - Allow plotting of boolean arrays. (:pull:`3766`)
   By `Marek Jacob <https://github.com/MeraX>`_
-- Enable using MultiIndex levels as cordinates in 1D and 2D plots (:issue:`3927`). 
+- Enable using MultiIndex levels as cordinates in 1D and 2D plots (:issue:`3927`).
   By `Mathias Hauser <https://github.com/mathause>`_.
 - A ``days_in_month`` accessor for :py:class:`xarray.CFTimeIndex`, analogous to
   the ``days_in_month`` accessor for a :py:class:`pandas.DatetimeIndex`, which

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -329,7 +329,7 @@ def split_indexes(
         else:
             vars_to_remove.append(d)
             if not drop:
-                vars_to_create[str(d) + "_"] = Variable(d, index)
+                vars_to_create[str(d) + "_"] = Variable(d, index, variables[d].attrs)
 
     for d, levs in dim_levels.items():
         index = variables[d].to_index()
@@ -341,7 +341,7 @@ def split_indexes(
         if not drop:
             for lev in levs:
                 idx = index.get_level_values(lev)
-                vars_to_create[idx.name] = Variable(d, idx)
+                vars_to_create[idx.name] = Variable(d, idx, variables[d].attrs)
 
     new_variables = dict(variables)
     for v in set(vars_to_remove):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1830,6 +1830,12 @@ class TestDataArray:
         expected = DataArray([1, 2], coords={"x_": ("x", ["a", "b"])}, dims="x")
         assert_identical(array.reset_index("x"), expected)
 
+    def test_reset_index_keep_attrs(self):
+        coord_1 = xr.DataArray([1, 2], dims=["coord_1"], attrs={"attrs": True})
+        da = xr.DataArray([1, 0], [coord_1])
+        obj = da.reset_index("coord_1").rename({"coord_1_": "coord_1"})
+        assert_identical(da, obj)
+
     def test_reorder_levels(self):
         midx = self.mindex.reorder_levels(["level_2", "level_1"])
         expected = DataArray(self.mda.values, coords={"x": midx}, dims="x")

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1831,10 +1831,11 @@ class TestDataArray:
         assert_identical(array.reset_index("x"), expected)
 
     def test_reset_index_keep_attrs(self):
-        coord_1 = xr.DataArray([1, 2], dims=["coord_1"], attrs={"attrs": True})
-        da = xr.DataArray([1, 0], [coord_1])
-        obj = da.reset_index("coord_1").rename({"coord_1_": "coord_1"})
-        assert_identical(da, obj)
+        coord_1 = DataArray([1, 2], dims=["coord_1"], attrs={"attrs": True})
+        da = DataArray([1, 0], [coord_1])
+        expected = DataArray([1, 0], {"coord_1_": coord_1}, dims=["coord_1"])
+        obj = da.reset_index("coord_1")
+        assert_identical(expected, obj)
 
     def test_reorder_levels(self):
         midx = self.mindex.reorder_levels(["level_2", "level_1"])

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2865,10 +2865,11 @@ class TestDataset:
             ds.reset_index("x", inplace=True)
 
     def test_reset_index_keep_attrs(self):
-        coord_1 = xr.DataArray([1, 2], dims=["coord_1"], attrs={"attrs": True})
-        ds = xr.Dataset({}, {"coord_1": coord_1})
+        coord_1 = DataArray([1, 2], dims=["coord_1"], attrs={"attrs": True})
+        ds = Dataset({}, {"coord_1": coord_1})
+        expected = Dataset({}, {"coord_1_": coord_1})
         obj = ds.reset_index("coord_1").rename({"coord_1_": "coord_1"})
-        assert_identical(ds, obj)
+        assert_identical(expected, obj)
 
     def test_reorder_levels(self):
         ds = create_test_multiindex()

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2868,7 +2868,7 @@ class TestDataset:
         coord_1 = DataArray([1, 2], dims=["coord_1"], attrs={"attrs": True})
         ds = Dataset({}, {"coord_1": coord_1})
         expected = Dataset({}, {"coord_1_": coord_1})
-        obj = ds.reset_index("coord_1").rename({"coord_1_": "coord_1"})
+        obj = ds.reset_index("coord_1")
         assert_identical(expected, obj)
 
     def test_reorder_levels(self):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2864,6 +2864,12 @@ class TestDataset:
         with pytest.raises(TypeError):
             ds.reset_index("x", inplace=True)
 
+    def test_reset_index_keep_attrs(self):
+        coord_1 = xr.DataArray([1, 2], dims=["coord_1"], attrs={"attrs": True})
+        ds = xr.Dataset({}, {"coord_1": coord_1})
+        obj = ds.reset_index("coord_1").rename({"coord_1_": "coord_1"})
+        assert_identical(ds, obj)
+
     def test_reorder_levels(self):
         ds = create_test_multiindex()
         mindex = ds["x"].to_index()


### PR DESCRIPTION
Modifies the code in `reset_index` to keep attributes when converting an indexing coordinate to non indexing coordinate. I have added tests for single index for both dataarray and dataset. Not sure if both are needed as they end up calling the same base function.

Regarding multiindex, I think it is not possible to keep the metadata as it is removed when creating the multiindex/stacking.

 - [x] Closes #4101 
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
