### PR TITLE
corrected a minor spelling mistake

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2670,7 +2670,7 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Converts all variables and attributes to native Python objects.
         Useful for converting to json. To avoid datetime incompatibility
-        use decode_times=False kwarg in xarrray.open_dataset.
+        use decode_times=False kwarg in xarray.open_dataset.
 
         Parameters
         ----------


### PR DESCRIPTION
What it says on the tin, changed `xarrray.open_dataset` to `xarray.open_dataset`.

The mistake was in documentation so no changes to any code have been made