### PR TITLE
don't skip the scheduled CI

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -32,7 +32,7 @@ jobs:
       always()
       && github.repository == 'pydata/xarray'
       && (
-        (github.event_name == 'scheduled' || github.event_name == 'workflow_dispatch')
+        (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         || needs.detect-ci-trigger.outputs.triggered == 'true'
       )
     defaults:


### PR DESCRIPTION
As pointed out by @andersy005 in https://github.com/pydata/xarray/issues/4801#issuecomment-759747669, the scheduled CI is currently skipped because we have a typo in the condition:
https://github.com/pydata/xarray/blob/fb67358ceb0c386560e6a6991dd937292ba54d46/.github/workflows/upstream-dev-ci.yaml#L35
the correct event name is `schedule`

- [x] Closes #4801
- [x] Passes `pre-commit run --all-files`


<sub>
<h3>
  Overriding CI behaviors
</h3>
   By default, the upstream dev CI is disabled on pull request and push events. You can override this behavior per commit by adding a `[test-upstream]` tag to the first line of the commit message. For documentation-only commits, you can skip the CI per commit by adding a `[skip-ci]` tag to the first line of the commit message
</sub>
