### PR TITLE
Disable the cfgrib backend if eccodes is not installed

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -61,7 +61,7 @@ New Features
   :py:class:`~core.groupby.DataArrayGroupBy`, inspired by pandas'
   :py:meth:`~pandas.core.groupby.GroupBy.get_group`.
   By `Deepak Cherian <https://github.com/dcherian>`_.
-- Disable the `cfgrib` backend if the `eccodes` library is not installed. By `Baudouin Raoult <https://github.com/b8raoult>`_.
+- Disable the `cfgrib` backend if the `eccodes` library is not installed (:pull:`5083`). By `Baudouin Raoult <https://github.com/b8raoult>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -61,6 +61,7 @@ New Features
   :py:class:`~core.groupby.DataArrayGroupBy`, inspired by pandas'
   :py:meth:`~pandas.core.groupby.GroupBy.get_group`.
   By `Deepak Cherian <https://github.com/dcherian>`_.
+- Disable the `cfgrib` backend if the `eccodes` library is not installed. By `Baudouin Raoult <https://github.com/b8raoult>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -1,5 +1,5 @@
 import os
-import sys
+import warnings
 
 import numpy as np
 

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -22,7 +22,7 @@ try:
 except ModuleNotFoundError:
     has_cfgrib = False
 except Exception as e:
-    print("WARNING: failed to load cfgrib, backend disabled", e, file=sys.stderr)
+    warnings.warn("Failed to load cfgrib - most likely eccodes is missing. Try `import cfgrib` to get the error message")
     has_cfgrib = False
 
 # FIXME: Add a dedicated lock, even if ecCodes is supposed to be thread-safe

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -21,7 +21,7 @@ try:
     has_cfgrib = True
 except ModuleNotFoundError:
     has_cfgrib = False
-except Exception as e:
+except RuntimeError:
     warnings.warn("Failed to load cfgrib - most likely eccodes is missing. Try `import cfgrib` to get the error message")
     has_cfgrib = False
 

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -22,7 +22,9 @@ try:
 except ModuleNotFoundError:
     has_cfgrib = False
 except RuntimeError:
-    warnings.warn("Failed to load cfgrib - most likely eccodes is missing. Try `import cfgrib` to get the error message")
+    warnings.warn(
+        "Failed to load cfgrib - most likely eccodes is missing. Try `import cfgrib` to get the error message"
+    )
     has_cfgrib = False
 
 # FIXME: Add a dedicated lock, even if ecCodes is supposed to be thread-safe

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import numpy as np
 
@@ -20,7 +21,9 @@ try:
     has_cfgrib = True
 except ModuleNotFoundError:
     has_cfgrib = False
-
+except Exception as e:
+    print("WARNING: failed to load cfgrib, backend disabled", e, file=sys.stderr)
+    has_cfgrib = False
 
 # FIXME: Add a dedicated lock, even if ecCodes is supposed to be thread-safe
 #   in most circumstances. See:

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -21,6 +21,7 @@ try:
     has_cfgrib = True
 except ModuleNotFoundError:
     has_cfgrib = False
+# cfgrib throws a RuntimeError if eccodes is not installed
 except RuntimeError:
     warnings.warn(
         "Failed to load cfgrib - most likely eccodes is missing. Try `import cfgrib` to get the error message"


### PR DESCRIPTION
If cfgrib is installed, but libeccodes.so is not installed on the system, Xarray does not load as cfgrib will throw a RuntimeError(), which is not caught.