### PR TITLE
document the option to pass a function to where

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -94,7 +94,9 @@ Documentation
 ~~~~~~~~~~~~~
 - document the API not supported with duck arrays (:pull:`4530`).
   By `Justus Magin <https://github.com/keewis>`_.
-
+- Mention the possibility to pass functions to :py:meth:`Dataset.where` or
+  :py:meth:`DataArray.where` in the parameter documentation (:issue:`4223`, :pull:`4613`).
+  By `Justus Magin <https://github.com/keewis>`_.
 - Update the docstring of :py:class:`DataArray` and :py:class:`Dataset`.
   (:pull:`4532`);
   By `Jimmy Westling <https://github.com/illviljan>`_.

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1158,8 +1158,9 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         Parameters
         ----------
-        cond : DataArray or Dataset
+        cond : DataArray, Dataset, or callable
             Locations at which to preserve this object's values. dtype must be `bool`.
+            If a callable, it must expect this object as its only parameter.
         other : scalar, DataArray or Dataset, optional
             Value to use for locations in this object where ``cond`` is False.
             By default, these locations filled with NA.


### PR DESCRIPTION
 - [x] Closes #4223
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
