### PR TITLE
Match all float types in formatitem

### DIFF
--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -141,7 +141,7 @@ def format_item(x, timedelta_format=None, quote_strings=True):
         return format_timedelta(x, timedelta_format=timedelta_format)
     elif isinstance(x, (str, bytes)):
         return repr(x) if quote_strings else x
-    elif isinstance(x, (float, np.float_)):
+    elif np.issubdtype(type(x), np.floating):
         return f"{x:.4}"
     else:
         return str(x)

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -87,6 +87,9 @@ class TestFormatting:
             (b"foo", "b'foo'"),
             (1, "1"),
             (1.0, "1.0"),
+            (np.float16(1.1234), "1.123"),
+            (np.float32(1.0111111), "1.011"),
+            (np.float64(22.222222), "22.22"),
         ]
         for item, expected in cases:
             actual = formatting.format_item(item)


### PR DESCRIPTION
This is a simple change to format_item in core/formatting.py that allows other float type (e.g. numpy.float16, numpy.float32) to be formatted the same as any other float.

 - [x] Partially Addresses #4575
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] Tests added

