### PR TITLE
DOC: add query examples

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4454,7 +4454,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
 
         Examples
         --------
-        >>> da = xr.DataArray(np.arange(0, 5, 1), dims="x", name="a")   
+        >>> da = xr.DataArray(np.arange(0, 5, 1), dims="x", name="a")
         >>> da
         <xarray.DataArray 'a' (x: 5)>
         array([0, 1, 2, 3, 4])

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4452,6 +4452,17 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
         Dataset.query
         pandas.eval
 
+        Examples
+        --------
+        >>> da = xr.DataArray(np.arange(0, 5, 1), dims="x", name="a")   
+        >>> da
+        <xarray.DataArray 'a' (x: 5)>
+        array([0, 1, 2, 3, 4])
+        Dimensions without coordinates: x
+        >>> da.query(x="a > 2")
+        <xarray.DataArray 'a' (x: 2)>
+        array([3, 4])
+        Dimensions without coordinates: x
         """
 
         ds = self._to_dataset_whole(shallow_copy=True)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -7235,6 +7235,25 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         Dataset.isel
         pandas.eval
 
+        Examples
+        --------
+        >>> a = np.arange(0, 5, 1)
+        >>> b = np.linspace(0, 1, 5)
+        >>> ds = xr.Dataset({"a": ("x", a), "b": ("x", b)})
+        >>> ds
+        <xarray.Dataset>
+        Dimensions:  (x: 5)
+        Dimensions without coordinates: x
+        Data variables:
+            a        (x) int64 0 1 2 3 4
+            b        (x) float64 0.0 0.25 0.5 0.75 1.0
+        >>> ds.query(x="a > 2")
+        <xarray.Dataset>
+        Dimensions:  (x: 2)
+        Dimensions without coordinates: x
+        Data variables:
+            a        (x) int64 3 4
+            b        (x) float64 0.75 1.0
         """
 
         # allow queries to be given either as a dict or as kwargs


### PR DESCRIPTION
Add query examples in the docstrings.

Relevent rtd buld links:
 - https://xray--5249.org.readthedocs.build/en/5249/generated/xarray.Dataset.query.html?highlight=query#xarray.Dataset.query
 - https://xray--5249.org.readthedocs.build/en/5249/generated/xarray.DataArray.query.html?highlight=query#xarray.DataArray.query