### PR TITLE
pd.Index: replace set operations

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -90,6 +90,9 @@ Internal Changes
   By `Mathias Hauser <https://github.com/mathause>`_.
 - Ensure tests are not skipped in the `py38-all-but-dask` test environment
   (:issue:`4509`). By `Mathias Hauser <https://github.com/mathause>`_.
+- Replace the internal use of ``pd.Index.__or__`` and ``pd.Index.__and__`` with ``pd.Index.union``
+  and ``pd.Index.intersection`` as they will stop working as set operations in the future
+  (:issue:`4565`). By `Mathias Hauser <https://github.com/mathause>`_.
 
 .. _whats-new.0.16.1:
 

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -19,9 +19,9 @@ if TYPE_CHECKING:
 
 def _get_joiner(join):
     if join == "outer":
-        return functools.partial(functools.reduce, operator.or_)
+        return functools.partial(functools.reduce, pd.Index.union)
     elif join == "inner":
-        return functools.partial(functools.reduce, operator.and_)
+        return functools.partial(functools.reduce, pd.Index.intersection)
     elif join == "left":
         return operator.itemgetter(0)
     elif join == "right":


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4565
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Pandas will change `pd.Index.__or__` and `pd.Index.__and__`. Use `pd.Index.union` and `pd.Index.intersection` inseated. There should be no change in functionality.
