### PR TITLE
Make typing-extensions optional

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
             types-pytz,
             # Dependencies that are typed
             numpy,
+            typing-extensions==3.10.0.0,
           ]
   # run this occasionally, ref discussion https://github.com/pydata/xarray/pull/3194
   # - repo: https://github.com/asottile/pyupgrade

--- a/doc/getting-started-guide/installing.rst
+++ b/doc/getting-started-guide/installing.rst
@@ -8,7 +8,6 @@ Required dependencies
 
 - Python (3.7 or later)
 - setuptools (40.4 or later)
-- typing-extensions (3.10 or later)
 - `numpy <http://www.numpy.org/>`__ (1.17 or later)
 - `pandas <http://pandas.pydata.org/>`__ (1.0 or later)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
 
 [options]
@@ -78,7 +79,6 @@ install_requires =
     numpy >= 1.17
     pandas >= 1.0
     setuptools >= 40.4  # For pkg_resources
-    typing-extensions >= 3.10  # Backported type hints
 
 [options.extras_require]
 io =

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -32,15 +32,6 @@ from typing import (
 import numpy as np
 import pandas as pd
 
-try:
-    if sys.version_info >= (3, 10):
-        from typing import TypeGuard
-    else:
-        from typing_extensions import TypeGuard
-    TypeGuardHashable = TypeGuard[Hashable]
-except ImportError:
-    TypeGuardHashable = bool
-
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -301,11 +292,7 @@ def either_dict_or_kwargs(
     return pos_kwargs
 
 
-def is_scalar(value: Any, include_0d: bool = True) -> TypeGuardHashable:
-    """Whether to treat a value as a scalar.
-
-    Any non-iterable, string, or 0-D array
-    """
+def _is_scalar(value, include_0d):
     from .variable import NON_NUMPY_SUPPORTED_ARRAY_TYPES
 
     if include_0d:
@@ -318,6 +305,27 @@ def is_scalar(value: Any, include_0d: bool = True) -> TypeGuardHashable:
             or hasattr(value, "__array_function__")
         )
     )
+
+
+try:
+    if sys.version_info >= (3, 10):
+        from typing import TypeGuard
+    else:
+        from typing_extensions import TypeGuard
+except ImportError:
+    def is_scalar(value: Any, include_0d: bool = True) -> bool:
+        """Whether to treat a value as a scalar.
+
+        Any non-iterable, string, or 0-D array
+        """
+        return _is_scalar(value, include_0d)
+else:
+    def is_scalar(value: Any, include_0d: bool = True) -> TypeGuard[Hashable]:
+        """Whether to treat a value as a scalar.
+
+        Any non-iterable, string, or 0-D array
+        """
+        return _is_scalar(value, include_0d)
 
 
 def is_valid_numpy_dtype(dtype: Any) -> bool:

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -32,10 +32,14 @@ from typing import (
 import numpy as np
 import pandas as pd
 
-if sys.version_info >= (3, 10):
-    from typing import TypeGuard
-else:
-    from typing_extensions import TypeGuard
+try:
+    if sys.version_info >= (3, 10):
+        from typing import TypeGuard
+    else:
+        from typing_extensions import TypeGuard
+    TypeGuardHashable = TypeGuard[Hashable]
+except ImportError:
+    TypeGuardHashable = bool
 
 
 K = TypeVar("K")
@@ -297,7 +301,7 @@ def either_dict_or_kwargs(
     return pos_kwargs
 
 
-def is_scalar(value: Any, include_0d: bool = True) -> TypeGuard[Hashable]:
+def is_scalar(value: Any, include_0d: bool = True) -> TypeGuardHashable:
     """Whether to treat a value as a scalar.
 
     Any non-iterable, string, or 0-D array

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -10,6 +10,7 @@ import sys
 import warnings
 from enum import Enum
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Collection,
@@ -31,7 +32,6 @@ from typing import (
 
 import numpy as np
 import pandas as pd
-
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -307,19 +307,29 @@ def _is_scalar(value, include_0d):
     )
 
 
+# See GH5624, this is a convoluted way to allow type-checking to use `TypeGuard` without
+# requiring typing_extensions as a required dependency to _run_ the code (it is required
+# to type-check).
 try:
     if sys.version_info >= (3, 10):
         from typing import TypeGuard
     else:
         from typing_extensions import TypeGuard
 except ImportError:
-    def is_scalar(value: Any, include_0d: bool = True) -> bool:
-        """Whether to treat a value as a scalar.
+    if TYPE_CHECKING:
+        raise
+    else:
 
-        Any non-iterable, string, or 0-D array
-        """
-        return _is_scalar(value, include_0d)
+        def is_scalar(value: Any, include_0d: bool = True) -> bool:
+            """Whether to treat a value as a scalar.
+
+            Any non-iterable, string, or 0-D array
+            """
+            return _is_scalar(value, include_0d)
+
+
 else:
+
     def is_scalar(value: Any, include_0d: bool = True) -> TypeGuard[Hashable]:
         """Whether to treat a value as a scalar.
 


### PR DESCRIPTION
Type checking may be a little worse if typing-extensions are not installed, but I don't think it's worth the trouble of adding another hard dependency just for one use for TypeGuard.

Note: sadly this doesn't work yet. Mypy (and pylance) don't like the type alias defined with try/except. Any ideas? In the worst case, we could revert the TypeGuard entirely, but that would be a shame...

- [x] Closes #5495
- [ ] Passes `pre-commit run --all-files`
