### PR TITLE
APIv2 internal cleanups

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -430,7 +430,7 @@ def open_dataset(
     open_mfdataset
     """
     if os.environ.get("XARRAY_BACKEND_API", "v1") == "v2":
-        kwargs = locals()
+        kwargs = {k: v for k, v in locals().items() if v is not None}
         from . import apiv2
 
         return apiv2.open_dataset(**kwargs)

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -247,8 +247,8 @@ def open_dataset(
     if cache is None:
         cache = chunks is None
 
-    if backend_kwargs is None:
-        backend_kwargs = {}
+    if backend_kwargs is not None:
+        kwargs.update(backend_kwargs)
 
     if engine is None:
         engine = plugins.guess_engine(filename_or_obj)
@@ -266,14 +266,12 @@ def open_dataset(
         decode_coords=decode_coords,
     )
 
-    backend_kwargs = backend_kwargs.copy()
-    overwrite_encoded_chunks = backend_kwargs.pop("overwrite_encoded_chunks", None)
+    overwrite_encoded_chunks = kwargs.pop("overwrite_encoded_chunks", None)
     backend_ds = backend.open_dataset(
         filename_or_obj,
         drop_variables=drop_variables,
         **decoders,
-        **backend_kwargs,
-        **{k: v for k, v in kwargs.items() if v is not None},
+        **kwargs,
     )
     ds = _dataset_from_backend_dataset(
         backend_ds,
@@ -284,7 +282,6 @@ def open_dataset(
         overwrite_encoded_chunks,
         drop_variables=drop_variables,
         **decoders,
-        **backend_kwargs,
         **kwargs,
     )
 

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -20,10 +20,16 @@ def _protect_dataset_variables_inplace(dataset, cache):
 def _get_mtime(filename_or_obj):
     # if passed an actual file path, augment the token with
     # the file modification time
-    if isinstance(filename_or_obj, str) and not is_remote_uri(filename_or_obj):
+    mtime = None
+
+    try:
+        path = os.fspath(filename_or_obj)
+    except TypeError:
+        path = None
+
+    if path and not is_remote_uri(path):
         mtime = os.path.getmtime(filename_or_obj)
-    else:
-        mtime = None
+
     return mtime
 
 

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -96,3 +96,13 @@ def guess_engine(store_spec):
             logging.exception(f"{engine!r} fails while guessing")
 
     raise ValueError("cannot guess the engine, try passing one explicitly")
+
+
+def get_backend(engine):
+    """Select open_dataset method based on current engine"""
+    engines = list_engines()
+    if engine not in engines:
+        raise ValueError(
+            f"unrecognized engine {engine} must be one of: {list(engines)}"
+        )
+    return engines[engine]


### PR DESCRIPTION
 - [x] Related to #4309 
 - [x] No tests added, all tests pass
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] No user visible change
 - [x] No new functions/methods

Stop importing `api.py` in `apiv2.py` and other internal cleanups.

This is needed by another change that results in a cyclic import due to `api`.