### PR TITLE
Tweaked Dataset.plot docs to better describe quiver

### DIFF
--- a/xarray/plot/dataset_plot.py
+++ b/xarray/plot/dataset_plot.py
@@ -198,15 +198,19 @@ def _dsplot(plotfunc):
     x, y : str
         Variable names for x, y axis.
     u, v : str, optional
-        Variable names for quiver or streamplot plots
+        Variable names for quiver or streamplot plots only
     hue: str, optional
-        Variable by which to color scattered points
+        Variable by which to color scattered points or arrows
     hue_style: str, optional
         Can be either 'discrete' (legend) or 'continuous' (color bar).
     markersize: str, optional
         scatter only. Variable by which to vary size of scattered points.
     size_norm: optional
         Either None or 'Norm' instance to normalize the 'markersize' variable.
+    scale: scalar, optional
+        Quiver only. Number of data units per arrow length unit. 
+        Use this to control the length of the arrows: larger values lead to 
+        smaller arrows
     add_guide: bool, optional
         Add a guide that depends on hue_style
             - for "discrete", build a legend.
@@ -245,12 +249,11 @@ def _dsplot(plotfunc):
         be either ``viridis`` (if the function infers a sequential
         dataset) or ``RdBu_r`` (if the function infers a diverging
         dataset).  When `Seaborn` is installed, ``cmap`` may also be a
-        `seaborn` color palette. If ``cmap`` is seaborn color palette
-        and the plot type is not ``contour`` or ``contourf``, ``levels``
-        must also be specified.
+        `seaborn` color palette. If ``cmap`` is seaborn color palette,
+         ``levels`` must also be specified.
     colors : color-like or list of color-like, optional
-        A single color or a list of colors. If the plot type is not ``contour``
-        or ``contourf``, the ``levels`` argument is required.
+        A single color or a list of colors. The ``levels`` argument 
+        is required.
     center : float, optional
         The value at which to center the colormap. Passing this value implies
         use of a diverging colormap. Setting it to ``False`` prevents use of a

--- a/xarray/plot/dataset_plot.py
+++ b/xarray/plot/dataset_plot.py
@@ -208,8 +208,8 @@ def _dsplot(plotfunc):
     size_norm: optional
         Either None or 'Norm' instance to normalize the 'markersize' variable.
     scale: scalar, optional
-        Quiver only. Number of data units per arrow length unit. 
-        Use this to control the length of the arrows: larger values lead to 
+        Quiver only. Number of data units per arrow length unit.
+        Use this to control the length of the arrows: larger values lead to
         smaller arrows
     add_guide: bool, optional
         Add a guide that depends on hue_style
@@ -252,7 +252,7 @@ def _dsplot(plotfunc):
         `seaborn` color palette. If ``cmap`` is seaborn color palette,
          ``levels`` must also be specified.
     colors : color-like or list of color-like, optional
-        A single color or a list of colors. The ``levels`` argument 
+        A single color or a list of colors. The ``levels`` argument
         is required.
     center : float, optional
         The value at which to center the colormap. Passing this value implies

--- a/xarray/plot/dataset_plot.py
+++ b/xarray/plot/dataset_plot.py
@@ -250,7 +250,7 @@ def _dsplot(plotfunc):
         dataset) or ``RdBu_r`` (if the function infers a diverging
         dataset).  When `Seaborn` is installed, ``cmap`` may also be a
         `seaborn` color palette. If ``cmap`` is seaborn color palette,
-         ``levels`` must also be specified.
+        ``levels`` must also be specified.
     colors : color-like or list of color-like, optional
         A single color or a list of colors. The ``levels`` argument
         is required.


### PR DESCRIPTION
Based on issue #5002, I did a few tweaks to make it clearer which parts of the generated documentation apply to `quiver`, and which apply to `scatter`. I also removed references to `contourf` because that is now documented in a separate location. 
