### PR TITLE
Fix the upstream-dev pandas build failure

### DIFF
--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -12,7 +12,7 @@ steps:
 
 - bash: |
     source activate xarray-tests
-    conda uninstall --force \
+    conda uninstall -y --force \
         numpy \
         scipy \
         pandas \

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -13,7 +13,7 @@ steps:
 - bash: |
     source activate xarray-tests
     python -m pip install \
-        -f https://anaconda.org/scipy-wheels-nightly \
+        -f https://anaconda.org/scipy-wheels-nightly/simple \
         --no-deps \
         --pre \
         --upgrade \

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -12,6 +12,18 @@ steps:
 
 - bash: |
     source activate xarray-tests
+    conda uninstall --force \
+        numpy \
+        scipy \
+        pandas \
+        matplotlib \
+        dask \
+        distributed \
+        zarr \
+        cftime \
+        rasterio \
+        pint \
+        bottleneck
     python -m pip install \
         -f https://anaconda.org/scipy-wheels-nightly/simple \
         --no-deps \

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -25,7 +25,7 @@ steps:
         pint \
         bottleneck
     python -m pip install \
-        -i https://anaconda.org/scipy-wheels-nightly/simple \
+        -i https://pypi.anaconda.org/scipy-wheels-nightly/simple \
         --no-deps \
         --pre \
         --upgrade \

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -13,13 +13,19 @@ steps:
 - bash: |
     source activate xarray-tests
     python -m pip install \
+        -f https://anaconda.org/scipy-wheels-nightly \
+        --no-deps \
+        --pre \
+        --upgrade \
+        numpy \
+        scipy \
+        pandas
+    python -m pip install \
         -f https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com \
         --no-deps \
         --pre \
         --upgrade \
-        matplotlib \
-        numpy \
-        scipy
+        matplotlib
     python -m pip install \
         --no-deps \
         --upgrade \
@@ -29,8 +35,7 @@ steps:
         git+https://github.com/Unidata/cftime \
         git+https://github.com/mapbox/rasterio \
         git+https://github.com/hgrecco/pint \
-        git+https://github.com/pydata/bottleneck \
-        git+https://github.com/pandas-dev/pandas
+        git+https://github.com/pydata/bottleneck
   condition: eq(variables['UPSTREAM_DEV'], 'true')
   displayName: Install upstream dev dependencies
 

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -25,7 +25,7 @@ steps:
         pint \
         bottleneck
     python -m pip install \
-        -f https://anaconda.org/scipy-wheels-nightly/simple \
+        -i https://anaconda.org/scipy-wheels-nightly/simple \
         --no-deps \
         --pre \
         --upgrade \


### PR DESCRIPTION
As pointed out by @TomAugspurger in https://github.com/pydata/xarray/issues/4133#issuecomment-641332231, there are pre-built nightly wheels for `numpy`, `scipy` and `pandas` in the [scipy-wheels-nightly repository](https://anaconda.org/scipy-wheels-nightly/).

Not sure how frequently these are updated, though, at least the `numpy` wheel doesn't really seem to be built daily.

 - [x] Closes #4133

