### PR TITLE
`dt.to_pytimedelta`  to allow arithmetic with cftime objects

### DIFF
--- a/xarray/core/accessor_dt.py
+++ b/xarray/core/accessor_dt.py
@@ -52,6 +52,8 @@ def _access_through_series(values, name):
         # isocalendar returns iso- year, week, and weekday -> reshape
         field_values = np.array(values_as_series.dt.isocalendar(), dtype=np.int64)
         return field_values.T.reshape(3, *values.shape)
+    elif name == "to_pytimedelta":
+        field_values = getattr(values_as_series.dt, name)()
     else:
         field_values = getattr(values_as_series.dt, name).values
     return field_values.reshape(values.shape)
@@ -508,6 +510,14 @@ class TimedeltaAccessor(Properties):
         "Number of nanoseconds (>= 0 and less than 1 microsecond) for each element.",
         np.int64,
     )
+
+    @property
+    def to_pytimedelta(self):
+        """Timedelta values as python timedelta objects."""
+        result = _get_date_field(self._obj.data, "to_pytimedelta", object)
+        new_obj = self._obj.copy()
+        new_obj.variable._data = result
+        return new_obj
 
 
 class CombinedDatetimelikeAccessor(DatetimeAccessor, TimedeltaAccessor):

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -356,6 +356,16 @@ class TestTimedeltaAccessor:
         assert_chunks_equal(actual, dask_times_2d)
         assert_equal(actual.compute(), expected.compute())
 
+    def test_to_pytimedelta(self):
+
+        np.testing.assert_equal(
+            self.times.to_pytimedelta(), self.data.time.dt.to_pytimedelta
+        )
+
+        td = self.times_data.dt.to_pytimedelta
+        assert td.dtype == "O"
+        assert_equal(td.copy(data=td), self.times_data)
+
 
 _CFTIME_CALENDARS = [
     "365_day",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

When playing with cftime objects a problem I encountered many times is that I can sub two arrays and them add it back to another. Subtracting to cftime datetime arrays result in an array of `np.timedelta64`. And when trying to add it back to another cftime array, we get a `UFuncTypeError` because the two arrays have incompatible dtypes : '<m8[ns]' and 'O'.

Example:
```python
import xarray as xr
da = xr.DataArray(xr.cftime_range('1900-01-01', freq='D', periods=10), dims=('time',))

# An array of timedelta64[ns]
dt = da - da[0]

da[-1] + dt # Fails
```

However, if the two arrays were of 'O' dtype, then the subtraction would be made by `cftime` which supports `datetime.timedelta` objects. 

This solution here adds a `to_pytimedelta` to the `TimedeltaAccessor`, mirroring the name of the similar function on `pd.Series.dt`. It uses a monkeypatching workaround to prevent xarray to case the array back into numpy objects.

The user still has to check if the data is in cftime or numpy to adapt the operation (calling `dt.to_pytimedelta` or not), but custom workaround were always overly complicated for such a simple problem, this helps.

Also, this doesn't work with dask arrays because loading a dask array triggers the variable constructor and thus recasts the array of `datetime.timedelta` to `numpy.timedelta[64]`.

I realize I maybe should have opened an issue before, but I had this idea and it all rushed along.