### PR TITLE
document update as inplace

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -65,7 +65,7 @@ Deprecations
   version 0.19.0 (:pull:`3993`).
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - the return value of :py:meth:`Dataset.update` is being deprecated to make it work more
-  like :py:meth:`dict.update`.
+  like :py:meth:`dict.update` (:pull:`4932`).
   By `Justus Magin <https://github.com/keewis>`_.
 
 
@@ -165,7 +165,7 @@ Documentation
 - add concat examples and improve combining documentation (:issue:`4620`, :pull:`4645`).
   By `Ray Bell <https://github.com/raybellwaves>`_ and
   `Justus Magin <https://github.com/keewis>`_.
-- explicitly mention that :py:meth:`Dataset.update` updates inplace (:issue:``, :pull:``).
+- explicitly mention that :py:meth:`Dataset.update` updates inplace (:issue:`2951`, :pull:`4932`).
   By `Justus Magin <https://github.com/keewis>`_.
 
 Internal Changes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -151,6 +151,8 @@ Documentation
 - add concat examples and improve combining documentation (:issue:`4620`, :pull:`4645`).
   By `Ray Bell <https://github.com/raybellwaves>`_ and
   `Justus Magin <https://github.com/keewis>`_.
+- explicitly mention that :py:meth:`Dataset.update` updates inplace (:issue:``, :pull:``).
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -64,6 +64,9 @@ Deprecations
   For now using ``dim`` issues a ``FutureWarning``. It will be removed in
   version 0.19.0 (:pull:`3993`).
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
+- the return value of :py:meth:`Dataset.update` is being deprecated to make it work more
+  like :py:meth:`dict.update`.
+  By `Justus Magin <https://github.com/keewis>`_.
 
 
 New Features

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -65,7 +65,7 @@ Deprecations
   version 0.19.0 (:pull:`3993`).
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - the return value of :py:meth:`Dataset.update` is being deprecated to make it work more
-  like :py:meth:`dict.update` (:pull:`4932`).
+  like :py:meth:`dict.update`. It will be removed in version 0.19.0 (:pull:`4932`).
   By `Justus Magin <https://github.com/keewis>`_.
 
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3881,7 +3881,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         Returns
         -------
         updated : Dataset
-            Updated dataset.
+            Updated dataset. Note that since the update is in-place this is the input
+            dataset.
+
+            Deprecated since 0.17.
 
         Raises
         ------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3863,7 +3863,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         return result
 
     def update(self, other: "CoercibleMapping") -> "Dataset":
-        """Update this dataset's variables with those from another dataset inplace.
+        """Update this dataset's variables with those from another dataset.
+
+        Just like :py:meth:`dict.update` this is a in-place operation.
 
         Parameters
         ----------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3863,7 +3863,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         return result
 
     def update(self, other: "CoercibleMapping") -> "Dataset":
-        """Update this dataset's variables with those from another dataset.
+        """Update this dataset's variables with those from another dataset inplace.
 
         Parameters
         ----------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3886,6 +3886,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         ValueError
             If any dimensions would have inconsistent sizes in the updated
             dataset.
+
+        See Also
+        --------
+        Dataset.assign
         """
         merge_result = dataset_update_method(self, other)
         return self._replace(inplace=True, **merge_result._asdict())

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3884,7 +3884,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             Updated dataset. Note that since the update is in-place this is the input
             dataset.
 
-            Deprecated since 0.17.
+            It is deprecated since version 0.17 and scheduled to be removed in 0.19.
 
         Raises
         ------


### PR DESCRIPTION
As pointed out in #2951 I don't think we are able to deprecate the return value. If we are fine with introducing the breaking change in 0.17, I can also remove the return value here.

- [x] closes #2951 (?)
- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
