### PR TITLE
Implicit dask import 4164

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,6 +33,8 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
+- Fixed a bug in backend caused by basic installation of Dask (:issue:`4164`, :pull:`4318`)
+  `Sam Morley <https://github.com/inakleinbottle>`_.
 
 
 Documentation

--- a/xarray/backends/locks.py
+++ b/xarray/backends/locks.py
@@ -76,6 +76,7 @@ def _get_scheduler(get=None, collection=None) -> Optional[str]:
         # Issue: 4164
         import dask
         from dask.base import get_scheduler  # noqa: F401
+
         actual_get = get_scheduler(get, collection)
     except ImportError:
         return None

--- a/xarray/backends/locks.py
+++ b/xarray/backends/locks.py
@@ -72,11 +72,13 @@ def _get_scheduler(get=None, collection=None) -> Optional[str]:
     dask.base.get_scheduler
     """
     try:
-        import dask  # noqa: F401
+        # Fix for bug caused by dask installation that doesn't involve the toolz library
+        # Issue: 4164
+        import dask
+        from dask.base import get_scheduler  # noqa: F401
+        actual_get = get_scheduler(get, collection)
     except ImportError:
         return None
-
-    actual_get = dask.base.get_scheduler(get, collection)
 
     try:
         from dask.distributed import Client


### PR DESCRIPTION
This is a fix for Issue 4164. I haven't written any tests since this issue involves partial installation of dask, and while I know ways to fake the results of failed imports, I'm not sure these are appropriate for a test bed. The test script from the issue no longer raises an error.

 - [ ] Closes #4164
 - [ ] Tests added
 - [ ] Passes `isort . && black . && mypy . && flake8`

