### PR TITLE
install the project on RTD

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -28,3 +28,7 @@ dependencies:
   - sphinx_rtd_theme>=0.4
   - sphinx-autosummary-accessors
   - zarr>=2.4
+  - pip
+  - pip:
+      # relative to this file. Needs to be editable to be accepted.
+      - -e ../..

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,19 +15,13 @@
 
 import datetime
 import os
-import pathlib
 import subprocess
 import sys
 from contextlib import suppress
 
 import sphinx_autosummary_accessors
 
-# make sure the source version is preferred (#3567)
-root = pathlib.Path(__file__).absolute().parent.parent
-os.environ["PYTHONPATH"] = str(root)
-sys.path.insert(0, str(root))
-
-import xarray  # isort:skip
+import xarray
 
 allowed_failures = set()
 


### PR DESCRIPTION
The versions were broken because instead of installing we simply extended `sys.path`. That way, `sphinx` is able to find the correct version, but `setuptools_scm` can't put the version in the `METADATA` file in the installed egg. Instead, `pkg_resources.get_distribution("xarray").version` gets its version from a released version of `xarray` that was pulled in by a dependency (hence the old version in the title bar). To fix that, we need to install before building the documentation.

However, since RTD installs with `--upgrade --upgrade-strategy=eager` (which upgrades all packages to the most recent version), we can't install using their `pip` method. The `setuptools` method doesn't work either because `cfgrib` pulls in the most recent released version of `xarray`, and `setuptools` can't seem to overwrite / uninstall previously installed versions. To work around that, this installs using the `pip` section in the environment file.

 - [x] Closes #4289