### PR TITLE
Support cupy in as_shared_dtype

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -138,6 +138,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-cftime.*]
 ignore_missing_imports = True
+[mypy-cupy.*]
+ignore_missing_imports = True
 [mypy-dask.*]
 ignore_missing_imports = True
 [mypy-distributed.*]

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -14,7 +14,7 @@ import pandas as pd
 
 from . import dask_array_compat, dask_array_ops, dtypes, npcompat, nputils
 from .nputils import nanfirst, nanlast
-from .pycompat import dask_array_type, cupy_array_type
+from .pycompat import cupy_array_type, dask_array_type
 
 try:
     import dask.array as dask_array

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -17,3 +17,11 @@ try:
     sparse_array_type = (sparse.SparseArray,)
 except ImportError:  # pragma: no cover
     sparse_array_type = ()
+
+try:
+    # solely for isinstance checks
+    import cupy
+
+    cupy_array_type = (cupy.core.core.ndarray,)
+except ImportError:  # pragma: no cover
+    cupy_array_type = ()

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -33,7 +33,7 @@ from .indexing import (
 )
 from .npcompat import IS_NEP18_ACTIVE
 from .options import _get_keep_attrs
-from .pycompat import dask_array_type, integer_types
+from .pycompat import cupy_array_type, dask_array_type, integer_types
 from .utils import (
     OrderedSet,
     _default,
@@ -45,9 +45,8 @@ from .utils import (
 )
 
 NON_NUMPY_SUPPORTED_ARRAY_TYPES = (
-    indexing.ExplicitlyIndexed,
-    pd.Index,
-) + dask_array_type
+    (indexing.ExplicitlyIndexed, pd.Index,) + dask_array_type + cupy_array_type
+)
 # https://github.com/python/mypy/issues/224
 BASIC_INDEXING_TYPES = integer_types + (slice,)  # type: ignore
 
@@ -257,7 +256,10 @@ def _as_array_or_item(data):
 
     TODO: remove this (replace with np.asarray) once these issues are fixed
     """
-    data = np.asarray(data)
+    if isinstance(data, cupy_array_type):
+        data = data.get()
+    else:
+        data = np.asarray(data)
     if data.ndim == 0:
         if data.dtype.kind == "M":
             data = np.datetime64(data, "ns")

--- a/xarray/tests/test_cupy.py
+++ b/xarray/tests/test_cupy.py
@@ -55,4 +55,6 @@ def test_where():
 
     data = cp.zeros(10)
 
-    assert where(data < 1, 1, data).all()
+    output = where(data < 1, 1, data).all()
+    assert output
+    assert isinstance(output, cp.ndarray)

--- a/xarray/tests/test_cupy.py
+++ b/xarray/tests/test_cupy.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import xarray as xr
+
+cp = pytest.importorskip("cupy")
+
+
+@pytest.fixture
+def toy_weather_data():
+    """Construct the example DataSet from the Toy weather data example.
+
+    http://xarray.pydata.org/en/stable/examples/weather-data.html
+
+    Here we construct the DataSet exactly as shown in the example and then
+    convert the numpy arrays to cupy.
+
+    """
+    np.random.seed(123)
+    times = pd.date_range("2000-01-01", "2001-12-31", name="time")
+    annual_cycle = np.sin(2 * np.pi * (times.dayofyear.values / 365.25 - 0.28))
+
+    base = 10 + 15 * annual_cycle.reshape(-1, 1)
+    tmin_values = base + 3 * np.random.randn(annual_cycle.size, 3)
+    tmax_values = base + 10 + 3 * np.random.randn(annual_cycle.size, 3)
+
+    ds = xr.Dataset(
+        {
+            "tmin": (("time", "location"), tmin_values),
+            "tmax": (("time", "location"), tmax_values),
+        },
+        {"time": times, "location": ["IA", "IN", "IL"]},
+    )
+
+    ds.tmax.data = cp.asarray(ds.tmax.data)
+    ds.tmin.data = cp.asarray(ds.tmin.data)
+
+    return ds
+
+
+def test_cupy_import():
+    """Check the import worked."""
+    assert cp
+
+
+def test_check_data_stays_on_gpu(toy_weather_data):
+    """Perform some operations and check the data stays on the GPU."""
+    freeze = (toy_weather_data["tmin"] <= 0).groupby("time.month").mean("time")
+    assert isinstance(freeze.data, cp.core.core.ndarray)

--- a/xarray/tests/test_cupy.py
+++ b/xarray/tests/test_cupy.py
@@ -48,3 +48,11 @@ def test_check_data_stays_on_gpu(toy_weather_data):
     """Perform some operations and check the data stays on the GPU."""
     freeze = (toy_weather_data["tmin"] <= 0).groupby("time.month").mean("time")
     assert isinstance(freeze.data, cp.core.core.ndarray)
+
+
+def test_where():
+    from xarray.core.duck_array_ops import where
+
+    data = cp.zeros(10)
+
+    assert where(data < 1, 1, data).all()


### PR DESCRIPTION
This implements solution 2 for #4231.

cc @quasiben

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4231
 - [x] Tests added
 - [x] Passes `isort -rc . && black . && mypy . && flake8`
