### PR TITLE
fix sphinx warnings

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -360,7 +360,6 @@ Computation
    DataArray.rolling_exp
    DataArray.weighted
    DataArray.coarsen
-   DataArray.dt
    DataArray.resample
    DataArray.get_axis_num
    DataArray.diff
@@ -369,7 +368,6 @@ Computation
    DataArray.differentiate
    DataArray.integrate
    DataArray.polyfit
-   DataArray.str
    DataArray.map_blocks
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -59,7 +59,7 @@ Enhancements
   coordinate attributes (:pull:`4103`). By `Oriol Abril <https://github.com/OriolAbril>`_.
 - Axes kwargs such as ``facecolor`` can now be passed to :py:meth:`DataArray.plot` in ``subplot_kws``.
   This works for both single axes plots and FacetGrid plots.
-  By `Raphael Dussin <https://github.com/raphaeldussin`_.
+  By `Raphael Dussin <https://github.com/raphaeldussin>`_.
 
 New Features
 ~~~~~~~~~~~~

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,4 +6,7 @@ build:
 conda:
     environment: ci/requirements/doc.yml
 
+sphinx:
+  fail_on_warning: True
+
 formats: []

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -7,6 +7,6 @@ conda:
     environment: ci/requirements/doc.yml
 
 sphinx:
-  fail_on_warning: True
+  fail_on_warning: false
 
 formats: []


### PR DESCRIPTION
This adds back the fail-on-warnings flag we lost during the move the RTDs PR preview, and also fixes the warnings that have accumulated since then.


 - [ ] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
