### PR TITLE
run tests on python 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.9"]
     outputs:
       artifacts_availability: ${{ steps.status.outputs.ARTIFACTS_AVAILABLE }}
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Scientific/Engineering
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,8 +75,8 @@ zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.htm
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    numpy >= 1.15
-    pandas >= 0.25
+    numpy >= 1.17
+    pandas >= 1.0
     setuptools >= 40.4  # For pkg_resources
 
 [options.extras_require]


### PR DESCRIPTION
`numba=0.53.0` has been released which means that we are able to construct a full environment on `python=3.9`. This also updates the required minimum versions for `pandas` and `numpy` to match `py37-bare-minimum`.

- [x] Passes `pre-commit run --all-files`
