### PR TITLE
Use deepcopy recursively on numpy arrays

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -932,14 +932,13 @@ class Variable(
                 # don't share caching between copies
                 data = indexing.MemoryCachedArray(data.array)
 
-            if deep:
-                if hasattr(data, "__array_function__") or isinstance(
-                    data, dask_array_type
-                ):
-                    data = data.copy()
-                elif not isinstance(data, PandasIndexAdapter):
-                    # pandas.Index is immutable
-                    data = np.array(data)
+            if deep and (
+                hasattr(data, "__array_function__")
+                or isinstance(data, dask_array_type)
+                or (not IS_NEP18_ACTIVE and isinstance(data, np.ndarray))
+            ):
+                data = copy.deepcopy(data)
+
         else:
             data = as_compatible_data(data)
             if self.shape != data.shape:

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6833,3 +6833,9 @@ def test_delete_coords():
     assert a1.dims == ("y", "x")
     assert set(a0.coords.keys()) == {"x", "y"}
     assert set(a1.coords.keys()) == {"x"}
+
+
+def test_deepcopy_obj_array():
+    x0 = DataArray(np.array([object()]))
+    x1 = deepcopy(x0)
+    assert x0.values[0] is not x1.values[0]

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6454,3 +6454,9 @@ def test_weakref():
     ds = Dataset()
     r = ref(ds)
     assert r() is ds
+
+
+def test_deepcopy_obj_array():
+    x0 = Dataset(dict(foo=DataArray(np.array([object()]))))
+    x1 = deepcopy(x0)
+    assert x0["foo"].values[0] is not x1["foo"].values[0]


### PR DESCRIPTION
 - [x] Closes #4362 
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

(Not sure this is worth noting in whats-new)