### PR TITLE
Readd order and subok parameters to astype (GH4644)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -418,6 +418,7 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org", None),
     "dask": ("https://docs.dask.org/en/latest", None),
     "cftime": ("https://unidata.github.io/cftime", None),
+    "sparse": ("https://sparse.pydata.org/en/latest/", None),
 }
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,8 +33,8 @@ Bug fixes
 
 - :py:func:`merge` with ``combine_attrs='override'`` makes a copy of the attrs (:issue:`4627`).
 - :py:meth:`DataArray.astype`, :py:meth:`Dataset.astype` and :py:meth:`Variable.astype` support
-  the `order` and `subok` parameters again. This fixes a regression introduced in version 0.16.1
-  (:issue:`4644`).
+  the ``order`` and ``subok`` parameters again. This fixes a regression introduced in version 0.16.1
+  (:issue:`4644`, :pull:`4683`).
   By `Richard Kleijn <https://github.com/rhkleijn>`_ .
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -32,6 +32,10 @@ Bug fixes
 ~~~~~~~~~
 
 - :py:func:`merge` with ``combine_attrs='override'`` makes a copy of the attrs (:issue:`4627`).
+- :py:meth:`DataArray.astype`, :py:meth:`Dataset.astype` and :py:meth:`Variable.astype` support
+  the `order` and `subok` parameters again. This fixes a regression introduced in version 0.16.1
+  (:issue:`4644`).
+  By `Richard Kleijn <https://github.com/rhkleijn>`_ .
 
 Documentation
 ~~~~~~~~~~~~~
@@ -166,8 +170,8 @@ Internal Changes
 - Replace the internal use of ``pd.Index.__or__`` and ``pd.Index.__and__`` with ``pd.Index.union``
   and ``pd.Index.intersection`` as they will stop working as set operations in the future
   (:issue:`4565`). By `Mathias Hauser <https://github.com/mathause>`_.
-- Add GitHub action for running nightly tests against upstream dependencies (:pull:`4583`). 
-  By `Anderson Banihirwe <https://github.com/andersy005>`_. 
+- Add GitHub action for running nightly tests against upstream dependencies (:pull:`4583`).
+  By `Anderson Banihirwe <https://github.com/andersy005>`_.
 - Ensure all figures are closed properly in plot tests (:pull:`4600`).
   By `Yash Saboo <https://github.com/yashsaboo>`_, `Nirupam K N
   <https://github.com/Nirupamkn>`_ and `Mathias Hauser

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1442,9 +1442,9 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         Notes
         -----
-        The `order`, `casting`, `subok` and `copy` arguments are only passed
-        through to the `asarray` method of the underlying array when a value
-        different than `None` is supplied.
+        The ``order``, ``casting``, ``subok`` and ``copy`` arguments are only passed
+        through to the ``asarray`` method of the underlying array when a value
+        different than ``None`` is supplied.
         Make sure to only supply these arguments if the underlying array class
         supports them.
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1391,7 +1391,16 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
             dask="allowed",
         )
 
-    def astype(self, dtype, casting="unsafe", copy=True, keep_attrs=True):
+    def astype(
+        self: T,
+        dtype,
+        *,
+        order=None,
+        casting=None,
+        subok=None,
+        copy=None,
+        keep_attrs=True,
+    ) -> T:
         """
         Copy of the xarray object, with data cast to a specified type.
         Leaves coordinate dtype unchanged.
@@ -1400,16 +1409,24 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         ----------
         dtype : str or dtype
             Typecode or data-type to which the array is cast.
+        order : {‘C’, ‘F’, ‘A’, ‘K’}, optional
+            Controls the memory layout order of the result. ‘C’ means C order,
+            ‘F’ means Fortran order, ‘A’ means ‘F’ order if all the arrays are
+            Fortran contiguous, ‘C’ order otherwise, and ‘K’ means as close to
+            the order the array elements appear in memory as possible.
         casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
-            Controls what kind of data casting may occur. Defaults to 'unsafe'
-            for backwards compatibility.
+            Controls what kind of data casting may occur.
 
             * 'no' means the data types should not be cast at all.
             * 'equiv' means only byte-order changes are allowed.
             * 'safe' means only casts which can preserve values are allowed.
             * 'same_kind' means only safe casts or casts within a kind,
-                like float64 to float32, are allowed.
+              like float64 to float32, are allowed.
             * 'unsafe' means any data conversions may be done.
+
+        subok : bool, optional
+            If True, then sub-classes will be passed-through, otherwise the
+            returned array will be forced to be a base-class array.
         copy : bool, optional
             By default, astype always returns a newly allocated array. If this
             is set to False and the `dtype` requirement is satisfied, the input
@@ -1423,17 +1440,30 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         out : same as object
             New object with data cast to the specified type.
 
+        Notes
+        -----
+        The `order`, `casting`, `subok` and `copy` arguments are only passed
+        through to the `asarray` method of the underlying array when a value
+        different than `None` is supplied.
+        Make sure to only supply these arguments if the underlying array class
+        supports them.
+
         See also
         --------
-        np.ndarray.astype
+        numpy.ndarray.astype
         dask.array.Array.astype
+        sparse.COO.astype
         """
         from .computation import apply_ufunc
+
+        kwargs = dict(order=order, casting=casting, subok=subok, copy=copy)
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
         return apply_ufunc(
             duck_array_ops.astype,
             self,
-            kwargs=dict(dtype=dtype, casting=casting, copy=copy),
+            dtype,
+            kwargs=kwargs,
             keep_attrs=keep_attrs,
             dask="allowed",
         )

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1409,7 +1409,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         ----------
         dtype : str or dtype
             Typecode or data-type to which the array is cast.
-        order : {‘C’, ‘F’, ‘A’, ‘K’}, optional
+        order : {'C', 'F', 'A', 'K'}, optional
             Controls the memory layout order of the result. ‘C’ means C order,
             ‘F’ means Fortran order, ‘A’ means ‘F’ order if all the arrays are
             Fortran contiguous, ‘C’ order otherwise, and ‘K’ means as close to

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1443,7 +1443,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         Notes
         -----
         The ``order``, ``casting``, ``subok`` and ``copy`` arguments are only passed
-        through to the ``asarray`` method of the underlying array when a value
+        through to the ``astype`` method of the underlying array when a value
         different than ``None`` is supplied.
         Make sure to only supply these arguments if the underlying array class
         supports them.

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -158,7 +158,7 @@ masked_invalid = _dask_or_eager_func(
 )
 
 
-def astype(data, **kwargs):
+def astype(data, dtype, **kwargs):
     try:
         import sparse
     except ImportError:
@@ -177,7 +177,7 @@ def astype(data, **kwargs):
         )
         kwargs.pop("casting")
 
-    return data.astype(**kwargs)
+    return data.astype(dtype, **kwargs)
 
 
 def asarray(data, xp=np):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -370,28 +370,45 @@ class Variable(
             )
         self._data = data
 
-    def astype(self, dtype, casting="unsafe", copy=True, keep_attrs=True):
+    def astype(
+        self: VariableType,
+        dtype,
+        *,
+        order=None,
+        casting=None,
+        subok=None,
+        copy=None,
+        keep_attrs=True,
+    ) -> VariableType:
         """
         Copy of the Variable object, with data cast to a specified type.
 
         Parameters
         ----------
         dtype : str or dtype
-             Typecode or data-type to which the array is cast.
+            Typecode or data-type to which the array is cast.
+        order : {‘C’, ‘F’, ‘A’, ‘K’}, optional
+            Controls the memory layout order of the result. ‘C’ means C order,
+            ‘F’ means Fortran order, ‘A’ means ‘F’ order if all the arrays are
+            Fortran contiguous, ‘C’ order otherwise, and ‘K’ means as close to
+            the order the array elements appear in memory as possible.
         casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
-             Controls what kind of data casting may occur. Defaults to 'unsafe'
-             for backwards compatibility.
+            Controls what kind of data casting may occur.
 
-             * 'no' means the data types should not be cast at all.
-             * 'equiv' means only byte-order changes are allowed.
-             * 'safe' means only casts which can preserve values are allowed.
-             * 'same_kind' means only safe casts or casts within a kind,
-                 like float64 to float32, are allowed.
-             * 'unsafe' means any data conversions may be done.
+            * 'no' means the data types should not be cast at all.
+            * 'equiv' means only byte-order changes are allowed.
+            * 'safe' means only casts which can preserve values are allowed.
+            * 'same_kind' means only safe casts or casts within a kind,
+              like float64 to float32, are allowed.
+            * 'unsafe' means any data conversions may be done.
+
+        subok : bool, optional
+            If True, then sub-classes will be passed-through, otherwise the
+            returned array will be forced to be a base-class array.
         copy : bool, optional
-             By default, astype always returns a newly allocated array. If this
-             is set to False and the `dtype` requirement is satisfied, the input
-             array is returned instead of a copy.
+            By default, astype always returns a newly allocated array. If this
+            is set to False and the `dtype` requirement is satisfied, the input
+            array is returned instead of a copy.
         keep_attrs : bool, optional
             By default, astype keeps attributes. Set to False to remove
             attributes in the returned object.
@@ -401,17 +418,30 @@ class Variable(
         out : same as object
             New object with data cast to the specified type.
 
+        Notes
+        -----
+        The `order`, `casting`, `subok` and `copy` arguments are only passed
+        through to the `asarray` method of the underlying array when a value
+        different than `None` is supplied.
+        Make sure to only supply these arguments if the underlying array class
+        supports them.
+
         See also
         --------
-        np.ndarray.astype
+        numpy.ndarray.astype
         dask.array.Array.astype
+        sparse.COO.astype
         """
         from .computation import apply_ufunc
+
+        kwargs = dict(order=order, casting=casting, subok=subok, copy=copy)
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
         return apply_ufunc(
             duck_array_ops.astype,
             self,
-            kwargs=dict(dtype=dtype, casting=casting, copy=copy),
+            dtype,
+            kwargs=kwargs,
             keep_attrs=keep_attrs,
             dask="allowed",
         )

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -387,7 +387,7 @@ class Variable(
         ----------
         dtype : str or dtype
             Typecode or data-type to which the array is cast.
-        order : {‘C’, ‘F’, ‘A’, ‘K’}, optional
+        order : {'C', 'F', 'A', 'K'}, optional
             Controls the memory layout order of the result. ‘C’ means C order,
             ‘F’ means Fortran order, ‘A’ means ‘F’ order if all the arrays are
             Fortran contiguous, ‘C’ order otherwise, and ‘K’ means as close to

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -421,7 +421,7 @@ class Variable(
         Notes
         -----
         The ``order``, ``casting``, ``subok`` and ``copy`` arguments are only passed
-        through to the ``asarray`` method of the underlying array when a value
+        through to the ``astype`` method of the underlying array when a value
         different than ``None`` is supplied.
         Make sure to only supply these arguments if the underlying array class
         supports them.

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -420,9 +420,9 @@ class Variable(
 
         Notes
         -----
-        The `order`, `casting`, `subok` and `copy` arguments are only passed
-        through to the `asarray` method of the underlying array when a value
-        different than `None` is supplied.
+        The ``order``, ``casting``, ``subok`` and ``copy`` arguments are only passed
+        through to the ``asarray`` method of the underlying array when a value
+        different than ``None`` is supplied.
         Make sure to only supply these arguments if the underlying array class
         supports them.
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1914,6 +1914,26 @@ class TestDataArray:
         assert np.issubdtype(original.dtype, np.integer)
         assert np.issubdtype(converted.dtype, np.floating)
 
+    def test_astype_order(self):
+        original = DataArray([[1, 2], [3, 4]])
+        converted = original.astype("d", order="F")
+        assert_equal(original, converted)
+        assert original.values.flags["C_CONTIGUOUS"]
+        assert converted.values.flags["F_CONTIGUOUS"]
+
+    def test_astype_subok(self):
+        class NdArraySubclass(np.ndarray):
+            pass
+
+        original = DataArray(NdArraySubclass(np.arange(3)))
+        converted_not_subok = original.astype("d", subok=False)
+        converted_subok = original.astype("d", subok=True)
+        if not isinstance(original.data, NdArraySubclass):
+            pytest.xfail("DataArray cannot be backed yet by a subclasses of np.ndarray")
+        assert isinstance(converted_not_subok.data, np.ndarray)
+        assert not isinstance(converted_not_subok.data, NdArraySubclass)
+        assert isinstance(converted_subok.data, NdArraySubclass)
+
     def test_is_null(self):
         x = np.random.RandomState(42).randn(5, 6)
         x[x < 0] = np.nan


### PR DESCRIPTION

 - [x] Closes #4644
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
