### PR TITLE
DOC: zarr note on encoding

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1994,6 +1994,10 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
             If not other chunks are found, Zarr uses its own heuristics to
             choose automatic chunk sizes.
 
+        encoding:
+            The encoding attribute (if exists) of the DataArray(s) will be
+            passed on to the corresponding .zarray file.
+
         See Also
         --------
         :ref:`io.zarr`

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1996,7 +1996,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
 
         encoding:
             The encoding attribute (if exists) of the DataArray(s) will be
-            passed on to the corresponding .zarray file.
+            used. Override any existing encodings by providing the ``encoding`` kwarg.
 
         See Also
         --------


### PR DESCRIPTION
It took me a while to realize this so I wanted to make a note in the docs for myself in the future and others uses.

I was playing with pint-xarray and I couldn't work out why I couldn't round trip a file (https://github.com/xarray-contrib/pint-xarray/issues/109). It turns out the DataArray had an enconding attribute which was being used (and overriding my unit conversion). In addition, I was also scratching my head for a while as to where my zarr store was getting chunks from which didn't correspomd to my numpy array (https://github.com/pydata/xarray/discussions/5407).

This PR just makes a note of the importance of encoding attribute of DataArray(s) when writing to a zarr store.

docs page change is here: https://xray--5427.org.readthedocs.build/en/5427/generated/xarray.Dataset.to_zarr.html?highlight=zarr#xarray.Dataset.to_zarr