### PR TITLE
bump the dependencies

### DIFF
--- a/ci/requirements/py37-bare-minimum.yml
+++ b/ci/requirements/py37-bare-minimum.yml
@@ -10,6 +10,6 @@ dependencies:
   - pytest-cov
   - pytest-env
   - pytest-xdist
-  - numpy=1.15
-  - pandas=0.25
+  - numpy=1.17
+  - pandas=1.0
   - setuptools=40.4

--- a/ci/requirements/py37-min-all-deps.yml
+++ b/ci/requirements/py37-min-all-deps.yml
@@ -8,42 +8,42 @@ dependencies:
   # When upgrading python, numpy, or pandas, must also change
   # doc/installing.rst and setup.py.
   - python=3.7
-  - boto3=1.9
-  - bottleneck=1.2
+  - boto3=1.12
+  - bottleneck=1.3
   - cartopy=0.17
   - cdms2=3.1
   - cfgrib=0.9
   - cftime=1.0
   - coveralls
-  - dask=2.9
-  - distributed=2.9
-  - h5netcdf=0.7
-  - h5py=2.9  # Policy allows for 2.10, but it's a conflict-fest
+  - dask=2.11
+  - distributed=2.11
+  - h5netcdf=0.8
+  - h5py=2.10  # Policy allows for 2.10, but it's a conflict-fest
   - hdf5=1.10
   - hypothesis
-  - iris=2.2
-  - lxml=4.4  # Optional dep of pydap
+  - iris=2.4
+  - lxml=4.5  # Optional dep of pydap
   - matplotlib-base=3.1
   - nc-time-axis=1.2
-  - netcdf4=1.4
-  - numba=0.46
-  - numpy=1.15
-  - pandas=0.25
+  - netcdf4=1.5
+  - numba=0.48
+  - numpy=1.17
+  - pandas=1.0
   # - pint  # See py37-min-nep18.yml
   - pip
-  - pseudonetcdf=3.0
+  - pseudonetcdf=3.1
   - pydap=3.2
   - pynio=1.5
   - pytest
   - pytest-cov
   - pytest-env
   - pytest-xdist
-  - rasterio=1.0
-  - scipy=1.3
-  - seaborn=0.9
+  - rasterio=1.1
+  - scipy=1.4
+  - seaborn=0.10
   - setuptools=40.4
   # - sparse  # See py37-min-nep18.yml
   - toolz=0.10
-  - zarr=2.3
+  - zarr=2.4
   - pip:
     - numbagg==0.1

--- a/ci/requirements/py37-min-all-deps.yml
+++ b/ci/requirements/py37-min-all-deps.yml
@@ -18,7 +18,7 @@ dependencies:
   - dask=2.11
   - distributed=2.11
   - h5netcdf=0.8
-  - h5py=2.10  # Policy allows for 2.10, but it's a conflict-fest
+  - h5py=2.10
   - hdf5=1.10
   - hypothesis
   - iris=2.4

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,15 +25,30 @@ Breaking changes
 - xarray no longer supports python 3.6
 
   The minimum version policy was changed to also apply to projects with irregular
-  releases.
-
-  The minimum versions of some other dependencies were changed:
+  releases. As a result, the minimum versions of some dependencies were changed:
 
   ============ ====== ====
   Package      Old    New
   ============ ====== ====
   Python       3.6    3.7
   setuptools   38.4   40.4
+  numpy        1.15   1.17
+  pandas       0.25   1.0
+  dask         2.9    2.11
+  distributed  2.9    2.11
+  boto3        1.9    1.12
+  bottleneck   1.2    1.3
+  h5netcdf     0.7    0.8
+  h5py         0.9    2.10
+  iris         2.2    2.4
+  lxml         4.4    4.5
+  netcdf4      1.4    1.5
+  numba        0.46   0.48
+  pseudonetcdf 3.0    3.1
+  rasterio     1.0    1.1
+  scipy        1.3    1.4
+  seaborn      0.9    0.10
+  zarr         2.3    2.4
   ============ ====== ====
 
   (:issue:`4688`, :pull:`4720`, :pull:`4907`)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -47,7 +47,7 @@ Breaking changes
   zarr         2.3    2.4
   ============ ====== ====
 
-  (:issue:`4688`, :pull:`4720`, :pull:`4907`)
+  (:issue:`4688`, :pull:`4720`, :pull:`4907`, :pull:`4942`)
   By `Justus Magin <https://github.com/keewis>`_.
 - use ``pyproject.toml`` instead of the ``setup_requires`` option for
   ``setuptools`` (:pull:`4897`).

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,14 +36,10 @@ Breaking changes
   pandas       0.25   1.0
   dask         2.9    2.11
   distributed  2.9    2.11
-  boto3        1.9    1.12
   bottleneck   1.2    1.3
   h5netcdf     0.7    0.8
-  h5py         0.9    2.10
   iris         2.2    2.4
-  lxml         4.4    4.5
   netcdf4      1.4    1.5
-  numba        0.46   0.48
   pseudonetcdf 3.0    3.1
   rasterio     1.0    1.1
   scipy        1.3    1.4

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,7 +25,7 @@ Breaking changes
 - xarray no longer supports python 3.6
 
   The minimum version policy was changed to also apply to projects with irregular
-  releases. As a result, the minimum versions of some dependencies were changed:
+  releases. As a result, the minimum versions of some dependencies have changed:
 
   ============ ====== ====
   Package      Old    New


### PR DESCRIPTION
The updated policy (see #4907) allows bumping quite a few dependencies. Not sure if bumping all of them makes sense, but I'd like to see what CI does with this.

- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
