### PR TITLE
support file-like objects in xarray.open_rasterio

### DIFF
--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -24,6 +24,8 @@ _ERROR_MSG = (
 def _file_object_opener(fobj, *args, **kwargs):
     from rasterio.io import MemoryFile
 
+    if "mode" in kwargs:
+        del kwargs["mode"]
     return MemoryFile(fobj).open(*args, **kwargs)
 
 

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -20,6 +20,7 @@ _ERROR_MSG = (
     "first."
 )
 
+
 def _file_object_opener(fobj, *args, **kwargs):
     from rasterio.io import MemoryFile
 
@@ -168,7 +169,9 @@ def _parse_envi(meta):
     return parsed_meta
 
 
-def open_rasterio(filename_or_obj, parse_coordinates=None, chunks=None, cache=None, lock=None):
+def open_rasterio(
+    filename_or_obj, parse_coordinates=None, chunks=None, cache=None, lock=None
+):
     """Open a file with rasterio (experimental).
 
     This should work with any file that rasterio can open (most often:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4201,13 +4201,13 @@ class TestRasterio:
 
     def test_rasterio_fileobj(self):
         with create_tmp_geotiff() as (tmp_file, expected):
-            with open(tmp_file, 'rb') as f:
+            with open(tmp_file, "rb") as f:
                 with xr.open_rasterio(f) as da:
                     assert_equal(da, expected)
 
     def test_rasterio_fileobj_dask(self):
         with create_tmp_geotiff() as (tmp_file, expected):
-            with open(tmp_file, 'rb') as f:
+            with open(tmp_file, "rb") as f:
                 with xr.open_rasterio(f, chunks=10) as da:
                     assert_equal(da, expected)
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4199,6 +4199,18 @@ class TestRasterio:
                         assert actual_res == expected_res
                         assert expected_val == actual_val
 
+    def test_rasterio_fileobj(self):
+        with create_tmp_geotiff() as (tmp_file, expected):
+            with open(tmp_file, 'rb') as f:
+                with xr.open_rasterio(f) as da:
+                    assert_equal(da, expected)
+
+    def test_rasterio_fileobj_dask(self):
+        with create_tmp_geotiff() as (tmp_file, expected):
+            with open(tmp_file, 'rb') as f:
+                with xr.open_rasterio(f, chunks=10) as da:
+                    assert_equal(da, expected)
+
 
 class TestEncodingInvalid:
     def test_extract_nc4_variable_encoding(self):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4205,10 +4205,11 @@ class TestRasterio:
                 with xr.open_rasterio(f) as da:
                     assert_equal(da, expected)
 
+    @requires_dask
     def test_rasterio_fileobj_dask(self):
         with create_tmp_geotiff() as (tmp_file, expected):
             with open(tmp_file, "rb") as f:
-                with xr.open_rasterio(f, chunks=10) as da:
+                with xr.open_rasterio(f, chunks={"band": 1, "y": 3, "x": 4}) as da:
                     assert_equal(da, expected)
 
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4139
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

cc @scottyhq and @martindurant 

xref: https://github.com/pangeo-data/pangeo-datastore/issues/109