### PR TITLE
Ensure `HighLevelGraph` layers are `Layer` instances

### DIFF
--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -540,10 +540,14 @@ def map_blocks(
         dependencies=[arg for arg in npargs if dask.is_dask_collection(arg)],
     )
 
-    for gname_l, layer in new_layers.items():
-        # This adds in the getitems for each variable in the dataset.
-        hlg.dependencies[gname_l] = {gname}
-        hlg.layers[gname_l] = layer
+    # This adds in the getitems for each variable in the dataset.
+    hlg = HighLevelGraph(
+        {**hlg.layers, **new_layers},
+        dependencies={
+            **hlg.dependencies,
+            **{name: {gname} for name in new_layers.keys()},
+        },
+    )
 
     result = Dataset(coords=indexes, attrs=template.attrs)
     for index in result.indexes:


### PR DESCRIPTION
This PR updates how we construct the `HighLevelGraph` in `subset_dataset_to_block`. Currently we create a `HighLevelGraph` and then manually add a few new layers, which are `dict`s, directly to `hlg.layers`.

https://github.com/pydata/xarray/blob/eec2b59bd08498fe3d50d8549b540d0a8409c7ac/xarray/core/parallel.py#L537-L546

However since (in more recent versions of Dask)  [`HighLevelGraph` layers are expected to be `Layer` class instances](https://github.com/dask/dask/blob/23c93d72c8fbd194b44614c29dd584ff93fc1eef/dask/highlevelgraph.py#L578-L582) this can result in unexpected errors (xref https://github.com/pydata/xarray/issues/5077#issuecomment-832359943). Instead of manually adding new layers to `hlg.layers`, this PR proposes we create a new `HighLevelGraph` altogether to ensure that `hlg.layers` won't contain any raw `dict` layers.