### PR TITLE
Clearer Vectorized Indexing example

### DIFF
--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -339,7 +339,7 @@ MATLAB, or after using the :py:func:`numpy.ix_` helper:
         coords={"x": [0, 1, 2], "y": ["a", "b", "c", "d"]},
     )
     da
-    da[[1, 2, 2], [0, 3]]
+    da[[0, 2, 2], [1, 3]]
 
 For more flexibility, you can supply :py:meth:`~xarray.DataArray` objects
 as indexers.

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -339,7 +339,7 @@ MATLAB, or after using the :py:func:`numpy.ix_` helper:
         coords={"x": [0, 1, 2], "y": ["a", "b", "c", "d"]},
     )
     da
-    da[[0, 1], [1, 1]]
+    da[[1, 2, 2], [0, 3]]
 
 For more flexibility, you can supply :py:meth:`~xarray.DataArray` objects
 as indexers.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -101,6 +101,8 @@ Documentation
   By `Sander van Rijn <https://github.com/sjvrijn>`_
 - Update the contributing guide to use merges instead of rebasing and state
   that we squash-merge. (:pull:`4355`) By `Justus Magin <https://github.com/keewis>`_.
+- Updated Vectorized Indexing to a clearer example.
+  By `Maximilian Roos <https://github.com/max-sixty>`_
 
 Internal Changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

I found the existing example not that clear as to why it was selecting `[[1,1],[5,5]]`, I think this is more obvious (open to disagreement of course!)

Before
```python
In [37]: da = xr.DataArray(
   ....:     np.arange(12).reshape((3, 4)),
   ....:     dims=["x", "y"],
   ....:     coords={"x": [0, 1, 2], "y": ["a", "b", "c", "d"]},
   ....: )
   ....: 

In [38]: da
Out[38]: 
<xarray.DataArray (x: 3, y: 4)>
array([[ 0,  1,  2,  3],
       [ 4,  5,  6,  7],
       [ 8,  9, 10, 11]])
Coordinates:
  * x        (x) int64 0 1 2
  * y        (y) <U1 'a' 'b' 'c' 'd'

In [39]: da[[0, 1], [1, 1]]
Out[39]: 
<xarray.DataArray (x: 2, y: 2)>
array([[1, 1],
       [5, 5]])
Coordinates:
  * x        (x) int64 0 1
  * y        (y) <U1 'b' 'b'
```

After:
```python

In [4]:     da[[1, 2, 2], [0, 3]]
Out[4]:
<xarray.DataArray (x: 3, y: 2)>
array([[ 4,  7],
       [ 8, 11],
       [ 8, 11]])
Coordinates:
  * x        (x) int64 1 2 2
  * y        (y) <U1 'a' 'd'`
```