### PR TITLE
Use dict in docs Dataset construction

### DIFF
--- a/doc/getting-started-guide/quick-overview.rst
+++ b/doc/getting-started-guide/quick-overview.rst
@@ -176,7 +176,7 @@ objects. You can think of it as a multi-dimensional generalization of the
 
 .. ipython:: python
 
-    ds = xr.Dataset({"foo": data, "bar": ("x", [1, 2]), "baz": np.pi})
+    ds = xr.Dataset(dict(foo=data, bar=("x", [1, 2]), baz=np.pi))
     ds
 
 

--- a/doc/internals/duck-arrays-integration.rst
+++ b/doc/internals/duck-arrays-integration.rst
@@ -48,4 +48,4 @@ To avoid duplicated information, this method must omit information about the sha
     b = sparse.COO.from_numpy(b)
     b
 
-    xr.Dataset({"a": ("x", a), "b": (("y", "z"), b)})
+    xr.Dataset(dict(a=("x", a), b=(("y", "z"), b)))

--- a/doc/user-guide/data-structures.rst
+++ b/doc/user-guide/data-structures.rst
@@ -310,12 +310,12 @@ in the dictionary:
 
 .. ipython:: python
 
-    xr.Dataset({"bar": foo})
+    xr.Dataset(dict(bar=foo))
 
 
 .. ipython:: python
 
-    xr.Dataset({"bar": foo.to_pandas()})
+    xr.Dataset(dict(bar=foo.to_pandas()))
 
 Where a pandas object is supplied as a value, the names of its indexes are used as dimension
 names, and its data is aligned to any existing dimensions.


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Passes `pre-commit run --all-files`

As discussed in other issues — I find this way significantly easier to read, particularly when we're passing tuples of tuples as part of the construction. I did these manually but can write something to do it more broadly if people agree.