### PR TITLE
Upstream CI: limit runtime

### DIFF
--- a/.github/workflows/parse_logs.py
+++ b/.github/workflows/parse_logs.py
@@ -18,7 +18,7 @@ def extract_short_test_summary_info(lines):
     )
     up_to_section_content = itertools.islice(up_to_start_of_section, 1, None)
     section_content = itertools.takewhile(
-        lambda l: l.startswith("FAILED"), up_to_section_content
+        lambda l: l.startswith("FAILED") or l.startswith("ERROR"), up_to_section_content
     )
     content = "\n".join(section_content)
 

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -77,7 +77,7 @@ jobs:
         id: status
         run: |
           set -euo pipefail
-          python -m pytest -rf | tee output-${{ matrix.python-version }}-log || (
+          python -m pytest --timeout=7200 -rf | tee output-${{ matrix.python-version }}-log || (
               echo '::set-output name=ARTIFACTS_AVAILABLE::true' && false
           )
       - name: Upload artifacts

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -77,7 +77,7 @@ jobs:
         id: status
         run: |
           set -euo pipefail
-          python -m pytest --timeout=7200 -rf | tee output-${{ matrix.python-version }}-log || (
+          python -m pytest --timeout=5400 -rf | tee output-${{ matrix.python-version }}-log || (
               echo '::set-output name=ARTIFACTS_AVAILABLE::true' && false
           )
       - name: Upload artifacts

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -16,6 +16,8 @@ conda uninstall -y --force \
     pint \
     bottleneck \
     sparse
+# to limit the runtime of Upstream CI
+python -m pip install pytest-timeout
 python -m pip install \
     -i https://pypi.anaconda.org/scipy-wheels-nightly/simple \
     --no-deps \


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- xref #4945

Try to limit the time of "CI Upstream" to avoid a silent failure.