### PR TITLE
Fix lag in Jupyter caused by CSS in `_repr_html_`

### DIFF
--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -2,17 +2,6 @@
  *
  */
 
-:root {
-  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
-  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
-  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
-  --xr-border-color: var(--jp-border-color2, #e0e0e0);
-  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
-  --xr-background-color: var(--jp-layout-color0, white);
-  --xr-background-color-row-even: var(--jp-layout-color1, white);
-  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
-}
-
 html[theme=dark],
 body.vscode-dark {
   --xr-font-color0: rgba(255, 255, 255, 1);
@@ -26,6 +15,14 @@ body.vscode-dark {
 }
 
 .xr-wrap {
+  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
+  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
+  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
+  --xr-border-color: var(--jp-border-color2, #e0e0e0);
+  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
+  --xr-background-color: var(--jp-layout-color0, white);
+  --xr-background-color-row-even: var(--jp-layout-color1, white);
+  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
   display: block;
   min-width: 300px;
   max-width: 700px;


### PR DESCRIPTION
## What

The CSS used by `_repr_html_` (for displaying objects in Jupyter) placed font colors in `:root` as CSS custom properties. This seems to cause lag in notebooks with more than a couple of dozens of cells when running a cell that displays outputs. We observed this on Chrome and Firefox, so it is probably not browser-specific.

## To reproduce

- In a new notebook, create a simple array:
  ```python
  import xarray as xr
  import numpy as np
  data = np.random.rand(4)
  a = xr.DataArray(data, coords=[np.arange(4)], dims=['x'])
  ```
- From a second cell, display `a`:
  ```python
  a
  ```
  This is probably fast with no noticable lag.
- Add 50-100 more cells. They CAN be empty. Run the second cell again. You may notice a small lag before the array is displayed, which can exceed 1 second in some cases (depending on number of cells in the notebook, and probably the type of hardware the browser is running on, it is clearly visible on my 2015 Macbook Pro).
- Probably other UI interactions such as switching tabs are also affected, but there the effect is not entirely clear.

## Fix

- Set CSS custom properties not in `:root` but the top-level class `xr-wrap`.
- TODO: I think the `vscode-dark` settings also may need to change, but my understanding of CSS is too limited. Can someone suggest how to fix this or take care of it?

## Discussion

Interestingly we ran into this problem independently of xarray: While `scipp` borrowed an early draft of `xarrays`'s `_repr_html_` implementation (thanks!), this was *before* the color configs were placed into `:root` --- we just happened to add such a color config independently. Since this was a recent change we managed to find the culprit yesterday (https://github.com/scipp/scipp/pull/1847). And then it occurred to me to check whether xarray has the same problem...

So this makes me think that *other* projects that define `_repr_html_` may well suffer from the same problem. Can we do anything to spread the word, or better, could there be a way to fix this for everyone (in Jupyter)?

## Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
