### PR TITLE
Protect against an exception raised by python-eccodes

### DIFF
--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -22,9 +22,10 @@ try:
 except ModuleNotFoundError:
     has_cfgrib = False
 # cfgrib throws a RuntimeError if eccodes is not installed
-except RuntimeError:
+except (ImportError, RuntimeError):
     warnings.warn(
-        "Failed to load cfgrib - most likely eccodes is missing. Try `import cfgrib` to get the error message"
+        "Failed to load cfgrib - most likely there is a problem accessing the ecCodes library. "
+        "Try `import cfgrib` to get the full error message"
     )
     has_cfgrib = False
 


### PR DESCRIPTION
Depending on the kind of problem `python-eccdodes` may return `RuntimeError` or `ImportError`.

- [x] Related to #5138
- [x] Passes `pre-commit run --all-files`