### PR TITLE
update the install guide

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -684,8 +684,12 @@ This will display stderr from the benchmarks, and use your local
 Information on how to write a benchmark and how to use asv can be found in the
 `asv documentation <https://asv.readthedocs.io/en/latest/writing_benchmarks.html>`_.
 
-The *xarray* benchmarking suite is run remotely and the results are
-available `here <http://pandas.pydata.org/speed/xarray/>`_.
+..
+   TODO: uncomment once we have a working setup
+         see https://github.com/pydata/xarray/pull/5066
+
+   The *xarray* benchmarking suite is run remotely and the results are
+   available `here <http://pandas.pydata.org/speed/xarray/>`_.
 
 Documenting your code
 ---------------------

--- a/doc/getting-started-guide/installing.rst
+++ b/doc/getting-started-guide/installing.rst
@@ -8,8 +8,8 @@ Required dependencies
 
 - Python (3.7 or later)
 - setuptools (40.4 or later)
-- `numpy <http://www.numpy.org/>`__ (1.15 or later)
-- `pandas <http://pandas.pydata.org/>`__ (0.25 or later)
+- `numpy <http://www.numpy.org/>`__ (1.17 or later)
+- `pandas <http://pandas.pydata.org/>`__ (1.0 or later)
 
 .. _optional-dependencies:
 

--- a/doc/getting-started-guide/installing.rst
+++ b/doc/getting-started-guide/installing.rst
@@ -169,8 +169,12 @@ repository.
 Performance Monitoring
 ~~~~~~~~~~~~~~~~~~~~~~
 
-A fixed-point performance monitoring of (a part of) our code can be seen on
-`this page <https://pandas.pydata.org/speed/xarray/>`__.
+..
+   TODO: uncomment once we have a working setup
+         see https://github.com/pydata/xarray/pull/5066
+
+   A fixed-point performance monitoring of (a part of) our code can be seen on
+   `this page <https://pandas.pydata.org/speed/xarray/>`__.
 
 To run these benchmark tests in a local machine, first install
 

--- a/doc/getting-started-guide/installing.rst
+++ b/doc/getting-started-guide/installing.rst
@@ -77,14 +77,6 @@ Alternative data containers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - `sparse <https://sparse.pydata.org/>`_: for sparse arrays
 - `pint <https://pint.readthedocs.io/>`_: for units of measure
-
-  .. note::
-
-    At the moment of writing, xarray requires a `highly experimental version of pint
-    <https://github.com/andrewgsavage/pint/pull/6>`_ (install with
-    ``pip install git+https://github.com/andrewgsavage/pint.git@refs/pull/6/head)``.
-    Even with it, interaction with non-numpy array libraries, e.g. dask or sparse, is broken.
-
 - Any numpy-like objects that support
   `NEP-18 <https://numpy.org/neps/nep-0018-array-function-protocol.html>`_.
   Note that while such libraries theoretically should work, they are untested.

--- a/doc/getting-started-guide/installing.rst
+++ b/doc/getting-started-guide/installing.rst
@@ -178,7 +178,7 @@ Performance Monitoring
 ~~~~~~~~~~~~~~~~~~~~~~
 
 A fixed-point performance monitoring of (a part of) our codes can be seen on
-`this page <https://tomaugspurger.github.io/asv-collection/xarray/>`__.
+`this page <https://pandas.pydata.org/speed/xarray/>`__.
 
 To run these benchmark tests in a local machine, first install
 

--- a/doc/getting-started-guide/installing.rst
+++ b/doc/getting-started-guide/installing.rst
@@ -169,7 +169,7 @@ repository.
 Performance Monitoring
 ~~~~~~~~~~~~~~~~~~~~~~
 
-A fixed-point performance monitoring of (a part of) our codes can be seen on
+A fixed-point performance monitoring of (a part of) our code can be seen on
 `this page <https://pandas.pydata.org/speed/xarray/>`__.
 
 To run these benchmark tests in a local machine, first install


### PR DESCRIPTION
This updates the version numbers for `pandas` and `numpy`, gets rid of the warning added for `pint<0.10` and updates the url for the asv monitoring page.

See #5064

- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

