### PR TITLE
Skip mean over empty axis

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -85,6 +85,10 @@ Breaking changes
   as positional, all others need to be passed are keyword arguments. This is part of the
   refactor to support external backends (:issue:`4309`, :pull:`4989`).
   By `Alessandro Amici <https://github.com/alexamici>`_.
+- :py:func:`mean` does not change the data if axis is None. This
+  ensures that Datasets where some variables do not have the averaged
+  dimensions are not accidentially changed (:issue:`4885`).
+  By `David Schwörer <https://github.com/dschwoerer>`_
 
 Deprecations
 ~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -85,10 +85,11 @@ Breaking changes
   as positional, all others need to be passed are keyword arguments. This is part of the
   refactor to support external backends (:issue:`4309`, :pull:`4989`).
   By `Alessandro Amici <https://github.com/alexamici>`_.
-- :py:func:`mean` does not change the data if axis is None. This
-  ensures that Datasets where some variables do not have the averaged
-  dimensions are not accidentially changed (:issue:`4885`).
-  By `David Schwörer <https://github.com/dschwoerer>`_
+- Functions that are identities for 0d data return the unchanged data
+  if axis is empty. This ensures that Datasets where some variables do
+  not have the averaged dimensions are not accidentially changed
+  (:issue:`4885`, :pull:`5207`).  By `David Schwörer
+  <https://github.com/dschwoerer>`_
 
 Deprecations
 ~~~~~~~~~~~~

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -537,6 +537,11 @@ def mean(array, axis=None, skipna=None, **kwargs):
     dtypes"""
     from .common import _contains_cftime_datetimes
 
+    # The mean over an empty axis shouldn't change the data
+    # See https://github.com/pydata/xarray/issues/4885
+    if axis == tuple():
+        return array
+
     array = asarray(array)
     if array.dtype.kind in "Mm":
         offset = _datetime_nanmin(array)

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -373,6 +373,16 @@ def test_cftime_datetime_mean_dask_error():
         da.mean()
 
 
+def test_mean_dtype():
+    ds = Dataset()
+    ds["pos"] = [1, 2, 3]
+    ds["data"] = ("pos", "time"), [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+    ds["var"] = "pos", [2, 3, 4]
+    ds2 = ds.mean(dim="time")
+    assert all(ds2["var"] == ds["var"])
+    assert ds2["var"].dtype == ds["var"].dtype
+
+
 @pytest.mark.parametrize("dim_num", [1, 2])
 @pytest.mark.parametrize("dtype", [float, int, np.float32, np.bool_])
 @pytest.mark.parametrize("dask", [False, True])

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -26,7 +26,7 @@ from xarray.core.duck_array_ops import (
     where,
 )
 from xarray.core.pycompat import dask_array_type
-from xarray.testing import assert_allclose, assert_equal
+from xarray.testing import assert_allclose, assert_equal, assert_identical
 
 from . import (
     arm_xfail,
@@ -373,14 +373,15 @@ def test_cftime_datetime_mean_dask_error():
         da.mean()
 
 
-def test_mean_dtype():
+def test_empty_axis_dtype():
     ds = Dataset()
     ds["pos"] = [1, 2, 3]
     ds["data"] = ("pos", "time"), [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
     ds["var"] = "pos", [2, 3, 4]
-    ds2 = ds.mean(dim="time")
-    assert all(ds2["var"] == ds["var"])
-    assert ds2["var"].dtype == ds["var"].dtype
+    assert_identical(ds.mean(dim="time")["var"], ds["var"])
+    assert_identical(ds.max(dim="time")["var"], ds["var"])
+    assert_identical(ds.min(dim="time")["var"], ds["var"])
+    assert_identical(ds.sum(dim="time")["var"], ds["var"])
 
 
 @pytest.mark.parametrize("dim_num", [1, 2])


### PR DESCRIPTION
Avoids changing the datatype if the data does not have the requested
axis.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #4885
- [x] Tests added
- [ ] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

