### PR TITLE
fix the variable repr with `display_expand_data=False`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -47,6 +47,9 @@ Bug fixes
 - Fix 1-level multi-index incorrectly converted to single index (:issue:`5384`,
   :pull:`5385`).
   By `Benoit Bovy <https://github.com/benbovy>`_.
+- Fix the ``repr`` of :py:class:`Variable` objects with ``display_expand_data=True``
+  (:pull:`5406`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 
 Documentation

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -502,14 +502,18 @@ def short_data_repr(array):
 
 
 def array_repr(arr):
+    from .variable import Variable
+
     # used for DataArray, Variable and IndexVariable
     if hasattr(arr, "name") and arr.name is not None:
         name_str = f"{arr.name!r} "
     else:
         name_str = ""
 
-    if _get_boolean_with_default("display_expand_data", default=True) or isinstance(
-        arr.variable._data, MemoryCachedArray
+    if (
+        isinstance(arr, Variable)
+        or _get_boolean_with_default("display_expand_data", default=True)
+        or isinstance(arr.variable._data, MemoryCachedArray)
     ):
         data_repr = short_data_repr(arr)
     else:

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -404,6 +404,14 @@ class TestFormatting:
 
             assert actual == expected
 
+    def test_array_repr_variable(self):
+        var = xr.Variable("x", [0, 1])
+
+        formatting.array_repr(var)
+
+        with xr.set_options(display_expand_data=False):
+            formatting.array_repr(var)
+
 
 def test_inline_variable_array_repr_custom_repr():
     class CustomArray:


### PR DESCRIPTION
In #5235 we seem to have accidentally broken the `repr` of `Variable` objects with `display_expand_data=False`. I don't think `Variable` objects benefit from the collapsed view, so the easiest fix seems to be to always use `short_data_repr` for `Variable` objects.

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
