### PR TITLE
Don't drop unreduced variables

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4987,6 +4987,8 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
                     variables[name] = var
             else:
                 if (
+                    # Some reduction functions (e.g. std, var) need to run on variables
+                    # that don't have the reduce dims: PR5393
                     not reduce_dims
                     or not numeric_only
                     or np.issubdtype(var.dtype, np.number)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4986,7 +4986,8 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
                     variables[name] = var
             else:
                 if (
-                    not numeric_only
+                    not reduce_dims
+                    or not numeric_only
                     or np.issubdtype(var.dtype, np.number)
                     or (var.dtype == np.bool_)
                 ):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4953,7 +4953,7 @@ class TestDataset:
             data = np.random.randint(0, 100, size=size).astype(np.str_)
             data1[v] = (dims, data, {"foo": "variable"})
 
-        assert all(var not in data1.mean() for var in add_vars)
+        assert "var4" not in data1.mean() and "var5" not in data1.mean()
         assert_equal(data1.mean(), data2.mean())
         assert_equal(data1.mean(dim="dim1"), data2.mean(dim="dim1"))
         assert "var4" not in data1.mean(dim="dim2") and "var5" in data1.mean(dim="dim2")

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4947,15 +4947,16 @@ class TestDataset:
     def test_reduce_non_numeric(self):
         data1 = create_test_data(seed=44)
         data2 = create_test_data(seed=44)
-        add_vars = {"var4": ["dim1", "dim2"]}
+        add_vars = {"var4": ["dim1", "dim2"], "var5": ["dim1"]}
         for v, dims in sorted(add_vars.items()):
             size = tuple(data1.dims[d] for d in dims)
             data = np.random.randint(0, 100, size=size).astype(np.str_)
             data1[v] = (dims, data, {"foo": "variable"})
 
-        assert "var4" not in data1.mean()
+        assert all(var not in data1.mean() for var in add_vars)
         assert_equal(data1.mean(), data2.mean())
         assert_equal(data1.mean(dim="dim1"), data2.mean(dim="dim1"))
+        assert "var4" not in data1.mean(dim="dim2") and "var5" in data1.mean(dim="dim2")
 
     @pytest.mark.filterwarnings(
         "ignore:Once the behaviour of DataArray:DeprecationWarning"


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #5368 
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Reduce methods such as `mean` drop non-numeric variables. However, there's no need to drop variables that are not actually reduced (i.e., when `"reduce_dim" not in da.dims`).

cc: @rcaneill