### PR TITLE
CI: ignore some warnings

### DIFF
--- a/xarray/tests/test_backends_file_manager.py
+++ b/xarray/tests/test_backends_file_manager.py
@@ -202,6 +202,8 @@ def test_file_manager_read(tmpdir, file_cache):
     manager.close()
 
 
+# __init__ fails, thus, __del__ fails -> ignore the warning
+@pytest.mark.filterwarnings("ignore:Exception ignored in")
 def test_file_manager_invalid_kwargs():
     with pytest.raises(TypeError):
         CachingFileManager(open, "dummy", mode="w", invalid=True)

--- a/xarray/tests/test_backends_file_manager.py
+++ b/xarray/tests/test_backends_file_manager.py
@@ -202,13 +202,6 @@ def test_file_manager_read(tmpdir, file_cache):
     manager.close()
 
 
-# __init__ fails, thus, __del__ fails -> ignore the warning
-@pytest.mark.filterwarnings("ignore:Exception ignored in")
-def test_file_manager_invalid_kwargs():
-    with pytest.raises(TypeError):
-        CachingFileManager(open, "dummy", mode="w", invalid=True)
-
-
 def test_file_manager_acquire_context(tmpdir, file_cache):
     path = str(tmpdir.join("testing.txt"))
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -924,11 +924,11 @@ def test_vectorize_dask_dtype_meta():
         vectorize=True,
         dask="parallelized",
         output_dtypes=[int],
-        dask_gufunc_kwargs=dict(meta=np.ndarray((0, 0), dtype=np.float)),
+        dask_gufunc_kwargs=dict(meta=np.ndarray((0, 0), dtype=float)),
     )
 
     assert_identical(expected, actual)
-    assert np.float == actual.dtype
+    assert float == actual.dtype
 
 
 def pandas_median_add(x, y):

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -835,6 +835,9 @@ class VariableSubclassobjects:
         ],
     )
     @pytest.mark.parametrize("xr_arg, np_arg", _PAD_XR_NP_ARGS)
+    @pytest.mark.filterwarnings(
+        r"ignore:dask.array.pad.+? converts integers to floats."
+    )
     def test_pad(self, mode, xr_arg, np_arg):
         data = np.arange(4 * 3 * 2).reshape(4, 3, 2)
         v = self.cls(["x", "y", "z"], data)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Part of #3266
- [x] Passes `isort . && black . && mypy . && flake8`

Supresses 3 warnings we get in the test suite. Two are trivial. The third is `PytestUnraisableExceptionWarning: Exception ignored in: CachingFileManager.__del__`:

- The test triggers an error is in `CachingFileManager.__init__`:

https://github.com/pydata/xarray/blob/31d540f9d668fc5f8c1c92165f950c568778db01/xarray/tests/test_backends_file_manager.py#L205-L207

- It then tries to run `__del__` but there is an error because an attribute is not available (as `__init__` failed)

https://github.com/pydata/xarray/blob/31d540f9d668fc5f8c1c92165f950c568778db01/xarray/backends/file_manager.py#L238

- However, errors in `__del__` are ignored, therefore we get a `PytestUnraisableExceptionWarning`

I decided to suppress the error and not fix  `CachingFileManager` as I think that's nothing user-facing...