### PR TITLE
Consistent chunking after broadcasting

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -38,7 +38,7 @@ from .accessor_dt import CombinedDatetimelikeAccessor
 from .accessor_str import StringAccessor
 from .alignment import (
     _broadcast_helper,
-    _get_broadcast_dims_map_common_coords,
+    _get_broadcast_dims_map_common_coords_chunks_map,
     align,
     reindex_like_indexers,
 )
@@ -1398,9 +1398,13 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
             exclude = set(exclude)
         args = align(other, self, join="outer", copy=False, exclude=exclude)
 
-        dims_map, common_coords = _get_broadcast_dims_map_common_coords(args, exclude)
+        (
+            dims_map,
+            common_coords,
+            chunks_map,
+        ) = _get_broadcast_dims_map_common_coords_chunks_map(args, exclude)
 
-        return _broadcast_helper(args[1], exclude, dims_map, common_coords)
+        return _broadcast_helper(args[1], exclude, dims_map, common_coords, chunks_map)
 
     def reindex_like(
         self,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -50,7 +50,11 @@ from . import (
     utils,
     weighted,
 )
-from .alignment import _broadcast_helper, _get_broadcast_dims_map_common_coords, align
+from .alignment import (
+    _broadcast_helper,
+    _get_broadcast_dims_map_common_coords_chunks_map,
+    align,
+)
 from .arithmetic import DatasetArithmetic
 from .common import DataWithCoords, _contains_datetime_like_objects
 from .coordinates import (
@@ -2617,9 +2621,13 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
             exclude = set(exclude)
         args = align(other, self, join="outer", copy=False, exclude=exclude)
 
-        dims_map, common_coords = _get_broadcast_dims_map_common_coords(args, exclude)
+        (
+            dims_map,
+            common_coords,
+            chunks_map,
+        ) = _get_broadcast_dims_map_common_coords_chunks_map(args, exclude)
 
-        return _broadcast_helper(args[1], exclude, dims_map, common_coords)
+        return _broadcast_helper(args[1], exclude, dims_map, common_coords, chunks_map)
 
     def reindex_like(
         self,

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1418,7 +1418,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
     def T(self) -> "Variable":
         return self.transpose()
 
-    def set_dims(self, dims, shape=None):
+    def set_dims(self, dims, shape=None, chunks=None):
         """Return a new variable with given set of dimensions.
         This method might be used to attach new dimension(s) to variable.
 
@@ -1458,7 +1458,13 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         elif shape is not None:
             dims_map = dict(zip(dims, shape))
             tmp_shape = tuple(dims_map[d] for d in expanded_dims)
-            expanded_data = duck_array_ops.broadcast_to(self.data, tmp_shape)
+            if chunks:
+                tmp_chunks = tuple(chunks[d] for d in expanded_dims)
+                expanded_data = duck_array_ops.broadcast_to(
+                    self.data, tmp_shape, tmp_chunks
+                )
+            else:
+                expanded_data = duck_array_ops.broadcast_to(self.data, tmp_shape)
         else:
             expanded_data = self.data[(None,) * (len(expanded_dims) - self.ndim)]
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #5435 
- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

I think it does the job, although I'm not sure whether this is the best approach. A couple of questions:
1. I should probably add a test. Where is the best place? `test_dask`?
2. I added a `chunks` arguments in `set_dims`. I haven't updated the docstring yet...
i) `shape` is not in the docstring either, is it because it is not meant to be public? If yes, I guess we can omit `chunks` as well.
ii) The `chunks` argument I've introduced must be a dict mapping dim to chunks. Is that a problem since `chunks` is used elsewhere and can be slightly different (e.g., just an integer, 'auto').
iii) Should I add a check and raise an error if `chunks` is not a dictionary or is missing dimensions?