### PR TITLE
black, v2

### DIFF
--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -56,9 +56,7 @@ _VALID_COMPAT = Frozen(
 )
 
 
-def broadcast_dimension_size(
-    variables: List[Variable],
-) -> Dict[Hashable, int]:
+def broadcast_dimension_size(variables: List[Variable]) -> Dict[Hashable, int]:
     """Extract dimension sizes from a dictionary of variables.
 
     Raises ValueError if any dimensions have different sizes.

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -322,9 +322,7 @@ def _assert_dataset_invariants(ds: Dataset):
     assert isinstance(ds._attrs, (type(None), dict))
 
 
-def _assert_internal_invariants(
-    xarray_obj: Union[DataArray, Dataset, Variable],
-):
+def _assert_internal_invariants(xarray_obj: Union[DataArray, Dataset, Variable]):
     """Validate that an xarray object satisfies its own internal invariants.
 
     This exists for the benefit of xarray's own test suite, but may be useful


### PR DESCRIPTION
Follow-up to #4381, removing some trailing commas.
