### PR TITLE
Fixing non-lazy behavior of sampled+weighted

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,6 +30,8 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
+- :py:meth:`DataArray.resample` and :py:meth:`Dataset.resample` do not trigger computations anymore if :py:meth:`Dataset.weighted` or :py:meth:`DataArray.weighted` are applied (:issue:`4625`, :pull:`4668`).
+By `Julius Busecke <https://github.com/jbusecke>`_.
 
 - :py:func:`merge` with ``combine_attrs='override'`` makes a copy of the attrs (:issue:`4627`).
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,9 +30,8 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
-- :py:meth:`DataArray.resample` and :py:meth:`Dataset.resample` do not trigger computations anymore if :py:meth:`Dataset.weighted` or :py:meth:`DataArray.weighted` are applied (:issue:`4625`, :pull:`4668`).
-By `Julius Busecke <https://github.com/jbusecke>`_.
 
+- :py:meth:`DataArray.resample` and :py:meth:`Dataset.resample` do not trigger computations anymore if :py:meth:`Dataset.weighted` or :py:meth:`DataArray.weighted` are applied (:issue:`4625`, :pull:`4668`). By `Julius Busecke <https://github.com/jbusecke>`_.
 - :py:func:`merge` with ``combine_attrs='override'`` makes a copy of the attrs (:issue:`4627`).
 
 Documentation

--- a/xarray/core/weighted.py
+++ b/xarray/core/weighted.py
@@ -114,7 +114,8 @@ class Weighted:
         if is_duck_dask_array(weights.data):
             # assign to copy - else the check is not triggered
             weights = weights.copy(
-                data=weights.data.map_blocks(_weight_check, dtype=weights.dtype)
+                data=weights.data.map_blocks(_weight_check, dtype=weights.dtype),
+                deep=False,
             )
 
         else:

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -49,6 +49,28 @@ def test_weighted_weights_nan_raises_dask(as_dataset, weights):
         weighted.sum().load()
 
 
+@requires_dask
+@pytest.mark.parametrize("time_chunks", (1, 5))
+@pytest.mark.parametrize("resample_spec", ("1AS", "5AS", "10AS"))
+def test_weighted_lazy_resample(time_chunks, resample_spec):
+    # https://github.com/pydata/xarray/issues/4625
+
+    # simple customized weighted mean function
+    def mean_func(ds):
+        return ds.weighted(ds.weights).mean("time")
+
+    # example dataset
+    t = xr.cftime_range(start="2000", periods=1000, freq="1AS")
+    weights = xr.DataArray(np.random.rand(len(t)), dims=["time"], coords={"time": t})
+    data = xr.DataArray(
+        np.random.rand(len(t)), dims=["time"], coords={"time": t, "weights": weights}
+    )
+    ds = xr.Dataset({"data": data}).chunk({"time": time_chunks})
+
+    with raise_if_dask_computes():
+        ds.resample(time=resample_spec).map(mean_func)
+
+
 @pytest.mark.parametrize(
     ("weights", "expected"),
     (([1, 2], 3), ([2, 0], 2), ([0, 0], np.nan), ([-1, 1], np.nan)),

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -31,7 +31,6 @@ def test_weighted_weights_nan_raises(as_dataset, weights):
         data.weighted(DataArray(weights))
 
 
-@requires_cftime
 @requires_dask
 @pytest.mark.parametrize("as_dataset", (True, False))
 @pytest.mark.parametrize("weights", ([np.nan, 2], [np.nan, np.nan]))
@@ -50,6 +49,7 @@ def test_weighted_weights_nan_raises_dask(as_dataset, weights):
         weighted.sum().load()
 
 
+@requires_cftime
 @requires_dask
 @pytest.mark.parametrize("time_chunks", (1, 5))
 @pytest.mark.parametrize("resample_spec", ("1AS", "5AS", "10AS"))

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -5,7 +5,7 @@ import xarray as xr
 from xarray import DataArray
 from xarray.tests import assert_allclose, assert_equal, raises_regex
 
-from . import raise_if_dask_computes, requires_dask
+from . import raise_if_dask_computes, requires_dask, requires_cftime
 
 
 @pytest.mark.parametrize("as_dataset", (True, False))
@@ -31,6 +31,7 @@ def test_weighted_weights_nan_raises(as_dataset, weights):
         data.weighted(DataArray(weights))
 
 
+@requires_cftime
 @requires_dask
 @pytest.mark.parametrize("as_dataset", (True, False))
 @pytest.mark.parametrize("weights", ([np.nan, 2], [np.nan, np.nan]))

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -5,7 +5,7 @@ import xarray as xr
 from xarray import DataArray
 from xarray.tests import assert_allclose, assert_equal, raises_regex
 
-from . import raise_if_dask_computes, requires_dask, requires_cftime
+from . import raise_if_dask_computes, requires_cftime, requires_dask
 
 
 @pytest.mark.parametrize("as_dataset", (True, False))

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -61,7 +61,7 @@ def test_weighted_lazy_resample(time_chunks, resample_spec):
         return ds.weighted(ds.weights).mean("time")
 
     # example dataset
-    t = xr.cftime_range(start="2000", periods=1000, freq="1AS")
+    t = xr.cftime_range(start="2000", periods=20, freq="1AS")
     weights = xr.DataArray(np.random.rand(len(t)), dims=["time"], coords={"time": t})
     data = xr.DataArray(
         np.random.rand(len(t)), dims=["time"], coords={"time": t, "weights": weights}


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4625
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
