### PR TITLE
FIX: h5py>=3 string decoding

### DIFF
--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -11,7 +11,7 @@ dependencies:
   - dask<2021.02.0
   - distributed
   - h5netcdf
-  - h5py=2
+  - h5py
   - hdf5
   - hypothesis
   - iris

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - dask<2021.02.0
   - distributed
   - h5netcdf
-  - h5py=2
+  - h5py
   - hdf5
   - hypothesis
   - iris

--- a/ci/requirements/py38-all-but-dask.yml
+++ b/ci/requirements/py38-all-but-dask.yml
@@ -12,7 +12,7 @@ dependencies:
   - cftime
   - coveralls
   - h5netcdf
-  - h5py=2
+  - h5py
   - hdf5
   - hypothesis
   - lxml    # Optional dep of pydap

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -113,6 +113,8 @@ Bug fixes
   By `Leif Denby <https://github.com/leifdenby>`_.
 - Fix time encoding bug associated with using cftime versions greater than
   1.4.0 with xarray (:issue:`4870`, :pull:`4871`). By `Spencer Clark <https://github.com/spencerkclark>`_.
+- Fix decoding of vlen strings using h5py versions greater than 3.0.0 with h5netcdf backend (:issue:`4570`, :pull:`4893`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -131,7 +131,7 @@ class H5NetCDFStore(WritableCFDataStore):
         autoclose=False,
         invalid_netcdf=None,
         phony_dims=None,
-        decode_strings=None,
+        decode_vlen_strings=None,
     ):
 
         if isinstance(filename, bytes):
@@ -161,7 +161,7 @@ class H5NetCDFStore(WritableCFDataStore):
         if LooseVersion(h5netcdf.__version__) >= LooseVersion(
             "0.10.0"
         ) and LooseVersion(h5netcdf.core.h5py.__version__) >= LooseVersion("3.0.0"):
-            kwargs["decode_strings"] = decode_strings
+            kwargs["decode_vlen_strings"] = decode_vlen_strings
 
         if lock is None:
             if mode == "r":
@@ -363,7 +363,7 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         lock=None,
         invalid_netcdf=None,
         phony_dims=None,
-        decode_strings=True,
+        decode_vlen_strings=True,
     ):
 
         store = H5NetCDFStore.open(
@@ -373,7 +373,7 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
             lock=lock,
             invalid_netcdf=invalid_netcdf,
             phony_dims=phony_dims,
-            decode_strings=decode_strings,
+            decode_strings=decode_vlen_strings,
         )
 
         store_entrypoint = StoreBackendEntrypoint()

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -158,9 +158,9 @@ class H5NetCDFStore(WritableCFDataStore):
                     "h5netcdf backend keyword argument 'phony_dims' needs "
                     "h5netcdf >= 0.8.0."
                 )
-        if LooseVersion(h5netcdf.__version__) >= LooseVersion("0.10.0") and LooseVersion(
-            h5netcdf.core.h5py.__version__
-        ) >= LooseVersion("3.0.0"):
+        if LooseVersion(h5netcdf.__version__) >= LooseVersion(
+            "0.10.0"
+        ) and LooseVersion(h5netcdf.core.h5py.__version__) >= LooseVersion("3.0.0"):
             kwargs["decode_strings"] = decode_strings
 
         if lock is None:

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -131,7 +131,7 @@ class H5NetCDFStore(WritableCFDataStore):
         autoclose=False,
         invalid_netcdf=None,
         phony_dims=None,
-        decode_vlen_strings=None,
+        decode_vlen_strings=True,
     ):
 
         if isinstance(filename, bytes):

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -131,6 +131,7 @@ class H5NetCDFStore(WritableCFDataStore):
         autoclose=False,
         invalid_netcdf=None,
         phony_dims=None,
+        decode_strings=None,
     ):
 
         if isinstance(filename, bytes):
@@ -157,6 +158,10 @@ class H5NetCDFStore(WritableCFDataStore):
                     "h5netcdf backend keyword argument 'phony_dims' needs "
                     "h5netcdf >= 0.8.0."
                 )
+        if LooseVersion(h5netcdf.__version__) >= LooseVersion("0.9.0") and LooseVersion(
+            h5netcdf.core.h5py.__version__
+        ) >= LooseVersion("3.0.0"):
+            kwargs["decode_strings"] = decode_strings
 
         if lock is None:
             if mode == "r":
@@ -358,6 +363,7 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         lock=None,
         invalid_netcdf=None,
         phony_dims=None,
+        decode_strings=True,
     ):
 
         store = H5NetCDFStore.open(
@@ -367,6 +373,7 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
             lock=lock,
             invalid_netcdf=invalid_netcdf,
             phony_dims=phony_dims,
+            decode_strings=decode_strings,
         )
 
         store_entrypoint = StoreBackendEntrypoint()

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -158,7 +158,7 @@ class H5NetCDFStore(WritableCFDataStore):
                     "h5netcdf backend keyword argument 'phony_dims' needs "
                     "h5netcdf >= 0.8.0."
                 )
-        if LooseVersion(h5netcdf.__version__) >= LooseVersion("0.9.0") and LooseVersion(
+        if LooseVersion(h5netcdf.__version__) >= LooseVersion("0.10.0") and LooseVersion(
             h5netcdf.core.h5py.__version__
         ) >= LooseVersion("3.0.0"):
             kwargs["decode_strings"] = decode_strings

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -373,7 +373,7 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
             lock=lock,
             invalid_netcdf=invalid_netcdf,
             phony_dims=phony_dims,
-            decode_strings=decode_vlen_strings,
+            decode_vlen_strings=decode_vlen_strings,
         )
 
         store_entrypoint = StoreBackendEntrypoint()

--- a/xarray/coding/strings.py
+++ b/xarray/coding/strings.py
@@ -191,8 +191,11 @@ def _numpy_char_to_bytes(arr):
     """Like netCDF4.chartostring, but faster and more flexible."""
     # based on: http://stackoverflow.com/a/10984878/809705
     arr = np.array(arr, copy=False, order="C")
-    dtype = "S" + str(arr.shape[-1])
-    return arr.view(dtype).reshape(arr.shape[:-1])
+    shape = arr.shape
+    dtype = "S" + str(shape[-1])
+    if arr.dtype.kind == "O":
+        arr = arr.astype("S1")
+    return arr.view(dtype).reshape(shape[:-1])
 
 
 class StackedBytesArray(indexing.ExplicitlyIndexedNDArrayMixin):

--- a/xarray/coding/strings.py
+++ b/xarray/coding/strings.py
@@ -191,11 +191,8 @@ def _numpy_char_to_bytes(arr):
     """Like netCDF4.chartostring, but faster and more flexible."""
     # based on: http://stackoverflow.com/a/10984878/809705
     arr = np.array(arr, copy=False, order="C")
-    shape = arr.shape
-    dtype = "S" + str(shape[-1])
-    if arr.dtype.kind == "O":
-        arr = arr.astype("S1")
-    return arr.view(dtype).reshape(shape[:-1])
+    dtype = "S" + str(arr.shape[-1])
+    return arr.view(dtype).reshape(arr.shape[:-1])
 
 
 class StackedBytesArray(indexing.ExplicitlyIndexedNDArrayMixin):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2578,13 +2578,13 @@ class TestH5NetCDFAlreadyOpen:
                 v = group.createVariable("x", "int")
                 v[...] = 42
 
-            h5 = h5netcdf.File(tmp_file, mode="r")
+            h5 = h5netcdf.File(tmp_file, mode="r", decode_vlen_strings=True)
             store = backends.H5NetCDFStore(h5["g"])
             with open_dataset(store) as ds:
                 expected = Dataset({"x": ((), 42)})
                 assert_identical(expected, ds)
 
-            h5 = h5netcdf.File(tmp_file, mode="r")
+            h5 = h5netcdf.File(tmp_file, mode="r", decode_vlen_strings=True)
             store = backends.H5NetCDFStore(h5, group="g")
             with open_dataset(store) as ds:
                 expected = Dataset({"x": ((), 42)})
@@ -2599,7 +2599,7 @@ class TestH5NetCDFAlreadyOpen:
                 v = nc.createVariable("y", np.int32, ("x",))
                 v[:] = np.arange(10)
 
-            h5 = h5netcdf.File(tmp_file, mode="r")
+            h5 = h5netcdf.File(tmp_file, mode="r", decode_vlen_strings=True)
             store = backends.H5NetCDFStore(h5)
             with open_dataset(store) as ds:
                 copied = ds.copy(deep=True)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2578,13 +2578,19 @@ class TestH5NetCDFAlreadyOpen:
                 v = group.createVariable("x", "int")
                 v[...] = 42
 
-            h5 = h5netcdf.File(tmp_file, mode="r", decode_vlen_strings=True)
+            kwargs = {}
+            if LooseVersion(h5netcdf.__version__) >= LooseVersion(
+                "0.10.0"
+            ) and LooseVersion(h5netcdf.core.h5py.__version__) >= LooseVersion("3.0.0"):
+                kwargs = dict(decode_vlen_strings=True)
+
+            h5 = h5netcdf.File(tmp_file, mode="r", **kwargs)
             store = backends.H5NetCDFStore(h5["g"])
             with open_dataset(store) as ds:
                 expected = Dataset({"x": ((), 42)})
                 assert_identical(expected, ds)
 
-            h5 = h5netcdf.File(tmp_file, mode="r", decode_vlen_strings=True)
+            h5 = h5netcdf.File(tmp_file, mode="r", **kwargs)
             store = backends.H5NetCDFStore(h5, group="g")
             with open_dataset(store) as ds:
                 expected = Dataset({"x": ((), 42)})
@@ -2599,7 +2605,13 @@ class TestH5NetCDFAlreadyOpen:
                 v = nc.createVariable("y", np.int32, ("x",))
                 v[:] = np.arange(10)
 
-            h5 = h5netcdf.File(tmp_file, mode="r", decode_vlen_strings=True)
+            kwargs = {}
+            if LooseVersion(h5netcdf.__version__) >= LooseVersion(
+                "0.10.0"
+            ) and LooseVersion(h5netcdf.core.h5py.__version__) >= LooseVersion("3.0.0"):
+                kwargs = dict(decode_vlen_strings=True)
+
+            h5 = h5netcdf.File(tmp_file, mode="r", **kwargs)
             store = backends.H5NetCDFStore(h5)
             with open_dataset(store) as ds:
                 copied = ds.copy(deep=True)


### PR DESCRIPTION
- set `decode_vlen_strings=True` for h5netcdf backend
- unpin h5py

This is an attempt to align with `h5py=>3.0.0` string decoding changes. Now all strings are read as `bytes` objects for variable-length strings, or numpy bytes arrays ('S' dtypes) for fixed-length strings [1]. From `h5netcdf=0.10.0` kwarg `decode_vlen_strings` is available. This PR makes use of this to keep backwards compatibility with `h5py=2` and conformance with `netcdf4-python`.

[1] https://docs.h5py.org/en/stable/strings.html

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #4570
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
