### PR TITLE
Improve error message for guess engine

### DIFF
--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -94,6 +94,8 @@ class CfGribDataStore(AbstractDataStore):
 
 
 class CfgribfBackendEntrypoint(BackendEntrypoint):
+    available = has_cfgrib
+
     def guess_can_open(self, filename_or_obj):
         try:
             _, ext = os.path.splitext(filename_or_obj)
@@ -145,10 +147,6 @@ class CfgribfBackendEntrypoint(BackendEntrypoint):
                 decode_timedelta=decode_timedelta,
             )
         return ds
-
-    @staticmethod
-    def are_dependencies_installed() -> bool:
-        return has_cfgrib
 
 
 BACKEND_ENTRYPOINTS["cfgrib"] = CfgribfBackendEntrypoint

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -147,7 +147,7 @@ class CfgribfBackendEntrypoint(BackendEntrypoint):
         return ds
 
     @staticmethod
-    def installed() -> bool:
+    def are_dependencies_installed() -> bool:
         return has_cfgrib
 
 

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -147,7 +147,8 @@ class CfgribfBackendEntrypoint(BackendEntrypoint):
             )
         return ds
 
-    def installed(self) -> bool:
+    @staticmethod
+    def installed() -> bool:
         return has_cfgrib
 
 

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -147,6 +147,8 @@ class CfgribfBackendEntrypoint(BackendEntrypoint):
             )
         return ds
 
+    def installed(self) -> bool:
+        return has_cfgrib
 
-if has_cfgrib:
-    BACKEND_ENTRYPOINTS["cfgrib"] = CfgribfBackendEntrypoint
+
+BACKEND_ENTRYPOINTS["cfgrib"] = CfgribfBackendEntrypoint

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -394,7 +394,7 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         return ds
 
     @staticmethod
-    def installed() -> bool:
+    def are_dependencies_installed() -> bool:
         return has_h5netcdf
 
 

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -392,7 +392,8 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         )
         return ds
 
-    def installed(self) -> bool:
+    @staticmethod
+    def installed() -> bool:
         return has_h5netcdf
 
 

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -337,6 +337,8 @@ class H5NetCDFStore(WritableCFDataStore):
 
 
 class H5netcdfBackendEntrypoint(BackendEntrypoint):
+    available = has_h5netcdf
+
     def guess_can_open(self, filename_or_obj):
         magic_number = try_read_magic_number_from_file_or_path(filename_or_obj)
         if magic_number is not None:
@@ -392,10 +394,6 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
             decode_timedelta=decode_timedelta,
         )
         return ds
-
-    @staticmethod
-    def are_dependencies_installed() -> bool:
-        return has_h5netcdf
 
 
 BACKEND_ENTRYPOINTS["h5netcdf"] = H5netcdfBackendEntrypoint

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -392,6 +392,8 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         )
         return ds
 
+    def installed(self) -> bool:
+        return has_h5netcdf
 
-if has_h5netcdf:
-    BACKEND_ENTRYPOINTS["h5netcdf"] = H5netcdfBackendEntrypoint
+
+BACKEND_ENTRYPOINTS["h5netcdf"] = H5netcdfBackendEntrypoint

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -512,6 +512,8 @@ class NetCDF4DataStore(WritableCFDataStore):
 
 
 class NetCDF4BackendEntrypoint(BackendEntrypoint):
+    available = has_netcdf4
+
     def guess_can_open(self, filename_or_obj):
         if isinstance(filename_or_obj, str) and is_remote_uri(filename_or_obj):
             return True
@@ -571,10 +573,6 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
                 decode_timedelta=decode_timedelta,
             )
         return ds
-
-    @staticmethod
-    def are_dependencies_installed() -> bool:
-        return has_netcdf4
 
 
 BACKEND_ENTRYPOINTS["netcdf4"] = NetCDF4BackendEntrypoint

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -348,12 +348,6 @@ class NetCDF4DataStore(WritableCFDataStore):
         if isinstance(filename, pathlib.Path):
             filename = os.fspath(filename)
 
-        if not isinstance(filename, str):
-            raise ValueError(
-                "can only read bytes or file-like objects "
-                "with engine='scipy' or 'h5netcdf'"
-            )
-
         if format is None:
             format = "NETCDF4"
 
@@ -570,7 +564,8 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
             )
         return ds
 
-    def installed(self) -> bool:
+    @staticmethod
+    def installed() -> bool:
         return has_netcdf4
 
 

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -349,6 +349,12 @@ class NetCDF4DataStore(WritableCFDataStore):
         if isinstance(filename, pathlib.Path):
             filename = os.fspath(filename)
 
+        if not isinstance(filename, str):
+            raise ValueError(
+                "can only read bytes or file-like objects "
+                "with engine='scipy' or 'h5netcdf'"
+            )
+
         if format is None:
             format = "NETCDF4"
 

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -573,7 +573,7 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
         return ds
 
     @staticmethod
-    def installed() -> bool:
+    def are_dependencies_installed() -> bool:
         return has_netcdf4
 
 

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -570,6 +570,8 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
             )
         return ds
 
+    def installed(self) -> bool:
+        return has_netcdf4
 
-if has_netcdf4:
-    BACKEND_ENTRYPOINTS["netcdf4"] = NetCDF4BackendEntrypoint
+
+BACKEND_ENTRYPOINTS["netcdf4"] = NetCDF4BackendEntrypoint

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -131,7 +131,7 @@ def guess_engine(store_spec):
         if compatible:
             error_msg = \
                 error_msg + \
-                "\nThe following engines reports a match with the input file: {compatible}."
+                f"\nThe following engines reports a match with the input file: {compatible}."
     else:
         error_msg = (
             "xarray is unable to open this file because it has no currently "
@@ -143,8 +143,8 @@ def guess_engine(store_spec):
         if compatible:
             error_msg = \
                 error_msg + \
-                "\nConsider to install the dependencies of following engines that reports "\
-                "a match with the input file: {compatible}."
+                f"\nConsider to install one of the following engines that reports "\
+                f"a match with the input file: {compatible}."
 
     raise ValueError(error_msg)
 

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -129,7 +129,7 @@ def guess_engine(store_spec):
                 "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html\n"
                 "http://xarray.pydata.org/en/stable/user-guide/io.html"
             )
-        if compatible:
+        else:
             error_msg = (
                 "did not find a match in any of xarray's currently installed IO "
                 f"backends {installed}. Consider explicitly selecting one of the "
@@ -146,7 +146,7 @@ def guess_engine(store_spec):
                 "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html\n"
                 "http://xarray.pydata.org/en/stable/user-guide/io"
             )
-        if compatible:
+        else:
             error_msg = (
                 "xarray is unable to open this file because it has no currently "
                 "installed IO engines. Xarray's read/write support requires "

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -132,8 +132,8 @@ def guess_engine(store_spec):
         else:
             error_msg = (
                 "xarray is unable to open this file because it has no currently "
-                "installed IO engines. Xarray's read/write support requires "
-                "optional IO dependencies, see:\n"
+                "installed IO backends. Xarray's read/write support requires "
+                "installing optional IO dependencies, see:\n"
                 "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html\n"
                 "http://xarray.pydata.org/en/stable/user-guide/io"
             )

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -110,8 +110,9 @@ def guess_engine(store_spec):
             warnings.warn(f"{engine!r} fails while guessing", RuntimeWarning)
 
     compatible = []
-    for engine, backend in BACKEND_ENTRYPOINTS.items():
+    for engine, backend_cls in BACKEND_ENTRYPOINTS.items():
         try:
+            backend = backend_cls()
             if backend.guess_can_open(store_spec):
                 compatible.append(engine)
         except Exception:

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -83,7 +83,7 @@ def sort_backends(backend_entrypoints):
 def build_engines(pkg_entrypoints):
     backend_entrypoints = {}
     for backend_name, backend in BACKEND_ENTRYPOINTS.items():
-        if backend.installed():
+        if backend.are_dependencies_installed():
             backend_entrypoints[backend_name] = backend
     pkg_entrypoints = remove_duplicates(pkg_entrypoints)
     external_backend_entrypoints = backends_dict_from_pkg(pkg_entrypoints)
@@ -119,8 +119,8 @@ def guess_engine(store_spec):
             warnings.warn(f"{engine!r} fails while guessing", RuntimeWarning)
 
     installed = [k for k in engines if k != "store"]
-    if installed:
-        if not compatible:
+    if not compatible:
+        if installed:
             error_msg = (
                 "did not find a match in any of xarray's currently installed IO "
                 f"backends {installed}. Consider explicitly selecting one of the "
@@ -131,29 +131,19 @@ def guess_engine(store_spec):
             )
         else:
             error_msg = (
-                "did not find a match in any of xarray's currently installed IO "
-                f"backends {installed}. Consider explicitly selecting one of the "
-                "installed engines via the ``engine`` parameter or to install one "
-                f"of the following engines that report a match with the input file: "
-                f"{compatible}"
-            )
-    else:
-        if not compatible:
-            error_msg = (
                 "xarray is unable to open this file because it has no currently "
                 "installed IO engines. Xarray's read/write support requires "
                 "optional IO dependencies, see:\n"
                 "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html\n"
                 "http://xarray.pydata.org/en/stable/user-guide/io"
             )
-        else:
-            error_msg = (
-                "xarray is unable to open this file because it has no currently "
-                "installed IO engines. Xarray's read/write support requires "
-                "optional dependencies."
-                f"\nConsider to install one of the following engines that report "
-                f"a match with the input file: {compatible}"
-            )
+    else:
+        error_msg = (
+            "found the following matches with the input file in xarray's IO "
+            f"backends: {compatible}. But their dependencies may not be installed, see:\n"
+            "http://xarray.pydata.org/en/stable/user-guide/io.html \n"
+            "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html"
+        )
 
     raise ValueError(error_msg)
 

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -120,31 +120,40 @@ def guess_engine(store_spec):
 
     installed = [k for k in engines if k != "store"]
     if installed:
-        error_msg = (
-            "did not find a match in any of xarray's currently installed IO "
-            f"backends {installed}. Consider explicitly selecting one of the "
-            "installed engines via the ``engine`` parameter, or installing " 
-            "additional IO dependencies:\n"
-            "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html\n"
-            "http://xarray.pydata.org/en/stable/user-guide/io.html"
-        )
+        if not compatible:
+            error_msg = (
+                "did not find a match in any of xarray's currently installed IO "
+                f"backends {installed}. Consider explicitly selecting one of the "
+                "installed engines via the ``engine`` parameter, or installing "
+                "additional IO dependencies, see:\n"
+                "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html\n"
+                "http://xarray.pydata.org/en/stable/user-guide/io.html"
+            )
         if compatible:
-            error_msg = \
-                error_msg + \
-                f"\nThe following engines reports a match with the input file: {compatible}."
+            error_msg = (
+                "did not find a match in any of xarray's currently installed IO "
+                f"backends {installed}. Consider explicitly selecting one of the "
+                "installed engines via the ``engine`` parameter or to install one "
+                f"of the following engines that report a match with the input file: "
+                f"{compatible}"
+            )
     else:
-        error_msg = (
-            "xarray is unable to open this file because it has no currently "
-            "installed IO engines. Xarray's read/write support requires "
-            "optional dependencies:\n"
-            "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html\n"
-            "http://xarray.pydata.org/en/stable/user-guide/io"
-        )
+        if not compatible:
+            error_msg = (
+                "xarray is unable to open this file because it has no currently "
+                "installed IO engines. Xarray's read/write support requires "
+                "optional IO dependencies, see:\n"
+                "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html\n"
+                "http://xarray.pydata.org/en/stable/user-guide/io"
+            )
         if compatible:
-            error_msg = \
-                error_msg + \
-                f"\nConsider to install one of the following engines that reports "\
-                f"a match with the input file: {compatible}."
+            error_msg = (
+                "xarray is unable to open this file because it has no currently "
+                "installed IO engines. Xarray's read/write support requires "
+                "optional dependencies."
+                f"\nConsider to install one of the following engines that report "
+                f"a match with the input file: {compatible}"
+            )
 
     raise ValueError(error_msg)
 

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -83,7 +83,7 @@ def sort_backends(backend_entrypoints):
 def build_engines(pkg_entrypoints):
     backend_entrypoints = {}
     for backend_name, backend in BACKEND_ENTRYPOINTS.items():
-        if backend.are_dependencies_installed():
+        if backend.available:
             backend_entrypoints[backend_name] = backend
     pkg_entrypoints = remove_duplicates(pkg_entrypoints)
     external_backend_entrypoints = backends_dict_from_pkg(pkg_entrypoints)
@@ -109,21 +109,21 @@ def guess_engine(store_spec):
         except Exception:
             warnings.warn(f"{engine!r} fails while guessing", RuntimeWarning)
 
-    compatible = []
+    compatible_engines = []
     for engine, backend_cls in BACKEND_ENTRYPOINTS.items():
         try:
             backend = backend_cls()
             if backend.guess_can_open(store_spec):
-                compatible.append(engine)
+                compatible_engines.append(engine)
         except Exception:
             warnings.warn(f"{engine!r} fails while guessing", RuntimeWarning)
 
-    installed = [k for k in engines if k != "store"]
-    if not compatible:
-        if installed:
+    installed_engines = [k for k in engines if k != "store"]
+    if not compatible_engines:
+        if installed_engines:
             error_msg = (
                 "did not find a match in any of xarray's currently installed IO "
-                f"backends {installed}. Consider explicitly selecting one of the "
+                f"backends {installed_engines}. Consider explicitly selecting one of the "
                 "installed engines via the ``engine`` parameter, or installing "
                 "additional IO dependencies, see:\n"
                 "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html\n"
@@ -140,7 +140,7 @@ def guess_engine(store_spec):
     else:
         error_msg = (
             "found the following matches with the input file in xarray's IO "
-            f"backends: {compatible}. But their dependencies may not be installed, see:\n"
+            f"backends: {compatible_engines}. But their dependencies may not be installed, see:\n"
             "http://xarray.pydata.org/en/stable/user-guide/io.html \n"
             "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html"
         )

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -81,7 +81,10 @@ def sort_backends(backend_entrypoints):
 
 
 def build_engines(pkg_entrypoints):
-    backend_entrypoints = BACKEND_ENTRYPOINTS.copy()
+    backend_entrypoints = {}
+    for backend_name, backend in BACKEND_ENTRYPOINTS.items():
+        if backend.installed():
+            backend_entrypoints[backend_name] = backend
     pkg_entrypoints = remove_duplicates(pkg_entrypoints)
     external_backend_entrypoints = backends_dict_from_pkg(pkg_entrypoints)
     backend_entrypoints.update(external_backend_entrypoints)
@@ -97,7 +100,6 @@ def build_engines(pkg_entrypoints):
 def list_engines():
     pkg_entrypoints = pkg_resources.iter_entry_points("xarray.backends")
     engines = build_engines(pkg_entrypoints)
-    engines = {key: engines[key] for key in engines if engines[key].installed()}
     return engines
 
 

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -127,6 +127,10 @@ def guess_engine(store_spec):
             "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html\n"
             "http://xarray.pydata.org/en/stable/user-guide/io.html"
         )
+        if compatible:
+            error_msg = \
+                error_msg + \
+                "\nThe following engines reports a match with the input file: {compatible}."
     else:
         error_msg = (
             "xarray is unable to open this file because it has no currently "
@@ -135,9 +139,11 @@ def guess_engine(store_spec):
             "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html\n"
             "http://xarray.pydata.org/en/stable/user-guide/io"
         )
-
-    if compatible:
-        error_msg = error_msg + "\nThe following engines reports a match with the input file: {compatible}."
+        if compatible:
+            error_msg = \
+                error_msg + \
+                "\nConsider to install the dependencies of following engines that reports "\
+                "a match with the input file: {compatible}."
 
     raise ValueError(error_msg)
 

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -109,46 +109,37 @@ def guess_engine(store_spec):
         except Exception:
             warnings.warn(f"{engine!r} fails while guessing", RuntimeWarning)
 
-    installed = [k for k in engines if k != "store"]
-    if installed:
-        raise ValueError(
-            "did not find a match in any of xarray's currently installed IO "
-            f"backends {installed}. Consider explicitly selecting one of the "
-            "installed backends via the ``engine`` parameter to "
-            "xarray.open_dataset(), or installing additional IO dependencies:\n"
-            "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html\n"
-            "http://xarray.pydata.org/en/stable/user-guide/io.html"
-        )
-    else:
-        raise ValueError(
-            "xarray is unable to open this file because it has no currently "
-            "installed IO backends. Xarray's read/write support requires "
-            "installing optional dependencies:\n"
-            "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html\n"
-            "http://xarray.pydata.org/en/stable/user-guide/io.html"
-        )
-
-    compatible_engines = []
+    compatible = []
     for engine, backend in BACKEND_ENTRYPOINTS.items():
         try:
             if backend.guess_can_open(store_spec):
-                compatible_engines.append(engine)
+                compatible.append(engine)
         except Exception:
             warnings.warn(f"{engine!r} fails while guessing", RuntimeWarning)
 
-    if len(compatible_engines):
-        error_message = (
-            f"Xarray cannot find a matching installed engine for this file in the installed engines"
-            f"{engines}. Try to pass one explicitly or consider installing one of the "
-            f"following engine which reports a match: {compatible_engines}."
+    installed = [k for k in engines if k != "store"]
+    if installed:
+        error_msg = (
+            "did not find a match in any of xarray's currently installed IO "
+            f"backends {installed}. Consider explicitly selecting one of the "
+            "installed engines via the ``engine`` parameter, or installing " 
+            "additional IO dependencies:\n"
+            "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html\n"
+            "http://xarray.pydata.org/en/stable/user-guide/io.html"
         )
     else:
-        error_message = (
-            "Xarray cannot detect the proper engine to open this file. "
-            "Check if it is installed and try to pass it explicitly."
+        error_msg = (
+            "xarray is unable to open this file because it has no currently "
+            "installed IO engines. Xarray's read/write support requires "
+            "optional dependencies:\n"
+            "http://xarray.pydata.org/en/stable/getting-started-guide/installing.html\n"
+            "http://xarray.pydata.org/en/stable/user-guide/io"
         )
 
-    raise ValueError(error_message)
+    if compatible:
+        error_msg = error_msg + "\nThe following engines reports a match with the input file: {compatible}."
+
+    raise ValueError(error_msg)
 
 
 def get_backend(engine):

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -152,6 +152,8 @@ class PseudoNetCDFBackendEntrypoint(BackendEntrypoint):
             )
         return ds
 
+    def installed(self) -> bool:
+        return has_pseudonetcdf
 
-if has_pseudonetcdf:
-    BACKEND_ENTRYPOINTS["pseudonetcdf"] = PseudoNetCDFBackendEntrypoint
+
+BACKEND_ENTRYPOINTS["pseudonetcdf"] = PseudoNetCDFBackendEntrypoint

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -102,6 +102,7 @@ class PseudoNetCDFDataStore(AbstractDataStore):
 
 
 class PseudoNetCDFBackendEntrypoint(BackendEntrypoint):
+    available = has_pseudonetcdf
 
     # *args and **kwargs are not allowed in open_backend_dataset_ kwargs,
     # unless the open_dataset_parameters are explicity defined like this:
@@ -151,10 +152,6 @@ class PseudoNetCDFBackendEntrypoint(BackendEntrypoint):
                 decode_timedelta=decode_timedelta,
             )
         return ds
-
-    @staticmethod
-    def are_dependencies_installed() -> bool:
-        return has_pseudonetcdf
 
 
 BACKEND_ENTRYPOINTS["pseudonetcdf"] = PseudoNetCDFBackendEntrypoint

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -153,7 +153,7 @@ class PseudoNetCDFBackendEntrypoint(BackendEntrypoint):
         return ds
 
     @staticmethod
-    def installed() -> bool:
+    def are_dependencies_installed() -> bool:
         return has_pseudonetcdf
 
 

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -152,7 +152,8 @@ class PseudoNetCDFBackendEntrypoint(BackendEntrypoint):
             )
         return ds
 
-    def installed(self) -> bool:
+    @staticmethod
+    def installed() -> bool:
         return has_pseudonetcdf
 
 

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -142,7 +142,8 @@ class PydapBackendEntrypoint(BackendEntrypoint):
             )
             return ds
 
-    def installed(self) -> bool:
+    @staticmethod
+    def installed() -> bool:
         return has_pydap
 
 

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -154,7 +154,7 @@ class PydapBackendEntrypoint(BackendEntrypoint):
             return ds
 
     @staticmethod
-    def installed() -> bool:
+    def are_dependencies_installed() -> bool:
         return has_pydap
 
 

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -110,6 +110,8 @@ class PydapDataStore(AbstractDataStore):
 
 
 class PydapBackendEntrypoint(BackendEntrypoint):
+    available = has_pydap
+
     def guess_can_open(self, filename_or_obj):
         return isinstance(filename_or_obj, str) and is_remote_uri(filename_or_obj)
 
@@ -152,10 +154,6 @@ class PydapBackendEntrypoint(BackendEntrypoint):
                 decode_timedelta=decode_timedelta,
             )
             return ds
-
-    @staticmethod
-    def are_dependencies_installed() -> bool:
-        return has_pydap
 
 
 BACKEND_ENTRYPOINTS["pydap"] = PydapBackendEntrypoint

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -142,6 +142,8 @@ class PydapBackendEntrypoint(BackendEntrypoint):
             )
             return ds
 
+    def installed(self) -> bool:
+        return has_pydap
 
-if has_pydap:
-    BACKEND_ENTRYPOINTS["pydap"] = PydapBackendEntrypoint
+
+BACKEND_ENTRYPOINTS["pydap"] = PydapBackendEntrypoint

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -99,6 +99,8 @@ class NioDataStore(AbstractDataStore):
 
 
 class PynioBackendEntrypoint(BackendEntrypoint):
+    available = has_pynio
+
     def open_dataset(
         self,
         filename_or_obj,
@@ -132,10 +134,6 @@ class PynioBackendEntrypoint(BackendEntrypoint):
                 decode_timedelta=decode_timedelta,
             )
         return ds
-
-    @staticmethod
-    def are_dependencies_installed() -> bool:
-        return has_pynio
 
 
 BACKEND_ENTRYPOINTS["pynio"] = PynioBackendEntrypoint

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -133,6 +133,8 @@ class PynioBackendEntrypoint(BackendEntrypoint):
             )
         return ds
 
+    def installed(self) -> bool:
+        return has_pynio
 
-if has_pynio:
-    BACKEND_ENTRYPOINTS["pynio"] = PynioBackendEntrypoint
+
+BACKEND_ENTRYPOINTS["pynio"] = PynioBackendEntrypoint

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -133,7 +133,8 @@ class PynioBackendEntrypoint(BackendEntrypoint):
             )
         return ds
 
-    def installed(self) -> bool:
+    @staticmethod
+    def installed() -> bool:
         return has_pynio
 
 

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -112,13 +112,13 @@ class PynioBackendEntrypoint(BackendEntrypoint):
         mode="r",
         lock=None,
     ):
+        filename_or_obj = _normalize_path(filename_or_obj)
         store = NioDataStore(
             filename_or_obj,
             mode=mode,
             lock=lock,
         )
 
-        filename_or_obj = _normalize_path(filename_or_obj)
         store_entrypoint = StoreBackendEntrypoint()
         with close_on_error(store):
             ds = store_entrypoint.open_dataset(

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -134,7 +134,7 @@ class PynioBackendEntrypoint(BackendEntrypoint):
         return ds
 
     @staticmethod
-    def installed() -> bool:
+    def are_dependencies_installed() -> bool:
         return has_pynio
 
 

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -290,7 +290,8 @@ class ScipyBackendEntrypoint(BackendEntrypoint):
         return ds
 
     @staticmethod
-    def installed() -> bool:        return has_scipy
+    def installed() -> bool:
+        return has_scipy
 
 
 BACKEND_ENTRYPOINTS["scipy"] = ScipyBackendEntrypoint

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -290,7 +290,7 @@ class ScipyBackendEntrypoint(BackendEntrypoint):
         return ds
 
     @staticmethod
-    def installed() -> bool:
+    def are_dependencies_installed() -> bool:
         return has_scipy
 
 

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -238,6 +238,8 @@ class ScipyDataStore(WritableCFDataStore):
 
 
 class ScipyBackendEntrypoint(BackendEntrypoint):
+    available = has_scipy
+
     def guess_can_open(self, filename_or_obj):
 
         magic_number = try_read_magic_number_from_file_or_path(filename_or_obj)
@@ -288,10 +290,6 @@ class ScipyBackendEntrypoint(BackendEntrypoint):
                 decode_timedelta=decode_timedelta,
             )
         return ds
-
-    @staticmethod
-    def are_dependencies_installed() -> bool:
-        return has_scipy
 
 
 BACKEND_ENTRYPOINTS["scipy"] = ScipyBackendEntrypoint

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -282,8 +282,8 @@ class ScipyBackendEntrypoint(BackendEntrypoint):
             )
         return ds
 
-    def installed(self) -> bool:
-        return has_scipy
+    @staticmethod
+    def installed() -> bool:        return has_scipy
 
 
 BACKEND_ENTRYPOINTS["scipy"] = ScipyBackendEntrypoint

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -282,6 +282,8 @@ class ScipyBackendEntrypoint(BackendEntrypoint):
             )
         return ds
 
+    def installed(self) -> bool:
+        return has_scipy
 
-if has_scipy:
-    BACKEND_ENTRYPOINTS["scipy"] = ScipyBackendEntrypoint
+
+BACKEND_ENTRYPOINTS["scipy"] = ScipyBackendEntrypoint

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -41,7 +41,8 @@ class StoreBackendEntrypoint(BackendEntrypoint):
 
         return ds
 
-    def installed(self) -> bool:
+    @staticmethod
+    def installed() -> bool:
         return True
 
 

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -42,7 +42,7 @@ class StoreBackendEntrypoint(BackendEntrypoint):
         return ds
 
     @staticmethod
-    def installed() -> bool:
+    def are_dependencies_installed() -> bool:
         return True
 
 

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -41,5 +41,8 @@ class StoreBackendEntrypoint(BackendEntrypoint):
 
         return ds
 
+    def installed(self) -> bool:
+        return True
+
 
 BACKEND_ENTRYPOINTS["store"] = StoreBackendEntrypoint

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -4,6 +4,8 @@ from .common import BACKEND_ENTRYPOINTS, AbstractDataStore, BackendEntrypoint
 
 
 class StoreBackendEntrypoint(BackendEntrypoint):
+    available = True
+
     def guess_can_open(self, filename_or_obj):
         return isinstance(filename_or_obj, AbstractDataStore)
 
@@ -40,10 +42,6 @@ class StoreBackendEntrypoint(BackendEntrypoint):
         ds.encoding = encoding
 
         return ds
-
-    @staticmethod
-    def are_dependencies_installed() -> bool:
-        return True
 
 
 BACKEND_ENTRYPOINTS["store"] = StoreBackendEntrypoint

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -764,7 +764,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
         return ds
 
     @staticmethod
-    def installed() -> bool:
+    def are_dependencies_installed() -> bool:
         return has_zarr
 
 

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -703,6 +703,8 @@ def open_zarr(
 
 
 class ZarrBackendEntrypoint(BackendEntrypoint):
+    available = has_zarr
+
     def guess_can_open(self, filename_or_obj):
         try:
             _, ext = os.path.splitext(filename_or_obj)
@@ -762,10 +764,6 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
                 decode_timedelta=decode_timedelta,
             )
         return ds
-
-    @staticmethod
-    def are_dependencies_installed() -> bool:
-        return has_zarr
 
 
 BACKEND_ENTRYPOINTS["zarr"] = ZarrBackendEntrypoint

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -756,6 +756,9 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
             )
         return ds
 
+    @staticmethod
+    def installed() -> bool:
+        return has_zarr
 
-if has_zarr:
-    BACKEND_ENTRYPOINTS["zarr"] = ZarrBackendEntrypoint
+
+BACKEND_ENTRYPOINTS["zarr"] = ZarrBackendEntrypoint

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -704,6 +704,13 @@ def open_zarr(
 
 
 class ZarrBackendEntrypoint(BackendEntrypoint):
+    def guess_can_open(self, filename_or_obj):
+        try:
+            _, ext = os.path.splitext(filename_or_obj)
+        except TypeError:
+            return False
+        return ext in {".zarr"}
+
     def open_dataset(
         self,
         filename_or_obj,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2764,7 +2764,7 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
         with pytest.raises(ValueError, match=r"HDF5 as bytes"):
             with open_dataset(b"\211HDF\r\n\032\n", engine="h5netcdf"):
                 pass
-        with pytest.raises(ValueError, match=r"cannot guess the engine"):
+        with pytest.raises(ValueError, match=r"Xarray cannot detect the proper engine"):
             with open_dataset(b"garbage"):
                 pass
         with pytest.raises(ValueError, match=r"can only read bytes"):
@@ -2816,7 +2816,7 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
             # `raises_regex`?). Ref https://github.com/pydata/xarray/pull/5191
             with open(tmp_file, "rb") as f:
                 f.seek(8)
-                with pytest.raises(ValueError, match="cannot guess the engine"):
+                with pytest.raises(ValueError, match="Xarray cannot detect the proper engine"):
                     open_dataset(f)
 
 

--- a/xarray/tests/test_plugins.py
+++ b/xarray/tests/test_plugins.py
@@ -175,16 +175,28 @@ def test_no_matching_engine_found():
     mock.MagicMock(return_value={}),
 )
 def test_no_engines_installed():
-    with pytest.raises(ValueError, match="no currently installed IO backends."):
+    with pytest.raises(
+        ValueError, match=r"xarray is unable to open.*IO dependencies, see:"
+    ):
         plugins.guess_engine("not-valid")
+
+    with pytest.raises(
+        ValueError, match=r"xarray is unable to open.*engines that report a match"
+    ):
+        plugins.guess_engine("foo.nc")
 
 
 @mock.patch(
     "xarray.backends.plugins.list_engines",
     mock.MagicMock(return_value={"dummy": DummyBackendEntrypointArgs()}),
 )
-def test_no_matching_engine_found():
+def test_engines_installed():
     with pytest.raises(
-        ValueError, match="match in any of xarray's currently installed IO"
+        ValueError, match=r"did not find a match in any.*IO dependencies, see:"
     ):
         plugins.guess_engine("not-valid")
+
+    with pytest.raises(
+        ValueError, match=r"did not find a match in any.*engines that report a match"
+    ):
+        plugins.guess_engine("foo.nc")

--- a/xarray/tests/test_plugins.py
+++ b/xarray/tests/test_plugins.py
@@ -177,3 +177,14 @@ def test_no_matching_engine_found():
 def test_no_engines_installed():
     with pytest.raises(ValueError, match="no currently installed IO backends."):
         plugins.guess_engine("not-valid")
+
+
+@mock.patch(
+    "xarray.backends.plugins.list_engines",
+    mock.MagicMock(return_value={"dummy": DummyBackendEntrypointArgs()}),
+)
+def test_no_matching_engine_found():
+    with pytest.raises(
+        ValueError, match="match in any of xarray's currently installed IO"
+    ):
+        plugins.guess_engine("not-valid")

--- a/xarray/tests/test_plugins.py
+++ b/xarray/tests/test_plugins.py
@@ -164,39 +164,20 @@ def test_build_engines_sorted():
     mock.MagicMock(return_value={"dummy": DummyBackendEntrypointArgs()}),
 )
 def test_no_matching_engine_found():
-    with pytest.raises(
-        ValueError, match="match in any of xarray's currently installed IO"
-    ):
+    with pytest.raises(ValueError, match=r"did not find a match in any"):
         plugins.guess_engine("not-valid")
+
+    with pytest.raises(ValueError, match=r"found the following matches with the input"):
+        plugins.guess_engine("foo.nc")
 
 
 @mock.patch(
     "xarray.backends.plugins.list_engines",
     mock.MagicMock(return_value={}),
 )
-def test_no_engines_installed():
-    with pytest.raises(
-        ValueError, match=r"xarray is unable to open.*IO dependencies, see:"
-    ):
+def test_engines_not_installed():
+    with pytest.raises(ValueError, match=r"xarray is unable to open"):
         plugins.guess_engine("not-valid")
 
-    with pytest.raises(
-        ValueError, match=r"xarray is unable to open.*engines that report a match"
-    ):
-        plugins.guess_engine("foo.nc")
-
-
-@mock.patch(
-    "xarray.backends.plugins.list_engines",
-    mock.MagicMock(return_value={"dummy": DummyBackendEntrypointArgs()}),
-)
-def test_engines_installed():
-    with pytest.raises(
-        ValueError, match=r"did not find a match in any.*IO dependencies, see:"
-    ):
-        plugins.guess_engine("not-valid")
-
-    with pytest.raises(
-        ValueError, match=r"did not find a match in any.*engines that report a match"
-    ):
+    with pytest.raises(ValueError, match=r"found the following matches with the input"):
         plugins.guess_engine("foo.nc")


### PR DESCRIPTION
When open_dataset() fails because no working engines are found, it suggests installing the dependencies of the compatible internal backends, providing explicitly the list. 
- [x] closes #5302
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
