### PR TITLE
Dataset subset assignments in doc

### DIFF
--- a/doc/user-guide/indexing.rst
+++ b/doc/user-guide/indexing.rst
@@ -234,9 +234,6 @@ arrays). However, you can do normal indexing with dimension names:
     ds[dict(space=[0], time=[0])]
     ds.loc[dict(time="2000-01-01")]
 
-Using indexing to *assign* values to a subset of dataset (e.g.,
-``ds[dict(space=0)] = 1``) is not yet supported.
-
 Dropping labels and dimensions
 ------------------------------
 
@@ -536,6 +533,22 @@ __ https://docs.scipy.org/doc/numpy/user/basics.indexing.html#assigning-values-t
       da.isel(x=[0, 1, 2])[1] = -1
       da
 
+You can also assign values in all variables of a ``Dataset`` at once:
+
+.. ipython:: python
+
+    ds = xr.tutorial.open_dataset("eraint_uvz")
+    # by integer
+    ds[dict(longitude=10, latitude=10)] = 1
+    # by label
+    ds.loc[dict(longitude=47.25, latitude=[11.25, 12])] = 100
+    # dataset as new values
+    ds.loc[dict(longitude=47.25, latitude=[11.25, 12])] = ds.loc[
+        dict(longitude=48.0, latitude=[11.25, 12])
+    ]
+
+The dimensions can differ between the variables in the dataset, but all variables need to possess at least the dimensions specified in the indexer dictionary.
+The new values must be either a scalar, a ``DataArray`` or a ``Dataset`` itself that contains all variables that also appear in the dataset to be modified.
 
 .. _more_advanced_indexing:
 

--- a/doc/user-guide/indexing.rst
+++ b/doc/user-guide/indexing.rst
@@ -538,13 +538,18 @@ You can also assign values in all variables of a ``Dataset`` at once:
 .. ipython:: python
 
     ds = xr.tutorial.open_dataset("eraint_uvz")
+    ds
+
     # by integer
+    ds[dict(longitude=10, latitude=10)]["u"]
     ds[dict(longitude=10, latitude=10)] = 1
     ds[dict(longitude=10, latitude=10)]["u"]
-    ds[dict(longitude=10, latitude=10)]["v"]
+
     # by label
+    ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])]["u"]
     ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])] = 100
     ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])]["u"]
+
     # dataset as new values
     ds.loc[dict(longitude=48, level=200, latitude=[11.25, 12])]["u"]
     ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])] = ds.loc[

--- a/doc/user-guide/indexing.rst
+++ b/doc/user-guide/indexing.rst
@@ -533,7 +533,7 @@ __ https://docs.scipy.org/doc/numpy/user/basics.indexing.html#assigning-values-t
       da.isel(x=[0, 1, 2])[1] = -1
       da
 
-You can also assign values in all variables of a ``Dataset`` at once:
+You can also assign values in all variables of a :py:class:`Dataset` at once:
 
 .. ipython:: python
 
@@ -557,7 +557,7 @@ You can also assign values in all variables of a ``Dataset`` at once:
     ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])]["u"]
 
 The dimensions can differ between the variables in the dataset, but all variables need to possess at least the dimensions specified in the indexer dictionary.
-The new values must be either a scalar, a ``DataArray`` or a ``Dataset`` itself that contains all variables that also appear in the dataset to be modified.
+The new values must be either a scalar, a :py:class:`DataArray` or a :py:class:`Dataset` itself that contains all variables that also appear in the dataset to be modified.
 
 .. _more_advanced_indexing:
 

--- a/doc/user-guide/indexing.rst
+++ b/doc/user-guide/indexing.rst
@@ -551,10 +551,9 @@ You can also assign values in all variables of a ``Dataset`` at once:
     ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])]["u"]
 
     # dataset as new values
-    ds.loc[dict(longitude=48, level=200, latitude=[11.25, 12])]["u"]
-    ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])] = ds.loc[
-        dict(longitude=48.0, level=200, latitude=[11.25, 12])
-    ]
+    new_dat = ds.loc[dict(longitude=48, level=200, latitude=[11.25, 12])]["u"]
+    new_dat
+    ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])] = new_dat
     ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])]["u"]
 
 The dimensions can differ between the variables in the dataset, but all variables need to possess at least the dimensions specified in the indexer dictionary.

--- a/doc/user-guide/indexing.rst
+++ b/doc/user-guide/indexing.rst
@@ -537,24 +537,25 @@ You can also assign values in all variables of a :py:class:`Dataset` at once:
 
 .. ipython:: python
 
-    ds = xr.tutorial.open_dataset("eraint_uvz")
+    ds_org = xr.tutorial.open_dataset("eraint_uvz").isel(
+        latitude=slice(56, 59), longitude=slice(255, 258), level=0
+    )
+    ds = ds_org * 0
     ds
 
     # by integer
-    ds[dict(longitude=10, latitude=10)]["u"]
-    ds[dict(longitude=10, latitude=10)] = 1
-    ds[dict(longitude=10, latitude=10)]["u"]
+    ds[dict(latitude=2, longitude=2)] = 1
+    ds["u"]
 
     # by label
-    ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])]["u"]
-    ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])] = 100
-    ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])]["u"]
+    ds.loc[dict(latitude=47.25, longitude=[11.25, 12])] = 100
+    ds["u"]
 
     # dataset as new values
-    new_dat = ds.loc[dict(longitude=48, level=200, latitude=[11.25, 12])]["u"]
+    new_dat = ds_org.loc[dict(latitude=48, longitude=[11.25, 12])]
     new_dat
-    ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])] = new_dat
-    ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])]["u"]
+    ds.loc[dict(latitude=47.25, longitude=[11.25, 12])] = new_dat
+    ds["u"]
 
 The dimensions can differ between the variables in the dataset, but all variables need to possess at least the dimensions specified in the indexer dictionary.
 The new values must be either a scalar, a :py:class:`DataArray` or a :py:class:`Dataset` itself that contains all variables that also appear in the dataset to be modified.

--- a/doc/user-guide/indexing.rst
+++ b/doc/user-guide/indexing.rst
@@ -540,12 +540,17 @@ You can also assign values in all variables of a ``Dataset`` at once:
     ds = xr.tutorial.open_dataset("eraint_uvz")
     # by integer
     ds[dict(longitude=10, latitude=10)] = 1
+    ds[dict(longitude=10, latitude=10)]["u"]
+    ds[dict(longitude=10, latitude=10)]["v"]
     # by label
-    ds.loc[dict(longitude=47.25, latitude=[11.25, 12])] = 100
+    ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])] = 100
+    ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])]["u"]
     # dataset as new values
-    ds.loc[dict(longitude=47.25, latitude=[11.25, 12])] = ds.loc[
-        dict(longitude=48.0, latitude=[11.25, 12])
+    ds.loc[dict(longitude=48, level=200, latitude=[11.25, 12])]["u"]
+    ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])] = ds.loc[
+        dict(longitude=48.0, level=200, latitude=[11.25, 12])
     ]
+    ds.loc[dict(longitude=47.25, level=200, latitude=[11.25, 12])]["u"]
 
 The dimensions can differ between the variables in the dataset, but all variables need to possess at least the dimensions specified in the indexer dictionary.
 The new values must be either a scalar, a ``DataArray`` or a ``Dataset`` itself that contains all variables that also appear in the dataset to be modified.

--- a/doc/user-guide/indexing.rst
+++ b/doc/user-guide/indexing.rst
@@ -533,19 +533,21 @@ __ https://docs.scipy.org/doc/numpy/user/basics.indexing.html#assigning-values-t
       da.isel(x=[0, 1, 2])[1] = -1
       da
 
-You can also assign values in all variables of a :py:class:`Dataset` at once:
+You can also assign values to all variables of a :py:class:`Dataset` at once:
 
 .. ipython:: python
 
     ds_org = xr.tutorial.open_dataset("eraint_uvz").isel(
         latitude=slice(56, 59), longitude=slice(255, 258), level=0
     )
-    ds = ds_org * 0
+    # set all values to 0
+    ds = xr.zeros_like(ds_org)
     ds
 
     # by integer
     ds[dict(latitude=2, longitude=2)] = 1
     ds["u"]
+    ds["v"]
 
     # by label
     ds.loc[dict(latitude=47.25, longitude=[11.25, 12])] = 100
@@ -557,7 +559,7 @@ You can also assign values in all variables of a :py:class:`Dataset` at once:
     ds.loc[dict(latitude=47.25, longitude=[11.25, 12])] = new_dat
     ds["u"]
 
-The dimensions can differ between the variables in the dataset, but all variables need to possess at least the dimensions specified in the indexer dictionary.
+The dimensions can differ between the variables in the dataset, but all variables need to have at least the dimensions specified in the indexer dictionary.
 The new values must be either a scalar, a :py:class:`DataArray` or a :py:class:`Dataset` itself that contains all variables that also appear in the dataset to be modified.
 
 .. _more_advanced_indexing:


### PR DESCRIPTION
Added explanation of new feature (PR #5045) that allows assigning values to a subset of a dataset to the documentation.
