### PR TITLE
Inconsistent docstring for isel etc.

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1102,7 +1102,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
             What to do if dimensions that should be selected from are not present in the
             DataArray:
             - "raise": raise an exception
-            - "warning": raise a warning, and ignore the missing dimensions
+            - "warn": raise a warning, and ignore the missing dimensions
             - "ignore": ignore the missing dimensions
         **indexers_kwargs : {dim: indexer, ...}, optional
             The keyword arguments form of ``indexers``.
@@ -2222,7 +2222,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
             What to do if dimensions that should be selected from are not present in the
             DataArray:
             - "raise": raise an exception
-            - "warning": raise a warning, and ignore the missing dimensions
+            - "warn": raise a warning, and ignore the missing dimensions
             - "ignore": ignore the missing dimensions
 
         Returns
@@ -4452,7 +4452,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
             What to do if dimensions that should be selected from are not present in the
             Dataset:
             - "raise": raise an exception
-            - "warning": raise a warning, and ignore the missing dimensions
+            - "warn": raise a warning, and ignore the missing dimensions
             - "ignore": ignore the missing dimensions
         **queries_kwargs : {dim: query, ...}, optional
             The keyword arguments form of ``queries``.


### PR DESCRIPTION
I found that the options for the `missing_dims` parameter where described inconsistently in the docstring (`"warning" vs "warn").

Not sure I found all occurrences of it here.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
