### PR TITLE
hide the decorator from the test traceback

### DIFF
--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -27,6 +27,8 @@ def ensure_warnings(func):
     # -> make sure that does not happen in the assert_* functions
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
+        __tracebackhide__ = True
+
         with warnings.catch_warnings():
             warnings.simplefilter("always")
 


### PR DESCRIPTION
follow-up to #4864. This makes sure the decorator function does not appear in the traceback.

- [x] Passes `pre-commit run --all-files`
