### PR TITLE
GH4228 Clearer error on scalar to dataframe

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -54,6 +54,8 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
+- Raise a more informative error when :py:meth:`DataArray.to_dataframe` is
+  is called on a scalar (:issue:`4228`). By `Pieter Gijsbers <https://github.com/pgijsbers>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2442,6 +2442,8 @@ class DataArray(AbstractArray, DataWithCoords):
                 "cannot convert an unnamed DataArray to a "
                 "DataFrame: use the ``name`` parameter"
             )
+        if self.ndim == 0:
+            raise ValueError("cannot convert a scalar to a DataFrame")
 
         # By using a unique name, we can convert a DataArray into a DataFrame
         # even if it shares a name with one of its coordinates.

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3538,6 +3538,9 @@ class TestDataArray:
         with pytest.raises(ValueError, match="does not match the set of dimensions"):
             arr.to_dataframe(dim_order=["B", "A", "C"])
 
+        with pytest.raises(ValueError, match=r"cannot convert a scalar"):
+            arr.sel(A="c", B=2).to_dataframe()
+
         arr.name = None  # unnamed
         with raises_regex(ValueError, "unnamed"):
             arr.to_dataframe()


### PR DESCRIPTION
When attempting to convert a scalar to a dataframe, as e.g.:

`xarray.DataArray([1], coords=[('onecoord', [2])]).sel(onecoord=2).to_dataframe(name='name')`

raise 

`ValueError: cannot convert a scalar to a Dataframe`

instead of 

`ValueError: no valid index for a 0-dimensional object`


 - [x] Closes #4228
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`.  
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
  > I was not sure if this was "notable". Please let me know if I should add.
 - [ ] New functions/methods are listed in `api.rst`
> n / a

I was not able to run all tests, but was able to run the changed one (more on that in the issue).