### PR TITLE
Ensure maximum accuracy when encoding and decoding np.datetime64[ns] values

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -32,7 +32,14 @@ Bug fixes
 ~~~~~~~~~
 
 - :py:func:`merge` with ``combine_attrs='override'`` makes a copy of the attrs (:issue:`4627`).
-
+- By default, when possible, xarray will now always use values of type ``int64`` when encoding
+  and decoding ``numpy.datetime64[ns]`` datetimes.  This ensures that maximum
+  precision and accuracy is maintained in the round-tripping process
+  (:issue:`4045`). It also enables encoding and decoding standard calendar
+  dates with time units of nanoseconds (:pull:`4400`). By `Spencer Clark
+  <https://github.com/spencerkclark>`_ and `Mark Harfouche <http://github.com/hmaarrfk>`_.
+  
+  
 Documentation
 ~~~~~~~~~~~~~
 - start a list of external I/O integrating with ``xarray`` (:issue:`683`, :pull:`4566`).

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,6 +22,11 @@ v0.16.3 (unreleased)
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
+- As a result of :pull:`4684` the default units encoding for
+  datetime-like values (``np.datetime64[ns]`` or ``cftime.datetime``) will now
+  always be set such that ``int64`` values can be used.  In the past, no units
+  finer than "seconds" were chosen, which would sometimes mean that ``float64``
+  values were required, which would lead to inaccurate I/O round-trips.
 
 
 New Features

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,8 +34,8 @@ Bug fixes
 - :py:func:`merge` with ``combine_attrs='override'`` makes a copy of the attrs (:issue:`4627`).
 - By default, when possible, xarray will now always use values of type ``int64`` when encoding
   and decoding ``numpy.datetime64[ns]`` datetimes.  This ensures that maximum
-  precision and accuracy is maintained in the round-tripping process
-  (:issue:`4045`). It also enables encoding and decoding standard calendar
+  precision and accuracy are maintained in the round-tripping process
+  (:issue:`4045`, :pull:`4684`). It also enables encoding and decoding standard calendar
   dates with time units of nanoseconds (:pull:`4400`). By `Spencer Clark
   <https://github.com/spencerkclark>`_ and `Mark Harfouche <http://github.com/hmaarrfk>`_.
   

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -164,14 +164,20 @@ def _decode_datetime_with_pandas(flat_num_dates, units, calendar):
     # To avoid integer overflow when converting to nanosecond units for integer
     # dtypes smaller than np.int64 cast all integer-dtype arrays to np.int64
     # (GH #2002).
+    print(f"flat_num_dates dtype prior to casting {flat_num_dates.dtype}")
     if flat_num_dates.dtype.kind == "i":
         flat_num_dates = flat_num_dates.astype(np.int64)
+    print(f"flat_num_dates dtype after casting {flat_num_dates.dtype}")
 
     # Cast input ordinals to integers of nanoseconds because pd.to_timedelta
     # works much faster when dealing with integers (GH #1399).
+    print("flat_num_dates_ns_int prior to casting")
+    print(flat_num_dates * _NS_PER_TIME_DELTA[delta])
     flat_num_dates_ns_int = (flat_num_dates * _NS_PER_TIME_DELTA[delta]).astype(
         np.int64
     )
+    print("flat_num_dates_ns_int after casting")
+    print(flat_num_dates_ns_int)
 
     # Use pd.to_timedelta to safely cast integer values to timedeltas,
     # and add those to a Timestamp to safely produce a DatetimeIndex.  This

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -263,6 +263,7 @@ def decode_cf_timedelta(num_timedeltas, units):
 
 
 def _infer_time_units_from_diff(unique_timedeltas):
+    unique_deltas_as_index = pd.TimedeltaIndex(unique_timedeltas)
     for time_unit in [
         "days",
         "hours",
@@ -273,8 +274,8 @@ def _infer_time_units_from_diff(unique_timedeltas):
         "nanoseconds",
     ]:
         delta_ns = _NS_PER_TIME_DELTA[_netcdf_to_numpy_timeunit(time_unit)]
-        unit_delta = np.timedelta64(delta_ns, "ns")
-        if np.all(unique_timedeltas % unit_delta == np.timedelta64(0, "ns")):
+        unit_delta = pd.to_timedelta(delta_ns, "ns")
+        if np.all(unique_deltas_as_index % unit_delta == np.timedelta64(0, "ns")):
             return time_unit
     return "seconds"
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -36,7 +36,15 @@ _NS_PER_TIME_DELTA = {
 }
 
 TIME_UNITS = frozenset(
-    ["days", "hours", "minutes", "seconds", "milliseconds", "microseconds"]
+    [
+        "days",
+        "hours",
+        "minutes",
+        "seconds",
+        "milliseconds",
+        "microseconds",
+        "nanoseconds",
+    ]
 )
 
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -274,8 +274,7 @@ def _infer_time_units_from_diff(unique_timedeltas):
     ]:
         delta_ns = _NS_PER_TIME_DELTA[_netcdf_to_numpy_timeunit(time_unit)]
         unit_delta = np.timedelta64(delta_ns, "ns")
-        diffs = unique_timedeltas / unit_delta
-        if np.all(diffs == diffs.astype(int)):
+        if np.all(unique_timedeltas % unit_delta == np.timedelta64(0, "ns")):
             return time_unit
     return "seconds"
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -438,7 +438,7 @@ def encode_cf_datetime(dates, units=None, calendar=None):
         dates_as_index = pd.DatetimeIndex(dates.ravel())
         time_deltas = dates_as_index - ref_date
 
-        # Use floor division if the time_delta evenly divides all differences
+        # Use floor division if time_delta evenly divides all differences
         # to preserve integer dtype if possible.
         if np.all(time_deltas % time_delta == np.timedelta64(0, delta_units)):
             num = time_deltas // time_delta

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -445,7 +445,7 @@ def encode_cf_datetime(dates, units=None, calendar=None):
 
         # Use floor division if time_delta evenly divides all differences
         # to preserve integer dtype if possible (GH 4045).
-        if np.all(time_deltas % time_delta == np.timedelta64(0, delta_units)):
+        if np.all(time_deltas % time_delta == np.timedelta64(0, "ns")):
             num = time_deltas // time_delta
         else:
             num = time_deltas / time_delta

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -164,20 +164,14 @@ def _decode_datetime_with_pandas(flat_num_dates, units, calendar):
     # To avoid integer overflow when converting to nanosecond units for integer
     # dtypes smaller than np.int64 cast all integer-dtype arrays to np.int64
     # (GH #2002).
-    print(f"flat_num_dates dtype prior to casting {flat_num_dates.dtype}")
     if flat_num_dates.dtype.kind == "i":
         flat_num_dates = flat_num_dates.astype(np.int64)
-    print(f"flat_num_dates dtype after casting {flat_num_dates.dtype}")
 
     # Cast input ordinals to integers of nanoseconds because pd.to_timedelta
     # works much faster when dealing with integers (GH #1399).
-    print("flat_num_dates_ns_int prior to casting")
-    print(flat_num_dates * _NS_PER_TIME_DELTA[delta])
     flat_num_dates_ns_int = (flat_num_dates * _NS_PER_TIME_DELTA[delta]).astype(
         np.int64
     )
-    print("flat_num_dates_ns_int after casting")
-    print(flat_num_dates_ns_int)
 
     # Use pd.to_timedelta to safely cast integer values to timedeltas,
     # and add those to a Timestamp to safely produce a DatetimeIndex.  This

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -995,14 +995,11 @@ def test_encode_cf_datetime_defaults_to_correct_dtype(encoding_units, data_freq)
         assert encoded.dtype == np.float64
 
 
-@pytest.mark.parametrize(
-    "encoding",
-    [{"units": "nanoseconds since 1900-01-01"}, {}],
-    ids=["explicit-units", "no-units"],
-)
-def test_encode_decode_roundtrip(encoding):
-    times = pd.date_range("2000", periods=12, freq="337N")
-    variable = Variable(["time"], times, encoding=encoding)
+@pytest.mark.parametrize("freq", ["N", "U", "L", "S", "T", "H", "D"])
+def test_encode_decode_roundtrip(freq):
+    initial_time = pd.date_range("1678-01-01", periods=1)
+    times = initial_time.append(pd.date_range("1968", periods=12, freq=freq))
+    variable = Variable(["time"], times)
     encoded = conventions.encode_cf_variable(variable)
     decoded = conventions.decode_cf_variable("time", encoded)
     assert_equal(variable, decoded)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -1016,4 +1016,6 @@ def test_encode_decode_roundtrip(freq):
     variable = Variable(["time"], times)
     encoded = conventions.encode_cf_variable(variable)
     decoded = conventions.decode_cf_variable("time", encoded)
+    print(encoded)
+    print(decoded)
     assert_equal(variable, decoded)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -546,6 +546,7 @@ def test_infer_cftime_datetime_units(calendar, date_args, expected):
         ("1h", "hours", np.int64(1)),
         ("1ms", "milliseconds", np.int64(1)),
         ("1us", "microseconds", np.int64(1)),
+        ("1ns", "nanoseconds", np.int64(1)),
         (["NaT", "0s", "1s"], None, [np.nan, 0, 1]),
         (["30m", "60m"], "hours", [0.5, 1.0]),
         ("NaT", "days", np.nan),

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -486,11 +486,13 @@ PANDAS_FREQUENCIES_TO_ENCODING_UNITS = {
     "S": "seconds",
     "T": "minutes",
     "H": "hours",
-    "D": "days"
+    "D": "days",
 }
 
 
-@pytest.mark.parametrize(("freq", "units"), PANDAS_FREQUENCIES_TO_ENCODING_UNITS.items())
+@pytest.mark.parametrize(
+    ("freq", "units"), PANDAS_FREQUENCIES_TO_ENCODING_UNITS.items()
+)
 def test_infer_datetime_units(freq, units):
     dates = pd.date_range("2000", periods=2, freq=freq)
     expected = f"{units} since 2000-01-01 00:00:00"

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -1000,8 +1000,8 @@ def test_encode_cf_datetime_defaults_to_correct_dtype(encoding_units, data_freq)
     encoded, _, _ = coding.times.encode_cf_datetime(times, units)
 
     numpy_timeunit = coding.times._netcdf_to_numpy_timeunit(encoding_units)
-    cf_units_as_timedelta = np.timedelta64(1, numpy_timeunit)
-    if data_freq >= cf_units_as_timedelta:
+    encoding_units_as_timedelta = np.timedelta64(1, numpy_timeunit)
+    if data_freq >= encoding_units_as_timedelta:
         assert encoded.dtype == np.int64
     else:
         assert encoded.dtype == np.float64

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -16,6 +16,7 @@ from xarray.coding.times import (
 from xarray.coding.variables import SerializationWarning
 from xarray.conventions import _update_bounds_attributes, cf_encoder
 from xarray.core.common import contains_cftime_datetimes
+from xarray.tests.test_backends import ON_WINDOWS
 from xarray.testing import assert_equal
 
 from . import arm_xfail, assert_array_equal, has_cftime, requires_cftime, requires_dask
@@ -1008,6 +1009,9 @@ def test_encode_cf_datetime_defaults_to_correct_dtype(encoding_units, data_freq)
 
 
 @pytest.mark.parametrize("freq", ["N", "U", "L", "S", "T", "H", "D"])
+@pytest.mark.xfail(
+    ON_WINDOWS, reason="We do not expect exact round-tripping on Windows"
+)
 def test_encode_decode_roundtrip(freq):
     # See GH #4045. Prior to #4684 this test would fail for frequencies of "S",
     # "L", "U", and "N".
@@ -1016,6 +1020,4 @@ def test_encode_decode_roundtrip(freq):
     variable = Variable(["time"], times)
     encoded = conventions.encode_cf_variable(variable)
     decoded = conventions.decode_cf_variable("time", encoded)
-    print(encoded)
-    print(decoded)
     assert_equal(variable, decoded)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -16,7 +16,6 @@ from xarray.coding.times import (
 from xarray.coding.variables import SerializationWarning
 from xarray.conventions import _update_bounds_attributes, cf_encoder
 from xarray.core.common import contains_cftime_datetimes
-from xarray.tests.test_backends import ON_WINDOWS
 from xarray.testing import assert_equal
 
 from . import arm_xfail, assert_array_equal, has_cftime, requires_cftime, requires_dask
@@ -1009,9 +1008,6 @@ def test_encode_cf_datetime_defaults_to_correct_dtype(encoding_units, data_freq)
 
 
 @pytest.mark.parametrize("freq", ["N", "U", "L", "S", "T", "H", "D"])
-@pytest.mark.xfail(
-    ON_WINDOWS, reason="We do not expect exact round-tripping on Windows"
-)
 def test_encode_decode_roundtrip(freq):
     # See GH #4045. Prior to #4684 this test would fail for frequencies of "S",
     # "L", "U", and "N".

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -99,12 +99,10 @@ def test_cf_datetime(num_dates, units, calendar):
     if min_y >= 1678 and max_y < 2262:
         expected = cftime_to_nptime(expected)
 
-    print(expected)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", "Unable to decode time axis")
         actual = coding.times.decode_cf_datetime(num_dates, units, calendar)
 
-    print(actual)
     abs_diff = np.asarray(abs(actual - expected)).ravel()
     abs_diff = pd.to_timedelta(abs_diff.tolist()).to_numpy()
 

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -1009,8 +1009,10 @@ def test_encode_cf_datetime_defaults_to_correct_dtype(encoding_units, data_freq)
 
 @pytest.mark.parametrize("freq", ["N", "U", "L", "S", "T", "H", "D"])
 def test_encode_decode_roundtrip(freq):
+    # See GH #4045. Prior to #4684 this test would fail for frequencies of "S",
+    # "L", "U", and "N".
     initial_time = pd.date_range("1678-01-01", periods=1)
-    times = initial_time.append(pd.date_range("1968", periods=12, freq=freq))
+    times = initial_time.append(pd.date_range("1968", periods=2, freq=freq))
     variable = Variable(["time"], times)
     encoded = conventions.encode_cf_variable(variable)
     decoded = conventions.decode_cf_variable("time", encoded)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #4045
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

This PR cleans up the logic used to encode and decode times with pandas so that by default we use `int64` values in both directions for all precisions down to nanosecond.  If a user specifies an encoding (or a file is read in) such that `float` values would be required, things still work as they did before.  I do this mainly by following the approach I described here: https://github.com/pydata/xarray/issues/4045#issuecomment-626257580.

In the process of doing this I made a few changes to `coding.times._decode_datetime_with_pandas`:
- I removed the checks on the minimum and maximum dates to decode, as the issue those checks were imposed for (#975) was fixed in pandas way back in 2016 (https://github.com/pandas-dev/pandas/issues/14068).
- I used an alternate approach for fixing #2002, which allows us to continue to use the optimization made in #1414 without having to cast the input array to a `float` dtype first.

Note this will change the default units that are chosen for encoding times in some instances -- previously we would never default to anything more precise than seconds -- but I think this change is for the better.

cc: @aldanor

@hmaarrfk this overlaps a little with your work in #4400, so I'm giving you credit here too (I hope you don't mind!).