### PR TITLE
combine_by_coords: error on differing calendars

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -45,6 +45,8 @@ Bug fixes
   is now ignored when not applicable, i.e. when ``skipna=False`` or when ``skipna=None``
   and the dtype does not have a missing value (:issue:`4352`).
   By `Mathias Hauser <https://github.com/mathause>`_.
+- :py:func:`combine_by_coords` now raises an informative error when passing coordinates
+  with differing calendars (:issue:`4495`). By `Mathias Hauser <https://github.com/mathause>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -93,7 +93,9 @@ def _infer_concat_order_from_coords(datasets):
                 # position indices - they should be concatenated along another
                 # dimension, not along this one
                 series = first_items.to_series()
-                rank = series.rank(method="dense", ascending=ascending)
+                rank = series.rank(
+                    method="dense", ascending=ascending, numeric_only=False
+                )
                 order = rank.astype(int).values - 1
 
                 # Append positions along extra dimension to structure which

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -855,5 +855,4 @@ def test_combine_by_coords_raises_for_differing_calendars():
     da_2 = DataArray([1], dims=["time"], coords=[time_2], name="a").to_dataset()
 
     with raises_regex(TypeError, r"cannot compare .* \(different calendars\)"):
-
         combine_by_coords([da_1, da_2])

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -798,7 +798,7 @@ class TestCombineAuto:
         ds0 = Dataset({"x": [0, 1, 5]})
         ds1 = Dataset({"x": [2, 3]})
         with raises_regex(
-            ValueError, "does not have monotonic global indexes" " along dimension x"
+            ValueError, "does not have monotonic global indexes along dimension x"
         ):
             combine_by_coords([ds1, ds0])
 
@@ -839,3 +839,21 @@ def test_combine_by_coords_distant_cftime_dates():
         [0, 1, 2], dims=["time"], coords=[expected_time], name="a"
     ).to_dataset()
     assert_identical(result, expected)
+
+
+@requires_cftime
+def test_combine_by_coords_raises_for_differing_calendars():
+    # previously failed with uninformative StopIteration instead of TypeError
+    # https://github.com/pydata/xarray/issues/4495
+
+    import cftime
+
+    time_1 = [cftime.DatetimeGregorian(2000, 1, 1)]
+    time_2 = [cftime.DatetimeProlepticGregorian(2001, 1, 1)]
+
+    da_1 = DataArray([0], dims=["time"], coords=[time_1], name="a").to_dataset()
+    da_2 = DataArray([1], dims=["time"], coords=[time_2], name="a").to_dataset()
+
+    with raises_regex(TypeError, r"cannot compare .* \(different calendars\)"):
+
+        combine_by_coords([da_1, da_2])


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4495
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`

Let's see if all tests pass or if the `numeric_only` keyword is new in pandas.