### PR TITLE
Use definition of DTypeLike from Numpy if found

### DIFF
--- a/xarray/core/npcompat.py
+++ b/xarray/core/npcompat.py
@@ -82,6 +82,7 @@ except ImportError:
     # fall back for numpy < 1.20
     DTypeLike = Union[np.dtype, str]
 
+
 # from dask/array/utils.py
 def _is_nep18_active():
     class A:

--- a/xarray/core/npcompat.py
+++ b/xarray/core/npcompat.py
@@ -75,11 +75,12 @@ def moveaxis(a, source, destination):
     return result
 
 
-# Type annotations stubs. See also / to be replaced by:
-# https://github.com/numpy/numpy/issues/7370
-# https://github.com/numpy/numpy-stubs/
-DTypeLike = Union[np.dtype, str]
-
+# Type annotations stubs.
+try:
+    from numpy.typing import DTypeLike
+except ImportError:
+    # fall back for numpy < 1.20
+    DTypeLike = Union[np.dtype, str]
 
 # from dask/array/utils.py
 def _is_nep18_active():


### PR DESCRIPTION
This allows application of numpy ufuncs to DataArrays to typecheck correctly with Numpy 1.20

E.g. without this fix:

```
import xarray as xr
import numpy as np

def applyufunctodataarray() -> xr.DataArray:
    a = xr.DataArray(np.array([-1,2,3]))
    a.__array__
    b = np.abs(a)
    print(b)
    return b
```

will result in:

```
test.py:9: error: Argument 1 to "__call__" of "ufunc" has incompatible type "DataArray"; expected "Union[Union[int, float, complex, str, bytes, generic], Sequence[Union[int, float, complex, str, bytes, generic]], Sequence[Sequence[Any]], _SupportsArray]"
Found 1 error in 1 file (checked 1 source file)
```
While it will type check without issues with this fix.

I have not yet documented this or added tests. 
Please let me know if this change is acceptable and I am happy to do that.

- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
