### PR TITLE
Handle scale_factor and add_offset as scalar

### DIFF
--- a/doc/io.rst
+++ b/doc/io.rst
@@ -105,6 +105,12 @@ Dataset and DataArray objects, and no array values are loaded into memory until
 you try to perform some sort of actual computation. For an example of how these
 lazy arrays work, see the OPeNDAP section below.
 
+There may be minor differences in the :py:class:`Dataset` object returned
+when reading a NetCDF file with different engines.  For example,
+single-valued attributes are returned as scalars by the default
+``engine=netcdf4``, but as arrays of size ``(1,)`` when reading with
+``engine=h5netcdf``.
+
 It is important to note that when you modify values of a Dataset, even one
 linked to files on disk, only the in-memory copy you are manipulating in xarray
 is modified: the original file on disk is never touched.

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -106,7 +106,7 @@ you try to perform some sort of actual computation. For an example of how these
 lazy arrays work, see the OPeNDAP section below.
 
 There may be minor differences in the :py:class:`Dataset` object returned
-when reading a NetCDF file with different engines.  For example,
+when reading a NetCDF file with different engines. For example,
 single-valued attributes are returned as scalars by the default
 ``engine=netcdf4``, but as arrays of size ``(1,)`` when reading with
 ``engine=h5netcdf``.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,6 +34,8 @@ New Features
 Bug fixes
 ~~~~~~~~~
 
+- Fix bug where reading a scalar value from a NetCDF file opened with the ``h5netcdf`` backend would raise a ``ValueError`` when ``decode_cf=True`` (:issue:`4471`, :pull:`4485`).
+  By `Gerrit Holl <https://github.com/gerritholl>`_.
 - Fix bug where datetime64 times are silently changed to incorrect values if they are outside the valid date range for ns precision when provided in some other units (:issue:`4427`, :pull:`4454`).
   By `Andrew Pauling <https://github.com/andrewpauling>`_
 - Fix silently overwriting the `engine` key when passing :py:func:`open_dataset` a file object

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -269,6 +269,10 @@ class CFScaleOffsetCoder(VariableCoder):
             scale_factor = pop_to(attrs, encoding, "scale_factor", name=name)
             add_offset = pop_to(attrs, encoding, "add_offset", name=name)
             dtype = _choose_float_dtype(data.dtype, "add_offset" in attrs)
+            if np.ndim(scale_factor) > 0:
+                scale_factor = scale_factor.item()
+            if np.ndim(add_offset) > 0:
+                add_offset = add_offset.item()
             transform = partial(
                 _scale_offset_decoding,
                 scale_factor=scale_factor,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4668,3 +4668,24 @@ def test_extract_zarr_variable_encoding():
         actual = backends.zarr.extract_zarr_variable_encoding(
             var, raise_on_invalid=True
         )
+
+
+@requires_h5netcdf
+def test_load_single_value_h5netcdf(tmp_path):
+    """Test that numeric single-element vector attributes are handled fine.
+
+    At present (h5netcdf v0.8.1), the h5netcdf exposes single-valued numeric variable
+    attributes as arrays of length 1, as oppesed to scalars for the NetCDF4
+    backend.  This was leading to a ValueError upon loading a single value from
+    a file, see #4471.  Test that loading causes no failure.
+    """
+    ds = xr.Dataset(
+        {
+            "test": xr.DataArray(
+                np.array([0]), dims=("x",), attrs={"scale_factor": 1, "add_offset": 0}
+            )
+        }
+    )
+    ds.to_netcdf(tmp_path / "test.nc")
+    with xr.open_dataset(tmp_path / "test.nc", engine="h5netcdf") as ds2:
+        ds2["test"][0].load()


### PR DESCRIPTION
The h5netcdf engine exposes single-valued attributes as arrays of shape
(1,), which is correct according to the NetCDF standard, but may cause
a problem when reading a value of shape () before the scale_factor and
add_offset have been applied.  This PR adds a check for the dimensionality
of add_offset and scale_factor and ensures they are scalar before they
are used for further processing, adds a unit test to verify that this
works correctly, and a note to the documentation to warn users of this
difference between the h5netcdf and netcdf4 engines.

 - [x] Closes #4471 
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
