### PR TITLE
Use ._replace rather than reconstructing vars

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -798,7 +798,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
 
     def _finalize_indexing_result(self: VariableType, dims, data) -> VariableType:
         """Used by IndexVariable to return IndexVariable objects when possible."""
-        return type(self)(dims, data, self._attrs, self._encoding, fastpath=True)
+        return self._replace(dims=dims, data=data)
 
     def _getitem_with_mask(self, key, fill_value=dtypes.NA):
         """Index this Variable with -1 remapped to fill_value."""
@@ -977,8 +977,8 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         return self._replace(data=data)
 
     def _replace(
-        self, dims=_default, data=_default, attrs=_default, encoding=_default
-    ) -> "Variable":
+        self: VariableType, dims=_default, data=_default, attrs=_default, encoding=_default
+    ) -> VariableType:
         if dims is _default:
             dims = copy.copy(self._dims)
         if data is _default:
@@ -1081,7 +1081,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
 
             data = da.from_array(data, chunks, name=name, lock=lock, **kwargs)
 
-        return type(self)(self.dims, data, self._attrs, self._encoding, fastpath=True)
+        return self._replace(data=data)
 
     def _as_sparse(self, sparse_format=_default, fill_value=dtypes.NA):
         """
@@ -1205,7 +1205,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
             # TODO: remove this once dask.array automatically aligns chunks
             data = data.rechunk(self.data.chunks)
 
-        return type(self)(self.dims, data, self._attrs, fastpath=True)
+        return self._replace(data=data)
 
     def shift(self, shifts=None, fill_value=dtypes.NA, **shifts_kwargs):
         """
@@ -1364,7 +1364,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
             # TODO: remove this once dask.array automatically aligns chunks
             data = data.rechunk(self.data.chunks)
 
-        return type(self)(self.dims, data, self._attrs, fastpath=True)
+        return self._replace(data=data)
 
     def roll(self, shifts=None, **shifts_kwargs):
         """
@@ -1426,7 +1426,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
             return self.copy(deep=False)
 
         data = as_indexable(self._data).transpose(axes)
-        return type(self)(dims, data, self._attrs, self._encoding, fastpath=True)
+        return self._replace(dims=dims, data=data)
 
     @property
     def T(self) -> "Variable":
@@ -2276,11 +2276,11 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
 
     @property
     def real(self):
-        return type(self)(self.dims, self.data.real, self._attrs)
+        return self._replace(data=self.data.real)
 
     @property
     def imag(self):
-        return type(self)(self.dims, self.data.imag, self._attrs)
+        return self._replace(data=self.data.imag)
 
     def __array_wrap__(self, obj, context=None):
         return Variable(self.dims, obj)
@@ -2555,7 +2555,7 @@ class IndexVariable(Variable):
             # returns Variable rather than IndexVariable if multi-dimensional
             return Variable(dims, data, self._attrs, self._encoding)
         else:
-            return type(self)(dims, data, self._attrs, self._encoding, fastpath=True)
+            return self._replace(dims=dims, data=data)
 
     def __setitem__(self, key, value):
         raise TypeError("%s values cannot be modified" % type(self).__name__)
@@ -2636,7 +2636,7 @@ class IndexVariable(Variable):
                         data.shape, self.shape
                     )
                 )
-        return type(self)(self.dims, data, self._attrs, self._encoding, fastpath=True)
+        return self._replace(data=data)
 
     def equals(self, other, equiv=None):
         # if equiv is specified, super up

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -977,7 +977,11 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         return self._replace(data=data)
 
     def _replace(
-        self: VariableType, dims=_default, data=_default, attrs=_default, encoding=_default
+        self: VariableType,
+        dims=_default,
+        data=_default,
+        attrs=_default,
+        encoding=_default,
     ) -> VariableType:
         if dims is _default:
             dims = copy.copy(self._dims)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Passes `pre-commit run --all-files`

I saw a few of these while looking through the code — generally we're using `._replace` now, so this grows that convention to `variable.py` too. It was a regex replace but I took a look through to confirm. And fixed one mypy error which the change caught.