### PR TITLE
temporarily pin dask

### DIFF
--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -8,7 +8,7 @@ dependencies:
   # - cdms2  # Not available on Windows
   # - cfgrib  # Causes Python interpreter crash on Windows: https://github.com/pydata/xarray/pull/3340
   - cftime
-  - dask
+  - dask<2021.02.0
   - distributed
   - h5netcdf
   - h5py=2

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - cdms2
   - cfgrib
   - cftime
-  - dask
+  - dask<2021.02.0
   - distributed
   - h5netcdf
   - h5py=2


### PR DESCRIPTION
`dask` recently released a new version, but because we do something non-standard with `dask` graphs we can't use that yet (see #4860). For now I'm pinning `dask` to avoid having the CI fail for a known issue.