### PR TITLE
Improve typehints of xr.Dataset.__getitem__

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.761  # Must match ci/requirements/*.yml
+    rev: v0.780  # Must match ci/requirements/*.yml
     hooks:
       - id: mypy
   # run this occasionally, ref discussion https://github.com/pydata/xarray/pull/3194

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -22,7 +22,7 @@ dependencies:
   - isort
   - lxml    # Optional dep of pydap
   - matplotlib
-  - mypy=0.761  # Must match .pre-commit-config.yaml
+  - mypy=0.780  # Must match .pre-commit-config.yaml
   - nc-time-axis
   - netcdf4
   - numba

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1243,7 +1243,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         return _LocIndexer(self)
 
     @overload  # noqa: F811
-    def __getitem__(self, key: Hashable) -> DataArray:
+    def __getitem__(self, key: Hashable) -> "DataArray":
         ...
 
     @overload  # noqa: F811

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1242,15 +1242,15 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         """
         return _LocIndexer(self)
 
-    @overload
+    @overload  # noqa: F811
     def __getitem__(self, key: Hashable) -> DataArray:
         ...
 
-    @overload
+    @overload  # noqa: F811
     def __getitem__(self, key: Any) -> "Union[DataArray, Dataset]":
         ...
 
-    def __getitem__(self, key):
+    def __getitem__(self, key):  # noqa: F811
         """Access variables or coordinates this dataset as a
         :py:class:`~xarray.DataArray`.
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1241,13 +1241,18 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         and only when the key is a dict of the form {dim: labels}.
         """
         return _LocIndexer(self)
-    
 
     @overload
-    def __getitem__(self, key: Hashable) -> DataArray: ...
+    def __getitem__(self, key: Hashable) -> DataArray:
+        ...
 
     @overload
-    def __getitem__(self, key: Any) -> Dataset: ...
+    def __getitem__(self, key: Mapping) -> "Dataset":
+        ...
+
+    @overload
+    def __getitem__(self, key: List) -> "Dataset":
+        ...
 
     def __getitem__(self, key):
         """Access variables or coordinates this dataset as a

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1242,21 +1242,25 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         """
         return _LocIndexer(self)
 
-    @overload  # noqa: F811
-    def __getitem__(self, key: Hashable) -> "DataArray":
+    # FIXME https://github.com/python/mypy/issues/7328
+    @overload
+    def __getitem__(self, key: Mapping) -> "Dataset":  # type: ignore
         ...
 
-    @overload  # noqa: F811
-    def __getitem__(self, key: Any) -> "Union[DataArray, Dataset]":
+    @overload
+    def __getitem__(self, key: Hashable) -> "DataArray":  # type: ignore
         ...
 
-    def __getitem__(self, key):  # noqa: F811
+    @overload
+    def __getitem__(self, key: Any) -> "Dataset":
+        ...
+
+    def __getitem__(self, key):
         """Access variables or coordinates this dataset as a
         :py:class:`~xarray.DataArray`.
 
         Indexing with a list of names will return a new ``Dataset`` object.
         """
-        # TODO(shoyer): type this properly: https://github.com/python/mypy/issues/7328
         if utils.is_dict_like(key):
             return self.isel(**cast(Mapping, key))
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1247,11 +1247,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         ...
 
     @overload
-    def __getitem__(self, key: Mapping) -> "Dataset":
-        ...
-
-    @overload
-    def __getitem__(self, key: List) -> "Dataset":
+    def __getitem__(self, key: Any) -> "Union[DataArray, Dataset]":
         ...
 
     def __getitem__(self, key):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -27,6 +27,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    overload,
 )
 
 import numpy as np
@@ -1240,8 +1241,15 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         and only when the key is a dict of the form {dim: labels}.
         """
         return _LocIndexer(self)
+    
 
-    def __getitem__(self, key: Any) -> "Union[DataArray, Dataset]":
+    @overload
+    def __getitem__(self, key: Hashable) -> DataArray: ...
+
+    @overload
+    def __getitem__(self, key: Any) -> Dataset: ...
+
+    def __getitem__(self, key):
         """Access variables or coordinates this dataset as a
         :py:class:`~xarray.DataArray`.
 

--- a/xarray/core/weighted.py
+++ b/xarray/core/weighted.py
@@ -72,11 +72,11 @@ class Weighted:
     def __init__(self, obj: "DataArray", weights: "DataArray") -> None:
         ...
 
-    @overload  # noqa: F811
-    def __init__(self, obj: "Dataset", weights: "DataArray") -> None:  # noqa: F811
+    @overload
+    def __init__(self, obj: "Dataset", weights: "DataArray") -> None:
         ...
 
-    def __init__(self, obj, weights):  # noqa: F811
+    def __init__(self, obj, weights):
         """
         Create a Weighted object
 


### PR DESCRIPTION
To resolve some common type-related errors, this PR adds some overload type hints to `Dataset.__getitem__`. Now mypy can correctly infer that hashable inputs return DataArrays.

 - [x] Closes #4125
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
