### PR TITLE
examples for interp and interpolate_na

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1519,12 +1519,68 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Examples
         --------
-        >>> da = xr.DataArray([1, 3], [("x", np.arange(2))])
-        >>> da.interp(x=0.5)
-        <xarray.DataArray ()>
-        array(2.)
+        da = xr.DataArray(
+            data=[
+                [0.1, 4.3, 2.1, 9.8],
+                [2.4, 7.9, 0.6, np.nan],
+                [6.9, np.nan, 5.3, 8.7],
+            ],
+            dims=("x", "y"),
+            coords={"x": [0, 1, 2], "y": [10, 12, 14, 16]},
+        )
+        >>> da
+        <xarray.DataArray (x: 3, y: 4)>
+        array([[0.1, 4.3, 2.1, 9.8],
+               [2.4, 7.9, 0.6, nan],
+               [6.9, nan, 5.3, 8.7]])
         Coordinates:
-            x        float64 0.5
+          * x        (x) int64 0 1 2
+          * y        (y) int64 10 12 14 16
+
+        1D linear interpolation (the default)
+        >>> da.interp(x=[0.25, 0.75, 1.25, 1.75])
+        <xarray.DataArray (x: 4, y: 4)>
+        array([[0.675, 5.2  , 1.725,   nan],
+               [1.825, 7.   , 0.975,   nan],
+               [3.525,   nan, 1.775,   nan],
+               [5.775,   nan, 4.125,   nan]])
+        Coordinates:
+          * y        (y) int64 10 12 14 16
+          * x        (x) float64 0.25 0.75 1.25 1.75
+
+        1D nearest interpolation:
+        >>> da.interp(x=[0.25, 0.75, 1.25, 1.75], method="nearest")
+        <xarray.DataArray (x: 4, y: 4)>
+        array([[0.1, 4.3, 2.1, 9.8],
+               [2.4, 7.9, 0.6, nan],
+               [2.4, 7.9, 0.6, nan],
+               [6.9, nan, 5.3, 8.7]])
+        Coordinates:
+          * y        (y) int64 10 12 14 16
+          * x        (x) float64 0.25 0.75 1.25 1.75
+
+        1D linear extrapolation:
+        >>> da.interp(
+        ...     x=[1.5, 2.5, 3.5], method="linear", kwargs={"fill_value": "extrapolate"}
+        ... )
+        <xarray.DataArray (x: 3, y: 4)>
+        array([[ 4.65,   nan,  2.95,   nan],
+               [ 9.15,   nan,  7.65,   nan],
+               [13.65,   nan, 12.35,   nan]])
+        Coordinates:
+          * y        (y) int64 10 12 14 16
+          * x        (x) float64 1.5 2.5 3.5
+
+        2D linear interpolation:
+        >>> da.interp(x=[0.25, 0.75, 1.25, 1.75], y=[11, 13, 15], method="linear")
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[2.9375, 3.4625,    nan],
+               [4.4125, 3.9875,    nan],
+               [   nan,    nan,    nan],
+               [   nan,    nan,    nan]])
+        Coordinates:
+          * x        (x) float64 0.25 0.75 1.25 1.75
+          * y        (y) int64 11 13 15
         """
         if self.dtype.kind not in "uifc":
             raise TypeError(
@@ -3496,6 +3552,7 @@ class DataArray(AbstractArray, DataWithCoords):
         ...     gb = da.groupby(groupby_type)
         ...     clim = gb.mean(dim="time")
         ...     return gb - clim
+        ...
         >>> time = xr.cftime_range("1990-01", "1992-01", freq="M")
         >>> month = xr.DataArray(time.month, coords={"time": time}, dims=["time"])
         >>> np.random.seed(123)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1520,66 +1520,65 @@ class DataArray(AbstractArray, DataWithCoords):
         Examples
         --------
         >>> da = xr.DataArray(
-        ...     data=[
-        ...         [0.1, 4.3, 2.1, 9.8],
-        ...         [2.4, 7.9, 0.6, np.nan],
-        ...         [6.9, np.nan, 5.3, 8.7],
-        ...     ],
+        ...     data=[[1, 4, 2, 9], [2, 7, 6, np.nan], [6, np.nan, 5, 8]],
         ...     dims=("x", "y"),
         ...     coords={"x": [0, 1, 2], "y": [10, 12, 14, 16]},
         ... )
         >>> da
         <xarray.DataArray (x: 3, y: 4)>
-        array([[0.1, 4.3, 2.1, 9.8],
-               [2.4, 7.9, 0.6, nan],
-               [6.9, nan, 5.3, 8.7]])
+        array([[ 1.,  4.,  2.,  9.],
+               [ 2.,  7.,  6., nan],
+               [ 6., nan,  5.,  8.]])
         Coordinates:
           * x        (x) int64 0 1 2
           * y        (y) int64 10 12 14 16
 
         1D linear interpolation (the default)
-        >>> da.interp(x=[0.25, 0.75, 1.25, 1.75])
+        >>> da.interp(x=[0, 0.75, 1.25, 1.75])
         <xarray.DataArray (x: 4, y: 4)>
-        array([[0.675, 5.2  , 1.725,   nan],
-               [1.825, 7.   , 0.975,   nan],
-               [3.525,   nan, 1.775,   nan],
-               [5.775,   nan, 4.125,   nan]])
+        array([[1.  , 4.  , 2.  ,  nan],
+               [1.75, 6.25, 5.  ,  nan],
+               [3.  ,  nan, 5.75,  nan],
+               [5.  ,  nan, 5.25,  nan]])
         Coordinates:
           * y        (y) int64 10 12 14 16
-          * x        (x) float64 0.25 0.75 1.25 1.75
+          * x        (x) float64 0.0 0.75 1.25 1.75
 
         1D nearest interpolation:
-        >>> da.interp(x=[0.25, 0.75, 1.25, 1.75], method="nearest")
+        >>> da.interp(x=[0, 0.75, 1.25, 1.75], method="nearest")
         <xarray.DataArray (x: 4, y: 4)>
-        array([[0.1, 4.3, 2.1, 9.8],
-               [2.4, 7.9, 0.6, nan],
-               [2.4, 7.9, 0.6, nan],
-               [6.9, nan, 5.3, 8.7]])
+        array([[ 1.,  4.,  2.,  9.],
+               [ 2.,  7.,  6., nan],
+               [ 2.,  7.,  6., nan],
+               [ 6., nan,  5.,  8.]])
         Coordinates:
           * y        (y) int64 10 12 14 16
-          * x        (x) float64 0.25 0.75 1.25 1.75
+          * x        (x) float64 0.0 0.75 1.25 1.75
 
         1D linear extrapolation:
         >>> da.interp(
-        ...     x=[1.5, 2.5, 3.5], method="linear", kwargs={"fill_value": "extrapolate"}
+        ...     x=[1, 1.5, 2.5, 3.5],
+        ...     method="linear",
+        ...     kwargs={"fill_value": "extrapolate"},
         ... )
-        <xarray.DataArray (x: 3, y: 4)>
-        array([[ 4.65,   nan,  2.95,   nan],
-               [ 9.15,   nan,  7.65,   nan],
-               [13.65,   nan, 12.35,   nan]])
+        <xarray.DataArray (x: 4, y: 4)>
+        array([[ 2. ,  7. ,  6. ,  nan],
+               [ 4. ,  nan,  5.5,  nan],
+               [ 8. ,  nan,  4.5,  nan],
+               [12. ,  nan,  3.5,  nan]])
         Coordinates:
           * y        (y) int64 10 12 14 16
-          * x        (x) float64 1.5 2.5 3.5
+          * x        (x) float64 1.0 1.5 2.5 3.5
 
         2D linear interpolation:
-        >>> da.interp(x=[0.25, 0.75, 1.25, 1.75], y=[11, 13, 15], method="linear")
+        >>> da.interp(x=[0, 0.75, 1.25, 1.75], y=[11, 13, 15], method="linear")
         <xarray.DataArray (x: 4, y: 3)>
-        array([[2.9375, 3.4625,    nan],
-               [4.4125, 3.9875,    nan],
-               [   nan,    nan,    nan],
-               [   nan,    nan,    nan]])
+        array([[2.5  , 3.   ,   nan],
+               [4.   , 5.625,   nan],
+               [  nan,   nan,   nan],
+               [  nan,   nan,   nan]])
         Coordinates:
-          * x        (x) float64 0.25 0.75 1.25 1.75
+          * x        (x) float64 0.0 0.75 1.25 1.75
           * y        (y) int64 11 13 15
         """
         if self.dtype.kind not in "uifc":
@@ -2381,7 +2380,7 @@ class DataArray(AbstractArray, DataWithCoords):
 
         >>> da.interpolate_na(dim="x", method="linear")
         <xarray.DataArray (x: 5)>
-        array([nan,  2.,  3., nan,  0.])
+        array([nan, 2. , 3. , 1.5, 0. ])
         Coordinates:
           * x        (x) int64 0 1 2 3 4
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2367,6 +2367,25 @@ class DataArray(AbstractArray, DataWithCoords):
         --------
         numpy.interp
         scipy.interpolate
+
+        Examples
+        --------
+        >>> da = xr.DataArray(
+        ...     [np.nan, 2, 3, np.nan, 0], dims="x", coords={"x": [0, 1, 2, 3, 4]}
+        ... )
+        >>> da
+
+        >>> da.interpolate_na(dim="x", method="linear")
+        <xarray.DataArray (x: 5)>
+        array([nan,  2.,  3., nan,  0.])
+        Coordinates:
+          * x        (x) int64 0 1 2 3 4
+
+        >>> da.interpolate_na(dim="x", method="linear", fill_value="extrapolate")
+        <xarray.DataArray (x: 5)>
+        array([1. , 2. , 3. , 1.5, 0. ])
+        Coordinates:
+          * x        (x) int64 0 1 2 3 4
         """
         from .missing import interp_na
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1519,15 +1519,15 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Examples
         --------
-        da = xr.DataArray(
-            data=[
-                [0.1, 4.3, 2.1, 9.8],
-                [2.4, 7.9, 0.6, np.nan],
-                [6.9, np.nan, 5.3, 8.7],
-            ],
-            dims=("x", "y"),
-            coords={"x": [0, 1, 2], "y": [10, 12, 14, 16]},
-        )
+        >>> da = xr.DataArray(
+        ...     data=[
+        ...         [0.1, 4.3, 2.1, 9.8],
+        ...         [2.4, 7.9, 0.6, np.nan],
+        ...         [6.9, np.nan, 5.3, 8.7],
+        ...     ],
+        ...     dims=("x", "y"),
+        ...     coords={"x": [0, 1, 2], "y": [10, 12, 14, 16]},
+        ... )
         >>> da
         <xarray.DataArray (x: 3, y: 4)>
         array([[0.1, 4.3, 2.1, 9.8],
@@ -2374,6 +2374,10 @@ class DataArray(AbstractArray, DataWithCoords):
         ...     [np.nan, 2, 3, np.nan, 0], dims="x", coords={"x": [0, 1, 2, 3, 4]}
         ... )
         >>> da
+        <xarray.DataArray (x: 5)>
+        array([nan,  2.,  3., nan,  0.])
+        Coordinates:
+          * x        (x) int64 0 1 2 3 4
 
         >>> da.interpolate_na(dim="x", method="linear")
         <xarray.DataArray (x: 5)>

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1533,7 +1533,8 @@ class DataArray(AbstractArray, DataWithCoords):
           * x        (x) int64 0 1 2
           * y        (y) int64 10 12 14 16
 
-        1D linear interpolation (the default)
+        1D linear interpolation (the default):
+
         >>> da.interp(x=[0, 0.75, 1.25, 1.75])
         <xarray.DataArray (x: 4, y: 4)>
         array([[1.  , 4.  , 2.  ,  nan],
@@ -1545,6 +1546,7 @@ class DataArray(AbstractArray, DataWithCoords):
           * x        (x) float64 0.0 0.75 1.25 1.75
 
         1D nearest interpolation:
+
         >>> da.interp(x=[0, 0.75, 1.25, 1.75], method="nearest")
         <xarray.DataArray (x: 4, y: 4)>
         array([[ 1.,  4.,  2.,  9.],
@@ -1556,6 +1558,7 @@ class DataArray(AbstractArray, DataWithCoords):
           * x        (x) float64 0.0 0.75 1.25 1.75
 
         1D linear extrapolation:
+
         >>> da.interp(
         ...     x=[1, 1.5, 2.5, 3.5],
         ...     method="linear",
@@ -1571,6 +1574,7 @@ class DataArray(AbstractArray, DataWithCoords):
           * x        (x) float64 1.0 1.5 2.5 3.5
 
         2D linear interpolation:
+
         >>> da.interp(x=[0, 0.75, 1.25, 1.75], y=[11, 13, 15], method="linear")
         <xarray.DataArray (x: 4, y: 3)>
         array([[2.5  , 3.   ,   nan],

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2735,6 +2735,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             b        (x, y) float64 1.0 4.0 2.0 9.0 2.0 7.0 6.0 nan 6.0 nan 5.0 8.0
 
         1D interpolation with the default method (linear):
+
         >>> ds.interp(x=[0, 0.75, 1.25, 1.75])
         <xarray.Dataset>
         Dimensions:  (x: 4, y: 4)
@@ -2746,6 +2747,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             b        (x, y) float64 1.0 4.0 2.0 nan 1.75 6.25 ... nan 5.0 nan 5.25 nan
 
         1D interpolation with a different method:
+
         >>> ds.interp(x=[0, 0.75, 1.25, 1.75], method="nearest")
         <xarray.Dataset>
         Dimensions:  (x: 4, y: 4)
@@ -2757,6 +2759,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             b        (x, y) float64 1.0 4.0 2.0 9.0 2.0 7.0 ... 6.0 nan 6.0 nan 5.0 8.0
 
         1D extrapolation:
+
         >>> ds.interp(
         ...     x=[1, 1.5, 2.5, 3.5],
         ...     method="linear",
@@ -2772,6 +2775,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             b        (x, y) float64 2.0 7.0 6.0 nan 4.0 nan ... 4.5 nan 12.0 nan 3.5 nan
 
         2D interpolation:
+
         >>> ds.interp(x=[0, 0.75, 1.25, 1.75], y=[11, 13, 15], method="linear")
         <xarray.Dataset>
         Dimensions:  (x: 4, y: 3)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2711,6 +2711,78 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         --------
         scipy.interpolate.interp1d
         scipy.interpolate.interpn
+
+        Examples
+        --------
+        >>> ds = xr.Dataset(
+        ...     data_vars={
+        ...         "a": ("x", [5, 7, 4]),
+        ...         "b": (
+        ...             ("x", "y"),
+        ...             [
+        ...                 [0.1, 4.3, 2.1, 9.8],
+        ...                 [2.4, 7.9, 0.6, np.nan],
+        ...                 [6.9, np.nan, 5.3, 8.7],
+        ...             ],
+        ...         ),
+        ...     },
+        ...     coords={"x": [0, 1, 2], "y": [10, 12, 14, 16]},
+        ... )
+        >>> ds
+        <xarray.Dataset>
+        Dimensions:  (x: 3, y: 4)
+        Coordinates:
+          * x        (x) int64 0 1 2
+          * y        (y) int64 10 12 14 16
+        Data variables:
+            a        (x) int64 5 7 4
+            b        (x, y) float64 0.1 4.3 2.1 9.8 2.4 7.9 0.6 nan 6.9 nan 5.3 8.7
+
+        1D interpolation with the default method (linear):
+        >>> ds.interp(x=[0.25, 0.75, 1.25, 1.75])
+        <xarray.Dataset>
+        Dimensions:  (x: 3)
+        Coordinates:
+            y        (x) float64 0.25 0.5 0.75
+          * x        (x) float64 -0.5 0.0 0.5
+        Data variables:
+            a        (x) float64 5.5 6.0 6.5
+            b        (x) float64 0.675 1.25 1.825
+
+        1D interpolation with a different method:
+        >>> ds.interp(x=[0.25, 0.75, 1.25, 1.75], method="nearest")
+        <xarray.Dataset>
+        Dimensions:  (x: 4, y: 4)
+        Coordinates:
+          * y        (y) int64 10 12 14 16
+          * x        (x) float64 0.25 0.75 1.25 1.75
+        Data variables:
+            a        (x) float64 5.0 7.0 7.0 4.0
+            b        (x, y) float64 0.1 4.3 2.1 9.8 2.4 7.9 ... 0.6 nan 6.9 nan 5.3 8.7
+
+        1D extrapolation:
+        >>> ds.interp(
+        ...     x=[1.5, 2.5, 3.5], method="linear", kwargs={"fill_value": "extrapolate"}
+        ... )
+        <xarray.Dataset>
+        Dimensions:  (x: 3, y: 4)
+        Coordinates:
+          * y        (y) int64 10 12 14 16
+          * x        (x) float64 1.5 2.5 3.5
+        Data variables:
+            a        (x) float64 5.5 2.5 -0.5
+            b        (x, y) float64 4.65 nan 2.95 nan 9.15 ... nan 13.65 nan 12.35 nan
+
+        2D interpolation:
+        >>> ds.interp(x=[0.25, 0.75, 1.25, 1.75], y=[11, 13, 15], method="linear")
+        <xarray.Dataset>
+        Dimensions:  (x: 4, y: 3)
+        Coordinates:
+          * x        (x) float64 0.25 0.75 1.25 1.75
+          * y        (y) int64 11 13 15
+        Data variables:
+            a        (x) float64 5.5 6.5 6.25 4.75
+            b        (x, y) float64 2.938 3.463 nan 4.412 3.987 ... nan nan nan nan nan
         """
         from . import missing
 
@@ -5974,6 +6046,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         ...     gb = da.groupby(groupby_type)
         ...     clim = gb.mean(dim="time")
         ...     return gb - clim
+        ...
         >>> time = xr.cftime_range("1990-01", "1992-01", freq="M")
         >>> month = xr.DataArray(time.month, coords={"time": time}, dims=["time"])
         >>> np.random.seed(123)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2719,11 +2719,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         ...         "a": ("x", [5, 7, 4]),
         ...         "b": (
         ...             ("x", "y"),
-        ...             [
-        ...                 [0.1, 4.3, 2.1, 9.8],
-        ...                 [2.4, 7.9, 0.6, np.nan],
-        ...                 [6.9, np.nan, 5.3, 8.7],
-        ...             ],
+        ...             [[1, 4, 2, 9], [2, 7, 6, np.nan], [6, np.nan, 5, 8]],
         ...         ),
         ...     },
         ...     coords={"x": [0, 1, 2], "y": [10, 12, 14, 16]},
@@ -2736,53 +2732,55 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
           * y        (y) int64 10 12 14 16
         Data variables:
             a        (x) int64 5 7 4
-            b        (x, y) float64 0.1 4.3 2.1 9.8 2.4 7.9 0.6 nan 6.9 nan 5.3 8.7
+            b        (x, y) float64 1.0 4.0 2.0 9.0 2.0 7.0 6.0 nan 6.0 nan 5.0 8.0
 
         1D interpolation with the default method (linear):
-        >>> ds.interp(x=[0.25, 0.75, 1.25, 1.75])
-        <xarray.Dataset>
-        Dimensions:  (x: 3)
-        Coordinates:
-            y        (x) float64 0.25 0.5 0.75
-          * x        (x) float64 -0.5 0.0 0.5
-        Data variables:
-            a        (x) float64 5.5 6.0 6.5
-            b        (x) float64 0.675 1.25 1.825
-
-        1D interpolation with a different method:
-        >>> ds.interp(x=[0.25, 0.75, 1.25, 1.75], method="nearest")
+        >>> ds.interp(x=[0, 0.75, 1.25, 1.75])
         <xarray.Dataset>
         Dimensions:  (x: 4, y: 4)
         Coordinates:
           * y        (y) int64 10 12 14 16
-          * x        (x) float64 0.25 0.75 1.25 1.75
+          * x        (x) float64 0.0 0.75 1.25 1.75
+        Data variables:
+            a        (x) float64 5.0 6.5 6.25 4.75
+            b        (x, y) float64 1.0 4.0 2.0 nan 1.75 6.25 ... nan 5.0 nan 5.25 nan
+
+        1D interpolation with a different method:
+        >>> ds.interp(x=[0, 0.75, 1.25, 1.75], method="nearest")
+        <xarray.Dataset>
+        Dimensions:  (x: 4, y: 4)
+        Coordinates:
+          * y        (y) int64 10 12 14 16
+          * x        (x) float64 0.0 0.75 1.25 1.75
         Data variables:
             a        (x) float64 5.0 7.0 7.0 4.0
-            b        (x, y) float64 0.1 4.3 2.1 9.8 2.4 7.9 ... 0.6 nan 6.9 nan 5.3 8.7
+            b        (x, y) float64 1.0 4.0 2.0 9.0 2.0 7.0 ... 6.0 nan 6.0 nan 5.0 8.0
 
         1D extrapolation:
         >>> ds.interp(
-        ...     x=[1.5, 2.5, 3.5], method="linear", kwargs={"fill_value": "extrapolate"}
+        ...     x=[1, 1.5, 2.5, 3.5],
+        ...     method="linear",
+        ...     kwargs={"fill_value": "extrapolate"},
         ... )
         <xarray.Dataset>
-        Dimensions:  (x: 3, y: 4)
+        Dimensions:  (x: 4, y: 4)
         Coordinates:
           * y        (y) int64 10 12 14 16
-          * x        (x) float64 1.5 2.5 3.5
+          * x        (x) float64 1.0 1.5 2.5 3.5
         Data variables:
-            a        (x) float64 5.5 2.5 -0.5
-            b        (x, y) float64 4.65 nan 2.95 nan 9.15 ... nan 13.65 nan 12.35 nan
+            a        (x) float64 7.0 5.5 2.5 -0.5
+            b        (x, y) float64 2.0 7.0 6.0 nan 4.0 nan ... 4.5 nan 12.0 nan 3.5 nan
 
         2D interpolation:
-        >>> ds.interp(x=[0.25, 0.75, 1.25, 1.75], y=[11, 13, 15], method="linear")
+        >>> ds.interp(x=[0, 0.75, 1.25, 1.75], y=[11, 13, 15], method="linear")
         <xarray.Dataset>
         Dimensions:  (x: 4, y: 3)
         Coordinates:
-          * x        (x) float64 0.25 0.75 1.25 1.75
+          * x        (x) float64 0.0 0.75 1.25 1.75
           * y        (y) int64 11 13 15
         Data variables:
-            a        (x) float64 5.5 6.5 6.25 4.75
-            b        (x, y) float64 2.938 3.463 nan 4.412 3.987 ... nan nan nan nan nan
+            a        (x) float64 5.0 6.5 6.25 4.75
+            b        (x, y) float64 2.5 3.0 nan 4.0 5.625 nan nan nan nan nan nan nan
         """
         from . import missing
 
@@ -5910,6 +5908,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         Examples
         --------
         >>> # Create an example dataset:
+        ...
         >>> import numpy as np
         >>> import pandas as pd
         >>> import xarray as xr

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4316,6 +4316,50 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         --------
         numpy.interp
         scipy.interpolate
+
+        Examples
+        --------
+        >>> ds = xr.Dataset(
+        ...     {
+        ...         "A": ("x", [np.nan, 2, 3, np.nan, 0]),
+        ...         "B": ("x", [3, 4, np.nan, 1, 7]),
+        ...         "C": ("x", [np.nan, np.nan, np.nan, 5, 0]),
+        ...         "D": ("x", [np.nan, 3, np.nan, -1, 4]),
+        ...     },
+        ...     coords={"x": [0, 1, 2, 3, 4]},
+        ... )
+        >>> ds
+        <xarray.Dataset>
+        Dimensions:  (x: 5)
+        Coordinates:
+          * x        (x) int64 0 1 2 3 4
+        Data variables:
+            A        (x) float64 nan 2.0 3.0 nan 0.0
+            B        (x) float64 3.0 4.0 nan 1.0 7.0
+            C        (x) float64 nan nan nan 5.0 0.0
+            D        (x) float64 nan 3.0 nan -1.0 4.0
+
+        >>> ds.interpolate_na(dim="x", method="linear")
+        <xarray.Dataset>
+        Dimensions:  (x: 5)
+        Coordinates:
+          * x        (x) int64 0 1 2 3 4
+        Data variables:
+            A        (x) float64 nan 2.0 3.0 1.5 0.0
+            B        (x) float64 3.0 4.0 2.5 1.0 7.0
+            C        (x) float64 nan nan nan 5.0 0.0
+            D        (x) float64 nan 3.0 1.0 -1.0 4.0
+
+        >>> ds.interpolate_na(dim="x", method="linear", fill_value="extrapolate")
+        <xarray.Dataset>
+        Dimensions:  (x: 5)
+        Coordinates:
+          * x        (x) int64 0 1 2 3 4
+        Data variables:
+            A        (x) float64 1.0 2.0 3.0 1.5 0.0
+            B        (x) float64 3.0 4.0 2.5 1.0 7.0
+            C        (x) float64 20.0 15.0 10.0 5.0 0.0
+            D        (x) float64 5.0 3.0 1.0 -1.0 4.0
         """
         from .missing import _apply_over_vars_with_dim, interp_na
 


### PR DESCRIPTION
This adds examples for `interp` and `interpolate_na` (`interp_like` still needs to be done). Also, is there a reason why `interp` and `interpolate_na` accept `kwargs` differently?

 - [x] Closes #4410
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
