### PR TITLE
Promote backend test fixture to conftest

### DIFF
--- a/xarray/tests/conftest.py
+++ b/xarray/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from . import requires_dask
+
+
+@pytest.fixture(params=["numpy", pytest.param("dask", marks=requires_dask)])
+def backend(request):
+    return request.param

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6447,11 +6447,6 @@ class TestReduceND(TestReduce):
         assert_equal(getattr(ar0_dsk, op)(dim="x"), getattr(ar0_raw, op)(dim="x"))
 
 
-@pytest.fixture(params=["numpy", pytest.param("dask", marks=requires_dask)])
-def backend(request):
-    return request.param
-
-
 @pytest.fixture(params=[1])
 def da(request, backend):
     if request.param == 1:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6075,7 +6075,7 @@ class TestDataset:
             ds.query(x="spam > 50")  # name not present
 
 
-# Py.test tests
+# pytest tests — new tests should go here, rather than in the class.
 
 
 @pytest.fixture(params=[None])
@@ -6084,7 +6084,7 @@ def data_set(request):
 
 
 @pytest.mark.parametrize("test_elements", ([1, 2], np.array([1, 2]), DataArray([1, 2])))
-def test_isin(test_elements):
+def test_isin(test_elements, backend):
     expected = Dataset(
         data_vars={
             "var1": (("dim1",), [0, 1]),
@@ -6092,6 +6092,9 @@ def test_isin(test_elements):
             "var3": (("dim1",), [0, 1]),
         }
     ).astype("bool")
+
+    if backend == "dask":
+        expected = expected.chunk()
 
     result = Dataset(
         data_vars={
@@ -6100,33 +6103,6 @@ def test_isin(test_elements):
             "var3": (("dim1",), [0, 1]),
         }
     ).isin(test_elements)
-
-    assert_equal(result, expected)
-
-
-@pytest.mark.skipif(not has_dask, reason="requires dask")
-@pytest.mark.parametrize("test_elements", ([1, 2], np.array([1, 2]), DataArray([1, 2])))
-def test_isin_dask(test_elements):
-    expected = Dataset(
-        data_vars={
-            "var1": (("dim1",), [0, 1]),
-            "var2": (("dim1",), [1, 1]),
-            "var3": (("dim1",), [0, 1]),
-        }
-    ).astype("bool")
-
-    result = (
-        Dataset(
-            data_vars={
-                "var1": (("dim1",), [0, 1]),
-                "var2": (("dim1",), [1, 2]),
-                "var3": (("dim1",), [0, 1]),
-            }
-        )
-        .chunk(1)
-        .isin(test_elements)
-        .compute()
-    )
 
     assert_equal(result, expected)
 


### PR DESCRIPTION
Also adds an example of parameterizing a test in dataset.py

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Passes `pre-commit run --all-files`

This uses the backend fixture (though not the `dataset` fixture, like https://github.com/pydata/xarray/pull/5350/files did)