### PR TITLE
move kwarg's `output_sizes` and `meta` to `dask_gufunc_kwargs` for in…

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -94,7 +94,7 @@ Documentation
 Internal Changes
 ~~~~~~~~~~~~~~~~
 - Use :py:func:`dask.array.apply_gufunc` instead of :py:func:`dask.array.blockwise` in
-  :py:func:`xarray.apply_ufunc` when using ``dask='parallelized'``. (:pull:`4060`)
+  :py:func:`xarray.apply_ufunc` when using ``dask='parallelized'``. (:pull:`4060`, :pull:`4391`)
 - Fix ``pip install .`` when no ``.git`` directory exists; namely when the xarray source
   directory has been rsync'ed by PyCharm Professional for a remote deployment over SSH.
   By `Guido Imperiale <https://github.com/crusaderky>`_

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1861,7 +1861,7 @@ class Variable(
             exclude_dims=set(dim),
             output_core_dims=[["quantile"]],
             output_dtypes=[np.float64],
-            output_sizes={"quantile": len(q)},
+            dask_gufunc_kwargs=dict(output_sizes={"quantile": len(q)}),
             dask="parallelized",
             kwargs={"q": q, "axis": axis, "interpolation": interpolation},
         )

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -782,7 +782,7 @@ def test_apply_dask_new_output_dimension():
             output_core_dims=[["sign"]],
             dask="parallelized",
             output_dtypes=[obj.dtype],
-            output_sizes={"sign": 2},
+            dask_gufunc_kwargs=dict(output_sizes={"sign": 2}),
         )
 
     expected = stack_negative(data_array.compute())
@@ -891,7 +891,7 @@ def test_vectorize_dask_dtype_meta():
         vectorize=True,
         dask="parallelized",
         output_dtypes=[int],
-        meta=np.ndarray((0, 0), dtype=np.float),
+        dask_gufunc_kwargs=dict(meta=np.ndarray((0, 0), dtype=np.float)),
     )
 
     assert_identical(expected, actual)
@@ -1121,7 +1121,7 @@ def test_vectorize_dask_new_output_dims():
         vectorize=True,
         dask="parallelized",
         output_dtypes=[float],
-        output_sizes={"z": 1},
+        dask_gufunc_kwargs=dict(output_sizes={"z": 1}),
     ).transpose(*expected.dims)
     assert_identical(expected, actual)
 
@@ -1133,7 +1133,7 @@ def test_vectorize_dask_new_output_dims():
             vectorize=True,
             dask="parallelized",
             output_dtypes=[float],
-            output_sizes={"z1": 1},
+            dask_gufunc_kwargs=dict(output_sizes={"z1": 1}),
         )
 
     with raises_regex(


### PR DESCRIPTION
…ternal use of `apply_ufunc` (follow-up to #4060, fixes #4385)

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4385
 - [ ] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
