### PR TITLE
pin sphinx

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -23,6 +23,6 @@ dependencies:
   - rasterio>=1.1
   - seaborn
   - setuptools
-  - sphinx>=2.3
+  - sphinx=3.1
   - sphinx_rtd_theme>=0.4
   - zarr>=2.4


### PR DESCRIPTION
The recently released `sphinx` 3.2 version includes a new type preprocessor that will warn about a few issues. These will be fixed / silenced in #4286, but to avoid a failing docs CI let's pin `sphinx` for now. I'm also pinning to `sphinx=3.1` instead of `sphinx<=3.1` because that is required for `sphinx-autosummary-accessors` to work properly.
