### PR TITLE
add a install xarray step to the upstream-dev CI

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -60,6 +60,9 @@ jobs:
         run: |
           mamba env update -f ci/requirements/environment.yml
           bash ci/install-upstream-wheels.sh
+      - name: Install xarray
+        run: |
+          python -m pip install --no-deps -e .
       - name: Version info
         run: |
           conda info -a

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -15,7 +15,8 @@ conda uninstall -y --force \
     rasterio \
     pint \
     bottleneck \
-    sparse
+    sparse \
+    xarray
 # to limit the runtime of Upstream CI
 python -m pip install pytest-timeout
 python -m pip install \


### PR DESCRIPTION
While trying to debug #5042 I noticed we don't have a "install xarray" step in the upstream-dev CI :man_facepalming:

Not sure how we missed that, especially since fixes like #4757 did work. Maybe the reason is that we're running `pytest` in the checked-out project directory?

- [x] Passes `pre-commit run --all-files`

