### PR TITLE
Eliminate use of calendar-naive cftime objects

### DIFF
--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -391,15 +391,15 @@ def test_decode_multidim_time_outside_timestamp_range(calendar):
 
 
 @requires_cftime
-@pytest.mark.parametrize("calendar", ["360_day", "all_leap", "366_day"])
-def test_decode_non_standard_calendar_single_element(calendar):
+@pytest.mark.parametrize(
+    ("calendar", "num_time"),
+    [("360_day", 720058.0), ("all_leap", 732059.0), ("366_day", 732059.0)],
+)
+def test_decode_non_standard_calendar_single_element(calendar, num_time):
     import cftime
 
     units = "days since 0001-01-01"
 
-    dt = cftime.datetime(2001, 2, 29)
-
-    num_time = cftime.date2num(dt, units, calendar)
     actual = coding.times.decode_cf_datetime(num_time, units, calendar=calendar)
 
     expected = np.asarray(


### PR DESCRIPTION
This is a minor cleanup to remove our use of calendar-naive cftime datetime objects (it just occurs in one test).  The behavior of the `cftime.datetime` constructor is set to change in Unidata/cftime#202.  By default it will create a calendar-aware datetime with a Gregorian calendar, instead of a calendar-naive datetime.  In xarray we don't have a real need to use calendar-naive datetimes, so I think it's just best to remove our use of them.

 - [x] Passes `isort . && black . && mypy . && flake8`

