### PR TITLE
Add initial cupy tests

### DIFF
--- a/xarray/tests/test_cupy.py
+++ b/xarray/tests/test_cupy.py
@@ -1,7 +1,6 @@
-import pytest
-
 import numpy as np
 import pandas as pd
+import pytest
 
 import xarray as xr
 

--- a/xarray/tests/test_cupy.py
+++ b/xarray/tests/test_cupy.py
@@ -1,0 +1,41 @@
+import pytest
+
+import numpy as np
+import pandas as pd
+
+import xarray as xr
+
+cp = pytest.importorskip("cupy")
+
+
+@pytest.fixture
+def toy_weather_data():
+    np.random.seed(123)
+    times = pd.date_range("2000-01-01", "2001-12-31", name="time")
+    annual_cycle = np.sin(2 * np.pi * (times.dayofyear.values / 365.25 - 0.28))
+
+    base = 10 + 15 * annual_cycle.reshape(-1, 1)
+    tmin_values = base + 3 * np.random.randn(annual_cycle.size, 3)
+    tmax_values = base + 10 + 3 * np.random.randn(annual_cycle.size, 3)
+
+    ds = xr.Dataset(
+        {
+            "tmin": (("time", "location"), tmin_values),
+            "tmax": (("time", "location"), tmax_values),
+        },
+        {"time": times, "location": ["IA", "IN", "IL"]},
+    )
+
+    ds.tmax.data = cp.asarray(ds.tmax.data)
+    ds.tmin.data = cp.asarray(ds.tmin.data)
+
+    return ds
+
+
+def test_cupy_import():
+    assert cp
+
+
+def test_check_mean(toy_weather_data):
+    freeze = (toy_weather_data["tmin"] <= 0).groupby("time.month").mean("time")
+    assert isinstance(freeze.data, cp.core.core.ndarray)

--- a/xarray/tests/test_cupy.py
+++ b/xarray/tests/test_cupy.py
@@ -9,6 +9,14 @@ cp = pytest.importorskip("cupy")
 
 @pytest.fixture
 def toy_weather_data():
+    """Construct the example DataSet from the Toy weather data example.
+
+    http://xarray.pydata.org/en/stable/examples/weather-data.html
+
+    Here we construct the DataSet exactly as shown in the example and then
+    convert the numpy arrays to cupy.
+
+    """
     np.random.seed(123)
     times = pd.date_range("2000-01-01", "2001-12-31", name="time")
     annual_cycle = np.sin(2 * np.pi * (times.dayofyear.values / 365.25 - 0.28))
@@ -32,9 +40,11 @@ def toy_weather_data():
 
 
 def test_cupy_import():
+    """Check the import worked."""
     assert cp
 
 
-def test_check_mean(toy_weather_data):
+def test_check_data_stays_on_gpu(toy_weather_data):
+    """Perform some operations and check the data stays on the GPU."""
     freeze = (toy_weather_data["tmin"] <= 0).groupby("time.month").mean("time")
     assert isinstance(freeze.data, cp.core.core.ndarray)


### PR DESCRIPTION
Added some initial unit tests for cupy. Mainly to create a place for cupy tests to go and to check some basic functionality.

I've created a fixture which constructs the dataset from the Toy weather data example and converts the underlying arrays to cupy. Then I've added a test which checks that after calling operations such as `mean` and `groupby` the resulting DataArray is still backed by a cupy array.

The main penalty with working on GPUs is accidentally shunting data back and forth between the GPU and system memory. Copying data over the PCI bus is slow compared to the rest of the work so should be avoided. So this first test is checking that we are leaving things on the GPU.

Because this data copying is so expensive cupy have intentionally broken the `__array__` method and introduced a `.get` method instead. This means that users have to be explicit in converting back to numpy and copying back to the main memory. Therefore we will need to add some logic to xarray to use `.get` in appropriate situations such as plotting.

 - [x] Releated to #4212 
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
