### PR TITLE
pin isort

### DIFF
--- a/ci/requirements/py36-min-all-deps.yml
+++ b/ci/requirements/py36-min-all-deps.yml
@@ -23,7 +23,7 @@ dependencies:
   - hdf5=1.10
   - hypothesis
   - iris=2.2
-  - isort<5
+  - isort=4.3.21
   - lxml=4.4  # Optional dep of pydap
   - matplotlib=3.1
   - mypy=0.761  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py36-min-all-deps.yml
+++ b/ci/requirements/py36-min-all-deps.yml
@@ -23,7 +23,7 @@ dependencies:
   - hdf5=1.10
   - hypothesis
   - iris=2.2
-  - isort
+  - isort<5
   - lxml=4.4  # Optional dep of pydap
   - matplotlib=3.1
   - mypy=0.761  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -19,7 +19,7 @@ dependencies:
   - hdf5
   - hypothesis
   - iris
-  - isort<5
+  - isort=4.3.21
   - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.761  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -19,7 +19,7 @@ dependencies:
   - hdf5
   - hypothesis
   - iris
-  - isort
+  - isort<5
   - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.761  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py37-windows.yml
+++ b/ci/requirements/py37-windows.yml
@@ -19,7 +19,7 @@ dependencies:
   - hdf5
   - hypothesis
   - iris
-  - isort<5
+  - isort=4.3.21
   - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.761  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py37-windows.yml
+++ b/ci/requirements/py37-windows.yml
@@ -19,7 +19,7 @@ dependencies:
   - hdf5
   - hypothesis
   - iris
-  - isort
+  - isort<5
   - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.761  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py37.yml
+++ b/ci/requirements/py37.yml
@@ -19,7 +19,7 @@ dependencies:
   - hdf5
   - hypothesis
   - iris
-  - isort<5
+  - isort=4.3.21
   - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.761  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py37.yml
+++ b/ci/requirements/py37.yml
@@ -19,7 +19,7 @@ dependencies:
   - hdf5
   - hypothesis
   - iris
-  - isort
+  - isort<5
   - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.761  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py38-all-but-dask.yml
+++ b/ci/requirements/py38-all-but-dask.yml
@@ -16,7 +16,7 @@ dependencies:
   - h5py
   - hdf5
   - hypothesis
-  - isort<5
+  - isort=4.3.21
   - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.761  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py38-all-but-dask.yml
+++ b/ci/requirements/py38-all-but-dask.yml
@@ -16,7 +16,7 @@ dependencies:
   - h5py
   - hdf5
   - hypothesis
-  - isort
+  - isort<5
   - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.761  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -19,7 +19,7 @@ dependencies:
   - hdf5
   - hypothesis
   - iris
-  - isort
+  - isort<5
   - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.780  # Must match .pre-commit-config.yaml

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -19,7 +19,7 @@ dependencies:
   - hdf5
   - hypothesis
   - iris
-  - isort<5
+  - isort=4.3.21
   - lxml    # Optional dep of pydap
   - matplotlib
   - mypy=0.780  # Must match .pre-commit-config.yaml


### PR DESCRIPTION
Since the new versions of `isort` want to reformat `import dask.array as da` styled imports, this pins the `isort` version for now.

We can undo this in #4204 and – if we decide they're harmless – also apply the changes `isort` suggests.

 - [ ] Tests added
 - [ ] Passes `isort -rc . && black . && mypy . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
