### PR TITLE
Allow "unit" in label_from_attrs

### DIFF
--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -460,6 +460,8 @@ def label_from_attrs(da, extra=""):
 
     if da.attrs.get("units"):
         units = " [{}]".format(da.attrs["units"])
+    elif da.attrs.get("unit"):
+        units = " [{}]".format(da.attrs["unit"])
     else:
         units = ""
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
It is also popular to call units `unit`. Allow both keys to be appended to labels in plots.

