### PR TITLE
WIP: Ensure that zarr.ZipStores are closed

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -71,6 +71,8 @@ Bug fixes
 - Fixed a bug in backend caused by basic installation of Dask (:issue:`4164`, :pull:`4318`)
   `Sam Morley <https://github.com/inakleinbottle>`_.
 - Fixed a few bugs with :py:meth:`Dataset.polyfit` when encountering deficient matrix ranks (:issue:`4190`, :pull:`4193`). By `Pascal Bourgault <https://github.com/aulemahal>`_.
+- Fix unclosed ``ZipStore`` when using ``to_zarr`` with a ``".zip"`` extension.
+  By `Mark Harfouche <https://github.com/hmaarrfk>`_.
 - Fixed inconsistencies between docstring and functionality for :py:meth:`DataArray.str.get`
   and :py:meth:`DataArray.str.wrap` (:issue:`4334`). By `Mathias Hauser <https://github.com/mathause>`_.
 - Fixed overflow issue causing incorrect results in computing means of :py:class:`cftime.datetime`

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -493,6 +493,10 @@ class ZarrStore(AbstractWritableDataStore):
             import zarr
 
             zarr.consolidate_metadata(self.ds.store)
+        # ZipStore has a close method, but DirectoryStore does not
+        # https://github.com/zarr-developers/zarr-python/issues/594
+        if hasattr(self.ds.store, "close"):
+            self.ds.store.close()
 
 
 def open_zarr(

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2025,6 +2025,16 @@ class ZarrBase(CFEncodedBase):
         ) as ds1:
             assert_equal(ds1, original)
 
+    def test_zip_store_close(self, tmp_path):
+        # Use a zip extension to ensure that a zip store gets used.
+        zip_filename = str(tmp_path / "store.zip")
+
+        ds = xr.DataArray((np.arange(12)), dims="x", name="var1").to_dataset()
+
+        ds_store = ds.to_zarr(zip_filename, mode="w")
+        # If the ZipStore is closed correctly, the file pointer will be None
+        assert ds_store.ds.store.zf.fp is None
+
 
 @requires_zarr
 class TestZarrDictStore(ZarrBase):


### PR DESCRIPTION
ZipStores aren't always closed making it hard to use them as fluidly as regular zarr stores.

 - [ ] Closes #xxxx
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`  # master doesn't pass black
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
