### PR TITLE
update the isort and blackdoc pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
   # isort should run before black as black sometimes tweaks the isort output
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.1.0
+    rev: 5.4.2
     hooks:
       - id: isort
   # https://github.com/python/black#version-control-integration
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/keewis/blackdoc
-    rev: v0.1.1
+    rev: v0.1.2
     hooks:
       - id: blackdoc
   - repo: https://gitlab.com/pycqa/flake8


### PR DESCRIPTION
Follow-up to #4388. Updates the versions of `isort` and `blackdoc` (by calling `pre-commit autoupdate`). The most recent version of `blackdoc` is important because it fixes the broken compatibility with `black` 20.08b1.
