### PR TITLE
Disable workflows on forks

### DIFF
--- a/.github/workflows/cancel-duplicate-runs.yaml
+++ b/.github/workflows/cancel-duplicate-runs.yaml
@@ -8,6 +8,7 @@ jobs:
   cancel:
     name: Cancel previous runs
     runs-on: ubuntu-latest
+    if: github.repository == 'pydata/xarray'
     steps:
     - uses: styfle/cancel-workflow-action@0.9.0
       with:

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -12,7 +12,9 @@ jobs:
   detect-ci-trigger:
     name: detect ci trigger
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: |
+      github.repository == 'pydata/xarray'
+      && (github.event_name == 'push' || github.event_name == 'pull_request')
     outputs:
       triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
     steps:
@@ -111,6 +113,7 @@ jobs:
   doctest:
     name: Doctests
     runs-on: "ubuntu-latest"
+    if: github.repository == 'pydata/xarray'
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -10,6 +10,7 @@ jobs:
   linting:
     name: "pre-commit hooks"
     runs-on: ubuntu-latest
+    if: github.repository == 'pydata/xarray'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,9 @@ jobs:
   detect-ci-trigger:
     name: detect ci trigger
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: |
+      github.repository == 'pydata/xarray'
+      && (github.event_name == 'push' || github.event_name == 'pull_request')
     outputs:
       triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
     steps:

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -14,7 +14,9 @@ jobs:
   detect-ci-trigger:
     name: detect upstream-dev ci trigger
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: |
+      github.repository == 'pydata/xarray'
+      && (github.event_name == 'push' || github.event_name == 'pull_request')
     outputs:
       triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
     steps:
@@ -31,12 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: detect-ci-trigger
     if: |
-      always()
-      && github.repository == 'pydata/xarray'
-      && (
         (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         || needs.detect-ci-trigger.outputs.triggered == 'true'
-      )
     defaults:
       run:
         shell: bash -l {0}
@@ -97,9 +95,7 @@ jobs:
     name: report
     needs: upstream-dev
     if: |
-      always()
-      && github.event_name == 'schedule'
-      && github.repository == 'pydata/xarray'
+      github.event_name == 'schedule'
       && needs.upstream-dev.outputs.artifacts_availability == 'true'
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Currently, the CI runs both on a user's fork and `pydata/xarray`. This leads to duplicate runs and the user is flooded with GitHub notifications in case of failures... This PR addresses this issue by making sure the workflows are triggered on `pydata/xarray` only. 


![Screen Shot 2021-05-06 at 8 55 24 AM](https://user-images.githubusercontent.com/13301940/117319777-daffaf00-ae48-11eb-8523-5309542c524e.png)
