### PR TITLE
silence the dask dataframe upstream-dev errors

### DIFF
--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -703,7 +703,7 @@ class TestDataArrayAndDataset(DaskTestCase):
         assert a.values.tolist() == [1, 2]
         assert not a._in_memory
 
-    def test_from_dask_variable(self):
+    def test_from_daskva_riable(self):
         # Test array creation from Variable with dask backend.
         # This is used e.g. in broadcast()
         a = DataArray(self.lazy_array.variable, coords={"x": range(4)}, name="foo")
@@ -737,7 +737,9 @@ class TestToDaskDataFrame:
 
         ds = Dataset({"a": ("t", x), "b": ("t", y), "t": ("t", t)})
 
-        expected_pd = pd.DataFrame({"a": x, "b": y}, index=pd.Index(t, name="t"))
+        expected_pd = pd.DataFrame(
+            {"a": x.compute(), "b": y}, index=pd.Index(t, name="t")
+        )
 
         # test if 1-D index is correctly set up
         expected = dd.from_pandas(expected_pd, chunksize=4)
@@ -768,7 +770,7 @@ class TestToDaskDataFrame:
         exp_index = pd.MultiIndex.from_arrays(
             [[0, 0, 0, 1, 1, 1], ["a", "b", "c", "a", "b", "c"]], names=["x", "y"]
         )
-        expected = pd.DataFrame({"w": w.reshape(-1)}, index=exp_index)
+        expected = pd.DataFrame({"w": w.compute().reshape(-1)}, index=exp_index)
         # so for now, reset the index
         expected = expected.reset_index(drop=False)
         actual = ds.to_dask_dataframe(set_index=False)
@@ -796,7 +798,7 @@ class TestToDaskDataFrame:
 
         ds = Dataset({"a": ("t", x), "t": ("t", t)})
 
-        expected_pd = pd.DataFrame({"a": x}, index=pd.Index(t, name="t"))
+        expected_pd = pd.DataFrame({"a": x.compute()}, index=pd.Index(t, name="t"))
         expected = dd.from_pandas(expected_pd, chunksize=4)
         actual = ds.to_dask_dataframe(set_index=True)
         assert isinstance(actual, dd.DataFrame)

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -731,15 +731,15 @@ class TestDataArrayAndDataset(DaskTestCase):
 class TestToDaskDataFrame:
     def test_to_dask_dataframe(self):
         # Test conversion of Datasets to dask DataFrames
-        x = da.from_array(np.random.randn(10), chunks=4)
+        x = np.random.randn(10)
         y = np.arange(10, dtype="uint8")
         t = list("abcdefghij")
 
-        ds = Dataset({"a": ("t", x), "b": ("t", y), "t": ("t", t)})
-
-        expected_pd = pd.DataFrame(
-            {"a": x.compute(), "b": y}, index=pd.Index(t, name="t")
+        ds = Dataset(
+            {"a": ("t", da.from_array(x, chunks=4)), "b": ("t", y), "t": ("t", t)}
         )
+
+        expected_pd = pd.DataFrame({"a": x, "b": y}, index=pd.Index(t, name="t"))
 
         # test if 1-D index is correctly set up
         expected = dd.from_pandas(expected_pd, chunksize=4)
@@ -760,8 +760,8 @@ class TestToDaskDataFrame:
 
     def test_to_dask_dataframe_2D(self):
         # Test if 2-D dataset is supplied
-        w = da.from_array(np.random.randn(2, 3), chunks=(1, 2))
-        ds = Dataset({"w": (("x", "y"), w)})
+        w = np.random.randn(2, 3)
+        ds = Dataset({"w": (("x", "y"), da.from_array(w, chunks=(1, 2)))})
         ds["x"] = ("x", np.array([0, 1], np.int64))
         ds["y"] = ("y", list("abc"))
 
@@ -770,7 +770,7 @@ class TestToDaskDataFrame:
         exp_index = pd.MultiIndex.from_arrays(
             [[0, 0, 0, 1, 1, 1], ["a", "b", "c", "a", "b", "c"]], names=["x", "y"]
         )
-        expected = pd.DataFrame({"w": w.compute().reshape(-1)}, index=exp_index)
+        expected = pd.DataFrame({"w": w.reshape(-1)}, index=exp_index)
         # so for now, reset the index
         expected = expected.reset_index(drop=False)
         actual = ds.to_dask_dataframe(set_index=False)
@@ -793,12 +793,17 @@ class TestToDaskDataFrame:
 
     def test_to_dask_dataframe_coordinates(self):
         # Test if coordinate is also a dask array
-        x = da.from_array(np.random.randn(10), chunks=4)
-        t = da.from_array(np.arange(10) * 2, chunks=4)
+        x = np.random.randn(10)
+        t = np.arange(10) * 2
 
-        ds = Dataset({"a": ("t", x), "t": ("t", t)})
+        ds = Dataset(
+            {
+                "a": ("t", da.from_array(x, chunks=4)),
+                "t": ("t", da.from_array(t, chunks=4)),
+            }
+        )
 
-        expected_pd = pd.DataFrame({"a": x.compute()}, index=pd.Index(t, name="t"))
+        expected_pd = pd.DataFrame({"a": x}, index=pd.Index(t, name="t"))
         expected = dd.from_pandas(expected_pd, chunksize=4)
         actual = ds.to_dask_dataframe(set_index=True)
         assert isinstance(actual, dd.DataFrame)

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -703,7 +703,7 @@ class TestDataArrayAndDataset(DaskTestCase):
         assert a.values.tolist() == [1, 2]
         assert not a._in_memory
 
-    def test_from_daskva_riable(self):
+    def test_from_dask_variable(self):
         # Test array creation from Variable with dask backend.
         # This is used e.g. in broadcast()
         a = DataArray(self.lazy_array.variable, coords={"x": range(4)}, name="foo")


### PR DESCRIPTION
Some of the `to_dask_dataframe` tests fail on the upstream-dev CI because the behavior of `pandas.DataFrame` changed (see pandas-dev/pandas#38645). For now we can silence these by computing all `dask` arrays we pass to `pandas.DataFrame`.

 - [x] Closes #4717
 - [x] Passes `isort . && black . && mypy . && flake8`
