### PR TITLE
Keep the original ordering of the coordinates

### DIFF
--- a/ci/requirements/py36-min-nep18.yml
+++ b/ci/requirements/py36-min-nep18.yml
@@ -10,7 +10,7 @@ dependencies:
   - distributed=2.9
   - numpy=1.17
   - pandas=0.25
-  - pint=0.13
+  - pint=0.15
   - pip
   - pytest
   - pytest-cov

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,7 +33,7 @@ New Features
   now accept more than 1 dimension. (:pull:`4219`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 - ``min_count`` can be supplied to reductions such as ``.sum`` when specifying
-  multiple dimension to reduce over. (:pull:`4356`) 
+  multiple dimension to reduce over. (:pull:`4356`)
   By `Maximilian Roos <https://github.com/max-sixty>`_.
 - :py:func:`xarray.cov` and :py:func:`xarray.corr` now handle missing values. (:pull:`4351`)
   By `Maximilian Roos <https://github.com/max-sixty>`_.
@@ -77,7 +77,7 @@ Bug fixes
   and :py:meth:`DataArray.str.wrap` (:issue:`4334`). By `Mathias Hauser <https://github.com/mathause>`_.
 - Fixed overflow issue causing incorrect results in computing means of :py:class:`cftime.datetime`
   arrays (:issue:`4341`). By `Spencer Clark <https://github.com/spencerkclark>`_.
-- Fixed :py:meth:`Dataset.coarsen`, :py:meth:`DataArray.coarsen` dropping attributes on original object (:issue:`4120`, :pull:`4360`). by `Julia Kent <https://github.com/jukent>`_.
+- Fixed :py:meth:`Dataset.coarsen`, :py:meth:`DataArray.coarsen` dropping attributes on original object (:issue:`4120`, :pull:`4360`). By `Julia Kent <https://github.com/jukent>`_.
 - fix the signature of the plot methods. (:pull:`4359`) By `Justus Magin <https://github.com/keewis>`_.
 - Fix :py:func:`xarray.apply_ufunc` with ``vectorize=True`` and ``exclude_dims`` (:issue:`3890`).
   By `Mathias Hauser <https://github.com/mathause>`_.
@@ -86,6 +86,8 @@ Bug fixes
   By `Jens Svensmark <https://github.com/jenssss>`_
 - Fix incorrect legend labels for :py:meth:`Dataset.plot.scatter` (:issue:`4126`).
   By `Peter Hausamann <https://github.com/phausamann>`_.
+- Avoid relying on :py:class:`set` objects for the ordering of the coordinates (:pull:`4409`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Documentation
 ~~~~~~~~~~~~~
@@ -96,6 +98,8 @@ Documentation
   By `Sander van Rijn <https://github.com/sjvrijn>`_
 - Update the contributing guide to use merges instead of rebasing and state
   that we squash-merge. (:pull:`4355`) By `Justus Magin <https://github.com/keewis>`_.
+- Make sure the examples from the docstrings actually work (:pull:`4408`).
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -349,9 +349,8 @@ def _parse_datasets(
         all_coord_names.update(ds.coords)
         data_vars.update(ds.data_vars)
 
-        common_dims = set(ds.dims) - dims
         for dim in ds.dims:
-            if dim not in common_dims:
+            if dim in dims:
                 continue
 
             if dim not in dim_coords:

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -349,6 +349,7 @@ def _parse_datasets(
         all_coord_names.update(ds.coords)
         data_vars.update(ds.data_vars)
 
+        # preserves ordering of dimensions
         for dim in ds.dims:
             if dim in dims:
                 continue

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -349,7 +349,11 @@ def _parse_datasets(
         all_coord_names.update(ds.coords)
         data_vars.update(ds.data_vars)
 
-        for dim in set(ds.dims) - dims:
+        common_dims = set(ds.dims) - dims
+        for dim in ds.dims:
+            if dim not in common_dims:
+                continue
+
             if dim not in dim_coords:
                 dim_coords[dim] = ds.coords[dim].variable
         dims = dims | set(ds.dims)

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -215,7 +215,15 @@ class DatasetCoordinates(Coordinates):
 
     def to_dataset(self) -> "Dataset":
         """Convert these coordinates into a new Dataset"""
-        return self._data._copy_listed(self._names)
+
+        def key(name):
+            try:
+                return list(self._data._variables.keys()).index(name)
+            except ValueError:
+                return len(self._data._variables)
+
+        names = sorted(self._names, key=key)
+        return self._data._copy_listed(names)
 
     def _update_coords(
         self, coords: Dict[Hashable, Variable], indexes: Mapping[Hashable, pd.Index]

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -216,13 +216,7 @@ class DatasetCoordinates(Coordinates):
     def to_dataset(self) -> "Dataset":
         """Convert these coordinates into a new Dataset"""
 
-        def key(name):
-            try:
-                return list(self._data._variables.keys()).index(name)
-            except ValueError:
-                return len(self._data._variables)
-
-        names = sorted(self._names, key=key)
+        names = [name for name in self._data._variables if name in self._names]
         return self._data._copy_listed(names)
 
     def _update_coords(

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1148,6 +1148,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         dims = {k: self.dims[k] for k in needed_dims}
 
+        # preserves ordering of coordinates
         for k in self._variables:
             if k not in self._coord_names:
                 continue

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1123,6 +1123,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         coord_names = set()
         indexes: Dict[Hashable, pd.Index] = {}
 
+        names = [name for name in self.variables.keys() if name in names]
         for name in names:
             try:
                 variables[name] = self._variables[name]
@@ -1142,7 +1143,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         dims = {k: self.dims[k] for k in needed_dims}
 
-        for k in self._coord_names:
+        for k in self._variables:
+            if k not in self._coord_names:
+                continue
+
             if set(self.variables[k].dims) <= needed_dims:
                 variables[k] = self._variables[k]
                 coord_names.add(k)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1123,8 +1123,13 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         coord_names = set()
         indexes: Dict[Hashable, pd.Index] = {}
 
-        names = [name for name in self.variables.keys() if name in names]
-        for name in names:
+        def key(name):
+            try:
+                return list(self._variables.keys()).index(name)
+            except ValueError:
+                return len(self._variables)
+
+        for name in sorted(names, key=key):
             try:
                 variables[name] = self._variables[name]
             except KeyError:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1123,13 +1123,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         coord_names = set()
         indexes: Dict[Hashable, pd.Index] = {}
 
-        def key(name):
-            try:
-                return list(self._variables.keys()).index(name)
-            except ValueError:
-                return len(self._variables)
-
-        for name in sorted(names, key=key):
+        for name in names:
             try:
                 variables[name] = self._variables[name]
             except KeyError:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5733,10 +5733,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         <xarray.Dataset>
         Dimensions:         (time: 3, x: 2, y: 2)
         Coordinates:
-            reference_time  datetime64[ns] 2014-09-05
+            lon             (x, y) float64 -99.83 -99.32 -99.79 -99.23
             lat             (x, y) float64 42.25 42.21 42.63 42.59
           * time            (time) datetime64[ns] 2014-09-06 2014-09-07 2014-09-08
-            lon             (x, y) float64 -99.83 -99.32 -99.79 -99.23
+            reference_time  datetime64[ns] 2014-09-05
         Dimensions without coordinates: x, y
         Data variables:
             precipitation   (x, y, time) float64 5.68 9.256 0.7104 ... 7.992 4.615 7.805
@@ -5746,10 +5746,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         <xarray.Dataset>
         Dimensions:         (time: 3, x: 2, y: 2)
         Coordinates:
-            reference_time  datetime64[ns] 2014-09-05
+            lon             (x, y) float64 -99.83 -99.32 -99.79 -99.23
             lat             (x, y) float64 42.25 42.21 42.63 42.59
           * time            (time) datetime64[ns] 2014-09-06 2014-09-07 2014-09-08
-            lon             (x, y) float64 -99.83 -99.32 -99.79 -99.23
+            reference_time  datetime64[ns] 2014-09-05
         Dimensions without coordinates: x, y
         Data variables:
             temperature     (x, y, time) float64 29.11 18.2 22.83 ... 18.28 16.15 26.63

--- a/xarray/tests/test_testing.py
+++ b/xarray/tests/test_testing.py
@@ -70,12 +70,7 @@ def test_assert_allclose(obj1, obj2):
         pytest.param(
             quantity,
             id="pint",
-            marks=[
-                pytest.mark.skipif(not has_pint, reason="requires pint"),
-                pytest.mark.xfail(
-                    reason="inconsistencies in the return value of pint's implementation of eq"
-                ),
-            ],
+            marks=pytest.mark.skipif(not has_pint, reason="requires pint"),
         ),
     ),
 )
@@ -115,12 +110,7 @@ def test_assert_duckarray_equal_failing(duckarray, obj1, obj2):
         pytest.param(
             quantity,
             id="pint",
-            marks=[
-                pytest.mark.skipif(not has_pint, reason="requires pint"),
-                pytest.mark.xfail(
-                    reason="inconsistencies in the return value of pint's implementation of eq"
-                ),
-            ],
+            marks=pytest.mark.skipif(not has_pint, reason="requires pint"),
         ),
     ),
 )


### PR DESCRIPTION
In #4408, The formatting of `coords` turned out to be non-deterministic. This sorts the data variables, coordinates and dimensions without coordinates sections as well as the dimensions summary of `Dataset` objects.

No tests, yet, because I'm not quite sure sorting using the `str` representation of the key is the best way to make the formatting deterministic (so I'd appreciate reviews). 

It might also be good to document somewhere that these sections are now sorted, and that it only makes sense to look at the order in the dimension summary of `DataArray` and `Variable` objects. 

 - [x] Closes #4072
 - [ ] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
