### PR TITLE
change default in ds.chunk and datarray.chunk variable.chunk

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1010,12 +1010,11 @@ class DataArray(AbstractArray, DataWithCoords):
     def chunk(
         self,
         chunks: Union[
-            None,
             Number,
             Tuple[Number, ...],
             Tuple[Tuple[Number, ...], ...],
             Mapping[Hashable, Union[None, Number, Tuple[Number, ...]]],
-        ] = None,
+        ] = {},
         name_prefix: str = "xarray-",
         token: str = None,
         lock: bool = False,

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1014,7 +1014,7 @@ class DataArray(AbstractArray, DataWithCoords):
             Tuple[Number, ...],
             Tuple[Tuple[Number, ...], ...],
             Mapping[Hashable, Union[None, Number, Tuple[Number, ...]]],
-        ] = {},
+        ] = {},  # {} even though it's technically unsafe, is being used intentionally here (#4667)
         name_prefix: str = "xarray-",
         token: str = None,
         lock: bool = False,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1822,8 +1822,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             Number,
             str,
             Mapping[Hashable, Union[None, Number, str, Tuple[Number, ...]]],
-        ] = {},
-        name_prefix: str = "xarray-",
+        ] = {},  # {} even though it's technically unsafe, is being used intentionally here (#4667)
         token: str = None,
         lock: bool = False,
     ) -> "Dataset":

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1823,6 +1823,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             str,
             Mapping[Hashable, Union[None, Number, str, Tuple[Number, ...]]],
         ] = {},  # {} even though it's technically unsafe, is being used intentionally here (#4667)
+        name_prefix: str = "xarray-",
         token: str = None,
         lock: bool = False,
     ) -> "Dataset":

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -362,7 +362,7 @@ def _assert_empty(args: tuple, msg: str = "%s") -> None:
 def _maybe_chunk(
     name,
     var,
-    chunks=None,
+    chunks,
     token=None,
     lock=None,
     name_prefix="xarray-",
@@ -1819,11 +1819,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
     def chunk(
         self,
         chunks: Union[
-            None,
             Number,
             str,
             Mapping[Hashable, Union[None, Number, str, Tuple[Number, ...]]],
-        ] = None,
+        ] = {},
         name_prefix: str = "xarray-",
         token: str = None,
         lock: bool = False,
@@ -1855,17 +1854,22 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         -------
         chunked : xarray.Dataset
         """
+        if chunks is None:
+            warnings.warn(
+                "None value for 'chunks' is deprecated. "
+                "It will raise an error in the future. Use instead '{}'",
+                category=FutureWarning,
+            )
+            chunks = {}
 
         if isinstance(chunks, (Number, str)):
             chunks = dict.fromkeys(self.dims, chunks)
 
-        if chunks is not None:
-            bad_dims = chunks.keys() - self.dims.keys()
-            if bad_dims:
-                raise ValueError(
-                    "some chunks keys are not dimensions on this "
-                    "object: %s" % bad_dims
-                )
+        bad_dims = chunks.keys() - self.dims.keys()
+        if bad_dims:
+            raise ValueError(
+                "some chunks keys are not dimensions on this " "object: %s" % bad_dims
+            )
 
         variables = {
             k: _maybe_chunk(k, v, chunks, token, lock, name_prefix)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -986,7 +986,7 @@ class Variable(
 
     _array_counter = itertools.count()
 
-    def chunk(self, chunks=None, name=None, lock=False):
+    def chunk(self, chunks={}, name=None, lock=False):
         """Coerce this array's data into a dask arrays with the given chunks.
 
         If this variable is a non-dask array, it will be converted to dask
@@ -1016,11 +1016,16 @@ class Variable(
         import dask
         import dask.array as da
 
+        if chunks is None:
+            warnings.warn(
+                "None value for 'chunks' is deprecated. "
+                "It will raise an error in the future. Use instead '{}'",
+                category=FutureWarning,
+            )
+            chunks = {}
+
         if utils.is_dict_like(chunks):
             chunks = {self.get_axis_num(dim): chunk for dim, chunk in chunks.items()}
-
-        if chunks is None:
-            chunks = self.chunks or self.shape
 
         data = self._data
         if is_duck_dask_array(data):
@@ -2368,7 +2373,7 @@ class IndexVariable(Variable):
             f"Please use DataArray.assign_coords, Dataset.assign_coords or Dataset.assign as appropriate."
         )
 
-    def chunk(self, chunks=None, name=None, lock=False):
+    def chunk(self, chunks={}, name=None, lock=False):
         # Dummy - do not chunk. This method is invoked e.g. by Dataset.chunk()
         return self.copy(deep=False)
 


### PR DESCRIPTION
The aim is to split the PR #4595 in small PRs.
The scope of this smaller PR is to modify the default of `chunks` in `dataset.chunk` to align the behaviour to `xr.open_dataset`. 
The main changes are:
- Modify the default of chunk in `dataset.chunk`, `datarray.chunk` and `variable.chunk` from None to {}.
- If the user pass `chunk=None` inside is set to `{}`
- Add a future warning to advice that the usage of `None` will raise an error in the future. 

Note that the changes currently don't modify the behaviour of `dataset.chunk`
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Related #4496
 - [x] Passes `isort . && black . && mypy . && flake8`
