### PR TITLE
Remove self from classes in How to add new backends docs

### DIFF
--- a/doc/internals/how-to-add-new-backend.rst
+++ b/doc/internals/how-to-add-new-backend.rst
@@ -37,7 +37,6 @@ This is what a ``BackendEntrypoint`` subclass should look like:
 
     class MyBackendEntrypoint(BackendEntrypoint):
         def open_dataset(
-            self,
             filename_or_obj,
             *,
             drop_variables=None,
@@ -48,7 +47,7 @@ This is what a ``BackendEntrypoint`` subclass should look like:
 
         open_dataset_parameters = ["filename_or_obj", "drop_variables"]
 
-        def guess_can_open(self, filename_or_obj):
+        def guess_can_open(filename_or_obj):
             try:
                 _, ext = os.path.splitext(filename_or_obj)
             except TypeError:
@@ -70,7 +69,6 @@ The following is an example of the high level processing steps:
 .. code-block:: python
 
     def open_dataset(
-        self,
         filename_or_obj,
         *,
         drop_variables=None,


### PR DESCRIPTION
Copy pasting the examples in  http://xarray.pydata.org/en/stable/internals/how-to-add-new-backend.html resulted in crashes. Make the docs copy/paste friendly by removing the self arguments.

Example:
```python
expected = xr.Dataset(
    dict(a=2 * np.arange(5)), coords=dict(x=("x", np.arange(5), dict(units="s")))
)

class CustomBackend(xr.backends.BackendEntrypoint):
    def open_dataset(
        self,
        filename_or_obj,
        drop_variables=None,
        **kwargs,
    ):
        return expected.copy(deep=True)

xr.open_dataset("fake_filename", engine=CustomBackend)
TypeError: open_dataset() missing 1 required positional argument: 'filename_or_obj'
```
This works if self is removed:
```python
expected = xr.Dataset(
    dict(a=2 * np.arange(5)), coords=dict(x=("x", np.arange(5), dict(units="s")))
)

class CustomBackend(xr.backends.BackendEntrypoint):
    def open_dataset(
        filename_or_obj,
        drop_variables=None,
        **kwargs,
    ):
        return expected.copy(deep=True)

xr.open_dataset("fake_filename", engine=CustomBackend)
<xarray.Dataset>
Dimensions:  (a: 5, x: 5)
Coordinates:
  * a        (a) int32 0 2 4 6 8
  * x        (x) int32 0 1 2 3 4
Data variables:
    *empty*
```
<!-- Feel free to remove check-list items aren't relevant to your change -->


- [x] Passes `pre-commit run --all-files`
