### PR TITLE
override the signature of plotfunc

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -73,6 +73,7 @@ Bug fixes
   and :py:meth:`DataArray.str.wrap` (:issue:`4334`). By `Mathias Hauser <https://github.com/mathause>`_.
 - Fixed overflow issue causing incorrect results in computing means of :py:class:`cftime.datetime`
   arrays (:issue:`4341`). By `Spencer Clark <https://github.com/spencerkclark>`_.
+- fix the signature of the plot methods. (:pull:`4359`) By `Justus Magin <https://github.com/keewis>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -463,6 +463,15 @@ class _PlotMethods:
         return step(self._da, *args, **kwargs)
 
 
+def override_signature(f):
+    def wrapper(func):
+        func.__wrapped__ = f
+
+        return func
+
+    return wrapper
+
+
 def _plot2d(plotfunc):
     """
     Decorator for common 2d plotting logic
@@ -572,6 +581,10 @@ def _plot2d(plotfunc):
     # Build on the original docstring
     plotfunc.__doc__ = f"{plotfunc.__doc__}\n{commondoc}"
 
+    def signature(darray, x, y, **kwargs):
+        pass
+
+    @override_signature(signature)
     @functools.wraps(plotfunc)
     def newplotfunc(
         darray,

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -581,6 +581,12 @@ def _plot2d(plotfunc):
     # Build on the original docstring
     plotfunc.__doc__ = f"{plotfunc.__doc__}\n{commondoc}"
 
+    # plotfunc and newplotfunc have different signatures:
+    # - plotfunc: (x, y, z, ax, **kwargs)
+    # - newplotfunc: (darray, x, y, **kwargs)
+    # where plotfunc accepts numpy arrays, while newplotfunc accepts a DataArray
+    # and variable names. newplotfunc also explicitly lists most kwargs, so we
+    # need to shorten it
     def signature(darray, x, y, **kwargs):
         pass
 


### PR DESCRIPTION
This fixes the documented signature of the plotting functions. Not sure if using a decorator to override `__wrapped__` is the best way to achieve this, though.

 - [x] Closes #4152
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
