### PR TITLE
unpin matplotlib for docs again

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -13,7 +13,7 @@ dependencies:
   - ipython
   - iris>=2.3
   - jupyter_client
-  - matplotlib-base=3.3.0
+  - matplotlib-base
   - nbsphinx
   - netcdf4>=1.5
   - numba


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4342

mpl 3.3.2 is out so we can try to unpin the version of the docs again. #4313