### PR TITLE
Remove bad extra Returns in Dataset.drop_dims docstr

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4429,12 +4429,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         -------
         obj : Dataset
             The dataset without the given dimensions (or any variables
-            containing those dimensions)
-        errors : {"raise", "ignore"}, optional
-            If 'raise' (default), raises a ValueError error if
-            any of the dimensions passed are not
-            in the dataset. If 'ignore', any given dimensions that are in the
-            dataset are dropped and no error is raised.
+            containing those dimensions).
         """
         if errors not in ["raise", "ignore"]:
             raise ValueError('errors must be either "raise" or "ignore"')


### PR DESCRIPTION
This is a minor docstr correction.

`Dataset.drop_dims` docstr said it was returning errors in golang-like way that made me double-take.

Thanks!
