### PR TITLE
add encodings["preferred_chunks"], used in open_dataset instead of en…

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -311,7 +311,7 @@ class ZarrStore(AbstractWritableDataStore):
         attributes = dict(attributes)
         encoding = {
             "chunks": zarr_array.chunks,
-            "preferred_chunks": zarr_array.chunks,
+            "preferred_chunks": dict(zip(dimensions, zarr_array.chunks)),
             "compressor": zarr_array.compressor,
             "filters": zarr_array.filters,
         }

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -311,6 +311,7 @@ class ZarrStore(AbstractWritableDataStore):
         attributes = dict(attributes)
         encoding = {
             "chunks": zarr_array.chunks,
+            "preferred_chunks": zarr_array.chunks,
             "compressor": zarr_array.compressor,
             "filters": zarr_array.filters,
         }

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -391,7 +391,9 @@ def _get_chunk(var, chunks):
         chunks = dict.fromkeys(var.dims, chunks)
 
     preferred_chunks = var.encoding.get("preferred_chunks", {})
-    preferred_chunks_list = [preferred_chunks.get(dim, None) for dim in var.dims]
+    preferred_chunks_list = [
+        preferred_chunks.get(dim, shape) for dim, shape in zip(var.dims, var.shape)
+    ]
 
     chunks_list = [
         chunks.get(dim, None) or preferred_chunks.get(dim, None) for dim in var.dims

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -390,8 +390,8 @@ def _get_chunk(var, chunks):
     if isinstance(chunks, int) or (chunks == "auto"):
         chunks = dict.fromkeys(var.dims, chunks)
 
-    preferred_chunks_list = var.encoding.get("chunks", {})
-    preferred_chunks = dict(zip(var.dims, var.encoding.get("chunks", {})))
+    preferred_chunks_list = var.encoding.get("preferred_chunks", {})
+    preferred_chunks = dict(zip(var.dims, preferred_chunks_list))
 
     chunks_list = [
         chunks.get(dim, None) or preferred_chunks.get(dim, None) for dim in var.dims

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -390,8 +390,8 @@ def _get_chunk(var, chunks):
     if isinstance(chunks, int) or (chunks == "auto"):
         chunks = dict.fromkeys(var.dims, chunks)
 
-    preferred_chunks_list = var.encoding.get("preferred_chunks", {})
-    preferred_chunks = dict(zip(var.dims, preferred_chunks_list))
+    preferred_chunks = var.encoding.get("preferred_chunks", {})
+    preferred_chunks_list = [preferred_chunks.get(dim, None) for dim in var.dims]
 
     chunks_list = [
         chunks.get(dim, None) or preferred_chunks.get(dim, None) for dim in var.dims


### PR DESCRIPTION
Related to https://github.com/pydata/xarray/issues/4496
Add `encodings["preferred_chunks"]` in zarr, used in open_dataset instead of `encodings["chunks"]`.

 - [x] Related to #https://github.com/pydata/xarray/issues/4496
 - [x] Passes `isort . && black . && mypy . && flake8`

