### PR TITLE
Allow pathlib.Path to be passed to all engines

### DIFF
--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -1,5 +1,7 @@
 import functools
 import operator
+import os
+import pathlib
 from contextlib import suppress
 
 import numpy as np
@@ -335,11 +337,12 @@ class NetCDF4DataStore(WritableCFDataStore):
     ):
         import netCDF4
 
-        if not isinstance(filename, str):
+        if not isinstance(filename, (str, pathlib.Path)):
             raise ValueError(
                 "can only read bytes or file-like objects "
                 "with engine='scipy' or 'h5netcdf'"
             )
+        filename = os.fspath(filename)
 
         if format is None:
             format = "NETCDF4"

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -337,12 +337,14 @@ class NetCDF4DataStore(WritableCFDataStore):
     ):
         import netCDF4
 
-        if not isinstance(filename, (str, pathlib.Path)):
+        if isinstance(filename, pathlib.Path):
+            filename = os.fspath(filename)
+
+        if not isinstance(filename, str):
             raise ValueError(
                 "can only read bytes or file-like objects "
                 "with engine='scipy' or 'h5netcdf'"
             )
-        filename = os.fspath(filename)
 
         if format is None:
             format = "NETCDF4"

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -287,6 +287,10 @@ class ZarrStore(AbstractWritableDataStore):
     ):
         import zarr
 
+        # zarr doesn't support pathlib.Path objects yet. zarr-python#601
+        if isinstance(store, pathlib.Path):
+            store = os.fspath(store)
+
         open_kwargs = dict(mode=mode, synchronizer=synchronizer, path=group)
         if chunk_store:
             open_kwargs["chunk_store"] = chunk_store
@@ -671,9 +675,6 @@ def open_backend_dataset_zarr(
     consolidate_on_close=False,
     chunk_store=None,
 ):
-    # zarr doesn't support pathlib.Path objects yet. zarr-python#601
-    if isinstance(filename_or_obj, pathlib.Path):
-        filename_or_obj = os.fspath(filename_or_obj)
 
     store = ZarrStore.open_group(
         filename_or_obj,

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 
 from .. import coding, conventions
@@ -667,6 +669,9 @@ def open_backend_dataset_zarr(
     consolidate_on_close=False,
     chunk_store=None,
 ):
+    # zarr doesn't support PathLike objects yet. zarr-python#601
+    if isinstance(filename_or_obj, os.PathLike):
+        filename_or_obj = os.fspath(filename_or_obj)
 
     store = ZarrStore.open_group(
         filename_or_obj,

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 
 import numpy as np
 
@@ -669,8 +670,8 @@ def open_backend_dataset_zarr(
     consolidate_on_close=False,
     chunk_store=None,
 ):
-    # zarr doesn't support PathLike objects yet. zarr-python#601
-    if isinstance(filename_or_obj, os.PathLike):
+    # zarr doesn't support pathlib.Path objects yet. zarr-python#601
+    if isinstance(filename_or_obj, pathlib.Path):
         filename_or_obj = os.fspath(filename_or_obj)
 
     store = ZarrStore.open_group(


### PR DESCRIPTION
 - Related to #4309 and in particular: https://github.com/pydata/xarray/issues/4309#issuecomment-747055666
 - [x] Passes `isort . && black . && mypy . && flake8`
 - No user visible change

Once `ZarrStore.open_group` and `NetCDF4DataStore.open` accepts `pathlib.Path` objects we can remove `_normalize_path` from `apiv2.open_dataset`. All other backends accept them.

Note that `zarr` itself doesn't support them, yet. See: https://github.com/zarr-developers/zarr-python/issues/601