### PR TITLE
Always force dask arrays to float in missing.interp_func

### DIFF
--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -733,6 +733,13 @@ def interp_func(var, x, new_x, method, kwargs):
 
         # if usefull, re-use localize for each chunk of new_x
         localize = (method in ["linear", "nearest"]) and (new_x[0].chunks is not None)
+        
+        # scipy.interpolate.interp1d always forces to float.
+        # Use the same check for blockwise as well:
+        if not issubclass(var.dtype.type, np.inexact):
+            dtype = np.float_
+        else:
+            dtype = var.dtype
 
         return da.blockwise(
             _dask_aware_interpnd,
@@ -742,7 +749,7 @@ def interp_func(var, x, new_x, method, kwargs):
             interp_kwargs=kwargs,
             localize=localize,
             concatenate=True,
-            dtype=float,  # scipy.interpolate.interp1d always forces to float.
+            dtype=dtype,
             new_axes=new_axes,
         )
 

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -733,7 +733,7 @@ def interp_func(var, x, new_x, method, kwargs):
 
         # if usefull, re-use localize for each chunk of new_x
         localize = (method in ["linear", "nearest"]) and (new_x[0].chunks is not None)
-        
+
         # scipy.interpolate.interp1d always forces to float.
         # Use the same check for blockwise as well:
         if not issubclass(var.dtype.type, np.inexact):

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -742,7 +742,7 @@ def interp_func(var, x, new_x, method, kwargs):
             interp_kwargs=kwargs,
             localize=localize,
             concatenate=True,
-            dtype=var.dtype,
+            dtype=float,  # scipy.interpolate.interp1d always forces to float.
             new_axes=new_axes,
         )
 

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -372,14 +372,14 @@ def test_interpolate_dask_raises_for_invalid_chunk_dim():
 
 @requires_dask
 @requires_scipy
-@pytest.mark.parametrize("dtype", [float, int])
-def test_interpolate_dask_expected_dtype(dtype):
+@pytest.mark.parametrize("dtype, method", [(int, "linear"), (int, "nearest")])
+def test_interpolate_dask_expected_dtype(dtype, method):
     da = xr.DataArray(
         data=np.array([0, 1], dtype=dtype),
         dims=["time"],
         coords=dict(time=np.array([0, 1])),
     ).chunk(dict(time=2))
-    da = da.interp(time=np.array([0, 0.5, 1, 2]), method="linear")
+    da = da.interp(time=np.array([0, 0.5, 1, 2]), method=method)
 
     assert da.dtype == da.compute().dtype
 

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -370,6 +370,20 @@ def test_interpolate_dask_raises_for_invalid_chunk_dim():
         da.interpolate_na("time")
 
 
+@requires_dask
+@requires_scipy
+@pytest.mark.parametrize("dtype", [float, int])
+def test_interpolate_dask_expected_dtype(dtype):
+    da = xr.DataArray(
+        data=np.array([0, 1], dtype=dtype),
+        dims=["time"],
+        coords=dict(time=np.array([0, 1])),
+    ).chunk(dict(time=2))
+    da = da.interp(time=np.array([0, 0.5, 1, 2]), method="linear")
+
+    assert da.dtype == da.compute().dtype
+
+
 @requires_bottleneck
 def test_ffill():
     da = xr.DataArray(np.array([4, 5, np.nan], dtype=np.float64), dims="x")


### PR DESCRIPTION
`scipy.interpolate.interp1d` always forces float so make sure that `da.blockwise` understands that as well.

- [x] Workaround for  #4770
- [x] Tests added
- [x] Passes `isort . && black . && mypy . && flake8`
