### PR TITLE
pin matplotlib in ci/requirements/doc.yml

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -13,7 +13,7 @@ dependencies:
   - ipython
   - iris>=2.3
   - jupyter_client
-  - matplotlib-base
+  - matplotlib-base=3.3.0
   - nbsphinx
   - netcdf4>=1.5
   - numba

--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -13,6 +13,7 @@ dependencies:
   - ipython
   - iris>=2.3
   - jupyter_client
+  - matplotlib-base
   - nbsphinx
   - netcdf4>=1.5
   - numba


### PR DESCRIPTION
I realised that matplotlib is not listed in `ci/requirements/doc.yml` I think it is drawn as cartopy is required.

But that's not the reason for this PR - matplotlib 3.3.1 came out 3 hours ago (https://anaconda.org/conda-forge/matplotlib) and I think this breaks the doc build. So let's test this.





