### PR TITLE
warn about the removal of the ufuncs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -572,7 +572,9 @@ Universal functions
    With recent versions of numpy, dask and xarray, NumPy ufuncs are now
    supported directly on all xarray and dask objects. This obviates the need
    for the ``xarray.ufuncs`` module, which should not be used for new code
-   unless compatibility with versions of NumPy prior to v1.13 is required.
+   unless compatibility with versions of NumPy prior to v1.13 is
+   required. They will be removed once support for NumPy prior to
+   v1.17 is dropped.
 
 These functions are copied from NumPy, but extended to work on NumPy arrays,
 dask arrays and all xarray objects. You can find them in the ``xarray.ufuncs``


### PR DESCRIPTION
As noted in #4116, using the functions in `xarray.ufuncs` will emit a warning stating that we'd remove those functions after support for `numpy < 1.17` was dropped. This also adds that to the API docs.