### PR TITLE
fix: min_counts for non-nan sum and prod

### DIFF
--- a/doc/related-projects.rst
+++ b/doc/related-projects.rst
@@ -58,6 +58,7 @@ Other domains
 ~~~~~~~~~~~~~
 - `ptsa <https://pennmem.github.io/ptsa_new/html/index.html>`_: EEG Time Series Analysis
 - `pycalphad <https://pycalphad.org/docs/latest/>`_: Computational Thermodynamics in Python
+- `pyomeca <https://pyomeca.github.io/>`_: Python framework for biomechanical analysis
 
 Extend xarray capabilities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -39,7 +39,6 @@ Bug fixes
 - Fix silently overwriting the `engine` key when passing :py:func:`open_dataset` a file object
   to an incompatible netCDF (:issue:`4457`). Now incompatible combinations of files and engines raise
   an exception instead. By `Alessandro Amici <https://github.com/alexamici>`_.
-
 - The `min_count` argument to :py:meth:`DataArray.sum()` and :py:meth:`DataArray.prod()`
   is now ignored when not applicable, i.e. when `skipna=False` or when `skipna=None`
   and the dtype does not have a missing value (:issue:`4352`).

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -39,8 +39,8 @@ Bug fixes
 - Fix silently overwriting the `engine` key when passing :py:func:`open_dataset` a file object
   to an incompatible netCDF (:issue:`4457`). Now incompatible combinations of files and engines raise
   an exception instead. By `Alessandro Amici <https://github.com/alexamici>`_.
-- The `min_count` argument to :py:meth:`DataArray.sum()` and :py:meth:`DataArray.prod()`
-  is now ignored when not applicable, i.e. when `skipna=False` or when `skipna=None`
+- The ``min_count`` argument to :py:meth:`DataArray.sum()` and :py:meth:`DataArray.prod()`
+  is now ignored when not applicable, i.e. when ``skipna=False`` or when ``skipna=None``
   and the dtype does not have a missing value (:issue:`4352`).
   By `Mathias Hauser <https://github.com/mathause>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -86,6 +86,10 @@ Bug fixes
   By `Jens Svensmark <https://github.com/jenssss>`_
 - Fix incorrect legend labels for :py:meth:`Dataset.plot.scatter` (:issue:`4126`).
   By `Peter Hausamann <https://github.com/phausamann>`_.
+- The `min_count` argument to :py:meth:`DataArray.sum()` and :py:meth:`DataArray.prod()`
+  is now ignored when not applicable, i.e. when `skipna=False` or when `skipna=None`
+  and the dtype does not have a missing value (:issue:`4352`).
+  By `Mathias Hauser <https://github.com/mathause>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -325,7 +325,6 @@ def _create_nan_agg_method(name, dask_module=dask_array, coerce_strings=False):
             nanname = "nan" + name
             func = getattr(nanops, nanname)
         else:
-            # Method 1
             if name in ["sum", "prod"]:
                 kwargs.pop("min_count", None)
             func = _dask_or_eager_func(name, dask_module=dask_module)
@@ -562,20 +561,6 @@ def mean(array, axis=None, skipna=None, **kwargs):
 
 
 mean.numeric_only = True  # type: ignore
-
-
-# Method 2
-def sum(array, axis=None, skipna=None, **kwargs):
-
-    # get rid of min_count if not applicable
-    if (skipna is None and array.dtype.kind not in "cfO") or not skipna:
-        kwargs.pop("min_count", None)
-
-    return _sum(array, axis=axis, skipna=skipna, **kwargs)
-
-
-sum.numeric_only = True  # type: ignore
-sum.available_min_count = True  # type: ignore
 
 
 def _nd_cum_func(cum_func, array, axis, **kwargs):

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -352,9 +352,9 @@ argmax = _create_nan_agg_method("argmax", coerce_strings=True)
 argmin = _create_nan_agg_method("argmin", coerce_strings=True)
 max = _create_nan_agg_method("max", coerce_strings=True)
 min = _create_nan_agg_method("min", coerce_strings=True)
-_sum = _create_nan_agg_method("sum")
-# sum.numeric_only = True
-# sum.available_min_count = True
+sum = _create_nan_agg_method("sum")
+sum.numeric_only = True
+sum.available_min_count = True
 std = _create_nan_agg_method("std")
 std.numeric_only = True
 var = _create_nan_agg_method("var")

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -325,6 +325,9 @@ def _create_nan_agg_method(name, dask_module=dask_array, coerce_strings=False):
             nanname = "nan" + name
             func = getattr(nanops, nanname)
         else:
+            # Method 1
+            if name in ["sum", "prod"]:
+                kwargs.pop("min_count", None)
             func = _dask_or_eager_func(name, dask_module=dask_module)
 
         try:
@@ -350,9 +353,9 @@ argmax = _create_nan_agg_method("argmax", coerce_strings=True)
 argmin = _create_nan_agg_method("argmin", coerce_strings=True)
 max = _create_nan_agg_method("max", coerce_strings=True)
 min = _create_nan_agg_method("min", coerce_strings=True)
-sum = _create_nan_agg_method("sum")
-sum.numeric_only = True
-sum.available_min_count = True
+_sum = _create_nan_agg_method("sum")
+# sum.numeric_only = True
+# sum.available_min_count = True
 std = _create_nan_agg_method("std")
 std.numeric_only = True
 var = _create_nan_agg_method("var")
@@ -361,7 +364,7 @@ median = _create_nan_agg_method("median", dask_module=dask_array_compat)
 median.numeric_only = True
 prod = _create_nan_agg_method("prod")
 prod.numeric_only = True
-sum.available_min_count = True
+prod.available_min_count = True
 cumprod_1d = _create_nan_agg_method("cumprod")
 cumprod_1d.numeric_only = True
 cumsum_1d = _create_nan_agg_method("cumsum")
@@ -559,6 +562,20 @@ def mean(array, axis=None, skipna=None, **kwargs):
 
 
 mean.numeric_only = True  # type: ignore
+
+
+# Method 2
+def sum(array, axis=None, skipna=None, **kwargs):
+
+    # get rid of min_count if not applicable
+    if (skipna is None and array.dtype.kind not in "cfO") or not skipna:
+        kwargs.pop("min_count", None)
+
+    return _sum(array, axis=axis, skipna=skipna, **kwargs)
+
+
+sum.numeric_only = True  # type: ignore
+sum.available_min_count = True  # type: ignore
 
 
 def _nd_cum_func(cum_func, array, axis, **kwargs):

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -580,15 +580,17 @@ def test_dask_gradient(axis, edge_order):
 @pytest.mark.parametrize("dask", [False, True])
 @pytest.mark.parametrize("func", ["sum", "prod"])
 @pytest.mark.parametrize("aggdim", [None, "x"])
-def test_min_count(dim_num, dtype, dask, func, aggdim):
+@pytest.mark.parametrize("contains_nan", [True, False])
+@pytest.mark.parametrize("skipna", [True, False, None])
+def test_min_count(dim_num, dtype, dask, func, aggdim, contains_nan, skipna):
     if dask and not has_dask:
         pytest.skip("requires dask")
 
-    da = construct_dataarray(dim_num, dtype, contains_nan=True, dask=dask)
+    da = construct_dataarray(dim_num, dtype, contains_nan=contains_nan, dask=dask)
     min_count = 3
 
-    actual = getattr(da, func)(dim=aggdim, skipna=True, min_count=min_count)
-    expected = series_reduce(da, func, skipna=True, dim=aggdim, min_count=min_count)
+    actual = getattr(da, func)(dim=aggdim, skipna=skipna, min_count=min_count)
+    expected = series_reduce(da, func, skipna=skipna, dim=aggdim, min_count=min_count)
     assert_allclose(actual, expected)
     assert_dask_array(actual, dask)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4352
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

I see two methods how to fix this (see code). I would prefer Method 1 - but maybe you don't want to add method-specific code to `_create_nan_agg_method`? Anyone an opinion?