### PR TITLE
enable fail_on_warning for the docs CI

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -7,6 +7,6 @@ conda:
     environment: ci/requirements/doc.yml
 
 sphinx:
-  fail_on_warning: false
+  fail_on_warning: true
 
 formats: []


### PR DESCRIPTION
RTD's sphinx extension released a new version since #4199, so let's try enabling the `fail_on_warning` setting again.

 - [x] Passes `isort . && black . && mypy . && flake8`
