### PR TITLE
pin jinja2

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -13,6 +13,7 @@ dependencies:
   - ipykernel
   - ipython
   - iris>=2.3
+  - jinja2<3.0  # jinja=3.0 is incompatible with nbsphinx
   - jupyter_client
   - matplotlib-base
   - nbsphinx


### PR DESCRIPTION
This can be reverted once the `nbsphinx` feedstock copies the library's pins.

- [x] Closes #5299
- [x] Passes `pre-commit run --all-files`
