### PR TITLE
Add version variable for optional imports in pycompat

### DIFF
--- a/xarray/core/dask_array_compat.py
+++ b/xarray/core/dask_array_compat.py
@@ -1,13 +1,12 @@
 import warnings
-from distutils.version import LooseVersion
 
 import numpy as np
 
+from .pycompat import dask_version
+
 try:
     import dask.array as da
-    from dask import __version__ as dask_version
 except ImportError:
-    dask_version = "0.0.0"
     da = None
 
 
@@ -57,7 +56,7 @@ def pad(array, pad_width, mode="constant", **kwargs):
     return padded
 
 
-if LooseVersion(dask_version) > LooseVersion("2.30.0"):
+if dask_version > "2.30.0":
     ensure_minimum_chunksize = da.overlap.ensure_minimum_chunksize
 else:
 
@@ -114,7 +113,7 @@ else:
         return tuple(output)
 
 
-if LooseVersion(dask_version) > LooseVersion("2021.03.0"):
+if dask_version > "2021.03.0":
     sliding_window_view = da.lib.stride_tricks.sliding_window_view
 else:
 
@@ -180,7 +179,7 @@ else:
             axis=axis,
         )
         # map_overlap's signature changed in https://github.com/dask/dask/pull/6165
-        if LooseVersion(dask_version) > "2.18.0":
+        if dask_version > "2.18.0":
             return map_overlap(_np_sliding_window_view, x, align_arrays=False, **kwargs)
         else:
             return map_overlap(x, _np_sliding_window_view, **kwargs)

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -8,16 +8,10 @@ from typing import Any, Callable, Iterable, List, Sequence, Tuple, Union
 import numpy as np
 import pandas as pd
 
-try:
-    import dask
-
-    DASK_VERSION = LooseVersion(dask.__version__)
-except ModuleNotFoundError:
-    DASK_VERSION = LooseVersion("0")
-
 from . import duck_array_ops, nputils, utils
 from .pycompat import (
     dask_array_type,
+    dask_version,
     integer_types,
     is_duck_dask_array,
     sparse_array_type,
@@ -1393,7 +1387,7 @@ class DaskIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
                 return value
 
     def __setitem__(self, key, value):
-        if DASK_VERSION >= "2021.04.1":
+        if dask_version >= "2021.04.1":
             if isinstance(key, BasicIndexer):
                 self.array[key.tuple] = value
             elif isinstance(key, VectorizedIndexer):

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -2,7 +2,6 @@ import enum
 import functools
 import operator
 from collections import defaultdict
-from distutils.version import LooseVersion
 from typing import Any, Callable, Iterable, List, Sequence, Tuple, Union
 
 import numpy as np

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -1,3 +1,5 @@
+from distutils.version import LooseVersion
+
 import numpy as np
 
 from .utils import is_duck_array
@@ -5,8 +7,10 @@ from .utils import is_duck_array
 integer_types = (int, np.integer)
 
 try:
-    import dask.array
+    import dask
     from dask.base import is_dask_collection
+
+    dask_version = LooseVersion(dask.__version__)
 
     # solely for isinstance checks
     dask_array_type = (dask.array.Array,)
@@ -16,6 +20,7 @@ try:
 
 
 except ImportError:  # pragma: no cover
+    dask_version = LooseVersion("0.0.0")
     dask_array_type = ()
     is_duck_dask_array = lambda _: False
     is_dask_collection = lambda _: False
@@ -24,14 +29,18 @@ try:
     # solely for isinstance checks
     import sparse
 
+    sparse_version = LooseVersion(sparse.__version__)
     sparse_array_type = (sparse.SparseArray,)
 except ImportError:  # pragma: no cover
+    sparse_version = LooseVersion("0.0.0")
     sparse_array_type = ()
 
 try:
     # solely for isinstance checks
     import cupy
 
+    cupy_version = LooseVersion(sparse.__version__)
     cupy_array_type = (cupy.ndarray,)
 except ImportError:  # pragma: no cover
+    cupy_version = LooseVersion("0.0.0")
     cupy_array_type = ()

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -8,6 +8,7 @@ integer_types = (int, np.integer)
 
 try:
     import dask
+    import dask.array
     from dask.base import is_dask_collection
 
     dask_version = LooseVersion(dask.__version__)

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -40,7 +40,7 @@ try:
     # solely for isinstance checks
     import cupy
 
-    cupy_version = LooseVersion(sparse.__version__)
+    cupy_version = LooseVersion(cupy.__version__)
     cupy_array_type = (cupy.ndarray,)
 except ImportError:  # pragma: no cover
     cupy_version = LooseVersion("0.0.0")

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -31,8 +31,6 @@ from typing import (
 import numpy as np
 import pandas as pd
 
-from . import dtypes
-
 K = TypeVar("K")
 V = TypeVar("V")
 T = TypeVar("T")
@@ -83,9 +81,10 @@ def maybe_coerce_to_str(index, original_coords):
 
     pd.Index uses object-dtype to store str - try to avoid this for coords
     """
+    from .dtypes import result_type as dtypes_result_type
 
     try:
-        result_type = dtypes.result_type(*original_coords)
+        result_type = dtypes_result_type(*original_coords)
     except TypeError:
         pass
     else:

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -81,10 +81,10 @@ def maybe_coerce_to_str(index, original_coords):
 
     pd.Index uses object-dtype to store str - try to avoid this for coords
     """
-    from .dtypes import result_type as dtypes_result_type
+    from . import dtypes
 
     try:
-        result_type = dtypes_result_type(*original_coords)
+        result_type = dtypes.result_type(*original_coords)
     except TypeError:
         pass
     else:


### PR DESCRIPTION
It was difficult to do version checks with optional imports so I added variables in pycompat and removed some of the imports I found.