### PR TITLE
upstream-dev: mention sparse

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# TODO: add sparse back in, once Numba works with the development version of
+# NumPy again: https://github.com/pydata/xarray/issues/4146
+
 conda uninstall -y --force \
     numpy \
     scipy \
@@ -36,5 +39,5 @@ python -m pip install \
     git+https://github.com/Unidata/cftime \
     git+https://github.com/mapbox/rasterio \
     git+https://github.com/hgrecco/pint \
-    git+https://github.com/pydata/bottleneck \
-    git+https://github.com/pydata/sparse
+    git+https://github.com/pydata/bottleneck # \
+    # git+https://github.com/pydata/sparse

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -36,4 +36,5 @@ python -m pip install \
     git+https://github.com/Unidata/cftime \
     git+https://github.com/mapbox/rasterio \
     git+https://github.com/hgrecco/pint \
-    git+https://github.com/pydata/bottleneck
+    git+https://github.com/pydata/bottleneck \
+    git+https://github.com/pydata/sparse


### PR DESCRIPTION
sparse is removed as conda package but not re-installed (https://github.com/pydata/xarray/blob/9802411b35291a6149d850e8e573cde71a93bfbf/ci/install-upstream-wheels.sh)

I assume this is not intentional, @andersy005?