### PR TITLE
Add junit test results to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,13 +90,13 @@ jobs:
           python -m pytest -n 4 \
              --cov=xarray \
              --cov-report=xml
-             --junitxml=junit/test-results.xml
+             --junitxml=test-results.xml
 
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()
         with:
-          files: junit/test-results.xml
+          files: test-results.xml
 
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,11 +86,10 @@ jobs:
         run: |
           python -c "import xarray"
       - name: Run tests
-        run: |
-          python -m pytest -n 4 \
-             --cov=xarray \
-             --cov-report=xml
-             --junitxml=test-results.xml
+        run: python -m pytest -n 4
+          --cov=xarray
+          --cov-report=xml
+          --junitxml=test-results.xml
 
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,8 +57,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/conda_pkgs_dir
-          key:
-            ${{ runner.os }}-conda-py${{ matrix.python-version }}-${{
+          key: ${{ runner.os }}-conda-py${{ matrix.python-version }}-${{
             hashFiles('ci/requirements/**.yml') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -91,6 +90,13 @@ jobs:
           python -m pytest -n 4 \
              --cov=xarray \
              --cov-report=xml
+             --junitxml=junit/test-results.xml
+
+      - name: Publish unit test results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          files: junit/test-results.xml
 
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,11 +91,12 @@ jobs:
           --cov-report=xml
           --junitxml=test-results.xml
 
-      - name: Publish unit test results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+      - name: Upload test results
         if: always()
+        uses: actions/upload-artifact@v2
         with:
-          files: test-results.xml
+          name: Test results ${{ matrix.python-version }}-${{ runner.os }}
+          path: test-results/${{ matrix.python-version }}-${{ runner.os }}.xml
 
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v1
@@ -105,3 +106,20 @@ jobs:
           env_vars: RUNNER_OS,PYTHON_VERSION
           name: codecov-umbrella
           fail_ci_if_error: false
+
+  publish-test-results:
+    needs: test
+    runs-on: ubuntu-latest
+    # the build-and-test job might be skipped, we don't need to run this job then
+    if: success() || failure()
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: artifacts/**/*.xml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,9 +117,9 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v2
         with:
-          path: artifacts
+          path: test-results
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
-          files: artifacts/**/*.xml
+          files: test-results/*.xml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,14 +89,14 @@ jobs:
         run: python -m pytest -n 4
           --cov=xarray
           --cov-report=xml
-          --junitxml=test-results.xml
+          --junitxml=test-results/${{ runner.os }}-${{ matrix.python-version }}.xml
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: Test results ${{ matrix.python-version }}-${{ runner.os }}
-          path: test-results/${{ matrix.python-version }}-${{ runner.os }}.xml
+          name: Test results for ${{ runner.os }}-${{ matrix.python-version }}
+          path: test-results/${{ runner.os }}-${{ matrix.python-version }}.xml
 
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/test-results.xml
+++ b/test-results.xml
@@ -1,1 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite name="pytest" errors="0" failures="0" skipped="0" tests="0" time="0.005" timestamp="2021-05-31T20:42:31.449398" hostname="Maximilian_Roos_Remote_Access_v3_TM_C02CH19EMD6T" /></testsuites>

--- a/test-results.xml
+++ b/test-results.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite name="pytest" errors="0" failures="0" skipped="0" tests="0" time="0.005" timestamp="2021-05-31T20:42:31.449398" hostname="Maximilian_Roos_Remote_Access_v3_TM_C02CH19EMD6T" /></testsuites>


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Passes `pre-commit run --all-files`

I'm not sure this is the best approach; potentially the comment this app adds is too noisy: https://github.com/marketplace/actions/publish-unit-test-results.

But it would be good to get an idea of the test results from the PR page and to understand where the test suite spends its time