### PR TITLE
Fix warning on chunks compatibility

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -358,12 +358,12 @@ def _assert_empty(args: tuple, msg: str = "%s") -> None:
         raise ValueError(msg % args)
 
 
-def _check_chunks_compatibility(var, chunks, chunk_spec):
+def _check_chunks_compatibility(var, chunks, preferred_chunks):
     for dim in var.dims:
-        if dim not in chunks or (dim not in chunk_spec):
+        if dim not in chunks or (dim not in preferred_chunks):
             continue
 
-        chunk_spec_dim = chunk_spec.get(dim)
+        preferred_chunks_dim = preferred_chunks.get(dim)
         chunks_dim = chunks.get(dim)
 
         if isinstance(chunks_dim, int):
@@ -371,10 +371,10 @@ def _check_chunks_compatibility(var, chunks, chunk_spec):
         else:
             chunks_dim = chunks_dim[:-1]
 
-        if any(s % chunk_spec_dim for s in chunks_dim):
+        if any(s % preferred_chunks_dim for s in chunks_dim):
             warnings.warn(
                 f"Specified Dask chunks {chunks[dim]} would separate "
-                f"on disks chunk shape {chunk_spec[dim]} for dimension {dim}. "
+                f"on disks chunk shape {preferred_chunks[dim]} for dimension {dim}. "
                 "This could degrade performance. "
                 "Consider rechunking after loading instead.",
                 stacklevel=2,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -368,6 +368,9 @@ def _check_chunks_compatibility(var, chunks, chunk_spec):
 
         if isinstance(chunks_dim, int):
             chunks_dim = (chunks_dim,)
+        else:
+            chunks_dim = chunks_dim[:-1]
+
         if any(s % chunk_spec_dim for s in chunks_dim):
             warnings.warn(
                 f"Specified Dask chunks {chunks[dim]} would separate "

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1676,7 +1676,7 @@ class ZarrBase(CFEncodedBase):
 
     @requires_dask
     def test_warning_on_bad_chunks(self):
-        original = create_test_data().chunk({"dim1": 4, "dim2": 3, "dim3": 6})
+        original = create_test_data().chunk({"dim1": 4, "dim2": 3, "dim3": 3})
 
         bad_chunks = (2, {"dim2": (3, 3, 2, 1)})
         for chunks in bad_chunks:
@@ -1687,7 +1687,7 @@ class ZarrBase(CFEncodedBase):
                         # only index variables should be in memory
                         assert v._in_memory == (k in actual.dims)
 
-        good_chunks = ({"dim2": 3}, {"dim3": 6}, {})
+        good_chunks = ({"dim2": 3}, {"dim3": (6, 4)}, {})
         for chunks in good_chunks:
             kwargs = {"chunks": chunks}
             with pytest.warns(None) as record:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1676,7 +1676,7 @@ class ZarrBase(CFEncodedBase):
 
     @requires_dask
     def test_warning_on_bad_chunks(self):
-        original = create_test_data().chunk({"dim1": 4, "dim2": 3, "dim3": 5})
+        original = create_test_data().chunk({"dim1": 4, "dim2": 3, "dim3": 6})
 
         bad_chunks = (2, {"dim2": (3, 3, 2, 1)})
         for chunks in bad_chunks:
@@ -1687,7 +1687,7 @@ class ZarrBase(CFEncodedBase):
                         # only index variables should be in memory
                         assert v._in_memory == (k in actual.dims)
 
-        good_chunks = ({"dim2": 3}, {"dim3": 10})
+        good_chunks = ({"dim2": 3}, {"dim3": 6}, {})
         for chunks in good_chunks:
             kwargs = {"chunks": chunks}
             with pytest.warns(None) as record:
@@ -1696,6 +1696,7 @@ class ZarrBase(CFEncodedBase):
                         # only index variables should be in memory
                         assert v._in_memory == (k in actual.dims)
             assert len(record) == 0
+
 
     @requires_dask
     def test_deprecate_auto_chunk(self):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1697,7 +1697,6 @@ class ZarrBase(CFEncodedBase):
                         assert v._in_memory == (k in actual.dims)
             assert len(record) == 0
 
-
     @requires_dask
     def test_deprecate_auto_chunk(self):
         original = create_test_data().chunk()


### PR DESCRIPTION
This PR fixes https://github.com/pydata/xarray/issues/4708. It's a very small change.
Changes:
- In `dataset._check_chunks_compatibility` now it doesn't raise a warning if the last chunk % preferred_chunk != 0.
- Update tests
- Style: rename a variable inside `dataset._check_chunks_compatibility` 

 - [x] Closes https://github.com/pydata/xarray/issues/4708
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
