### PR TITLE
document restrictions to the inline repr

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -23,6 +23,7 @@ dependencies:
   - rasterio>=1.1
   - seaborn
   - setuptools
+  - sparse
   - sphinx=3.3
   - sphinx_rtd_theme>=0.4
   - sphinx-autosummary-accessors

--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -83,6 +83,8 @@ argument:
 
         ...
 
+To avoid duplicated information, this method must omit information about the shape and
+:term:`dtype`.
 
 Extending xarray
 ----------------

--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -10,6 +10,15 @@ stack, NumPy and pandas. It is written in pure Python (no C or Cython
 extensions), which makes it easy to develop and extend. Instead, we push
 compiled code to :ref:`optional dependencies<installing>`.
 
+.. ipython:: python
+    :suppress:
+
+    import numpy as np
+    import pandas as pd
+    import xarray as xr
+
+    np.random.seed(123456)
+
 Variable objects
 ----------------
 
@@ -77,15 +86,6 @@ argument:
 
 Extending xarray
 ----------------
-
-.. ipython:: python
-    :suppress:
-
-    import numpy as np
-    import pandas as pd
-    import xarray as xr
-
-    np.random.seed(123456)
 
 xarray is designed as a general purpose library, and hence tries to avoid
 including overly domain specific functionality. But inevitably, the need for more

--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -95,9 +95,9 @@ To avoid duplicated information, this method must omit information about the sha
     a = sparse.COO.from_numpy(a)
     a
 
-    xr.Dataset(
-        {"a": ("x", np.linspace(0, 1, 10)), "b": (("y", "z"), sparse.COO.from_numpy(a))}
-    ).chunk({"x": 2})
+    xr.Dataset({"a": ("x", np.linspace(0, 1, 10)), "b": (("y", "z"), a)}).chunk(
+        {"x": 2}
+    )
 
 Extending xarray
 ----------------

--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -15,6 +15,7 @@ compiled code to :ref:`optional dependencies<installing>`.
 
     import numpy as np
     import pandas as pd
+    import sparse
     import xarray as xr
 
     np.random.seed(123456)
@@ -84,7 +85,19 @@ argument:
         ...
 
 To avoid duplicated information, this method must omit information about the shape and
-:term:`dtype`.
+:term:`dtype`. For example, the string representation of a ``dask`` array or a
+``sparse`` matrix would be:
+
+.. ipython:: python
+
+    a = np.eye(10)
+    a[[5, 7, 3, 0], [6, 8, 2, 9]] = 2
+    a = sparse.COO.from_numpy(a)
+    a
+
+    xr.Dataset(
+        {"a": ("x", np.linspace(0, 1, 10)), "b": (("y", "z"), sparse.COO.from_numpy(a))}
+    ).chunk({"x": 2})
 
 Extending xarray
 ----------------

--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -13,6 +13,7 @@ compiled code to :ref:`optional dependencies<installing>`.
 .. ipython:: python
     :suppress:
 
+    import dask.array as da
     import numpy as np
     import pandas as pd
     import sparse
@@ -90,14 +91,15 @@ To avoid duplicated information, this method must omit information about the sha
 
 .. ipython:: python
 
-    a = np.eye(10)
-    a[[5, 7, 3, 0], [6, 8, 2, 9]] = 2
-    a = sparse.COO.from_numpy(a)
+    a = da.linspace(0, 1, 20, chunks=2)
     a
 
-    xr.Dataset({"a": ("x", np.linspace(0, 1, 10)), "b": (("y", "z"), a)}).chunk(
-        {"x": 2}
-    )
+    b = np.eye(10)
+    b[[5, 7, 3, 0], [6, 8, 2, 9]] = 2
+    b = sparse.COO.from_numpy(b)
+    b
+
+    xr.Dataset({"a": ("x", a), "b": (("y", "z"), b)})
 
 Extending xarray
 ----------------


### PR DESCRIPTION
As suggested in #4248, this asks not to include shape and dtype in `_repr_inline_` implementations and shows `sparse` and `dask` reprs as examples.

- [x] follow-up to #4248
- [x] Passes `pre-commit run --all-files`