### PR TITLE
Replace bare assert with assert_identical

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -63,6 +63,11 @@ Internal Changes
   - Run the tests in parallel using pytest-xdist (:pull:`4694`).
 
   By `Justus Magin <https://github.com/keewis>`_ and `Mathias Hauser <https://github.com/mathause>`_.
+  
+- Replace all usages of ``assert x.identical(y)`` with ``assert_identical(x,  y)`` 
+  for clearer error messages.
+  (:pull:`4752`);
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 .. _whats-new.0.16.2:
 

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -482,7 +482,7 @@ class TestNestedCombine:
 
         expected = data[["var1", "var2"]]
         actual = combine_nested(objs, concat_dim=[None, "dim2"])
-        assert expected.identical(actual)
+        assert_identical(expected, actual)
 
     def test_auto_combine_2d(self):
         ds = create_test_data

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -30,7 +30,7 @@ dask = pytest.importorskip("dask")
 def assert_identical(a, b):
     if hasattr(a, "identical"):
         msg = f"not identical:\n{a!r}\n{b!r}"
-        assert_identical(a, b), msg
+        assert_identical(a, b)
     else:
         assert_array_equal(a, b)
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -28,8 +28,11 @@ dask = pytest.importorskip("dask")
 
 
 def assert_identical(a, b):
+    """ A version of this function which accepts numpy arrays """
+    from xarray.testing import assert_identical as assert_identical_
+
     if hasattr(a, "identical"):
-        assert_identical(a, b)
+        assert_identical_(a, b)
     else:
         assert_array_equal(a, b)
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -30,7 +30,7 @@ dask = pytest.importorskip("dask")
 def assert_identical(a, b):
     if hasattr(a, "identical"):
         msg = f"not identical:\n{a!r}\n{b!r}"
-        assert a.identical(b), msg
+        assert_identical(a, b), msg
     else:
         assert_array_equal(a, b)
 
@@ -1306,7 +1306,7 @@ def test_dot(use_dask):
     # for only a single array is passed without dims argument, just return
     # as is
     actual = xr.dot(da_a)
-    assert da_a.identical(actual)
+    assert_identical(da_a, actual)
 
     # test for variable
     actual = xr.dot(da_a.variable, da_b.variable)

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -29,7 +29,6 @@ dask = pytest.importorskip("dask")
 
 def assert_identical(a, b):
     if hasattr(a, "identical"):
-        msg = f"not identical:\n{a!r}\n{b!r}"
         assert_identical(a, b)
     else:
         assert_array_equal(a, b)

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -123,7 +123,7 @@ class TestVariable(DaskTestCase):
         v = self.lazy_var
         assert v.equals(v)
         assert isinstance(v.data, da.Array)
-        assert_identical(v, v)
+        assert v.identical(v)
         assert isinstance(v.data, da.Array)
 
     def test_transpose(self):

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -123,7 +123,7 @@ class TestVariable(DaskTestCase):
         v = self.lazy_var
         assert v.equals(v)
         assert isinstance(v.data, da.Array)
-        assert v.identical(v)
+        assert_identical(v, v)
         assert isinstance(v.data, da.Array)
 
     def test_transpose(self):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -430,7 +430,7 @@ class TestDataArray:
         expected = orig
         actual = orig.copy()
         assert expected.equals(actual)
-        assert_identical(expected, actual)
+        assert expected.identical(actual)
 
         actual = expected.rename("baz")
         assert expected.equals(actual)
@@ -458,7 +458,7 @@ class TestDataArray:
         actual[0] = np.nan
         expected = actual.copy()
         assert expected.equals(actual)
-        assert_identical(expected, actual)
+        assert expected.identical(actual)
 
         actual[:] = np.nan
         assert not expected.equals(actual)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -430,7 +430,7 @@ class TestDataArray:
         expected = orig
         actual = orig.copy()
         assert expected.equals(actual)
-        assert expected.identical(actual)
+        assert_identical(expected, actual)
 
         actual = expected.rename("baz")
         assert expected.equals(actual)
@@ -458,7 +458,7 @@ class TestDataArray:
         actual[0] = np.nan
         expected = actual.copy()
         assert expected.equals(actual)
-        assert expected.identical(actual)
+        assert_identical(expected, actual)
 
         actual[:] = np.nan
         assert not expected.equals(actual)
@@ -1494,8 +1494,8 @@ class TestDataArray:
         new1 = arr1.broadcast_like(arr2)
         new2 = arr2.broadcast_like(arr1)
 
-        assert orig1.identical(new1)
-        assert orig2.identical(new2)
+        assert_identical(orig1, new1)
+        assert_identical(orig2, new2)
 
         orig3 = DataArray(np.random.randn(5), [("x", range(5))])
         orig4 = DataArray(np.random.randn(6), [("y", range(6))])

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -885,7 +885,7 @@ class TestDataset:
     def test_equals_and_identical(self):
         data = create_test_data(seed=42)
         assert data.equals(data)
-        assert_identical(data, data)
+        assert data.identical(data)
 
         data2 = create_test_data(seed=42)
         data2.attrs["foobar"] = "baz"
@@ -897,7 +897,7 @@ class TestDataset:
 
         data = create_test_data(seed=42).rename({"var1": None})
         assert data.equals(data)
-        assert_identical(data, data)
+        assert data.identical(data)
 
         data2 = data.reset_coords()
         assert not data2.equals(data)
@@ -2127,7 +2127,8 @@ class TestDataset:
     def test_align_non_unique(self):
         x = Dataset({"foo": ("x", [3, 4, 5]), "x": [0, 0, 1]})
         x1, x2 = align(x, x)
-        assert_identical(x1, x) and x2.identical(x)
+        assert_identical(x1, x)
+        assert_identical(x2, x)
 
         y = Dataset({"bar": ("x", [6, 7]), "x": [0, 1]})
         with raises_regex(ValueError, "cannot reindex or align"):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -885,7 +885,7 @@ class TestDataset:
     def test_equals_and_identical(self):
         data = create_test_data(seed=42)
         assert data.equals(data)
-        assert data.identical(data)
+        assert_identical(data, data)
 
         data2 = create_test_data(seed=42)
         data2.attrs["foobar"] = "baz"
@@ -897,7 +897,7 @@ class TestDataset:
 
         data = create_test_data(seed=42).rename({"var1": None})
         assert data.equals(data)
-        assert data.identical(data)
+        assert_identical(data, data)
 
         data2 = data.reset_coords()
         assert not data2.equals(data)
@@ -2127,7 +2127,7 @@ class TestDataset:
     def test_align_non_unique(self):
         x = Dataset({"foo": ("x", [3, 4, 5]), "x": [0, 0, 1]})
         x1, x2 = align(x, x)
-        assert x1.identical(x) and x2.identical(x)
+        assert_identical(x1, x) and x2.identical(x)
 
         y = Dataset({"bar": ("x", [6, 7]), "x": [0, 1]})
         with raises_regex(ValueError, "cannot reindex or align"):

--- a/xarray/tests/test_extensions.py
+++ b/xarray/tests/test_extensions.py
@@ -3,7 +3,7 @@ import pickle
 import pytest
 
 import xarray as xr
-from xarray.testing import assert_identical
+from . import assert_identical
 
 from . import raises_regex
 

--- a/xarray/tests/test_extensions.py
+++ b/xarray/tests/test_extensions.py
@@ -3,6 +3,7 @@ import pickle
 import pytest
 
 import xarray as xr
+from xarray.testing import assert_identical
 
 from . import raises_regex
 
@@ -61,20 +62,20 @@ class TestAccessor:
     def test_pickle_dataset(self):
         ds = xr.Dataset()
         ds_restored = pickle.loads(pickle.dumps(ds))
-        assert ds.identical(ds_restored)
+        assert_identical(ds, ds_restored)
 
         # state save on the accessor is restored
         assert ds.example_accessor is ds.example_accessor
         ds.example_accessor.value = "foo"
         ds_restored = pickle.loads(pickle.dumps(ds))
-        assert ds.identical(ds_restored)
+        assert_identical(ds, ds_restored)
         assert ds_restored.example_accessor.value == "foo"
 
     def test_pickle_dataarray(self):
         array = xr.Dataset()
         assert array.example_accessor is array.example_accessor
         array_restored = pickle.loads(pickle.dumps(array))
-        assert array.identical(array_restored)
+        assert_identical(array, array_restored)
 
     def test_broken_accessor(self):
         # regression test for GH933

--- a/xarray/tests/test_extensions.py
+++ b/xarray/tests/test_extensions.py
@@ -3,9 +3,8 @@ import pickle
 import pytest
 
 import xarray as xr
-from . import assert_identical
 
-from . import raises_regex
+from . import assert_identical, raises_regex
 
 
 @xr.register_dataset_accessor("example_accessor")

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -4,7 +4,7 @@ import pytest
 import xarray as xr
 from xarray.core import dtypes, merge
 from xarray.core.merge import MergeError
-from xarray.testing import assert_identical
+from xarray.testing import assert_equal, assert_identical
 
 from . import raises_regex
 from .test_dataset import create_test_data
@@ -183,7 +183,7 @@ class TestMergeFunction:
         del data2["var3"]
 
         actual = xr.merge([data1, data2], compat="no_conflicts")
-        assert data.equals(actual)
+        assert_equal(data, actual)
 
     def test_merge_no_conflicts_preserve_attrs(self):
         data = xr.Dataset({"x": ([], 0, {"foo": "bar"})})

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -33,17 +33,17 @@ class TestMergeFunction:
         data = create_test_data()
         actual = xr.merge([data.var1, data.var2])
         expected = data[["var1", "var2"]]
-        assert actual.identical(expected)
+        assert_identical(actual, expected)
 
     def test_merge_datasets(self):
         data = create_test_data()
 
         actual = xr.merge([data[["var1"]], data[["var2"]]])
         expected = data[["var1", "var2"]]
-        assert actual.identical(expected)
+        assert_identical(actual, expected)
 
         actual = xr.merge([data, data])
-        assert actual.identical(data)
+        assert_identical(actual, data)
 
     def test_merge_dataarray_unnamed(self):
         data = xr.DataArray([1, 2], dims="x")
@@ -61,7 +61,7 @@ class TestMergeFunction:
         actual = xr.merge([data.var1, data.var2])
         expected = data[["var1", "var2"]]
         expected.attrs = expected_attrs
-        assert actual.identical(expected)
+        assert_identical(actual, expected)
 
     @pytest.mark.parametrize(
         "combine_attrs, var1_attrs, var2_attrs, expected_attrs, expect_exception",
@@ -107,7 +107,7 @@ class TestMergeFunction:
             actual = xr.merge([data.var1, data.var2], combine_attrs=combine_attrs)
             expected = data[["var1", "var2"]]
             expected.attrs = expected_attrs
-            assert actual.identical(expected)
+            assert_identical(actual, expected)
 
     def test_merge_attrs_override_copy(self):
         ds1 = xr.Dataset(attrs={"x": 0})
@@ -119,12 +119,12 @@ class TestMergeFunction:
     def test_merge_dicts_simple(self):
         actual = xr.merge([{"foo": 0}, {"bar": "one"}, {"baz": 3.5}])
         expected = xr.Dataset({"foo": 0, "bar": "one", "baz": 3.5})
-        assert actual.identical(expected)
+        assert_identical(actual, expected)
 
     def test_merge_dicts_dims(self):
         actual = xr.merge([{"y": ("x", [13])}, {"x": [12]}])
         expected = xr.Dataset({"x": [12], "y": ("x", [13])})
-        assert actual.identical(expected)
+        assert_identical(actual, expected)
 
     def test_merge_error(self):
         ds = xr.Dataset({"x": 0})
@@ -174,7 +174,7 @@ class TestMergeFunction:
 
         expected = data[["var1", "var2"]]
         actual = xr.merge([data1.var1, data2.var2], compat="no_conflicts")
-        assert expected.identical(actual)
+        assert_identical(expected, actual)
 
         data1["var1"][:, :5] = np.nan
         data2["var1"][:, 5:] = np.nan
@@ -188,17 +188,17 @@ class TestMergeFunction:
     def test_merge_no_conflicts_preserve_attrs(self):
         data = xr.Dataset({"x": ([], 0, {"foo": "bar"})})
         actual = xr.merge([data, data])
-        assert data.identical(actual)
+        assert_identical(data, actual)
 
     def test_merge_no_conflicts_broadcast(self):
         datasets = [xr.Dataset({"x": ("y", [0])}), xr.Dataset({"x": np.nan})]
         actual = xr.merge(datasets)
         expected = xr.Dataset({"x": ("y", [0])})
-        assert expected.identical(actual)
+        assert_identical(expected, actual)
 
         datasets = [xr.Dataset({"x": ("y", [np.nan])}), xr.Dataset({"x": 0})]
         actual = xr.merge(datasets)
-        assert expected.identical(actual)
+        assert_identical(expected, actual)
 
 
 class TestMergeMethod:
@@ -208,17 +208,17 @@ class TestMergeMethod:
         ds2 = data[["var3"]]
         expected = data[["var1", "var3"]]
         actual = ds1.merge(ds2)
-        assert expected.identical(actual)
+        assert_identical(expected, actual)
 
         actual = ds2.merge(ds1)
-        assert expected.identical(actual)
+        assert_identical(expected, actual)
 
         actual = data.merge(data)
-        assert data.identical(actual)
+        assert_identical(data, actual)
         actual = data.reset_coords(drop=True).merge(data)
-        assert data.identical(actual)
+        assert_identical(data, actual)
         actual = data.merge(data.reset_coords(drop=True))
-        assert data.identical(actual)
+        assert_identical(data, actual)
 
         with pytest.raises(ValueError):
             ds1.merge(ds2.rename({"var3": "var1"}))
@@ -231,19 +231,19 @@ class TestMergeMethod:
         ds1 = xr.Dataset({"x": 0})
         ds2 = xr.Dataset({"x": ("y", [0, 0])})
         actual = ds1.merge(ds2)
-        assert ds2.identical(actual)
+        assert_identical(ds2, actual)
 
         actual = ds2.merge(ds1)
-        assert ds2.identical(actual)
+        assert_identical(ds2, actual)
 
         actual = ds1.copy()
         actual.update(ds2)
-        assert ds2.identical(actual)
+        assert_identical(ds2, actual)
 
         ds1 = xr.Dataset({"x": np.nan})
         ds2 = xr.Dataset({"x": ("y", [np.nan, np.nan])})
         actual = ds1.merge(ds2)
-        assert ds2.identical(actual)
+        assert_identical(ds2, actual)
 
     def test_merge_compat(self):
         ds1 = xr.Dataset({"x": 0})

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -651,7 +651,7 @@ class TestSparseDataArrayAndDataset:
         assert_equal(expected, stacked)
 
         roundtripped = stacked.unstack()
-        assert arr.identical(roundtripped)
+        assert_identical(arr, roundtripped)
 
     @pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
     def test_ufuncs(self):

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -406,7 +406,7 @@ class VariableSubclassobjects:
         for v, _ in self.example_1d_objects():
             v2 = v.copy()
             assert v.equals(v2)
-            assert v.identical(v2)
+            assert_identical(v, v2)
             assert v.no_conflicts(v2)
             assert v[0].equals(v2[0])
             assert v[0].identical(v2[0])
@@ -972,7 +972,7 @@ class TestVariable(VariableSubclassobjects):
         v1 = Variable(("dim1", "dim2"), data=d, attrs={"att1": 3, "att2": [1, 2, 3]})
         v2 = Variable(("dim1", "dim2"), data=d, attrs={"att1": 3, "att2": [1, 2, 3]})
         assert v1.equals(v2)
-        assert v1.identical(v2)
+        assert_identical(v1, v2)
 
         v3 = Variable(("dim1", "dim3"), data=d)
         assert not v1.equals(v3)
@@ -1392,7 +1392,7 @@ class TestVariable(VariableSubclassobjects):
         ]:
             variable = Variable([], value)
             actual = variable.transpose()
-            assert actual.identical(variable)
+            assert_identical(actual, variable)
 
     def test_squeeze(self):
         v = Variable(["x", "y"], [[1]])
@@ -1445,7 +1445,7 @@ class TestVariable(VariableSubclassobjects):
         for i in range(3):
             exp_values[i] = ("a", 1)
         expected = Variable(["x"], exp_values)
-        assert actual.identical(expected)
+        assert_identical(actual, expected)
 
     def test_stack(self):
         v = Variable(["x", "y"], [[0, 1], [2, 3]], {"foo": "bar"})
@@ -2075,12 +2075,12 @@ class TestIndexVariable(VariableSubclassobjects):
         coords = [IndexVariable("t", periods[:5]), IndexVariable("t", periods[5:])]
         expected = IndexVariable("t", periods)
         actual = IndexVariable.concat(coords, dim="t")
-        assert actual.identical(expected)
+        assert_identical(actual, expected)
         assert isinstance(actual.to_index(), pd.PeriodIndex)
 
         positions = [list(range(5)), list(range(5, 10))]
         actual = IndexVariable.concat(coords, dim="t", positions=positions)
-        assert actual.identical(expected)
+        assert_identical(actual, expected)
         assert isinstance(actual.to_index(), pd.PeriodIndex)
 
     def test_concat_multiindex(self):
@@ -2088,7 +2088,7 @@ class TestIndexVariable(VariableSubclassobjects):
         coords = [IndexVariable("x", idx[:2]), IndexVariable("x", idx[2:])]
         expected = IndexVariable("x", idx)
         actual = IndexVariable.concat(coords, dim="x")
-        assert actual.identical(expected)
+        assert_identical(actual, expected)
         assert isinstance(actual.to_index(), pd.MultiIndex)
 
     def test_coordinate_alias(self):

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -406,7 +406,7 @@ class VariableSubclassobjects:
         for v, _ in self.example_1d_objects():
             v2 = v.copy()
             assert v.equals(v2)
-            assert_identical(v, v2)
+            assert v.identical(v2)
             assert v.no_conflicts(v2)
             assert v[0].equals(v2[0])
             assert v[0].identical(v2[0])
@@ -972,7 +972,7 @@ class TestVariable(VariableSubclassobjects):
         v1 = Variable(("dim1", "dim2"), data=d, attrs={"att1": 3, "att2": [1, 2, 3]})
         v2 = Variable(("dim1", "dim2"), data=d, attrs={"att1": 3, "att2": [1, 2, 3]})
         assert v1.equals(v2)
-        assert_identical(v1, v2)
+        assert v1.identical(v2)
 
         v3 = Variable(("dim1", "dim3"), data=d)
         assert not v1.equals(v3)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] closes #3908
- [x] Passes `isort . && black . && mypy . && flake8`

IIRC `assert_identical` shows nice pytest error messages.

This was a quick regex but did a quick check that it looked reasonable.