### PR TITLE
Fix bulleted list indentation in docstrings

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6741,24 +6741,23 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
             {dim: pad} is a shortcut for pad_before = pad_after = pad
         mode : str, default: "constant"
             One of the following string values (taken from numpy docs).
-                - 'constant': Pads with a constant value.
-                - 'edge': Pads with the edge values of array.
-                - 'linear_ramp': Pads with the linear ramp between end_value and the
+              - 'constant': Pads with a constant value.
+              - 'edge': Pads with the edge values of array.
+              - 'linear_ramp': Pads with the linear ramp between end_value and the
                     array edge value.
-                - 'maximum': Pads with the maximum value of all or part of the
+              - 'maximum': Pads with the maximum value of all or part of the
                     vector along each axis.
-                - 'mean': Pads with the mean value of all or part of the
+              - 'mean': Pads with the mean value of all or part of the
                     vector along each axis.
-                - 'median': Pads with the median value of all or part of the
+              - 'median': Pads with the median value of all or part of the
                     vector along each axis.
-                - 'minimum': Pads with the minimum value of all or part of the
+              - 'minimum': Pads with the minimum value of all or part of the
                     vector along each axis.
-                - 'reflect': Pads with the reflection of the vector mirrored on
-                    the first and last values of the vector along each
-                    axis.
-                - 'symmetric': Pads with the reflection of the vector mirrored
+              - 'reflect': Pads with the reflection of the vector mirrored on
+                    the first and last values of the vector along each axis.
+              - 'symmetric': Pads with the reflection of the vector mirrored
                     along the edge of the array.
-                - 'wrap': Pads with the wrap of the vector along the axis.
+              - 'wrap': Pads with the wrap of the vector along the axis.
                     The first values are used to pad the end and the
                     end values are used to pad the beginning.
         stat_length : int, tuple or mapping of hashable to tuple, default: None
@@ -7199,15 +7198,15 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
             parser to retain strict Python semantics.
         engine : {"python", "numexpr", None}, default: None
             The engine used to evaluate the expression. Supported engines are:
-                - None: tries to use numexpr, falls back to python
-                - "numexpr": evaluates expressions using numexpr
-                - "python": performs operations as if you had eval’d in top level python
+              - None: tries to use numexpr, falls back to python
+              - "numexpr": evaluates expressions using numexpr
+              - "python": performs operations as if you had eval’d in top level python
         missing_dims : {"raise", "warn", "ignore"}, default: "raise"
             What to do if dimensions that should be selected from are not present in the
             Dataset:
-                - "raise": raise an exception
-                - "warning": raise a warning, and ignore the missing dimensions
-                - "ignore": ignore the missing dimensions
+              - "raise": raise an exception
+              - "warning": raise a warning, and ignore the missing dimensions
+              - "ignore": ignore the missing dimensions
         **queries_kwargs : {dim: query, ...}, optional
             The keyword arguments form of ``queries``.
             One of queries or queries_kwargs must be provided.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6741,37 +6741,26 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
             {dim: pad} is a shortcut for pad_before = pad_after = pad
         mode : str, default: "constant"
             One of the following string values (taken from numpy docs).
-
-            'constant' (default)
-                Pads with a constant value.
-            'edge'
-                Pads with the edge values of array.
-            'linear_ramp'
-                Pads with the linear ramp between end_value and the
-                array edge value.
-            'maximum'
-                Pads with the maximum value of all or part of the
-                vector along each axis.
-            'mean'
-                Pads with the mean value of all or part of the
-                vector along each axis.
-            'median'
-                Pads with the median value of all or part of the
-                vector along each axis.
-            'minimum'
-                Pads with the minimum value of all or part of the
-                vector along each axis.
-            'reflect'
-                Pads with the reflection of the vector mirrored on
-                the first and last values of the vector along each
-                axis.
-            'symmetric'
-                Pads with the reflection of the vector mirrored
-                along the edge of the array.
-            'wrap'
-                Pads with the wrap of the vector along the axis.
-                The first values are used to pad the end and the
-                end values are used to pad the beginning.
+                - 'constant': Pads with a constant value.
+                - 'edge': Pads with the edge values of array.
+                - 'linear_ramp': Pads with the linear ramp between end_value and the
+                    array edge value.
+                - 'maximum': Pads with the maximum value of all or part of the
+                    vector along each axis.
+                - 'mean': Pads with the mean value of all or part of the
+                    vector along each axis.
+                - 'median': Pads with the median value of all or part of the
+                    vector along each axis.
+                - 'minimum': Pads with the minimum value of all or part of the
+                    vector along each axis.
+                - 'reflect': Pads with the reflection of the vector mirrored on
+                    the first and last values of the vector along each
+                    axis.
+                - 'symmetric': Pads with the reflection of the vector mirrored
+                    along the edge of the array.
+                - 'wrap': Pads with the wrap of the vector along the axis.
+                    The first values are used to pad the end and the
+                    end values are used to pad the beginning.
         stat_length : int, tuple or mapping of hashable to tuple, default: None
             Used in 'maximum', 'mean', 'median', and 'minimum'.  Number of
             values at edge of each axis used to calculate the statistic value.
@@ -7210,15 +7199,15 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
             parser to retain strict Python semantics.
         engine : {"python", "numexpr", None}, default: None
             The engine used to evaluate the expression. Supported engines are:
-            - None: tries to use numexpr, falls back to python
-            - "numexpr": evaluates expressions using numexpr
-            - "python": performs operations as if you had eval’d in top level python
+                - None: tries to use numexpr, falls back to python
+                - "numexpr": evaluates expressions using numexpr
+                - "python": performs operations as if you had eval’d in top level python
         missing_dims : {"raise", "warn", "ignore"}, default: "raise"
             What to do if dimensions that should be selected from are not present in the
             Dataset:
-            - "raise": raise an exception
-            - "warning": raise a warning, and ignore the missing dimensions
-            - "ignore": ignore the missing dimensions
+                - "raise": raise an exception
+                - "warning": raise a warning, and ignore the missing dimensions
+                - "ignore": ignore the missing dimensions
         **queries_kwargs : {dim: query, ...}, optional
             The keyword arguments form of ``queries``.
             One of queries or queries_kwargs must be provided.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6741,25 +6741,27 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
             {dim: pad} is a shortcut for pad_before = pad_after = pad
         mode : str, default: "constant"
             One of the following string values (taken from numpy docs).
-              - 'constant': Pads with a constant value.
-              - 'edge': Pads with the edge values of array.
-              - 'linear_ramp': Pads with the linear ramp between end_value and the
-                    array edge value.
-              - 'maximum': Pads with the maximum value of all or part of the
-                    vector along each axis.
-              - 'mean': Pads with the mean value of all or part of the
-                    vector along each axis.
-              - 'median': Pads with the median value of all or part of the
-                    vector along each axis.
-              - 'minimum': Pads with the minimum value of all or part of the
-                    vector along each axis.
-              - 'reflect': Pads with the reflection of the vector mirrored on
-                    the first and last values of the vector along each axis.
-              - 'symmetric': Pads with the reflection of the vector mirrored
-                    along the edge of the array.
-              - 'wrap': Pads with the wrap of the vector along the axis.
-                    The first values are used to pad the end and the
-                    end values are used to pad the beginning.
+
+            - constant: Pads with a constant value.
+            - edge: Pads with the edge values of array.
+            - linear_ramp: Pads with the linear ramp between end_value and the
+              array edge value.
+            - maximum: Pads with the maximum value of all or part of the
+              vector along each axis.
+            - mean: Pads with the mean value of all or part of the
+              vector along each axis.
+            - median: Pads with the median value of all or part of the
+              vector along each axis.
+            - minimum: Pads with the minimum value of all or part of the
+              vector along each axis.
+            - reflect: Pads with the reflection of the vector mirrored on
+              the first and last values of the vector along each axis.
+            - symmetric: Pads with the reflection of the vector mirrored
+              along the edge of the array.
+            - wrap: Pads with the wrap of the vector along the axis.
+              The first values are used to pad the end and the
+              end values are used to pad the beginning.
+
         stat_length : int, tuple or mapping of hashable to tuple, default: None
             Used in 'maximum', 'mean', 'median', and 'minimum'.  Number of
             values at edge of each axis used to calculate the statistic value.
@@ -7198,15 +7200,19 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
             parser to retain strict Python semantics.
         engine : {"python", "numexpr", None}, default: None
             The engine used to evaluate the expression. Supported engines are:
-              - None: tries to use numexpr, falls back to python
-              - "numexpr": evaluates expressions using numexpr
-              - "python": performs operations as if you had eval’d in top level python
+
+            - None: tries to use numexpr, falls back to python
+            - "numexpr": evaluates expressions using numexpr
+            - "python": performs operations as if you had eval’d in top level python
+
         missing_dims : {"raise", "warn", "ignore"}, default: "raise"
             What to do if dimensions that should be selected from are not present in the
             Dataset:
-              - "raise": raise an exception
-              - "warning": raise a warning, and ignore the missing dimensions
-              - "ignore": ignore the missing dimensions
+
+            - "raise": raise an exception
+            - "warning": raise a warning, and ignore the missing dimensions
+            - "ignore": ignore the missing dimensions
+
         **queries_kwargs : {dim: query, ...}, optional
             The keyword arguments form of ``queries``.
             One of queries or queries_kwargs must be provided.


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #5248
- [x] Passes `pre-commit run --all-files`


As I understand it, the issue described in #5248 is caused by bad indentation... With this PR, we get the following:

![Screen Shot 2021-05-02 at 11 06 41 PM](https://user-images.githubusercontent.com/13301940/116842888-60f6ce00-ab9b-11eb-826e-7eeb26827d34.png)

@max-sixty, let me know if there are other instances that need to be fixed as part of this PR.... 



