### PR TITLE
use conda for upstream dev uninstall again

### DIFF
--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -15,7 +15,7 @@ steps:
 # NumPy again: https://github.com/pydata/xarray/issues/4146 
 - bash: |
     source activate xarray-tests
-    mamba uninstall -y --force \
+    conda uninstall -y --force \
         numpy \
         scipy \
         pandas \


### PR DESCRIPTION
#4694 was just merged a bit too soon. Unfortunately using `mamba` to uninstall the packages for upstream dev did not work - it uninstalled too much, thus switch back to conda. I'll just merge right away.

@dcherian