### PR TITLE
Improvements to lazy behaviour of `xr.cov()` and `xr.corr()`

### DIFF
--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1371,16 +1371,14 @@ def _cov_corr(da_a, da_b, dim=None, ddof=0, method=None):
     da_b = da_b.map_blocks(_get_valid_values, args=[da_a])
 
     # 3. Detrend along the given dim
-    demeaned_da_a = da_a - da_a.mean(dim=dim)
-    demeaned_da_b = da_b - da_b.mean(dim=dim)
+    # https://github.com/pydata/xarray/issues/4804#issuecomment-760114285
+    demeaned_da_ab = (da_a * da_b) - (da_a.mean(dim=dim) * da_b.mean(dim=dim))
 
     # 4. Compute covariance along the given dim
     # N.B. `skipna=False` is required or there is a bug when computing
     # auto-covariance. E.g. Try xr.cov(da,da) for
     # da = xr.DataArray([[1, 2], [1, np.nan]], dims=["x", "time"])
-    cov = (demeaned_da_a * demeaned_da_b).sum(dim=dim, skipna=True, min_count=1) / (
-        valid_count
-    )
+    cov = demeaned_da_ab.sum(dim=dim, skipna=True, min_count=1) / (valid_count)
 
     if method == "cov":
         return cov


### PR DESCRIPTION
Following @willirath 's suggestion in #4804, I've changed https://github.com/pydata/xarray/blob/master/xarray/core/computation.py#L1373_L1375 so that Dask doesn't hold all chunks in memory

- [x] Closes (more of) #4804, specifically [this comment](https://github.com/pydata/xarray/issues/4804#issuecomment-760114285)
- [x] Passes `pre-commit run --all-files`
