### PR TITLE
Pin pre-commit versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,11 @@ repos:
       - id: isort
   # https://github.com/python/black#version-control-integration
   - repo: https://github.com/python/black
-    rev: stable
+    rev: 20.8b1
     hooks:
       - id: black
   - repo: https://github.com/keewis/blackdoc
-    rev: stable
+    rev: v0.1.1
     hooks:
       - id: blackdoc
   - repo: https://gitlab.com/pycqa/flake8

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -104,7 +104,7 @@ Internal Changes
   By `Mathias Hauser <https://github.com/mathause>`_.
 - Updated plot functions for matplotlib version 3.3 and silenced warnings in the
   plot tests (:pull:`4365`). By `Mathias Hauser <https://github.com/mathause>`_.
-- Versions in ``pre-commit.yaml'' are now pinned, to reduce the chances of
+- Versions in ``pre-commit.yaml`` are now pinned, to reduce the chances of
   conflicting versions.
   By `Maximilian Roos <https://github.com/max-sixty>`_
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -105,7 +105,7 @@ Internal Changes
 - Updated plot functions for matplotlib version 3.3 and silenced warnings in the
   plot tests (:pull:`4365`). By `Mathias Hauser <https://github.com/mathause>`_.
 - Versions in ``pre-commit.yaml`` are now pinned, to reduce the chances of
-  conflicting versions.
+  conflicting versions. (:pull:`4388`)
   By `Maximilian Roos <https://github.com/max-sixty>`_
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -84,11 +84,11 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
-- update the docstring of :py:meth:`DataArray.copy` to remove incorrect mention of 'dataset' (:issue:`3606`)
+- Update the docstring of :py:meth:`DataArray.copy` to remove incorrect mention of 'dataset' (:issue:`3606`)
   By `Sander van Rijn <https://github.com/sjvrijn>`_.
-- removed skipna argument from :py:meth:`DataArray.count`, :py:meth:`DataArray.any`, :py:meth:`DataArray.all`. (:issue:`755`)
+- Removed skipna argument from :py:meth:`DataArray.count`, :py:meth:`DataArray.any`, :py:meth:`DataArray.all`. (:issue:`755`)
   By `Sander van Rijn <https://github.com/sjvrijn>`_
-- update the contributing guide to use merges instead of rebasing and state
+- Update the contributing guide to use merges instead of rebasing and state
   that we squash-merge. (:pull:`4355`) By `Justus Magin <https://github.com/keewis>`_.
 
 Internal Changes
@@ -104,6 +104,11 @@ Internal Changes
   By `Mathias Hauser <https://github.com/mathause>`_.
 - Updated plot functions for matplotlib version 3.3 and silenced warnings in the
   plot tests (:pull:`4365`). By `Mathias Hauser <https://github.com/mathause>`_.
+- Versions in ``pre-commit.yaml'' are now pinned, to reduce the chances of
+  conflicting versions.
+  By `Maximilian Roos <https://github.com/max-sixty>`_
+
+
 
 .. _whats-new.0.16.0:
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

I had some issues with the version changing — this approach seems more explicit and less likely to cause hard-to-debug issues