### PR TITLE
Use integer type hints in chunk functions 

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1,6 +1,5 @@
 import datetime
 import warnings
-from numbers import Number
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1039,10 +1039,10 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
     def chunk(
         self,
         chunks: Union[
-            Number,
-            Tuple[Number, ...],
-            Tuple[Tuple[Number, ...], ...],
-            Mapping[Hashable, Union[None, Number, Tuple[Number, ...]]],
+            int,
+            Tuple[int, ...],
+            Tuple[Tuple[int, ...], ...],
+            Mapping[Hashable, Union[None, int, Tuple[int, ...]]],
         ] = {},  # {} even though it's technically unsafe, is being used intentionally here (#4667)
         name_prefix: str = "xarray-",
         token: str = None,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2132,7 +2132,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
             )
             chunks = {}
 
-        if isinstance(chunks, (Number, str)):
+        if isinstance(chunks, (Number, str, int)):
             chunks = dict.fromkeys(self.dims, chunks)
 
         bad_dims = chunks.keys() - self.dims.keys()

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2089,9 +2089,9 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
     def chunk(
         self,
         chunks: Union[
-            Number,
+            int,
             str,
-            Mapping[Hashable, Union[None, Number, str, Tuple[Number, ...]]],
+            Mapping[Hashable, Union[None, int, str, Tuple[int, ...]]],
         ] = {},  # {} even though it's technically unsafe, is being used intentionally here (#4667)
         name_prefix: str = "xarray-",
         token: str = None,


### PR DESCRIPTION
Attempt to fix errors found in #5365. I've changed it to integers because when does it ever make sense to input 1.5 or a complex number? It will always be forced to integers anyway: https://github.com/dask/dask/blob/8aea537d925b794a94f828d35211a5da05ad9dce/dask/array/core.py#L2815

Integers don't work with Numbers:
```
xarray/core/computation.py:1576: error: Dict entry 0 has incompatible type "Hashable": "int"; expected "Hashable": "Union[None, Number, str, Tuple[Number, ...]]"  [dict-item]
xarray/core/computation.py:1576: error: Dict entry 0 has incompatible type "Hashable": "int"; expected "Hashable": "Union[None, Number, Tuple[Number, ...]]"  [dict-item]
xarray/core/computation.py:1536: error: Dict entry 0 has incompatible type "Hashable": "int"; expected "Hashable": "Union[None, Number, str, Tuple[Number, ...]]"  [dict-item]
```

Floats don't work with Numbers:
```
xarray/core/computation.py:1536: error: Dict entry 0 has incompatible type "Hashable": "int"; expected "Hashable": "Union[None, Number, str, Tuple[Number, ...]]"  [dict-item]
xarray/core/computation.py:1578: error: Dict entry 0 has incompatible type "Hashable": "float"; expected "Hashable": "Union[None, Number, str, Tuple[Number, ...]]"  [dict-item]
xarray/core/computation.py:1578: error: Dict entry 0 has incompatible type "Hashable": "float"; expected "Hashable": "Union[None, Number, Tuple[Number, ...]]"  [dict-item]
```
This workaround seems related to: https://github.com/python/mypy/issues/3186

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
