### PR TITLE
Raise error when datetime64 or timedelta64 values that are outside the valid range for ns precision are converted to ns precision

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,10 +15,10 @@ What's New
     np.random.seed(123456)
 
 
-.. _whats-new.{0.16.2}:
+.. _whats-new.0.16.2:
 
-v{0.16.2} (unreleased)
----------------------
+v0.16.2 (unreleased)
+--------------------
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,7 +30,8 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
-
+- Fix bug where datetime64 times are silently changed to incorrect values if they are outside the valid date range for ns precision when provided in some other units (:issue:`4427`).
+  `Andrew Pauling <https://github.com/andrewpauling>`_
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,8 +30,8 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
-- Fix bug where datetime64 times are silently changed to incorrect values if they are outside the valid date range for ns precision when provided in some other units (:issue:`4427`).
-  `Andrew Pauling <https://github.com/andrewpauling>`_
+- Fix bug where datetime64 times are silently changed to incorrect values if they are outside the valid date range for ns precision when provided in some other units (:issue:`4427`, :pull:`4454`).
+  By `Andrew Pauling <https://github.com/andrewpauling>`_
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -255,7 +255,9 @@ def map_blocks(
     to the function being applied in ``xr.map_blocks()``:
 
     >>> array.map_blocks(
-    ...     calculate_anomaly, kwargs={"groupby_type": "time.year"}, template=array,
+    ...     calculate_anomaly,
+    ...     kwargs={"groupby_type": "time.year"},
+    ...     template=array,
     ... )  # doctest: +ELLIPSIS
     <xarray.DataArray (time: 24)>
     dask.array<calculate_anomaly-...-<this, shape=(24,), dtype=float64, chunksize=(24,), chunktype=numpy.ndarray>

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -179,7 +179,7 @@ def _possibly_convert_objects(values):
     """Convert arrays of datetime.datetime and datetime.timedelta objects into
     datetime64 and timedelta64, according to the pandas convention. Also used for
     validating that datetime64 and timedelta64 objects are within the valid date
-    range for ns precision, as pandas will raise an error if they are not.  
+    range for ns precision, as pandas will raise an error if they are not.
     """
     return np.asarray(pd.Series(values.ravel())).reshape(values.shape)
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -177,7 +177,9 @@ def _maybe_wrap_data(data):
 
 def _possibly_convert_objects(values):
     """Convert arrays of datetime.datetime and datetime.timedelta objects into
-    datetime64 and timedelta64, according to the pandas convention.
+    datetime64 and timedelta64, according to the pandas convention. Also used for
+    validating that datetime64 and timedelta64 objects are within the valid date
+    range for ns precision, as pandas will raise an error if they are not.  
     """
     return np.asarray(pd.Series(values.ravel())).reshape(values.shape)
 
@@ -238,16 +240,16 @@ def as_compatible_data(data, fastpath=False):
                     '"1"'
                 )
 
-    # validate whether the data is valid data types
+    # validate whether the data is valid data types.
     data = np.asarray(data)
 
     if isinstance(data, np.ndarray):
         if data.dtype.kind == "O":
             data = _possibly_convert_objects(data)
         elif data.dtype.kind == "M":
-            data = np.asarray(data, "datetime64[ns]")
+            data = _possibly_convert_objects(data)
         elif data.dtype.kind == "m":
-            data = np.asarray(data, "timedelta64[ns]")
+            data = _possibly_convert_objects(data)
 
     return _maybe_wrap_data(data)
 

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -294,6 +294,12 @@ class VariableSubclassobjects:
         actual = self.cls("x", data)
         assert actual.dtype == data.dtype
 
+    def test_datetime64_valid_range(self):
+        data = np.datetime64('1250-01-01', 'us')
+        pderror = pd._libs.tslibs.np_datetime.OutOfBoundsDatetime
+        with raises_regex(pderror, 'Out of bounds nanosecond'):
+            self.cls(["t"], [data])
+
     def test_pandas_data(self):
         v = self.cls(["x"], pd.Series([0, 1, 2], index=[3, 2, 1]))
         assert_identical(v, v[[0, 1, 2]])

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -300,7 +300,7 @@ class VariableSubclassobjects:
         with raises_regex(pderror, "Out of bounds nanosecond"):
             self.cls(["t"], [data])
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="pandas issue 36615")
     def test_timedelta64_valid_range(self):
         data = np.timedelta64("200000", "D")
         pderror = pd.errors.OutOfBoundsTimedelta

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -296,7 +296,14 @@ class VariableSubclassobjects:
 
     def test_datetime64_valid_range(self):
         data = np.datetime64("1250-01-01", "us")
-        pderror = pd._libs.tslibs.np_datetime.OutOfBoundsDatetime
+        pderror = pd.errors.OutOfBoundsDatetime
+        with raises_regex(pderror, "Out of bounds nanosecond"):
+            self.cls(["t"], [data])
+
+    @pytest.mark.xfail
+    def test_timedelta64_valid_range(self):
+        data = np.timedelta64("200000", "D")
+        pderror = pd.errors.OutOfBoundsTimedelta
         with raises_regex(pderror, "Out of bounds nanosecond"):
             self.cls(["t"], [data])
 

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -295,9 +295,9 @@ class VariableSubclassobjects:
         assert actual.dtype == data.dtype
 
     def test_datetime64_valid_range(self):
-        data = np.datetime64('1250-01-01', 'us')
+        data = np.datetime64("1250-01-01", "us")
         pderror = pd._libs.tslibs.np_datetime.OutOfBoundsDatetime
-        with raises_regex(pderror, 'Out of bounds nanosecond'):
+        with raises_regex(pderror, "Out of bounds nanosecond"):
             self.cls(["t"], [data])
 
     def test_pandas_data(self):


### PR DESCRIPTION
Use _possibly_convert_obhects to raise an error when converting datetime64 or timedelta64 objects that are in some units other than ns to ns as per pandas requirements, resulting in dates outside the valid range for ns precision being silently changed to incorrect values.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4427 
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
