### PR TITLE
`differentiate` should not cast to `numpy.array`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -47,6 +47,9 @@ Bug fixes
 - Fix 1-level multi-index incorrectly converted to single index (:issue:`5384`,
   :pull:`5385`).
   By `Benoit Bovy <https://github.com/benbovy>`_.
+- Don't cast a duck array in a coordinate to :py:class:`numpy.ndarray` in
+  :py:meth:`DataArray.differentiate` (:pull:``)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -48,7 +48,8 @@ Bug fixes
   :pull:`5385`).
   By `Benoit Bovy <https://github.com/benbovy>`_.
 - Don't cast a duck array in a coordinate to :py:class:`numpy.ndarray` in
-  :py:meth:`DataArray.differentiate` (:pull:``)
+  :py:meth:`DataArray.differentiate` (:pull:`5408`)
+  By `Justus Magin <https://github.com/keewis>`_.
 - Fix the ``repr`` of :py:class:`Variable` objects with ``display_expand_data=True``
   (:pull:`5406`)
   By `Justus Magin <https://github.com/keewis>`_.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6244,7 +6244,10 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
                 if _contains_datetime_like_objects(v):
                     v = v._to_numeric(datetime_unit=datetime_unit)
                 grad = duck_array_ops.gradient(
-                    v.data, coord_var, edge_order=edge_order, axis=v.get_axis_num(dim)
+                    v.data,
+                    coord_var.data,
+                    edge_order=edge_order,
+                    axis=v.get_axis_num(dim),
                 )
                 variables[k] = Variable(v.dims, grad)
             else:

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -305,15 +305,14 @@ class method:
                 if key not in exclude_kwargs
             }
             if self.fallback is not None:
-                func = self.fallback
+                func = partial(self.fallback, obj)
             else:
                 func = getattr(obj, self.name, None)
 
                 if func is None or not callable(func):
                     # fall back to module level numpy functions
-                    func = getattr(np, self.name)
-
-            func = partial(func, obj)
+                    numpy_func = getattr(np, self.name)
+                    func = partial(numpy_func, obj)
         else:
             func = getattr(obj, self.name)
 

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -276,8 +276,9 @@ class method:
     This is works a bit similar to using `partial(Class.method, arg, kwarg)`
     """
 
-    def __init__(self, name, *args, **kwargs):
+    def __init__(self, name, *args, fallback_func=None, **kwargs):
         self.name = name
+        self.fallback = fallback_func
         self.args = args
         self.kwargs = kwargs
 

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 import xarray as xr
-from xarray.core import dtypes
+from xarray.core import dtypes, duck_array_ops
 
 from . import assert_allclose, assert_duckarray_allclose, assert_equal, assert_identical
 from .test_variable import _PAD_XR_NP_ARGS
@@ -3668,6 +3668,65 @@ class TestDataArray:
     @pytest.mark.parametrize(
         "variant",
         (
+            pytest.param(
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
+            ),
+            "coords",
+        ),
+    )
+    @pytest.mark.parametrize(
+        "func",
+        (
+            method("differentiate", fallback_func=np.gradient),
+            method("integrate", fallback_func=duck_array_ops.cumulative_trapezoid),
+            method("cumulative_integrate", fallback_func=duck_array_ops.trapz),
+        ),
+        ids=repr,
+    )
+    def test_differentiate_integrate(self, func, variant, dtype):
+        data_unit = unit_registry.m
+        unit = unit_registry.s
+
+        variants = {
+            "dims": ("x", unit, 1),
+            "coords": ("u", 1, unit),
+        }
+        coord, dim_unit, coord_unit = variants.get(variant)
+
+        array = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
+
+        x = np.arange(array.shape[0]) * dim_unit
+        y = np.arange(array.shape[1]) * dim_unit
+
+        u = np.linspace(0, 1, array.shape[0]) * coord_unit
+
+        data_array = xr.DataArray(
+            data=array, coords={"x": x, "y": y, "u": ("x", u)}, dims=("x", "y")
+        )
+        # we want to make sure the output unit is correct
+        units = extract_units(data_array)
+        units.update(
+            extract_units(
+                func(
+                    data_array.data,
+                    getattr(data_array, coord).data,
+                    axis=0,
+                )
+            )
+        )
+
+        expected = attach_units(
+            func(strip_units(data_array), coord=strip_units(coord)),
+            units,
+        )
+        actual = func(data_array, coord=coord)
+
+        assert_units_equal(expected, actual)
+        assert_identical(expected, actual)
+
+    @pytest.mark.parametrize(
+        "variant",
+        (
             "data",
             pytest.param(
                 "dims", marks=pytest.mark.skip(reason="indexes don't support units")
@@ -3679,8 +3738,6 @@ class TestDataArray:
         "func",
         (
             method("diff", dim="x"),
-            method("differentiate", coord="x"),
-            method("integrate", coord="x"),
             method("quantile", q=[0.25, 0.75]),
             method("reduce", func=np.sum, dim="x"),
             pytest.param(lambda x: x.dot(x), id="method_dot"),


### PR DESCRIPTION
Apparently the test coverage was not high enough: we were passing a `Variable` object to `numpy.gradient`. This only adds tests for `DataArray.differentiate` because `Dataset.differentiate` doesn't seem to be as easy to check (the axis might be different).

- [x] Closes xarray-contrib/pint-xarray#106
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
