### PR TITLE
install the dev version of sparse in the upstream-dev CI

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# TODO: add sparse back in, once Numba works with the development version of
-# NumPy again: https://github.com/pydata/xarray/issues/4146
-
 conda uninstall -y --force \
     numpy \
     scipy \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -42,5 +42,5 @@ python -m pip install \
     git+https://github.com/Unidata/cftime \
     git+https://github.com/mapbox/rasterio \
     git+https://github.com/hgrecco/pint \
-    git+https://github.com/pydata/bottleneck # \
-    # git+https://github.com/pydata/sparse
+    git+https://github.com/pydata/bottleneck \
+    git+https://github.com/pydata/sparse

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -227,6 +227,10 @@ def test_variable_method(func, sparse_output):
     ret_s = func(var_s)
     ret_d = func(var_d)
 
+    # TODO: figure out how to verify the results of each method
+    if isinstance(ret_d, xr.Variable) and isinstance(ret_d.data, sparse.SparseArray):
+        ret_d = ret_d.copy(data=ret_d.data.todense())
+
     if sparse_output:
         assert isinstance(ret_s.data, sparse.SparseArray)
         assert np.allclose(ret_s.data.todense(), ret_d.data, equal_nan=True)


### PR DESCRIPTION
`sparse` issued a release yesterday, which seems to break one of our tests (`numpy.allcose` on a `ndarray` and `COO` is not implemented). This enables installing the dev version of sparse in the upstream-dev CI, and I'm planning to either xfail or fix the failing test here.

Edit: ~I can reproduce the failure with `sparse=0.11.2` so that's not the reason for the failing test...~ that's wrong, a new environment downgraded to `sparse=0.11.2` will not fail, but upgrading will introduce the failure again.

- [x] Passes `pre-commit run --all-files`
