### PR TITLE
Request a reproducible example for SO questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,7 @@
 blank_issues_enabled: true
 contact_links:
-  - name: General Question
+  - name: Usage question
     url: https://stackoverflow.com/questions/tagged/python-xarray
-    about: "If you have a question like *How do I append to an xarray.Dataset?* then please ask on Stack Overflow using the #python-xarray tag."
+    about: "Post a question on Stack Overflow using the #python-xarray
+    tag. These are regularly reviewed by xarray's maintainers, and questions which
+    include a reproducible example will receive a response."


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

I've been trying to answer most questions on SO over the past month or so. The quality of questions is not great — is there a way we could encourage people to post reproducible examples? I think our push to do that on GH issues has been broadly successful. 

I occasionally reply asking for a reproducible example, but it's not that friendly an approach.

There are some SO docs: https://stackoverflow.com/help/minimal-reproducible-example, but they're not explicitly linked to from SO.