### PR TITLE
Remove push event trigger for the release workflow

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -3,14 +3,11 @@ on:
   release:
     types:
       - published
-  push:
-    branches:
-      - master
 
 jobs:
   build-artifacts:
     runs-on: ubuntu-latest
-    if: github.repository == 'pydata/xarray'
+    if: github.repository == 'pydata/xarray' &&  startsWith(github.event.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v2
         with:
@@ -63,16 +60,13 @@ jobs:
           ls -ltrh
           ls -ltrh dist
       - name: Publish package to TestPyPI
-        if: github.event_name == 'push' || startsWith(github.event.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           verbose: true
-
       - name: Check uploaded package
-        if: github.event_name == 'push' || startsWith(github.event.ref, 'refs/tags/v')
         run: |
           sleep 3
           python -m pip install --upgrade pip
@@ -81,7 +75,6 @@ jobs:
 
   upload-to-pypi:
     needs: test-built-dist
-    if: github.event_name == 'release' && startsWith(github.event.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

It turns out that pushes on main branch result in [an invalid package version](https://github.com/pydata/xarray/runs/2519311659). To address this issue, I am disabling the `push` event trigger on the release workflow

Cc @keewis 

```html
Uploading xarray-0.17.1.dev108+gf5e4fd5f-py3-none-any.whl

  0%|          | 0.00/796k [00:00<?, ?B/s]
 73%|███████▎  | 584k/796k [00:00<00:00, 3.39MB/s]
100%|██████████| 796k/796k [00:00<00:00, 1.52MB/s]
Content received from server:
<html>
 <head>
  <title>400 '0.17.1.dev108+gf5e4fd5f' is an invalid value for Version. Error: Can't use PEP 440 local versions. See packaging.python.org/specifications/core-metadata for more information.</title>
 </head>
 <body>
  <h1>400 '0.17.1.dev108+gf5e4fd5f' is an invalid value for Version. Error: Can't use PEP 440 local versions. See packaging.python.org/specifications/core-metadata for more information.</h1>
  The server could not comply with the request since it is either malformed or otherwise incorrect.<br/><br/>
&#x27;0.17.1.dev108+gf5e4fd5f&#x27; is an invalid value for Version. Error: Can&#x27;t use PEP 440 local versions. See packaging.python.org/specifications/core-metadata for more information.


 </body>
</html>
HTTPError: 400 Bad Request from test.pypi.org/legacy
'0.17.1.dev108+gf5e4fd5f' is an invalid value for Version. Error: Can't use PEP 440 local versions. See packaging.python.org/specifications/core-metadata for more information.
```