### PR TITLE
use the latest image of RTD

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-    image: stable
+    image: latest
 
 conda:
     environment: ci/requirements/doc.yml


### PR DESCRIPTION
This switches back to using the `latest` image on RTD (we tried using `stable` when we had build issues a few months ago and forgot to switch back after they were resolved).