### PR TITLE
Adapt exception handling logic in CFTimeIndex.__sub__ and __rsub__

### DIFF
--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -59,6 +59,12 @@ ITEMS_IN_REPR_MAX_ELSE_ELLIPSIS = 100
 REPR_ELLIPSIS_SHOW_ITEMS_FRONT_END = 10
 
 
+if LooseVersion(pd.__version__) > LooseVersion("1.2.3"):
+    OUT_OF_BOUNDS_TIMEDELTA_ERROR = pd.errors.OutOfBoundsTimedelta
+else:
+    OUT_OF_BOUNDS_TIMEDELTA_ERROR = OverflowError
+
+
 def named(name, pattern):
     return "(?P<" + name + ">" + pattern + ")"
 
@@ -562,7 +568,7 @@ class CFTimeIndex(pd.Index):
         elif _contains_cftime_datetimes(np.array(other)):
             try:
                 return pd.TimedeltaIndex(np.array(self) - np.array(other))
-            except OverflowError:
+            except OUT_OF_BOUNDS_TIMEDELTA_ERROR:
                 raise ValueError(
                     "The time difference exceeds the range of values "
                     "that can be expressed at the nanosecond resolution."
@@ -573,7 +579,7 @@ class CFTimeIndex(pd.Index):
     def __rsub__(self, other):
         try:
             return pd.TimedeltaIndex(other - np.array(self))
-        except OverflowError:
+        except OUT_OF_BOUNDS_TIMEDELTA_ERROR:
             raise ValueError(
                 "The time difference exceeds the range of values "
                 "that can be expressed at the nanosecond resolution."


### PR DESCRIPTION
The exception that was raised in pandas when a `datetime.timedelta` object outside the range that could be expressed in units of nanoseconds was passed to the `pandas.TimedeltaIndex` constructor changed from an `OverflowError` to an `OutOfBoundsTimedelta` error in the development version of pandas.  This PR adjusts our exception handling logic in `CFTimeIndex.__sub__` and `CFTimeIndex.__rsub__` to account for this.

- [x] closes #4947

<details>

Previous versions of pandas:
```python
>>> import pandas as pd; from datetime import timedelta
>>> pd.TimedeltaIndex([timedelta(days=300 * 365)])
Traceback (most recent call last):
 File "pandas/_libs/tslibs/timedeltas.pyx", line 263, in pandas._libs.tslibs.timedeltas.array_to_timedelta64
TypeError: Expected unicode, got datetime.timedelta

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
 File "<stdin>", line 1, in <module>
 File "/Users/spencer/Software/miniconda3/envs/xarray-tests/lib/python3.7/site-packages/pandas/core/indexes/timedeltas.py", line 157, in __new__
   data, freq=freq, unit=unit, dtype=dtype, copy=copy
 File "/Users/spencer/Software/miniconda3/envs/xarray-tests/lib/python3.7/site-packages/pandas/core/arrays/timedeltas.py", line 216, in _from_sequence
   data, inferred_freq = sequence_to_td64ns(data, copy=copy, unit=unit)
 File "/Users/spencer/Software/miniconda3/envs/xarray-tests/lib/python3.7/site-packages/pandas/core/arrays/timedeltas.py", line 926, in sequence_to_td64ns
   data = objects_to_td64ns(data, unit=unit, errors=errors)
 File "/Users/spencer/Software/miniconda3/envs/xarray-tests/lib/python3.7/site-packages/pandas/core/arrays/timedeltas.py", line 1036, in objects_to_td64ns
   result = array_to_timedelta64(values, unit=unit, errors=errors)
 File "pandas/_libs/tslibs/timedeltas.pyx", line 268, in pandas._libs.tslibs.timedeltas.array_to_timedelta64
 File "pandas/_libs/tslibs/timedeltas.pyx", line 221, in pandas._libs.tslibs.timedeltas.convert_to_timedelta64
 File "pandas/_libs/tslibs/timedeltas.pyx", line 166, in pandas._libs.tslibs.timedeltas.delta_to_nanoseconds
OverflowError: Python int too large to convert to C long
```

Development version of pandas:
```python
>>> import pandas as pd; from datetime import timedelta
>>> pd.TimedeltaIndex([timedelta(days=300 * 365)])
Traceback (most recent call last):
 File "pandas/_libs/tslibs/timedeltas.pyx", line 348, in pandas._libs.tslibs.timedeltas.array_to_timedelta64
TypeError: Expected unicode, got datetime.timedelta

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
 File "pandas/_libs/tslibs/timedeltas.pyx", line 186, in pandas._libs.tslibs.timedeltas.delta_to_nanoseconds
OverflowError: Python int too large to convert to C long

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
 File "<stdin>", line 1, in <module>
 File "/Users/spencer/software/pandas/pandas/core/indexes/timedeltas.py", line 161, in __new__
   tdarr = TimedeltaArray._from_sequence_not_strict(
 File "/Users/spencer/software/pandas/pandas/core/arrays/timedeltas.py", line 270, in _from_sequence_not_strict
   data, inferred_freq = sequence_to_td64ns(data, copy=copy, unit=unit)
 File "/Users/spencer/software/pandas/pandas/core/arrays/timedeltas.py", line 970, in sequence_to_td64ns
   data = objects_to_td64ns(data, unit=unit, errors=errors)
 File "/Users/spencer/software/pandas/pandas/core/arrays/timedeltas.py", line 1079, in objects_to_td64ns
   result = array_to_timedelta64(values, unit=unit, errors=errors)
 File "pandas/_libs/tslibs/timedeltas.pyx", line 362, in pandas._libs.tslibs.timedeltas.array_to_timedelta64
 File "pandas/_libs/tslibs/timedeltas.pyx", line 353, in pandas._libs.tslibs.timedeltas.array_to_timedelta64
 File "pandas/_libs/tslibs/timedeltas.pyx", line 306, in pandas._libs.tslibs.timedeltas.convert_to_timedelta64
 File "pandas/_libs/tslibs/timedeltas.pyx", line 189, in pandas._libs.tslibs.timedeltas.delta_to_nanoseconds
pandas._libs.tslibs.conversion.OutOfBoundsTimedelta: Python int too large to convert to C long
```

</details>