### PR TITLE
remove the compatibility code in duck_array_ops.allclose_or_equiv

### DIFF
--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -6,7 +6,6 @@ accept or return xarray objects.
 import contextlib
 import inspect
 import warnings
-from distutils.version import LooseVersion
 from functools import partial
 
 import numpy as np
@@ -20,14 +19,6 @@ try:
     import dask.array as dask_array
 except ImportError:
     dask_array = None  # type: ignore
-
-# TODO: remove after we stop supporting dask < 2.9.1
-try:
-    import dask
-
-    dask_version = dask.__version__
-except ImportError:
-    dask_version = None
 
 
 def _dask_or_eager_func(
@@ -217,16 +208,6 @@ def allclose_or_equiv(arr1, arr2, rtol=1e-5, atol=1e-8):
 
     lazy_equiv = lazy_array_equiv(arr1, arr2)
     if lazy_equiv is None:
-        # TODO: remove after we require dask >= 2.9.1
-        sufficient_dask_version = (
-            dask_version is not None and LooseVersion(dask_version) >= "2.9.1"
-        )
-        if not sufficient_dask_version and any(
-            isinstance(arr, dask_array_type) for arr in [arr1, arr2]
-        ):
-            arr1 = np.array(arr1)
-            arr2 = np.array(arr2)
-
         return bool(isclose(arr1, arr2, rtol=rtol, atol=atol, equal_nan=True).all())
     else:
         return lazy_equiv


### PR DESCRIPTION
#3847 added compatibility code for `dask < 2.9.1`. Since we bumped to `2.9` this code can be safely removed. If we can't require `dask >= 2.9.1` yet, we can wait with the merge of this PR until we can bump `dask` again.

 - [x] Passes `isort . && black . && mypy . && flake8`

