### PR TITLE
nd-rolling

### DIFF
--- a/doc/computation.rst
+++ b/doc/computation.rst
@@ -188,9 +188,16 @@ a value when aggregating:
     r = arr.rolling(y=3, center=True, min_periods=2)
     r.mean()
 
+From version 0.17, xarray supports multidimensional rolling,
+
+.. ipython:: python
+
+    r = arr.rolling(x=2, y=3, min_periods=2)
+    r.mean()
+
 .. tip::
 
-   Note that rolling window aggregations are faster and use less memory when bottleneck_ is installed. This only applies to numpy-backed xarray objects.
+   Note that rolling window aggregations are faster and use less memory when bottleneck_ is installed. This only applies to numpy-backed xarray objects with 1d-rolling.
 
 .. _bottleneck: https://github.com/pydata/bottleneck/
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -89,6 +89,9 @@ Breaking changes
 
 New Features
 ~~~~~~~~~~~~
+- :py:meth:`~xarray.DataArray.rolling` and :py:meth:`~xarray.Dataset.rolling`
+  now accept more than 1 dimension.(:pull:`4219`)
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - :py:meth:`DataArray.argmin` and :py:meth:`DataArray.argmax` now support
   sequences of 'dim' arguments, and if a sequence is passed return a dict
   (which can be passed to :py:meth:`isel` to get the value of the minimum) of

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,6 +25,9 @@ Breaking changes
 
 New Features
 ~~~~~~~~~~~~
+- :py:meth:`~xarray.DataArray.rolling` and :py:meth:`~xarray.Dataset.rolling`
+  now accept more than 1 dimension.(:pull:`4219`)
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 
 
 Bug fixes
@@ -89,9 +92,6 @@ Breaking changes
 
 New Features
 ~~~~~~~~~~~~
-- :py:meth:`~xarray.DataArray.rolling` and :py:meth:`~xarray.Dataset.rolling`
-  now accept more than 1 dimension.(:pull:`4219`)
-  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - :py:meth:`DataArray.argmin` and :py:meth:`DataArray.argmax` now support
   sequences of 'dim' arguments, and if a sequence is passed return a dict
   (which can be passed to :py:meth:`isel` to get the value of the minimum) of

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -786,7 +786,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         self,
         dim: Mapping[Hashable, int] = None,
         min_periods: int = None,
-        center: bool = False,
+        center: Union[bool, Mapping[Hashable, bool]] = False,
         keep_attrs: bool = None,
         **window_kwargs: int,
     ):

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -802,7 +802,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
             Minimum number of observations in window required to have a value
             (otherwise result is NA). The default, None, is equivalent to
             setting min_periods equal to the size of the window.
-        center : boolean, default False
+        center : boolean, or a mapping, default False
             Set the labels at the center of the window.
         keep_attrs : bool, optional
             If True, the object's attributes (`attrs`) will be copied from

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -32,10 +32,10 @@ def rolling_window(a, axis, window, center, fill_value):
     """
     import dask.array as da
 
-    # for nd-rolling. 
+    # for nd-rolling.
     # TODO It can be more efficient. Currently, the chunks at the boundaries
     # will be copied, but it might be OK for many-chunked-arrays.
-    if hasattr(axis, '__len__'):
+    if hasattr(axis, "__len__"):
         for ax, win, cen in zip(axis, window, center):
             a = rolling_window(a, ax, win, cen, fill_value)
         return a

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -32,6 +32,14 @@ def rolling_window(a, axis, window, center, fill_value):
     """
     import dask.array as da
 
+    # for nd-rolling. 
+    # TODO It can be more efficient. Currently, the chunks at the boundaries
+    # will be copied, but it might be OK for many-chunked-arrays.
+    if hasattr(axis, '__len__'):
+        for ax, win, cen in zip(axis, window, center):
+            a = rolling_window(a, ax, win, cen, fill_value)
+        return a
+
     orig_shape = a.shape
     if axis < 0:
         axis = a.ndim + axis

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -86,7 +86,7 @@ def rolling_window(a, axis, window, center, fill_value):
 
     # create overlap arrays
     ag = da.overlap.overlap(a, depth=depth, boundary=boundary)
-    
+
     def func(x, window, axis):
         x = np.asarray(x)
         index = [slice(None)] * x.ndim

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -86,7 +86,7 @@ def rolling_window(a, axis, window, center, fill_value):
 
     # create overlap arrays
     ag = da.overlap.overlap(a, depth=depth, boundary=boundary)
-    # apply rolling func
+    
     def func(x, window, axis):
         x = np.asarray(x)
         index = [slice(None)] * x.ndim

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -32,77 +32,80 @@ def rolling_window(a, axis, window, center, fill_value):
     """
     import dask.array as da
 
-    # for nd-rolling.
-    # TODO It can be more efficient. Currently, the chunks at the boundaries
-    # will be copied, but it might be OK for many-chunked-arrays.
-    if hasattr(axis, "__len__"):
-        for ax, win, cen in zip(axis, window, center):
-            a = rolling_window(a, ax, win, cen, fill_value)
-        return a
+    if not hasattr(axis, "__len__"):
+        axis = [axis]
+        window = [window]
+        center = [center]
 
     orig_shape = a.shape
-    if axis < 0:
-        axis = a.ndim + axis
     depth = {d: 0 for d in range(a.ndim)}
-    depth[axis] = int(window / 2)
-    # For evenly sized window, we need to crop the first point of each block.
-    offset = 1 if window % 2 == 0 else 0
+    offset = [0] * a.ndim
+    drop_size = [0] * a.ndim
+    pad_size = [0] * a.ndim
+    for ax, win, cent in zip(axis, window, center):
+        if ax < 0:
+            ax = a.ndim + ax
+        depth[ax] = int(win / 2)
+        # For evenly sized window, we need to crop the first point of each block.
+        offset[ax] = 1 if win % 2 == 0 else 0
 
-    if depth[axis] > min(a.chunks[axis]):
-        raise ValueError(
-            "For window size %d, every chunk should be larger than %d, "
-            "but the smallest chunk size is %d. Rechunk your array\n"
-            "with a larger chunk size or a chunk size that\n"
-            "more evenly divides the shape of your array."
-            % (window, depth[axis], min(a.chunks[axis]))
-        )
+        if depth[ax] > min(a.chunks[ax]):
+            raise ValueError(
+                "For window size %d, every chunk should be larger than %d, "
+                "but the smallest chunk size is %d. Rechunk your array\n"
+                "with a larger chunk size or a chunk size that\n"
+                "more evenly divides the shape of your array."
+                % (win, depth[ax], min(a.chunks[ax]))
+            )
 
-    # Although da.overlap pads values to boundaries of the array,
-    # the size of the generated array is smaller than what we want
-    # if center == False.
-    if center:
-        start = int(window / 2)  # 10 -> 5,  9 -> 4
-        end = window - 1 - start
-    else:
-        start, end = window - 1, 0
-    pad_size = max(start, end) + offset - depth[axis]
-    drop_size = 0
-    # pad_size becomes more than 0 when the overlapped array is smaller than
-    # needed. In this case, we need to enlarge the original array by padding
-    # before overlapping.
-    if pad_size > 0:
-        if pad_size < depth[axis]:
-            # overlapping requires each chunk larger than depth. If pad_size is
-            # smaller than the depth, we enlarge this and truncate it later.
-            drop_size = depth[axis] - pad_size
-            pad_size = depth[axis]
-        shape = list(a.shape)
-        shape[axis] = pad_size
-        chunks = list(a.chunks)
-        chunks[axis] = (pad_size,)
-        fill_array = da.full(shape, fill_value, dtype=a.dtype, chunks=chunks)
-        a = da.concatenate([fill_array, a], axis=axis)
+        # Although da.overlap pads values to boundaries of the array,
+        # the size of the generated array is smaller than what we want
+        # if center == False.
+        if cent:
+            start = int(win / 2)  # 10 -> 5,  9 -> 4
+            end = win - 1 - start
+        else:
+            start, end = win - 1, 0
+        pad_size[ax] = max(start, end) + offset[ax] - depth[ax]
+        drop_size[ax] = 0
+        # pad_size becomes more than 0 when the overlapped array is smaller than
+        # needed. In this case, we need to enlarge the original array by padding
+        # before overlapping.
+        if pad_size[ax] > 0:
+            if pad_size[ax] < depth[ax]:
+                # overlapping requires each chunk larger than depth. If pad_size is
+                # smaller than the depth, we enlarge this and truncate it later.
+                drop_size[ax] = depth[ax] - pad_size[ax]
+                pad_size[ax] = depth[ax]
 
+    # TODO maybe following two lines can be summarized.
+    a = da.pad(
+        a, [(p, 0) for p in pad_size], mode="constant", constant_values=fill_value
+    )
     boundary = {d: fill_value for d in range(a.ndim)}
 
     # create overlap arrays
     ag = da.overlap.overlap(a, depth=depth, boundary=boundary)
-
     # apply rolling func
-    def func(x, window, axis=-1):
+    def func(x, window, axis):
         x = np.asarray(x)
-        rolling = nputils._rolling_window(x, window, axis)
-        return rolling[(slice(None),) * axis + (slice(offset, None),)]
+        index = [slice(None)] * x.ndim
+        for ax, win in zip(axis, window):
+            x = nputils._rolling_window(x, win, ax)
+            index[ax] = slice(offset[ax], None)
+        return x[tuple(index)]
 
-    chunks = list(a.chunks)
-    chunks.append(window)
+    chunks = list(a.chunks) + window
+    new_axis = [a.ndim + i for i in range(len(axis))]
     out = ag.map_blocks(
-        func, dtype=a.dtype, new_axis=a.ndim, chunks=chunks, window=window, axis=axis
+        func, dtype=a.dtype, new_axis=new_axis, chunks=chunks, window=window, axis=axis
     )
 
     # crop boundary.
-    index = (slice(None),) * axis + (slice(drop_size, drop_size + orig_shape[axis]),)
-    return out[index]
+    index = [slice(None)] * a.ndim
+    for ax in axis:
+        index[ax] = slice(drop_size[ax], drop_size[ax] + orig_shape[ax])
+    return out[tuple(index)]
 
 
 def least_squares(lhs, rhs, rcond=None, skipna=False):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5969,7 +5969,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                     skipna_da = np.any(da.isnull())
 
             dims_to_stack = [dimname for dimname in da.dims if dimname != dim]
-            stacked_coords = {}
+            stacked_coords: Dict[Hashable, DataArray] = {}
             if dims_to_stack:
                 stacked_dim = utils.get_temp_dimname(dims_to_stack, "stacked")
                 rhs = da.transpose(dim, *dims_to_stack).stack(

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -135,7 +135,7 @@ class NumpyVIndexAdapter:
 def rolling_window(a, axis, window, center, fill_value):
     """ rolling window with padding. """
     pads = [(0, 0) for s in a.shape]
-    if not hasattr(axis, '__len__'):
+    if not hasattr(axis, "__len__"):
         axis = [axis]
         window = [window]
         center = [center]

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -135,14 +135,22 @@ class NumpyVIndexAdapter:
 def rolling_window(a, axis, window, center, fill_value):
     """ rolling window with padding. """
     pads = [(0, 0) for s in a.shape]
-    if center:
-        start = int(window / 2)  # 10 -> 5,  9 -> 4
-        end = window - 1 - start
-        pads[axis] = (start, end)
-    else:
-        pads[axis] = (window - 1, 0)
+    if not hasattr(axis, '__len__'):
+        axis = [axis]
+        window = [window]
+        center = [center]
+
+    for ax, win, cent in zip(axis, window, center):
+        if cent:
+            start = int(win / 2)  # 10 -> 5,  9 -> 4
+            end = win - 1 - start
+            pads[ax] = (start, end)
+        else:
+            pads[ax] = (win - 1, 0)
     a = np.pad(a, pads, mode="constant", constant_values=fill_value)
-    return _rolling_window(a, window, axis)
+    for ax, win in zip(axis, window):
+        a = _rolling_window(a, win, ax)
+    return a
 
 
 def _rolling_window(a, window, axis=-1):

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -235,12 +235,15 @@ class DataArrayRolling(Rolling):
 
         Parameters
         ----------
-        window_dim: str
-            New name of the window dimension.
-        stride: integer, optional
+        window_dim: str or a mapping, optional
+            A mapping from dimension name to the new window dimension names.
+            Just a string can be used for 1d-rolling.
+        stride: integer or a mapping, optional
             Size of stride for the rolling window.
         fill_value: optional. Default dtypes.NA
             Filling value to match the dimension size.
+        **window_dim_kwargs : {dim: new_name, ...}, optional
+            The keyword arguments form of ``window_dim``.
 
         Returns
         -------
@@ -456,7 +459,7 @@ class DatasetRolling(Rolling):
             Minimum number of observations in window required to have a value
             (otherwise result is NA). The default, None, is equivalent to
             setting min_periods equal to the size of the window.
-        center : boolean, default False
+        center : boolean, or a mapping from dimension name to boolean, default False
             Set the labels at the center of the window.
         keep_attrs : bool, optional
             If True, the object's attributes (`attrs`) will be copied from
@@ -556,12 +559,15 @@ class DatasetRolling(Rolling):
 
         Parameters
         ----------
-        window_dim: str
-            New name of the window dimension.
+        window_dim: str or a mapping, optional
+            A mapping from dimension name to the new window dimension names.
+            Just a string can be used for 1d-rolling.
         stride: integer, optional
             size of stride for the rolling window.
         fill_value: optional. Default dtypes.NA
             Filling value to match the dimension size.
+        **window_dim_kwargs : {dim: new_name, ...}, optional
+            The keyword arguments form of ``window_dim``.
 
         Returns
         -------

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -269,9 +269,12 @@ class DataArrayRolling(Rolling):
 
         from .dataarray import DataArray
 
-        window_dim = utils.either_dict_or_kwargs(
-            window_dim, window_dim_kwargs, "Dataset.rolling"
-        )
+        if window_dim is None:
+            if len(window_dim_kwargs) == 0:
+                raise ValueError(
+                    "Either window_dim or window_dim_kwargs need to be specified."
+                )
+            window_dim = {d: window_dim_kwargs[d] for d in self.dim}
 
         window_dim = self._mapping_to_list(
             window_dim, allow_default=False, allow_allsame=False

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -100,10 +100,7 @@ class Rolling:
 
         attrs = [
             "{k}->{v}".format(k=k, v=getattr(self, k))
-            for k in list(self.dim)
-            + list(self.window)
-            + list(self.center)
-            + [self.min_periods]
+            for k in list(self.dim) + self.window + self.center + [self.min_periods]
         ]
         return "{klass} [{attrs}]".format(
             klass=self.__class__.__name__, attrs=",".join(attrs)
@@ -272,12 +269,9 @@ class DataArrayRolling(Rolling):
 
         from .dataarray import DataArray
 
-        if window_dim is None:
-            if len(window_dim_kwargs) == 0:
-                raise ValueError(
-                    "Either window_dim or window_dim_kwargs need to be specified."
-                )
-            window_dim = {d: window_dim_kwargs[d] for d in self.dim}
+        window_dim = utils.either_dict_or_kwargs(
+            window_dim, window_dim_kwargs, "Dataset.rolling"
+        )
 
         window_dim = self._mapping_to_list(
             window_dim, allow_default=False, allow_allsame=False

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1881,11 +1881,14 @@ class Variable(
         Parameters
         ----------
         dim: str
-            Dimension over which to compute rolling_window
+            Dimension over which to compute rolling_window.
+            For nd-rolling, should be list of dimensions.
         window: int
             Window size of the rolling
+            For nd-rolling, should be list of integers.
         window_dim: str
             New name of the window dimension.
+            For nd-rolling, should be list of integers.
         center: boolean. default False.
             If True, pad fill_value for both ends. Otherwise, pad in the head
             of the axis.
@@ -1918,13 +1921,23 @@ class Variable(
         else:
             dtype = self.dtype
             array = self.data
-
-        new_dims = self.dims + (window_dim,)
+        
+        if isinstance(dim, list):
+            assert len(dim) == len(window)
+            assert len(dim) == len(window_dim)
+            assert len(dim) == len(center)
+        else:
+            dim = [dim]
+            window = [window]
+            window_dim = [window_dim]
+            center = [center]
+        axis = [self.get_axis_num(d) for d in dim]
+        new_dims = self.dims + tuple(window_dim)
         return Variable(
             new_dims,
             duck_array_ops.rolling_window(
                 array,
-                axis=self.get_axis_num(dim),
+                axis=axis,
                 window=window,
                 center=center,
                 fill_value=fill_value,

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1921,7 +1921,7 @@ class Variable(
         else:
             dtype = self.dtype
             array = self.data
-        
+
         if isinstance(dim, list):
             assert len(dim) == len(window)
             assert len(dim) == len(window_dim)
@@ -1936,11 +1936,7 @@ class Variable(
         return Variable(
             new_dims,
             duck_array_ops.rolling_window(
-                array,
-                axis=axis,
-                window=window,
-                center=center,
-                fill_value=fill_value,
+                array, axis=axis, window=window, center=center, fill_value=fill_value
             ),
         )
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6403,11 +6403,10 @@ def test_rolling_count_correct():
 def test_ndrolling_reduce(da, center, min_periods):
     rolling_obj = da.rolling(time=3, x=2, center=center, min_periods=min_periods)
 
-    # add nan prefix to numpy methods to get similar # behavior as bottleneck
-    actual = rolling_obj.sum(skipna=False)
+    actual = rolling_obj.sum()
     expected = (
-        da.rolling(time=3, center=center, min_periods=min_periods).sum(skipna=False)
-        .rolling(x=2, center=center, min_periods=min_periods).sum(skipna=False))
+        da.rolling(time=3, center=center, min_periods=min_periods).sum()
+        .rolling(x=2, center=center, min_periods=min_periods).sum())
 
     assert_allclose(actual, expected)
     assert actual.dims == expected.dims

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6405,8 +6405,11 @@ def test_ndrolling_reduce(da, center, min_periods):
 
     actual = rolling_obj.sum()
     expected = (
-        da.rolling(time=3, center=center, min_periods=min_periods).sum()
-        .rolling(x=2, center=center, min_periods=min_periods).sum())
+        da.rolling(time=3, center=center, min_periods=min_periods)
+        .sum()
+        .rolling(x=2, center=center, min_periods=min_periods)
+        .sum()
+    )
 
     assert_allclose(actual, expected)
     assert actual.dims == expected.dims

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6401,11 +6401,14 @@ def test_rolling_count_correct():
 @pytest.mark.parametrize("center", (True, False))
 @pytest.mark.parametrize("min_periods", (None, 1))
 def test_ndrolling_reduce(da, center, min_periods):
-    rolling_obj = da.rolling(time=3, a=2, center=center, min_periods=min_periods)
+    rolling_obj = da.rolling(time=3, x=2, center=center, min_periods=min_periods)
 
     # add nan prefix to numpy methods to get similar # behavior as bottleneck
-    actual = rolling_obj.reduce(np.nansum)
-    expected = rolling_obj.sum()
+    actual = rolling_obj.sum(skipna=False)
+    expected = (
+        da.rolling(time=3, center=center, min_periods=min_periods).sum(skipna=False)
+        .rolling(x=2, center=center, min_periods=min_periods).sum(skipna=False))
+
     assert_allclose(actual, expected)
     assert actual.dims == expected.dims
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6397,9 +6397,9 @@ def test_rolling_count_correct():
         assert_equal(result, expected)
 
 
-@pytest.mark.parametrize("da", (1, ), indirect=True)
+@pytest.mark.parametrize("da", (1,), indirect=True)
 @pytest.mark.parametrize("center", (True, False))
-@pytest.mark.parametrize("min_periods", (None, 1, ))
+@pytest.mark.parametrize("min_periods", (None, 1))
 def test_ndrolling_reduce(da, center, min_periods):
     rolling_obj = da.rolling(time=3, a=2, center=center, min_periods=min_periods)
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6193,8 +6193,6 @@ def test_rolling_properties(da):
     assert rolling_obj.obj.get_axis_num("time") == 1
 
     # catching invalid args
-    with pytest.raises(ValueError, match="exactly one dim/window should"):
-        da.rolling(time=7, x=2)
     with pytest.raises(ValueError, match="window must be > 0"):
         da.rolling(time=-2)
     with pytest.raises(ValueError, match="min_periods must be greater than zero"):
@@ -6397,6 +6395,19 @@ def test_rolling_count_correct():
 
         result = da.to_dataset(name="var1").rolling(**kwarg).count()["var1"]
         assert_equal(result, expected)
+
+
+@pytest.mark.parametrize("da", (1, ), indirect=True)
+@pytest.mark.parametrize("center", (True, False))
+@pytest.mark.parametrize("min_periods", (None, 1, ))
+def test_ndrolling_reduce(da, center, min_periods):
+    rolling_obj = da.rolling(time=3, a=2, center=center, min_periods=min_periods)
+
+    # add nan prefix to numpy methods to get similar # behavior as bottleneck
+    actual = rolling_obj.reduce(np.nansum)
+    expected = rolling_obj.sum()
+    assert_allclose(actual, expected)
+    assert actual.dims == expected.dims
 
 
 def test_raise_no_warning_for_nan_in_binary_ops():

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6009,7 +6009,7 @@ def test_rolling_reduce(ds, center, min_periods, window, name):
 @pytest.mark.parametrize("center", (True, False))
 @pytest.mark.parametrize("min_periods", (None, 1))
 @pytest.mark.parametrize("name", ("sum", "max"))
-@pytest.mark.parameteris("dask", (True, False))
+@pytest.mark.parametrize("dask", (True, False))
 def test_ndrolling_reduce(ds, center, min_periods, name, dask):
     if dask and has_dask:
         ds = ds.chunk({"x": 4})

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6005,6 +6005,48 @@ def test_rolling_reduce(ds, center, min_periods, window, name):
         assert src_var.dims == actual[key].dims
 
 
+@pytest.mark.parametrize("ds", (1,), indirect=True)
+@pytest.mark.parametrize("center", (True, False))
+@pytest.mark.parametrize("min_periods", (None, 1))
+@pytest.mark.parametrize("name", ("sum", "mean", "max"))
+def test_ndrolling_reduce(ds, center, min_periods, name):
+    rolling_obj = ds.rolling(time=3, x=2, center=center, min_periods=min_periods)
+
+    actual = getattr(rolling_obj, name)()
+    expected = getattr(
+        getattr(
+            ds.rolling(time=3, center=center, min_periods=min_periods), name
+        )().rolling(x=2, center=center, min_periods=min_periods),
+        name,
+    )()
+
+    assert_allclose(actual, expected)
+    assert actual.dims == expected.dims
+
+
+@pytest.mark.parametrize("center", (True, False, (True, False)))
+@pytest.mark.parametrize("fill_value", (np.nan, 0.0))
+def test_ndrolling_construct(center, fill_value):
+    da = DataArray(
+        np.arange(5 * 6 * 7).reshape(5, 6, 7).astype(float),
+        dims=["x", "y", "z"],
+        coords={"x": ["a", "b", "c", "d", "e"], "y": np.arange(6)},
+    )
+    ds = xr.Dataset({"da": da})
+    actual = ds.rolling(x=3, z=2, center=center).construct(
+        x="x1", z="z1", fill_value=fill_value
+    )
+    if not isinstance(center, tuple):
+        center = (center, center)
+    expected = (
+        ds.rolling(x=3, center=center[0])
+        .construct(x="x1", fill_value=fill_value)
+        .rolling(z=2, center=center[1])
+        .construct(z="z1", fill_value=fill_value)
+    )
+    assert_allclose(actual, expected)
+
+
 def test_raise_no_warning_for_nan_in_binary_ops():
     with pytest.warns(None) as record:
         Dataset(data_vars={"x": ("y", [1, 2, np.NaN])}) > 0

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6008,15 +6008,25 @@ def test_rolling_reduce(ds, center, min_periods, window, name):
 @pytest.mark.parametrize("ds", (1,), indirect=True)
 @pytest.mark.parametrize("center", (True, False))
 @pytest.mark.parametrize("min_periods", (None, 1))
-@pytest.mark.parametrize("name", ("sum", "mean", "max"))
+@pytest.mark.parametrize("name", ("sum", "mean", "max", "std"))
 def test_ndrolling_reduce(ds, center, min_periods, name):
-    rolling_obj = ds.rolling(time=3, x=2, center=center, min_periods=min_periods)
+    rolling_obj = ds.rolling(time=4, x=3, center=center, min_periods=min_periods)
 
     actual = getattr(rolling_obj, name)()
     expected = getattr(
         getattr(
-            ds.rolling(time=3, center=center, min_periods=min_periods), name
-        )().rolling(x=2, center=center, min_periods=min_periods),
+            ds.rolling(time=4, center=center, min_periods=min_periods), name
+        )().rolling(x=3, center=center, min_periods=min_periods),
+        name,
+    )()
+    assert_allclose(actual, expected)
+    assert actual.dims == expected.dims
+
+    # Do it in the oposite order
+    expected = getattr(
+        getattr(
+            ds.rolling(x=3, center=center, min_periods=min_periods), name
+        )().rolling(time=4, center=center, min_periods=min_periods),
         name,
     )()
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6005,11 +6005,15 @@ def test_rolling_reduce(ds, center, min_periods, window, name):
         assert src_var.dims == actual[key].dims
 
 
-@pytest.mark.parametrize("ds", (1,), indirect=True)
+@pytest.mark.parametrize("ds", (2,), indirect=True)
 @pytest.mark.parametrize("center", (True, False))
 @pytest.mark.parametrize("min_periods", (None, 1))
-@pytest.mark.parametrize("name", ("sum", "mean", "max", "std"))
-def test_ndrolling_reduce(ds, center, min_periods, name):
+@pytest.mark.parametrize("name", ("sum", "max"))
+@pytest.mark.parameteris("dask", (True, False))
+def test_ndrolling_reduce(ds, center, min_periods, name, das):
+    if dask and has_dask:
+        ds = ds.chunk({"x": 4})
+
     rolling_obj = ds.rolling(time=4, x=3, center=center, min_periods=min_periods)
 
     actual = getattr(rolling_obj, name)()
@@ -6036,13 +6040,17 @@ def test_ndrolling_reduce(ds, center, min_periods, name):
 
 @pytest.mark.parametrize("center", (True, False, (True, False)))
 @pytest.mark.parametrize("fill_value", (np.nan, 0.0))
-def test_ndrolling_construct(center, fill_value):
+@pytest.mark.parametrize("dask", (True, False))
+def test_ndrolling_construct(center, fill_value, dask):
     da = DataArray(
         np.arange(5 * 6 * 7).reshape(5, 6, 7).astype(float),
         dims=["x", "y", "z"],
         coords={"x": ["a", "b", "c", "d", "e"], "y": np.arange(6)},
     )
     ds = xr.Dataset({"da": da})
+    if dask and has_dask:
+        ds = ds.chunk({"x": 4})
+
     actual = ds.rolling(x=3, z=2, center=center).construct(
         x="x1", z="z1", fill_value=fill_value
     )

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5962,7 +5962,6 @@ def test_rolling_construct(center, window):
     df_rolling = df.rolling(window, center=center, min_periods=1).mean()
     ds_rolling = ds.rolling(index=window, center=center)
 
-    print(ds_rolling.construct("window"))
     ds_rolling_mean = ds_rolling.construct("window").mean("window")
     np.testing.assert_allclose(df_rolling["x"].values, ds_rolling_mean["x"].values)
     np.testing.assert_allclose(df_rolling.index, ds_rolling_mean["index"])

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6010,7 +6010,7 @@ def test_rolling_reduce(ds, center, min_periods, window, name):
 @pytest.mark.parametrize("min_periods", (None, 1))
 @pytest.mark.parametrize("name", ("sum", "max"))
 @pytest.mark.parameteris("dask", (True, False))
-def test_ndrolling_reduce(ds, center, min_periods, name, das):
+def test_ndrolling_reduce(ds, center, min_periods, name, dask):
     if dask and has_dask:
         ds = ds.chunk({"x": 4})
 
@@ -6026,7 +6026,7 @@ def test_ndrolling_reduce(ds, center, min_periods, name, das):
     assert_allclose(actual, expected)
     assert actual.dims == expected.dims
 
-    # Do it in the oposite order
+    # Do it in the opposite order
     expected = getattr(
         getattr(
             ds.rolling(x=3, center=center, min_periods=min_periods), name

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5962,6 +5962,7 @@ def test_rolling_construct(center, window):
     df_rolling = df.rolling(window, center=center, min_periods=1).mean()
     ds_rolling = ds.rolling(index=window, center=center)
 
+    print(ds_rolling.construct("window"))
     ds_rolling_mean = ds_rolling.construct("window").mean("window")
     np.testing.assert_allclose(df_rolling["x"].values, ds_rolling_mean["x"].values)
     np.testing.assert_allclose(df_rolling.index, ds_rolling_mean["index"])

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5881,8 +5881,6 @@ def test_rolling_keep_attrs():
 
 def test_rolling_properties(ds):
     # catching invalid args
-    with pytest.raises(ValueError, match="exactly one dim/window should"):
-        ds.rolling(time=7, x=2)
     with pytest.raises(ValueError, match="window must be > 0"):
         ds.rolling(time=-2)
     with pytest.raises(ValueError, match="min_periods must be greater than zero"):

--- a/xarray/tests/test_nputils.py
+++ b/xarray/tests/test_nputils.py
@@ -1,6 +1,6 @@
 import numpy as np
-from numpy.testing import assert_array_equal
 import pytest
+from numpy.testing import assert_array_equal
 
 from xarray.core.nputils import NumpyVIndexAdapter, _is_contiguous, rolling_window
 

--- a/xarray/tests/test_nputils.py
+++ b/xarray/tests/test_nputils.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numpy.testing import assert_array_equal
+import pytest
 
 from xarray.core.nputils import NumpyVIndexAdapter, _is_contiguous, rolling_window
 
@@ -47,3 +48,22 @@ def test_rolling():
     actual = rolling_window(x, axis=-1, window=3, center=False, fill_value=0.0)
     expected = np.stack([expected, expected * 1.1], axis=0)
     assert_array_equal(actual, expected)
+
+
+@pytest.mark.parametrize('center', [[True, True], [False, False]])
+@pytest.mark.parametrize('axis', [(0, 1), (1, 2), (2, 0)])
+def test_nd_rolling(center, axis):
+    x = np.arange(7 * 6 * 8).reshape(7, 6, 8).astype(float)
+    window = [3, 3]
+    actual = rolling_window(
+        x, axis=axis, window=window, 
+        center=center, fill_value=np.nan)
+    expected = x
+    for ax, win, cent in zip(axis, window, center):
+        expected = rolling_window(
+            expected, axis=ax, window=win, center=cent, fill_value=np.nan)
+    assert_array_equal(actual, expected)
+
+    
+
+

--- a/xarray/tests/test_nputils.py
+++ b/xarray/tests/test_nputils.py
@@ -50,20 +50,17 @@ def test_rolling():
     assert_array_equal(actual, expected)
 
 
-@pytest.mark.parametrize('center', [[True, True], [False, False]])
-@pytest.mark.parametrize('axis', [(0, 1), (1, 2), (2, 0)])
+@pytest.mark.parametrize("center", [[True, True], [False, False]])
+@pytest.mark.parametrize("axis", [(0, 1), (1, 2), (2, 0)])
 def test_nd_rolling(center, axis):
     x = np.arange(7 * 6 * 8).reshape(7, 6, 8).astype(float)
     window = [3, 3]
     actual = rolling_window(
-        x, axis=axis, window=window, 
-        center=center, fill_value=np.nan)
+        x, axis=axis, window=window, center=center, fill_value=np.nan
+    )
     expected = x
     for ax, win, cent in zip(axis, window, center):
         expected = rolling_window(
-            expected, axis=ax, window=win, center=cent, fill_value=np.nan)
+            expected, axis=ax, window=win, center=cent, fill_value=np.nan
+        )
     assert_array_equal(actual, expected)
-
-    
-
-

--- a/xarray/tests/test_testing.py
+++ b/xarray/tests/test_testing.py
@@ -37,7 +37,7 @@ def test_allclose_regression():
     "obj1,obj2",
     (
         pytest.param(
-            xr.Variable("x", [1e-17, 2]), xr.Variable("x", [0, 3]), id="Variable",
+            xr.Variable("x", [1e-17, 2]), xr.Variable("x", [0, 3]), id="Variable"
         ),
         pytest.param(
             xr.DataArray([1e-17, 2], dims="x"),

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -624,7 +624,7 @@ def test_align_dataset(value, unit, variant, error, dtype):
     units_a = extract_units(ds1)
     units_b = extract_units(ds2)
     expected_a, expected_b = func(
-        strip_units(ds1), strip_units(convert_units(ds2, units_a)), **stripped_kwargs,
+        strip_units(ds1), strip_units(convert_units(ds2, units_a)), **stripped_kwargs
     )
     expected_a = attach_units(expected_a, units_a)
     if isinstance(array2, Quantity):
@@ -1223,11 +1223,7 @@ def test_merge_dataset(variant, unit, error, dtype):
 def test_replication_dataarray(func, variant, dtype):
     unit = unit_registry.m
 
-    variants = {
-        "data": (unit, 1, 1),
-        "dims": (1, unit, 1),
-        "coords": (1, 1, unit),
-    }
+    variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
     data_unit, dim_unit, coord_unit = variants.get(variant)
 
     array = np.linspace(0, 10, 20).astype(dtype) * data_unit
@@ -1308,11 +1304,7 @@ def test_replication_full_like_dataarray(variant, dtype):
     # fill value, we don't need to try multiple units
     unit = unit_registry.m
 
-    variants = {
-        "data": (unit, 1, 1),
-        "dims": (1, unit, 1),
-        "coords": (1, 1, unit),
-    }
+    variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
     data_unit, dim_unit, coord_unit = variants.get(variant)
 
     array = np.linspace(0, 5, 10) * data_unit
@@ -1370,10 +1362,7 @@ def test_replication_full_like_dataset(variant, dtype):
 
     fill_value = -1 * unit_registry.degK
 
-    units = {
-        **extract_units(ds),
-        **{name: unit_registry.degK for name in ds.data_vars},
-    }
+    units = {**extract_units(ds), **{name: unit_registry.degK for name in ds.data_vars}}
     expected = attach_units(
         xr.full_like(strip_units(ds), fill_value=strip_units(fill_value)), units
     )
@@ -1735,7 +1724,7 @@ class TestVariable:
             pytest.param(1, id="no_unit"),
             pytest.param(unit_registry.dimensionless, id="dimensionless"),
             pytest.param(unit_registry.s, id="incompatible_unit"),
-            pytest.param(unit_registry.cm, id="compatible_unit",),
+            pytest.param(unit_registry.cm, id="compatible_unit"),
             pytest.param(unit_registry.m, id="identical_unit"),
         ),
     )
@@ -2186,7 +2175,7 @@ class TestVariable:
         v = xr.Variable(["x", "y", "z"], data)
 
         expected = attach_units(
-            strip_units(v).pad(mode=mode, **xr_arg), extract_units(v),
+            strip_units(v).pad(mode=mode, **xr_arg), extract_units(v)
         )
         actual = v.pad(mode=mode, **xr_arg)
 
@@ -2424,7 +2413,7 @@ class TestDataArray:
                 id="equal",
                 marks=pytest.mark.xfail(
                     # LooseVersion(pint.__version__) < "0.14",
-                    reason="inconsistencies in the return values of pint's eq",
+                    reason="inconsistencies in the return values of pint's eq"
                 ),
             ),
         ),
@@ -2918,8 +2907,8 @@ class TestDataArray:
                 unit_registry.dimensionless, DimensionalityError, id="dimensionless"
             ),
             pytest.param(unit_registry.s, DimensionalityError, id="incompatible_unit"),
-            pytest.param(unit_registry.cm, None, id="compatible_unit",),
-            pytest.param(unit_registry.m, None, id="identical_unit",),
+            pytest.param(unit_registry.cm, None, id="compatible_unit"),
+            pytest.param(unit_registry.m, None, id="identical_unit"),
         ),
     )
     def test_combine_first(self, unit, error, dtype):
@@ -3167,11 +3156,7 @@ class TestDataArray:
     def test_content_manipulation(self, func, variant, dtype):
         unit = unit_registry.m
 
-        variants = {
-            "data": (unit, 1, 1),
-            "dims": (1, unit, 1),
-            "coords": (1, 1, unit),
-        }
+        variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
         data_unit, dim_unit, coord_unit = variants.get(variant)
 
         quantity = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
@@ -3437,10 +3422,7 @@ class TestDataArray:
         ids=repr,
     )
     def test_interp_reindex(self, variant, func, dtype):
-        variants = {
-            "data": (unit_registry.m, 1),
-            "coords": (1, unit_registry.m),
-        }
+        variants = {"data": (unit_registry.m, 1), "coords": (1, unit_registry.m)}
         data_unit, coord_unit = variants.get(variant)
 
         array = np.linspace(1, 2, 10).astype(dtype) * data_unit
@@ -3470,9 +3452,7 @@ class TestDataArray:
             pytest.param(unit_registry.m, None, id="identical_unit"),
         ),
     )
-    @pytest.mark.parametrize(
-        "func", (method("interp"), method("reindex")), ids=repr,
-    )
+    @pytest.mark.parametrize("func", (method("interp"), method("reindex")), ids=repr)
     def test_interp_reindex_indexing(self, func, unit, error, dtype):
         array = np.linspace(1, 2, 10).astype(dtype)
         x = np.arange(10) * unit_registry.m
@@ -3510,10 +3490,7 @@ class TestDataArray:
         ids=repr,
     )
     def test_interp_reindex_like(self, variant, func, dtype):
-        variants = {
-            "data": (unit_registry.m, 1),
-            "coords": (1, unit_registry.m),
-        }
+        variants = {"data": (unit_registry.m, 1), "coords": (1, unit_registry.m)}
         data_unit, coord_unit = variants.get(variant)
 
         array = np.linspace(1, 2, 10).astype(dtype) * data_unit
@@ -3545,7 +3522,7 @@ class TestDataArray:
         ),
     )
     @pytest.mark.parametrize(
-        "func", (method("interp_like"), method("reindex_like")), ids=repr,
+        "func", (method("interp_like"), method("reindex_like")), ids=repr
     )
     def test_interp_reindex_like_indexing(self, func, unit, error, dtype):
         array = np.linspace(1, 2, 10).astype(dtype)
@@ -3681,11 +3658,7 @@ class TestDataArray:
     def test_computation(self, func, variant, dtype):
         unit = unit_registry.m
 
-        variants = {
-            "data": (unit, 1, 1),
-            "dims": (1, unit, 1),
-            "coords": (1, 1, unit),
-        }
+        variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
         data_unit, dim_unit, coord_unit = variants.get(variant)
 
         array = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
@@ -3745,11 +3718,7 @@ class TestDataArray:
     def test_computation_objects(self, func, variant, dtype):
         unit = unit_registry.m
 
-        variants = {
-            "data": (unit, 1, 1),
-            "dims": (1, unit, 1),
-            "coords": (1, 1, unit),
-        }
+        variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
         data_unit, dim_unit, coord_unit = variants.get(variant)
 
         array = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
@@ -3808,11 +3777,7 @@ class TestDataArray:
     def test_grouped_operations(self, func, variant, dtype):
         unit = unit_registry.m
 
-        variants = {
-            "data": (unit, 1, 1),
-            "dims": (1, unit, 1),
-            "coords": (1, 1, unit),
-        }
+        variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
         data_unit, dim_unit, coord_unit = variants.get(variant)
         array = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
 
@@ -3927,7 +3892,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units"),
+                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -3943,11 +3908,7 @@ class TestDataset:
         x = np.arange(len(array1)) * unit_registry.s
         y = x.to(unit_registry.ms)
 
-        variants = {
-            "dims": {"x": x},
-            "coords": {"y": ("x", y)},
-            "data": {},
-        }
+        variants = {"dims": {"x": x}, "coords": {"y": ("x", y)}, "data": {}}
 
         ds = xr.Dataset(
             data_vars={"a": ("x", array1), "b": ("x", array2)},
@@ -4195,7 +4156,7 @@ class TestDataset:
                 unit_registry.dimensionless, DimensionalityError, id="dimensionless"
             ),
             pytest.param(unit_registry.s, DimensionalityError, id="incompatible_unit"),
-            pytest.param(unit_registry.cm, None, id="compatible_unit",),
+            pytest.param(unit_registry.cm, None, id="compatible_unit"),
             pytest.param(unit_registry.m, None, id="identical_unit"),
         ),
     )
@@ -4340,7 +4301,7 @@ class TestDataset:
             for key, value in kwargs.items()
         }
 
-        expected = attach_units(strip_units(ds).where(**kwargs_without_units), units,)
+        expected = attach_units(strip_units(ds).where(**kwargs_without_units), units)
         actual = ds.where(**kwargs)
 
         assert_units_equal(expected, actual)
@@ -4359,7 +4320,7 @@ class TestDataset:
         ds = xr.Dataset({"a": ("x", array1), "b": ("x", array2)})
         units = extract_units(ds)
 
-        expected = attach_units(strip_units(ds).interpolate_na(dim="x"), units,)
+        expected = attach_units(strip_units(ds).interpolate_na(dim="x"), units)
         actual = ds.interpolate_na(dim="x")
 
         assert_units_equal(expected, actual)
@@ -4382,7 +4343,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units"),
+                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
             ),
         ),
     )
@@ -4401,7 +4362,7 @@ class TestDataset:
         )
         x = np.arange(len(array1)) * dims_unit
         ds = xr.Dataset(
-            data_vars={"a": ("x", array1), "b": ("x", array2)}, coords={"x": x},
+            data_vars={"a": ("x", array1), "b": ("x", array2)}, coords={"x": x}
         )
         units = extract_units(ds)
 
@@ -4478,7 +4439,7 @@ class TestDataset:
         y = coord * coord_unit
 
         ds = xr.Dataset(
-            data_vars={"a": ("x", a), "b": ("x", b)}, coords={"x": x, "y": ("x", y)},
+            data_vars={"a": ("x", a), "b": ("x", b)}, coords={"x": x, "y": ("x", y)}
         )
         units = extract_units(ds)
 
@@ -4535,7 +4496,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units"),
+                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
             ),
         ),
     )
@@ -4588,7 +4549,7 @@ class TestDataset:
         right_array2 = np.zeros(shape=(3,)) * unit
 
         left = xr.Dataset(
-            {"a": (("x", "y"), left_array1), "b": (("y", "z"), left_array2)},
+            {"a": (("x", "y"), left_array1), "b": (("y", "z"), left_array2)}
         )
         right = xr.Dataset({"a": ("x", right_array1), "b": ("y", right_array2)})
 
@@ -4626,15 +4587,12 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units"),
+                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
             ),
         ),
     )
     def test_stacking_stacked(self, variant, func, dtype):
-        variants = {
-            "data": (unit_registry.m, 1),
-            "dims": (1, unit_registry.m),
-        }
+        variants = {"data": (unit_registry.m, 1), "dims": (1, unit_registry.m)}
         data_unit, dim_unit = variants.get(variant)
 
         array1 = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
@@ -4677,7 +4635,7 @@ class TestDataset:
         func = method("to_stacked_array", "z", variable_dim="y", sample_dims=["x"])
 
         actual = func(ds).rename(None)
-        expected = attach_units(func(strip_units(ds)).rename(None), units,)
+        expected = attach_units(func(strip_units(ds)).rename(None), units)
 
         assert_units_equal(expected, actual)
         assert_equal(expected, actual)
@@ -4983,7 +4941,7 @@ class TestDataset:
             data_vars={
                 "a": (tuple(names[: len(shape)]), array1),
                 "b": (tuple(names[: len(shape)]), array2),
-            },
+            }
         )
         units = extract_units(ds)
 
@@ -5008,10 +4966,7 @@ class TestDataset:
         ids=repr,
     )
     def test_interp_reindex(self, func, variant, dtype):
-        variants = {
-            "data": (unit_registry.m, 1),
-            "coords": (1, unit_registry.m),
-        }
+        variants = {"data": (unit_registry.m, 1), "coords": (1, unit_registry.m)}
         data_unit, coord_unit = variants.get(variant)
 
         array1 = np.linspace(-1, 0, 10).astype(dtype) * data_unit
@@ -5081,10 +5036,7 @@ class TestDataset:
         ids=repr,
     )
     def test_interp_reindex_like(self, func, variant, dtype):
-        variants = {
-            "data": (unit_registry.m, 1),
-            "coords": (1, unit_registry.m),
-        }
+        variants = {"data": (unit_registry.m, 1), "coords": (1, unit_registry.m)}
         data_unit, coord_unit = variants.get(variant)
 
         array1 = np.linspace(-1, 0, 10).astype(dtype) * data_unit

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -624,7 +624,7 @@ def test_align_dataset(value, unit, variant, error, dtype):
     units_a = extract_units(ds1)
     units_b = extract_units(ds2)
     expected_a, expected_b = func(
-        strip_units(ds1), strip_units(convert_units(ds2, units_a)), **stripped_kwargs
+        strip_units(ds1), strip_units(convert_units(ds2, units_a)), **stripped_kwargs,
     )
     expected_a = attach_units(expected_a, units_a)
     if isinstance(array2, Quantity):
@@ -1223,7 +1223,11 @@ def test_merge_dataset(variant, unit, error, dtype):
 def test_replication_dataarray(func, variant, dtype):
     unit = unit_registry.m
 
-    variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
+    variants = {
+        "data": (unit, 1, 1),
+        "dims": (1, unit, 1),
+        "coords": (1, 1, unit),
+    }
     data_unit, dim_unit, coord_unit = variants.get(variant)
 
     array = np.linspace(0, 10, 20).astype(dtype) * data_unit
@@ -1304,7 +1308,11 @@ def test_replication_full_like_dataarray(variant, dtype):
     # fill value, we don't need to try multiple units
     unit = unit_registry.m
 
-    variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
+    variants = {
+        "data": (unit, 1, 1),
+        "dims": (1, unit, 1),
+        "coords": (1, 1, unit),
+    }
     data_unit, dim_unit, coord_unit = variants.get(variant)
 
     array = np.linspace(0, 5, 10) * data_unit
@@ -1362,7 +1370,10 @@ def test_replication_full_like_dataset(variant, dtype):
 
     fill_value = -1 * unit_registry.degK
 
-    units = {**extract_units(ds), **{name: unit_registry.degK for name in ds.data_vars}}
+    units = {
+        **extract_units(ds),
+        **{name: unit_registry.degK for name in ds.data_vars},
+    }
     expected = attach_units(
         xr.full_like(strip_units(ds), fill_value=strip_units(fill_value)), units
     )
@@ -1724,7 +1735,7 @@ class TestVariable:
             pytest.param(1, id="no_unit"),
             pytest.param(unit_registry.dimensionless, id="dimensionless"),
             pytest.param(unit_registry.s, id="incompatible_unit"),
-            pytest.param(unit_registry.cm, id="compatible_unit"),
+            pytest.param(unit_registry.cm, id="compatible_unit",),
             pytest.param(unit_registry.m, id="identical_unit"),
         ),
     )
@@ -2175,7 +2186,7 @@ class TestVariable:
         v = xr.Variable(["x", "y", "z"], data)
 
         expected = attach_units(
-            strip_units(v).pad(mode=mode, **xr_arg), extract_units(v)
+            strip_units(v).pad(mode=mode, **xr_arg), extract_units(v),
         )
         actual = v.pad(mode=mode, **xr_arg)
 
@@ -2413,7 +2424,7 @@ class TestDataArray:
                 id="equal",
                 marks=pytest.mark.xfail(
                     # LooseVersion(pint.__version__) < "0.14",
-                    reason="inconsistencies in the return values of pint's eq"
+                    reason="inconsistencies in the return values of pint's eq",
                 ),
             ),
         ),
@@ -2907,8 +2918,8 @@ class TestDataArray:
                 unit_registry.dimensionless, DimensionalityError, id="dimensionless"
             ),
             pytest.param(unit_registry.s, DimensionalityError, id="incompatible_unit"),
-            pytest.param(unit_registry.cm, None, id="compatible_unit"),
-            pytest.param(unit_registry.m, None, id="identical_unit"),
+            pytest.param(unit_registry.cm, None, id="compatible_unit",),
+            pytest.param(unit_registry.m, None, id="identical_unit",),
         ),
     )
     def test_combine_first(self, unit, error, dtype):
@@ -3156,7 +3167,11 @@ class TestDataArray:
     def test_content_manipulation(self, func, variant, dtype):
         unit = unit_registry.m
 
-        variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
+        variants = {
+            "data": (unit, 1, 1),
+            "dims": (1, unit, 1),
+            "coords": (1, 1, unit),
+        }
         data_unit, dim_unit, coord_unit = variants.get(variant)
 
         quantity = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
@@ -3422,7 +3437,10 @@ class TestDataArray:
         ids=repr,
     )
     def test_interp_reindex(self, variant, func, dtype):
-        variants = {"data": (unit_registry.m, 1), "coords": (1, unit_registry.m)}
+        variants = {
+            "data": (unit_registry.m, 1),
+            "coords": (1, unit_registry.m),
+        }
         data_unit, coord_unit = variants.get(variant)
 
         array = np.linspace(1, 2, 10).astype(dtype) * data_unit
@@ -3452,7 +3470,9 @@ class TestDataArray:
             pytest.param(unit_registry.m, None, id="identical_unit"),
         ),
     )
-    @pytest.mark.parametrize("func", (method("interp"), method("reindex")), ids=repr)
+    @pytest.mark.parametrize(
+        "func", (method("interp"), method("reindex")), ids=repr,
+    )
     def test_interp_reindex_indexing(self, func, unit, error, dtype):
         array = np.linspace(1, 2, 10).astype(dtype)
         x = np.arange(10) * unit_registry.m
@@ -3490,7 +3510,10 @@ class TestDataArray:
         ids=repr,
     )
     def test_interp_reindex_like(self, variant, func, dtype):
-        variants = {"data": (unit_registry.m, 1), "coords": (1, unit_registry.m)}
+        variants = {
+            "data": (unit_registry.m, 1),
+            "coords": (1, unit_registry.m),
+        }
         data_unit, coord_unit = variants.get(variant)
 
         array = np.linspace(1, 2, 10).astype(dtype) * data_unit
@@ -3522,7 +3545,7 @@ class TestDataArray:
         ),
     )
     @pytest.mark.parametrize(
-        "func", (method("interp_like"), method("reindex_like")), ids=repr
+        "func", (method("interp_like"), method("reindex_like")), ids=repr,
     )
     def test_interp_reindex_like_indexing(self, func, unit, error, dtype):
         array = np.linspace(1, 2, 10).astype(dtype)
@@ -3658,7 +3681,11 @@ class TestDataArray:
     def test_computation(self, func, variant, dtype):
         unit = unit_registry.m
 
-        variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
+        variants = {
+            "data": (unit, 1, 1),
+            "dims": (1, unit, 1),
+            "coords": (1, 1, unit),
+        }
         data_unit, dim_unit, coord_unit = variants.get(variant)
 
         array = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
@@ -3718,7 +3745,11 @@ class TestDataArray:
     def test_computation_objects(self, func, variant, dtype):
         unit = unit_registry.m
 
-        variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
+        variants = {
+            "data": (unit, 1, 1),
+            "dims": (1, unit, 1),
+            "coords": (1, 1, unit),
+        }
         data_unit, dim_unit, coord_unit = variants.get(variant)
 
         array = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
@@ -3777,7 +3808,11 @@ class TestDataArray:
     def test_grouped_operations(self, func, variant, dtype):
         unit = unit_registry.m
 
-        variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
+        variants = {
+            "data": (unit, 1, 1),
+            "dims": (1, unit, 1),
+            "coords": (1, 1, unit),
+        }
         data_unit, dim_unit, coord_unit = variants.get(variant)
         array = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
 
@@ -3892,7 +3927,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.xfail(reason="indexes don't support units"),
             ),
             "coords",
         ),
@@ -3908,7 +3943,11 @@ class TestDataset:
         x = np.arange(len(array1)) * unit_registry.s
         y = x.to(unit_registry.ms)
 
-        variants = {"dims": {"x": x}, "coords": {"y": ("x", y)}, "data": {}}
+        variants = {
+            "dims": {"x": x},
+            "coords": {"y": ("x", y)},
+            "data": {},
+        }
 
         ds = xr.Dataset(
             data_vars={"a": ("x", array1), "b": ("x", array2)},
@@ -4156,7 +4195,7 @@ class TestDataset:
                 unit_registry.dimensionless, DimensionalityError, id="dimensionless"
             ),
             pytest.param(unit_registry.s, DimensionalityError, id="incompatible_unit"),
-            pytest.param(unit_registry.cm, None, id="compatible_unit"),
+            pytest.param(unit_registry.cm, None, id="compatible_unit",),
             pytest.param(unit_registry.m, None, id="identical_unit"),
         ),
     )
@@ -4301,7 +4340,7 @@ class TestDataset:
             for key, value in kwargs.items()
         }
 
-        expected = attach_units(strip_units(ds).where(**kwargs_without_units), units)
+        expected = attach_units(strip_units(ds).where(**kwargs_without_units), units,)
         actual = ds.where(**kwargs)
 
         assert_units_equal(expected, actual)
@@ -4320,7 +4359,7 @@ class TestDataset:
         ds = xr.Dataset({"a": ("x", array1), "b": ("x", array2)})
         units = extract_units(ds)
 
-        expected = attach_units(strip_units(ds).interpolate_na(dim="x"), units)
+        expected = attach_units(strip_units(ds).interpolate_na(dim="x"), units,)
         actual = ds.interpolate_na(dim="x")
 
         assert_units_equal(expected, actual)
@@ -4343,7 +4382,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.xfail(reason="indexes don't support units"),
             ),
         ),
     )
@@ -4362,7 +4401,7 @@ class TestDataset:
         )
         x = np.arange(len(array1)) * dims_unit
         ds = xr.Dataset(
-            data_vars={"a": ("x", array1), "b": ("x", array2)}, coords={"x": x}
+            data_vars={"a": ("x", array1), "b": ("x", array2)}, coords={"x": x},
         )
         units = extract_units(ds)
 
@@ -4439,7 +4478,7 @@ class TestDataset:
         y = coord * coord_unit
 
         ds = xr.Dataset(
-            data_vars={"a": ("x", a), "b": ("x", b)}, coords={"x": x, "y": ("x", y)}
+            data_vars={"a": ("x", a), "b": ("x", b)}, coords={"x": x, "y": ("x", y)},
         )
         units = extract_units(ds)
 
@@ -4496,7 +4535,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.xfail(reason="indexes don't support units"),
             ),
         ),
     )
@@ -4549,7 +4588,7 @@ class TestDataset:
         right_array2 = np.zeros(shape=(3,)) * unit
 
         left = xr.Dataset(
-            {"a": (("x", "y"), left_array1), "b": (("y", "z"), left_array2)}
+            {"a": (("x", "y"), left_array1), "b": (("y", "z"), left_array2)},
         )
         right = xr.Dataset({"a": ("x", right_array1), "b": ("y", right_array2)})
 
@@ -4587,12 +4626,15 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.xfail(reason="indexes don't support units"),
             ),
         ),
     )
     def test_stacking_stacked(self, variant, func, dtype):
-        variants = {"data": (unit_registry.m, 1), "dims": (1, unit_registry.m)}
+        variants = {
+            "data": (unit_registry.m, 1),
+            "dims": (1, unit_registry.m),
+        }
         data_unit, dim_unit = variants.get(variant)
 
         array1 = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
@@ -4635,7 +4677,7 @@ class TestDataset:
         func = method("to_stacked_array", "z", variable_dim="y", sample_dims=["x"])
 
         actual = func(ds).rename(None)
-        expected = attach_units(func(strip_units(ds)).rename(None), units)
+        expected = attach_units(func(strip_units(ds)).rename(None), units,)
 
         assert_units_equal(expected, actual)
         assert_equal(expected, actual)
@@ -4941,7 +4983,7 @@ class TestDataset:
             data_vars={
                 "a": (tuple(names[: len(shape)]), array1),
                 "b": (tuple(names[: len(shape)]), array2),
-            }
+            },
         )
         units = extract_units(ds)
 
@@ -4966,7 +5008,10 @@ class TestDataset:
         ids=repr,
     )
     def test_interp_reindex(self, func, variant, dtype):
-        variants = {"data": (unit_registry.m, 1), "coords": (1, unit_registry.m)}
+        variants = {
+            "data": (unit_registry.m, 1),
+            "coords": (1, unit_registry.m),
+        }
         data_unit, coord_unit = variants.get(variant)
 
         array1 = np.linspace(-1, 0, 10).astype(dtype) * data_unit
@@ -5036,7 +5081,10 @@ class TestDataset:
         ids=repr,
     )
     def test_interp_reindex_like(self, func, variant, dtype):
-        variants = {"data": (unit_registry.m, 1), "coords": (1, unit_registry.m)}
+        variants = {
+            "data": (unit_registry.m, 1),
+            "coords": (1, unit_registry.m),
+        }
         data_unit, coord_unit = variants.get(variant)
 
         array1 = np.linspace(-1, 0, 10).astype(dtype) * data_unit


### PR DESCRIPTION
 - [x] Closes #4196
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`

I noticed that the implementation of nd-rolling is straightforward.
The core part is implemented but I am wondering what the best API is, with keeping it backward-compatible.

Obviously, it is basically should look like
```python
da.rolling(x=3, y=3).mean()
```

A problem is other parameters, `centers` and `min_periods`.
In principle, they can depend on dimension. 
For example, we can have `center=True` only for `x` but not for `y`.

So, maybe we allow dictionary for them?
```python
da.rolling(x=3, y=3, center={'x': True, 'y': False}, min_periods={'x': 1, 'y': None}).mean()
```

The same thing happens for `.construct` method.
```python
da.rolling(x=3, y=3).construct(x='x_window', y='y_window', stride={'x': 2, 'y': 1})
```
I'm afraid if this dictionary argument was a bit too redundant.

Does anyone have another idea?
