### PR TITLE
xfail failing upstream plotting tests

### DIFF
--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2251,7 +2251,7 @@ class TestDatetimePlot(PlotTestCase):
         self.darray.plot.line()
 
 
-@pytest.xfail("Failing on upstream tests asof 2020-07-25")
+@pytest.mark.xfail(reason="Failing on upstream tests asof 2020-07-25")
 @requires_nc_time_axis
 @requires_cftime
 class TestCFDatetimePlot(PlotTestCase):

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2251,7 +2251,7 @@ class TestDatetimePlot(PlotTestCase):
         self.darray.plot.line()
 
 
-@pytest.mark.xfail("Failing on upstream tests asof 2020-07-25")
+@pytest.xfail("Failing on upstream tests asof 2020-07-25")
 @requires_nc_time_axis
 @requires_cftime
 class TestCFDatetimePlot(PlotTestCase):

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2251,6 +2251,7 @@ class TestDatetimePlot(PlotTestCase):
         self.darray.plot.line()
 
 
+@pytest.mark.xfail("Failing on upstream tests asof 2020-07-25")
 @requires_nc_time_axis
 @requires_cftime
 class TestCFDatetimePlot(PlotTestCase):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `isort . && black . && mypy . && flake8`

Master ~has been failing for a while now~ recently started failing — while xfailing these isn't ideal, I think it's probably better than the having master continue to fail — any thoughts?

If there's some middle ground — like the "allowed failures" we had in Travis a few years ago, that could be ideal.