### PR TITLE
workaround for failing dask zeros_like

### DIFF
--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -101,6 +101,8 @@ def isnull(data):
         return isnan(data)
     elif issubclass(scalar_type, (np.bool_, np.integer, np.character, np.void)):
         # these types cannot represent missing values
+        if hasattr(data, "_meta"):
+            data._meta = None  # workaround for GH4502
         return zeros_like(data, dtype=bool)
     else:
         # at this point, array should have dtype=object


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4502
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`