### PR TITLE
Simplify and restore old behavior for deep-copies

### DIFF
--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1467,14 +1467,6 @@ class PandasIndexAdapter(ExplicitlyIndexedNDArrayMixin):
             type(self).__name__, self.array, self.dtype
         )
 
-    def __copy__(self):
-        # We don't use `copy.copy(self.array)`, as shallow copies of the
-        # underlying numpy.ndarrays become deep ones upon pickling
-        # >>> len(pickle.dumps((self.array, self.array)))
-        # 4000281
-        # >>> len(pickle.dumps((self.array, self.array.copy(deep=False))))
-        # 8000341
-        return PandasIndexAdapter(self.array, self._dtype)
-
     def __deepcopy__(self, memo):
-        return PandasIndexAdapter(copy.deepcopy(self.array, memo), self._dtype)
+        # pandas.Index is (mostly) immutable
+        return PandasIndexAdapter(self.array, self._dtype)


### PR DESCRIPTION
Intended to fix https://github.com/pydata/xarray/issues/4449

The goal is to restore behavior to match what we had prior to https://github.com/pydata/xarray/pull/4379 for all types of `data` other than `np.ndarray` objects

Needs tests!

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && mypy . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
