### PR TITLE
Print number of variables in repr

### DIFF
--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -370,10 +370,11 @@ def _mapping_repr(mapping, title, summarizer, col_width=None, max_rows=None):
         col_width = _calculate_col_width(mapping)
     if max_rows is None:
         max_rows = OPTIONS["display_max_rows"]
+    summary = [f"{title}:"]
     if mapping:
         len_mapping = len(mapping)
-        summary = [f"{title} ({min(max_rows, len_mapping)}/{len_mapping}):"]
         if len_mapping > max_rows:
+            summary = [f"{title} ({min(max_rows, len_mapping)}/{len_mapping}):"]
             first_rows = max_rows // 2 + max_rows % 2
             items = list(mapping.items())
             summary += [summarizer(k, v, col_width) for k, v in items[:first_rows]]
@@ -384,7 +385,6 @@ def _mapping_repr(mapping, title, summarizer, col_width=None, max_rows=None):
         else:
             summary += [summarizer(k, v, col_width) for k, v in mapping.items()]
     else:
-        summary = [f"{title}:"]
         summary += [EMPTY_REPR]
     return "\n".join(summary)
 

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -370,9 +370,10 @@ def _mapping_repr(mapping, title, summarizer, col_width=None, max_rows=None):
         col_width = _calculate_col_width(mapping)
     if max_rows is None:
         max_rows = OPTIONS["display_max_rows"]
-    summary = [f"{title}:"]
     if mapping:
-        if len(mapping) > max_rows:
+        len_mapping = len(mapping)
+        summary = [f"{title} ({min(max_rows, len_mapping)}/{len_mapping}):"]
+        if len_mapping > max_rows:
             first_rows = max_rows // 2 + max_rows % 2
             items = list(mapping.items())
             summary += [summarizer(k, v, col_width) for k, v in items[:first_rows]]
@@ -383,6 +384,7 @@ def _mapping_repr(mapping, title, summarizer, col_width=None, max_rows=None):
         else:
             summary += [summarizer(k, v, col_width) for k, v in mapping.items()]
     else:
+        summary = [f"{title}:"]
         summary += [EMPTY_REPR]
     return "\n".join(summary)
 

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -374,7 +374,7 @@ def _mapping_repr(mapping, title, summarizer, col_width=None, max_rows=None):
     if mapping:
         len_mapping = len(mapping)
         if len_mapping > max_rows:
-            summary = [f"{title} ({min(max_rows, len_mapping)}/{len_mapping}):"]
+            summary = [f"{summary[0]} ({max_rows}/{len_mapping})"]
             first_rows = max_rows // 2 + max_rows % 2
             items = list(mapping.items())
             summary += [summarizer(k, v, col_width) for k, v in items[:first_rows]]


### PR DESCRIPTION
Show the printed and total number of variables in the repr.

- [x] Passes `isort . && black . && mypy . && flake8`


```python
import numpy as np
import xarray as xr

a = np.arange(0, 15)
b = np.core.defchararray.add("long_variable_name", a.astype(str))
c = np.arange(0, 25)
d = np.core.defchararray.add("attr_", c.astype(str))
e = {k: 2 for k in d}
coords = dict(time=da.array([0, 1]))
data_vars = dict()
for v in b:
    data_vars[v] = xr.DataArray(
        name=v,
        data=np.array([0, 1]).astype(bool),
        dims=["time"],
        coords=coords,
    )
ds1 = xr.Dataset(data_vars)
ds1.attrs = e

# The repr now shows how many attributes in total there are:
print(ds1)
Out[10]: 
<xarray.Dataset>
Dimensions:               (time: 2)
Coordinates:
  * time                  (time) int32 0 1
Data variables: (12/15)
    long_variable_name0   (time) bool False True
    long_variable_name1   (time) bool False True
    long_variable_name2   (time) bool False True
    long_variable_name3   (time) bool False True
    long_variable_name4   (time) bool False True
    long_variable_name5   (time) bool False True
                   ...
    long_variable_name9   (time) bool False True
    long_variable_name10  (time) bool False True
    long_variable_name11  (time) bool False True
    long_variable_name12  (time) bool False True
    long_variable_name13  (time) bool False True
    long_variable_name14  (time) bool False True
Attributes: (12/25)
    attr_0:   2
    attr_1:   2
    attr_2:   2
    attr_3:   2
    attr_4:   2
    attr_5:   2
      ...
    attr_19:  2
    attr_20:  2
    attr_21:  2
    attr_22:  2
    attr_23:  2
    attr_24:  2
```