### PR TITLE
Fix 4009

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -105,7 +105,7 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
-- Errors combining attrs in open_mfdataset (:issue:`4009`, :pull:`4173`)
+- Fix errors combining attrs in :py:func:`open_mfdataset` (:issue:`4009`, :pull:`4173`)
   By `John Omotani <https://github.com/johnomotani>`_
 - If groupby receives a ``DataArray`` with name=None, assign a default name (:issue:`158`)
   By `Phil Butcher <https://github.com/pjbutcher>`_.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -105,6 +105,8 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
+- Errors combining attrs in open_mfdataset (:issue:`4009`, :pull:`4173`)
+  By `John Omotani <https://github.com/johnomotani>`_
 - If groupby receives a ``DataArray`` with name=None, assign a default name (:issue:`158`)
   By `Phil Butcher <https://github.com/pjbutcher>`_.
 - Support dark mode in VS code (:issue:`4024`)

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -967,12 +967,18 @@ def open_mfdataset(
                 coords=coords,
                 ids=ids,
                 join=join,
+                combine_attrs="drop",
             )
         elif combine == "by_coords":
             # Redo ordering from coordinates, ignoring how they were ordered
             # previously
             combined = combine_by_coords(
-                datasets, compat=compat, data_vars=data_vars, coords=coords, join=join
+                datasets,
+                compat=compat,
+                data_vars=data_vars,
+                coords=coords,
+                join=join,
+                combine_attrs="drop",
             )
         else:
             raise ValueError(

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2662,6 +2662,36 @@ class TestOpenMFDatasetWithDataVarsAndCoordsKw:
                 ds_expect = xr.concat([ds1, ds2], data_vars=opt, dim="t", join=join)
                 assert_identical(ds, ds_expect)
 
+    def test_open_mfdataset_dataset_attr_by_coords(self):
+        """
+        Case when an attribute of type list differs across the multiple files
+        """
+        with self.setup_files_and_datasets() as (files, [ds1, ds2]):
+            # Give the files an inconsistent attribute
+            for i, f in enumerate(files):
+                ds = open_dataset(f).load()
+                ds.attrs["test_dataset_attr"] = 10 + i
+                ds.close()
+                ds.to_netcdf(f)
+
+            with xr.open_mfdataset(files, combine="by_coords", concat_dim="t") as ds:
+                assert ds.test_dataset_attr == 10
+
+    def test_open_mfdataset_dataarray_attr_by_coords(self):
+        """
+        Case when an attribute of type list differs across the multiple files
+        """
+        with self.setup_files_and_datasets() as (files, [ds1, ds2]):
+            # Give the files an inconsistent attribute
+            for i, f in enumerate(files):
+                ds = open_dataset(f).load()
+                ds["v1"].attrs["test_dataarray_attr"] = i
+                ds.close()
+                ds.to_netcdf(f)
+
+            with xr.open_mfdataset(files, combine="by_coords", concat_dim="t") as ds:
+                assert ds["v1"].test_dataarray_attr == 0
+
     @pytest.mark.parametrize("combine", ["nested", "by_coords"])
     @pytest.mark.parametrize("opt", ["all", "minimal", "different"])
     def test_open_mfdataset_exact_join_raises_error(self, combine, opt):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2664,7 +2664,7 @@ class TestOpenMFDatasetWithDataVarsAndCoordsKw:
 
     def test_open_mfdataset_dataset_attr_by_coords(self):
         """
-        Case when an attribute of type list differs across the multiple files
+        Case when an attribute differs across the multiple files
         """
         with self.setup_files_and_datasets() as (files, [ds1, ds2]):
             # Give the files an inconsistent attribute
@@ -2679,7 +2679,7 @@ class TestOpenMFDatasetWithDataVarsAndCoordsKw:
 
     def test_open_mfdataset_dataarray_attr_by_coords(self):
         """
-        Case when an attribute of type list differs across the multiple files
+        Case when an attribute of a member DataArray differs across the multiple files
         """
         with self.setup_files_and_datasets() as (files, [ds1, ds2]):
             # Give the files an inconsistent attribute


### PR DESCRIPTION
Don't know if/when I'll have time to finish #4017, so pulling out the fix for #4009 into a separate PR here that is ready to merge.

 - [x] Closes #4009
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
