### PR TITLE
Update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
   # isort should run before black as black sometimes tweaks the isort output
   - repo: https://github.com/PyCQA/isort
-    rev: 5.5.4
+    rev: 5.6.4
     hooks:
       - id: isort
   # https://github.com/python/black#version-control-integration
@@ -11,11 +11,11 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/keewis/blackdoc
-    rev: v0.2
+    rev: v0.3
     hooks:
       - id: blackdoc
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.8.4
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -22,7 +22,7 @@ dependencies:
   - isort
   - lxml    # Optional dep of pydap
   - matplotlib
-  - mypy=0.780  # Must match .pre-commit-config.yaml
+  - mypy=0.782  # Must match .pre-commit-config.yaml
   - nc-time-axis
   - netcdf4
   - numba


### PR DESCRIPTION
`pre-commit autoupdate` also wants to update `mypy` to `0.790`, but running that prints a error:
```
xarray/core/utils.py:466: error: Value of type variable "_LT" of "sorted" cannot be "K"
```
I'm not sure how to fix that, so I'll leave the upgrade to someone else.
