### PR TITLE
iris update doc url

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -411,7 +411,7 @@ htmlhelp_basename = "xarraydoc"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
-    "iris": ("https://scitools.org.uk/iris/docs/latest", None),
+    "iris": ("https://scitools-iris.readthedocs.io/en/latest", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
     "numba": ("https://numba.pydata.org/numba-doc/latest", None),

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -166,7 +166,7 @@ different approaches to handling metadata: Iris strictly interprets
 `CF conventions`_. Iris particularly shines at mapping, thanks to its
 integration with Cartopy_.
 
-.. _Iris: http://scitools.org.uk/iris/
+.. _Iris: https://scitools-iris.readthedocs.io/en/stable/
 .. _Cartopy: http://scitools.org.uk/cartopy/docs/latest/
 
 `UV-CDAT`__ is another Python library that implements in-memory netCDF-like


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

iris moved its documentation to https://scitools-iris.readthedocs.io/en/stable/