### PR TITLE
Cleanup logic inside `open_dataset`, mostly `extra_kwargs`

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -454,9 +454,8 @@ def open_dataset(
 
     if backend_kwargs is None:
         backend_kwargs = {}
-    extra_kwargs = {}
 
-    def maybe_decode_store(store, chunks, lock=False):
+    def maybe_decode_store(store, chunks):
         ds = conventions.decode_cf(
             store,
             mask_and_scale=mask_and_scale,
@@ -551,18 +550,17 @@ def open_dataset(
                 )
             engine = _get_engine_from_magic_number(filename_or_obj)
 
-        if engine in ["netcdf4", "h5netcdf"]:
+        extra_kwargs = {}
+        if group is not None:
             extra_kwargs["group"] = group
+        if lock is not None:
             extra_kwargs["lock"] = lock
-        elif engine in ["pynio", "pseudonetcdf", "cfgrib"]:
-            extra_kwargs["lock"] = lock
-        elif engine == "zarr":
+
+        if engine == "zarr":
             backend_kwargs = backend_kwargs.copy()
             overwrite_encoded_chunks = backend_kwargs.pop(
                 "overwrite_encoded_chunks", None
             )
-            extra_kwargs["mode"] = "r"
-            extra_kwargs["group"] = group
 
         opener = _get_backend_cls(engine)
         store = opener(filename_or_obj, **extra_kwargs, **backend_kwargs)


### PR DESCRIPTION
This is a small, pure code-refactor PR that removes some of the cruft left in `open_dataset` from #4187 and #4431 

 - [x] Additional clean ups after #4431 
 - [x] Pure code refactor, no change in tests
 - [x] Passes `isort . && black . && mypy . && flake8`

Note that `mode="r"` is the default in `open_group`.