### PR TITLE
Alignment with tolerance2

### DIFF
--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -13,6 +13,7 @@ from typing import (
     cast,
 )
 
+import numpy as np
 import pandas as pd
 
 from . import formatting, indexing
@@ -106,9 +107,47 @@ class Coordinates(Mapping[Hashable, "DataArray"]):
             (dim,) = ordered_dims
             return self._data.get_index(dim)  # type: ignore
         else:
+            from pandas.core.arrays.categorical import factorize_from_iterable
+
             indexes = [self._data.get_index(k) for k in ordered_dims]  # type: ignore
-            names = list(ordered_dims)
-            return pd.MultiIndex.from_product(indexes, names=names)
+
+            # compute the sizes of the repeat and tile for the cartesian product
+            # (taken from pandas.core.reshape.util)
+            lenX = np.fromiter((len(index) for index in indexes), dtype=np.intp)
+            cumprodX = np.cumproduct(lenX)
+
+            if cumprodX[-1] != 0:
+                # sizes of the repeats
+                b = cumprodX[-1] / cumprodX
+            else:
+                # if any factor is empty, the cartesian product is empty
+                b = np.zeros_like(cumprodX)
+
+            # sizes of the tiles
+            a = np.roll(cumprodX, 1)
+            a[0] = 1
+
+            # loop over the indexes
+            # for each MultiIndex or Index compute the cartesian product of the codes
+
+            code_list = []
+            level_list = []
+            names = []
+
+            for i, index in enumerate(indexes):
+                if isinstance(index, pd.MultiIndex):
+                    codes, levels = index.codes, index.levels
+                else:
+                    code, level = factorize_from_iterable(index)
+                    codes = [code]
+                    levels = [level]
+                    
+                # compute the cartesian product
+                code_list += [np.tile(np.repeat(code, b[i]), a[i]) for code in codes]
+                level_list += levels
+                names += index.names
+
+            return pd.MultiIndex(level_list, code_list, names=names)
 
     def update(self, other: Mapping[Hashable, Any]) -> None:
         other_vars = getattr(other, "variables", other)

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -141,7 +141,7 @@ class Coordinates(Mapping[Hashable, "DataArray"]):
                     code, level = factorize_from_iterable(index)
                     codes = [code]
                     levels = [level]
-                    
+
                 # compute the cartesian product
                 code_list += [np.tile(np.repeat(code, b[i]), a[i]) for code in codes]
                 level_list += levels

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -111,18 +111,20 @@ class Coordinates(Mapping[Hashable, "DataArray"]):
 
             # compute the sizes of the repeat and tile for the cartesian product
             # (taken from pandas.core.reshape.util)
-            lenX = np.fromiter((len(index) for index in indexes), dtype=np.intp)
-            cumprodX = np.cumproduct(lenX)
+            index_lengths = np.fromiter(
+                (len(index) for index in indexes), dtype=np.intp
+            )
+            cumprod_lengths = np.cumproduct(index_lengths)
 
-            if cumprodX[-1] != 0:
+            if cumprod_lengths[-1] != 0:
                 # sizes of the repeats
-                repeat_counts = cumprodX[-1] / cumprodX
+                repeat_counts = cumprod_lengths[-1] / cumprod_lengths
             else:
                 # if any factor is empty, the cartesian product is empty
-                repeat_counts = np.zeros_like(cumprodX)
+                repeat_counts = np.zeros_like(cumprod_lengths)
 
             # sizes of the tiles
-            tile_counts = np.roll(cumprodX, 1)
+            tile_counts = np.roll(cumprod_lengths, 1)
             tile_counts[0] = 1
 
             # loop over the indexes
@@ -141,7 +143,10 @@ class Coordinates(Mapping[Hashable, "DataArray"]):
                     levels = [level]
 
                 # compute the cartesian product
-                code_list += [np.tile(np.repeat(code, repeat_counts[i]), tile_counts[i]) for code in codes]
+                code_list += [
+                    np.tile(np.repeat(code, repeat_counts[i]), tile_counts[i])
+                    for code in codes
+                ]
                 level_list += levels
                 names += index.names
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3535,6 +3535,18 @@ class TestDataArray:
         assert_array_equal(actual.index.levels[1], ["a", "b"])
         assert_array_equal(actual.index.levels[2], [5, 6, 7])
 
+    def test_to_dataframe_0length(self):
+        # regression test for #3008
+        arr_np = np.random.randn(4, 0)
+
+        mindex = pd.MultiIndex.from_product([[1, 2], list("ab")], names=["A", "B"])
+
+        arr = DataArray(arr_np, [("MI", mindex), ("C", [])], name="foo")
+
+        actual = arr.to_dataframe()
+        assert len(actual) == 0
+        assert_array_equal(actual.index.names, list("ABC"))
+
     def test_to_pandas_name_matches_coordinate(self):
         # coordinate with same name as array
         arr = DataArray([1, 2, 3], dims="x", name="x")

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3523,16 +3523,16 @@ class TestDataArray:
     def test_to_dataframe_multiindex(self):
         # regression test for #3008
         arr_np = np.random.randn(4, 3)
-     
-        mindex = pd.MultiIndex.from_product([[1, 2], list('ab')], names=['A', 'B'])
 
-        arr = DataArray(arr_np, [('MI', mindex), ('C', [5, 6, 7])], name="foo")
+        mindex = pd.MultiIndex.from_product([[1, 2], list("ab")], names=["A", "B"])
+
+        arr = DataArray(arr_np, [("MI", mindex), ("C", [5, 6, 7])], name="foo")
 
         actual = arr.to_dataframe()
-        assert_array_equal(actual['foo'].values, arr_np.flatten())
-        assert_array_equal(actual.index.names, list('ABC'))
+        assert_array_equal(actual["foo"].values, arr_np.flatten())
+        assert_array_equal(actual.index.names, list("ABC"))
         assert_array_equal(actual.index.levels[0], [1, 2])
-        assert_array_equal(actual.index.levels[1], ['a', 'b'])
+        assert_array_equal(actual.index.levels[1], ["a", "b"])
         assert_array_equal(actual.index.levels[2], [5, 6, 7])
 
     def test_to_pandas_name_matches_coordinate(self):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -453,7 +453,7 @@ class TestDataArray:
         assert not expected.identical(actual)
 
         actual = expected.copy()
-        actual["a"] = 100000
+        actual["a"] = 100_000
         assert not expected.equals(actual)
         assert not expected.identical(actual)
 
@@ -3371,6 +3371,37 @@ class TestDataArray:
                 DataArray([1, 2, 3], dims=["x"]),
                 DataArray([1, 2], coords=[("x", [0, 1])]),
             )
+
+    def test_align_with_tolerance_when_nearly_equal_index(self):
+        da1 = DataArray([1, 2, 3], coords=[("x", [1.0001, 2.0004, 2.9999])])
+
+        da2 = DataArray([4, 5, 6], coords=[("x", [1, 2, 3])])
+
+        aligned_da1, aligned_da2 = align(da1, da2, tolerance=4e-4)
+
+        assert_identical(aligned_da1.x, da1.x)
+        assert_identical(aligned_da2.x, da1.x)
+
+    def test_align_with_tolereance_and_intersect(self):
+        da1 = DataArray([1, 2, 3, 4], coords=[("x", [1.0001, 1.5, 2.0004, 2.9999])])
+
+        da2 = DataArray([5, 6, 7, 8], coords=[("x", [1, 2, 3, 5])])
+
+        aligned_da1, aligned_da2 = align(da1, da2, tolerance=4e-4, join="inner")
+
+        assert_identical(aligned_da1.x, aligned_da2.x)
+        print(aligned_da1.x)
+        assert_array_equal(aligned_da1.x, np.array([1.0, 2.0, 2.9999]))
+
+    def test_align_with_tolereance_and_union(self):
+        da1 = DataArray([1, 2, 3, 4], coords=[("x", [1.0001, 1.5, 2.0004, 2.9999])])
+
+        da2 = DataArray([5, 6, 7, 8], coords=[("x", [1, 2, 3, 5])])
+
+        aligned_da1, aligned_da2 = align(da1, da2, tolerance=4e-4, join="outer")
+
+        assert_identical(aligned_da1.x, aligned_da2.x)
+        assert_array_equal(aligned_da1.x, np.array([1.0, 1.5, 2.0, 2.9999, 5.0]))
 
     def test_broadcast_arrays(self):
         x = DataArray([1, 2], coords=[("a", [-1, -2])], name="x")

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3520,6 +3520,21 @@ class TestDataArray:
         with raises_regex(ValueError, "unnamed"):
             arr.to_dataframe()
 
+    def test_to_dataframe_multiindex(self):
+        # regression test for #3008
+        arr_np = np.random.randn(4, 3)
+     
+        mindex = pd.MultiIndex.from_product([[1, 2], list('ab')], names=['A', 'B'])
+
+        arr = DataArray(arr_np, [('MI', mindex), ('C', [5, 6, 7])], name="foo")
+
+        actual = arr.to_dataframe()
+        assert_array_equal(actual['foo'].values, arr_np.flatten())
+        assert_array_equal(actual.index.names, list('ABC'))
+        assert_array_equal(actual.index.levels[0], [1, 2])
+        assert_array_equal(actual.index.levels[1], ['a', 'b'])
+        assert_array_equal(actual.index.levels[2], [5, 6, 7])
+
     def test_to_pandas_name_matches_coordinate(self):
         # coordinate with same name as array
         arr = DataArray([1, 2, 3], dims="x", name="x")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2217
 - [x] Tests added
 - [ ] Passes `isort . && black . && mypy . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`

Reading #2217, I've implemented fast algorithms for union and intersection of arrays with numerical tolerance. 
This works fine in the "normal" case, when each array has all its values different (outside the tolerance) and the first and second arrays have some values in common within the tolerance. Conversely, the behavior is not well defined when one array has some values that are not within the tolerance (or are equal) of each other. In this case, the behavior of union and intersection is not well defined anyway. The "bad" cases could be checked to raise an Exception (duplicate values within the tolerance), but this is not implemented yet.

I've also implemented a function to test index equality within the tolerance.

At last, the logic of xarray.align has been changed to deal with the tolerance. It was not possible to avoid some changes in align.

I'd appreciate some tests and code review, because there are certainly some rough corners I've not though about.