### PR TITLE
maybe accelerate windows tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
       py37:
         conda_env: py37-windows
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   steps:
   - template: ci/azure/unit-tests.yml
 

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -6,8 +6,8 @@ steps:
 - template: add-conda-to-path.yml
 
 - bash: |
-    conda update -y conda
-    conda env create -n xarray-tests --file ${{ parameters.env_file }}
+    conda install -y mamba
+    mamba env create -n xarray-tests -c conda-forge --override-channels --strict-channel-priority --file ${{ parameters.env_file }}
   displayName: Install conda dependencies
 
 # TODO: add sparse back in, once Numba works with the development version of

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -6,7 +6,7 @@ steps:
 - template: add-conda-to-path.yml
 
 - bash: |
-    conda install -y mamba
+    conda install -y mamba -c conda-forge
     mamba env create -n xarray-tests -c conda-forge --override-channels --strict-channel-priority --file ${{ parameters.env_file }}
   displayName: Install conda dependencies
 

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -7,6 +7,7 @@ steps:
 
 - bash: |
     conda install -y mamba -c conda-forge
+    source activate
     mamba env create -n xarray-tests --file ${{ parameters.env_file }}
   displayName: Install conda dependencies
 

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -7,7 +7,7 @@ steps:
 
 - bash: |
     conda install -y mamba -c conda-forge
-    mamba env create -n xarray-tests -c conda-forge --override-channels --strict-channel-priority --file ${{ parameters.env_file }}
+    mamba env create -n xarray-tests --file ${{ parameters.env_file }}
   displayName: Install conda dependencies
 
 # TODO: add sparse back in, once Numba works with the development version of

--- a/ci/azure/unit-tests.yml
+++ b/ci/azure/unit-tests.yml
@@ -15,6 +15,7 @@ steps:
     --junitxml=junit/test-results.xml \
     --cov=xarray \
     --cov-report=xml \
+    --durations=200 \
     $(pytest_extra_flags) \
     || ( \
       [ "$ALLOW_FAILURE" = "true" ] \

--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -2,6 +2,7 @@ name: xarray-docs
 channels:
   # Don't change to pkgs/main, as it causes random timeouts in readthedocs
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.8
   - bottleneck

--- a/ci/requirements/py36-bare-minimum.yml
+++ b/ci/requirements/py36-bare-minimum.yml
@@ -1,6 +1,7 @@
 name: xarray-tests
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.6
   - coveralls

--- a/ci/requirements/py36-min-all-deps.yml
+++ b/ci/requirements/py36-min-all-deps.yml
@@ -1,6 +1,7 @@
 name: xarray-tests
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   # MINIMUM VERSIONS POLICY: see doc/installing.rst
   # Run ci/min_deps_check.py to verify that this file respects the policy.

--- a/ci/requirements/py36-min-all-deps.yml
+++ b/ci/requirements/py36-min-all-deps.yml
@@ -1,7 +1,6 @@
 name: xarray-tests
 channels:
   - conda-forge
-  - nodefaults
 dependencies:
   # MINIMUM VERSIONS POLICY: see doc/installing.rst
   # Run ci/min_deps_check.py to verify that this file respects the policy.

--- a/ci/requirements/py36-min-nep18.yml
+++ b/ci/requirements/py36-min-nep18.yml
@@ -1,6 +1,7 @@
 name: xarray-tests
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   # Optional dependencies that require NEP18, such as sparse and pint,
   # require drastically newer packages than everything else

--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -1,6 +1,7 @@
 name: xarray-tests
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.6
   - black

--- a/ci/requirements/py37-windows.yml
+++ b/ci/requirements/py37-windows.yml
@@ -1,6 +1,7 @@
 name: xarray-tests
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.7
   - black

--- a/ci/requirements/py37-windows.yml
+++ b/ci/requirements/py37-windows.yml
@@ -21,7 +21,7 @@ dependencies:
   - iris
   - isort
   - lxml    # Optional dep of pydap
-  - matplotlib
+  - matplotlib-base
   - mypy=0.790  # Must match .pre-commit-config.yaml
   - nc-time-axis
   - netcdf4

--- a/ci/requirements/py37-windows.yml
+++ b/ci/requirements/py37-windows.yml
@@ -1,7 +1,6 @@
 name: xarray-tests
 channels:
   - conda-forge
-  - nodefaults
 dependencies:
   - python=3.7
   - black

--- a/ci/requirements/py37.yml
+++ b/ci/requirements/py37.yml
@@ -1,6 +1,7 @@
 name: xarray-tests
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.7
   - black

--- a/ci/requirements/py38-all-but-dask.yml
+++ b/ci/requirements/py38-all-but-dask.yml
@@ -1,6 +1,7 @@
 name: xarray-tests
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.8
   - black

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -1,6 +1,7 @@
 name: xarray-tests
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.8
   - black


### PR DESCRIPTION
Towards #4671

ok let's start with the simplest one

- [x] switch to the newest windows image (does not help)
- [x] use mamba to resolve dependencies
- [ ] use matplotlib-base
- [ ] find the slowest tests using `py.test xarray/tests/ --durations=100`
- [ ] de-parametrize tests with a slow setup (if possible)
- [ ] reduce the number of xfails
- [ ] other ideas?