### PR TITLE
Add xarray-custom to related projects

### DIFF
--- a/doc/related-projects.rst
+++ b/doc/related-projects.rst
@@ -62,6 +62,7 @@ Extend xarray capabilities
 - `eofs <https://ajdawson.github.io/eofs/>`_: EOF analysis in Python.
 - `hypothesis-gufunc <https://hypothesis-gufunc.readthedocs.io/en/latest/>`_: Extension to hypothesis. Makes it easy to write unit tests with xarray objects as input.
 - `nxarray <https://github.com/nxarray/nxarray>`_: NeXus input/output capability for xarray.
+- `xarray-custom <https://github.com/astropenguin/xarray-custom>`_: Data classes for custom xarray creation.
 - `xarray_extras <https://github.com/crusaderky/xarray_extras>`_: Advanced algorithms for xarray objects (e.g. integrations/interpolations).
 - `xpublish <https://xpublish.readthedocs.io/>`_: Publish Xarray Datasets via a Zarr compatible REST API.
 - `xrft <https://github.com/rabernat/xrft>`_: Fourier transforms for xarray data.


### PR DESCRIPTION
We have released [xarray-custom](https://github.com/astropenguin/xarray-custom), a Python package which helps to create custom DataArray in the same manner as [the Python's native dataclass](https://docs.python.org/3/library/dataclasses.html). This PR adds the project to the "Extend xarray capabilities" section in `doc/related-projects.rst`. It would be appreciated if you could merge it (if this PR fits the purpose of the xarray documentation).
