### PR TITLE
Fix `bounds_error=True` ignored with 1D interpolation

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -96,6 +96,7 @@ Bug fixes
   :py:meth:`Dataset.to_zarr` (:issue:`4783`, :pull:`4795`).
   By `Julien Seguinot <https://github.com/juseg>`_.
 - Add :py:meth:`Dataset.drop_isel` and :py:meth:`DataArray.drop_isel` (:issue:`4658`, :pull:`4819`). By `Daniel Mesejo <https://github.com/mesejo>`_.
+- Ensure that `Dataset.interp` raises `ValueError` when interpolating outside coordinate range and `bounds_error=True` (:issue:`4854`, :pull:`4855`). By `Leif Denby <https://github.com/leifdenby>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -96,7 +96,7 @@ Bug fixes
   :py:meth:`Dataset.to_zarr` (:issue:`4783`, :pull:`4795`).
   By `Julien Seguinot <https://github.com/juseg>`_.
 - Add :py:meth:`Dataset.drop_isel` and :py:meth:`DataArray.drop_isel` (:issue:`4658`, :pull:`4819`). By `Daniel Mesejo <https://github.com/mesejo>`_.
-- Ensure that `Dataset.interp` raises `ValueError` when interpolating outside coordinate range and `bounds_error=True` (:issue:`4854`, :pull:`4855`). By `Leif Denby <https://github.com/leifdenby>`_.
+- Ensure that :py:meth:`Dataset.interp` raises ``ValueError`` when interpolating outside coordinate range and ``bounds_error=True`` (:issue:`4854`, :pull:`4855`). By `Leif Denby <https://github.com/leifdenby>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -98,7 +98,7 @@ Bug fixes
   :py:meth:`Dataset.to_zarr` (:issue:`4783`, :pull:`4795`).
   By `Julien Seguinot <https://github.com/juseg>`_.
 - Add :py:meth:`Dataset.drop_isel` and :py:meth:`DataArray.drop_isel` (:issue:`4658`, :pull:`4819`). By `Daniel Mesejo <https://github.com/mesejo>`_.
-- Ensure that :py:meth:`Dataset.interp` raises ``ValueError`` when interpolating outside coordinate range and ``bounds_error=True`` (:issue:`4854`, :pull:`4855`). 
+- Ensure that :py:meth:`Dataset.interp` raises ``ValueError`` when interpolating outside coordinate range and ``bounds_error=True`` (:issue:`4854`, :pull:`4855`).
   By `Leif Denby <https://github.com/leifdenby>`_.
 - Fix time encoding bug associated with using cftime versions greater than
   1.4.0 with xarray (:issue:`4870`, :pull:`4871`). By `Spencer Clark <https://github.com/spencerkclark>`_.

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -154,7 +154,7 @@ class ScipyInterpolator(BaseInterpolator):
             yi,
             kind=self.method,
             fill_value=fill_value,
-            bounds_error=False,
+            bounds_error=bounds_error,
             assume_sorted=assume_sorted,
             copy=copy,
             **self.cons_kwargs,

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -866,3 +866,20 @@ def test_interpolate_chunk_advanced(method):
     z = z.chunk(3)
     actual = da.interp(t=0.5, x=x, y=y, z=z, kwargs=kwargs, method=method)
     assert_identical(actual, expected)
+
+
+@requires_scipy
+@pytest.mark.parametrize("bounds_error", [True, False])
+def test_interp1d_bounds_error(bounds_error):
+    """Ensure exception on bounds error is raised if requested"""
+    da = xr.DataArray(
+        np.sin(0.3 * np.arange(4)),
+        [("time", np.arange(4))],
+    )
+
+    if bounds_error:
+        with pytest.raises(ValueError):
+            da.interp(time=3.5, kwargs=dict(bounds_error=bounds_error))
+    else:
+        # default is to fill with nans, so this should pass
+        da.interp(time=3.5, kwargs=dict(bounds_error=bounds_error))

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -869,17 +869,15 @@ def test_interpolate_chunk_advanced(method):
 
 
 @requires_scipy
-@pytest.mark.parametrize("bounds_error", [True, False])
-def test_interp1d_bounds_error(bounds_error):
+def test_interp1d_bounds_error():
     """Ensure exception on bounds error is raised if requested"""
     da = xr.DataArray(
         np.sin(0.3 * np.arange(4)),
         [("time", np.arange(4))],
     )
 
-    if bounds_error:
-        with pytest.raises(ValueError):
-            da.interp(time=3.5, kwargs=dict(bounds_error=bounds_error))
-    else:
-        # default is to fill with nans, so this should pass
-        da.interp(time=3.5, kwargs=dict(bounds_error=bounds_error))
+    with pytest.raises(ValueError):
+        da.interp(time=3.5, kwargs=dict(bounds_error=True))
+
+    # default is to fill with nans, so this should pass
+    da.interp(time=3.5)


### PR DESCRIPTION
Previously `bounds_error` was always passed as `False` to
`scipy.interpolate.interp1d` and the value in `kwargs` was ignored
making it impossible to get bounds errors when doing 1D interpolation.

- [x] Closes #4854
- [x] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
