### PR TITLE
small fixes for the docstrings of swap_dims and integrate

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -47,7 +47,8 @@ Deprecations
 
 - ``dim`` argument to :py:meth:`DataArray.integrate` is being deprecated in
   favour of a ``coord`` argument, for consistency with :py:meth:`Dataset.integrate`.
-  For now using ``dim`` issues a ``FutureWarning``. It will be removed in version 0.19.0.
+  For now using ``dim`` issues a ``FutureWarning``. It will be removed in
+  version 0.19.0 (:pull:`3993`).
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -47,7 +47,8 @@ Deprecations
 
 - ``dim`` argument to :py:meth:`DataArray.integrate` is being deprecated in
   favour of a ``coord`` argument, for consistency with :py:meth:`Dataset.integrate`.
-  For now using ``dim`` issues a ``FutureWarning``. By `Tom Nicholas <https://github.com/TomNicholas>`_.
+  For now using ``dim`` issues a ``FutureWarning``. It will be removed in version 0.19.0.
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 
 New Features

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3495,21 +3495,22 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Parameters
         ----------
-        coord: hashable, or a sequence of hashable
+        coord : hashable, or sequence of hashable
             Coordinate(s) used for the integration.
         dim : hashable, or sequence of hashable
             Coordinate(s) used for the integration.
-        datetime_unit: {'Y', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns', \
+        datetime_unit : {'Y', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns', \
                         'ps', 'fs', 'as'}, optional
+            Specify the unit if a datetime coordinate is used.
 
         Returns
         -------
-        integrated: DataArray
+        integrated : DataArray
 
         See also
         --------
         Dataset.integrate
-        numpy.trapz: corresponding numpy function
+        numpy.trapz : corresponding numpy function
 
         Examples
         --------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1710,7 +1710,7 @@ class DataArray(AbstractArray, DataWithCoords):
             Dictionary whose keys are current dimension names and whose values
             are new names.
 
-        **dim_kwargs : {dim: , ...}, optional
+        **dims_kwargs : {existing_dim: new_dim, ...}, optional
             The keyword arguments form of ``dims_dict``.
             One of dims_dict or dims_kwargs must be provided.
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3167,7 +3167,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             Dictionary whose keys are current dimension names and whose values
             are new names.
 
-        **dim_kwargs : {existing_dim: new_dim, ...}, optional
+        **dims_kwargs : {existing_dim: new_dim, ...}, optional
             The keyword arguments form of ``dims_dict``.
             One of dims_dict or dims_kwargs must be provided.
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5974,9 +5974,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Parameters
         ----------
-        coord: hashable, or a sequence of hashable
+        coord : hashable, or sequence of hashable
             Coordinate(s) used for the integration.
-        datetime_unit: {'Y', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns', \
+        datetime_unit : {'Y', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns', \
                         'ps', 'fs', 'as'}, optional
             Specify the unit if datetime coordinate is used.
 
@@ -5987,7 +5987,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         See also
         --------
         DataArray.integrate
-        numpy.trapz: corresponding numpy function
+        numpy.trapz : corresponding numpy function
 
         Examples
         --------


### PR DESCRIPTION
follow-up to #4841 and #3993

- [x] Passes `pre-commit run --all-files`
