### PR TITLE
More correct deprecation warning for `lock` argument

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -133,7 +133,7 @@ Deprecations
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - The `lock` keyword argument to :py:func:`open_dataset` and :py:func:`open_dataarray` is now
   a backend specific option. It will give a warning if passed to a backend that doesn't support it
-  instead of being siletly ignored. From the next version it will raise an error.
+  instead of being silently ignored. From the next version it will raise an error.
   This is part of the refactor to support external backends (:issue:`5073`).
   By `Tom Nicholas <https://github.com/TomNicholas>`_ and `Alessandro Amici <https://github.com/alexamici>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -131,6 +131,11 @@ Deprecations
   :py:func:`xarray.open_mfdataset` when `combine='by_coords'` is specified.
   Fixes (:issue:`5230`), via (:pull:`5231`, :pull:`5255`).
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
+- The `lock` keyword argument to :py:func:`open_dataset` and :py:func:`open_dataarray` is now
+  a backend specific option. It will give a warning if passed to a backend that doesn't support it
+  instead of being siletly ignored. From the next version it will raise an error.
+  This is part of the refactor to support external backends (:issue:`5073`).
+  By `Tom Nicholas <https://github.com/TomNicholas>`_ and `Alessandro Amici <https://github.com/alexamici>`_.
 
 
 Bug fixes

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -449,7 +449,7 @@ def open_dataset(
           relevant when using dask or another form of parallelism. By default,
           appropriate locks are chosen to safely read and write files with the
           currently active dask scheduler. Supported by "netcdf4", "h5netcdf",
-          "pynio", "pseudonetcdf", "cfgrib".
+          "scipy", "pynio", "pseudonetcdf", "cfgrib".
 
         See engine open function for kwargs accepted by each specific engine.
 
@@ -633,7 +633,7 @@ def open_dataarray(
           relevant when using dask or another form of parallelism. By default,
           appropriate locks are chosen to safely read and write files with the
           currently active dask scheduler. Supported by "netcdf4", "h5netcdf",
-          "pynio", "pseudonetcdf", "cfgrib".
+          "scipy", "pynio", "pseudonetcdf", "cfgrib".
 
         See engine open function for kwargs accepted by each specific engine.
 

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 from ..core import indexing
@@ -125,7 +127,7 @@ class PydapBackendEntrypoint(BackendEntrypoint):
         lock=None,
     ):
         # TODO remove after v0.19
-        if kwargs.pop("lock", None):
+        if lock is None:
             warnings.warn(
                 "The kwarg 'lock' has been deprecated for this backend, and is now "
                 "ignored. In the future passing lock will raise an error.",

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -122,7 +122,16 @@ class PydapBackendEntrypoint(BackendEntrypoint):
         use_cftime=None,
         decode_timedelta=None,
         session=None,
+        lock=None,
     ):
+        # TODO remove after v0.19
+        if kwargs.pop("lock", None):
+            warnings.warn(
+                "The kwarg 'lock' has been deprecated for this backend, and is now "
+                "ignored. In the future passing lock will raise an error.",
+                DeprecationWarning,
+            )
+
         store = PydapDataStore.open(
             filename_or_obj,
             session=session,

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -127,7 +127,7 @@ class PydapBackendEntrypoint(BackendEntrypoint):
         lock=None,
     ):
         # TODO remove after v0.19
-        if lock is None:
+        if lock is not None:
             warnings.warn(
                 "The kwarg 'lock' has been deprecated for this backend, and is now "
                 "ignored. In the future passing lock will raise an error.",

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -725,7 +725,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
         lock=None,
     ):
         # TODO remove after v0.19
-        if lock is None:
+        if lock is not None:
             warnings.warn(
                 "The kwarg 'lock' has been deprecated for this backend, and is now "
                 "ignored. In the future passing lock will raise an error.",

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import warnings
 from distutils.version import LooseVersion
 
 import numpy as np
@@ -721,7 +722,15 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
         consolidate_on_close=False,
         chunk_store=None,
         storage_options=None,
+        lock=None,
     ):
+        # TODO remove after v0.19
+        if kwargs.pop("lock", None):
+            warnings.warn(
+                "The kwarg 'lock' has been deprecated for this backend, and is now "
+                "ignored. In the future passing lock will raise an error.",
+                DeprecationWarning,
+            )
 
         filename_or_obj = _normalize_path(filename_or_obj)
         store = ZarrStore.open_group(

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -725,7 +725,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
         lock=None,
     ):
         # TODO remove after v0.19
-        if kwargs.pop("lock", None):
+        if lock is None:
             warnings.warn(
                 "The kwarg 'lock' has been deprecated for this backend, and is now "
                 "ignored. In the future passing lock will raise an error.",


### PR DESCRIPTION
- [x] Closes #5073 (alternative to and more precise than #5237)
- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`

@TomNicholas and all, sorry again for addressing this late.