### PR TITLE
FIX: decode/encode `time_reference`

### DIFF
--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -115,16 +115,21 @@ def _ensure_padded_year(ref_date):
     return ref_date_padded
 
 
-def _unpack_netcdf_time_units(units):
-    # CF datetime units follow the format: "UNIT since DATE"
-    # this parses out the unit and date allowing for extraneous
-    # whitespace. It also ensures that the year is padded with zeros
-    # so it will be correctly understood by pandas (via dateutil).
+def _unpack_netcdf_delta_units_ref_date(units):
     matches = re.match(r"(.+) since (.+)", units)
     if not matches:
         raise ValueError(f"invalid time units: {units}")
 
     delta_units, ref_date = [s.strip() for s in matches.groups()]
+    return delta_units, ref_date
+
+
+def _unpack_netcdf_time_units(units):
+    # CF datetime units follow the format: "UNIT since DATE"
+    # this parses out the unit and date allowing for extraneous
+    # whitespace. It also ensures that the year is padded with zeros
+    # so it will be correctly understood by pandas (via dateutil).
+    delta_units, ref_date = _unpack_netcdf_delta_units_ref_date(units)
     ref_date = _ensure_padded_year(ref_date)
 
     return delta_units, ref_date

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -420,6 +420,7 @@ def _encode_datetime_with_cftime(dates, units, calendar):
 
     return np.array([encode_datetime(d) for d in dates.ravel()]).reshape(dates.shape)
 
+
 def _ensure_encode_time_reference(units, encoding):
     delta_units, _ = _unpack_netcdf_delta_units_ref_date(units)
     time_reference = encoding.pop("time_reference")

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -379,6 +379,20 @@ def decode_cf_variable(
     return Variable(dimensions, data, attributes, encoding=encoding)
 
 
+def _update_time_reference_attributes(variables):
+    # For all time variables with time_reference
+    for v in variables.values():
+        attrs = v.attrs
+        has_date_units = "units" in attrs and "since" in attrs["units"]
+        if has_date_units:
+            delta_units, time_reference = times._unpack_netcdf_delta_units_ref_date(
+                attrs["units"]
+            )
+            if time_reference in variables:
+                ref_date = str(variables[time_reference].data)
+                attrs["units"] = " ".join([delta_units, "since", ref_date])
+
+
 def _update_bounds_attributes(variables):
     """Adds time attributes to time bounds variables.
 
@@ -498,6 +512,7 @@ def decode_cf_variables(
     # Time bounds coordinates might miss the decoding attributes
     if decode_times:
         _update_bounds_attributes(variables)
+        _update_time_reference_attributes(variables)
 
     new_vars = {}
     for k, v in variables.items():

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -383,7 +383,6 @@ def _update_time_reference_attributes(variables):
     # For all time variables with time_reference
     for v in variables.values():
         attrs = v.attrs
-        encoding = v.encoding
         has_date_units = "units" in attrs and "since" in attrs["units"]
         if has_date_units:
             delta_units, time_reference = times._unpack_netcdf_delta_units_ref_date(
@@ -391,7 +390,7 @@ def _update_time_reference_attributes(variables):
             )
             if time_reference in variables:
                 ref_date = str(variables[time_reference].data)
-                encoding["time_reference"] = time_reference
+                v.encoding["time_reference"] = time_reference
                 attrs["units"] = " ".join([delta_units, "since", ref_date])
 
 

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -383,6 +383,7 @@ def _update_time_reference_attributes(variables):
     # For all time variables with time_reference
     for v in variables.values():
         attrs = v.attrs
+        encoding = v.encoding
         has_date_units = "units" in attrs and "since" in attrs["units"]
         if has_date_units:
             delta_units, time_reference = times._unpack_netcdf_delta_units_ref_date(
@@ -390,6 +391,7 @@ def _update_time_reference_attributes(variables):
             )
             if time_reference in variables:
                 ref_date = str(variables[time_reference].data)
+                encoding["time_reference"] = time_reference
                 attrs["units"] = " ".join([delta_units, "since", ref_date])
 
 

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -657,6 +657,33 @@ def test_decode_cf(calendar):
             assert ds.test.dtype == np.dtype("M8[ns]")
 
 
+def test_cf_time_reference():
+    time = np.array([0])
+    time_attrs = dict(
+        standard_name="time", units="seconds since time_reference", calendar="gregorian"
+    )
+    time_ref_attrs = dict(
+        comments="UTC reference date. Format follows ISO 8601 standard."
+    )
+
+    expected = Dataset(
+        data_vars=dict(
+            time=(["time"], time, time_attrs),
+            time_reference=([], "1970-01-01T00:00:00Z", time_ref_attrs),
+        )
+    )
+
+    decoded = decode_cf(expected)
+    assert decoded.time.values == np.array(
+        ["1970-01-01T00:00:00.000000000"], dtype="datetime64[ns]"
+    )
+    assert decoded.time.encoding["time_reference"] == "time_reference"
+    assert decoded.time.encoding["units"] == "seconds since 1970-01-01T00:00:00Z"
+
+    encoded, _ = cf_encoder(decoded.variables, decoded.attrs)
+    assert encoded == expected
+
+
 def test_decode_cf_time_bounds():
 
     da = DataArray(


### PR DESCRIPTION
This is a fix for #4927.  

- `time_reference` is overwritten with the actual time string inside `time_reference` before decoding, but only if a variable with the name exists. 
- `time_reference` name is kept in `encoding` (the name might change, eg. `reference_time`).
- `time_reference` is added back to `units` attribute when encoding, to make roundtrips possible.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #4927
- [x] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
