### PR TITLE
Use black profile for isort

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -157,13 +157,11 @@ exclude=
     doc
 
 [isort]
+profile = black
+skip_gitignore = true
+force_to_top = true
 default_section = THIRDPARTY
 known_first_party = xarray
-multi_line_output = 3
-include_trailing_comma = True
-force_grid_wrap = 0
-use_parentheses = True
-line_length = 88
 
 # Most of the numerical computing stack doesn't have type annotations yet.
 [mypy-affine.*]


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `isort . && black . && mypy . && flake8`

Purely aesthetic simplification