### PR TITLE
Make `kind` argument in `CFTimeIndex._maybe_cast_slice_bound` optional

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,6 +33,9 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
+- Fix a minor incompatibility between partial datetime string indexing with a
+:py:class:`CFTimeIndex` and upcoming pandas version 1.3.0 (:issue:`5356`,
+:pull:`5359`).  By `Spencer Clark <https://github.com/spencerkclark>`_.
 
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,8 +34,9 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 - Fix a minor incompatibility between partial datetime string indexing with a
-:py:class:`CFTimeIndex` and upcoming pandas version 1.3.0 (:issue:`5356`,
-:pull:`5359`).  By `Spencer Clark <https://github.com/spencerkclark>`_.
+  :py:class:`CFTimeIndex` and upcoming pandas version 1.3.0 (:issue:`5356`,
+  :pull:`5359`).
+  By `Spencer Clark <https://github.com/spencerkclark>`_.
 
 
 Documentation

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -465,9 +465,14 @@ class CFTimeIndex(pd.Index):
         else:
             return pd.Index.get_loc(self, key, method=method, tolerance=tolerance)
 
-    def _maybe_cast_slice_bound(self, label, side, kind):
+    def _maybe_cast_slice_bound(self, label, side, kind=None):
         """Adapted from
-        pandas.tseries.index.DatetimeIndex._maybe_cast_slice_bound"""
+        pandas.tseries.index.DatetimeIndex._maybe_cast_slice_bound
+
+        Note that we have never used the kind argument in CFTimeIndex and it is
+        deprecated as of pandas version 1.3.0.  It exists only for compatibility
+        reasons.  We can remove it when our minimum version of pandas is 1.3.0.
+        """
         if not isinstance(label, str):
             return label
 


### PR DESCRIPTION
Pandas recently deprecated the `kind` argument in `Index._maybe_cast_slice_bound`, and removed its use in several internal calls: https://github.com/pandas-dev/pandas/pull/41378.  This led to some errors in the CFTimeIndex tests in our upstream build.  We never made use of it in `CFTimeIndex._maybe_cast_slice_bound` so the simplest fix for backwards compatibility seems to be to make it optional for now -- in previous versions of pandas it was required -- and remove it when our minimum version of pandas is at least 1.3.0.

- [x] Closes #5356
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
