### PR TITLE
type: ignore - use error codes

### DIFF
--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -7,7 +7,7 @@ import sys
 from datetime import datetime
 from typing import Dict, Iterator, Optional, Tuple
 
-import conda.api
+import conda.api  # type: ignore[import]
 import yaml
 from dateutil.relativedelta import relativedelta
 
@@ -76,9 +76,9 @@ def parse_requirements(fname) -> Iterator[Tuple[str, int, int, Optional[int]]]:
             raise ValueError("non-numerical version: " + row)
 
         if len(version_tup) == 2:
-            yield (pkg, *version_tup, None)  # type: ignore
+            yield (pkg, *version_tup, None)  # type: ignore[misc]
         elif len(version_tup) == 3:
-            yield (pkg, *version_tup)  # type: ignore
+            yield (pkg, *version_tup)  # type: ignore[misc]
         else:
             raise ValueError("expected major.minor or major.minor.patch: " + row)
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -99,6 +99,9 @@ Documentation
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
+- Enable displaying mypy error codes and add ignore only specific error codes using
+  ``# type: ignore[error-code]`` (:pull:`5095`). By `Mathias Hauser <https://github.com/mathause>`_.
+
 
 .. _whats-new.0.17.0:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -99,8 +99,8 @@ Documentation
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Enable displaying mypy error codes and add ignore only specific error codes using
-  ``# type: ignore[error-code]`` (:pull:`5095`). By `Mathias Hauser <https://github.com/mathause>`_.
+- Enable displaying mypy error codes and ignore only specific error codes using
+  ``# type: ignore[error-code]`` (:pull:`5096`). By `Mathias Hauser <https://github.com/mathause>`_.
 
 
 .. _whats-new.0.17.0:

--- a/setup.cfg
+++ b/setup.cfg
@@ -162,11 +162,14 @@ default_section = THIRDPARTY
 known_first_party = xarray
 
 [mypy]
+show_error_codes = True
 
 # Most of the numerical computing stack doesn't have type annotations yet.
 [mypy-affine.*]
 ignore_missing_imports = True
 [mypy-bottleneck.*]
+ignore_missing_imports = True
+[mypy-cartopy.*]
 ignore_missing_imports = True
 [mypy-cdms2.*]
 ignore_missing_imports = True

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -58,7 +58,7 @@ class ImplementsArrayReduce:
 
         else:
 
-            def wrapped_func(self, dim=None, axis=None, **kwargs):  # type: ignore
+            def wrapped_func(self, dim=None, axis=None, **kwargs):  # type: ignore[misc]
                 return self.reduce(func, dim, axis, **kwargs)
 
         return wrapped_func
@@ -97,7 +97,7 @@ class ImplementsDatasetReduce:
 
         else:
 
-            def wrapped_func(self, dim=None, **kwargs):  # type: ignore
+            def wrapped_func(self, dim=None, **kwargs):  # type: ignore[misc]
                 return self.reduce(func, dim, numeric_only=numeric_only, **kwargs)
 
         return wrapped_func

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -50,7 +50,7 @@ class Coordinates(Mapping[Hashable, "DataArray"]):
 
     @property
     def indexes(self) -> Indexes:
-        return self._data.indexes  # type: ignore
+        return self._data.indexes  # type: ignore[attr-defined]
 
     @property
     def variables(self):
@@ -105,9 +105,11 @@ class Coordinates(Mapping[Hashable, "DataArray"]):
             raise ValueError("no valid index for a 0-dimensional object")
         elif len(ordered_dims) == 1:
             (dim,) = ordered_dims
-            return self._data.get_index(dim)  # type: ignore
+            return self._data.get_index(dim)  # type: ignore[attr-defined]
         else:
-            indexes = [self._data.get_index(k) for k in ordered_dims]  # type: ignore
+            indexes = [
+                self._data.get_index(k) for k in ordered_dims  # type: ignore[attr-defined]
+            ]
 
             # compute the sizes of the repeat and tile for the cartesian product
             # (taken from pandas.core.reshape.util)

--- a/xarray/core/dask_array_compat.py
+++ b/xarray/core/dask_array_compat.py
@@ -158,7 +158,7 @@ else:
 
     def sliding_window_view(x, window_shape, axis=None):
         from dask.array.overlap import map_overlap
-        from numpy.core.numeric import normalize_axis_tuple  # type: ignore
+        from numpy.core.numeric import normalize_axis_tuple
 
         from .npcompat import sliding_window_view as _np_sliding_window_view
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -758,7 +758,7 @@ class DataArray(AbstractArray, DataWithCoords):
     @attrs.setter
     def attrs(self, value: Mapping[Hashable, Any]) -> None:
         # Disable type checking to work around mypy bug - see mypy#4167
-        self.variable.attrs = value  # type: ignore
+        self.variable.attrs = value  # type: ignore[assignment]
 
     @property
     def encoding(self) -> Dict[Hashable, Any]:
@@ -1003,7 +1003,7 @@ class DataArray(AbstractArray, DataWithCoords):
 
     # mutable objects should not be hashable
     # https://github.com/python/mypy/issues/4266
-    __hash__ = None  # type: ignore
+    __hash__ = None  # type: ignore[assignment]
 
     @property
     def chunks(self) -> Optional[Tuple[Tuple[int, ...], ...]]:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1396,11 +1396,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
     # FIXME https://github.com/python/mypy/issues/7328
     @overload
-    def __getitem__(self, key: Mapping) -> "Dataset":  # type: ignore
+    def __getitem__(self, key: Mapping) -> "Dataset":  # type: ignore[misc]
         ...
 
     @overload
-    def __getitem__(self, key: Hashable) -> "DataArray":  # type: ignore
+    def __getitem__(self, key: Hashable) -> "DataArray":  # type: ignore[misc]
         ...
 
     @overload
@@ -1450,7 +1450,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
     # mutable objects should not be hashable
     # https://github.com/python/mypy/issues/4266
-    __hash__ = None  # type: ignore
+    __hash__ = None  # type: ignore[assignment]
 
     def _all_compat(self, other: "Dataset", compat_str: str) -> bool:
         """Helper function for equals and identical"""
@@ -4350,7 +4350,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             array = self._variables[k]
             if dim in array.dims:
                 dims = [d for d in array.dims if d != dim]
-                count += np.asarray(array.count(dims))  # type: ignore
+                count += np.asarray(array.count(dims))  # type: ignore[attr-defined]
                 size += np.prod([self.dims[d] for d in dims])
 
         if thresh is not None:
@@ -4731,7 +4731,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                         # prefer to aggregate over axis=None rather than
                         # axis=(0, 1) if they will be equivalent, because
                         # the former is often more efficient
-                        reduce_dims = None  # type: ignore
+                        reduce_dims = None  # type: ignore[assignment]
                     variables[name] = var.reduce(
                         func,
                         dim=reduce_dims,
@@ -6411,7 +6411,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         lhs = np.vander(x, order)
 
         if rcond is None:
-            rcond = x.shape[0] * np.core.finfo(x.dtype).eps  # type: ignore
+            rcond = (
+                x.shape[0] * np.core.finfo(x.dtype).eps  # type: ignore[attr-defined]
+            )
 
         # Weights:
         if w is not None:
@@ -6687,7 +6689,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                 variables[name] = var.pad(
                     pad_width=var_pad_width,
                     mode=coord_pad_mode,
-                    **coord_pad_options,  # type: ignore
+                    **coord_pad_options,  # type: ignore[arg-type]
                 )
 
         return self._replace_vars_and_dims(variables)

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -27,7 +27,7 @@ try:
     import dask.array as dask_array
     from dask.base import tokenize
 except ImportError:
-    dask_array = None  # type: ignore
+    dask_array = None
 
 
 def _dask_or_eager_func(
@@ -564,7 +564,7 @@ def mean(array, axis=None, skipna=None, **kwargs):
         return _mean(array, axis=axis, skipna=skipna, **kwargs)
 
 
-mean.numeric_only = True  # type: ignore
+mean.numeric_only = True  # type: ignore[attr-defined]
 
 
 def _nd_cum_func(cum_func, array, axis, **kwargs):

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -189,7 +189,7 @@ def format_array_flat(array, max_width: int):
         (max_possibly_relevant < array.size) or (cum_len > max_width).any()
     ):
         padding = " ... "
-        max_len = max(np.argmax(cum_len + len(padding) - 1 > max_width), 2)  # type: ignore
+        max_len = max(np.argmax(cum_len + len(padding) - 1 > max_width), 2)  # type: ignore[type-var]
         count = min(array.size, max_len)
     else:
         count = array.size

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -140,6 +140,6 @@ def propagate_indexes(
     if indexes is not None:
         new_indexes = {k: v for k, v in indexes.items() if k not in exclude}
     else:
-        new_indexes = None  # type: ignore
+        new_indexes = None  # type: ignore[assignment]
 
     return new_indexes

--- a/xarray/core/nanops.py
+++ b/xarray/core/nanops.py
@@ -19,7 +19,7 @@ try:
     from . import dask_array_compat
 except ImportError:
     dask_array = None
-    dask_array_compat = None  # type: ignore
+    dask_array_compat = None  # type: ignore[assignment]
 
 
 def _replace_nan(a, val):

--- a/xarray/core/npcompat.py
+++ b/xarray/core/npcompat.py
@@ -81,13 +81,13 @@ try:
     from numpy.typing import DTypeLike
 except ImportError:
     # fall back for numpy < 1.20
-    DTypeLike = Union[np.dtype, str]  # type: ignore
+    DTypeLike = Union[np.dtype, str]  # type: ignore[misc]
 
 
 if LooseVersion(np.__version__) >= "1.20.0":
     sliding_window_view = np.lib.stride_tricks.sliding_window_view
 else:
-    from numpy.core.numeric import normalize_axis_tuple  # type: ignore
+    from numpy.core.numeric import normalize_axis_tuple  # type: ignore[attr-defined]
     from numpy.lib.stride_tricks import as_strided
 
     # copied from numpy.lib.stride_tricks

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -2,7 +2,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
-from numpy.core.multiarray import normalize_axis_index  # type: ignore
+from numpy.core.multiarray import normalize_axis_index  # type: ignore[attr-defined]
 
 try:
     import bottleneck as bn

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -379,7 +379,9 @@ def map_blocks(
         # template xarray object has been provided with proper sizes and chunk shapes
         indexes = dict(template.indexes)
         if isinstance(template, DataArray):
-            output_chunks = dict(zip(template.dims, template.chunks))  # type: ignore
+            output_chunks = dict(
+                zip(template.dims, template.chunks)  # type: ignore[arg-type]
+            )
         else:
             output_chunks = dict(template.chunks)
 
@@ -497,8 +499,8 @@ def map_blocks(
         expected["shapes"] = {
             k: output_chunks[k][v] for k, v in chunk_index.items() if k in output_chunks
         }
-        expected["data_vars"] = set(template.data_vars.keys())  # type: ignore
-        expected["coords"] = set(template.coords.keys())  # type: ignore
+        expected["data_vars"] = set(template.data_vars.keys())  # type: ignore[assignment]
+        expected["coords"] = set(template.coords.keys())  # type: ignore[assignment]
         expected["indexes"] = {
             dim: indexes[dim][_get_chunk_slicer(dim, chunk_index, output_chunk_bounds)]
             for dim in indexes
@@ -571,5 +573,5 @@ def map_blocks(
     if result_is_array:
         da = dataset_to_dataarray(result)
         da.name = template_name
-        return da  # type: ignore
-    return result  # type: ignore
+        return da  # type: ignore[return-value]
+    return result  # type: ignore[return-value]

--- a/xarray/core/pdcompat.py
+++ b/xarray/core/pdcompat.py
@@ -46,7 +46,7 @@ if LooseVersion(pd.__version__) < "0.25.0":
     Panel = pd.Panel
 else:
 
-    class Panel:  # type: ignore
+    class Panel:  # type: ignore[no-redef]
         pass
 
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -111,7 +111,9 @@ class Rolling:
     def __len__(self):
         return self.obj.sizes[self.dim]
 
-    def _reduce_method(name: str, fillna, rolling_agg_func: Callable = None) -> Callable:  # type: ignore
+    def _reduce_method(  # type: ignore[misc]
+        name: str, fillna, rolling_agg_func: Callable = None
+    ) -> Callable:
         """Constructs reduction methods built on a numpy reduction function (e.g. sum),
         a bottleneck reduction function (e.g. move_sum), or a Rolling reduction (_mean)."""
         if rolling_agg_func:

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -503,7 +503,7 @@ class SortedKeysDict(MutableMapping[K, V]):
 
     def __iter__(self) -> Iterator[K]:
         # see #4571 for the reason of the type ignore
-        return iter(sorted(self.mapping))  # type: ignore
+        return iter(sorted(self.mapping))  # type: ignore[type-var]
 
     def __len__(self) -> int:
         return len(self.mapping)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -60,7 +60,7 @@ NON_NUMPY_SUPPORTED_ARRAY_TYPES = (
     + cupy_array_type
 )
 # https://github.com/python/mypy/issues/224
-BASIC_INDEXING_TYPES = integer_types + (slice,)  # type: ignore
+BASIC_INDEXING_TYPES = integer_types + (slice,)
 
 VariableType = TypeVar("VariableType", bound="Variable")
 """Type annotation to be used when methods of Variable return self or a copy of self.
@@ -999,7 +999,7 @@ class Variable(
 
     # mutable objects should not be hashable
     # https://github.com/python/mypy/issues/4266
-    __hash__ = None  # type: ignore
+    __hash__ = None  # type: ignore[assignment]
 
     @property
     def chunks(self):
@@ -1317,7 +1317,7 @@ class Variable(
 
         # workaround for bug in Dask's default value of stat_length https://github.com/dask/dask/issues/5303
         if stat_length is None and mode in ["maximum", "mean", "median", "minimum"]:
-            stat_length = [(n, n) for n in self.data.shape]  # type: ignore
+            stat_length = [(n, n) for n in self.data.shape]  # type: ignore[assignment]
 
         # change integer values to a tuple of two of those values and change pad_width to index
         for k, v in pad_width.items():
@@ -1334,7 +1334,7 @@ class Variable(
         if end_values is not None:
             pad_option_kwargs["end_values"] = end_values
         if reflect_type is not None:
-            pad_option_kwargs["reflect_type"] = reflect_type  # type: ignore
+            pad_option_kwargs["reflect_type"] = reflect_type  # type: ignore[assignment]
 
         array = duck_array_ops.pad(
             self.data.astype(dtype, copy=False),
@@ -2541,14 +2541,14 @@ class IndexVariable(Variable):
         return self
 
     # https://github.com/python/mypy/issues/1465
-    @Variable.data.setter  # type: ignore
+    @Variable.data.setter  # type: ignore[attr-defined]
     def data(self, data):
         raise ValueError(
             f"Cannot assign to the .data attribute of dimension coordinate a.k.a IndexVariable {self.name!r}. "
             f"Please use DataArray.assign_coords, Dataset.assign_coords or Dataset.assign as appropriate."
         )
 
-    @Variable.values.setter  # type: ignore
+    @Variable.values.setter  # type: ignore[attr-defined]
     def values(self, values):
         raise ValueError(
             f"Cannot assign to the .values attribute of dimension coordinate a.k.a IndexVariable {self.name!r}. "

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -447,7 +447,7 @@ class _PlotMethods:
 
     # we can't use functools.wraps here since that also modifies the name / qualname
     __doc__ = __call__.__doc__ = plot.__doc__
-    __call__.__wrapped__ = plot  # type: ignore
+    __call__.__wrapped__ = plot  # type: ignore[attr-defined]
     __call__.__annotations__ = plot.__annotations__
 
     @functools.wraps(hist)

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -479,7 +479,7 @@ def test_minus_offset(a, b):
 
 @pytest.mark.parametrize(
     ("a", "b"),
-    list(zip(np.roll(_EQ_TESTS_A, 1), _EQ_TESTS_B))  # type: ignore
+    list(zip(np.roll(_EQ_TESTS_A, 1), _EQ_TESTS_B))  # type: ignore[arg-type]
     + [(YearEnd(month=1), YearEnd(month=2))],
     ids=_id_func,
 )

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -438,7 +438,7 @@ def test_groupby(da):
 
 SEL_STRING_OR_LIST_TESTS = {
     "string": "0001",
-    "string-slice": slice("0001-01-01", "0001-12-30"),  # type: ignore
+    "string-slice": slice("0001-01-01", "0001-12-30"),
     "bool-list": [True, True, False, False],
 }
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -40,9 +40,9 @@ except ImportError:
     pass
 
 try:
-    import cartopy as ctpy  # type: ignore
+    import cartopy
 except ImportError:
-    ctpy = None
+    pass
 
 
 @contextlib.contextmanager
@@ -2650,7 +2650,7 @@ def test_get_axis():
 @requires_cartopy
 def test_get_axis_cartopy():
 
-    kwargs = {"projection": ctpy.crs.PlateCarree()}
+    kwargs = {"projection": cartopy.crs.PlateCarree()}
     with figure_context():
         ax = get_axis(**kwargs)
-        assert isinstance(ax, ctpy.mpl.geoaxes.GeoAxesSubplot)
+        assert isinstance(ax, cartopy.mpl.geoaxes.GeoAxesSubplot)

--- a/xarray/tests/test_testing.py
+++ b/xarray/tests/test_testing.py
@@ -143,7 +143,7 @@ def test_ensure_warnings_not_elevated(func):
 
     # define a custom Variable class that raises a warning in assert_*
     class WarningVariable(xr.Variable):
-        @property  # type: ignore
+        @property  # type: ignore[misc]
         def dims(self):
             warnings.warn("warning in test")
             return super().dims


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Adds error codes to all `# type: ignore` comments. mypy should raise if a different type of error is encountered. Also enable showing the error code for typing errors. See: [mypy: displaying-error-codes](https://mypy.readthedocs.io/en/stable/error_codes.html#displaying-error-codes). Also remove some `# type: ignore` that are no longer necessary.