### PR TITLE
Run the scheduled nightly CI only on the main repo

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -14,9 +14,7 @@ jobs:
   upstream-dev:
     name: upstream-dev
     runs-on: ubuntu-latest
-    if: |
-      always()
-      && github.repository == 'pydata/xarray'
+    if: github.repository == 'pydata/xarray'
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -14,6 +14,9 @@ jobs:
   upstream-dev:
     name: upstream-dev
     runs-on: ubuntu-latest
+    if: |
+      always()
+      && github.repository == 'pydata/xarray'
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
It seems [the only way](https://github.community/t/do-not-run-cron-workflows-in-forks/17636) to stop running the scheduled CI on forks is by skipping the jobs if they are run on a fork.

~I'm not sure if I have to make an exception for PR CI (i.e. also check for `github.event_name != 'schedule'`), but I guess we can just try it out.~
Edit: apparently we don't need that, it runs just fine.

cc @andersy005

 - [x] follow-up to #4604