### PR TITLE
combine_attrs merge errors with compat="minimal" are silenced

### DIFF
--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -232,14 +232,14 @@ def merge_collected(
                 variables = [variable for variable, _ in elements_list]
                 try:
                     merged_vars[name] = unique_variable(name, variables, compat)
-                    merged_vars[name].attrs = merge_attrs(
-                        [var.attrs for var in variables], combine_attrs=combine_attrs
-                    )
                 except MergeError:
                     if compat != "minimal":
                         # we need more than "minimal" compatibility (for which
                         # we drop conflicting coordinates)
                         raise
+                merged_vars[name].attrs = merge_attrs(
+                    [var.attrs for var in variables], combine_attrs=combine_attrs
+                )
 
     return merged_vars, merged_indexes
 

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -515,11 +515,11 @@ def merge_attrs(variable_attrs, combine_attrs):
         for attrs in variable_attrs[1:]:
             try:
                 result = compat_dict_union(result, attrs)
-            except ValueError:
+            except ValueError as e:
                 raise MergeError(
                     "combine_attrs='no_conflicts', but some values are not "
                     "the same. Merging %s with %s" % (str(result), str(attrs))
-                )
+                ) from e
         return result
     elif combine_attrs == "drop_conflicts":
         result = {}

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -237,9 +237,11 @@ def merge_collected(
                         # we need more than "minimal" compatibility (for which
                         # we drop conflicting coordinates)
                         raise
-                merged_vars[name].attrs = merge_attrs(
-                    [var.attrs for var in variables], combine_attrs=combine_attrs
-                )
+
+                if name in merged_vars:
+                    merged_vars[name].attrs = merge_attrs(
+                        [var.attrs for var in variables], combine_attrs=combine_attrs
+                    )
 
     return merged_vars, merged_indexes
 

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -202,6 +202,14 @@ class TestMergeFunction:
         expected = xr.Dataset(attrs={"a": 0, "d": 0, "e": 0})
         assert_identical(actual, expected)
 
+    def test_merge_attrs_no_conflicts_compat_minimal(self):
+        """make sure compat="minimal" does not silence errors"""
+        ds1 = xr.Dataset({"a": ("x", [], {"a": 0})})
+        ds2 = xr.Dataset({"a": ("x", [], {"a": 1})})
+
+        with pytest.raises(xr.MergeError, match="combine_attrs"):
+            xr.merge([ds1, ds2], combine_attrs="no_conflicts", compat="minimal")
+
     def test_merge_dicts_simple(self):
         actual = xr.merge([{"foo": 0}, {"bar": "one"}, {"baz": 3.5}])
         expected = xr.Dataset({"foo": 0, "bar": "one", "baz": 3.5})


### PR DESCRIPTION
follow-up to #4902: the way it was written, calling `xr.merge(..., combine_attrs="no_conflicts", compat="minimal")` would silence `MergeError`. The tests didn't catch this because I was trying to test both variables and dimension variables at the same time, and the dimension variable raised.

If I'm wrong in assuming that `compat="minimal"` should not interfere with `combine_attrs` I guess we can close this (or remove everything except the change to raise the merge error from the value error).

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
