### PR TITLE
use numpy's new intersphinx url

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -351,7 +351,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
     "iris": ("https://scitools.org.uk/iris/docs/latest", None),
-    "numpy": ("https://docs.scipy.org/doc/numpy", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
     "numba": ("https://numba.pydata.org/numba-doc/latest", None),
     "matplotlib": ("https://matplotlib.org", None),


### PR DESCRIPTION
With the recent documentation changes, `numpy` also changed the location of the intersphinx inventory (`objects.inv`). This makes sure we use the new location.