### PR TITLE
Add DataArrayCoarsen.reduce and DatasetCoarsen.reduce methods

### DIFF
--- a/doc/api-hidden.rst
+++ b/doc/api-hidden.rst
@@ -47,6 +47,7 @@
    core.rolling.DatasetCoarsen.median
    core.rolling.DatasetCoarsen.min
    core.rolling.DatasetCoarsen.prod
+   core.rolling.DatasetCoarsen.reduce
    core.rolling.DatasetCoarsen.std
    core.rolling.DatasetCoarsen.sum
    core.rolling.DatasetCoarsen.var
@@ -190,6 +191,7 @@
    core.rolling.DataArrayCoarsen.median
    core.rolling.DataArrayCoarsen.min
    core.rolling.DataArrayCoarsen.prod
+   core.rolling.DataArrayCoarsen.reduce
    core.rolling.DataArrayCoarsen.std
    core.rolling.DataArrayCoarsen.sum
    core.rolling.DataArrayCoarsen.var

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -91,6 +91,10 @@ New Features
   (including globs for the latter) for ``engine="zarr"``, and so allow reading from
   many remote and other file systems (:pull:`4461`)
   By `Martin Durant <https://github.com/martindurant>`_
+- :py:class:`DataArrayCoarsen` and :py:class:`DatasetCoarsen` now implement a
+  ``reduce`` method, enabling coarsening operations with custom reduction
+  functions (:issue:`3741`, :pull:`4939`).  By `Spencer Clark
+  <https://github.com/spencerkclark>`.
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -94,7 +94,7 @@ New Features
 - :py:class:`DataArrayCoarsen` and :py:class:`DatasetCoarsen` now implement a
   ``reduce`` method, enabling coarsening operations with custom reduction
   functions (:issue:`3741`, :pull:`4939`).  By `Spencer Clark
-  <https://github.com/spencerkclark>`.
+  <https://github.com/spencerkclark>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -874,18 +874,18 @@ class DataArrayCoarsen(Coarsen):
         return wrapped_func
 
     def reduce(self, func: Callable, **kwargs):
-        """Reduce the items in this group by applying `func` along some
+        """Reduce the items in this group by applying ``func`` along some
         dimension(s).
 
         Parameters
         ----------
         func : callable
-            Function which can be called in the form
-            `func(x, axis, **kwargs)` to return the result of collapsing an
-            np.ndarray over the coarsening dimensions.  It must be possible to
-            provide the `axis` argument with a tuple of integers.
+            Function which can be called in the form ``func(x, axis, **kwargs)``
+            to return the result of collapsing an np.ndarray over the coarsening
+            dimensions.  It must be possible to provide the ``axis`` argument
+            with a tuple of integers.
         **kwargs : dict
-            Additional keyword arguments passed on to `func`.
+            Additional keyword arguments passed on to ``func``.
 
         Returns
         -------
@@ -954,23 +954,21 @@ class DatasetCoarsen(Coarsen):
         return wrapped_func
 
     def reduce(self, func: Callable, **kwargs):
-        """Reduce the items in this group by applying `func` along some
+        """Reduce the items in this group by applying ``func`` along some
         dimension(s).
 
         Parameters
         ----------
-        func : callable
-            Function which can be called in the form
-            `func(x, axis, **kwargs)` to return the result of collapsing an
-            np.ndarray over the coarsening dimensions.  It must be possible to
-            provide the `axis` argument with a tuple of integers.
+        func : callable Function which can be called in the form ``func(x, axis,
+            **kwargs)`` to return the result of collapsing an np.ndarray over
+            the coarsening dimensions.  It must be possible to provide the
+            ``axis`` argument with a tuple of integers.
         **kwargs : dict
-            Additional keyword arguments passed on to `func`.
+            Additional keyword arguments passed on to ``func``.
 
         Returns
         -------
-        reduced : Dataset
-            Arrays with summarized data.
+        reduced : Dataset Arrays with summarized data.
         """
         wrapped_func = self._reduce_method(func)
         return wrapped_func(self, **kwargs)

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -960,10 +960,10 @@ class DatasetCoarsen(Coarsen):
         Parameters
         ----------
         func : callable 
-             Function which can be called in the form  `func(x, axis, **kwargs)` 
-             to return the result of collapsing an np.ndarray over the coarsening 
-             dimensions.  It must be possible to  provide the `axis` argument with 
-             a tuple of integers.
+            Function which can be called in the form  `func(x, axis, **kwargs)` 
+            to return the result of collapsing an np.ndarray over the coarsening 
+            dimensions.  It must be possible to  provide the `axis` argument with 
+            a tuple of integers.
         **kwargs : dict
             Additional keyword arguments passed on to `func.
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -969,7 +969,8 @@ class DatasetCoarsen(Coarsen):
 
         Returns
         -------
-        reduced : Dataset Arrays with summarized data.
+        reduced : Dataset
+            Arrays with summarized data.
         """
         wrapped_func = self._reduce_method(func)
         return wrapped_func(self, **kwargs)

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -962,7 +962,7 @@ class DatasetCoarsen(Coarsen):
         func : callable
             Function which can be called in the form `func(x, axis, **kwargs)`
             to return the result of collapsing an np.ndarray over the coarsening
-            dimensions.  It must be possible to  provide the `axis` argument with
+            dimensions.  It must be possible to provide the `axis` argument with
             a tuple of integers.
         **kwargs : dict
             Additional keyword arguments passed on to `func`.

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -960,7 +960,7 @@ class DatasetCoarsen(Coarsen):
         Parameters
         ----------
         func : callable
-            Function which can be called in the form  `func(x, axis, **kwargs)`
+            Function which can be called in the form `func(x, axis, **kwargs)`
             to return the result of collapsing an np.ndarray over the coarsening
             dimensions.  It must be possible to  provide the `axis` argument with
             a tuple of integers.

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -959,10 +959,10 @@ class DatasetCoarsen(Coarsen):
 
         Parameters
         ----------
-        func : callable 
-            Function which can be called in the form  `func(x, axis, **kwargs)` 
-            to return the result of collapsing an np.ndarray over the coarsening 
-            dimensions.  It must be possible to  provide the `axis` argument with 
+        func : callable
+            Function which can be called in the form  `func(x, axis, **kwargs)`
+            to return the result of collapsing an np.ndarray over the coarsening
+            dimensions.  It must be possible to  provide the `axis` argument with
             a tuple of integers.
         **kwargs : dict
             Additional keyword arguments passed on to `func.

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -965,7 +965,7 @@ class DatasetCoarsen(Coarsen):
             dimensions.  It must be possible to  provide the `axis` argument with
             a tuple of integers.
         **kwargs : dict
-            Additional keyword arguments passed on to `func.
+            Additional keyword arguments passed on to `func`.
 
         Returns
         -------

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -874,18 +874,18 @@ class DataArrayCoarsen(Coarsen):
         return wrapped_func
 
     def reduce(self, func: Callable, **kwargs):
-        """Reduce the items in this group by applying ``func`` along some
+        """Reduce the items in this group by applying `func` along some
         dimension(s).
 
         Parameters
         ----------
         func : callable
-            Function which can be called in the form ``func(x, axis, **kwargs)``
+            Function which can be called in the form `func(x, axis, **kwargs)`
             to return the result of collapsing an np.ndarray over the coarsening
-            dimensions.  It must be possible to provide the ``axis`` argument
+            dimensions.  It must be possible to provide the `axis` argument
             with a tuple of integers.
         **kwargs : dict
-            Additional keyword arguments passed on to ``func``.
+            Additional keyword arguments passed on to `func`.
 
         Returns
         -------
@@ -954,17 +954,17 @@ class DatasetCoarsen(Coarsen):
         return wrapped_func
 
     def reduce(self, func: Callable, **kwargs):
-        """Reduce the items in this group by applying ``func`` along some
+        """Reduce the items in this group by applying `func` along some
         dimension(s).
 
         Parameters
         ----------
-        func : callable Function which can be called in the form ``func(x, axis,
-            **kwargs)`` to return the result of collapsing an np.ndarray over
+        func : callable Function which can be called in the form `func(x, axis,
+            **kwargs)` to return the result of collapsing an np.ndarray over
             the coarsening dimensions.  It must be possible to provide the
-            ``axis`` argument with a tuple of integers.
+            `axis` argument with a tuple of integers.
         **kwargs : dict
-            Additional keyword arguments passed on to ``func``.
+            Additional keyword arguments passed on to `func.
 
         Returns
         -------

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -836,7 +836,9 @@ class DataArrayCoarsen(Coarsen):
     _reduce_extra_args_docstring = """"""
 
     @classmethod
-    def _reduce_method(cls, func: Callable, include_skipna: bool, numeric_only: bool):
+    def _reduce_method(
+        cls, func: Callable, include_skipna: bool = False, numeric_only: bool = False
+    ):
         """
         Return a wrapped function for injecting reduction methods.
         see ops.inject_reduce_methods
@@ -871,6 +873,38 @@ class DataArrayCoarsen(Coarsen):
 
         return wrapped_func
 
+    def reduce(self, func: Callable, **kwargs):
+        """Reduce the items in this group by applying `func` along some
+        dimension(s).
+
+        Parameters
+        ----------
+        func : callable
+            Function which can be called in the form
+            `func(x, axis, **kwargs)` to return the result of collapsing an
+            np.ndarray over the coarsening dimensions.  It must be possible to
+            provide the `axis` argument with a tuple of integers.
+        **kwargs : dict
+            Additional keyword arguments passed on to `func`.
+
+        Returns
+        -------
+        reduced : DataArray
+            Array with summarized data.
+
+        Examples
+        --------
+        >>> da = xr.DataArray(np.arange(8).reshape(2, 4), dims=("a", "b"))
+        >>> coarsen = da.coarsen(b=2)
+        >>> coarsen.reduce(np.sum)
+        <xarray.DataArray (a: 2, b: 2)>
+        array([[ 1,  5],
+               [ 9, 13]])
+        Dimensions without coordinates: a, b
+        """
+        wrapped_func = self._reduce_method(func)
+        return wrapped_func(self, **kwargs)
+
 
 class DatasetCoarsen(Coarsen):
     __slots__ = ()
@@ -878,7 +912,9 @@ class DatasetCoarsen(Coarsen):
     _reduce_extra_args_docstring = """"""
 
     @classmethod
-    def _reduce_method(cls, func: Callable, include_skipna: bool, numeric_only: bool):
+    def _reduce_method(
+        cls, func: Callable, include_skipna: bool = False, numeric_only: bool = False
+    ):
         """
         Return a wrapped function for injecting reduction methods.
         see ops.inject_reduce_methods
@@ -916,6 +952,28 @@ class DatasetCoarsen(Coarsen):
             return Dataset(reduced, coords=coords, attrs=attrs)
 
         return wrapped_func
+
+    def reduce(self, func: Callable, **kwargs):
+        """Reduce the items in this group by applying `func` along some
+        dimension(s).
+
+        Parameters
+        ----------
+        func : callable
+            Function which can be called in the form
+            `func(x, axis, **kwargs)` to return the result of collapsing an
+            np.ndarray over the coarsening dimensions.  It must be possible to
+            provide the `axis` argument with a tuple of integers.
+        **kwargs : dict
+            Additional keyword arguments passed on to `func`.
+
+        Returns
+        -------
+        reduced : Dataset
+            Arrays with summarized data.
+        """
+        wrapped_func = self._reduce_method(func)
+        return wrapped_func(self, **kwargs)
 
 
 inject_reduce_methods(DataArrayCoarsen)

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -959,10 +959,11 @@ class DatasetCoarsen(Coarsen):
 
         Parameters
         ----------
-        func : callable Function which can be called in the form `func(x, axis,
-            **kwargs)` to return the result of collapsing an np.ndarray over
-            the coarsening dimensions.  It must be possible to provide the
-            `axis` argument with a tuple of integers.
+        func : callable 
+             Function which can be called in the form  `func(x, axis, **kwargs)` 
+             to return the result of collapsing an np.ndarray over the coarsening 
+             dimensions.  It must be possible to  provide the `axis` argument with 
+             a tuple of integers.
         **kwargs : dict
             Additional keyword arguments passed on to `func.
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6383,6 +6383,24 @@ def test_coarsen_keep_attrs():
 
 
 @pytest.mark.parametrize("da", (1, 2), indirect=True)
+@pytest.mark.parametrize("window", (1, 2, 3, 4))
+@pytest.mark.parametrize("name", ("sum", "mean", "std", "max"))
+def test_coarsen_reduce(da, window, name):
+    if da.isnull().sum() > 1 and window == 1:
+        # this causes all nan slices
+        window = 2
+
+    # Use boundary="trim" to accomodate all window sizes used in tests
+    coarsen_obj = da.coarsen(time=window, boundary="trim")
+
+    # add nan prefix to numpy methods to get similar # behavior as bottleneck
+    actual = coarsen_obj.reduce(getattr(np, "nan%s" % name))
+    expected = getattr(coarsen_obj, name)()
+    assert_allclose(actual, expected)
+    assert actual.dims == expected.dims
+
+
+@pytest.mark.parametrize("da", (1, 2), indirect=True)
 def test_rolling_iter(da):
     rolling_obj = da.rolling(time=7)
     rolling_obj_mean = rolling_obj.mean()

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6387,17 +6387,15 @@ def test_coarsen_keep_attrs():
 @pytest.mark.parametrize("name", ("sum", "mean", "std", "max"))
 def test_coarsen_reduce(da, window, name):
     if da.isnull().sum() > 1 and window == 1:
-        # this causes all nan slices
-        window = 2
+        pytest.skip("These parameters lead to all-NaN slices")
 
     # Use boundary="trim" to accomodate all window sizes used in tests
     coarsen_obj = da.coarsen(time=window, boundary="trim")
 
     # add nan prefix to numpy methods to get similar # behavior as bottleneck
-    actual = coarsen_obj.reduce(getattr(np, "nan%s" % name))
+    actual = coarsen_obj.reduce(getattr(np, f"nan{name}"))
     expected = getattr(coarsen_obj, name)()
     assert_allclose(actual, expected)
-    assert actual.dims == expected.dims
 
 
 @pytest.mark.parametrize("da", (1, 2), indirect=True)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6064,10 +6064,10 @@ def test_coarsen_reduce(ds, window, name):
     coarsen_obj = ds.coarsen(time=window, boundary="trim")
 
     # add nan prefix to numpy methods to get similar behavior as bottleneck
-    actual = coarsen_obj.reduce(getattr(np, "nan%s" % name))
+    actual = coarsen_obj.reduce(getattr(np, f"nan{name}"))
     expected = getattr(coarsen_obj, name)()
     assert_allclose(actual, expected)
-    assert actual.dims == expected.dims
+
     # make sure the order of data_var are not changed.
     assert list(ds.data_vars.keys()) == list(actual.data_vars.keys())
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6055,6 +6055,27 @@ def test_coarsen_keep_attrs():
     xr.testing.assert_identical(ds, ds2)
 
 
+@pytest.mark.slow
+@pytest.mark.parametrize("ds", (1, 2), indirect=True)
+@pytest.mark.parametrize("window", (1, 2, 3, 4))
+@pytest.mark.parametrize("name", ("sum", "mean", "std", "var", "min", "max", "median"))
+def test_coarsen_reduce(ds, window, name):
+    # Use boundary="trim" to accomodate all window sizes used in tests
+    coarsen_obj = ds.coarsen(time=window, boundary="trim")
+
+    # add nan prefix to numpy methods to get similar behavior as bottleneck
+    actual = coarsen_obj.reduce(getattr(np, "nan%s" % name))
+    expected = getattr(coarsen_obj, name)()
+    assert_allclose(actual, expected)
+    assert actual.dims == expected.dims
+    # make sure the order of data_var are not changed.
+    assert list(ds.data_vars.keys()) == list(actual.data_vars.keys())
+
+    # Make sure the dimension order is restored
+    for key, src_var in ds.data_vars.items():
+        assert src_var.dims == actual[key].dims
+
+
 @pytest.mark.parametrize(
     "funcname, argument",
     [


### PR DESCRIPTION
As suggested by @dcherian, this was quite similar to `rolling`; it was useful in particular to follow how the tests were implemented there.  

- [x] Closes #3741
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`