### PR TITLE
use assert_allcose on test_resample_loffset

### DIFF
--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3987,7 +3987,7 @@ class TestDataset:
         expected_ = ds.bar.to_series().resample("24H").mean()
         expected_.index += to_offset("-12H")
         expected = DataArray.from_series(expected_)
-        assert_identical(actual, expected)
+        assert_allclose(actual, expected)
 
     def test_resample_by_mean_discarding_attrs(self):
         times = pd.date_range("2000-01-01", freq="6H", periods=10)


### PR DESCRIPTION
`test_resample_loffset` failed on i586 with Python 3.9 as it used
`assert_identical`.
Changed to the more permissive `assert_allclose`.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #5341
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
