### PR TITLE
fix matplotlib errors for single level discrete colormaps

### DIFF
--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -60,9 +60,7 @@ def _build_discrete_cmap(cmap, levels, extend, filled):
     """
     import matplotlib as mpl
 
-    if isinstance(levels, (int, float)):
-        levels = [levels, levels]
-    elif len(levels) == 1:
+    if len(levels) == 1:
         levels = [levels[0], levels[0]]
 
     if not filled:

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -60,6 +60,11 @@ def _build_discrete_cmap(cmap, levels, extend, filled):
     """
     import matplotlib as mpl
 
+    if isinstance(levels, (int, float)):
+        levels = [levels, levels]
+    elif len(levels) == 1:
+        levels = [levels[0], levels[0]]
+
     if not filled:
         # non-filled contour plots
         extend = "max"


### PR DESCRIPTION
~I'm not quite sure what happened, but our upstream-dev CI doesn't fail anymore. Looking at the build log, the install of the dev version of `matplotlib` seems to fail, so this tries to additionally remove the `matplotlib-base` package to see if the error comes up again if we make sure we get the dev version of `matplotlib`.~

`matplotlib` released a preview version to PyPI so we can run our tests again. This follows the suggestion from https://github.com/pydata/xarray/issues/4226#issuecomment-663030222: convert single levels to degenerate levels.

 - [x] Closes #4226, towards #4947
 - [x] Passes `pre-commit run --all-files`
