### PR TITLE
update howto release guide numbers

### DIFF
--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -1,4 +1,4 @@
-# How to issue an xarray release in 17 easy steps
+# How to issue an xarray release in 20 easy steps
 
 Time required: about an hour.
 
@@ -23,9 +23,9 @@ upstream        https://github.com/pydata/xarray (push)
     git log v{0.X.Y-1}.. --format=%aN | sort -u | perl -pe 's/\n/$1, /'
     ```
     Add these into `whats-new.rst` somewhere :)
- 2. Write a release summary: ~50 words describing the high level features. This
+ 3. Write a release summary: ~50 words describing the high level features. This
     will be used in the release emails, tweets, GitHub release notes, etc. 
- 3. Look over whats-new.rst and the docs. Make sure "What's New" is complete
+ 4. Look over whats-new.rst and the docs. Make sure "What's New" is complete
     (check the date!) and add the release summary at the top.
     Things to watch out for:
     - Important new features should be highlighted towards the top.
@@ -34,46 +34,46 @@ upstream        https://github.com/pydata/xarray (push)
       due to a bad merge. Check for these before a release by using git diff,
       e.g., `git diff v{0.X.Y-1} whats-new.rst` where {0.X.Y-1} is the previous
       release.
- 4. If possible, open a PR with the release summary and whatsnew changes.
- 4. After merging, again ensure your master branch is synced to upstream:
+ 5. If possible, open a PR with the release summary and whatsnew changes.
+ 6. After merging, again ensure your master branch is synced to upstream:
      ```sh
      git pull upstream master
      ```
- 4. If you have any doubts, run the full test suite one final time!
+ 7. If you have any doubts, run the full test suite one final time!
       ```sh
       pytest
       ```
- 5. Check that the ReadTheDocs build is passing.
- 6. On the master branch, commit the release in git:
+ 8. Check that the ReadTheDocs build is passing.
+ 9. On the master branch, commit the release in git:
       ```s
       git commit -am 'Release v{0.X.Y}'
       ```
- 7. Tag the release:
+10. Tag the release:
       ```sh
       git tag -a v{0.X.Y} -m 'v{0.X.Y}'
       ```
- 8. Build source and binary wheels for PyPI:
+11. Build source and binary wheels for PyPI:
       ```sh
       git clean -xdf  # this deletes all uncommitted changes!
       python setup.py bdist_wheel sdist
       ```
- 9. Use twine to check the package build:
+12. Use twine to check the package build:
       ```sh
       twine check dist/xarray-{0.X.Y}*
       ```
-10. Use twine to register and upload the release on PyPI. Be careful, you can't
+13. Use twine to register and upload the release on PyPI. Be careful, you can't
     take this back!
       ```sh
       twine upload dist/xarray-{0.X.Y}*
       ```
     You will need to be listed as a package owner at
     https://pypi.python.org/pypi/xarray for this to work.
-11. Push your changes to master:
+14. Push your changes to master:
       ```sh
       git push upstream master
       git push upstream --tags
       ```
-12. Update the stable branch (used by ReadTheDocs) and switch back to master:
+15. Update the stable branch (used by ReadTheDocs) and switch back to master:
      ```sh
       git checkout stable
       git rebase master
@@ -83,7 +83,7 @@ upstream        https://github.com/pydata/xarray (push)
     It's OK to force push to 'stable' if necessary. (We also update the stable 
     branch with `git cherry-pick` for documentation only fixes that apply the 
     current released version.)
-13. Add a section for the next release {0.X.Y+1} to doc/whats-new.rst:
+16. Add a section for the next release {0.X.Y+1} to doc/whats-new.rst:
      ```
      .. _whats-new.{0.X.Y+1}:
 
@@ -109,19 +109,19 @@ upstream        https://github.com/pydata/xarray (push)
      Internal Changes
      ~~~~~~~~~~~~~~~~
      ```
-14. Commit your changes and push to master again:
+17. Commit your changes and push to master again:
       ```sh
       git commit -am 'New whatsnew section'
       git push upstream master
       ```
     You're done pushing to master!
-15. Issue the release on GitHub. Click on "Draft a new release" at
+18. Issue the release on GitHub. Click on "Draft a new release" at
     https://github.com/pydata/xarray/releases. Type in the version number
     and paste the release summary in the notes.
-16. Update the docs. Login to https://readthedocs.org/projects/xray/versions/
+19. Update the docs. Login to https://readthedocs.org/projects/xray/versions/
     and switch your new release tag (at the bottom) from "Inactive" to "Active".
     It should now build automatically.
-17. Issue the release announcement to mailing lists & Twitter. For bug fix releases, I 
+20. Issue the release announcement to mailing lists & Twitter. For bug fix releases, I 
     usually only email xarray@googlegroups.com. For major/feature releases, I will email a broader
     list (no more than once every 3-6 months):
       - pydata@googlegroups.com


### PR DESCRIPTION
#4217 didn't update the task item numbers, this fixes that. I'm also hoping to reuse this PR to document the push-to-`master` rules from #4218, but where would I put those?

 - [x] Closes #4218