### PR TITLE
Fix issue tuple as dimension

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1381,9 +1381,14 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         try:
             variable = self._variables[name]
         except KeyError:
-            _, name, variable = _get_virtual_variable(
-                self._variables, name, self._level_coords, self.dims
-            )
+            if isinstance(name, tuple):
+                raise KeyError(
+                    "The dimension provided is a tuple, you may intended to pass a list"
+                )
+            else:
+                _, name, variable = _get_virtual_variable(
+                    self._variables, name, self._level_coords, self.dims
+                )
 
         needed_dims = set(variable.dims)
 
@@ -5983,10 +5988,11 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         """
         from .dataarray import DataArray
 
-        if not isinstance(variables, list):
+        if not isinstance(variables, (list, tuple)):
             variables = [variables]
         else:
             variables = variables
+
         variables = [v if isinstance(v, DataArray) else self[v] for v in variables]
         aligned_vars = align(self, *variables, join="left")
         aligned_self = aligned_vars[0]

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4429,6 +4429,11 @@ class TestDataArray:
         actual = da.sortby(["x", "y"])
         assert_equal(actual, expected)
 
+        # test not throwing an error if sorted with tuple
+        expected = sorted2d
+        actual = da.sortby(da.dims)
+        assert_equal(actual, expected)
+
     @requires_bottleneck
     def test_rank(self):
         # floats

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3296,13 +3296,16 @@ class TestDataset:
         expected = data.isel(dim1=0)
         assert_identical(expected, actual)
 
-    def test_getitem_hashable(self):
+    def test_error_tuple(self):
         data = create_test_data()
         data[(3, 4)] = data["var1"] + 1
         expected = data["var1"] + 1
         expected.name = (3, 4)
         assert_identical(expected, data[(3, 4)])
-        with pytest.raises(KeyError, match=r"('var1', 'var2')"):
+        with pytest.raises(
+            KeyError,
+            match="The dimension provided is a tuple, you may intended to pass a list",
+        ):
             data[("var1", "var2")]
 
     def test_virtual_variables_default_coords(self):


### PR DESCRIPTION
I edited dataset in core to try to solve the [issue 4821](https://github.com/pydata/xarray/issues/4821). Some tests are still currently missing, also I believe there is still one more issue related to using tuple as dim. 

The code `xr.Dataset({"a": ([("a", "b")], [1])})` does not error yet.

- [ ] Closes [#4821](https://github.com/pydata/xarray/issues/4821)
- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
