### PR TITLE
Add try/except logic to handle renaming of cftime datetime base class

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -64,7 +64,7 @@ For plotting
 - `seaborn <http://seaborn.pydata.org/>`__: for better
   color palettes
 - `nc-time-axis <https://github.com/SciTools/nc-time-axis>`__: for plotting
-  cftime.datetime objects
+  ``cftime`` datetime objects
 
 Alternative data containers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -26,7 +26,7 @@ makes for an easy transition between the two.
 Matplotlib must be installed before xarray can plot.
 
 To use xarray's plotting capabilities with time coordinates containing
-``cftime.datetime`` objects
+``cftime`` datetime objects
 `nc-time-axis <https://github.com/SciTools/nc-time-axis>`_ v1.2.0 or later
 needs to be installed.
 

--- a/doc/time-series.rst
+++ b/doc/time-series.rst
@@ -71,7 +71,7 @@ You can manual decode arrays in this form by passing a dataset to
 One unfortunate limitation of using ``datetime64[ns]`` is that it limits the
 native representation of dates to those that fall between the years 1678 and
 2262. When a netCDF file contains dates outside of these bounds, dates will be
-returned as arrays of :py:class:`cftime.datetime` objects and a :py:class:`~xarray.CFTimeIndex`
+returned as arrays of ``cftime`` datetime objects and a :py:class:`~xarray.CFTimeIndex`
 will be used for indexing.  :py:class:`~xarray.CFTimeIndex` enables a subset of
 the indexing functionality of a :py:class:`pandas.DatetimeIndex` and is only
 fully compatible with the standalone version of ``cftime`` (not the version

--- a/doc/weather-climate.rst
+++ b/doc/weather-climate.rst
@@ -37,7 +37,7 @@ using a standard calendar, but outside the `Timestamp-valid range`_
 
 .. note::
 
-   As of xarray version 0.11, by default, :py:class:`cftime.datetime` objects
+   As of xarray version 0.11, by default, ``cftime`` datetime objects
    will be used to represent times (either in indexes, as a
    :py:class:`~xarray.CFTimeIndex`, or in data arrays with dtype object) if
    any of the following are true:
@@ -144,7 +144,7 @@ For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
 
     da.groupby("time.month").sum()
 
-- Interpolation using :py:class:`cftime.datetime` objects:
+- Interpolation using ``cftime`` datetime objects:
 
 .. ipython:: python
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -75,7 +75,7 @@ Bug fixes
 - Fixed a few bugs with :py:meth:`Dataset.polyfit` when encountering deficient matrix ranks (:issue:`4190`, :pull:`4193`). By `Pascal Bourgault <https://github.com/aulemahal>`_.
 - Fixed inconsistencies between docstring and functionality for :py:meth:`DataArray.str.get`
   and :py:meth:`DataArray.str.wrap` (:issue:`4334`). By `Mathias Hauser <https://github.com/mathause>`_.
-- Fixed overflow issue causing incorrect results in computing means of :py:class:`cftime.datetime`
+- Fixed overflow issue causing incorrect results in computing means of ``cftime`` datetime
   arrays (:issue:`4341`). By `Spencer Clark <https://github.com/spencerkclark>`_.
 - Fixed :py:meth:`Dataset.coarsen`, :py:meth:`DataArray.coarsen` dropping attributes on original object (:issue:`4120`, :pull:`4360`). by `Julia Kent <https://github.com/jukent>`_.
 - fix the signature of the plot methods. (:pull:`4359`) By `Justus Magin <https://github.com/keewis>`_.
@@ -118,7 +118,9 @@ Internal Changes
 - Versions in ``pre-commit.yaml`` are now pinned, to reduce the chances of
   conflicting versions. (:pull:`4388`)
   By `Maximilian Roos <https://github.com/max-sixty>`_
-
+- Add compatibility for the latest version of ``cftime``, where the name of the base
+  datetime class was changed to ``cftime.datetime_base`` from ``cftime.datetime``.
+  By `Spencer Clark <https://github.com/spencerkclark>`_.
 
 
 .. _whats-new.0.16.0:
@@ -385,7 +387,7 @@ New Features
   disable, use ``xarray.set_options(display_style="text")``.
   By `Julia Signell <https://github.com/jsignell>`_.
 - Added support for :py:class:`pandas.DatetimeIndex`-style rounding of
-  ``cftime.datetime`` objects directly via a :py:class:`CFTimeIndex` or via the
+  ``cftime`` datetime objects directly via a :py:class:`CFTimeIndex` or via the
   :py:class:`~core.accessor_dt.DatetimeAccessor`.
   By `Spencer Clark <https://github.com/spencerkclark>`_
 - Support new h5netcdf backend keyword `phony_dims` (available from h5netcdf
@@ -1361,12 +1363,12 @@ cftime related enhancements
   By `Jwen Fai Low <https://github.com/jwenfai>`_ and
   `Spencer Clark <https://github.com/spencerkclark>`_.
 
-- Taking the mean of arrays of :py:class:`cftime.datetime` objects, and
+- Taking the mean of arrays of ``cftime`` datetime objects, and
   by extension, use of :py:meth:`~xarray.DataArray.coarsen` with
-  :py:class:`cftime.datetime` coordinates is now possible. By `Spencer Clark
+  ``cftime`` datetime coordinates is now possible. By `Spencer Clark
   <https://github.com/spencerkclark>`_.
 
-- Internal plotting now supports ``cftime.datetime`` objects as time series.
+- Internal plotting now supports ``cftime`` datetime objects as time series.
   (:issue:`2164`)
   By `Julius Busecke <https://github.com/jbusecke>`_ and
   `Spencer Clark <https://github.com/spencerkclark>`_.
@@ -1375,7 +1377,7 @@ cftime related enhancements
   By `Jwen Fai Low <https://github.com/jwenfai>`_
 
 - :py:meth:`~xarray.open_dataset` now accepts a ``use_cftime`` argument, which
-  can be used to require that ``cftime.datetime`` objects are always used, or
+  can be used to require that ``cftime`` datetime objects are always used, or
   never used when decoding dates encoded with a standard calendar.  This can be
   used to ensure consistent date types are returned when using
   :py:meth:`~xarray.open_mfdataset` (:issue:`1263`) and/or to silence
@@ -1432,7 +1434,7 @@ Bug fixes
 - Line plots with the ``x`` argument set to a non-dimensional coord now plot
   the correct data for 1D DataArrays.
   (:issue:`2725`). By `Tom Nicholas <https://github.com/TomNicholas>`_.
-- Subtracting a scalar ``cftime.datetime`` object from a
+- Subtracting a scalar ``cftime`` datetime object from a
   :py:class:`CFTimeIndex` now results in a :py:class:`pandas.TimedeltaIndex`
   instead of raising a ``TypeError`` (:issue:`2671`).  By `Spencer Clark
   <https://github.com/spencerkclark>`_.
@@ -1628,7 +1630,7 @@ Breaking changes
 
 - Support for non-standard calendars used in climate science:
 
-  - Xarray will now always use :py:class:`cftime.datetime` objects, rather
+  - Xarray will now always use ``cftime`` datetime objects, rather
     than by default trying to coerce them into ``np.datetime64[ns]`` objects.
     A :py:class:`~xarray.CFTimeIndex` will be used for indexing along time
     coordinates in these cases.
@@ -1655,7 +1657,7 @@ Enhancements
 - Added :py:meth:`~xarray.CFTimeIndex.shift` for shifting the values of a
   CFTimeIndex by a specified frequency. (:issue:`2244`).
   By `Spencer Clark <https://github.com/spencerkclark>`_.
-- Added support for using ``cftime.datetime`` coordinates with
+- Added support for using ``cftime`` datetime coordinates with
   :py:meth:`~xarray.DataArray.differentiate`,
   :py:meth:`~xarray.Dataset.differentiate`,
   :py:meth:`~xarray.DataArray.interp`, and
@@ -2051,7 +2053,7 @@ Enhancements
   (:issue:`789`, :issue:`1084`, :issue:`1252`)
   By `Spencer Clark <https://github.com/spencerkclark>`_ with help from
   `Stephan Hoyer <https://github.com/shoyer>`_.
-- Allow for serialization of ``cftime.datetime`` objects (:issue:`789`,
+- Allow for serialization of ``cftime`` datetime objects (:issue:`789`,
   :issue:`1084`, :issue:`2008`, :issue:`1252`) using the standalone ``cftime``
   library.
   By `Spencer Clark <https://github.com/spencerkclark>`_.

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -377,8 +377,8 @@ def open_dataset(
         (e.g. "gregorian", "proleptic_gregorian", "standard", or not
         specified).  If None (default), attempt to decode times to
         ``np.datetime64[ns]`` objects; if this is not possible, decode times to
-        ``cftime.datetime`` objects. If True, always decode times to
-        ``cftime.datetime`` objects, regardless of whether or not they can be
+        ``cftime`` datetime objects. If True, always decode times to
+        ``cftime`` datetime objects, regardless of whether or not they can be
         represented using ``np.datetime64[ns]`` objects.  If False, always
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error.
@@ -643,8 +643,8 @@ def open_dataarray(
         (e.g. "gregorian", "proleptic_gregorian", "standard", or not
         specified).  If None (default), attempt to decode times to
         ``np.datetime64[ns]`` objects; if this is not possible, decode times to
-        ``cftime.datetime`` objects. If True, always decode times to
-        ``cftime.datetime`` objects, regardless of whether or not they can be
+        ``cftime`` datetime objects. If True, always decode times to
+        ``cftime`` datetime objects, regardless of whether or not they can be
         represented using ``np.datetime64[ns]`` objects.  If False, always
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error.

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -582,8 +582,8 @@ def open_zarr(
         (e.g. "gregorian", "proleptic_gregorian", "standard", or not
         specified).  If None (default), attempt to decode times to
         ``np.datetime64[ns]`` objects; if this is not possible, decode times to
-        ``cftime.datetime`` objects. If True, always decode times to
-        ``cftime.datetime`` objects, regardless of whether or not they can be
+        ``cftime`` datetime objects. If True, always decode times to
+        ``cftime`` datetime objects, regardless of whether or not they can be
         represented using ``np.datetime64[ns]`` objects.  If False, always
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error.

--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -1,4 +1,4 @@
-"""Time offset classes for use with cftime.datetime objects"""
+"""Time offset classes for use with cftime datetime objects"""
 # The offset classes and mechanisms for generating time ranges defined in
 # this module were copied/adapted from those defined in pandas.  See in
 # particular the objects and methods defined in pandas.tseries.offsets
@@ -48,6 +48,7 @@ from typing import ClassVar, Optional
 
 import numpy as np
 
+from ..core.common import _import_cftime_datetime_base
 from ..core.pdcompat import count_not_none
 from .cftimeindex import CFTimeIndex, _parse_iso8601_with_reso
 from .times import format_cftime_datetime
@@ -99,10 +100,10 @@ class BaseCFTimeOffset:
         return self.__apply__(other)
 
     def __sub__(self, other):
-        import cftime
+        cftime_datetime_base = _import_cftime_datetime_base()
 
-        if isinstance(other, cftime.datetime):
-            raise TypeError("Cannot subtract a cftime.datetime " "from a time offset.")
+        if isinstance(other, cftime_datetime_base):
+            raise TypeError("Cannot subtract a cftime datetime " "from a time offset.")
         elif type(other) == type(self):
             return type(self)(self.n - other.n)
         else:
@@ -164,7 +165,7 @@ def _get_day_of_month(other, day_option):
 
     Parameters
     ----------
-    other : cftime.datetime
+    other : cftime datetime
     day_option : 'start', 'end'
         'start': returns 1
         'end': returns last day of the month
@@ -255,7 +256,7 @@ def roll_qtrday(other, n, month, day_option, modby=3):
 
     Parameters
     ----------
-    other : cftime.datetime
+    other : cftime datetime
     n : number of periods to increment, before adjusting for rolling
     month : int reference month giving the first month of the year
     day_option : 'start', 'end'
@@ -382,10 +383,10 @@ class QuarterOffset(BaseCFTimeOffset):
         return mod_month == 0 and date.day == self._get_offset_day(date)
 
     def __sub__(self, other):
-        import cftime
+        cftime_datetime_base = _import_cftime_datetime_base()
 
-        if isinstance(other, cftime.datetime):
-            raise TypeError("Cannot subtract cftime.datetime from offset.")
+        if isinstance(other, cftime_datetime_base):
+            raise TypeError("Cannot subtract cftime datetime from offset.")
         elif type(other) == type(self) and other.month == self.month:
             return type(self)(self.n - other.n, month=self.month)
         else:
@@ -467,10 +468,10 @@ class YearOffset(BaseCFTimeOffset):
         return _shift_month(other, months, self._day_option)
 
     def __sub__(self, other):
-        import cftime
+        cftime_datetime_base = _import_cftime_datetime_base()
 
-        if isinstance(other, cftime.datetime):
-            raise TypeError("Cannot subtract cftime.datetime from offset.")
+        if isinstance(other, cftime_datetime_base):
+            raise TypeError("Cannot subtract cftime datetime from offset.")
         elif type(other) == type(self) and other.month == self.month:
             return type(self)(self.n - other.n, month=self.month)
         else:
@@ -672,22 +673,22 @@ def to_offset(freq):
 
 
 def to_cftime_datetime(date_str_or_date, calendar=None):
-    import cftime
+    cftime_datetime_base = _import_cftime_datetime_base()
 
     if isinstance(date_str_or_date, str):
         if calendar is None:
             raise ValueError(
-                "If converting a string to a cftime.datetime object, "
+                "If converting a string to a cftime datetime object, "
                 "a calendar type must be provided"
             )
         date, _ = _parse_iso8601_with_reso(get_date_type(calendar), date_str_or_date)
         return date
-    elif isinstance(date_str_or_date, cftime.datetime):
+    elif isinstance(date_str_or_date, cftime_datetime_base):
         return date_str_or_date
     else:
         raise TypeError(
             "date_str_or_date must be a string or a "
-            "subclass of cftime.datetime. Instead got "
+            "subclass of cftime.datetime_base. Instead got "
             "{!r}.".format(date_str_or_date)
         )
 
@@ -706,7 +707,7 @@ def _maybe_normalize_date(date, normalize):
 
 
 def _generate_linear_range(start, end, periods):
-    """Generate an equally-spaced sequence of cftime.datetime objects between
+    """Generate an equally-spaced sequence of cftime datetime objects between
     and including two dates (whose length equals the number of periods)."""
     import cftime
 
@@ -720,21 +721,21 @@ def _generate_linear_range(start, end, periods):
 
 
 def _generate_range(start, end, periods, offset):
-    """Generate a regular range of cftime.datetime objects with a
+    """Generate a regular range of cftime datetime objects with a
     given time offset.
 
     Adapted from pandas.tseries.offsets.generate_range.
 
     Parameters
     ----------
-    start : cftime.datetime, or None
+    start : cftime datetime, or None
         Start of range
-    end : cftime.datetime, or None
+    end : cftime datetime, or None
         End of range
     periods : int, or None
         Number of elements in the sequence
     offset : BaseCFTimeOffset
-        An offset class designed for working with cftime.datetime objects
+        An offset class designed for working with cftime datetime objects
 
     Returns
     -------
@@ -789,9 +790,9 @@ def cftime_range(
 
     Parameters
     ----------
-    start : str or cftime.datetime, optional
+    start : str or cftime datetime, optional
         Left bound for generating dates.
-    end : str or cftime.datetime, optional
+    end : str or cftime datetime, optional
         Right bound for generating dates.
     periods : int, optional
         Number of periods to generate.
@@ -815,7 +816,7 @@ def cftime_range(
     -----
 
     This function is an analog of ``pandas.date_range`` for use in generating
-    sequences of ``cftime.datetime`` objects.  It supports most of the
+    sequences of ``cftime`` datetime objects.  It supports most of the
     features of ``pandas.date_range`` (e.g. specifying how the index is
     ``closed`` on either side, or whether or not to ``normalize`` the start and
     end bounds); however, there are some notable exceptions:
@@ -933,7 +934,7 @@ def cftime_range(
     Examples
     --------
 
-    This function returns a ``CFTimeIndex``, populated with ``cftime.datetime``
+    This function returns a ``CFTimeIndex``, populated with ``cftime`` datetime
     objects associated with the specified calendar type, e.g.
 
     >>> xr.cftime_range(start="2000", periods=6, freq="2MS", calendar="noleap")

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -1,6 +1,6 @@
-"""DatetimeIndex analog for cftime.datetime objects"""
+"""DatetimeIndex analog for cftime datetime objects"""
 # The pandas.Index subclass defined here was copied and adapted for
-# use with cftime.datetime objects based on the source code defining
+# use with cftime datetime objects based on the source code defining
 # pandas.DatetimeIndex.
 
 # For reference, here is a copy of the pandas copyright notice:
@@ -49,7 +49,7 @@ import pandas as pd
 
 from xarray.core.utils import is_scalar
 
-from ..core.common import _contains_cftime_datetimes
+from ..core.common import _contains_cftime_datetimes, _import_cftime_datetime_base
 from ..core.options import OPTIONS
 from .times import _STANDARD_CALENDARS, cftime_to_nptime, infer_calendar_name
 
@@ -131,7 +131,7 @@ def _parse_iso8601_with_reso(date_type, timestr):
 def _parsed_string_to_bounds(date_type, resolution, parsed):
     """Generalization of
     pandas.tseries.index.DatetimeIndex._parsed_string_to_bounds
-    for use with non-standard calendars and cftime.datetime
+    for use with non-standard calendars and cftime datetime
     objects.
     """
     if resolution == "year":
@@ -207,14 +207,14 @@ def get_date_type(self):
 
 
 def assert_all_valid_date_type(data):
-    import cftime
+    cftime_datetime_base = _import_cftime_datetime_base()
 
     if len(data) > 0:
         sample = data[0]
         date_type = type(sample)
-        if not isinstance(sample, cftime.datetime):
+        if not isinstance(sample, cftime_datetime_base):
             raise TypeError(
-                "CFTimeIndex requires cftime.datetime "
+                "CFTimeIndex requires cftime datetime "
                 "objects. Got object of {}.".format(date_type)
             )
         if not all(isinstance(value, date_type) for value in data):
@@ -269,12 +269,12 @@ def format_attrs(index, separator=", "):
 class CFTimeIndex(pd.Index):
     """Custom Index for working with CF calendars and dates
 
-    All elements of a CFTimeIndex must be cftime.datetime objects.
+    All elements of a CFTimeIndex must be cftime datetime objects.
 
     Parameters
     ----------
     data : array or CFTimeIndex
-        Sequence of cftime.datetime objects to use in index
+        Sequence of cftime datetime objects to use in index
     name : str, default: None
         Name of the resulting index
 
@@ -763,7 +763,7 @@ def _parse_array_of_cftime_strings(strings, date_type):
     ----------
     strings : array of strings
         Strings to convert to dates
-    date_type : cftime.datetime type
+    date_type : cftime datetime type
         Calendar type to use for dates
 
     Returns
@@ -788,7 +788,7 @@ def _cftimeindex_from_i8(values, date_type, name):
     ----------
     values : np.array
         Integers representing microseconds since 1970-01-01.
-    date_type : cftime.datetime
+    date_type : cftime datetime
         Type of date for the index.
     name : str
         Name of the index.

--- a/xarray/coding/frequencies.py
+++ b/xarray/coding/frequencies.py
@@ -1,7 +1,7 @@
-"""FrequencyInferer analog for cftime.datetime objects"""
+"""FrequencyInferer analog for cftime datetime objects"""
 # The infer_freq method and the _CFTimeFrequencyInferer
 # subclass defined here were copied and adapted for
-# use with cftime.datetime objects based on the source code in
+# use with cftime datetime objects based on the source code in
 # pandas.tseries.Frequencies._FrequencyInferer
 
 # For reference, here is a copy of the pandas copyright notice:

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -169,7 +169,7 @@ def decode_cf_datetime(num_dates, units, calendar=None, use_cftime=None):
                     warnings.warn(
                         "Unable to decode time axis into full "
                         "numpy.datetime64 objects, continuing using "
-                        "cftime.datetime objects instead, reason: dates out "
+                        "cftime datetime objects instead, reason: dates out "
                         "of range",
                         SerializationWarning,
                         stacklevel=3,
@@ -258,7 +258,7 @@ def infer_datetime_units(dates):
 
 
 def format_cftime_datetime(date):
-    """Converts a cftime.datetime object to a string with the format:
+    """Converts a cftime datetime object to a string with the format:
     YYYY-MM-DD HH:MM:SS.UUUUUU
     """
     return "{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}.{:06d}".format(
@@ -284,7 +284,7 @@ def infer_timedelta_units(deltas):
 
 
 def cftime_to_nptime(times):
-    """Given an array of cftime.datetime objects, return an array of
+    """Given an array of cftime datetime objects, return an array of
     numpy.datetime64 objects of the same size"""
     times = np.asarray(times)
     new = np.empty(times.shape, dtype="M8[ns]")

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -304,8 +304,8 @@ def decode_cf_variable(
         (e.g. "gregorian", "proleptic_gregorian", "standard", or not
         specified).  If None (default), attempt to decode times to
         ``np.datetime64[ns]`` objects; if this is not possible, decode times to
-        ``cftime.datetime`` objects. If True, always decode times to
-        ``cftime.datetime`` objects, regardless of whether or not they can be
+        ``cftime`` datetime objects. If True, always decode times to
+        ``cftime`` datetime objects, regardless of whether or not they can be
         represented using ``np.datetime64[ns]`` objects.  If False, always
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error.
@@ -554,8 +554,8 @@ def decode_cf(
         (e.g. "gregorian", "proleptic_gregorian", "standard", or not
         specified).  If None (default), attempt to decode times to
         ``np.datetime64[ns]`` objects; if this is not possible, decode times to
-        ``cftime.datetime`` objects. If True, always decode times to
-        ``cftime.datetime`` objects, regardless of whether or not they can be
+        ``cftime`` datetime objects. If True, always decode times to
+        ``cftime`` datetime objects, regardless of whether or not they can be
         represented using ``np.datetime64[ns]`` objects.  If False, always
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error.

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1663,9 +1663,9 @@ def is_np_timedelta_like(dtype: DTypeLike) -> bool:
 
 
 def _contains_cftime_datetimes(array) -> bool:
-    """Check if an array contains cftime.datetime objects"""
+    """Check if an array contains cftime datetime objects"""
     try:
-        from cftime import datetime as cftime_datetime
+        cftime_datetime_base = _import_cftime_datetime_base()
     except ImportError:
         return False
     else:
@@ -1675,18 +1675,26 @@ def _contains_cftime_datetimes(array) -> bool:
                 sample = sample.compute()
                 if isinstance(sample, np.ndarray):
                     sample = sample.item()
-            return isinstance(sample, cftime_datetime)
+            return isinstance(sample, cftime_datetime_base)
         else:
             return False
 
 
 def contains_cftime_datetimes(var) -> bool:
-    """Check if an xarray.Variable contains cftime.datetime objects"""
+    """Check if an xarray.Variable contains cftime datetime objects"""
     return _contains_cftime_datetimes(var.data)
 
 
 def _contains_datetime_like_objects(var) -> bool:
     """Check if a variable contains datetime like objects (either
-    np.datetime64, np.timedelta64, or cftime.datetime)
+    np.datetime64, np.timedelta64, or cftime datetime)
     """
     return is_np_datetime_like(var.dtype) or contains_cftime_datetimes(var)
+
+
+def _import_cftime_datetime_base():
+    try:
+        from cftime import datetime_base as datetime
+    except ImportError:
+        from cftime import datetime
+    return datetime

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -401,7 +401,7 @@ def datetime_to_numeric(array, offset=None, datetime_unit=None, dtype=float):
     ----------
     da : array-like
       Input data
-    offset: None, datetime or cftime.datetime
+    offset: None, datetime or cftime datetime
       Datetime offset. If None, this is set by default to the array's minimum
       value to reduce round off errors.
     datetime_unit: {None, Y, M, W, D, h, m, s, ms, us, ns, ps, fs, as}
@@ -527,7 +527,7 @@ def py_timedelta_to_float(array, datetime_unit):
 
 
 def mean(array, axis=None, skipna=None, **kwargs):
-    """inhouse mean that can handle np.datetime64 or cftime.datetime
+    """inhouse mean that can handle np.datetime64 or cftime datetime
     dtypes"""
     from .common import _contains_cftime_datetimes
 
@@ -547,7 +547,7 @@ def mean(array, axis=None, skipna=None, **kwargs):
         if is_duck_dask_array(array):
             raise NotImplementedError(
                 "Computing the mean of an array containing "
-                "cftime.datetime objects is not yet implemented on "
+                "cftime datetime objects is not yet implemented on "
                 "dask arrays."
             )
         offset = min(array)

--- a/xarray/core/resample_cftime.py
+++ b/xarray/core/resample_cftime.py
@@ -229,10 +229,10 @@ def _get_range_edges(first, last, offset, closed="left", base=0):
 
     Parameters
     ----------
-    first : cftime.datetime
+    first : cftime datetime
         Uncorrected starting datetime object for resampled CFTimeIndex range.
         Usually the min of the original CFTimeIndex.
-    last : cftime.datetime
+    last : cftime datetime
         Uncorrected ending datetime object for resampled CFTimeIndex range.
         Usually the max of the original CFTimeIndex.
     offset : xarray.coding.cftime_offsets.BaseCFTimeOffset
@@ -248,9 +248,9 @@ def _get_range_edges(first, last, offset, closed="left", base=0):
 
     Returns
     -------
-    first : cftime.datetime
+    first : cftime datetime
         Corrected starting datetime object for resampled CFTimeIndex range.
-    last : cftime.datetime
+    last : cftime datetime
         Corrected ending datetime object for resampled CFTimeIndex range.
     """
     if isinstance(offset, CFTIME_TICKS):
@@ -279,9 +279,9 @@ def _adjust_dates_anchored(first, last, offset, closed="right", base=0):
 
     Parameters
     ----------
-    first : cftime.datetime
+    first : cftime datetime
         A datetime object representing the start of a CFTimeIndex range.
-    last : cftime.datetime
+    last : cftime datetime
         A datetime object representing the end of a CFTimeIndex range.
     offset : xarray.coding.cftime_offsets.BaseCFTimeOffset
         The offset object representing target conversion a.k.a. resampling
@@ -296,10 +296,10 @@ def _adjust_dates_anchored(first, last, offset, closed="right", base=0):
 
     Returns
     -------
-    fresult : cftime.datetime
+    fresult : cftime datetime
         A datetime object representing the start of a date range that has been
         adjusted to fix resampling errors.
-    lresult : cftime.datetime
+    lresult : cftime datetime
         A datetime object representing the end of a date range that has been
         adjusted to fix resampling errors.
     """
@@ -352,15 +352,15 @@ def exact_cftime_datetime_difference(a, b):
 
     By construction, we know that b_0 - a_0 must be a round number
     of seconds.  Therefore we can take the result of b_0 - a_0 using
-    ordinary cftime.datetime arithmetic and round to the nearest
+    ordinary cftime datetime arithmetic and round to the nearest
     second.  b_m - a_m is the remainder, in microseconds, and we
     can simply add this to the rounded timedelta.
 
     Parameters
     ----------
-    a : cftime.datetime
+    a : cftime datetime
         Input datetime
-    b : cftime.datetime
+    b : cftime datetime
         Input datetime
 
     Returns

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -8,6 +8,7 @@ from typing import Any, Iterable, Mapping, Tuple, Union
 import numpy as np
 import pandas as pd
 
+from ..core.common import _import_cftime_datetime_base
 from ..core.options import OPTIONS
 from ..core.utils import is_scalar
 
@@ -583,9 +584,8 @@ def _ensure_plottable(*args):
     numpy_types = [np.floating, np.integer, np.timedelta64, np.datetime64, np.bool_]
     other_types = [datetime]
     try:
-        import cftime
-
-        cftime_datetime = [cftime.datetime]
+        cftime_datetime_base = _import_cftime_datetime_base()
+        cftime_datetime = [cftime_datetime_base]
     except ImportError:
         cftime_datetime = []
     other_types = other_types + cftime_datetime
@@ -597,7 +597,7 @@ def _ensure_plottable(*args):
             raise TypeError(
                 "Plotting requires coordinates to be numeric, boolean, "
                 "or dates of type numpy.datetime64, "
-                "datetime.datetime, cftime.datetime or "
+                "datetime.datetime, cftime datetime or "
                 f"pandas.Interval. Received data of type {np.array(x).dtype} instead."
             )
         if (
@@ -605,9 +605,9 @@ def _ensure_plottable(*args):
             and not nc_time_axis_available
         ):
             raise ImportError(
-                "Plotting of arrays of cftime.datetime "
+                "Plotting of arrays of cftime datetime "
                 "objects or arrays indexed by "
-                "cftime.datetime objects requires the "
+                "cftime datetime objects requires the "
                 "optional `nc-time-axis` (v1.2.0 or later) "
                 "package."
             )

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -467,7 +467,7 @@ def test_cftime_floor_accessor(cftime_rounding_dataarray, cftime_date_type, use_
     if use_dask:
         chunks = {"dim_0": 1}
         # Currently a compute is done to inspect a single value of the array
-        # if it is of object dtype to check if it is a cftime.datetime (if not
+        # if it is of object dtype to check if it is a cftime datetime (if not
         # we raise an error when using the dt accessor).
         with raise_if_dask_computes(max_computes=1):
             result = cftime_rounding_dataarray.chunk(chunks).dt.floor(freq)
@@ -498,7 +498,7 @@ def test_cftime_ceil_accessor(cftime_rounding_dataarray, cftime_date_type, use_d
     if use_dask:
         chunks = {"dim_0": 1}
         # Currently a compute is done to inspect a single value of the array
-        # if it is of object dtype to check if it is a cftime.datetime (if not
+        # if it is of object dtype to check if it is a cftime datetime (if not
         # we raise an error when using the dt accessor).
         with raise_if_dask_computes(max_computes=1):
             result = cftime_rounding_dataarray.chunk(chunks).dt.ceil(freq)
@@ -529,7 +529,7 @@ def test_cftime_round_accessor(cftime_rounding_dataarray, cftime_date_type, use_
     if use_dask:
         chunks = {"dim_0": 1}
         # Currently a compute is done to inspect a single value of the array
-        # if it is of object dtype to check if it is a cftime.datetime (if not
+        # if it is of object dtype to check if it is a cftime datetime (if not
         # we raise an error when using the dt accessor).
         with raise_if_dask_computes(max_computes=1):
             result = cftime_rounding_dataarray.chunk(chunks).dt.round(freq)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -397,7 +397,8 @@ def test_decode_non_standard_calendar_single_element(calendar):
 
     units = "days since 0001-01-01"
 
-    dt = cftime.datetime(2001, 2, 29)
+    date_type = _all_cftime_date_types()[calendar]
+    dt = date_type(2001, 2, 29)
 
     num_time = cftime.date2num(dt, units, calendar)
     actual = coding.times.decode_cf_datetime(num_time, units, calendar=calendar)

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2300,7 +2300,7 @@ class TestCFDatetimePlot(PlotTestCase):
     @pytest.fixture(autouse=True)
     def setUp(self):
         """
-        Create a DataArray with a time-axis that contains cftime.datetime
+        Create a DataArray with a time-axis that contains cftime datetime
         objects.
         """
         # case for 1d array
@@ -2327,7 +2327,7 @@ class TestNcAxisNotInstalled(PlotTestCase):
     @pytest.fixture(autouse=True)
     def setUp(self):
         """
-        Create a DataArray with a time-axis that contains cftime.datetime
+        Create a DataArray with a time-axis that contains cftime datetime
         objects.
         """
         month = np.arange(1, 13, 1)


### PR DESCRIPTION
`cftime` is planning on renaming the base class for its datetime objects from `cftime.datetime` to `cftime.datetime_base`.  See discussion in https://github.com/Unidata/cftime/issues/198 and https://github.com/Unidata/cftime/pull/199.  This PR adds the appropriate logic in xarray to handle this in a backwards-compatible way.  

In the documentation in places where we refer to ``    :py:class:`cftime.datetime` `` objects, I have modified things to read ```    ``cftime`` datetime ```.  Being more generic is probably better in any case, as in most instances we do not explicitly mean that the base class can be used, only subclasses of the base class.

cc: @jswhit

 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

