### PR TITLE
Replace raises_regex with pytest.raises

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -110,6 +110,10 @@ Internal Changes
 ~~~~~~~~~~~~~~~~
 - Enable displaying mypy error codes and ignore only specific error codes using
   ``# type: ignore[error-code]`` (:pull:`5096`). By `Mathias Hauser <https://github.com/mathause>`_.
+- Replace most uses of ``raises_regex`` with the more standard
+``pytest.raises(Exception, match="foo")``;
+  (:pull:`5188`).
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 
 .. _whats-new.0.17.0:

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -111,7 +111,7 @@ Internal Changes
 - Enable displaying mypy error codes and ignore only specific error codes using
   ``# type: ignore[error-code]`` (:pull:`5096`). By `Mathias Hauser <https://github.com/mathause>`_.
 - Replace most uses of ``raises_regex`` with the more standard
-``pytest.raises(Exception, match="foo")``;
+  ``pytest.raises(Exception, match="foo")``;
   (:pull:`5188`).
   By `Maximilian Roos <https://github.com/max-sixty>`_.
 

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -124,7 +124,7 @@ class TestDatetimeAccessor:
         nontime_data = self.data.copy()
         int_data = np.arange(len(self.data.time)).astype("int8")
         nontime_data = nontime_data.assign_coords(time=int_data)
-        with raises_regex(TypeError, "dt"):
+        with pytest.raises(TypeError, match=r"dt"):
             nontime_data.time.dt
 
     @pytest.mark.filterwarnings("ignore:dt.weekofyear and dt.week have been deprecated")
@@ -293,7 +293,7 @@ class TestTimedeltaAccessor:
         nontime_data = self.data.copy()
         int_data = np.arange(len(self.data.time)).astype("int8")
         nontime_data = nontime_data.assign_coords(time=int_data)
-        with raises_regex(TypeError, "dt"):
+        with pytest.raises(TypeError, match=r"dt"):
             nontime_data.time.dt
 
     @pytest.mark.parametrize(

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2795,11 +2795,12 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
                         assert_identical(expected, actual)
 
                 f.seek(0)
-                with pytest.raises(TypeError, match=r"not a valid NetCDF 3"):
+                # Seems to fail with pytest.raises
+                with raises_regex(TypeError, "not a valid NetCDF 3"):
                     open_dataset(f, engine="scipy")
 
                 f.seek(8)
-                with pytest.raises(ValueError, match=r"cannot guess the engine"):
+                with raises_regex(ValueError, "cannot guess the engine"):
                     open_dataset(f)
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1058,12 +1058,12 @@ class CFEncodedBase(DatasetIOBase):
         assert ds.x.encoding == {}
 
         kwargs = dict(encoding={"x": {"foo": "bar"}})
-        with raises_regex(ValueError, "unexpected encoding"):
+        with pytest.raises(ValueError, match=r"unexpected encoding"):
             with self.roundtrip(ds, save_kwargs=kwargs) as actual:
                 pass
 
         kwargs = dict(encoding={"x": "foo"})
-        with raises_regex(ValueError, "must be castable"):
+        with pytest.raises(ValueError, match=r"must be castable"):
             with self.roundtrip(ds, save_kwargs=kwargs) as actual:
                 pass
 
@@ -1179,7 +1179,7 @@ class CFEncodedBase(DatasetIOBase):
         ds = Dataset(coords={"y": ("x", [1, 2]), "z": ("x", ["a", "b"])}).set_index(
             x=["y", "z"]
         )
-        with raises_regex(NotImplementedError, "MultiIndex"):
+        with pytest.raises(NotImplementedError, match=r"MultiIndex"):
             with self.roundtrip(ds):
                 pass
 
@@ -1238,7 +1238,7 @@ class NetCDF4Base(CFEncodedBase):
             # check that missing group raises appropriate exception
             with pytest.raises(IOError):
                 open_dataset(tmp_file, group="bar")
-            with raises_regex(ValueError, "must be a string"):
+            with pytest.raises(ValueError, match=r"must be a string"):
                 open_dataset(tmp_file, group=(1, 2, 3))
 
     def test_open_subgroup(self):
@@ -1861,25 +1861,25 @@ class ZarrBase(CFEncodedBase):
 
         # should fail if dask_chunks are irregular...
         ds_chunk_irreg = ds.chunk({"x": (5, 4, 3)})
-        with raises_regex(ValueError, "uniform chunk sizes."):
+        with pytest.raises(ValueError, match=r"uniform chunk sizes."):
             with self.roundtrip(ds_chunk_irreg) as actual:
                 pass
 
         # should fail if encoding["chunks"] clashes with dask_chunks
         badenc = ds.chunk({"x": 4})
         badenc.var1.encoding["chunks"] = (6,)
-        with raises_regex(NotImplementedError, "named 'var1' would overlap"):
+        with pytest.raises(NotImplementedError, match=r"named 'var1' would overlap"):
             with self.roundtrip(badenc) as actual:
                 pass
 
         badenc.var1.encoding["chunks"] = (2,)
-        with raises_regex(ValueError, "Specified Zarr chunk encoding"):
+        with pytest.raises(ValueError, match=r"Specified Zarr chunk encoding"):
             with self.roundtrip(badenc) as actual:
                 pass
 
         badenc = badenc.chunk({"x": (3, 3, 6)})
         badenc.var1.encoding["chunks"] = (3,)
-        with raises_regex(ValueError, "incompatible with this encoding"):
+        with pytest.raises(ValueError, match=r"incompatible with this encoding"):
             with self.roundtrip(badenc) as actual:
                 pass
 
@@ -2212,7 +2212,7 @@ class ZarrBase(CFEncodedBase):
             data2.to_zarr(store, region={"x": slice(2)})
 
         with setup_and_verify_store() as store:
-            with raises_regex(ValueError, "cannot use consolidated=True"):
+            with pytest.raises(ValueError, match=r"cannot use consolidated=True"):
                 data2.to_zarr(store, region={"x": slice(2)}, consolidated=True)
 
         with setup_and_verify_store() as store:
@@ -2222,15 +2222,15 @@ class ZarrBase(CFEncodedBase):
                 data.to_zarr(store, region={"x": slice(None)}, mode="w")
 
         with setup_and_verify_store() as store:
-            with raises_regex(TypeError, "must be a dict"):
+            with pytest.raises(TypeError, match=r"must be a dict"):
                 data.to_zarr(store, region=slice(None))
 
         with setup_and_verify_store() as store:
-            with raises_regex(TypeError, "must be slice objects"):
+            with pytest.raises(TypeError, match=r"must be slice objects"):
                 data2.to_zarr(store, region={"x": [0, 1]})
 
         with setup_and_verify_store() as store:
-            with raises_regex(ValueError, "step on all slices"):
+            with pytest.raises(ValueError, match=r"step on all slices"):
                 data2.to_zarr(store, region={"x": slice(None, None, 2)})
 
         with setup_and_verify_store() as store:
@@ -2247,7 +2247,9 @@ class ZarrBase(CFEncodedBase):
                 data2.assign(v=2).to_zarr(store, region={"x": slice(2)})
 
         with setup_and_verify_store() as store:
-            with raises_regex(ValueError, "cannot list the same dimension in both"):
+            with pytest.raises(
+                ValueError, match=r"cannot list the same dimension in both"
+            ):
                 data.to_zarr(store, region={"x": slice(None)}, append_dim="x")
 
         with setup_and_verify_store() as store:
@@ -2375,7 +2377,7 @@ class TestScipyFilePath(CFEncodedBase, NetCDF3Only):
 
     def test_array_attrs(self):
         ds = Dataset(attrs={"foo": [[1, 2], [3, 4]]})
-        with raises_regex(ValueError, "must be 1-dimensional"):
+        with pytest.raises(ValueError, match=r"must be 1-dimensional"):
             with self.roundtrip(ds):
                 pass
 
@@ -2396,7 +2398,7 @@ class TestScipyFilePath(CFEncodedBase, NetCDF3Only):
             with nc4.Dataset(tmp_file, "w", format="NETCDF4") as rootgrp:
                 rootgrp.createGroup("foo")
 
-            with raises_regex(TypeError, "pip install netcdf4"):
+            with pytest.raises(TypeError, match=r"pip install netcdf4"):
                 open_dataset(tmp_file, engine="scipy")
 
 
@@ -2416,7 +2418,7 @@ class TestNetCDF3ViaNetCDF4Data(CFEncodedBase, NetCDF3Only):
     def test_encoding_kwarg_vlen_string(self):
         original = Dataset({"x": ["foo", "bar", "baz"]})
         kwargs = dict(encoding={"x": {"dtype": str}})
-        with raises_regex(ValueError, "encoding dtype=str for vlen"):
+        with pytest.raises(ValueError, match=r"encoding dtype=str for vlen"):
             with self.roundtrip(original, save_kwargs=kwargs):
                 pass
 
@@ -2448,18 +2450,18 @@ class TestGenericNetCDFData(CFEncodedBase, NetCDF3Only):
     @requires_scipy
     def test_engine(self):
         data = create_test_data()
-        with raises_regex(ValueError, "unrecognized engine"):
+        with pytest.raises(ValueError, match=r"unrecognized engine"):
             data.to_netcdf("foo.nc", engine="foobar")
-        with raises_regex(ValueError, "invalid engine"):
+        with pytest.raises(ValueError, match=r"invalid engine"):
             data.to_netcdf(engine="netcdf4")
 
         with create_tmp_file() as tmp_file:
             data.to_netcdf(tmp_file)
-            with raises_regex(ValueError, "unrecognized engine"):
+            with pytest.raises(ValueError, match=r"unrecognized engine"):
                 open_dataset(tmp_file, engine="foobar")
 
         netcdf_bytes = data.to_netcdf()
-        with raises_regex(ValueError, "unrecognized engine"):
+        with pytest.raises(ValueError, match=r"unrecognized engine"):
             open_dataset(BytesIO(netcdf_bytes), engine="foobar")
 
     def test_cross_engine_read_write_netcdf3(self):
@@ -2746,23 +2748,25 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
     engine = "h5netcdf"
 
     def test_open_badbytes(self):
-        with raises_regex(ValueError, "HDF5 as bytes"):
+        with pytest.raises(ValueError, match=r"HDF5 as bytes"):
             with open_dataset(b"\211HDF\r\n\032\n", engine="h5netcdf"):
                 pass
-        with raises_regex(ValueError, "cannot guess the engine"):
+        with pytest.raises(ValueError, match=r"cannot guess the engine"):
             with open_dataset(b"garbage"):
                 pass
-        with raises_regex(ValueError, "can only read bytes"):
+        with pytest.raises(ValueError, match=r"can only read bytes"):
             with open_dataset(b"garbage", engine="netcdf4"):
                 pass
-        with raises_regex(ValueError, "not the signature of a valid netCDF file"):
+        with pytest.raises(
+            ValueError, match=r"not the signature of a valid netCDF file"
+        ):
             with open_dataset(BytesIO(b"garbage"), engine="h5netcdf"):
                 pass
 
     def test_open_twice(self):
         expected = create_test_data()
         expected.attrs["foo"] = "bar"
-        with raises_regex(ValueError, "read/write pointer not at the start"):
+        with pytest.raises(ValueError, match=r"read/write pointer not at the start"):
             with create_tmp_file() as tmp_file:
                 expected.to_netcdf(tmp_file, engine="h5netcdf")
                 with open(tmp_file, "rb") as f:
@@ -2791,11 +2795,11 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
                         assert_identical(expected, actual)
 
                 f.seek(0)
-                with raises_regex(TypeError, "not a valid NetCDF 3"):
+                with pytest.raises(TypeError, match=r"not a valid NetCDF 3"):
                     open_dataset(f, engine="scipy")
 
                 f.seek(8)
-                with raises_regex(ValueError, "cannot guess the engine"):
+                with pytest.raises(ValueError, match=r"cannot guess the engine"):
                     open_dataset(f)
 
 
@@ -3094,7 +3098,7 @@ class TestOpenMFDatasetWithDataVarsAndCoordsKw:
         with self.setup_files_and_datasets(fuzz=0.1) as (files, [ds1, ds2]):
             if combine == "by_coords":
                 files.reverse()
-            with raises_regex(ValueError, "indexes along dimension"):
+            with pytest.raises(ValueError, match=r"indexes along dimension"):
                 open_mfdataset(
                     files, data_vars=opt, combine=combine, concat_dim="t", join="exact"
                 )
@@ -3226,9 +3230,9 @@ class TestDask(DatasetIOBase):
                 ) as actual:
                     assert actual.foo.variable.data.chunks == ((3, 2, 3, 2),)
 
-        with raises_regex(IOError, "no files to open"):
+        with pytest.raises(IOError, match=r"no files to open"):
             open_mfdataset("foo-bar-baz-*.nc")
-        with raises_regex(ValueError, "wild-card"):
+        with pytest.raises(ValueError, match=r"wild-card"):
             open_mfdataset("http://some/remote/uri")
 
     @requires_fsspec
@@ -3236,7 +3240,7 @@ class TestDask(DatasetIOBase):
         pytest.importorskip("aiobotocore")
 
         # glob is attempted as of #4823, but finds no files
-        with raises_regex(OSError, "no files"):
+        with pytest.raises(OSError, match=r"no files"):
             open_mfdataset("http://some/remote/uri", engine="zarr")
 
     def test_open_mfdataset_2d(self):
@@ -3331,7 +3335,7 @@ class TestDask(DatasetIOBase):
                     # first dataset loaded
                     assert actual.test1 == ds1.test1
                     # attributes from ds2 are not retained, e.g.,
-                    with raises_regex(AttributeError, "no attribute"):
+                    with pytest.raises(AttributeError, match=r"no attribute"):
                         actual.test2
 
     def test_open_mfdataset_attrs_file(self):
@@ -3430,15 +3434,15 @@ class TestDask(DatasetIOBase):
 
     def test_save_mfdataset_invalid(self):
         ds = Dataset()
-        with raises_regex(ValueError, "cannot use mode"):
+        with pytest.raises(ValueError, match=r"cannot use mode"):
             save_mfdataset([ds, ds], ["same", "same"])
-        with raises_regex(ValueError, "same length"):
+        with pytest.raises(ValueError, match=r"same length"):
             save_mfdataset([ds, ds], ["only one path"])
 
     def test_save_mfdataset_invalid_dataarray(self):
         # regression test for GH1555
         da = DataArray([1, 2])
-        with raises_regex(TypeError, "supports writing Dataset"):
+        with pytest.raises(TypeError, match=r"supports writing Dataset"):
             save_mfdataset([da], ["dataarray"])
 
     def test_save_mfdataset_pathlib_roundtrip(self):
@@ -4577,7 +4581,7 @@ class TestRasterio:
 class TestEncodingInvalid:
     def test_extract_nc4_variable_encoding(self):
         var = xr.Variable(("x",), [1, 2, 3], {}, {"foo": "bar"})
-        with raises_regex(ValueError, "unexpected encoding"):
+        with pytest.raises(ValueError, match=r"unexpected encoding"):
             _extract_nc4_variable_encoding(var, raise_on_invalid=True)
 
         var = xr.Variable(("x",), [1, 2, 3], {}, {"chunking": (2, 1)})
@@ -4597,7 +4601,7 @@ class TestEncodingInvalid:
     def test_extract_h5nc_encoding(self):
         # not supported with h5netcdf (yet)
         var = xr.Variable(("x",), [1, 2, 3], {}, {"least_sigificant_digit": 2})
-        with raises_regex(ValueError, "unexpected encoding"):
+        with pytest.raises(ValueError, match=r"unexpected encoding"):
             _extract_nc4_variable_encoding(var, raise_on_invalid=True)
 
 
@@ -4631,17 +4635,17 @@ class TestValidateAttrs:
             ds, attrs = new_dataset_and_attrs()
 
             attrs[123] = "test"
-            with raises_regex(TypeError, "Invalid name for attr: 123"):
+            with pytest.raises(TypeError, match=r"Invalid name for attr: 123"):
                 ds.to_netcdf("test.nc")
 
             ds, attrs = new_dataset_and_attrs()
             attrs[MiscObject()] = "test"
-            with raises_regex(TypeError, "Invalid name for attr: "):
+            with pytest.raises(TypeError, match=r"Invalid name for attr: "):
                 ds.to_netcdf("test.nc")
 
             ds, attrs = new_dataset_and_attrs()
             attrs[""] = "test"
-            with raises_regex(ValueError, "Invalid name for attr '':"):
+            with pytest.raises(ValueError, match=r"Invalid name for attr '':"):
                 ds.to_netcdf("test.nc")
 
             # This one should work
@@ -4652,12 +4656,12 @@ class TestValidateAttrs:
 
             ds, attrs = new_dataset_and_attrs()
             attrs["test"] = {"a": 5}
-            with raises_regex(TypeError, "Invalid value for attr 'test'"):
+            with pytest.raises(TypeError, match=r"Invalid value for attr 'test'"):
                 ds.to_netcdf("test.nc")
 
             ds, attrs = new_dataset_and_attrs()
             attrs["test"] = MiscObject()
-            with raises_regex(TypeError, "Invalid value for attr 'test'"):
+            with pytest.raises(TypeError, match=r"Invalid value for attr 'test'"):
                 ds.to_netcdf("test.nc")
 
             ds, attrs = new_dataset_and_attrs()
@@ -4943,7 +4947,7 @@ def test_use_cftime_false_nonstandard_calendar(calendar, units_year):
 @pytest.mark.parametrize("engine", ["netcdf4", "scipy"])
 def test_invalid_netcdf_raises(engine):
     data = create_test_data()
-    with raises_regex(ValueError, "unrecognized option 'invalid_netcdf'"):
+    with pytest.raises(ValueError, match=r"unrecognized option 'invalid_netcdf'"):
         data.to_netcdf("foo.nc", engine=engine, invalid_netcdf=True)
 
 
@@ -4988,7 +4992,7 @@ def test_extract_zarr_variable_encoding():
 
     # raises on invalid
     var = xr.Variable("x", [1, 2], encoding={"foo": (1,)})
-    with raises_regex(ValueError, "unexpected encoding parameters"):
+    with pytest.raises(ValueError, match=r"unexpected encoding parameters"):
         actual = backends.zarr.extract_zarr_variable_encoding(
             var, raise_on_invalid=True
         )

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -16,7 +16,7 @@ from xarray.coding.cftimeindex import (
 )
 from xarray.tests import assert_array_equal, assert_identical
 
-from . import raises_regex, requires_cftime, requires_cftime_1_1_0
+from . import requires_cftime, requires_cftime_1_1_0
 from .test_coding_times import (
     _ALL_CALENDARS,
     _NON_STANDARD_CALENDARS,
@@ -340,7 +340,7 @@ def test_get_loc(date_type, index):
     result = index.get_loc("0001-02-01")
     assert result == slice(1, 2)
 
-    with raises_regex(KeyError, "1234"):
+    with pytest.raises(KeyError, match=r"1234"):
         index.get_loc("1234")
 
 

--- a/xarray/tests/test_coding_strings.py
+++ b/xarray/tests/test_coding_strings.py
@@ -7,13 +7,7 @@ from xarray import Variable
 from xarray.coding import strings
 from xarray.core import indexing
 
-from . import (
-    IndexerMaker,
-    assert_array_equal,
-    assert_identical,
-    raises_regex,
-    requires_dask,
-)
+from . import IndexerMaker, assert_array_equal, assert_identical, requires_dask
 
 with suppress(ImportError):
     import dask.array as da
@@ -210,7 +204,7 @@ def test_char_to_bytes_dask():
     assert actual.dtype == "S3"
     assert_array_equal(np.array(actual), expected)
 
-    with raises_regex(ValueError, "stacked dask character array"):
+    with pytest.raises(ValueError, match=r"stacked dask character array"):
         strings.char_to_bytes(array.rechunk(1))
 
 

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -162,7 +162,7 @@ class TestTileIDsFromCoords:
     def test_no_dimension_coords(self):
         ds0 = Dataset({"foo": ("x", [0, 1])})
         ds1 = Dataset({"foo": ("x", [2, 3])})
-        with raises_regex(ValueError, "Could not find any dimension"):
+        with pytest.raises(ValueError, match=r"Could not find any dimension"):
             _infer_concat_order_from_coords([ds1, ds0])
 
     def test_coord_not_monotonic(self):
@@ -320,13 +320,17 @@ class TestCheckShapeTileIDs:
     def test_check_depths(self):
         ds = create_test_data(0)
         combined_tile_ids = {(0,): ds, (0, 1): ds}
-        with raises_regex(ValueError, "sub-lists do not have consistent depths"):
+        with pytest.raises(
+            ValueError, match=r"sub-lists do not have consistent depths"
+        ):
             _check_shape_tile_ids(combined_tile_ids)
 
     def test_check_lengths(self):
         ds = create_test_data(0)
         combined_tile_ids = {(0, 0): ds, (0, 1): ds, (0, 2): ds, (1, 0): ds, (1, 1): ds}
-        with raises_regex(ValueError, "sub-lists do not have consistent lengths"):
+        with pytest.raises(
+            ValueError, match=r"sub-lists do not have consistent lengths"
+        ):
             _check_shape_tile_ids(combined_tile_ids)
 
 
@@ -380,7 +384,7 @@ class TestNestedCombine:
 
     def test_combine_nested_join_exact(self):
         objs = [Dataset({"x": [0], "y": [0]}), Dataset({"x": [1], "y": [1]})]
-        with raises_regex(ValueError, "indexes along dimension"):
+        with pytest.raises(ValueError, match=r"indexes along dimension"):
             combine_nested(objs, concat_dim="x", join="exact")
 
     def test_empty_input(self):
@@ -529,7 +533,7 @@ class TestNestedCombine:
         datasets[1][1].attrs = {"a": 1, "e": 5}
         datasets[1][2].attrs = {"a": 1, "f": 6}
 
-        with raises_regex(ValueError, "combine_attrs='identical'"):
+        with pytest.raises(ValueError, match=r"combine_attrs='identical'"):
             result = combine_nested(
                 datasets, concat_dim=["dim1", "dim2"], combine_attrs="identical"
             )
@@ -557,15 +561,19 @@ class TestNestedCombine:
         ds = create_test_data
 
         datasets = [[ds(0), ds(1), ds(2)], [ds(3), ds(4)]]
-        with raises_regex(ValueError, "sub-lists do not have consistent lengths"):
+        with pytest.raises(
+            ValueError, match=r"sub-lists do not have consistent lengths"
+        ):
             combine_nested(datasets, concat_dim=["dim1", "dim2"])
 
         datasets = [[ds(0), ds(1)], [[ds(3), ds(4)]]]
-        with raises_regex(ValueError, "sub-lists do not have consistent depths"):
+        with pytest.raises(
+            ValueError, match=r"sub-lists do not have consistent depths"
+        ):
             combine_nested(datasets, concat_dim=["dim1", "dim2"])
 
         datasets = [[ds(0), ds(1)], [ds(3), ds(4)]]
-        with raises_regex(ValueError, "concat_dims has length"):
+        with pytest.raises(ValueError, match=r"concat_dims has length"):
             combine_nested(datasets, concat_dim=["dim1"])
 
     def test_merge_one_dim_concat_another(self):
@@ -658,11 +666,13 @@ class TestCombineAuto:
         assert_equal(actual, expected)
 
         objs = [Dataset({"x": 0}), Dataset({"x": 1})]
-        with raises_regex(ValueError, "Could not find any dimension coordinates"):
+        with pytest.raises(
+            ValueError, match=r"Could not find any dimension coordinates"
+        ):
             combine_by_coords(objs)
 
         objs = [Dataset({"x": [0], "y": [0]}), Dataset({"x": [0]})]
-        with raises_regex(ValueError, "Every dimension needs a coordinate"):
+        with pytest.raises(ValueError, match=r"Every dimension needs a coordinate"):
             combine_by_coords(objs)
 
         def test_empty_input(self):
@@ -684,7 +694,7 @@ class TestCombineAuto:
 
     def test_combine_coords_join_exact(self):
         objs = [Dataset({"x": [0], "y": [0]}), Dataset({"x": [1], "y": [1]})]
-        with raises_regex(ValueError, "indexes along dimension"):
+        with pytest.raises(ValueError, match=r"indexes along dimension"):
             combine_nested(objs, concat_dim="x", join="exact")
 
     @pytest.mark.parametrize(
@@ -710,7 +720,7 @@ class TestCombineAuto:
 
         if combine_attrs == "no_conflicts":
             objs[1].attrs["a"] = 2
-            with raises_regex(ValueError, "combine_attrs='no_conflicts'"):
+            with pytest.raises(ValueError, match=r"combine_attrs='no_conflicts'"):
                 actual = combine_nested(
                     objs, concat_dim="x", join="outer", combine_attrs=combine_attrs
                 )
@@ -728,7 +738,7 @@ class TestCombineAuto:
 
         objs[1].attrs["b"] = 2
 
-        with raises_regex(ValueError, "combine_attrs='identical'"):
+        with pytest.raises(ValueError, match=r"combine_attrs='identical'"):
             actual = combine_nested(
                 objs, concat_dim="x", join="outer", combine_attrs="identical"
             )

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -568,9 +568,9 @@ def test_dataset_join():
     ds1 = xr.Dataset({"a": ("x", [99, 3]), "x": [1, 2]})
 
     # by default, cannot have different labels
-    with raises_regex(ValueError, "indexes .* are not equal"):
+    with pytest.raises(ValueError, match=r"indexes .* are not equal"):
         apply_ufunc(operator.add, ds0, ds1)
-    with raises_regex(TypeError, "must supply"):
+    with pytest.raises(TypeError, match=r"must supply"):
         apply_ufunc(operator.add, ds0, ds1, dataset_join="outer")
 
     def add(a, b, join, dataset_join):
@@ -590,7 +590,7 @@ def test_dataset_join():
     actual = add(ds0, ds1, "outer", "outer")
     assert_identical(actual, expected)
 
-    with raises_regex(ValueError, "data variable names"):
+    with pytest.raises(ValueError, match=r"data variable names"):
         apply_ufunc(operator.add, ds0, xr.Dataset({"b": 1}))
 
     ds2 = xr.Dataset({"b": ("x", [99, 3]), "x": [1, 2]})
@@ -708,11 +708,11 @@ def test_apply_dask_parallelized_errors():
     data_array = xr.DataArray(array, dims=("x", "y"))
 
     # from apply_array_ufunc
-    with raises_regex(ValueError, "at least one input is an xarray object"):
+    with pytest.raises(ValueError, match=r"at least one input is an xarray object"):
         apply_ufunc(identity, array, dask="parallelized")
 
     # formerly from _apply_blockwise, now from apply_variable_ufunc
-    with raises_regex(ValueError, "consists of multiple chunks"):
+    with pytest.raises(ValueError, match=r"consists of multiple chunks"):
         apply_ufunc(
             identity,
             data_array,
@@ -1160,7 +1160,9 @@ def test_vectorize_dask_new_output_dims():
     ).transpose(*expected.dims)
     assert_identical(expected, actual)
 
-    with raises_regex(ValueError, "dimension 'z1' in 'output_sizes' must correspond"):
+    with pytest.raises(
+        ValueError, match=r"dimension 'z1' in 'output_sizes' must correspond"
+    ):
         apply_ufunc(
             func,
             data_array.chunk({"x": 1}),
@@ -1193,10 +1195,10 @@ def test_output_wrong_number():
     def tuple3x(x):
         return (x, x, x)
 
-    with raises_regex(ValueError, "number of outputs"):
+    with pytest.raises(ValueError, match=r"number of outputs"):
         apply_ufunc(identity, variable, output_core_dims=[(), ()])
 
-    with raises_regex(ValueError, "number of outputs"):
+    with pytest.raises(ValueError, match=r"number of outputs"):
         apply_ufunc(tuple3x, variable, output_core_dims=[(), ()])
 
 
@@ -1209,13 +1211,13 @@ def test_output_wrong_dims():
     def remove_dim(x):
         return x[..., 0]
 
-    with raises_regex(ValueError, "unexpected number of dimensions"):
+    with pytest.raises(ValueError, match=r"unexpected number of dimensions"):
         apply_ufunc(add_dim, variable, output_core_dims=[("y", "z")])
 
-    with raises_regex(ValueError, "unexpected number of dimensions"):
+    with pytest.raises(ValueError, match=r"unexpected number of dimensions"):
         apply_ufunc(add_dim, variable)
 
-    with raises_regex(ValueError, "unexpected number of dimensions"):
+    with pytest.raises(ValueError, match=r"unexpected number of dimensions"):
         apply_ufunc(remove_dim, variable)
 
 
@@ -1231,11 +1233,11 @@ def test_output_wrong_dim_size():
     def apply_truncate_broadcast_invalid(obj):
         return apply_ufunc(truncate, obj)
 
-    with raises_regex(ValueError, "size of dimension"):
+    with pytest.raises(ValueError, match=r"size of dimension"):
         apply_truncate_broadcast_invalid(variable)
-    with raises_regex(ValueError, "size of dimension"):
+    with pytest.raises(ValueError, match=r"size of dimension"):
         apply_truncate_broadcast_invalid(data_array)
-    with raises_regex(ValueError, "size of dimension"):
+    with pytest.raises(ValueError, match=r"size of dimension"):
         apply_truncate_broadcast_invalid(dataset)
 
     def apply_truncate_x_x_invalid(obj):
@@ -1243,11 +1245,11 @@ def test_output_wrong_dim_size():
             truncate, obj, input_core_dims=[["x"]], output_core_dims=[["x"]]
         )
 
-    with raises_regex(ValueError, "size of dimension"):
+    with pytest.raises(ValueError, match=r"size of dimension"):
         apply_truncate_x_x_invalid(variable)
-    with raises_regex(ValueError, "size of dimension"):
+    with pytest.raises(ValueError, match=r"size of dimension"):
         apply_truncate_x_x_invalid(data_array)
-    with raises_regex(ValueError, "size of dimension"):
+    with pytest.raises(ValueError, match=r"size of dimension"):
         apply_truncate_x_x_invalid(dataset)
 
     def apply_truncate_x_z(obj):
@@ -1442,7 +1444,7 @@ def test_dot_align_coords(use_dask):
     xr.testing.assert_allclose(expected, actual)
 
     with xr.set_options(arithmetic_join="exact"):
-        with raises_regex(ValueError, "indexes along dimension"):
+        with pytest.raises(ValueError, match=r"indexes along dimension"):
             xr.dot(da_a, da_b)
 
     # NOTE: dot always uses `join="inner"` because `(a * b).sum()` yields the same for all

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -41,9 +41,11 @@ def test_concat_compat():
 
     for var in ["has_x", "no_x_y"]:
         assert "y" not in result[var].dims and "y" not in result[var].coords
-    with raises_regex(ValueError, "coordinates in some datasets but not others"):
+    with pytest.raises(
+        ValueError, match=r"coordinates in some datasets but not others"
+    ):
         concat([ds1, ds2], dim="q")
-    with raises_regex(ValueError, "'q' is not present in all datasets"):
+    with pytest.raises(ValueError, match=r"'q' is not present in all datasets"):
         concat([ds2, ds1], dim="q")
 
 
@@ -185,36 +187,40 @@ class TestConcatDataset:
         data = create_test_data()
         split_data = [data.isel(dim1=slice(3)), data.isel(dim1=slice(3, None))]
 
-        with raises_regex(ValueError, "must supply at least one"):
+        with pytest.raises(ValueError, match=r"must supply at least one"):
             concat([], "dim1")
 
-        with raises_regex(ValueError, "Cannot specify both .*='different'"):
+        with pytest.raises(ValueError, match=r"Cannot specify both .*='different'"):
             concat(
                 [data, data], dim="concat_dim", data_vars="different", compat="override"
             )
 
-        with raises_regex(ValueError, "must supply at least one"):
+        with pytest.raises(ValueError, match=r"must supply at least one"):
             concat([], "dim1")
 
-        with raises_regex(ValueError, "are not coordinates"):
+        with pytest.raises(ValueError, match=r"are not coordinates"):
             concat([data, data], "new_dim", coords=["not_found"])
 
-        with raises_regex(ValueError, "global attributes not"):
+        with pytest.raises(ValueError, match=r"global attributes not"):
             data0, data1 = deepcopy(split_data)
             data1.attrs["foo"] = "bar"
             concat([data0, data1], "dim1", compat="identical")
         assert_identical(data, concat([data0, data1], "dim1", compat="equals"))
 
-        with raises_regex(ValueError, "compat.* invalid"):
+        with pytest.raises(ValueError, match=r"compat.* invalid"):
             concat(split_data, "dim1", compat="foobar")
 
-        with raises_regex(ValueError, "unexpected value for"):
+        with pytest.raises(ValueError, match=r"unexpected value for"):
             concat([data, data], "new_dim", coords="foobar")
 
-        with raises_regex(ValueError, "coordinate in some datasets but not others"):
+        with pytest.raises(
+            ValueError, match=r"coordinate in some datasets but not others"
+        ):
             concat([Dataset({"x": 0}), Dataset({"x": [1]})], dim="z")
 
-        with raises_regex(ValueError, "coordinate in some datasets but not others"):
+        with pytest.raises(
+            ValueError, match=r"coordinate in some datasets but not others"
+        ):
             concat([Dataset({"x": 0}), Dataset({}, {"x": 1})], dim="z")
 
     def test_concat_join_kwarg(self):
@@ -242,7 +248,7 @@ class TestConcatDataset:
             coords={"x": [0, 1], "y": [0]},
         )
 
-        with raises_regex(ValueError, "indexes along dimension 'y'"):
+        with pytest.raises(ValueError, match=r"indexes along dimension 'y'"):
             actual = concat([ds1, ds2], join="exact", dim="x")
 
         for join in expected:
@@ -528,10 +534,10 @@ class TestConcatDataArray:
         expected = foo[:2].rename({"x": "concat_dim"})
         assert_identical(expected, actual)
 
-        with raises_regex(ValueError, "not identical"):
+        with pytest.raises(ValueError, match=r"not identical"):
             concat([foo, bar], dim="w", compat="identical")
 
-        with raises_regex(ValueError, "not a valid argument"):
+        with pytest.raises(ValueError, match=r"not a valid argument"):
             concat([foo, bar], dim="w", data_vars="minimal")
 
     def test_concat_encoding(self):
@@ -609,7 +615,7 @@ class TestConcatDataArray:
             coords={"x": [0, 1], "y": [0]},
         )
 
-        with raises_regex(ValueError, "indexes along dimension 'y'"):
+        with pytest.raises(ValueError, match=r"indexes along dimension 'y'"):
             actual = concat([ds1, ds2], join="exact", dim="x")
 
         for join in expected:
@@ -629,9 +635,9 @@ class TestConcatDataArray:
             [0, 0], coords=[("x", [0, 1])], attrs={"b": 42}
         )
 
-        with raises_regex(ValueError, "combine_attrs='identical'"):
+        with pytest.raises(ValueError, match=r"combine_attrs='identical'"):
             actual = concat([da1, da2], dim="x", combine_attrs="identical")
-        with raises_regex(ValueError, "combine_attrs='no_conflicts'"):
+        with pytest.raises(ValueError, match=r"combine_attrs='no_conflicts'"):
             da3 = da2.copy(deep=True)
             da3.attrs["b"] = 44
             actual = concat([da1, da3], dim="x", combine_attrs="no_conflicts")
@@ -684,14 +690,14 @@ def test_concat_merge_single_non_dim_coord():
         actual = concat([da1, da2], "x", coords=coords)
         assert_identical(actual, expected)
 
-    with raises_regex(ValueError, "'y' is not present in all datasets."):
+    with pytest.raises(ValueError, match=r"'y' is not present in all datasets."):
         concat([da1, da2], dim="x", coords="all")
 
     da1 = DataArray([1, 2, 3], dims="x", coords={"x": [1, 2, 3], "y": 1})
     da2 = DataArray([4, 5, 6], dims="x", coords={"x": [4, 5, 6]})
     da3 = DataArray([7, 8, 9], dims="x", coords={"x": [7, 8, 9], "y": 1})
     for coords in ["different", "all"]:
-        with raises_regex(ValueError, "'y' not present in all datasets"):
+        with pytest.raises(ValueError, match=r"'y' not present in all datasets"):
             concat([da1, da2, da3], dim="x")
 
 

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -18,13 +18,7 @@ from xarray.backends.memory import InMemoryDataStore
 from xarray.conventions import decode_cf
 from xarray.testing import assert_identical
 
-from . import (
-    assert_array_equal,
-    raises_regex,
-    requires_cftime,
-    requires_dask,
-    requires_netCDF4,
-)
+from . import assert_array_equal, requires_cftime, requires_dask, requires_netCDF4
 from .test_backends import CFEncodedBase
 
 
@@ -145,7 +139,7 @@ class TestEncodeCFVariable:
         assert enc["a"].attrs["coordinates"] == "y"
         assert enc["b"].attrs["coordinates"] == "z"
         orig["a"].attrs["coordinates"] = "foo"
-        with raises_regex(ValueError, "'coordinates' found in both attrs"):
+        with pytest.raises(ValueError, match=r"'coordinates' found in both attrs"):
             conventions.encode_dataset_coordinates(orig)
 
     @requires_dask
@@ -236,7 +230,7 @@ class TestDecodeCF:
     @pytest.mark.filterwarnings("ignore:Ambiguous reference date string")
     def test_invalid_time_units_raises_eagerly(self):
         ds = Dataset({"time": ("time", [0, 1], {"units": "foobar since 123"})})
-        with raises_regex(ValueError, "unable to decode time"):
+        with pytest.raises(ValueError, match=r"unable to decode time"):
             decode_cf(ds)
 
     @requires_cftime

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -24,7 +24,6 @@ from . import (
     assert_frame_equal,
     assert_identical,
     raise_if_dask_computes,
-    raises_regex,
     requires_pint_0_15,
     requires_scipy_or_netCDF4,
 )
@@ -39,7 +38,7 @@ ON_WINDOWS = sys.platform == "win32"
 
 def test_raise_if_dask_computes():
     data = da.from_array(np.random.RandomState(0).randn(4, 6), chunks=(2, 2))
-    with raises_regex(RuntimeError, "Too many computes"):
+    with pytest.raises(RuntimeError, match=r"Too many computes"):
         with raise_if_dask_computes():
             data.compute()
 
@@ -111,7 +110,7 @@ class TestVariable(DaskTestCase):
         self.assertLazyAndIdentical(u[0], v[0])
         self.assertLazyAndIdentical(u[:1], v[:1])
         self.assertLazyAndIdentical(u[[0, 1], [0, 1, 2]], v[[0, 1], [0, 1, 2]])
-        with raises_regex(TypeError, "stored in a dask array"):
+        with pytest.raises(TypeError, match=r"stored in a dask array"):
             v[:1] = 0
 
     def test_squeeze(self):
@@ -194,9 +193,9 @@ class TestVariable(DaskTestCase):
         self.assertLazyAndAllClose(u.argmin(dim="x"), actual)
         self.assertLazyAndAllClose((u > 1).any(), (v > 1).any())
         self.assertLazyAndAllClose((u < 1).all("x"), (v < 1).all("x"))
-        with raises_regex(NotImplementedError, "only works along an axis"):
+        with pytest.raises(NotImplementedError, match=r"only works along an axis"):
             v.median()
-        with raises_regex(NotImplementedError, "only works along an axis"):
+        with pytest.raises(NotImplementedError, match=r"only works along an axis"):
             v.median(v.dims)
         with raise_if_dask_computes():
             v.reduce(duck_array_ops.mean)
@@ -506,7 +505,7 @@ class TestDataArrayAndDataset(DaskTestCase):
 
         for coords in [u.coords, v.coords]:
             coords["ab"] = ("x", ["a", "a", "b", "b"])
-        with raises_regex(NotImplementedError, "dask"):
+        with pytest.raises(NotImplementedError, match=r"dask"):
             v.groupby("ab").first()
         expected = u.groupby("ab").first()
         with raise_if_dask_computes():
@@ -851,7 +850,7 @@ class TestToDaskDataFrame:
         assert isinstance(actual, dd.DataFrame)
         assert_frame_equal(expected, actual.compute())
 
-        with raises_regex(ValueError, "does not match the set of dimensions"):
+        with pytest.raises(ValueError, match=r"does not match the set of dimensions"):
             ds.to_dask_dataframe(dim_order=["x"])
 
 
@@ -1038,7 +1037,7 @@ def test_unify_chunks(map_ds):
     ds_copy = map_ds.copy()
     ds_copy["cxy"] = ds_copy.cxy.chunk({"y": 10})
 
-    with raises_regex(ValueError, "inconsistent chunks"):
+    with pytest.raises(ValueError, match=r"inconsistent chunks"):
         ds_copy.chunks
 
     expected_chunks = {"x": (4, 4, 2), "y": (5, 5, 5, 5), "z": (4,)}
@@ -1070,34 +1069,34 @@ def test_map_blocks_error(map_da, map_ds):
     def bad_func(darray):
         return (darray * darray.x + 5 * darray.y)[:1, :1]
 
-    with raises_regex(ValueError, "Received dimension 'x' of length 1"):
+    with pytest.raises(ValueError, match=r"Received dimension 'x' of length 1"):
         xr.map_blocks(bad_func, map_da).compute()
 
     def returns_numpy(darray):
         return (darray * darray.x + 5 * darray.y).values
 
-    with raises_regex(TypeError, "Function must return an xarray DataArray"):
+    with pytest.raises(TypeError, match=r"Function must return an xarray DataArray"):
         xr.map_blocks(returns_numpy, map_da)
 
-    with raises_regex(TypeError, "args must be"):
+    with pytest.raises(TypeError, match=r"args must be"):
         xr.map_blocks(operator.add, map_da, args=10)
 
-    with raises_regex(TypeError, "kwargs must be"):
+    with pytest.raises(TypeError, match=r"kwargs must be"):
         xr.map_blocks(operator.add, map_da, args=[10], kwargs=[20])
 
     def really_bad_func(darray):
         raise ValueError("couldn't do anything.")
 
-    with raises_regex(Exception, "Cannot infer"):
+    with pytest.raises(Exception, match=r"Cannot infer"):
         xr.map_blocks(really_bad_func, map_da)
 
     ds_copy = map_ds.copy()
     ds_copy["cxy"] = ds_copy.cxy.chunk({"y": 10})
 
-    with raises_regex(ValueError, "inconsistent chunks"):
+    with pytest.raises(ValueError, match=r"inconsistent chunks"):
         xr.map_blocks(bad_func, ds_copy)
 
-    with raises_regex(TypeError, "Cannot pass dask collections"):
+    with pytest.raises(TypeError, match=r"Cannot pass dask collections"):
         xr.map_blocks(bad_func, map_da, kwargs=dict(a=map_da.chunk()))
 
 
@@ -1152,10 +1151,10 @@ def test_map_blocks_dask_args():
         mapped = xr.map_blocks(operator.add, da1, args=[da2])
     xr.testing.assert_equal(da1 + da2, mapped)
 
-    with raises_regex(ValueError, "Chunk sizes along dimension 'x'"):
+    with pytest.raises(ValueError, match=r"Chunk sizes along dimension 'x'"):
         xr.map_blocks(operator.add, da1, args=[da1.chunk({"x": 1})])
 
-    with raises_regex(ValueError, "indexes along dimension 'x' are not equal"):
+    with pytest.raises(ValueError, match=r"indexes along dimension 'x' are not equal"):
         xr.map_blocks(operator.add, da1, args=[da1.reindex(x=np.arange(20))])
 
     # reduction
@@ -1296,21 +1295,21 @@ def test_map_blocks_template_convert_object():
 
 @pytest.mark.parametrize("obj", [make_da(), make_ds()])
 def test_map_blocks_errors_bad_template(obj):
-    with raises_regex(ValueError, "unexpected coordinate variables"):
+    with pytest.raises(ValueError, match=r"unexpected coordinate variables"):
         xr.map_blocks(lambda x: x.assign_coords(a=10), obj, template=obj).compute()
-    with raises_regex(ValueError, "does not contain coordinate variables"):
+    with pytest.raises(ValueError, match=r"does not contain coordinate variables"):
         xr.map_blocks(lambda x: x.drop_vars("cxy"), obj, template=obj).compute()
-    with raises_regex(ValueError, "Dimensions {'x'} missing"):
+    with pytest.raises(ValueError, match=r"Dimensions {'x'} missing"):
         xr.map_blocks(lambda x: x.isel(x=1), obj, template=obj).compute()
-    with raises_regex(ValueError, "Received dimension 'x' of length 1"):
+    with pytest.raises(ValueError, match=r"Received dimension 'x' of length 1"):
         xr.map_blocks(lambda x: x.isel(x=[1]), obj, template=obj).compute()
-    with raises_regex(TypeError, "must be a DataArray"):
+    with pytest.raises(TypeError, match=r"must be a DataArray"):
         xr.map_blocks(lambda x: x.isel(x=[1]), obj, template=(obj,)).compute()
-    with raises_regex(ValueError, "map_blocks requires that one block"):
+    with pytest.raises(ValueError, match=r"map_blocks requires that one block"):
         xr.map_blocks(
             lambda x: x.isel(x=[1]).assign_coords(x=10), obj, template=obj.isel(x=[1])
         ).compute()
-    with raises_regex(ValueError, "Expected index 'x' to be"):
+    with pytest.raises(ValueError, match=r"Expected index 'x' to be"):
         xr.map_blocks(
             lambda a: a.isel(x=[1]).assign_coords(x=[120]),  # assign bad index values
             obj,
@@ -1319,7 +1318,7 @@ def test_map_blocks_errors_bad_template(obj):
 
 
 def test_map_blocks_errors_bad_template_2(map_ds):
-    with raises_regex(ValueError, "unexpected data variables {'xyz'}"):
+    with pytest.raises(ValueError, match=r"unexpected data variables {'xyz'}"):
         xr.map_blocks(lambda x: x.assign(xyz=1), map_ds, template=map_ds).compute()
 
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -132,7 +132,7 @@ class TestDataArray:
         with pytest.raises(AttributeError):
             self.dv.dataset
         assert isinstance(self.ds["x"].to_index(), pd.Index)
-        with raises_regex(ValueError, "must be 1-dimensional"):
+        with pytest.raises(ValueError, match=r"must be 1-dimensional"):
             self.ds["foo"].to_index()
         with pytest.raises(AttributeError):
             self.dv.variable = self.v
@@ -243,7 +243,7 @@ class TestDataArray:
         arr = self.dv
         assert arr.dims == ("x", "y")
 
-        with raises_regex(AttributeError, "you cannot assign"):
+        with pytest.raises(AttributeError, match=r"you cannot assign"):
             arr.dims = ("w", "z")
 
     def test_sizes(self):
@@ -331,28 +331,28 @@ class TestDataArray:
     def test_constructor_invalid(self):
         data = np.random.randn(3, 2)
 
-        with raises_regex(ValueError, "coords is not dict-like"):
+        with pytest.raises(ValueError, match=r"coords is not dict-like"):
             DataArray(data, [[0, 1, 2]], ["x", "y"])
 
-        with raises_regex(ValueError, "not a subset of the .* dim"):
+        with pytest.raises(ValueError, match=r"not a subset of the .* dim"):
             DataArray(data, {"x": [0, 1, 2]}, ["a", "b"])
-        with raises_regex(ValueError, "not a subset of the .* dim"):
+        with pytest.raises(ValueError, match=r"not a subset of the .* dim"):
             DataArray(data, {"x": [0, 1, 2]})
 
-        with raises_regex(TypeError, "is not a string"):
+        with pytest.raises(TypeError, match=r"is not a string"):
             DataArray(data, dims=["x", None])
 
-        with raises_regex(ValueError, "conflicting sizes for dim"):
+        with pytest.raises(ValueError, match=r"conflicting sizes for dim"):
             DataArray([1, 2, 3], coords=[("x", [0, 1])])
-        with raises_regex(ValueError, "conflicting sizes for dim"):
+        with pytest.raises(ValueError, match=r"conflicting sizes for dim"):
             DataArray([1, 2], coords={"x": [0, 1], "y": ("x", [1])}, dims="x")
 
-        with raises_regex(ValueError, "conflicting MultiIndex"):
+        with pytest.raises(ValueError, match=r"conflicting MultiIndex"):
             DataArray(np.random.rand(4, 4), [("x", self.mindex), ("y", self.mindex)])
-        with raises_regex(ValueError, "conflicting MultiIndex"):
+        with pytest.raises(ValueError, match=r"conflicting MultiIndex"):
             DataArray(np.random.rand(4, 4), [("x", self.mindex), ("level_1", range(4))])
 
-        with raises_regex(ValueError, "matching the dimension size"):
+        with pytest.raises(ValueError, match=r"matching the dimension size"):
             DataArray(data, coords={"x": 0}, dims=["x", "y"])
 
     def test_constructor_from_self_described(self):
@@ -692,7 +692,7 @@ class TestDataArray:
         da = get_data()
         # indexer with inconsistent coordinates.
         ind = DataArray(np.arange(1, 4), dims=["x"], coords={"x": np.random.randn(3)})
-        with raises_regex(IndexError, "dimension coordinate 'x'"):
+        with pytest.raises(IndexError, match=r"dimension coordinate 'x'"):
             da[dict(x=ind)] = 0
 
         # indexer with consistent coordinates.
@@ -709,7 +709,7 @@ class TestDataArray:
             dims=["x", "y", "z"],
             coords={"x": [0, 1, 2], "non-dim": ("x", [0, 2, 4])},
         )
-        with raises_regex(IndexError, "dimension coordinate 'x'"):
+        with pytest.raises(IndexError, match=r"dimension coordinate 'x'"):
             da[dict(x=ind)] = value
 
         # consistent coordinate in the assigning values
@@ -737,7 +737,7 @@ class TestDataArray:
             dims=["x", "y", "z"],
             coords={"x": [0, 1, 2], "non-dim": ("x", [0, 2, 4])},
         )
-        with raises_regex(IndexError, "dimension coordinate 'x'"):
+        with pytest.raises(IndexError, match=r"dimension coordinate 'x'"):
             da[dict(x=ind)] = value
 
         # consistent coordinate in the assigning values
@@ -871,7 +871,7 @@ class TestDataArray:
         )
 
         # make sure we're raising errors in the right places
-        with raises_regex(IndexError, "Dimensions of indexers mismatch"):
+        with pytest.raises(IndexError, match=r"Dimensions of indexers mismatch"):
             da.isel(y=(("points",), [1, 2]), x=(("points",), [1, 2, 3]))
 
         # tests using index or DataArray as indexers
@@ -885,7 +885,7 @@ class TestDataArray:
         assert "station" in actual.dims
         assert_identical(actual["station"], stations["station"])
 
-        with raises_regex(ValueError, "conflicting values for "):
+        with pytest.raises(ValueError, match=r"conflicting values for "):
             da.isel(
                 x=DataArray([0, 1, 2], dims="station", coords={"station": [0, 1, 2]}),
                 y=DataArray([0, 1, 2], dims="station", coords={"station": [0, 1, 3]}),
@@ -950,7 +950,7 @@ class TestDataArray:
 
     def test_sel_invalid_slice(self):
         array = DataArray(np.arange(10), [("x", np.arange(10))])
-        with raises_regex(ValueError, "cannot use non-scalar arrays"):
+        with pytest.raises(ValueError, match=r"cannot use non-scalar arrays"):
             array.sel(x=slice(array.x))
 
     def test_sel_dataarray_datetime_slice(self):
@@ -1043,11 +1043,11 @@ class TestDataArray:
         assert_equal(
             self.dv.isel({dim: slice(5) for dim in self.dv.dims}), self.dv.head()
         )
-        with raises_regex(TypeError, "either dict-like or a single int"):
+        with pytest.raises(TypeError, match=r"either dict-like or a single int"):
             self.dv.head([3])
-        with raises_regex(TypeError, "expected integer type"):
+        with pytest.raises(TypeError, match=r"expected integer type"):
             self.dv.head(x=3.1)
-        with raises_regex(ValueError, "expected positive int"):
+        with pytest.raises(ValueError, match=r"expected positive int"):
             self.dv.head(-3)
 
     def test_tail(self):
@@ -1060,11 +1060,11 @@ class TestDataArray:
         assert_equal(
             self.dv.isel({dim: slice(-5, None) for dim in self.dv.dims}), self.dv.tail()
         )
-        with raises_regex(TypeError, "either dict-like or a single int"):
+        with pytest.raises(TypeError, match=r"either dict-like or a single int"):
             self.dv.tail([3])
-        with raises_regex(TypeError, "expected integer type"):
+        with pytest.raises(TypeError, match=r"expected integer type"):
             self.dv.tail(x=3.1)
-        with raises_regex(ValueError, "expected positive int"):
+        with pytest.raises(ValueError, match=r"expected positive int"):
             self.dv.tail(-3)
 
     def test_thin(self):
@@ -1073,13 +1073,13 @@ class TestDataArray:
             self.dv.isel({dim: slice(None, None, 6) for dim in self.dv.dims}),
             self.dv.thin(6),
         )
-        with raises_regex(TypeError, "either dict-like or a single int"):
+        with pytest.raises(TypeError, match=r"either dict-like or a single int"):
             self.dv.thin([3])
-        with raises_regex(TypeError, "expected integer type"):
+        with pytest.raises(TypeError, match=r"expected integer type"):
             self.dv.thin(x=3.1)
-        with raises_regex(ValueError, "expected positive int"):
+        with pytest.raises(ValueError, match=r"expected positive int"):
             self.dv.thin(-3)
-        with raises_regex(ValueError, "cannot be zero"):
+        with pytest.raises(ValueError, match=r"cannot be zero"):
             self.dv.thin(time=0)
 
     def test_loc(self):
@@ -1137,7 +1137,7 @@ class TestDataArray:
         da = get_data()
         # indexer with inconsistent coordinates.
         ind = DataArray(np.arange(1, 4), dims=["y"], coords={"y": np.random.randn(3)})
-        with raises_regex(IndexError, "dimension coordinate 'y'"):
+        with pytest.raises(IndexError, match=r"dimension coordinate 'y'"):
             da.loc[dict(x=ind)] = 0
 
         # indexer with consistent coordinates.
@@ -1154,7 +1154,7 @@ class TestDataArray:
             dims=["x", "y", "z"],
             coords={"x": [0, 1, 2], "non-dim": ("x", [0, 2, 4])},
         )
-        with raises_regex(IndexError, "dimension coordinate 'x'"):
+        with pytest.raises(IndexError, match=r"dimension coordinate 'x'"):
             da.loc[dict(x=ind)] = value
 
         # consistent coordinate in the assigning values
@@ -1318,14 +1318,14 @@ class TestDataArray:
         expected = DataArray(da.values, {"y": [0, 1, 2]}, dims=["x", "y"], name="foo")
         assert_identical(da, expected)
 
-        with raises_regex(ValueError, "conflicting MultiIndex"):
+        with pytest.raises(ValueError, match=r"conflicting MultiIndex"):
             self.mda["level_1"] = np.arange(4)
             self.mda.coords["level_1"] = np.arange(4)
 
     def test_coords_to_index(self):
         da = DataArray(np.zeros((2, 3)), [("x", [1, 2]), ("y", list("abc"))])
 
-        with raises_regex(ValueError, "no valid index"):
+        with pytest.raises(ValueError, match=r"no valid index"):
             da[0, 0].coords.to_index()
 
         expected = pd.Index(["a", "b", "c"], name="y")
@@ -1344,7 +1344,7 @@ class TestDataArray:
         actual = da.coords.to_index(["y", "x"])
         assert expected.equals(actual)
 
-        with raises_regex(ValueError, "ordered_dims must match"):
+        with pytest.raises(ValueError, match=r"ordered_dims must match"):
             da.coords.to_index(["x"])
 
     def test_coord_coords(self):
@@ -1418,11 +1418,11 @@ class TestDataArray:
         )
         assert_identical(actual, expected)
 
-        with raises_regex(ValueError, "cannot be found"):
+        with pytest.raises(ValueError, match=r"cannot be found"):
             data.reset_coords("foo", drop=True)
-        with raises_regex(ValueError, "cannot be found"):
+        with pytest.raises(ValueError, match=r"cannot be found"):
             data.reset_coords("not_found")
-        with raises_regex(ValueError, "cannot remove index"):
+        with pytest.raises(ValueError, match=r"cannot remove index"):
             data.reset_coords("y")
 
     def test_assign_coords(self):
@@ -1437,7 +1437,7 @@ class TestDataArray:
         expected.coords["d"] = ("x", [1.5, 1.5, 3.5, 3.5])
         assert_identical(actual, expected)
 
-        with raises_regex(ValueError, "conflicting MultiIndex"):
+        with pytest.raises(ValueError, match=r"conflicting MultiIndex"):
             self.mda.assign_coords(level_1=range(4))
 
         # GH: 2112
@@ -1522,7 +1522,7 @@ class TestDataArray:
         assert_identical(foo, foo.reindex_like(foo))
 
         bar = foo[:4]
-        with raises_regex(ValueError, "different size for unlabeled"):
+        with pytest.raises(ValueError, match=r"different size for unlabeled"):
             foo.reindex_like(bar)
 
     def test_reindex_regressions(self):
@@ -1618,9 +1618,9 @@ class TestDataArray:
         actual = DataArray(coords=[("x", np.arange(10)), ("y", ["a", "b"])])
         assert_identical(expected, actual)
 
-        with raises_regex(ValueError, "different number of dim"):
+        with pytest.raises(ValueError, match=r"different number of dim"):
             DataArray(np.array(1), coords={"x": np.arange(10)}, dims=["x"])
-        with raises_regex(ValueError, "does not match the 0 dim"):
+        with pytest.raises(ValueError, match=r"does not match the 0 dim"):
             DataArray(np.array(1), coords=[("x", np.arange(10))])
 
     def test_swap_dims(self):
@@ -1671,20 +1671,20 @@ class TestDataArray:
             attrs={"key": "entry"},
         )
 
-        with raises_regex(TypeError, "dim should be hashable or"):
+        with pytest.raises(TypeError, match=r"dim should be hashable or"):
             array.expand_dims(0)
-        with raises_regex(ValueError, "lengths of dim and axis"):
+        with pytest.raises(ValueError, match=r"lengths of dim and axis"):
             # dims and axis argument should be the same length
             array.expand_dims(dim=["a", "b"], axis=[1, 2, 3])
-        with raises_regex(ValueError, "Dimension x already"):
+        with pytest.raises(ValueError, match=r"Dimension x already"):
             # Should not pass the already existing dimension.
             array.expand_dims(dim=["x"])
         # raise if duplicate
-        with raises_regex(ValueError, "duplicate values"):
+        with pytest.raises(ValueError, match=r"duplicate values"):
             array.expand_dims(dim=["y", "y"])
-        with raises_regex(ValueError, "duplicate values"):
+        with pytest.raises(ValueError, match=r"duplicate values"):
             array.expand_dims(dim=["y", "z"], axis=[1, 1])
-        with raises_regex(ValueError, "duplicate values"):
+        with pytest.raises(ValueError, match=r"duplicate values"):
             array.expand_dims(dim=["y", "z"], axis=[2, -2])
 
         # out of bounds error, axis must be in [-4, 3]
@@ -1850,7 +1850,7 @@ class TestDataArray:
             coords={"x": ("x", [0, 1]), "level": ("y", [1, 2])},
             dims=("x", "y"),
         )
-        with raises_regex(ValueError, "dimension mismatch"):
+        with pytest.raises(ValueError, match=r"dimension mismatch"):
             array2d.set_index(x="level")
 
         # Issue 3176: Ensure clear error message on key error.
@@ -1910,7 +1910,7 @@ class TestDataArray:
             array.reorder_levels(x=["level_1", "level_2"])
 
         array["x"] = [0, 1]
-        with raises_regex(ValueError, "has no MultiIndex"):
+        with pytest.raises(ValueError, match=r"has no MultiIndex"):
             array.reorder_levels(x=["level_1", "level_2"])
 
     def test_dataset_getitem(self):
@@ -2312,14 +2312,14 @@ class TestDataArray:
         actual = expected.drop_vars("not found", errors="ignore")
         assert_identical(actual, expected)
 
-        with raises_regex(ValueError, "cannot be found"):
+        with pytest.raises(ValueError, match=r"cannot be found"):
             arr.drop_vars("w")
 
         actual = expected.drop_vars("w", errors="ignore")
         assert_identical(actual, expected)
 
         renamed = arr.rename("foo")
-        with raises_regex(ValueError, "cannot be found"):
+        with pytest.raises(ValueError, match=r"cannot be found"):
             renamed.drop_vars("foo")
 
         actual = renamed.drop_vars("foo", errors="ignore")
@@ -2601,10 +2601,10 @@ class TestDataArray:
         actual = a.fillna(b[:0])
         assert_identical(a, actual)
 
-        with raises_regex(TypeError, "fillna on a DataArray"):
+        with pytest.raises(TypeError, match=r"fillna on a DataArray"):
             a.fillna({0: 0})
 
-        with raises_regex(ValueError, "broadcast"):
+        with pytest.raises(ValueError, match=r"broadcast"):
             a.fillna([1, 2])
 
         fill_value = DataArray([0, 1], dims="y")
@@ -2819,11 +2819,11 @@ class TestDataArray:
         actual_agg = actual.groupby("abc").mean(...)
         assert_allclose(expected_agg, actual_agg)
 
-        with raises_regex(TypeError, "only support binary ops"):
+        with pytest.raises(TypeError, match=r"only support binary ops"):
             grouped + 1
-        with raises_regex(TypeError, "only support binary ops"):
+        with pytest.raises(TypeError, match=r"only support binary ops"):
             grouped + grouped
-        with raises_regex(TypeError, "in-place operations"):
+        with pytest.raises(TypeError, match=r"in-place operations"):
             array += grouped
 
     def test_groupby_math_not_aligned(self):
@@ -3001,7 +3001,7 @@ class TestDataArray:
         expected = DataArray.from_series(expected_)
         assert_identical(actual, expected)
 
-        with raises_regex(ValueError, "index must be monotonic"):
+        with pytest.raises(ValueError, match=r"index must be monotonic"):
             array[[2, 0, 1]].resample(time="1D")
 
     def test_da_resample_func_args(self):
@@ -3050,7 +3050,7 @@ class TestDataArray:
     def test_resample_bad_resample_dim(self):
         times = pd.date_range("2000-01-01", freq="6H", periods=10)
         array = DataArray(np.arange(10), [("__resample_dim__", times)])
-        with raises_regex(ValueError, "Proxy resampling dimension"):
+        with pytest.raises(ValueError, match=r"Proxy resampling dimension"):
             array.resample(**{"__resample_dim__": "1D"}).first()
 
     @requires_scipy
@@ -3387,7 +3387,7 @@ class TestDataArray:
         assert_identical(left.isel(x=0, drop=True), new_left)
         assert_identical(right, new_right)
 
-        with raises_regex(ValueError, "Indexes along dimension 'x' don't have"):
+        with pytest.raises(ValueError, match=r"Indexes along dimension 'x' don't have"):
             align(left.isel(x=0).expand_dims("x"), right, join="override")
 
     @pytest.mark.parametrize(
@@ -3406,7 +3406,7 @@ class TestDataArray:
         ],
     )
     def test_align_override_error(self, darrays):
-        with raises_regex(ValueError, "Indexes along dimension 'x' don't have"):
+        with pytest.raises(ValueError, match=r"Indexes along dimension 'x' don't have"):
             xr.align(*darrays, join="override")
 
     def test_align_exclude(self):
@@ -3462,10 +3462,10 @@ class TestDataArray:
         assert_identical(result1, array_with_coord)
 
     def test_align_without_indexes_errors(self):
-        with raises_regex(ValueError, "cannot be aligned"):
+        with pytest.raises(ValueError, match=r"cannot be aligned"):
             align(DataArray([1, 2, 3], dims=["x"]), DataArray([1, 2], dims=["x"]))
 
-        with raises_regex(ValueError, "cannot be aligned"):
+        with pytest.raises(ValueError, match=r"cannot be aligned"):
             align(
                 DataArray([1, 2, 3], dims=["x"]),
                 DataArray([1, 2], coords=[("x", [0, 1])]),
@@ -3605,7 +3605,7 @@ class TestDataArray:
             roundtripped = DataArray(da.to_pandas()).drop_vars(dims)
             assert_identical(da, roundtripped)
 
-        with raises_regex(ValueError, "cannot convert"):
+        with pytest.raises(ValueError, match=r"cannot convert"):
             DataArray(np.random.randn(1, 2, 3, 4, 5)).to_pandas()
 
     def test_to_dataframe(self):
@@ -3639,7 +3639,7 @@ class TestDataArray:
             arr.sel(A="c", B=2).to_dataframe()
 
         arr.name = None  # unnamed
-        with raises_regex(ValueError, "unnamed"):
+        with pytest.raises(ValueError, match=r"unnamed"):
             arr.to_dataframe()
 
     def test_to_dataframe_multiindex(self):
@@ -3799,7 +3799,9 @@ class TestDataArray:
 
         # this one is missing some necessary information
         d = {"dims": ("t")}
-        with raises_regex(ValueError, "cannot convert dict without the key 'data'"):
+        with pytest.raises(
+            ValueError, match=r"cannot convert dict without the key 'data'"
+        ):
             DataArray.from_dict(d)
 
         # check the data=False option
@@ -3984,7 +3986,7 @@ class TestDataArray:
 
     def test_to_dataset_whole(self):
         unnamed = DataArray([1, 2], dims="x")
-        with raises_regex(ValueError, "unable to convert unnamed"):
+        with pytest.raises(ValueError, match=r"unable to convert unnamed"):
             unnamed.to_dataset()
 
         actual = unnamed.to_dataset(name="foo")
@@ -4179,11 +4181,11 @@ class TestDataArray:
 
     def test_setattr_raises(self):
         array = DataArray(0, coords={"scalar": 1}, attrs={"foo": "bar"})
-        with raises_regex(AttributeError, "cannot set attr"):
+        with pytest.raises(AttributeError, match=r"cannot set attr"):
             array.scalar = 2
-        with raises_regex(AttributeError, "cannot set attr"):
+        with pytest.raises(AttributeError, match=r"cannot set attr"):
             array.foo = 2
-        with raises_regex(AttributeError, "cannot set attr"):
+        with pytest.raises(AttributeError, match=r"cannot set attr"):
             array.other = 2
 
     def test_full_like(self):
@@ -4270,7 +4272,7 @@ class TestDataArray:
         dm = DataArray(dm_vals, coords=[z_m], dims=["z"])
 
         with xr.set_options(arithmetic_join="exact"):
-            with raises_regex(ValueError, "indexes along dimension"):
+            with pytest.raises(ValueError, match=r"indexes along dimension"):
                 da.dot(dm)
 
         da_aligned, dm_aligned = xr.align(da, dm, join="inner")
@@ -4321,7 +4323,7 @@ class TestDataArray:
         assert_identical(result, expected)
 
         with xr.set_options(arithmetic_join="exact"):
-            with raises_regex(ValueError, "indexes along dimension"):
+            with pytest.raises(ValueError, match=r"indexes along dimension"):
                 da_a @ da_b
 
     def test_binary_op_propagate_indexes(self):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -385,13 +385,13 @@ class TestDataset:
         x2 = ("x", np.arange(1000))
         z = (["x", "y"], np.arange(1000).reshape(100, 10))
 
-        with raises_regex(ValueError, "conflicting sizes"):
+        with pytest.raises(ValueError, match=r"conflicting sizes"):
             Dataset({"a": x1, "b": x2})
-        with raises_regex(ValueError, "disallows such variables"):
+        with pytest.raises(ValueError, match=r"disallows such variables"):
             Dataset({"a": x1, "x": z})
-        with raises_regex(TypeError, "tuple of form"):
+        with pytest.raises(TypeError, match=r"tuple of form"):
             Dataset({"x": (1, 2, 3, 4, 5, 6, 7)})
-        with raises_regex(ValueError, "already exists as a scalar"):
+        with pytest.raises(ValueError, match=r"already exists as a scalar"):
             Dataset({"x": 0, "y": ("x", [1, 2, 3])})
 
         # verify handling of DataArrays
@@ -444,7 +444,7 @@ class TestDataset:
             assert_identical(expected, actual)
 
     def test_constructor_deprecated(self):
-        with raises_regex(ValueError, "DataArray dimensions"):
+        with pytest.raises(ValueError, match=r"DataArray dimensions"):
             DataArray([1, 2, 3], coords={"x": [0, 1, 2]})
 
     def test_constructor_auto_align(self):
@@ -474,7 +474,7 @@ class TestDataset:
         assert_identical(expected3, actual)
 
         e = ("x", [0, 0])
-        with raises_regex(ValueError, "conflicting sizes"):
+        with pytest.raises(ValueError, match=r"conflicting sizes"):
             Dataset({"a": a, "b": b, "e": e})
 
     def test_constructor_pandas_sequence(self):
@@ -541,7 +541,7 @@ class TestDataset:
         assert_identical(expected, actual)
 
     def test_constructor_with_coords(self):
-        with raises_regex(ValueError, "found in both data_vars and"):
+        with pytest.raises(ValueError, match=r"found in both data_vars and"):
             Dataset({"a": ("x", [1])}, {"a": ("x", [1])})
 
         ds = Dataset({}, {"a": ("x", [1])})
@@ -551,7 +551,7 @@ class TestDataset:
         mindex = pd.MultiIndex.from_product(
             [["a", "b"], [1, 2]], names=("level_1", "level_2")
         )
-        with raises_regex(ValueError, "conflicting MultiIndex"):
+        with pytest.raises(ValueError, match=r"conflicting MultiIndex"):
             Dataset({}, {"x": mindex, "y": mindex})
             Dataset({}, {"x": mindex, "level_1": range(4)})
 
@@ -596,7 +596,7 @@ class TestDataset:
 
     def test_asarray(self):
         ds = Dataset({"x": 0})
-        with raises_regex(TypeError, "cannot directly convert"):
+        with pytest.raises(TypeError, match=r"cannot directly convert"):
             np.asarray(ds)
 
     def test_get_index(self):
@@ -724,7 +724,7 @@ class TestDataset:
         assert_array_equal(actual["z"], ["a", "b"])
 
         actual = data.copy(deep=True)
-        with raises_regex(ValueError, "conflicting sizes"):
+        with pytest.raises(ValueError, match=r"conflicting sizes"):
             actual.coords["x"] = ("x", [-1])
         assert_identical(actual, data)  # should not be modified
 
@@ -761,7 +761,7 @@ class TestDataset:
 
     def test_coords_setitem_multiindex(self):
         data = create_test_multiindex()
-        with raises_regex(ValueError, "conflicting MultiIndex"):
+        with pytest.raises(ValueError, match=r"conflicting MultiIndex"):
             data.coords["level_1"] = range(4)
 
     def test_coords_set(self):
@@ -794,7 +794,7 @@ class TestDataset:
         actual = all_coords.reset_coords("zzz")
         assert_identical(two_coords, actual)
 
-        with raises_regex(ValueError, "cannot remove index"):
+        with pytest.raises(ValueError, match=r"cannot remove index"):
             one_coord.reset_coords("x")
 
         actual = all_coords.reset_coords("zzz", drop=True)
@@ -970,7 +970,7 @@ class TestDataset:
         for k, v in new_dask_names.items():
             assert v == orig_dask_names[k]
 
-        with raises_regex(ValueError, "some chunks"):
+        with pytest.raises(ValueError, match=r"some chunks"):
             data.chunk({"foo": 10})
 
     @requires_dask
@@ -1132,9 +1132,9 @@ class TestDataset:
             data.isel(dim2=(("points",), pdim2), dim1=(("points",), pdim1)),
         )
         # make sure we're raising errors in the right places
-        with raises_regex(IndexError, "Dimensions of indexers mismatch"):
+        with pytest.raises(IndexError, match=r"Dimensions of indexers mismatch"):
             data.isel(dim1=(("points",), [1, 2]), dim2=(("points",), [1, 2, 3]))
-        with raises_regex(TypeError, "cannot use a Dataset"):
+        with pytest.raises(TypeError, match=r"cannot use a Dataset"):
             data.isel(dim1=Dataset({"points": [1, 2]}))
 
         # test to be sure we keep around variables that were not indexed
@@ -1153,7 +1153,7 @@ class TestDataset:
         assert "station" in actual.dims
         assert_identical(actual["station"].drop_vars(["dim2"]), stations["station"])
 
-        with raises_regex(ValueError, "conflicting values for "):
+        with pytest.raises(ValueError, match=r"conflicting values for "):
             data.isel(
                 dim1=DataArray(
                     [0, 1, 2], dims="station", coords={"station": [0, 1, 2]}
@@ -1206,12 +1206,12 @@ class TestDataset:
         indexing_da = DataArray(
             np.arange(1, 4), dims=["dim2"], coords={"dim2": np.random.randn(3)}
         )
-        with raises_regex(IndexError, "dimension coordinate 'dim2'"):
+        with pytest.raises(IndexError, match=r"dimension coordinate 'dim2'"):
             actual = data.isel(dim2=indexing_da)
         # Also the case for DataArray
-        with raises_regex(IndexError, "dimension coordinate 'dim2'"):
+        with pytest.raises(IndexError, match=r"dimension coordinate 'dim2'"):
             actual = data["var2"].isel(dim2=indexing_da)
-        with raises_regex(IndexError, "dimension coordinate 'dim2'"):
+        with pytest.raises(IndexError, match=r"dimension coordinate 'dim2'"):
             data["dim2"].isel(dim2=indexing_da)
 
         # same name coordinate which does not conflict
@@ -1278,7 +1278,7 @@ class TestDataset:
 
         # indexer generated from coordinates
         indexing_ds = Dataset({}, coords={"dim2": [0, 1, 2]})
-        with raises_regex(IndexError, "dimension coordinate 'dim2'"):
+        with pytest.raises(IndexError, match=r"dimension coordinate 'dim2'"):
             actual = data.isel(dim2=indexing_ds["dim2"])
 
     def test_sel(self):
@@ -1414,7 +1414,7 @@ class TestDataset:
         assert_identical(actual_isel, actual_sel)
 
         # Vectorized indexing with level-variables raises an error
-        with raises_regex(ValueError, "Vectorized selection is "):
+        with pytest.raises(ValueError, match=r"Vectorized selection is "):
             mds.sel(one=["a", "b"])
 
         with raises_regex(
@@ -1532,11 +1532,11 @@ class TestDataset:
         actual = data.head()
         assert_equal(expected, actual)
 
-        with raises_regex(TypeError, "either dict-like or a single int"):
+        with pytest.raises(TypeError, match=r"either dict-like or a single int"):
             data.head([3])
-        with raises_regex(TypeError, "expected integer type"):
+        with pytest.raises(TypeError, match=r"expected integer type"):
             data.head(dim2=3.1)
-        with raises_regex(ValueError, "expected positive int"):
+        with pytest.raises(ValueError, match=r"expected positive int"):
             data.head(time=-3)
 
     def test_tail(self):
@@ -1558,11 +1558,11 @@ class TestDataset:
         actual = data.tail()
         assert_equal(expected, actual)
 
-        with raises_regex(TypeError, "either dict-like or a single int"):
+        with pytest.raises(TypeError, match=r"either dict-like or a single int"):
             data.tail([3])
-        with raises_regex(TypeError, "expected integer type"):
+        with pytest.raises(TypeError, match=r"expected integer type"):
             data.tail(dim2=3.1)
-        with raises_regex(ValueError, "expected positive int"):
+        with pytest.raises(ValueError, match=r"expected positive int"):
             data.tail(time=-3)
 
     def test_thin(self):
@@ -1576,13 +1576,13 @@ class TestDataset:
         actual = data.thin(6)
         assert_equal(expected, actual)
 
-        with raises_regex(TypeError, "either dict-like or a single int"):
+        with pytest.raises(TypeError, match=r"either dict-like or a single int"):
             data.thin([3])
-        with raises_regex(TypeError, "expected integer type"):
+        with pytest.raises(TypeError, match=r"expected integer type"):
             data.thin(dim2=3.1)
-        with raises_regex(ValueError, "cannot be zero"):
+        with pytest.raises(ValueError, match=r"cannot be zero"):
             data.thin(time=0)
-        with raises_regex(ValueError, "expected positive int"):
+        with pytest.raises(ValueError, match=r"expected positive int"):
             data.thin(time=-3)
 
     @pytest.mark.filterwarnings("ignore::DeprecationWarning")
@@ -1696,15 +1696,15 @@ class TestDataset:
         actual = data.sel(dim2=[1.45], method="backfill")
         assert_identical(expected, actual)
 
-        with raises_regex(NotImplementedError, "slice objects"):
+        with pytest.raises(NotImplementedError, match=r"slice objects"):
             data.sel(dim2=slice(1, 3), method="ffill")
 
-        with raises_regex(TypeError, "``method``"):
+        with pytest.raises(TypeError, match=r"``method``"):
             # this should not pass silently
             data.sel(method=data)
 
         # cannot pass method if there is no associated coordinate
-        with raises_regex(ValueError, "cannot supply"):
+        with pytest.raises(ValueError, match=r"cannot supply"):
             data.sel(dim1=0, method="nearest")
 
     def test_loc(self):
@@ -1712,7 +1712,7 @@ class TestDataset:
         expected = data.sel(dim3="a")
         actual = data.loc[dict(dim3="a")]
         assert_identical(expected, actual)
-        with raises_regex(TypeError, "can only lookup dict"):
+        with pytest.raises(TypeError, match=r"can only lookup dict"):
             data.loc["a"]
         with pytest.raises(TypeError):
             data.loc[dict(dim3="a")] = 0
@@ -1803,7 +1803,9 @@ class TestDataset:
         actual = data.reindex(dim1=data["dim1"].to_index())
         assert_identical(actual, expected)
 
-        with raises_regex(ValueError, "cannot reindex or align along dimension"):
+        with pytest.raises(
+            ValueError, match=r"cannot reindex or align along dimension"
+        ):
             data.reindex(dim1=data["dim1"][:5])
 
         expected = data.isel(dim2=slice(5))
@@ -1814,13 +1816,13 @@ class TestDataset:
         actual = data.reindex({"dim2": data["dim2"]})
         expected = data
         assert_identical(actual, expected)
-        with raises_regex(ValueError, "cannot specify both"):
+        with pytest.raises(ValueError, match=r"cannot specify both"):
             data.reindex({"x": 0}, x=0)
-        with raises_regex(ValueError, "dictionary"):
+        with pytest.raises(ValueError, match=r"dictionary"):
             data.reindex("foo")
 
         # invalid dimension
-        with raises_regex(ValueError, "invalid reindex dim"):
+        with pytest.raises(ValueError, match=r"invalid reindex dim"):
             data.reindex(invalid=0)
 
         # out of order
@@ -2032,7 +2034,7 @@ class TestDataset:
 
         assert np.isnan(left2["var3"][-2:]).all()
 
-        with raises_regex(ValueError, "invalid value for join"):
+        with pytest.raises(ValueError, match=r"invalid value for join"):
             align(left, right, join="foobar")
         with pytest.raises(TypeError):
             align(left, right, foo="bar")
@@ -2045,7 +2047,7 @@ class TestDataset:
         assert_identical(left1, left)
         assert_identical(left2, left)
 
-        with raises_regex(ValueError, "indexes .* not equal"):
+        with pytest.raises(ValueError, match=r"indexes .* not equal"):
             xr.align(left, right, join="exact")
 
     def test_align_override(self):
@@ -2067,7 +2069,7 @@ class TestDataset:
         assert_identical(left.isel(x=0, drop=True), new_left)
         assert_identical(right, new_right)
 
-        with raises_regex(ValueError, "Indexes along dimension 'x' don't have"):
+        with pytest.raises(ValueError, match=r"Indexes along dimension 'x' don't have"):
             xr.align(left.isel(x=0).expand_dims("x"), right, join="override")
 
     def test_align_exclude(self):
@@ -2142,7 +2144,7 @@ class TestDataset:
         assert_identical(x2, x)
 
         y = Dataset({"bar": ("x", [6, 7]), "x": [0, 1]})
-        with raises_regex(ValueError, "cannot reindex or align"):
+        with pytest.raises(ValueError, match=r"cannot reindex or align"):
             align(x, y)
 
     def test_align_str_dtype(self):
@@ -2302,7 +2304,7 @@ class TestDataset:
         actual = data.drop_vars(["time"])
         assert_identical(expected, actual)
 
-        with raises_regex(ValueError, "cannot be found"):
+        with pytest.raises(ValueError, match=r"cannot be found"):
             data.drop_vars("not_found_here")
 
         actual = data.drop_vars("not_found_here", errors="ignore")
@@ -2376,7 +2378,7 @@ class TestDataset:
         expected = data.isel(y=[0, 2])
         assert_identical(expected, actual)
 
-        with raises_regex(KeyError, "not found in axis"):
+        with pytest.raises(KeyError, match=r"not found in axis"):
             data.drop_sel(x=0)
 
     def test_drop_labels_by_keyword(self):
@@ -2570,11 +2572,11 @@ class TestDataset:
     def test_copy_with_data_errors(self):
         orig = create_test_data()
         new_var1 = np.arange(orig["var1"].size).reshape(orig["var1"].shape)
-        with raises_regex(ValueError, "Data must be dict-like"):
+        with pytest.raises(ValueError, match=r"Data must be dict-like"):
             orig.copy(data=new_var1)
-        with raises_regex(ValueError, "only contain variables in original"):
+        with pytest.raises(ValueError, match=r"only contain variables in original"):
             orig.copy(data={"not_in_original": new_var1})
-        with raises_regex(ValueError, "contain all variables in original"):
+        with pytest.raises(ValueError, match=r"contain all variables in original"):
             orig.copy(data={"var1": new_var1})
 
     def test_rename(self):
@@ -2602,10 +2604,10 @@ class TestDataset:
         assert "var1" not in renamed
         assert "dim2" not in renamed
 
-        with raises_regex(ValueError, "cannot rename 'not_a_var'"):
+        with pytest.raises(ValueError, match=r"cannot rename 'not_a_var'"):
             data.rename({"not_a_var": "nada"})
 
-        with raises_regex(ValueError, "'var1' conflicts"):
+        with pytest.raises(ValueError, match=r"'var1' conflicts"):
             data.rename({"var2": "var1"})
 
         # verify that we can rename a variable without accessing the data
@@ -2622,7 +2624,7 @@ class TestDataset:
         # regtest for GH1477
         data = create_test_data()
 
-        with raises_regex(ValueError, "'samecol' conflicts"):
+        with pytest.raises(ValueError, match=r"'samecol' conflicts"):
             data.rename({"var1": "samecol", "var2": "samecol"})
 
         # This shouldn't cause any problems.
@@ -2676,7 +2678,7 @@ class TestDataset:
             [([1, 2]), ([3, 4])], names=["level0", "level1"]
         )
         data = Dataset({}, {"x": mindex})
-        with raises_regex(ValueError, "conflicting MultiIndex"):
+        with pytest.raises(ValueError, match=r"conflicting MultiIndex"):
             data.rename({"x": "level0"})
 
     @requires_cftime
@@ -2738,9 +2740,9 @@ class TestDataset:
         roundtripped = actual.swap_dims({"y": "x"})
         assert_identical(original.set_coords("y"), roundtripped)
 
-        with raises_regex(ValueError, "cannot swap"):
+        with pytest.raises(ValueError, match=r"cannot swap"):
             original.swap_dims({"y": "x"})
-        with raises_regex(ValueError, "replacement dimension"):
+        with pytest.raises(ValueError, match=r"replacement dimension"):
             original.swap_dims({"x": "z"})
 
         expected = Dataset(
@@ -2781,13 +2783,13 @@ class TestDataset:
             attrs={"key": "entry"},
         )
 
-        with raises_regex(ValueError, "already exists"):
+        with pytest.raises(ValueError, match=r"already exists"):
             original.expand_dims(dim=["x"])
 
         # Make sure it raises true error also for non-dimensional coordinates
         # which has dimension.
         original = original.set_coords("z")
-        with raises_regex(ValueError, "already exists"):
+        with pytest.raises(ValueError, match=r"already exists"):
             original.expand_dims(dim=["z"])
 
         original = Dataset(
@@ -2803,9 +2805,9 @@ class TestDataset:
             },
             attrs={"key": "entry"},
         )
-        with raises_regex(TypeError, "value of new dimension"):
+        with pytest.raises(TypeError, match=r"value of new dimension"):
             original.expand_dims({"d": 3.2})
-        with raises_regex(ValueError, "both keyword and positional"):
+        with pytest.raises(ValueError, match=r"both keyword and positional"):
             original.expand_dims({"d": 4}, e=4)
 
     def test_expand_dims_int(self):
@@ -2994,7 +2996,7 @@ class TestDataset:
         assert_identical(reindexed, expected)
 
         ds = Dataset({}, coords={"x": [1, 2]})
-        with raises_regex(ValueError, "has no MultiIndex"):
+        with pytest.raises(ValueError, match=r"has no MultiIndex"):
             ds.reorder_levels(x=["level_1", "level_2"])
 
     def test_stack(self):
@@ -3039,9 +3041,9 @@ class TestDataset:
 
     def test_unstack_errors(self):
         ds = Dataset({"x": [1, 2, 3]})
-        with raises_regex(ValueError, "does not contain the dimensions"):
+        with pytest.raises(ValueError, match=r"does not contain the dimensions"):
             ds.unstack("foo")
-        with raises_regex(ValueError, "do not have a MultiIndex"):
+        with pytest.raises(ValueError, match=r"do not have a MultiIndex"):
             ds.unstack("x")
 
     def test_unstack_fill_value(self):
@@ -3217,7 +3219,7 @@ class TestDataset:
         expected = Dataset({"x": ("t", [3, 4]), "y": ("t", [np.nan, 5])}, {"t": [0, 1]})
         actual = ds.copy()
         other = {"y": ("t", [5]), "t": [1]}
-        with raises_regex(ValueError, "conflicting sizes"):
+        with pytest.raises(ValueError, match=r"conflicting sizes"):
             actual.update(other)
         actual.update(Dataset(other))
         assert_identical(expected, actual)
@@ -3262,7 +3264,7 @@ class TestDataset:
         expected = data["var1"] + 1
         expected.name = (3, 4)
         assert_identical(expected, data[(3, 4)])
-        with raises_regex(KeyError, "('var1', 'var2')"):
+        with pytest.raises(KeyError, match=r"('var1', 'var2')"):
             data[("var1", "var2")]
 
     def test_virtual_variables_default_coords(self):
@@ -3360,7 +3362,7 @@ class TestDataset:
         data2["B"] = dv
         assert_identical(data1, data2)
         # can't assign an ND array without dimensions
-        with raises_regex(ValueError, "without explicit dimension names"):
+        with pytest.raises(ValueError, match=r"without explicit dimension names"):
             data2["C"] = var.values.reshape(2, 4)
         # but can assign a 1D array
         data1["C"] = var.values
@@ -3371,10 +3373,10 @@ class TestDataset:
         data2["scalar"] = ([], 0)
         assert_identical(data1, data2)
         # can't use the same dimension name as a scalar var
-        with raises_regex(ValueError, "already exists as a scalar"):
+        with pytest.raises(ValueError, match=r"already exists as a scalar"):
             data1["newvar"] = ("scalar", [3, 4, 5])
         # can't resize a used dimension
-        with raises_regex(ValueError, "arguments without labels"):
+        with pytest.raises(ValueError, match=r"arguments without labels"):
             data1["dim1"] = data1["dim1"][:5]
         # override an existing value
         data1["A"] = 3 * data2["A"]
@@ -3550,7 +3552,7 @@ class TestDataset:
 
     def test_assign_multiindex_level(self):
         data = create_test_multiindex()
-        with raises_regex(ValueError, "conflicting MultiIndex"):
+        with pytest.raises(ValueError, match=r"conflicting MultiIndex"):
             data.assign(level_1=range(4))
             data.assign_coords(level_1=range(4))
         # raise an Error when any level name is used as dimension GH:2299
@@ -3597,7 +3599,7 @@ class TestDataset:
 
     def test_setitem_multiindex_level(self):
         data = create_test_multiindex()
-        with raises_regex(ValueError, "conflicting MultiIndex"):
+        with pytest.raises(ValueError, match=r"conflicting MultiIndex"):
             data["level_1"] = range(4)
 
     def test_delitem(self):
@@ -3628,7 +3630,7 @@ class TestDataset:
             expected = expected.set_coords(data.coords)
             assert_identical(expected, data.squeeze(*args))
         # invalid squeeze
-        with raises_regex(ValueError, "cannot select a dimension"):
+        with pytest.raises(ValueError, match=r"cannot select a dimension"):
             data.squeeze("y")
 
     def test_squeeze_drop(self):
@@ -3700,11 +3702,11 @@ class TestDataset:
 
     def test_groupby_errors(self):
         data = create_test_data()
-        with raises_regex(TypeError, "`group` must be"):
+        with pytest.raises(TypeError, match=r"`group` must be"):
             data.groupby(np.arange(10))
-        with raises_regex(ValueError, "length does not match"):
+        with pytest.raises(ValueError, match=r"length does not match"):
             data.groupby(data["dim1"][:3])
-        with raises_regex(TypeError, "`group` must be"):
+        with pytest.raises(TypeError, match=r"`group` must be"):
             data.groupby(data.coords["dim1"].to_index())
 
     def test_groupby_reduce(self):
@@ -3771,15 +3773,15 @@ class TestDataset:
         actual = zeros + grouped
         assert_equal(expected, actual)
 
-        with raises_regex(ValueError, "incompat.* grouped binary"):
+        with pytest.raises(ValueError, match=r"incompat.* grouped binary"):
             grouped + ds
-        with raises_regex(ValueError, "incompat.* grouped binary"):
+        with pytest.raises(ValueError, match=r"incompat.* grouped binary"):
             ds + grouped
-        with raises_regex(TypeError, "only support binary ops"):
+        with pytest.raises(TypeError, match=r"only support binary ops"):
             grouped + 1
-        with raises_regex(TypeError, "only support binary ops"):
+        with pytest.raises(TypeError, match=r"only support binary ops"):
             grouped + grouped
-        with raises_regex(TypeError, "in-place operations"):
+        with pytest.raises(TypeError, match=r"in-place operations"):
             ds += grouped
 
         ds = Dataset(
@@ -3788,7 +3790,7 @@ class TestDataset:
                 "time": pd.date_range("2000-01-01", periods=100),
             }
         )
-        with raises_regex(ValueError, "incompat.* grouped binary"):
+        with pytest.raises(ValueError, match=r"incompat.* grouped binary"):
             ds + ds.groupby("time.month")
 
     def test_groupby_math_virtual(self):
@@ -3978,13 +3980,13 @@ class TestDataset:
             }
         )
 
-        with raises_regex(TypeError, r"resample\(\) no longer supports"):
+        with pytest.raises(TypeError, match=r"resample\(\) no longer supports"):
             ds.resample("1D", "time")
 
-        with raises_regex(TypeError, r"resample\(\) no longer supports"):
+        with pytest.raises(TypeError, match=r"resample\(\) no longer supports"):
             ds.resample("1D", dim="time", how="mean")
 
-        with raises_regex(TypeError, r"resample\(\) no longer supports"):
+        with pytest.raises(TypeError, match=r"resample\(\) no longer supports"):
             ds.resample("1D", dim="time")
 
     def test_resample_ds_da_are_the_same(self):
@@ -4193,7 +4195,7 @@ class TestDataset:
         assert_identical(actual, expected3)
 
         df_nonunique = df.iloc[[0, 0], :]
-        with raises_regex(ValueError, "non-unique MultiIndex"):
+        with pytest.raises(ValueError, match=r"non-unique MultiIndex"):
             Dataset.from_dataframe(df_nonunique)
 
     def test_from_dataframe_unsorted_levels(self):
@@ -4216,7 +4218,7 @@ class TestDataset:
         # regression test for GH449
         df = pd.DataFrame(np.zeros((2, 2)))
         df.columns = ["foo", "foo"]
-        with raises_regex(ValueError, "non-unique columns"):
+        with pytest.raises(ValueError, match=r"non-unique columns"):
             Dataset.from_dataframe(df)
 
     def test_convert_dataframe_with_many_types_and_multiindex(self):
@@ -4313,7 +4315,9 @@ class TestDataset:
             "t": {"data": t, "dims": "t"},
             "b": {"dims": "t", "data": y},
         }
-        with raises_regex(ValueError, "cannot convert dict without the key 'dims'"):
+        with pytest.raises(
+            ValueError, match=r"cannot convert dict without the key 'dims'"
+        ):
             Dataset.from_dict(d)
 
     def test_to_and_from_dict_with_time_dim(self):
@@ -4447,11 +4451,11 @@ class TestDataset:
         expected = ds.isel(a=[1, 3])
         assert_identical(actual, ds)
 
-        with raises_regex(ValueError, "a single dataset dimension"):
+        with pytest.raises(ValueError, match=r"a single dataset dimension"):
             ds.dropna("foo")
-        with raises_regex(ValueError, "invalid how"):
+        with pytest.raises(ValueError, match=r"invalid how"):
             ds.dropna("a", how="somehow")
-        with raises_regex(TypeError, "must specify how or thresh"):
+        with pytest.raises(TypeError, match=r"must specify how or thresh"):
             ds.dropna("a", how=None)
 
     def test_fillna(self):
@@ -4496,7 +4500,7 @@ class TestDataset:
         assert_identical(expected, actual)
 
         # but new data variables is not okay
-        with raises_regex(ValueError, "must be contained"):
+        with pytest.raises(ValueError, match=r"must be contained"):
             ds.fillna({"x": 0})
 
         # empty argument should be OK
@@ -4628,13 +4632,13 @@ class TestDataset:
         actual = ds.where(lambda x: x > 1, -1)
         assert_equal(expected, actual)
 
-        with raises_regex(ValueError, "cannot set"):
+        with pytest.raises(ValueError, match=r"cannot set"):
             ds.where(ds > 1, other=0, drop=True)
 
-        with raises_regex(ValueError, "indexes .* are not equal"):
+        with pytest.raises(ValueError, match=r"indexes .* are not equal"):
             ds.where(ds > 1, ds.isel(x=slice(3)))
 
-        with raises_regex(ValueError, "exact match required"):
+        with pytest.raises(ValueError, match=r"exact match required"):
             ds.where(ds > 1, ds.assign(b=2))
 
     def test_where_drop(self):
@@ -4657,7 +4661,7 @@ class TestDataset:
         actual = ds.where(ds.a > 1, drop=True)
         assert_identical(expected, actual)
 
-        with raises_regex(TypeError, "must be a"):
+        with pytest.raises(TypeError, match=r"must be a"):
             ds.where(np.arange(5) > 1, drop=True)
 
         # 1d with odd coordinates
@@ -4778,7 +4782,7 @@ class TestDataset:
 
     def test_reduce_bad_dim(self):
         data = create_test_data()
-        with raises_regex(ValueError, "Dataset does not contain"):
+        with pytest.raises(ValueError, match=r"Dataset does not contain"):
             data.mean(dim="bad_dim")
 
     def test_reduce_cumsum(self):
@@ -4795,7 +4799,7 @@ class TestDataset:
     def test_reduce_cumsum_test_dims(self):
         data = create_test_data()
         for cumfunc in ["cumsum", "cumprod"]:
-            with raises_regex(ValueError, "Dataset does not contain"):
+            with pytest.raises(ValueError, match=r"Dataset does not contain"):
                 getattr(data, cumfunc)(dim="bad_dim")
 
             # ensure dimensions are correct
@@ -4929,7 +4933,9 @@ class TestDataset:
         actual = ds.reduce(mean_only_one_axis, "y")
         assert_identical(expected, actual)
 
-        with raises_regex(TypeError, "missing 1 required positional argument: 'axis'"):
+        with pytest.raises(
+            TypeError, match=r"missing 1 required positional argument: 'axis'"
+        ):
             ds.reduce(mean_only_one_axis)
 
     def test_reduce_no_axis(self):
@@ -4941,7 +4947,7 @@ class TestDataset:
         actual = ds.reduce(total_sum)
         assert_identical(expected, actual)
 
-        with raises_regex(TypeError, "unexpected keyword argument 'axis'"):
+        with pytest.raises(TypeError, match=r"unexpected keyword argument 'axis'"):
             ds.reduce(total_sum, dim="x")
 
     def test_reduce_keepdims(self):
@@ -5019,7 +5025,7 @@ class TestDataset:
         assert list(z.coords) == list(ds.coords)
         assert list(x.coords) == list(y.coords)
         # invalid dim
-        with raises_regex(ValueError, "does not contain"):
+        with pytest.raises(ValueError, match=r"does not contain"):
             x.rank("invalid_dim")
 
     def test_count(self):
@@ -5186,7 +5192,7 @@ class TestDataset:
             ds["foo"] += ds
         with pytest.raises(TypeError):
             ds["foo"].variable += ds
-        with raises_regex(ValueError, "must have the same"):
+        with pytest.raises(ValueError, match=r"must have the same"):
             ds += ds[["bar"]]
 
         # verify we can rollback in-place operations if something goes wrong
@@ -5248,9 +5254,9 @@ class TestDataset:
             expected_dims = tuple(d for d in new_order if d in ds[k].dims)
             assert actual[k].dims == expected_dims
 
-        with raises_regex(ValueError, "permuted"):
+        with pytest.raises(ValueError, match=r"permuted"):
             ds.transpose("dim1", "dim2", "dim3")
-        with raises_regex(ValueError, "permuted"):
+        with pytest.raises(ValueError, match=r"permuted"):
             ds.transpose("dim1", "dim2", "dim3", "time", "extra_dim")
 
         assert "T" not in dir(ds)
@@ -5332,12 +5338,12 @@ class TestDataset:
 
     def test_dataset_diff_exception_n_neg(self):
         ds = create_test_data(seed=1)
-        with raises_regex(ValueError, "must be non-negative"):
+        with pytest.raises(ValueError, match=r"must be non-negative"):
             ds.diff("dim2", n=-1)
 
     def test_dataset_diff_exception_label_str(self):
         ds = create_test_data(seed=1)
-        with raises_regex(ValueError, "'label' argument has to"):
+        with pytest.raises(ValueError, match=r"'label' argument has to"):
             ds.diff("dim2", label="raise_me")
 
     @pytest.mark.parametrize("fill_value", [dtypes.NA, 2, 2.0, {"foo": -10}])
@@ -5355,7 +5361,7 @@ class TestDataset:
         expected = Dataset({"foo": ("x", [fill_value, 1, 2])}, coords, attrs)
         assert_identical(expected, actual)
 
-        with raises_regex(ValueError, "dimensions"):
+        with pytest.raises(ValueError, match=r"dimensions"):
             ds.shift(foo=123)
 
     def test_roll_coords(self):
@@ -5368,7 +5374,7 @@ class TestDataset:
         expected = Dataset({"foo": ("x", [3, 1, 2])}, ex_coords, attrs)
         assert_identical(expected, actual)
 
-        with raises_regex(ValueError, "dimensions"):
+        with pytest.raises(ValueError, match=r"dimensions"):
             ds.roll(foo=123, roll_coords=True)
 
     def test_roll_no_coords(self):
@@ -5380,7 +5386,7 @@ class TestDataset:
         expected = Dataset({"foo": ("x", [3, 1, 2])}, coords, attrs)
         assert_identical(expected, actual)
 
-        with raises_regex(ValueError, "dimensions"):
+        with pytest.raises(ValueError, match=r"dimensions"):
             ds.roll(abc=321, roll_coords=False)
 
     def test_roll_coords_none(self):
@@ -5420,11 +5426,11 @@ class TestDataset:
 
     def test_setattr_raises(self):
         ds = Dataset({}, coords={"scalar": 1}, attrs={"foo": "bar"})
-        with raises_regex(AttributeError, "cannot set attr"):
+        with pytest.raises(AttributeError, match=r"cannot set attr"):
             ds.scalar = 2
-        with raises_regex(AttributeError, "cannot set attr"):
+        with pytest.raises(AttributeError, match=r"cannot set attr"):
             ds.foo = 2
-        with raises_regex(AttributeError, "cannot set attr"):
+        with pytest.raises(AttributeError, match=r"cannot set attr"):
             ds.other = 2
 
     def test_filter_by_attrs(self):
@@ -6098,7 +6104,7 @@ def ds(request):
 
 
 def test_coarsen_absent_dims_error(ds):
-    with raises_regex(ValueError, "not found in Dataset."):
+    with pytest.raises(ValueError, match=r"not found in Dataset."):
         ds.coarsen(foo=2)
 
 

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -34,7 +34,6 @@ from . import (
     has_dask,
     has_scipy,
     raise_if_dask_computes,
-    raises_regex,
     requires_cftime,
     requires_dask,
 )
@@ -72,7 +71,7 @@ class TestOps:
         actual = first(self.x, axis=-1, skipna=False)
         assert_array_equal(expected, actual)
 
-        with raises_regex(IndexError, "out of bounds"):
+        with pytest.raises(IndexError, match=r"out of bounds"):
             first(self.x, 3)
 
     def test_last(self):
@@ -93,7 +92,7 @@ class TestOps:
         actual = last(self.x, axis=-1, skipna=False)
         assert_array_equal(expected, actual)
 
-        with raises_regex(IndexError, "out of bounds"):
+        with pytest.raises(IndexError, match=r"out of bounds"):
             last(self.x, 3)
 
     def test_count(self):

--- a/xarray/tests/test_extensions.py
+++ b/xarray/tests/test_extensions.py
@@ -4,7 +4,7 @@ import pytest
 
 import xarray as xr
 
-from . import assert_identical, raises_regex
+from . import assert_identical
 
 
 @xr.register_dataset_accessor("example_accessor")
@@ -84,5 +84,5 @@ class TestAccessor:
             def __init__(self, xarray_obj):
                 raise AttributeError("broken")
 
-        with raises_regex(RuntimeError, "error initializing"):
+        with pytest.raises(RuntimeError, match=r"error initializing"):
             xr.Dataset().stupid_accessor

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -8,8 +8,6 @@ import pytest
 import xarray as xr
 from xarray.core import formatting
 
-from . import raises_regex
-
 
 class TestFormatting:
     def test_get_indexer_at_least_n_items(self):
@@ -50,7 +48,7 @@ class TestFormatting:
             expected = array.flat[:n]
             assert (expected == actual).all()
 
-        with raises_regex(ValueError, "at least one item"):
+        with pytest.raises(ValueError, match=r"at least one item"):
             formatting.first_n_items(array, 0)
 
     def test_last_n_items(self):
@@ -60,7 +58,7 @@ class TestFormatting:
             expected = array.flat[-n:]
             assert (expected == actual).all()
 
-        with raises_regex(ValueError, "at least one item"):
+        with pytest.raises(ValueError, match=r"at least one item"):
             formatting.first_n_items(array, 0)
 
     def test_last_item(self):

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -5,7 +5,7 @@ import pytest
 import xarray as xr
 from xarray.core.groupby import _consolidate_slices
 
-from . import assert_allclose, assert_equal, assert_identical, raises_regex
+from . import assert_allclose, assert_equal, assert_identical
 
 
 @pytest.fixture
@@ -479,34 +479,38 @@ def test_groupby_drops_nans():
 
 def test_groupby_grouping_errors():
     dataset = xr.Dataset({"foo": ("x", [1, 1, 1])}, {"x": [1, 2, 3]})
-    with raises_regex(ValueError, "None of the data falls within bins with edges"):
+    with pytest.raises(
+        ValueError, match=r"None of the data falls within bins with edges"
+    ):
         dataset.groupby_bins("x", bins=[0.1, 0.2, 0.3])
 
-    with raises_regex(ValueError, "None of the data falls within bins with edges"):
+    with pytest.raises(
+        ValueError, match=r"None of the data falls within bins with edges"
+    ):
         dataset.to_array().groupby_bins("x", bins=[0.1, 0.2, 0.3])
 
-    with raises_regex(ValueError, "All bin edges are NaN."):
+    with pytest.raises(ValueError, match=r"All bin edges are NaN."):
         dataset.groupby_bins("x", bins=[np.nan, np.nan, np.nan])
 
-    with raises_regex(ValueError, "All bin edges are NaN."):
+    with pytest.raises(ValueError, match=r"All bin edges are NaN."):
         dataset.to_array().groupby_bins("x", bins=[np.nan, np.nan, np.nan])
 
-    with raises_regex(ValueError, "Failed to group data."):
+    with pytest.raises(ValueError, match=r"Failed to group data."):
         dataset.groupby(dataset.foo * np.nan)
 
-    with raises_regex(ValueError, "Failed to group data."):
+    with pytest.raises(ValueError, match=r"Failed to group data."):
         dataset.to_array().groupby(dataset.foo * np.nan)
 
 
 def test_groupby_reduce_dimension_error(array):
     grouped = array.groupby("y")
-    with raises_regex(ValueError, "cannot reduce over dimensions"):
+    with pytest.raises(ValueError, match=r"cannot reduce over dimensions"):
         grouped.mean()
 
-    with raises_regex(ValueError, "cannot reduce over dimensions"):
+    with pytest.raises(ValueError, match=r"cannot reduce over dimensions"):
         grouped.mean("huh")
 
-    with raises_regex(ValueError, "cannot reduce over dimensions"):
+    with pytest.raises(ValueError, match=r"cannot reduce over dimensions"):
         grouped.mean(("x", "y", "asd"))
 
     grouped = array.groupby("y", squeeze=False)

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -7,7 +7,7 @@ import pytest
 from xarray import DataArray, Dataset, Variable
 from xarray.core import indexing, nputils
 
-from . import IndexerMaker, ReturnItem, assert_array_equal, raises_regex
+from . import IndexerMaker, ReturnItem, assert_array_equal
 
 B = IndexerMaker(indexing.BasicIndexer)
 
@@ -37,7 +37,7 @@ class TestIndexers:
             j = indexing.expanded_indexer(i, x.ndim)
             assert_array_equal(x[i], x[j])
             assert_array_equal(self.set_to_zero(x, i), self.set_to_zero(x, j))
-        with raises_regex(IndexError, "too many indices"):
+        with pytest.raises(IndexError, match=r"too many indices"):
             indexing.expanded_indexer(arr[1, 2, 3], 2)
 
     def test_asarray_tuplesafe(self):
@@ -69,15 +69,15 @@ class TestIndexers:
     def test_convert_label_indexer(self):
         # TODO: add tests that aren't just for edge cases
         index = pd.Index([1, 2, 3])
-        with raises_regex(KeyError, "not all values found"):
+        with pytest.raises(KeyError, match=r"not all values found"):
             indexing.convert_label_indexer(index, [0])
         with pytest.raises(KeyError):
             indexing.convert_label_indexer(index, 0)
-        with raises_regex(ValueError, "does not have a MultiIndex"):
+        with pytest.raises(ValueError, match=r"does not have a MultiIndex"):
             indexing.convert_label_indexer(index, {"one": 0})
 
         mindex = pd.MultiIndex.from_product([["a", "b"], [1, 2]], names=("one", "two"))
-        with raises_regex(KeyError, "not all values found"):
+        with pytest.raises(KeyError, match=r"not all values found"):
             indexing.convert_label_indexer(mindex, [0])
         with pytest.raises(KeyError):
             indexing.convert_label_indexer(mindex, 0)
@@ -110,13 +110,13 @@ class TestIndexers:
         dim_indexers = indexing.get_dim_indexers(mdata, {"one": "a", "two": 1})
         assert dim_indexers == {"x": {"one": "a", "two": 1}}
 
-        with raises_regex(ValueError, "cannot combine"):
+        with pytest.raises(ValueError, match=r"cannot combine"):
             indexing.get_dim_indexers(mdata, {"x": "a", "two": 1})
 
-        with raises_regex(ValueError, "do not exist"):
+        with pytest.raises(ValueError, match=r"do not exist"):
             indexing.get_dim_indexers(mdata, {"y": "a"})
 
-        with raises_regex(ValueError, "do not exist"):
+        with pytest.raises(ValueError, match=r"do not exist"):
             indexing.get_dim_indexers(mdata, {"four": 1})
 
     def test_remap_label_indexers(self):
@@ -469,7 +469,7 @@ def test_vectorized_indexer():
     check_slice(indexing.VectorizedIndexer)
     check_array1d(indexing.VectorizedIndexer)
     check_array2d(indexing.VectorizedIndexer)
-    with raises_regex(ValueError, "numbers of dimensions"):
+    with pytest.raises(ValueError, match=r"numbers of dimensions"):
         indexing.VectorizedIndexer(
             (np.array(1, dtype=np.int64), np.arange(5, dtype=np.int64))
         )
@@ -734,7 +734,7 @@ def test_create_mask_dask():
 
 
 def test_create_mask_error():
-    with raises_regex(TypeError, "unexpected key type"):
+    with pytest.raises(TypeError, match=r"unexpected key type"):
         indexing.create_mask((1, 2), (3, 4))
 
 

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -6,7 +6,6 @@ from xarray.core import dtypes, merge
 from xarray.core.merge import MergeError
 from xarray.testing import assert_equal, assert_identical
 
-from . import raises_regex
 from .test_dataset import create_test_data
 
 
@@ -47,7 +46,7 @@ class TestMergeFunction:
 
     def test_merge_dataarray_unnamed(self):
         data = xr.DataArray([1, 2], dims="x")
-        with raises_regex(ValueError, "without providing an explicit name"):
+        with pytest.raises(ValueError, match=r"without providing an explicit name"):
             xr.merge([data])
 
     def test_merge_arrays_attrs_default(self):
@@ -115,7 +114,7 @@ class TestMergeFunction:
         data.var1.attrs = var1_attrs
         data.var2.attrs = var2_attrs
         if expect_exception:
-            with raises_regex(MergeError, "combine_attrs"):
+            with pytest.raises(MergeError, match=r"combine_attrs"):
                 actual = xr.merge([data.var1, data.var2], combine_attrs=combine_attrs)
         else:
             actual = xr.merge([data.var1, data.var2], combine_attrs=combine_attrs)
@@ -175,7 +174,7 @@ class TestMergeFunction:
         data2.dim1.attrs = attrs2
 
         if expect_exception:
-            with raises_regex(MergeError, "combine_attrs"):
+            with pytest.raises(MergeError, match=r"combine_attrs"):
                 actual = xr.merge([data1, data2], combine_attrs=combine_attrs)
         else:
             actual = xr.merge([data1, data2], combine_attrs=combine_attrs)
@@ -219,16 +218,16 @@ class TestMergeFunction:
     def test_merge_alignment_error(self):
         ds = xr.Dataset(coords={"x": [1, 2]})
         other = xr.Dataset(coords={"x": [2, 3]})
-        with raises_regex(ValueError, "indexes .* not equal"):
+        with pytest.raises(ValueError, match=r"indexes .* not equal"):
             xr.merge([ds, other], join="exact")
 
     def test_merge_wrong_input_error(self):
-        with raises_regex(TypeError, "objects must be an iterable"):
+        with pytest.raises(TypeError, match=r"objects must be an iterable"):
             xr.merge([1])
         ds = xr.Dataset(coords={"x": [1, 2]})
-        with raises_regex(TypeError, "objects must be an iterable"):
+        with pytest.raises(TypeError, match=r"objects must be an iterable"):
             xr.merge({"a": ds})
-        with raises_regex(TypeError, "objects must be an iterable"):
+        with pytest.raises(TypeError, match=r"objects must be an iterable"):
             xr.merge([ds, 1])
 
     def test_merge_no_conflicts_single_var(self):
@@ -307,9 +306,9 @@ class TestMergeMethod:
 
         with pytest.raises(ValueError):
             ds1.merge(ds2.rename({"var3": "var1"}))
-        with raises_regex(ValueError, "should be coordinates or not"):
+        with pytest.raises(ValueError, match=r"should be coordinates or not"):
             data.reset_coords().merge(data)
-        with raises_regex(ValueError, "should be coordinates or not"):
+        with pytest.raises(ValueError, match=r"should be coordinates or not"):
             data.merge(data.reset_coords())
 
     def test_merge_broadcast_equals(self):
@@ -339,14 +338,14 @@ class TestMergeMethod:
 
         ds2 = xr.Dataset({"x": [0, 0]})
         for compat in ["equals", "identical"]:
-            with raises_regex(ValueError, "should be coordinates or not"):
+            with pytest.raises(ValueError, match=r"should be coordinates or not"):
                 ds1.merge(ds2, compat=compat)
 
         ds2 = xr.Dataset({"x": ((), 0, {"foo": "bar"})})
         with pytest.raises(xr.MergeError):
             ds1.merge(ds2, compat="identical")
 
-        with raises_regex(ValueError, "compat=.* invalid"):
+        with pytest.raises(ValueError, match=r"compat=.* invalid"):
             ds1.merge(ds2, compat="foobar")
 
         assert ds1.identical(ds1.merge(ds2, compat="override"))

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -174,26 +174,26 @@ def test_interpolate_pd_compat_polynomial():
 def test_interpolate_unsorted_index_raises():
     vals = np.array([1, 2, 3], dtype=np.float64)
     expected = xr.DataArray(vals, dims="x", coords={"x": [2, 1, 3]})
-    with raises_regex(ValueError, "Index 'x' must be monotonically increasing"):
+    with pytest.raises(ValueError, match=r"Index 'x' must be monotonically increasing"):
         expected.interpolate_na(dim="x", method="index")
 
 
 def test_interpolate_no_dim_raises():
     da = xr.DataArray(np.array([1, 2, np.nan, 5], dtype=np.float64), dims="x")
-    with raises_regex(NotImplementedError, "dim is a required argument"):
+    with pytest.raises(NotImplementedError, match=r"dim is a required argument"):
         da.interpolate_na(method="linear")
 
 
 def test_interpolate_invalid_interpolator_raises():
     da = xr.DataArray(np.array([1, 2, np.nan, 5], dtype=np.float64), dims="x")
-    with raises_regex(ValueError, "not a valid"):
+    with pytest.raises(ValueError, match=r"not a valid"):
         da.interpolate_na(dim="x", method="foo")
 
 
 def test_interpolate_duplicate_values_raises():
     data = np.random.randn(2, 3)
     da = xr.DataArray(data, coords=[("x", ["a", "a"]), ("y", [0, 1, 2])])
-    with raises_regex(ValueError, "Index 'x' has duplicate values"):
+    with pytest.raises(ValueError, match=r"Index 'x' has duplicate values"):
         da.interpolate_na(dim="x", method="foo")
 
 
@@ -202,7 +202,7 @@ def test_interpolate_multiindex_raises():
     data[1, 1] = np.nan
     da = xr.DataArray(data, coords=[("x", ["a", "b"]), ("y", [0, 1, 2])])
     das = da.stack(z=("x", "y"))
-    with raises_regex(TypeError, "Index 'z' must be castable to float64"):
+    with pytest.raises(TypeError, match=r"Index 'z' must be castable to float64"):
         das.interpolate_na(dim="z")
 
 
@@ -215,7 +215,7 @@ def test_interpolate_2d_coord_raises():
     data = np.random.randn(2, 3)
     data[1, 1] = np.nan
     da = xr.DataArray(data, dims=("a", "b"), coords=coords)
-    with raises_regex(ValueError, "interpolation must be 1D"):
+    with pytest.raises(ValueError, match=r"interpolation must be 1D"):
         da.interpolate_na(dim="a", use_coordinate="x")
 
 
@@ -366,7 +366,7 @@ def test_interpolate_dask_raises_for_invalid_chunk_dim():
     da, _ = make_interpolate_example_data((40, 40), 0.5)
     da = da.chunk({"time": 5})
     # this checks for ValueError in dask.array.apply_gufunc
-    with raises_regex(ValueError, "consists of multiple chunks"):
+    with pytest.raises(ValueError, match=r"consists of multiple chunks"):
         da.interpolate_na("time")
 
 
@@ -575,17 +575,17 @@ def test_interpolate_na_max_gap_errors(da_time):
     ):
         da_time.interpolate_na("t", max_gap=1)
 
-    with raises_regex(ValueError, "max_gap must be a scalar."):
+    with pytest.raises(ValueError, match=r"max_gap must be a scalar."):
         da_time.interpolate_na("t", max_gap=(1,))
 
     da_time["t"] = pd.date_range("2001-01-01", freq="H", periods=11)
-    with raises_regex(TypeError, "Expected value of type str"):
+    with pytest.raises(TypeError, match=r"Expected value of type str"):
         da_time.interpolate_na("t", max_gap=1)
 
-    with raises_regex(TypeError, "Expected integer or floating point"):
+    with pytest.raises(TypeError, match=r"Expected integer or floating point"):
         da_time.interpolate_na("t", max_gap="1H", use_coordinate=False)
 
-    with raises_regex(ValueError, "Could not convert 'huh' to timedelta64"):
+    with pytest.raises(ValueError, match=r"Could not convert 'huh' to timedelta64"):
         da_time.interpolate_na("t", max_gap="huh")
 
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -24,7 +24,6 @@ from . import (
     assert_array_equal,
     assert_equal,
     has_nc_time_axis,
-    raises_regex,
     requires_cartopy,
     requires_cftime,
     requires_matplotlib,
@@ -185,10 +184,10 @@ class TestPlot(PlotTestCase):
     def test1d(self):
         self.darray[:, 0, 0].plot()
 
-        with raises_regex(ValueError, "x must be one of None, 'dim_0'"):
+        with pytest.raises(ValueError, match=r"x must be one of None, 'dim_0'"):
             self.darray[:, 0, 0].plot(x="dim_1")
 
-        with raises_regex(TypeError, "complex128"):
+        with pytest.raises(TypeError, match=r"complex128"):
             (self.darray[:, 0, 0] + 1j).plot()
 
     def test_1d_bool(self):
@@ -204,14 +203,14 @@ class TestPlot(PlotTestCase):
         for aa, (x, y) in enumerate(xy):
             da.plot(x=x, y=y, ax=ax.flat[aa])
 
-        with raises_regex(ValueError, "Cannot specify both"):
+        with pytest.raises(ValueError, match=r"Cannot specify both"):
             da.plot(x="z", y="z")
 
         error_msg = "must be one of None, 'z'"
-        with raises_regex(ValueError, f"x {error_msg}"):
+        with pytest.raises(ValueError, match=rf"x {error_msg}"):
             da.plot(x="f")
 
-        with raises_regex(ValueError, f"y {error_msg}"):
+        with pytest.raises(ValueError, match=rf"y {error_msg}"):
             da.plot(y="f")
 
     def test_multiindex_level_as_coord(self):
@@ -277,7 +276,7 @@ class TestPlot(PlotTestCase):
             da.plot(x="t", hue="wrong_coord")
 
     def test_2d_line(self):
-        with raises_regex(ValueError, "hue"):
+        with pytest.raises(ValueError, match=r"hue"):
             self.darray[:, :, 0].plot.line()
 
         self.darray[:, :, 0].plot.line(hue="dim_1")
@@ -286,7 +285,7 @@ class TestPlot(PlotTestCase):
         self.darray[:, :, 0].plot.line(x="dim_0", hue="dim_1")
         self.darray[:, :, 0].plot.line(y="dim_0", hue="dim_1")
 
-        with raises_regex(ValueError, "Cannot"):
+        with pytest.raises(ValueError, match=r"Cannot"):
             self.darray[:, :, 0].plot.line(x="dim_1", y="dim_0", hue="dim_1")
 
     def test_2d_line_accepts_legend_kw(self):
@@ -518,10 +517,10 @@ class TestPlot(PlotTestCase):
         for ax in g.axes.flat:
             assert ax.has_data()
 
-        with raises_regex(ValueError, "[Ff]acet"):
+        with pytest.raises(ValueError, match=r"[Ff]acet"):
             d.plot(x="x", y="y", col="z", ax=plt.gca())
 
-        with raises_regex(ValueError, "[Ff]acet"):
+        with pytest.raises(ValueError, match=r"[Ff]acet"):
             d[0].plot(x="x", y="y", col="z", ax=plt.gca())
 
     @pytest.mark.slow
@@ -555,16 +554,16 @@ class TestPlot(PlotTestCase):
         self.darray.plot(size=5, aspect=2)
         assert tuple(plt.gcf().get_size_inches()) == (10, 5)
 
-        with raises_regex(ValueError, "cannot provide both"):
+        with pytest.raises(ValueError, match=r"cannot provide both"):
             self.darray.plot(ax=plt.gca(), figsize=(3, 4))
 
-        with raises_regex(ValueError, "cannot provide both"):
+        with pytest.raises(ValueError, match=r"cannot provide both"):
             self.darray.plot(size=5, figsize=(3, 4))
 
-        with raises_regex(ValueError, "cannot provide both"):
+        with pytest.raises(ValueError, match=r"cannot provide both"):
             self.darray.plot(size=5, ax=plt.gca())
 
-        with raises_regex(ValueError, "cannot provide `aspect`"):
+        with pytest.raises(ValueError, match=r"cannot provide `aspect`"):
             self.darray.plot(aspect=1)
 
     @pytest.mark.slow
@@ -578,7 +577,7 @@ class TestPlot(PlotTestCase):
         for ax in g.axes.flat:
             assert ax.has_data()
 
-        with raises_regex(ValueError, "[Ff]acet"):
+        with pytest.raises(ValueError, match=r"[Ff]acet"):
             d.plot(x="x", y="y", col="columns", ax=plt.gca())
 
     def test_coord_with_interval(self):
@@ -655,7 +654,7 @@ class TestPlot1D(PlotTestCase):
 
     def test_nonnumeric_index_raises_typeerror(self):
         a = DataArray([1, 2, 3], {"letter": ["a", "b", "c"]}, dims="letter")
-        with raises_regex(TypeError, r"[Pp]lot"):
+        with pytest.raises(TypeError, match=r"[Pp]lot"):
             a.plot.line()
 
     def test_primitive_returned(self):
@@ -1111,26 +1110,26 @@ class Common2dMixin:
         assert "y_long_name [y_units]" == plt.gca().get_ylabel()
 
     def test_1d_raises_valueerror(self):
-        with raises_regex(ValueError, r"DataArray must be 2d"):
+        with pytest.raises(ValueError, match=r"DataArray must be 2d"):
             self.plotfunc(self.darray[0, :])
 
     def test_bool(self):
         xr.ones_like(self.darray, dtype=bool).plot()
 
     def test_complex_raises_typeerror(self):
-        with raises_regex(TypeError, "complex128"):
+        with pytest.raises(TypeError, match=r"complex128"):
             (self.darray + 1j).plot()
 
     def test_3d_raises_valueerror(self):
         a = DataArray(easy_array((2, 3, 4)))
         if self.plotfunc.__name__ == "imshow":
             pytest.skip()
-        with raises_regex(ValueError, r"DataArray must be 2d"):
+        with pytest.raises(ValueError, match=r"DataArray must be 2d"):
             self.plotfunc(a)
 
     def test_nonnumeric_index_raises_typeerror(self):
         a = DataArray(easy_array((3, 2)), coords=[["a", "b", "c"], ["d", "e"]])
-        with raises_regex(TypeError, r"[Pp]lot"):
+        with pytest.raises(TypeError, match=r"[Pp]lot"):
             self.plotfunc(a)
 
     def test_multiindex_raises_typeerror(self):
@@ -1140,7 +1139,7 @@ class Common2dMixin:
             coords=dict(x=("x", [0, 1, 2]), a=("y", [0, 1]), b=("y", [2, 3])),
         )
         a = a.set_index(y=("a", "b"))
-        with raises_regex(TypeError, r"[Pp]lot"):
+        with pytest.raises(TypeError, match=r"[Pp]lot"):
             self.plotfunc(a)
 
     def test_can_pass_in_axis(self):
@@ -1252,15 +1251,15 @@ class Common2dMixin:
 
     def test_bad_x_string_exception(self):
 
-        with raises_regex(ValueError, "x and y cannot be equal."):
+        with pytest.raises(ValueError, match=r"x and y cannot be equal."):
             self.plotmethod(x="y", y="y")
 
         error_msg = "must be one of None, 'x', 'x2d', 'y', 'y2d'"
-        with raises_regex(ValueError, f"x {error_msg}"):
+        with pytest.raises(ValueError, match=rf"x {error_msg}"):
             self.plotmethod("not_a_real_dim", "y")
-        with raises_regex(ValueError, f"x {error_msg}"):
+        with pytest.raises(ValueError, match=rf"x {error_msg}"):
             self.plotmethod(x="not_a_real_dim")
-        with raises_regex(ValueError, f"y {error_msg}"):
+        with pytest.raises(ValueError, match=rf"y {error_msg}"):
             self.plotmethod(y="not_a_real_dim")
         self.darray.coords["z"] = 100
 
@@ -1310,10 +1309,10 @@ class Common2dMixin:
             assert x == ax.get_xlabel()
             assert y == ax.get_ylabel()
 
-        with raises_regex(ValueError, "levels of the same MultiIndex"):
+        with pytest.raises(ValueError, match=r"levels of the same MultiIndex"):
             self.plotfunc(da, x="a", y="b")
 
-        with raises_regex(ValueError, "y must be one of None, 'a', 'b', 'x'"):
+        with pytest.raises(ValueError, match=r"y must be one of None, 'a', 'b', 'x'"):
             self.plotfunc(da, x="a", y="y")
 
     def test_default_title(self):
@@ -1608,7 +1607,7 @@ class TestContour(Common2dMixin, PlotTestCase):
             self.plotmethod(colors="k", cmap="RdBu")
 
     def list_of_colors_in_cmap_raises_error(self):
-        with raises_regex(ValueError, "list of colors"):
+        with pytest.raises(ValueError, match=r"list of colors"):
             self.plotmethod(cmap=["k", "b"])
 
     @pytest.mark.slow
@@ -1680,7 +1679,7 @@ class TestImshow(Common2dMixin, PlotTestCase):
     @pytest.mark.slow
     def test_cannot_change_mpl_aspect(self):
 
-        with raises_regex(ValueError, "not available in xarray"):
+        with pytest.raises(ValueError, match=r"not available in xarray"):
             self.darray.plot.imshow(aspect="equal")
 
         # with numbers we fall back to fig control
@@ -1700,7 +1699,7 @@ class TestImshow(Common2dMixin, PlotTestCase):
             self.plotmethod(cmap="husl")
 
     def test_2d_coord_names(self):
-        with raises_regex(ValueError, "requires 1D coordinates"):
+        with pytest.raises(ValueError, match=r"requires 1D coordinates"):
             self.plotmethod(x="x2d", y="y2d")
 
     def test_plot_rgb_image(self):
@@ -1861,7 +1860,7 @@ class TestFacetGrid(PlotTestCase):
 
     @pytest.mark.slow
     def test_norow_nocol_error(self):
-        with raises_regex(ValueError, r"[Rr]ow"):
+        with pytest.raises(ValueError, match=r"[Rr]ow"):
             xplt.FacetGrid(self.darray)
 
     @pytest.mark.slow
@@ -1882,7 +1881,7 @@ class TestFacetGrid(PlotTestCase):
     @pytest.mark.slow
     def test_nonunique_index_error(self):
         self.darray.coords["z"] = [0.1, 0.2, 0.2]
-        with raises_regex(ValueError, r"[Uu]nique"):
+        with pytest.raises(ValueError, match=r"[Uu]nique"):
             xplt.FacetGrid(self.darray, col="z")
 
     @pytest.mark.slow
@@ -1949,10 +1948,10 @@ class TestFacetGrid(PlotTestCase):
         g = xplt.FacetGrid(self.darray, col="z", figsize=(9, 4))
         assert_array_equal(g.fig.get_size_inches(), (9, 4))
 
-        with raises_regex(ValueError, "cannot provide both"):
+        with pytest.raises(ValueError, match=r"cannot provide both"):
             g = xplt.plot(self.darray, row=2, col="z", figsize=(6, 4), size=6)
 
-        with raises_regex(ValueError, "Can't use"):
+        with pytest.raises(ValueError, match=r"Can't use"):
             g = xplt.plot(self.darray, row=2, col="z", ax=plt.gca(), size=6)
 
     @pytest.mark.slow
@@ -2187,10 +2186,10 @@ class TestDatasetQuiverPlots(PlotTestCase):
         with figure_context():
             hdl = self.ds.isel(row=0, col=0).plot.quiver(x="x", y="y", u="u", v="v")
             assert isinstance(hdl, mpl.quiver.Quiver)
-        with raises_regex(ValueError, "specify x, y, u, v"):
+        with pytest.raises(ValueError, match=r"specify x, y, u, v"):
             self.ds.isel(row=0, col=0).plot.quiver(x="x", y="y", u="u")
 
-        with raises_regex(ValueError, "hue_style"):
+        with pytest.raises(ValueError, match=r"hue_style"):
             self.ds.isel(row=0, col=0).plot.quiver(
                 x="x", y="y", u="u", v="v", hue="mag", hue_style="discrete"
             )
@@ -2217,7 +2216,7 @@ class TestDatasetQuiverPlots(PlotTestCase):
                 add_guide=False,
             )
             assert fg.quiverkey is None
-        with raises_regex(ValueError, "Please provide scale"):
+        with pytest.raises(ValueError, match=r"Please provide scale"):
             self.ds.plot.quiver(x="x", y="y", u="u", v="v", row="row", col="col")
 
 
@@ -2247,10 +2246,10 @@ class TestDatasetStreamplotPlots(PlotTestCase):
         with figure_context():
             hdl = self.ds.isel(row=0, col=0).plot.streamplot(x="x", y="y", u="u", v="v")
             assert isinstance(hdl, mpl.collections.LineCollection)
-        with raises_regex(ValueError, "specify x, y, u, v"):
+        with pytest.raises(ValueError, match=r"specify x, y, u, v"):
             self.ds.isel(row=0, col=0).plot.streamplot(x="x", y="y", u="u")
 
-        with raises_regex(ValueError, "hue_style"):
+        with pytest.raises(ValueError, match=r"hue_style"):
             self.ds.isel(row=0, col=0).plot.streamplot(
                 x="x", y="y", u="u", v="v", hue="mag", hue_style="discrete"
             )
@@ -2403,7 +2402,7 @@ class TestDatasetScatterPlots(PlotTestCase):
     def test_scatter(self, x, y, hue, markersize):
         self.ds.plot.scatter(x, y, hue=hue, markersize=markersize)
 
-        with raises_regex(ValueError, "u, v"):
+        with pytest.raises(ValueError, match=r"u, v"):
             self.ds.plot.scatter(x, y, u="col", v="row")
 
     def test_non_numeric_legend(self):
@@ -2505,7 +2504,7 @@ class TestNcAxisNotInstalled(PlotTestCase):
         self.darray = darray
 
     def test_ncaxis_notinstalled_line_plot(self):
-        with raises_regex(ImportError, "optional `nc-time-axis`"):
+        with pytest.raises(ImportError, match=r"optional `nc-time-axis`"):
             self.darray.plot.line()
 
 

--- a/xarray/tests/test_ufuncs.py
+++ b/xarray/tests/test_ufuncs.py
@@ -8,7 +8,7 @@ import xarray.ufuncs as xu
 
 from . import assert_array_equal
 from . import assert_identical as assert_identical_
-from . import mock, raises_regex
+from . import mock
 
 
 def assert_identical(a, b):
@@ -79,7 +79,7 @@ def test_groupby():
     assert_identical(ds.a, np.maximum(arr_grouped, group_mean.a))
     assert_identical(ds.a, np.maximum(group_mean.a, arr_grouped))
 
-    with raises_regex(ValueError, "mismatched lengths for dimension"):
+    with pytest.raises(ValueError, match=r"mismatched lengths for dimension"):
         np.maximum(ds.a.variable, ds_grouped)
 
 
@@ -136,7 +136,7 @@ def test_dask_defers_to_xarray():
 
 def test_gufunc_methods():
     xarray_obj = xr.DataArray([1, 2, 3])
-    with raises_regex(NotImplementedError, "reduce method"):
+    with pytest.raises(NotImplementedError, match=r"reduce method"):
         np.add.reduce(xarray_obj, 1)
 
 
@@ -144,7 +144,7 @@ def test_out():
     xarray_obj = xr.DataArray([1, 2, 3])
 
     # xarray out arguments should raise
-    with raises_regex(NotImplementedError, "`out` argument"):
+    with pytest.raises(NotImplementedError, match=r"`out` argument"):
         np.add(xarray_obj, 1, out=xarray_obj)
 
     # but non-xarray should be OK
@@ -156,7 +156,7 @@ def test_out():
 def test_gufuncs():
     xarray_obj = xr.DataArray([1, 2, 3])
     fake_gufunc = mock.Mock(signature="(n)->()", autospec=np.sin)
-    with raises_regex(NotImplementedError, "generalized ufuncs"):
+    with pytest.raises(NotImplementedError, match=r"generalized ufuncs"):
         xarray_obj.__array_ufunc__(fake_gufunc, "__call__", xarray_obj)
 
 

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -120,7 +120,7 @@ class VariableSubclassobjects:
         v_new = v[[True, False, True]]
         assert_identical(v[[0, 2]], v_new)
 
-        with raises_regex(IndexError, "Boolean indexer should"):
+        with pytest.raises(IndexError, match=r"Boolean indexer should"):
             ind = Variable(("a",), [True, False, True])
             v[ind]
 
@@ -298,14 +298,14 @@ class VariableSubclassobjects:
     def test_datetime64_valid_range(self):
         data = np.datetime64("1250-01-01", "us")
         pderror = pd.errors.OutOfBoundsDatetime
-        with raises_regex(pderror, "Out of bounds nanosecond"):
+        with pytest.raises(pderror, match=r"Out of bounds nanosecond"):
             self.cls(["t"], [data])
 
     @pytest.mark.xfail(reason="pandas issue 36615")
     def test_timedelta64_valid_range(self):
         data = np.timedelta64("200000", "D")
         pderror = pd.errors.OutOfBoundsTimedelta
-        with raises_regex(pderror, "Out of bounds nanosecond"):
+        with pytest.raises(pderror, match=r"Out of bounds nanosecond"):
             self.cls(["t"], [data])
 
     def test_pandas_data(self):
@@ -455,7 +455,7 @@ class VariableSubclassobjects:
         assert_identical(
             Variable(["b", "a"], np.array([x, y])), Variable.concat((v, w), "b")
         )
-        with raises_regex(ValueError, "Variable has dimensions"):
+        with pytest.raises(ValueError, match=r"Variable has dimensions"):
             Variable.concat([v, Variable(["c"], y)], "b")
         # test indexers
         actual = Variable.concat(
@@ -470,7 +470,7 @@ class VariableSubclassobjects:
         assert_identical(v, Variable.concat([v[:1], v[1:]], "time"))
         # test dimension order
         assert_identical(v, Variable.concat([v[:, :5], v[:, 5:]], "x"))
-        with raises_regex(ValueError, "all input arrays must have"):
+        with pytest.raises(ValueError, match=r"all input arrays must have"):
             Variable.concat([v[:, 0], v[:, 1:]], "x")
 
     def test_concat_attrs(self):
@@ -546,7 +546,7 @@ class VariableSubclassobjects:
     def test_copy_with_data_errors(self):
         orig = Variable(("x", "y"), [[1.5, 2.0], [3.1, 4.3]], {"foo": "bar"})
         new_data = [2.5, 5.0]
-        with raises_regex(ValueError, "must match shape of object"):
+        with pytest.raises(ValueError, match=r"must match shape of object"):
             orig.copy(data=new_data)
 
     def test_copy_index_with_data(self):
@@ -559,11 +559,11 @@ class VariableSubclassobjects:
     def test_copy_index_with_data_errors(self):
         orig = IndexVariable("x", np.arange(5))
         new_data = np.arange(5, 20)
-        with raises_regex(ValueError, "must match shape of object"):
+        with pytest.raises(ValueError, match=r"must match shape of object"):
             orig.copy(data=new_data)
-        with raises_regex(ValueError, "Cannot assign to the .data"):
+        with pytest.raises(ValueError, match=r"Cannot assign to the .data"):
             orig.data = new_data
-        with raises_regex(ValueError, "Cannot assign to the .values"):
+        with pytest.raises(ValueError, match=r"Cannot assign to the .values"):
             orig.values = new_data
 
     def test_replace(self):
@@ -659,12 +659,12 @@ class VariableSubclassobjects:
 
         # with boolean variable with wrong shape
         ind = np.array([True, False])
-        with raises_regex(IndexError, "Boolean array size 2 is "):
+        with pytest.raises(IndexError, match=r"Boolean array size 2 is "):
             v[Variable(("a", "b"), [[0, 1]]), ind]
 
         # boolean indexing with different dimension
         ind = Variable(["a"], [True, False, False])
-        with raises_regex(IndexError, "Boolean indexer should be"):
+        with pytest.raises(IndexError, match=r"Boolean indexer should be"):
             v[dict(y=ind)]
 
     def test_getitem_uint_1d(self):
@@ -794,21 +794,21 @@ class VariableSubclassobjects:
     def test_getitem_error(self):
         v = self.cls(["x", "y"], [[0, 1, 2], [3, 4, 5]])
 
-        with raises_regex(IndexError, "labeled multi-"):
+        with pytest.raises(IndexError, match=r"labeled multi-"):
             v[[[0, 1], [1, 2]]]
 
         ind_x = Variable(["a"], [0, 1, 1])
         ind_y = Variable(["a"], [0, 1])
-        with raises_regex(IndexError, "Dimensions of indexers "):
+        with pytest.raises(IndexError, match=r"Dimensions of indexers "):
             v[ind_x, ind_y]
 
         ind = Variable(["a", "b"], [[True, False], [False, True]])
-        with raises_regex(IndexError, "2-dimensional boolean"):
+        with pytest.raises(IndexError, match=r"2-dimensional boolean"):
             v[dict(x=ind)]
 
         v = Variable(["x", "y", "z"], np.arange(60).reshape(3, 4, 5))
         ind = Variable(["x"], [0, 1])
-        with raises_regex(IndexError, "Dimensions of indexers mis"):
+        with pytest.raises(IndexError, match=r"Dimensions of indexers mis"):
             v[:, ind]
 
     @pytest.mark.parametrize(
@@ -1129,11 +1129,11 @@ class TestVariable(VariableSubclassobjects):
         )
         assert_identical(expected_extra, as_variable(xarray_tuple))
 
-        with raises_regex(TypeError, "tuple of form"):
+        with pytest.raises(TypeError, match=r"tuple of form"):
             as_variable(tuple(data))
-        with raises_regex(ValueError, "tuple of form"):  # GH1016
+        with pytest.raises(ValueError, match=r"tuple of form"):  # GH1016
             as_variable(("five", "six", "seven"))
-        with raises_regex(TypeError, "without an explicit list of dimensions"):
+        with pytest.raises(TypeError, match=r"without an explicit list of dimensions"):
             as_variable(data)
 
         actual = as_variable(data, name="x")
@@ -1145,9 +1145,9 @@ class TestVariable(VariableSubclassobjects):
 
         data = np.arange(9).reshape((3, 3))
         expected = Variable(("x", "y"), data)
-        with raises_regex(ValueError, "without explicit dimension names"):
+        with pytest.raises(ValueError, match=r"without explicit dimension names"):
             as_variable(data, name="x")
-        with raises_regex(ValueError, "has more than 1-dimension"):
+        with pytest.raises(ValueError, match=r"has more than 1-dimension"):
             as_variable(expected, name="x")
 
         # test datetime, timedelta conversion
@@ -1275,7 +1275,7 @@ class TestVariable(VariableSubclassobjects):
         # test iteration
         for n, item in enumerate(v):
             assert_identical(Variable(["y"], data[n]), item)
-        with raises_regex(TypeError, "iteration over a 0-d"):
+        with pytest.raises(TypeError, match=r"iteration over a 0-d"):
             iter(Variable([], 0))
         # test setting
         v.values[:] = 0
@@ -1404,7 +1404,7 @@ class TestVariable(VariableSubclassobjects):
         assert_identical(expected, v.shift(x=5, fill_value=fill_value))
         assert_identical(expected, v.shift(x=6, fill_value=fill_value))
 
-        with raises_regex(ValueError, "dimension"):
+        with pytest.raises(ValueError, match=r"dimension"):
             v.shift(z=0)
 
         v = Variable("x", [1, 2, 3, 4, 5], {"foo": "bar"})
@@ -1433,7 +1433,7 @@ class TestVariable(VariableSubclassobjects):
         assert_identical(expected, v.roll(x=2))
         assert_identical(expected, v.roll(x=-3))
 
-        with raises_regex(ValueError, "dimension"):
+        with pytest.raises(ValueError, match=r"dimension"):
             v.roll(z=0)
 
     def test_roll_consistency(self):
@@ -1486,7 +1486,7 @@ class TestVariable(VariableSubclassobjects):
         v = Variable(["x", "y"], [[1, 2]])
         assert_identical(Variable(["y"], [1, 2]), v.squeeze())
         assert_identical(Variable(["y"], [1, 2]), v.squeeze("x"))
-        with raises_regex(ValueError, "cannot select a dimension"):
+        with pytest.raises(ValueError, match=r"cannot select a dimension"):
             v.squeeze("y")
 
     def test_get_axis_num(self):
@@ -1495,7 +1495,7 @@ class TestVariable(VariableSubclassobjects):
         assert v.get_axis_num(["x"]) == (0,)
         assert v.get_axis_num(["x", "y"]) == (0, 1)
         assert v.get_axis_num(["z", "y", "x"]) == (2, 1, 0)
-        with raises_regex(ValueError, "not found in array dim"):
+        with pytest.raises(ValueError, match=r"not found in array dim"):
             v.get_axis_num("foobar")
 
     def test_set_dims(self):
@@ -1516,7 +1516,7 @@ class TestVariable(VariableSubclassobjects):
         expected = v
         assert_identical(actual, expected)
 
-        with raises_regex(ValueError, "must be a superset"):
+        with pytest.raises(ValueError, match=r"must be a superset"):
             v.set_dims(["z"])
 
     def test_set_dims_object_dtype(self):
@@ -1548,9 +1548,9 @@ class TestVariable(VariableSubclassobjects):
     def test_stack_errors(self):
         v = Variable(["x", "y"], [[0, 1], [2, 3]], {"foo": "bar"})
 
-        with raises_regex(ValueError, "invalid existing dim"):
+        with pytest.raises(ValueError, match=r"invalid existing dim"):
             v.stack(z=("x1",))
-        with raises_regex(ValueError, "cannot create a new dim"):
+        with pytest.raises(ValueError, match=r"cannot create a new dim"):
             v.stack(x=("x",))
 
     def test_unstack(self):
@@ -1569,11 +1569,11 @@ class TestVariable(VariableSubclassobjects):
 
     def test_unstack_errors(self):
         v = Variable("z", [0, 1, 2, 3])
-        with raises_regex(ValueError, "invalid existing dim"):
+        with pytest.raises(ValueError, match=r"invalid existing dim"):
             v.unstack(foo={"x": 4})
-        with raises_regex(ValueError, "cannot create a new dim"):
+        with pytest.raises(ValueError, match=r"cannot create a new dim"):
             v.stack(z=("z",))
-        with raises_regex(ValueError, "the product of the new dim"):
+        with pytest.raises(ValueError, match=r"the product of the new dim"):
             v.unstack(z={"x": 5})
 
     def test_unstack_2d(self):
@@ -1618,9 +1618,9 @@ class TestVariable(VariableSubclassobjects):
         a = Variable(["x"], np.arange(10))
         b = Variable(["x"], np.arange(5))
         c = Variable(["x", "x"], np.arange(100).reshape(10, 10))
-        with raises_regex(ValueError, "mismatched lengths"):
+        with pytest.raises(ValueError, match=r"mismatched lengths"):
             a + b
-        with raises_regex(ValueError, "duplicate dimensions"):
+        with pytest.raises(ValueError, match=r"duplicate dimensions"):
             a + c
 
     def test_inplace_math(self):
@@ -1633,7 +1633,7 @@ class TestVariable(VariableSubclassobjects):
         assert source_ndarray(v.values) is x
         assert_array_equal(v.values, np.arange(5) + 1)
 
-        with raises_regex(ValueError, "dimensions cannot change"):
+        with pytest.raises(ValueError, match=r"dimensions cannot change"):
             v += Variable("y", np.arange(5))
 
     def test_reduce(self):
@@ -1650,7 +1650,7 @@ class TestVariable(VariableSubclassobjects):
         )
         assert_allclose(v.mean("x"), v.reduce(np.mean, "x"))
 
-        with raises_regex(ValueError, "cannot supply both"):
+        with pytest.raises(ValueError, match=r"cannot supply both"):
             v.mean(dim="x", axis=0)
 
     @pytest.mark.parametrize("skipna", [True, False])
@@ -1680,7 +1680,7 @@ class TestVariable(VariableSubclassobjects):
         v = Variable(["x", "y"], self.d).chunk({"x": 2})
 
         # this checks for ValueError in dask.array.apply_gufunc
-        with raises_regex(ValueError, "consists of multiple chunks"):
+        with pytest.raises(ValueError, match=r"consists of multiple chunks"):
             v.quantile(0.5, dim="x")
 
     @pytest.mark.parametrize("q", [-0.1, 1.1, [2], [0.25, 2]])
@@ -1688,14 +1688,16 @@ class TestVariable(VariableSubclassobjects):
         v = Variable(["x", "y"], self.d)
 
         # escape special characters
-        with raises_regex(ValueError, r"Quantiles must be in the range \[0, 1\]"):
+        with pytest.raises(
+            ValueError, match=r"Quantiles must be in the range \[0, 1\]"
+        ):
             v.quantile(q, dim="x")
 
     @requires_dask
     @requires_bottleneck
     def test_rank_dask_raises(self):
         v = Variable(["x"], [3.0, 1.0, np.nan, 2.0, 4.0]).chunk(2)
-        with raises_regex(TypeError, "arrays stored as dask"):
+        with pytest.raises(TypeError, match=r"arrays stored as dask"):
             v.rank("x")
 
     @requires_bottleneck
@@ -1721,7 +1723,7 @@ class TestVariable(VariableSubclassobjects):
         v_expect = Variable(["x"], [0.75, 0.25, np.nan, 0.5, 1.0])
         assert_equal(v.rank("x", pct=True), v_expect)
         # invalid dim
-        with raises_regex(ValueError, "not found"):
+        with pytest.raises(ValueError, match=r"not found"):
             v.rank("y")
 
     def test_big_endian_reduce(self):
@@ -1928,7 +1930,7 @@ class TestVariable(VariableSubclassobjects):
         expected = Variable(["x", "y"], [[0, 0], [0, 0], [1, 1]])
         assert_identical(expected, v)
 
-        with raises_regex(ValueError, "shape mismatch"):
+        with pytest.raises(ValueError, match=r"shape mismatch"):
             v[ind, ind] = np.zeros((1, 2, 1))
 
         v = Variable(["x", "y"], [[0, 3, 2], [3, 4, 5]])
@@ -2124,7 +2126,7 @@ class TestIndexVariable(VariableSubclassobjects):
     cls = staticmethod(IndexVariable)
 
     def test_init(self):
-        with raises_regex(ValueError, "must be 1-dimensional"):
+        with pytest.raises(ValueError, match=r"must be 1-dimensional"):
             IndexVariable((), 0)
 
     def test_to_index(self):
@@ -2144,7 +2146,7 @@ class TestIndexVariable(VariableSubclassobjects):
         assert float == x.dtype
         assert_array_equal(np.arange(3), x)
         assert float == x.values.dtype
-        with raises_regex(TypeError, "cannot be modified"):
+        with pytest.raises(TypeError, match=r"cannot be modified"):
             x[:] = 0
 
     def test_name(self):
@@ -2171,7 +2173,7 @@ class TestIndexVariable(VariableSubclassobjects):
         level_1 = IndexVariable("x", midx.get_level_values("level_1"))
         assert_identical(x.get_level_variable("level_1"), level_1)
 
-        with raises_regex(ValueError, "has no MultiIndex"):
+        with pytest.raises(ValueError, match=r"has no MultiIndex"):
             IndexVariable("y", [10.0]).get_level_variable("level")
 
     def test_concat_periods(self):
@@ -2354,7 +2356,7 @@ class TestAsCompatibleData:
         assert_identical(expect, full_like(orig, True, dtype=bool))
 
         # raise error on non-scalar fill_value
-        with raises_regex(ValueError, "must be scalar"):
+        with pytest.raises(ValueError, match=r"must be scalar"):
             full_like(orig, [1.0, 2.0])
 
         with pytest.raises(ValueError, match="'dtype' cannot be dict-like"):
@@ -2459,7 +2461,7 @@ class TestBackendIndexing:
         self.check_orthogonal_indexing(v)
         self.check_vectorized_indexing(v)
         # could not doubly wrapping
-        with raises_regex(TypeError, "NumpyIndexingAdapter only wraps "):
+        with pytest.raises(TypeError, match=r"NumpyIndexingAdapter only wraps "):
             v = Variable(
                 dims=("x", "y"), data=NumpyIndexingAdapter(NumpyIndexingAdapter(self.d))
             )

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -3,7 +3,7 @@ import pytest
 
 import xarray as xr
 from xarray import DataArray
-from xarray.tests import assert_allclose, assert_equal, raises_regex
+from xarray.tests import assert_allclose, assert_equal
 
 from . import raise_if_dask_computes, requires_cftime, requires_dask
 
@@ -15,7 +15,7 @@ def test_weighted_non_DataArray_weights(as_dataset):
     if as_dataset:
         data = data.to_dataset(name="data")
 
-    with raises_regex(ValueError, "`weights` must be a DataArray"):
+    with pytest.raises(ValueError, match=r"`weights` must be a DataArray"):
         data.weighted([1, 2])
 
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Is there a reason we have our own `raises_regex`? This replaces it with the standard pytest check.

This is another regex special, so it misses multi-line statements. I can dust off the multi-line regex manual if this ends up working.
