### PR TITLE
Support PyCharm deployment over SSH

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -45,6 +45,9 @@ Documentation
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
+- Fix ``pip install .`` when no ``.git`` directory exists; namely when the xarray source
+  directory has been rsync'ed by PyCharm Professional for a remote deployment over SSH.
+  By `Guido Imperiale <https://github.com/crusaderky>`_
 
 
 .. _whats-new.0.16.0:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-setup(use_scm_version=True)
+try:
+    setup(use_scm_version=True)
+except LookupError as e:
+    # .git has been removed, and this is not a package created by sdist
+    # This is the case e.g. of a remote deployment with PyCharm Professional
+    if not str(e).startswith("setuptools-scm was unable to detect version"):
+        raise
+    setup(version="999")


### PR DESCRIPTION
Fix ``pip install .`` when no ``.git`` directory exists; namely when the xarray source directory has been rsync'ed by PyCharm Professional for a remote deployment over SSH.