### PR TITLE
Explicitly state datetime units in array constructors in `test_datetime_mean`

### DIFF
--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -285,15 +285,15 @@ def assert_dask_array(da, dask):
 def test_datetime_mean(dask):
     # Note: only testing numpy, as dask is broken upstream
     da = DataArray(
-        np.array(["2010-01-01", "NaT", "2010-01-03", "NaT", "NaT"], dtype="M8"),
+        np.array(["2010-01-01", "NaT", "2010-01-03", "NaT", "NaT"], dtype="M8[ns]"),
         dims=["time"],
     )
     if dask:
         # Trigger use case where a chunk is full of NaT
         da = da.chunk({"time": 3})
 
-    expect = DataArray(np.array("2010-01-02", dtype="M8"))
-    expect_nat = DataArray(np.array("NaT", dtype="M8"))
+    expect = DataArray(np.array("2010-01-02", dtype="M8[ns]"))
+    expect_nat = DataArray(np.array("NaT", dtype="M8[ns]"))
 
     actual = da.mean()
     if dask:
@@ -891,6 +891,6 @@ def test_push_dask():
         actual = push(
             dask.array.from_array(array, chunks=(1, 2, 3, 2, 2, 1, 1)),
             axis=0,
-            n=None,
+            n=None
         )
     np.testing.assert_equal(actual, expected)

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -889,8 +889,6 @@ def test_push_dask():
     # some chunks of size-1 with NaN
     with raise_if_dask_computes():
         actual = push(
-            dask.array.from_array(array, chunks=(1, 2, 3, 2, 2, 1, 1)),
-            axis=0,
-            n=None
+            dask.array.from_array(array, chunks=(1, 2, 3, 2, 2, 1, 1)), axis=0, n=None
         )
     np.testing.assert_equal(actual, expected)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This addresses the `test_datetime_mean` failures reported in #5366.  Pandas now requires that we make sure the units of datetime arrays are specified explicitly in array constructors: https://github.com/pandas-dev/pandas/issues/36615#issuecomment-860040013.

- [x] Passes `pre-commit run --all-files`
