### PR TITLE
Silence plot warnings

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -96,7 +96,7 @@ Internal Changes
 - Enable type checking for :py:func:`concat` (:issue:`4238`)
   By `Mathias Hauser <https://github.com/mathause>`_.
 - Updated plot functions for matplotlib version 3.3 and silenced warnings in the
-  plot tests.  By `Mathias Hauser <https://github.com/mathause>`_.
+  plot tests (:pull:`4365`). By `Mathias Hauser <https://github.com/mathause>`_.
 
 .. _whats-new.0.16.0:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -95,7 +95,8 @@ Internal Changes
   (:issue:`4294`) By `Guido Imperiale <https://github.com/crusaderky>`_
 - Enable type checking for :py:func:`concat` (:issue:`4238`)
   By `Mathias Hauser <https://github.com/mathause>`_.
-
+- Updated plot functions for matplotlib version 3.3 and silenced warnings in the
+  plot tests.  By `Mathias Hauser <https://github.com/mathause>`_.
 
 .. _whats-new.0.16.0:
 

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -413,7 +413,8 @@ class FacetGrid:
         """Draw a colorbar
         """
         kwargs = kwargs.copy()
-        if self._cmap_extend is not None:
+        # dont pass extend as kwarg if it is in the mappable
+        if self._cmap_extend is not None and not hasattr(self._mappables[-1], "extend"):
             kwargs.setdefault("extend", self._cmap_extend)
         if "label" not in kwargs:
             kwargs.setdefault("label", label_from_attrs(self.data))

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -413,9 +413,11 @@ class FacetGrid:
         """Draw a colorbar
         """
         kwargs = kwargs.copy()
-        # dont pass extend as kwarg if it is in the mappable
-        if self._cmap_extend is not None and not hasattr(self._mappables[-1], "extend"):
+        if self._cmap_extend is not None:
             kwargs.setdefault("extend", self._cmap_extend)
+        # dont pass extend as kwarg if it is in the mappable
+        if hasattr(self._mappables[-1], "extend"):
+            kwargs.pop("extend", None)
         if "label" not in kwargs:
             kwargs.setdefault("label", label_from_attrs(self.data))
         self.cbar = self.fig.colorbar(

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -292,6 +292,7 @@ def _determine_cmap_params(
         norm = newnorm if norm is None else norm
 
     # vmin & vmax needs to be None if norm is passed
+    # TODO: always return a norm with vmin and vmax
     if norm is not None:
         vmin = None
         vmax = None

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -291,6 +291,11 @@ def _determine_cmap_params(
         cmap, newnorm = _build_discrete_cmap(cmap, levels, extend, filled)
         norm = newnorm if norm is None else norm
 
+    # vmin & vmax needs to be None if norm is passed
+    if norm is not None:
+        vmin = None
+        vmax = None
+
     return dict(
         vmin=vmin, vmax=vmax, cmap=cmap, extend=extend, levels=levels, norm=norm
     )
@@ -619,6 +624,10 @@ def _add_colorbar(primitive, ax, cbar_ax, cbar_kwargs, cmap_params):
         cbar_kwargs.setdefault("ax", ax)
     else:
         cbar_kwargs.setdefault("cax", cbar_ax)
+
+    # dont pass extend as kwarg if it is in the mappable
+    if hasattr(primitive, "extend"):
+        cbar_kwargs.pop("extend")
 
     fig = ax.get_figure()
     cbar = fig.colorbar(primitive, **cbar_kwargs)

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -59,14 +59,18 @@ def figure_context(*args, **kwargs):
 def test_all_figures_closed():
     """meta-test to ensure all figures are closed at the end of a test
 
-       Note: may give false positives if tests are run in parallel
+       Notes:  Scope is kept to module (only invoke this function once per test
+       module) else tests cannot be run in parallel (locally). Disadvantage: only
+       catches one open figure per run. May still give a false positive if tests
+       are run in parallel.
     """
     yield None
 
-    fignums = plt.get_fignums()
-    if fignums:
-        raise RuntimeError("test did not close all figures")
-        plt.close("all")
+    open_figs = len(plt.get_fignums())
+    if open_figs:
+        raise RuntimeError(
+            f"tests did not close all figures ({open_figs} figures open)"
+        )
 
 
 @pytest.mark.flaky

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -375,9 +375,9 @@ class TestPlot(PlotTestCase):
         pl = a.plot.contourf(cmap=copy(cmap), vmin=0.1, vmax=0.9)
 
         # check the set_bad color
-        assert np.all(
-            pl.cmap(np.ma.masked_invalid([np.nan]))[0]
-            == cmap(np.ma.masked_invalid([np.nan]))[0]
+        assert_array_equal(
+            pl.cmap(np.ma.masked_invalid([np.nan]))[0],
+            cmap(np.ma.masked_invalid([np.nan]))[0],
         )
 
         # check the set_under color
@@ -411,9 +411,9 @@ class TestPlot(PlotTestCase):
         pl = a.plot.contourf(cmap=copy(cmap))
 
         # check the set_bad color has been kept
-        assert np.all(
-            pl.cmap(np.ma.masked_invalid([np.nan]))[0]
-            == cmap(np.ma.masked_invalid([np.nan]))[0]
+        assert_array_equal(
+            pl.cmap(np.ma.masked_invalid([np.nan]))[0],
+            cmap(np.ma.masked_invalid([np.nan]))[0],
         )
 
         # check the set_under color has been kept
@@ -2395,14 +2395,14 @@ class TestAxesKwargs:
         plt.clf()
         da.plot(xticks=np.arange(5))
         expected = np.arange(5).tolist()
-        assert np.all(plt.gca().get_xticks() == expected)
+        assert_array_equal(plt.gca().get_xticks(), expected)
 
     @pytest.mark.parametrize("da", test_da_list)
     def test_yticks_kwarg(self, da):
         plt.clf()
         da.plot(yticks=np.arange(5))
         expected = np.arange(5)
-        assert np.all(plt.gca().get_yticks() == expected)
+        assert_array_equal(plt.gca().get_yticks(), expected)
 
 
 @requires_matplotlib
@@ -2431,7 +2431,7 @@ def test_plot_transposes_properly(plotfunc):
         # get_array doesn't work for contour, contourf. It returns the colormap intervals.
         # pcolormesh returns 1D array but imshow returns a 2D array so it is necessary
         # to ravel() on the LHS
-        np.testing.assert_equal(hdl.get_array().ravel(), da.to_masked_array().ravel())
+        assert_array_equal(hdl.get_array().ravel(), da.to_masked_array().ravel())
 
 
 @requires_matplotlib

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1,6 +1,6 @@
 import contextlib
 import inspect
-from copy import copy, deepcopy
+from copy import copy
 from datetime import datetime
 
 import numpy as np
@@ -364,7 +364,7 @@ class TestPlot(PlotTestCase):
 
         cmap = mpl.cm.viridis
 
-        # deepcopy to ensure cmap is not changed by contourf()
+        # use copy to ensure cmap is not changed by contourf()
         # Set vmin and vmax so that _build_discrete_colormap is called with
         # extend='both'. extend is passed to
         # mpl.colors.from_levels_and_colors(), which returns a result with
@@ -372,7 +372,7 @@ class TestPlot(PlotTestCase):
         # extend='neither' (but if extend='neither' the under and over values
         # would not be used because the data would all be within the plotted
         # range)
-        pl = a.plot.contourf(cmap=deepcopy(cmap), vmin=0.1, vmax=0.9)
+        pl = a.plot.contourf(cmap=copy(cmap), vmin=0.1, vmax=0.9)
 
         # check the set_bad color
         assert np.all(
@@ -389,9 +389,7 @@ class TestPlot(PlotTestCase):
     def test_contourf_cmap_set_with_bad_under_over(self):
         a = DataArray(easy_array((4, 4)), dims=["z", "time"])
 
-        # Make a copy here because we want a local cmap that we will modify.
-        # Use deepcopy because matplotlib Colormap objects have tuple members
-        # and we want to ensure we do not change the original.
+        # make a copy here because we want a local cmap that we will modify.
         cmap = copy(mpl.cm.viridis)
 
         cmap.set_bad("w")
@@ -409,8 +407,8 @@ class TestPlot(PlotTestCase):
         # check we actually changed the set_over color
         assert cmap(np.inf) != mpl.cm.viridis(-np.inf)
 
-        # deepcopy to ensure cmap is not changed by contourf()
-        pl = a.plot.contourf(cmap=deepcopy(cmap))
+        # copy to ensure cmap is not changed by contourf()
+        pl = a.plot.contourf(cmap=copy(cmap))
 
         # check the set_bad color has been kept
         assert np.all(
@@ -2433,7 +2431,7 @@ def test_plot_transposes_properly(plotfunc):
         # get_array doesn't work for contour, contourf. It returns the colormap intervals.
         # pcolormesh returns 1D array but imshow returns a 2D array so it is necessary
         # to ravel() on the LHS
-        assert np.all(hdl.get_array().ravel() == da.to_masked_array().ravel())
+        np.testing.assert_equal(hdl.get_array().ravel(), da.to_masked_array().ravel())
 
 
 @requires_matplotlib


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Towards #3266
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

I gave a try to silence some of the warning for the plotting functions. I brought it down from 67 to 5 (4 of which come from external libraries).

 - [x] `MatplotlibDeprecationWarning: The 'extend' parameter to Colorbar has no effect because it is overridden by the mappable; it is deprecated since 3.3 and will be removed two minor releases later.`
 - [x] `MatplotlibDeprecationWarning: You are modifying the state of a globally registered colormap. In future versions, you will not be able to modify a registered colormap in-place. To remove this warning, you can make a copy of the colormap first. cmap = copy.copy(mpl.cm.get_cmap("viridis"))`
 - [x] `MatplotlibDeprecationWarning: Passing parameters norm and vmin/vmax simultaneously is deprecated since 3.3 and will become an error two minor releases later. Please pass vmin/vmax directly to the norm when creating it.`
 - [ ] `MatplotlibDeprecationWarning: shading='flat' when X and Y have the same dimensions as C is deprecated since 3.3.  Either specify the corners of the quadrilaterals with X and Y, or pass shading='auto', 'nearest' or 'gouraud', or set rcParams['pcolor.shading'].  This will become an error two minor releases later.` See #4364
 - [x] `UserWarning: Requested projection is different from current axis projection, creating new axis with requested projection.`
 - [x] Made sure all figures are closed at the end of a test.
 - [x] Added a meta-test to ensure all figures will be closed if tests are added in the future

I cannot exclude that one of these changes has an effect on the plots that is not tested in the suite... Tests pass locally for py38 and py36-bare-minimum.
