### PR TITLE
Silencing numpy warnings

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -100,6 +100,8 @@ Internal Changes
   By `Guido Imperiale <https://github.com/crusaderky>`_
 - Only load resource files when running inside a Jupyter Notebook
   (:issue:`4294`) By `Guido Imperiale <https://github.com/crusaderky>`_
+- Silenced most ``numpy`` warnings such as ``Mean of empty slice``. (:pull:`4369`)
+  By `Maximilian Roos <https://github.com/max-sixty>`_
 - Enable type checking for :py:func:`concat` (:issue:`4238`)
   By `Mathias Hauser <https://github.com/mathause>`_.
 - Updated plot functions for matplotlib version 3.3 and silenced warnings in the

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2711,7 +2711,7 @@ class DataArray(AbstractArray, DataWithCoords):
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", r"All-NaN (slice|axis) encountered")
                 warnings.filterwarnings(
-                    "ignore", r"Mean of emmty slice", category=RuntimeWarning
+                    "ignore", r"Mean of empty slice", category=RuntimeWarning
                 )
                 with np.errstate(all="ignore"):
                     return self.__array_wrap__(f(self.variable.data, *args, **kwargs))

--- a/xarray/core/nanops.py
+++ b/xarray/core/nanops.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 from . import dtypes, nputils, utils
@@ -133,10 +135,14 @@ def nanmean(a, axis=None, dtype=None, out=None):
     if a.dtype.kind == "O":
         return _nanmean_ddof_object(0, a, axis=axis, dtype=dtype)
 
-    if isinstance(a, dask_array_type):
-        return dask_array.nanmean(a, axis=axis, dtype=dtype)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", r"Mean of empty slice", category=RuntimeWarning
+        )
+        if isinstance(a, dask_array_type):
+            return dask_array.nanmean(a, axis=axis, dtype=dtype)
 
-    return np.nanmean(a, axis=axis, dtype=dtype)
+        return np.nanmean(a, axis=axis, dtype=dtype)
 
 
 def nanmedian(a, axis=None, out=None):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1636,10 +1636,14 @@ class Variable(
 
         input_data = self.data if allow_lazy else self.values
 
-        if axis is not None:
-            data = func(input_data, axis=axis, **kwargs)
-        else:
-            data = func(input_data, **kwargs)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", r"Mean of empty slice", category=RuntimeWarning
+            )
+            if axis is not None:
+                data = func(input_data, axis=axis, **kwargs)
+            else:
+                data = func(input_data, **kwargs)
 
         if getattr(data, "shape", ()) == self.shape:
             dims = self.dims

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6186,12 +6186,12 @@ def test_isin(da):
     assert_equal(result, expected)
 
 
+@pytest.mark.filterwarnings("error:Mean of empty slice")
 @pytest.mark.parametrize("da", (1, 2), indirect=True)
 def test_rolling_iter(da):
 
     rolling_obj = da.rolling(time=7)
-    with warnings.catch_warnings():
-        rolling_obj_mean = rolling_obj.mean()
+    rolling_obj_mean = rolling_obj.mean()
 
     assert len(rolling_obj.window_labels) == len(da["time"])
     assert_identical(rolling_obj.window_labels, da["time"])
@@ -6486,10 +6486,9 @@ def test_raise_no_warning_for_nan_in_binary_ops():
     assert len(record) == 0
 
 
+@pytest.mark.filterwarnings("error")
 def test_no_warning_for_all_nan():
-    with pytest.warns(None) as record:
-        _ = xr.DataArray([np.NaN, np.NaN]).mean()
-    assert len(record) == 0
+    _ = xr.DataArray([np.NaN, np.NaN]).mean()
 
 
 def test_name_in_masking():

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6480,6 +6480,20 @@ def test_raise_no_warning_for_nan_in_binary_ops():
     assert len(record) == 0
 
 
+def test_no_warning_for_all_nan():
+
+    # with warnings.catch_warnings():
+    #     warnings.filterwarnings("error", message=r".*slice.*", category=RuntimeWarning)
+    #     _ = xr.DataArray([np.NaN, np.NaN]).mean()
+
+    with pytest.warns(None) as record:
+        _ = xr.DataArray([np.NaN, np.NaN]).mean()
+    assert len(record) == 0
+
+    # if record:
+    #     raise AssertionError(record[0].message)
+
+
 def test_name_in_masking():
     name = "RingoStarr"
     da = xr.DataArray(range(10), coords=[("x", range(10))], name=name)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6492,13 +6492,6 @@ def test_no_warning_for_all_nan():
     assert len(record) == 0
 
 
-# @pytest.mark.xfail()
-# def test_no_warning_for_rolling_nan_dask():
-#     with pytest.warns(None) as record:
-#         _ = xr.DataArray([np.NaN, np.NaN], dims="a").rolling(a=1).mean()
-#     assert len(record) == 0
-
-
 def test_name_in_masking():
     name = "RingoStarr"
     da = xr.DataArray(range(10), coords=[("x", range(10))], name=name)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6191,7 +6191,6 @@ def test_rolling_iter(da):
 
     rolling_obj = da.rolling(time=7)
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "Mean of empty slice")
         rolling_obj_mean = rolling_obj.mean()
 
     assert len(rolling_obj.window_labels) == len(da["time"])
@@ -6200,10 +6199,8 @@ def test_rolling_iter(da):
     for i, (label, window_da) in enumerate(rolling_obj):
         assert label == da["time"].isel(time=i)
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "Mean of empty slice")
-            actual = rolling_obj_mean.isel(time=i)
-            expected = window_da.mean("time")
+        actual = rolling_obj_mean.isel(time=i)
+        expected = window_da.mean("time")
 
         # TODO add assert_allclose_with_nan, which compares nan position
         # as well as the closeness of the values.
@@ -6490,17 +6487,16 @@ def test_raise_no_warning_for_nan_in_binary_ops():
 
 
 def test_no_warning_for_all_nan():
-
-    # with warnings.catch_warnings():
-    #     warnings.filterwarnings("error", message=r".*slice.*", category=RuntimeWarning)
-    #     _ = xr.DataArray([np.NaN, np.NaN]).mean()
-
     with pytest.warns(None) as record:
         _ = xr.DataArray([np.NaN, np.NaN]).mean()
     assert len(record) == 0
 
-    # if record:
-    #     raise AssertionError(record[0].message)
+
+# @pytest.mark.xfail()
+# def test_no_warning_for_rolling_nan_dask():
+#     with pytest.warns(None) as record:
+#         _ = xr.DataArray([np.NaN, np.NaN], dims="a").rolling(a=1).mean()
+#     assert len(record) == 0
 
 
 def test_name_in_masking():

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6193,13 +6193,10 @@ def test_raise_no_warning_for_nan_in_binary_ops():
     assert len(record) == 0
 
 
+@pytest.mark.filterwarnings("error")
 @pytest.mark.parametrize("ds", (2,), indirect=True)
 def test_raise_no_warning_assert_close(ds):
-
-    with pytest.warns(None) as record:
-        assert_allclose(ds, ds)
-
-    assert len(record) == 0
+    assert_allclose(ds, ds)
 
 
 @pytest.mark.xfail(reason="See https://github.com/pydata/xarray/pull/4369 or docstring")

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6027,6 +6027,8 @@ def test_rolling_wrapped_bottleneck(ds, name, center, min_periods, key):
         expected = getattr(bn, func_name)(
             ds[key].values, window=7, axis=0, min_count=min_periods
         )
+    else:
+        raise ValueError
     assert_array_equal(actual[key].values, expected)
 
     # Test center

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6200,7 +6200,7 @@ def test_raise_no_warning_assert_close(ds):
     assert len(record) == 0
 
 
-@pytest.mark.xfail("See https://github.com/pydata/xarray/pull/4369 or docstring")
+@pytest.mark.xfail(reason="See https://github.com/pydata/xarray/pull/4369 or docstring")
 @pytest.mark.filterwarnings("error")
 @pytest.mark.parametrize("ds", (2,), indirect=True)
 @pytest.mark.parametrize("name", ("mean", "max"))

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6201,29 +6201,17 @@ def test_raise_no_warning_assert_close(ds):
 
 
 @pytest.mark.xfail()
+@pytest.mark.filterwarnings("error")
 @pytest.mark.parametrize("ds", (2,), indirect=True)
 @pytest.mark.parametrize("name", ("mean", "max"))
 def test_raise_no_warning_dask_rolling_assert_close(ds, name):
     ds = ds.chunk({"x": 4})
 
-    with pytest.warns(None) as record:
+    rolling_obj = ds.rolling(time=4, x=3)
 
-        rolling_obj = ds.rolling(
-            time=4,
-            x=3,
-        )
-
-        actual = getattr(rolling_obj, name)()
-        expected = getattr(
-            getattr(ds.rolling(time=4,), name)().rolling(
-                x=3,
-            ),
-            name,
-        )()
-        assert_allclose(actual, expected)
-
-    if record:
-        raise AssertionError(record[0].message)
+    actual = getattr(rolling_obj, name)()
+    expected = getattr(getattr(ds.rolling(time=4,), name)().rolling(x=3,), name,)()
+    assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize("dask", [True, False])

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6191,6 +6191,33 @@ def test_raise_no_warning_for_nan_in_binary_ops():
     assert len(record) == 0
 
 
+@pytest.mark.parametrize("ds", (2,), indirect=True)
+def test_raise_no_warning_assert_close(ds):
+
+    with pytest.warns(None) as record:
+        assert_allclose(ds, ds)
+
+    assert len(record) == 0
+
+
+@pytest.mark.xfail()
+@pytest.mark.parametrize("ds", (2,), indirect=True)
+@pytest.mark.parametrize("name", ("mean", "max"))
+def test_raise_no_warning_dask_rolling_assert_close(ds, name):
+    ds = ds.chunk({"x": 4})
+
+    with pytest.warns(None) as record:
+
+        rolling_obj = ds.rolling(time=4, x=3,)
+
+        actual = getattr(rolling_obj, name)()
+        expected = getattr(getattr(ds.rolling(time=4,), name)().rolling(x=3,), name,)()
+        assert_allclose(actual, expected)
+
+    if record:
+        raise AssertionError(record[0].message)
+
+
 @pytest.mark.parametrize("dask", [True, False])
 @pytest.mark.parametrize("edge_order", [1, 2])
 def test_differentiate(dask, edge_order):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6208,10 +6208,18 @@ def test_raise_no_warning_dask_rolling_assert_close(ds, name):
 
     with pytest.warns(None) as record:
 
-        rolling_obj = ds.rolling(time=4, x=3,)
+        rolling_obj = ds.rolling(
+            time=4,
+            x=3,
+        )
 
         actual = getattr(rolling_obj, name)()
-        expected = getattr(getattr(ds.rolling(time=4,), name)().rolling(x=3,), name,)()
+        expected = getattr(
+            getattr(ds.rolling(time=4,), name)().rolling(
+                x=3,
+            ),
+            name,
+        )()
         assert_allclose(actual, expected)
 
     if record:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6210,12 +6210,7 @@ def test_raise_no_warning_dask_rolling_assert_close(ds, name):
     rolling_obj = ds.rolling(time=4, x=3)
 
     actual = getattr(rolling_obj, name)()
-    expected = getattr(
-        getattr(ds.rolling(time=4,), name)().rolling(
-            x=3,
-        ),
-        name,
-    )()
+    expected = getattr(getattr(ds.rolling(time=4), name)().rolling(x=3), name)()
     assert_allclose(actual, expected)
 
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6200,11 +6200,15 @@ def test_raise_no_warning_assert_close(ds):
     assert len(record) == 0
 
 
-@pytest.mark.xfail()
+@pytest.mark.xfail("See https://github.com/pydata/xarray/pull/4369 or docstring")
 @pytest.mark.filterwarnings("error")
 @pytest.mark.parametrize("ds", (2,), indirect=True)
 @pytest.mark.parametrize("name", ("mean", "max"))
 def test_raise_no_warning_dask_rolling_assert_close(ds, name):
+    # This is a puzzle — I can't easily find the source of the warning. It
+    # requires `assert_allclose` to be run, for the `ds` param to be 2, and is
+    # different for `mean` and `max`. `sum` raises no warning.
+
     ds = ds.chunk({"x": 4})
 
     rolling_obj = ds.rolling(time=4, x=3)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6204,9 +6204,11 @@ def test_raise_no_warning_assert_close(ds):
 @pytest.mark.parametrize("ds", (2,), indirect=True)
 @pytest.mark.parametrize("name", ("mean", "max"))
 def test_raise_no_warning_dask_rolling_assert_close(ds, name):
-    # This is a puzzle — I can't easily find the source of the warning. It
-    # requires `assert_allclose` to be run, for the `ds` param to be 2, and is
-    # different for `mean` and `max`. `sum` raises no warning.
+    """
+    This is a puzzle — I can't easily find the source of the warning. It
+    requires `assert_allclose` to be run, for the `ds` param to be 2, and is
+    different for `mean` and `max`. `sum` raises no warning.
+    """
 
     ds = ds.chunk({"x": 4})
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6210,7 +6210,12 @@ def test_raise_no_warning_dask_rolling_assert_close(ds, name):
     rolling_obj = ds.rolling(time=4, x=3)
 
     actual = getattr(rolling_obj, name)()
-    expected = getattr(getattr(ds.rolling(time=4,), name)().rolling(x=3,), name,)()
+    expected = getattr(
+        getattr(ds.rolling(time=4,), name)().rolling(
+            x=3,
+        ),
+        name,
+    )()
     assert_allclose(actual, expected)
 
 

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -121,10 +121,7 @@ class TestOps:
         assert_array_equal(result, np.array([1, "b"], dtype=object))
 
     def test_all_nan_arrays(self):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "All-NaN slice")
-            warnings.filterwarnings("ignore", "Mean of empty slice")
-            assert np.isnan(mean([np.nan, np.nan]))
+        assert np.isnan(mean([np.nan, np.nan]))
 
 
 def test_cumsum_1d():

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -120,6 +120,7 @@ class TestOps:
         result = concatenate([[1], ["b"]])
         assert_array_equal(result, np.array([1, "b"], dtype=object))
 
+    @pytest.mark.filterwarnings("error")
     def test_all_nan_arrays(self):
         assert np.isnan(mean([np.nan, np.nan]))
 

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -447,8 +447,7 @@ def test_groupby_drops_nans():
 
     # reduction operation along a different dimension
     actual = grouped.mean("time")
-    with pytest.warns(RuntimeWarning):  # mean of empty slice
-        expected = ds.mean("time").where(ds.id.notnull())
+    expected = ds.mean("time").where(ds.id.notnull())
     assert_identical(actual, expected)
 
     # NaN in non-dimensional coordinate

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -119,6 +119,7 @@ def test_weighted_sum_nan(weights, expected, skipna):
     assert_equal(expected, result)
 
 
+@pytest.mark.filterwarnings("error")
 @pytest.mark.parametrize("da", ([1.0, 2], [1, np.nan], [np.nan, np.nan]))
 @pytest.mark.parametrize("skipna", (True, False))
 @pytest.mark.parametrize("factor", [1, 2, 3.14])

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -119,7 +119,6 @@ def test_weighted_sum_nan(weights, expected, skipna):
     assert_equal(expected, result)
 
 
-@pytest.mark.filterwarnings("ignore:Mean of empty slice")
 @pytest.mark.parametrize("da", ([1.0, 2], [1, np.nan], [np.nan, np.nan]))
 @pytest.mark.parametrize("skipna", (True, False))
 @pytest.mark.parametrize("factor", [1, 2, 3.14])


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes https://github.com/pydata/xarray/issues/3811
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Is this the right approach? Or should we be using `np.errstate` machinery?
