### PR TITLE
Add dataset line plot

### DIFF
--- a/xarray/plot/dataset_plot.py
+++ b/xarray/plot/dataset_plot.py
@@ -469,6 +469,7 @@ def line(ds, x, y, ax, **kwargs):
         )
 
     cmap_params = kwargs.pop("cmap_params")
+    print(cmap_params)
     hue = kwargs.pop("hue")
     kwargs.pop("hue_style")
     markersize = kwargs.pop("markersize", None)
@@ -478,21 +479,25 @@ def line(ds, x, y, ax, **kwargs):
     # Transpose the data to same shape:
     data = _infer_scatter_data(ds, x, y, hue, markersize, size_norm, size_mapping)
 
-    # Number of lines to plot, hopefully it's always the last axis it splits on:
-    len_lines = data["x"].shape[-1]
+    if hue is not None:
+        # Number of lines to plot, hopefully it's always the last axis it splits on:
+        len_lines = data["x"].shape[-1]
 
-    # ax.plot doesn't allow multiple colors, workaround it by setting the default
-    # colors to follow the colormap instead:
-    cmap = plt.get_cmap(cmap_params["cmap"], len_lines)
-    ax.set_prop_cycle(plt.cycler(color=cmap(np.arange(len_lines))))
+        # ax.plot doesn't allow multiple colors, workaround it by setting the default
+        # colors to follow the colormap instead:
+        cmap = plt.get_cmap(cmap_params["cmap"], len_lines)
+        ax.set_prop_cycle(plt.cycler(color=cmap(np.arange(len_lines))))
 
-    # Plot data:
-    ax.plot(data["x"], data["y"], **kwargs)
+        # Plot data:
+        ax.plot(data["x"], data["y"], **kwargs)
 
-    # ax.plot doesn't return a mappable that fig.colorbar can parse. Create
-    # one and return that one instead:
-    norm = plt.Normalize(vmin=cmap_params["vmin"], vmax=cmap_params["vmax"])
-    primitive = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
+        # ax.plot doesn't return a mappable that fig.colorbar can parse. Create
+        # one and return that one instead:
+        norm = plt.Normalize(vmin=cmap_params["vmin"], vmax=cmap_params["vmax"])
+        primitive = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
+    else:
+        # Plot data:
+        primitive = ax.plot(data["x"], data["y"], **kwargs)
 
     # TODO: Should really be the line2d returned from ax.plot.
     # Return primitive, mappable instead?

--- a/xarray/plot/dataset_plot.py
+++ b/xarray/plot/dataset_plot.py
@@ -1,6 +1,5 @@
 import functools
 
-import matplotlib as mpl
 import numpy as np
 import pandas as pd
 
@@ -460,6 +459,8 @@ def line(ds, x, y, ax, **kwargs):
 
     Wraps :func:`matplotlib:matplotlib.pyplot.plot`
     """
+    import matplotlib.pyplot as plt
+
     if "add_colorbar" in kwargs or "add_legend" in kwargs:
         raise ValueError(
             "Dataset.plot.line does not accept "
@@ -482,16 +483,16 @@ def line(ds, x, y, ax, **kwargs):
 
     # ax.plot doesn't allow multiple colors, workaround it by setting the default
     # colors to follow the colormap instead:
-    cmap = mpl.pyplot.get_cmap(cmap_params["cmap"], len_lines)
-    ax.set_prop_cycle(mpl.cycler(color=cmap(np.arange(len_lines))))
+    cmap = plt.get_cmap(cmap_params["cmap"], len_lines)
+    ax.set_prop_cycle(plt.cycler(color=cmap(np.arange(len_lines))))
 
     # Plot data:
     ax.plot(data["x"], data["y"], **kwargs)
 
     # ax.plot doesn't return a mappable that fig.colorbar can parse. Create
     # one and return that one instead:
-    norm = mpl.colors.Normalize(vmin=cmap_params["vmin"], vmax=cmap_params["vmax"])
-    primitive = mpl.pyplot.cm.ScalarMappable(cmap=cmap, norm=norm)
+    norm = plt.Normalize(vmin=cmap_params["vmin"], vmax=cmap_params["vmax"])
+    primitive = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
 
     # TODO: Should really be the line2d returned from ax.plot.
     # Return primitive, mappable instead?

--- a/xarray/plot/dataset_plot.py
+++ b/xarray/plot/dataset_plot.py
@@ -1,8 +1,8 @@
 import functools
 
+import matplotlib as mpl
 import numpy as np
 import pandas as pd
-import matplotlib as mpl
 
 from ..core.alignment import broadcast
 from .facetgrid import _easy_facetgrid

--- a/xarray/plot/dataset_plot.py
+++ b/xarray/plot/dataset_plot.py
@@ -469,15 +469,18 @@ def line(ds, x, y, ax, **kwargs):
         )
 
     cmap_params = kwargs.pop("cmap_params")
-    print(cmap_params)
     hue = kwargs.pop("hue")
     kwargs.pop("hue_style")
-    markersize = kwargs.pop("markersize", None)
+    linewidth = kwargs.pop("markersize", None)
     size_norm = kwargs.pop("size_norm", None)
     size_mapping = kwargs.pop("size_mapping", None)  # set by facetgrid
 
     # Transpose the data to same shape:
-    data = _infer_scatter_data(ds, x, y, hue, markersize, size_norm, size_mapping)
+    data = _infer_scatter_data(ds, x, y, hue, linewidth, size_norm, size_mapping)
+
+    # Sort data so lines are connected correctly:
+    ind = np.argsort(data["x"], axis=0)
+    data["x"], data["y"] = data["x"][ind], data["y"][ind]
 
     if hue is not None:
         # Number of lines to plot, hopefully it's always the last axis it splits on:
@@ -495,6 +498,11 @@ def line(ds, x, y, ax, **kwargs):
         # one and return that one instead:
         norm = plt.Normalize(vmin=cmap_params["vmin"], vmax=cmap_params["vmax"])
         primitive = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
+    elif linewidth is not None:
+        ax.set_prop_cycle(plt.cycler(lw=data["sizes"][0] / 10))
+
+        # Plot data:
+        primitive = ax.plot(data["x"], data["y"], **kwargs)
     else:
         # Plot data:
         primitive = ax.plot(data["x"], data["y"], **kwargs)

--- a/xarray/plot/dataset_plot.py
+++ b/xarray/plot/dataset_plot.py
@@ -510,3 +510,34 @@ def line(ds, x, y, ax, **kwargs):
     # TODO: Should really be the line2d returned from ax.plot.
     # Return primitive, mappable instead?
     return primitive
+
+
+def _attach_to_plot_class(plotfunc):
+    @functools.wraps(plotfunc)
+    def plotmethod(self, *args, **kwargs):
+        plotfunc(self._ds, *args, **kwargs)
+
+    # Add to class _PlotMethods
+    setattr(_Dataset_PlotMethods, plotmethod.__name__, plotmethod)
+
+
+@_attach_to_plot_class
+def line2(ds, x=None, y=None, ax=None, **kwargs):
+    """
+    Line plot Dataset data variables against each other.
+    Wraps :func:`matplotlib:matplotlib.pyplot.plot`
+
+    Parameters
+    ----------
+    something
+
+    """
+    from ..core.dataarray import DataArray
+
+    # Create a temporary datarray with the x-axis as a coordinate:
+    coords = dict(ds.indexes)
+    coords[x] = ds[x]
+    da = DataArray(ds[y], coords=coords)
+
+    # Plot
+    return da.plot.line(x=x, ax=ax, **kwargs)

--- a/xarray/plot/dataset_plot.py
+++ b/xarray/plot/dataset_plot.py
@@ -452,92 +452,28 @@ def scatter(ds, x, y, ax, **kwargs):
     return primitive
 
 
-@_dsplot
-def line(ds, x, y, ax, **kwargs):
-    """
-    Line plot Dataset data variables against each other.
-
-    Wraps :func:`matplotlib:matplotlib.pyplot.plot`
-    """
-    import matplotlib.pyplot as plt
-
-    if "add_colorbar" in kwargs or "add_legend" in kwargs:
-        raise ValueError(
-            "Dataset.plot.line does not accept "
-            "'add_colorbar' or 'add_legend'. "
-            "Use 'add_guide' instead."
-        )
-
-    cmap_params = kwargs.pop("cmap_params")
-    hue = kwargs.pop("hue")
-    kwargs.pop("hue_style")
-    linewidth = kwargs.pop("markersize", None)
-    size_norm = kwargs.pop("size_norm", None)
-    size_mapping = kwargs.pop("size_mapping", None)  # set by facetgrid
-
-    # Transpose the data to same shape:
-    data = _infer_scatter_data(ds, x, y, hue, linewidth, size_norm, size_mapping)
-
-    # Sort data so lines are connected correctly:
-    ind = np.argsort(data["x"], axis=0)
-    data["x"], data["y"] = data["x"][ind], data["y"][ind]
-
-    if hue is not None:
-        # Number of lines to plot, hopefully it's always the last axis it splits on:
-        len_lines = data["x"].shape[-1]
-
-        # ax.plot doesn't allow multiple colors, workaround it by setting the default
-        # colors to follow the colormap instead:
-        cmap = plt.get_cmap(cmap_params["cmap"], len_lines)
-        ax.set_prop_cycle(plt.cycler(color=cmap(np.arange(len_lines))))
-
-        # Plot data:
-        ax.plot(data["x"], data["y"], **kwargs)
-
-        # ax.plot doesn't return a mappable that fig.colorbar can parse. Create
-        # one and return that one instead:
-        norm = plt.Normalize(vmin=cmap_params["vmin"], vmax=cmap_params["vmax"])
-        primitive = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
-    elif linewidth is not None:
-        ax.set_prop_cycle(plt.cycler(lw=data["sizes"][0] / 10))
-
-        # Plot data:
-        primitive = ax.plot(data["x"], data["y"], **kwargs)
-    else:
-        # Plot data:
-        primitive = ax.plot(data["x"], data["y"], **kwargs)
-
-    # TODO: Should really be the line2d returned from ax.plot.
-    # Return primitive, mappable instead?
-    return primitive
-
-
 def _attach_to_plot_class(plotfunc):
     @functools.wraps(plotfunc)
     def plotmethod(self, *args, **kwargs):
-        plotfunc(self._ds, *args, **kwargs)
+        return plotfunc(self._ds, *args, **kwargs)
 
     # Add to class _PlotMethods
     setattr(_Dataset_PlotMethods, plotmethod.__name__, plotmethod)
 
 
-@_attach_to_plot_class
-def line2(ds, x=None, y=None, ax=None, **kwargs):
-    """
-    Line plot Dataset data variables against each other.
-    Wraps :func:`matplotlib:matplotlib.pyplot.plot`
-
-    Parameters
-    ----------
-    something
-
-    """
+def _temp_dataarray(ds, x, y):
+    """Create a temporary datarray with the x-axis as a coordinate."""
     from ..core.dataarray import DataArray
 
-    # Create a temporary datarray with the x-axis as a coordinate:
     coords = dict(ds.indexes)
     coords[x] = ds[x]
-    da = DataArray(ds[y], coords=coords)
 
-    # Plot
+    return DataArray(ds[y], coords=coords)
+
+
+@_attach_to_plot_class
+def line(ds, x=None, y=None, ax=None, **kwargs):
+    """Line plot Dataset data variables against each other."""
+    da = _temp_dataarray(ds, x, y)
+
     return da.plot.line(x=x, ax=ax, **kwargs)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #4235
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

TODO:
- [ ] markersize/linewidth should work, easy if linewidth is only defined. But the hue/linewidth combo is trickier.
- [ ] hue only works with coordinates. Should it work with variables? How to do that? groupby?
- [ ] Should lines always be sorted to avoid weird lines?
- [ ] linewidth not shown anywhere


Adds `ds.plot.line`. The function wraps `ax.plot` which should feel pretty homely for most matplotlib users.

It was a mess getting the colorbar to work because scatter returns a mappable that colorbar can handle but plot returns a list of line2ds that it can't handle. You also can't add cmaps directly to ax.plot, so to avoid for loops I changed the default color settings instead.

Feel free to break it.

Example:
![bild](https://user-images.githubusercontent.com/14371165/104847719-244fe100-58e2-11eb-815c-46940b7fc40e.png)

