### PR TITLE
Expand user dir paths (~) in open_mfdataset.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -68,6 +68,9 @@ Bug fixes
   By `Alessandro Amici <https://github.com/alexamici>`_
 - Limit number of data rows when printing large datasets. (:issue:`4736`, :pull:`4750`). By `Jimmy Westling <https://github.com/illviljan>`_.
 - Add ``missing_dims`` parameter to transpose (:issue:`4647`, :pull:`4767`). By `Daniel Mesejo <https://github.com/mesejo>`_.
+- Expand user directory paths (for instance ``~/`` on unix) in
+  :py:func:`open_mfdataset` (:issue:`4783`, :pull:`4795`).
+  By `Julien Seguinot <https://github.com/juseg>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -73,11 +73,11 @@ Bug fixes
   (:issue:`2658` and :issue:`4543`) by `Mathias Hauser <https://github.com/mathause>`_.
 - Limit number of data rows when printing large datasets. (:issue:`4736`, :pull:`4750`). By `Jimmy Westling <https://github.com/illviljan>`_.
 - Add ``missing_dims`` parameter to transpose (:issue:`4647`, :pull:`4767`). By `Daniel Mesejo <https://github.com/mesejo>`_.
-- Expand user directory paths (for instance ``~/`` on unix) in
-  :py:func:`open_mfdataset` (:issue:`4783`, :pull:`4795`).
-  By `Julien Seguinot <https://github.com/juseg>`_.
 - Resolve intervals before appending other metadata to labels when plotting (:issue:`4322`, :pull:`4794`).
   By `Justus Magin <https://github.com/keewis>`_.
+- Expand user directory paths (e.g. ``~/``) in :py:func:`open_mfdataset` and
+  :py:meth:`Dataset.to_zarr` (:issue:`4783`, :pull:`4795`).
+  By `Julien Seguinot <https://github.com/juseg>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1386,10 +1386,11 @@ def to_zarr(
 
     See `Dataset.to_zarr` for full API docs.
     """
-    if isinstance(store, Path):
-        store = str(store)
-    if isinstance(chunk_store, Path):
-        chunk_store = str(store)
+
+    # expand str and Path arguments
+    store = _normalize_path(store)
+    chunk_store = _normalize_path(chunk_store)
+
     if encoding is None:
         encoding = {}
 
@@ -1418,9 +1419,6 @@ def to_zarr(
             "Instead, set consolidated=True when writing to zarr with "
             "compute=False before writing data."
         )
-
-    if isinstance(store, Path):
-        store = str(store)
 
     # validate Dataset keys, DataArray names, and attr keys/values
     _validate_dataset_names(dataset)

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -887,7 +887,7 @@ def open_mfdataset(
                     paths
                 )
             )
-        paths = sorted(glob(paths))
+        paths = sorted(glob(_normalize_path(paths)))
     else:
         paths = [str(p) if isinstance(p, Path) else p for p in paths]
 


### PR DESCRIPTION
- [x] Closes #4783 
- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`


<sub>
<h3>
  Overriding CI behaviors
</h3>
   By default, the upstream dev CI is disabled on pull request and push events. You can override this behavior per commit by adding a `[test-upstream]` tag to the first line of the commit message. For documentation-only commits, you can skip the CI per commit by adding a `[skip-ci]` tag to the first line of the commit message
</sub>
