### PR TITLE
Refactor index vs. coordinate variable(s)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -43,6 +43,9 @@ Documentation
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Explicit indexes refactor: decouple ``xarray.Index`` from ``xarray.Variable`` (:pull:`5636`).
+  By `Benoit Bovy <https://github.com/benbovy>`_.
+
 .. _whats-new.0.19.0:
 
 v0.19.0 (23 July 2021)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -43,7 +43,9 @@ Documentation
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
-- Explicit indexes refactor: decouple ``xarray.Index`` from ``xarray.Variable`` (:pull:`5636`).
+- Explicit indexes refactor: avoid ``len(index)`` in ``map_blocks`` (:pull:`5670`).
+  By `Deepak Cherian <https://github.com/dcherian`_.
+- Explicit indexes refactor: decouple ``xarray.Index``` from ``xarray.Variable`` (:pull:`5636`).
   By `Benoit Bovy <https://github.com/benbovy>`_.
 - Improve the performance of reprs for large datasets or dataarrays. (:pull:`5661`)
   By `Jimmy Westling <https://github.com/illviljan>`_.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -44,7 +44,7 @@ Internal Changes
 ~~~~~~~~~~~~~~~~
 
 - Explicit indexes refactor: avoid ``len(index)`` in ``map_blocks`` (:pull:`5670`).
-  By `Deepak Cherian <https://github.com/dcherian`_.
+  By `Deepak Cherian <https://github.com/dcherian>`_.
 - Explicit indexes refactor: decouple ``xarray.Index``` from ``xarray.Variable`` (:pull:`5636`).
   By `Benoit Bovy <https://github.com/benbovy>`_.
 - Improve the performance of reprs for large datasets or dataarrays. (:pull:`5661`)

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -18,7 +18,7 @@ import numpy as np
 import pandas as pd
 
 from . import dtypes
-from .indexes import Index, PandasIndex, get_indexer_nd, wrap_pandas_index
+from .indexes import Index, PandasIndex, get_indexer_nd
 from .utils import is_dict_like, is_full_slice, maybe_coerce_to_str, safe_cast_to_index
 from .variable import IndexVariable, Variable
 
@@ -53,7 +53,10 @@ def _get_joiner(join, index_cls):
 def _override_indexes(objects, all_indexes, exclude):
     for dim, dim_indexes in all_indexes.items():
         if dim not in exclude:
-            lengths = {index.size for index in dim_indexes}
+            lengths = {
+                getattr(index, "size", index.to_pandas_index().size)
+                for index in dim_indexes
+            }
             if len(lengths) != 1:
                 raise ValueError(
                     f"Indexes along dimension {dim!r} don't have the same length."
@@ -300,11 +303,12 @@ def align(
     joined_indexes = {}
     for dim, matching_indexes in all_indexes.items():
         if dim in indexes:
-            # TODO: benbovy - flexible indexes. maybe move this logic in util func
             if isinstance(indexes[dim], Index):
                 index = indexes[dim]
             else:
-                index = PandasIndex(safe_cast_to_index(indexes[dim]))
+                index, _ = PandasIndex.from_pandas_index(
+                    safe_cast_to_index(indexes[dim]), dim
+                )
             if (
                 any(not index.equals(other) for other in matching_indexes)
                 or dim in unlabeled_dim_sizes
@@ -323,17 +327,18 @@ def align(
                 joiner = _get_joiner(join, type(matching_indexes[0]))
                 index = joiner(matching_indexes)
                 # make sure str coords are not cast to object
-                index = maybe_coerce_to_str(index, all_coords[dim])
+                index = maybe_coerce_to_str(index.to_pandas_index(), all_coords[dim])
                 joined_indexes[dim] = index
             else:
                 index = all_coords[dim][0]
 
         if dim in unlabeled_dim_sizes:
             unlabeled_sizes = unlabeled_dim_sizes[dim]
-            # TODO: benbovy - flexible indexes: expose a size property for xarray.Index?
-            # Some indexes may not have a defined size (e.g., built from multiple coords of
-            # different sizes)
-            labeled_size = index.size
+            # TODO: benbovy - flexible indexes: https://github.com/pydata/xarray/issues/5647
+            if isinstance(index, PandasIndex):
+                labeled_size = index.to_pandas_index().size
+            else:
+                labeled_size = index.size
             if len(unlabeled_sizes | {labeled_size}) > 1:
                 raise ValueError(
                     f"arguments without labels along dimension {dim!r} cannot be "
@@ -350,7 +355,14 @@ def align(
 
     result = []
     for obj in objects:
-        valid_indexers = {k: v for k, v in joined_indexes.items() if k in obj.dims}
+        # TODO: benbovy - flexible indexes: https://github.com/pydata/xarray/issues/5647
+        valid_indexers = {}
+        for k, index in joined_indexes.items():
+            if k in obj.dims:
+                if isinstance(index, Index):
+                    valid_indexers[k] = index.to_pandas_index()
+                else:
+                    valid_indexers[k] = index
         if not valid_indexers:
             # fast path for no reindexing necessary
             new_obj = obj.copy(deep=copy)
@@ -471,7 +483,11 @@ def reindex_like_indexers(
     ValueError
         If any dimensions without labels have different sizes.
     """
-    indexers = {k: v for k, v in other.xindexes.items() if k in target.dims}
+    # TODO: benbovy - flexible indexes: https://github.com/pydata/xarray/issues/5647
+    # this doesn't support yet indexes other than pd.Index
+    indexers = {
+        k: v.to_pandas_index() for k, v in other.xindexes.items() if k in target.dims
+    }
 
     for dim in other.dims:
         if dim not in indexers and dim in target.dims:
@@ -560,7 +576,8 @@ def reindex_variables(
                 "from that to be indexed along {:s}".format(str(indexer.dims), dim)
             )
 
-        target = new_indexes[dim] = wrap_pandas_index(safe_cast_to_index(indexers[dim]))
+        target = safe_cast_to_index(indexers[dim])
+        new_indexes[dim] = PandasIndex(target, dim)
 
         if dim in indexes:
             # TODO (benbovy - flexible indexes): support other indexes than pd.Index?

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -303,17 +303,14 @@ def align(
     joined_indexes = {}
     for dim, matching_indexes in all_indexes.items():
         if dim in indexes:
-            if isinstance(indexes[dim], Index):
-                index = indexes[dim]
-            else:
-                index, _ = PandasIndex.from_pandas_index(
-                    safe_cast_to_index(indexes[dim]), dim
-                )
+            index, _ = PandasIndex.from_pandas_index(
+                safe_cast_to_index(indexes[dim]), dim
+            )
             if (
                 any(not index.equals(other) for other in matching_indexes)
                 or dim in unlabeled_dim_sizes
             ):
-                joined_indexes[dim] = index
+                joined_indexes[dim] = indexes[dim]
         else:
             if (
                 any(

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -77,9 +77,8 @@ def _infer_concat_order_from_coords(datasets):
                     "inferring concatenation order"
                 )
 
-            # TODO (benbovy, flexible indexes): all indexes should be Pandas.Index
-            # get pd.Index objects from Index objects
-            indexes = [index.array for index in indexes]
+            # TODO (benbovy, flexible indexes): support flexible indexes?
+            indexes = [index.to_pandas_index() for index in indexes]
 
             # If dimension coordinate values are same on every dataset then
             # should be leaving this dimension alone (it's just a "bystander")

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -62,6 +62,13 @@ class Index:
     def intersection(self, other):  # pragma: no cover
         raise NotImplementedError()
 
+    def copy(self, deep: bool = True):  # pragma: no cover
+        raise NotImplementedError()
+
+    def __getitem__(self, indexer: Any):
+        # if not implemented, index will be dropped from the Dataset or DataArray
+        raise NotImplementedError()
+
 
 def _sanitize_slice_element(x):
     from .dataarray import DataArray
@@ -249,6 +256,12 @@ class PandasIndex(Index):
         new_index = self.index.intersection(other)
 
         return type(self).from_pandas_index(new_index, self.dim)
+
+    def copy(self, deep=True):
+        return type(self)(self.index.copy(deep=deep), self.dim)
+
+    def __getitem__(self, indexer: Any):
+        return type(self)(self.index[indexer], self.dim)
 
 
 def _create_variables_from_multiindex(index, dim, level_meta=None):

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -19,7 +19,6 @@ from . import formatting, utils
 from .indexing import (
     LazilyIndexedArray,
     PandasIndexingAdapter,
-    PandasLevelIndexingAdapter,
     PandasMultiIndexingAdapter,
 )
 from .utils import is_dict_like, is_scalar
@@ -240,13 +239,17 @@ class PandasMultiIndex(PandasIndex):
             [var.values for var in variables.values()], names=variables.keys()
         )
 
-        mindex_adapter = PandasMultiIndexingAdapter(self.index)
-        dim_var = IndexVariable(dim, LazilyIndexedArray(mindex_adapter), fastpath=True)
+        dim_coord_adapter = PandasMultiIndexingAdapter(self.index)
+        dim_var = IndexVariable(
+            dim, LazilyIndexedArray(dim_coord_adapter), fastpath=True
+        )
 
         self.coords = {dim: dim_var}
 
         for name, var in variables.items():
-            data = PandasLevelIndexingAdapter(mindex_adapter, name, var.dtype)
+            data = PandasMultiIndexingAdapter(
+                self.index, dtype=var.dtype, level=name, adapter=dim_coord_adapter
+            )
             self.coords[name] = IndexVariable(
                 dim, LazilyIndexedArray(data), fastpath=True
             )

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -2,12 +2,15 @@ import enum
 import functools
 import operator
 from collections import defaultdict
+from contextlib import suppress
+from datetime import timedelta
 from typing import Any, Callable, Iterable, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
 
 from . import duck_array_ops, nputils, utils
+from .npcompat import DTypeLike
 from .pycompat import (
     dask_array_type,
     dask_version,
@@ -1259,3 +1262,147 @@ class DaskIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
 
     def transpose(self, order):
         return self.array.transpose(order)
+
+
+class PandasIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
+    """Wrap a pandas.Index to preserve dtypes and handle explicit indexing."""
+
+    __slots__ = ("array", "_dtype")
+
+    def __init__(self, array: pd.Index, dtype: DTypeLike = None):
+        self.array = array
+
+        if dtype is None:
+            if isinstance(array, pd.PeriodIndex):
+                dtype_ = np.dtype("O")
+            elif hasattr(array, "categories"):
+                # category isn't a real numpy dtype
+                dtype_ = array.categories.dtype
+            elif not utils.is_valid_numpy_dtype(array.dtype):
+                dtype_ = np.dtype("O")
+            else:
+                dtype_ = array.dtype
+        else:
+            dtype_ = np.dtype(dtype)  # type: ignore[assignment]
+        self._dtype = dtype_
+
+    @property
+    def dtype(self) -> np.dtype:
+        return self._dtype
+
+    def __array__(self, dtype: DTypeLike = None) -> np.ndarray:
+        if dtype is None:
+            dtype = self.dtype
+        array = self.array
+        if isinstance(array, pd.PeriodIndex):
+            with suppress(AttributeError):
+                # this might not be public API
+                array = array.astype("object")
+        return np.asarray(array.values, dtype=dtype)
+
+    @property
+    def shape(self) -> Tuple[int]:
+        return (len(self.array),)
+
+    def __getitem__(
+        self, indexer
+    ) -> Union[
+        "PandasIndexingAdapter",
+        NumpyIndexingAdapter,
+        np.ndarray,
+        np.datetime64,
+        np.timedelta64,
+    ]:
+        key = indexer.tuple
+        if isinstance(key, tuple) and len(key) == 1:
+            # unpack key so it can index a pandas.Index object (pandas.Index
+            # objects don't like tuples)
+            (key,) = key
+
+        if getattr(key, "ndim", 0) > 1:  # Return np-array if multidimensional
+            return NumpyIndexingAdapter(self.array.values)[indexer]
+
+        result = self.array[key]
+
+        if isinstance(result, pd.Index):
+            result = type(self)(result, dtype=self.dtype)
+        else:
+            # result is a scalar
+            if result is pd.NaT:
+                # work around the impossibility of casting NaT with asarray
+                # note: it probably would be better in general to return
+                # pd.Timestamp rather np.than datetime64 but this is easier
+                # (for now)
+                result = np.datetime64("NaT", "ns")
+            elif isinstance(result, timedelta):
+                result = np.timedelta64(getattr(result, "value", result), "ns")
+            elif isinstance(result, pd.Timestamp):
+                # Work around for GH: pydata/xarray#1932 and numpy/numpy#10668
+                # numpy fails to convert pd.Timestamp to np.datetime64[ns]
+                result = np.asarray(result.to_datetime64())
+            elif self.dtype != object:
+                result = np.asarray(result, dtype=self.dtype)
+
+            # as for numpy.ndarray indexing, we always want the result to be
+            # a NumPy array.
+            result = utils.to_0d_array(result)
+
+        return result
+
+    def transpose(self, order) -> pd.Index:
+        return self.array  # self.array should be always one-dimensional
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(array={self.array!r}, dtype={self.dtype!r})"
+
+    def copy(self, deep: bool = True) -> "PandasIndexingAdapter":
+        # Not the same as just writing `self.array.copy(deep=deep)`, as
+        # shallow copies of the underlying numpy.ndarrays become deep ones
+        # upon pickling
+        # >>> len(pickle.dumps((self.array, self.array)))
+        # 4000281
+        # >>> len(pickle.dumps((self.array, self.array.copy(deep=False))))
+        # 8000341
+        array = self.array.copy(deep=True) if deep else self.array
+        return type(self)(array, self._dtype)
+
+
+class PandasMultiIndexingAdapter(PandasIndexingAdapter):
+    @functools.lru_cache(1)
+    def __getitem__(self, indexer):
+        return super().__getitem__(indexer)
+
+
+class PandasLevelIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
+    """Handles explicit indexing for a pandas.MultiIndex level."""
+
+    __slots__ = ("mindex_adapter", "array", "level", "_dtype")
+
+    def __init__(
+        self, mindex_adapter: PandasMultiIndexingAdapter, level: str, dtype: DTypeLike
+    ):
+        self.mindex_adapter = mindex_adapter
+        self.array = mindex_adapter.array
+        self.level = level
+        self._dtype = np.dtype(dtype)
+
+    @property
+    def dtype(self) -> np.dtype:
+        return self._dtype
+
+    def __array__(self, dtype: DTypeLike = None) -> np.ndarray:
+        return self.array.get_level_values(self.level).values
+
+    @property
+    def shape(self) -> Tuple[int]:
+        return (len(self.array),)
+
+    def __getitem__(self, indexer):
+        return self.mindex_adapter[indexer]
+
+    def transpose(self, order) -> pd.Index:
+        return self.array  # self.array should be always one-dimensional
+
+    def __repr__(self) -> str:
+        props = "(array={self.array!r}, level={self.level!r}, dtype={self.dtype!r})"
+        return f"{type(self).__name__}{props}"

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -572,9 +572,7 @@ def as_indexable(array):
     if isinstance(array, np.ndarray):
         return NumpyIndexingAdapter(array)
     if isinstance(array, pd.Index):
-        from .indexes import PandasIndex
-
-        return PandasIndex(array)
+        return PandasIndexingAdapter(array)
     if isinstance(array, dask_array_type):
         return DaskIndexingAdapter(array)
     if hasattr(array, "__array_function__"):
@@ -1270,7 +1268,7 @@ class PandasIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
     __slots__ = ("array", "_dtype")
 
     def __init__(self, array: pd.Index, dtype: DTypeLike = None):
-        self.array = array
+        self.array = utils.safe_cast_to_index(array)
 
         if dtype is None:
             if isinstance(array, pd.PeriodIndex):

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -291,7 +291,7 @@ def map_blocks(
             )
 
         # check that index lengths and values are as expected
-        for name, index in result.xindexes.items():
+        for name, index in result.indexes.items():
             if name in expected["shapes"]:
                 if len(index) != expected["shapes"][name]:
                     raise ValueError(
@@ -357,20 +357,20 @@ def map_blocks(
 
     # check that chunk sizes are compatible
     input_chunks = dict(npargs[0].chunks)
-    input_indexes = dict(npargs[0].xindexes)
+    input_indexes = dict(npargs[0].indexes)
     for arg in xarray_objs[1:]:
         assert_chunks_compatible(npargs[0], arg)
         input_chunks.update(arg.chunks)
-        input_indexes.update(arg.xindexes)
+        input_indexes.update(arg.indexes)
 
     if template is None:
         # infer template by providing zero-shaped arrays
         template = infer_template(func, aligned[0], *args, **kwargs)
-        template_indexes = set(template.xindexes)
+        template_indexes = set(template.indexes)
         preserved_indexes = template_indexes & set(input_indexes)
         new_indexes = template_indexes - set(input_indexes)
         indexes = {dim: input_indexes[dim] for dim in preserved_indexes}
-        indexes.update({k: template.xindexes[k] for k in new_indexes})
+        indexes.update({k: template.indexes[k] for k in new_indexes})
         output_chunks = {
             dim: input_chunks[dim] for dim in template.dims if dim in input_chunks
         }
@@ -550,7 +550,7 @@ def map_blocks(
     )
 
     result = Dataset(coords=indexes, attrs=template.attrs)
-    for index in result.xindexes:
+    for index in result.indexes:
         result[index].attrs = template[index].attrs
         result[index].encoding = template[index].encoding
 

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -291,7 +291,7 @@ def map_blocks(
             )
 
         # check that index lengths and values are as expected
-        for name, index in result.indexes.items():
+        for name, index in result.xindexes.items():
             if name in expected["shapes"]:
                 if result.sizes[name] != expected["shapes"][name]:
                     raise ValueError(
@@ -358,27 +358,27 @@ def map_blocks(
 
     # check that chunk sizes are compatible
     input_chunks = dict(npargs[0].chunks)
-    input_indexes = dict(npargs[0].indexes)
+    input_indexes = dict(npargs[0].xindexes)
     for arg in xarray_objs[1:]:
         assert_chunks_compatible(npargs[0], arg)
         input_chunks.update(arg.chunks)
-        input_indexes.update(arg.indexes)
+        input_indexes.update(arg.xindexes)
 
     if template is None:
         # infer template by providing zero-shaped arrays
         template = infer_template(func, aligned[0], *args, **kwargs)
-        template_indexes = set(template.indexes)
+        template_indexes = set(template.xindexes)
         preserved_indexes = template_indexes & set(input_indexes)
         new_indexes = template_indexes - set(input_indexes)
         indexes = {dim: input_indexes[dim] for dim in preserved_indexes}
-        indexes.update({k: template.indexes[k] for k in new_indexes})
+        indexes.update({k: template.xindexes[k] for k in new_indexes})
         output_chunks = {
             dim: input_chunks[dim] for dim in template.dims if dim in input_chunks
         }
 
     else:
         # template xarray object has been provided with proper sizes and chunk shapes
-        indexes = dict(template.indexes)
+        indexes = dict(template.xindexes)
         if isinstance(template, DataArray):
             output_chunks = dict(
                 zip(template.dims, template.chunks)  # type: ignore[arg-type]
@@ -550,8 +550,14 @@ def map_blocks(
         },
     )
 
-    result = Dataset(coords=indexes, attrs=template.attrs)
-    for index in result.indexes:
+    # TODO: benbovy - flexible indexes: make it work with custom indexes
+    # this will need to pass both indexes and coords to the Dataset constructor
+    result = Dataset(
+        coords={k: idx.to_pandas_index() for k, idx in indexes.items()},
+        attrs=template.attrs,
+    )
+
+    for index in result.xindexes:
         result[index].attrs = template[index].attrs
         result[index].encoding = template[index].encoding
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -25,8 +25,14 @@ import xarray as xr  # only for Dataset and DataArray
 from . import common, dtypes, duck_array_ops, indexing, nputils, ops, utils
 from .arithmetic import VariableArithmetic
 from .common import AbstractArray
-from .indexes import PandasIndex, wrap_pandas_index
-from .indexing import BasicIndexer, OuterIndexer, VectorizedIndexer, as_indexable
+from .indexes import PandasIndex, PandasMultiIndex
+from .indexing import (
+    BasicIndexer,
+    OuterIndexer,
+    PandasIndexingAdapter,
+    VectorizedIndexer,
+    as_indexable,
+)
 from .options import _get_keep_attrs
 from .pycompat import (
     DuckArrayModule,
@@ -170,11 +176,11 @@ def _maybe_wrap_data(data):
     Put pandas.Index and numpy.ndarray arguments in adapter objects to ensure
     they can be indexed properly.
 
-    NumpyArrayAdapter, PandasIndex and LazilyIndexedArray should
+    NumpyArrayAdapter, PandasIndexingAdapter and LazilyIndexedArray should
     all pass through unmodified.
     """
     if isinstance(data, pd.Index):
-        return wrap_pandas_index(data)
+        return PandasIndexingAdapter(data)
     return data
 
 
@@ -331,7 +337,9 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
 
     @property
     def _in_memory(self):
-        return isinstance(self._data, (np.ndarray, np.number, PandasIndex)) or (
+        return isinstance(
+            self._data, (np.ndarray, np.number, PandasIndexingAdapter)
+        ) or (
             isinstance(self._data, indexing.MemoryCachedArray)
             and isinstance(self._data.array, indexing.NumpyIndexingAdapter)
         )
@@ -539,7 +547,14 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
     def _to_xindex(self):
         # temporary function used internally as a replacement of to_index()
         # returns an xarray Index instance instead of a pd.Index instance
-        return wrap_pandas_index(self.to_index())
+        index_var = self.to_index_variable()
+        index = index_var.to_index()
+        dim = index_var.dims[0]
+
+        if isinstance(index, pd.MultiIndex):
+            return PandasMultiIndex(index, dim)
+        else:
+            return PandasIndex(index, dim)
 
     def to_index(self):
         """Convert this variable to a pandas.Index"""
@@ -2571,8 +2586,8 @@ class IndexVariable(Variable):
             raise ValueError(f"{type(self).__name__} objects must be 1-dimensional")
 
         # Unlike in Variable, always eagerly load values into memory
-        if not isinstance(self._data, PandasIndex):
-            self._data = PandasIndex(self._data)
+        if not isinstance(self._data, PandasIndexingAdapter):
+            self._data = PandasIndexingAdapter(self._data)
 
     def __dask_tokenize__(self):
         from dask.base import normalize_token
@@ -2907,7 +2922,7 @@ def assert_unique_multiindex_level_names(variables):
     level_names = defaultdict(list)
     all_level_names = set()
     for var_name, var in variables.items():
-        if isinstance(var._data, PandasIndex):
+        if isinstance(var._data, PandasIndexingAdapter):
             idx_level_names = var.to_index_variable().level_names
             if idx_level_names is not None:
                 for n in idx_level_names:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -42,7 +42,7 @@ from xarray.backends.pydap_ import PydapDataStore
 from xarray.backends.scipy_ import ScipyBackendEntrypoint
 from xarray.coding.variables import SerializationWarning
 from xarray.conventions import encode_dataset_coordinates
-from xarray.core import indexes, indexing
+from xarray.core import indexing
 from xarray.core.options import set_options
 from xarray.core.pycompat import dask_array_type
 from xarray.tests import LooseVersion, mock
@@ -738,7 +738,7 @@ class DatasetIOBase:
                     elif isinstance(obj.array, dask_array_type):
                         assert isinstance(obj, indexing.DaskIndexingAdapter)
                     elif isinstance(obj.array, pd.Index):
-                        assert isinstance(obj, indexes.PandasIndex)
+                        assert isinstance(obj, indexing.PandasIndexingAdapter)
                     else:
                         raise TypeError(
                             "{} is wrapped by {}".format(type(obj.array), type(obj))

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1475,7 +1475,7 @@ class TestDataArray:
     def test_set_coords_update_index(self):
         actual = DataArray([1, 2, 3], [("x", [1, 2, 3])])
         actual.coords["x"] = ["a", "b", "c"]
-        assert actual.xindexes["x"].equals(pd.Index(["a", "b", "c"]))
+        assert actual.xindexes["x"].to_pandas_index().equals(pd.Index(["a", "b", "c"]))
 
     def test_coords_replacement_alignment(self):
         # regression test for GH725

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -150,7 +150,9 @@ class TestDataArray:
     def test_indexes(self):
         array = DataArray(np.zeros((2, 3)), [("x", [0, 1]), ("y", ["a", "b", "c"])])
         expected_indexes = {"x": pd.Index([0, 1]), "y": pd.Index(["a", "b", "c"])}
-        expected_xindexes = {k: PandasIndex(idx) for k, idx in expected_indexes.items()}
+        expected_xindexes = {
+            k: PandasIndex(idx, k) for k, idx in expected_indexes.items()
+        }
         assert array.xindexes.keys() == expected_xindexes.keys()
         assert array.indexes.keys() == expected_indexes.keys()
         assert all([isinstance(idx, pd.Index) for idx in array.indexes.values()])
@@ -1637,15 +1639,6 @@ class TestDataArray:
             DataArray(np.array(1), coords=[("x", np.arange(10))])
 
     def test_swap_dims(self):
-        array = DataArray(np.random.randn(3), {"y": ("x", list("abc"))}, "x")
-        expected = DataArray(array.values, {"y": list("abc")}, dims="y")
-        actual = array.swap_dims({"x": "y"})
-        assert_identical(expected, actual)
-        for dim_name in set().union(expected.xindexes.keys(), actual.xindexes.keys()):
-            pd.testing.assert_index_equal(
-                expected.xindexes[dim_name].array, actual.xindexes[dim_name].array
-            )
-
         array = DataArray(np.random.randn(3), {"x": list("abc")}, "x")
         expected = DataArray(array.values, {"x": ("y", list("abc"))}, dims="y")
         actual = array.swap_dims({"x": "y"})

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -730,7 +730,7 @@ class TestDataset:
     def test_update_index(self):
         actual = Dataset(coords={"x": [1, 2, 3]})
         actual["x"] = ["a", "b", "c"]
-        assert actual.xindexes["x"].equals(pd.Index(["a", "b", "c"]))
+        assert actual.xindexes["x"].to_pandas_index().equals(pd.Index(["a", "b", "c"]))
 
     def test_coords_setitem_with_new_dimension(self):
         actual = Dataset()
@@ -3559,6 +3559,7 @@ class TestDataset:
     def test_setitem_str_dtype(self, dtype):
 
         ds = xr.Dataset(coords={"x": np.array(["x", "y"], dtype=dtype)})
+        # test Dataset update
         ds["foo"] = xr.DataArray(np.array([0, 0]), dims=["x"])
 
         assert np.issubdtype(ds.x.dtype, dtype)

--- a/xarray/tests/test_indexes.py
+++ b/xarray/tests/test_indexes.py
@@ -2,7 +2,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import xarray as xr
 from xarray.core.indexes import PandasIndex, PandasMultiIndex, _asarray_tuplesafe
+from xarray.core.variable import IndexVariable
 
 
 def test_asarray_tuplesafe():
@@ -18,6 +20,54 @@ def test_asarray_tuplesafe():
 
 
 class TestPandasIndex:
+    def test_constructor(self):
+        pd_idx = pd.Index([1, 2, 3])
+        index = PandasIndex(pd_idx, "x")
+
+        assert index.index is pd_idx
+        assert index.dim == "x"
+
+    def test_from_variables(self):
+        var = xr.Variable(
+            "x", [1, 2, 3], attrs={"unit": "m"}, encoding={"dtype": np.int32}
+        )
+
+        index, index_vars = PandasIndex.from_variables({"x": var})
+        xr.testing.assert_identical(var.to_index_variable(), index_vars["x"])
+        assert index.dim == "x"
+        assert index.index.equals(index_vars["x"].to_index())
+
+        var2 = xr.Variable(("x", "y"), [[1, 2, 3], [4, 5, 6]])
+        with pytest.raises(ValueError, match=r".*only accepts one variable.*"):
+            PandasIndex.from_variables({"x": var, "foo": var2})
+
+        with pytest.raises(
+            ValueError, match=r".*only accepts a 1-dimensional variable.*"
+        ):
+            PandasIndex.from_variables({"foo": var2})
+
+    def test_from_pandas_index(self):
+        pd_idx = pd.Index([1, 2, 3], name="foo")
+
+        index, index_vars = PandasIndex.from_pandas_index(pd_idx, "x")
+
+        assert index.dim == "x"
+        assert index.index is pd_idx
+        assert index.index.name == "foo"
+        xr.testing.assert_identical(index_vars["foo"], IndexVariable("x", [1, 2, 3]))
+
+        # test no name set for pd.Index
+        pd_idx.name = None
+        index, index_vars = PandasIndex.from_pandas_index(pd_idx, "x")
+        assert "x" in index_vars
+        assert index.index is not pd_idx
+        assert index.index.name == "x"
+
+    def to_pandas_index(self):
+        pd_idx = pd.Index([1, 2, 3], name="foo")
+        index = PandasIndex(pd_idx, "x")
+        assert index.to_pandas_index() is pd_idx
+
     def test_query(self):
         # TODO: add tests that aren't just for edge cases
         index = PandasIndex(pd.Index([1, 2, 3]), "x")
@@ -47,8 +97,86 @@ class TestPandasIndex:
             # slice is always a view.
             index.query({"x": slice("2001", "2002")})
 
+    def test_equals(self):
+        index1 = PandasIndex([1, 2, 3], "x")
+        index2 = PandasIndex([1, 2, 3], "x")
+        assert index1.equals(index2) is True
+
+    def test_union(self):
+        index1 = PandasIndex([1, 2, 3], "x")
+        index2 = PandasIndex([4, 5, 6], "y")
+        actual = index1.union(index2)
+        assert actual.index.equals(pd.Index([1, 2, 3, 4, 5, 6]))
+        assert actual.dim == "x"
+
+    def test_intersection(self):
+        index1 = PandasIndex([1, 2, 3], "x")
+        index2 = PandasIndex([2, 3, 4], "y")
+        actual = index1.intersection(index2)
+        assert actual.index.equals(pd.Index([2, 3]))
+        assert actual.dim == "x"
+
+    def test_copy(self):
+        expected = PandasIndex([1, 2, 3], "x")
+        actual = expected.copy()
+
+        assert actual.index.equals(expected.index)
+        assert actual.index is not expected.index
+        assert actual.dim == expected.dim
+
+    def test_getitem(self):
+        pd_idx = pd.Index([1, 2, 3])
+        expected = PandasIndex(pd_idx, "x")
+        actual = expected[1:]
+
+        assert actual.index.equals(pd_idx[1:])
+        assert actual.dim == expected.dim
+
 
 class TestPandasMultiIndex:
+    def test_from_variables(self):
+        v_level1 = xr.Variable(
+            "x", [1, 2, 3], attrs={"unit": "m"}, encoding={"dtype": np.int32}
+        )
+        v_level2 = xr.Variable(
+            "x", ["a", "b", "c"], attrs={"unit": "m"}, encoding={"dtype": "U"}
+        )
+
+        index, index_vars = PandasMultiIndex.from_variables(
+            {"level1": v_level1, "level2": v_level2}
+        )
+
+        expected_idx = pd.MultiIndex.from_arrays([v_level1.data, v_level2.data])
+        assert index.dim == "x"
+        assert index.index.equals(expected_idx)
+
+        assert list(index_vars) == ["x", "level1", "level2"]
+        xr.testing.assert_equal(xr.IndexVariable("x", expected_idx), index_vars["x"])
+        xr.testing.assert_identical(v_level1.to_index_variable(), index_vars["level1"])
+        xr.testing.assert_identical(v_level2.to_index_variable(), index_vars["level2"])
+
+        var = xr.Variable(("x", "y"), [[1, 2, 3], [4, 5, 6]])
+        with pytest.raises(
+            ValueError, match=r".*only accepts 1-dimensional variables.*"
+        ):
+            PandasMultiIndex.from_variables({"var": var})
+
+        v_level3 = xr.Variable("y", [4, 5, 6])
+        with pytest.raises(ValueError, match=r"unmatched dimensions for variables.*"):
+            PandasMultiIndex.from_variables({"level1": v_level1, "level3": v_level3})
+
+    def test_from_pandas_index(self):
+        pd_idx = pd.MultiIndex.from_arrays([[1, 2, 3], [4, 5, 6]], names=("foo", "bar"))
+
+        index, index_vars = PandasMultiIndex.from_pandas_index(pd_idx, "x")
+
+        assert index.dim == "x"
+        assert index.index is pd_idx
+        assert index.index.names == ("foo", "bar")
+        xr.testing.assert_identical(index_vars["x"], IndexVariable("x", pd_idx))
+        xr.testing.assert_identical(index_vars["foo"], IndexVariable("x", [1, 2, 3]))
+        xr.testing.assert_identical(index_vars["bar"], IndexVariable("x", [4, 5, 6]))
+
     def test_query(self):
         index = PandasMultiIndex(
             pd.MultiIndex.from_product([["a", "b"], [1, 2]], names=("one", "two")), "x"

--- a/xarray/tests/test_indexes.py
+++ b/xarray/tests/test_indexes.py
@@ -20,7 +20,7 @@ def test_asarray_tuplesafe():
 class TestPandasIndex:
     def test_query(self):
         # TODO: add tests that aren't just for edge cases
-        index = PandasIndex(pd.Index([1, 2, 3]))
+        index = PandasIndex(pd.Index([1, 2, 3]), "x")
         with pytest.raises(KeyError, match=r"not all values found"):
             index.query({"x": [0]})
         with pytest.raises(KeyError):
@@ -29,7 +29,9 @@ class TestPandasIndex:
             index.query({"x": {"one": 0}})
 
     def test_query_datetime(self):
-        index = PandasIndex(pd.to_datetime(["2000-01-01", "2001-01-01", "2002-01-01"]))
+        index = PandasIndex(
+            pd.to_datetime(["2000-01-01", "2001-01-01", "2002-01-01"]), "x"
+        )
         actual = index.query({"x": "2001-01-01"})
         expected = (1, None)
         assert actual == expected
@@ -38,7 +40,7 @@ class TestPandasIndex:
         assert actual == expected
 
     def test_query_unsorted_datetime_index_raises(self):
-        index = PandasIndex(pd.to_datetime(["2001", "2000", "2002"]))
+        index = PandasIndex(pd.to_datetime(["2001", "2000", "2002"]), "x")
         with pytest.raises(KeyError):
             # pandas will try to convert this into an array indexer. We should
             # raise instead, so we can be sure the result of indexing with a
@@ -49,7 +51,7 @@ class TestPandasIndex:
 class TestPandasMultiIndex:
     def test_query(self):
         index = PandasMultiIndex(
-            pd.MultiIndex.from_product([["a", "b"], [1, 2]], names=("one", "two"))
+            pd.MultiIndex.from_product([["a", "b"], [1, 2]], names=("one", "two")), "x"
         )
         # test tuples inside slice are considered as scalar indexer values
         assert index.query({"x": slice(("a", 1), ("b", 2))}) == (slice(0, 4), None)

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -81,9 +81,12 @@ class TestIndexers:
 
     def test_remap_label_indexers(self):
         def test_indexer(data, x, expected_pos, expected_idx=None):
-            pos, idx = indexing.remap_label_indexers(data, {"x": x})
+            pos, new_idx_vars = indexing.remap_label_indexers(data, {"x": x})
+            idx, _ = new_idx_vars.get("x", (None, None))
+            if idx is not None:
+                idx = idx.to_pandas_index()
             assert_array_equal(pos.get("x"), expected_pos)
-            assert_array_equal(idx.get("x"), expected_idx)
+            assert_array_equal(idx, expected_idx)
 
         data = Dataset({"x": ("x", [1, 2, 3])})
         mindex = pd.MultiIndex.from_product(

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -29,13 +29,11 @@ def test_safe_cast_to_index():
     dates = pd.date_range("2000-01-01", periods=10)
     x = np.arange(5)
     td = x * np.timedelta64(1, "D")
-    midx = pd.MultiIndex.from_tuples([(0,)], names=["a"])
     for expected, array in [
         (dates, dates.values),
         (pd.Index(x, dtype=object), x.astype(object)),
         (pd.Index(td), td),
         (pd.Index(td, dtype=object), td.astype(object)),
-        (midx, PandasIndex(midx)),
     ]:
         actual = utils.safe_cast_to_index(array)
         assert_array_equal(expected, actual)

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -7,7 +7,6 @@ import pytest
 
 from xarray.coding.cftimeindex import CFTimeIndex
 from xarray.core import duck_array_ops, utils
-from xarray.core.indexes import PandasIndex
 from xarray.core.utils import either_dict_or_kwargs, iterate_nested
 
 from . import assert_array_equal, requires_cftime, requires_dask

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -11,7 +11,6 @@ import pytz
 from xarray import Coordinate, DataArray, Dataset, IndexVariable, Variable, set_options
 from xarray.core import dtypes, duck_array_ops, indexing
 from xarray.core.common import full_like, ones_like, zeros_like
-from xarray.core.indexes import PandasIndex
 from xarray.core.indexing import (
     BasicIndexer,
     CopyOnWriteArray,
@@ -20,6 +19,7 @@ from xarray.core.indexing import (
     MemoryCachedArray,
     NumpyIndexingAdapter,
     OuterIndexer,
+    PandasIndexingAdapter,
     VectorizedIndexer,
 )
 from xarray.core.pycompat import dask_array_type
@@ -537,7 +537,7 @@ class VariableSubclassobjects:
         v = self.cls("x", midx)
         for deep in [True, False]:
             w = v.copy(deep=deep)
-            assert isinstance(w._data, PandasIndex)
+            assert isinstance(w._data, PandasIndexingAdapter)
             assert isinstance(w.to_index(), pd.MultiIndex)
             assert_array_equal(v._data.array, w._data.array)
 
@@ -2161,7 +2161,7 @@ class TestIndexVariable(VariableSubclassobjects):
 
     def test_data(self):
         x = IndexVariable("x", np.arange(3.0))
-        assert isinstance(x._data, PandasIndex)
+        assert isinstance(x._data, PandasIndexingAdapter)
         assert isinstance(x.data, np.ndarray)
         assert float == x.dtype
         assert_array_equal(np.arange(3), x)
@@ -2303,7 +2303,7 @@ class TestIndexVariable(VariableSubclassobjects):
 
 class TestAsCompatibleData:
     def test_unchanged_types(self):
-        types = (np.asarray, PandasIndex, LazilyIndexedArray)
+        types = (np.asarray, PandasIndexingAdapter, LazilyIndexedArray)
         for t in types:
             for data in [
                 np.arange(3),


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #5553
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

This implements option 3 (sort of) described in https://github.com/pydata/xarray/issues/5553#issue-933551030:

- the goal is to avoid wrapping an `xarray.Index` into an `xarray.Variable` and keep those two concepts distinct from each other.
- the `xarray.Index.from_variables` class constructor accepts a dictionary of `xarray.Variable` objects as argument and may (or should?) also return corresponding `xarray.IndexVariable` objects to ensure immutability.
- for `PandasIndex`,  the new returned `xarray.IndexVariable` wraps the underlying `pd.Index` via a `PandasIndexingAdapter` (this reverts some changes made in #5102).
- for `PandasMultiIndex`, this PR adds `PandasMultiIndexingAdapter` so that we can wrap the pandas multi-index in separate coordinate variables objects: one for the dimension + one for each level. The level coordinates data internally hold a reference to the dimension coordinate data to avoid indexing the same underlying `pd.MultiIndex` for each of those coordinates (`PandasMultiIndexingAdapter.__getitem__` is memoized for that purpose).

This is very much work in progress, I need to update (or revert) all related parts of Xarray's internals, update tests, etc. At this stage any comment on the approach described above is welcome. 