### PR TITLE
Remove null pytest env option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -94,8 +94,6 @@ testpaths = xarray/tests properties
 # Fixed upstream in https://github.com/pydata/bottleneck/pull/199
 filterwarnings =
     ignore:Using a non-tuple sequence for multidimensional indexing is deprecated:FutureWarning
-env =
-    UVCDAT_ANONYMOUS_LOG=no
 markers =
     flaky: flaky tests
     network: tests requiring a network connection


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

I don't think these lines do anything, and I see this warning on each run. 

People wiser than me (@jhamman ) put it here — is there something it does do?

```
/usr/local/lib/python3.8/site-packages/_pytest/config/__init__.py:1148
  /usr/local/lib/python3.8/site-packages/_pytest/config/__init__.py:1148: PytestConfigWarning: Unknown config ini key: env

    self._warn_or_fail_if_strict("Unknown config ini key: {}\n".format(key))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```