### PR TITLE
fixes bug #4627 to make a copy of the attrs in the merged object

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -31,7 +31,7 @@ New Features
 Bug fixes
 ~~~~~~~~~
 
-- :py:func:`Xarray.merge` with :py:attr:`combine_attrs='override'` makes a copy of the attrs (:issue:`4627`).
+- :py:func:`merge` with ``combine_attrs='override'`` makes a copy of the attrs (:issue:`4627`).
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -31,6 +31,7 @@ New Features
 Bug fixes
 ~~~~~~~~~
 
+- :py:func:`Xarray.merge` with :py:attr:`combine_attrs='override'` makes a copy of the attrs (:issue:`4627`).
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -501,7 +501,7 @@ def merge_attrs(variable_attrs, combine_attrs):
     if combine_attrs == "drop":
         return {}
     elif combine_attrs == "override":
-        return variable_attrs[0]
+        return dict(variable_attrs[0])
     elif combine_attrs == "no_conflicts":
         result = dict(variable_attrs[0])
         for attrs in variable_attrs[1:]:

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -109,6 +109,13 @@ class TestMergeFunction:
             expected.attrs = expected_attrs
             assert actual.identical(expected)
 
+    def test_merge_attrs_override_copy(self):
+        ds1 = xr.Dataset(attrs={"x": 0})
+        ds2 = xr.Dataset(attrs={"x": 1})
+        ds3 = xr.merge([ds1, ds2], combine_attrs="override")
+        ds3.attrs["x"] = 2
+        assert ds1.x == 0
+
     def test_merge_dicts_simple(self):
         actual = xr.merge([{"foo": 0}, {"bar": "one"}, {"baz": 3.5}])
         expected = xr.Dataset({"foo": 0, "bar": "one", "baz": 3.5})


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4627 
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
