### PR TITLE
Remove the references to `_file_obj` outside low level code paths, change to `_close`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -103,6 +103,8 @@ Internal Changes
   By `Maximilian Roos <https://github.com/max-sixty>`_.
 - Speed up attribute style access (e.g. ``ds.somevar`` instead of ``ds["somevar"]``) and tab completion
   in ipython (:issue:`4741`, :pull:`4742`). By `Richard Kleijn <https://github.com/rhkleijn>`_.
+- Added the ``set_close`` method to ``Dataset`` and ``DataArray`` for beckends to specify how to voluntary release
+  all resources. (:pull:`#4809`), By `Alessandro Amici <https://github.com/alexamici>`_.
 
 .. _whats-new.0.16.2:
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -522,7 +522,6 @@ def open_dataset(
 
         else:
             ds2 = ds
-        ds2._close = ds._close
         return ds2
 
     filename_or_obj = _normalize_path(filename_or_obj)
@@ -700,8 +699,6 @@ def open_dataarray(
         )
     else:
         (data_array,) = dataset.data_vars.values()
-
-    data_array._close = dataset._close
 
     # Reset names if they were changed during saving
     # to ensure that we can 'roundtrip' perfectly

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -522,6 +522,7 @@ def open_dataset(
 
         else:
             ds2 = ds
+        ds2.set_close(ds._close)
         return ds2
 
     filename_or_obj = _normalize_path(filename_or_obj)
@@ -699,6 +700,8 @@ def open_dataarray(
         )
     else:
         (data_array,) = dataset.data_vars.values()
+
+    data_array.set_close(dataset._close)
 
     # Reset names if they were changed during saving
     # to ensure that we can 'roundtrip' perfectly

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -712,17 +712,6 @@ def open_dataarray(
     return data_array
 
 
-class _MultiFileCloser:
-    __slots__ = ("closers",)
-
-    def __init__(self, closers):
-        self.closers = closers
-
-    def __call__(self):
-        for dataset_close in self.closers:
-            dataset_close()
-
-
 def open_mfdataset(
     paths,
     chunks=None,
@@ -960,7 +949,11 @@ def open_mfdataset(
             ds.close()
         raise
 
-    combined._close = _MultiFileCloser(closers)
+    def multi_file_closer():
+        for closer in closers:
+            closer()
+
+    combined._close = multi_file_closer
 
     # read global attributes from the attrs_file or from the first dataset
     if attrs_file is not None:

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -956,7 +956,7 @@ def open_mfdataset(
         for closer in closers:
             closer()
 
-    combined._close = multi_file_closer
+    combined.set_close(multi_file_closer)
 
     # read global attributes from the attrs_file or from the first dataset
     if attrs_file is not None:

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -522,7 +522,7 @@ def open_dataset(
 
         else:
             ds2 = ds
-        ds2._file_obj = ds._file_obj
+        ds2._close = ds._close
         return ds2
 
     filename_or_obj = _normalize_path(filename_or_obj)
@@ -701,7 +701,7 @@ def open_dataarray(
     else:
         (data_array,) = dataset.data_vars.values()
 
-    data_array._file_obj = dataset._file_obj
+    data_array._close = dataset._close
 
     # Reset names if they were changed during saving
     # to ensure that we can 'roundtrip' perfectly
@@ -716,14 +716,14 @@ def open_dataarray(
 
 
 class _MultiFileCloser:
-    __slots__ = ("file_objs",)
+    __slots__ = ("closers",)
 
-    def __init__(self, file_objs):
-        self.file_objs = file_objs
+    def __init__(self, closers):
+        self.closers = closers
 
-    def close(self):
-        for f in self.file_objs:
-            f.close()
+    def __call__(self):
+        for dataset_close in self.closers:
+            dataset_close()
 
 
 def open_mfdataset(
@@ -918,14 +918,14 @@ def open_mfdataset(
         getattr_ = getattr
 
     datasets = [open_(p, **open_kwargs) for p in paths]
-    file_objs = [getattr_(ds, "_file_obj") for ds in datasets]
+    closers = [getattr_(ds, "_close") for ds in datasets]
     if preprocess is not None:
         datasets = [preprocess(ds) for ds in datasets]
 
     if parallel:
         # calling compute here will return the datasets/file_objs lists,
         # the underlying datasets will still be stored as dask arrays
-        datasets, file_objs = dask.compute(datasets, file_objs)
+        datasets, closers = dask.compute(datasets, closers)
 
     # Combine all datasets, closing them in case of a ValueError
     try:
@@ -963,7 +963,7 @@ def open_mfdataset(
             ds.close()
         raise
 
-    combined._file_obj = _MultiFileCloser(file_objs)
+    combined._close = _MultiFileCloser(closers)
 
     # read global attributes from the attrs_file or from the first dataset
     if attrs_file is not None:

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -90,8 +90,6 @@ def _dataset_from_backend_dataset(
             **extra_tokens,
         )
 
-    ds._close = backend_ds._close
-
     # Ensure source filename always stored in dataset object (GH issue #2550)
     if "source" not in ds.encoding:
         if isinstance(filename_or_obj, str):

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -90,7 +90,7 @@ def _dataset_from_backend_dataset(
             **extra_tokens,
         )
 
-    ds._file_obj = backend_ds._file_obj
+    ds._close = backend_ds._close
 
     # Ensure source filename always stored in dataset object (GH issue #2550)
     if "source" not in ds.encoding:

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -90,6 +90,8 @@ def _dataset_from_backend_dataset(
             **extra_tokens,
         )
 
+    ds.set_close(backend_ds._close)
+
     # Ensure source filename always stored in dataset object (GH issue #2550)
     if "source" not in ds.encoding:
         if isinstance(filename_or_obj, str):

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -350,8 +350,8 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None, loc
         dims=("band", "y", "x"),
         coords=coords,
         attrs=attrs,
-        close=manager.close,
     )
+    result.set_close(manager.close)
 
     if chunks is not None:
         from dask.base import tokenize

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -345,7 +345,13 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None, loc
     if cache and chunks is None:
         data = indexing.MemoryCachedArray(data)
 
-    result = DataArray(data=data, dims=("band", "y", "x"), coords=coords, attrs=attrs)
+    result = DataArray(
+        data=data,
+        dims=("band", "y", "x"),
+        coords=coords,
+        attrs=attrs,
+        close=manager.close,
+    )
 
     if chunks is not None:
         from dask.base import tokenize
@@ -359,8 +365,5 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None, loc
         token = tokenize(filename, mtime, chunks)
         name_prefix = "open_rasterio-%s" % token
         result = result.chunk(chunks, name_prefix=name_prefix, token=token)
-
-    # Make the file closeable
-    result._close = manager.close
 
     return result

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -345,12 +345,7 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None, loc
     if cache and chunks is None:
         data = indexing.MemoryCachedArray(data)
 
-    result = DataArray(
-        data=data,
-        dims=("band", "y", "x"),
-        coords=coords,
-        attrs=attrs,
-    )
+    result = DataArray(data=data, dims=("band", "y", "x"), coords=coords, attrs=attrs)
     result.set_close(manager.close)
 
     if chunks is not None:

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -346,7 +346,6 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None, loc
         data = indexing.MemoryCachedArray(data)
 
     result = DataArray(data=data, dims=("band", "y", "x"), coords=coords, attrs=attrs)
-    result.set_close(manager.close)
 
     if chunks is not None:
         from dask.base import tokenize
@@ -360,5 +359,8 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None, loc
         token = tokenize(filename, mtime, chunks)
         name_prefix = "open_rasterio-%s" % token
         result = result.chunk(chunks, name_prefix=name_prefix, token=token)
+
+    # Make the file closeable
+    result.set_close(manager.close)
 
     return result

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -361,6 +361,6 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None, loc
         result = result.chunk(chunks, name_prefix=name_prefix, token=token)
 
     # Make the file closeable
-    result._file_obj = manager
+    result._close = manager.close
 
     return result

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -33,9 +33,8 @@ def open_backend_dataset_store(
         decode_timedelta=decode_timedelta,
     )
 
-    ds = Dataset(vars, attrs=attrs)
+    ds = Dataset(vars, attrs=attrs, close=store.close)
     ds = ds.set_coords(coord_names.intersection(vars))
-    ds._close = store.close
     ds.encoding = encoding
 
     return ds

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -19,7 +19,6 @@ def open_backend_dataset_store(
     decode_timedelta=None,
 ):
     vars, attrs = store.load()
-    file_obj = store
     encoding = store.get_encoding()
 
     vars, attrs, coord_names = conventions.decode_cf_variables(
@@ -36,7 +35,7 @@ def open_backend_dataset_store(
 
     ds = Dataset(vars, attrs=attrs)
     ds = ds.set_coords(coord_names.intersection(vars))
-    ds._file_obj = file_obj
+    ds._close = store.close
     ds.encoding = encoding
 
     return ds

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -34,8 +34,8 @@ def open_backend_dataset_store(
     )
 
     ds = Dataset(vars, attrs=attrs)
-    ds.set_close(store.close)
     ds = ds.set_coords(coord_names.intersection(vars))
+    ds.set_close(store.close)
     ds.encoding = encoding
 
     return ds

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -33,7 +33,8 @@ def open_backend_dataset_store(
         decode_timedelta=decode_timedelta,
     )
 
-    ds = Dataset(vars, attrs=attrs, close=store.close)
+    ds = Dataset(vars, attrs=attrs)
+    ds.set_close(store.close)
     ds = ds.set_coords(coord_names.intersection(vars))
     ds.encoding = encoding
 

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -598,8 +598,8 @@ def decode_cf(
         decode_timedelta=decode_timedelta,
     )
     ds = Dataset(vars, attrs=attrs)
-    ds.set_close(close)
     ds = ds.set_coords(coord_names.union(extra_coords).intersection(vars))
+    ds.set_close(close)
     ds.encoding = encoding
 
     return ds

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -576,12 +576,12 @@ def decode_cf(
         vars = obj._variables
         attrs = obj.attrs
         extra_coords = set(obj.coords)
-        file_obj = obj._file_obj
+        close = obj._close
         encoding = obj.encoding
     elif isinstance(obj, AbstractDataStore):
         vars, attrs = obj.load()
         extra_coords = set()
-        file_obj = obj
+        close = obj.close
         encoding = obj.get_encoding()
     else:
         raise TypeError("can only decode Dataset or DataStore objects")
@@ -599,7 +599,7 @@ def decode_cf(
     )
     ds = Dataset(vars, attrs=attrs)
     ds = ds.set_coords(coord_names.union(extra_coords).intersection(vars))
-    ds._file_obj = file_obj
+    ds._close = close
     ds.encoding = encoding
 
     return ds

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -597,9 +597,8 @@ def decode_cf(
         use_cftime=use_cftime,
         decode_timedelta=decode_timedelta,
     )
-    ds = Dataset(vars, attrs=attrs)
+    ds = Dataset(vars, attrs=attrs, close=close)
     ds = ds.set_coords(coord_names.union(extra_coords).intersection(vars))
-    ds._close = close
     ds.encoding = encoding
 
     return ds

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -597,7 +597,8 @@ def decode_cf(
         use_cftime=use_cftime,
         decode_timedelta=decode_timedelta,
     )
-    ds = Dataset(vars, attrs=attrs, close=close)
+    ds = Dataset(vars, attrs=attrs)
+    ds.set_close(close)
     ds = ds.set_coords(coord_names.union(extra_coords).intersection(vars))
     ds.encoding = encoding
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1269,13 +1269,16 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
     def set_close(self, close_store: Optional[Callable[[], None]]) -> None:
         """Register the function that releases all resources used by the data store.
 
-        This method is mostly intended for backend developers and it is rarely
-        needed by regular end-users.
+        This method controls how xarray cleans up resources associated
+        with this object when the .close() method is called. It is mostly
+        intended for backend developers and it is rarely needed by regular
+        end-users.
 
         Parameters
         ----------
         close_store : callable
-            A callable that releases all resources used by the data store.
+            A callable that when called like ``close_store()`` releases
+            all resources used by the data store.
         """
         self._close = close_store
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1266,8 +1266,18 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         return ops.where_method(self, cond, other)
 
-    def set_close(self, close: Optional[Callable[[], None]]) -> None:
-        self._close = close
+    def set_close(self, close_store: Optional[Callable[[], None]]) -> None:
+        """Register the function that releases all resources used by the data store.
+
+        This method is mostly intended for backend developers and it is rarely
+        needed by regular end-users.
+
+        Parameters
+        ----------
+        close_store : callable
+            A callable that releases all resources used by the data store.
+        """
+        self._close = close_store
 
     def close(self: Any) -> None:
         """Close any files linked to this object"""

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -11,6 +11,7 @@ from typing import (
     Iterator,
     List,
     Mapping,
+    Optional,
     Tuple,
     TypeVar,
     Union,
@@ -1265,6 +1266,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
     def close(self: Any) -> None:
         """Close any files linked to this object"""
+        self._close: Optional[Callable[[], None]]
         if self._close is not None:
             self._close()
         self._close = None

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1266,7 +1266,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         return ops.where_method(self, cond, other)
 
-    def set_close(self, close_store: Optional[Callable[[], None]]) -> None:
+    def set_close(self, close: Optional[Callable[[], None]]) -> None:
         """Register the function that releases all resources used by the data store.
 
         This method controls how xarray cleans up resources associated
@@ -1276,11 +1276,11 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         Parameters
         ----------
-        close_store : callable
-            A callable that when called like ``close_store()`` releases
+        close : callable
+            A callable that when called like ``close()`` releases
             all resources used by the data store.
         """
-        self._close = close_store
+        self._close = close
 
     def close(self: Any) -> None:
         """Close any files linked to this object"""

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1267,23 +1267,23 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         return ops.where_method(self, cond, other)
 
     def set_close(self, close: Optional[Callable[[], None]]) -> None:
-        """Register the function that releases all resources used by the data store.
+        """Register the function that releases any resources linked to this object.
 
         This method controls how xarray cleans up resources associated
-        with this object when the .close() method is called. It is mostly
+        with this object when the ``.close()`` method is called. It is mostly
         intended for backend developers and it is rarely needed by regular
         end-users.
 
         Parameters
         ----------
         close : callable
-            A callable that when called like ``close()`` releases
-            all resources used by the data store.
+            The function that when called like ``close()`` releases
+            any resources linked to this object.
         """
         self._close = close
 
     def close(self: Any) -> None:
-        """Close any files linked to this object"""
+        """Release any resources linked to this object."""
         if self._close is not None:
             self._close()
         self._close = None

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1265,9 +1265,9 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
     def close(self: Any) -> None:
         """Close any files linked to this object"""
-        if self._file_obj is not None:
-            self._file_obj.close()
-        self._file_obj = None
+        if self._close is not None:
+            self._close()
+        self._close = None
 
     def isnull(self, keep_attrs: bool = None):
         """Test each value in the array for whether it is a missing value.

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -331,7 +331,9 @@ def get_squeeze_dims(
 class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
     """Shared base class for Dataset and DataArray."""
 
-    __slots__ = ()
+    _close: Optional[Callable[[], None]]
+
+    __slots__ = ("_close",)
 
     _rolling_exp_cls = RollingExp
 
@@ -1264,9 +1266,11 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         return ops.where_method(self, cond, other)
 
+    def set_close(self, close: Optional[Callable[[], None]]) -> None:
+        self._close = close
+
     def close(self: Any) -> None:
         """Close any files linked to this object"""
-        self._close: Optional[Callable[[], None]]
         if self._close is not None:
             self._close()
         self._close = None

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -430,7 +430,6 @@ class DataArray(AbstractArray, DataWithCoords):
         coords=None,
         name: Union[Hashable, None, Default] = _default,
         indexes=None,
-        close: Union[Callable[[], None], None, Default] = _default,
     ) -> "DataArray":
         if variable is None:
             variable = self.variable
@@ -438,13 +437,7 @@ class DataArray(AbstractArray, DataWithCoords):
             coords = self._coords
         if name is _default:
             name = self.name
-        if close is _default:
-            close = self._close
-        replaced = type(self)(
-            variable, coords, name=name, fastpath=True, indexes=indexes
-        )
-        replaced.set_close(close)
-        return replaced
+        return type(self)(variable, coords, name=name, fastpath=True, indexes=indexes)
 
     def _replace_maybe_drop_dims(
         self, variable: Variable, name: Union[Hashable, None, Default] = _default
@@ -500,8 +493,7 @@ class DataArray(AbstractArray, DataWithCoords):
         variable = dataset._variables.pop(_THIS_ARRAY)
         coords = dataset._variables
         indexes = dataset._indexes
-        close = dataset._close
-        return self._replace(variable, coords, name, indexes=indexes, close=close)
+        return self._replace(variable, coords, name, indexes=indexes)
 
     def _to_dataset_split(self, dim: Hashable) -> Dataset:
         """ splits dataarray along dimension 'dim' """
@@ -545,10 +537,7 @@ class DataArray(AbstractArray, DataWithCoords):
         indexes = self._indexes
 
         coord_names = set(self._coords)
-        close = self._close
-        dataset = Dataset._construct_direct(
-            variables, coord_names, indexes=indexes, close=close
-        )
+        dataset = Dataset._construct_direct(variables, coord_names, indexes=indexes)
         return dataset
 
     def to_dataset(

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -431,7 +431,7 @@ class DataArray(AbstractArray, DataWithCoords):
         coords=None,
         name: Union[Hashable, None, Default] = _default,
         indexes=None,
-        close: Optional[Callable[[], None]] = _default,
+        close: Union[Callable[[], None], None, Default] = _default,
     ) -> "DataArray":
         if variable is None:
             variable = self.variable

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -377,7 +377,6 @@ class DataArray(AbstractArray, DataWithCoords):
         # internal parameters
         indexes: Dict[Hashable, pd.Index] = None,
         fastpath: bool = False,
-        close: Optional[Callable[[], None]] = None,
     ):
         if fastpath:
             variable = data
@@ -423,7 +422,7 @@ class DataArray(AbstractArray, DataWithCoords):
         # public interface.
         self._indexes = indexes
 
-        self._close = close
+        self._close = None
 
     def _replace(
         self,
@@ -442,8 +441,9 @@ class DataArray(AbstractArray, DataWithCoords):
         if close is _default:
             close = self._close
         replaced = type(self)(
-            variable, coords, name=name, fastpath=True, indexes=indexes, close=close
+            variable, coords, name=name, fastpath=True, indexes=indexes
         )
+        replaced.set_close(close)
         return replaced
 
     def _replace_maybe_drop_dims(

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -344,6 +344,7 @@ class DataArray(AbstractArray, DataWithCoords):
 
     _cache: Dict[str, Any]
     _coords: Dict[Any, Variable]
+    _close: Optional[Callable[[], None]]
     _indexes: Optional[Dict[Hashable, pd.Index]]
     _name: Optional[Hashable]
     _variable: Variable
@@ -351,7 +352,7 @@ class DataArray(AbstractArray, DataWithCoords):
     __slots__ = (
         "_cache",
         "_coords",
-        "_file_obj",
+        "_close",
         "_indexes",
         "_name",
         "_variable",
@@ -376,6 +377,7 @@ class DataArray(AbstractArray, DataWithCoords):
         # internal parameters
         indexes: Dict[Hashable, pd.Index] = None,
         fastpath: bool = False,
+        close: Optional[Callable[[], None]] = None,
     ):
         if fastpath:
             variable = data
@@ -421,7 +423,7 @@ class DataArray(AbstractArray, DataWithCoords):
         # public interface.
         self._indexes = indexes
 
-        self._file_obj = None
+        self._close = close
 
     def _replace(
         self,

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -441,9 +441,10 @@ class DataArray(AbstractArray, DataWithCoords):
             name = self.name
         if close is _default:
             close = self._close
-        return type(self)(
+        replaced = type(self)(
             variable, coords, name=name, fastpath=True, indexes=indexes, close=close
         )
+        return replaced
 
     def _replace_maybe_drop_dims(
         self, variable: Variable, name: Union[Hashable, None, Default] = _default

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -665,7 +665,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         data_vars: Mapping[Hashable, Any] = None,
         coords: Mapping[Hashable, Any] = None,
         attrs: Mapping[Hashable, Any] = None,
-        close: Optional[Callable[[], None]] = None,
     ):
         # TODO(shoyer): expose indexes as a public argument in __init__
 
@@ -689,7 +688,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         )
 
         self._attrs = dict(attrs) if attrs is not None else None
-        self._close = close
+        self._close = None
         self._encoding = None
         self._variables = variables
         self._coord_names = coord_names
@@ -1343,8 +1342,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             name=name,
             indexes=indexes,
             fastpath=True,
-            close=self._close,
         )
+        da.set_close(self._close)
         return da
 
     def __copy__(self) -> "Dataset":
@@ -4808,8 +4807,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             attrs=self.attrs,
             name=name,
             indexes=indexes,
-            close=self._close,
         )
+        da.set_close(self._close)
         return da
 
     def _normalize_dim_order(

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1331,9 +1331,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         else:
             indexes = {k: v for k, v in self._indexes.items() if k in coords}
 
-        da = DataArray(variable, coords, name=name, indexes=indexes, fastpath=True)
-        da.set_close(self._close)
-        return da
+        return DataArray(variable, coords, name=name, indexes=indexes, fastpath=True)
 
     def __copy__(self) -> "Dataset":
         return self.copy(deep=False)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -704,7 +704,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         if decoder:
             variables, attributes = decoder(variables, attributes)
         obj = cls(variables, attrs=attributes)
-        obj._close = store.close
+        obj.set_close(store.close)
         return obj
 
     @property

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1034,7 +1034,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         indexes: Union[Dict[Any, pd.Index], None, Default] = _default,
         encoding: Union[dict, None, Default] = _default,
         inplace: bool = False,
-        close: Union[Callable[[], None], None, Default] = _default,
     ) -> "Dataset":
         """Fastpath constructor for internal use.
 
@@ -1057,8 +1056,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 self._indexes = indexes
             if encoding is not _default:
                 self._encoding = encoding
-            if close is not _default:
-                self._close = close
             obj = self
         else:
             if variables is None:
@@ -1073,10 +1070,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 indexes = copy.copy(self._indexes)
             if encoding is _default:
                 encoding = copy.copy(self._encoding)
-            if close is _default:
-                close = self._close
             obj = self._construct_direct(
-                variables, coord_names, dims, attrs, indexes, encoding, close
+                variables, coord_names, dims, attrs, indexes, encoding
             )
         return obj
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1336,13 +1336,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         else:
             indexes = {k: v for k, v in self._indexes.items() if k in coords}
 
-        da = DataArray(
-            variable,
-            coords,
-            name=name,
-            indexes=indexes,
-            fastpath=True,
-        )
+        da = DataArray(variable, coords, name=name, indexes=indexes, fastpath=True)
         da.set_close(self._close)
         return da
 
@@ -4800,14 +4794,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         dims = (dim,) + broadcast_vars[0].dims
 
-        da = DataArray(
-            data,
-            coords,
-            dims,
-            attrs=self.attrs,
-            name=name,
-            indexes=indexes,
-        )
+        da = DataArray(data, coords, dims, attrs=self.attrs, name=name, indexes=indexes)
         da.set_close(self._close)
         return da
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1035,7 +1035,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         indexes: Union[Dict[Any, pd.Index], None, Default] = _default,
         encoding: Union[dict, None, Default] = _default,
         inplace: bool = False,
-        close: Optional[Callable[[], None]] = _default,
+        close: Union[Callable[[], None], None, Default] = _default,
     ) -> "Dataset":
         """Fastpath constructor for internal use.
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4787,9 +4787,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         dims = (dim,) + broadcast_vars[0].dims
 
-        da = DataArray(data, coords, dims, attrs=self.attrs, name=name, indexes=indexes)
-        da.set_close(self._close)
-        return da
+        return DataArray(
+            data, coords, dims, attrs=self.attrs, name=name, indexes=indexes
+        )
 
     def _normalize_dim_order(
         self, dim_order: List[Hashable] = None

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1337,7 +1337,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         else:
             indexes = {k: v for k, v in self._indexes.items() if k in coords}
 
-        return DataArray(
+        da = DataArray(
             variable,
             coords,
             name=name,
@@ -1345,6 +1345,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             fastpath=True,
             close=self._close,
         )
+        return da
 
     def __copy__(self) -> "Dataset":
         return self.copy(deep=False)
@@ -4800,7 +4801,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         dims = (dim,) + broadcast_vars[0].dims
 
-        return DataArray(
+        da = DataArray(
             data,
             coords,
             dims,
@@ -4809,6 +4810,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             indexes=indexes,
             close=self._close,
         )
+        return da
 
     def _normalize_dim_order(
         self, dim_order: List[Hashable] = None


### PR DESCRIPTION
- [x] Related to #4309
- [x] No tests added, all tests passing
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] No new functions/methods are listed in `api.rst`

You can now pass a `close` argument to `xr.Dataset` that closes the backend resources. This is only useful to backend developers, we need to add the documentation as per #4803 but it may need to be hidden and not documented to end-users. 

The PR is draft pending some cleanups and the documentation.