### PR TITLE
Remove dictionary unpacking when using `.loc` to avoid collision with `.sel` parameters

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -32,6 +32,8 @@ Bug fixes
 ~~~~~~~~~
 
 - :py:func:`merge` with ``combine_attrs='override'`` makes a copy of the attrs (:issue:`4627`).
+- Remove dictionary unpacking when using ``.loc`` to avoid collision with ``.sel`` parameters (:pull:`4695`).
+  By `Anderson Banihirwe <https://github.com/andersy005>`_
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -196,7 +196,7 @@ class _LocIndexer:
             # expand the indexer so we can handle Ellipsis
             labels = indexing.expanded_indexer(key, self.data_array.ndim)
             key = dict(zip(self.data_array.dims, labels))
-        return self.data_array.sel(**key)
+        return self.data_array.sel(key)
 
     def __setitem__(self, key, value) -> None:
         if not utils.is_dict_like(key):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1176,7 +1176,9 @@ class TestDataArray:
             dims=["dim1", "method"],
             coords={"dim1": ["x", "y"], "method": ["a", "b"]},
         )
-        assert da.loc[dict(dim1=["x", "y"], method=["a"])] == [[0], [1]]
+        np.testing.assert_array_equal(
+            da.loc[dict(dim1=["x", "y"], method=["a"])], [[0], [1]]
+        )
 
     def test_selection_multiindex(self):
         mindex = pd.MultiIndex.from_product(

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1170,6 +1170,14 @@ class TestDataArray:
         assert data.loc[True] == 0
         assert data.loc[False] == 1
 
+    def test_loc_dim_name_collision_with_sel_params(self):
+        da = xr.DataArray(
+            [[0, 0], [1, 1]],
+            dims=["dim1", "method"],
+            coords={"dim1": ["x", "y"], "method": ["a", "b"]},
+        )
+        assert da.loc[dict(dim1=["x", "y"], method=["a"])] == [[0], [1]]
+
     def test_selection_multiindex(self):
         mindex = pd.MultiIndex.from_product(
             [["a", "b"], [1, 2], [-1, -2]], names=("one", "two", "three")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #2840
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
