### PR TITLE
Optimize slice_slice for faster isel of huge datasets

### DIFF
--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -138,3 +138,15 @@ class BooleanIndexing:
 
     def time_indexing(self):
         self.ds.isel(time=self.time_filter)
+
+
+class HugeAxisSmallSliceIndexing:
+    # https://github.com/pydata/xarray/pull/4560
+    def setup(self):
+        self.ds = xr.Dataset(
+            {"a": ("time", np.arange(10_000_000))},
+            coords={"time": np.arange(10_000_000)},
+        )
+
+    def time_indexing(self):
+        self.ds.isel(time=slice(1000))

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pandas as pd
 
@@ -143,10 +145,17 @@ class BooleanIndexing:
 class HugeAxisSmallSliceIndexing:
     # https://github.com/pydata/xarray/pull/4560
     def setup(self):
-        self.ds = xr.Dataset(
-            {"a": ("time", np.arange(10_000_000))},
-            coords={"time": np.arange(10_000_000)},
-        )
+        self.filepath = "test_indexing_huge_axis_small_slice.nc"
+        if not os.path.isfile(self.filepath):
+            xr.Dataset(
+                {"a": ("x", np.arange(10_000_000))},
+                coords={"x": np.arange(10_000_000)},
+            ).to_netcdf(self.filepath, format="NETCDF4")
+
+        self.ds = xr.open_dataset(self.filepath)
 
     def time_indexing(self):
-        self.ds.isel(time=slice(1000))
+            self.ds.isel(x=slice(100))
+
+    def cleanup(self):
+        self.ds.close()

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -155,7 +155,7 @@ class HugeAxisSmallSliceIndexing:
         self.ds = xr.open_dataset(self.filepath)
 
     def time_indexing(self):
-            self.ds.isel(x=slice(100))
+        self.ds.isel(x=slice(100))
 
     def cleanup(self):
         self.ds.close()

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -58,6 +58,7 @@ Bug fixes
   By `Mathias Hauser <https://github.com/mathause>`_.
 - :py:func:`combine_by_coords` now raises an informative error when passing coordinates
   with differing calendars (:issue:`4495`). By `Mathias Hauser <https://github.com/mathause>`_.
+- Fix performance bug where reading small slices from huge dimensions was slower than necessary (:pull:`4560`). By `Dion Häfner <https://github.com/dionhaefner>`_.
 
 Documentation
 ~~~~~~~~~~~~~
@@ -66,7 +67,7 @@ Documentation
   (:pull:`4532`);
   By `Jimmy Westling <https://github.com/illviljan>`_.
 - Raise a more informative error when :py:meth:`DataArray.to_dataframe` is
-  is called on a scalar, (:issue:`4228`); 
+  is called on a scalar, (:issue:`4228`);
   By `Pieter Gijsbers <https://github.com/pgijsbers>`_.
 - Fix grammar and typos in the :doc:`contributing` guide (:pull:`4545`).
   By `Sahid Velji <https://github.com/sahidvelji>`_.

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1,6 +1,5 @@
 import enum
 import functools
-import math
 import operator
 from collections import defaultdict
 from contextlib import suppress
@@ -289,10 +288,8 @@ def slice_slice(old_slice, applied_slice, size):
     """
     old_slice = _normalize_slice(old_slice, size)
 
-    size_after_old_slice = math.ceil(
-        (old_slice.stop - old_slice.start) / old_slice.step
-    )
-    if size_after_old_slice <= 0:
+    size_after_old_slice = len(range(old_slice.start, old_slice.stop, old_slice.step))
+    if not size_after_old_slice:
         # nothing left after applying first slice
         return slice(0)
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1,6 +1,6 @@
-import math
 import enum
 import functools
+import math
 import operator
 from collections import defaultdict
 from contextlib import suppress

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1,3 +1,4 @@
+import math
 import enum
 import functools
 import operator
@@ -275,25 +276,39 @@ def remap_label_indexers(data_obj, indexers, method=None, tolerance=None):
     return pos_indexers, new_indexes
 
 
+def _normalize_slice(sl, size):
+    """Ensure that given slice only contains positive start and stop values
+    (stop can be -1 for negative steps)"""
+    return slice(*sl.indices(size))
+
+
 def slice_slice(old_slice, applied_slice, size):
     """Given a slice and the size of the dimension to which it will be applied,
     index it with another slice to return a new slice equivalent to applying
     the slices sequentially
     """
-    step = (old_slice.step or 1) * (applied_slice.step or 1)
+    old_slice = _normalize_slice(old_slice, size)
 
-    # For now, use the hack of turning old_slice into an ndarray to reconstruct
-    # the slice start and stop. This is not entirely ideal, but it is still
-    # definitely better than leaving the indexer as an array.
-    items = _expand_slice(old_slice, size)[applied_slice]
-    if len(items) > 0:
-        start = items[0]
-        stop = items[-1] + int(np.sign(step))
-        if stop < 0:
-            stop = None
-    else:
-        start = 0
-        stop = 0
+    size_after_old_slice = math.ceil(
+        (old_slice.stop - old_slice.start) / old_slice.step
+    )
+    if size_after_old_slice < 0:
+        # nothing left after applying first slice
+        return slice(0)
+
+    applied_slice = _normalize_slice(applied_slice, size_after_old_slice)
+
+    start = old_slice.start + applied_slice.start * old_slice.step
+    if start < 0:
+        # nothing left after applying second slice
+        return slice(0)
+
+    stop = old_slice.start + applied_slice.stop * old_slice.step
+    if stop < 0:
+        stop = None
+
+    step = old_slice.step * applied_slice.step
+
     return slice(start, stop, step)
 
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -278,7 +278,7 @@ def remap_label_indexers(data_obj, indexers, method=None, tolerance=None):
 
 def _normalize_slice(sl, size):
     """Ensure that given slice only contains positive start and stop values
-    (stop can be -1 for negative steps)"""
+    (stop can be -1 for full-size slices with negative steps, e.g. [-10::-1])"""
     return slice(*sl.indices(size))
 
 
@@ -292,7 +292,7 @@ def slice_slice(old_slice, applied_slice, size):
     size_after_old_slice = math.ceil(
         (old_slice.stop - old_slice.start) / old_slice.step
     )
-    if size_after_old_slice < 0:
+    if size_after_old_slice <= 0:
         # nothing left after applying first slice
         return slice(0)
 
@@ -301,6 +301,7 @@ def slice_slice(old_slice, applied_slice, size):
     start = old_slice.start + applied_slice.start * old_slice.step
     if start < 0:
         # nothing left after applying second slice
+        # (can only happen for old_slice.step < 0, e.g. [10::-1], [20:])
         return slice(0)
 
     stop = old_slice.start + applied_slice.stop * old_slice.step

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -289,7 +289,7 @@ def slice_slice(old_slice, applied_slice, size):
     old_slice = _normalize_slice(old_slice, size)
 
     size_after_old_slice = len(range(old_slice.start, old_slice.stop, old_slice.step))
-    if not size_after_old_slice:
+    if size_after_old_slice == 0:
         # nothing left after applying first slice
         return slice(0)
 


### PR DESCRIPTION
I noticed that reading small slices of huge datasets (>1e8 rows) was very slow, even if they were properly chunked. I traced the issue back to `xarray.core.indexing.slice_slice`, which essentially calls `np.arange(ds_size)` to compute a slice. This is obviously `O(ds_size)`, even if the actual slice to be read is tiny.

You can see the issue in this gist:

https://gist.github.com/dionhaefner/a3e97bae0a4e28f0d39294074419a683

I took the liberty to optimize the function by computing the resulting slice arithmetically. With this in place, reading from disk is now the bottleneck as it should be. I saw performance increases by about a factor of 10, but this obviously varies with dimension size, slice size, and chunk size.

---

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `isort . && black . && mypy . && flake8`
