### PR TITLE
remove autoclose in open_dataset and related warning test

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,7 +22,8 @@ v0.16.3 (unreleased)
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
-
+- remove deprecated ``autoclose`` kwargs from :py:func:`open_dataset` (:pull: `4725`).
+  By `Aureliana Barghini <https://github.com/aurghs>`_
 
 New Features
 ~~~~~~~~~~~~

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 from glob import glob
 from io import BytesIO
 from numbers import Number
@@ -914,9 +913,7 @@ def open_mfdataset(
     combined_ids_paths = _infer_concat_order_from_positions(paths)
     ids, paths = (list(combined_ids_paths.keys()), list(combined_ids_paths.values()))
 
-    open_kwargs = dict(
-        engine=engine, chunks=chunks or {}, lock=lock, **kwargs
-    )
+    open_kwargs = dict(engine=engine, chunks=chunks or {}, lock=lock, **kwargs)
 
     if parallel:
         import dask

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -746,7 +746,6 @@ def open_mfdataset(
     data_vars="all",
     coords="different",
     combine="by_coords",
-    autoclose=None,
     parallel=False,
     join="outer",
     attrs_file=None,

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -320,7 +320,6 @@ def open_dataset(
     decode_cf=True,
     mask_and_scale=None,
     decode_times=True,
-    autoclose=None,
     concat_characters=True,
     decode_coords=True,
     engine=None,
@@ -360,10 +359,6 @@ def open_dataset(
     decode_times : bool, optional
         If True, decode times encoded in the standard NetCDF datetime format
         into datetime objects. Otherwise, leave them encoded as numbers.
-    autoclose : bool, optional
-        If True, automatically close files to avoid OS Error of too many files
-        being open.  However, this option doesn't work with streams, e.g.,
-        BytesIO.
     concat_characters : bool, optional
         If True, concatenate along the last dimension of character arrays to
         form string arrays. Dimensions will only be concatenated over (and
@@ -442,17 +437,6 @@ def open_dataset(
         from . import apiv2
 
         return apiv2.open_dataset(**kwargs)
-
-    if autoclose is not None:
-        warnings.warn(
-            "The autoclose argument is no longer used by "
-            "xarray.open_dataset() and is now ignored; it will be removed in "
-            "a future version of xarray. If necessary, you can control the "
-            "maximum number of simultaneous open files with "
-            "xarray.set_options(file_cache_maxsize=...).",
-            FutureWarning,
-            stacklevel=2,
-        )
 
     if mask_and_scale is None:
         mask_and_scale = not engine == "pseudonetcdf"
@@ -591,7 +575,6 @@ def open_dataarray(
     decode_cf=True,
     mask_and_scale=None,
     decode_times=True,
-    autoclose=None,
     concat_characters=True,
     decode_coords=True,
     engine=None,
@@ -707,7 +690,6 @@ def open_dataarray(
         decode_cf=decode_cf,
         mask_and_scale=mask_and_scale,
         decode_times=decode_times,
-        autoclose=autoclose,
         concat_characters=concat_characters,
         decode_coords=decode_coords,
         engine=engine,
@@ -933,7 +915,7 @@ def open_mfdataset(
     ids, paths = (list(combined_ids_paths.keys()), list(combined_ids_paths.values()))
 
     open_kwargs = dict(
-        engine=engine, chunks=chunks or {}, lock=lock, autoclose=autoclose, **kwargs
+        engine=engine, chunks=chunks or {}, lock=lock, **kwargs
     )
 
     if parallel:

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -113,7 +113,6 @@ def open_dataset(
     concat_characters=None,
     decode_coords=None,
     drop_variables=None,
-    autoclose=None,
     backend_kwargs=None,
     **kwargs,
 ):
@@ -228,16 +227,6 @@ def open_dataset(
     --------
     open_mfdataset
     """
-    if autoclose is not None:
-        warnings.warn(
-            "The autoclose argument is no longer used by "
-            "xarray.open_dataset() and is now ignored; it will be removed in "
-            "a future version of xarray. If necessary, you can control the "
-            "maximum number of simultaneous open files with "
-            "xarray.set_options(file_cache_maxsize=...).",
-            FutureWarning,
-            stacklevel=2,
-        )
 
     if cache is None:
         cache = chunks is None

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 
 from ..core.dataset import _get_chunk, _maybe_chunk
 from ..core.utils import is_remote_uri

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1454,14 +1454,6 @@ class TestNetCDF4Data(NetCDF4Base):
                 assert_array_equal(one_element_list_of_strings, totest.attrs["bar"])
                 assert one_string == totest.attrs["baz"]
 
-    def test_autoclose_future_warning(self):
-        data = create_test_data()
-        with create_tmp_file() as tmp_file:
-            self.save(data, tmp_file)
-            with pytest.warns(FutureWarning):
-                with self.open(tmp_file, autoclose=True) as actual:
-                    assert_identical(data, actual)
-
 
 @requires_netCDF4
 class TestNetCDF4AlreadyOpen:


### PR DESCRIPTION
This PR remove `autoclose` option from `open_dataset` (both api.py and apiv2.py) and the corresponding test `test_autoclose_future_warning` from test.py
`autoclose=True` option was deprecated in  https://github.com/pydata/xarray/pull/2261 since xarray now uses a LRU cache to manage open file handles.


 - [x] Related to https://github.com/pydata/xarray/issues/4309 and https://github.com/pydata/xarray/pull/2261,
 - [x] Tests updated
 - [x] Passes `isort . && black . && mypy . && flake8`
