### PR TITLE
Un-xfail cftime plotting tests

### DIFF
--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2251,7 +2251,7 @@ class TestDatetimePlot(PlotTestCase):
         self.darray.plot.line()
 
 
-@pytest.mark.xfail(reason="Failing on upstream tests asof 2020-07-25")
+@pytest.mark.filterwarnings("ignore:setting an array element with a sequence")
 @requires_nc_time_axis
 @requires_cftime
 class TestCFDatetimePlot(PlotTestCase):


### PR DESCRIPTION
Closes #4265 

The change that broke these tests in NumPy master has now been relaxed to trigger a DeprecationWarning (https://github.com/numpy/numpy/pull/16943).