### PR TITLE
link maintenance

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -31,7 +31,7 @@ dependencies:
   - sphinx-book-theme >= 0.0.38
   - sphinx-copybutton
   - sphinx-panels
-  - sphinx>=3.3
+  - sphinx<4
   - zarr>=2.4
   - pip:
       - sphinxext-rediraffe

--- a/doc/api-hidden.rst
+++ b/doc/api-hidden.rst
@@ -826,10 +826,9 @@
    backends.DummyFileManager.acquire_context
    backends.DummyFileManager.close
 
-   backends.common.BackendArray
-   backends.common.BackendEntrypoint
-   backends.common.BackendEntrypoint.guess_can_open
-   backends.common.BackendEntrypoint.open_dataset
+   backends.BackendArray
+   backends.BackendEntrypoint.guess_can_open
+   backends.BackendEntrypoint.open_dataset
 
    core.indexing.IndexingSupport
    core.indexing.explicit_indexing_adapter

--- a/doc/api-hidden.rst
+++ b/doc/api-hidden.rst
@@ -171,6 +171,8 @@
    DataArray.std
    DataArray.var
 
+   DataArray.str
+
    core.coordinates.DataArrayCoordinates.get
    core.coordinates.DataArrayCoordinates.items
    core.coordinates.DataArrayCoordinates.keys

--- a/doc/api-hidden.rst
+++ b/doc/api-hidden.rst
@@ -171,8 +171,6 @@
    DataArray.std
    DataArray.var
 
-   DataArray.str
-
    core.coordinates.DataArrayCoordinates.get
    core.coordinates.DataArrayCoordinates.items
    core.coordinates.DataArrayCoordinates.keys

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -422,6 +422,12 @@ String manipulation
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/accessor.rst
+
+   DataArray.str
+
+.. autosummary::
+   :toctree: generated/
    :template: autosummary/accessor_method.rst
 
    DataArray.str.capitalize

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -890,6 +890,8 @@ Advanced API
    as_variable
    register_dataset_accessor
    register_dataarray_accessor
+   backends.BackendArray
+   backends.BackendEntrypoint
 
 These backends provide a low-level interface for lazily loading data from
 external file-formats or protocols, and can be manually invoked to create

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -424,12 +424,6 @@ String manipulation
    :toctree: generated/
    :template: autosummary/accessor_method.rst
 
-   DataArray.str._apply
-   DataArray.str._padder
-   DataArray.str._partitioner
-   DataArray.str._re_compile
-   DataArray.str._splitter
-   DataArray.str._stringify
    DataArray.str.capitalize
    DataArray.str.casefold
    DataArray.str.cat

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -890,6 +890,7 @@ Advanced API
    as_variable
    register_dataset_accessor
    register_dataarray_accessor
+   Dataset.set_close
    backends.BackendArray
    backends.BackendEntrypoint
 

--- a/doc/internals/how-to-add-new-backend.rst
+++ b/doc/internals/how-to-add-new-backend.rst
@@ -6,7 +6,7 @@ How to add a new backend
 Adding a new backend for read support to Xarray does not require
 to integrate any code in Xarray; all you need to do is:
 
-- Create a class that inherits from Xarray :py:class:`~xarray.backends.common.BackendEntrypoint`
+- Create a class that inherits from Xarray :py:class:`~xarray.backends.BackendEntrypoint`
   and implements the method ``open_dataset`` see :ref:`RST backend_entrypoint`
 
 - Declare this class as an external plugin in your ``setup.py``, see :ref:`RST backend_registration`
@@ -161,8 +161,8 @@ guess_can_open
 ``guess_can_open`` is used to identify the proper engine to open your data
 file automatically in case the engine is not specified explicitly. If you are
 not interested in supporting this feature, you can skip this step since
-:py:class:`~xarray.backends.common.BackendEntrypoint` already provides a
-default :py:meth:`~xarray.backend.common.BackendEntrypoint.guess_can_open`
+:py:class:`~xarray.backends.BackendEntrypoint` already provides a
+default :py:meth:`~xarray.backends.BackendEntrypoint.guess_can_open`
 that always returns ``False``.
 
 Backend ``guess_can_open`` takes as input the ``filename_or_obj`` parameter of
@@ -299,7 +299,7 @@ Where:
 - :py:class:`~xarray.core.indexing.LazilyIndexedArray` is a class
   provided by Xarray that manages the lazy loading.
 - ``MyBackendArray`` shall be implemented by the backend and shall inherit
-  from :py:class:`~xarray.backends.common.BackendArray`.
+  from :py:class:`~xarray.backends.BackendArray`.
 
 BackendArray subclassing
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/internals/how-to-add-new-backend.rst
+++ b/doc/internals/how-to-add-new-backend.rst
@@ -455,5 +455,5 @@ In the first case Xarray uses the chunks size specified in
 ``preferred_chunks``.
 In the second case Xarray accommodates ideal chunk sizes, preserving if
 possible the "preferred_chunks". The ideal chunk size is computed using
-:py:func:`dask.core.normalize_chunks`, setting
+:py:func:`dask.array.core.normalize_chunks`, setting
 ``previous_chunks = preferred_chunks``.

--- a/doc/internals/zarr-encoding-spec.rst
+++ b/doc/internals/zarr-encoding-spec.rst
@@ -1,3 +1,4 @@
+.. currentmodule:: xarray
 
 .. _zarr_encoding:
 

--- a/doc/user-guide/computation.rst
+++ b/doc/user-guide/computation.rst
@@ -451,7 +451,7 @@ Fitting arbitrary functions
 ===========================
 
 Xarray objects also provide an interface for fitting more complex functions using
-:py:meth:`scipy.optimize.curve_fit`. :py:meth:`~xarray.DataArray.curvefit` accepts
+:py:func:`scipy.optimize.curve_fit`. :py:meth:`~xarray.DataArray.curvefit` accepts
 user-defined functions and can fit along multiple coordinates.
 
 For example, we can fit a relationship between two ``DataArray`` objects, maintaining

--- a/doc/user-guide/weather-climate.rst
+++ b/doc/user-guide/weather-climate.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: xarray
+
 .. _weather-climate:
 
 Weather and climate data

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -37,7 +37,7 @@ New Features
 - Many of the arguments for the :py:attr:`DataArray.str` methods now support
   providing an array-like input. In this case, the array provided to the
   arguments is broadcast against the original array and applied elementwise.
-- :py:attr:`DataArray.str` now supports `+`, `*`, and `%` operators. These
+- :py:attr:`DataArray.str` now supports ``+``, ``*``, and ``%`` operators. These
   behave the same as they do for :py:class:`str`, except that they follow
   array broadcasting rules.
 - A large number of new :py:attr:`DataArray.str` methods were implemented,

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -202,10 +202,10 @@ New Features
   By `Justus Magin <https://github.com/keewis>`_.
 - Allow installing from git archives (:pull:`4897`).
   By `Justus Magin <https://github.com/keewis>`_.
-- :py:class:`DataArrayCoarsen` and :py:class:`DatasetCoarsen` now implement a
-  ``reduce`` method, enabling coarsening operations with custom reduction
-  functions (:issue:`3741`, :pull:`4939`).  By `Spencer Clark
-  <https://github.com/spencerkclark>`_.
+- :py:class:`~core.rolling.DataArrayCoarsen` and :py:class:`~core.rolling.DatasetCoarsen`
+  now implement a ``reduce`` method, enabling coarsening operations with custom
+  reduction functions (:issue:`3741`, :pull:`4939`).
+  By `Spencer Clark <https://github.com/spencerkclark>`_.
 - Most rolling operations use significantly less memory. (:issue:`4325`).
   By `Deepak Cherian <https://github.com/dcherian>`_.
 - Add :py:meth:`Dataset.drop_isel` and :py:meth:`DataArray.drop_isel`
@@ -224,9 +224,8 @@ New Features
 
 Bug fixes
 ~~~~~~~~~
-- Use specific type checks in
-  :py:func:`~xarray.core.variable.as_compatible_data` instead of blanket
-  access to ``values`` attribute (:issue:`2097`)
+- Use specific type checks in ``xarray.core.variable.as_compatible_data`` instead of
+  blanket access to ``values`` attribute (:issue:`2097`)
   By `Yunus Sevinchan <https://github.com/blsqr>`_.
 - :py:meth:`DataArray.resample` and :py:meth:`Dataset.resample` do not trigger
   computations anymore if :py:meth:`Dataset.weighted` or

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4433,7 +4433,7 @@ class DataArray(AbstractArray, DataWithCoords):
 
         Parameters
         ----------
-        coords : DataArray, str or sequence of DataArray, str
+        coords : hashable, DataArray, or sequence of DataArray or hashable
             Independent coordinate(s) over which to perform the curve fitting. Must share
             at least one dimension with the calling object. When fitting multi-dimensional
             functions, supply `coords` as a sequence in the same order as arguments in
@@ -4444,27 +4444,27 @@ class DataArray(AbstractArray, DataWithCoords):
             array of length `len(x)`. `params` are the fittable parameters which are optimized
             by scipy curve_fit. `x` can also be specified as a sequence containing multiple
             coordinates, e.g. `f((x0, x1), *params)`.
-        reduce_dims : str or sequence of str
+        reduce_dims : hashable or sequence of hashable
             Additional dimension(s) over which to aggregate while fitting. For example,
             calling `ds.curvefit(coords='time', reduce_dims=['lat', 'lon'], ...)` will
             aggregate all lat and lon points and fit the specified function along the
             time dimension.
         skipna : bool, optional
             Whether to skip missing values when fitting. Default is True.
-        p0 : dictionary, optional
+        p0 : dict-like, optional
             Optional dictionary of parameter names to initial guesses passed to the
             `curve_fit` `p0` arg. If none or only some parameters are passed, the rest will
             be assigned initial values following the default scipy behavior.
-        bounds : dictionary, optional
+        bounds : dict-like, optional
             Optional dictionary of parameter names to bounding values passed to the
             `curve_fit` `bounds` arg. If none or only some parameters are passed, the rest
             will be unbounded following the default scipy behavior.
-        param_names : seq, optional
+        param_names : sequence of hashable, optional
             Sequence of names for the fittable parameters of `func`. If not supplied,
             this will be automatically determined by arguments of `func`. `param_names`
             should be manually supplied when fitting a function that takes a variable
             number of parameters.
-        kwargs : dictionary
+        **kwargs : optional
             Additional keyword arguments to passed to scipy curve_fit.
 
         Returns

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5528,9 +5528,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
         -------
         difference : same type as caller
             The n-th order finite difference of this object.
-        .. note::
-            `n` matches numpy's behavior and is different from pandas' first
-            argument named `periods`.
+
+        Notes
+        -----
+        `n` matches numpy's behavior and is different from pandas' first argument named
+        `periods`.
 
         Examples
         --------
@@ -7152,7 +7154,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
 
         Parameters
         ----------
-        coords : DataArray, str or sequence of DataArray, str
+        coords : hashable, DataArray, or sequence of hashable or DataArray
             Independent coordinate(s) over which to perform the curve fitting. Must share
             at least one dimension with the calling object. When fitting multi-dimensional
             functions, supply `coords` as a sequence in the same order as arguments in
@@ -7163,27 +7165,27 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
             array of length `len(x)`. `params` are the fittable parameters which are optimized
             by scipy curve_fit. `x` can also be specified as a sequence containing multiple
             coordinates, e.g. `f((x0, x1), *params)`.
-        reduce_dims : str or sequence of str
+        reduce_dims : hashable or sequence of hashable
             Additional dimension(s) over which to aggregate while fitting. For example,
             calling `ds.curvefit(coords='time', reduce_dims=['lat', 'lon'], ...)` will
             aggregate all lat and lon points and fit the specified function along the
             time dimension.
         skipna : bool, optional
             Whether to skip missing values when fitting. Default is True.
-        p0 : dictionary, optional
+        p0 : dict-like, optional
             Optional dictionary of parameter names to initial guesses passed to the
             `curve_fit` `p0` arg. If none or only some parameters are passed, the rest will
             be assigned initial values following the default scipy behavior.
-        bounds : dictionary, optional
+        bounds : dict-like, optional
             Optional dictionary of parameter names to bounding values passed to the
             `curve_fit` `bounds` arg. If none or only some parameters are passed, the rest
             will be unbounded following the default scipy behavior.
-        param_names : seq, optional
+        param_names : sequence of hashable, optional
             Sequence of names for the fittable parameters of `func`. If not supplied,
             this will be automatically determined by arguments of `func`. `param_names`
             should be manually supplied when fitting a function that takes a variable
             number of parameters.
-        kwargs : dictionary
+        **kwargs : optional
             Additional keyword arguments to passed to scipy curve_fit.
 
         Returns


### PR DESCRIPTION
This fixes a few broken links in our RST files and moves a few links.

Note that the module referenced here: https://github.com/pydata/xarray/blob/b5a84baa96c244a35004f940bd5f25737e984553/doc/internals/how-to-add-new-backend.rst#L430-L432
does not have a API page, yet. Should we try to fix that, or would linking to github be better? Also, were the `explicit indexing` and `numpy indexing` meant to be links or literal text?

- [x] Passes `pre-commit run --all-files`