### PR TITLE
Simplify the user experience of a backend developer (imports and docs)

### DIFF
--- a/doc/internals/how-to-add-new-backend.rst
+++ b/doc/internals/how-to-add-new-backend.rst
@@ -269,7 +269,7 @@ in ``setup.cfg``:
 See https://packaging.python.org/specifications/entry-points/#data-model
 for more information
 
-If you are using [Poetry](https://python-poetry.org/) for your build system, you can accomplish the same thing using "plugins". In this case you would need to add the following to your ``pyproject.toml`` file:
+If you are using `Poetry <https://python-poetry.org/>`_ for your build system, you can accomplish the same thing using "plugins". In this case you would need to add the following to your ``pyproject.toml`` file:
 
 .. code-block:: toml
 

--- a/doc/internals/how-to-add-new-backend.rst
+++ b/doc/internals/how-to-add-new-backend.rst
@@ -34,6 +34,7 @@ This is what a ``BackendEntrypoint`` subclass should look like:
 
     from xarray.backends import BackendEntrypoint
 
+
     class MyBackendEntrypoint(BackendEntrypoint):
         def open_dataset(
             self,
@@ -252,9 +253,7 @@ You can declare the entrypoint in ``setup.py`` using the following syntax:
 
     setuptools.setup(
         entry_points={
-            "xarray.backends": [
-                "my_engine=my_package.my_module:MyBackendEntryClass"
-            ],
+            "xarray.backends": ["my_engine=my_package.my_module:MyBackendEntryClass"],
         },
     )
 
@@ -330,6 +329,7 @@ This is an example ``BackendArray`` subclass implementation:
 .. code-block:: python
 
     from xarray.backends import BackendArray
+
 
     class MyBackendArray(BackendArray):
         def __init__(

--- a/xarray/backends/__init__.py
+++ b/xarray/backends/__init__.py
@@ -4,7 +4,7 @@ DataStores provide a uniform interface for saving and loading data in different
 formats. They should not be used directly, but rather through Dataset objects.
 """
 from .cfgrib_ import CfGribDataStore
-from .common import AbstractDataStore
+from .common import AbstractDataStore, BackendArray, BackendEntrypoint
 from .file_manager import CachingFileManager, DummyFileManager, FileManager
 from .h5netcdf_ import H5NetCDFStore
 from .memory import InMemoryDataStore
@@ -18,6 +18,8 @@ from .zarr import ZarrStore
 
 __all__ = [
     "AbstractDataStore",
+    "BackendArray",
+    "BackendEntrypoint",
     "FileManager",
     "CachingFileManager",
     "CfGribDataStore",


### PR DESCRIPTION
- [x] Proposed fix for #5125
- [x] No need to add tests
- [x] Passes `pre-commit run --all-files`
- [x] Documentation is synced

This is mostly a stylistic revamp of the documentation on "How to add a new backend" after I followed the process a couple of times:
* add import statments
* use always `my_*`/`My` (there where some `your_`)
* avoid ellipsis

The main code change is adding references to `BackendEntrypoint` and `BackendArray` in `xarray.backends`.