### PR TITLE
Lazily load resource files

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -45,6 +45,8 @@ Documentation
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
+- Only load resource files when running inside a Jupyter Notebook
+  (:issue:`4294`) By `Guido Imperiale <https://github.com/crusaderky>`_
 
 
 .. _whats-new.0.16.0:

--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -1,18 +1,24 @@
 import uuid
 from collections import OrderedDict
-from functools import partial
+from functools import lru_cache, partial
 from html import escape
 
 import pkg_resources
 
 from .formatting import inline_variable_array_repr, short_data_repr
 
-CSS_FILE_PATH = "/".join(("static", "css", "style.css"))
-CSS_STYLE = pkg_resources.resource_string("xarray", CSS_FILE_PATH).decode("utf8")
+
+STATIC_FILES = ("static/html/icons-svg-inline.html", "static/css/style.css")
 
 
-ICONS_SVG_PATH = "/".join(("static", "html", "icons-svg-inline.html"))
-ICONS_SVG = pkg_resources.resource_string("xarray", ICONS_SVG_PATH).decode("utf8")
+@lru_cache(None)
+def _load_static_files():
+    """Lazily load the resource files into memory the first time they are needed
+    """
+    return [
+        pkg_resources.resource_string("xarray", fname).decode("utf8")
+        for fname in STATIC_FILES
+    ]
 
 
 def short_data_repr_html(array):
@@ -233,9 +239,10 @@ def _obj_repr(obj, header_components, sections):
     header = f"<div class='xr-header'>{''.join(h for h in header_components)}</div>"
     sections = "".join(f"<li class='xr-section-item'>{s}</li>" for s in sections)
 
+    icons_svg, css_style = _load_static_files()
     return (
         "<div>"
-        f"{ICONS_SVG}<style>{CSS_STYLE}</style>"
+        f"{icons_svg}<style>{css_style}</style>"
         f"<pre class='xr-text-repr-fallback'>{escape(repr(obj))}</pre>"
         "<div class='xr-wrap' hidden>"
         f"{header}"

--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -7,7 +7,6 @@ import pkg_resources
 
 from .formatting import inline_variable_array_repr, short_data_repr
 
-
 STATIC_FILES = ("static/html/icons-svg-inline.html", "static/css/style.css")
 
 


### PR DESCRIPTION
- Marginal speed-up and RAM footprint reduction when not running in Jupyter Notebook
- Closes #4294