### PR TITLE
Dask-friendly nan check in xr.corr() and xr.cov()

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -28,7 +28,7 @@ New Features
 - :py:func:`xarray.cov` and :py:func:`xarray.corr` now lazily check for missing
   values if inputs are dask arrays (:issue:`4804`, :pull:`5284`).
   By `Andrew Williams <https://github.com/AndrewWilliams3142>`_.
-  
+
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,7 +21,9 @@ v0.18.1 (unreleased)
 
 New Features
 ~~~~~~~~~~~~
-
+- :py:func:`xarray.cov` and :py:func:`xarray.corr` now lazily check for missing
+  values if inputs are dask arrays (:issue:`4804`, :pull:`5284`).
+  By `Andrew Williams <https://github.com/AndrewWilliams3142>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1326,28 +1326,23 @@ def _cov_corr(da_a, da_b, dim=None, ddof=0, method=None):
 
     # 2. Ignore the nans
     valid_values = da_a.notnull() & da_b.notnull()
-
-    def _nan_check(d):
-        if d.all():
-            return True
-        else:
-            return False
-
-    if is_duck_dask_array(valid_values.data):
-        # assign to copy - else the check is not triggered
-        _are_there_nans = valid_values.copy(
-            data=valid_values.data.map_blocks(_nan_check, dtype=valid_values.dtype),
-            deep=False,
-        )
-
-    else:
-        _are_there_nans = _nan_check(valid_values.data)
-
-    if not _are_there_nans:
-        da_a = da_a.where(valid_values)
-        da_b = da_b.where(valid_values)
-
     valid_count = valid_values.sum(dim) - ddof
+
+    def _get_valid_values(da, other):
+        """
+        Function to lazily mask da_a and da_b
+        following a similar approach to
+        https://github.com/pydata/xarray/pull/4559
+        """
+        missing_vals = np.logical_or(da.isnull(), other.isnull())
+        if missing_vals.any():
+            da = da.where(~missing_vals)
+            return da
+        else:
+            return da
+
+    da_a = da_a.map_blocks(_get_valid_values, args=[da_b])
+    da_b = da_b.map_blocks(_get_valid_values, args=[da_a])
 
     # 3. Detrend along the given dim
     demeaned_da_a = da_a - da_a.mean(dim=dim)

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -1000,6 +1000,7 @@ def arrays_w_tuples():
         (arrays[2], arrays[2]),
         (arrays[2], arrays[3]),
         (arrays[2], arrays[4]),
+        (arrays[4], arrays[2]),
         (arrays[3], arrays[3]),
     ]
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -1015,6 +1015,7 @@ def arrays_w_tuples():
         arrays_w_tuples()[1][4],
         arrays_w_tuples()[1][5],
         arrays_w_tuples()[1][6],
+        arrays_w_tuples()[1][7],
     ],
 )
 @pytest.mark.parametrize("dim", [None, "x", "time"])

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -1002,6 +1002,7 @@ def arrays_w_tuples():
         (arrays[2], arrays[4]),
         (arrays[4], arrays[2]),
         (arrays[3], arrays[3]),
+        (arrays[4], arrays[4]),
     ]
 
     return arrays, array_tuples
@@ -1016,6 +1017,7 @@ def arrays_w_tuples():
         arrays_w_tuples()[1][5],
         arrays_w_tuples()[1][6],
         arrays_w_tuples()[1][7],
+        arrays_w_tuples()[1][8],
     ],
 )
 @pytest.mark.parametrize("dim", [None, "x", "time"])

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -990,6 +990,7 @@ def arrays_w_tuples():
         da.isel(time=range(2, 20)).rolling(time=3, center=True).mean(),
         xr.DataArray([[1, 2], [1, np.nan]], dims=["x", "time"]),
         xr.DataArray([[1, 2], [np.nan, np.nan]], dims=["x", "time"]),
+        xr.DataArray([[1, 2], [2, 1]], dims=["x", "time"]),
     ]
 
     array_tuples = [
@@ -998,6 +999,7 @@ def arrays_w_tuples():
         (arrays[1], arrays[1]),
         (arrays[2], arrays[2]),
         (arrays[2], arrays[3]),
+        (arrays[2], arrays[4]),
         (arrays[3], arrays[3]),
     ]
 
@@ -1007,7 +1009,12 @@ def arrays_w_tuples():
 @pytest.mark.parametrize("ddof", [0, 1])
 @pytest.mark.parametrize(
     "da_a, da_b",
-    [arrays_w_tuples()[1][3], arrays_w_tuples()[1][4], arrays_w_tuples()[1][5]],
+    [
+        arrays_w_tuples()[1][3],
+        arrays_w_tuples()[1][4],
+        arrays_w_tuples()[1][5],
+        arrays_w_tuples()[1][6],
+    ],
 )
 @pytest.mark.parametrize("dim", [None, "x", "time"])
 def test_lazy_corrcov(da_a, da_b, dim, ddof):


### PR DESCRIPTION
Was reading the discussion [here](https://github.com/pydata/xarray/issues/4804) and thought I'd draft a PR to implement some of the changes people suggested. It seems like the main problem is that currently in `computation.py`, `if not valid_values.all()` is not a lazy operation, and so can be a bottleneck for very large dataarrays. To get around this, I've lifted some neat tricks from #4559 so that `valid_values` remains a dask array. 


---

- [x] Closes #4804
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
