### PR TITLE
Do not write an empty "coordinates" attribute to a netCDF file

### DIFF
--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -761,7 +761,7 @@ def _encode_coordinates(variables, attributes, non_dim_coord_names):
                 for coord_name in variable_coordinates[name]
                 if coord_name not in not_technically_coordinates
             )
-            if len(coordinates_text) > 0:
+            if coordinates_text:
                 attrs["coordinates"] = coordinates_text
         if "coordinates" in attrs:
             written_coords.update(attrs["coordinates"].split())

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -761,8 +761,8 @@ def _encode_coordinates(variables, attributes, non_dim_coord_names):
                 for coord_name in variable_coordinates[name]
                 if coord_name not in not_technically_coordinates
             )
-        if "coordinates" in attrs and len(attrs.get("coordinates")) == 0:
-            attrs.pop("coordinates")
+            if "coordinates" in attrs and len(attrs.get("coordinates")) == 0:
+                attrs.pop("coordinates")
         if "coordinates" in attrs:
             written_coords.update(attrs["coordinates"].split())
 

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -761,6 +761,8 @@ def _encode_coordinates(variables, attributes, non_dim_coord_names):
                 for coord_name in variable_coordinates[name]
                 if coord_name not in not_technically_coordinates
             )
+        if "coordinates" in attrs and len(attrs.get("coordinates")) == 0:
+            attrs.pop("coordinates")
         if "coordinates" in attrs:
             written_coords.update(attrs["coordinates"].split())
 

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -756,13 +756,13 @@ def _encode_coordinates(variables, attributes, non_dim_coord_names):
         # we get support for attrs["coordinates"] for free.
         coords_str = pop_to(encoding, attrs, "coordinates")
         if not coords_str and variable_coordinates[name]:
-            attrs["coordinates"] = " ".join(
+            coordinates_text = " ".join(
                 str(coord_name)
                 for coord_name in variable_coordinates[name]
                 if coord_name not in not_technically_coordinates
             )
-            if "coordinates" in attrs and len(attrs.get("coordinates")) == 0:
-                attrs.pop("coordinates")
+            if len(coordinates_text) > 0:
+                attrs["coordinates"] = coordinates_text
         if "coordinates" in attrs:
             written_coords.update(attrs["coordinates"].split())
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -920,7 +920,7 @@ class CFEncodedBase(DatasetIOBase):
             with open_dataset(tmp_file, decode_coords=False) as ds:
                 assert ds.coords["latitude"].attrs["bounds"] == "latitude_bnds"
                 assert ds.coords["longitude"].attrs["bounds"] == "longitude_bnds"
-                assert "latlon" not in ds["variable"].attrs["coordinates"]
+                assert "coordinates" not in ds["variable"].attrs
                 assert "coordinates" not in ds.attrs
 
     def test_coordinate_variables_after_dataset_roundtrip(self):


### PR DESCRIPTION
- [x] No issue, trivial cleanup
- [x] Tests modified to match

The behaviour is not too problematic as CF checkers don't complain about the empty string, but it is aesthetically annoying.

This happens more frequently after #2844 added the auxiliary variable to `.coords`.