### PR TITLE
Fix broken engine breakes xarray.open_dataset

### DIFF
--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -1,7 +1,6 @@
 import functools
 import inspect
 import itertools
-import logging
 import warnings
 
 import pkg_resources
@@ -59,7 +58,7 @@ def backends_dict_from_pkg(pkg_entrypoints):
             backend = pkg_ep.load()
             backend_entrypoints[name] = backend
         except Exception as ex:
-            warnings.warn(f"Engine {name} loading failed: \n {ex}", RuntimeWarning)
+            warnings.warn(f"Engine {name} loading failed:\n{ex}", RuntimeWarning)
     return backend_entrypoints
 
 
@@ -108,7 +107,7 @@ def guess_engine(store_spec):
             if backend.guess_can_open and backend.guess_can_open(store_spec):
                 return engine
         except Exception:
-            logging.exception(f"{engine!r} fails while guessing")
+            warnings.warn(f"{engine!r} fails while guessing", RuntimeWarning)
 
     raise ValueError("cannot guess the engine, try passing one explicitly")
 

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -55,8 +55,11 @@ def backends_dict_from_pkg(pkg_entrypoints):
     backend_entrypoints = {}
     for pkg_ep in pkg_entrypoints:
         name = pkg_ep.name
-        backend = pkg_ep.load()
-        backend_entrypoints[name] = backend
+        try:
+            backend = pkg_ep.load()
+            backend_entrypoints[name] = backend
+        except Exception as ex:
+            warnings.warn(f"Engine {name} loading failed: \n {ex}", RuntimeWarning)
     return backend_entrypoints
 
 

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -58,7 +58,7 @@ def backends_dict_from_pkg(pkg_entrypoints):
             backend = pkg_ep.load()
             backend_entrypoints[name] = backend
         except Exception as ex:
-            warnings.warn(f"Engine {name} loading failed:\n{ex}", RuntimeWarning)
+            warnings.warn(f"Engine {name!r} loading failed:\n{ex}", RuntimeWarning)
     return backend_entrypoints
 
 

--- a/xarray/tests/test_plugins.py
+++ b/xarray/tests/test_plugins.py
@@ -45,6 +45,18 @@ def test_remove_duplicates(dummy_duplicated_entrypoints):
     assert len(entrypoints) == 2
 
 
+def test_broken_plugin():
+    broken_backend = pkg_resources.EntryPoint.parse(
+        "broken_backend = xarray.tests.test_plugins:backend_1"
+    )
+    with pytest.warns(RuntimeWarning) as record:
+        _ = plugins.build_engines([broken_backend])
+    assert len(record) == 1
+    message = str(record[0].message)
+    assert "Engine broken_backend" in message
+
+
+
 def test_remove_duplicates_warnings(dummy_duplicated_entrypoints):
 
     with pytest.warns(RuntimeWarning) as record:

--- a/xarray/tests/test_plugins.py
+++ b/xarray/tests/test_plugins.py
@@ -56,7 +56,6 @@ def test_broken_plugin():
     assert "Engine broken_backend" in message
 
 
-
 def test_remove_duplicates_warnings(dummy_duplicated_entrypoints):
 
     with pytest.warns(RuntimeWarning) as record:

--- a/xarray/tests/test_plugins.py
+++ b/xarray/tests/test_plugins.py
@@ -53,7 +53,7 @@ def test_broken_plugin():
         _ = plugins.build_engines([broken_backend])
     assert len(record) == 1
     message = str(record[0].message)
-    assert "Engine broken_backend" in message
+    assert "Engine 'broken_backend'" in message
 
 
 def test_remove_duplicates_warnings(dummy_duplicated_entrypoints):


### PR DESCRIPTION
Currently, a broken engine breaks xarray.open_dataset. I have added a `try except` to avoid this problem.

Old behaviour:

```python
>>> ds = xr.open_dataset('example.nc')
Traceback (most recent call last):

  File "/usr/local/Caskroom/miniconda/base/envs/xarray/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3331, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)

  File "<ipython-input-3-0c694cae8262>", line 1, in <module>
    arr = xr.open_dataset("example.nc")

  File "/Users/barghini/devel/xarray/xarray/backends/api.py", line 495, in open_dataset
    backend = plugins.get_backend(engine)

  File "/Users/barghini/devel/xarray/xarray/backends/plugins.py", line 115, in get_backend
    engines = list_engines()

  File "/Users/barghini/devel/xarray/xarray/backends/plugins.py", line 97, in list_engines
    return build_engines(pkg_entrypoints)

  File "/Users/barghini/devel/xarray/xarray/backends/plugins.py", line 84, in build_engines
    external_backend_entrypoints = backends_dict_from_pkg(pkg_entrypoints)

  File "/Users/barghini/devel/xarray/xarray/backends/plugins.py", line 58, in backends_dict_from_pkg
    backend = pkg_ep.load()

  File "/usr/local/Caskroom/miniconda/base/envs/xarray/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2450, in load
    return self.resolve()

  File "/usr/local/Caskroom/miniconda/base/envs/xarray/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2456, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)

  File "/Users/barghini/devel/xarray-sentinel/xarray_sentinel/sentinel1.py", line 13
    ERROR
            ^
SyntaxError: invalid syntax
```

New behaviour:

```python
>>> ds = xr.open_dataset('example.nc')
/Users/barghini/devel/xarray/xarray/backends/plugins.py:61: RuntimeWarning: Engine sentinel-1 loading failed:
name 'ERROR' is not defined
  warnings.warn(f"Engine {name} loading failed:\n{ex}", RuntimeWarning)
```

- [x] Tests added
- [x] Passes `pre-commit run --all-files`

