### PR TITLE
Update test for CuPy v9

### DIFF
--- a/xarray/tests/test_cupy.py
+++ b/xarray/tests/test_cupy.py
@@ -47,7 +47,7 @@ def test_cupy_import():
 def test_check_data_stays_on_gpu(toy_weather_data):
     """Perform some operations and check the data stays on the GPU."""
     freeze = (toy_weather_data["tmin"] <= 0).groupby("time.month").mean("time")
-    assert isinstance(freeze.data, cp.core.core.ndarray)
+    assert isinstance(freeze.data, cp.ndarray)
 
 
 def test_where():


### PR DESCRIPTION
This change simply update CuPy tests for v9 support, where `cupy.core.core.ndarray` was removed in favor of `cupy.ndarray`. That was already available in v8 so it doesn't break backwards compatibility either.