### PR TITLE
Increase support window of all dependencies

### DIFF
--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -23,8 +23,8 @@ IGNORE_DEPS = {
     "pytest-env",
 }
 
-POLICY_MONTHS = {"python": 42, "numpy": 24, "pandas": 12, "scipy": 12}
-POLICY_MONTHS_DEFAULT = 6
+POLICY_MONTHS = {"python": 42, "numpy": 24, "setuptools": 42}
+POLICY_MONTHS_DEFAULT = 12
 
 has_errors = False
 

--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -25,7 +25,11 @@ IGNORE_DEPS = {
 
 POLICY_MONTHS = {"python": 42, "numpy": 24, "setuptools": 42}
 POLICY_MONTHS_DEFAULT = 12
-
+# setuptools-scm doesn't work with setuptools < 36.7 (Nov 2017).
+# The conda metadata is malformed for setuptools < 38.4 (Jan 2018)
+# (it's missing a timestamp which prevents this tool from working).
+# TODO remove this special case and the matching note in installing.rst after July 2021.
+POLICY_OVERRIDE = {"setuptools": (38, 4)}
 has_errors = False
 
 
@@ -150,6 +154,11 @@ def process_pkg(
         policy_major = major
         policy_minor = minor
         policy_published_actual = published
+
+    try:
+        policy_major, policy_minor = POLICY_OVERRIDE[pkg]
+    except KeyError:
+        pass
 
     if (req_major, req_minor) < (policy_major, policy_minor):
         status = "<"

--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -25,11 +25,19 @@ IGNORE_DEPS = {
 
 POLICY_MONTHS = {"python": 42, "numpy": 24, "setuptools": 42}
 POLICY_MONTHS_DEFAULT = 12
-# setuptools-scm doesn't work with setuptools < 36.7 (Nov 2017).
-# The conda metadata is malformed for setuptools < 38.4 (Jan 2018)
-# (it's missing a timestamp which prevents this tool from working).
-# TODO remove this special case and the matching note in installing.rst after July 2021.
-POLICY_OVERRIDE = {"setuptools": (38, 4)}
+POLICY_OVERRIDE = {
+    # dask < 2.9 has trouble with nan-reductions
+    # TODO remove this special case and the matching note in installing.rst
+    #      after January 2021.
+    "dask": (2, 9),
+    "distributed": (2, 9),
+    # setuptools-scm doesn't work with setuptools < 36.7 (Nov 2017).
+    # The conda metadata is malformed for setuptools < 38.4 (Jan 2018)
+    # (it's missing a timestamp which prevents this tool from working).
+    # TODO remove this special case and the matching note in installing.rst
+    #      after July 2021.
+    "setuptools": (38, 4)
+}
 has_errors = False
 
 

--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -36,7 +36,7 @@ POLICY_OVERRIDE = {
     # (it's missing a timestamp which prevents this tool from working).
     # TODO remove this special case and the matching note in installing.rst
     #      after July 2021.
-    "setuptools": (38, 4)
+    "setuptools": (38, 4),
 }
 has_errors = False
 

--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -17,7 +17,9 @@ dependencies:
   - netcdf4>=1.5
   - numba
   - numpy>=1.17
-  - pandas>=1.0
+  # FIXME https://github.com/pydata/xarray/issues/4287
+  # - pandas>=1.0
+  - pandas=1.0
   - rasterio>=1.1
   - seaborn
   - setuptools

--- a/ci/requirements/py36-bare-minimum.yml
+++ b/ci/requirements/py36-bare-minimum.yml
@@ -10,4 +10,4 @@ dependencies:
   - pytest-env
   - numpy=1.15
   - pandas=0.25
-  - setuptools=36.5
+  - setuptools=38.4

--- a/ci/requirements/py36-bare-minimum.yml
+++ b/ci/requirements/py36-bare-minimum.yml
@@ -10,4 +10,4 @@ dependencies:
   - pytest-env
   - numpy=1.15
   - pandas=0.25
-  - setuptools=41.2
+  - setuptools=36.5

--- a/ci/requirements/py36-min-all-deps.yml
+++ b/ci/requirements/py36-min-all-deps.yml
@@ -15,8 +15,8 @@ dependencies:
   - cfgrib=0.9
   - cftime=1.0
   - coveralls
-  - dask=2.3
-  - distributed=2.3
+  - dask=2.9
+  - distributed=2.9
   - flake8
   - h5netcdf=0.7
   - h5py=2.9  # Policy allows for 2.10, but it's a conflict-fest

--- a/ci/requirements/py36-min-all-deps.yml
+++ b/ci/requirements/py36-min-all-deps.yml
@@ -15,8 +15,8 @@ dependencies:
   - cfgrib=0.9
   - cftime=1.0
   - coveralls
-  - dask=2.9
-  - distributed=2.9
+  - dask=2.3
+  - distributed=2.3
   - flake8
   - h5netcdf=0.7
   - h5py=2.9  # Policy allows for 2.10, but it's a conflict-fest
@@ -43,7 +43,7 @@ dependencies:
   - rasterio=1.0
   - scipy=1.3
   - seaborn=0.9
-  - setuptools=41.2
+  - setuptools=36.5
   # - sparse  # See py36-min-nep18.yml
   - toolz=0.10
   - zarr=2.3

--- a/ci/requirements/py36-min-all-deps.yml
+++ b/ci/requirements/py36-min-all-deps.yml
@@ -43,7 +43,7 @@ dependencies:
   - rasterio=1.0
   - scipy=1.3
   - seaborn=0.9
-  - setuptools=36.5
+  - setuptools=38.4
   # - sparse  # See py36-min-nep18.yml
   - toolz=0.10
   - zarr=2.3

--- a/ci/requirements/py36-min-nep18.yml
+++ b/ci/requirements/py36-min-nep18.yml
@@ -6,8 +6,8 @@ dependencies:
   # require drastically newer packages than everything else
   - python=3.6
   - coveralls
-  - dask=2.9
-  - distributed=2.9
+  - dask=2.3
+  - distributed=2.3
   - numpy=1.17
   - pandas=0.25
   - pint=0.13
@@ -15,6 +15,6 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-env
-  - scipy=1.2
-  - setuptools=41.2
+  - scipy=1.3
+  - setuptools=36.5
   - sparse=0.8

--- a/ci/requirements/py36-min-nep18.yml
+++ b/ci/requirements/py36-min-nep18.yml
@@ -6,8 +6,8 @@ dependencies:
   # require drastically newer packages than everything else
   - python=3.6
   - coveralls
-  - dask=2.3
-  - distributed=2.3
+  - dask=2.9
+  - distributed=2.9
   - numpy=1.17
   - pandas=0.25
   - pint=0.13

--- a/ci/requirements/py36-min-nep18.yml
+++ b/ci/requirements/py36-min-nep18.yml
@@ -16,5 +16,5 @@ dependencies:
   - pytest-cov
   - pytest-env
   - scipy=1.3
-  - setuptools=36.5
+  - setuptools=38.4
   - sparse=0.8

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -7,7 +7,7 @@ Required dependencies
 ---------------------
 
 - Python (3.6 or later)
-- setuptools (36.5 or later)
+- setuptools (38.4 or later)
 - `numpy <http://www.numpy.org/>`__ (1.15 or later)
 - `pandas <http://pandas.pydata.org/>`__ (0.25 or later)
 
@@ -93,7 +93,7 @@ dependencies:
 
 - **Python:** 42 months
   (`NEP-29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_)
-- **setuptools:** 42 months
+- **setuptools:** 42 months (but no older than 38.4)
 - **numpy:** 24 months
   (`NEP-29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_)
 - **sparse, pint** and other libraries that rely on

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -7,7 +7,7 @@ Required dependencies
 ---------------------
 
 - Python (3.6 or later)
-- setuptools
+- setuptools (36.5 or later)
 - `numpy <http://www.numpy.org/>`__ (1.15 or later)
 - `pandas <http://pandas.pydata.org/>`__ (0.25 or later)
 
@@ -93,16 +93,15 @@ dependencies:
 
 - **Python:** 42 months
   (`NEP-29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_)
+- setuptools: 42 months
 - **numpy:** 24 months
   (`NEP-29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_)
-- **pandas:** 12 months
-- **scipy:** 12 months
 - **sparse, pint** and other libraries that rely on
   `NEP-18 <https://numpy.org/neps/nep-0018-array-function-protocol.html>`_
   for integration: very latest available versions only, until the technology will have
   matured. This extends to dask when used in conjunction with any of these libraries.
   numpy >=1.17.
-- **all other libraries:** 6 months
+- **all other libraries:** 12 months
 
 The above should be interpreted as *the minor version (X.Y) initially published no more
 than N months ago*. Patch versions (x.y.Z) are not pinned, and only the latest available

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -96,6 +96,7 @@ dependencies:
 - **setuptools:** 42 months (but no older than 38.4)
 - **numpy:** 24 months
   (`NEP-29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_)
+- **dask and dask.distributed:** 12 months (but no older than 2.9)
 - **sparse, pint** and other libraries that rely on
   `NEP-18 <https://numpy.org/neps/nep-0018-array-function-protocol.html>`_
   for integration: very latest available versions only, until the technology will have

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -93,7 +93,7 @@ dependencies:
 
 - **Python:** 42 months
   (`NEP-29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_)
-- setuptools: 42 months
+- **setuptools:** 42 months
 - **numpy:** 24 months
   (`NEP-29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_)
 - **sparse, pint** and other libraries that rely on

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -29,9 +29,9 @@ New Features
   property for :py:class:`CFTimeIndex` and show ``calendar`` and ``length`` in
   :py:meth:`CFTimeIndex.__repr__` (:issue:`2416`, :pull:`4092`)
   `Aaron Spring <https://github.com/aaronspring>`_.
-- Relaxed the :ref:`mindeps_policy` to support all versions of setuptools
-  released in the last 42 months and all versions of other packages released
-  in the last 12 months, both up from 6 months (:issue:`4295`)
+- Relaxed the :ref:`mindeps_policy` to support all versions of setuptools released in
+  the last 42 months (but no older than 38.4) and all versions of other packages
+  released in the last 12 months, both up from 6 months (:issue:`4295`)
   `Guido Imperiale <https://github.com/crusaderky>`_.
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -29,9 +29,14 @@ New Features
   property for :py:class:`CFTimeIndex` and show ``calendar`` and ``length`` in
   :py:meth:`CFTimeIndex.__repr__` (:issue:`2416`, :pull:`4092`)
   `Aaron Spring <https://github.com/aaronspring>`_.
-- Relaxed the :ref:`mindeps_policy` to support all versions of setuptools released in
-  the last 42 months (but no older than 38.4) and all versions of other packages
-  released in the last 12 months, both up from 6 months (:issue:`4295`)
+- Relaxed the :ref:`mindeps_policy` to support:
+
+  - all versions of setuptools released in the last 42 months (but no older than 38.4)
+  - all versions of dask and dask.distributed released in the last 12 months (but no
+    older than 2.9)
+  - all versions of other packages released in the last 12 months
+
+  All are  up from 6 months (:issue:`4295`)
   `Guido Imperiale <https://github.com/crusaderky>`_.
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -29,6 +29,10 @@ New Features
   property for :py:class:`CFTimeIndex` and show ``calendar`` and ``length`` in
   :py:meth:`CFTimeIndex.__repr__` (:issue:`2416`, :pull:`4092`)
   `Aaron Spring <https://github.com/aaronspring>`_.
+- Relaxed the :ref:`mindeps_policy` to support all versions of setuptools
+  released in the last 42 months and all versions of other packages released
+  in the last 12 months, both up from 6 months (:issue:`4295`)
+  `Guido Imperiale <https://github.com/crusaderky>`_.
 
 
 Bug fixes

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 
 numpy >= 1.15
 pandas >= 0.25
-setuptools >= 41.2
+setuptools >= 36.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 
 numpy >= 1.15
 pandas >= 0.25
-setuptools >= 36.5
+setuptools >= 38.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,9 +76,9 @@ python_requires = >=3.6
 install_requires =
     numpy >= 1.15
     pandas >= 0.25
-    setuptools >= 36.5  # For pkg_resources
+    setuptools >= 38.4  # For pkg_resources
 setup_requires =
-    setuptools >= 36.5
+    setuptools >= 38.4
     setuptools_scm
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,9 +76,9 @@ python_requires = >=3.6
 install_requires =
     numpy >= 1.15
     pandas >= 0.25
-    setuptools >= 41.2  # For pkg_resources
+    setuptools >= 36.5  # For pkg_resources
 setup_requires =
-    setuptools >= 41.2
+    setuptools >= 36.5
     setuptools_scm
 
 [options.package_data]

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -33,6 +33,7 @@ from . import (
     arm_xfail,
     assert_array_equal,
     has_dask,
+    has_scipy,
     raises_regex,
     requires_cftime,
     requires_dask,
@@ -767,8 +768,8 @@ def test_timedelta_to_numeric(td):
 @pytest.mark.parametrize("use_dask", [True, False])
 @pytest.mark.parametrize("skipna", [True, False])
 def test_least_squares(use_dask, skipna):
-    if use_dask and not has_dask:
-        pytest.skip("requires dask")
+    if use_dask and (not has_dask or not has_scipy):
+        pytest.skip("requires dask and scipy")
     lhs = np.array([[1, 2], [1, 2], [3, 2]])
     rhs = DataArray(np.array([3, 5, 7]), dims=("y",))
 


### PR DESCRIPTION
Closes #4295

Increase width of the sliding window for minimum supported version:
- setuptools from 6 months sliding window to hardcoded >= 38.4, and to 42 months sliding window starting from July 2021
- dask and distributed from 6 months sliding window to hardcoded >= 2.9, and to 12 months sliding window starting from January 2021
- all other libraries from 6 months to 12 months sliding window