### PR TITLE
Corrected reference to blockwise to refer to apply_gufunc instead

### DIFF
--- a/doc/examples/apply_ufunc_vectorize_1d.ipynb
+++ b/doc/examples/apply_ufunc_vectorize_1d.ipynb
@@ -494,7 +494,7 @@
    "source": [
     "So far our function can only handle numpy arrays. A real benefit of `apply_ufunc` is the ability to easily parallelize over dask chunks _when needed_. \n",
     "\n",
-    "We want to apply this function in a vectorized fashion over each chunk of the dask array. This is possible using dask's `blockwise` or `map_blocks`. `apply_ufunc` wraps `blockwise` and asking it to map the function over chunks using `blockwise` is as simple as specifying `dask=\"parallelized\"`. With this level of flexibility we need to provide dask with some extra information: \n",
+    "We want to apply this function in a vectorized fashion over each chunk of the dask array. This is possible using dask's `blockwise`, `map_blocks`, or `apply_gufunc`. Xarray's `apply_ufunc` wraps dask's `apply_gufunc` and asking it to map the function over chunks using `apply_gufunc` is as simple as specifying `dask=\"parallelized\"`. With this level of flexibility we need to provide dask with some extra information: \n",
     "  1. `output_dtypes`: dtypes of all returned objects, and \n",
     "  2. `output_sizes`: lengths of any new dimensions. \n",
     "  \n",
@@ -711,7 +711,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.10"
   },
   "nbsphinx": {
    "allow_errors": true
@@ -732,5 +732,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
I noticed that the apply_ufunc tutorial notebook says that `xarray.apply_ufunc` uses `dask.array.blockwise`, but that's no longer true as of PR #4060 .

- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
