### PR TITLE
Fix open_dataset regression

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -28,7 +28,7 @@ from ..core.dataarray import DataArray
 from ..core.dataset import Dataset, _get_chunk, _maybe_chunk
 from ..core.utils import is_remote_uri
 from . import plugins
-from .common import AbstractDataStore, ArrayWriter
+from .common import AbstractDataStore, ArrayWriter, _normalize_path
 from .locks import _get_scheduler
 
 if TYPE_CHECKING:
@@ -107,16 +107,6 @@ def _get_default_engine(path: str, allow_remote: bool = False):
     else:
         engine = _get_default_engine_netcdf()
     return engine
-
-
-def _normalize_path(path):
-    if isinstance(path, Path):
-        path = str(path)
-
-    if isinstance(path, str) and not is_remote_uri(path):
-        path = os.path.abspath(os.path.expanduser(path))
-
-    return path
 
 
 def _validate_dataset_names(dataset):

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -120,6 +120,7 @@ class CfgribfBackendEntrypoint(BackendEntrypoint):
         time_dims=("time", "step"),
     ):
 
+        filename_or_obj = os.path.expanduser(filename_or_obj)
         store = CfGribDataStore(
             filename_or_obj,
             indexpath=indexpath,

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -3,6 +3,7 @@ import warnings
 
 import numpy as np
 
+from .api import _normalize_path
 from ..core import indexing
 from ..core.utils import Frozen, FrozenDict, close_on_error
 from ..core.variable import Variable
@@ -120,7 +121,7 @@ class CfgribfBackendEntrypoint(BackendEntrypoint):
         time_dims=("time", "step"),
     ):
 
-        filename_or_obj = os.path.expanduser(filename_or_obj)
+        filename_or_obj = _normalize_path(filename_or_obj)
         store = CfGribDataStore(
             filename_or_obj,
             indexpath=indexpath,

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -3,7 +3,7 @@ import warnings
 
 import numpy as np
 
-from .api import _normalize_path
+from .common import _normalize_path
 from ..core import indexing
 from ..core.utils import Frozen, FrozenDict, close_on_error
 from ..core.variable import Variable

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -3,7 +3,6 @@ import warnings
 
 import numpy as np
 
-from .common import _normalize_path
 from ..core import indexing
 from ..core.utils import Frozen, FrozenDict, close_on_error
 from ..core.variable import Variable
@@ -12,6 +11,7 @@ from .common import (
     AbstractDataStore,
     BackendArray,
     BackendEntrypoint,
+    _normalize_path,
 )
 from .locks import SerializableLock, ensure_lock
 from .store import StoreBackendEntrypoint

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -1,8 +1,8 @@
-import os
 import logging
-from pathlib import Path
+import os
 import time
 import traceback
+from pathlib import Path
 from typing import Any, Dict, Tuple, Type, Union
 
 import numpy as np

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -1,4 +1,6 @@
+import os
 import logging
+from pathlib import Path
 import time
 import traceback
 from typing import Any, Dict, Tuple, Type, Union
@@ -8,13 +10,23 @@ import numpy as np
 from ..conventions import cf_encoder
 from ..core import indexing
 from ..core.pycompat import is_duck_dask_array
-from ..core.utils import FrozenDict, NdimSizeLenMixin
+from ..core.utils import FrozenDict, NdimSizeLenMixin, is_remote_uri
 
 # Create a logger object, but don't add any handlers. Leave that to user code.
 logger = logging.getLogger(__name__)
 
 
 NONE_VAR_NAME = "__values__"
+
+
+def _normalize_path(path):
+    if isinstance(path, Path):
+        path = str(path)
+
+    if isinstance(path, str) and not is_remote_uri(path):
+        path = os.path.abspath(os.path.expanduser(path))
+
+    return path
 
 
 def _encode_variable_name(name):

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -1,5 +1,5 @@
 import logging
-import os
+import os.path
 import time
 import traceback
 from pathlib import Path

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -5,7 +5,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
-from .api import _normalize_path
+from .common import _normalize_path
 from ..core import indexing
 from ..core.utils import FrozenDict, is_remote_uri, read_magic_number
 from ..core.variable import Variable

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -5,7 +5,6 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
-from .common import _normalize_path
 from ..core import indexing
 from ..core.utils import FrozenDict, is_remote_uri, read_magic_number
 from ..core.variable import Variable
@@ -13,6 +12,7 @@ from .common import (
     BACKEND_ENTRYPOINTS,
     BackendEntrypoint,
     WritableCFDataStore,
+    _normalize_path,
     find_root_and_group,
 )
 from .file_manager import CachingFileManager, DummyFileManager

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -5,6 +5,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
+from .api import _normalize_path
 from ..core import indexing
 from ..core.utils import FrozenDict, is_remote_uri, read_magic_number
 from ..core.variable import Variable
@@ -366,8 +367,7 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         decode_vlen_strings=True,
     ):
 
-        if isinstance(filename_or_obj, str):
-            filename_or_obj = os.path.expanduser(filename_or_obj)
+        filename_or_obj = _normalize_path(filename_or_obj)
         store = H5NetCDFStore.open(
             filename_or_obj,
             format=format,

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -366,6 +366,8 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         decode_vlen_strings=True,
     ):
 
+        if isinstance(filename_or_obj, str):
+            filename_or_obj = os.path.expanduser(filename_or_obj)
         store = H5NetCDFStore.open(
             filename_or_obj,
             format=format,

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -15,6 +15,7 @@ from .common import (
     BACKEND_ENTRYPOINTS,
     BackendArray,
     BackendEntrypoint,
+    _normalize_path,
     WritableCFDataStore,
     find_root_and_group,
     robust_getitem,
@@ -542,8 +543,7 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
         autoclose=False,
     ):
 
-        if isinstance(filename_or_obj, str) and not is_remote_uri(filename_or_obj):
-            filename_or_obj = os.path.expanduser(filename_or_obj)
+        filename_or_obj = _normalize_path(filename_or_obj)
         store = NetCDF4DataStore.open(
             filename_or_obj,
             mode=mode,

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -542,6 +542,8 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
         autoclose=False,
     ):
 
+        if isinstance(filename_or_obj, str) and not is_remote_uri(filename_or_obj):
+            filename_or_obj = os.path.expanduser(filename_or_obj)
         store = NetCDF4DataStore.open(
             filename_or_obj,
             mode=mode,

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -15,8 +15,8 @@ from .common import (
     BACKEND_ENTRYPOINTS,
     BackendArray,
     BackendEntrypoint,
-    _normalize_path,
     WritableCFDataStore,
+    _normalize_path,
     find_root_and_group,
     robust_getitem,
 )

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 
 from ..core import indexing
@@ -131,6 +133,9 @@ class PseudoNetCDFBackendEntrypoint(BackendEntrypoint):
         lock=None,
         **format_kwargs,
     ):
+
+        if isinstance(filename_or_obj, str):
+            filename_or_obj = os.path.expanduser(filename_or_obj)
         store = PseudoNetCDFDataStore.open(
             filename_or_obj, lock=lock, mode=mode, **format_kwargs
         )

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -2,7 +2,6 @@ import os.path
 
 import numpy as np
 
-from .common import _normalize_path
 from ..core import indexing
 from ..core.utils import Frozen, FrozenDict, close_on_error
 from ..core.variable import Variable
@@ -11,6 +10,7 @@ from .common import (
     AbstractDataStore,
     BackendArray,
     BackendEntrypoint,
+    _normalize_path,
 )
 from .file_manager import CachingFileManager
 from .locks import HDF5_LOCK, NETCDFC_LOCK, combine_locks, ensure_lock

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -136,8 +136,6 @@ class PseudoNetCDFBackendEntrypoint(BackendEntrypoint):
     ):
 
         filename_or_obj = _normalize_path(filename_or_obj)
-        if isinstance(filename_or_obj, str):
-            filename_or_obj = os.path.expanduser(filename_or_obj)
         store = PseudoNetCDFDataStore.open(
             filename_or_obj, lock=lock, mode=mode, **format_kwargs
         )

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -1,5 +1,3 @@
-import os.path
-
 import numpy as np
 
 from ..core import indexing

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -2,6 +2,7 @@ import os.path
 
 import numpy as np
 
+from .api import _normalize_path
 from ..core import indexing
 from ..core.utils import Frozen, FrozenDict, close_on_error
 from ..core.variable import Variable
@@ -134,6 +135,7 @@ class PseudoNetCDFBackendEntrypoint(BackendEntrypoint):
         **format_kwargs,
     ):
 
+        filename_or_obj = _normalize_path(filename_or_obj)
         if isinstance(filename_or_obj, str):
             filename_or_obj = os.path.expanduser(filename_or_obj)
         store = PseudoNetCDFDataStore.open(

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -2,7 +2,7 @@ import os.path
 
 import numpy as np
 
-from .api import _normalize_path
+from .common import _normalize_path
 from ..core import indexing
 from ..core.utils import Frozen, FrozenDict, close_on_error
 from ..core.variable import Variable

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -1,4 +1,4 @@
-import os
+import os.path
 
 import numpy as np
 

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .api import _normalize_path
+from .common import _normalize_path
 from ..core import indexing
 from ..core.utils import Frozen, FrozenDict, close_on_error
 from ..core.variable import Variable

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from .common import _normalize_path
 from ..core import indexing
 from ..core.utils import Frozen, FrozenDict, close_on_error
 from ..core.variable import Variable
@@ -9,6 +8,7 @@ from .common import (
     AbstractDataStore,
     BackendArray,
     BackendEntrypoint,
+    _normalize_path,
 )
 from .file_manager import CachingFileManager
 from .locks import HDF5_LOCK, NETCDFC_LOCK, SerializableLock, combine_locks, ensure_lock

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from .api import _normalize_path
 from ..core import indexing
 from ..core.utils import Frozen, FrozenDict, close_on_error
 from ..core.variable import Variable
@@ -117,6 +118,7 @@ class PynioBackendEntrypoint(BackendEntrypoint):
             lock=lock,
         )
 
+        filename_or_obj = _normalize_path(filename_or_obj)
         store_entrypoint = StoreBackendEntrypoint()
         with close_on_error(store):
             ds = store_entrypoint.open_dataset(

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -2,7 +2,7 @@ import io
 import os
 
 import numpy as np
-from .api import _normalize_path
+from .common import _normalize_path
 
 from ..core.indexing import NumpyIndexingAdapter
 from ..core.utils import Frozen, FrozenDict, close_on_error, read_magic_number

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -2,7 +2,6 @@ import io
 import os
 
 import numpy as np
-from .common import _normalize_path
 
 from ..core.indexing import NumpyIndexingAdapter
 from ..core.utils import Frozen, FrozenDict, close_on_error, read_magic_number
@@ -12,6 +11,7 @@ from .common import (
     BackendArray,
     BackendEntrypoint,
     WritableCFDataStore,
+    _normalize_path,
 )
 from .file_manager import CachingFileManager, DummyFileManager
 from .locks import ensure_lock, get_write_lock

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -2,6 +2,7 @@ import io
 import os
 
 import numpy as np
+from .api import _normalize_path
 
 from ..core.indexing import NumpyIndexingAdapter
 from ..core.utils import Frozen, FrozenDict, close_on_error, read_magic_number
@@ -262,8 +263,7 @@ class ScipyBackendEntrypoint(BackendEntrypoint):
         lock=None,
     ):
 
-        if isinstance(filename_or_obj, str):
-            filename_or_obj = os.path.expanduser(filename_or_obj)
+        filename_or_obj = _normalize_path(filename_or_obj)
         store = ScipyDataStore(
             filename_or_obj, mode=mode, format=format, group=group, mmap=mmap, lock=lock
         )

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -262,6 +262,8 @@ class ScipyBackendEntrypoint(BackendEntrypoint):
         lock=None,
     ):
 
+        if isinstance(filename_or_obj, str):
+            filename_or_obj = os.path.expanduser(filename_or_obj)
         store = ScipyDataStore(
             filename_or_obj, mode=mode, format=format, group=group, mmap=mmap, lock=lock
         )

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -4,7 +4,6 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
-from .common import _normalize_path
 from .. import coding, conventions
 from ..core import indexing
 from ..core.pycompat import integer_types
@@ -16,6 +15,7 @@ from .common import (
     BackendArray,
     BackendEntrypoint,
     _encode_variable_name,
+    _normalize_path,
 )
 from .store import StoreBackendEntrypoint
 

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -4,6 +4,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
+from .api import _normalize_path
 from .. import coding, conventions
 from ..core import indexing
 from ..core.pycompat import integer_types
@@ -702,6 +703,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
         storage_options=None,
     ):
 
+        filename_or_obj = _normalize_path(filename_or_obj)
         if isinstance(filename_or_obj, str):
             filename_or_obj = os.path.expanduser(filename_or_obj)
         store = ZarrStore.open_group(

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -704,8 +704,6 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
     ):
 
         filename_or_obj = _normalize_path(filename_or_obj)
-        if isinstance(filename_or_obj, str):
-            filename_or_obj = os.path.expanduser(filename_or_obj)
         store = ZarrStore.open_group(
             filename_or_obj,
             group=group,

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -4,7 +4,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
-from .api import _normalize_path
+from .common import _normalize_path
 from .. import coding, conventions
 from ..core import indexing
 from ..core.pycompat import integer_types

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -701,6 +701,9 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
         chunk_store=None,
         storage_options=None,
     ):
+
+        if isinstance(filename_or_obj, str):
+            filename_or_obj = os.path.expanduser(filename_or_obj)
         store = ZarrStore.open_group(
             filename_or_obj,
             group=group,


### PR DESCRIPTION
Fix `open_dataset` regression, expands ~ in `filepath_or_obj` when necessary. 
I have checked the behaviour of the engines. It seems that `pynio`  already expands  ~.

- [x] Closes #5098
- [x] Passes `pre-commit run --all-files`
