### PR TITLE
docstrings for isnull and notnull

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -109,6 +109,9 @@ Documentation
   By `Sahid Velji <https://github.com/sahidvelji>`_.
 - Update link to NumPy docstring standard in the :doc:`contributing` guide (:pull:`4558`).
   By `Sahid Velji <https://github.com/sahidvelji>`_.
+- Add docstrings to ``isnull`` and ``notnull``, and fix the displayed signature
+  (:issue:`2760`, :pull:`4618`).
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1268,7 +1268,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
             self._file_obj.close()
         self._file_obj = None
 
-    def isnull(self):
+    def isnull(self, keep_attrs: bool = None):
         """Test each value in the array for whether it is a missing value.
 
         Returns
@@ -1294,13 +1294,17 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         """
         from .computation import apply_ufunc
 
+        if keep_attrs is None:
+            keep_attrs = _get_keep_attrs(default=False)
+
         return apply_ufunc(
             duck_array_ops.isnull,
             self,
             dask="allowed",
+            keep_attrs=keep_attrs,
         )
 
-    def notnull(self):
+    def notnull(self, keep_attrs: bool = None):
         """Test each value in the array for whether it is not a missing value.
 
         Returns
@@ -1326,10 +1330,14 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         """
         from .computation import apply_ufunc
 
+        if keep_attrs is None:
+            keep_attrs = _get_keep_attrs(default=False)
+
         return apply_ufunc(
             duck_array_ops.notnull,
             self,
             dask="allowed",
+            keep_attrs=keep_attrs,
         )
 
     def isin(self, test_elements):

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1268,6 +1268,70 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
             self._file_obj.close()
         self._file_obj = None
 
+    def isnull(self):
+        """Test each value in the array for whether it is a missing value.
+
+        Returns
+        -------
+        isnull : DataArray or Dataset
+            Same type and shape as object, but the dtype of the data is bool.
+
+        See Also
+        --------
+        pandas.isnull
+
+        Examples
+        --------
+        >>> array = xr.DataArray([1, np.nan, 3], dims="x")
+        >>> array
+        <xarray.DataArray (x: 3)>
+        array([ 1., nan,  3.])
+        Dimensions without coordinates: x
+        >>> array.isnull()
+        <xarray.DataArray (x: 3)>
+        array([False,  True, False])
+        Dimensions without coordinates: x
+        """
+        from .computation import apply_ufunc
+
+        return apply_ufunc(
+            duck_array_ops.isnull,
+            self,
+            dask="allowed",
+        )
+
+    def notnull(self):
+        """Test each value in the array for whether it is not a missing value.
+
+        Returns
+        -------
+        notnull : DataArray or Dataset
+            Same type and shape as object, but the dtype of the data is bool.
+
+        See Also
+        --------
+        pandas.notnull
+
+        Examples
+        --------
+        >>> array = xr.DataArray([1, np.nan, 3], dims="x")
+        >>> array
+        <xarray.DataArray (x: 3)>
+        array([ 1., nan,  3.])
+        Dimensions without coordinates: x
+        >>> array.notnull()
+        <xarray.DataArray (x: 3)>
+        array([ True, False,  True])
+        Dimensions without coordinates: x
+        """
+        from .computation import apply_ufunc
+
+        return apply_ufunc(
+            duck_array_ops.notnull,
+            self,
+            dask="allowed",
+        )
+
     def isin(self, test_elements):
         """Tests each value in the array for whether it is in test elements.
 

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -89,6 +89,13 @@ pandas_isnull = _dask_or_eager_func("isnull", eager_module=pd)
 
 
 def isnull(data):
+    """Test each value in the array for whether it is missing.
+
+    Returns
+    -------
+    isnull: DataArray or Dataset
+        Same type and shape as object, but the dtype of the data is bool.
+    """
     data = asarray(data)
     scalar_type = data.dtype.type
     if issubclass(scalar_type, (np.datetime64, np.timedelta64)):
@@ -115,6 +122,13 @@ def isnull(data):
 
 
 def notnull(data):
+    """Test each value in the array for whether it is not missing.
+
+    Returns
+    -------
+    notnull: DataArray or Dataset
+        Same type and shape as object, but the dtype of the data is bool.
+    """
     return ~isnull(data)
 
 

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -89,13 +89,6 @@ pandas_isnull = _dask_or_eager_func("isnull", eager_module=pd)
 
 
 def isnull(data):
-    """Test each value in the array for whether it is missing.
-
-    Returns
-    -------
-    isnull: DataArray or Dataset
-        Same type and shape as object, but the dtype of the data is bool.
-    """
     data = asarray(data)
     scalar_type = data.dtype.type
     if issubclass(scalar_type, (np.datetime64, np.timedelta64)):
@@ -122,13 +115,6 @@ def isnull(data):
 
 
 def notnull(data):
-    """Test each value in the array for whether it is not missing.
-
-    Returns
-    -------
-    notnull: DataArray or Dataset
-        Same type and shape as object, but the dtype of the data is bool.
-    """
     return ~isnull(data)
 
 

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -43,7 +43,6 @@ NUMPY_SAME_METHODS = ["item", "searchsorted"]
 # methods which don't modify the data shape, so the result should still be
 # wrapped in an Variable/DataArray
 NUMPY_UNARY_METHODS = ["argsort", "clip", "conj", "conjugate"]
-PANDAS_UNARY_FUNCTIONS = ["isnull", "notnull"]
 # methods which remove an axis
 REDUCE_METHODS = ["all", "any"]
 NAN_REDUCE_METHODS = [
@@ -333,10 +332,6 @@ def inject_all_ops_and_reduce_methods(cls, priority=50, array_only=True):
     # patch in numpy/pandas methods
     for name in NUMPY_UNARY_METHODS:
         setattr(cls, name, cls._unary_op(_method_wrapper(name)))
-
-    for name in PANDAS_UNARY_FUNCTIONS:
-        f = _func_slash_method_wrapper(getattr(duck_array_ops, name), name=name)
-        setattr(cls, name, cls._unary_op(f))
 
     f = _func_slash_method_wrapper(duck_array_ops.around, name="round")
     setattr(cls, "round", cls._unary_op(f))

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2101,7 +2101,7 @@ class Variable(
 
         Examples
         --------
-        >>> var = xr.Variable([1, np.nan, 3], dims="x")
+        >>> var = xr.Variable("x", [1, np.nan, 3])
         >>> var
         <xarray.Variable (x: 3)>
         array([ 1., nan,  3.])
@@ -2135,7 +2135,7 @@ class Variable(
 
         Examples
         --------
-        >>> var = xr.Variable([1, np.nan, 3], dims="x")
+        >>> var = xr.Variable("x", [1, np.nan, 3])
         >>> var
         <xarray.Variable (x: 3)>
         array([ 1., nan,  3.])

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2087,6 +2087,74 @@ class Variable(
 
         return variable.data.reshape(shape), tuple(axes)
 
+    def isnull(self, keep_attrs: bool = None):
+        """Test each value in the array for whether it is a missing value.
+
+        Returns
+        -------
+        isnull : Variable
+            Same type and shape as object, but the dtype of the data is bool.
+
+        See Also
+        --------
+        pandas.isnull
+
+        Examples
+        --------
+        >>> var = xr.Variable([1, np.nan, 3], dims="x")
+        >>> var
+        <xarray.Variable (x: 3)>
+        array([ 1., nan,  3.])
+        >>> var.isnull()
+        <xarray.Variable (x: 3)>
+        array([False,  True, False])
+        """
+        from .computation import apply_ufunc
+
+        if keep_attrs is None:
+            keep_attrs = _get_keep_attrs(default=False)
+
+        return apply_ufunc(
+            duck_array_ops.isnull,
+            self,
+            dask="allowed",
+            keep_attrs=keep_attrs,
+        )
+
+    def notnull(self, keep_attrs: bool = None):
+        """Test each value in the array for whether it is not a missing value.
+
+        Returns
+        -------
+        notnull : Variable
+            Same type and shape as object, but the dtype of the data is bool.
+
+        See Also
+        --------
+        pandas.notnull
+
+        Examples
+        --------
+        >>> var = xr.Variable([1, np.nan, 3], dims="x")
+        >>> var
+        <xarray.Variable (x: 3)>
+        array([ 1., nan,  3.])
+        >>> var.notnull()
+        <xarray.Variable (x: 3)>
+        array([ True, False,  True])
+        """
+        from .computation import apply_ufunc
+
+        if keep_attrs is None:
+            keep_attrs = _get_keep_attrs(default=False)
+
+        return apply_ufunc(
+            duck_array_ops.notnull,
+            self,
+            dask="allowed",
+            keep_attrs=keep_attrs,
+        )
+
     @property
     def real(self):
         return type(self)(self.dims, self.data.real, self._attrs)


### PR DESCRIPTION
As suggested in #2760 this moves the `isnull` and `notnull` to `DataWithCoords`. The body is adapted from `DataWithCoords.isin`, but I'm not certain `dask="allowed"` is the right option for `duck_array_ops.isnull`. Can someone with more experience with `apply_ufunc` confirm?

 - [x] Closes #2760
 - [ ] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
