### PR TITLE
install conda as a library in the minimum dependency check CI

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -183,6 +183,6 @@ jobs:
 
       - name: minimum versions policy
         run: |
-          mamba install -y pyyaml
+          mamba install -y pyyaml conda
           python ci/min_deps_check.py ci/requirements/py37-bare-minimum.yml
           python ci/min_deps_check.py ci/requirements/py37-min-all-deps.yml

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -183,6 +183,6 @@ jobs:
 
       - name: minimum versions policy
         run: |
-          mamba install -y pyyaml conda
+          mamba install -y pyyaml conda python=3.8
           python ci/min_deps_check.py ci/requirements/py37-bare-minimum.yml
           python ci/min_deps_check.py ci/requirements/py37-min-all-deps.yml

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -180,9 +180,10 @@ jobs:
           channel-priority: strict
           mamba-version: "*"
           auto-update-conda: false
+          python-version: "3.8"
 
       - name: minimum versions policy
         run: |
-          mamba install -y pyyaml conda python=3.8
+          mamba install -y pyyaml conda
           python ci/min_deps_check.py ci/requirements/py37-bare-minimum.yml
           python ci/min_deps_check.py ci/requirements/py37-min-all-deps.yml


### PR DESCRIPTION
#4775 changed the min_deps_check CI to require `conda` as a library. This was not an issue before because we used `conda` to install the dependencies, but now that we use `mamba` instead we have to make sure `conda` is installed.

<sub>
<h3>
  Overriding CI behaviors
</h3>
   By default, the upstream dev CI is disabled on pull request and push events. You can override this behavior per commit by adding a `[test-upstream]` tag to the first line of the commit message. For documentation-only commits, you can skip the CI per commit by adding a `[skip-ci]` tag to the first line of the commit message
</sub>
