### PR TITLE
suppress 'ambiguous reference date string' warning

### DIFF
--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -86,6 +86,7 @@ def _all_cftime_date_types():
 
 
 @requires_cftime
+@pytest.mark.filterwarnings("ignore:Ambiguous reference date string")
 @pytest.mark.parametrize(["num_dates", "units", "calendar"], _CF_DATETIME_TESTS)
 def test_cf_datetime(num_dates, units, calendar):
     import cftime

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -233,6 +233,7 @@ class TestDecodeCF:
         assert_identical(expected, actual)
         assert_identical(expected, actual2)
 
+    @pytest.mark.filterwarnings("ignore:Ambiguous reference date string")
     def test_invalid_time_units_raises_eagerly(self):
         ds = Dataset({"time": ("time", [0, 1], {"units": "foobar since 123"})})
         with raises_regex(ValueError, "unable to decode time"):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Follow up to #4506

Suppress some `"Ambiguous reference date string"` warnings. See e.g.: https://dev.azure.com/xarray/xarray/_build/results?buildId=4233&view=logs&j=2280efed-fda1-53bd-9213-1fa8ec9b4fa8&t=175181ee-1928-5a6b-f537-168f7a8b7c2d&l=361
