### PR TITLE
Document external io libraries

### DIFF
--- a/doc/io.rst
+++ b/doc/io.rst
@@ -1067,3 +1067,11 @@ For CSV files, one might also consider `xarray_extras`_.
 .. _xarray_extras: https://xarray-extras.readthedocs.io/en/latest/api/csv.html
 
 .. _IO tools: http://pandas.pydata.org/pandas-docs/stable/io.html
+
+
+Third party libraries
+---------------------
+
+More formats are supported by extension libraries:
+
+- `MongoDB <https://xarray-mongodb.readthedocs.io>`_

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -1074,4 +1074,4 @@ Third party libraries
 
 More formats are supported by extension libraries:
 
-- `MongoDB <https://xarray-mongodb.readthedocs.io>`_
+- `xarray-mongodb <https://xarray-mongodb.readthedocs.io/en/latest/>`_: Store xarray objects on MongoDB

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,10 +15,10 @@ What's New
     np.random.seed(123456)
 
 
-.. _whats-new.{0.16.3}:
+.. _whats-new.0.16.3:
 
-v{0.16.3} (unreleased)
-----------------------
+v0.16.3 (unreleased)
+--------------------
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,7 +35,8 @@ Bug fixes
 
 Documentation
 ~~~~~~~~~~~~~
-
+- start a list of external I/O integrating with ``xarray`` (:issue:`683`, :pull:`4566`).
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
There are a few external libraries that add support for more I/O formats. This adds `xarray-mongodb` to a new section in `io.rst`, but we might just as well maintain that list in `related-projects.rst` and point to that list in `io.rst`. Same for #4530, where I started a list of duck array support libraries (currently only `pint-xarray`).

 - [x] Closes #683
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

