### PR TITLE
update isort CI and pre-commit hook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,6 @@
 
  - [ ] Closes #xxxx
  - [ ] Tests added
- - [ ] Passes `isort -rc . && black . && mypy . && flake8`
+ - [ ] Passes `isort . && black . && mypy . && flake8`
  - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
  - [ ] New functions/methods are listed in `api.rst`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,9 @@
 repos:
   # isort should run before black as black sometimes tweaks the isort output
   - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21-2
+    rev: 5.0.4
     hooks:
       - id: isort
-        files: .+\.py$
   # https://github.com/python/black#version-control-integration
   - repo: https://github.com/python/black
     rev: stable

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
   # isort should run before black as black sometimes tweaks the isort output
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.0.4
+    rev: 5.1.0
     hooks:
       - id: isort
   # https://github.com/python/black#version-control-integration

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: blackdoc
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.3
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,7 +95,7 @@ jobs:
   - template: ci/azure/install.yml
   - bash: |
       source activate xarray-tests
-      isort -rc --check .
+      isort --check .
     displayName: isort formatting checks
 
 - job: MinimumVersionsPolicy

--- a/ci/requirements/py36-min-all-deps.yml
+++ b/ci/requirements/py36-min-all-deps.yml
@@ -23,7 +23,7 @@ dependencies:
   - hdf5=1.10
   - hypothesis
   - iris=2.2
-  - isort=4.3.21
+  - isort
   - lxml=4.4  # Optional dep of pydap
   - matplotlib=3.1
   - mypy=0.761  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -19,7 +19,7 @@ dependencies:
   - hdf5
   - hypothesis
   - iris
-  - isort=4.3.21
+  - isort
   - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.761  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py37-windows.yml
+++ b/ci/requirements/py37-windows.yml
@@ -19,7 +19,7 @@ dependencies:
   - hdf5
   - hypothesis
   - iris
-  - isort=4.3.21
+  - isort
   - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.761  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py37.yml
+++ b/ci/requirements/py37.yml
@@ -19,7 +19,7 @@ dependencies:
   - hdf5
   - hypothesis
   - iris
-  - isort=4.3.21
+  - isort
   - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.761  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py38-all-but-dask.yml
+++ b/ci/requirements/py38-all-but-dask.yml
@@ -16,7 +16,7 @@ dependencies:
   - h5py
   - hdf5
   - hypothesis
-  - isort=4.3.21
+  - isort
   - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.761  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -19,7 +19,7 @@ dependencies:
   - hdf5
   - hypothesis
   - iris
-  - isort=4.3.21
+  - isort
   - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.780  # Must match .pre-commit-config.yaml

--- a/conftest.py
+++ b/conftest.py
@@ -27,6 +27,7 @@ def pytest_runtest_setup(item):
 def add_standard_imports(doctest_namespace):
     import numpy as np
     import pandas as pd
+
     import xarray as xr
 
     doctest_namespace["np"] = np

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -368,7 +368,7 @@ xarray uses several tools to ensure a consistent code format throughout the proj
 
 and then run from the root of the Xarray repository::
 
-   isort -rc .
+   isort .
    black -t py36 .
    blackdoc -t py36 .
    flake8

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -57,8 +57,9 @@ class ScipyArrayWrapper(BackendArray):
 
 
 def _open_scipy_netcdf(filename, mode, mmap, version):
-    import scipy.io
     import gzip
+
+    import scipy.io
 
     # if the string ends with .gz, then gunzip and open as netcdf file
     if isinstance(filename, str) and filename.endswith(".gz"):

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -567,8 +567,8 @@ def decode_cf(
     -------
     decoded : Dataset
     """
-    from .core.dataset import Dataset
     from .backends.common import AbstractDataStore
+    from .core.dataset import Dataset
 
     if isinstance(obj, Dataset):
         vars = obj._variables

--- a/xarray/convert.py
+++ b/xarray/convert.py
@@ -254,6 +254,7 @@ def from_iris(cube):
     """ Convert a Iris cube into an DataArray
     """
     import iris.exceptions
+
     from xarray.core.pycompat import dask_array_type
 
     name = _name(cube)

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1088,9 +1088,9 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         """
         # TODO support non-string indexer after removing the old API.
 
+        from ..coding.cftimeindex import CFTimeIndex
         from .dataarray import DataArray
         from .resample import RESAMPLE_DIM
-        from ..coding.cftimeindex import CFTimeIndex
 
         if keep_attrs is None:
             keep_attrs = _get_keep_attrs(default=False)
@@ -1283,8 +1283,8 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         numpy.isin
         """
         from .computation import apply_ufunc
-        from .dataset import Dataset
         from .dataarray import DataArray
+        from .dataset import Dataset
         from .variable import Variable
 
         if isinstance(test_elements, Dataset):

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -976,8 +976,8 @@ def apply_ufunc(
     .. [2] http://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
     .. [3] http://xarray.pydata.org/en/stable/computation.html#wrapping-custom-computation
     """
-    from .groupby import GroupBy
     from .dataarray import DataArray
+    from .groupby import GroupBy
     from .variable import Variable
 
     if input_core_dims is None:

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -116,8 +116,8 @@ def concat(
     # TODO: add ignore_index arguments copied from pandas.concat
     # TODO: support concatenating scalar coordinates even if the concatenated
     # dimension already exists
-    from .dataset import Dataset
     from .dataarray import DataArray
+    from .dataset import Dataset
 
     try:
         first_obj, objs = utils.peek_at(objs)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1248,14 +1248,14 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         ...
 
     @overload
-    def __getitem__(self, key: Hashable) -> "DataArray":  # type: ignore
+    def __getitem__(self, key: Hashable) -> "DataArray":  # type: ignore # noqa: F811
         ...
 
     @overload
-    def __getitem__(self, key: Any) -> "Dataset":
+    def __getitem__(self, key: Any) -> "Dataset":  # noqa: F811
         ...
 
-    def __getitem__(self, key):
+    def __getitem__(self, key):  # noqa: F811
         """Access variables or coordinates this dataset as a
         :py:class:`~xarray.DataArray`.
 
@@ -4144,7 +4144,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         numpy.interp
         scipy.interpolate
         """
-        from .missing import interp_na, _apply_over_vars_with_dim
+        from .missing import _apply_over_vars_with_dim, interp_na
 
         new = _apply_over_vars_with_dim(
             interp_na,
@@ -4178,7 +4178,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         -------
         Dataset
         """
-        from .missing import ffill, _apply_over_vars_with_dim
+        from .missing import _apply_over_vars_with_dim, ffill
 
         new = _apply_over_vars_with_dim(ffill, self, dim=dim, limit=limit)
         return new
@@ -4203,7 +4203,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         -------
         Dataset
         """
-        from .missing import bfill, _apply_over_vars_with_dim
+        from .missing import _apply_over_vars_with_dim, bfill
 
         new = _apply_over_vars_with_dim(bfill, self, dim=dim, limit=limit)
         return new

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1248,14 +1248,14 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         ...
 
     @overload
-    def __getitem__(self, key: Hashable) -> "DataArray":  # type: ignore # noqa: F811
+    def __getitem__(self, key: Hashable) -> "DataArray":  # type: ignore
         ...
 
     @overload
-    def __getitem__(self, key: Any) -> "Dataset":  # noqa: F811
+    def __getitem__(self, key: Any) -> "Dataset":
         ...
 
-    def __getitem__(self, key):  # noqa: F811
+    def __getitem__(self, key):
         """Access variables or coordinates this dataset as a
         :py:class:`~xarray.DataArray`.
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -64,8 +64,8 @@ def unique_value_groups(ar, sort=True):
 
 
 def _dummy_copy(xarray_obj):
-    from .dataset import Dataset
     from .dataarray import DataArray
+    from .dataset import Dataset
 
     if isinstance(xarray_obj, Dataset):
         res = Dataset(

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -50,8 +50,8 @@ def _expand_slice(slice_, size):
 
 
 def _sanitize_slice_element(x):
-    from .variable import Variable
     from .dataarray import DataArray
+    from .variable import Variable
 
     if isinstance(x, (Variable, DataArray)):
         x = x.values

--- a/xarray/core/nanops.py
+++ b/xarray/core/nanops.py
@@ -6,6 +6,7 @@ from .pycompat import dask_array_type
 
 try:
     import dask.array as dask_array
+
     from . import dask_array_compat
 except ImportError:
     dask_array = None
@@ -118,7 +119,7 @@ def nansum(a, axis=None, dtype=None, out=None, min_count=None):
 
 def _nanmean_ddof_object(ddof, value, axis=None, dtype=None, **kwargs):
     """ In house nanmean. ddof argument will be used in _nanvar method """
-    from .duck_array_ops import count, fillna, _dask_or_eager_func, where_method
+    from .duck_array_ops import _dask_or_eager_func, count, fillna, where_method
 
     valid_count = count(value, axis=axis)
     value = fillna(value, 0)

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -2,6 +2,7 @@ try:
     import dask
     import dask.array
     from dask.highlevelgraph import HighLevelGraph
+
     from .dask_array_compat import meta_from_array
 
 except ImportError:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3207,7 +3207,7 @@ class TestDask(DatasetIOBase):
 @pytest.mark.filterwarnings("ignore:The binary mode of fromstring is deprecated")
 class TestPydap:
     def convert_to_pydap_dataset(self, original):
-        from pydap.model import GridType, BaseType, DatasetType
+        from pydap.model import BaseType, DatasetType, GridType
 
         ds = DatasetType("bears", **original.attrs)
         for key, var in original.data_vars.items():
@@ -3747,8 +3747,9 @@ class TestRasterio:
 
     def test_notransform(self):
         # regression test for https://github.com/pydata/xarray/issues/1686
-        import rasterio
         import warnings
+
+        import rasterio
 
         # Create a geotiff file
         with warnings.catch_warnings():
@@ -4097,8 +4098,8 @@ class TestRasterio:
         # Test open_rasterio() support of WarpedVRT with transform, width and
         # height (issue #2864)
         import rasterio
-        from rasterio.warp import calculate_default_transform
         from affine import Affine
+        from rasterio.warp import calculate_default_transform
 
         with create_tmp_geotiff() as (tmp_file, expected):
             with rasterio.open(tmp_file) as src:

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -222,8 +222,9 @@ def test_decode_non_standard_calendar_inside_timestamp_range(calendar):
 @requires_cftime
 @pytest.mark.parametrize("calendar", _ALL_CALENDARS)
 def test_decode_dates_outside_timestamp_range(calendar):
-    import cftime
     from datetime import datetime
+
+    import cftime
 
     units = "days since 0001-01-01"
     times = [datetime(1, 4, 1, h) for h in range(1, 5)]
@@ -358,8 +359,9 @@ def test_decode_nonstandard_calendar_multidim_time_inside_timestamp_range(calend
 @requires_cftime
 @pytest.mark.parametrize("calendar", _ALL_CALENDARS)
 def test_decode_multidim_time_outside_timestamp_range(calendar):
-    import cftime
     from datetime import datetime
+
+    import cftime
 
     units = "days since 0001-01-01"
     times1 = [datetime(1, 4, day) for day in range(1, 6)]

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6417,8 +6417,8 @@ def test_name_in_masking():
 class TestIrisConversion:
     @requires_iris
     def test_to_and_from_iris(self):
-        import iris
         import cf_units  # iris requirement
+        import iris
 
         # to iris
         coord_dict = {}
@@ -6488,9 +6488,9 @@ class TestIrisConversion:
     @requires_iris
     @requires_dask
     def test_to_and_from_iris_dask(self):
+        import cf_units  # iris requirement
         import dask.array as da
         import iris
-        import cf_units  # iris requirement
 
         coord_dict = {}
         coord_dict["distance"] = ("distance", [-2, 2], {"units": "meters"})
@@ -6623,8 +6623,8 @@ class TestIrisConversion:
         ],
     )
     def test_da_coord_name_from_cube(self, std_name, long_name, var_name, name, attrs):
-        from iris.cube import Cube
         from iris.coords import DimCoord
+        from iris.cube import Cube
 
         latitude = DimCoord(
             [-90, 0, 90], standard_name=std_name, var_name=var_name, long_name=long_name
@@ -6637,8 +6637,8 @@ class TestIrisConversion:
 
     @requires_iris
     def test_prevent_duplicate_coord_names(self):
-        from iris.cube import Cube
         from iris.coords import DimCoord
+        from iris.cube import Cube
 
         # Iris enforces unique coordinate names. Because we use a different
         # name resolution order a valid iris Cube with coords that have the
@@ -6659,8 +6659,8 @@ class TestIrisConversion:
         [["IA", "IL", "IN"], [0, 2, 1]],  # non-numeric values  # non-monotonic values
     )
     def test_fallback_to_iris_AuxCoord(self, coord_values):
-        from iris.cube import Cube
         from iris.coords import AuxCoord
+        from iris.cube import Cube
 
         data = [0, 0, 0]
         da = xr.DataArray(data, coords=[coord_values], dims=["space"])


### PR DESCRIPTION
Now that the conda-forge feedstock has been updated, we would see a failing `isort` CI because of the removed `-rc` (short for `--recursive`). I also updated the version used by `pre-commit` to the `5.0.4` version released about an hour ago, which allows us to remove the file regex as recommended by @asottile in https://github.com/pydata/xarray/issues/3750#issuecomment-624402070 (we couldn't follow that advice before since we were using the `use_parentheses` setting which was broken on `4.3.21`)

 - [x] Closes #4202
 - [ ] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
