### PR TITLE
annotate concat

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -76,6 +76,8 @@ Internal Changes
   By `Guido Imperiale <https://github.com/crusaderky>`_
 - Only load resource files when running inside a Jupyter Notebook
   (:issue:`4294`) By `Guido Imperiale <https://github.com/crusaderky>`_
+- Enable type checking for :py:func:`concat` (:issue:`4238`)
+  By `Mathias Hauser <https://github.com/mathause>`_.
 
 
 .. _whats-new.0.16.0:

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -20,6 +20,10 @@ from .merge import _VALID_COMPAT, merge_attrs, unique_variable
 from .variable import IndexVariable, Variable, as_variable
 from .variable import concat as concat_vars
 
+if TYPE_CHECKING:
+    from .dataarray import DataArray
+    from .dataset import Dataset
+
 
 @overload
 def concat(

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -20,10 +20,6 @@ from .merge import _VALID_COMPAT, merge_attrs, unique_variable
 from .variable import IndexVariable, Variable, as_variable
 from .variable import concat as concat_vars
 
-if TYPE_CHECKING:
-    from .dataarray import DataArray
-    from .dataset import Dataset
-
 
 @overload
 def concat(

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -422,7 +422,7 @@ class DataArray(AbstractArray, DataWithCoords):
         return self._to_dataset_whole(name=_THIS_ARRAY, shallow_copy=False)
 
     def _from_temp_dataset(
-        self, dataset: Dataset, name: Hashable = _default
+        self, dataset: Dataset, name: Union[Hashable, None, Default] = _default
     ) -> "DataArray":
         variable = dataset._variables.pop(_THIS_ARRAY)
         coords = dataset._variables


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4238
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

The issue mentions `xr.Dataset.to_dataframe` and `xr.concat`. `xr.Dataset.to_dataframe` was [annotated](https://github.com/pydata/xarray/blob/26547d19d477cc77461c09b3aadd55f7eb8b4dbf/xarray/core/dataset.py#L4566) in #4333, so only `xr.concat` is left.






