### PR TITLE
speed up the repr for big MultiIndex objects

### DIFF
--- a/asv_bench/benchmarks/repr.py
+++ b/asv_bench/benchmarks/repr.py
@@ -11,8 +11,8 @@ class ReprMultiIndex:
         series = pd.Series(range(100000000), index=index)
         self.da = xr.DataArray(series)
 
-    def repr(self):
+    def time_repr(self):
         repr(self.da)
 
-    def repr_html(self):
+    def time_repr_html(self):
         self.da._repr_html_()

--- a/asv_bench/benchmarks/repr.py
+++ b/asv_bench/benchmarks/repr.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+import xarray as xr
+
+
+class ReprMultiIndex:
+    def setup(self, key):
+        index = pd.MultiIndex.from_product(
+            [range(10000), range(10000)], names=("level_0", "level_1")
+        )
+        series = pd.Series(range(100000000), index=index)
+        self.da = xr.DataArray(series)
+
+    def repr(self):
+        repr(self.da)
+
+    def repr_html(self):
+        self.da._repr_html_()

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -300,11 +300,14 @@ def _summarize_coord_multiindex(coord, col_width, marker):
 
 
 def _summarize_coord_levels(coord, col_width, marker="-"):
+    n_values = col_width // 4
+    indices = list(range(0, n_values)) + list(range(-n_values, 0))
+    subset = coord[indices]
     return "\n".join(
         summarize_variable(
-            lname, coord.get_level_variable(lname), col_width, marker=marker
+            lname, subset.get_level_variable(lname), col_width, marker=marker
         )
-        for lname in coord.level_names
+        for lname in subset.level_names
     )
 
 

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -300,9 +300,13 @@ def _summarize_coord_multiindex(coord, col_width, marker):
 
 
 def _summarize_coord_levels(coord, col_width, marker="-"):
-    n_values = col_width // 4
-    indices = list(range(0, n_values)) + list(range(-n_values, 0))
-    subset = coord[indices]
+    if col_width < len(coord):
+        n_values = col_width // 4
+        indices = list(range(0, n_values)) + list(range(-n_values, 0))
+        subset = coord[indices]
+    else:
+        subset = coord
+
     return "\n".join(
         summarize_variable(
             lname, subset.get_level_variable(lname), col_width, marker=marker

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -300,7 +300,7 @@ def _summarize_coord_multiindex(coord, col_width, marker):
 
 
 def _summarize_coord_levels(coord, col_width, marker="-"):
-    if col_width < len(coord):
+    if len(coord) > 100 and col_width < len(coord):
         n_values = col_width // 4
         indices = list(range(0, n_values)) + list(range(-n_values, 0))
         subset = coord[indices]

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -301,7 +301,7 @@ def _summarize_coord_multiindex(coord, col_width, marker):
 
 def _summarize_coord_levels(coord, col_width, marker="-"):
     if len(coord) > 100 and col_width < len(coord):
-        n_values = col_width // 4
+        n_values = col_width
         indices = list(range(0, n_values)) + list(range(-n_values, 0))
         subset = coord[indices]
     else:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
I'm not able to check if this actually works for bigger arrays, but with `xr.DataArray(pd.Series(range(25_000_000), index=idx))` I get a significant speed-up of about 180x for `repr`.

- [x] Closes #4789
- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
