### PR TITLE
update url for isort in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # https://pre-commit.com/
 repos:
   # isort should run before black as black sometimes tweaks the isort output
-  - repo: https://github.com/timothycrosley/isort
+  - repo: https://github.com/PyCQA/isort
     rev: 5.4.2
     hooks:
       - id: isort


### PR DESCRIPTION
When opening the current url https://github.com/timothycrosley/isort it points to a new url https://github.com/PyCQA/isort.

This PR replaces the old url with the new one
