### PR TITLE
implemented pad with new-indexes

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,6 +22,10 @@ v0.17.1 (unreleased)
 
 New Features
 ~~~~~~~~~~~~
+- Now :py:meth:`DataArray.pad` and :py:meth:`Dataset.pad` accept a tuple of indexes 
+  as its arguments. In this case, these values will be used as the newly extended parts 
+  of the IndexVariable.
+  By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 
 
 Breaking changes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -23,7 +23,7 @@ v0.17.1 (unreleased)
 New Features
 ~~~~~~~~~~~~
 - Now :py:meth:`DataArray.pad` and :py:meth:`Dataset.pad` accept a tuple of indexes
-  as its arguments. In this case, these values will be used as the newly extended parts
+  as its arguments. In this case, these values will be used as the newly extended coordinate labels
   of the IndexVariable.
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,8 +22,8 @@ v0.17.1 (unreleased)
 
 New Features
 ~~~~~~~~~~~~
-- Now :py:meth:`DataArray.pad` and :py:meth:`Dataset.pad` accept a tuple of indexes 
-  as its arguments. In this case, these values will be used as the newly extended parts 
+- Now :py:meth:`DataArray.pad` and :py:meth:`Dataset.pad` accept a tuple of indexes
+  as its arguments. In this case, these values will be used as the newly extended parts
   of the IndexVariable.
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3950,6 +3950,8 @@ class DataArray(AbstractArray, DataWithCoords):
           * y        (y) int64 10 20 30 40
             z        (x) float64 nan 100.0 200.0 nan
 
+        Specify coordinate labels for padded values by passing a tuple of sequences
+        
         >>> da.pad(x=([-2, -1], [2]))
         <xarray.DataArray (x: 5, y: 4)>
         array([[nan, nan, nan, nan],

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3789,7 +3789,7 @@ class DataArray(AbstractArray, DataWithCoords):
     def pad(
         self,
         pad_width: Mapping[
-            Hashable, Union[int, Tuple[Union[int, Sequence], Union[int, Sequence]]]
+            Hashable, Union[int, Tuple[int, int], Tuple[Sequence, Sequence]]
         ] = None,
         mode: str = "constant",
         stat_length: Union[
@@ -3821,9 +3821,9 @@ class DataArray(AbstractArray, DataWithCoords):
             describing the number of values padded along each dimension.
             {dim: pad} is a shortcut for pad_before = pad_after = pad
             Note that having np.nan in IndexVariable loses most of the useful
-            functionalities of xarray. To avoid this problem, an iterable,
-            such as a list or np.array, can be used for either pad_before or pad_after.
-            In this case, these values will be used for an IndexVariable and preventing
+            functionalities of xarray. To avoid this problem, sequences,
+            such as lists or np.arrays, can be used for pad_before and pad_after.
+            In this case, these values will be used for an IndexVariable preventing
             from the loss of functionalities.
         mode : str, default: "constant"
             One of the following string values (taken from numpy docs)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3788,7 +3788,7 @@ class DataArray(AbstractArray, DataWithCoords):
 
     def pad(
         self,
-        pad_width: Mapping[Hashable, Union[int, Tuple[int, int]]] = None,
+        pad_width: Mapping[Hashable, Union[int, Tuple[Union[int, Iterable], Union[int, Iterable]]]] = None,
         mode: str = "constant",
         stat_length: Union[
             int, Tuple[int, int], Mapping[Hashable, Tuple[int, int]]
@@ -3818,6 +3818,11 @@ class DataArray(AbstractArray, DataWithCoords):
             Mapping with the form of {dim: (pad_before, pad_after)}
             describing the number of values padded along each dimension.
             {dim: pad} is a shortcut for pad_before = pad_after = pad
+            Note that having np.nan in IndexVariable loses most of the useful 
+            functionalities of xarray. To avoid this problem, an iterable, 
+            such as a list or np.array, can be used for either pad_before or pad_after.
+            In this case, these values will be used for an IndexVariable and preventing 
+            from the loss of functionalities.
         mode : str, default: "constant"
             One of the following string values (taken from numpy docs)
 
@@ -3942,6 +3947,18 @@ class DataArray(AbstractArray, DataWithCoords):
           * x        (x) float64 nan 0.0 1.0 nan
           * y        (y) int64 10 20 30 40
             z        (x) float64 nan 100.0 200.0 nan
+
+        >>> da.pad(x=([-2, -1], [2])) 
+        <xarray.DataArray (x: 5, y: 4)>
+        array([[nan, nan, nan, nan],
+            [nan, nan, nan, nan],
+            [ 0.,  1.,  2.,  3.],
+            [10., 11., 12., 13.],
+            [nan, nan, nan, nan]])
+        Coordinates:
+          * x        (x) int64 -2 -1 0 1 2
+          * y        (y) int64 10 20 30 40
+            z        (x) float64 nan nan 100.0 200.0 nan
         """
         ds = self._to_temp_dataset().pad(
             pad_width=pad_width,

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3788,7 +3788,9 @@ class DataArray(AbstractArray, DataWithCoords):
 
     def pad(
         self,
-        pad_width: Mapping[Hashable, Union[int, Tuple[Union[int, Iterable], Union[int, Iterable]]]] = None,
+        pad_width: Mapping[
+            Hashable, Union[int, Tuple[Union[int, Iterable], Union[int, Iterable]]]
+        ] = None,
         mode: str = "constant",
         stat_length: Union[
             int, Tuple[int, int], Mapping[Hashable, Tuple[int, int]]
@@ -3818,10 +3820,10 @@ class DataArray(AbstractArray, DataWithCoords):
             Mapping with the form of {dim: (pad_before, pad_after)}
             describing the number of values padded along each dimension.
             {dim: pad} is a shortcut for pad_before = pad_after = pad
-            Note that having np.nan in IndexVariable loses most of the useful 
-            functionalities of xarray. To avoid this problem, an iterable, 
+            Note that having np.nan in IndexVariable loses most of the useful
+            functionalities of xarray. To avoid this problem, an iterable,
             such as a list or np.array, can be used for either pad_before or pad_after.
-            In this case, these values will be used for an IndexVariable and preventing 
+            In this case, these values will be used for an IndexVariable and preventing
             from the loss of functionalities.
         mode : str, default: "constant"
             One of the following string values (taken from numpy docs)
@@ -3948,7 +3950,7 @@ class DataArray(AbstractArray, DataWithCoords):
           * y        (y) int64 10 20 30 40
             z        (x) float64 nan 100.0 200.0 nan
 
-        >>> da.pad(x=([-2, -1], [2])) 
+        >>> da.pad(x=([-2, -1], [2]))
         <xarray.DataArray (x: 5, y: 4)>
         array([[nan, nan, nan, nan],
             [nan, nan, nan, nan],

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3789,7 +3789,7 @@ class DataArray(AbstractArray, DataWithCoords):
     def pad(
         self,
         pad_width: Mapping[
-            Hashable, Union[int, Tuple[Union[int, Iterable], Union[int, Iterable]]]
+            Hashable, Union[int, Tuple[Union[int, Sequence], Union[int, Sequence]]]
         ] = None,
         mode: str = "constant",
         stat_length: Union[

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3953,10 +3953,10 @@ class DataArray(AbstractArray, DataWithCoords):
         >>> da.pad(x=([-2, -1], [2]))
         <xarray.DataArray (x: 5, y: 4)>
         array([[nan, nan, nan, nan],
-              [nan, nan, nan, nan],
-              [ 0.,  1.,  2.,  3.],
-              [10., 11., 12., 13.],
-              [nan, nan, nan, nan]])
+               [nan, nan, nan, nan],
+               [ 0.,  1.,  2.,  3.],
+               [10., 11., 12., 13.],
+               [nan, nan, nan, nan]])
         Coordinates:
           * x        (x) int64 -2 -1 0 1 2
           * y        (y) int64 10 20 30 40

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3953,10 +3953,10 @@ class DataArray(AbstractArray, DataWithCoords):
         >>> da.pad(x=([-2, -1], [2]))
         <xarray.DataArray (x: 5, y: 4)>
         array([[nan, nan, nan, nan],
-            [nan, nan, nan, nan],
-            [ 0.,  1.,  2.,  3.],
-            [10., 11., 12., 13.],
-            [nan, nan, nan, nan]])
+              [nan, nan, nan, nan],
+              [ 0.,  1.,  2.,  3.],
+              [10., 11., 12., 13.],
+              [nan, nan, nan, nan]])
         Coordinates:
           * x        (x) int64 -2 -1 0 1 2
           * y        (y) int64 10 20 30 40

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6497,7 +6497,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
     def pad(
         self,
         pad_width: Mapping[
-            Hashable, Union[int, Tuple[Union[int, Iterable], Union[int, Iterable]]]
+            Hashable, Union[int, Tuple[Union[int, Sequence], Union[int, Sequence]]]
         ] = None,
         mode: str = "constant",
         stat_length: Union[
@@ -6655,7 +6655,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         variables = {}
 
         # standarize pad_width
-        pad_width_standarized = {}  # type: Mapping[Hashable, Tuple[int, int]]
+        pad_width_standardized = {}  # type: Dict[Hashable, Tuple[int, int]]
         for k, v in pad_width.items():
             if not isinstance(v, int):
                 # if pad_width is a tuple of iterable, we use its length for
@@ -6666,7 +6666,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                     len(v1) if isinstance(v1, Sequence) else v1 for v1 in v
                 )
             else:  # just an int
-                pad_width_standarized[k] = [v, v]
+                pad_width_standarized[k] = (v, v)
 
         for name, var in self.variables.items():
             var_pad_width = {
@@ -6686,17 +6686,17 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             elif name in var_pad_width.keys() and not isinstance(
                 var_pad_width[name], int
             ):  # dimension coordinates
-                w0, w1 = pad_width[name]
+                w0, w1 = pad_width[name]  # type: ignore
                 fill_value_ind = dtypes.get_fill_value(var.dtype)
                 if isinstance(w0, int):
-                    w0 = IndexVariable(name, [fill_value_ind] * w0)
+                    w0_ = IndexVariable(name, [fill_value_ind] * w0)
                 else:
-                    w0 = IndexVariable(name, w0)
+                    w0_ = IndexVariable(name, w0)
                 if isinstance(w1, int):
-                    w1 = IndexVariable(name, [fill_value_ind] * w1)
+                    w1_ = IndexVariable(name, [fill_value_ind] * w1)
                 else:
-                    w1 = IndexVariable(name, w1)
-                variables[name] = var.concat([w0, var, w1], dim=name)
+                    w1_ = IndexVariable(name, w1)
+                variables[name] = var.concat([w0_, var, w1_], dim=name)
             else:
                 variables[name] = var.pad(
                     pad_width=var_pad_width,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6684,7 +6684,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                     reflect_type=reflect_type,
                 )
             elif name in var_pad_width.keys() and not isinstance(
-                var_pad_width[name], int
+                pad_width[name], int
             ):  # dimension coordinates
                 w0, w1 = pad_width[name]  # type: ignore
                 fill_value_ind = dtypes.get_fill_value(var.dtype)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6524,7 +6524,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Parameters
         ----------
-        pad_width : mapping of hashable to tuple of int or Iterable.
+        pad_width : mapping of hashable to int or tuple of int or Sequence.
             Mapping with the form of {dim: (pad_before, pad_after)}
             describing the number of values padded along each dimension.
             {dim: pad} is a shortcut for pad_before = pad_after = pad

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6529,9 +6529,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             describing the number of values padded along each dimension.
             {dim: pad} is a shortcut for pad_before = pad_after = pad
             Note that having np.nan in IndexVariable loses most of the useful
-            functionalities of xarray. To avoid this problem, an iterable,
+            functionalities of xarray. To avoid this problem, a sequence,
             such as a list or np.array, can be used for either pad_before or pad_after.
-            In this case, these values will be used for an IndexVariable and preventing
+            In this case, these values will be used for an IndexVariable preventing
             from the loss of functionalities.
         mode : str, default: "constant"
             One of the following string values (taken from numpy docs).

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6634,7 +6634,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         <xarray.Dataset>
         Dimensions:  (x: 5)
         Coordinates:
-        * x        (x) int64 -1 0 1 2 3
+          * x        (x) int64 -1 0 1 2 3
         Data variables:
             foo      (x) float64 nan 0.0 1.0 2.0 nan
         """

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3016,7 +3016,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         return variables, coord_names, dims, indexes
 
     def rename(
-        self, name_dict: Mapping[Hashable, Hashable] = None, **names: Hashable,
+        self,
+        name_dict: Mapping[Hashable, Hashable] = None,
+        **names: Hashable,
     ) -> "Dataset":
         """Returns a new object with renamed variables and dimensions.
 
@@ -3438,7 +3440,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         return self._replace_vars_and_dims(variables, coord_names=coord_names)
 
     def reset_index(
-        self, dims_or_levels: Union[Hashable, Sequence[Hashable]], drop: bool = False,
+        self,
+        dims_or_levels: Union[Hashable, Sequence[Hashable]],
+        drop: bool = False,
     ) -> "Dataset":
         """Reset the specified index(es) or multi-index level(s).
 
@@ -6524,10 +6528,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             Mapping with the form of {dim: (pad_before, pad_after)}
             describing the number of values padded along each dimension.
             {dim: pad} is a shortcut for pad_before = pad_after = pad
-            Note that having np.nan in IndexVariable loses most of the useful 
-            functionalities of xarray. To avoid this problem, an iterable, 
+            Note that having np.nan in IndexVariable loses most of the useful
+            functionalities of xarray. To avoid this problem, an iterable,
             such as a list or np.array, can be used for either pad_before or pad_after.
-            In this case, these values will be used for an IndexVariable and preventing 
+            In this case, these values will be used for an IndexVariable and preventing
             from the loss of functionalities.
         mode : str, default: "constant"
             One of the following string values (taken from numpy docs).
@@ -6651,13 +6655,13 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         variables = {}
 
         # standarize pad_width
-        pad_width_standarized = {}
+        pad_width_standarized = {}  # type: Mapping[Hashable, Tuple[int, int]]
         for k, v in pad_width.items():
             if not isinstance(v, int):
                 # if pad_width is a tuple of iterable, we use its length for
                 # pad_width_standarized
                 pad_width_standarized[k] = [
-                    len(v1) if hasattr(v1, "__len__") else v1 for v1 in v
+                    len(v1) if isinstance(v1, Iterable) else v1 for v1 in v
                 ]
             else:  # just an int
                 pad_width_standarized[k] = [v, v]

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6659,18 +6659,18 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         for k, v in pad_width.items():
             if not isinstance(v, int):
                 # if pad_width is a tuple of iterable, we use its length for
-                # pad_width_standarized
+                # pad_width_standardized
                 # mypy does not know the length here and infers Tuple[int, ...]
                 # see https://github.com/python/mypy/issues/7509
                 pad_width_standardized[k] = tuple(  # type: ignore
                     len(v1) if isinstance(v1, Sequence) else v1 for v1 in v
                 )
             else:  # just an int
-                pad_width_standarized[k] = (v, v)
+                pad_width_standardized[k] = (v, v)
 
         for name, var in self.variables.items():
             var_pad_width = {
-                k: v for k, v in pad_width_standarized.items() if k in var.dims
+                k: v for k, v in pad_width_standardized.items() if k in var.dims
             }
             if not var_pad_width:
                 variables[name] = var

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6660,9 +6660,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             if not isinstance(v, int):
                 # if pad_width is a tuple of iterable, we use its length for
                 # pad_width_standarized
-                pad_width_standarized[k] = [
-                    len(v1) if isinstance(v1, Iterable) else v1 for v1 in v
-                ]
+                # mypy does not know the length here and infers Tuple[int, ...]
+                # see https://github.com/python/mypy/issues/7509
+                pad_width_standardized[k] = tuple(  # type: ignore
+                    len(v1) if isinstance(v1, Sequence) else v1 for v1 in v
+                )
             else:  # just an int
                 pad_width_standarized[k] = [v, v]
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1362,6 +1362,15 @@ class Variable(
 
         return type(self)(self.dims, array)
 
+    def pad_indexes(self, pad_start: Sequence, pad_end: Sequence):
+        """
+        Return a new (Index)Variable with [pad_start, pad_end] padded at the head and tail
+        of the original array. Used in dataset.pad
+        """
+        start = type(self)(self.dims[0], pad_start)
+        end = type(self)(self.dims[0], pad_end)
+        return type(self).concat([start, self, end], dim=self.dims[0])
+
     def _roll_one_dim(self, dim, count):
         axis = self.get_axis_num(dim)
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5801,7 +5801,7 @@ class TestDataset:
 
     def test_pad_index(self):
         ds = create_test_data(seed=1)
-        padded = ds.pad(dim2=([0, 1, 2], 0), constant_values=42)
+        padded = ds.pad(dim2=([0, 1, 2], []), constant_values=42)
 
         assert padded["dim2"].shape == (12,)
         assert padded["var1"].shape == (8, 12)
@@ -5810,7 +5810,7 @@ class TestDataset:
         assert dict(padded.dims) == {"dim1": 8, "dim2": 12, "dim3": 10, "time": 20}
         assert np.nan not in padded["dim2"]
 
-        padded = ds.pad(dim2=(0, [0, 1, 2]), constant_values=42)
+        padded = ds.pad(dim2=([], [0, 1, 2]), constant_values=42)
         assert np.nan not in padded["dim2"]
 
         padded = ds.pad(dim2=([0, 1], [0, 1, 2]), constant_values=42)
@@ -5818,6 +5818,11 @@ class TestDataset:
 
         padded = ds.pad(dim2=([0, 1], [2]), constant_values=42)
         assert np.nan not in padded["dim2"]
+
+    def test_pad_index_error(self):
+        with pytest.raises(TypeError):
+            ds = create_test_data(seed=1)
+            ds.pad(dim2=(0, [1, 2]))
 
     def test_pad_index_doc(self):
         ds = xr.Dataset({"foo": ("x", range(3))}, coords={"x": [0, 1, 2]})

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5798,6 +5798,24 @@ class TestDataset:
         np.testing.assert_equal(padded["var1"].isel(dim2=[0, -1]).data, 42)
         np.testing.assert_equal(padded["dim2"][[0, -1]].data, np.nan)
 
+    def test_pad_index(self):
+        ds = create_test_data(seed=1)
+        padded = ds.pad(dim2=([0, 1, 2], 0), constant_values=42)
+
+        assert padded["dim2"].shape == (12,)
+        assert padded["var1"].shape == (8, 12)
+        assert padded["var2"].shape == (8, 12)
+        assert padded["var3"].shape == (10, 8)
+        assert dict(padded.dims) == {"dim1": 8, "dim2": 12, "dim3": 10, "time": 20}
+        assert np.nan not in padded["dim2"]
+
+        padded = ds.pad(dim2=(0, [0, 1, 2]), constant_values=42)
+        assert np.nan not in padded["dim2"]
+
+        padded = ds.pad(dim2=([0, 1], [0, 1, 2]), constant_values=42)
+        assert np.nan not in padded["dim2"]
+
+
     def test_astype_attrs(self):
         data = create_test_data(seed=123)
         data.attrs["foo"] = "bar"

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5787,16 +5787,17 @@ class TestDataset:
 
     def test_pad(self):
         ds = create_test_data(seed=1)
-        padded = ds.pad(dim2=(1, 1), constant_values=42)
+        for width in [(1, 1), 1]:
+            padded = ds.pad(dim2=width, constant_values=42)
 
-        assert padded["dim2"].shape == (11,)
-        assert padded["var1"].shape == (8, 11)
-        assert padded["var2"].shape == (8, 11)
-        assert padded["var3"].shape == (10, 8)
-        assert dict(padded.dims) == {"dim1": 8, "dim2": 11, "dim3": 10, "time": 20}
+            assert padded["dim2"].shape == (11,)
+            assert padded["var1"].shape == (8, 11)
+            assert padded["var2"].shape == (8, 11)
+            assert padded["var3"].shape == (10, 8)
+            assert dict(padded.dims) == {"dim1": 8, "dim2": 11, "dim3": 10, "time": 20}
 
-        np.testing.assert_equal(padded["var1"].isel(dim2=[0, -1]).data, 42)
-        np.testing.assert_equal(padded["dim2"][[0, -1]].data, np.nan)
+            np.testing.assert_equal(padded["var1"].isel(dim2=[0, -1]).data, 42)
+            np.testing.assert_equal(padded["dim2"][[0, -1]].data, np.nan)
 
     def test_pad_index(self):
         ds = create_test_data(seed=1)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5816,6 +5816,22 @@ class TestDataset:
         padded = ds.pad(dim2=([0, 1], [0, 1, 2]), constant_values=42)
         assert np.nan not in padded["dim2"]
 
+        padded = ds.pad(dim2=([0, 1], [2]), constant_values=42)
+        assert np.nan not in padded["dim2"]
+
+    def test_pad_index_doc(self):
+        ds = xr.Dataset({"foo": ("x", range(3))}, coords={"x": [0, 1, 2]})
+        padded = ds.pad(x=([-1], [3]))
+        assert np.nan not in padded["x"]
+
+        da = xr.DataArray(
+            [[0, 1, 2, 3], [10, 11, 12, 13]],
+            dims=["x", "y"],
+            coords={"x": [0, 1], "y": [10, 20, 30, 40], "z": ("x", [100, 200])},
+        )
+        padded = da.pad(x=([-2, -1], [2]))
+        assert np.nan not in padded["x"]
+
     def test_astype_attrs(self):
         data = create_test_data(seed=123)
         data.attrs["foo"] = "bar"

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5815,7 +5815,6 @@ class TestDataset:
         padded = ds.pad(dim2=([0, 1], [0, 1, 2]), constant_values=42)
         assert np.nan not in padded["dim2"]
 
-
     def test_astype_attrs(self):
         data = create_test_data(seed=123)
         data.attrs["foo"] = "bar"


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #3868
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Now we use a tuple of indexes for `DataArray.pad` and `Dataset.pad`.