### PR TITLE
Set coord name concat when `concat`ing along a DataArray

### DIFF
--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -264,6 +264,8 @@ def _calc_concat_dim_coord(dim):
         (dim,) = coord.dims
     else:
         coord = dim
+        if coord.name is None:
+            coord.name = dim.dims[0]
         (dim,) = coord.dims
     return dim, coord
 

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -678,6 +678,15 @@ class TestConcatDataArray:
 
         assert np.issubdtype(actual.x2.dtype, dtype)
 
+    def test_concat_coord_name(self):
+
+        da = DataArray([0], dims="a")
+        da_concat = concat([da, da], dim=DataArray([0, 1], dims="b"))
+        assert list(da_concat.coords) == ["b"]
+
+        da_concat_std = concat([da, da], dim=DataArray([0, 1]))
+        assert list(da_concat_std.coords) == ["dim_0"]
+
 
 @pytest.mark.parametrize("attr1", ({"a": {"meta": [10, 20, 30]}}, {"a": [1, 2, 3]}, {}))
 @pytest.mark.parametrize("attr2", ({"a": [1, 2, 3]}, {}))


### PR DESCRIPTION
- [x] Closes #5240 
- [x] Tests added
- [x] Passes `pre-commit run --all-files`

Technically this creates user visible changes, but not sure whether it's worth adding it to the whatsnew.
