### PR TITLE
Faster corrcov

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -28,7 +28,7 @@ New Features
 - :py:func:`xarray.cov` and :py:func:`xarray.corr` now lazily check for missing
   values if inputs are dask arrays (:issue:`4804`, :pull:`5284`).
   By `Andrew Williams <https://github.com/AndrewWilliams3142>`_.
-  
+
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,7 +21,9 @@ v0.18.1 (unreleased)
 
 New Features
 ~~~~~~~~~~~~
-
+- :py:func:`xarray.cov` and :py:func:`xarray.corr` now lazily check for missing
+  values if inputs are dask arrays (:issue:`4804`, :pull:`5284`).
+  By `Andrew Williams <https://github.com/AndrewWilliams3142>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1371,16 +1371,14 @@ def _cov_corr(da_a, da_b, dim=None, ddof=0, method=None):
     da_b = da_b.map_blocks(_get_valid_values, args=[da_a])
 
     # 3. Detrend along the given dim
-    demeaned_da_a = da_a - da_a.mean(dim=dim)
-    demeaned_da_b = da_b - da_b.mean(dim=dim)
+    # https://github.com/pydata/xarray/issues/4804#issuecomment-760114285
+    demeaned_da_ab = (da_a * da_b) - (da_a.mean(dim=dim) * da_b.mean(dim=dim))
 
     # 4. Compute covariance along the given dim
     # N.B. `skipna=False` is required or there is a bug when computing
     # auto-covariance. E.g. Try xr.cov(da,da) for
     # da = xr.DataArray([[1, 2], [1, np.nan]], dims=["x", "time"])
-    cov = (demeaned_da_a * demeaned_da_b).sum(dim=dim, skipna=True, min_count=1) / (
-        valid_count
-    )
+    cov = demeaned_da_ab.sum(dim=dim, skipna=True, min_count=1) / (valid_count)
 
     if method == "cov":
         return cov

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1326,28 +1326,23 @@ def _cov_corr(da_a, da_b, dim=None, ddof=0, method=None):
 
     # 2. Ignore the nans
     valid_values = da_a.notnull() & da_b.notnull()
-
-    def _nan_check(d):
-        if d.all():
-            return True
-        else:
-            return False
-
-    if is_duck_dask_array(valid_values.data):
-        # assign to copy - else the check is not triggered
-        _are_there_nans = valid_values.copy(
-            data=valid_values.data.map_blocks(_nan_check, dtype=valid_values.dtype),
-            deep=False,
-        )
-
-    else:
-        _are_there_nans = _nan_check(valid_values.data)
-
-    if not _are_there_nans:
-        da_a = da_a.where(valid_values)
-        da_b = da_b.where(valid_values)
-
     valid_count = valid_values.sum(dim) - ddof
+
+    def _get_valid_values(da, other):
+        """
+        Function to lazily mask da_a and da_b
+        following a similar approach to
+        https://github.com/pydata/xarray/pull/4559
+        """
+        missing_vals = np.logical_or(da.isnull(), other.isnull())
+        if missing_vals.any():
+            da = da.where(~missing_vals)
+            return da
+        else:
+            return da
+
+    da_a = da_a.map_blocks(_get_valid_values, args=[da_b])
+    da_b = da_b.map_blocks(_get_valid_values, args=[da_a])
 
     # 3. Detrend along the given dim
     demeaned_da_a = da_a - da_a.mean(dim=dim)

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -1000,6 +1000,7 @@ def arrays_w_tuples():
         (arrays[2], arrays[2]),
         (arrays[2], arrays[3]),
         (arrays[2], arrays[4]),
+        (arrays[4], arrays[2]),
         (arrays[3], arrays[3]),
     ]
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -1015,6 +1015,7 @@ def arrays_w_tuples():
         arrays_w_tuples()[1][4],
         arrays_w_tuples()[1][5],
         arrays_w_tuples()[1][6],
+        arrays_w_tuples()[1][7],
     ],
 )
 @pytest.mark.parametrize("dim", [None, "x", "time"])

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -1002,6 +1002,7 @@ def arrays_w_tuples():
         (arrays[2], arrays[4]),
         (arrays[4], arrays[2]),
         (arrays[3], arrays[3]),
+        (arrays[4], arrays[4]),
     ]
 
     return arrays, array_tuples
@@ -1016,6 +1017,7 @@ def arrays_w_tuples():
         arrays_w_tuples()[1][5],
         arrays_w_tuples()[1][6],
         arrays_w_tuples()[1][7],
+        arrays_w_tuples()[1][8],
     ],
 )
 @pytest.mark.parametrize("dim", [None, "x", "time"])

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -990,6 +990,7 @@ def arrays_w_tuples():
         da.isel(time=range(2, 20)).rolling(time=3, center=True).mean(),
         xr.DataArray([[1, 2], [1, np.nan]], dims=["x", "time"]),
         xr.DataArray([[1, 2], [np.nan, np.nan]], dims=["x", "time"]),
+        xr.DataArray([[1, 2], [2, 1]], dims=["x", "time"]),
     ]
 
     array_tuples = [
@@ -998,6 +999,7 @@ def arrays_w_tuples():
         (arrays[1], arrays[1]),
         (arrays[2], arrays[2]),
         (arrays[2], arrays[3]),
+        (arrays[2], arrays[4]),
         (arrays[3], arrays[3]),
     ]
 
@@ -1007,7 +1009,12 @@ def arrays_w_tuples():
 @pytest.mark.parametrize("ddof", [0, 1])
 @pytest.mark.parametrize(
     "da_a, da_b",
-    [arrays_w_tuples()[1][3], arrays_w_tuples()[1][4], arrays_w_tuples()[1][5]],
+    [
+        arrays_w_tuples()[1][3],
+        arrays_w_tuples()[1][4],
+        arrays_w_tuples()[1][5],
+        arrays_w_tuples()[1][6],
+    ],
 )
 @pytest.mark.parametrize("dim", [None, "x", "time"])
 def test_lazy_corrcov(da_a, da_b, dim, ddof):


### PR DESCRIPTION
Following @willirath 's suggestion in #4804, I've changed https://github.com/pydata/xarray/blob/master/xarray/core/computation.py#L1373_L1375 so that Dask doesn't hold all chunks in memory

- [ ] Closes (more of) #4804, specifically [this comment](https://github.com/pydata/xarray/issues/4804#issuecomment-760114285)
- [ ] Passes `pre-commit run --all-files`
