### PR TITLE
rolling_exp: keep_attrs and typing

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -46,7 +46,7 @@ New Features
 - :py:meth:`Dataset.weighted` and :py:meth:`DataArray.weighted` are now executing value checks lazily if weights are provided as dask arrays (:issue:`4541`, :pull:`4559`).
   By `Julius Busecke <https://github.com/jbusecke>`_.
 - Added the ``keep_attrs`` keyword to :py:meth:`~xarray.DataArray.rolling_exp.mean` and :py:meth:`~xarray.Dataset.rolling_exp.mean`.
-  The attributes are now kept per default.
+  The attributes are now kept per default (:pull:`4592`).
   By `Mathias Hauser <https://github.com/mathause>`_.
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -45,6 +45,10 @@ New Features
   By `Michal Baumgartner <https://github.com/m1so>`_.
 - :py:meth:`Dataset.weighted` and :py:meth:`DataArray.weighted` are now executing value checks lazily if weights are provided as dask arrays (:issue:`4541`, :pull:`4559`).
   By `Julius Busecke <https://github.com/jbusecke>`_.
+- Added the ``keep_attrs`` keyword to :py:meth:`~xarray.DataArray.rolling_exp.mean` and :py:meth:`~xarray.Dataset.rolling_exp.mean`.
+  The attributes are now kept per default.
+  By `Mathias Hauser <https://github.com/mathause>`_.
+
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -45,10 +45,8 @@ New Features
   By `Michal Baumgartner <https://github.com/m1so>`_.
 - :py:meth:`Dataset.weighted` and :py:meth:`DataArray.weighted` are now executing value checks lazily if weights are provided as dask arrays (:issue:`4541`, :pull:`4559`).
   By `Julius Busecke <https://github.com/jbusecke>`_.
-- Added the ``keep_attrs`` keyword to :py:meth:`~xarray.DataArray.rolling_exp.mean` and :py:meth:`~xarray.Dataset.rolling_exp.mean`.
-  The attributes are now kept per default (:pull:`4592`).
-  By `Mathias Hauser <https://github.com/mathause>`_.
-
+- Added the ``keep_attrs`` keyword to ``rolling_exp.mean()``; it now keeps attributes
+  per default. By `Mathias Hauser <https://github.com/mathause>`_ (:pull:`4592`).
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6927,6 +6927,35 @@ def test_rolling_exp(da, dim, window_type, window):
     assert_allclose(expected.variable, result.variable)
 
 
+@requires_numbagg
+def test_rolling_exp_keep_attrs(da):
+
+    attrs = {"attrs": "da"}
+    da.attrs = attrs
+
+    # attrs are kept per default
+    result = da.rolling_exp(time=10).mean()
+    assert result.attrs == attrs
+
+    # discard attrs
+    result = da.rolling_exp(time=10).mean(keep_attrs=False)
+    assert result.attrs == {}
+
+    # test discard attrs using global option
+    with set_options(keep_attrs=False):
+        result = da.rolling_exp(time=10).mean()
+    assert result.attrs == {}
+
+    # keyword takes precedence over global option
+    with set_options(keep_attrs=False):
+        result = da.rolling_exp(time=10).mean(keep_attrs=True)
+    assert result.attrs == attrs
+
+    with set_options(keep_attrs=True):
+        result = da.rolling_exp(time=10).mean(keep_attrs=False)
+    assert result.attrs == {}
+
+
 def test_no_dict():
     d = DataArray()
     with pytest.raises(AttributeError):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6145,6 +6145,43 @@ def test_rolling_exp(ds):
     assert isinstance(result, Dataset)
 
 
+@requires_numbagg
+def test_rolling_exp_keep_attrs(ds):
+
+    attrs_global = {"attrs": "global"}
+    attrs_z1 = {"attr": "z1"}
+
+    ds.attrs = attrs_global
+    ds.z1.attrs = attrs_z1
+
+    # attrs are kept per default
+    result = ds.rolling_exp(time=10).mean()
+    assert result.attrs == attrs_global
+    assert result.z1.attrs == attrs_z1
+
+    # discard attrs
+    result = ds.rolling_exp(time=10).mean(keep_attrs=False)
+    assert result.attrs == {}
+    assert result.z1.attrs == {}
+
+    # test discard attrs using global option
+    with set_options(keep_attrs=False):
+        result = ds.rolling_exp(time=10).mean()
+    assert result.attrs == {}
+    assert result.z1.attrs == {}
+
+    # keyword takes precedence over global option
+    with set_options(keep_attrs=False):
+        result = ds.rolling_exp(time=10).mean(keep_attrs=True)
+    assert result.attrs == attrs_global
+    assert result.z1.attrs == attrs_z1
+
+    with set_options(keep_attrs=True):
+        result = ds.rolling_exp(time=10).mean(keep_attrs=False)
+    assert result.attrs == {}
+    assert result.z1.attrs == {}
+
+
 @pytest.mark.parametrize("center", (True, False))
 @pytest.mark.parametrize("min_periods", (None, 1, 2, 3))
 @pytest.mark.parametrize("window", (1, 2, 3, 4))


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Towards #4513
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

