### PR TITLE
Fix polyfit fail on deficient rank

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -55,7 +55,7 @@ Bug fixes
 ~~~~~~~~~
 - Fixed a bug in backend caused by basic installation of Dask (:issue:`4164`, :pull:`4318`)
   `Sam Morley <https://github.com/inakleinbottle>`_.
-- Fixed a few bugs with :py:meth:`Dataset.polyfit` when encountering deficient matrix ranks (:issue:`4190`, :pull:`4193`) `Pascal Bourgault <https://github.com/aulemahal>`_.
+- Fixed a few bugs with :py:meth:`Dataset.polyfit` when encountering deficient matrix ranks (:issue:`4190`, :pull:`4193`). By `Pascal Bourgault <https://github.com/aulemahal>`_.
 - Fixed inconsistencies between docstring and functionality for :py:meth:`DataArray.str.get`
   and :py:meth:`DataArray.str.wrap` (:issue:`4334`). By `Mathias Hauser <https://github.com/mathause>`_.
 - Fixed overflow issue causing incorrect results in computing means of :py:class:`cftime.datetime`

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -51,6 +51,7 @@ Bug fixes
 ~~~~~~~~~
 - Fixed a bug in backend caused by basic installation of Dask (:issue:`4164`, :pull:`4318`)
   `Sam Morley <https://github.com/inakleinbottle>`_.
+- Fixed a few bugs with :py:meth:`Dataset.polyfit` when encountering deficient matrix ranks (:issue:`4190`, :pull:`4193`) `Pascal Bourgault <https://github.com/aulemahal>`_.
 
 
 Documentation

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -120,5 +120,6 @@ def least_squares(lhs, rhs, rcond=None, skipna=False):
             coeffs = coeffs.reshape(coeffs.shape[0])
             residuals = residuals.reshape(residuals.shape[0])
     else:
-        coeffs, residuals, _, _ = da.linalg.lstsq(lhs_da, rhs)
+        coeffs, residuals, rank, _ = da.linalg.lstsq(lhs_da, rhs)
+        nputils.warn_on_deficient_rank(rank, lhs.shape[1])
     return coeffs, residuals

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -120,6 +120,7 @@ def least_squares(lhs, rhs, rcond=None, skipna=False):
             coeffs = coeffs.reshape(coeffs.shape[0])
             residuals = residuals.reshape(residuals.shape[0])
     else:
-        coeffs, residuals, rank, _ = da.linalg.lstsq(lhs_da, rhs)
-        nputils.warn_on_deficient_rank(rank, lhs.shape[1])
+        # Residuals here are (1, 1) but should be (K,) as rhs is (N, K)
+        # See issue dask/dask#6516
+        coeffs, residuals, _, _ = da.linalg.lstsq(lhs_da, rhs)
     return coeffs, residuals

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3440,7 +3440,8 @@ class DataArray(AbstractArray, DataWithCoords):
             polyfit_coefficients
                 The coefficients of the best fit.
             polyfit_residuals
-                The residuals of the least-square computation (only included if `full=True`)
+                The residuals of the least-square computation (only included if `full=True`).
+                When the matrix rank is deficient, np.nan is returned.
             [dim]_matrix_rank
                 The effective rank of the scaled Vandermonde coefficient matrix (only included if `full=True`)
             [dim]_singular_value

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5909,6 +5909,12 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             [var]_polyfit_covariance
                 The covariance matrix of the polynomial coefficient estimates (only included if `full=False` and `cov=True`)
 
+        Warns
+        -----
+        RankWarning
+            The rank of the coefficient matrix in the least-squares fit is deficient.
+            The warning is not raised with in-memory (not dask) data and `full=True`.
+
         See also
         --------
         numpy.polyfit
@@ -5959,7 +5965,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             if dim not in da.dims:
                 continue
 
-            if isinstance(da.data, dask_array_type) and (rank != order or full or skipna is None):
+            if isinstance(da.data, dask_array_type) and (
+                rank != order or full or skipna is None
+            ):
                 # Current algorithm with dask and skipna=False neither supports
                 # deficient ranks nor does it output the "full" info (issue dask/dask#6516)
                 skipna_da = True

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -233,7 +233,7 @@ def _nanpolyfit_1d(arr, x, rcond=None):
     mask = np.isnan(arr)
     if not np.all(mask):
         out[:-1], resid, rank, _ = np.linalg.lstsq(x[~mask, :], arr[~mask], rcond=rcond)
-        out[-1] = resid or np.nan
+        out[-1] = resid if resid.size > 0 else np.nan
         warn_on_deficient_rank(rank, x.shape[1])
     return out
 

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -224,7 +224,8 @@ def _nanpolyfit_1d(arr, x, rcond=None):
     out = np.full((x.shape[1] + 1,), np.nan)
     mask = np.isnan(arr)
     if not np.all(mask):
-        out[:-1], out[-1], _, _ = np.linalg.lstsq(x[~mask, :], arr[~mask], rcond=rcond)
+        out[:-1], resid, _, _ = np.linalg.lstsq(x[~mask, :], arr[~mask], rcond=rcond)
+        out[-1] = resid or np.nan
     return out
 
 

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -268,7 +268,7 @@ def least_squares(lhs, rhs, rcond=None, skipna=False):
     else:
         coeffs, residuals, rank, _ = np.linalg.lstsq(lhs, rhs, rcond=rcond)
         if residuals.size == 0:
-            residuals = coeffs[0, :] * np.nan
+            residuals = coeffs[0] * np.nan
         warn_on_deficient_rank(rank, lhs.shape[1])
     return coeffs, residuals
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4290,7 +4290,7 @@ class TestDataArray:
 
         # Full output and deficient rank
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', np.RankWarning)
+            warnings.simplefilter("ignore", np.RankWarning)
             out = da.polyfit("x", 12, full=True)
             assert out.polyfit_residuals.isnull().all()
 
@@ -4311,7 +4311,7 @@ class TestDataArray:
         np.testing.assert_almost_equal(out.polyfit_residuals, [0, 0])
 
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', np.RankWarning)
+            warnings.simplefilter("ignore", np.RankWarning)
             out = da.polyfit("x", 9, full=True)
             assert out.polyfit_residuals.isnull().all()
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4283,8 +4283,10 @@ class TestDataArray:
         assert_allclose(out.polyfit_coefficients, expected, rtol=1e-3)
 
         # Full output and deficient rank
-        out = da.polyfit("x", 12, full=True)
-        assert out.polyfit_residuals.isnull().all()
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', np.RankWarning)
+            out = da.polyfit("x", 12, full=True)
+            assert out.polyfit_residuals.isnull().all()
 
         # With NaN
         da_raw[0, 1] = np.nan
@@ -4301,6 +4303,11 @@ class TestDataArray:
         assert_allclose(out.polyfit_coefficients, expected, rtol=1e-3)
         assert out.x_matrix_rank == 3
         np.testing.assert_almost_equal(out.polyfit_residuals, [0, 0])
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', np.RankWarning)
+            out = da.polyfit("x", 9, full=True)
+            assert out.polyfit_residuals.isnull().all()
 
     def test_pad_constant(self):
         ar = DataArray(np.arange(3 * 4 * 5).reshape(3, 4, 5))

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4295,7 +4295,7 @@ class TestDataArray:
             assert out.polyfit_residuals.isnull().all()
 
         # With NaN
-        da_raw[0, 1] = np.nan
+        da_raw[0, 1:3] = np.nan
         if use_dask:
             da = da_raw.chunk({"d": 1})
         else:
@@ -4312,8 +4312,8 @@ class TestDataArray:
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", np.RankWarning)
-            out = da.polyfit("x", 9, full=True)
-            assert out.polyfit_residuals.isnull().all()
+            out = da.polyfit("x", 8, full=True)
+            np.testing.assert_array_equal(out.polyfit_residuals.isnull(), [True, False])
 
     def test_pad_constant(self):
         ar = DataArray(np.arange(3 * 4 * 5).reshape(3, 4, 5))

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4286,6 +4286,10 @@ class TestDataArray:
         ).T
         assert_allclose(out.polyfit_coefficients, expected, rtol=1e-3)
 
+        # Full output and deficient rank
+        out = da.polyfit("x", 12, full=True)
+        assert out.polyfit_residuals.isnull().all()
+
         # With NaN
         da_raw[0, 1] = np.nan
         if use_dask:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5594,6 +5594,16 @@ class TestDataset:
         out = ds.polyfit("time", 2)
         assert len(out.data_vars) == 0
 
+    def test_polyfit_warnings(self):
+        ds = create_test_data(seed=1)
+
+        with warnings.catch_warnings(record=True) as ws:
+            ds.var1.polyfit("dim2", 10, full=False)
+            assert len(ws) == 1
+            assert ws[0].category == np.RankWarning
+            ds.var1.polyfit("dim2", 10, full=True)
+            assert len(ws) == 1
+
     def test_pad(self):
         ds = create_test_data(seed=1)
         padded = ds.pad(dim2=(1, 1), constant_values=42)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4190
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`

Fixes #4190. In cases where the input matrix had a deficient rank (matrix rank != order) because of the number of NaN values, polyfit would fail, simply because numpy's lstsq returned an empty array for the residuals (instead of a size 1 array). This fixes the problem by catching the case and returning `np.nan` instead.

The other point in the issue was that `RankWarning` is also not raised in that case. That was due to the fact that `da.polyfit` was computing the rank from the coordinate (Vandermonde) matrix, instead of the masked data. Thus, is a given line has too many NaN values, its deficient rank was not detected. I added a test and warning at all places where a rank is computed (5 different lines). Also, to match np.polyfit behaviour of no warning when `full=True`, I changed the warning filters using a context manager, ignoring the `RankWarning` in that case. Overall, it feels a bi ugly because of the duplicated code and it will print the warning for every line of an array that has a deficient rank, which can be a lot... 