### PR TITLE
Properly infer intervals of pcolormesh when plotting on logscale

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -57,6 +57,9 @@ Bug fixes
 - Fix the ``repr`` of :py:class:`Variable` objects with ``display_expand_data=True``
   (:pull:`5406`)
   By `Justus Magin <https://github.com/keewis>`_.
+- Plotting a pcolormesh with ``xscale="log"`` and/or ``yscale="log"`` works as
+  expected after improving the way the interval breaks are generated (:issue:`5333`).
+  By `Santiago Soler <https://github.com/santisoler>`_
 
 
 Documentation
@@ -110,9 +113,6 @@ New Features
 Bug fixes
 ~~~~~~~~~
 
-- Plotting a pcolormesh with ``xscale="log"`` and/or ``yscale="log"`` works as
-  expected after improving the way the interval breaks are generated (:issue:`5333`).
-  By `Santiago Soler <https://github.com/santisoler>`_
 - Opening netCDF files from a path that doesn't end in ``.nc`` without supplying
   an explicit ``engine`` works again (:issue:`5295`), fixing a bug introduced in
   0.18.0.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -45,6 +45,9 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Plotting a pcolormesh with ``xscale="log"`` and/or ``yscale="log"`` works as
+  expected after improving the way the interval breaks are generated (:issue:`5333`).
+  By `Santiago Soler <https://github.com/santisoler>`_
 - Opening netCDF files from a path that doesn't end in ``.nc`` without supplying
   an explicit ``engine`` works again (:issue:`5295`), fixing a bug introduced in
   0.18.0.

--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -780,6 +780,8 @@ def _plot2d(plotfunc):
 
         if "pcolormesh" == plotfunc.__name__:
             kwargs["infer_intervals"] = infer_intervals
+            kwargs["xscale"] = xscale
+            kwargs["yscale"] = yscale
 
         if "imshow" == plotfunc.__name__ and isinstance(aspect, str):
             # forbid usage of mpl strings
@@ -993,7 +995,7 @@ def contourf(x, y, z, ax, **kwargs):
 
 
 @_plot2d
-def pcolormesh(x, y, z, ax, infer_intervals=None, **kwargs):
+def pcolormesh(x, y, z, ax, xscale=None, yscale=None, infer_intervals=None, **kwargs):
     """
     Pseudocolor plot of 2D DataArray.
 
@@ -1016,19 +1018,19 @@ def pcolormesh(x, y, z, ax, infer_intervals=None, **kwargs):
         or ((x.ndim > 1) and (np.shape(x)[1] == np.shape(z)[1]))
     ):
         if len(x.shape) == 1:
-            x = _infer_interval_breaks(x, check_monotonic=True)
+            x = _infer_interval_breaks(x, check_monotonic=True, scale=xscale)
         else:
             # we have to infer the intervals on both axes
-            x = _infer_interval_breaks(x, axis=1)
-            x = _infer_interval_breaks(x, axis=0)
+            x = _infer_interval_breaks(x, axis=1, scale=xscale)
+            x = _infer_interval_breaks(x, axis=0, scale=xscale)
 
     if infer_intervals and (np.shape(y)[0] == np.shape(z)[0]):
         if len(y.shape) == 1:
-            y = _infer_interval_breaks(y, check_monotonic=True)
+            y = _infer_interval_breaks(y, check_monotonic=True, scale=yscale)
         else:
             # we have to infer the intervals on both axes
-            y = _infer_interval_breaks(y, axis=1)
-            y = _infer_interval_breaks(y, axis=0)
+            y = _infer_interval_breaks(y, axis=1, scale=yscale)
+            y = _infer_interval_breaks(y, axis=0, scale=yscale)
 
     primitive = ax.pcolormesh(x, y, z, **kwargs)
 

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -756,7 +756,7 @@ def _infer_interval_breaks(coord, axis=0, scale=None, check_monotonic=False):
     >>> _infer_interval_breaks([[0, 1], [3, 4]], axis=1)
     array([[-0.5,  0.5,  1.5],
            [ 2.5,  3.5,  4.5]])
-    >>> _infer_interval_breaks(np.logspace(-2, 2, 5), logscale=True)
+    >>> _infer_interval_breaks(np.logspace(-2, 2, 5), scale="log")
     array([3.16227766e-03, 3.16227766e-02, 3.16227766e-01, 3.16227766e+00,
            3.16227766e+01, 3.16227766e+02])
     """

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -774,6 +774,11 @@ def _infer_interval_breaks(coord, axis=0, scale=None, check_monotonic=False):
 
     # If logscale, compute the intervals in the logarithmic space
     if scale == "log":
+        if (coord <= 0).any():
+            raise ValueError(
+                "Found negative or zero value in coordinates. "
+                + "Coordinates must be positive on logscale plots."
+            )
         coord = np.log10(coord)
 
     deltas = 0.5 * np.diff(coord, axis=axis)

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2716,6 +2716,16 @@ test_da_list = [
     DataArray(easy_array((10, 3, 2))),
 ]
 
+# Define a few arrays for testing scale="log"
+test_da_list_log = [
+    DataArray(np.arange(7), dims=("x",), coords={"x": np.logspace(-3, 3, 7)}),
+    DataArray(
+        np.arange(16).reshape(4, 4),
+        dims=("y", "x"),
+        coords={"x": np.logspace(-1, 2, 4), "y": np.logspace(-5, -1, 4)},
+    ),
+]
+
 
 @requires_matplotlib
 class TestAxesKwargs:
@@ -2734,17 +2744,29 @@ class TestAxesKwargs:
             assert plt.gca().yaxis_inverted() == (not yincrease)
 
     @pytest.mark.parametrize("da", test_da_list)
-    @pytest.mark.parametrize("xscale", ["linear", "log", "logit", "symlog"])
+    @pytest.mark.parametrize("xscale", ["linear", "logit", "symlog"])
     def test_xscale_kwarg(self, da, xscale):
         with figure_context():
             da.plot(xscale=xscale)
             assert plt.gca().get_xscale() == xscale
 
-    @pytest.mark.parametrize(
-        "da", [DataArray(easy_array((10,))), DataArray(easy_array((10, 3)))]
-    )
-    @pytest.mark.parametrize("yscale", ["linear", "log", "logit", "symlog"])
+    @pytest.mark.parametrize("da", test_da_list)
+    @pytest.mark.parametrize("yscale", ["linear", "logit", "symlog"])
     def test_yscale_kwarg(self, da, yscale):
+        with figure_context():
+            da.plot(yscale=yscale)
+            assert plt.gca().get_yscale() == yscale
+
+    @pytest.mark.parametrize("da", test_da_list_log)
+    def test_xscale_log_kwarg(self, da):
+        xscale = "log"
+        with figure_context():
+            da.plot(xscale=xscale)
+            assert plt.gca().get_xscale() == xscale
+
+    @pytest.mark.parametrize("da", test_da_list_log)
+    def test_yscale_log_kwarg(self, da):
+        yscale = "log"
         with figure_context():
             da.plot(yscale=yscale)
             assert plt.gca().get_yscale() == yscale

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2717,19 +2717,26 @@ test_da_list = [
     DataArray(easy_array((10, 3, 2))),
 ]
 
-# Define a few arrays for testing scale="log"
-test_da_list_log = [
-    DataArray(np.arange(7), dims=("x",), coords={"x": np.logspace(-3, 3, 7)}),
-    DataArray(
-        np.arange(16).reshape(4, 4),
-        dims=("y", "x"),
-        coords={"x": np.logspace(-1, 2, 4), "y": np.logspace(-5, -1, 4)},
-    ),
-]
-
 
 @requires_matplotlib
 class TestAxesKwargs:
+    @pytest.fixture(params=[1, 2])
+    def data_array_logspaced(self, request):
+        """
+        Return a simple DataArray with logspaced coordinates
+        """
+        dims = request.param
+        if dims == 1:
+            return DataArray(
+                np.arange(7), dims=("x",), coords={"x": np.logspace(-3, 3, 7)}
+            )
+        if dims == 2:
+            return DataArray(
+                np.arange(16).reshape(4, 4),
+                dims=("y", "x"),
+                coords={"x": np.logspace(-1, 2, 4), "y": np.logspace(-5, -1, 4)},
+            )
+
     @pytest.mark.parametrize("da", test_da_list)
     @pytest.mark.parametrize("xincrease", [True, False])
     def test_xincrease_kwarg(self, da, xincrease):
@@ -2758,18 +2765,16 @@ class TestAxesKwargs:
             da.plot(yscale=yscale)
             assert plt.gca().get_yscale() == yscale
 
-    @pytest.mark.parametrize("da", test_da_list_log)
-    def test_xscale_log_kwarg(self, da):
+    def test_xscale_log_kwarg(self, data_array_logspaced):
         xscale = "log"
         with figure_context():
-            da.plot(xscale=xscale)
+            data_array_logspaced.plot(xscale=xscale)
             assert plt.gca().get_xscale() == xscale
 
-    @pytest.mark.parametrize("da", test_da_list_log)
-    def test_yscale_log_kwarg(self, da):
+    def test_yscale_log_kwarg(self, data_array_logspaced):
         yscale = "log"
         with figure_context():
-            da.plot(yscale=yscale)
+            data_array_logspaced.plot(yscale=yscale)
             assert plt.gca().get_yscale() == yscale
 
     @pytest.mark.parametrize("da", test_da_list)

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -493,6 +493,26 @@ class TestPlot(PlotTestCase):
         with pytest.raises(ValueError):
             _infer_interval_breaks(np.array([0, 2, 1]), check_monotonic=True)
 
+    def test__infer_interval_breaks_logscale(self):
+        """
+        Check if interval breaks are defined in the logspace if scale="log"
+        """
+        # Check for 1d arrays
+        x = np.logspace(-4, 3, 8)
+        expected_interval_breaks = 10 ** np.linspace(-4.5, 3.5, 9)
+        np.testing.assert_allclose(
+            _infer_interval_breaks(x, scale="log"), expected_interval_breaks
+        )
+
+        # Check for 2d arrays
+        x = np.logspace(-4, 3, 8)
+        y = np.linspace(-5, 5, 11)
+        x, y = np.meshgrid(x, y)
+        expected_interval_breaks = np.vstack([10 ** np.linspace(-4.5, 3.5, 9)] * 12)
+        x = _infer_interval_breaks(x, axis=1, scale="log")
+        x = _infer_interval_breaks(x, axis=0, scale="log")
+        np.testing.assert_allclose(x, expected_interval_breaks)
+
     def test_geo_data(self):
         # Regression test for gh2250
         # Realistic coordinates taken from the example dataset

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2711,15 +2711,21 @@ class TestNcAxisNotInstalled(PlotTestCase):
             self.darray.plot.line()
 
 
-test_da_list = [
-    DataArray(easy_array((10,))),
-    DataArray(easy_array((10, 3))),
-    DataArray(easy_array((10, 3, 2))),
-]
-
-
 @requires_matplotlib
 class TestAxesKwargs:
+    @pytest.fixture(params=[1, 2, 3])
+    def data_array(self, request):
+        """
+        Return a simple DataArray
+        """
+        dims = request.param
+        if dims == 1:
+            return DataArray(easy_array((10,)))
+        if dims == 2:
+            return DataArray(easy_array((10, 3)))
+        if dims == 3:
+            return DataArray(easy_array((10, 3, 2)))
+
     @pytest.fixture(params=[1, 2])
     def data_array_logspaced(self, request):
         """
@@ -2737,32 +2743,28 @@ class TestAxesKwargs:
                 coords={"x": np.logspace(-1, 2, 4), "y": np.logspace(-5, -1, 4)},
             )
 
-    @pytest.mark.parametrize("da", test_da_list)
     @pytest.mark.parametrize("xincrease", [True, False])
-    def test_xincrease_kwarg(self, da, xincrease):
+    def test_xincrease_kwarg(self, data_array, xincrease):
         with figure_context():
-            da.plot(xincrease=xincrease)
+            data_array.plot(xincrease=xincrease)
             assert plt.gca().xaxis_inverted() == (not xincrease)
 
-    @pytest.mark.parametrize("da", test_da_list)
     @pytest.mark.parametrize("yincrease", [True, False])
-    def test_yincrease_kwarg(self, da, yincrease):
+    def test_yincrease_kwarg(self, data_array, yincrease):
         with figure_context():
-            da.plot(yincrease=yincrease)
+            data_array.plot(yincrease=yincrease)
             assert plt.gca().yaxis_inverted() == (not yincrease)
 
-    @pytest.mark.parametrize("da", test_da_list)
     @pytest.mark.parametrize("xscale", ["linear", "logit", "symlog"])
-    def test_xscale_kwarg(self, da, xscale):
+    def test_xscale_kwarg(self, data_array, xscale):
         with figure_context():
-            da.plot(xscale=xscale)
+            data_array.plot(xscale=xscale)
             assert plt.gca().get_xscale() == xscale
 
-    @pytest.mark.parametrize("da", test_da_list)
     @pytest.mark.parametrize("yscale", ["linear", "logit", "symlog"])
-    def test_yscale_kwarg(self, da, yscale):
+    def test_yscale_kwarg(self, data_array, yscale):
         with figure_context():
-            da.plot(yscale=yscale)
+            data_array.plot(yscale=yscale)
             assert plt.gca().get_yscale() == yscale
 
     def test_xscale_log_kwarg(self, data_array_logspaced):
@@ -2777,31 +2779,27 @@ class TestAxesKwargs:
             data_array_logspaced.plot(yscale=yscale)
             assert plt.gca().get_yscale() == yscale
 
-    @pytest.mark.parametrize("da", test_da_list)
-    def test_xlim_kwarg(self, da):
+    def test_xlim_kwarg(self, data_array):
         with figure_context():
             expected = (0.0, 1000.0)
-            da.plot(xlim=[0, 1000])
+            data_array.plot(xlim=[0, 1000])
             assert plt.gca().get_xlim() == expected
 
-    @pytest.mark.parametrize("da", test_da_list)
-    def test_ylim_kwarg(self, da):
+    def test_ylim_kwarg(self, data_array):
         with figure_context():
-            da.plot(ylim=[0, 1000])
+            data_array.plot(ylim=[0, 1000])
             expected = (0.0, 1000.0)
             assert plt.gca().get_ylim() == expected
 
-    @pytest.mark.parametrize("da", test_da_list)
-    def test_xticks_kwarg(self, da):
+    def test_xticks_kwarg(self, data_array):
         with figure_context():
-            da.plot(xticks=np.arange(5))
+            data_array.plot(xticks=np.arange(5))
             expected = np.arange(5).tolist()
             assert_array_equal(plt.gca().get_xticks(), expected)
 
-    @pytest.mark.parametrize("da", test_da_list)
-    def test_yticks_kwarg(self, da):
+    def test_yticks_kwarg(self, data_array):
         with figure_context():
-            da.plot(yticks=np.arange(5))
+            data_array.plot(yticks=np.arange(5))
             expected = np.arange(5)
             assert_array_equal(plt.gca().get_yticks(), expected)
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -513,6 +513,19 @@ class TestPlot(PlotTestCase):
         x = _infer_interval_breaks(x, axis=0, scale="log")
         np.testing.assert_allclose(x, expected_interval_breaks)
 
+    def test__infer_interval_breaks_logscale_invalid_coords(self):
+        """
+        Check error is raised when passing non-positive coordinates with logscale
+        """
+        # Check if error is raised after a zero value in the array
+        x = np.linspace(0, 5, 6)
+        with pytest.raises(ValueError):
+            _infer_interval_breaks(x, scale="log")
+        # Check if error is raised after nagative values in the array
+        x = np.linspace(-5, 5, 11)
+        with pytest.raises(ValueError):
+            _infer_interval_breaks(x, scale="log")
+
     def test_geo_data(self):
         # Regression test for gh2250
         # Realistic coordinates taken from the example dataset

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -1710,6 +1710,52 @@ class TestPcolormesh(Common2dMixin, PlotTestCase):
         assert artist.get_array().size <= self.darray.size
 
 
+class TestPcolormeshLogscale(PlotTestCase):
+    """
+    Test pcolormesh axes when x and y are in logscale
+    """
+
+    plotfunc = staticmethod(xplt.pcolormesh)
+
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        self.boundaries = (-1, 9, -4, 3)
+        shape = (8, 11)
+        x = np.logspace(self.boundaries[0], self.boundaries[1], shape[1])
+        y = np.logspace(self.boundaries[2], self.boundaries[3], shape[0])
+        da = DataArray(
+            easy_array(shape, start=-1),
+            dims=["y", "x"],
+            coords={"y": y, "x": x},
+            name="testvar",
+        )
+        self.darray = da
+
+    def test_interval_breaks_logspace(self):
+        """
+        Check if the outer vertices of the pcolormesh are the expected values
+
+        Checks bugfix for #5333
+        """
+        artist = self.darray.plot.pcolormesh(xscale="log", yscale="log")
+
+        # Grab the coordinates of the vertices of the Patches
+        x_vertices = [p.vertices[:, 0] for p in artist.properties()["paths"]]
+        y_vertices = [p.vertices[:, 1] for p in artist.properties()["paths"]]
+
+        # Get the maximum and minimum values for each set of vertices
+        xmin, xmax = np.min(x_vertices), np.max(x_vertices)
+        ymin, ymax = np.min(y_vertices), np.max(y_vertices)
+
+        # Check if they are equal to 10 to the power of the outer value of its
+        # corresponding axis plus or minus the interval in the logspace
+        log_interval = 0.5
+        np.testing.assert_allclose(xmin, 10 ** (self.boundaries[0] - log_interval))
+        np.testing.assert_allclose(xmax, 10 ** (self.boundaries[1] + log_interval))
+        np.testing.assert_allclose(ymin, 10 ** (self.boundaries[2] - log_interval))
+        np.testing.assert_allclose(ymax, 10 ** (self.boundaries[3] + log_interval))
+
+
 @pytest.mark.slow
 class TestImshow(Common2dMixin, PlotTestCase):
 


### PR DESCRIPTION
When inferring the interval breaks, the `coord` and first linearized if
`scale="log"` and then the intervals are brought back to the original scale
before being returned to `pcolormesh`. Raise an error if at least one of the
elements of the coodinates has a non-positive element when using a logscale.

- [x] Closes #5333
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`
