### PR TITLE
Dask/cleanup

### DIFF
--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -92,7 +92,9 @@ def lazy_elemwise_func(array, func, dtype):
     Either a dask.array.Array or _ElementwiseFunctionArray.
     """
     if isinstance(array, dask_array_type):
-        return array.map_blocks(func, dtype=dtype)
+        import dask.array as da
+
+        return da.map_blocks(func, array, dtype=dtype)
     else:
         return _ElementwiseFunctionArray(array, func, dtype)
 

--- a/xarray/core/dask_array_compat.py
+++ b/xarray/core/dask_array_compat.py
@@ -4,100 +4,12 @@ from typing import Iterable
 
 import numpy as np
 
-from .pycompat import dask_array_type
-
 try:
     import dask.array as da
     from dask import __version__ as dask_version
 except ImportError:
     dask_version = "0.0.0"
     da = None
-
-if LooseVersion(dask_version) >= LooseVersion("2.0.0"):
-    meta_from_array = da.utils.meta_from_array
-else:
-    # Copied from dask v2.4.0
-    # Used under the terms of Dask's license, see licenses/DASK_LICENSE.
-    import numbers
-
-    def meta_from_array(x, ndim=None, dtype=None):
-        """Normalize an array to appropriate meta object
-
-        Parameters
-        ----------
-        x: array-like, callable
-        Either an object that looks sufficiently like a Numpy array,
-        or a callable that accepts shape and dtype keywords
-        ndim: int
-        Number of dimensions of the array
-        dtype: Numpy dtype
-        A valid input for ``np.dtype``
-
-        Returns
-        -------
-        array-like with zero elements of the correct dtype
-        """
-        # If using x._meta, x must be a Dask Array, some libraries (e.g. zarr)
-        # implement a _meta attribute that are incompatible with Dask Array._meta
-        if hasattr(x, "_meta") and isinstance(x, dask_array_type):
-            x = x._meta
-
-        if dtype is None and x is None:
-            raise ValueError("You must specify the meta or dtype of the array")
-
-        if np.isscalar(x):
-            x = np.array(x)
-
-        if x is None:
-            x = np.ndarray
-
-        if isinstance(x, type):
-            x = x(shape=(0,) * (ndim or 0), dtype=dtype)
-
-        if (
-            not hasattr(x, "shape")
-            or not hasattr(x, "dtype")
-            or not isinstance(x.shape, tuple)
-        ):
-            return x
-
-        if isinstance(x, list) or isinstance(x, tuple):
-            ndims = [
-                0
-                if isinstance(a, numbers.Number)
-                else a.ndim
-                if hasattr(a, "ndim")
-                else len(a)
-                for a in x
-            ]
-            a = [a if nd == 0 else meta_from_array(a, nd) for a, nd in zip(x, ndims)]
-            return a if isinstance(x, list) else tuple(x)
-
-        if ndim is None:
-            ndim = x.ndim
-
-        try:
-            meta = x[tuple(slice(0, 0, None) for _ in range(x.ndim))]
-            if meta.ndim != ndim:
-                if ndim > x.ndim:
-                    meta = meta[
-                        (Ellipsis,) + tuple(None for _ in range(ndim - meta.ndim))
-                    ]
-                    meta = meta[tuple(slice(0, 0, None) for _ in range(meta.ndim))]
-                elif ndim == 0:
-                    meta = meta.sum()
-                else:
-                    meta = meta.reshape((0,) * ndim)
-        except Exception:
-            meta = np.empty((0,) * ndim, dtype=dtype or x.dtype)
-
-        if np.isscalar(meta):
-            meta = np.array(meta)
-
-        if dtype and meta.dtype != dtype:
-            meta = meta.astype(dtype)
-
-        return meta
 
 
 def _validate_pad_output_shape(input_shape, pad_width, output_shape):

--- a/xarray/core/dask_array_compat.py
+++ b/xarray/core/dask_array_compat.py
@@ -58,43 +58,6 @@ def pad(array, pad_width, mode="constant", **kwargs):
     return padded
 
 
-if LooseVersion(dask_version) >= LooseVersion("2.8.1"):
-    median = da.median
-else:
-    # Copied from dask v2.8.1
-    # Used under the terms of Dask's license, see licenses/DASK_LICENSE.
-    def median(a, axis=None, keepdims=False):
-        """
-        This works by automatically chunking the reduced axes to a single chunk
-        and then calling ``numpy.median`` function across the remaining dimensions
-        """
-
-        if axis is None:
-            raise NotImplementedError(
-                "The da.median function only works along an axis.  "
-                "The full algorithm is difficult to do in parallel"
-            )
-
-        if not isinstance(axis, Iterable):
-            axis = (axis,)
-
-        axis = [ax + a.ndim if ax < 0 else ax for ax in axis]
-
-        a = a.rechunk({ax: -1 if ax in axis else "auto" for ax in range(a.ndim)})
-
-        result = a.map_blocks(
-            np.median,
-            axis=axis,
-            keepdims=keepdims,
-            drop_axis=axis if not keepdims else None,
-            chunks=[1 if ax in axis else c for ax, c in enumerate(a.chunks)]
-            if keepdims
-            else None,
-        )
-
-        return result
-
-
 if LooseVersion(dask_version) > LooseVersion("2.9.0"):
     nanmedian = da.nanmedian
 else:

--- a/xarray/core/dask_array_compat.py
+++ b/xarray/core/dask_array_compat.py
@@ -118,8 +118,9 @@ else:
 
         a = a.rechunk({ax: -1 if ax in axis else "auto" for ax in range(a.ndim)})
 
-        result = a.map_blocks(
+        result = da.map_blocks(
             np.nanmedian,
+            a,
             axis=axis,
             keepdims=keepdims,
             drop_axis=axis if not keepdims else None,

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -18,8 +18,8 @@ def dask_rolling_wrapper(moving_func, a, window, min_count=None, axis=-1):
     # Create overlap array.
     ag = da.overlap.overlap(a, depth=depth, boundary=boundary)
     # apply rolling func
-    out = ag.map_blocks(
-        moving_func, window, min_count=min_count, axis=axis, dtype=a.dtype
+    out = da.map_blocks(
+        moving_func, ag, window, min_count=min_count, axis=axis, dtype=a.dtype
     )
     # trim array
     result = da.overlap.trim_internal(out, depth)
@@ -95,8 +95,14 @@ def rolling_window(a, axis, window, center, fill_value):
 
     chunks = list(a.chunks) + window
     new_axis = [a.ndim + i for i in range(len(axis))]
-    out = ag.map_blocks(
-        func, dtype=a.dtype, new_axis=new_axis, chunks=chunks, window=window, axis=axis
+    out = da.map_blocks(
+        func,
+        ag,
+        dtype=a.dtype,
+        new_axis=new_axis,
+        chunks=chunks,
+        window=window,
+        axis=axis,
     )
 
     # crop boundary.

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -1,9 +1,8 @@
 try:
     import dask
     import dask.array
+    from dask.array.utils import meta_from_array
     from dask.highlevelgraph import HighLevelGraph
-
-    from .dask_array_compat import meta_from_array
 
 except ImportError:
     pass
@@ -256,9 +255,7 @@ def map_blocks(
     to the function being applied in ``xr.map_blocks()``:
 
     >>> array.map_blocks(
-    ...     calculate_anomaly,
-    ...     kwargs={"groupby_type": "time.year"},
-    ...     template=array,
+    ...     calculate_anomaly, kwargs={"groupby_type": "time.year"}, template=array,
     ... )  # doctest: +ELLIPSIS
     <xarray.DataArray (time: 24)>
     dask.array<calculate_anomaly-...-<this, shape=(24,), dtype=float64, chunksize=(24,), chunktype=numpy.ndarray>


### PR DESCRIPTION
Some dask array cleanups

1. switch to using `dask.array.map_blocks` instead of `Array.map_blocks` (duck dask array compatibility)
2. Stop vendoring `meta_from_array` and `median`