### PR TITLE
mark most failing units tests as skipped

### DIFF
--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -2420,10 +2420,6 @@ class TestDataArray:
             pytest.param(
                 operator.eq,
                 id="equal",
-                marks=pytest.mark.xfail(
-                    # LooseVersion(pint.__version__) < "0.14",
-                    reason="inconsistencies in the return values of pint's eq",
-                ),
             ),
         ),
     )

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -2977,7 +2977,7 @@ class TestDataArray:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="units in indexes not supported")
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -3158,7 +3158,7 @@ class TestDataArray:
             method("rename", u="v"),
             pytest.param(
                 method("swap_dims", {"x": "u"}),
-                marks=pytest.mark.xfail(reason="indexes don't support units"),
+                marks=pytest.mark.skip(reason="indexes don't support units"),
             ),
             pytest.param(
                 method(
@@ -3166,7 +3166,7 @@ class TestDataArray:
                     dim={"z": np.linspace(10, 20, 12) * unit_registry.s},
                     axis=1,
                 ),
-                marks=pytest.mark.xfail(reason="indexes don't support units"),
+                marks=pytest.mark.skip(reason="indexes don't support units"),
             ),
             method("drop_vars", "x"),
             method("reset_coords", names="u"),
@@ -3254,7 +3254,7 @@ class TestDataArray:
         assert_units_equal(expected, actual)
         assert_identical(expected, actual)
 
-    @pytest.mark.xfail(reason="indexes don't support units")
+    @pytest.mark.skip(reason="indexes don't support units")
     @pytest.mark.parametrize(
         "raw_values",
         (
@@ -3299,7 +3299,7 @@ class TestDataArray:
         assert_units_equal(expected, actual)
         assert_identical(expected, actual)
 
-    @pytest.mark.xfail(reason="indexes don't support units")
+    @pytest.mark.skip(reason="indexes don't support units")
     @pytest.mark.parametrize(
         "raw_values",
         (
@@ -3344,7 +3344,7 @@ class TestDataArray:
         assert_units_equal(expected, actual)
         assert_identical(expected, actual)
 
-    @pytest.mark.xfail(reason="indexes don't support units")
+    @pytest.mark.skip(reason="indexes don't support units")
     @pytest.mark.parametrize(
         "raw_values",
         (
@@ -3468,7 +3468,7 @@ class TestDataArray:
         assert_units_equal(expected, actual)
         assert_allclose(expected, actual)
 
-    @pytest.mark.xfail(reason="indexes don't support units")
+    @pytest.mark.skip(reason="indexes don't support units")
     @pytest.mark.parametrize(
         "unit,error",
         (
@@ -3544,7 +3544,7 @@ class TestDataArray:
         assert_units_equal(expected, actual)
         assert_allclose(expected, actual)
 
-    @pytest.mark.xfail(reason="indexes don't support units")
+    @pytest.mark.skip(reason="indexes don't support units")
     @pytest.mark.parametrize(
         "unit,error",
         (
@@ -3612,7 +3612,7 @@ class TestDataArray:
         assert_units_equal(expected, actual)
         assert_identical(expected, actual)
 
-    @pytest.mark.xfail(reason="indexes don't support units")
+    @pytest.mark.skip(reason="indexes don't support units")
     def test_to_unstacked_dataset(self, dtype):
         array = (
             np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype)
@@ -3943,7 +3943,7 @@ class TestDataset:
             "data",
             pytest.param(
                 "dims",
-                marks=pytest.mark.xfail(reason="indexes don't support units"),
+                marks=pytest.mark.skip(reason="indexes don't support units"),
             ),
             "coords",
         ),
@@ -4406,7 +4406,7 @@ class TestDataset:
             "data",
             pytest.param(
                 "dims",
-                marks=pytest.mark.xfail(reason="indexes don't support units"),
+                marks=pytest.mark.skip(reason="indexes don't support units"),
             ),
         ),
     )
@@ -4562,7 +4562,7 @@ class TestDataset:
             "data",
             pytest.param(
                 "dims",
-                marks=pytest.mark.xfail(reason="indexes don't support units"),
+                marks=pytest.mark.skip(reason="indexes don't support units"),
             ),
         ),
     )
@@ -4654,7 +4654,7 @@ class TestDataset:
             "data",
             pytest.param(
                 "dims",
-                marks=pytest.mark.xfail(reason="indexes don't support units"),
+                marks=pytest.mark.skip(reason="indexes don't support units"),
             ),
         ),
     )
@@ -4777,7 +4777,7 @@ class TestDataset:
         assert_units_equal(expected, actual)
         assert_equal(expected, actual)
 
-    @pytest.mark.xfail(reason="indexes don't support units")
+    @pytest.mark.skip(reason="indexes don't support units")
     @pytest.mark.parametrize(
         "raw_values",
         (
@@ -4830,7 +4830,7 @@ class TestDataset:
         assert_units_equal(expected, actual)
         assert_equal(expected, actual)
 
-    @pytest.mark.xfail(reason="indexes don't support units")
+    @pytest.mark.skip(reason="indexes don't support units")
     @pytest.mark.parametrize(
         "raw_values",
         (
@@ -4883,7 +4883,7 @@ class TestDataset:
         assert_units_equal(expected, actual)
         assert_equal(expected, actual)
 
-    @pytest.mark.xfail(reason="indexes don't support units")
+    @pytest.mark.skip(reason="indexes don't support units")
     @pytest.mark.parametrize(
         "raw_values",
         (
@@ -5064,7 +5064,7 @@ class TestDataset:
         assert_units_equal(expected, actual)
         assert_equal(expected, actual)
 
-    @pytest.mark.xfail(reason="indexes don't support units")
+    @pytest.mark.skip(reason="indexes don't support units")
     @pytest.mark.parametrize(
         "unit,error",
         (
@@ -5400,7 +5400,7 @@ class TestDataset:
                 method(
                     "expand_dims", v=np.linspace(10, 20, 12) * unit_registry.s, axis=1
                 ),
-                marks=pytest.mark.xfail(reason="indexes don't support units"),
+                marks=pytest.mark.skip(reason="indexes don't support units"),
             ),
             method("drop_vars", "x"),
             method("drop_dims", "z"),

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -2239,7 +2239,7 @@ class TestDataArray:
         (
             pytest.param(
                 "with_dims",
-                marks=pytest.mark.xfail(reason="indexes don't support units"),
+                marks=pytest.mark.skip(reason="indexes don't support units"),
             ),
             "with_coords",
             "without_coords",
@@ -2276,7 +2276,7 @@ class TestDataArray:
         (
             pytest.param(
                 "with_dims",
-                marks=pytest.mark.xfail(reason="indexes don't support units"),
+                marks=pytest.mark.skip(reason="indexes don't support units"),
             ),
             pytest.param("with_coords"),
             pytest.param("without_coords"),
@@ -5134,7 +5134,7 @@ class TestDataset:
         assert_units_equal(expected, actual)
         assert_equal(expected, actual)
 
-    @pytest.mark.xfail(reason="indexes don't support units")
+    @pytest.mark.skip(reason="indexes don't support units")
     @pytest.mark.parametrize(
         "unit,error",
         (

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -2173,12 +2173,7 @@ class TestVariable:
             "median",
             "reflect",
             "edge",
-            pytest.param(
-                "linear_ramp",
-                marks=pytest.mark.xfail(
-                    reason="pint bug: https://github.com/hgrecco/pint/issues/1026"
-                ),
-            ),
+            "linear_ramp",
             "maximum",
             "minimum",
             "symmetric",

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1509,10 +1509,7 @@ class TestVariable:
             method("mean"),
             method("median"),
             method("min"),
-            pytest.param(
-                method("prod"),
-                marks=pytest.mark.xfail(reason="not implemented by pint"),
-            ),
+            method("prod"),
             method("std"),
             method("sum"),
             method("var"),
@@ -1520,6 +1517,9 @@ class TestVariable:
         ids=repr,
     )
     def test_aggregation(self, func, dtype):
+        if func.name == "prod" and dtype.kind == "f":
+            pytest.xfail(reason="nanprod is not supported, yet")
+
         array = np.linspace(0, 1, 10).astype(dtype) * (
             unit_registry.m if func.name != "cumprod" else unit_registry.dimensionless
         )
@@ -2333,10 +2333,7 @@ class TestDataArray:
                 ),
             ),
             function("min"),
-            pytest.param(
-                function("prod"),
-                marks=pytest.mark.xfail(reason="not implemented by pint yet"),
-            ),
+            function("prod"),
             function("sum"),
             function("std"),
             function("var"),
@@ -2350,10 +2347,7 @@ class TestDataArray:
             method("mean"),
             method("median"),
             method("min"),
-            pytest.param(
-                method("prod"),
-                marks=pytest.mark.xfail(reason="not implemented by pint yet"),
-            ),
+            method("prod"),
             method("sum"),
             method("std"),
             method("var"),
@@ -2363,6 +2357,9 @@ class TestDataArray:
         ids=repr,
     )
     def test_aggregation(self, func, dtype):
+        if func.name == "prod" and dtype.kind == "f":
+            pytest.xfail(reason="nanprod is not supported, yet")
+
         array = np.arange(10).astype(dtype) * (
             unit_registry.m if func.name != "cumprod" else unit_registry.dimensionless
         )
@@ -4004,10 +4001,7 @@ class TestDataset:
                 marks=pytest.mark.xfail(reason="median does not work with dataset yet"),
             ),
             function("sum"),
-            pytest.param(
-                function("prod"),
-                marks=pytest.mark.xfail(reason="prod does not work with dataset yet"),
-            ),
+            function("prod"),
             function("std"),
             function("var"),
             function("cumsum"),
@@ -4021,10 +4015,7 @@ class TestDataset:
             method("mean"),
             method("median"),
             method("sum"),
-            pytest.param(
-                method("prod"),
-                marks=pytest.mark.xfail(reason="prod does not work with dataset yet"),
-            ),
+            method("prod"),
             method("std"),
             method("var"),
             method("cumsum"),
@@ -4033,6 +4024,9 @@ class TestDataset:
         ids=repr,
     )
     def test_aggregation(self, func, dtype):
+        if func.name == "prod" and dtype.kind == "f":
+            pytest.xfail(reason="nanprod is not supported, yet")
+
         unit_a, unit_b = (
             (unit_registry.Pa, unit_registry.degK)
             if func.name != "cumprod"

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1976,7 +1976,7 @@ class TestVariable:
             method("quantile", q=[0.25, 0.75]),
             pytest.param(
                 method("rank", dim="x"),
-                marks=pytest.mark.xfail(reason="rank not implemented for non-ndarray"),
+                marks=pytest.mark.skip(reason="rank not implemented for non-ndarray"),
             ),
             method("roll", {"x": 2}),
             pytest.param(
@@ -3634,6 +3634,10 @@ class TestDataArray:
             method("stack", a=("x", "y")),
             method("set_index", x="x2"),
             method("shift", x=2),
+            pytest.param(
+                method("rank", dim="x"),
+                marks=pytest.mark.skip(reason="rank not implemented for non-ndarray"),
+            ),
             method("roll", x=2, roll_coords=False),
             method("sortby", "x2"),
         ),
@@ -4711,6 +4715,10 @@ class TestDataset:
             method("stack", u=("x", "y")),
             method("set_index", x="x2"),
             method("shift", x=2),
+            pytest.param(
+                method("rank", dim="x"),
+                marks=pytest.mark.skip(reason="rank not implemented for non-ndarray"),
+            ),
             method("roll", x=2, roll_coords=False),
             method("sortby", "x2"),
         ),

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -364,7 +364,7 @@ class function:
     (
         "data",
         pytest.param(
-            "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+            "dims", marks=pytest.mark.skip(reason="indexes don't support units")
         ),
         "coords",
     ),
@@ -397,7 +397,7 @@ def test_apply_ufunc_dataarray(variant, dtype):
     (
         "data",
         pytest.param(
-            "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+            "dims", marks=pytest.mark.skip(reason="indexes don't support units")
         ),
         "coords",
     ),
@@ -452,7 +452,7 @@ def test_apply_ufunc_dataset(variant, dtype):
     (
         "data",
         pytest.param(
-            "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+            "dims", marks=pytest.mark.skip(reason="indexes don't support units")
         ),
         "coords",
     ),
@@ -556,7 +556,7 @@ def test_align_dataarray(value, variant, unit, error, dtype):
     (
         "data",
         pytest.param(
-            "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+            "dims", marks=pytest.mark.skip(reason="indexes don't support units")
         ),
         "coords",
     ),
@@ -718,7 +718,7 @@ def test_broadcast_dataset(dtype):
     (
         "data",
         pytest.param(
-            "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+            "dims", marks=pytest.mark.skip(reason="indexes don't support units")
         ),
         "coords",
     ),
@@ -795,7 +795,7 @@ def test_combine_by_coords(variant, unit, error, dtype):
     (
         "data",
         pytest.param(
-            "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+            "dims", marks=pytest.mark.skip(reason="indexes don't support units")
         ),
         "coords",
     ),
@@ -901,7 +901,7 @@ def test_combine_nested(variant, unit, error, dtype):
     (
         "data",
         pytest.param(
-            "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+            "dims", marks=pytest.mark.skip(reason="indexes don't support units")
         ),
         "coords",
     ),
@@ -969,7 +969,7 @@ def test_concat_dataarray(variant, unit, error, dtype):
     (
         "data",
         pytest.param(
-            "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+            "dims", marks=pytest.mark.skip(reason="indexes don't support units")
         ),
         "coords",
     ),
@@ -1035,7 +1035,7 @@ def test_concat_dataset(variant, unit, error, dtype):
     (
         "data",
         pytest.param(
-            "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+            "dims", marks=pytest.mark.skip(reason="indexes don't support units")
         ),
         "coords",
     ),
@@ -1139,7 +1139,7 @@ def test_merge_dataarray(variant, unit, error, dtype):
     (
         "data",
         pytest.param(
-            "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+            "dims", marks=pytest.mark.skip(reason="indexes don't support units")
         ),
         "coords",
     ),
@@ -1216,7 +1216,7 @@ def test_merge_dataset(variant, unit, error, dtype):
     (
         "data",
         pytest.param(
-            "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+            "dims", marks=pytest.mark.skip(reason="indexes don't support units")
         ),
         "coords",
     ),
@@ -1252,7 +1252,7 @@ def test_replication_dataarray(func, variant, dtype):
     (
         "data",
         pytest.param(
-            "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+            "dims", marks=pytest.mark.skip(reason="indexes don't support units")
         ),
         "coords",
     ),
@@ -1297,7 +1297,7 @@ def test_replication_dataset(func, variant, dtype):
     (
         "data",
         pytest.param(
-            "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+            "dims", marks=pytest.mark.skip(reason="indexes don't support units")
         ),
         pytest.param(
             "coords",
@@ -1340,7 +1340,7 @@ def test_replication_full_like_dataarray(variant, dtype):
     (
         "data",
         pytest.param(
-            "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+            "dims", marks=pytest.mark.skip(reason="indexes don't support units")
         ),
         pytest.param(
             "coords",
@@ -3057,7 +3057,7 @@ class TestDataArray:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -3147,7 +3147,7 @@ class TestDataArray:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -3679,7 +3679,7 @@ class TestDataArray:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -3733,7 +3733,7 @@ class TestDataArray:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -3808,7 +3808,7 @@ class TestDataArray:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -3879,7 +3879,7 @@ class TestDataset:
         (
             "nothing",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -4474,7 +4474,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -4956,7 +4956,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -5202,7 +5202,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -5261,7 +5261,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -5298,7 +5298,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -5351,7 +5351,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -5421,7 +5421,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -5492,7 +5492,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims", marks=pytest.mark.xfail(reason="indexes don't support units")
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),


### PR DESCRIPTION
To reduce the build time of the CI, all tests that depend on units in indexes are marked as skipped. There were also a few previously failing tests that were fixed upstream.

Among these, there are the `prod` tests which pass for `int` dtypes but not for `float`: for `float`, `nanops.nanprod` is used which tries to replace all `nan` with a `1` and fails because `1` (unlike `0`) is only compatible with dimensionless units.

 - [x] Passes `isort . && black . && mypy . && flake8`
