### PR TITLE
fix dask meta and output_dtypes error

### DIFF
--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -1306,7 +1306,7 @@ def test_vectorize_dask_dtype_without_output_dtypes(data_array):
     assert expected.dtype == actual.dtype
 
 
-@pytest.mark.skip(
+@pytest.mark.skipif(
     LooseVersion(dask.__version__) > "2021.06",
     reason="dask/dask#7669: can no longer pass output_dtypes and meta",
 )


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #5444

This was changed in dask/dask#7669. Looks like they did not deprecate this behavior (i.e. passing both `meta` and `output_dtypes`). I'd suggest to follow dask's example here and not add a deprecation cycle. Thoughts?

