### PR TITLE
Small simplification to RollingExp

### DIFF
--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -345,8 +345,6 @@ class DataWithCoords(AttrAccessMixin):
 
     __slots__ = ("_close",)
 
-    _rolling_exp_cls = RollingExp
-
     def squeeze(
         self,
         dim: Union[Hashable, Iterable[Hashable], None] = None,
@@ -908,7 +906,7 @@ class DataWithCoords(AttrAccessMixin):
         """
         window = either_dict_or_kwargs(window, window_kwargs, "rolling_exp")
 
-        return self._rolling_exp_cls(self, window, window_type)
+        return RollingExp(self, window, window_type)
 
     def coarsen(
         self,


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Passes `pre-commit run --all-files`

I'm adding a method to this class — separate PR — and noticed this. 

At least for `RollingExp`, we don't need this class attribute. 
I think the others, like `Rolling` / `Coarsen` maybe require different classes for DataArray / Dataset, so I'm less confident on those.