### PR TITLE
APIv2: pass user defined `filename_or_obj` to backends as is

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import warnings
 from glob import glob
 from io import BytesIO
@@ -159,7 +160,7 @@ def _get_default_engine(path, allow_remote=False):
 def _autodetect_engine(filename_or_obj):
     if isinstance(filename_or_obj, AbstractDataStore):
         engine = "store"
-    elif isinstance(filename_or_obj, str):
+    elif isinstance(filename_or_obj, (str, pathlib.Path)):
         engine = _get_default_engine(filename_or_obj, allow_remote=True)
     else:
         engine = _get_engine_from_magic_number(filename_or_obj)

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -145,7 +145,7 @@ def _get_engine_from_magic_number(filename_or_obj):
     return engine
 
 
-def _get_default_engine(path, allow_remote=False):
+def _get_default_engine(path: str, allow_remote: bool = False):
     if allow_remote and is_remote_uri(path):
         engine = _get_default_engine_remote_uri()
     elif is_grib_path(path):
@@ -161,7 +161,7 @@ def _autodetect_engine(filename_or_obj):
     if isinstance(filename_or_obj, AbstractDataStore):
         engine = "store"
     elif isinstance(filename_or_obj, (str, pathlib.Path)):
-        engine = _get_default_engine(filename_or_obj, allow_remote=True)
+        engine = _get_default_engine(str(filename_or_obj), allow_remote=True)
     else:
         engine = _get_engine_from_magic_number(filename_or_obj)
     return engine

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -7,7 +7,6 @@ from . import plugins
 from .api import (
     _autodetect_engine,
     _get_backend_cls,
-    _normalize_path,
     _protect_dataset_variables_inplace,
 )
 

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -245,8 +245,6 @@ def open_dataset(
     if backend_kwargs is None:
         backend_kwargs = {}
 
-    filename_or_obj = _normalize_path(filename_or_obj)
-
     if engine is None:
         engine = _autodetect_engine(filename_or_obj)
 


### PR DESCRIPTION
 - [x] Related to #4309
 - No test added, but all tests pass.
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - No new functions/methods.

**The change affects only APIv2.**

Pros:
- `open_dataset` passes the dataset description object `filename_or_obj` to the backends without fiddling with it. This is more and more important as several backends know how to open `dict`s, `file`'s `str`s that are not paths (*rasterio* for example accepts GDAL strings that are not paths and that is one of the reasons `engine="rasterio"` cannot be used in `open_dataset`)

Cons:
- at the moment backends expect paths to always be absolute, not sure if they use this info.