### PR TITLE
Fix 2 type annotations in dataarray.py

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1902,7 +1902,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
         indexes: Mapping[Hashable, Union[Hashable, Sequence[Hashable]]] = None,
         append: bool = False,
         **indexes_kwargs: Union[Hashable, Sequence[Hashable]],
-    ) -> Optional["DataArray"]:
+    ) -> "DataArray":
         """Set DataArray (multi-)indexes using one or more existing
         coordinates.
 
@@ -1958,7 +1958,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
         self,
         dims_or_levels: Union[Hashable, Sequence[Hashable]],
         drop: bool = False,
-    ) -> Optional["DataArray"]:
+    ) -> "DataArray":
         """Reset the specified index(es) or multi-index level(s).
 
         Parameters


### PR DESCRIPTION
Both `set_index` and `reset_index` are wrappers to other methods that return `"DataArray"`, not `Optional["DataArray"]`. That is, they will never return None. That's why these methods should also have only `"DataArray"` in there return signature. This way it will be possible to do something like `myarray = myarray.reset_index(...)` without getting a complaint from Mypy.

For extended discussion, see https://github.com/pydata/xarray/issues/5533#issuecomment-869822366

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #5533
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
