### PR TITLE
unpin jinja2

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -13,7 +13,6 @@ dependencies:
   - ipykernel
   - ipython
   - iris>=2.3
-  - jinja2<3.0  # jinja=3.0 is incompatible with nbsphinx
   - jupyter_client
   - matplotlib-base
   - nbsphinx


### PR DESCRIPTION
Follow-up to #5303. The feedstock has been updated (thanks for the ping, @kmuehlbauer), so we can unpin it again.

- [x] Passes `pre-commit run --all-files`
