### PR TITLE
Remove all unused and warn-raising methods from AbstractDataStore

### DIFF
--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -1,8 +1,6 @@
 import logging
 import time
 import traceback
-import warnings
-from collections.abc import Mapping
 
 import numpy as np
 
@@ -74,17 +72,8 @@ class BackendArray(NdimSizeLenMixin, indexing.ExplicitlyIndexed):
         return np.asarray(self[key], dtype=dtype)
 
 
-class AbstractDataStore(Mapping):
+class AbstractDataStore:
     __slots__ = ()
-
-    def __iter__(self):
-        return iter(self.variables)
-
-    def __getitem__(self, key):
-        return self.variables[key]
-
-    def __len__(self):
-        return len(self.variables)
 
     def get_dimensions(self):  # pragma: no cover
         raise NotImplementedError()
@@ -124,38 +113,6 @@ class AbstractDataStore(Mapping):
         )
         attributes = FrozenDict(self.get_attrs())
         return variables, attributes
-
-    @property
-    def variables(self):  # pragma: no cover
-        warnings.warn(
-            "The ``variables`` property has been deprecated and "
-            "will be removed in xarray v0.11.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        variables, _ = self.load()
-        return variables
-
-    @property
-    def attrs(self):  # pragma: no cover
-        warnings.warn(
-            "The ``attrs`` property has been deprecated and "
-            "will be removed in xarray v0.11.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        _, attrs = self.load()
-        return attrs
-
-    @property
-    def dimensions(self):  # pragma: no cover
-        warnings.warn(
-            "The ``dimensions`` property has been deprecated and "
-            "will be removed in xarray v0.11.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self.get_dimensions()
 
     def close(self):
         pass


### PR DESCRIPTION
 - [x] Related but really orthogonal to #4309
 - [x] Remove code, but keeps all existing tests passing (on MacOS with pandas=1.0.5)
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] No user / developer visible changes are expected

@shoyer this could be the first pass of the simplification of the current backend API. It not needed for #4309, but it make more obvious that we'd be free to keep the AbstractDataStore class if we wanted to.

The reason the change can be considered reasonably innocuous is that warnings would have been printed on access to any of the removed methods, but you never know. Your call (but I'd love to have a delete-only contribution to *xarray* :D).

Please note that:
 1. this change is the absolute lowest hanging fruit,
 2. removing `__enter__` and `__exit__` appears feasible as they are used only in tests, but it is a slightly bigger change,
 3. removing `load` is marginally more complex because it handle the special case when a variable name is equal to `None`.