### PR TITLE
fix the build wheel test

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -76,7 +76,7 @@ jobs:
         run: |
           sleep 3
           python -m pip install --upgrade pip
-          python -m pip install --index-url https://test.pypi.org/simple --upgrade xarray
+          python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade xarray
           python -m xarray.util.print_versions
 
   upload-to-pypi:


### PR DESCRIPTION
uploading to TestPyPI works now, but the check afterwards still fails, which I think is because we use `--index-url` instead of `--extra-index-url`

- [x] Passes `pre-commit run --all-files`

