### PR TITLE
fix dtype complex for rasterio backend

### DIFF
--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -39,7 +39,10 @@ class RasterioArrayWrapper(BackendArray):
         dtypes = riods.dtypes
         if not np.all(np.asarray(dtypes) == dtypes[0]):
             raise ValueError("All bands should have the same dtype")
-        self._dtype = np.dtype(dtypes[0])
+        if dtypes[0]!='complex_int16':
+            self._dtype = np.dtype(dtypes[0])
+        else:
+            self._dtype = np.complex
 
     @property
     def dtype(self):

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -39,10 +39,10 @@ class RasterioArrayWrapper(BackendArray):
         dtypes = riods.dtypes
         if not np.all(np.asarray(dtypes) == dtypes[0]):
             raise ValueError("All bands should have the same dtype")
-        if dtypes[0] == "complex_int16":
-            self._dtype = np.complex
-        else:
+        if dtypes[0] != 'complex_int16' :
             self._dtype = np.dtype(dtypes[0])
+        else :
+            self._dtype = complex
 
     @property
     def dtype(self):

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -39,10 +39,10 @@ class RasterioArrayWrapper(BackendArray):
         dtypes = riods.dtypes
         if not np.all(np.asarray(dtypes) == dtypes[0]):
             raise ValueError("All bands should have the same dtype")
-        if dtypes[0]!='complex_int16':
-            self._dtype = np.dtype(dtypes[0])
-        else:
+        if dtypes[0] == "complex_int16":
             self._dtype = np.complex
+        else:
+            self._dtype = np.dtype(dtypes[0])
 
     @property
     def dtype(self):


### PR DESCRIPTION
rasterio backend support for the `complex_int16` dtype

- [x] Closes #5491 
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

