### PR TITLE
action to detect keywords in the commit summary line

### DIFF
--- a/.github/actions/detect-ci-trigger/action.yaml
+++ b/.github/actions/detect-ci-trigger/action.yaml
@@ -1,0 +1,30 @@
+name: Detect CI Trigger
+description: |
+  Detect keywords used to control the CI in the subject line of a commit message
+inputs:
+  keywords:
+    description: |
+      The keywords to detect. Currently, only a single keyword is supported.
+    required: true
+outputs:
+  trigger-found:
+    description: |
+      true if any of the keywords has been found in the subject line of the commit
+      message
+    value: ${{ steps.detect-trigger.outputs.CI_TRIGGERED }}
+runs:
+  using: "composite"
+  steps:
+    - name: detect trigger
+      id: detect-trigger
+      run: |
+        bash $GITHUB_ACTION_PATH/script.sh ${{ github.event_name }} ${{ inputs.keywords }}
+      shell: bash
+    - name: show detection result
+      run: |
+        echo "::group::final summary"
+        echo "commit message: ${{ steps.detect-trigger.outputs.COMMIT_MESSAGE }}"
+        echo "trigger keyword: ${{ inputs.keywords }}"
+        echo "trigger found: ${{ steps.detect-trigger.outputs.CI_TRIGGERED }}"
+        echo "::endgroup::"
+      shell: bash

--- a/.github/actions/detect-ci-trigger/script.sh
+++ b/.github/actions/detect-ci-trigger/script.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+event_name="$1"
+keywords="$2"
+
+echo "::group::extracting the commit message"
+echo "event name: $event_name"
+if [[ "$event_name" == "pull_request" ]]; then
+    ref="HEAD^2"
+else
+    ref="HEAD"
+fi
+
+commit_message="$(git log -n 1 --pretty=format:%s "$ref")"
+
+if [[ $(echo $commit_message | wc -l) -le 1 ]]; then
+    echo "commit message: '$commit_message'"
+else
+    echo -e "commit message:\n--- start ---\n$commit_message\n--- end ---"
+fi
+echo "::endgroup::"
+
+echo "::group::scanning for keywords"
+echo "searching for: '$keywords'"
+if echo "$commit_message" | grep -qF "$keywords"; then
+    result="true"
+else
+    result="false"
+fi
+echo "keywords detected: $result"
+echo "::endgroup::"
+
+echo "::set-output name=COMMIT_MESSAGE::$commit_message"
+echo "::set-output name=CI_TRIGGERED::$result"


### PR DESCRIPTION
follow-up to #4729 and #4730

To use the `detect-ci-trigger` action in workflows, add a new job:
```yaml
  detect-ci-trigger:
    name: Detect CI Trigger
    runs-on: ubuntu-latest
    outputs:
      triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
    steps:
    - uses: actions/checkout@v2
      with:
        fetch-depth: 2
    - uses: ./.github/actions/detect-ci-trigger
      id: detect-trigger
      with:
        keywords: "<keyword>"
```
the require the new job in jobs that should be conditionally ignored:
```yaml
  my-ci-job:
    runs-on: ubuntu-latest
    needs: detect-ci-trigger
    if: needs.detect-ci-trigger.outputs.triggered == 'false'  # for skip-ci
    # if: needs.detect-ci-trigger.outputs.triggered == 'true'  # for test-upstream
    steps:
    - actions/checkout@v2
    # ...
```

unfortunately, this still requires `actions/checkout` with `fetch-depth`, running `git fetch` in the action script does not seem to work.

cc @andersy005