### PR TITLE
docs: fix simple typo, usualy -> usually

### DIFF
--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -816,7 +816,7 @@ def test_interpolate_chunk_1d(method, data_ndim, interp_ndim, nscalar, chunked):
 
                 assert_identical(actual, expected)
 
-                # all the combinations are usualy not necessary
+                # all the combinations are usually not necessary
                 break
             break
         break


### PR DESCRIPTION
There is a small typo in xarray/tests/test_interp.py.

Should read `usually` rather than `usualy`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md