### PR TITLE
Better rolling reductions

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -57,6 +57,8 @@ New Features
 - Xarray now leverages updates as of cftime version 1.4.1, which enable exact I/O
   roundtripping of ``cftime.datetime`` objects (:pull:`4758`).
   By `Spencer Clark <https://github.com/spencerkclark>`_.
+- Most rolling operations use significantly less memory. (:issue:`4325`).
+  By `Deepak Cherian <https://github.com/dcherian>`_.
 - :py:meth:`~xarray.cftime_range` and :py:meth:`DataArray.resample` now support
   millisecond (``"L"`` or ``"ms"``) and microsecond (``"U"`` or ``"us"``) frequencies
   for ``cftime.datetime`` coordinates (:issue:`4097`, :pull:`4758`).

--- a/xarray/core/dtypes.py
+++ b/xarray/core/dtypes.py
@@ -96,19 +96,27 @@ def get_fill_value(dtype):
     return fill_value
 
 
-def get_pos_infinity(dtype):
+def get_pos_infinity(dtype, max_for_int=False):
     """Return an appropriate positive infinity for this dtype.
 
     Parameters
     ----------
     dtype : np.dtype
+    max_for_int : bool
+        Return np.iinfo(dtype).max instead of np.inf
 
     Returns
     -------
     fill_value : positive infinity value corresponding to this dtype.
     """
-    if issubclass(dtype.type, (np.floating, np.integer)):
+    if issubclass(dtype.type, np.floating):
         return np.inf
+
+    if issubclass(dtype.type, np.integer):
+        if max_for_int:
+            return np.iinfo(dtype).max
+        else:
+            return np.inf
 
     if issubclass(dtype.type, np.complexfloating):
         return np.inf + 1j * np.inf
@@ -116,19 +124,27 @@ def get_pos_infinity(dtype):
     return INF
 
 
-def get_neg_infinity(dtype):
+def get_neg_infinity(dtype, min_for_int=False):
     """Return an appropriate positive infinity for this dtype.
 
     Parameters
     ----------
     dtype : np.dtype
+    min_for_int : bool
+        Return np.iinfo(dtype).min instead of -np.inf
 
     Returns
     -------
     fill_value : positive infinity value corresponding to this dtype.
     """
-    if issubclass(dtype.type, (np.floating, np.integer)):
+    if issubclass(dtype.type, np.floating):
         return -np.inf
+
+    if issubclass(dtype.type, np.integer):
+        if min_for_int:
+            return np.iinfo(dtype).min
+        else:
+            return -np.inf
 
     if issubclass(dtype.type, np.complexfloating):
         return -np.inf - 1j * np.inf

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -529,9 +529,9 @@ class DataArrayRolling(Rolling):
         else:
             if fillna is not None:
                 if fillna is dtypes.INF:
-                    fillna = dtypes.get_pos_infinity(self.obj.dtype)
+                    fillna = dtypes.get_pos_infinity(self.obj.dtype, max_for_int=True)
                 elif fillna is dtypes.NINF:
-                    fillna = dtypes.get_neg_infinity(self.obj.dtype)
+                    fillna = dtypes.get_neg_infinity(self.obj.dtype, min_for_int=True)
                 kwargs.setdefault("skipna", False)
                 kwargs.setdefault("fillna", fillna)
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -139,7 +139,7 @@ class Rolling:
         return method
 
     def _mean(self, keep_attrs, **kwargs):
-        result = self.sum(**kwargs) / self.count()
+        result = self.sum(keep_attrs=False, **kwargs) / self.count(keep_attrs=False)
         if keep_attrs:
             result.attrs = self.obj.attrs
         return result

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6623,6 +6623,16 @@ def test_ndrolling_reduce(da, center, min_periods, name):
     assert_allclose(actual, expected)
     assert actual.dims == expected.dims
 
+    if name in ["mean"]:
+        # test our reimplementation of nanmean using np.nanmean
+        expected = getattr(rolling_obj.construct({"time": "tw", "x": "xw"}), name)(
+            ["tw", "xw"]
+        )
+        count = rolling_obj.count()
+        if min_periods is None:
+            min_periods = 1
+        assert_allclose(actual, expected.where(count >= min_periods))
+
 
 @pytest.mark.parametrize("center", (True, False, (True, False)))
 @pytest.mark.parametrize("fill_value", (np.nan, 0.0))


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Implements most of https://github.com/pydata/xarray/issues/4325#issuecomment-716399575
``` python
%load_ext memory_profiler

import numpy as np
import xarray as xr

temp = xr.DataArray(np.zeros((5000, 500)), dims=("x", "y"))

roll = temp.rolling(x=10, y=20)

%memit roll.sum()
%memit roll.reduce(np.sum)
%memit roll.reduce(np.nansum)  # master  branch behaviour
```
```
peak memory: 245.18 MiB, increment: 81.92 MiB
peak memory: 226.09 MiB, increment: 62.69 MiB
peak memory: 4493.82 MiB, increment: 4330.43 MiB
```
- [x] xref #4325
- [x] asv benchmarks added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
