### PR TITLE
Test test_missing.py without cftime installed

### DIFF
--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -229,3 +229,15 @@ def create_test_data(seed=None, add_attrs=True):
     obj.encoding = {"foo": "bar"}
     assert all(obj.data.flags.writeable for obj in obj.variables.values())
     return obj
+
+
+_CFTIME_CALENDARS = [
+    "365_day",
+    "360_day",
+    "julian",
+    "all_leap",
+    "366_day",
+    "gregorian",
+    "proleptic_gregorian",
+    "standard",
+]

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -28,7 +28,6 @@ from xarray.coding.cftime_offsets import (
 )
 from xarray.tests import _CFTIME_CALENDARS
 
-
 cftime = pytest.importorskip("cftime")
 
 

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -26,20 +26,10 @@ from xarray.coding.cftime_offsets import (
     to_cftime_datetime,
     to_offset,
 )
+from xarray.tests import _CFTIME_CALENDARS
+
 
 cftime = pytest.importorskip("cftime")
-
-
-_CFTIME_CALENDARS = [
-    "365_day",
-    "360_day",
-    "julian",
-    "all_leap",
-    "366_day",
-    "gregorian",
-    "proleptic_gregorian",
-    "standard",
-]
 
 
 def _id_func(param):

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -24,16 +24,11 @@ from xarray.tests import (
     requires_scipy,
 )
 
-_CFTIME_CALENDARS = [
-    "365_day",
-    "360_day",
-    "julian",
-    "all_leap",
-    "366_day",
-    "gregorian",
-    "proleptic_gregorian",
-    "standard",
-]
+try:
+	import cftime
+	from xarray.tests.test_cftime_offsets import _CFTIME_CALENDARS
+except ImportError:
+	_CFTIME_CALENDARS = []
 
 
 @pytest.fixture

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -24,7 +24,6 @@ from xarray.tests import (
     requires_scipy,
 )
 
-
 _CFTIME_CALENDARS = [
     "365_day",
     "360_day",

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -14,7 +14,6 @@ from xarray.core.missing import (
 )
 from xarray.core.pycompat import dask_array_type
 from xarray.tests import (
-    _CFTIME_CALENDARS,
     assert_allclose,
     assert_array_equal,
     assert_equal,
@@ -24,6 +23,7 @@ from xarray.tests import (
     requires_dask,
     requires_scipy,
 )
+from xarray.tests.test_cftime_offsets import _CFTIME_CALENDARS
 
 
 @pytest.fixture
@@ -542,7 +542,6 @@ def test_get_clean_interp_index_dt(cf_da, calendar, freq):
     np.testing.assert_array_equal(gi, si)
 
 
-@requires_cftime
 def test_get_clean_interp_index_potential_overflow():
     da = xr.DataArray(
         [0, 1, 2],
@@ -593,10 +592,7 @@ def test_interpolate_na_max_gap_errors(da_time):
 
 
 @requires_bottleneck
-@pytest.mark.parametrize(
-    "time_range_func",
-    [pd.date_range, pytest.param(xr.cftime_range, marks=requires_cftime)],
-)
+@pytest.mark.parametrize("time_range_func", [pd.date_range, xr.cftime_range])
 @pytest.mark.parametrize("transform", [lambda x: x, lambda x: x.to_dataset(name="a")])
 @pytest.mark.parametrize(
     "max_gap", ["3H", np.timedelta64(3, "h"), pd.to_timedelta("3H")]

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -25,7 +25,7 @@ from xarray.tests import (
 )
 
 try:
-    import cftime  # flake8: noqa
+    import cftime  # type: ignore # noqa
 
     from xarray.tests.test_cftime_offsets import _CFTIME_CALENDARS
 except ImportError:

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -36,6 +36,7 @@ _CFTIME_CALENDARS = [
     "standard",
 ]
 
+
 @pytest.fixture
 def da():
     return xr.DataArray([0, np.nan, 1, 2, np.nan, 3, 4, 5, np.nan, 6, 7], dims="time")

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -25,7 +25,7 @@ from xarray.tests import (
 )
 
 try:
-    import cftime
+    import cftime  # flake8: noqa
 
     from xarray.tests.test_cftime_offsets import _CFTIME_CALENDARS
 except ImportError:

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -14,6 +14,7 @@ from xarray.core.missing import (
 )
 from xarray.core.pycompat import dask_array_type
 from xarray.tests import (
+    _CFTIME_CALENDARS,
     assert_allclose,
     assert_array_equal,
     assert_equal,
@@ -23,13 +24,6 @@ from xarray.tests import (
     requires_dask,
     requires_scipy,
 )
-
-try:
-    import cftime  # type: ignore # noqa
-
-    from xarray.tests.test_cftime_offsets import _CFTIME_CALENDARS
-except ImportError:
-    _CFTIME_CALENDARS = []
 
 
 @pytest.fixture

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -23,8 +23,18 @@ from xarray.tests import (
     requires_dask,
     requires_scipy,
 )
-from xarray.tests.test_cftime_offsets import _CFTIME_CALENDARS
 
+
+_CFTIME_CALENDARS = [
+    "365_day",
+    "360_day",
+    "julian",
+    "all_leap",
+    "366_day",
+    "gregorian",
+    "proleptic_gregorian",
+    "standard",
+]
 
 @pytest.fixture
 def da():
@@ -542,6 +552,7 @@ def test_get_clean_interp_index_dt(cf_da, calendar, freq):
     np.testing.assert_array_equal(gi, si)
 
 
+@requires_cftime
 def test_get_clean_interp_index_potential_overflow():
     da = xr.DataArray(
         [0, 1, 2],
@@ -592,7 +603,10 @@ def test_interpolate_na_max_gap_errors(da_time):
 
 
 @requires_bottleneck
-@pytest.mark.parametrize("time_range_func", [pd.date_range, xr.cftime_range])
+@pytest.mark.parametrize(
+    "time_range_func",
+    [pd.date_range, pytest.param(xr.cftime_range, marks=requires_cftime)],
+)
 @pytest.mark.parametrize("transform", [lambda x: x, lambda x: x.to_dataset(name="a")])
 @pytest.mark.parametrize(
     "max_gap", ["3H", np.timedelta64(3, "h"), pd.to_timedelta("3H")]

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -25,10 +25,11 @@ from xarray.tests import (
 )
 
 try:
-	import cftime
-	from xarray.tests.test_cftime_offsets import _CFTIME_CALENDARS
+    import cftime
+
+    from xarray.tests.test_cftime_offsets import _CFTIME_CALENDARS
 except ImportError:
-	_CFTIME_CALENDARS = []
+    _CFTIME_CALENDARS = []
 
 
 @pytest.fixture

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -14,6 +14,7 @@ from xarray.core.missing import (
 )
 from xarray.core.pycompat import dask_array_type
 from xarray.tests import (
+    _CFTIME_CALENDARS,
     assert_allclose,
     assert_array_equal,
     assert_equal,
@@ -23,7 +24,6 @@ from xarray.tests import (
     requires_dask,
     requires_scipy,
 )
-from xarray.tests.test_cftime_offsets import _CFTIME_CALENDARS
 
 
 @pytest.fixture
@@ -542,6 +542,7 @@ def test_get_clean_interp_index_dt(cf_da, calendar, freq):
     np.testing.assert_array_equal(gi, si)
 
 
+@requires_cftime
 def test_get_clean_interp_index_potential_overflow():
     da = xr.DataArray(
         [0, 1, 2],
@@ -592,7 +593,10 @@ def test_interpolate_na_max_gap_errors(da_time):
 
 
 @requires_bottleneck
-@pytest.mark.parametrize("time_range_func", [pd.date_range, xr.cftime_range])
+@pytest.mark.parametrize(
+    "time_range_func",
+    [pd.date_range, pytest.param(xr.cftime_range, marks=requires_cftime)],
+)
 @pytest.mark.parametrize("transform", [lambda x: x, lambda x: x.to_dataset(name="a")])
 @pytest.mark.parametrize(
     "max_gap", ["3H", np.timedelta64(3, "h"), pd.to_timedelta("3H")]


### PR DESCRIPTION
The checks that didn't install cftime skipped the entire test_missing.py. Because cftime is also imported when importing the list of calenders `_CFTIME_CALENDERS`.

Added also skips for the cases that assumed cftime was installed so they are correctly skipped.

<!-- Feel free to remove check-list items aren't relevant to your change -->


- [x] Passes `pre-commit run --all-files`
