### PR TITLE
Remove `xfail` decorator from tests that depend on nc-time-axis

### DIFF
--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2581,7 +2581,6 @@ class TestDatetimePlot(PlotTestCase):
         self.darray.plot.line()
 
 
-@pytest.mark.xfail(reason="recent versions of nc-time-axis and cftime are incompatible")
 @pytest.mark.filterwarnings("ignore:setting an array element with a sequence")
 @requires_nc_time_axis
 @requires_cftime


### PR DESCRIPTION
nc-time-axis [version 1.3.0](https://github.com/SciTools/nc-time-axis/releases/tag/v1.3.0) was released today (thanks @bjlittle!), which includes various fixes for incompatibilities with the latest version of cftime.  This means that our tests that depend on nc-time-axis should now pass.

- [x] Closes #5344
