### PR TITLE
improve the documentation on accessors

### DIFF
--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -177,9 +177,9 @@ for an open source library. In the future, we will maintain a list of accessors
 and the libraries that implement them on this page.
 
 To make documenting accessors with ``sphinx`` and ``sphinx.ext.autosummary``
-easier, you can use `sphinx-ext-autosummary`_.
+easier, you can use `sphinx-autosummary-accessors`_.
 
-.. _sphinx-ext-autosummary: https://sphinx-autosummary-accessors.readthedocs.io/
+.. _sphinx-autosummary-accessors: https://sphinx-autosummary-accessors.readthedocs.io/
 
 .. _zarr_encoding:
 

--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -116,9 +116,9 @@ xarray:
 
 .. literalinclude:: examples/_code/accessor_example.py
 
-In general, the only requirement on these custom classes is that ``__init__`` has only a
-single parameter except from ``self``: the ``Dataset`` or ``DataArray`` object it is
-supposed to work on.
+In general, the only requirement is that the accessor's ``__init__`` only has a single
+parameter except from ``self``: the ``Dataset`` or ``DataArray`` object it is supposed
+to work on.
 
 This achieves the same result as if the ``Dataset`` class had a cached property
 defined that returns an instance of your class:

--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -116,6 +116,10 @@ xarray:
 
 .. literalinclude:: examples/_code/accessor_example.py
 
+In general, the only requirement on these custom classes is that ``__init__`` has only a
+single parameter except from ``self``: the ``Dataset`` or ``DataArray`` object it is
+supposed to work on.
+
 This achieves the same result as if the ``Dataset`` class had a cached property
 defined that returns an instance of your class:
 

--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -116,8 +116,8 @@ xarray:
 
 .. literalinclude:: examples/_code/accessor_example.py
 
-In general, the only requirement is that the accessor's ``__init__`` only has a single
-parameter except from ``self``: the ``Dataset`` or ``DataArray`` object it is supposed
+In general, the only restriction on the accessor class is that the ``__init__`` method
+must have a single parameter: the ``Dataset`` or ``DataArray`` object it is supposed
 to work on.
 
 This achieves the same result as if the ``Dataset`` class had a cached property

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,7 +35,8 @@ Bug fixes
 
 Documentation
 ~~~~~~~~~~~~~
-
+- add information about requirements for accessor classes (:issue:`2788`, :pull:`4657`).
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We currently have a example for a accessor class in our `internals` page, but we didn't explicitly say what we require of these classes. This PR adds that information, and also fixes the displayed text for the link to `sphinx-autosummary-accessors`.

 - [x] Closes #2788
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
