### PR TITLE
Update link to NumPy docstring standard in contributing guide

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -252,7 +252,7 @@ Some other important things to know about the docs:
 - The docstrings follow the **Numpy Docstring Standard**, which is used widely
   in the Scientific Python community. This standard specifies the format of
   the different sections of the docstring. See `this document
-  <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_
+  <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_
   for a detailed explanation, or look at some of the existing functions to
   extend it in a similar manner.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -72,6 +72,8 @@ Documentation
   By `Sahid Velji <https://github.com/sahidvelji>`_.
 - Fix grammar and typos in the :doc:`io` guide (:pull:`4553`).
   By `Sahid Velji <https://github.com/sahidvelji>`_.
+- Update link to NumPy docstring standard in the :doc:`contributing` guide (:pull:`4558`).
+  By `Sahid Velji <https://github.com/sahidvelji>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

I updated the link to the NumPy docstring standard in the [contributing guide](http://xarray.pydata.org/en/stable/contributing.html).