### PR TITLE
add a version info step to the upstream-dev CI

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -62,7 +62,11 @@ jobs:
         run: |
           mamba env update -f ci/requirements/environment.yml
           bash ci/install-upstream-wheels.sh
+      - name: Version info
+        run: |
+          conda info -a
           conda list
+          python xarray/util/print_versions.py
       - name: import xarray
         run: |
           python -c 'import xarray'


### PR DESCRIPTION
The upstream-dev CI doesn't have the version info step the other CI have.

- [x] Closes #4808
- [x] Passes `pre-commit run --all-files`

<sub>
<h3>
  Overriding CI behaviors
</h3>
   By default, the upstream dev CI is disabled on pull request and push events. You can override this behavior per commit by adding a <tt>[test-upstream]</tt> tag to the first line of the commit message. For documentation-only commits, you can skip the CI per commit by adding a <tt>[skip-ci]</tt> tag to the first line of the commit message
</sub>
