### PR TITLE
Removed skipna argument from count, any, all [GH755]

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,7 +33,8 @@ Bug fixes
 
 Documentation
 ~~~~~~~~~~~~~
-
+- removed skipna argument from :py:meth:`DataArray.count`, any, all. (:issue:`755`)
+  By `Sander van Rijn <https://github.com/sjvrijn>`_
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -90,12 +90,7 @@ Reduce this {cls}'s data by applying `{name}` along some dimension(s).
 
 Parameters
 ----------
-{extra_args}
-skipna : bool, optional
-    If True, skip missing values (as marked by NaN). By default, only
-    skips missing values for float dtypes; other dtypes either do not
-    have a sentinel missing value (int) or skipna=True has not been
-    implemented (object, datetime64 or timedelta64).{min_count_docs}
+{extra_args}{skip_na_docs}{min_count_docs}
 keep_attrs : bool, optional
     If True, the attributes (`attrs`) will be copied from the original
     object to the new one.  If False (default), the new object will be
@@ -110,6 +105,13 @@ reduced : {cls}
     New {cls} object with `{name}` applied to its data and the
     indicated dimension(s) removed.
 """
+
+_SKIPNA_DOCSTRING = """
+skipna : bool, optional
+    If True, skip missing values (as marked by NaN). By default, only
+    skips missing values for float dtypes; other dtypes either do not
+    have a sentinel missing value (int) or skipna=True has not been
+    implemented (object, datetime64 or timedelta64)."""
 
 _MINCOUNT_DOCSTRING = """
 min_count : int, default None
@@ -260,6 +262,7 @@ def inject_reduce_methods(cls):
     for name, f, include_skipna in methods:
         numeric_only = getattr(f, "numeric_only", False)
         available_min_count = getattr(f, "available_min_count", False)
+        skip_na_docs = _SKIPNA_DOCSTRING if include_skipna else ""
         min_count_docs = _MINCOUNT_DOCSTRING if available_min_count else ""
 
         func = cls._reduce_method(f, include_skipna, numeric_only)
@@ -268,6 +271,7 @@ def inject_reduce_methods(cls):
             name=name,
             cls=cls.__name__,
             extra_args=cls._reduce_extra_args_docstring.format(name=name),
+            skip_na_docs=skip_na_docs,
             min_count_docs=min_count_docs,
         )
         setattr(cls, name, func)


### PR DESCRIPTION
 - [x] Closes #755
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Could not confirm in the web-based documentation (see #4257), but manually confirmed to work:
```python
>>> import xarray as xr
>>> help(xr.DataArray.count)
Help on function count in module xarray.core.common:

count(self, dim=None, axis=None, **kwargs)
    Reduce this DataArray's data by applying `count` along some dimension(s).

    Parameters
    ----------
    dim : str or sequence of str, optional
        Dimension(s) over which to apply `count`.
    axis : int or sequence of int, optional
        Axis(es) over which to apply `count`. Only one of the 'dim'
        and 'axis' arguments can be supplied. If neither are supplied, then
        `count` is calculated over axes.
    keep_attrs : bool, optional
        If True, the attributes (`attrs`) will be copied from the original
        object to the new one.  If False (default), the new object will be
        returned without attributes.
    **kwargs : dict
        Additional keyword arguments passed on to the appropriate array
        function for calculating `count` on this object's data.

    Returns
    -------
    reduced : DataArray
        New DataArray object with `count` applied to its data and the
        indicated dimension(s) removed.
```