### PR TITLE
Remove deprecated usages of drop

### DIFF
--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -250,7 +250,9 @@ class TestConcatDataset:
             assert_equal(actual, expected[join])
 
         # regression test for #3681
-        actual = concat([ds1.drop("x"), ds2.drop("x")], join="override", dim="y")
+        actual = concat(
+            [ds1.drop_vars("x"), ds2.drop_vars("x")], join="override", dim="y"
+        )
         expected = Dataset(
             {"a": (("x", "y"), np.array([0, 0], ndmin=2))}, coords={"y": [0, 0.0001]}
         )

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -847,13 +847,15 @@ def test_interpolate_chunk_advanced(method):
     theta = np.linspace(0, 2 * np.pi, 5)
     w = np.linspace(-0.25, 0.25, 7)
     r = xr.DataArray(
-        data=1 + w[:, np.newaxis] * np.cos(theta), coords=[("w", w), ("theta", theta)],
+        data=1 + w[:, np.newaxis] * np.cos(theta),
+        coords=[("w", w), ("theta", theta)],
     )
 
     x = r * np.cos(theta)
     y = r * np.sin(theta)
     z = xr.DataArray(
-        data=w[:, np.newaxis] * np.sin(theta), coords=[("w", w), ("theta", theta)],
+        data=w[:, np.newaxis] * np.sin(theta),
+        coords=[("w", w), ("theta", theta)],
     )
 
     kwargs = {"fill_value": None}

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -742,8 +742,10 @@ def test_decompose(method):
     x_broadcast, y_broadcast = xr.broadcast(x_new, y_new)
     assert x_broadcast.ndim == 2
 
-    actual = da.interp(x=x_new, y=y_new, method=method).drop(("x", "y"))
-    expected = da.interp(x=x_broadcast, y=y_broadcast, method=method).drop(("x", "y"))
+    actual = da.interp(x=x_new, y=y_new, method=method).drop_vars(("x", "y"))
+    expected = da.interp(x=x_broadcast, y=y_broadcast, method=method).drop_vars(
+        ("x", "y")
+    )
     assert_allclose(actual, expected)
 
 
@@ -845,15 +847,13 @@ def test_interpolate_chunk_advanced(method):
     theta = np.linspace(0, 2 * np.pi, 5)
     w = np.linspace(-0.25, 0.25, 7)
     r = xr.DataArray(
-        data=1 + w[:, np.newaxis] * np.cos(theta),
-        coords=[("w", w), ("theta", theta)],
+        data=1 + w[:, np.newaxis] * np.cos(theta), coords=[("w", w), ("theta", theta)],
     )
 
     x = r * np.cos(theta)
     y = r * np.sin(theta)
     z = xr.DataArray(
-        data=w[:, np.newaxis] * np.sin(theta),
-        coords=[("w", w), ("theta", theta)],
+        data=w[:, np.newaxis] * np.sin(theta), coords=[("w", w), ("theta", theta)],
     )
 
     kwargs = {"fill_value": None}


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `isort . && black . && mypy . && flake8`