### PR TITLE
clean up upstream-dev CI

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -41,7 +41,7 @@ jobs:
           conda list
       - name: Run Tests
         run: |
-          python -m pytest --verbose -rf | tee output-${{ matrix.python-version }}-log
+          python -m pytest -rf | tee output-${{ matrix.python-version }}-log
 
       - name: Upload artifacts
         if: "failure()&&(github.event_name == 'schedule')&&(github.repository == 'pydata/xarray')" # Check the exit code of previous step

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -41,7 +41,7 @@ jobs:
           conda list
       - name: Run Tests
         run: |
-          python -m pytest --verbose -rf > output-${{ matrix.python-version }}-log
+          python -m pytest --verbose -rf | tee output-${{ matrix.python-version }}-log
 
       - name: Upload artifacts
         if: "failure()&&(github.event_name == 'schedule')&&(github.repository == 'pydata/xarray')" # Check the exit code of previous step

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -41,6 +41,7 @@ jobs:
           conda list
       - name: Run Tests
         run: |
+          set -o pipefail
           python -m pytest -rf | tee output-${{ matrix.python-version }}-log
 
       - name: Upload artifacts


### PR DESCRIPTION
follow-up to #4583, which also added a PR upstream-dev CI. However, because the output of `pytest` has been redirected to a file, the failures are hard to diagnose. The fix is to duplicate `stdout` using `tee`.

~Additionally, we now have two upstream-dev CI, so I guess we should remove the old one?~ #4584 will probably set the upstream-dev CI to `allow_failure: true`, so it might be better to remove the new CI (or to somehow mark the new PR CI with `allow_failure: true` while not changing the scheduled CI).