### PR TITLE
pin pip for upstream-dev

### DIFF
--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -29,7 +29,7 @@ dependencies:
   - numpy
   - pandas
   - pint
-  - pip
+  - pip=20.2
   - pseudonetcdf
   - pydap
   # - pynio: not compatible with netCDF4>1.5.3; only tested in py36-bare-minimum


### PR DESCRIPTION
Our upstream-dev is failing again. See numpy/numpy#17885 and pypa/pip#9186 for the probable cause. So this will need to be fixed upstream first.
