### PR TITLE
Add remark about dim units in `.polyfit()`

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3812,7 +3812,8 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
         Parameters
         ----------
         dim : hashable
-            Coordinate along which to fit the polynomials.
+            Coordinate along which to fit the polynomials. (Note that when dim is time in 
+            `datetime64` format then the units are nanoseconds.)
         deg : int
             Degree of the fitting polynomial.
         skipna : bool, optional

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3812,7 +3812,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
         Parameters
         ----------
         dim : hashable
-            Coordinate along which to fit the polynomials. (Note that when dim is time in 
+            Coordinate along which to fit the polynomials. (Note that when dim is time in
             `datetime64` format then the units are nanoseconds.)
         deg : int
             Degree of the fitting polynomial.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6703,7 +6703,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         Parameters
         ----------
         dim : hashable
-            Coordinate along which to fit the polynomials. (Note that when dim is time in 
+            Coordinate along which to fit the polynomials. (Note that when dim is time in
             `datetime64` format then the units are nanoseconds.)
         deg : int
             Degree of the fitting polynomial.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6703,7 +6703,8 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         Parameters
         ----------
         dim : hashable
-            Coordinate along which to fit the polynomials.
+            Coordinate along which to fit the polynomials. (Note that when dim is time in 
+            `datetime64` format then the units are nanoseconds.)
         deg : int
             Degree of the fitting polynomial.
         skipna : bool, optional


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes  #4455

This PR just adds a not on the `.polyfit()` docstrings for Dataarrays and Datasets.