### PR TITLE
Fix failing upstream-dev build & remove docs build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,21 +108,3 @@ jobs:
       python ci/min_deps_check.py ci/requirements/py36-bare-minimum.yml
       python ci/min_deps_check.py ci/requirements/py36-min-all-deps.yml
     displayName: minimum versions policy
-
-- job: Docs
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-  - template: ci/azure/install.yml
-    parameters:
-      env_file: ci/requirements/doc.yml
-  - bash: |
-      source activate xarray-tests
-      # Replicate the exact environment created by the readthedocs CI
-      conda install --yes --quiet -c pkgs/main mock pillow sphinx sphinx_rtd_theme
-    displayName: Replicate readthedocs CI environment
-  - bash: |
-      source activate xarray-tests
-      cd doc
-      sphinx-build -W --keep-going -j auto -b html -d _build/doctrees . _build/html
-    displayName: Build HTML docs

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -10,6 +10,8 @@ steps:
     conda env create -n xarray-tests --file ${{ parameters.env_file }}
   displayName: Install conda dependencies
 
+# TODO: add sparse back in, once Numba works with the development version of
+# NumPy again: https://github.com/pydata/xarray/issues/4146 
 - bash: |
     source activate xarray-tests
     conda uninstall -y --force \
@@ -23,7 +25,8 @@ steps:
         cftime \
         rasterio \
         pint \
-        bottleneck
+        bottleneck \
+        sparse
     python -m pip install \
         -i https://pypi.anaconda.org/scipy-wheels-nightly/simple \
         --no-deps \


### PR DESCRIPTION
Instead, we'll use RTD's new doc builder instead. For an example, click on
"docs/readthedocs.org:xray" below or look at GH4159

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes https://github.com/pydata/xarray/issues/4146
