### PR TITLE
plt.gca() no longer accepts kwargs

### DIFF
--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -450,12 +450,13 @@ def _maybe_gca(**kwargs):
 
     import matplotlib.pyplot as plt
 
+    # can call gcf unconditionally: either it exists or would be created by plt.axes
+    f = plt.gcf()
+
     # only call gca if an active axes exists
-    if plt.get_fignums():
-        f = plt.gcf()
-        if f.axes:
-            # can not pass kwargs to active axes
-            return plt.gca()
+    if f.axes:
+        # can not pass kwargs to active axes
+        return plt.gca()
 
     return plt.axes(**kwargs)
 

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -441,9 +441,23 @@ def get_axis(figsize=None, size=None, aspect=None, ax=None, **kwargs):
         raise ValueError("cannot use subplot_kws with existing ax")
 
     if ax is None:
-        ax = plt.gca(**kwargs)
+        ax = _maybe_gca(**kwargs)
 
     return ax
+
+
+def _maybe_gca(**kwargs):
+
+    import matplotlib.pyplot as plt
+
+    # only call gca if an active axes exists
+    if plt.get_fignums():
+        f = plt.gcf()
+        if f.axes:
+            # can not pass kwargs to active axes
+            return plt.gca()
+
+    return plt.axes(**kwargs)
 
 
 def label_from_attrs(da, extra=""):

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -17,6 +17,7 @@ from xarray.plot.utils import (
     _build_discrete_cmap,
     _color_palette,
     _determine_cmap_params,
+    _maybe_gca,
     get_axis,
     label_from_attrs,
 )
@@ -2777,3 +2778,31 @@ def test_get_axis_cartopy():
     with figure_context():
         ax = get_axis(**kwargs)
         assert isinstance(ax, cartopy.mpl.geoaxes.GeoAxesSubplot)
+
+
+@requires_matplotlib
+def test_maybe_gca():
+
+    with figure_context():
+        ax = _maybe_gca(aspect=1)
+
+        assert isinstance(ax, mpl.axes.Axes)
+        assert ax.get_aspect() == 1
+
+    with figure_context():
+
+        # create figure without axes
+        plt.figure()
+        ax = _maybe_gca(aspect=1)
+
+        assert isinstance(ax, mpl.axes.Axes)
+        assert ax.get_aspect() == 1
+
+    with figure_context():
+        existing_axes = plt.axes()
+        ax = _maybe_gca(aspect=1)
+
+        # re-uses the existing axes
+        assert existing_axes == ax
+        # kwargs are ignored when reusing axes
+        assert ax.get_aspect() == "auto"


### PR DESCRIPTION
matplotlib warns: `Calling gca() with keyword arguments was deprecated in Matplotlib 3.4. Starting two minor releases later, gca() will take no keyword arguments. The gca() function should only be used to get the current axes, or if no axes exist, create new axes with default keyword arguments. To create a new axes with non-default arguments, use plt.axes() or plt.subplot().`

This only uses `plt.gca()` if there are active axes, else it calls `plt.axes(**kwargs)`. Note that this can silently ignore some arguments. However, that this is already the case.


