### PR TITLE
Fix broken Pydagogue URL

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -97,7 +97,7 @@ Some great resources for learning Git:
 
 * the `GitHub help pages <http://help.github.com/>`_.
 * the `NumPy's documentation <http://docs.scipy.org/doc/numpy/dev/index.html>`_.
-* Matthew Brett's `Pydagogue <http://matthew-brett.github.com/pydagogue/>`_.
+* Matthew Brett's `Pydagogue <http://matthew-brett.github.io/pydagogue/>`_.
 
 Getting started with Git
 ------------------------


### PR DESCRIPTION
Another minor doc fix. This points Pydagogue link in contributing docs to correct URL. It was a broken link.

Thanks!