### PR TITLE
Add dask stack tests

### DIFF
--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2218,12 +2218,10 @@ class TestDataArray:
         actual = DataArray(s, dims="z").unstack("z")
         assert_identical(expected, actual)
 
-    def test_stack_nonunique_consistency(self):
-        orig = DataArray(
-            [[0, 1], [2, 3]], dims=["x", "y"], coords={"x": [0, 1], "y": [0, 0]}
-        )
-        actual = orig.stack(z=["x", "y"])
-        expected = DataArray(orig.to_pandas().stack(), dims="z")
+    def test_stack_nonunique_consistency(self, da):
+        da = da.isel(time=0, drop=True)  # 2D
+        actual = da.stack(z=["a", "x"])
+        expected = DataArray(da.to_pandas().stack(), dims="z")
         assert_identical(expected, actual)
 
     def test_to_unstacked_dataset_raises_value_error(self):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests added
- [x] Passes `pre-commit run --all-files`

I think we could consider gradually moving to this fixture model of tests, where we pass `da` and it's paramaterized across dask / numpy (and anything we choose to add in the future). And it's possible to select the backing array type like selecting any other fixture type.

The general proposal probably needs some socializing and refinement before we start applying it more broadly. I'd be keen to pursue it if others agree — it could bring some more robustness to our testing suite while also making it simpler.