### PR TITLE
pypi upload workflow maintenance

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*'
 
 jobs:
   build-artifacts:

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -4,8 +4,6 @@ on:
     types:
       - published
   push:
-    branches:
-      - master
     tags:
       - 'v*'
 

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -63,7 +63,7 @@ jobs:
           ls -ltrh
           ls -ltrh dist
       - name: Publish package to TestPyPI
-        if: github.event_name == 'push' || startsWith(github.event.ref, 'refs/tags/v')
+        if: github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__
@@ -72,7 +72,7 @@ jobs:
           verbose: true
 
       - name: Check uploaded package
-        if: github.event_name == 'push' || startsWith(github.event.ref, 'refs/tags/v')
+        if: github.event_name == 'push'
         run: |
           sleep 3
           python -m pip install --upgrade pip


### PR DESCRIPTION
follow-up to #5244: as far as I can tell, it does not run on tags. We also have to decide whether we want to fix uploading dev versions (i.e. new commits on master) because `setuptools-scm` creates versions which are rejected by PyPI.

cc @andersy005

- [x] Passes `pre-commit run --all-files`
