### PR TITLE
More robust guess_can_open for netCDF4/scipy/h5netcdf entrypoints

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,6 +34,10 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Opening netCDF files from a path that doesn't end in ``.nc`` without supplying
+  an explicit ``engine`` works again (:issue:`5295`), fixing a bug introduced in
+  0.18.0.
+  By `Stephan Hoyer <https://github.com/shoyer>`_
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -9,7 +9,12 @@ import numpy as np
 from .. import coding
 from ..coding.variables import pop_to
 from ..core import indexing
-from ..core.utils import FrozenDict, close_on_error, is_remote_uri
+from ..core.utils import (
+    FrozenDict,
+    close_on_error,
+    is_remote_uri,
+    try_read_magic_number_from_path,
+)
 from ..core.variable import Variable
 from .common import (
     BACKEND_ENTRYPOINTS,
@@ -517,6 +522,10 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
     def guess_can_open(self, filename_or_obj):
         if isinstance(filename_or_obj, str) and is_remote_uri(filename_or_obj):
             return True
+        magic_number = try_read_magic_number_from_path(filename_or_obj)
+        if magic_number is not None:
+            # netcdf 3 or HDF5
+            return magic_number.startswith((b"CDF", b"\211HDF\r\n\032\n"))
         try:
             _, ext = os.path.splitext(filename_or_obj)
         except TypeError:

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -1,3 +1,4 @@
+import gzip
 import io
 import os
 
@@ -77,8 +78,6 @@ class ScipyArrayWrapper(BackendArray):
 
 
 def _open_scipy_netcdf(filename, mode, mmap, version):
-    import gzip
-
     # if the string ends with .gz, then gunzip and open as netcdf file
     if isinstance(filename, str) and filename.endswith(".gz"):
         try:
@@ -242,6 +241,9 @@ class ScipyBackendEntrypoint(BackendEntrypoint):
     def guess_can_open(self, filename_or_obj):
 
         magic_number = try_read_magic_number_from_file_or_path(filename_or_obj)
+        if magic_number is not None and magic_number.startswith(b'\x1f\x8b'):
+            with gzip.open(filename_or_obj) as f:
+                magic_number = try_read_magic_number_from_file_or_path(f)
         if magic_number is not None:
             return magic_number.startswith(b"CDF")
 

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -241,7 +241,7 @@ class ScipyBackendEntrypoint(BackendEntrypoint):
     def guess_can_open(self, filename_or_obj):
 
         magic_number = try_read_magic_number_from_file_or_path(filename_or_obj)
-        if magic_number is not None and magic_number.startswith(b'\x1f\x8b'):
+        if magic_number is not None and magic_number.startswith(b"\x1f\x8b"):
             with gzip.open(filename_or_obj) as f:
                 magic_number = try_read_magic_number_from_file_or_path(f)
         if magic_number is not None:

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -4,7 +4,12 @@ import os
 import numpy as np
 
 from ..core.indexing import NumpyIndexingAdapter
-from ..core.utils import Frozen, FrozenDict, close_on_error, read_magic_number
+from ..core.utils import (
+    Frozen,
+    FrozenDict,
+    close_on_error,
+    try_read_magic_number_from_file_or_path,
+)
 from ..core.variable import Variable
 from .common import (
     BACKEND_ENTRYPOINTS,
@@ -235,10 +240,10 @@ class ScipyDataStore(WritableCFDataStore):
 
 class ScipyBackendEntrypoint(BackendEntrypoint):
     def guess_can_open(self, filename_or_obj):
-        try:
-            return read_magic_number(filename_or_obj).startswith(b"CDF")
-        except TypeError:
-            pass
+
+        magic_number = try_read_magic_number_from_file_or_path(filename_or_obj)
+        if magic_number is not None:
+            return magic_number.startswith(b"CDF")
 
         try:
             _, ext = os.path.splitext(filename_or_obj)

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -4,6 +4,7 @@ import contextlib
 import functools
 import io
 import itertools
+import os
 import re
 import warnings
 from enum import Enum
@@ -652,7 +653,7 @@ def is_remote_uri(path: str) -> bool:
     return bool(re.search(r"^[a-z][a-z0-9]*(\://|\:\:)", path))
 
 
-def read_magic_number(filename_or_obj, count=8):
+def read_magic_number_from_file(filename_or_obj, count=8) -> bytes:
     # check byte header to determine file type
     if isinstance(filename_or_obj, bytes):
         magic_number = filename_or_obj[:count]
@@ -663,10 +664,33 @@ def read_magic_number(filename_or_obj, count=8):
                 "file-like object read/write pointer not at the start of the file, "
                 "please close and reopen, or use a context manager"
             )
-        magic_number = filename_or_obj.read(count)
+        magic_number = filename_or_obj.read(count)  # type: ignore
         filename_or_obj.seek(0)
     else:
         raise TypeError(f"cannot read the magic number form {type(filename_or_obj)}")
+    return magic_number
+
+
+def try_read_magic_number_from_path(pathlike, count=8) -> Optional[bytes]:
+    if isinstance(pathlike, str) or hasattr(pathlike, "__fspath__"):
+        path = os.fspath(pathlike)
+        try:
+            with open(path, "rb") as f:
+                return read_magic_number_from_file(f, count)
+        except (FileNotFoundError, TypeError):
+            pass
+    return None
+
+
+def try_read_magic_number_from_file_or_path(
+    filename_or_obj, count=8
+) -> Optional[bytes]:
+    magic_number = try_read_magic_number_from_path(filename_or_obj, count)
+    if magic_number is None:
+        try:
+            magic_number = read_magic_number_from_file(filename_or_obj, count)
+        except TypeError:
+            pass
     return magic_number
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2824,7 +2824,10 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
             with open(tmp_file, "rb") as f:
                 f.seek(8)
                 with pytest.raises(ValueError, match="cannot guess the engine"):
-                    with pytest.warns(RuntimeWarning, match=re.escape("'h5netcdf' fails while guessing")):
+                    with pytest.warns(
+                        RuntimeWarning,
+                        match=re.escape("'h5netcdf' fails while guessing"),
+                    ):
                         open_dataset(f)
 
 
@@ -5223,7 +5226,7 @@ def test_scipy_entrypoint(tmp_path):
     )
 
     path = tmp_path / "foo.nc.gz"
-    with gzip.open(path, mode='wb') as f:
+    with gzip.open(path, mode="wb") as f:
         f.write(contents)
     _check_guess_can_open_and_open(entrypoint, path, engine="scipy", expected=ds)
     _check_guess_can_open_and_open(entrypoint, str(path), engine="scipy", expected=ds)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -30,9 +30,14 @@ from xarray import (
     save_mfdataset,
 )
 from xarray.backends.common import robust_getitem
+from xarray.backends.h5netcdf_ import H5netcdfBackendEntrypoint
 from xarray.backends.netcdf3 import _nc3_dtype_coercions
-from xarray.backends.netCDF4_ import _extract_nc4_variable_encoding
+from xarray.backends.netCDF4_ import (
+    NetCDF4BackendEntrypoint,
+    _extract_nc4_variable_encoding,
+)
 from xarray.backends.pydap_ import PydapDataStore
+from xarray.backends.scipy_ import ScipyBackendEntrypoint
 from xarray.coding.variables import SerializationWarning
 from xarray.conventions import encode_dataset_coordinates
 from xarray.core import indexes, indexing
@@ -5161,3 +5166,80 @@ def test_chunking_consintency(chunks, tmp_path):
 
         with xr.open_dataset(tmp_path / "test.nc", chunks=chunks) as actual:
             xr.testing.assert_chunks_equal(actual, expected)
+
+
+def _check_guess_can_open_and_open(entrypoint, obj, engine, expected):
+    assert entrypoint.guess_can_open(obj)
+    with open_dataset(obj, engine=engine) as actual:
+        assert_identical(expected, actual)
+
+
+@requires_netCDF4
+def test_netcdf4_entrypoint(tmp_path):
+    entrypoint = NetCDF4BackendEntrypoint()
+    ds = create_test_data()
+
+    path = tmp_path / "foo"
+    ds.to_netcdf(path, format="netcdf3_classic")
+    _check_guess_can_open_and_open(entrypoint, path, engine="netcdf4", expected=ds)
+    _check_guess_can_open_and_open(entrypoint, str(path), engine="netcdf4", expected=ds)
+
+    path = tmp_path / "bar"
+    ds.to_netcdf(path, format="netcdf4_classic")
+    _check_guess_can_open_and_open(entrypoint, path, engine="netcdf4", expected=ds)
+    _check_guess_can_open_and_open(entrypoint, str(path), engine="netcdf4", expected=ds)
+
+    assert entrypoint.guess_can_open("http://something/remote")
+    assert entrypoint.guess_can_open("something-local.nc")
+    assert entrypoint.guess_can_open("something-local.nc4")
+    assert entrypoint.guess_can_open("something-local.cdf")
+    assert not entrypoint.guess_can_open("not-found-and-no-extension")
+
+    path = tmp_path / "baz"
+    with open(path, "wb") as f:
+        f.write(b"not-a-netcdf-file")
+    assert not entrypoint.guess_can_open(path)
+
+
+@requires_scipy
+def test_scipy_entrypoint(tmp_path):
+    entrypoint = ScipyBackendEntrypoint()
+    ds = create_test_data()
+
+    path = tmp_path / "foo"
+    ds.to_netcdf(path, engine="scipy")
+    _check_guess_can_open_and_open(entrypoint, path, engine="scipy", expected=ds)
+    _check_guess_can_open_and_open(entrypoint, str(path), engine="scipy", expected=ds)
+    with open(path, "rb") as f:
+        _check_guess_can_open_and_open(entrypoint, f, engine="scipy", expected=ds)
+
+    contents = ds.to_netcdf(engine="scipy")
+    _check_guess_can_open_and_open(entrypoint, contents, engine="scipy", expected=ds)
+    _check_guess_can_open_and_open(
+        entrypoint, BytesIO(contents), engine="scipy", expected=ds
+    )
+
+    assert entrypoint.guess_can_open("something-local.nc")
+    assert entrypoint.guess_can_open("something-local.nc.gz")
+    assert not entrypoint.guess_can_open("not-found-and-no-extension")
+    assert not entrypoint.guess_can_open(b"not-a-netcdf-file")
+
+
+@requires_h5netcdf
+def test_h5netcdf_entrypoint(tmp_path):
+    entrypoint = H5netcdfBackendEntrypoint()
+    ds = create_test_data()
+
+    path = tmp_path / "foo"
+    ds.to_netcdf(path, engine="h5netcdf")
+    _check_guess_can_open_and_open(entrypoint, path, engine="h5netcdf", expected=ds)
+    _check_guess_can_open_and_open(
+        entrypoint, str(path), engine="h5netcdf", expected=ds
+    )
+    with open(path, "rb") as f:
+        _check_guess_can_open_and_open(entrypoint, f, engine="h5netcdf", expected=ds)
+
+    assert entrypoint.guess_can_open("something-local.nc")
+    assert entrypoint.guess_can_open("something-local.nc4")
+    assert entrypoint.guess_can_open("something-local.cdf")
+    assert not entrypoint.guess_can_open("not-found-and-no-extension")


### PR DESCRIPTION
The new version checks magic numbers in files on disk, not just already open file objects.

I've also added a bunch of unit-tests.

Fixes GH5295

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #5295
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
