### PR TITLE
numpy_groupies

### DIFF
--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -3,6 +3,7 @@ from contextlib import suppress
 from html import escape
 from textwrap import dedent
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -26,6 +27,12 @@ from .options import OPTIONS, _get_keep_attrs
 from .pycompat import is_duck_dask_array
 from .rolling_exp import RollingExp
 from .utils import Frozen, either_dict_or_kwargs, is_scalar
+
+if TYPE_CHECKING:
+    from xarray.core.variable import IndexVariable
+
+    from .dataarray import DataArray
+
 
 # Used as a sentinel value to indicate a all dimensions
 ALL_DIMS = ...
@@ -577,13 +584,13 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         >>> def adder(data, arg):
         ...     return data + arg
-        ...
+
         >>> def div(data, arg):
         ...     return data / arg
-        ...
+
         >>> def sub_mult(data, sub_arg, mult_arg):
         ...     return (data * mult_arg) - sub_arg
-        ...
+
         >>> x.pipe(adder, 2)
         <xarray.Dataset>
         Dimensions:        (lat: 2, lon: 2)
@@ -633,7 +640,12 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         else:
             return func(self, *args, **kwargs)
 
-    def groupby(self, group, squeeze: bool = True, restore_coord_dims: bool = None):
+    def groupby(
+        self,
+        group: Union[Hashable, "DataArray", "IndexVariable"],
+        squeeze: bool = True,
+        restore_coord_dims: bool = None,
+    ):
         """Returns a GroupBy object for performing grouped operations.
 
         Parameters

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -9,7 +9,7 @@ CMAP_SEQUENTIAL = "cmap_sequential"
 CMAP_DIVERGENT = "cmap_divergent"
 KEEP_ATTRS = "keep_attrs"
 DISPLAY_STYLE = "display_style"
-
+NUMPY_GROUPIES = "numpy_groupies"
 
 OPTIONS = {
     DISPLAY_WIDTH: 80,
@@ -21,6 +21,7 @@ OPTIONS = {
     CMAP_DIVERGENT: "RdBu_r",
     KEEP_ATTRS: "default",
     DISPLAY_STYLE: "html",
+    NUMPY_GROUPIES: True,
 }
 
 _JOIN_OPTIONS = frozenset(["inner", "outer", "left", "right", "exact"])
@@ -104,6 +105,7 @@ class set_options:
       Default: ``'default'``.
     - ``display_style``: display style to use in jupyter for xarray objects.
       Default: ``'text'``. Other options are ``'html'``.
+    - ``numpy_groupies``: use numpy groupies.
 
 
     You can use ``set_options`` either as a context manager:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes https://github.com/pydata/xarray/issues/4473
 - [ ] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`

Very early effort — I found this harder than I expected — I was trying to use the existing groupby infra, but think I maybe should start afresh. The result of the `numpy_groupies` operation is a fully formed array, whereas we're used to handling an iterable of results which need to be concat.

I also added some type signature / notes and I was going through the existing code; mostly for my own understanding

If anyone has any thoughts, feel free to comment — otherwise I'll resume this soon