### PR TITLE
fix the formatting of the nightly CI

### DIFF
--- a/.github/workflows/parse_logs.py
+++ b/.github/workflows/parse_logs.py
@@ -31,7 +31,7 @@ def format_log_message(path):
     with open(path) as f:
         data = extract_short_test_summary_info(line.rstrip() for line in f)
     message = textwrap.dedent(
-        f"""\
+        """\
         <details><summary>{summary}</summary>
 
         ```
@@ -40,7 +40,7 @@ def format_log_message(path):
 
         </details>
         """
-    )
+    ).format(summary=summary, data=data)
 
     return message
 

--- a/.github/workflows/parse_logs.py
+++ b/.github/workflows/parse_logs.py
@@ -30,8 +30,9 @@ def format_log_message(path):
     summary = f"Python {py_version} Test Summary Info"
     with open(path) as f:
         data = extract_short_test_summary_info(line.rstrip() for line in f)
-    message = textwrap.dedent(
-        """\
+    message = (
+        textwrap.dedent(
+            """\
         <details><summary>{summary}</summary>
 
         ```
@@ -40,7 +41,10 @@ def format_log_message(path):
 
         </details>
         """
-    ).format(summary=summary, data=data)
+        )
+        .rstrip()
+        .format(summary=summary, data=data)
+    )
 
     return message
 

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -43,7 +43,11 @@ jobs:
           mamba env update -f ci/requirements/py38.yml
           bash ci/install-upstream-wheels.sh
           conda list
+      - name: import xarray
+        run: |
+          python -c 'import xarray'
       - name: Run Tests
+        if: success()
         id: status
         run: |
           set -euo pipefail
@@ -53,6 +57,7 @@ jobs:
       - name: Upload artifacts
         if: |
           failure()
+          && steps.status.outcome == 'failure'
           && github.event_name == 'schedule'
           && github.repository == 'pydata/xarray'
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
If more than a single test fails, the nightly CI would create a issue with a malformed issue body. The reason for that was that the string interpolation would happen before dedenting the template, so we would have had to partially indent the failure summary.

Also, if a required dependency (such as `pandas` or `numpy`) failed to import, the nightly CI would still try to run the test.

This should fix both issues.

cc @andersy005 