### PR TITLE
add a fallback_version to the setuptools_scm configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,4 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-try:
-    setup(use_scm_version=True)
-except LookupError as e:
-    # .git has been removed, and this is not a package created by sdist
-    # This is the case e.g. of a remote deployment with PyCharm Professional
-    if not str(e).startswith("setuptools-scm was unable to detect version"):
-        raise
-    setup(version="999")
+setup(use_scm_version={"fallback_version": "999"})


### PR DESCRIPTION
Follow-up to #4299. While investigating version issues on RTD, I noticed that `setuptools_scm` allows configuring its behavior, and the custom `try: ... except ...` clause can be replaced by setting `fallback_version`. The advantage is that once we switch to `pyproject.toml` (for which we need to drop python 3.6), the changes are much more straightforward.

cc @crusaderky 