### PR TITLE
Remove maybe chunck duplicated function

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -18,7 +18,7 @@ from typing import (
 import numpy as np
 
 from .. import backends, coding, conventions
-from ..core import indexing
+from ..core import dataset, indexing
 from ..core.combine import (
     _infer_concat_order_from_positions,
     _nested_combine,
@@ -524,10 +524,16 @@ def open_dataset(
             if isinstance(chunks, int):
                 chunks = dict.fromkeys(ds.dims, chunks)
 
-            variables = {
-                k: store.maybe_chunk(k, v, chunks, overwrite_encoded_chunks)
-                for k, v in ds.variables.items()
-            }
+            variables = {}
+            for name, var in ds.variables.items():
+                chunk_spec = store.get_chunk(name, var, chunks)
+                if chunk_spec is not None:
+                    variables[name] = dataset._maybe_chunk(
+                        name,
+                        var,
+                        chunk_spec,
+                        overwrite_encoded_chunks=overwrite_encoded_chunks,
+                    )
             ds2 = ds._replace(variables)
 
         else:

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -300,7 +300,7 @@ def load_dataarray(filename_or_obj, **kwargs):
         The newly created DataArray.
 
     See Also
-    --------
+    --------dataset
     open_dataarray
     """
     if "cache" in kwargs:
@@ -525,7 +525,12 @@ def open_dataset(
                 chunks = dict.fromkeys(ds.dims, chunks)
 
             variables = {
-                k: _maybe_chunk(k, v, store.get_chunk(k, v, chunks), overwrite_encoded_chunks=overwrite_encoded_chunks)
+                k: _maybe_chunk(
+                    k,
+                    v,
+                    store.get_chunk(k, v, chunks),
+                    overwrite_encoded_chunks=overwrite_encoded_chunks,
+                )
                 for k, v in ds.variables.items()
             }
             ds2 = ds._replace(variables)

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -300,7 +300,7 @@ def load_dataarray(filename_or_obj, **kwargs):
         The newly created DataArray.
 
     See Also
-    --------dataset
+    --------
     open_dataarray
     """
     if "cache" in kwargs:

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -390,22 +390,6 @@ class ZarrStore(AbstractWritableDataStore):
                 chunk_spec[dim] = chunks[dim]
         return chunk_spec
 
-    def maybe_chunk(self, name, var, chunks, overwrite_encoded_chunks):
-        chunk_spec = self.get_chunk(name, var, chunks)
-
-        if (var.ndim > 0) and (chunk_spec is not None):
-            from dask.base import tokenize
-
-            # does this cause any data to be read?
-            token2 = tokenize(name, var._data, chunks)
-            name2 = f"xarray-{name}-{token2}"
-            var = var.chunk(chunk_spec, name=name2, lock=None)
-            if overwrite_encoded_chunks and var.chunks is not None:
-                var.encoding["chunks"] = tuple(x[0] for x in var.chunks)
-            return var
-        else:
-            return var
-
     def store(
         self,
         variables,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1806,10 +1806,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                     "object: %s" % bad_dims
                 )
 
-        variables = {
-            k: _maybe_chunk(k, v, chunks, token, lock, name_prefix)
-            for k, v in self.variables.items()
-        }
+        variables = {k: _maybe_chunk(k, v, chunks, token, lock, name_prefix) for k, v in self.variables.items()}
         return self._replace(variables)
 
     def _validate_indexers(

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1806,7 +1806,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                     "object: %s" % bad_dims
                 )
 
-        variables = {k: _maybe_chunk(k, v, chunks, token, lock, name_prefix) for k, v in self.variables.items()}
+        variables = {
+            k: _maybe_chunk(k, v, chunks, token, lock, name_prefix)
+            for k, v in self.variables.items()
+        }
         return self._replace(variables)
 
     def _validate_indexers(

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -359,12 +359,6 @@ def _assert_empty(args: tuple, msg: str = "%s") -> None:
         raise ValueError(msg % args)
 
 
-def _selkeys(dict_, keys):
-    if dict_ is None:
-        return None
-    return {d: dict_[d] for d in keys if d in dict_}
-
-
 def _maybe_chunk(
     name,
     var,
@@ -376,7 +370,8 @@ def _maybe_chunk(
 ):
     from dask.base import tokenize
 
-    chunks = _selkeys(chunks, var.dims)
+    if chunks is not None:
+        chunks = {dim: chunks[dim] for dim in var.dims if dim in chunks}
     if var.ndim:
         # when rechunking by different amounts, make sure dask names change
         # by provinding chunks as an input to tokenize.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -359,6 +359,39 @@ def _assert_empty(args: tuple, msg: str = "%s") -> None:
         raise ValueError(msg % args)
 
 
+def _selkeys(dict_, keys):
+    if dict_ is None:
+        return None
+    return {d: dict_[d] for d in keys if d in dict_}
+
+
+def _maybe_chunk(
+    name,
+    var,
+    chunks=None,
+    token=None,
+    lock=None,
+    name_prefix="xarray-",
+    overwrite_encoded_chunks=False,
+):
+    from dask.base import tokenize
+
+    chunks = _selkeys(chunks, var.dims)
+    if var.ndim:
+        # when rechunking by different amounts, make sure dask names change
+        # by provinding chunks as an input to tokenize.
+        # subtle bugs result otherwise. see GH3350
+        token2 = tokenize(name, token if token else var._data, chunks)
+        name2 = f"{name_prefix}{name}-{token2}"
+        var = var.chunk(chunks, name=name2, lock=lock)
+
+        if overwrite_encoded_chunks and var.chunks is not None:
+            var.encoding["chunks"] = tuple(x[0] for x in var.chunks)
+        return var
+    else:
+        return var
+
+
 def as_dataset(obj: Any) -> "Dataset":
     """Cast the given object to a Dataset.
 
@@ -1761,7 +1794,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         -------
         chunked : xarray.Dataset
         """
-        from dask.base import tokenize
 
         if isinstance(chunks, (Number, str)):
             chunks = dict.fromkeys(self.dims, chunks)
@@ -1774,26 +1806,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                     "object: %s" % bad_dims
                 )
 
-        def selkeys(dict_, keys):
-            if dict_ is None:
-                return None
-            return {d: dict_[d] for d in keys if d in dict_}
-
-        def maybe_chunk(name, var, chunks):
-            chunks = selkeys(chunks, var.dims)
-            if not chunks:
-                chunks = None
-            if var.ndim > 0:
-                # when rechunking by different amounts, make sure dask names change
-                # by provinding chunks as an input to tokenize.
-                # subtle bugs result otherwise. see GH3350
-                token2 = tokenize(name, token if token else var._data, chunks)
-                name2 = f"{name_prefix}{name}-{token2}"
-                return var.chunk(chunks, name=name2, lock=lock)
-            else:
-                return var
-
-        variables = {k: maybe_chunk(k, v, chunks) for k, v in self.variables.items()}
+        variables = {
+            k: _maybe_chunk(k, v, chunks, token, lock, name_prefix)
+            for k, v in self.variables.items()
+        }
         return self._replace(variables)
 
     def _validate_indexers(


### PR DESCRIPTION
I propose this small change with a view to unifying in `open_dataset` the logic of zarr chunking with that of the other backends.
Currently, the function `maybe_chunk` is duplicated: it is defined inside the function `dataset.chunks` and as method of `zarr.ZarrStore`. This last function has been added with the recent merge of #4187 . 
I merged the two functions in a private function `_maybe_chunk` inside the module `dataset`.

 - [x] Addresses #4309
 - [ ] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
