### PR TITLE
Remove special case in guess_engines

### DIFF
--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -104,11 +104,6 @@ def list_engines():
 def guess_engine(store_spec):
     engines = list_engines()
 
-    # use the pre-defined selection order for netCDF files
-    for engine in ["netcdf4", "h5netcdf", "scipy"]:
-        if engine in engines and engines[engine].guess_can_open(store_spec):
-            return engine
-
     for engine, backend in engines.items():
         try:
             if backend.guess_can_open and backend.guess_can_open(store_spec):

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -640,6 +640,7 @@ def read_magic_number(filename_or_obj, count=8):
     elif isinstance(filename_or_obj, io.IOBase):
         if filename_or_obj.tell() != 0:
             raise ValueError(
+                "cannot guess the engine, "
                 "file-like object read/write pointer not at the start of the file, "
                 "please close and reopen, or use a context manager"
             )

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2661,7 +2661,7 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
                     open_dataset(f, engine="scipy")
 
                 f.seek(8)
-                with raises_regex(ValueError, "read/write pointer not at the start"):
+                with raises_regex(ValueError, "cannot guess the engine"):
                     open_dataset(f)
 
 


### PR DESCRIPTION
- [x] Related to #4724
- [x] Tests sync'ed
- [x] Passes `isort . && black . && mypy . && flake8`
- [x] No user visible changes
- [x] No new functions/methods

This is a minor cleanup of the backend API v2.