### PR TITLE
Fix open_rasterio() for WarpedVRT with specified src_crs

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -140,6 +140,8 @@ Bug fixes
   By `Mathias Hauser <https://github.com/mathause>`_.
 - Fix html repr in untrusted notebooks: fallback to plain text repr. (:pull:`4053`)
   By `Benoit Bovy <https://github.com/benbovy>`_.
+- Fix open_rastario() for WarpedVRT with specified src_crs. (:pull:`4104`)
+  By `Dave Cole <https://github.com/dtpc>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -140,7 +140,7 @@ Bug fixes
   By `Mathias Hauser <https://github.com/mathause>`_.
 - Fix html repr in untrusted notebooks: fallback to plain text repr. (:pull:`4053`)
   By `Benoit Bovy <https://github.com/benbovy>`_.
-- Fix open_rastario() for WarpedVRT with specified src_crs. (:pull:`4104`)
+- Fix :py:func:`open_rasterio` for ``WarpedVRT`` with specified ``src_crs``. (:pull:`4104`)
   By `Dave Cole <https://github.com/dtpc>`_.
 
 Documentation

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -221,14 +221,17 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None, loc
         vrt = filename
         filename = vrt.src_dataset.name
         vrt_params = dict(
+            src_crs=vrt.src_crs.to_string(),
             crs=vrt.crs.to_string(),
             resampling=vrt.resampling,
+            tolerance=vrt.tolerance,
             src_nodata=vrt.src_nodata,
             nodata=vrt.nodata,
-            tolerance=vrt.tolerance,
-            transform=vrt.transform,
             width=vrt.width,
             height=vrt.height,
+            src_transform=vrt.src_transform,
+            transform=vrt.transform,
+            dtype=vrt.working_dtype,
             warp_extras=vrt.warp_extras,
         )
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4160,6 +4160,19 @@ class TestRasterio:
                         assert actual_shape == expected_shape
                         assert actual_transform == expected_transform
 
+    def test_rasterio_vrt_with_src_crs(self):
+        # Test open_rasterio() support of WarpedVRT with specified src_crs
+        import rasterio
+
+        # create geotiff with no CRS and specify it manually
+        with create_tmp_geotiff(crs=None) as (tmp_file, expected):
+            src_crs = rasterio.crs.CRS({"init": "epsg:32618"})
+            with rasterio.open(tmp_file) as src:
+                assert src.crs is None
+                with rasterio.vrt.WarpedVRT(src, src_crs=src_crs) as vrt:
+                    with xr.open_rasterio(vrt) as da:
+                        assert da.crs == src_crs
+
     @network
     def test_rasterio_vrt_network(self):
         # Make sure loading w/ rasterio give same results as xarray


### PR DESCRIPTION
Fix bug when passing a `WarpedVRT` object, for which `src_crs` was explicitly specified, to `open_raster()`.

`open_rastario()` creates a new `WarpedVRT` object by getting init params from the original `vrt`. This PR adds some of those params (e.g. `src_crs`) which were missing.   

 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
