### PR TITLE
second attempt to fix the upstream-dev CI

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -98,7 +98,7 @@ jobs:
     name: report
     needs: upstream-dev
     if: |
-      always()
+      failure()
       && github.event_name == 'schedule'
       && needs.upstream-dev.outputs.artifacts_availability == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -98,7 +98,8 @@ jobs:
     name: report
     needs: upstream-dev
     if: |
-      github.event_name == 'schedule'
+      always()
+      && github.event_name == 'schedule'
       && needs.upstream-dev.outputs.artifacts_availability == 'true'
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
follow-up to #5343, which got the upstream-dev CI to run but unfortunately not the "report" job.

- [x] Passes `pre-commit run --all-files`