### PR TITLE
autoupdate mypy

### DIFF
--- a/.github/workflows/ci-pre-commit-autoupdate.yaml
+++ b/.github/workflows/ci-pre-commit-autoupdate.yaml
@@ -37,6 +37,8 @@ jobs:
             python -m pre_commit autoupdate
             python .github/workflows/sync_linter_versions.py .pre-commit-config.yaml ci/requirements/mypy_only
           COMMIT_MESSAGE: 'pre-commit: autoupdate hook versions'
+          COMMIT_NAME: 'github-actions[bot]'
+          COMMIT_EMAIL: 'github-actions[bot]@users.noreply.github.com'
           PR_TITLE: 'pre-commit: autoupdate hook versions'
           PR_BRANCH_PREFIX: 'pre-commit/'
           PR_BRANCH_NAME: 'autoupdate-${PR_ID}'

--- a/.github/workflows/ci-pre-commit-autoupdate.yaml
+++ b/.github/workflows/ci-pre-commit-autoupdate.yaml
@@ -35,6 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EXECUTE_COMMANDS: |
             python -m pre_commit autoupdate
+            python .github/workflows/sync_linter_versions.py .pre-commit-config.yaml ci/requirements/mypy_only
           COMMIT_MESSAGE: 'pre-commit: autoupdate hook versions'
           PR_TITLE: 'pre-commit: autoupdate hook versions'
           PR_BRANCH_PREFIX: 'pre-commit/'

--- a/.github/workflows/ci-pre-commit-autoupdate.yaml
+++ b/.github/workflows/ci-pre-commit-autoupdate.yaml
@@ -25,8 +25,8 @@ jobs:
         uses: actions/setup-python@v2
       - name: upgrade pip
         run: python -m pip install --upgrade pip
-      - name: install pre-commit
-        run: python -m pip install --upgrade pre-commit
+      - name: install dependencies
+        run: python -m pip install --upgrade pre-commit pyyaml packaging
       - name: version info
         run: python -m pip list
       - name: autoupdate

--- a/.github/workflows/sync_linter_versions.py
+++ b/.github/workflows/sync_linter_versions.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+import argparse
+import pathlib
+
+import yaml
+from packaging import version
+
+
+def extract_version(config, name):
+    repos = config.get("repos")
+    if repos is None:
+        raise ValueError("invalid pre-commit configuration")
+
+    for repo in repos:
+        hooks = repo["hooks"]
+        hook_names = [hook["id"] for hook in hooks]
+        if name in hook_names:
+            return version.parse(repo["rev"])
+
+    raise KeyError(f"cannot find hook {name!r} in the pre-commit configuration")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry", action="store_true")
+    parser.add_argument(
+        metavar="pre-commit-config", dest="pre_commit_config", type=pathlib.Path
+    )
+    parser.add_argument("requirements", type=pathlib.Path)
+    args = parser.parse_args()
+
+    with args.pre_commit_config.open() as f:
+        config = yaml.safe_load(f)
+
+    mypy_version = extract_version(config, "mypy")
+
+    requirements = args.requirements.read_text()
+    new_requirements = "\n".join(
+        [
+            line if not line.startswith("mypy=") else f"mypy={mypy_version}"
+            for line in requirements.split("\n")
+        ]
+    )
+
+    if args.dry:
+        separator = "\n" + "—" * 80 + "\n"
+        print(
+            "contents of the new requirements file:",
+            new_requirements,
+            sep=separator,
+            end=separator,
+        )
+    else:
+        args.requirements.write_text(new_requirements)

--- a/.github/workflows/sync_linter_versions.py
+++ b/.github/workflows/sync_linter_versions.py
@@ -61,8 +61,10 @@ if __name__ == "__main__":
     if args.dry:
         separator = "\n" + "—" * 80 + "\n"
         print(
+            "contents of the old requirements file:",
+            requirements_text,
             "contents of the new requirements file:",
-            new_requirements,
+            new_requirements_text,
             sep=separator,
             end=separator,
         )

--- a/.github/workflows/sync_linter_versions.py
+++ b/.github/workflows/sync_linter_versions.py
@@ -2,10 +2,13 @@
 import argparse
 import itertools
 import pathlib
+import re
 
 import yaml
 from packaging import version
 from packaging.requirements import Requirement
+
+operator_re = re.compile("=+")
 
 
 def extract_versions(config):
@@ -21,7 +24,8 @@ def extract_versions(config):
 
 
 def update_requirement(line, new_versions):
-    preprocessed = line.replace("=", "==")  # convert to pep-508 compatible
+    # convert to pep-508 compatible
+    preprocessed = operator_re.sub("==", line)
     requirement = Requirement(preprocessed)
 
     specifier, *_ = requirement.specifier


### PR DESCRIPTION
As requested in #4929, this will automatically sync the mypy version in the `mypy_only` environment file with the hook version.

- [x] Passes `pre-commit run --all-files`

Edit: triggering the linting workflow from a automatically generated PR might need a bit more investigation. `pandas` works around that by running `pre-commit run -a` after `pre-commit autoupdate` completed, but that doesn't work if we want to also run the new `mypy` CI.