### PR TITLE
WIP: testing.assert_* check dtype

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2783,17 +2783,19 @@ class DataArray(AbstractArray, DataWithCoords):
 
         return from_iris(cube)
 
-    def _all_compat(self, other: "DataArray", compat_str: str) -> bool:
+    def _all_compat(
+        self, other: "DataArray", compat_str: str, check_dtype: bool = False
+    ) -> bool:
         """Helper function for equals, broadcast_equals, and identical"""
 
         def compat(x, y):
-            return getattr(x.variable, compat_str)(y.variable)
+            return getattr(x.variable, compat_str)(y.variable, check_dtype=check_dtype)
 
         return utils.dict_equiv(self.coords, other.coords, compat=compat) and compat(
             self, other
         )
 
-    def broadcast_equals(self, other: "DataArray") -> bool:
+    def broadcast_equals(self, other: "DataArray", check_dtype: bool = False) -> bool:
         """Two DataArrays are broadcast equal if they are equal after
         broadcasting them against each other such that they have the same
         dimensions.
@@ -2804,11 +2806,11 @@ class DataArray(AbstractArray, DataWithCoords):
         DataArray.identical
         """
         try:
-            return self._all_compat(other, "broadcast_equals")
+            return self._all_compat(other, "broadcast_equals", check_dtype=check_dtype)
         except (TypeError, AttributeError):
             return False
 
-    def equals(self, other: "DataArray") -> bool:
+    def equals(self, other: "DataArray", check_dtype: bool = False) -> bool:
         """True if two DataArrays have the same dimensions, coordinates and
         values; otherwise False.
 
@@ -2824,11 +2826,11 @@ class DataArray(AbstractArray, DataWithCoords):
         DataArray.identical
         """
         try:
-            return self._all_compat(other, "equals")
+            return self._all_compat(other, "equals", check_dtype=check_dtype)
         except (TypeError, AttributeError):
             return False
 
-    def identical(self, other: "DataArray") -> bool:
+    def identical(self, other: "DataArray", check_dtype: bool = False) -> bool:
         """Like equals, but also checks the array name and attributes, and
         attributes on all coordinates.
 
@@ -2838,7 +2840,9 @@ class DataArray(AbstractArray, DataWithCoords):
         DataArray.equals
         """
         try:
-            return self.name == other.name and self._all_compat(other, "identical")
+            return self.name == other.name and self._all_compat(
+                other, "identical", check_dtype=check_dtype
+            )
         except (TypeError, AttributeError):
             return False
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1446,19 +1446,19 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
     # https://github.com/python/mypy/issues/4266
     __hash__ = None  # type: ignore
 
-    def _all_compat(self, other: "Dataset", compat_str: str) -> bool:
+    def _all_compat(self, other: "Dataset", compat_str: str, check_dtype: bool) -> bool:
         """Helper function for equals and identical"""
 
         # some stores (e.g., scipy) do not seem to preserve order, so don't
         # require matching order for equality
         def compat(x: Variable, y: Variable) -> bool:
-            return getattr(x, compat_str)(y)
+            return getattr(x, compat_str)(y, check_dtype=check_dtype)
 
         return self._coord_names == other._coord_names and utils.dict_equiv(
             self._variables, other._variables, compat=compat
         )
 
-    def broadcast_equals(self, other: "Dataset") -> bool:
+    def broadcast_equals(self, other: "Dataset", check_dtype: bool = False) -> bool:
         """Two Datasets are broadcast equal if they are equal after
         broadcasting all variables against each other.
 
@@ -1472,11 +1472,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         Dataset.identical
         """
         try:
-            return self._all_compat(other, "broadcast_equals")
+            return self._all_compat(other, "broadcast_equals", check_dtype=check_dtype)
         except (TypeError, AttributeError):
             return False
 
-    def equals(self, other: "Dataset") -> bool:
+    def equals(self, other: "Dataset", check_dtype: bool = False) -> bool:
         """Two Datasets are equal if they have matching variables and
         coordinates, all of which are equal.
 
@@ -1492,11 +1492,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         Dataset.identical
         """
         try:
-            return self._all_compat(other, "equals")
+            return self._all_compat(other, "equals", check_dtype=check_dtype)
         except (TypeError, AttributeError):
             return False
 
-    def identical(self, other: "Dataset") -> bool:
+    def identical(self, other: "Dataset", check_dtype: bool = False) -> bool:
         """Like equals, but also checks all dataset attributes and the
         attributes on all variables and coordinates.
 
@@ -1507,7 +1507,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         """
         try:
             return utils.dict_equiv(self.attrs, other.attrs) and self._all_compat(
-                other, "identical"
+                other, "identical", check_dtype=check_dtype
             )
         except (TypeError, AttributeError):
             return False

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -226,12 +226,12 @@ def lazy_array_equiv(arr1, arr2, check_dtype=False):
     return None
 
 
-def allclose_or_equiv(arr1, arr2, rtol=1e-5, atol=1e-8):
+def allclose_or_equiv(arr1, arr2, rtol=1e-5, atol=1e-8, check_dtype=False):
     """Like np.allclose, but also allows values to be NaN in both arrays"""
     arr1 = asarray(arr1)
     arr2 = asarray(arr2)
 
-    lazy_equiv = lazy_array_equiv(arr1, arr2)
+    lazy_equiv = lazy_array_equiv(arr1, arr2, check_dtype=check_dtype)
     if lazy_equiv is None:
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", r"All-NaN (slice|axis) encountered")

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -201,10 +201,11 @@ def as_shared_dtype(scalars_or_arrays):
     return [x.astype(out_type, copy=False) for x in arrays]
 
 
-def lazy_array_equiv(arr1, arr2):
+def lazy_array_equiv(arr1, arr2, check_dtype=False):
     """Like array_equal, but doesn't actually compare values.
     Returns True when arr1, arr2 identical or their dask tokens are equal.
     Returns False when shapes are not equal.
+    Returns False if dtype does not match and check_dtype is True.
     Returns None when equality cannot determined: one or both of arr1, arr2 are numpy arrays;
     or their dask tokens are not equal
     """
@@ -212,6 +213,8 @@ def lazy_array_equiv(arr1, arr2):
         return True
     arr1 = asarray(arr1)
     arr2 = asarray(arr2)
+    if check_dtype and arr1.dtype != arr2.dtype:
+        return False
     if arr1.shape != arr2.shape:
         return False
     if dask_array and is_duck_dask_array(arr1) and is_duck_dask_array(arr2):
@@ -237,11 +240,11 @@ def allclose_or_equiv(arr1, arr2, rtol=1e-5, atol=1e-8):
         return lazy_equiv
 
 
-def array_equiv(arr1, arr2):
+def array_equiv(arr1, arr2, check_dtype=False):
     """Like np.array_equal, but also allows values to be NaN in both arrays"""
     arr1 = asarray(arr1)
     arr2 = asarray(arr2)
-    lazy_equiv = lazy_array_equiv(arr1, arr2)
+    lazy_equiv = lazy_array_equiv(arr1, arr2, check_dtype)
     if lazy_equiv is None:
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", "In the future, 'NAT == x'")
@@ -251,13 +254,13 @@ def array_equiv(arr1, arr2):
         return lazy_equiv
 
 
-def array_notnull_equiv(arr1, arr2):
+def array_notnull_equiv(arr1, arr2, check_dtype=False):
     """Like np.array_equal, but also allows values to be NaN in either or both
     arrays
     """
     arr1 = asarray(arr1)
     arr2 = asarray(arr2)
-    lazy_equiv = lazy_array_equiv(arr1, arr2)
+    lazy_equiv = lazy_array_equiv(arr1, arr2, check_dtype=check_dtype)
     if lazy_equiv is None:
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", "In the future, 'NAT == x'")

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -38,7 +38,7 @@ def _data_allclose_or_equiv(arr1, arr2, rtol=1e-05, atol=1e-08, decode_bytes=Tru
         return duck_array_ops.allclose_or_equiv(arr1, arr2, rtol=rtol, atol=atol)
 
 
-def assert_equal(a, b):
+def assert_equal(a, b, check_dtype=True):
     """Like :py:func:`numpy.testing.assert_array_equal`, but for xarray
     objects.
 
@@ -62,14 +62,18 @@ def assert_equal(a, b):
     __tracebackhide__ = True
     assert type(a) == type(b)
     if isinstance(a, (Variable, DataArray)):
-        assert a.equals(b), formatting.diff_array_repr(a, b, "equals")
+        assert a.equals(b, check_dtype=check_dtype), formatting.diff_array_repr(
+            a, b, "equals", check_dtype=check_dtype
+        )
     elif isinstance(a, Dataset):
-        assert a.equals(b), formatting.diff_dataset_repr(a, b, "equals")
+        assert a.equals(b, check_dtype=check_dtype), formatting.diff_dataset_repr(
+            a, b, "equals", check_dtype=check_dtype
+        )
     else:
         raise TypeError("{} not supported by assertion comparison".format(type(a)))
 
 
-def assert_identical(a, b):
+def assert_identical(a, b, check_dtype=True):
     """Like :py:func:`xarray.testing.assert_equal`, but also matches the
     objects' names and attributes.
 
@@ -89,12 +93,18 @@ def assert_identical(a, b):
     __tracebackhide__ = True
     assert type(a) == type(b)
     if isinstance(a, Variable):
-        assert a.identical(b), formatting.diff_array_repr(a, b, "identical")
+        assert a.identical(b, check_dtype=check_dtype), formatting.diff_array_repr(
+            a, b, "identical", check_dtype=check_dtype
+        )
     elif isinstance(a, DataArray):
         assert a.name == b.name
-        assert a.identical(b), formatting.diff_array_repr(a, b, "identical")
-    elif isinstance(a, (Dataset, Variable)):
-        assert a.identical(b), formatting.diff_dataset_repr(a, b, "identical")
+        assert a.identical(b, check_dtype=check_dtype), formatting.diff_array_repr(
+            a, b, "identical", check_dtype=check_dtype
+        )
+    elif isinstance(a, Dataset):
+        assert a.identical(b, check_dtype=check_dtype), formatting.diff_dataset_repr(
+            a, b, "identical", check_dtype=check_dtype
+        )
     else:
         raise TypeError("{} not supported by assertion comparison".format(type(a)))
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #4727
- [ ] Tests added
- [ ] Passes `isort . && black . && mypy . && flake8`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

---

This adds a dtype check for `equal`, `identical`, `broadcast_equal`, and the `xr.testing.assert_*` functions. It is far from complete: tests and documentation are still missing, but I wanted to get it online for feedback.

When I set `check_dtype=True` there are around 600 failures. Fixing that is for another PR. #4759 should help a bit.

- [ ] I added the checks to `lazy_array_equiv`, however, sometimes dask can get the dtype wrong before the compute (see below). Do you think I need to put it in the non-lazy part?

```python
import numpy as np
import xarray as xr

da = xr.DataArray(np.array([0, np.nan], dtype=object)).chunk()

da.prod().dtype # -> dtype('O')
da.prod().compute().dtype # -> dtype('int64')

```

- [ ] `check_dtype` is still missing from `assert_duckarray_allclose` & `assert_duckarray_equal` - do you think there are required?

- [ ] The dtypes of array elements are not tested (see below). I don't think I'll implement that here.

```python
da0 = xr.DataArray(np.array([0], dtype=object))
da1 = xr.DataArray(np.array([0.], dtype=object))

xr.testting.assert_equal(da0, da1, check_dtype=True)
```





