### PR TITLE
improve the error message for invalid hue names

### DIFF
--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -65,6 +65,7 @@ def _infer_line_data(darray, x, y, hue):
             raise ValueError("For 2D inputs, please specify either hue, x or y.")
 
         if y is None:
+            _assert_valid_xy(darray, hue, "hue")
             xname, huename = _infer_xy_labels(darray=darray, x=x, y=hue)
             xplt = darray[xname]
             if xplt.ndim > 1:

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -65,7 +65,8 @@ def _infer_line_data(darray, x, y, hue):
             raise ValueError("For 2D inputs, please specify either hue, x or y.")
 
         if y is None:
-            _assert_valid_xy(darray, hue, "hue")
+            if hue is not None:
+                _assert_valid_xy(darray, hue, "hue")
             xname, huename = _infer_xy_labels(darray=darray, x=x, y=hue)
             xplt = darray[xname]
             if xplt.ndim > 1:

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -267,6 +267,15 @@ class TestPlot(PlotTestCase):
         line = da.plot(y="time", hue="x")[0]
         assert_array_equal(line.get_ydata(), da.coords["time"].values)
 
+    def test_line_plot_wrong_hue(self):
+        da = xr.DataArray(
+            data=np.array([[0, 1], [5, 9]]),
+            dims=["x", "t"],
+        )
+
+        with pytest.raises(ValueError, match="hue must be one of"):
+            da.plot(x="t", hue="wrong_coord")
+
     def test_2d_line(self):
         with raises_regex(ValueError, "hue"):
             self.darray[:, :, 0].plot.line()


### PR DESCRIPTION
I chose to implement the easier fix described in https://github.com/pydata/xarray/issues/4913#issuecomment-803281142, but if refactoring `_infer_xy_labels` would be better I can do that, too.

- [x] Closes #4913
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
