### PR TITLE
Autodetect the engine only when `engine=None`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,9 +34,9 @@ New Features
 Bug fixes
 ~~~~~~~~~
 
-- Fix silently overwriting the `engine` key when passing a file object to an incompatible netCDF to
-  :py:func:`open_dataset` (:issue:#4457). Now incompatible combinations of files and engines
-  raise an exception instead. By `Alessandro Amici <https://github.com/alexamici>`_.
+- Fix silently overwriting the `engine` key when passing :py:func:`open_dataset` a file object
+  to an incompatible netCDF (:issue:#4457). Now incompatible combinations of files and engines raise
+  an exception instead. By `Alessandro Amici <https://github.com/alexamici>`_.
 
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,7 +35,7 @@ Bug fixes
 ~~~~~~~~~
 
 - Fix silently overwriting the `engine` key when passing :py:func:`open_dataset` a file object
-  to an incompatible netCDF (:issue:#4457). Now incompatible combinations of files and engines raise
+  to an incompatible netCDF (:issue:`4457`). Now incompatible combinations of files and engines raise
   an exception instead. By `Alessandro Amici <https://github.com/alexamici>`_.
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,6 +34,10 @@ New Features
 Bug fixes
 ~~~~~~~~~
 
+- Fix silently overwriting the `engine` key when passing a file object to an incompatible netCDF to
+  :py:func:`open_dataset` (:issue:#4457). Now incompatible combinations of files and engines
+  raise an exception instead. By `Alessandro Amici <https://github.com/alexamici>`_.
+
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -137,11 +137,9 @@ def _get_engine_from_magic_number(filename_or_obj):
     elif magic_number.startswith(b"\211HDF\r\n\032\n"):
         engine = "h5netcdf"
     else:
-        if isinstance(filename_or_obj, bytes) and len(filename_or_obj) > 80:
-            filename_or_obj = filename_or_obj[:80] + b"..."
         raise ValueError(
-            "{} is not a supported file format "
-            "did you mean to pass a string for a path instead?".format(filename_or_obj)
+            "{} is not the signature of any supported file format "
+            "did you mean to pass a string for a path instead?".format(magic_number)
         )
     return engine
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -138,7 +138,7 @@ def _get_engine_from_magic_number(filename_or_obj):
         engine = "h5netcdf"
     else:
         raise ValueError(
-            "{} is not the signature of any supported file format "
+            f"{magic_number} is not the signature of any supported file format "
             "did you mean to pass a string for a path instead?".format(magic_number)
         )
     return engine

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -134,8 +134,15 @@ def _get_engine_from_magic_number(filename_or_obj):
 
     if magic_number.startswith(b"CDF"):
         engine = "scipy"
-    else:
+    elif magic_number.startswith(b"\211HDF\r\n\032\n"):
         engine = "h5netcdf"
+    else:
+        if isinstance(filename_or_obj, bytes) and len(filename_or_obj) > 80:
+            filename_or_obj = filename_or_obj[:80] + b"..."
+        raise ValueError(
+            "{} is not a supported file format "
+            "did you mean to pass a string for a path instead?".format(filename_or_obj)
+        )
     return engine
 
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -126,8 +126,7 @@ def _get_engine_from_magic_number(filename_or_obj):
         if filename_or_obj.tell() != 0:
             raise ValueError(
                 "file-like object read/write pointer not at zero "
-                "please close and reopen, or use a context "
-                "manager"
+                "please close and reopen, or use a context manager"
             )
         magic_number = filename_or_obj.read(8)
         filename_or_obj.seek(0)

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -171,10 +171,14 @@ def _get_backend_cls(engine):
 
 
 def _normalize_path(path):
-    if is_remote_uri(path):
-        return path
-    else:
-        return os.path.abspath(os.path.expanduser(path))
+    if isinstance(path, Path):
+        path = str(path)
+
+    if isinstance(path, str):
+        if not is_remote_uri(path):
+            path = os.path.abspath(os.path.expanduser(path))
+
+    return path
 
 
 def _validate_dataset_names(dataset):
@@ -528,11 +532,7 @@ def open_dataset(
         ds2._file_obj = ds._file_obj
         return ds2
 
-    if isinstance(filename_or_obj, Path):
-        filename_or_obj = str(filename_or_obj)
-
-    if isinstance(filename_or_obj, str):
-        filename_or_obj = _normalize_path(filename_or_obj)
+    filename_or_obj = _normalize_path(filename_or_obj)
 
     if isinstance(filename_or_obj, AbstractDataStore):
         store = filename_or_obj

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -179,9 +179,8 @@ def _normalize_path(path):
     if isinstance(path, Path):
         path = str(path)
 
-    if isinstance(path, str):
-        if not is_remote_uri(path):
-            path = os.path.abspath(os.path.expanduser(path))
+    if isinstance(path, str) and not is_remote_uri(path):
+        path = os.path.abspath(os.path.expanduser(path))
 
     return path
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -139,7 +139,7 @@ def _get_engine_from_magic_number(filename_or_obj):
     else:
         raise ValueError(
             f"{magic_number} is not the signature of any supported file format "
-            "did you mean to pass a string for a path instead?".format(magic_number)
+            "did you mean to pass a string for a path instead?"
         )
     return engine
 

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -137,11 +137,9 @@ class H5NetCDFStore(WritableCFDataStore):
                 magic_number = filename.read(8)
                 filename.seek(0)
                 if not magic_number.startswith(b"\211HDF\r\n\032\n"):
-                    if isinstance(filename, bytes) and len(filename) > 80:
-                        filename = filename[:80] + b"..."
                     raise ValueError(
-                        "{} is not a valid netCDF file did you mean"
-                        "to pass a string for a path instead?".format(filename)
+                        "{} is not the signature "
+                        "of a valid netCDF file".format(magic_number)
                     )
 
         if format not in [None, "NETCDF4"]:

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -127,7 +127,14 @@ class H5NetCDFStore(WritableCFDataStore):
                     "can't open netCDF4/HDF5 as bytes "
                     "try passing a path or file-like object"
                 )
-        elif not isinstance(filename, str) and filename.tell() != 0:
+            else:
+                if len(filename) > 80:
+                    filename = filename[:80] + b"..."
+                raise ValueError(
+                    "{} is not a valid netCDF file "
+                    "did you mean to pass a string for a path instead?".format(filename)
+                )
+        elif hasattr(filename, 'tell') and filename.tell() != 0:
             raise ValueError(
                 "file-like object read/write pointer not at zero "
                 "please close and reopen, or use a context "

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -140,8 +140,8 @@ class H5NetCDFStore(WritableCFDataStore):
                     if isinstance(filename, bytes) and len(filename) > 80:
                         filename = filename[:80] + b"..."
                     raise ValueError(
-                        "{} is not a valid netCDF file "
-                        "did you mean to pass a string for a path instead?".format(filename)
+                        "{} is not a valid netCDF file did you mean"
+                        "to pass a string for a path instead?".format(filename)
                     )
 
         if format not in [None, "NETCDF4"]:

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -130,8 +130,7 @@ class H5NetCDFStore(WritableCFDataStore):
             if filename.tell() != 0:
                 raise ValueError(
                     "file-like object read/write pointer not at zero "
-                    "please close and reopen, or use a context "
-                    "manager"
+                    "please close and reopen, or use a context manager"
                 )
             else:
                 magic_number = filename.read(8)

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -134,7 +134,7 @@ class H5NetCDFStore(WritableCFDataStore):
                     "{} is not a valid netCDF file "
                     "did you mean to pass a string for a path instead?".format(filename)
                 )
-        elif hasattr(filename, 'tell') and filename.tell() != 0:
+        elif hasattr(filename, "tell") and filename.tell() != 0:
             raise ValueError(
                 "file-like object read/write pointer not at zero "
                 "please close and reopen, or use a context "
@@ -162,7 +162,9 @@ class H5NetCDFStore(WritableCFDataStore):
 
         manager = CachingFileManager(h5netcdf.File, filename, mode=mode, kwargs=kwargs)
         try:
-            instance = cls(manager, group=group, mode=mode, lock=lock, autoclose=autoclose)
+            instance = cls(
+                manager, group=group, mode=mode, lock=lock, autoclose=autoclose
+            )
         except OSError:
             if isinstance(filename, bytes) and len(filename) > 80:
                 filename = filename[:80] + b"..."

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -137,8 +137,7 @@ class H5NetCDFStore(WritableCFDataStore):
                 filename.seek(0)
                 if not magic_number.startswith(b"\211HDF\r\n\032\n"):
                     raise ValueError(
-                        "{} is not the signature "
-                        "of a valid netCDF file".format(magic_number)
+                        f"{magic_number} is not the signature of a valid netCDF file"
                     )
 
         if format not in [None, "NETCDF4"]:

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -333,6 +333,12 @@ class NetCDF4DataStore(WritableCFDataStore):
     ):
         import netCDF4
 
+        if not isinstance(filename, str):
+            raise ValueError(
+                "can only read bytes or file-like objects "
+                "with engine='scipy' or 'h5netcdf'"
+            )
+
         if format is None:
             format = "NETCDF4"
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2494,7 +2494,7 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
         with raises_regex(ValueError, "HDF5 as bytes"):
             with open_dataset(b"\211HDF\r\n\032\n", engine="h5netcdf"):
                 pass
-        with raises_regex(ValueError, "not a valid netCDF"):
+        with raises_regex(ValueError, "is not a supported file format"):
             with open_dataset(b"garbage"):
                 pass
         with raises_regex(ValueError, "can only read bytes"):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2494,13 +2494,13 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
         with raises_regex(ValueError, "HDF5 as bytes"):
             with open_dataset(b"\211HDF\r\n\032\n", engine="h5netcdf"):
                 pass
-        with raises_regex(ValueError, "is not a supported file format"):
+        with raises_regex(ValueError, "not the signature of any supported file"):
             with open_dataset(b"garbage"):
                 pass
         with raises_regex(ValueError, "can only read bytes"):
             with open_dataset(b"garbage", engine="netcdf4"):
                 pass
-        with raises_regex(ValueError, "not a valid netCDF"):
+        with raises_regex(ValueError, "not the signature of a valid netCDF file"):
             with open_dataset(BytesIO(b"garbage"), engine="h5netcdf"):
                 pass
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2224,7 +2224,7 @@ class TestGenericNetCDFData(CFEncodedBase, NetCDF3Only):
                 open_dataset(tmp_file, engine="foobar")
 
         netcdf_bytes = data.to_netcdf()
-        with raises_regex(ValueError, "can only read bytes or file-like"):
+        with raises_regex(ValueError, "unrecognized engine"):
             open_dataset(BytesIO(netcdf_bytes), engine="foobar")
 
     def test_cross_engine_read_write_netcdf3(self):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2527,6 +2527,10 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
                     assert_identical(expected, actual)
 
                 f.seek(0)
+                with open_dataset(f) as actual:
+                    assert_identical(expected, actual)
+
+                f.seek(0)
                 with BytesIO(f.read()) as bio:
                     with open_dataset(bio, engine="h5netcdf") as actual:
                         assert_identical(expected, actual)
@@ -2534,6 +2538,10 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
                 f.seek(0)
                 with raises_regex(TypeError, "not a valid NetCDF 3"):
                     open_dataset(f, engine="scipy")
+
+                f.seek(8)
+                with raises_regex(ValueError, "read/write pointer not at zero"):
+                    open_dataset(f)
 
 
 @requires_h5netcdf

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2531,6 +2531,10 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
                     with open_dataset(bio, engine="h5netcdf") as actual:
                         assert_identical(expected, actual)
 
+                f.seek(0)
+                with raises_regex(TypeError, "not a valid NetCDF 3"):
+                    open_dataset(f, engine="scipy")
+
 
 @requires_h5netcdf
 @requires_dask


### PR DESCRIPTION
Always use the `engine` explicitly selected by the user and perform auto detection only when `engine=None`.

 - [x] Closes #4457
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [x] No new functions/methods

The refactor complexity stems mostly from moving or duplicating some logic from `_get_engine_from_magic_number` to the backend stores. The current, rather ugly, code minimizes changes to the error conditions and messages.

Later in the backend refactor the plugins will provide the functionalities to identify the format from the file content and the duplication should be eliminated.

@jhamman do you think I need to acknowledge the CZI sponsorship in the changelog?