### PR TITLE
vélin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,10 @@ repos:
     rev: 3.8.4
     hooks:
       - id: flake8
+  - repo: https://github.com/Carreau/velin
+    rev: 0.0.8
+    hooks:
+      - id: velin
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.790  # Must match ci/requirements/*.yml
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
   #   rev: 0.0.8
   #   hooks:
   #     - id: velin
+  #       args: ["--write", "--compact"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.790  # Must match ci/requirements/*.yml
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,10 +24,10 @@ repos:
     rev: 3.8.4
     hooks:
       - id: flake8
-  - repo: https://github.com/Carreau/velin
-    rev: 0.0.8
-    hooks:
-      - id: velin
+  # - repo: https://github.com/Carreau/velin
+  #   rev: 0.0.8
+  #   hooks:
+  #     - id: velin
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.790  # Must match ci/requirements/*.yml
     hooks:

--- a/xarray/backends/locks.py
+++ b/xarray/backends/locks.py
@@ -67,7 +67,7 @@ def _get_scheduler(get=None, collection=None) -> Optional[str]:
 
     None is returned if no dask scheduler is active.
 
-    See also
+    See Also
     --------
     dask.base.get_scheduler
     """

--- a/xarray/backends/lru_cache.py
+++ b/xarray/backends/lru_cache.py
@@ -34,7 +34,7 @@ class LRUCache(MutableMapping[K, V]):
         ----------
         maxsize : int
             Integer maximum number of items to hold in the cache.
-        on_evict: callable, optional
+        on_evict : callable, optional
             Function to call like ``on_evict(key, value)`` when items are
             evicted.
         """

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -52,9 +52,9 @@ class RasterioArrayWrapper(BackendArray):
     def _get_indexer(self, key):
         """Get indexer for rasterio array.
 
-        Parameter
-        ---------
-        key: tuple of int
+        Parameters
+        ----------
+        key : tuple of int
 
         Returns
         -------
@@ -63,7 +63,7 @@ class RasterioArrayWrapper(BackendArray):
         squeeze_axis: axes to be squeezed
         np_ind: indexer for loaded numpy array
 
-        See also
+        See Also
         --------
         indexing.decompose_indexer
         """
@@ -179,7 +179,6 @@ def open_rasterio(filename, parse_coordinates=None, chunks=None, cache=None, loc
         transform = Affine.from_gdal(*da.attrs['transform'])
         nx, ny = da.sizes['x'], da.sizes['y']
         x, y = np.meshgrid(np.arange(nx)+0.5, np.arange(ny)+0.5) * transform
-
 
     Parameters
     ----------

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -462,7 +462,7 @@ class ZarrStore(AbstractWritableDataStore):
         check_encoding_set : list-like
             List of variables that should be checked for invalid encoding
             values
-        writer :
+        writer
         unlimited_dims : list-like
             List of dimension names that should be treated as unlimited
             dimensions.
@@ -566,7 +566,7 @@ def open_zarr(
         based on the variable's zarr chunks. If `chunks=None`, zarr array
         data will lazily convert to numpy arrays upon access. This accepts
         all the chunk specifications as Dask does.
-    overwrite_encoded_chunks: bool, optional
+    overwrite_encoded_chunks : bool, optional
         Whether to drop the zarr chunks encoded for each variable when a
         dataset is loaded with specified chunk sizes (default: False)
     decode_cf : bool, optional
@@ -605,7 +605,7 @@ def open_zarr(
         {'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds'}
         into timedelta objects. If False, leave them encoded as numbers.
         If None (default), assume the same value of decode_time.
-    use_cftime: bool, optional
+    use_cftime : bool, optional
         Only relevant if encoded dates come from a standard calendar
         (e.g. "gregorian", "proleptic_gregorian", "standard", or not
         specified).  If None (default), attempt to decode times to

--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -796,7 +796,7 @@ def cftime_range(
     periods : int, optional
         Number of periods to generate.
     freq : str or None, default: "D"
-       Frequency strings can have multiples, e.g. "5H".
+        Frequency strings can have multiples, e.g. "5H".
     normalize : bool, default: False
         Normalize start/end dates to midnight before generating date range.
     name : str, default: None
@@ -813,7 +813,6 @@ def cftime_range(
 
     Notes
     -----
-
     This function is an analog of ``pandas.date_range`` for use in generating
     sequences of ``cftime.datetime`` objects.  It supports most of the
     features of ``pandas.date_range`` (e.g. specifying how the index is
@@ -911,7 +910,6 @@ def cftime_range(
     | Q(S)-DEC | Quarter frequency, anchored at the end (or beginning) of December  |
     +----------+--------------------------------------------------------------------+
 
-
     Finally, the following calendar aliases are supported.
 
     +--------------------------------+---------------------------------------+
@@ -932,7 +930,6 @@ def cftime_range(
 
     Examples
     --------
-
     This function returns a ``CFTimeIndex``, populated with ``cftime.datetime``
     objects associated with the specified calendar type, e.g.
 

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -516,7 +516,7 @@ class CFTimeIndex(pd.Index):
         -------
         CFTimeIndex
 
-        See also
+        See Also
         --------
         pandas.DatetimeIndex.shift
 

--- a/xarray/coding/frequencies.py
+++ b/xarray/coding/frequencies.py
@@ -62,8 +62,8 @@ def infer_freq(index):
     Parameters
     ----------
     index : CFTimeIndex, DataArray, DatetimeIndex, TimedeltaIndex, Series
-      If not passed a CFTimeIndex, this simply calls `pandas.infer_freq`.
-      If passed a Series or a DataArray will use the values of the series (NOT THE INDEX).
+        If not passed a CFTimeIndex, this simply calls `pandas.infer_freq`.
+        If passed a Series or a DataArray will use the values of the series (NOT THE INDEX).
 
     Returns
     -------

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -191,7 +191,7 @@ def decode_cf_datetime(num_dates, units, calendar=None, use_cftime=None):
     Note that time unit in `units` must not be smaller than microseconds and
     not larger than days.
 
-    See also
+    See Also
     --------
     cftime.num2date
     """
@@ -407,7 +407,7 @@ def encode_cf_datetime(dates, units=None, calendar=None):
 
     Unlike `date2num`, this function can handle datetime64 arrays.
 
-    See also
+    See Also
     --------
     cftime.date2num
     """

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -624,7 +624,7 @@ def cf_decoder(
     concat_characters : bool
         Should character arrays be concatenated to strings, for
         example: ["h", "e", "l", "l", "o"] -> "hello"
-    mask_and_scale: bool
+    mask_and_scale : bool
         Lazily scale (using scale_factor and add_offset) and mask
         (using _FillValue).
     decode_times : bool
@@ -637,7 +637,7 @@ def cf_decoder(
     decoded_attributes : dict
         A dictionary mapping from attribute name to values.
 
-    See also
+    See Also
     --------
     decode_cf_variable
     """
@@ -747,7 +747,6 @@ def cf_encoder(variables, attributes):
     This includes masking, scaling, character array handling,
     and CF-time encoding.
 
-
     Parameters
     ----------
     variables : dict
@@ -762,7 +761,7 @@ def cf_encoder(variables, attributes):
     encoded_attributes : dict
         A dictionary mapping from attribute name to value
 
-    See also
+    See Also
     --------
     decode_cf_variable, encode_cf_variable
     """

--- a/xarray/core/accessor_dt.py
+++ b/xarray/core/accessor_dt.py
@@ -322,8 +322,8 @@ class DatetimeAccessor(Properties):
     def isocalendar(self):
         """Dataset containing ISO year, week number, and weekday.
 
-        Note
-        ----
+        Notes
+        -----
         The iso year and weekday differ from the nominal year and weekday.
         """
 

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -93,6 +93,7 @@ def align(
     ----------
     *objects : Dataset or DataArray
         Objects to align.
+
     join : {"outer", "inner", "left", "right", "exact", "override"}, optional
         Method for joining the indexes of the passed objects along each
         dimension:
@@ -106,16 +107,20 @@ def align(
         - "override": if indexes are of same size, rewrite indexes to be
           those of the first object with that dimension. Indexes for the same
           dimension must have the same size in all objects.
+
     copy : bool, optional
         If ``copy=True``, data in the return values is always copied. If
         ``copy=False`` and reindexing is unnecessary, or can be performed with
         only slice operations, then the output may share memory with the input.
         In either case, new xarray objects are always returned.
+
     indexes : dict-like, optional
         Any indexes explicitly provided with the `indexes` argument should be
         used in preference to the aligned indexes.
+
     exclude : sequence of str, optional
         Dimensions that must be excluded from alignment
+
     fill_value : scalar or dict-like, optional
         Value to use for newly missing values. If a dict-like, maps
         variable names to fill values. Use a data array's name to
@@ -135,7 +140,6 @@ def align(
 
     Examples
     --------
-
     >>> import xarray as xr
     >>> x = xr.DataArray(
     ...     [[25, 35], [10, 24]],
@@ -532,7 +536,7 @@ def reindex_variables(
         the input. In either case, new xarray objects are always returned.
     fill_value : scalar, optional
         Value to use for newly missing values
-    sparse: bool, optional
+    sparse : bool, optional
         Use an sparse-array
 
     Returns
@@ -704,7 +708,6 @@ def broadcast(*args, exclude=None):
 
     Examples
     --------
-
     Broadcast two data arrays against one another to fill out their dimensions:
 
     >>> a = xr.DataArray([1, 2, 3], dims="x")

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -93,7 +93,6 @@ def align(
     ----------
     *objects : Dataset or DataArray
         Objects to align.
-
     join : {"outer", "inner", "left", "right", "exact", "override"}, optional
         Method for joining the indexes of the passed objects along each
         dimension:
@@ -107,20 +106,16 @@ def align(
         - "override": if indexes are of same size, rewrite indexes to be
           those of the first object with that dimension. Indexes for the same
           dimension must have the same size in all objects.
-
     copy : bool, optional
         If ``copy=True``, data in the return values is always copied. If
         ``copy=False`` and reindexing is unnecessary, or can be performed with
         only slice operations, then the output may share memory with the input.
         In either case, new xarray objects are always returned.
-
     indexes : dict-like, optional
         Any indexes explicitly provided with the `indexes` argument should be
         used in preference to the aligned indexes.
-
     exclude : sequence of str, optional
         Dimensions that must be excluded from alignment
-
     fill_value : scalar or dict-like, optional
         Value to use for newly missing values. If a dict-like, maps
         variable names to fill values. Use a data array's name to

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -187,7 +187,7 @@ class AbstractArray(ImplementsArrayReduce):
 
         Immutable.
 
-        See also
+        See Also
         --------
         Dataset.sizes
         """
@@ -409,7 +409,6 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
             defined and attached to an existing dimension using a tuple with
             the first element the dimension name and the second element the
             values for this new coordinate.
-
         **coords_kwargs : optional
             The keyword arguments form of ``coords``.
             One of ``coords`` or ``coords_kwargs`` must be provided.
@@ -470,7 +469,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         is possible, but you cannot reference other variables created within
         the same ``assign_coords`` call.
 
-        See also
+        See Also
         --------
         Dataset.assign
         Dataset.swap_dims
@@ -498,7 +497,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         assigned : same type as caller
             A new object with the new attrs in addition to the existing data.
 
-        See also
+        See Also
         --------
         Dataset.assign
         """
@@ -537,7 +536,6 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         Notes
         -----
-
         Use ``.pipe`` when chaining together functions that expect
         xarray or pandas objects, e.g., instead of writing
 
@@ -561,7 +559,6 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         Examples
         --------
-
         >>> import numpy as np
         >>> import xarray as xr
         >>> x = xr.Dataset(
@@ -813,7 +810,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         Parameters
         ----------
-        dim: dict, optional
+        dim : dict, optional
             Mapping from the dimension name to create the rolling iterator
             along (e.g. `time`) to its moving window size.
         min_periods : int, default: None
@@ -1101,7 +1098,6 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         References
         ----------
-
         .. [1] http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
         """
         # TODO support non-string indexer after removing the old API.
@@ -1189,7 +1185,6 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         Examples
         --------
-
         >>> import numpy as np
         >>> a = xr.DataArray(np.arange(25).reshape(5, 5), dims=("x", "y"))
         >>> a
@@ -1235,7 +1230,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
                [15., nan, nan, nan]])
         Dimensions without coordinates: x, y
 
-        See also
+        See Also
         --------
         numpy.where : corresponding numpy function
         where : equivalent function
@@ -1386,14 +1381,13 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
 
         Examples
         --------
-
         >>> array = xr.DataArray([1, 2, 3], dims="x")
         >>> array.isin([1, 3])
         <xarray.DataArray (x: 3)>
         array([ True, False,  True])
         Dimensions without coordinates: x
 
-        See also
+        See Also
         --------
         numpy.isin
         """
@@ -1438,11 +1432,13 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         ----------
         dtype : str or dtype
             Typecode or data-type to which the array is cast.
+
         order : {'C', 'F', 'A', 'K'}, optional
             Controls the memory layout order of the result. ‘C’ means C order,
             ‘F’ means Fortran order, ‘A’ means ‘F’ order if all the arrays are
             Fortran contiguous, ‘C’ order otherwise, and ‘K’ means as close to
             the order the array elements appear in memory as possible.
+
         casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
             Controls what kind of data casting may occur.
 
@@ -1456,10 +1452,12 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         subok : bool, optional
             If True, then sub-classes will be passed-through, otherwise the
             returned array will be forced to be a base-class array.
+
         copy : bool, optional
             By default, astype always returns a newly allocated array. If this
             is set to False and the `dtype` requirement is satisfied, the input
             array is returned instead of a copy.
+
         keep_attrs : bool, optional
             By default, astype keeps attributes. Set to False to remove
             attributes in the returned object.
@@ -1477,7 +1475,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         Make sure to only supply these arguments if the underlying array class
         supports them.
 
-        See also
+        See Also
         --------
         numpy.ndarray.astype
         dask.array.Array.astype
@@ -1533,7 +1531,6 @@ def full_like(other, fill_value, dtype: DTypeLike = None):
 
     Examples
     --------
-
     >>> import numpy as np
     >>> import xarray as xr
     >>> x = xr.DataArray(
@@ -1609,9 +1606,8 @@ def full_like(other, fill_value, dtype: DTypeLike = None):
         a        (x) bool True True True
         b        (x) float64 2.0 2.0 2.0
 
-    See also
+    See Also
     --------
-
     zeros_like
     ones_like
 
@@ -1692,7 +1688,6 @@ def zeros_like(other, dtype: DTypeLike = None):
 
     Examples
     --------
-
     >>> import numpy as np
     >>> import xarray as xr
     >>> x = xr.DataArray(
@@ -1724,9 +1719,8 @@ def zeros_like(other, dtype: DTypeLike = None):
       * lat      (lat) int64 1 2
       * lon      (lon) int64 0 1 2
 
-    See also
+    See Also
     --------
-
     ones_like
     full_like
 
@@ -1752,7 +1746,6 @@ def ones_like(other, dtype: DTypeLike = None):
 
     Examples
     --------
-
     >>> import numpy as np
     >>> import xarray as xr
     >>> x = xr.DataArray(
@@ -1776,9 +1769,8 @@ def ones_like(other, dtype: DTypeLike = None):
       * lat      (lat) int64 1 2
       * lon      (lon) int64 0 1 2
 
-    See also
+    See Also
     --------
-
     zeros_like
     full_like
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1432,13 +1432,11 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         ----------
         dtype : str or dtype
             Typecode or data-type to which the array is cast.
-
         order : {'C', 'F', 'A', 'K'}, optional
             Controls the memory layout order of the result. ‘C’ means C order,
             ‘F’ means Fortran order, ‘A’ means ‘F’ order if all the arrays are
             Fortran contiguous, ‘C’ order otherwise, and ‘K’ means as close to
             the order the array elements appear in memory as possible.
-
         casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
             Controls what kind of data casting may occur.
 
@@ -1448,16 +1446,13 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
             * 'same_kind' means only safe casts or casts within a kind,
               like float64 to float32, are allowed.
             * 'unsafe' means any data conversions may be done.
-
         subok : bool, optional
             If True, then sub-classes will be passed-through, otherwise the
             returned array will be forced to be a base-class array.
-
         copy : bool, optional
             By default, astype always returns a newly allocated array. If this
             is set to False and the `dtype` requirement is satisfied, the input
             array is returned instead of a copy.
-
         keep_attrs : bool, optional
             By default, astype keeps attributes. Set to False to remove
             attributes in the returned object.

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -826,10 +826,8 @@ def apply_ufunc(
         the style of NumPy universal functions [1]_ (if this is not the case,
         set ``vectorize=True``). If this function returns multiple outputs, you
         must set ``output_core_dims`` as well.
-
     *args : Dataset, DataArray, GroupBy, Variable, numpy.ndarray, dask.array.Array or scalar
         Mix of labeled and/or unlabeled arrays to which to apply the function.
-
     input_core_dims : sequence of sequence, optional
         List of the same length as ``args`` giving the list of core dimensions
         on each input argument that should not be broadcast. By default, we
@@ -842,7 +840,6 @@ def apply_ufunc(
         Core dimensions are automatically moved to the last axes of input
         variables before applying ``func``, which facilitates using NumPy style
         generalized ufuncs [2]_.
-
     output_core_dims : list of tuple, optional
         List of the same length as the number of output arguments from
         ``func``, giving the list of core dimensions on each output that were
@@ -852,21 +849,18 @@ def apply_ufunc(
 
         Core dimensions are assumed to appear as the last dimensions of each
         output in the provided order.
-
     exclude_dims : set, optional
         Core dimensions on the inputs to exclude from alignment and
         broadcasting entirely. Any input coordinates along these dimensions
         will be dropped. Each excluded dimension must also appear in
         ``input_core_dims`` for at least one argument. Only dimensions listed
         here are allowed to change size between input and output objects.
-
     vectorize : bool, optional
         If True, then assume ``func`` only takes arrays defined over core
         dimensions as input and vectorize it automatically with
         :py:func:`numpy.vectorize`. This option exists for convenience, but is
         almost always slower than supplying a pre-vectorized function.
         Using this option requires NumPy version 1.12 or newer.
-
     join : {"outer", "inner", "left", "right", "exact"}, default: "exact"
         Method for joining the indexes of the passed objects along each
         dimension, and the variables of Dataset objects with mismatched
@@ -878,7 +872,6 @@ def apply_ufunc(
         - 'right': use indexes from the last object with each dimension
         - 'exact': raise `ValueError` instead of aligning when indexes to be
           aligned are not equal
-
     dataset_join : {"outer", "inner", "left", "right", "exact"}, default: "exact"
         Method for joining variables of Dataset objects with mismatched
         data variables.
@@ -888,18 +881,14 @@ def apply_ufunc(
         - 'left': take only variables from the first object
         - 'right': take only variables from the last object
         - 'exact': data variables on all Dataset objects must match exactly
-
     dataset_fill_value : optional
         Value used in place of missing variables on Dataset inputs when the
         datasets do not share the exact same ``data_vars``. Required if
         ``dataset_join not in {'inner', 'exact'}``, otherwise ignored.
-
     keep_attrs : bool, optional
         Whether to copy attributes from the first argument to the output.
-
     kwargs : dict, optional
         Optional keyword arguments passed directly on to call ``func``.
-
     dask : {"forbidden", "allowed", "parallelized"}, default: "forbidden"
         How to handle applying to objects containing lazy data in the form of
         dask arrays:
@@ -911,22 +900,18 @@ def apply_ufunc(
           inputs are a dask array by using `dask.array.apply_gufunc`. Multiple output
           arguments are supported. Only use this option if ``func`` does not natively
           support dask arrays (e.g. converts them to numpy arrays).
-
     dask_gufunc_kwargs : dict, optional
         Optional keyword arguments passed to ``dask.array.apply_gufunc`` if
         dask='parallelized'. Possible keywords are ``output_sizes``, ``allow_rechunk``
         and ``meta``.
-
     output_dtypes : list of dtype, optional
         Optional list of output dtypes. Only used if ``dask='parallelized'`` or
         vectorize=True.
-
     output_sizes : dict, optional
         Optional mapping from dimension names to sizes for outputs. Only used
         if dask='parallelized' and new dimensions (not found on inputs) appear
         on outputs. ``output_sizes`` should be given in the ``dask_gufunc_kwargs``
         parameter. It will be removed as direct parameter in a future version.
-
     meta : optional
         Size-0 object representing the type of array wrapped by dask array. Passed on to
         ``dask.array.apply_gufunc``. ``meta`` should be given in the

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -826,8 +826,10 @@ def apply_ufunc(
         the style of NumPy universal functions [1]_ (if this is not the case,
         set ``vectorize=True``). If this function returns multiple outputs, you
         must set ``output_core_dims`` as well.
+
     *args : Dataset, DataArray, GroupBy, Variable, numpy.ndarray, dask.array.Array or scalar
         Mix of labeled and/or unlabeled arrays to which to apply the function.
+
     input_core_dims : sequence of sequence, optional
         List of the same length as ``args`` giving the list of core dimensions
         on each input argument that should not be broadcast. By default, we
@@ -840,6 +842,7 @@ def apply_ufunc(
         Core dimensions are automatically moved to the last axes of input
         variables before applying ``func``, which facilitates using NumPy style
         generalized ufuncs [2]_.
+
     output_core_dims : list of tuple, optional
         List of the same length as the number of output arguments from
         ``func``, giving the list of core dimensions on each output that were
@@ -849,18 +852,21 @@ def apply_ufunc(
 
         Core dimensions are assumed to appear as the last dimensions of each
         output in the provided order.
+
     exclude_dims : set, optional
         Core dimensions on the inputs to exclude from alignment and
         broadcasting entirely. Any input coordinates along these dimensions
         will be dropped. Each excluded dimension must also appear in
         ``input_core_dims`` for at least one argument. Only dimensions listed
         here are allowed to change size between input and output objects.
+
     vectorize : bool, optional
         If True, then assume ``func`` only takes arrays defined over core
         dimensions as input and vectorize it automatically with
         :py:func:`numpy.vectorize`. This option exists for convenience, but is
         almost always slower than supplying a pre-vectorized function.
         Using this option requires NumPy version 1.12 or newer.
+
     join : {"outer", "inner", "left", "right", "exact"}, default: "exact"
         Method for joining the indexes of the passed objects along each
         dimension, and the variables of Dataset objects with mismatched
@@ -872,6 +878,7 @@ def apply_ufunc(
         - 'right': use indexes from the last object with each dimension
         - 'exact': raise `ValueError` instead of aligning when indexes to be
           aligned are not equal
+
     dataset_join : {"outer", "inner", "left", "right", "exact"}, default: "exact"
         Method for joining variables of Dataset objects with mismatched
         data variables.
@@ -881,15 +888,19 @@ def apply_ufunc(
         - 'left': take only variables from the first object
         - 'right': take only variables from the last object
         - 'exact': data variables on all Dataset objects must match exactly
+
     dataset_fill_value : optional
         Value used in place of missing variables on Dataset inputs when the
         datasets do not share the exact same ``data_vars``. Required if
         ``dataset_join not in {'inner', 'exact'}``, otherwise ignored.
-    keep_attrs: bool, optional
+
+    keep_attrs : bool, optional
         Whether to copy attributes from the first argument to the output.
-    kwargs: dict, optional
+
+    kwargs : dict, optional
         Optional keyword arguments passed directly on to call ``func``.
-    dask: {"forbidden", "allowed", "parallelized"}, default: "forbidden"
+
+    dask : {"forbidden", "allowed", "parallelized"}, default: "forbidden"
         How to handle applying to objects containing lazy data in the form of
         dask arrays:
 
@@ -900,18 +911,22 @@ def apply_ufunc(
           inputs are a dask array by using `dask.array.apply_gufunc`. Multiple output
           arguments are supported. Only use this option if ``func`` does not natively
           support dask arrays (e.g. converts them to numpy arrays).
+
     dask_gufunc_kwargs : dict, optional
         Optional keyword arguments passed to ``dask.array.apply_gufunc`` if
         dask='parallelized'. Possible keywords are ``output_sizes``, ``allow_rechunk``
         and ``meta``.
+
     output_dtypes : list of dtype, optional
         Optional list of output dtypes. Only used if ``dask='parallelized'`` or
         vectorize=True.
+
     output_sizes : dict, optional
         Optional mapping from dimension names to sizes for outputs. Only used
         if dask='parallelized' and new dimensions (not found on inputs) appear
         on outputs. ``output_sizes`` should be given in the ``dask_gufunc_kwargs``
         parameter. It will be removed as direct parameter in a future version.
+
     meta : optional
         Size-0 object representing the type of array wrapped by dask array. Passed on to
         ``dask.array.apply_gufunc``. ``meta`` should be given in the
@@ -925,7 +940,6 @@ def apply_ufunc(
 
     Examples
     --------
-
     Calculate the vector magnitude of two arguments:
 
     >>> def magnitude(a, b):
@@ -1011,7 +1025,7 @@ def apply_ufunc(
     works well with numba's vectorize and guvectorize. Further explanation with
     examples are provided in the xarray documentation [3]_.
 
-    See also
+    See Also
     --------
     numpy.broadcast_arrays
     numba.vectorize
@@ -1162,10 +1176,10 @@ def cov(da_a, da_b, dim=None, ddof=1):
     -------
     covariance : DataArray
 
-    See also
+    See Also
     --------
     pandas.Series.cov : corresponding pandas function
-    xarray.corr: respective function to calculate correlation
+    xarray.corr : respective function to calculate correlation
 
     Examples
     --------
@@ -1240,7 +1254,7 @@ def corr(da_a, da_b, dim=None):
     -------
     correlation: DataArray
 
-    See also
+    See Also
     --------
     pandas.Series.corr : corresponding pandas function
     xarray.cov : underlying covariance function
@@ -1361,7 +1375,6 @@ def dot(*arrays, dims=None, **kwargs):
 
     Examples
     --------
-
     >>> import numpy as np
     >>> import xarray as xr
     >>> da_a = xr.DataArray(np.arange(3 * 2).reshape(3, 2), dims=["a", "b"])
@@ -1496,7 +1509,6 @@ def where(cond, x, y):
     All dimension coordinates on `x` and `y`  must be aligned with each
     other and with `cond`.
 
-
     Parameters
     ----------
     cond : scalar, array, Variable, DataArray or Dataset
@@ -1566,10 +1578,11 @@ def where(cond, x, y):
            [0, 0]])
     Dimensions without coordinates: x, y
 
-    See also
+    See Also
     --------
     numpy.where : corresponding numpy function
-    Dataset.where, DataArray.where : equivalent methods
+    Dataset.where, DataArray.where :
+        equivalent methods
     """
     # alignment for three arguments is complicated, so don't support it yet
     return apply_ufunc(
@@ -1595,7 +1608,7 @@ def polyval(coord, coeffs, degree_dim="degree"):
     degree_dim : str, default: "degree"
         Name of the polynomial degree dimension in `coeffs`.
 
-    See also
+    See Also
     --------
     xarray.DataArray.polyfit
     numpy.polyval

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1168,7 +1168,6 @@ class DataArray(AbstractArray, DataWithCoords):
             If DataArrays are passed as indexers, xarray-style indexing will be
             carried out. See :ref:`indexing` for the details.
             One of indexers or indexers_kwargs must be provided.
-
         method : {None, "nearest", "pad", "ffill", "backfill", "bfill"}, optional
             Method to use for inexact matches:
 
@@ -1176,16 +1175,13 @@ class DataArray(AbstractArray, DataWithCoords):
             * pad / ffill: propagate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
-
         tolerance : optional
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
-
         drop : bool, optional
             If ``drop=True``, drop coordinates variables in `indexers` instead
             of making them scalar.
-
         **indexers_kwargs : {dim: indexer, ...}, optional
             The keyword arguments form of ``indexers``.
             One of indexers or indexers_kwargs must be provided.
@@ -1361,7 +1357,6 @@ class DataArray(AbstractArray, DataWithCoords):
             other object need not be the same as the indexes on this
             dataset. Any mis-matched index values will be filled in with
             NaN, and any mis-matched dimension names will simply be ignored.
-
         method : {None, "nearest", "pad", "ffill", "backfill", "bfill"}, optional
             Method to use for filling index values from other not found on this
             data array:
@@ -1370,18 +1365,15 @@ class DataArray(AbstractArray, DataWithCoords):
             * pad / ffill: propagate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
-
         tolerance : optional
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
-
         copy : bool, optional
             If ``copy=True``, data in the return value is always copied. If
             ``copy=False`` and reindexing is unnecessary, or can be performed
             with only slice operations, then the output may share memory with
             the input. In either case, a new xarray object is always returned.
-
         fill_value : scalar or dict-like, optional
             Value to use for newly missing values. If a dict-like, maps
             variable names (including coordinates) to fill values. Use this
@@ -1427,13 +1419,11 @@ class DataArray(AbstractArray, DataWithCoords):
             values will be filled in with NaN, and any mis-matched dimension
             names will simply be ignored.
             One of indexers or indexers_kwargs must be provided.
-
         copy : bool, optional
             If ``copy=True``, data in the return value is always copied. If
             ``copy=False`` and reindexing is unnecessary, or can be performed
             with only slice operations, then the output may share memory with
             the input. In either case, a new xarray object is always returned.
-
         method : {None, 'nearest', 'pad'/'ffill', 'backfill'/'bfill'}, optional
             Method to use for filling index values in ``indexers`` not found on
             this data array:
@@ -1442,17 +1432,14 @@ class DataArray(AbstractArray, DataWithCoords):
             * pad / ffill: propagate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
-
         tolerance : optional
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
-
         fill_value : scalar or dict-like, optional
             Value to use for newly missing values. If a dict-like, maps
             variable names (including coordinates) to fill values. Use this
             data array's name to refer to the data array's values.
-
         **indexers_kwargs : {dim: indexer, ...}, optional
             The keyword arguments form of ``indexers``.
             One of indexers or indexers_kwargs must be provided.
@@ -1502,23 +1489,19 @@ class DataArray(AbstractArray, DataWithCoords):
             New coordinate can be an scalar, array-like or DataArray.
             If DataArrays are passed as new coordinates, their dimensions are
             used for the broadcasting. Missing values are skipped.
-
         method : str, default: "linear"
             The method used to interpolate. Choose from
 
             - {"linear", "nearest"} for multidimensional array,
             - {"linear", "nearest", "zero", "slinear", "quadratic", "cubic"} for 1-dimensional array.
-
         assume_sorted : bool, optional
             If False, values of x can be in any order and they are sorted
             first. If True, x has to be an array of monotonically increasing
             values.
-
         kwargs : dict
             Additional keyword arguments passed to scipy's interpolator. Valid
             options and their behavior depend on if 1-dimensional or
             multi-dimensional interpolation is used.
-
         **coords_kwargs : {dim: coordinate, ...}, optional
             The keyword arguments form of ``coords``.
             One of coords or coords_kwargs must be provided.
@@ -1635,19 +1618,16 @@ class DataArray(AbstractArray, DataWithCoords):
             Object with an 'indexes' attribute giving a mapping from dimension
             names to an 1d array-like, which provides coordinates upon
             which to index the variables in this dataset. Missing values are skipped.
-
         method : str, default: "linear"
             The method used to interpolate. Choose from
 
             - {"linear", "nearest"} for multidimensional array,
             - {"linear", "nearest", "zero", "slinear", "quadratic", "cubic"} for 1-dimensional array.
-
         assume_sorted : bool, optional
             If False, values of coordinates that are interpolated over can be
             in any order and they are sorted first. If True, interpolated
             coordinates are assumed to be an array of monotonically increasing
             values.
-
         kwargs : dict, optional
             Additional keyword passed to scipy's interpolator.
 
@@ -2358,7 +2338,6 @@ class DataArray(AbstractArray, DataWithCoords):
         ----------
         dim : str
             Specifies the dimension along which to interpolate.
-
         method : str, optional
             String indicating which method to use for interpolation:
 
@@ -2370,20 +2349,17 @@ class DataArray(AbstractArray, DataWithCoords):
               provided.
             - 'barycentric', 'krog', 'pchip', 'spline', 'akima': use their
               respective :py:class:`scipy.interpolate` classes.
-
         use_coordinate : bool or str, default: True
             Specifies which index to use as the x values in the interpolation
             formulated as `y = f(x)`. If False, values are treated as if
             eqaully-spaced along ``dim``. If True, the IndexVariable `dim` is
             used. If ``use_coordinate`` is a string, it specifies the name of a
             coordinate variariable to use as the index.
-
         limit : int, default: None
             Maximum number of consecutive NaNs to fill. Must be greater than 0
             or None for no limit. This filling is done regardless of the size of
             the gap in the data. To only interpolate over gaps less than a given length,
             see ``max_gap``.
-
         max_gap : int, float, str, pandas.Timedelta, numpy.timedelta64, datetime.timedelta, default: None
             Maximum size of gap, a continuous sequence of NaNs, that will be filled.
             Use None for no limit. When interpolating along a datetime64 dimension
@@ -2407,12 +2383,10 @@ class DataArray(AbstractArray, DataWithCoords):
                   * x        (x) int64 0 1 2 3 4 5 6 7 8
 
             The gap lengths are 3-0 = 3; 6-3 = 3; and 8-6 = 2 respectively
-
         keep_attrs : bool, default: True
             If True, the dataarray's attributes (`attrs`) will be copied from
             the original object to the new one.  If False, the new
             object will be returned without attributes.
-
         kwargs : dict, optional
             parameters passed verbatim to the underlying interpolation function
 
@@ -2614,7 +2588,6 @@ class DataArray(AbstractArray, DataWithCoords):
         ----------
         name
             Name to give to this array (required if unnamed).
-
         dim_order
             Hierarchical dimension order for the resulting dataframe.
             Array content is transposed to this order and then written out as flat
@@ -3315,10 +3288,8 @@ class DataArray(AbstractArray, DataWithCoords):
         ----------
         q : float or array-like of float
             Quantile to compute, which must be between 0 and 1 inclusive.
-
         dim : hashable or sequence of hashable, optional
             Dimension(s) over which to apply quantile.
-
         interpolation : {"linear", "lower", "higher", "midpoint", "nearest"}, default: "linear"
             This optional parameter specifies the interpolation method to
             use when the desired quantile lies between two data points
@@ -3331,12 +3302,10 @@ class DataArray(AbstractArray, DataWithCoords):
                 - higher: ``j``.
                 - nearest: ``i`` or ``j``, whichever is nearest.
                 - midpoint: ``(i + j) / 2``.
-
         keep_attrs : bool, optional
             If True, the dataset's attributes (`attrs`) will be copied from
             the original object to the new one.  If False (default), the new
             object will be returned without attributes.
-
         skipna : bool, optional
             Whether to skip missing values when aggregating.
 
@@ -3605,15 +3574,12 @@ class DataArray(AbstractArray, DataWithCoords):
             This function must return either a single DataArray or a single Dataset.
 
             This function cannot add a new chunked dimension.
-
         args : sequence
             Passed to func after unpacking and subsetting any xarray objects by blocks.
             xarray objects in args must be aligned with this object, otherwise an error is raised.
-
         kwargs : mapping
             Passed verbatim to func after unpacking. xarray objects, if any, will not be
             subset to blocks. Passing dask collections in kwargs is not allowed.
-
         template : DataArray or Dataset, optional
             xarray object representing the final result after compute is called. If not provided,
             the function will be first run on mocked-up data, that looks like this object but
@@ -3783,7 +3749,6 @@ class DataArray(AbstractArray, DataWithCoords):
             Mapping with the form of {dim: (pad_before, pad_after)}
             describing the number of values padded along each dimension.
             {dim: pad} is a shortcut for pad_before = pad_after = pad
-
         mode : str, default: "constant"
             One of the following string values (taken from numpy docs)
 
@@ -3817,7 +3782,6 @@ class DataArray(AbstractArray, DataWithCoords):
                 Pads with the wrap of the vector along the axis.
                 The first values are used to pad the end and the
                 end values are used to pad the beginning.
-
         stat_length : int, tuple or mapping of hashable to tuple, default: None
             Used in 'maximum', 'mean', 'median', and 'minimum'.  Number of
             values at edge of each axis used to calculate the statistic value.
@@ -3828,7 +3792,6 @@ class DataArray(AbstractArray, DataWithCoords):
             (stat_length,) or int is a shortcut for before = after = statistic
             length for all axes.
             Default is ``None``, to use the entire axis.
-
         constant_values : scalar, tuple or mapping of hashable to tuple, default: 0
             Used in 'constant'.  The values to set the padded values for each
             axis.
@@ -3839,7 +3802,6 @@ class DataArray(AbstractArray, DataWithCoords):
             ``(constant,)`` or ``constant`` is a shortcut for ``before = after = constant`` for
             all dimensions.
             Default is 0.
-
         end_values : scalar, tuple or mapping of hashable to tuple, default: 0
             Used in 'linear_ramp'.  The values used for the ending value of the
             linear_ramp and that will form the edge of the padded array.
@@ -3850,13 +3812,11 @@ class DataArray(AbstractArray, DataWithCoords):
             ``(constant,)`` or ``constant`` is a shortcut for ``before = after = constant`` for
             all axes.
             Default is 0.
-
         reflect_type : {"even", "odd"}, optional
             Used in "reflect", and "symmetric".  The "even" style is the
             default with an unaltered reflection around the edge value.  For
             the "odd" style, the extended part of the array is created by
             subtracting the reflected values from two times the edge value.
-
         **pad_width_kwargs
             The keyword arguments form of ``pad_width``.
             One of ``pad_width`` or ``pad_width_kwargs`` must be provided.

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -945,7 +945,6 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Examples
         --------
-
         Shallow versus deep copy
 
         >>> array = xr.DataArray([1, 2, 3], dims="x", coords={"x": ["a", "b", "c"]})
@@ -1169,6 +1168,7 @@ class DataArray(AbstractArray, DataWithCoords):
             If DataArrays are passed as indexers, xarray-style indexing will be
             carried out. See :ref:`indexing` for the details.
             One of indexers or indexers_kwargs must be provided.
+
         method : {None, "nearest", "pad", "ffill", "backfill", "bfill"}, optional
             Method to use for inexact matches:
 
@@ -1176,13 +1176,16 @@ class DataArray(AbstractArray, DataWithCoords):
             * pad / ffill: propagate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
+
         tolerance : optional
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+
         drop : bool, optional
             If ``drop=True``, drop coordinates variables in `indexers` instead
             of making them scalar.
+
         **indexers_kwargs : {dim: indexer, ...}, optional
             The keyword arguments form of ``indexers``.
             One of indexers or indexers_kwargs must be provided.
@@ -1294,7 +1297,6 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Examples
         --------
-
         >>> arr1 = xr.DataArray(
         ...     np.random.randn(2, 3),
         ...     dims=("x", "y"),
@@ -1359,6 +1361,7 @@ class DataArray(AbstractArray, DataWithCoords):
             other object need not be the same as the indexes on this
             dataset. Any mis-matched index values will be filled in with
             NaN, and any mis-matched dimension names will simply be ignored.
+
         method : {None, "nearest", "pad", "ffill", "backfill", "bfill"}, optional
             Method to use for filling index values from other not found on this
             data array:
@@ -1367,15 +1370,18 @@ class DataArray(AbstractArray, DataWithCoords):
             * pad / ffill: propagate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
+
         tolerance : optional
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+
         copy : bool, optional
             If ``copy=True``, data in the return value is always copied. If
             ``copy=False`` and reindexing is unnecessary, or can be performed
             with only slice operations, then the output may share memory with
             the input. In either case, a new xarray object is always returned.
+
         fill_value : scalar or dict-like, optional
             Value to use for newly missing values. If a dict-like, maps
             variable names (including coordinates) to fill values. Use this
@@ -1421,11 +1427,13 @@ class DataArray(AbstractArray, DataWithCoords):
             values will be filled in with NaN, and any mis-matched dimension
             names will simply be ignored.
             One of indexers or indexers_kwargs must be provided.
+
         copy : bool, optional
             If ``copy=True``, data in the return value is always copied. If
             ``copy=False`` and reindexing is unnecessary, or can be performed
             with only slice operations, then the output may share memory with
             the input. In either case, a new xarray object is always returned.
+
         method : {None, 'nearest', 'pad'/'ffill', 'backfill'/'bfill'}, optional
             Method to use for filling index values in ``indexers`` not found on
             this data array:
@@ -1434,14 +1442,17 @@ class DataArray(AbstractArray, DataWithCoords):
             * pad / ffill: propagate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
+
         tolerance : optional
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+
         fill_value : scalar or dict-like, optional
             Value to use for newly missing values. If a dict-like, maps
             variable names (including coordinates) to fill values. Use this
             data array's name to refer to the data array's values.
+
         **indexers_kwargs : {dim: indexer, ...}, optional
             The keyword arguments form of ``indexers``.
             One of indexers or indexers_kwargs must be provided.
@@ -1491,19 +1502,23 @@ class DataArray(AbstractArray, DataWithCoords):
             New coordinate can be an scalar, array-like or DataArray.
             If DataArrays are passed as new coordinates, their dimensions are
             used for the broadcasting. Missing values are skipped.
+
         method : str, default: "linear"
             The method used to interpolate. Choose from
 
             - {"linear", "nearest"} for multidimensional array,
             - {"linear", "nearest", "zero", "slinear", "quadratic", "cubic"} for 1-dimensional array.
+
         assume_sorted : bool, optional
             If False, values of x can be in any order and they are sorted
             first. If True, x has to be an array of monotonically increasing
             values.
+
         kwargs : dict
             Additional keyword arguments passed to scipy's interpolator. Valid
             options and their behavior depend on if 1-dimensional or
             multi-dimensional interpolation is used.
+
         **coords_kwargs : {dim: coordinate, ...}, optional
             The keyword arguments form of ``coords``.
             One of coords or coords_kwargs must be provided.
@@ -1620,16 +1635,19 @@ class DataArray(AbstractArray, DataWithCoords):
             Object with an 'indexes' attribute giving a mapping from dimension
             names to an 1d array-like, which provides coordinates upon
             which to index the variables in this dataset. Missing values are skipped.
+
         method : str, default: "linear"
             The method used to interpolate. Choose from
 
             - {"linear", "nearest"} for multidimensional array,
             - {"linear", "nearest", "zero", "slinear", "quadratic", "cubic"} for 1-dimensional array.
+
         assume_sorted : bool, optional
             If False, values of coordinates that are interpolated over can be
             in any order and they are sorted first. If True, interpolated
             coordinates are assumed to be an array of monotonically increasing
             values.
+
         kwargs : dict, optional
             Additional keyword passed to scipy's interpolator.
 
@@ -1709,7 +1727,6 @@ class DataArray(AbstractArray, DataWithCoords):
         dims_dict : dict-like
             Dictionary whose keys are current dimension names and whose values
             are new names.
-
         **dim_kwargs : {dim: , ...}, optional
             The keyword arguments form of ``dims_dict``.
             One of dims_dict or dims_kwargs must be provided.
@@ -1721,7 +1738,6 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Examples
         --------
-
         >>> arr = xr.DataArray(
         ...     data=[0, 1],
         ...     dims="x",
@@ -1751,7 +1767,6 @@ class DataArray(AbstractArray, DataWithCoords):
 
         See Also
         --------
-
         DataArray.rename
         Dataset.swap_dims
         """
@@ -1768,7 +1783,6 @@ class DataArray(AbstractArray, DataWithCoords):
         """Return a new object with an additional axis (or axes) inserted at
         the corresponding position in the array shape. The new object is a
         view into the underlying array, not a copy.
-
 
         If dim is already a scalar coordinate, it will be promoted to a 1D
         coordinate consisting of a single value.
@@ -1965,7 +1979,6 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Examples
         --------
-
         >>> arr = xr.DataArray(
         ...     np.arange(6).reshape(2, 3),
         ...     coords=[("x", ["a", "b"]), ("y", [0, 1, 2])],
@@ -2026,7 +2039,6 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Examples
         --------
-
         >>> arr = xr.DataArray(
         ...     np.arange(6).reshape(2, 3),
         ...     coords=[("x", ["a", "b"]), ("y", [0, 1, 2])],
@@ -2191,7 +2203,7 @@ class DataArray(AbstractArray, DataWithCoords):
         ----------
         names : hashable or iterable of hashable
             Name(s) of variables to drop.
-        errors: {"raise", "ignore"}, optional
+        errors : {"raise", "ignore"}, optional
             If 'raise' (default), raises a ValueError error if any of the variable
             passed are not in the dataset. If 'ignore', any given names that are in the
             DataArray are dropped and no error is raised.
@@ -2346,6 +2358,7 @@ class DataArray(AbstractArray, DataWithCoords):
         ----------
         dim : str
             Specifies the dimension along which to interpolate.
+
         method : str, optional
             String indicating which method to use for interpolation:
 
@@ -2364,12 +2377,14 @@ class DataArray(AbstractArray, DataWithCoords):
             eqaully-spaced along ``dim``. If True, the IndexVariable `dim` is
             used. If ``use_coordinate`` is a string, it specifies the name of a
             coordinate variariable to use as the index.
+
         limit : int, default: None
             Maximum number of consecutive NaNs to fill. Must be greater than 0
             or None for no limit. This filling is done regardless of the size of
             the gap in the data. To only interpolate over gaps less than a given length,
             see ``max_gap``.
-        max_gap: int, float, str, pandas.Timedelta, numpy.timedelta64, datetime.timedelta, default: None
+
+        max_gap : int, float, str, pandas.Timedelta, numpy.timedelta64, datetime.timedelta, default: None
             Maximum size of gap, a continuous sequence of NaNs, that will be filled.
             Use None for no limit. When interpolating along a datetime64 dimension
             and ``use_coordinate=True``, ``max_gap`` can be one of the following:
@@ -2392,10 +2407,12 @@ class DataArray(AbstractArray, DataWithCoords):
                   * x        (x) int64 0 1 2 3 4 5 6 7 8
 
             The gap lengths are 3-0 = 3; 6-3 = 3; and 8-6 = 2 respectively
+
         keep_attrs : bool, default: True
             If True, the dataarray's attributes (`attrs`) will be copied from
             the original object to the new one.  If False, the new
             object will be returned without attributes.
+
         kwargs : dict, optional
             parameters passed verbatim to the underlying interpolation function
 
@@ -2404,7 +2421,7 @@ class DataArray(AbstractArray, DataWithCoords):
         interpolated: DataArray
             Filled in DataArray.
 
-        See also
+        See Also
         --------
         numpy.interp
         scipy.interpolate
@@ -2597,6 +2614,7 @@ class DataArray(AbstractArray, DataWithCoords):
         ----------
         name
             Name to give to this array (required if unnamed).
+
         dim_order
             Hierarchical dimension order for the resulting dataframe.
             Array content is transposed to this order and then written out as flat
@@ -2716,7 +2734,7 @@ class DataArray(AbstractArray, DataWithCoords):
             Whether to include the actual data in the dictionary. When set to
             False, returns just the schema.
 
-        See also
+        See Also
         --------
         DataArray.from_dict
         """
@@ -2757,7 +2775,7 @@ class DataArray(AbstractArray, DataWithCoords):
         -------
         obj : xarray.DataArray
 
-        See also
+        See Also
         --------
         DataArray.to_dict
         Dataset.from_dict
@@ -2794,7 +2812,7 @@ class DataArray(AbstractArray, DataWithCoords):
         If sparse=True, creates a sparse array instead of a dense NumPy array.
         Requires the pydata/sparse package.
 
-        See also
+        See Also
         --------
         xarray.Dataset.from_dataframe
         """
@@ -3047,7 +3065,6 @@ class DataArray(AbstractArray, DataWithCoords):
         `n` matches numpy's behavior and is different from pandas' first argument named
         `periods`.
 
-
         Examples
         --------
         >>> arr = xr.DataArray([5, 5, 6, 6], [[1, 2, 3, 4]], ["x"])
@@ -3087,7 +3104,7 @@ class DataArray(AbstractArray, DataWithCoords):
             Integer offset to shift along each of the given dimensions.
             Positive offsets shift to the right; negative offsets shift to the
             left.
-        fill_value: scalar, optional
+        fill_value : scalar, optional
             Value to use for newly missing values
         **shifts_kwargs
             The keyword arguments form of ``shifts``.
@@ -3099,13 +3116,12 @@ class DataArray(AbstractArray, DataWithCoords):
             DataArray with the same coordinates and attributes but shifted
             data.
 
-        See also
+        See Also
         --------
         roll
 
         Examples
         --------
-
         >>> arr = xr.DataArray([5, 6, 7], dims="x")
         >>> arr.shift(x=1)
         <xarray.DataArray (x: 3)>
@@ -3149,13 +3165,12 @@ class DataArray(AbstractArray, DataWithCoords):
         rolled : DataArray
             DataArray with the same attributes but rolled data and coordinates.
 
-        See also
+        See Also
         --------
         shift
 
         Examples
         --------
-
         >>> arr = xr.DataArray([5, 6, 7], dims="x")
         >>> arr.roll(x=1)
         <xarray.DataArray (x: 3)>
@@ -3195,14 +3210,13 @@ class DataArray(AbstractArray, DataWithCoords):
         result : DataArray
             Array resulting from the dot product over all shared dimensions.
 
-        See also
+        See Also
         --------
         dot
         numpy.tensordot
 
         Examples
         --------
-
         >>> da_vals = np.arange(6 * 5 * 4).reshape((6, 5, 4))
         >>> da = xr.DataArray(da_vals, dims=["x", "y", "z"])
         >>> dm_vals = np.arange(4)
@@ -3265,7 +3279,6 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Examples
         --------
-
         >>> da = xr.DataArray(
         ...     np.random.rand(5),
         ...     coords=[pd.date_range("1/1/2000", periods=5)],
@@ -3302,8 +3315,10 @@ class DataArray(AbstractArray, DataWithCoords):
         ----------
         q : float or array-like of float
             Quantile to compute, which must be between 0 and 1 inclusive.
+
         dim : hashable or sequence of hashable, optional
             Dimension(s) over which to apply quantile.
+
         interpolation : {"linear", "lower", "higher", "midpoint", "nearest"}, default: "linear"
             This optional parameter specifies the interpolation method to
             use when the desired quantile lies between two data points
@@ -3316,10 +3331,12 @@ class DataArray(AbstractArray, DataWithCoords):
                 - higher: ``j``.
                 - nearest: ``i`` or ``j``, whichever is nearest.
                 - midpoint: ``(i + j) / 2``.
+
         keep_attrs : bool, optional
             If True, the dataset's attributes (`attrs`) will be copied from
             the original object to the new one.  If False (default), the new
             object will be returned without attributes.
+
         skipna : bool, optional
             Whether to skip missing values when aggregating.
 
@@ -3338,7 +3355,6 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Examples
         --------
-
         >>> da = xr.DataArray(
         ...     data=[[0.7, 4.2, 9.4, 1.5], [6.5, 7.3, 2.6, 1.9]],
         ...     coords={"x": [7, 9], "y": [1, 1.5, 2, 2.5]},
@@ -3410,7 +3426,6 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Examples
         --------
-
         >>> arr = xr.DataArray([5, 6, 7], dims="x")
         >>> arr.rank("x")
         <xarray.DataArray (x: 3)>
@@ -3557,12 +3572,10 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Returns
         -------
-
         DataArray with consistent chunk sizes for all dask-array variables
 
         See Also
         --------
-
         dask.array.core.unify_chunks
         """
         ds = self._to_temp_dataset().unify_chunks()
@@ -3592,12 +3605,15 @@ class DataArray(AbstractArray, DataWithCoords):
             This function must return either a single DataArray or a single Dataset.
 
             This function cannot add a new chunked dimension.
+
         args : sequence
             Passed to func after unpacking and subsetting any xarray objects by blocks.
             xarray objects in args must be aligned with this object, otherwise an error is raised.
+
         kwargs : mapping
             Passed verbatim to func after unpacking. xarray objects, if any, will not be
             subset to blocks. Passing dask collections in kwargs is not allowed.
+
         template : DataArray or Dataset, optional
             xarray object representing the final result after compute is called. If not provided,
             the function will be first run on mocked-up data, that looks like this object but
@@ -3623,12 +3639,11 @@ class DataArray(AbstractArray, DataWithCoords):
 
         See Also
         --------
-        dask.array.map_blocks, xarray.apply_ufunc, xarray.Dataset.map_blocks,
+        dask.array.map_blocks, xarray.apply_ufunc, xarray.Dataset.map_blocks
         xarray.DataArray.map_blocks
 
         Examples
         --------
-
         Calculate an anomaly from climatology using ``.groupby()``. Using
         ``xr.map_blocks()`` allows for parallel operations with knowledge of ``xarray``,
         its indices, and its methods like ``.groupby()``.
@@ -3728,7 +3743,7 @@ class DataArray(AbstractArray, DataWithCoords):
             polyfit_covariance
                 The covariance matrix of the polynomial coefficient estimates (only included if `full=False` and `cov=True`)
 
-        See also
+        See Also
         --------
         numpy.polyfit
         """
@@ -3768,6 +3783,7 @@ class DataArray(AbstractArray, DataWithCoords):
             Mapping with the form of {dim: (pad_before, pad_after)}
             describing the number of values padded along each dimension.
             {dim: pad} is a shortcut for pad_before = pad_after = pad
+
         mode : str, default: "constant"
             One of the following string values (taken from numpy docs)
 
@@ -3801,6 +3817,7 @@ class DataArray(AbstractArray, DataWithCoords):
                 Pads with the wrap of the vector along the axis.
                 The first values are used to pad the end and the
                 end values are used to pad the beginning.
+
         stat_length : int, tuple or mapping of hashable to tuple, default: None
             Used in 'maximum', 'mean', 'median', and 'minimum'.  Number of
             values at edge of each axis used to calculate the statistic value.
@@ -3811,6 +3828,7 @@ class DataArray(AbstractArray, DataWithCoords):
             (stat_length,) or int is a shortcut for before = after = statistic
             length for all axes.
             Default is ``None``, to use the entire axis.
+
         constant_values : scalar, tuple or mapping of hashable to tuple, default: 0
             Used in 'constant'.  The values to set the padded values for each
             axis.
@@ -3821,6 +3839,7 @@ class DataArray(AbstractArray, DataWithCoords):
             ``(constant,)`` or ``constant`` is a shortcut for ``before = after = constant`` for
             all dimensions.
             Default is 0.
+
         end_values : scalar, tuple or mapping of hashable to tuple, default: 0
             Used in 'linear_ramp'.  The values used for the ending value of the
             linear_ramp and that will form the edge of the padded array.
@@ -3831,11 +3850,13 @@ class DataArray(AbstractArray, DataWithCoords):
             ``(constant,)`` or ``constant`` is a shortcut for ``before = after = constant`` for
             all axes.
             Default is 0.
+
         reflect_type : {"even", "odd"}, optional
             Used in "reflect", and "symmetric".  The "even" style is the
             default with an unaltered reflection around the edge value.  For
             the "odd" style, the extended part of the array is created by
             subtracting the reflected values from two times the edge value.
+
         **pad_width_kwargs
             The keyword arguments form of ``pad_width``.
             One of ``pad_width`` or ``pad_width_kwargs`` must be provided.
@@ -3845,7 +3866,7 @@ class DataArray(AbstractArray, DataWithCoords):
         padded : DataArray
             DataArray with the padded coordinates and data.
 
-        See also
+        See Also
         --------
         DataArray.shift, DataArray.roll, DataArray.bfill, DataArray.ffill, numpy.pad, dask.array.pad
 
@@ -3857,7 +3878,6 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Examples
         --------
-
         >>> arr = xr.DataArray([5, 6, 7], coords=[("x", [0, 1, 2])])
         >>> arr.pad(x=(1, 2), constant_values=0)
         <xarray.DataArray (x: 6)>
@@ -3949,13 +3969,12 @@ class DataArray(AbstractArray, DataWithCoords):
             New `DataArray` object with `idxmin` applied to its data and the
             indicated dimension removed.
 
-        See also
+        See Also
         --------
         Dataset.idxmin, DataArray.idxmax, DataArray.min, DataArray.argmin
 
         Examples
         --------
-
         >>> array = xr.DataArray(
         ...     [0, 2, 1, 0, -2], dims="x", coords={"x": ["a", "b", "c", "d", "e"]}
         ... )
@@ -4046,13 +4065,12 @@ class DataArray(AbstractArray, DataWithCoords):
             New `DataArray` object with `idxmax` applied to its data and the
             indicated dimension removed.
 
-        See also
+        See Also
         --------
         Dataset.idxmax, DataArray.idxmin, DataArray.max, DataArray.argmax
 
         Examples
         --------
-
         >>> array = xr.DataArray(
         ...     [0, 2, 1, 0, -2], dims="x", coords={"x": ["a", "b", "c", "d", "e"]}
         ... )
@@ -4140,7 +4158,7 @@ class DataArray(AbstractArray, DataWithCoords):
         -------
         result : DataArray or dict of DataArray
 
-        See also
+        See Also
         --------
         Variable.argmin, DataArray.idxmin
 
@@ -4243,7 +4261,7 @@ class DataArray(AbstractArray, DataWithCoords):
         -------
         result : DataArray or dict of DataArray
 
-        See also
+        See Also
         --------
         Variable.argmax, DataArray.idxmax
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1732,11 +1732,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         ----------
         store : MutableMapping, str or Path, optional
             Store or path to directory in file system.
-
         chunk_store : MutableMapping, str or Path, optional
             Store or path to directory in file system only for Zarr array chunks.
             Requires zarr-python v2.4.0 or later.
-
         mode : {"w", "w-", "a", None}, optional
             Persistence mode: "w" means create (overwrite if exists);
             "w-" means create (fail if exists);
@@ -1744,31 +1742,24 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             If ``append_dim`` is set, ``mode`` can be omitted as it is
             internally set to ``"a"``. Otherwise, ``mode`` will default to
             `w-` if not set.
-
         synchronizer : object, optional
             Zarr array synchronizer.
-
         group : str, optional
             Group path. (a.k.a. `path` in zarr terminology.)
-
         encoding : dict, optional
             Nested dictionary with variable names as keys and dictionaries of
             variable specific encodings as values, e.g.,
             ``{"my_variable": {"dtype": "int16", "scale_factor": 0.1,}, ...}``
-
         compute : bool, optional
             If True write array data immediately, otherwise return a
             ``dask.delayed.Delayed`` object that can be computed to write
             array data later. Metadata is always updated eagerly.
-
         consolidated : bool, optional
             If True, apply zarr's `consolidate_metadata` function to the store
             after writing metadata.
-
         append_dim : hashable, optional
             If set, the dimension along which the data will be appended. All
             other dimensions on overriden variables must remain the same size.
-
         region : dict, optional
             Optional mapping from dimension names to integer slices along
             dataset dimensions to indicate the region of existing zarr array(s)
@@ -2211,7 +2202,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             If DataArrays are passed as indexers, xarray-style indexing will be
             carried out. See :ref:`indexing` for the details.
             One of indexers or indexers_kwargs must be provided.
-
         method : {None, "nearest", "pad", "ffill", "backfill", "bfill"}, optional
             Method to use for inexact matches:
 
@@ -2219,16 +2209,13 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             * pad / ffill: propagate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
-
         tolerance : optional
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
-
         drop : bool, optional
             If ``drop=True``, drop coordinates variables in `indexers` instead
             of making them scalar.
-
         **indexers_kwargs : {dim: indexer, ...}, optional
             The keyword arguments form of ``indexers``.
             One of indexers or indexers_kwargs must be provided.
@@ -2444,7 +2431,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             other object need not be the same as the indexes on this
             dataset. Any mis-matched index values will be filled in with
             NaN, and any mis-matched dimension names will simply be ignored.
-
         method : {None, "nearest", "pad", "ffill", "backfill", "bfill"}, optional
             Method to use for filling index values from other not found in this
             dataset:
@@ -2453,18 +2439,15 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             * pad / ffill: propagate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
-
         tolerance : optional
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
-
         copy : bool, optional
             If ``copy=True``, data in the return value is always copied. If
             ``copy=False`` and reindexing is unnecessary, or can be performed
             with only slice operations, then the output may share memory with
             the input. In either case, a new xarray object is always returned.
-
         fill_value : scalar or dict-like, optional
             Value to use for newly missing values. If a dict-like maps
             variable names to fill values.
@@ -2509,7 +2492,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             values will be filled in with NaN, and any mis-matched dimension
             names will simply be ignored.
             One of indexers or indexers_kwargs must be provided.
-
         method : {None, "nearest", "pad", "ffill", "backfill", "bfill"}, optional
             Method to use for filling index values in ``indexers`` not found in
             this dataset:
@@ -2518,25 +2500,20 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             * pad / ffill: propagate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
-
         tolerance : optional
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
-
         copy : bool, optional
             If ``copy=True``, data in the return value is always copied. If
             ``copy=False`` and reindexing is unnecessary, or can be performed
             with only slice operations, then the output may share memory with
             the input. In either case, a new xarray object is always returned.
-
         fill_value : scalar or dict-like, optional
             Value to use for newly missing values. If a dict-like,
             maps variable names (including coordinates) to fill values.
-
         sparse : bool, default: False
             use sparse-array.
-
         **indexers_kwargs : {dim: indexer, ...}, optional
             Keyword arguments in the same form as ``indexers``.
             One of indexers or indexers_kwargs must be provided.
@@ -4465,7 +4442,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         ----------
         dim : str
             Specifies the dimension along which to interpolate.
-
         method : str, optional
             String indicating which method to use for interpolation:
 
@@ -4477,20 +4453,17 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
               provided.
             - 'barycentric', 'krog', 'pchip', 'spline', 'akima': use their
               respective :py:class:`scipy.interpolate` classes.
-
         use_coordinate : bool, str, default: True
             Specifies which index to use as the x values in the interpolation
             formulated as `y = f(x)`. If False, values are treated as if
             eqaully-spaced along ``dim``. If True, the IndexVariable `dim` is
             used. If ``use_coordinate`` is a string, it specifies the name of a
             coordinate variariable to use as the index.
-
         limit : int, default: None
             Maximum number of consecutive NaNs to fill. Must be greater than 0
             or None for no limit. This filling is done regardless of the size of
             the gap in the data. To only interpolate over gaps less than a given length,
             see ``max_gap``.
-
         max_gap : int, float, str, pandas.Timedelta, numpy.timedelta64, datetime.timedelta, default: None
             Maximum size of gap, a continuous sequence of NaNs, that will be filled.
             Use None for no limit. When interpolating along a datetime64 dimension
@@ -4514,7 +4487,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                   * x        (x) int64 0 1 2 3 4 5 6 7 8
 
             The gap lengths are 3-0 = 3; 6-3 = 3; and 8-6 = 2 respectively
-
         kwargs : dict, optional
             parameters passed verbatim to the underlying interpolation function
 
@@ -5181,7 +5153,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
             If provided, must include all dimensions of this dataset. By
             default, dimensions are sorted alphabetically.
-
         set_index : bool, optional
             If set_index=True, the dask DataFrame is indexed by this dataset's
             coordinate. Since dask DataFrames do not support multi-indexes,
@@ -5745,10 +5716,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         ----------
         q : float or array-like of float
             Quantile to compute, which must be between 0 and 1 inclusive.
-
         dim : str or sequence of str, optional
             Dimension(s) over which to apply quantile.
-
         interpolation : {"linear", "lower", "higher", "midpoint", "nearest"}, default: "linear"
             This optional parameter specifies the interpolation method to
             use when the desired quantile lies between two data points
@@ -5761,15 +5730,12 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 * higher: ``j``.
                 * nearest: ``i`` or ``j``, whichever is nearest.
                 * midpoint: ``(i + j) / 2``.
-
         keep_attrs : bool, optional
             If True, the dataset's attributes (`attrs`) will be copied from
             the original object to the new one.  If False (default), the new
             object will be returned without attributes.
-
         numeric_only : bool, optional
             If True, only apply ``func`` to variables with a numeric dtype.
-
         skipna : bool, optional
             Whether to skip missing values when aggregating.
 
@@ -6256,15 +6222,12 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             This function must return either a single DataArray or a single Dataset.
 
             This function cannot add a new chunked dimension.
-
         args : sequence
             Passed to func after unpacking and subsetting any xarray objects by blocks.
             xarray objects in args must be aligned with obj, otherwise an error is raised.
-
         kwargs : mapping
             Passed verbatim to func after unpacking. xarray objects, if any, will not be
             subset to blocks. Passing dask collections in kwargs is not allowed.
-
         template : DataArray or Dataset, optional
             xarray object representing the final result after compute is called. If not provided,
             the function will be first run on mocked-up data, that looks like this object but
@@ -6564,7 +6527,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             Mapping with the form of {dim: (pad_before, pad_after)}
             describing the number of values padded along each dimension.
             {dim: pad} is a shortcut for pad_before = pad_after = pad
-
         mode : str, default: "constant"
             One of the following string values (taken from numpy docs).
 
@@ -6598,7 +6560,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 Pads with the wrap of the vector along the axis.
                 The first values are used to pad the end and the
                 end values are used to pad the beginning.
-
         stat_length : int, tuple or mapping of hashable to tuple, default: None
             Used in 'maximum', 'mean', 'median', and 'minimum'.  Number of
             values at edge of each axis used to calculate the statistic value.
@@ -6609,7 +6570,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             (stat_length,) or int is a shortcut for before = after = statistic
             length for all axes.
             Default is ``None``, to use the entire axis.
-
         constant_values : scalar, tuple or mapping of hashable to tuple, default: 0
             Used in 'constant'.  The values to set the padded values for each
             axis.
@@ -6620,7 +6580,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             ``(constant,)`` or ``constant`` is a shortcut for ``before = after = constant`` for
             all dimensions.
             Default is 0.
-
         end_values : scalar, tuple or mapping of hashable to tuple, default: 0
             Used in 'linear_ramp'.  The values used for the ending value of the
             linear_ramp and that will form the edge of the padded array.
@@ -6631,13 +6590,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             ``(constant,)`` or ``constant`` is a shortcut for ``before = after = constant`` for
             all axes.
             Default is 0.
-
         reflect_type : {"even", "odd"}, optional
             Used in "reflect", and "symmetric".  The "even" style is the
             default with an unaltered reflection around the edge value.  For
             the "odd" style, the extended part of the array is created by
             subtracting the reflected values from two times the edge value.
-
         **pad_width_kwargs
             The keyword arguments form of ``pad_width``.
             One of ``pad_width`` or ``pad_width_kwargs`` must be provided.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -762,7 +762,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         This is an alias for `Dataset.dims` provided for the benefit of
         consistency with `DataArray.sizes`.
 
-        See also
+        See Also
         --------
         DataArray.sizes
         """
@@ -1159,7 +1159,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Examples
         --------
-
         Shallow copy versus deep copy
 
         >>> da = xr.DataArray(np.random.randn(2, 3))
@@ -1549,7 +1548,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         -------
         Dataset
 
-        See also
+        See Also
         --------
         Dataset.swap_dims
         """
@@ -1733,9 +1732,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         ----------
         store : MutableMapping, str or Path, optional
             Store or path to directory in file system.
+
         chunk_store : MutableMapping, str or Path, optional
             Store or path to directory in file system only for Zarr array chunks.
             Requires zarr-python v2.4.0 or later.
+
         mode : {"w", "w-", "a", None}, optional
             Persistence mode: "w" means create (overwrite if exists);
             "w-" means create (fail if exists);
@@ -1743,25 +1744,32 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             If ``append_dim`` is set, ``mode`` can be omitted as it is
             internally set to ``"a"``. Otherwise, ``mode`` will default to
             `w-` if not set.
+
         synchronizer : object, optional
             Zarr array synchronizer.
+
         group : str, optional
             Group path. (a.k.a. `path` in zarr terminology.)
+
         encoding : dict, optional
             Nested dictionary with variable names as keys and dictionaries of
             variable specific encodings as values, e.g.,
             ``{"my_variable": {"dtype": "int16", "scale_factor": 0.1,}, ...}``
-        compute: bool, optional
+
+        compute : bool, optional
             If True write array data immediately, otherwise return a
             ``dask.delayed.Delayed`` object that can be computed to write
             array data later. Metadata is always updated eagerly.
-        consolidated: bool, optional
+
+        consolidated : bool, optional
             If True, apply zarr's `consolidate_metadata` function to the store
             after writing metadata.
-        append_dim: hashable, optional
+
+        append_dim : hashable, optional
             If set, the dimension along which the data will be appended. All
             other dimensions on overriden variables must remain the same size.
-        region: dict, optional
+
+        region : dict, optional
             Optional mapping from dimension names to integer slices along
             dataset dimensions to indicate the region of existing zarr array(s)
             in which to write this dataset's data. For example,
@@ -1832,7 +1840,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         See Also
         --------
         pandas.DataFrame.assign
-        ncdump: netCDF's ncdump
+        ncdump : netCDF's ncdump
         """
         if buf is None:  # pragma: no cover
             buf = sys.stdout
@@ -2203,6 +2211,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             If DataArrays are passed as indexers, xarray-style indexing will be
             carried out. See :ref:`indexing` for the details.
             One of indexers or indexers_kwargs must be provided.
+
         method : {None, "nearest", "pad", "ffill", "backfill", "bfill"}, optional
             Method to use for inexact matches:
 
@@ -2210,13 +2219,16 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             * pad / ffill: propagate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
+
         tolerance : optional
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+
         drop : bool, optional
             If ``drop=True``, drop coordinates variables in `indexers` instead
             of making them scalar.
+
         **indexers_kwargs : {dim: indexer, ...}, optional
             The keyword arguments form of ``indexers``.
             One of indexers or indexers_kwargs must be provided.
@@ -2231,7 +2243,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             In general, each array's data will be a view of the array's data
             in this dataset, unless vectorized indexing was triggered by using
             an array indexer, in which case the data will be a copy.
-
 
         See Also
         --------
@@ -2262,7 +2273,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         **indexers_kwargs : {dim: n, ...}, optional
             The keyword arguments form of ``indexers``.
             One of indexers or indexers_kwargs must be provided.
-
 
         See Also
         --------
@@ -2309,7 +2319,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         **indexers_kwargs : {dim: n, ...}, optional
             The keyword arguments form of ``indexers``.
             One of indexers or indexers_kwargs must be provided.
-
 
         See Also
         --------
@@ -2359,7 +2368,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         **indexers_kwargs : {dim: n, ...}, optional
             The keyword arguments form of ``indexers``.
             One of indexers or indexers_kwargs must be provided.
-
 
         See Also
         --------
@@ -2436,6 +2444,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             other object need not be the same as the indexes on this
             dataset. Any mis-matched index values will be filled in with
             NaN, and any mis-matched dimension names will simply be ignored.
+
         method : {None, "nearest", "pad", "ffill", "backfill", "bfill"}, optional
             Method to use for filling index values from other not found in this
             dataset:
@@ -2444,15 +2453,18 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             * pad / ffill: propagate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
+
         tolerance : optional
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+
         copy : bool, optional
             If ``copy=True``, data in the return value is always copied. If
             ``copy=False`` and reindexing is unnecessary, or can be performed
             with only slice operations, then the output may share memory with
             the input. In either case, a new xarray object is always returned.
+
         fill_value : scalar or dict-like, optional
             Value to use for newly missing values. If a dict-like maps
             variable names to fill values.
@@ -2497,6 +2509,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             values will be filled in with NaN, and any mis-matched dimension
             names will simply be ignored.
             One of indexers or indexers_kwargs must be provided.
+
         method : {None, "nearest", "pad", "ffill", "backfill", "bfill"}, optional
             Method to use for filling index values in ``indexers`` not found in
             this dataset:
@@ -2505,20 +2518,25 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             * pad / ffill: propagate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
+
         tolerance : optional
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+
         copy : bool, optional
             If ``copy=True``, data in the return value is always copied. If
             ``copy=False`` and reindexing is unnecessary, or can be performed
             with only slice operations, then the output may share memory with
             the input. In either case, a new xarray object is always returned.
+
         fill_value : scalar or dict-like, optional
             Value to use for newly missing values. If a dict-like,
             maps variable names (including coordinates) to fill values.
+
         sparse : bool, default: False
             use sparse-array.
+
         **indexers_kwargs : {dim: indexer, ...}, optional
             Keyword arguments in the same form as ``indexers``.
             One of indexers or indexers_kwargs must be provided.
@@ -2536,7 +2554,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Examples
         --------
-
         Create a dataset with some fictional data.
 
         >>> import xarray as xr
@@ -2750,7 +2767,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             in any order and they are sorted first. If True, interpolated
             coordinates are assumed to be an array of monotonically increasing
             values.
-        kwargs: dict, optional
+        kwargs : dict, optional
             Additional keyword arguments passed to scipy's interpolator. Valid
             options and their behavior depend on if 1-dimensional or
             multi-dimensional interpolation is used.
@@ -2952,7 +2969,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             in any order and they are sorted first. If True, interpolated
             coordinates are assumed to be an array of monotonically increasing
             values.
-        kwargs: dict, optional
+        kwargs : dict, optional
             Additional keyword passed to scipy's interpolator.
 
         Returns
@@ -3166,7 +3183,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         dims_dict : dict-like
             Dictionary whose keys are current dimension names and whose values
             are new names.
-
         **dim_kwargs : {existing_dim: new_dim, ...}, optional
             The keyword arguments form of ``dims_dict``.
             One of dims_dict or dims_kwargs must be provided.
@@ -3215,7 +3231,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         See Also
         --------
-
         Dataset.rename
         DataArray.swap_dims
         """
@@ -3586,7 +3601,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         stacked : Dataset
             Dataset with stacked data.
 
-        See also
+        See Also
         --------
         Dataset.unstack
         """
@@ -3815,7 +3830,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         unstacked : Dataset
             Dataset with unstacked data.
 
-        See also
+        See Also
         --------
         Dataset.stack
         """
@@ -3893,7 +3908,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             - mapping {var name: Variable}
             - mapping {var name: (dimension name, array-like)}
             - mapping {var name: (tuple of dimension names, array-like)}
-
 
         Returns
         -------
@@ -4375,7 +4389,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Examples
         --------
-
         >>> import numpy as np
         >>> import xarray as xr
         >>> ds = xr.Dataset(
@@ -4471,11 +4484,13 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             eqaully-spaced along ``dim``. If True, the IndexVariable `dim` is
             used. If ``use_coordinate`` is a string, it specifies the name of a
             coordinate variariable to use as the index.
+
         limit : int, default: None
             Maximum number of consecutive NaNs to fill. Must be greater than 0
             or None for no limit. This filling is done regardless of the size of
             the gap in the data. To only interpolate over gaps less than a given length,
             see ``max_gap``.
+
         max_gap : int, float, str, pandas.Timedelta, numpy.timedelta64, datetime.timedelta, default: None
             Maximum size of gap, a continuous sequence of NaNs, that will be filled.
             Use None for no limit. When interpolating along a datetime64 dimension
@@ -4499,6 +4514,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                   * x        (x) int64 0 1 2 3 4 5 6 7 8
 
             The gap lengths are 3-0 = 3; 6-3 = 3; and 8-6 = 2 respectively
+
         kwargs : dict, optional
             parameters passed verbatim to the underlying interpolation function
 
@@ -4507,7 +4523,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         interpolated: Dataset
             Filled in Dataset.
 
-        See also
+        See Also
         --------
         numpy.interp
         scipy.interpolate
@@ -5101,7 +5117,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         -------
         New Dataset.
 
-        See also
+        See Also
         --------
         xarray.DataArray.from_series
         pandas.DataFrame.to_xarray
@@ -5165,6 +5181,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
             If provided, must include all dimensions of this dataset. By
             default, dimensions are sorted alphabetically.
+
         set_index : bool, optional
             If set_index=True, the dask DataFrame is indexed by this dataset's
             coordinate. Since dask DataFrames do not support multi-indexes,
@@ -5232,7 +5249,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             Whether to include the actual data in the dictionary. When set to
             False, returns just the schema.
 
-        See also
+        See Also
         --------
         Dataset.from_dict
         """
@@ -5453,9 +5470,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         -------
         difference : same type as caller
             The n-th order finite difference of this object.
-
         .. note::
-
             `n` matches numpy's behavior and is different from pandas' first
             argument named `periods`.
 
@@ -5543,13 +5558,12 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             Dataset with the same coordinates and attributes but shifted data
             variables.
 
-        See also
+        See Also
         --------
         roll
 
         Examples
         --------
-
         >>> ds = xr.Dataset({"foo": ("x", list("abcde"))})
         >>> ds.shift(x=2)
         <xarray.Dataset>
@@ -5588,7 +5602,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Parameters
         ----------
-
         shifts : dict, optional
             A dict with keys matching dimensions and values given
             by integers to rotate each of the given dimensions. Positive
@@ -5607,13 +5620,12 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             Dataset with the same coordinates and attributes but rolled
             variables.
 
-        See also
+        See Also
         --------
         shift
 
         Examples
         --------
-
         >>> ds = xr.Dataset({"foo": ("x", list("abcde"))})
         >>> ds.roll(x=2)
         <xarray.Dataset>
@@ -5680,10 +5692,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Parameters
         ----------
-        variables: str, DataArray, or list of str or DataArray
+        variables : str, DataArray, or list of str or DataArray
             1D DataArray objects or name(s) of 1D variable(s) in
             coords/data_vars whose values are used to sort the dataset.
-        ascending: bool, optional
+        ascending : bool, optional
             Whether to sort by ascending or descending order.
 
         Returns
@@ -5733,8 +5745,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         ----------
         q : float or array-like of float
             Quantile to compute, which must be between 0 and 1 inclusive.
+
         dim : str or sequence of str, optional
             Dimension(s) over which to apply quantile.
+
         interpolation : {"linear", "lower", "higher", "midpoint", "nearest"}, default: "linear"
             This optional parameter specifies the interpolation method to
             use when the desired quantile lies between two data points
@@ -5747,12 +5761,15 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 * higher: ``j``.
                 * nearest: ``i`` or ``j``, whichever is nearest.
                 * midpoint: ``(i + j) / 2``.
+
         keep_attrs : bool, optional
             If True, the dataset's attributes (`attrs`) will be copied from
             the original object to the new one.  If False (default), the new
             object will be returned without attributes.
+
         numeric_only : bool, optional
             If True, only apply ``func`` to variables with a numeric dtype.
+
         skipna : bool, optional
             Whether to skip missing values when aggregating.
 
@@ -5771,7 +5788,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Examples
         --------
-
         >>> ds = xr.Dataset(
         ...     {"a": (("x", "y"), [[0.7, 4.2, 9.4, 1.5], [6.5, 7.3, 2.6, 1.9]])},
         ...     coords={"x": [7, 9], "y": [1, 1.5, 2, 2.5]},
@@ -6177,12 +6193,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Returns
         -------
-
         Dataset with consistent chunk sizes for all dask-array variables
 
         See Also
         --------
-
         dask.array.core.unify_chunks
         """
 
@@ -6242,12 +6256,15 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             This function must return either a single DataArray or a single Dataset.
 
             This function cannot add a new chunked dimension.
+
         args : sequence
             Passed to func after unpacking and subsetting any xarray objects by blocks.
             xarray objects in args must be aligned with obj, otherwise an error is raised.
+
         kwargs : mapping
             Passed verbatim to func after unpacking. xarray objects, if any, will not be
             subset to blocks. Passing dask collections in kwargs is not allowed.
+
         template : DataArray or Dataset, optional
             xarray object representing the final result after compute is called. If not provided,
             the function will be first run on mocked-up data, that looks like this object but
@@ -6256,7 +6273,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             ``template`` must be provided if the function changes the size of existing dimensions.
             When provided, ``attrs`` on variables in `template` are copied over to the result. Any
             ``attrs`` set by ``func`` will be ignored.
-
 
         Returns
         -------
@@ -6274,12 +6290,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         See Also
         --------
-        dask.array.map_blocks, xarray.apply_ufunc, xarray.Dataset.map_blocks,
+        dask.array.map_blocks, xarray.apply_ufunc, xarray.Dataset.map_blocks
         xarray.DataArray.map_blocks
 
         Examples
         --------
-
         Calculate an anomaly from climatology using ``.groupby()``. Using
         ``xr.map_blocks()`` allows for parallel operations with knowledge of ``xarray``,
         its indices, and its methods like ``.groupby()``.
@@ -6365,7 +6380,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             Whether to return to the covariance matrix in addition to the coefficients.
             The matrix is not scaled if `cov='unscaled'`.
 
-
         Returns
         -------
         polyfit_results : Dataset
@@ -6390,7 +6404,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             The rank of the coefficient matrix in the least-squares fit is deficient.
             The warning is not raised with in-memory (not dask) data and `full=True`.
 
-        See also
+        See Also
         --------
         numpy.polyfit
         """
@@ -6550,6 +6564,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             Mapping with the form of {dim: (pad_before, pad_after)}
             describing the number of values padded along each dimension.
             {dim: pad} is a shortcut for pad_before = pad_after = pad
+
         mode : str, default: "constant"
             One of the following string values (taken from numpy docs).
 
@@ -6583,6 +6598,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 Pads with the wrap of the vector along the axis.
                 The first values are used to pad the end and the
                 end values are used to pad the beginning.
+
         stat_length : int, tuple or mapping of hashable to tuple, default: None
             Used in 'maximum', 'mean', 'median', and 'minimum'.  Number of
             values at edge of each axis used to calculate the statistic value.
@@ -6593,6 +6609,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             (stat_length,) or int is a shortcut for before = after = statistic
             length for all axes.
             Default is ``None``, to use the entire axis.
+
         constant_values : scalar, tuple or mapping of hashable to tuple, default: 0
             Used in 'constant'.  The values to set the padded values for each
             axis.
@@ -6603,6 +6620,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             ``(constant,)`` or ``constant`` is a shortcut for ``before = after = constant`` for
             all dimensions.
             Default is 0.
+
         end_values : scalar, tuple or mapping of hashable to tuple, default: 0
             Used in 'linear_ramp'.  The values used for the ending value of the
             linear_ramp and that will form the edge of the padded array.
@@ -6613,11 +6631,13 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             ``(constant,)`` or ``constant`` is a shortcut for ``before = after = constant`` for
             all axes.
             Default is 0.
+
         reflect_type : {"even", "odd"}, optional
             Used in "reflect", and "symmetric".  The "even" style is the
             default with an unaltered reflection around the edge value.  For
             the "odd" style, the extended part of the array is created by
             subtracting the reflected values from two times the edge value.
+
         **pad_width_kwargs
             The keyword arguments form of ``pad_width``.
             One of ``pad_width`` or ``pad_width_kwargs`` must be provided.
@@ -6627,7 +6647,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         padded : Dataset
             Dataset with the padded coordinates and data.
 
-        See also
+        See Also
         --------
         Dataset.shift, Dataset.roll, Dataset.bfill, Dataset.ffill, numpy.pad, dask.array.pad
 
@@ -6639,7 +6659,6 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Examples
         --------
-
         >>> ds = xr.Dataset({"foo": ("x", range(5))})
         >>> ds.pad(x=(1, 2))
         <xarray.Dataset>
@@ -6728,13 +6747,12 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             New `Dataset` object with `idxmin` applied to its data and the
             indicated dimension removed.
 
-        See also
+        See Also
         --------
         DataArray.idxmin, Dataset.idxmax, Dataset.min, Dataset.argmin
 
         Examples
         --------
-
         >>> array1 = xr.DataArray(
         ...     [0, 2, 1, 0, -2], dims="x", coords={"x": ["a", "b", "c", "d", "e"]}
         ... )
@@ -6826,13 +6844,12 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             New `Dataset` object with `idxmax` applied to its data and the
             indicated dimension removed.
 
-        See also
+        See Also
         --------
         DataArray.idxmax, Dataset.idxmin, Dataset.max, Dataset.argmax
 
         Examples
         --------
-
         >>> array1 = xr.DataArray(
         ...     [0, 2, 1, 0, -2], dims="x", coords={"x": ["a", "b", "c", "d", "e"]}
         ... )
@@ -6912,7 +6929,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         -------
         result : Dataset
 
-        See also
+        See Also
         --------
         DataArray.argmin
 
@@ -6975,7 +6992,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         -------
         result : Dataset
 
-        See also
+        See Also
         --------
         DataArray.argmax
 

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -405,21 +405,21 @@ def datetime_to_numeric(array, offset=None, datetime_unit=None, dtype=float):
 
     Parameters
     ----------
-    da : array-like
-      Input data
-    offset: None, datetime or cftime.datetime
-      Datetime offset. If None, this is set by default to the array's minimum
-      value to reduce round off errors.
-    datetime_unit: {None, Y, M, W, D, h, m, s, ms, us, ns, ps, fs, as}
-      If not None, convert output to a given datetime unit. Note that some
-      conversions are not allowed due to non-linear relationships between units.
-    dtype: dtype
-      Output dtype.
+    array : array-like
+        Input data
+    offset : None, datetime or cftime.datetime
+        Datetime offset. If None, this is set by default to the array's minimum
+        value to reduce round off errors.
+    datetime_unit : {None, Y, M, W, D, h, m, s, ms, us, ns, ps, fs, as}
+        If not None, convert output to a given datetime unit. Note that some
+        conversions are not allowed due to non-linear relationships between units.
+    dtype : dtype
+        Output dtype.
 
     Returns
     -------
     array
-      Numerical representation of datetime object relative to an offset.
+        Numerical representation of datetime object relative to an offset.
 
     Notes
     -----
@@ -463,12 +463,12 @@ def timedelta_to_numeric(value, datetime_unit="ns", dtype=float):
     Parameters
     ----------
     value : datetime.timedelta, numpy.timedelta64, pandas.Timedelta, str
-      Time delta representation.
+        Time delta representation.
     datetime_unit : {Y, M, W, D, h, m, s, ms, us, ns, ps, fs, as}
-      The time units of the output values. Note that some conversions are not allowed due to
-      non-linear relationships between units.
+        The time units of the output values. Note that some conversions are not allowed due to
+        non-linear relationships between units.
     dtype : type
-      The output data type.
+        The output data type.
 
     """
     import datetime as dt

--- a/xarray/core/extensions.py
+++ b/xarray/core/extensions.py
@@ -69,7 +69,7 @@ def register_dataarray_accessor(name):
         Name under which the accessor should be registered. A warning is issued
         if this name conflicts with a preexisting attribute.
 
-    See also
+    See Also
     --------
     register_dataset_accessor
     """
@@ -87,7 +87,6 @@ def register_dataset_accessor(name):
 
     Examples
     --------
-
     In your library code:
 
     >>> @xr.register_dataset_accessor("geo")
@@ -115,7 +114,7 @@ def register_dataset_accessor(name):
     (10.0, 5.0)
     >>> ds.geo.plot()  # plots data on a map
 
-    See also
+    See Also
     --------
     register_dataarray_accessor
     """

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -541,7 +541,7 @@ class GroupBy(SupportsArithmetic):
         -------
         same type as the grouped object
 
-        See also
+        See Also
         --------
         Dataset.fillna
         DataArray.fillna
@@ -560,9 +560,11 @@ class GroupBy(SupportsArithmetic):
         q : float or sequence of float
             Quantile to compute, which must be between 0 and 1
             inclusive.
+
         dim : ..., str or sequence of str, optional
             Dimension(s) over which to apply quantile.
             Defaults to the grouped dimension.
+
         interpolation : {"linear", "lower", "higher", "midpoint", "nearest"}, default: "linear"
             This optional parameter specifies the interpolation method to
             use when the desired quantile lies between two data points
@@ -575,6 +577,7 @@ class GroupBy(SupportsArithmetic):
                 * higher: ``j``.
                 * nearest: ``i`` or ``j``, whichever is nearest.
                 * midpoint: ``(i + j) / 2``.
+
         skipna : bool, optional
             Whether to skip missing values when aggregating.
 
@@ -590,12 +593,11 @@ class GroupBy(SupportsArithmetic):
 
         See Also
         --------
-        numpy.nanquantile, numpy.quantile, pandas.Series.quantile, Dataset.quantile,
+        numpy.nanquantile, numpy.quantile, pandas.Series.quantile, Dataset.quantile
         DataArray.quantile
 
         Examples
         --------
-
         >>> da = xr.DataArray(
         ...     [[1.3, 8.4, 0.7, 6.9], [0.7, 4.2, 9.4, 1.5], [6.5, 7.3, 2.6, 1.9]],
         ...     coords={"x": [0, 0, 1], "y": [1, 1, 2, 2]},
@@ -672,7 +674,7 @@ class GroupBy(SupportsArithmetic):
         -------
         same type as the grouped object
 
-        See also
+        See Also
         --------
         Dataset.where
         """
@@ -698,7 +700,7 @@ class GroupBy(SupportsArithmetic):
     def assign_coords(self, coords=None, **coords_kwargs):
         """Assign coordinates by group.
 
-        See also
+        See Also
         --------
         Dataset.assign_coords
         Dataset.swap_dims
@@ -770,6 +772,7 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
         ----------
         func : callable
             Callable to apply to each array.
+
         shortcut : bool, optional
             Whether or not to shortcut evaluation under the assumptions that:
 
@@ -782,8 +785,10 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
             If these conditions are satisfied `shortcut` provides significant
             speedup. This should be the case for many common groupby operations
             (e.g., applying numpy ufuncs).
+
         *args : tuple, optional
             Positional arguments passed to `func`.
+
         **kwargs
             Used to call `func(ar, **kwargs)` for each array `ar`.
 
@@ -996,7 +1001,7 @@ class DatasetGroupBy(GroupBy, ImplementsDatasetReduce):
     def assign(self, **kwargs):
         """Assign data variables by group.
 
-        See also
+        See Also
         --------
         Dataset.assign
         """

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -560,11 +560,9 @@ class GroupBy(SupportsArithmetic):
         q : float or sequence of float
             Quantile to compute, which must be between 0 and 1
             inclusive.
-
         dim : ..., str or sequence of str, optional
             Dimension(s) over which to apply quantile.
             Defaults to the grouped dimension.
-
         interpolation : {"linear", "lower", "higher", "midpoint", "nearest"}, default: "linear"
             This optional parameter specifies the interpolation method to
             use when the desired quantile lies between two data points
@@ -577,7 +575,6 @@ class GroupBy(SupportsArithmetic):
                 * higher: ``j``.
                 * nearest: ``i`` or ``j``, whichever is nearest.
                 * midpoint: ``(i + j) / 2``.
-
         skipna : bool, optional
             Whether to skip missing values when aggregating.
 
@@ -772,7 +769,6 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
         ----------
         func : callable
             Callable to apply to each array.
-
         shortcut : bool, optional
             Whether or not to shortcut evaluation under the assumptions that:
 
@@ -785,10 +781,8 @@ class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
             If these conditions are satisfied `shortcut` provides significant
             speedup. This should be the case for many common groupby operations
             (e.g., applying numpy ufuncs).
-
         *args : tuple, optional
             Positional arguments passed to `func`.
-
         **kwargs
             Used to call `func(ar, **kwargs)` for each array `ar`.
 

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -47,7 +47,7 @@ class Indexes(collections.abc.Mapping):
         Parameters
         ----------
         indexes : Dict[Any, pandas.Index]
-           Indexes held by this object.
+            Indexes held by this object.
         """
         self._indexes = indexes
 
@@ -75,7 +75,7 @@ def default_indexes(
     Parameters
     ----------
     coords : Mapping[Any, xarray.Variable]
-       Coordinate variables from which to draw default indexes.
+        Coordinate variables from which to draw default indexes.
     dims : iterable
         Iterable of dimension names.
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -787,11 +787,11 @@ def _combine_indexers(old_key, shape, new_key):
 
     Parameters
     ----------
-    old_key: ExplicitIndexer
+    old_key : ExplicitIndexer
         The first indexer for the original array
-    shape: tuple of ints
+    shape : tuple of ints
         Shape of the original array to be indexed by old_key
-    new_key:
+    new_key
         The second indexer for indexing original[old_key]
     """
     if not isinstance(old_key, VectorizedIndexer):
@@ -841,7 +841,7 @@ def explicit_indexing_adapter(
         Shape of the indexed array.
     indexing_support : IndexingSupport enum
         Form of indexing supported by raw_indexing_method.
-    raw_indexing_method: callable
+    raw_indexing_method : callable
         Function (like ndarray.__getitem__) that when called with indexing key
         in the form of a tuple returns an indexed array.
 
@@ -895,8 +895,8 @@ def _decompose_vectorized_indexer(
 
     Parameters
     ----------
-    indexer: VectorizedIndexer
-    indexing_support: one of IndexerSupport entries
+    indexer : VectorizedIndexer
+    indexing_support : one of IndexerSupport entries
 
     Returns
     -------
@@ -977,8 +977,8 @@ def _decompose_outer_indexer(
 
     Parameters
     ----------
-    indexer: OuterIndexer or BasicIndexer
-    indexing_support: One of the entries of IndexingSupport
+    indexer : OuterIndexer or BasicIndexer
+    indexing_support : One of the entries of IndexingSupport
 
     Returns
     -------

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -216,20 +216,20 @@ def get_clean_interp_index(
     Parameters
     ----------
     arr : DataArray
-      Array to interpolate or fit to a curve.
+        Array to interpolate or fit to a curve.
     dim : str
-      Name of dimension along which to fit.
+        Name of dimension along which to fit.
     use_coordinate : str or bool
-      If use_coordinate is True, the coordinate that shares the name of the
-      dimension along which interpolation is being performed will be used as the
-      x values. If False, the x values are set as an equally spaced sequence.
+        If use_coordinate is True, the coordinate that shares the name of the
+        dimension along which interpolation is being performed will be used as the
+        x values. If False, the x values are set as an equally spaced sequence.
     strict : bool
-      Whether to raise errors if the index is either non-unique or non-monotonic (default).
+        Whether to raise errors if the index is either non-unique or non-monotonic (default).
 
     Returns
     -------
     Variable
-      Numerical values for the x-coordinates.
+        Numerical values for the x-coordinates.
 
     Notes
     -----
@@ -589,16 +589,16 @@ def interp(var, indexes_coords, method, **kwargs):
 
     Parameters
     ----------
-    var: Variable
-    index_coords:
+    var : Variable
+    indexes_coords
         Mapping from dimension name to a pair of original and new coordinates.
         Original coordinates should be sorted in strictly ascending order.
         Note that all the coordinates should be Variable objects.
-    method: string
+    method : string
         One of {'linear', 'nearest', 'zero', 'slinear', 'quadratic',
         'cubic'}. For multidimensional interpolation, only
         {'linear', 'nearest'} can be used.
-    **kwargs:
+    **kwargs
         keyword arguments to be passed to scipy.interpolate
 
     Returns
@@ -658,17 +658,17 @@ def interp_func(var, x, new_x, method, kwargs):
 
     Parameters
     ----------
-    var: np.ndarray or dask.array.Array
+    var : np.ndarray or dask.array.Array
         Array to be interpolated. The final dimension is interpolated.
-    x: a list of 1d array.
+    x : a list of 1d array.
         Original coordinates. Should not contain NaN.
-    new_x: a list of 1d array
+    new_x : a list of 1d array
         New coordinates. Should not contain NaN.
-    method: string
+    method : string
         {'linear', 'nearest', 'zero', 'slinear', 'quadratic', 'cubic'} for
         1-dimensional interpolation.
         {'linear', 'nearest'} for multidimensional interpolation
-    **kwargs:
+    **kwargs
         Optional keyword arguments to be passed to scipy.interpolator
 
     Returns
@@ -676,8 +676,8 @@ def interp_func(var, x, new_x, method, kwargs):
     interpolated: array
         Interpolated array
 
-    Note
-    ----
+    Notes
+    -----
     This requiers scipy installed.
 
     See Also

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -160,7 +160,7 @@ def _rolling_window(a, window, axis=-1):
     ----------
     a : array_like
         Array to add rolling window to
-    axis: int
+    axis : int
         axis position along which rolling window will be applied.
     window : int
         Size of rolling window

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -183,18 +183,14 @@ def map_blocks(
         This function must return either a single DataArray or a single Dataset.
 
         This function cannot add a new chunked dimension.
-
     obj : DataArray, Dataset
         Passed to the function as its first argument, one block at a time.
-
     args : sequence
         Passed to func after unpacking and subsetting any xarray objects by blocks.
         xarray objects in args must be aligned with obj, otherwise an error is raised.
-
     kwargs : mapping
         Passed verbatim to func after unpacking. xarray objects, if any, will not be
         subset to blocks. Passing dask collections in kwargs is not allowed.
-
     template : DataArray or Dataset, optional
         xarray object representing the final result after compute is called. If not provided,
         the function will be first run on mocked-up data, that looks like ``obj`` but

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -186,12 +186,15 @@ def map_blocks(
 
     obj : DataArray, Dataset
         Passed to the function as its first argument, one block at a time.
+
     args : sequence
         Passed to func after unpacking and subsetting any xarray objects by blocks.
         xarray objects in args must be aligned with obj, otherwise an error is raised.
+
     kwargs : mapping
         Passed verbatim to func after unpacking. xarray objects, if any, will not be
         subset to blocks. Passing dask collections in kwargs is not allowed.
+
     template : DataArray or Dataset, optional
         xarray object representing the final result after compute is called. If not provided,
         the function will be first run on mocked-up data, that looks like ``obj`` but
@@ -200,7 +203,6 @@ def map_blocks(
         ``template`` must be provided if the function changes the size of existing dimensions.
         When provided, ``attrs`` on variables in `template` are copied over to the result. Any
         ``attrs`` set by ``func`` will be ignored.
-
 
     Returns
     -------
@@ -218,12 +220,11 @@ def map_blocks(
 
     See Also
     --------
-    dask.array.map_blocks, xarray.apply_ufunc, xarray.Dataset.map_blocks,
+    dask.array.map_blocks, xarray.apply_ufunc, xarray.Dataset.map_blocks
     xarray.DataArray.map_blocks
 
     Examples
     --------
-
     Calculate an anomaly from climatology using ``.groupby()``. Using
     ``xr.map_blocks()`` allows for parallel operations with knowledge of ``xarray``,
     its indices, and its methods like ``.groupby()``.

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -195,6 +195,7 @@ class DataArrayResample(DataArrayGroupBy, Resample):
         ----------
         func : callable
             Callable to apply to each array.
+
         shortcut : bool, optional
             Whether or not to shortcut evaluation under the assumptions that:
 
@@ -207,8 +208,10 @@ class DataArrayResample(DataArrayGroupBy, Resample):
             If these conditions are satisfied `shortcut` provides significant
             speedup. This should be the case for many common groupby operations
             (e.g., applying numpy ufuncs).
+
         args : tuple, optional
             Positional arguments passed on to `func`.
+
         **kwargs
             Used to call `func(ar, **kwargs)` for each array `ar`.
 

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -195,7 +195,6 @@ class DataArrayResample(DataArrayGroupBy, Resample):
         ----------
         func : callable
             Callable to apply to each array.
-
         shortcut : bool, optional
             Whether or not to shortcut evaluation under the assumptions that:
 
@@ -208,10 +207,8 @@ class DataArrayResample(DataArrayGroupBy, Resample):
             If these conditions are satisfied `shortcut` provides significant
             speedup. This should be the case for many common groupby operations
             (e.g., applying numpy ufuncs).
-
         args : tuple, optional
             Positional arguments passed on to `func`.
-
         **kwargs
             Used to call `func(ar, **kwargs)` for each array `ar`.
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -721,7 +721,7 @@ class Coarsen:
             multiple of window size. If 'trim', the excess indexes are trimed.
             If 'pad', NA will be padded.
         side : 'left' or 'right' or mapping from dimension to 'left' or 'right'
-        coord_func: mapping from coordinate name to func.
+        coord_func : mapping from coordinate name to func.
 
         Returns
         -------

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -96,7 +96,6 @@ def as_variable(obj, name=None) -> "Union[Variable, IndexVariable]":
           it into a new Variable.
         - If all else fails, attempt to convert the object into a Variable by
           unpacking it into the arguments for creating a new Variable.
-
     name : str, optional
         If provided:
 
@@ -390,13 +389,11 @@ class Variable(
         ----------
         dtype : str or dtype
             Typecode or data-type to which the array is cast.
-
         order : {'C', 'F', 'A', 'K'}, optional
             Controls the memory layout order of the result. ‘C’ means C order,
             ‘F’ means Fortran order, ‘A’ means ‘F’ order if all the arrays are
             Fortran contiguous, ‘C’ order otherwise, and ‘K’ means as close to
             the order the array elements appear in memory as possible.
-
         casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
             Controls what kind of data casting may occur.
 
@@ -406,16 +403,13 @@ class Variable(
             * 'same_kind' means only safe casts or casts within a kind,
               like float64 to float32, are allowed.
             * 'unsafe' means any data conversions may be done.
-
         subok : bool, optional
             If True, then sub-classes will be passed-through, otherwise the
             returned array will be forced to be a base-class array.
-
         copy : bool, optional
             By default, astype always returns a newly allocated array. If this
             is set to False and the `dtype` requirement is satisfied, the input
             array is returned instead of a copy.
-
         keep_attrs : bool, optional
             By default, astype keeps attributes. Set to False to remove
             attributes in the returned object.
@@ -1890,10 +1884,8 @@ class Variable(
         q : float or sequence of float
             Quantile to compute, which must be between 0 and 1
             inclusive.
-
         dim : str or sequence of str, optional
             Dimension(s) over which to apply quantile.
-
         interpolation : {"linear", "lower", "higher", "midpoint", "nearest"}, default: "linear"
             This optional parameter specifies the interpolation method to
             use when the desired quantile lies between two data points
@@ -1906,7 +1898,6 @@ class Variable(
                 * higher: ``j``.
                 * nearest: ``i`` or ``j``, whichever is nearest.
                 * midpoint: ``(i + j) / 2``.
-
         keep_attrs : bool, optional
             If True, the variable's attributes (`attrs`) will be copied from
             the original object to the new one.  If False (default), the new

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -96,6 +96,7 @@ def as_variable(obj, name=None) -> "Union[Variable, IndexVariable]":
           it into a new Variable.
         - If all else fails, attempt to convert the object into a Variable by
           unpacking it into the arguments for creating a new Variable.
+
     name : str, optional
         If provided:
 
@@ -389,11 +390,13 @@ class Variable(
         ----------
         dtype : str or dtype
             Typecode or data-type to which the array is cast.
+
         order : {'C', 'F', 'A', 'K'}, optional
             Controls the memory layout order of the result. ‘C’ means C order,
             ‘F’ means Fortran order, ‘A’ means ‘F’ order if all the arrays are
             Fortran contiguous, ‘C’ order otherwise, and ‘K’ means as close to
             the order the array elements appear in memory as possible.
+
         casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
             Controls what kind of data casting may occur.
 
@@ -407,10 +410,12 @@ class Variable(
         subok : bool, optional
             If True, then sub-classes will be passed-through, otherwise the
             returned array will be forced to be a base-class array.
+
         copy : bool, optional
             By default, astype always returns a newly allocated array. If this
             is set to False and the `dtype` requirement is satisfied, the input
             array is returned instead of a copy.
+
         keep_attrs : bool, optional
             By default, astype keeps attributes. Set to False to remove
             attributes in the returned object.
@@ -428,7 +433,7 @@ class Variable(
         Make sure to only supply these arguments if the underlying array class
         supports them.
 
-        See also
+        See Also
         --------
         numpy.ndarray.astype
         dask.array.Array.astype
@@ -606,8 +611,8 @@ class Variable(
         """Prepare an indexing key for an indexing operation.
 
         Parameters
-        -----------
-        key: int, slice, array-like, dict or tuple of integer, slice and array-like
+        ----------
+        key : int, slice, array-like, dict or tuple of integer, slice and array-like
             Any valid input for indexing.
 
         Returns
@@ -929,7 +934,6 @@ class Variable(
 
         Examples
         --------
-
         Shallow copy versus deep copy
 
         >>> var = xr.Variable(data=[1, 2, 3], dims="x")
@@ -1225,7 +1229,7 @@ class Variable(
             Integer offset to shift along each of the given dimensions.
             Positive offsets shift to the right; negative offsets shift to the
             left.
-        fill_value: scalar, optional
+        fill_value : scalar, optional
             Value to use for newly missing values
         **shifts_kwargs
             The keyword arguments form of ``shifts``.
@@ -1535,7 +1539,7 @@ class Variable(
         stacked : Variable
             Variable with the same attributes but stacked data.
 
-        See also
+        See Also
         --------
         Variable.unstack
         """
@@ -1655,7 +1659,7 @@ class Variable(
         unstacked : Variable
             Variable with the same attributes but unstacked data.
 
-        See also
+        See Also
         --------
         Variable.stack
         DataArray.unstack
@@ -1886,8 +1890,10 @@ class Variable(
         q : float or sequence of float
             Quantile to compute, which must be between 0 and 1
             inclusive.
+
         dim : str or sequence of str, optional
             Dimension(s) over which to apply quantile.
+
         interpolation : {"linear", "lower", "higher", "midpoint", "nearest"}, default: "linear"
             This optional parameter specifies the interpolation method to
             use when the desired quantile lies between two data points
@@ -1917,7 +1923,7 @@ class Variable(
 
         See Also
         --------
-        numpy.nanquantile, pandas.Series.quantile, Dataset.quantile,
+        numpy.nanquantile, pandas.Series.quantile, Dataset.quantile
         DataArray.quantile
         """
 
@@ -2432,7 +2438,7 @@ class Variable(
         -------
         result : Variable or dict of Variable
 
-        See also
+        See Also
         --------
         DataArray.argmin, DataArray.idxmin
         """
@@ -2477,7 +2483,7 @@ class Variable(
         -------
         result : Variable or dict of Variable
 
-        See also
+        See Also
         --------
         DataArray.argmax, DataArray.idxmax
         """

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -233,7 +233,7 @@ class FacetGrid:
             plotting method such as `xarray.plot.imshow`
         x, y : string
             Names of the coordinates to plot on x, y axes
-        kwargs :
+        kwargs
             additional keyword arguments to func
 
         Returns

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -351,7 +351,6 @@ def step(darray, *args, where="pre", drawstyle=None, ds=None, **kwargs):
         :py:func:`pandas.Interval` values, e.g. as a result of
         :py:func:`xarray.Dataset.groupby_bins`. In this case, the actual
         boundaries of the interval are used.
-
     *args, **kwargs : optional
         Additional arguments following :py:func:`xarray.plot.line`
     """

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -159,12 +159,12 @@ def _determine_cmap_params(
     Use some heuristics to set good defaults for colorbar and range.
 
     Parameters
-    ==========
-    plot_data: Numpy array
+    ----------
+    plot_data : Numpy array
         Doesn't handle xarray objects
 
     Returns
-    =======
+    -------
     cmap_params : dict
         Use depends on the type of the plotting function
     """
@@ -791,15 +791,14 @@ def _process_cmap_cbar_kwargs(
 ):
     """
     Parameters
-    ==========
+    ----------
     func : plotting function
     data : ndarray,
         Data values
 
     Returns
-    =======
+    -------
     cmap_params
-
     cbar_kwargs
     """
     cbar_kwargs = {} if cbar_kwargs is None else dict(cbar_kwargs)

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -54,9 +54,9 @@ def assert_equal(a, b):
     b : xarray.Dataset, xarray.DataArray or xarray.Variable
         The second object to compare.
 
-    See also
+    See Also
     --------
-    assert_identical, assert_allclose, Dataset.equals, DataArray.equals,
+    assert_identical, assert_allclose, Dataset.equals, DataArray.equals
     numpy.testing.assert_array_equal
     """
     __tracebackhide__ = True
@@ -82,7 +82,7 @@ def assert_identical(a, b):
     b : xarray.Dataset, xarray.DataArray or xarray.Variable
         The second object to compare.
 
-    See also
+    See Also
     --------
     assert_equal, assert_allclose, Dataset.equals, DataArray.equals
     """
@@ -120,7 +120,7 @@ def assert_allclose(a, b, rtol=1e-05, atol=1e-08, decode_bytes=True):
         This is useful for testing serialization methods on Python 3 that
         return saved strings as bytes.
 
-    See also
+    See Also
     --------
     assert_identical, assert_equal, numpy.testing.assert_allclose
     """


### PR DESCRIPTION
as suggested by @dcherian in https://github.com/pydata/xarray/pull/4867#issuecomment-774489458, ~this adds [`velin`](https://github.com/Carreau/velin) to the `pre-commit` hooks~ as suggested below, we'll leave that hook deactivated for now.

I think this would help enforcing the style of the docstrings a bit more. However, while most of the changes it proposes are great, the tool itself does not seem to be mature, so I'll mark this PR as a draft.

- [x] Passes `pre-commit run --all-files`
