### PR TITLE
DOC: add combine_by_coords in merge see also

### DIFF
--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -880,7 +880,7 @@ def merge(
     See also
     --------
     concat
-	combine_nested
+    combine_nested
     combine_by_coords
     """
     from .dataarray import DataArray

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -880,6 +880,7 @@ def merge(
     See also
     --------
     concat
+	combine_nested
     combine_by_coords
     """
     from .dataarray import DataArray

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -880,6 +880,7 @@ def merge(
     See also
     --------
     concat
+    combine_by_coords
     """
     from .dataarray import DataArray
     from .dataset import Dataset


### PR DESCRIPTION
Keewis mentioned other options to `merge` are `concat` and `combine_by_coords` (https://github.com/pydata/xarray/discussions/5462#discussioncomment-861492). This PR adds `combine_by_coords` in the see also docstring of `merge`