### PR TITLE
Raise error for invalid reference date for encoding time units

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,6 +27,8 @@ New Features
 - :py:meth:`Dataset.interp` now allows interpolation with non-numerical datatypes,
   such as booleans, instead of dropping them. (:issue:`4761` :pull:`5008`).
   By `Jimmy Westling <https://github.com/illviljan>`_.
+- Raise more informative error when decoding time variables with invalid reference dates.
+  (:issue:`5199`, :pull:`5288`). By `Giacomo Caria <https://github.com/gcaria>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -127,7 +127,6 @@ def _unpack_netcdf_time_units(units):
     # whitespace. It also ensures that the year is padded with zeros
     # so it will be correctly understood by pandas (via dateutil).
     matches = re.match(r"(.+) since (.+)", units)
-
     if not matches:
         raise ValueError(f"invalid time units: {units}")
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -104,6 +104,8 @@ def _ensure_padded_year(ref_date):
     # No four-digit strings, assume the first digits are the year and pad
     # appropriately
     matches_start_digits = re.match(r"(\d+)(.*)", ref_date)
+    if not matches_start_digits:
+        raise ValueError(f"invalid reference date for time units: {ref_date}")
     ref_year, everything_else = [s for s in matches_start_digits.groups()]
     ref_date_padded = "{:04d}{}".format(int(ref_year), everything_else)
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -127,6 +127,7 @@ def _unpack_netcdf_time_units(units):
     # whitespace. It also ensures that the year is padded with zeros
     # so it will be correctly understood by pandas (via dateutil).
     matches = re.match(r"(.+) since (.+)", units)
+
     if not matches:
         raise ValueError(f"invalid time units: {units}")
 

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -823,6 +823,12 @@ def test_encode_cf_datetime_overflow(shape):
     roundtrip = decode_cf_datetime(num, units, calendar)
     np.testing.assert_array_equal(dates, roundtrip)
 
+    with pytest.raises(ValueError, match="invalid time units"):
+        encode_cf_datetime(dates, units="days after 2000-01-01")
+
+    with pytest.raises(ValueError, match="invalid reference date"):
+        encode_cf_datetime(dates, units="days since NO_YEAR")
+
 
 def test_encode_cf_datetime_pandas_min():
     # GH 2623


### PR DESCRIPTION
- [x] Closes #5199
- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Although the error raised by this commit does not include the whole units string, I believe it is actually more useful and specific since it focuses on the part (reference date) that's actually causing the problem.
Also, the reference date is the only information available in `coding.times._ensure_padded_year`, so this is the simplest way of raising an error.

I had a look in `tests/test_coding_times.py` and could not find a test for this related error raising (since I'd put a test for this commit around there)
https://github.com/pydata/xarray/blob/234b40a37e484a795e6b12916315c80d70570b27/xarray/coding/times.py#L127-L129

Have I missed it?

EDIT: I've tried to substitute the error raise on line 129 with a `pass` and all the tests passed anyway.