### PR TITLE
add a ci for doctests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,6 +74,18 @@ jobs:
   - bash: black --check .
     displayName: black formatting check
 
+- job: Doctests
+  variables:
+    conda_env: py38
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - template: ci/azure/install.yml
+    - bash: |
+        source activate xarray-tests
+        python -m pytest --doctest-modules xarray --ignore xarray/tests
+      displayName: doctests
+
 - job: TypeChecking
   variables:
     conda_env: py38

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ jobs:
     - bash: |
         source activate xarray-tests
         python -m pytest --doctest-modules xarray --ignore xarray/tests
-      displayName: doctests
+      displayName: Run doctests
 
 - job: TypeChecking
   variables:


### PR DESCRIPTION
Now that #4409 is merged, we can add a CI that makes sure all examples actually work.

 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
