### PR TITLE
WIP: automatic duck array testing

### DIFF
--- a/xarray/duckarray.py
+++ b/xarray/duckarray.py
@@ -44,7 +44,7 @@ def duckarray_module(name, create, global_marks=None, marks=None):
     import pytest
 
     class TestModule:
-        pytestmarks = global_marks
+        pytestmark = global_marks
 
         class TestDataset:
             @pytest.mark.parametrize(

--- a/xarray/duckarray.py
+++ b/xarray/duckarray.py
@@ -1,0 +1,79 @@
+import re
+
+import numpy as np
+
+import xarray as xr
+
+identifier_re = r"[a-zA-Z_][a-zA-Z0-9_]*"
+variant_re = re.compile(
+    rf"^(?P<name>{identifier_re}(?:\.{identifier_re})*)(?:\[(?P<variant>[^]]+)\])?$"
+)
+
+
+def apply_marks(module, name, marks):
+    def get_test(module, components):
+        *parent_names, name = components
+
+        parent = module
+        for parent_name in parent_names:
+            parent = getattr(parent, parent_name)
+
+        test = getattr(parent, name)
+
+        return parent, test, name
+
+    match = variant_re.match(name)
+    if match is not None:
+        groups = match.groupdict()
+        variant = groups["variant"]
+        name = groups["name"]
+    else:
+        raise ValueError(f"invalid test name: {name!r}")
+
+    components = name.split(".")
+    if variant is not None:
+        raise ValueError("variants are not supported, yet")
+    else:
+        parent, test, test_name = get_test(module, components)
+        for mark in marks:
+            test = mark(test)
+        setattr(parent, test_name, test)
+
+
+def duckarray_module(name, create, global_marks=None, marks=None):
+    import pytest
+
+    class TestModule:
+        pytestmarks = global_marks
+
+        class TestDataset:
+            @pytest.mark.parametrize(
+                "method",
+                (
+                    "mean",
+                    "median",
+                    "prod",
+                    "sum",
+                    "std",
+                    "var",
+                ),
+            )
+            def test_reduce(self, method):
+                a = create(np.linspace(0, 1, 10), method)
+                b = create(np.arange(10), method)
+
+                reduced_a = getattr(np, method)(a)
+                reduced_b = getattr(np, method)(b)
+
+                ds = xr.Dataset({"a": ("x", a), "b": ("x", b)})
+                expected = xr.Dataset({"a": reduced_a, "b": reduced_b})
+                actual = getattr(ds, method)()
+                xr.testing.assert_identical(actual, expected)
+
+    for name, marks_ in marks.items():
+        apply_marks(TestModule, name, marks_)
+
+    TestModule.__name__ = f"Test{name.title()}"
+    TestModule.__qualname__ = f"Test{name.title()}"
+
+    return TestModule

--- a/xarray/duckarray.py
+++ b/xarray/duckarray.py
@@ -70,8 +70,9 @@ def duckarray_module(name, create, global_marks=None, marks=None):
                 actual = getattr(ds, method)()
                 xr.testing.assert_identical(actual, expected)
 
-    for name, marks_ in marks.items():
-        apply_marks(TestModule, name, marks_)
+    if marks is not None:
+        for name, marks_ in marks.items():
+            apply_marks(TestModule, name, marks_)
 
     TestModule.__name__ = f"Test{name.title()}"
     TestModule.__qualname__ = f"Test{name.title()}"

--- a/xarray/tests/test_duckarray_testing.py
+++ b/xarray/tests/test_duckarray_testing.py
@@ -1,0 +1,23 @@
+import pint
+import pytest
+
+from xarray.duckarray import duckarray_module
+
+ureg = pint.UnitRegistry(force_ndarray_like=True)
+
+
+def create(data, method):
+    if method in ("prod"):
+        units = "dimensionless"
+    else:
+        units = "m"
+    return ureg.Quantity(data, units)
+
+
+TestPint = duckarray_module(
+    "pint",
+    create,
+    marks={
+        "TestDataset.test_reduce": [pytest.mark.skip(reason="not implemented yet")],
+    },
+)

--- a/xarray/tests/test_duckarray_testing.py
+++ b/xarray/tests/test_duckarray_testing.py
@@ -7,7 +7,7 @@ ureg = pint.UnitRegistry(force_ndarray_like=True)
 
 
 def create(data, method):
-    if method in ("prod"):
+    if method in ("prod",):
         units = "dimensionless"
     else:
         units = "m"


### PR DESCRIPTION
This is a initial draft of the automatic [duckarray testing](https://github.com/pydata/xarray/issues/4285#issuecomment-667637217) machinery.

I'm really not sure how the API would look to be as flexible as possible or if something like this is possible with `pytest`, but I thought I'd share it anyways.

Options I'm currently considering:
- use fixtures instead of a function to create the duckarray
- use a nested dict instead of a flat dict with test selectors for marks
---
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
