### PR TITLE
Refactor the pytest test summary info parsing script

### DIFF
--- a/.github/workflows/parse_logs.py
+++ b/.github/workflows/parse_logs.py
@@ -11,18 +11,17 @@ args = parser.parse_args()
 filepaths = sorted(p for p in args.filepaths if p.is_file())
 
 
-def extract_short_test_summary_info(path):
-    with open(path) as f:
-        lines = (line.rstrip() for line in f)
-        up_to_start_of_section = itertools.dropwhile(
-            lambda l: "=== short test summary info ===" not in l,
-            lines,
-        )
-        up_to_section_content = itertools.islice(up_to_start_of_section, 1, None)
-        section_content = itertools.takewhile(
-            lambda l: l.startswith("FAILED"), up_to_section_content
-        )
-        content = "\n".join(section_content)
+def extract_short_test_summary_info(raw_lines):
+    lines = (line.rstrip() for line in raw_lines)
+    up_to_start_of_section = itertools.dropwhile(
+        lambda l: "=== short test summary info ===" not in l,
+        lines,
+    )
+    up_to_section_content = itertools.islice(up_to_start_of_section, 1, None)
+    section_content = itertools.takewhile(
+        lambda l: l.startswith("FAILED"), up_to_section_content
+    )
+    content = "\n".join(section_content)
 
     return content
 
@@ -30,7 +29,8 @@ def extract_short_test_summary_info(path):
 def format_log_message(path):
     py_version = path.name.split("-")[1]
     summary = f"Python {py_version} Test Summary Info"
-    data = extract_short_test_summary_info(path)
+    with open(path) as f:
+        data = extract_short_test_summary_info(f)
     message = textwrap.dedent(
         f"""\
         <details><summary>{summary}</summary>

--- a/.github/workflows/parse_logs.py
+++ b/.github/workflows/parse_logs.py
@@ -1,21 +1,54 @@
 # type: ignore
+import argparse
+import itertools
 import pathlib
+import textwrap
 
-files = pathlib.Path("logs").rglob("**/*-log")
-files = sorted(filter(lambda x: x.is_file(), files))
+parser = argparse.ArgumentParser()
+parser.add_argument("filepaths", nargs="+", type=pathlib.Path)
+args = parser.parse_args()
 
-message = "\n"
+filepaths = sorted(p for p in args.filepaths if p.is_file())
+
+
+def extract_short_test_summary_info(path):
+    with open(path) as f:
+        lines = (line.rstrip() for line in f)
+        up_to_start_of_section = itertools.dropwhile(
+            lambda l: "=== short test summary info ===" not in l,
+            lines,
+        )
+        up_to_section_content = itertools.islice(up_to_start_of_section, 1, None)
+        section_content = itertools.takewhile(
+            lambda l: l.startswith("FAILED"), up_to_section_content
+        )
+        content = "\n".join(section_content)
+
+    return content
+
+
+def format_log_message(path):
+    py_version = path.name.split("-")[1]
+    summary = f"Python {py_version} Test Summary Info"
+    data = extract_short_test_summary_info(path)
+    message = textwrap.dedent(
+        f"""\
+        <details><summary>{summary}</summary>
+
+        ```
+        {data}
+        ```
+
+        </details>
+        """
+    )
+
+    return message
+
 
 print("Parsing logs ...")
-for file in files:
-    with open(file) as fpt:
-        print(f"Parsing {file.absolute()}")
-        data = fpt.read().split("test summary info")[-1].splitlines()[1:-1]
-        data = "\n".join(data)
-        py_version = file.name.split("-")[1]
-        message = f"{message}\n<details>\n<summary>\nPython {py_version} Test Summary Info\n</summary>\n\n```bash\n{data}\n```\n</details>\n"
+message = "\n\n".join(format_log_message(path) for path in filepaths)
 
 output_file = pathlib.Path("pytest-logs.txt")
-with open(output_file, "w") as fpt:
-    print(f"Writing output file to: {output_file.absolute()} ")
-    fpt.write(message)
+print(f"Writing output file to: {output_file.absolute()}")
+output_file.write_text(message)

--- a/.github/workflows/parse_logs.py
+++ b/.github/workflows/parse_logs.py
@@ -11,8 +11,7 @@ args = parser.parse_args()
 filepaths = sorted(p for p in args.filepaths if p.is_file())
 
 
-def extract_short_test_summary_info(raw_lines):
-    lines = (line.rstrip() for line in raw_lines)
+def extract_short_test_summary_info(lines):
     up_to_start_of_section = itertools.dropwhile(
         lambda l: "=== short test summary info ===" not in l,
         lines,
@@ -30,7 +29,7 @@ def format_log_message(path):
     py_version = path.name.split("-")[1]
     summary = f"Python {py_version} Test Summary Info"
     with open(path) as f:
-        data = extract_short_test_summary_info(f)
+        data = extract_short_test_summary_info(line.rstrip() for line in f)
     message = textwrap.dedent(
         f"""\
         <details><summary>{summary}</summary>

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -74,7 +74,8 @@ jobs:
           ls -R ./logs
       - name: Parse logs
         run: |
-          python .github/workflows/parse_logs.py
+          shopt -s globstar
+          python .github/workflows/parse_logs.py logs/**/*-log
       - name: Report failures
         uses: actions/github-script@v3
         with:


### PR DESCRIPTION
As mentioned in #4604, I think being able to run `parse_logs.py` by hand is pretty useful, so I refactored the current script.

cc @andersy005

 - [x] Passes `isort . && black . && mypy . && flake8`

