### PR TITLE
Modify zarr chunking as suggested in #4496

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -377,10 +377,12 @@ def open_dataset(
         "netcdf4".
     chunks : int or dict, optional
         If chunks is provided, it is used to load the new dataset into dask
-        arrays. ``chunks={}`` loads the dataset with dask using a single
-        chunk for all arrays. When using ``engine="zarr"``, setting
-        ``chunks='auto'`` will create dask chunks based on the variable's zarr
-        chunks.
+        arrays. ``chunks=-1`` loads the dataset with dask using a single
+        chunk for all arrays. `chunks={}`` loads the dataset with dask using
+        engine preferred chunks if exposed by the backend, otherwise with
+        a single chunk for all arrays.
+        ``chunks='auto'`` will use dask ``auto`` chunking taking into account the
+        engine preferred chunks. See dask chunking for more details.
     lock : False or lock-like, optional
         Resource lock to use when reading data from disk. Only relevant when
         using dask or another form of parallelism. By default, appropriate

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -536,7 +536,7 @@ def open_dataset(
                 k: _maybe_chunk(
                     k,
                     v,
-                    _get_chunk(k, v, chunks),
+                    _get_chunk(v, chunks),
                     overwrite_encoded_chunks=overwrite_encoded_chunks,
                 )
                 for k, v in ds.variables.items()

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -146,10 +146,12 @@ def open_dataset(
         "pynio", "cfgrib", "pseudonetcdf", "zarr"}.
     chunks : int or dict, optional
         If chunks is provided, it is used to load the new dataset into dask
-        arrays. ``chunks={}`` loads the dataset with dask using a single
-        chunk for all arrays. When using ``engine="zarr"``, setting
-        ``chunks='auto'`` will create dask chunks based on the variable's zarr
-        chunks.
+        arrays. ``chunks=-1`` loads the dataset with dask using a single
+        chunk for all arrays. `chunks={}`` loads the dataset with dask using
+        engine preferred chunks if exposed by the backend, otherwise with
+        a single chunk for all arrays.
+        ``chunks='auto'`` will use dask ``auto`` chunking taking into account the
+        engine preferred chunks. See dask chunking for more details.
     cache : bool, optional
         If True, cache data is loaded from the underlying datastore in memory as
         NumPy arrays when accessed to avoid reading from the underlying data-

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -53,7 +53,7 @@ def _chunk_ds(
 
         variables = {}
         for k, v in backend_ds.variables.items():
-            var_chunks = _get_chunk(k, v, chunks)
+            var_chunks = _get_chunk(v, chunks)
             variables[k] = _maybe_chunk(
                 k,
                 v,

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -611,6 +611,14 @@ def open_zarr(
     """
     from .api import open_dataset
 
+    if chunks == "auto":
+        try:
+            import dask.array  # noqa
+
+            chunks = {}
+        except ImportError:
+            chunks = None
+
     if kwargs:
         raise TypeError(
             "open_zarr() got unexpected keyword arguments " + ",".join(kwargs.keys())

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -362,7 +362,7 @@ def _assert_empty(args: tuple, msg: str = "%s") -> None:
 def _check_chunks_compatibility(var, chunks, chunk_spec):
     for dim in var.dims:
         if dim not in chunks or (dim not in chunk_spec):
-            pass
+            continue
 
         chunk_spec_dim = chunk_spec.get(dim)
         chunks_dim = chunks.get(dim)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -383,6 +383,7 @@ def _get_chunk(var, chunks):
     # chunks need to be explicity computed to take correctly into accout
     # backend preferred chunking
     import dask.array as da
+
     if isinstance(var, IndexVariable):
         return {}
 
@@ -393,8 +394,7 @@ def _get_chunk(var, chunks):
     preferred_chunks = dict(zip(var.dims, var.encoding.get("chunks", {})))
 
     chunks_list = [
-        chunks.get(dim, None) or preferred_chunks.get(dim, None)
-        for dim in var.dims
+        chunks.get(dim, None) or preferred_chunks.get(dim, None) for dim in var.dims
     ]
 
     output_chunks_list = da.core.normalize_chunks(

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -359,32 +359,55 @@ def _assert_empty(args: tuple, msg: str = "%s") -> None:
         raise ValueError(msg % args)
 
 
-def _get_chunk(name, var, chunks):
-    chunk_spec = dict(zip(var.dims, var.encoding.get("chunks")))
-
-    # Coordinate labels aren't chunked
-    if var.ndim == 1 and var.dims[0] == name:
-        return chunk_spec
-
-    if chunks == "auto":
-        return chunk_spec
-
+def _check_chunks_compatibility(var, chunks, chunk_spec):
     for dim in var.dims:
-        if dim in chunks:
-            spec = chunks[dim]
-            if isinstance(spec, int):
-                spec = (spec,)
-            if isinstance(spec, (tuple, list)) and chunk_spec[dim]:
-                if any(s % chunk_spec[dim] for s in spec):
-                    warnings.warn(
-                        f"Specified Dask chunks {chunks[dim]} would separate "
-                        f"on disks chunk shape {chunk_spec[dim]} for dimension {dim}. "
-                        "This could degrade performance. "
-                        "Consider rechunking after loading instead.",
-                        stacklevel=2,
-                    )
-            chunk_spec[dim] = chunks[dim]
-    return chunk_spec
+        if dim not in chunks or (dim not in chunk_spec):
+            pass
+
+        chunk_spec_dim = chunk_spec.get(dim)
+        chunks_dim = chunks.get(dim)
+
+        if isinstance(chunks_dim, int):
+            chunks_dim = (chunks_dim,)
+        if any(s % chunk_spec_dim for s in chunks_dim):
+            warnings.warn(
+                f"Specified Dask chunks {chunks[dim]} would separate "
+                f"on disks chunk shape {chunk_spec[dim]} for dimension {dim}. "
+                "This could degrade performance. "
+                "Consider rechunking after loading instead.",
+                stacklevel=2,
+            )
+
+
+def _get_chunk(var, chunks):
+    # chunks need to be explicity computed to take correctly into accout
+    # backend preferred chunking
+    import dask.array as da
+    if isinstance(var, IndexVariable):
+        return {}
+
+    if isinstance(chunks, int) or (chunks == "auto"):
+        chunks = dict.fromkeys(var.dims, chunks)
+
+    preferred_chunks_list = var.encoding.get("chunks", {})
+    preferred_chunks = dict(zip(var.dims, var.encoding.get("chunks", {})))
+
+    chunks_list = [
+        chunks.get(dim, None) or preferred_chunks.get(dim, None)
+        for dim in var.dims
+    ]
+
+    output_chunks_list = da.core.normalize_chunks(
+        chunks_list,
+        shape=var.shape,
+        dtype=var.dtype,
+        previous_chunks=preferred_chunks_list,
+    )
+
+    output_chunks = dict(zip(var.dims, output_chunks_list))
+    _check_chunks_compatibility(var, output_chunks, preferred_chunks)
+
+    return output_chunks
 
 
 def _maybe_chunk(

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -673,7 +673,7 @@ class DatasetIOBase:
         multiple_indexing(indexers)
 
     @pytest.mark.xfail(
-        reason="the code for indexing without dask handles negative steps in slices incorrectly",
+        reason="zarr without dask handles negative steps in slices incorrectly",
     )
     def test_vectorized_indexing_negative_step_no_dask(self, open_kwargs=None):
         in_memory = create_test_data()

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -672,7 +672,10 @@ class DatasetIOBase:
         ]
         multiple_indexing(indexers)
 
-    def test_vectorized_indexing_negative_step_slice(self, open_kwargs=None):
+    @pytest.mark.xfail(
+        reason="the code for indexing without dask handles negative steps in slices incorrectly",
+    )
+    def test_vectorized_indexing_negative_step_no_dask(self, open_kwargs=None):
         in_memory = create_test_data()
 
         def multiple_indexing(indexers):
@@ -704,6 +707,10 @@ class DatasetIOBase:
             }
         ]
         multiple_indexing(indexers)
+
+    @requires_dask
+    def test_vectorized_indexing_negative_step_with_dask(self):
+        self.test_vectorized_indexing_negative_step_no_dask(open_kwargs={"chunks": {}})
 
     def test_isel_dataarray(self):
         # Make sure isel works lazily. GH:issue:1688
@@ -2178,10 +2185,6 @@ class ZarrBase(CFEncodedBase):
             assert_identical(ds, ds_a)
             ds_b = xr.open_zarr(store_target, consolidated=True, use_cftime=True)
             assert xr.coding.times.contains_cftime_datetimes(ds_b.time)
-
-    @requires_dask
-    def test_vectorized_indexing_negative_step_slice(self):
-        super().test_vectorized_indexing_negative_step_slice(open_kwargs={"chunks": {}})
 
 
 @requires_zarr

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -675,7 +675,11 @@ class DatasetIOBase:
     @pytest.mark.xfail(
         reason="zarr without dask handles negative steps in slices incorrectly",
     )
-    def test_vectorized_indexing_negative_step_no_dask(self, open_kwargs=None):
+    def test_vectorized_indexing_negative_step(self):
+        if has_dask:
+            open_kwargs = {"chunks": {}}
+        else:
+            open_kwargs = None
         in_memory = create_test_data()
 
         def multiple_indexing(indexers):
@@ -707,10 +711,6 @@ class DatasetIOBase:
             }
         ]
         multiple_indexing(indexers)
-
-    @requires_dask
-    def test_vectorized_indexing_negative_step_with_dask(self):
-        self.test_vectorized_indexing_negative_step_no_dask(open_kwargs={"chunks": {}})
 
     def test_isel_dataarray(self):
         # Make sure isel works lazily. GH:issue:1688

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -676,6 +676,7 @@ class DatasetIOBase:
         reason="zarr without dask handles negative steps in slices incorrectly",
     )
     def test_vectorized_indexing_negative_step(self):
+        # use dask explicitly when present
         if has_dask:
             open_kwargs = {"chunks": {}}
         else:


### PR DESCRIPTION
Part of https://github.com/pydata/xarray/pull/4595
The changes involve only `open_dataset(..., engine=zarr)` (and marginally `open_zarr`), in particular, `_get_chunks` has been modified to fit #4496 (comment) option 1 chunking behaviour and align open_dataset chunking with `dataset.chunk`:

- with `auto` it uses dask auto-chunking (if a preferred_chunking is defined, dask will take it into account as done in `dataset.chunk`)
- with `-1` it uses dask but no chunking.
- with `{}` it uses the backend encoded chunks (when available) for on-disk data (`xr.open_dataset`) and the current chunking for already opened datasets (`ds.chunk`)

Add some test
 - [x] Releted to pydata#4496
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
