### PR TITLE
Convert calendar to lowercase in standard calendar checks

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -94,6 +94,9 @@ Bug fixes
   By `Justus Magin <https://github.com/keewis>`_.
 - Decode values as signed if attribute `_Unsigned = "false"` (:issue:`4954`)
   By `Tobias Kölling <https://github.com/d70-t>`_.
+- Ensure standard calendar dates encoded with a calendar attribute with some or
+  all uppercase letters can be decoded or encoded without ``cftime`` installed
+  (:issue:`5093`).  By `Spencer Clark <https://github.com/spencerkclark>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -95,7 +95,8 @@ Bug fixes
 - Decode values as signed if attribute `_Unsigned = "false"` (:issue:`4954`)
   By `Tobias Kölling <https://github.com/d70-t>`_.
 - Ensure standard calendar dates encoded with a calendar attribute with some or
-  all uppercase letters can be decoded or encoded without ``cftime`` installed
+  all uppercase letters can be decoded or encoded to or from
+  ``np.datetime64[ns]`` dates with or without ``cftime`` installed 
   (:issue:`5093`, :pull:`5180`).  By `Spencer Clark
   <https://github.com/spencerkclark>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -96,7 +96,7 @@ Bug fixes
   By `Tobias Kölling <https://github.com/d70-t>`_.
 - Ensure standard calendar dates encoded with a calendar attribute with some or
   all uppercase letters can be decoded or encoded to or from
-  ``np.datetime64[ns]`` dates with or without ``cftime`` installed 
+  ``np.datetime64[ns]`` dates with or without ``cftime`` installed
   (:issue:`5093`, :pull:`5180`).  By `Spencer Clark
   <https://github.com/spencerkclark>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -96,7 +96,8 @@ Bug fixes
   By `Tobias Kölling <https://github.com/d70-t>`_.
 - Ensure standard calendar dates encoded with a calendar attribute with some or
   all uppercase letters can be decoded or encoded without ``cftime`` installed
-  (:issue:`5093`).  By `Spencer Clark <https://github.com/spencerkclark>`_.
+  (:issue:`5093`, :pull:`5180`).  By `Spencer Clark
+  <https://github.com/spencerkclark>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -26,7 +26,7 @@ from xarray.coding.times import (
 from xarray.coding.variables import SerializationWarning
 from xarray.conventions import _update_bounds_attributes, cf_encoder
 from xarray.core.common import contains_cftime_datetimes
-from xarray.testing import assert_equal
+from xarray.testing import assert_equal, assert_identical
 
 from . import (
     arm_xfail,
@@ -1049,3 +1049,21 @@ def test__encode_datetime_with_cftime():
     expected = cftime.date2num(times, encoding_units, calendar)
     result = _encode_datetime_with_cftime(times, encoding_units, calendar)
     np.testing.assert_equal(result, expected)
+
+
+@pytest.mark.parametrize("calendar", ["gregorian", "Gregorian", "GREGORIAN"])
+def test_decode_encode_roundtrip_with_non_lowercase_letters(calendar):
+    # See GH 5093.  This is primarily relevant for standard calendar times when
+    # cftime is not installed (cftime.num2date already lowers the calendar name
+    # internally).
+    times = [0, 1]
+    units = "days since 2000-01-01"
+    attrs = {"calendar": calendar, "units": units}
+    variable = Variable(["time"], times, attrs)
+    decoded = conventions.decode_cf_variable("time", variable)
+    encoded = conventions.encode_cf_variable(decoded)
+
+    # Use assert_identical to ensure that the calendar attribute maintained its
+    # original form throughout the roundtripping process, uppercase letters and
+    # all.
+    assert_identical(variable, encoded)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -1053,14 +1053,16 @@ def test__encode_datetime_with_cftime():
 
 @pytest.mark.parametrize("calendar", ["gregorian", "Gregorian", "GREGORIAN"])
 def test_decode_encode_roundtrip_with_non_lowercase_letters(calendar):
-    # See GH 5093.  This is primarily relevant for standard calendar times when
-    # cftime is not installed (cftime.num2date already lowers the calendar name
-    # internally).
+    # See GH 5093.
     times = [0, 1]
     units = "days since 2000-01-01"
     attrs = {"calendar": calendar, "units": units}
     variable = Variable(["time"], times, attrs)
     decoded = conventions.decode_cf_variable("time", variable)
+
+    # Previously this would erroneously be an array of cftime.datetime
+    # objects.  We check here that it is decoded properly to np.datetime64.
+    assert np.issubdtype(decoded.dtype, np.datetime64)
     encoded = conventions.encode_cf_variable(decoded)
 
     # Use assert_identical to ensure that the calendar attribute maintained its

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -1059,11 +1059,11 @@ def test_decode_encode_roundtrip_with_non_lowercase_letters(calendar):
     attrs = {"calendar": calendar, "units": units}
     variable = Variable(["time"], times, attrs)
     decoded = conventions.decode_cf_variable("time", variable)
+    encoded = conventions.encode_cf_variable(decoded)
 
     # Previously this would erroneously be an array of cftime.datetime
     # objects.  We check here that it is decoded properly to np.datetime64.
     assert np.issubdtype(decoded.dtype, np.datetime64)
-    encoded = conventions.encode_cf_variable(decoded)
 
     # Use assert_identical to ensure that the calendar attribute maintained its
     # original form throughout the roundtripping process, uppercase letters and


### PR DESCRIPTION
This fixes the issue in #5093, by ensuring that we always convert the calendar to lowercase before checking if it is one of the standard calendars in the decoding and encoding process.  I've been careful to test that the calendar attribute is faithfully roundtripped despite this, uppercase letters and all.

~~I think part of the reason this went unnoticed for a while was that we could still decode times like this if cftime was installed; it is only in the case when cftime was not installed that our logic failed.  This is because `cftime.num2date` already converts the calendar to lowercase internally.~~

Upon re-reading @pont-us's issue description, while it didn't cause an error, the behavior was incorrect with cftime installed too.  I updated the test to check the dtype is `np.datetime64` as well.

- [x] Closes #5093
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
