### PR TITLE
don't skip the doctests CI

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -121,8 +121,6 @@ jobs:
   doctest:
     name: Doctests
     runs-on: "ubuntu-latest"
-    needs: detect-ci-trigger
-    if: needs.detect-ci-trigger.outputs.triggered == 'false'
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
when we introduced the `[skip-ci]` tag we decided to skip doctests CI, too. I don't think that's correct: the doctests CI checks the docs, not the code.
