### PR TITLE
Declare only BASIC indexing for cfgrib. Fixes #4733 and ecmwf/cfgrib#157

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,7 +40,7 @@ Bug fixes
   By `Richard Kleijn <https://github.com/rhkleijn>`_ .
 - Remove dictionary unpacking when using ``.loc`` to avoid collision with ``.sel`` parameters (:pull:`4695`).
   By `Anderson Banihirwe <https://github.com/andersy005>`_
-- Fix a crash in orthogonal indexing on geographic coordinates with ``engine='cfgrib'`` (:issue:`4733` :pull:`4734`).
+- Fix a crash in orthogonal indexing on geographic coordinates with ``engine='cfgrib'`` (:issue:`4733` :pull:`4737`).
   By `Alessandro Amici <https://github.com/alexamici>`_
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,6 +40,8 @@ Bug fixes
   By `Richard Kleijn <https://github.com/rhkleijn>`_ .
 - Remove dictionary unpacking when using ``.loc`` to avoid collision with ``.sel`` parameters (:pull:`4695`).
   By `Anderson Banihirwe <https://github.com/andersy005>`_
+- Fix a crash in orthogonal indexing on geographic coordinates with `engine='cfgrib'` (:issue:`4733`` :pull:`4734`).
+  By `Alessandro Amici <https://github.com/alexamici>`_
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,7 +40,7 @@ Bug fixes
   By `Richard Kleijn <https://github.com/rhkleijn>`_ .
 - Remove dictionary unpacking when using ``.loc`` to avoid collision with ``.sel`` parameters (:pull:`4695`).
   By `Anderson Banihirwe <https://github.com/andersy005>`_
-- Fix a crash in orthogonal indexing on geographic coordinates with `engine='cfgrib'` (:issue:`4733`` :pull:`4734`).
+- Fix a crash in orthogonal indexing on geographic coordinates with ``engine='cfgrib'`` (:issue:`4733` :pull:`4734`).
   By `Alessandro Amici <https://github.com/alexamici>`_
 
 Documentation

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -24,7 +24,7 @@ class CfGribArrayWrapper(BackendArray):
 
     def __getitem__(self, key):
         return indexing.explicit_indexing_adapter(
-            key, self.shape, indexing.IndexingSupport.OUTER, self._getitem
+            key, self.shape, indexing.IndexingSupport.BASIC, self._getitem
         )
 
     def _getitem(self, key):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3575,6 +3575,19 @@ class TestCfGrib:
             assert list(ds.data_vars) == ["t"]
             assert ds["t"].min() == 231.0
 
+    def test_read_outer(self):
+        expected = {
+            "number": 2,
+            "time": 3,
+            "isobaricInhPa": 2,
+            "latitude": 2,
+            "longitude": 3,
+        }
+        with open_example_dataset("example.grib", engine="cfgrib") as ds:
+            res = ds.isel(latitude=[0, 2], longitude=[0, 1, 2])
+            assert res.dims == expected
+            assert res["t"].min() == 231.
+
 
 @requires_pseudonetcdf
 @pytest.mark.filterwarnings("ignore:IOAPI_ISPH is assumed to be 6370000")

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3586,7 +3586,7 @@ class TestCfGrib:
         with open_example_dataset("example.grib", engine="cfgrib") as ds:
             res = ds.isel(latitude=[0, 2], longitude=[0, 1, 2])
             assert res.dims == expected
-            assert res["t"].min() == 231.
+            assert res["t"].min() == 231.0
 
 
 @requires_pseudonetcdf


### PR DESCRIPTION
 - [x] Closes #4733
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - No new functions/methods are listed in `api.rst`
