### PR TITLE
fix the ci trigger action

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,5 @@
 <h3>
   Overriding CI behaviors
 </h3>
-   By default, the upstream dev CI is disabled on pull request and push events. You can override this behavior per commit by adding a `[test-upstream]` tag to the first line of the commit message. For documentation-only commits, you can skip the CI per commit by adding a `[skip-ci]` tag to the first line of the commit message
+   By default, the upstream dev CI is disabled on pull request and push events. You can override this behavior per commit by adding a <tt>[test-upstream]</tt> tag to the first line of the commit message. For documentation-only commits, you can skip the CI per commit by adding a <tt>[skip-ci]</tt> tag to the first line of the commit message
 </sub>

--- a/.github/actions/detect-ci-trigger/script.sh
+++ b/.github/actions/detect-ci-trigger/script.sh
@@ -6,7 +6,8 @@ echo "::group::fetch a sufficient number of commits"
 git log -n 5 2>&1
 if [[ "$event_name" == "pull_request" ]]; then
     ref=$(git log -1 --format='%H')
-    git -c protocol.version=2 fetch --deepen=2 --no-tags origin $ref 2>&1
+    git -c protocol.version=2 fetch --deepen=2 --no-tags --prune --progress origin $ref 2>&1
+    git log FETCH_HEAD
     git checkout FETCH_HEAD
 else
     echo "nothing to do."

--- a/.github/actions/detect-ci-trigger/script.sh
+++ b/.github/actions/detect-ci-trigger/script.sh
@@ -6,7 +6,7 @@ echo "::group::fetch a sufficient number of commits"
 git log -n 5 2>&1
 if [[ "$event_name" == "pull_request" ]]; then
     ref=$(git log -1 --format='%H')
-    git -c protocol.version=2 fetch --deepen=2 --no-tags --prune --progress origin $ref 2>&1
+    git -c protocol.version=2 fetch --deepen=2 --no-tags --prune origin $ref 2>&1
     git log FETCH_HEAD
     git checkout FETCH_HEAD
 else

--- a/.github/actions/detect-ci-trigger/script.sh
+++ b/.github/actions/detect-ci-trigger/script.sh
@@ -3,6 +3,7 @@ event_name="$1"
 keyword="$2"
 
 echo "::group::fetch a sufficient number of commits"
+git log -n 5 2>&1
 if [[ "$event_name" == "pull_request" ]]; then
     git fetch --deepen=1 --no-tags 2>&1
 else

--- a/.github/actions/detect-ci-trigger/script.sh
+++ b/.github/actions/detect-ci-trigger/script.sh
@@ -5,7 +5,9 @@ keyword="$2"
 echo "::group::fetch a sufficient number of commits"
 git log -n 5 2>&1
 if [[ "$event_name" == "pull_request" ]]; then
-    git fetch --deepen=1 --no-tags 2>&1
+    ref=$(git log -1 --format='%H')
+    git -c protocol.version=2 fetch --deepen=2 --no-tags origin $ref 2>&1
+    git checkout FETCH_HEAD
 else
     echo "nothing to do."
 fi

--- a/.github/actions/detect-ci-trigger/script.sh
+++ b/.github/actions/detect-ci-trigger/script.sh
@@ -3,16 +3,17 @@ event_name="$1"
 keyword="$2"
 
 echo "::group::fetch a sufficient number of commits"
-git log -n 5 2>&1
-if [[ "$event_name" == "pull_request" ]]; then
-    ref=$(git log -1 --format='%H')
-    git -c protocol.version=2 fetch --deepen=2 --no-tags --prune --progress -q origin $ref 2>&1
-    git log FETCH_HEAD
-    git checkout FETCH_HEAD
-else
-    echo "nothing to do."
-fi
-git log -n 5 2>&1
+echo "skipped"
+# git log -n 5 2>&1
+# if [[ "$event_name" == "pull_request" ]]; then
+#     ref=$(git log -1 --format='%H')
+#     git -c protocol.version=2 fetch --deepen=2 --no-tags --prune --progress -q origin $ref 2>&1
+#     git log FETCH_HEAD
+#     git checkout FETCH_HEAD
+# else
+#     echo "nothing to do."
+# fi
+# git log -n 5 2>&1
 echo "::endgroup::"
 
 echo "::group::extracting the commit message"

--- a/.github/actions/detect-ci-trigger/script.sh
+++ b/.github/actions/detect-ci-trigger/script.sh
@@ -9,6 +9,7 @@ if [[ "$event_name" == "pull_request" ]]; then
 else
     echo "nothing to do."
 fi
+git log -n 5 2>&1
 echo "::endgroup::"
 
 echo "::group::extracting the commit message"

--- a/.github/actions/detect-ci-trigger/script.sh
+++ b/.github/actions/detect-ci-trigger/script.sh
@@ -6,7 +6,7 @@ echo "::group::fetch a sufficient number of commits"
 git log -n 5 2>&1
 if [[ "$event_name" == "pull_request" ]]; then
     ref=$(git log -1 --format='%H')
-    git -c protocol.version=2 fetch --deepen=2 --no-tags --prune origin $ref 2>&1
+    git -c protocol.version=2 fetch --deepen=2 --no-tags --prune --progress -q origin $ref 2>&1
     git log FETCH_HEAD
     git checkout FETCH_HEAD
 else

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -17,6 +17,8 @@ jobs:
       triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - uses: ./.github/actions/detect-ci-trigger
         id: detect-trigger
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ jobs:
       triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - uses: ./.github/actions/detect-ci-trigger
         id: detect-trigger
         with:

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -19,6 +19,8 @@ jobs:
       triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - uses: ./.github/actions/detect-ci-trigger
         id: detect-trigger
         with:


### PR DESCRIPTION
This attempts to fix the CI trigger action, which fails when trying to get the commit message.

Edit: the action only fails for merge commits

- [x] Closes #4801

<sub>
<h3>
  Overriding CI behaviors
</h3>
   By default, the upstream dev CI is disabled on pull request and push events. You can override this behavior per commit by adding a `[test-upstream]` tag to the first line of the commit message. For documentation-only commits, you can skip the CI per commit by adding a `[skip-ci]` tag to the first line of the commit message
</sub>
