### PR TITLE
preserve original dimension, coordinate and variable order in ``concat``

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -86,6 +86,8 @@ Bug fixes
   By `Jens Svensmark <https://github.com/jenssss>`_
 - Fix incorrect legend labels for :py:meth:`Dataset.plot.scatter` (:issue:`4126`).
   By `Peter Hausamann <https://github.com/phausamann>`_.
+- Preserve dimension and coordinate order during :py:func:`xarray.concat` (:issue:`2811`, :issue:`4072`, :pull:`4419`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -459,6 +459,9 @@ def _dataset_concat(
             combined = concat_vars(vars, dim, positions)
             assert isinstance(combined, Variable)
             result_vars[k] = combined
+        else:
+            # preserves original variable order
+            result_vars[k] = result_vars.pop(k)
 
     result = Dataset(result_vars, attrs=result_attrs)
     absent_coord_names = coord_names - set(result.variables)

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -459,7 +459,7 @@ def _dataset_concat(
             combined = concat_vars(vars, dim, positions)
             assert isinstance(combined, Variable)
             result_vars[k] = combined
-        else:
+        elif k in result_vars:
             # preserves original variable order
             result_vars[k] = result_vars.pop(k)
 

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -563,16 +563,16 @@ def test_concat_merge_single_non_dim_coord():
 def test_concat_preserve_coordinate_order():
     x = np.arange(0, 5)
     y = np.arange(0, 10)
-    time = [0, 1]
-    data = np.zeros((2, 10, 5), dtype=bool)
+    time = np.arange(0, 4)
+    data = np.zeros((4, 10, 5), dtype=bool)
 
     ds1 = Dataset(
-        {"data": (["time", "y", "x"], [data[0]])},
-        coords={"time": time[0], "y": y, "x": x},
+        {"data": (["time", "y", "x"], data[0:2])},
+        coords={"time": time[0:2], "y": y, "x": x},
     )
     ds2 = Dataset(
-        {"data": (["time", "y", "x"], [data[1]])},
-        coords={"time": time[1], "y": y, "x": x},
+        {"data": (["time", "y", "x"], data[2:4])},
+        coords={"time": time[2:4], "y": y, "x": x},
     )
 
     expected = Dataset(

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -567,17 +567,17 @@ def test_concat_preserve_coordinate_order():
     data = np.zeros((2, 10, 5), dtype=bool)
 
     ds1 = Dataset(
-        {"data": (["time", "y", "x"], [data[0]])},
-        coords={"time": (["time"], [time[0]]), "y": (["y"], y), "x": (["x"], x)},
+        {"data": (["time", "y", "x"], data[0])},
+        coords={"time": time[0], "y": y, "x": x},
     )
     ds2 = Dataset(
-        {"data": (["time", "y", "x"], [data[1]])},
-        coords={"time": (["time"], [time[1]]), "y": (["y"], y), "x": (["x"], x)},
+        {"data": (["time", "y", "x"], data[1])},
+        coords={"time": time[1], "y": y, "x": x},
     )
 
     expected = Dataset(
         {"data": (["time", "y", "x"], data)},
-        coords={"time": (["time"], time), "y": (["y"], y), "x": (["x"], x)},
+        coords={"time": time, "y": y, "x": x},
     )
 
     actual = concat([ds1, ds2], dim="time")

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -558,3 +558,36 @@ def test_concat_merge_single_non_dim_coord():
     for coords in ["different", "all"]:
         with raises_regex(ValueError, "'y' not present in all datasets"):
             concat([da1, da2, da3], dim="x")
+
+
+def test_concat_preserve_coordinate_order():
+    x = np.arange(0, 5)
+    y = np.arange(0, 10)
+    time = [0, 1]
+    data = np.zeros((2, 10, 5), dtype=bool)
+
+    ds1 = Dataset({"data": (['time', 'y', 'x'], [data[0]])},
+                  coords={"time": (['time'], [time[0]]),
+                          "y": (['y'], y),
+                          "x": (['x'], x)})
+    ds2 = Dataset({"data": (['time', 'y', 'x'], [data[1]])},
+                  coords={"time": (['time'], [time[1]]),
+                          "y": (['y'], y),
+                          "x": (['x'], x)})
+
+    expected = Dataset({"data": (['time', 'y', 'x'], data)},
+                       coords={"time": (['time'], time),
+                               "y": (['y'], y),
+                               "x": (['x'], x)})
+
+    actual = concat([ds1, ds2], dim='time')
+
+    # check dimension order
+    for act, exp in zip(actual.dims, expected.dims):
+        assert act == exp
+        assert actual.dims[act] == expected.dims[exp]
+
+    # check coordinate order
+    for act, exp in zip(actual.coords, expected.coords):
+        assert act == exp
+        assert_identical(actual.coords[act], expected.coords[exp])

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -566,21 +566,21 @@ def test_concat_preserve_coordinate_order():
     time = [0, 1]
     data = np.zeros((2, 10, 5), dtype=bool)
 
-    ds1 = Dataset({"data": (['time', 'y', 'x'], [data[0]])},
-                  coords={"time": (['time'], [time[0]]),
-                          "y": (['y'], y),
-                          "x": (['x'], x)})
-    ds2 = Dataset({"data": (['time', 'y', 'x'], [data[1]])},
-                  coords={"time": (['time'], [time[1]]),
-                          "y": (['y'], y),
-                          "x": (['x'], x)})
+    ds1 = Dataset(
+        {"data": (["time", "y", "x"], [data[0]])},
+        coords={"time": (["time"], [time[0]]), "y": (["y"], y), "x": (["x"], x)},
+    )
+    ds2 = Dataset(
+        {"data": (["time", "y", "x"], [data[1]])},
+        coords={"time": (["time"], [time[1]]), "y": (["y"], y), "x": (["x"], x)},
+    )
 
-    expected = Dataset({"data": (['time', 'y', 'x'], data)},
-                       coords={"time": (['time'], time),
-                               "y": (['y'], y),
-                               "x": (['x'], x)})
+    expected = Dataset(
+        {"data": (["time", "y", "x"], data)},
+        coords={"time": (["time"], time), "y": (["y"], y), "x": (["x"], x)},
+    )
 
-    actual = concat([ds1, ds2], dim='time')
+    actual = concat([ds1, ds2], dim="time")
 
     # check dimension order
     for act, exp in zip(actual.dims, expected.dims):

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -567,11 +567,11 @@ def test_concat_preserve_coordinate_order():
     data = np.zeros((2, 10, 5), dtype=bool)
 
     ds1 = Dataset(
-        {"data": (["time", "y", "x"], data[0])},
+        {"data": (["time", "y", "x"], [data[0]])},
         coords={"time": time[0], "y": y, "x": x},
     )
     ds2 = Dataset(
-        {"data": (["time", "y", "x"], data[1])},
+        {"data": (["time", "y", "x"], [data[1]])},
         coords={"time": time[1], "y": y, "x": x},
     )
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
The problem is that the `result_vars`-dict is filled in two separate loops, handling variables and coordinates (AFAICT). This can change the ordering of dimensions and coordinates depending over which dimensions is concatenated.

This fix hooks into the second loop and reinsert the variable in question at the appropriate position by popping it out of the `result_vars`. There might be a more elegant solution to this.

 - [x] Closes #2811, #4072
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
