### PR TITLE
run pre-commit on all files after autoupdating

### DIFF
--- a/.github/workflows/ci-pre-commit-autoupdate.yaml
+++ b/.github/workflows/ci-pre-commit-autoupdate.yaml
@@ -36,6 +36,7 @@ jobs:
           EXECUTE_COMMANDS: |
             python -m pre_commit autoupdate
             python .github/workflows/sync_linter_versions.py .pre-commit-config.yaml ci/requirements/mypy_only
+            python -m pre_commit run --all-files
           COMMIT_MESSAGE: 'pre-commit: autoupdate hook versions'
           COMMIT_NAME: 'github-actions[bot]'
           COMMIT_EMAIL: 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
This implements the easier fix described in #5241 which doesn't involve creating a personal access token (which I *think* is tied to a specific account, even though it is set on a repository). Of course, it would be great to have the `Additional CI` and `linting` workflows run on PRs created by the action.

- [x] closes #5241
- [x] Passes `pre-commit run --all-files`
