### PR TITLE
xr.DataArray.from_dask_dataframe feature

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -400,13 +400,12 @@ class DataArray(AbstractArray, DataWithCoords):
                 attrs = getattr(data, "attrs", None)
 
             def compute_delayed_tuple_elements(tuple_):
-                tuple_ = tuple([
-                    elem.compute() 
-                    if hasattr(elem, 'compute') 
-                    else elem 
-                    for elem 
-                    in tuple_
-                    ])
+                tuple_ = tuple(
+                    [
+                        elem.compute() if hasattr(elem, "compute") else elem
+                        for elem in tuple_
+                    ]
+                )
 
                 return tuple_
 
@@ -862,7 +861,7 @@ class DataArray(AbstractArray, DataWithCoords):
         return DataArray(variable, coords, name=name, fastpath=True)
 
     @classmethod
-    def from_dask_dataframe(cls, df: ddf, index_name: str='', columns_name: str=''):
+    def from_dask_dataframe(cls, df: ddf, index_name: str = "", columns_name: str = ""):
         """Convert a pandas.DataFrame into an xarray.DataArray
 
         This method will produce a DataArray from a Dask DataFrame.
@@ -888,23 +887,23 @@ class DataArray(AbstractArray, DataWithCoords):
         xarray.DataArray.from_series
         pandas.DataFrame.to_xarray
         """
-        assert len(set(df.dtypes)) == 1, 'Each variable can include only one data-type'
+        assert len(set(df.dtypes)) == 1, "Each variable can include only one data-type"
 
-        def extract_dim_name(df, dim='index'):
+        def extract_dim_name(df, dim="index"):
             if getattr(df, dim).name is None:
                 getattr(df, dim).name = dim
 
             dim_name = getattr(df, dim).name
 
             return dim_name
-        
-        if index_name == '':
-            index_name = extract_dim_name(df, 'index')
-        if columns_name == '':
-            columns_name = extract_dim_name(df, 'columns')
-            
+
+        if index_name == "":
+            index_name = extract_dim_name(df, "index")
+        if columns_name == "":
+            columns_name = extract_dim_name(df, "columns")
+
         da = cls(df, coords=[df.index, df.columns], dims=[index_name, columns_name])
-        
+
         return da
 
     def load(self, **kwargs) -> "DataArray":

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -20,6 +20,7 @@ from typing import (
 
 import numpy as np
 import pandas as pd
+import dask
 
 import xarray as xr  # only for Dataset and DataArray
 
@@ -198,6 +199,9 @@ def as_compatible_data(data, fastpath=False):
     if fastpath and getattr(data, "ndim", 0) > 0:
         # can't use fastpath (yet) for scalars
         return _maybe_wrap_data(data)
+
+    if isinstance(data, dask.dataframe.core.DataFrame):
+        return data.to_dask_array(lengths=True)
 
     if isinstance(data, Variable):
         return data.data

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -18,9 +18,9 @@ from typing import (
     Union,
 )
 
+import dask
 import numpy as np
 import pandas as pd
-import dask
 
 import xarray as xr  # only for Dataset and DataArray
 


### PR DESCRIPTION
This feature allows users to convert Dask DataFrames (of a single type) into a DataArray that uses a Dask array. This solves a gap in the Python ecosystem around saving Dask DataFrames to Zarr which is currently not possible without loading the full dataset into memory.

This feature specifically handles the case where a DataFrame is of a single type, a xr.Dataset.from_dask_dataframe could be developed in future to handle the multi-type case.

 - [x] Closes [4650](https://github.com/pydata/xarray/issues/4650) fully and [3929](https://github.com/pydata/xarray/issues/3929) partially 
 - [ ] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
