### PR TITLE
update the pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
   # isort should run before black as black sometimes tweaks the isort output
   - repo: https://github.com/PyCQA/isort
-    rev: 5.4.2
+    rev: 5.5.4
     hooks:
       - id: isort
   # https://github.com/python/black#version-control-integration
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/keewis/blackdoc
-    rev: v0.1.2
+    rev: v0.2
     hooks:
       - id: blackdoc
   - repo: https://gitlab.com/pycqa/flake8


### PR DESCRIPTION
this updates the version of `blackdoc` pinned in `.pre-commit-hooks.yaml` (using `pre-commit autoupdate` so `isort` is also updated)