### PR TITLE
pin pytest

### DIFF
--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -33,7 +33,7 @@ dependencies:
   - pseudonetcdf
   - pydap
   - pynio
-  - pytest
+  - pytest!=6.0.0rc1
   - pytest-cov
   - pytest-env
   - rasterio


### PR DESCRIPTION
This pins `pytest` to a version that is not `6.0.0rc1`. We just have to remember to remove the pin once a new version (a new release candidate or `6.0.0`) was released.

 - [x] Closes #4225

