### PR TITLE
Speed up Dataset._construct_dataarray

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,11 +27,11 @@ Breaking changes
 
 New Features
 ~~~~~~~~~~~~
-
+- Performance improvement when constructing DataArrays. Significantly speeds up repr for Datasets with large number of variables.
+  By `Deepak Cherian <https://github.com/dcherian>`_
 
 Bug fixes
 ~~~~~~~~~
-
 - :py:meth:`DataArray.resample` and :py:meth:`Dataset.resample` do not trigger computations anymore if :py:meth:`Dataset.weighted` or :py:meth:`DataArray.weighted` are applied (:issue:`4625`, :pull:`4668`). By `Julius Busecke <https://github.com/jbusecke>`_.
 - :py:func:`merge` with ``combine_attrs='override'`` makes a copy of the attrs (:issue:`4627`).
 - :py:meth:`DataArray.astype`, :py:meth:`Dataset.astype` and :py:meth:`Variable.astype` support

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1320,8 +1320,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         needed_dims = set(variable.dims)
 
         coords: Dict[Hashable, Variable] = {}
-        for k in self._coord_names:
-            if set(self.variables[k].dims) <= needed_dims:
+        # preserve ordering
+        for k in self._variables:
+            if k in self._coord_names and set(self.variables[k].dims) <= needed_dims:
                 coords[k] = self.variables[k]
 
         if self._indexes is None:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1320,7 +1320,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         needed_dims = set(variable.dims)
 
         coords: Dict[Hashable, Variable] = {}
-        for k in self.coords:
+        for k in self._coord_names:
             if set(self.variables[k].dims) <= needed_dims:
                 coords[k] = self.variables[k]
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Significantly speeds up `_construct_dataarray` by iterating over `._coord_names` instead of `.coords`. This avoids unnecessarily constructing a `DatasetCoordinates` object and massively speeds up repr construction for datasets with large numbers of variables.

Construct a 2000 variable dataset
```python
import numpy as np
import xarray as xr

a = np.arange(0, 2000)
b = np.core.defchararray.add("long_variable_name", a.astype(str))
coords = dict(time=np.array([0, 1]))
data_vars = dict()
for v in b:
    data_vars[v] = xr.DataArray(
        name=v,
        data=np.array([3, 4]),
        dims=["time"],
        coords=coords
    )
ds0 = xr.Dataset(data_vars)
```

Before:
```
%timeit ds0['long_variable_name1999']
%timeit ds0.__repr__()

1.33 ms ± 23 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
2.66 s ± 52.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

After:

```
%timeit ds0['long_variable_name1999']
%timeit ds0.__repr__()

10.5 µs ± 203 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
84.2 ms ± 1.28 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```