### PR TITLE
apply to dataset

### DIFF
--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -635,6 +635,21 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         else:
             return func(self, *args, **kwargs)
 
+    def apply_to_dataset(self, f):
+        from .dataarray import DataArray
+
+        if isinstance(self, DataArray):
+            ds = self._to_temp_dataset()
+        else:
+            ds = self
+
+        result = f(ds)
+
+        if isinstance(self, DataArray):
+            return self._from_temp_dataset(result, name=self.name)
+        else:
+            return result
+
     def groupby(self, group, squeeze: bool = True, restore_coord_dims: bool = None):
         """Returns a GroupBy object for performing grouped operations.
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2617,6 +2617,17 @@ class TestDataArray:
         actual = a.groupby("b").fillna(DataArray([0, 2], dims="b"))
         assert_identical(expected, actual)
 
+    def test_apply_to_dataset(self):
+        def func(ds):
+            return Dataset(ds.data_vars, coords=ds.coords)
+
+        da = DataArray(
+            [[0, 1], [2, 3], [4, 5]],
+            dims=("x", "y"),
+            name="abc",
+        )
+        assert_identical(da, da.apply_to_dataset(func))
+
     def test_groupby_iter(self):
         for ((act_x, act_dv), (exp_x, exp_ds)) in zip(
             self.dv.groupby("y"), self.ds.groupby("y")

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5028,6 +5028,13 @@ class TestDataset:
         actual = ds.count()
         assert_identical(expected, actual)
 
+    def test_apply_to_dataset(self):
+        def func(ds):
+            return Dataset(ds.data_vars, coords=ds.coords)
+
+        ds = create_test_data()
+        assert_identical(ds, ds.apply_to_dataset(func))
+
     def test_map(self):
         data = create_test_data()
         data.attrs["foo"] = "bar"


### PR DESCRIPTION
as discussed in #4837, it is incredibly useful to treat `DataArray` objects as single-variable `Dataset`s. This adds a method that applies a function to a `DataArray` by first converting it to a temporary dataset using `_to_temp_dataset`, applies the function and converts it back. I'm not really happy with the name but I find a better one.

This function is really similar to `pipe`, so I guess a keyword argument to pipe would work, too. The disadvantage of that is that `pipe` passes all kwargs to the passed function, which means we would shadow a specific kwarg.

- [x] Closes #4837
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
