### PR TITLE
install sphinx-autosummary-accessors from conda-forge

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -25,6 +25,5 @@ dependencies:
   - setuptools
   - sphinx=3.1
   - sphinx_rtd_theme>=0.4
+  - sphinx-autosummary-accessors
   - zarr>=2.4
-  - pip:
-      - sphinx-autosummary-accessors


### PR DESCRIPTION
`sphinx-autosummary-accessors` is now on [`conda-forge`](https://github.com/conda-forge/sphinx-autosummary-accessors-feedstock) and I hopefully fixed all issues with the package (but it would probably be good if someone with more experience with conda-forge packaging than me could review the feedstock).

This makes our docs CI install from `conda-forge` instead of PyPI.
