### PR TITLE
silence the known docs CI issues

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -17,7 +17,9 @@ dependencies:
   - netcdf4>=1.5
   - numba
   - numpy>=1.17
-  - pandas>=1.0
+  # FIXME https://github.com/pydata/xarray/issues/4287
+  # - pandas>=1.0
+  - pandas=1.0
   - rasterio>=1.1
   - seaborn
   - setuptools

--- a/doc/api-hidden.rst
+++ b/doc/api-hidden.rst
@@ -686,14 +686,11 @@
    backends.NetCDF4DataStore.store_dataset
    backends.NetCDF4DataStore.sync
    backends.NetCDF4DataStore.values
-   backends.NetCDF4DataStore.attrs
    backends.NetCDF4DataStore.autoclose
-   backends.NetCDF4DataStore.dimensions
    backends.NetCDF4DataStore.ds
    backends.NetCDF4DataStore.format
    backends.NetCDF4DataStore.is_remote
    backends.NetCDF4DataStore.lock
-   backends.NetCDF4DataStore.variables
 
    backends.H5NetCDFStore.close
    backends.H5NetCDFStore.encode
@@ -719,10 +716,7 @@
    backends.H5NetCDFStore.store_dataset
    backends.H5NetCDFStore.sync
    backends.H5NetCDFStore.values
-   backends.H5NetCDFStore.attrs
-   backends.H5NetCDFStore.dimensions
    backends.H5NetCDFStore.ds
-   backends.H5NetCDFStore.variables
 
    backends.PydapDataStore.close
    backends.PydapDataStore.get
@@ -736,9 +730,6 @@
    backends.PydapDataStore.open
    backends.PydapDataStore.open_store_variable
    backends.PydapDataStore.values
-   backends.PydapDataStore.attrs
-   backends.PydapDataStore.dimensions
-   backends.PydapDataStore.variables
 
    backends.ScipyDataStore.close
    backends.ScipyDataStore.encode
@@ -764,10 +755,7 @@
    backends.ScipyDataStore.store_dataset
    backends.ScipyDataStore.sync
    backends.ScipyDataStore.values
-   backends.ScipyDataStore.attrs
-   backends.ScipyDataStore.dimensions
    backends.ScipyDataStore.ds
-   backends.ScipyDataStore.variables
 
    backends.FileManager.acquire
    backends.FileManager.acquire_context

--- a/doc/api-hidden.rst
+++ b/doc/api-hidden.rst
@@ -665,13 +665,10 @@
    backends.NetCDF4DataStore.encode
    backends.NetCDF4DataStore.encode_attribute
    backends.NetCDF4DataStore.encode_variable
-   backends.NetCDF4DataStore.get
    backends.NetCDF4DataStore.get_attrs
    backends.NetCDF4DataStore.get_dimensions
    backends.NetCDF4DataStore.get_encoding
    backends.NetCDF4DataStore.get_variables
-   backends.NetCDF4DataStore.items
-   backends.NetCDF4DataStore.keys
    backends.NetCDF4DataStore.load
    backends.NetCDF4DataStore.open
    backends.NetCDF4DataStore.open_store_variable
@@ -685,7 +682,6 @@
    backends.NetCDF4DataStore.store
    backends.NetCDF4DataStore.store_dataset
    backends.NetCDF4DataStore.sync
-   backends.NetCDF4DataStore.values
    backends.NetCDF4DataStore.autoclose
    backends.NetCDF4DataStore.ds
    backends.NetCDF4DataStore.format
@@ -696,13 +692,10 @@
    backends.H5NetCDFStore.encode
    backends.H5NetCDFStore.encode_attribute
    backends.H5NetCDFStore.encode_variable
-   backends.H5NetCDFStore.get
    backends.H5NetCDFStore.get_attrs
    backends.H5NetCDFStore.get_dimensions
    backends.H5NetCDFStore.get_encoding
    backends.H5NetCDFStore.get_variables
-   backends.H5NetCDFStore.items
-   backends.H5NetCDFStore.keys
    backends.H5NetCDFStore.load
    backends.H5NetCDFStore.open_store_variable
    backends.H5NetCDFStore.prepare_variable
@@ -715,33 +708,25 @@
    backends.H5NetCDFStore.store
    backends.H5NetCDFStore.store_dataset
    backends.H5NetCDFStore.sync
-   backends.H5NetCDFStore.values
    backends.H5NetCDFStore.ds
 
    backends.PydapDataStore.close
-   backends.PydapDataStore.get
    backends.PydapDataStore.get_attrs
    backends.PydapDataStore.get_dimensions
    backends.PydapDataStore.get_encoding
    backends.PydapDataStore.get_variables
-   backends.PydapDataStore.items
-   backends.PydapDataStore.keys
    backends.PydapDataStore.load
    backends.PydapDataStore.open
    backends.PydapDataStore.open_store_variable
-   backends.PydapDataStore.values
 
    backends.ScipyDataStore.close
    backends.ScipyDataStore.encode
    backends.ScipyDataStore.encode_attribute
    backends.ScipyDataStore.encode_variable
-   backends.ScipyDataStore.get
    backends.ScipyDataStore.get_attrs
    backends.ScipyDataStore.get_dimensions
    backends.ScipyDataStore.get_encoding
    backends.ScipyDataStore.get_variables
-   backends.ScipyDataStore.items
-   backends.ScipyDataStore.keys
    backends.ScipyDataStore.load
    backends.ScipyDataStore.open_store_variable
    backends.ScipyDataStore.prepare_variable
@@ -754,7 +739,6 @@
    backends.ScipyDataStore.store
    backends.ScipyDataStore.store_dataset
    backends.ScipyDataStore.sync
-   backends.ScipyDataStore.values
    backends.ScipyDataStore.ds
 
    backends.FileManager.acquire


### PR DESCRIPTION
In order to get our docs CI running again and to help find issues with the documentation (we already missed a few), this pins `pandas` to 1.0 (copied from #4296). Once we merged #4292 and fixed #4287 (mostly by using the upcoming `sphinx` 3.2 release), we can undo this.
