### PR TITLE
Flexible indexes: add and use IndexAdapter base class

### DIFF
--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -64,6 +64,10 @@ def _infer_concat_order_from_coords(datasets):
                     "inferring concatenation order"
                 )
 
+            # TODO (benbovy, flexible indexes): all indexes should be Pandas.Index
+            # get pd.Index objects from IndexAdapter objects
+            indexes = [index.array for index in indexes]
+
             # If dimension coordinate values are same on every dataset then
             # should be leaving this dimension alone (it's just a "bystander")
             if not all(index.equals(indexes[0]) for index in indexes[1:]):
@@ -786,9 +790,13 @@ def combine_by_coords(
         )
 
         # Check the overall coordinates are monotonically increasing
+        # TODO (benbovy - flexible indexes): only with pandas.Index?
         for dim in concat_dims:
             indexes = concatenated.indexes.get(dim)
-            if not (indexes.is_monotonic_increasing or indexes.is_monotonic_decreasing):
+            if not (
+                indexes.array.is_monotonic_increasing
+                or indexes.array.is_monotonic_decreasing
+            ):
                 raise ValueError(
                     "Resulting object does not have monotonic"
                     " global indexes along dimension {}".format(dim)

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -386,7 +386,7 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
             raise KeyError(key)
 
         try:
-            return self.indexes[key]
+            return self.indexes[key].array
         except KeyError:
             return pd.Index(range(self.sizes[key]), name=key)
 
@@ -1140,7 +1140,8 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
                 category=FutureWarning,
             )
 
-            if isinstance(self.indexes[dim_name], CFTimeIndex):
+            # TODO (benbovy - flexible indexes): update when CFTimeIndex is an IndexAdpater subclass
+            if isinstance(self.indexes[dim_name].array, CFTimeIndex):
                 from .resample_cftime import CFTimeGrouper
 
                 grouper = CFTimeGrouper(freq, closed, label, base, loffset)

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -17,7 +17,7 @@ import numpy as np
 import pandas as pd
 
 from . import formatting, indexing
-from .indexes import Indexes
+from .indexes import IndexAdapter, Indexes
 from .merge import merge_coordinates_without_align, merge_coords
 from .utils import Frozen, ReprObject, either_dict_or_kwargs
 from .variable import Variable
@@ -262,7 +262,7 @@ class DatasetCoordinates(Coordinates):
         return self._data._copy_listed(names)
 
     def _update_coords(
-        self, coords: Dict[Hashable, Variable], indexes: Mapping[Hashable, pd.Index]
+        self, coords: Dict[Hashable, Variable], indexes: Mapping[Hashable, IndexAdapter]
     ) -> None:
         from .dataset import calculate_dimensions
 
@@ -325,7 +325,7 @@ class DataArrayCoordinates(Coordinates):
         return self._data._getitem_coord(key)
 
     def _update_coords(
-        self, coords: Dict[Hashable, Variable], indexes: Mapping[Hashable, pd.Index]
+        self, coords: Dict[Hashable, Variable], indexes: Mapping[Hashable, IndexAdapter]
     ) -> None:
         from .dataset import calculate_dimensions
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -51,7 +51,13 @@ from .coordinates import (
 )
 from .dataset import Dataset, split_indexes
 from .formatting import format_item
-from .indexes import Indexes, default_indexes, propagate_indexes
+from .indexes import (
+    IndexAdapter,
+    Indexes,
+    PandasIndexAdapter,
+    default_indexes,
+    propagate_indexes,
+)
 from .indexing import is_fancy_indexer
 from .merge import PANDAS_TYPES, MergeError, _extract_indexes_from_coords
 from .options import OPTIONS, _get_keep_attrs
@@ -345,7 +351,7 @@ class DataArray(AbstractArray, DataWithCoords):
     _cache: Dict[str, Any]
     _coords: Dict[Any, Variable]
     _close: Optional[Callable[[], None]]
-    _indexes: Optional[Dict[Hashable, pd.Index]]
+    _indexes: Optional[Dict[Hashable, IndexAdapter]]
     _name: Optional[Hashable]
     _variable: Variable
 
@@ -990,7 +996,10 @@ class DataArray(AbstractArray, DataWithCoords):
         if self._indexes is None:
             indexes = self._indexes
         else:
-            indexes = {k: v.copy(deep=deep) for k, v in self._indexes.items()}
+            indexes = {
+                k: PandasIndexAdapter(v.array.copy(deep=deep))
+                for k, v in self._indexes.items()
+            }
         return self._replace(variable, coords, indexes=indexes)
 
     def __copy__(self) -> "DataArray":

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -108,6 +108,8 @@ def convert_label_indexer(index, label, index_name="", method=None, tolerance=No
     dimension. If `index` is a pandas.MultiIndex and depending on `label`,
     return a new pandas.Index or pandas.MultiIndex (otherwise return None).
     """
+    from .indexes import PandasIndexAdapter
+
     new_index = None
 
     if isinstance(label, slice):
@@ -197,6 +199,10 @@ def convert_label_indexer(index, label, index_name="", method=None, tolerance=No
             indexer = get_indexer_nd(index, label, method, tolerance)
             if np.any(indexer < 0):
                 raise KeyError(f"not all values found in index {index_name!r}")
+
+    if new_index is not None:
+        new_index = PandasIndexAdapter(new_index)
+
     return indexer, new_index
 
 
@@ -251,7 +257,7 @@ def remap_label_indexers(data_obj, indexers, method=None, tolerance=None):
     dim_indexers = get_dim_indexers(data_obj, indexers)
     for dim, label in dim_indexers.items():
         try:
-            index = data_obj.indexes[dim]
+            index = data_obj.indexes[dim].array
         except KeyError:
             # no index for this dimension: reuse the provided labels
             if method is not None or tolerance is not None:

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -2,15 +2,12 @@ import enum
 import functools
 import operator
 from collections import defaultdict
-from contextlib import suppress
-from datetime import timedelta
 from typing import Any, Callable, Iterable, List, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
 
 from . import duck_array_ops, nputils, utils
-from .npcompat import DTypeLike
 from .pycompat import (
     dask_array_type,
     integer_types,
@@ -714,6 +711,8 @@ def as_indexable(array):
     if isinstance(array, np.ndarray):
         return NumpyIndexingAdapter(array)
     if isinstance(array, pd.Index):
+        from .indexes import PandasIndexAdapter
+
         return PandasIndexAdapter(array)
     if isinstance(array, dask_array_type):
         return DaskIndexingAdapter(array)
@@ -1386,101 +1385,3 @@ class DaskIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
 
     def transpose(self, order):
         return self.array.transpose(order)
-
-
-class PandasIndexAdapter(ExplicitlyIndexedNDArrayMixin):
-    """Wrap a pandas.Index to preserve dtypes and handle explicit indexing."""
-
-    __slots__ = ("array", "_dtype")
-
-    def __init__(self, array: Any, dtype: DTypeLike = None):
-        self.array = utils.safe_cast_to_index(array)
-        if dtype is None:
-            if isinstance(array, pd.PeriodIndex):
-                dtype_ = np.dtype("O")
-            elif hasattr(array, "categories"):
-                # category isn't a real numpy dtype
-                dtype_ = array.categories.dtype
-            elif not utils.is_valid_numpy_dtype(array.dtype):
-                dtype_ = np.dtype("O")
-            else:
-                dtype_ = array.dtype
-        else:
-            dtype_ = np.dtype(dtype)
-        self._dtype = dtype_
-
-    @property
-    def dtype(self) -> np.dtype:
-        return self._dtype
-
-    def __array__(self, dtype: DTypeLike = None) -> np.ndarray:
-        if dtype is None:
-            dtype = self.dtype
-        array = self.array
-        if isinstance(array, pd.PeriodIndex):
-            with suppress(AttributeError):
-                # this might not be public API
-                array = array.astype("object")
-        return np.asarray(array.values, dtype=dtype)
-
-    @property
-    def shape(self) -> Tuple[int]:
-        return (len(self.array),)
-
-    def __getitem__(
-        self, indexer
-    ) -> Union[NumpyIndexingAdapter, np.ndarray, np.datetime64, np.timedelta64]:
-        key = indexer.tuple
-        if isinstance(key, tuple) and len(key) == 1:
-            # unpack key so it can index a pandas.Index object (pandas.Index
-            # objects don't like tuples)
-            (key,) = key
-
-        if getattr(key, "ndim", 0) > 1:  # Return np-array if multidimensional
-            return NumpyIndexingAdapter(self.array.values)[indexer]
-
-        result = self.array[key]
-
-        if isinstance(result, pd.Index):
-            result = PandasIndexAdapter(result, dtype=self.dtype)
-        else:
-            # result is a scalar
-            if result is pd.NaT:
-                # work around the impossibility of casting NaT with asarray
-                # note: it probably would be better in general to return
-                # pd.Timestamp rather np.than datetime64 but this is easier
-                # (for now)
-                result = np.datetime64("NaT", "ns")
-            elif isinstance(result, timedelta):
-                result = np.timedelta64(getattr(result, "value", result), "ns")
-            elif isinstance(result, pd.Timestamp):
-                # Work around for GH: pydata/xarray#1932 and numpy/numpy#10668
-                # numpy fails to convert pd.Timestamp to np.datetime64[ns]
-                result = np.asarray(result.to_datetime64())
-            elif self.dtype != object:
-                result = np.asarray(result, dtype=self.dtype)
-
-            # as for numpy.ndarray indexing, we always want the result to be
-            # a NumPy array.
-            result = utils.to_0d_array(result)
-
-        return result
-
-    def transpose(self, order) -> pd.Index:
-        return self.array  # self.array should be always one-dimensional
-
-    def __repr__(self) -> str:
-        return "{}(array={!r}, dtype={!r})".format(
-            type(self).__name__, self.array, self.dtype
-        )
-
-    def copy(self, deep: bool = True) -> "PandasIndexAdapter":
-        # Not the same as just writing `self.array.copy(deep=deep)`, as
-        # shallow copies of the underlying numpy.ndarrays become deep ones
-        # upon pickling
-        # >>> len(pickle.dumps((self.array, self.array)))
-        # 4000281
-        # >>> len(pickle.dumps((self.array, self.array.copy(deep=False))))
-        # 8000341
-        array = self.array.copy(deep=True) if deep else self.array
-        return PandasIndexAdapter(array, self._dtype)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -25,13 +25,8 @@ import pandas as pd
 import xarray as xr  # only for Dataset and DataArray
 
 from . import arithmetic, common, dtypes, duck_array_ops, indexing, nputils, ops, utils
-from .indexing import (
-    BasicIndexer,
-    OuterIndexer,
-    PandasIndexAdapter,
-    VectorizedIndexer,
-    as_indexable,
-)
+from .indexes import PandasIndexAdapter
+from .indexing import BasicIndexer, OuterIndexer, VectorizedIndexer, as_indexable
 from .options import _get_keep_attrs
 from .pycompat import (
     cupy_array_type,

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -551,6 +551,11 @@ class Variable(
 
     to_coord = utils.alias(to_index_variable, "to_coord")
 
+    def _to_index_adpater(self):
+        # temporary function used internally as a replacement of to_index()
+        # returns an IndexAdpater instance instead of a pd.Index instance
+        return PandasIndexAdapter(self.to_index())
+
     def to_index(self):
         """Convert this variable to a pandas.Index"""
         return self.to_index_variable().to_index()

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -4,12 +4,11 @@ import warnings
 from typing import Hashable, Set, Union
 
 import numpy as np
-import pandas as pd
 
 from xarray.core import duck_array_ops, formatting, utils
 from xarray.core.dataarray import DataArray
 from xarray.core.dataset import Dataset
-from xarray.core.indexes import default_indexes
+from xarray.core.indexes import IndexAdapter, default_indexes
 from xarray.core.variable import IndexVariable, Variable
 
 __all__ = (
@@ -254,7 +253,7 @@ def assert_chunks_equal(a, b):
 
 def _assert_indexes_invariants_checks(indexes, possible_coord_variables, dims):
     assert isinstance(indexes, dict), indexes
-    assert all(isinstance(v, pd.Index) for v in indexes.values()), {
+    assert all(isinstance(v, IndexAdapter) for v in indexes.values()), {
         k: type(v) for k, v in indexes.items()
     }
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -35,7 +35,7 @@ from xarray.backends.netCDF4_ import _extract_nc4_variable_encoding
 from xarray.backends.pydap_ import PydapDataStore
 from xarray.coding.variables import SerializationWarning
 from xarray.conventions import encode_dataset_coordinates
-from xarray.core import indexing
+from xarray.core import indexes, indexing
 from xarray.core.options import set_options
 from xarray.core.pycompat import dask_array_type
 from xarray.tests import LooseVersion, mock
@@ -736,7 +736,7 @@ class DatasetIOBase:
                     elif isinstance(obj.array, dask_array_type):
                         assert isinstance(obj, indexing.DaskIndexingAdapter)
                     elif isinstance(obj.array, pd.Index):
-                        assert isinstance(obj, indexing.PandasIndexAdapter)
+                        assert isinstance(obj, indexes.PandasIndexAdapter)
                     else:
                         raise TypeError(
                             "{} is wrapped by {}".format(type(obj.array), type(obj))

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -696,7 +696,7 @@ def test_concat_cftimeindex(date_type):
     )
     da = xr.concat([da1, da2], dim="time")
 
-    assert isinstance(da.indexes["time"], CFTimeIndex)
+    assert isinstance(da.indexes["time"].array, CFTimeIndex)
 
 
 @requires_cftime

--- a/xarray/tests/test_cftimeindex_resample.py
+++ b/xarray/tests/test_cftimeindex_resample.py
@@ -99,7 +99,8 @@ def test_resample(freqs, closed, label, base):
             )
             .mean()
         )
-        da_cftime["time"] = da_cftime.indexes["time"].to_datetimeindex()
+        # TODO (benbovy - flexible indexes): update when CFTimeIndex is a IndexAdpater subclass
+        da_cftime["time"] = da_cftime.indexes["time"].array.to_datetimeindex()
         xr.testing.assert_identical(da_cftime, da_datetime)
 
 
@@ -145,5 +146,6 @@ def test_calendars(calendar):
         .resample(time=freq, closed=closed, label=label, base=base, loffset=loffset)
         .mean()
     )
-    da_cftime["time"] = da_cftime.indexes["time"].to_datetimeindex()
+    # TODO (benbovy - flexible indexes): update when CFTimeIndex is a IndexAdpater subclass
+    da_cftime["time"] = da_cftime.indexes["time"].array.to_datetimeindex()
     xr.testing.assert_identical(da_cftime, da_datetime)

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -517,7 +517,7 @@ class TestConcatDataArray:
         stacked = concat(grouped, ds["x"])
         assert_identical(foo, stacked)
         # with an index as the 'dim' argument
-        stacked = concat(grouped, ds.indexes["x"])
+        stacked = concat(grouped, pd.Index(ds["x"], name="x"))
         assert_identical(foo, stacked)
 
         actual = concat([foo[0], foo[1]], pd.Index([0, 1])).reset_coords(drop=True)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1630,7 +1630,7 @@ class TestDataArray:
         assert_identical(expected, actual)
         for dim_name in set().union(expected.indexes.keys(), actual.indexes.keys()):
             pd.testing.assert_index_equal(
-                expected.indexes[dim_name], actual.indexes[dim_name]
+                expected.indexes[dim_name].array, actual.indexes[dim_name].array
             )
 
         array = DataArray(np.random.randn(3), {"x": list("abc")}, "x")
@@ -1660,7 +1660,7 @@ class TestDataArray:
         assert_identical(expected, actual)
         for dim_name in set().union(expected.indexes.keys(), actual.indexes.keys()):
             pd.testing.assert_index_equal(
-                expected.indexes[dim_name], actual.indexes[dim_name]
+                expected.indexes[dim_name].array, actual.indexes[dim_name].array
             )
 
     def test_expand_dims_error(self):

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -11,6 +11,7 @@ import pytz
 from xarray import Coordinate, DataArray, Dataset, IndexVariable, Variable, set_options
 from xarray.core import dtypes, duck_array_ops, indexing
 from xarray.core.common import full_like, ones_like, zeros_like
+from xarray.core.indexes import PandasIndexAdapter
 from xarray.core.indexing import (
     BasicIndexer,
     CopyOnWriteArray,
@@ -19,7 +20,6 @@ from xarray.core.indexing import (
     MemoryCachedArray,
     NumpyIndexingAdapter,
     OuterIndexer,
-    PandasIndexAdapter,
     VectorizedIndexer,
 )
 from xarray.core.pycompat import dask_array_type


### PR DESCRIPTION
This PR clears up the path for flexible indexes:

- it adds a new `IndexAdapter` base class that is meant to be inherited by all xarray-compatible indexes (built-in or custom)
- `PandasIndexAdapter` now inherits from `IndexAdapter`
- the `xarray_obj.indexes` property now returns `IndexAdapter` (`PandasIndexAdapter`) instances instead of `pandas.Index` instances

The latter is a breaking change, although I'm not sure if the `indexes` property has been made public yet.

This is still work in progress, there are many broken tests that are not fixed yet.

There's a lot of dirty fixes to avoid circular dependencies and in the many places where we still need direct access to the `pandas.Index` objects, but I'd expect that these will be cleaned-up further in the refactoring.