### PR TITLE
Remove unused kwarg

### DIFF
--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -814,7 +814,7 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
         )
         return self.map(func, shortcut=shortcut, args=args, **kwargs)
 
-    def _combine(self, applied, restore_coord_dims=False, shortcut=False):
+    def _combine(self, applied, shortcut=False):
         """Recombine the applied objects like the original."""
         applied_example, applied = peek_at(applied)
         coord, dim, positions = self._infer_concat_args(applied_example)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `isort . && black . && mypy . && flake8`

This doesn't seem to be used? Unless it's required for compatibility with an interface?