### PR TITLE
Explained what a deprecation cycle is

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -394,7 +394,7 @@ a user passes ``old_arg``, we would instead catch it:
 
             warn(
                 "`old_arg` has been deprecated, and in the future will raise an error."
-                "Please use `new_arg` from now on."
+                "Please use `new_arg` from now on.", DeprecationWarning
             )
 
             # Still do what the user intended here

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -379,10 +379,28 @@ with ``git commit --no-verify``.
 Backwards Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Please try to maintain backward compatibility. *xarray* has growing number of users with
+Please try to maintain backwards compatibility. *xarray* has growing number of users with
 lots of existing code, so don't break it if at all possible.  If you think breakage is
-required, clearly state why as part of the pull request.  Also, be careful when changing
-method signatures and add deprecation warnings where needed.
+required, clearly state why as part of the pull request.
+
+Be especially careful when changing function and method signatures, because any change
+may require a deprecation warning. For example, if your pull request means that the
+argument `old_arg` to `func` is no longer valid, instead of simply raising an error if
+a user passes `old_arg`, we would instead catch it:
+
+    def func(new_arg, old_arg=None):
+        if old_arg is not None:
+            from warnings import warn
+            warn("`old_arg` has now been deprecated, and in future will raise an error.
+                  please use `new_arg` from now on.")
+
+            # Still do what the user intended here
+
+This temporary check would then be removed in the subsequent version of xarray.
+This process of first warning users before actually breaking their code is known as a
+"deprecation cycle", and makes changes significantly easier to handle both for users
+of xarray, and for developers of other libraries that depend on xarray.
+
 
 .. _contributing.ci:
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -391,8 +391,11 @@ a user passes `old_arg`, we would instead catch it:
     def func(new_arg, old_arg=None):
         if old_arg is not None:
             from warnings import warn
-            warn("`old_arg` has now been deprecated, and in future will raise an error.
-                  Please use `new_arg` from now on.")
+
+            warn(
+                "`old_arg` has been deprecated, and in the future will raise an error."
+                "Please use `new_arg` from now on."
+            )
 
             # Still do what the user intended here
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -385,8 +385,8 @@ required, clearly state why as part of the pull request.
 
 Be especially careful when changing function and method signatures, because any change
 may require a deprecation warning. For example, if your pull request means that the
-argument `old_arg` to `func` is no longer valid, instead of simply raising an error if
-a user passes `old_arg`, we would instead catch it:
+argument ``old_arg`` to ``func`` is no longer valid, instead of simply raising an error if
+a user passes ``old_arg``, we would instead catch it:
 
     def func(new_arg, old_arg=None):
         if old_arg is not None:

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -392,7 +392,7 @@ a user passes `old_arg`, we would instead catch it:
         if old_arg is not None:
             from warnings import warn
             warn("`old_arg` has now been deprecated, and in future will raise an error.
-                  please use `new_arg` from now on.")
+                  Please use `new_arg` from now on.")
 
             # Still do what the user intended here
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -399,7 +399,7 @@ a user passes `old_arg`, we would instead catch it:
 
             # Still do what the user intended here
 
-This temporary check would then be removed in the subsequent version of xarray.
+This temporary check would then be removed in a subsequent version of xarray.
 This process of first warning users before actually breaking their code is known as a
 "deprecation cycle", and makes changes significantly easier to handle both for users
 of xarray, and for developers of other libraries that depend on xarray.

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -388,13 +388,16 @@ may require a deprecation warning. For example, if your pull request means that 
 argument ``old_arg`` to ``func`` is no longer valid, instead of simply raising an error if
 a user passes ``old_arg``, we would instead catch it:
 
+.. code-block:: python
+
     def func(new_arg, old_arg=None):
         if old_arg is not None:
             from warnings import warn
 
             warn(
                 "`old_arg` has been deprecated, and in the future will raise an error."
-                "Please use `new_arg` from now on.", DeprecationWarning
+                "Please use `new_arg` from now on.",
+                DeprecationWarning,
             )
 
             # Still do what the user intended here

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -379,7 +379,7 @@ with ``git commit --no-verify``.
 Backwards Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Please try to maintain backwards compatibility. *xarray* has growing number of users with
+Please try to maintain backwards compatibility. *xarray* has a growing number of users with
 lots of existing code, so don't break it if at all possible.  If you think breakage is
 required, clearly state why as part of the pull request.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,6 +38,10 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
+- Explanation of deprecation cycles and how to implement them added to contributors
+  guide. (:pull:`5289`)
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
+
 
 Internal Changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Inspired by a question asked in #4696, but does not close that issue
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
