### PR TITLE
Remove unexpected warnings in tests

### DIFF
--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -33,7 +33,7 @@ def remove_duplicates(backend_entrypoints):
             selected_module_name = matches[0].module_name
             all_module_names = [e.module_name for e in matches]
             warnings.warn(
-                f"\nFound {matches_len} entrypoints for the engine name {name}:"
+                f"Found {matches_len} entrypoints for the engine name {name}:"
                 f"\n {all_module_names}.\n It will be used: {selected_module_name}.",
                 RuntimeWarning,
             )

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4849,6 +4849,7 @@ def test_open_dataset_chunking_zarr(chunks, tmp_path):
 @pytest.mark.parametrize(
     "chunks", ["auto", -1, {}, {"x": "auto"}, {"x": -1}, {"x": "auto", "y": -1}]
 )
+@pytest.mark.filterwarnings("ignore:Specified Dask chunks")
 def test_chunking_consintency(chunks, tmp_path):
     encoded_chunks = {}
     dask_arr = da.from_array(

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4838,8 +4838,10 @@ def test_open_dataset_chunking_zarr(chunks, tmp_path):
 
     with dask.config.set({"array.chunk-size": "1MiB"}):
         expected = ds.chunk(chunks)
-        actual = xr.open_dataset(tmp_path / "test.zarr", engine="zarr", chunks=chunks)
-        xr.testing.assert_chunks_equal(actual, expected)
+        with open_dataset(
+            tmp_path / "test.zarr", engine="zarr", chunks=chunks
+        ) as actual:
+            xr.testing.assert_chunks_equal(actual, expected)
 
 
 @requires_zarr
@@ -4866,8 +4868,10 @@ def test_chunking_consintency(chunks, tmp_path):
 
     with dask.config.set({"array.chunk-size": "1MiB"}):
         expected = ds.chunk(chunks)
-        actual = xr.open_dataset(tmp_path / "test.zarr", engine="zarr", chunks=chunks)
-        xr.testing.assert_chunks_equal(actual, expected)
+        with xr.open_dataset(
+            tmp_path / "test.zarr", engine="zarr", chunks=chunks
+        ) as actual:
+            xr.testing.assert_chunks_equal(actual, expected)
 
-        actual = xr.open_dataset(tmp_path / "test.nc", chunks=chunks)
-        xr.testing.assert_chunks_equal(actual, expected)
+        with xr.open_dataset(tmp_path / "test.nc", chunks=chunks) as actual:
+            xr.testing.assert_chunks_equal(actual, expected)

--- a/xarray/tests/test_plugins.py
+++ b/xarray/tests/test_plugins.py
@@ -30,6 +30,7 @@ def dummy_duplicated_entrypoints():
     return eps
 
 
+@pytest.mark.filterwarnings("ignore:Found")
 def test_remove_duplicates(dummy_duplicated_entrypoints):
     entrypoints = plugins.remove_duplicates(dummy_duplicated_entrypoints)
     assert len(entrypoints) == 2


### PR DESCRIPTION
- #4646 add tests on chunking without using a `with` statement, causing unexpected warnings. 
- Add filterwarnings in test_plugins.test_remove_duplicates tests and backend_tests.test_chunking_consintency
 - [x] Tests fixex
 - [x] Passes `isort . && black . && mypy . && flake8`

