### PR TITLE
pin h5py to v2.10

### DIFF
--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -15,7 +15,7 @@ dependencies:
   - distributed
   - flake8
   - h5netcdf
-  - h5py
+  - h5py=2
   - hdf5
   - hypothesis
   - iris

--- a/ci/requirements/py37-windows.yml
+++ b/ci/requirements/py37-windows.yml
@@ -15,7 +15,7 @@ dependencies:
   - distributed
   - flake8
   - h5netcdf
-  - h5py
+  - h5py=2
   - hdf5
   - hypothesis
   - iris

--- a/ci/requirements/py37.yml
+++ b/ci/requirements/py37.yml
@@ -15,7 +15,7 @@ dependencies:
   - distributed
   - flake8
   - h5netcdf
-  - h5py
+  - h5py=2
   - hdf5
   - hypothesis
   - iris

--- a/ci/requirements/py38-all-but-dask.yml
+++ b/ci/requirements/py38-all-but-dask.yml
@@ -13,7 +13,7 @@ dependencies:
   - coveralls
   - flake8
   - h5netcdf
-  - h5py
+  - h5py=2
   - hdf5
   - hypothesis
   - isort

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -15,7 +15,7 @@ dependencies:
   - distributed
   - flake8
   - h5netcdf
-  - h5py
+  - h5py=2
   - hdf5
   - hypothesis
   - iris


### PR DESCRIPTION
There is a compatibility issue with h5py v3. Pin h5py to version 2 for the moment. I can open an issue shortly.
