### PR TITLE
speed up map_blocks

### DIFF
--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -347,8 +347,8 @@ def map_blocks(
     # all xarray objects must be aligned. This is consistent with apply_ufunc.
     aligned = align(*xarray_objs, join="exact")
     xarray_objs = tuple(
-        dataarray_to_dataset(arg) if isinstance(arg, DataArray) else arg
-        for arg in aligned
+        dataarray_to_dataset(arg) if is_da else arg
+        for is_da, arg in zip(is_array, aligned)
     )
 
     _, npargs = unzip(

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -352,7 +352,7 @@ def map_blocks(
     )
 
     _, npargs = unzip(
-        sorted((list(zip(xarray_indices, xarray_objs)) + others), key=lambda x: x[0])
+        sorted(list(zip(xarray_indices, xarray_objs)) + others, key=lambda x: x[0])
     )
 
     # check that chunk sizes are compatible


### PR DESCRIPTION
I'm not sure if I broke something, but this is what I would suggest to use instead of putting xarray objects into an object array. The list of arguments is normally far less than 100 elements, so using python for that should not be a problem.

Edit: we're back to a more reasonable 6 minutes for the CI (the build itself takes about 3 minutes)

 - [x] might close #4147
 - [ ] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
