### PR TITLE
remove deprecations scheduled for 0.19

### DIFF
--- a/doc/api-hidden.rst
+++ b/doc/api-hidden.rst
@@ -54,7 +54,6 @@
    core.rolling.DatasetCoarsen.var
    core.rolling.DatasetCoarsen.boundary
    core.rolling.DatasetCoarsen.coord_func
-   core.rolling.DatasetCoarsen.keep_attrs
    core.rolling.DatasetCoarsen.obj
    core.rolling.DatasetCoarsen.side
    core.rolling.DatasetCoarsen.trim_excess
@@ -120,7 +119,6 @@
    core.rolling.DatasetRolling.var
    core.rolling.DatasetRolling.center
    core.rolling.DatasetRolling.dim
-   core.rolling.DatasetRolling.keep_attrs
    core.rolling.DatasetRolling.min_periods
    core.rolling.DatasetRolling.obj
    core.rolling.DatasetRolling.rollings
@@ -199,7 +197,6 @@
    core.rolling.DataArrayCoarsen.var
    core.rolling.DataArrayCoarsen.boundary
    core.rolling.DataArrayCoarsen.coord_func
-   core.rolling.DataArrayCoarsen.keep_attrs
    core.rolling.DataArrayCoarsen.obj
    core.rolling.DataArrayCoarsen.side
    core.rolling.DataArrayCoarsen.trim_excess
@@ -263,7 +260,6 @@
    core.rolling.DataArrayRolling.var
    core.rolling.DataArrayRolling.center
    core.rolling.DataArrayRolling.dim
-   core.rolling.DataArrayRolling.keep_attrs
    core.rolling.DataArrayRolling.min_periods
    core.rolling.DataArrayRolling.obj
    core.rolling.DataArrayRolling.window

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -70,6 +70,13 @@ Breaking changes
 Deprecations
 ~~~~~~~~~~~~
 
+- Removed the deprecated ``dim`` kwarg to :py:func:`DataArray.integrate` (:pull:`5630`)
+- Removed the deprecated ``keep_attrs`` kwarg to :py:func:`DataArray.rolling` (:pull:`5630`)
+- Removed the deprecated ``keep_attrs`` kwarg to :py:func:`DataArray.coarsen` (:pull:`5630`)
+- Completed deprecation of passing an ``xarray.DataArray`` to :py:func:`Variable` - will now raise a ``TypeError`` (:pull:`5630`)
+- Removed the deprecated return value of :py:func:`Dataset.update` (:pull:`5630`)
+- Removed the deprecated lock kwarg to :py:func:`DataArray.open_dataset` (:pull:`5630`)
+- Removed the deprecated datasets argument to :py:func:`combine_by_coords` (:pull:`5630`)
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -74,7 +74,6 @@ Deprecations
 - Removed the deprecated ``keep_attrs`` kwarg to :py:func:`DataArray.rolling` (:pull:`5630`)
 - Removed the deprecated ``keep_attrs`` kwarg to :py:func:`DataArray.coarsen` (:pull:`5630`)
 - Completed deprecation of passing an ``xarray.DataArray`` to :py:func:`Variable` - will now raise a ``TypeError`` (:pull:`5630`)
-- Removed the deprecated return value of :py:func:`Dataset.update` (:pull:`5630`)
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -75,8 +75,6 @@ Deprecations
 - Removed the deprecated ``keep_attrs`` kwarg to :py:func:`DataArray.coarsen` (:pull:`5630`)
 - Completed deprecation of passing an ``xarray.DataArray`` to :py:func:`Variable` - will now raise a ``TypeError`` (:pull:`5630`)
 - Removed the deprecated return value of :py:func:`Dataset.update` (:pull:`5630`)
-- Removed the deprecated lock kwarg to :py:func:`DataArray.open_dataset` (:pull:`5630`)
-- Removed the deprecated datasets argument to :py:func:`combine_by_coords` (:pull:`5630`)
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -1,5 +1,4 @@
 import itertools
-import warnings
 from collections import Counter
 
 import pandas as pd

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -1,4 +1,5 @@
 import itertools
+import warnings
 from collections import Counter
 
 import pandas as pd
@@ -634,14 +635,16 @@ def _combine_single_variable_hypercube(
     return concatenated
 
 
+# TODO remove empty list default param after version 0.21, see PR4696
 def combine_by_coords(
-    data_objects,
+    data_objects=[],
     compat="no_conflicts",
     data_vars="all",
     coords="different",
     fill_value=dtypes.NA,
     join="outer",
     combine_attrs="no_conflicts",
+    datasets=None,
 ):
     """
     Attempt to auto-magically combine the given datasets (or data arrays)
@@ -845,6 +848,14 @@ def combine_by_coords(
         temperature    (y, x) float64 10.98 14.3 12.06 nan ... 18.89 10.44 8.293
         precipitation  (y, x) float64 0.4376 0.8918 0.9637 ... 0.5684 0.01879 0.6176
     """
+
+    # TODO remove after version 0.21, see PR4696
+    if datasets is not None:
+        warnings.warn(
+            "The datasets argument has been renamed to `data_objects`."
+            " From 0.21 on passing a value for datasets will raise an error."
+        )
+        data_objects = datasets
 
     if not data_objects:
         return Dataset()

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -635,16 +635,14 @@ def _combine_single_variable_hypercube(
     return concatenated
 
 
-# TODO remove empty list default param after version 0.19, see PR4696
 def combine_by_coords(
-    data_objects=[],
+    data_objects,
     compat="no_conflicts",
     data_vars="all",
     coords="different",
     fill_value=dtypes.NA,
     join="outer",
     combine_attrs="no_conflicts",
-    datasets=None,
 ):
     """
     Attempt to auto-magically combine the given datasets (or data arrays)
@@ -848,14 +846,6 @@ def combine_by_coords(
         temperature    (y, x) float64 10.98 14.3 12.06 nan ... 18.89 10.44 8.293
         precipitation  (y, x) float64 0.4376 0.8918 0.9637 ... 0.5684 0.01879 0.6176
     """
-
-    # TODO remove after version 0.19, see PR4696
-    if datasets is not None:
-        warnings.warn(
-            "The datasets argument has been renamed to `data_objects`."
-            " In future passing a value for datasets will raise an error."
-        )
-        data_objects = datasets
 
     if not data_objects:
         return Dataset()

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -937,7 +937,6 @@ class DataWithCoords(AttrAccessMixin):
         boundary: str = "exact",
         side: Union[str, Mapping[Hashable, str]] = "left",
         coord_func: str = "mean",
-        keep_attrs: bool = None,
         **window_kwargs: int,
     ):
         """
@@ -1006,7 +1005,6 @@ class DataWithCoords(AttrAccessMixin):
             boundary=boundary,
             side=side,
             coord_func=coord_func,
-            keep_attrs=keep_attrs,
         )
 
     def resample(

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -821,7 +821,6 @@ class DataWithCoords(AttrAccessMixin):
         dim: Mapping[Hashable, int] = None,
         min_periods: int = None,
         center: Union[bool, Mapping[Hashable, bool]] = False,
-        keep_attrs: bool = None,
         **window_kwargs: int,
     ):
         """
@@ -889,9 +888,7 @@ class DataWithCoords(AttrAccessMixin):
         """
 
         dim = either_dict_or_kwargs(dim, window_kwargs, "rolling")
-        return self._rolling_cls(
-            self, dim, min_periods=min_periods, center=center, keep_attrs=keep_attrs
-        )
+        return self._rolling_cls(self, dim, min_periods=min_periods, center=center)
 
     def rolling_exp(
         self,

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3540,8 +3540,6 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
         self,
         coord: Union[Hashable, Sequence[Hashable]] = None,
         datetime_unit: str = None,
-        *,
-        dim: Union[Hashable, Sequence[Hashable]] = None,
     ) -> "DataArray":
         """Integrate along the given coordinate using the trapezoidal rule.
 
@@ -3552,8 +3550,6 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
         Parameters
         ----------
         coord : hashable, or sequence of hashable
-            Coordinate(s) used for the integration.
-        dim : hashable, or sequence of hashable
             Coordinate(s) used for the integration.
         datetime_unit : {'Y', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns', \
                         'ps', 'fs', 'as'}, optional
@@ -3591,21 +3587,6 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
         array([5.4, 6.6, 7.8])
         Dimensions without coordinates: y
         """
-        if dim is not None and coord is not None:
-            raise ValueError(
-                "Cannot pass both 'dim' and 'coord'. Please pass only 'coord' instead."
-            )
-
-        if dim is not None and coord is None:
-            coord = dim
-            msg = (
-                "The `dim` keyword argument to `DataArray.integrate` is "
-                "being replaced with `coord`, for consistency with "
-                "`Dataset.integrate`. Please pass `coord` instead."
-                " `dim` will be removed in version 0.19.0."
-            )
-            warnings.warn(msg, FutureWarning, stacklevel=2)
-
         ds = self._to_temp_dataset().integrate(coord, datetime_unit)
         return self._from_temp_dataset(ds)
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4157,7 +4157,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
                 result = result._unstack_once(dim, fill_value)
         return result
 
-    def update(self, other: "CoercibleMapping") -> None:
+    def update(self, other: "CoercibleMapping") -> "Dataset":
         """Update this dataset's variables with those from another dataset.
 
         Just like :py:meth:`dict.update` this is a in-place operation.
@@ -4174,6 +4174,14 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
             - mapping {var name: (dimension name, array-like)}
             - mapping {var name: (tuple of dimension names, array-like)}
 
+        Returns
+        -------
+        updated : Dataset
+            Updated dataset. Note that since the update is in-place this is the input
+            dataset.
+
+            It is deprecated since version 0.17 and scheduled to be removed in 0.21.
+
         Raises
         ------
         ValueError
@@ -4186,7 +4194,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         Dataset.merge
         """
         merge_result = dataset_update_method(self, other)
-        self._replace(inplace=True, **merge_result._asdict())
+        return self._replace(inplace=True, **merge_result._asdict())
 
     def merge(
         self,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4157,7 +4157,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
                 result = result._unstack_once(dim, fill_value)
         return result
 
-    def update(self, other: "CoercibleMapping") -> "Dataset":
+    def update(self, other: "CoercibleMapping") -> None:
         """Update this dataset's variables with those from another dataset.
 
         Just like :py:meth:`dict.update` this is a in-place operation.
@@ -4173,14 +4173,6 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
             - mapping {var name: (dimension name, array-like)}
             - mapping {var name: (tuple of dimension names, array-like)}
 
-        Returns
-        -------
-        updated : Dataset
-            Updated dataset. Note that since the update is in-place this is the input
-            dataset.
-
-            It is deprecated since version 0.17 and scheduled to be removed in 0.19.
-
         Raises
         ------
         ValueError
@@ -4192,7 +4184,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         Dataset.assign
         """
         merge_result = dataset_update_method(self, other)
-        return self._replace(inplace=True, **merge_result._asdict())
+        self._replace(inplace=True, **merge_result._asdict())
 
     def merge(
         self,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4161,6 +4161,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         """Update this dataset's variables with those from another dataset.
 
         Just like :py:meth:`dict.update` this is a in-place operation.
+        For a non-inplace version, see :py:meth:`Dataset.merge`.
 
         Parameters
         ----------
@@ -4182,6 +4183,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         See Also
         --------
         Dataset.assign
+        Dataset.merge
         """
         merge_result = dataset_update_method(self, other)
         self._replace(inplace=True, **merge_result._asdict())
@@ -4255,6 +4257,10 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         ------
         MergeError
             If any variables conflict (see ``compat``).
+
+        See Also
+        --------
+        Dataset.update
         """
         other = other.to_dataset() if isinstance(other, xr.DataArray) else other
         merge_result = dataset_merge_method(

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -750,11 +750,10 @@ class Coarsen(CoarsenArithmetic):
         "windows",
         "side",
         "trim_excess",
-        "keep_attrs",
     )
     _attributes = ("windows", "side", "trim_excess")
 
-    def __init__(self, obj, windows, boundary, side, coord_func, keep_attrs):
+    def __init__(self, obj, windows, boundary, side, coord_func):
         """
         Moving window object.
 
@@ -781,17 +780,6 @@ class Coarsen(CoarsenArithmetic):
         self.side = side
         self.boundary = boundary
 
-        if keep_attrs is not None:
-            warnings.warn(
-                "Passing ``keep_attrs`` to ``coarsen`` is deprecated and will raise an"
-                " error in xarray 0.19. Please pass ``keep_attrs`` directly to the"
-                " applied function, i.e. use ``ds.coarsen(...).mean(keep_attrs=False)``"
-                " instead of ``ds.coarsen(..., keep_attrs=False).mean()``"
-                " Note that keep_attrs is now True per default.",
-                FutureWarning,
-            )
-        self.keep_attrs = keep_attrs
-
         absent_dims = [dim for dim in windows.keys() if dim not in self.obj.dims]
         if absent_dims:
             raise ValueError(
@@ -805,15 +793,8 @@ class Coarsen(CoarsenArithmetic):
         self.coord_func = coord_func
 
     def _get_keep_attrs(self, keep_attrs):
-
         if keep_attrs is None:
-            # TODO: uncomment the next line and remove the others after the deprecation
-            # keep_attrs = _get_keep_attrs(default=True)
-
-            if self.keep_attrs is None:
-                keep_attrs = _get_keep_attrs(default=True)
-            else:
-                keep_attrs = self.keep_attrs
+            keep_attrs = _get_keep_attrs(default=True)
 
         return keep_attrs
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -48,10 +48,10 @@ class Rolling:
     xarray.DataArray.rolling
     """
 
-    __slots__ = ("obj", "window", "min_periods", "center", "dim", "keep_attrs")
-    _attributes = ("window", "min_periods", "center", "dim", "keep_attrs")
+    __slots__ = ("obj", "window", "min_periods", "center", "dim")
+    _attributes = ("window", "min_periods", "center", "dim")
 
-    def __init__(self, obj, windows, min_periods=None, center=False, keep_attrs=None):
+    def __init__(self, obj, windows, min_periods=None, center=False):
         """
         Moving window object.
 
@@ -88,15 +88,6 @@ class Rolling:
             raise ValueError("min_periods must be greater than zero or None")
 
         self.min_periods = np.prod(self.window) if min_periods is None else min_periods
-
-        if keep_attrs is not None:
-            warnings.warn(
-                "Passing ``keep_attrs`` to ``rolling`` is deprecated and will raise an"
-                " error in xarray 0.18. Please pass ``keep_attrs`` directly to the"
-                " applied function. Note that keep_attrs is now True per default.",
-                FutureWarning,
-            )
-        self.keep_attrs = keep_attrs
 
     def __repr__(self):
         """provide a nice str repr of our rolling object"""
@@ -188,15 +179,8 @@ class Rolling:
             )
 
     def _get_keep_attrs(self, keep_attrs):
-
         if keep_attrs is None:
-            # TODO: uncomment the next line and remove the others after the deprecation
-            # keep_attrs = _get_keep_attrs(default=True)
-
-            if self.keep_attrs is None:
-                keep_attrs = _get_keep_attrs(default=True)
-            else:
-                keep_attrs = self.keep_attrs
+            keep_attrs = _get_keep_attrs(default=True)
 
         return keep_attrs
 
@@ -204,7 +188,7 @@ class Rolling:
 class DataArrayRolling(Rolling):
     __slots__ = ("window_labels",)
 
-    def __init__(self, obj, windows, min_periods=None, center=False, keep_attrs=None):
+    def __init__(self, obj, windows, min_periods=None, center=False):
         """
         Moving window object for DataArray.
         You should use DataArray.rolling() method to construct this object
@@ -235,9 +219,7 @@ class DataArrayRolling(Rolling):
         xarray.Dataset.rolling
         xarray.Dataset.groupby
         """
-        super().__init__(
-            obj, windows, min_periods=min_periods, center=center, keep_attrs=keep_attrs
-        )
+        super().__init__(obj, windows, min_periods=min_periods, center=center)
 
         # TODO legacy attribute
         self.window_labels = self.obj[self.dim[0]]
@@ -561,7 +543,7 @@ class DataArrayRolling(Rolling):
 class DatasetRolling(Rolling):
     __slots__ = ("rollings",)
 
-    def __init__(self, obj, windows, min_periods=None, center=False, keep_attrs=None):
+    def __init__(self, obj, windows, min_periods=None, center=False):
         """
         Moving window object for Dataset.
         You should use Dataset.rolling() method to construct this object
@@ -592,7 +574,7 @@ class DatasetRolling(Rolling):
         xarray.Dataset.groupby
         xarray.DataArray.groupby
         """
-        super().__init__(obj, windows, min_periods, center, keep_attrs)
+        super().__init__(obj, windows, min_periods, center)
         if any(d not in self.obj.dims for d in self.dim):
             raise KeyError(self.dim)
         # Keep each Rolling object as a dictionary

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -116,14 +116,9 @@ def as_variable(obj, name=None) -> "Union[Variable, IndexVariable]":
         obj = obj.copy(deep=False)
     elif isinstance(obj, tuple):
         if isinstance(obj[1], DataArray):
-            # TODO: change into TypeError
-            warnings.warn(
-                (
-                    "Using a DataArray object to construct a variable is"
-                    " ambiguous, please extract the data using the .data property."
-                    " This will raise a TypeError in 0.19.0."
-                ),
-                DeprecationWarning,
+            raise TypeError(
+                "Using a DataArray object to construct a variable is"
+                " ambiguous, please extract the data using the .data property."
             )
         try:
             obj = Variable(*obj)

--- a/xarray/tests/test_coarsen.py
+++ b/xarray/tests/test_coarsen.py
@@ -153,39 +153,6 @@ def test_coarsen_keep_attrs(funcname, argument):
     assert result.da_not_coarsend.name == "da_not_coarsend"
 
 
-def test_coarsen_keep_attrs_deprecated():
-    global_attrs = {"units": "test", "long_name": "testing"}
-    attrs_da = {"da_attr": "test"}
-
-    data = np.linspace(10, 15, 100)
-    coords = np.linspace(1, 10, 100)
-
-    ds = Dataset(
-        data_vars={"da": ("coord", data)},
-        coords={"coord": coords},
-        attrs=global_attrs,
-    )
-    ds.da.attrs = attrs_da
-
-    # deprecated option
-    with pytest.warns(
-        FutureWarning, match="Passing ``keep_attrs`` to ``coarsen`` is deprecated"
-    ):
-        result = ds.coarsen(dim={"coord": 5}, keep_attrs=False).mean()
-
-    assert result.attrs == {}
-    assert result.da.attrs == {}
-
-    # the keep_attrs in the reduction function takes precedence
-    with pytest.warns(
-        FutureWarning, match="Passing ``keep_attrs`` to ``coarsen`` is deprecated"
-    ):
-        result = ds.coarsen(dim={"coord": 5}, keep_attrs=True).mean(keep_attrs=False)
-
-    assert result.attrs == {}
-    assert result.da.attrs == {}
-
-
 @pytest.mark.slow
 @pytest.mark.parametrize("ds", (1, 2), indirect=True)
 @pytest.mark.parametrize("window", (1, 2, 3, 4))
@@ -265,31 +232,6 @@ def test_coarsen_da_keep_attrs(funcname, argument):
     assert result.attrs == {}
     da.coord.attrs == {}
     assert result.name == "name"
-
-
-def test_coarsen_da_keep_attrs_deprecated():
-    attrs_da = {"da_attr": "test"}
-
-    data = np.linspace(10, 15, 100)
-    coords = np.linspace(1, 10, 100)
-
-    da = DataArray(data, dims=("coord"), coords={"coord": coords}, attrs=attrs_da)
-
-    # deprecated option
-    with pytest.warns(
-        FutureWarning, match="Passing ``keep_attrs`` to ``coarsen`` is deprecated"
-    ):
-        result = da.coarsen(dim={"coord": 5}, keep_attrs=False).mean()
-
-    assert result.attrs == {}
-
-    # the keep_attrs in the reduction function takes precedence
-    with pytest.warns(
-        FutureWarning, match="Passing ``keep_attrs`` to ``coarsen`` is deprecated"
-    ):
-        result = da.coarsen(dim={"coord": 5}, keep_attrs=True).mean(keep_attrs=False)
-
-    assert result.attrs == {}
 
 
 @pytest.mark.parametrize("da", (1, 2), indirect=True)

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1619,7 +1619,7 @@ def test_more_transforms_pass_lazy_array_equiv(map_da, map_ds):
         assert_equal(xr.broadcast(map_ds.cxy, map_ds.cxy)[0], map_ds.cxy)
         assert_equal(map_ds.map(lambda x: x), map_ds)
         assert_equal(map_ds.set_coords("a").reset_coords("a"), map_ds)
-        assert_equal(map_ds.update({"a": map_ds.a}), map_ds)
+        assert_equal(map_ds.assign({"a": map_ds.a}), map_ds)
 
         # fails because of index error
         # assert_equal(

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6865,33 +6865,6 @@ def test_rolling_keep_attrs(funcname, argument):
     assert result.name == "name"
 
 
-def test_rolling_keep_attrs_deprecated():
-    attrs_da = {"da_attr": "test"}
-
-    data = np.linspace(10, 15, 100)
-    coords = np.linspace(1, 10, 100)
-
-    da = DataArray(data, dims=("coord"), coords={"coord": coords}, attrs=attrs_da)
-
-    # deprecated option
-    with pytest.warns(
-        FutureWarning, match="Passing ``keep_attrs`` to ``rolling`` is deprecated"
-    ):
-        result = da.rolling(dim={"coord": 5}, keep_attrs=False).construct("window_dim")
-
-    assert result.attrs == {}
-
-    # the keep_attrs in the reduction function takes precedence
-    with pytest.warns(
-        FutureWarning, match="Passing ``keep_attrs`` to ``rolling`` is deprecated"
-    ):
-        result = da.rolling(dim={"coord": 5}, keep_attrs=True).construct(
-            "window_dim", keep_attrs=False
-        )
-
-    assert result.attrs == {}
-
-
 def test_raise_no_warning_for_nan_in_binary_ops():
     with pytest.warns(None) as record:
         xr.DataArray([1, 2, np.NaN]) > 0

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6580,9 +6580,6 @@ def test_integrate(dask):
     with pytest.raises(ValueError):
         da.integrate("x2d")
 
-    with pytest.warns(FutureWarning):
-        da.integrate(dim="x")
-
 
 @requires_scipy
 @pytest.mark.parametrize("dask", [True, False])

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6100,41 +6100,6 @@ def test_rolling_keep_attrs(funcname, argument):
     assert result.da_not_rolled.name == "da_not_rolled"
 
 
-def test_rolling_keep_attrs_deprecated():
-    global_attrs = {"units": "test", "long_name": "testing"}
-    attrs_da = {"da_attr": "test"}
-
-    data = np.linspace(10, 15, 100)
-    coords = np.linspace(1, 10, 100)
-
-    ds = Dataset(
-        data_vars={"da": ("coord", data)},
-        coords={"coord": coords},
-        attrs=global_attrs,
-    )
-    ds.da.attrs = attrs_da
-
-    # deprecated option
-    with pytest.warns(
-        FutureWarning, match="Passing ``keep_attrs`` to ``rolling`` is deprecated"
-    ):
-        result = ds.rolling(dim={"coord": 5}, keep_attrs=False).construct("window_dim")
-
-    assert result.attrs == {}
-    assert result.da.attrs == {}
-
-    # the keep_attrs in the reduction function takes precedence
-    with pytest.warns(
-        FutureWarning, match="Passing ``keep_attrs`` to ``rolling`` is deprecated"
-    ):
-        result = ds.rolling(dim={"coord": 5}, keep_attrs=True).construct(
-            "window_dim", keep_attrs=False
-        )
-
-    assert result.attrs == {}
-    assert result.da.attrs == {}
-
-
 def test_rolling_properties(ds):
     # catching invalid args
     with pytest.raises(ValueError, match="window must be > 0"):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3191,13 +3191,13 @@ class TestDataset:
         data = create_test_data(seed=0)
         expected = data.copy()
         var2 = Variable("dim1", np.arange(8))
-        actual = data.update({"var2": var2})
+        actual = data
+        actual.update({"var2": var2})
         expected["var2"] = var2
         assert_identical(expected, actual)
 
         actual = data.copy()
-        actual_result = actual.update(data)
-        assert actual_result is actual
+        actual.update(data)
         assert_identical(expected, actual)
 
         other = Dataset(attrs={"new": "attr"})

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1160,7 +1160,7 @@ class TestVariable(VariableSubclassobjects):
         td = np.array([timedelta(days=x) for x in range(10)])
         assert as_variable(td, "time").dtype.kind == "m"
 
-        with pytest.warns(DeprecationWarning):
+        with pytest.raises(TypeError):
             as_variable(("x", DataArray([])))
 
     def test_repr(self):


### PR DESCRIPTION
As discussed in the meeting yesterday, here's the PR for the scheduled deprecations. We also have quite a few deprecations which are not scheduled... we should check which of them can be removed / completed, but that can wait until after the release.

I tried to keep the changes for each individual deprecation in their own commit, which should make rolling back easier in case we decide removing / completing a specific deprecation is too aggressive.

`whats-new.rst` still needs to be updated, but I'll leave that until after the code changes have been approved.

- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
