### PR TITLE
maint: pandas can now index with np.timedelta64

### DIFF
--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -68,11 +68,6 @@ def _sanitize_slice_element(x):
             )
         x = x[()]
 
-    if isinstance(x, np.timedelta64):
-        # pandas does not support indexing with np.timedelta64 yet:
-        # https://github.com/pandas-dev/pandas/issues/20393
-        x = pd.Timedelta(x)
-
     return x
 
 


### PR DESCRIPTION
pandas-dev/pandas#20393 was resolved in pandas version 0.23, so this should no longer be necessary. The relevant test is

https://github.com/pydata/xarray/blob/063606b90946d869e90a6273e2e18ed24bffb052/xarray/tests/test_dataarray.py#L955-L957

so let's see if this passes