### PR TITLE
unpin sphinx

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -23,7 +23,7 @@ dependencies:
   - rasterio>=1.1
   - seaborn
   - setuptools
-  - sphinx=3.3
+  - sphinx>=3.3
   - sphinx_rtd_theme>=0.4
   - sphinx-autosummary-accessors
   - zarr>=2.4


### PR DESCRIPTION
We pinned `sphinx` to 3.3 when that came out because there were some issues we had to fix first. Since then, 3.4 and 3.5 have been released which I think don't really affect us, so this unpins `sphinx`.
