### PR TITLE
Catch either OutOfBoundsTimedelta or OverflowError in CFTimeIndex.__sub__ and CFTimeIndex.__rsub__

### DIFF
--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -57,7 +57,12 @@ from .times import _STANDARD_CALENDARS, cftime_to_nptime, infer_calendar_name
 CFTIME_REPR_LENGTH = 19
 ITEMS_IN_REPR_MAX_ELSE_ELLIPSIS = 100
 REPR_ELLIPSIS_SHOW_ITEMS_FRONT_END = 10
-OUT_OF_BOUNDS_TIMEDELTA_ERRORS = (pd.errors.OutOfBoundsTimedelta, OverflowError)
+
+
+if LooseVersion(pd.__version__) > LooseVersion("1.1.0"):
+    OUT_OF_BOUNDS_TIMEDELTA_ERRORS = (pd.errors.OutOfBoundsTimedelta, OverflowError)
+else:
+    OUT_OF_BOUNDS_TIMEDELTA_ERRORS = (OverflowError, )
 
 
 def named(name, pattern):

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -62,7 +62,7 @@ REPR_ELLIPSIS_SHOW_ITEMS_FRONT_END = 10
 if LooseVersion(pd.__version__) > LooseVersion("1.1.0"):
     OUT_OF_BOUNDS_TIMEDELTA_ERRORS = (pd.errors.OutOfBoundsTimedelta, OverflowError)
 else:
-    OUT_OF_BOUNDS_TIMEDELTA_ERRORS = (OverflowError, )
+    OUT_OF_BOUNDS_TIMEDELTA_ERRORS = (OverflowError,)
 
 
 def named(name, pattern):

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -57,12 +57,7 @@ from .times import _STANDARD_CALENDARS, cftime_to_nptime, infer_calendar_name
 CFTIME_REPR_LENGTH = 19
 ITEMS_IN_REPR_MAX_ELSE_ELLIPSIS = 100
 REPR_ELLIPSIS_SHOW_ITEMS_FRONT_END = 10
-
-
-if LooseVersion(pd.__version__) > LooseVersion("1.2.3"):
-    OUT_OF_BOUNDS_TIMEDELTA_ERROR = pd.errors.OutOfBoundsTimedelta
-else:
-    OUT_OF_BOUNDS_TIMEDELTA_ERROR = OverflowError
+OUT_OF_BOUNDS_TIMEDELTA_ERRORS = (pd.errors.OutOfBoundsTimedelta, OverflowError)
 
 
 def named(name, pattern):
@@ -568,7 +563,7 @@ class CFTimeIndex(pd.Index):
         elif _contains_cftime_datetimes(np.array(other)):
             try:
                 return pd.TimedeltaIndex(np.array(self) - np.array(other))
-            except OUT_OF_BOUNDS_TIMEDELTA_ERROR:
+            except OUT_OF_BOUNDS_TIMEDELTA_ERRORS:
                 raise ValueError(
                     "The time difference exceeds the range of values "
                     "that can be expressed at the nanosecond resolution."
@@ -579,7 +574,7 @@ class CFTimeIndex(pd.Index):
     def __rsub__(self, other):
         try:
             return pd.TimedeltaIndex(other - np.array(self))
-        except OUT_OF_BOUNDS_TIMEDELTA_ERROR:
+        except OUT_OF_BOUNDS_TIMEDELTA_ERRORS:
             raise ValueError(
                 "The time difference exceeds the range of values "
                 "that can be expressed at the nanosecond resolution."

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -43,6 +43,7 @@ import re
 import warnings
 from datetime import timedelta
 from distutils.version import LooseVersion
+from typing import Tuple, Type
 
 import numpy as np
 import pandas as pd
@@ -59,6 +60,7 @@ ITEMS_IN_REPR_MAX_ELSE_ELLIPSIS = 100
 REPR_ELLIPSIS_SHOW_ITEMS_FRONT_END = 10
 
 
+OUT_OF_BOUNDS_TIMEDELTA_ERRORS: Tuple[Type[Exception], ...]
 if LooseVersion(pd.__version__) > LooseVersion("1.1.0"):
     OUT_OF_BOUNDS_TIMEDELTA_ERRORS = (pd.errors.OutOfBoundsTimedelta, OverflowError)
 else:

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -61,9 +61,9 @@ REPR_ELLIPSIS_SHOW_ITEMS_FRONT_END = 10
 
 
 OUT_OF_BOUNDS_TIMEDELTA_ERRORS: Tuple[Type[Exception], ...]
-if LooseVersion(pd.__version__) > LooseVersion("1.1.0"):
+try:
     OUT_OF_BOUNDS_TIMEDELTA_ERRORS = (pd.errors.OutOfBoundsTimedelta, OverflowError)
-else:
+except AttributeError:
     OUT_OF_BOUNDS_TIMEDELTA_ERRORS = (OverflowError,)
 
 


### PR DESCRIPTION
It seems that pandas did not include the change that led to #5006 in their latest release.  Perhaps it is safer to just catch either error regardless of the pandas version.

- [x] Closes #5147

