### PR TITLE
Improve the speed of from_dataframe with a MultiIndex (by 40x!)

### DIFF
--- a/asv_bench/benchmarks/pandas.py
+++ b/asv_bench/benchmarks/pandas.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from . import parameterized
+
+
+class MultiIndexSeries:
+    def setup(self, dtype, subset):
+        data = np.random.rand(100000).astype(dtype)
+        index = pd.MultiIndex.from_product(
+            [
+                list("abcdefhijk"),
+                list("abcdefhijk"),
+                pd.date_range(start="2000-01-01", periods=1000, freq="B"),
+            ]
+        )
+        series = pd.Series(data, index)
+        if subset:
+            series = series[::3]
+        self.series = series
+
+    @parameterized(["dtype", "subset"], ([int, float], [True, False]))
+    def time_to_xarray(self, dtype, subset):
+        self.series.to_xarray()

--- a/asv_bench/benchmarks/pandas.py
+++ b/asv_bench/benchmarks/pandas.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-import xarray as xr
 
 from . import parameterized
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -127,8 +127,9 @@ Bug fixes
   By `Deepak Cherian <https://github.com/dcherian>`_.
 - ``ValueError`` is raised when ``fill_value`` is not a scalar in :py:meth:`full_like`. (:issue:`3977`)
   By `Huite Bootsma <https://github.com/huite>`_.
-- Fix wrong order in converting a ``pd.Series`` with a MultiIndex to ``DataArray``. (:issue:`3951`)
-  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
+- Fix wrong order in converting a ``pd.Series`` with a MultiIndex to ``DataArray``.
+  (:issue:`3951`, :issue:`4186`)
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_ and `Stephan Hoyer <https://github.com/shoyer>`_.
 - Fix renaming of coords when one or more stacked coords is not in
   sorted order during stack+groupby+apply operations. (:issue:`3287`,
   :pull:`3906`) By `Spencer Hill <https://github.com/spencerahill>`_

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -47,7 +47,10 @@ Enhancements
   For orthogonal linear- and nearest-neighbor interpolation, we do 1d-interpolation sequentially
   rather than interpolating in multidimensional space. (:issue:`2223`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
-- :py:meth:`DataArray.reset_index` and :py:meth:`Dataset.reset_index` now keep
+- Major performance improvement for :py:meth:`Dataset.from_dataframe` when the
+  dataframe has a MultiIndex (:pull:`4184`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
+  - :py:meth:`DataArray.reset_index` and :py:meth:`Dataset.reset_index` now keep
   coordinate attributes (:pull:`4103`). By `Oriol Abril <https://github.com/OriolAbril>`_.
 
 New Features

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4598,8 +4598,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 dtype, fill_value = dtypes.maybe_promote(values.dtype)
                 data = np.full(shape, fill_value, dtype)
             else:
-                # TODO: consider removing this special case, which can
-                # sometimes result in a different dtype (e.g., for int)
+                # If there are no missing values, keep the existing dtype
+                # instead of promoting to support NA, e.g., keep integer
+                # columns as integers.
+                # TODO: consider removing this special case, which doesn't
+                # exist for sparse=True.
                 data = np.zeros(shape, values.dtype)
             data[indexer] = values
             self[name] = (dims, data)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4616,40 +4616,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             new_data[full_indexer] = data
             self[name] = (dims, new_data)
 
-        # # all elements in the result index a unique combination of MultiIndex
-        # # levels, so if there are more of them than elements in the source,
-        # # then we *must* be inserting missing values
-        # definitely_inserting_na = np.prod(shape) > dataframe.shape[0]
-
-        # if definitely_inserting_na or all(
-        #     issubclass(dtype.type, dtypes.TYPES_WITH_NA) for dtype in dataframe.dtypes
-        # ):
-        #     full_indexer = tuple(idx.codes)
-        #     for name, series in dataframe.items():
-        #         data = np.asarray(series)
-        #         dtype, fill_value = dtypes.maybe_promote(data.dtype)
-        #         # much faster than reindex:
-        #         # https://stackoverflow.com/a/35049899/809705
-        #         new_data = np.full(shape, fill_value, dtype)
-        #         new_data[full_indexer] = data
-        #         self[name] = (dims, new_data)
-        # else:
-        #     # It can be very expensive to use get_indexer/reindex to check
-        #     # whether all values are found in a MultiIndex:
-        #     # https://github.com/pydata/xarray/issues/2459
-
-        #     # Unfortunately, we sometimes need to do this in order to return
-        #     # the correct dtype for columns that don't support NA: if there are
-        #     # no missing values, then the dtype should be preserved and we
-        #     # cannot insert a fill value.
-
-        #     full_idx = pd.MultiIndex.from_product(idx.levels, names=idx.names)
-        #     dataframe = dataframe.reindex(full_idx)
-        #     shape = tuple(lev.size for lev in idx.levels)
-        #     for name, series in dataframe.items():
-        #         data = np.asarray(series).reshape(shape)
-        #         self[name] = (dims, data)
-
     @classmethod
     def from_dataframe(cls, dataframe: pd.DataFrame, sparse: bool = False) -> "Dataset":
         """Convert a pandas.DataFrame into an xarray.Dataset

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4582,17 +4582,49 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
     def _set_numpy_data_from_dataframe(
         self, dataframe: pd.DataFrame, dims: tuple
     ) -> None:
+
         idx = dataframe.index
-        if isinstance(idx, pd.MultiIndex):
-            # expand the DataFrame to include the product of all levels
+
+        if not isinstance(idx, pd.MultiIndex):
+            for name, series in dataframe.items():
+                self[name] = (dims, np.asarray(series))
+            return
+
+        shape = tuple(lev.size for lev in idx.levels)
+
+        # all elements in the result index a unique combination of MultiIndex
+        # levels, so if there are more of them than elements in the source,
+        # then we *must* be inserting missing values
+        definitely_inserting_na = np.prod(shape) > dataframe.shape[0]
+
+        if definitely_inserting_na or all(
+            issubclass(dtype.type, dtypes.TYPES_WITH_NA) for dtype in dataframe.dtypes
+        ):
+            full_indexer = tuple(idx.codes)
+            for name, series in dataframe.items():
+                data = np.asarray(series)
+                dtype, fill_value = dtypes.maybe_promote(data.dtype)
+                # much faster than reindex:
+                # https://stackoverflow.com/a/35049899/809705
+                new_data = np.full(shape, fill_value, dtype)
+                new_data[full_indexer] = data
+                self[name] = (dims, new_data)
+        else:
+            # It can be very expensive to use get_indexer/reindex to check
+            # whether all values are found in a MultiIndex:
+            # https://github.com/pydata/xarray/issues/2459
+
+            # Unfortunately, we sometimes need to do this in order to return
+            # the correct dtype for columns that don't support NA: if there are
+            # no missing values, then the dtype should be preserved and we
+            # cannot insert a fill value.
+
             full_idx = pd.MultiIndex.from_product(idx.levels, names=idx.names)
             dataframe = dataframe.reindex(full_idx)
             shape = tuple(lev.size for lev in idx.levels)
-        else:
-            shape = (idx.size,)
-        for name, series in dataframe.items():
-            data = np.asarray(series).reshape(shape)
-            self[name] = (dims, data)
+            for name, series in dataframe.items():
+                data = np.asarray(series).reshape(shape)
+                self[name] = (dims, data)
 
     @classmethod
     def from_dataframe(cls, dataframe: pd.DataFrame, sparse: bool = False) -> "Dataset":

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4582,11 +4582,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 self[name] = (dims, values)
             return
 
-        if not idx.is_unique:
-            raise ValueError(
-                "cannot convert a DataFrame with a non-unique MultiIndex into xarray"
-            )
-
         shape = tuple(lev.size for lev in idx.levels)
         indexer = tuple(idx.codes)
 
@@ -4647,6 +4642,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             raise ValueError("cannot convert DataFrame with non-unique columns")
 
         idx = remove_unused_levels_categories(dataframe.index)
+
+        if isinstance(idx, pd.MultiIndex) and not idx.is_unique:
+            raise ValueError(
+                "cannot convert a DataFrame with a non-unique MultiIndex into xarray"
+            )
 
         # Cast to a NumPy array first, in case the Series is a pandas Extension
         # array (which doesn't have a valid NumPy dtype)

--- a/xarray/core/dtypes.py
+++ b/xarray/core/dtypes.py
@@ -42,6 +42,9 @@ PROMOTE_TO_OBJECT = [
 ]
 
 
+TYPES_WITH_NA = (np.inexact, np.timedelta64, np.datetime64)
+
+
 def maybe_promote(dtype):
     """Simpler equivalent of pandas.core.common._maybe_promote
 

--- a/xarray/core/dtypes.py
+++ b/xarray/core/dtypes.py
@@ -42,9 +42,6 @@ PROMOTE_TO_OBJECT = [
 ]
 
 
-TYPES_WITH_NA = (np.inexact, np.timedelta64, np.datetime64)
-
-
 def maybe_promote(dtype):
     """Simpler equivalent of pandas.core.common._maybe_promote
 

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -25,6 +25,11 @@ def remove_unused_levels_categories(index: pd.Index) -> pd.Index:
                 else:
                     level = level[index.codes[i]]
                 levels.append(level)
+            # TODO: calling from_array() reorders MultiIndex levels. It would
+            # be best to avoid this, if possible, e.g., by using
+            # MultiIndex.remove_unused_levels() (which does not reorder) on the
+            # part of the MultiIndex that is not categorical, or by fixing this
+            # upstream in pandas.
             index = pd.MultiIndex.from_arrays(levels, names=index.names)
     elif isinstance(index, pd.CategoricalIndex):
         index = index.remove_unused_categories()

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -9,7 +9,7 @@ from .utils import is_scalar
 from .variable import Variable
 
 
-def remove_unused_levels_categories(index, dataframe=None):
+def remove_unused_levels_categories(index: pd.Index) -> pd.Index:
     """
     Remove unused levels from MultiIndex and unused categories from CategoricalIndex
     """
@@ -28,11 +28,7 @@ def remove_unused_levels_categories(index, dataframe=None):
             index = pd.MultiIndex.from_arrays(levels, names=index.names)
     elif isinstance(index, pd.CategoricalIndex):
         index = index.remove_unused_categories()
-
-    if dataframe is None:
-        return index
-    dataframe = dataframe.set_index(index)
-    return dataframe.index, dataframe
+    return index
 
 
 class Indexes(collections.abc.Mapping):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4013,6 +4013,15 @@ class TestDataset:
         assert len(actual) == 0
         assert expected.equals(actual)
 
+    def test_from_dataframe_non_unique_levels(self):
+        index = pd.MultiIndex.from_product(
+            [list("abc"), [1, 2, 3]], names=["letters", "numbers"]
+        )
+        df = pd.DataFrame(np.arange(9), index=index)
+        df_nonunique = df.iloc[[0, 0], :]
+        with raises_regex(ValueError, "non-unique MultiIndex"):
+            Dataset.from_dataframe(df_nonunique)
+
     def test_from_dataframe_non_unique_columns(self):
         # regression test for GH449
         df = pd.DataFrame(np.zeros((2, 2)))

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4040,6 +4040,22 @@ class TestDataset:
         with raises_regex(ValueError, "non-unique MultiIndex"):
             Dataset.from_dataframe(df_nonunique)
 
+    def test_from_dataframe_unsorted_levels(self):
+        # regression test for GH-4186
+        index = pd.MultiIndex(
+            levels=[["b", "a"], ["foo"]], codes=[[0, 1], [0, 0]], names=["lev1", "lev2"]
+        )
+        df = pd.DataFrame({"c1": [0, 2], "c2": [1, 3]}, index=index)
+        expected = Dataset(
+            {
+                "c1": (("lev1", "lev2"), [[0], [2]]),
+                "c2": (("lev1", "lev2"), [[1], [3]]),
+            },
+            coords={"lev1": ["b", "a"], "lev2": ["foo"]},
+        )
+        actual = Dataset.from_dataframe(df)
+        assert_identical(actual, expected)
+
     def test_from_dataframe_non_unique_columns(self):
         # regression test for GH449
         df = pd.DataFrame(np.zeros((2, 2)))


### PR DESCRIPTION
Before:

    pandas.MultiIndexSeries.time_to_xarray
    ======= ========= ==========
    --             subset
    ------- --------------------
    dtype     True     False
    ======= ========= ==========
      int    505±0ms   37.1±0ms
     float   485±0ms   38.3±0ms
    ======= ========= ==========

After:

    pandas.MultiIndexSeries.time_to_xarray
    ======= ============ ==========
    --               subset
    ------- -----------------------
    dtype      True       False
    ======= ============ ==========
      int    10.7±0.4ms   22.6±1ms
     float   10.0±0.8ms   21.1±1ms
    ======= ============ ==========

~~There are still some cases where we have to fall back to the existing
slow implementation, but hopefully they should now be relatively rare.~~ Edit: now we always use the new implementation


<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2459, closes #4186 
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
