### PR TITLE
Fix overflow-related bug in computing means of cftime.datetime arrays

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -57,6 +57,8 @@ Bug fixes
   `Sam Morley <https://github.com/inakleinbottle>`_.
 - Fixed inconsistencies between docstring and functionality for :py:meth:`DataArray.str.get`
   and :py:meth:`DataArray.str.wrap` (:issue:`4334`). By `Mathias Hauser <https://github.com/mathause>`_.
+- Fixed overflow issue causing incorrect results in computing means of :py:class:`cftime.datetime`
+  arrays (:issue:`4341`). By `Spencer Clark <https://github.com/spencerkclark>`_.
 
 
 Documentation

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -4,6 +4,7 @@ Currently, this means Dask or NumPy arrays. None of these functions should
 accept or return xarray objects.
 """
 import contextlib
+import datetime
 import inspect
 import warnings
 from functools import partial
@@ -470,8 +471,7 @@ def timedelta_to_numeric(value, datetime_unit="ns", dtype=float):
 
 
 def _to_pytimedelta(array, unit="us"):
-    index = pd.TimedeltaIndex(array.ravel(), unit=unit)
-    return index.to_pytimedelta().reshape(array.shape)
+    return array.astype(f"timedelta64[{unit}]").astype(datetime.timedelta)
 
 
 def np_timedelta64_to_float(array, datetime_unit):

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -334,6 +334,40 @@ def test_cftime_datetime_mean():
 
 
 @requires_cftime
+def test_cftime_datetime_mean_long_time_period():
+    import cftime
+
+    times = np.array(
+        [
+            [
+                cftime.DatetimeNoLeap(400, 12, 31, 0, 0, 0, 0),
+                cftime.DatetimeNoLeap(520, 12, 31, 0, 0, 0, 0),
+            ],
+            [
+                cftime.DatetimeNoLeap(520, 12, 31, 0, 0, 0, 0),
+                cftime.DatetimeNoLeap(640, 12, 31, 0, 0, 0, 0),
+            ],
+            [
+                cftime.DatetimeNoLeap(640, 12, 31, 0, 0, 0, 0),
+                cftime.DatetimeNoLeap(760, 12, 31, 0, 0, 0, 0),
+            ],
+        ]
+    )
+
+    da = DataArray(times, dims=["time", "d2"])
+    result = da.mean("d2")
+    expected = DataArray(
+        [
+            cftime.DatetimeNoLeap(460, 12, 31, 0, 0, 0, 0),
+            cftime.DatetimeNoLeap(580, 12, 31, 0, 0, 0, 0),
+            cftime.DatetimeNoLeap(700, 12, 31, 0, 0, 0, 0),
+        ],
+        dims=["time"],
+    )
+    assert_equal(result, expected)
+
+
+@requires_cftime
 @requires_dask
 def test_cftime_datetime_mean_dask_error():
     times = cftime_range("2000", periods=4)


### PR DESCRIPTION
Going through `pandas.TimedeltaIndex` within `duck_array_ops._to_pytimedelta` leads to overflow problems (presumably it casts to a `"timedelta64[ns]"` type internally).  This PR updates the logic to directly use NumPy to do the casting, first to `"timedelta64[us]"`, then to `datetime.timedelta`.

 - [x] Closes #4341  
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
