### PR TITLE
Add xarray-compare to related projects

### DIFF
--- a/doc/related-projects.rst
+++ b/doc/related-projects.rst
@@ -65,6 +65,7 @@ Extend xarray capabilities
 - `eofs <https://ajdawson.github.io/eofs/>`_: EOF analysis in Python.
 - `hypothesis-gufunc <https://hypothesis-gufunc.readthedocs.io/en/latest/>`_: Extension to hypothesis. Makes it easy to write unit tests with xarray objects as input.
 - `nxarray <https://github.com/nxarray/nxarray>`_: NeXus input/output capability for xarray.
+- `xarray-compare <https://github.com/astropenguin/xarray-compare>`_: xarray extension for data comparison.
 - `xarray-custom <https://github.com/astropenguin/xarray-custom>`_: Data classes for custom xarray creation.
 - `xarray_extras <https://github.com/crusaderky/xarray_extras>`_: Advanced algorithms for xarray objects (e.g. integrations/interpolations).
 - `xpublish <https://xpublish.readthedocs.io/>`_: Publish Xarray Datasets via a Zarr compatible REST API.


### PR DESCRIPTION
We have released [xarray-compare](https://github.com/astropenguin/xarray-compare), a Python package which provides extra data-comparison features (e.g., `dataarray.isbetween(lower, upper)`).
This PR adds the project to the "Extend xarray capabilities" section in `doc/related-projects.rst`.

We have a concern: This package **directly** adds some methods to `xarray.DataArray` by using [the accessor feature](https://xarray.pydata.org/en/stable/internals.html#extending-xarray).
For example, `dataarray.isbetween()` is implemented by registering an accessor whose name is `'isbetween'`.
This usage may not be what is expected by the xarray's developers.

So it would be appreciated if you could merge it, but if you feel that it does not fit the docs, please reject the PR.
Thank you!