### PR TITLE
RFC: Add more scipy interpolations methods

### DIFF
--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -460,7 +460,6 @@ def _get_interpolator(method, vectorizeable_only=False, **kwargs):
         "quadratic",
         "cubic",
         "polynomial",
-        "nearest-up",
         "previous",
         "next",
     ]
@@ -598,7 +597,7 @@ def interp(var, indexes_coords, method, **kwargs):
         Original coordinates should be sorted in strictly ascending order.
         Note that all the coordinates should be Variable objects.
     method : string
-        One of {'linear', 'nearest', 'nearest-up', 'zero', 'slinear', 'quadratic',
+        One of {'linear', 'nearest', 'zero', 'slinear', 'quadratic',
         'cubic', 'previous', 'next'}. For multidimensional interpolation, only
         {'linear', 'nearest'} can be used.
     **kwargs

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -598,8 +598,8 @@ def interp(var, indexes_coords, method, **kwargs):
         Original coordinates should be sorted in strictly ascending order.
         Note that all the coordinates should be Variable objects.
     method : string
-        One of {'linear', 'nearest', 'zero', 'slinear', 'quadratic',
-        'cubic'}. For multidimensional interpolation, only
+        One of {'linear', 'nearest', 'nearest-up', 'zero', 'slinear', 'quadratic',
+        'cubic', 'previous', 'next'}. For multidimensional interpolation, only
         {'linear', 'nearest'} can be used.
     **kwargs
         keyword arguments to be passed to scipy.interpolate

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -460,6 +460,9 @@ def _get_interpolator(method, vectorizeable_only=False, **kwargs):
         "quadratic",
         "cubic",
         "polynomial",
+        "nearest-up",
+        "previous",
+        "next",
     ]
     valid_methods = interp1d_methods + [
         "barycentric",

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -95,13 +95,13 @@ def test_interpolate_pd_compat():
     methods = [
         "linear",
         "nearest",
-        "nearest-up",
+        # "nearest-up",
         "zero",
         "slinear",
         "quadratic",
         "cubic",
-        "next",
-        "previous",
+        # "next",
+        # "previous",
     ]
 
     for (shape, frac_nan, method) in itertools.product(shapes, frac_nans, methods):
@@ -301,7 +301,17 @@ def test_interpolate_limits():
 
 @requires_scipy
 def test_interpolate_methods():
-    for method in ["linear", "nearest", "zero", "slinear", "quadratic", "cubic"]:
+    for method in [
+        "linear",
+        "nearest",
+        "zero",
+        "slinear",
+        "quadratic",
+        "cubic",
+        "nearest-up",
+        "previous",
+        "next",
+    ]:
         kwargs = {}
         da = xr.DataArray(
             np.array([0, 1, 2, np.nan, np.nan, np.nan, 6, 7, 8], dtype=np.float64),

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -92,7 +92,17 @@ def make_interpolate_example_data(shape, frac_nan, seed=12345, non_uniform=False
 def test_interpolate_pd_compat():
     shapes = [(8, 8), (1, 20), (20, 1), (100, 100)]
     frac_nans = [0, 0.5, 1]
-    methods = ["linear", "nearest", "zero", "slinear", "quadratic", "cubic"]
+    methods = [
+        "linear",
+        "nearest",
+        "nearest-up",
+        "zero",
+        "slinear",
+        "quadratic",
+        "cubic",
+        "next",
+        "previous",
+    ]
 
     for (shape, frac_nan, method) in itertools.product(shapes, frac_nans, methods):
 

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -95,7 +95,6 @@ def test_interpolate_pd_compat():
     methods = [
         "linear",
         "nearest",
-        # "nearest-up",
         "zero",
         "slinear",
         "quadratic",
@@ -308,7 +307,6 @@ def test_interpolate_methods():
         "slinear",
         "quadratic",
         "cubic",
-        "nearest-up",
         "previous",
         "next",
     ]:


### PR DESCRIPTION
This extends the list of applicable interpolation methods from scipy's `interp1d` to match the methods listed in https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html 

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Is such a small change worth being included in `whats-new.rst`?