### PR TITLE
improve typing of OrderedSet

### DIFF
--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -651,7 +651,7 @@ def interp(var, indexes_coords, method, **kwargs):
                 out_dims.update(indexes_coords[d][1].dims)
             else:
                 out_dims.add(d)
-        result = result.transpose(*tuple(out_dims))
+        result = result.transpose(*out_dims)
     return result
 
 

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -9,7 +9,6 @@ import re
 import warnings
 from enum import Enum
 from typing import (
-    AbstractSet,
     Any,
     Callable,
     Collection,
@@ -509,17 +508,14 @@ class OrderedSet(MutableSet[T]):
 
     __slots__ = ("_d",)
 
-    def __init__(self, values: AbstractSet[T] = None):
+    def __init__(self, values: Iterable[T] = None):
         self._d = {}
         if values is not None:
-            # Disable type checking - both mypy and PyCharm believe that
-            # we're altering the type of self in place (see signature of
-            # MutableSet.__ior__)
-            self |= values  # type: ignore
+            self.update(values)
 
     # Required methods for MutableSet
 
-    def __contains__(self, value: object) -> bool:
+    def __contains__(self, value: Any) -> bool:
         return value in self._d
 
     def __iter__(self) -> Iterator[T]:
@@ -536,9 +532,9 @@ class OrderedSet(MutableSet[T]):
 
     # Additional methods
 
-    def update(self, values: AbstractSet[T]) -> None:
-        # See comment on __init__ re. type checking
-        self |= values  # type: ignore
+    def update(self, values: Iterable[T]) -> None:
+        for v in values:
+            self._d[v] = None
 
     def __repr__(self) -> str:
         return "{}({!r})".format(type(self).__name__, list(self))

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -515,7 +515,7 @@ class OrderedSet(MutableSet[T]):
 
     # Required methods for MutableSet
 
-    def __contains__(self, value: Any) -> bool:
+    def __contains__(self, value: Hashable) -> bool:
         return value in self._d
 
     def __iter__(self) -> Iterator[T]:


### PR DESCRIPTION
- [x] Passes `isort . && black . && mypy . && flake8`

Small patch to improve typing of OrderedSet: allowing more general input type in its constructor and .update method (Iterator instead of AbstractSet) helps to get rid of ``# type: ignore``.

Side-effect: some performance gain in micro-benchmark (before and after):
```
%timeit xr.core.utils.OrderedSet(range(10))
3.46 µs ± 5.37 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```
```
2.06 µs ± 6.39 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```