### PR TITLE
update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790  # Must match ci/requirements/*.yml
+    rev: v0.790
     hooks:
       - id: mypy
         exclude: "properties|asv_bench"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/keewis/blackdoc
-    rev: v0.3.2
+    rev: v0.3.3
     hooks:
       - id: blackdoc
   - repo: https://gitlab.com/pycqa/flake8

--- a/ci/requirements/py37-min-all-deps.yml
+++ b/ci/requirements/py37-min-all-deps.yml
@@ -27,7 +27,6 @@ dependencies:
   - isort
   - lxml=4.4  # Optional dep of pydap
   - matplotlib-base=3.1
-  - mypy=0.782  # Must match .pre-commit-config.yaml
   - nc-time-axis=1.2
   - netcdf4=1.4
   - numba=0.46

--- a/ci/requirements/py37-min-all-deps.yml
+++ b/ci/requirements/py37-min-all-deps.yml
@@ -8,7 +8,6 @@ dependencies:
   # When upgrading python, numpy, or pandas, must also change
   # doc/installing.rst and setup.py.
   - python=3.7
-  - black
   - boto3=1.9
   - bottleneck=1.2
   - cartopy=0.17
@@ -18,13 +17,11 @@ dependencies:
   - coveralls
   - dask=2.9
   - distributed=2.9
-  - flake8
   - h5netcdf=0.7
   - h5py=2.9  # Policy allows for 2.10, but it's a conflict-fest
   - hdf5=1.10
   - hypothesis
   - iris=2.2
-  - isort
   - lxml=4.4  # Optional dep of pydap
   - matplotlib-base=3.1
   - nc-time-axis=1.2

--- a/ci/requirements/py38-all-but-dask.yml
+++ b/ci/requirements/py38-all-but-dask.yml
@@ -20,7 +20,6 @@ dependencies:
   - isort
   - lxml    # Optional dep of pydap
   - matplotlib-base
-  - mypy=0.790  # Must match .pre-commit-config.yaml
   - nc-time-axis
   - netcdf4
   - numba

--- a/ci/requirements/py38-all-but-dask.yml
+++ b/ci/requirements/py38-all-but-dask.yml
@@ -4,7 +4,6 @@ channels:
   - nodefaults
 dependencies:
   - python=3.8
-  - black
   - boto3
   - bottleneck
   - cartopy
@@ -12,12 +11,10 @@ dependencies:
   - cfgrib
   - cftime
   - coveralls
-  - flake8
   - h5netcdf
   - h5py=2
   - hdf5
   - hypothesis
-  - isort
   - lxml    # Optional dep of pydap
   - matplotlib-base
   - nc-time-axis


### PR DESCRIPTION
I issued a bugfix release for the issue detected in https://github.com/pydata/xarray/pull/4810#discussion_r569830387, so we should use that. `pre-commit autoupdate` also tried to update to `mypy=v0.800`, but this fails because `mypy` does not like the redefinition of `dask_array_type` (and the other `*_type` variables in `xarray.core.pycompat`):
```
xarray/core/pycompat.py:19: error: Incompatible types in assignment (expression has type "Tuple[]", variable has type "Tuple[Any]")
xarray/core/pycompat.py:29: error: Incompatible types in assignment (expression has type "Tuple[]", variable has type "Tuple[Any]")
xarray/core/pycompat.py:37: error: Incompatible types in assignment (expression has type "Tuple[]", variable has type "Tuple[Any]")
```
Does anyone know how to fix that?

- [x] Passes `pre-commit run --all-files`
