### PR TITLE
BUG: fix the CSS for dt / dd to only apply to xarray repr

### DIFF
--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -298,7 +298,8 @@ dl.xr-attrs {
   grid-template-columns: 125px auto;
 }
 
-.xr-attrs dt, dd {
+.xr-attrs dt,
+.xr-attrs dd {
   padding: 0;
   margin: 0;
   float: left;


### PR DESCRIPTION
xref https://github.com/pandas-dev/pydata-sphinx-theme/issues/284 

The current CSS had the consequence that those rules were applied to all `<dd>` elements, and not only the ones with the `xr-attrs` class. 
I don't know if there is a smarter way in CSS to select two element types using the class rather than repeating the class name as I did here, but this works.

cc @benbovy 