### PR TITLE
Fix docstring for missing_dims argument to isel methods

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1027,7 +1027,7 @@ class DataArray(AbstractArray, DataWithCoords):
         missing_dims : {"raise", "warn", "ignore"}, default "raise"
             What to do if dimensions that should be selected from are not present in the
             DataArray:
-            - "exception": raise an exception
+            - "raise": raise an exception
             - "warning": raise a warning, and ignore the missing dimensions
             - "ignore": ignore the missing dimensions
         **indexers_kwargs : {dim: indexer, ...}, optional

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1923,7 +1923,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         missing_dims : {"raise", "warn", "ignore"}, default "raise"
             What to do if dimensions that should be selected from are not present in the
             Dataset:
-            - "exception": raise an exception
+            - "raise": raise an exception
             - "warning": raise a warning, and ignore the missing dimensions
             - "ignore": ignore the missing dimensions
         **indexers_kwargs : {dim: indexer, ...}, optional

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1056,7 +1056,7 @@ class Variable(
         missing_dims : {"raise", "warn", "ignore"}, default "raise"
             What to do if dimensions that should be selected from are not present in the
             DataArray:
-            - "exception": raise an exception
+            - "raise": raise an exception
             - "warning": raise a warning, and ignore the missing dimensions
             - "ignore": ignore the missing dimensions
 


### PR DESCRIPTION
Incorrect value "exception" was given in the description of `missing_dims` argument - "exception" was renamed to "raise".

 - [x] Passes `isort . && black . && mypy . && flake8`
