### PR TITLE
pre-commit autoupdate CI

### DIFF
--- a/.github/workflows/ci-pre-commit-autoupdate.yaml
+++ b/.github/workflows/ci-pre-commit-autoupdate.yaml
@@ -1,0 +1,41 @@
+name: "pre-commit autoupdate CI"
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"  # every Sunday at 00:00 UTC
+  workflow_dispatch:
+
+
+jobs:
+  autoupdate:
+    name: 'pre-commit autoupdate'
+    runs-on: ubuntu-latest
+    if: github.repository == 'pydata/xarray'
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Cache pip and pre-commit
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/pre-commit
+            ~/.cache/pip
+          key: ${{ runner.os }}-pre-commit-autoupdate
+      - name: setup python
+        uses: actions/setup-python@v2
+      - name: upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: install pre-commit
+        run: python -m pip install --upgrade pre-commit
+      - name: version info
+        run: python -m pip list
+      - name: autoupdate
+        uses: technote-space/create-pr-action@837dbe469b39f08d416889369a52e2a993625c84
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXECUTE_COMMANDS: |
+            python -m pre_commit autoupdate
+          COMMIT_MESSAGE: 'pre-commit: autoupdate hook versions'
+          PR_TITLE: 'pre-commit: autoupdate hook versions'
+          PR_BRANCH_PREFIX: 'pre-commit/'
+          PR_BRANCH_NAME: 'autoupdate-${PR_ID}'


### PR DESCRIPTION
Inspired by the one `pandas` is using, this adds a workflow which periodically updates the `pre-commit` hook versions. For a example, see keewis/blackdoc#84

- [x] follow-up to #4388
- [x] Passes `pre-commit run --all-files`

cc @andersy005 