### PR TITLE
Use checks from .pycompat in more places

### DIFF
--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -6,7 +6,6 @@ import itertools
 import operator
 import warnings
 from collections import Counter
-from distutils.version import LooseVersion
 from typing import (
     TYPE_CHECKING,
     AbstractSet,

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -29,7 +29,7 @@ from . import dtypes, duck_array_ops, utils
 from .alignment import align, deep_align
 from .merge import merge_attrs, merge_coordinates_without_align
 from .options import OPTIONS, _get_keep_attrs
-from .pycompat import is_duck_dask_array
+from .pycompat import dask_version, is_duck_dask_array
 from .utils import is_dict_like
 from .variable import Variable
 
@@ -715,9 +715,7 @@ def apply_variable_ufunc(
 
                 # todo: covers for https://github.com/dask/dask/pull/6207
                 #  remove when minimal dask version >= 2.17.0
-                from dask import __version__ as dask_version
-
-                if LooseVersion(dask_version) < LooseVersion("2.17.0"):
+                if dask_version < "2.17.0":
                     if signature.num_outputs > 1:
                         res = tuple(res)
 

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -7,7 +7,6 @@ import contextlib
 import datetime
 import inspect
 import warnings
-from distutils.version import LooseVersion
 from functools import partial
 
 import numpy as np
@@ -20,6 +19,7 @@ from .pycompat import (
     dask_array_type,
     is_duck_dask_array,
     sparse_array_type,
+    sparse_version,
 )
 from .utils import is_duck_array
 

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -176,15 +176,9 @@ masked_invalid = _dask_or_eager_func(
 
 
 def astype(data, dtype, **kwargs):
-    try:
-        import sparse
-    except ImportError:
-        sparse = None
-
     if (
-        sparse is not None
-        and isinstance(data, sparse_array_type)
-        and LooseVersion(sparse.__version__) < LooseVersion("0.11.0")
+        isinstance(data, sparse_array_type)
+        and sparse_version < "0.11.0"
         and "casting" in kwargs
     ):
         warnings.warn(


### PR DESCRIPTION
Found a few more places where modules are being imported just for version checking.