### PR TITLE
Move get_chunks from zarr.py to dataset.py

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -26,7 +26,7 @@ from ..core.combine import (
     combine_by_coords,
 )
 from ..core.dataarray import DataArray
-from ..core.dataset import Dataset, _maybe_chunk
+from ..core.dataset import Dataset, _maybe_chunk, _get_chunk
 from ..core.utils import close_on_error, is_grib_path, is_remote_uri
 from .common import AbstractDataStore, ArrayWriter
 from .locks import _get_scheduler
@@ -536,7 +536,7 @@ def open_dataset(
                 k: _maybe_chunk(
                     k,
                     v,
-                    store.get_chunk(k, v, chunks),
+                    _get_chunk(k, v, chunks),
                     overwrite_encoded_chunks=overwrite_encoded_chunks,
                 )
                 for k, v in ds.variables.items()

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -26,7 +26,7 @@ from ..core.combine import (
     combine_by_coords,
 )
 from ..core.dataarray import DataArray
-from ..core.dataset import Dataset, _maybe_chunk, _get_chunk
+from ..core.dataset import Dataset, _get_chunk, _maybe_chunk
 from ..core.utils import close_on_error, is_grib_path, is_remote_uri
 from .common import AbstractDataStore, ArrayWriter
 from .locks import _get_scheduler

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -59,7 +59,10 @@ def dataset_from_backend_dataset(
         for k, v in ds.variables.items():
             var_chunks = _get_chunk(k, v, chunks)
             variables[k] = _maybe_chunk(
-                k, v, var_chunks, overwrite_encoded_chunks=overwrite_encoded_chunks,
+                k,
+                v,
+                var_chunks,
+                overwrite_encoded_chunks=overwrite_encoded_chunks,
             )
         ds2 = ds._replace(variables)
 

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -1,7 +1,8 @@
 import os
 
+from ..core.dataset import _get_chunk, _maybe_chunk
 from ..core.utils import is_remote_uri
-from . import plugins, zarr
+from . import plugins
 from .api import (
     _autodetect_engine,
     _get_backend_cls,
@@ -54,10 +55,12 @@ def dataset_from_backend_dataset(
         if isinstance(chunks, int):
             chunks = dict.fromkeys(ds.dims, chunks)
 
-        variables = {
-            k: zarr.ZarrStore.maybe_chunk(k, v, chunks, overwrite_encoded_chunks)
-            for k, v in ds.variables.items()
-        }
+        variables = {}
+        for k, v in ds.variables.items():
+            var_chunks = _get_chunk(k, v, chunks)
+            variables[k] = _maybe_chunk(
+                k, v, var_chunks, overwrite_encoded_chunks=overwrite_encoded_chunks,
+            )
         ds2 = ds._replace(variables)
 
     else:

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 
 from .. import coding, conventions

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -368,53 +368,6 @@ class ZarrStore(AbstractWritableDataStore):
     def encode_attribute(self, a):
         return encode_zarr_attr_value(a)
 
-    @staticmethod
-    def get_chunk(name, var, chunks):
-        chunk_spec = dict(zip(var.dims, var.encoding.get("chunks")))
-
-        # Coordinate labels aren't chunked
-        if var.ndim == 1 and var.dims[0] == name:
-            return chunk_spec
-
-        if chunks == "auto":
-            return chunk_spec
-
-        for dim in var.dims:
-            if dim in chunks:
-                spec = chunks[dim]
-                if isinstance(spec, int):
-                    spec = (spec,)
-                if isinstance(spec, (tuple, list)) and chunk_spec[dim]:
-                    if any(s % chunk_spec[dim] for s in spec):
-                        warnings.warn(
-                            "Specified Dask chunks %r would "
-                            "separate Zarr chunk shape %r for "
-                            "dimension %r. This significantly "
-                            "degrades performance. Consider "
-                            "rechunking after loading instead."
-                            % (chunks[dim], chunk_spec[dim], dim),
-                            stacklevel=2,
-                        )
-                chunk_spec[dim] = chunks[dim]
-        return chunk_spec
-
-    @classmethod
-    def maybe_chunk(cls, name, var, chunks, overwrite_encoded_chunks):
-        chunk_spec = cls.get_chunk(name, var, chunks)
-
-        if (var.ndim > 0) and (chunk_spec is not None):
-            from dask.base import tokenize
-
-            # does this cause any data to be read?
-            token2 = tokenize(name, var._data, chunks)
-            name2 = f"xarray-{name}-{token2}"
-            var = var.chunk(chunk_spec, name=name2, lock=None)
-            if overwrite_encoded_chunks and var.chunks is not None:
-                var.encoding["chunks"] = tuple(x[0] for x in var.chunks)
-            return var
-        else:
-            return var
-
     def store(
         self,
         variables,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -377,12 +377,10 @@ def _get_chunk(name, var, chunks):
             if isinstance(spec, (tuple, list)) and chunk_spec[dim]:
                 if any(s % chunk_spec[dim] for s in spec):
                     warnings.warn(
-                        "Specified Dask chunks %r would "
-                        "separate on disks chunk shape %r for "
-                        "dimension %r. This could "
-                        "degrades performance. Consider "
-                        "rechunking after loading instead."
-                        % (chunks[dim], chunk_spec[dim], dim),
+                        f"Specified Dask chunks {chunks[dim]} would separate "
+                        f"on disks chunk shape {chunk_spec[dim]} for dimension {dim}. "
+                        "This could degrade performance. "
+                        "Consider rechunking after loading instead.",
                         stacklevel=2,
                     )
             chunk_spec[dim] = chunks[dim]

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -378,8 +378,8 @@ def _get_chunk(name, var, chunks):
                 if any(s % chunk_spec[dim] for s in spec):
                     warnings.warn(
                         "Specified Dask chunks %r would "
-                        "separate Zarr chunk shape %r for "
-                        "dimension %r. This significantly "
+                        "separate on disks chunk shape %r for "
+                        "dimension %r. This could "
                         "degrades performance. Consider "
                         "rechunking after loading instead."
                         % (chunks[dim], chunk_spec[dim], dim),

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2900,7 +2900,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
     def rename(
         self,
         name_dict: Mapping[Hashable, Hashable] = None,
-        inplace: bool = None,
         **names: Hashable,
     ) -> "Dataset":
         """Returns a new object with renamed variables and dimensions.
@@ -2926,7 +2925,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         Dataset.rename_dims
         DataArray.rename
         """
-        _check_inplace(inplace)
         name_dict = either_dict_or_kwargs(name_dict, names, "rename")
         for k in name_dict.keys():
             if k not in self and k not in self.dims:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2569,12 +2569,6 @@ class TestDataset:
         renamed = data.rename(newnames)
         assert_identical(renamed, data)
 
-    def test_rename_inplace(self):
-        times = pd.date_range("2000-01-01", periods=3)
-        data = Dataset({"z": ("x", [2, 3, 4]), "t": ("t", times)})
-        with pytest.raises(TypeError):
-            data.rename({"x": "y"}, inplace=True)
-
     def test_rename_dims(self):
         original = Dataset({"x": ("x", [0, 1, 2]), "y": ("x", [10, 11, 12]), "z": 42})
         expected = Dataset(


### PR DESCRIPTION
The aim is to split the PR https://github.com/pydata/xarray/pull/4595 in small PRs. 
In this smaller PR  there aren't changes in xarry interfaces, it's only a small code refactor:
- Move `get_chunks` from zarr.py to dataset.py
- Align `apiv2` to `apiv1`: in `apiv2`  replace `zarr.ZarrStore.maybe_chunk`  with `dataset._maybe_chunk` and `zarr.ZarrStore.get_chunk`  with `dataset._get_chunks`.
- remove `zarr.ZarrStore.maybe_chunk` and `zarr.ZarrStore.get_chunks` (no more used)


 - [x] Related #4496
 - [x] Passes `isort . && black . && mypy . && flake8`
 - No user visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - No new functions/methods are listed in `api.rst`
