### PR TITLE
rm inplace arg to rename

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2918,7 +2918,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         Dataset.rename_dims
         DataArray.rename
         """
-        _check_inplace(inplace)
         name_dict = either_dict_or_kwargs(name_dict, names, "rename")
         for k in name_dict.keys():
             if k not in self and k not in self.dims:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2893,7 +2893,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
     def rename(
         self,
         name_dict: Mapping[Hashable, Hashable] = None,
-        inplace: bool = None,
         **names: Hashable,
     ) -> "Dataset":
         """Returns a new object with renamed variables and dimensions.

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2569,12 +2569,6 @@ class TestDataset:
         renamed = data.rename(newnames)
         assert_identical(renamed, data)
 
-    def test_rename_inplace(self):
-        times = pd.date_range("2000-01-01", periods=3)
-        data = Dataset({"z": ("x", [2, 3, 4]), "t": ("t", times)})
-        with pytest.raises(TypeError):
-            data.rename({"x": "y"}, inplace=True)
-
     def test_rename_dims(self):
         original = Dataset({"x": ("x", [0, 1, 2]), "y": ("x", [10, 11, 12]), "z": 42})
         expected = Dataset(


### PR DESCRIPTION
This PR follows a TypeError I got

```
ds = xr.open_dataset('https://thredds.ucar.edu/thredds/dodsC/grib/NCEP/GFS/Global_0p25deg/Best')
ds.rename({'lat': 'latitude', 'lon': 'longitude'}, inplace=True)
TypeError: The `inplace` argument has been removed from xarray. You can achieve an identical effect with python's standard assignment.
```

I saw the option of the inplace in the docs
http://xarray.pydata.org/en/stable/generated/xarray.Dataset.rename.html

Removing this argument.

TODO:

 - [ ] rm test_rename_inplace