### PR TITLE
improve the error message when pooch is not installed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -90,6 +90,7 @@ io =
     cftime
     rasterio
     cfgrib
+    pooch
     ## Scitools packages & dependencies (e.g: cartopy, cf-units) can be hard to install
     # scitools-iris
 

--- a/xarray/tutorial.py
+++ b/xarray/tutorial.py
@@ -77,8 +77,11 @@ def open_dataset(
     """
     try:
         import pooch
-    except ImportError:
-        raise ImportError("using the tutorial data requires pooch")
+    except ImportError as e:
+        raise ImportError(
+            "tutorial.open_dataset depends on pooch to download and manage datasets."
+            " To proceed please install it from PyPI or conda / conda-forge."
+        ) from e
 
     logger = pooch.get_logger()
     logger.setLevel("WARNING")
@@ -146,8 +149,11 @@ def open_rasterio(
     """
     try:
         import pooch
-    except ImportError:
-        raise ImportError("using the tutorial data requires pooch")
+    except ImportError as e:
+        raise ImportError(
+            "tutorial.open_rasterio depends on pooch to download and manage datasets."
+            " To proceed please install it from PyPI or conda / conda-forge."
+        ) from e
 
     logger = pooch.get_logger()
     logger.setLevel("WARNING")

--- a/xarray/tutorial.py
+++ b/xarray/tutorial.py
@@ -80,7 +80,7 @@ def open_dataset(
     except ImportError as e:
         raise ImportError(
             "tutorial.open_dataset depends on pooch to download and manage datasets."
-            " To proceed please install it from PyPI or conda / conda-forge."
+            " To proceed please install pooch."
         ) from e
 
     logger = pooch.get_logger()
@@ -152,7 +152,7 @@ def open_rasterio(
     except ImportError as e:
         raise ImportError(
             "tutorial.open_rasterio depends on pooch to download and manage datasets."
-            " To proceed please install it from PyPI or conda / conda-forge."
+            " To proceed please install pooch."
         ) from e
 
     logger = pooch.get_logger()


### PR DESCRIPTION
Since it seems difficult to fix the situation using the package manager, this improves the error message by explicitly suggesting to install `pooch`.

- [x] partial fix for #5291
- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
