### PR TITLE
Convert new_shape from list to tuple in _unstack_once

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1579,7 +1579,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
 
         # Potentially we could replace `len(other_dims)` with just `-1`
         other_dims = [d for d in self.dims if d != dim]
-        new_shape = list(reordered.shape[: len(other_dims)]) + new_dim_sizes
+        new_shape = tuple(list(reordered.shape[: len(other_dims)]) + new_dim_sizes)
         new_dims = reordered.dims[: len(other_dims)] + new_dim_names
 
         if fill_value is dtypes.NA:
@@ -1592,7 +1592,6 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         else:
             dtype = self.dtype
 
-        # Currently fails on sparse due to https://github.com/pydata/sparse/issues/422
         data = np.full_like(
             self.data,
             fill_value=fill_value,
@@ -1603,6 +1602,8 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         # Indexer is a list of lists of locations. Each list is the locations
         # on the new dimension. This is robust to the data being sparse; in that
         # case the destinations will be NaN / zero.
+        # sparse doesn't support item assigment,
+        # https://github.com/pydata/sparse/issues/114
         data[(..., *indexer)] = reordered
 
         return self._replace(dims=new_dims, data=data)


### PR DESCRIPTION
Having `new_shape` as a `list` broke some checks in sparse. `.shape` is usually a tuple so I changed `new_shape` to be a tuple as well. sparse arrays errors one step further down now instead, at the item assignment...

- Related to #5315
- [x] Passes `pre-commit run --all-files`

