### PR TITLE
Faster transpose

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1402,11 +1402,10 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         --------
         numpy.transpose
         """
-        ndim = len(dims)
-        if ndim == 0:
+        if len(dims) == 0:
             dims = self.dims[::-1]
         dims = tuple(infix_dims(dims, self.dims))
-        if ndim < 2 or dims == self.dims:
+        if len(dims) < 2 or dims == self.dims:
             # no need to transpose if only one dimension
             # or dims are in same order
             return self.copy(deep=False)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1402,10 +1402,11 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         --------
         numpy.transpose
         """
-        if len(dims) == 0:
+        ndim = len(dims)
+        if ndim == 0:
             dims = self.dims[::-1]
         dims = tuple(infix_dims(dims, self.dims))
-        if len(dims) < 2 or dims == self.dims:
+        if ndim < 2 or dims == self.dims:
             # no need to transpose if only one dimension
             # or dims are in same order
             return self.copy(deep=False)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1405,12 +1405,12 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         if len(dims) == 0:
             dims = self.dims[::-1]
         dims = tuple(infix_dims(dims, self.dims))
-        axes = self.get_axis_num(dims)
         if len(dims) < 2 or dims == self.dims:
             # no need to transpose if only one dimension
             # or dims are in same order
             return self.copy(deep=False)
 
+        axes = self.get_axis_num(dims)
         data = as_indexable(self._data).transpose(axes)
         return self._replace(dims=dims, data=data)
 


### PR DESCRIPTION
Make the transpose faster.
* `get_axis_num` seems slow, avoid triggering it unnecessarily for example when using 1d arrays.
* .copy(deep=False) is the bottleneck for 1d arrays. Not sure if it can be dealt with though.



<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
