### PR TITLE
Fix bug when querying unnamed dataarray

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4490,7 +4490,8 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
         Dimensions without coordinates: x
         """
 
-        ds = self._to_dataset_whole(shallow_copy=True)
+        name = _THIS_ARRAY if self.name is None else self.name
+        ds = self._to_dataset_whole(name=name, shallow_copy=True)
         ds = ds.query(
             queries=queries,
             parser=parser,
@@ -4498,7 +4499,8 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
             missing_dims=missing_dims,
             **queries_kwargs,
         )
-        return ds[self.name]
+        da = self._from_temp_dataset(ds) if name is _THIS_ARRAY else ds[name]
+        return da
 
     def curvefit(
         self,

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4659,6 +4659,7 @@ class TestDataArray:
             bb = DataArray(data=b, dims=["x"], name="b")
             cc = DataArray(data=c, dims=["y"], name="c")
             dd = DataArray(data=d, dims=["z"], name="d")
+            nn = DataArray(data=a, dims=["x"], name=None)
 
         elif backend == "dask":
             import dask.array as da
@@ -4667,6 +4668,7 @@ class TestDataArray:
             bb = DataArray(data=da.from_array(b, chunks=3), dims=["x"], name="b")
             cc = DataArray(data=da.from_array(c, chunks=7), dims=["y"], name="c")
             dd = DataArray(data=da.from_array(d, chunks=12), dims=["z"], name="d")
+            nn = DataArray(data=da.from_array(a, chunks=3), dims=["x"], name=None)
 
         # query single dim, single variable
         actual = aa.query(x="a > 5", engine=engine, parser=parser)
@@ -4703,6 +4705,11 @@ class TestDataArray:
             aa.query(x=(a > 5))  # must be query string
         with pytest.raises(UndefinedVariableError):
             aa.query(x="spam > 50")  # name not present
+
+        # test with nameless dataarray (GH issue 5492)
+        actual = nn.query(x="x > 5", engine=engine, parser=parser)
+        expect = nn.isel(x=(nn.x > 5))
+        assert_identical(expect, actual)
 
     @requires_scipy
     @pytest.mark.parametrize("use_dask", [True, False])


### PR DESCRIPTION
There might be a slightly neater way to do this, but this works.

- [x] Closes #5492
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
