### PR TITLE
add pyproject.toml

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # reduce the number of merge conflicts
 doc/whats-new.rst merge=union
+# allow installing from git archives
+.git_archival.txt  export-subst

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,6 +34,9 @@ Breaking changes
 
   (:issue:`4688`, :pull:`4720`)
   By `Justus Magin <https://github.com/keewis>`_.
+- use ``pyproject.toml`` instead of the ``setup_requires`` option for
+  ``setuptools`` (:pull:`4897`).
+  By `Justus Magin <https://github.com/keewis>`_.
 - As a result of :pull:`4684` the default units encoding for
   datetime-like values (``np.datetime64[ns]`` or ``cftime.datetime``) will now
   always be set such that ``int64`` values can be used.  In the past, no units
@@ -62,6 +65,8 @@ New Features
 - :py:meth:`DataArray.swap_dims` & :py:meth:`Dataset.swap_dims` now accept dims
   in the form of kwargs as well as a dict, like most similar methods.
   By `Maximilian Roos <https://github.com/max-sixty>`_.
+- Allow installing from git archives (:pull:`4897`).
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=40.4",
+    "setuptools>=42",
     "wheel",
     "setuptools_scm[toml]>=3.4",
     "setuptools_scm_git_archive",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "setuptools>=40.4",
     "wheel",
     "setuptools_scm[toml]>=3.4",
+    "setuptools_scm_git_archive",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["setuptools>=40.4", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = [
+    "setuptools>=40.4",
+    "wheel",
+    "setuptools_scm[toml]>=3.4",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools>=40.4", "wheel", "setuptools_scm[toml]>=3.4"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,4 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+fallback_version = "999"

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,10 +77,6 @@ install_requires =
     numpy >= 1.15
     pandas >= 0.25
     setuptools >= 40.4  # For pkg_resources
-setup_requires =
-    setuptools >= 40.4
-    setuptools_scm
-
 
 [options.extras_require]
 io =


### PR DESCRIPTION
Along with [`pyproject.toml`](https://snarky.ca/what-the-heck-is-pyproject-toml/), this adds support for [git archives](https://github.com/pydata/xarray/releases) using `setuptools_scm_git_archive`.

This shouldn't be a breaking change since `python setup.py sdist bdist_wheel` still works, but it makes tools that know about it (like `pip`) behave differently.

Edit: do we need a entry to `whats-new.rst`?

- [x] closes #4274
- [x] Passes `pre-commit run --all-files`
