### PR TITLE
update pre-commit hooks (mypy)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
   #     - id: velin
   #       args: ["--write", "--compact"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.800
     hooks:
       - id: mypy
         exclude: "properties|asv_bench"

--- a/setup.cfg
+++ b/setup.cfg
@@ -164,6 +164,8 @@ force_to_top = true
 default_section = THIRDPARTY
 known_first_party = xarray
 
+[mypy]
+
 # Most of the numerical computing stack doesn't have type annotations yet.
 [mypy-affine.*]
 ignore_missing_imports = True


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

mypy v0.800 was ignoring our config (https://github.com/pydata/xarray/pull/4874#issuecomment-774771523)... Adding an (empty) `[mypy]` section to `setup.cfg` seems to do the trick, this is in contrast to the [documentation](https://mypy.readthedocs.io/en/stable/config_file.html#config-file-format) and may get changed again (c.f. python/mypy#9940), but it does not hurt either.

@keewis 
