### PR TITLE
ndrolling repr fix

### DIFF
--- a/doc/computation.rst
+++ b/doc/computation.rst
@@ -236,7 +236,7 @@ windowed rolling, convolution, short-time FFT etc.
     # rolling with 2-point stride
     rolling_da = r.construct(x="x_win", y="y_win", stride=2)
     rolling_da
-    rolling_da.mean("window_dim", skipna=False)
+    rolling_da.mean(["x_win", "y_win"], skipna=False)
 
 Because the ``DataArray`` given by ``r.construct('window_dim')`` is a view
 of the original array, it is memory efficient.

--- a/doc/computation.rst
+++ b/doc/computation.rst
@@ -234,7 +234,7 @@ windowed rolling, convolution, short-time FFT etc.
 .. ipython:: python
 
     # rolling with 2-point stride
-    rolling_da = r.construct("window_dim", stride=2)
+    rolling_da = r.construct(x="x_win", y="y_win", stride=2)
     rolling_da
     rolling_da.mean("window_dim", skipna=False)
 
@@ -245,7 +245,7 @@ You can also use ``construct`` to compute a weighted rolling sum:
 .. ipython:: python
 
     weight = xr.DataArray([0.25, 0.5, 0.25], dims=["window"])
-    arr.rolling(y=3).construct("window").dot(weight)
+    arr.rolling(y=3).construct(y="window").dot(weight)
 
 .. note::
   numpy's Nan-aggregation functions such as ``nansum`` copy the original array.

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -156,7 +156,9 @@ class Rolling:
         elif len(self.dim) == 1:
             return [arg]
         else:
-            raise ValueError("Mapping argument is necessary.")
+            raise ValueError(
+                "Mapping argument is necessary for {}d-rolling.".format(len(self.dim))
+            )
 
 
 class DataArrayRolling(Rolling):

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -99,8 +99,8 @@ class Rolling:
         """provide a nice str repr of our rolling object"""
 
         attrs = [
-            "{k}->{v}".format(k=k, v=getattr(self, k))
-            for k in list(self.dim) + self.window + self.center + [self.min_periods]
+            "{k}->{v}{c}".format(k=k, v=w, c="(center)" if c else "")
+            for k, w, c in zip(self.dim, self.window, self.center)
         ]
         return "{klass} [{attrs}]".format(
             klass=self.__class__.__name__, attrs=",".join(attrs)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6178,8 +6178,16 @@ def test_rolling_iter(da):
                 actual.values[actual.values.nonzero()],
                 expected.values[expected.values.nonzero()],
             )
-    # no error
-    repr(rolling_obj)
+
+
+@pytest.mark.parametrize("da", (1,), indirect=True)
+def test_rolling_repr(da):
+    rolling_obj = da.rolling(time=7)
+    assert repr(rolling_obj) == "DataArrayRolling [time->7]"
+    rolling_obj = da.rolling(time=7, center=True)
+    assert repr(rolling_obj) == "DataArrayRolling [time->7(center)]"
+    rolling_obj = da.rolling(time=7, x=3, center=True)
+    assert repr(rolling_obj) == "DataArrayRolling [time->7(center),x->3(center)]"
 
 
 def test_rolling_doc(da):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6178,6 +6178,8 @@ def test_rolling_iter(da):
                 actual.values[actual.values.nonzero()],
                 expected.values[expected.values.nonzero()],
             )
+    # no error
+    repr(rolling_obj)
 
 
 def test_rolling_doc(da):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4328
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`

There was a bug in `rolling.__repr__` but it was not tested.
Fixed and tests are added.