### PR TITLE
GHA for automatically canceling previous CI runs

### DIFF
--- a/.github/workflows/cancel-duplicate-runs.yaml
+++ b/.github/workflows/cancel-duplicate-runs.yaml
@@ -1,0 +1,14 @@
+name: Cancel
+on:
+  workflow_run:
+    workflows: ["CI", "CI Additional", "CI Upstream"]
+    types:
+      - requested
+jobs:
+  cancel:
+    name: Cancel previous runs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        workflow_id: ${{ github.event.workflow.id }}

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -45,10 +45,6 @@ jobs:
             "py38-flaky",
           ]
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.
@@ -120,10 +116,6 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.
@@ -161,10 +153,6 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.
@@ -205,10 +193,6 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,10 +37,6 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.7", "3.8"]
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -47,10 +47,6 @@ jobs:
     outputs:
       artifacts_availability: ${{ steps.status.outputs.ARTIFACTS_AVAILABLE }}
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

The `styfle/cancel-workflow-action` requires a token with write permissions in order to cancel duplicate runs. It turns out that the default GitHub token access made available to pull requests from forks has read permissions only. To address this issue, this PR introduces a new workflow that uses a special `workflow_run` trigger which allows the workflow to run to run with a token with write permissions. 

- [x] Passes `pre-commit run --all-files`

Cc @keewis