### PR TITLE
Fix performance bug from cftime import

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,6 +34,9 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
+- Fixed performance bug where ``cftime`` import attempted within various core operations if ``cftime`` not
+  installed (:pull:`5640`).
+  By `Luke Sewell <https://github.com/lusewell>`_
 
 
 Documentation

--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -52,12 +52,15 @@ from ..core.pdcompat import count_not_none
 from .cftimeindex import CFTimeIndex, _parse_iso8601_with_reso
 from .times import format_cftime_datetime
 
+try:
+    import cftime
+except ImportError:
+    cftime = None
+
 
 def get_date_type(calendar):
     """Return the cftime date type for a given calendar name."""
-    try:
-        import cftime
-    except ImportError:
+    if cftime is None:
         raise ImportError("cftime is required for dates with non-standard calendars")
     else:
         calendars = {
@@ -99,7 +102,8 @@ class BaseCFTimeOffset:
         return self.__apply__(other)
 
     def __sub__(self, other):
-        import cftime
+        if cftime is None:
+            raise ModuleNotFoundError("No module named 'cftime'")
 
         if isinstance(other, cftime.datetime):
             raise TypeError("Cannot subtract a cftime.datetime from a time offset.")
@@ -221,7 +225,8 @@ def _adjust_n_years(other, n, month, reference_day):
 
 def _shift_month(date, months, day_option="start"):
     """Shift the date to a month start or end a given number of months away."""
-    import cftime
+    if cftime is None:
+        raise ModuleNotFoundError("No module named 'cftime'")
 
     delta_year = (date.month + months) // 12
     month = (date.month + months) % 12
@@ -378,7 +383,8 @@ class QuarterOffset(BaseCFTimeOffset):
         return mod_month == 0 and date.day == self._get_offset_day(date)
 
     def __sub__(self, other):
-        import cftime
+        if cftime is None:
+            raise ModuleNotFoundError("No module named 'cftime'")
 
         if isinstance(other, cftime.datetime):
             raise TypeError("Cannot subtract cftime.datetime from offset.")
@@ -463,7 +469,8 @@ class YearOffset(BaseCFTimeOffset):
         return _shift_month(other, months, self._day_option)
 
     def __sub__(self, other):
-        import cftime
+        if cftime is None:
+            raise ModuleNotFoundError("No module named 'cftime'")
 
         if isinstance(other, cftime.datetime):
             raise TypeError("Cannot subtract cftime.datetime from offset.")
@@ -688,7 +695,8 @@ def to_offset(freq):
 
 
 def to_cftime_datetime(date_str_or_date, calendar=None):
-    import cftime
+    if cftime is None:
+        raise ModuleNotFoundError("No module named 'cftime'")
 
     if isinstance(date_str_or_date, str):
         if calendar is None:
@@ -724,7 +732,8 @@ def _maybe_normalize_date(date, normalize):
 def _generate_linear_range(start, end, periods):
     """Generate an equally-spaced sequence of cftime.datetime objects between
     and including two dates (whose length equals the number of periods)."""
-    import cftime
+    if cftime is None:
+        raise ModuleNotFoundError("No module named 'cftime'")
 
     total_seconds = (end - start).total_seconds()
     values = np.linspace(0.0, total_seconds, periods, endpoint=True)

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -54,6 +54,12 @@ from ..core.common import _contains_cftime_datetimes
 from ..core.options import OPTIONS
 from .times import _STANDARD_CALENDARS, cftime_to_nptime, infer_calendar_name
 
+try:
+    import cftime
+except ImportError:
+    cftime = None
+
+
 # constants for cftimeindex.repr
 CFTIME_REPR_LENGTH = 19
 ITEMS_IN_REPR_MAX_ELSE_ELLIPSIS = 100
@@ -114,7 +120,8 @@ def parse_iso8601_like(datetime_string):
 
 
 def _parse_iso8601_with_reso(date_type, timestr):
-    import cftime
+    if cftime is None:
+        raise ModuleNotFoundError("No module named 'cftime'")
 
     default = date_type(1, 1, 1)
     result = parse_iso8601_like(timestr)
@@ -189,7 +196,8 @@ def _field_accessor(name, docstring=None, min_cftime_version="0.0"):
     """Adapted from pandas.tseries.index._field_accessor"""
 
     def f(self, min_cftime_version=min_cftime_version):
-        import cftime
+        if cftime is None:
+            raise ModuleNotFoundError("No module named 'cftime'")
 
         version = cftime.__version__
 
@@ -215,7 +223,8 @@ def get_date_type(self):
 
 
 def assert_all_valid_date_type(data):
-    import cftime
+    if cftime is None:
+        raise ModuleNotFoundError("No module named 'cftime'")
 
     if len(data) > 0:
         sample = data[0]

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -22,6 +22,11 @@ from .variables import (
     unpack_for_encoding,
 )
 
+try:
+    import cftime
+except ImportError:
+    cftime = None
+
 # standard calendars recognized by cftime
 _STANDARD_CALENDARS = {"standard", "gregorian", "proleptic_gregorian"}
 
@@ -164,8 +169,8 @@ def _decode_cf_datetime_dtype(data, units, calendar, use_cftime):
 
 
 def _decode_datetime_with_cftime(num_dates, units, calendar):
-    import cftime
-
+    if cftime is None:
+        raise ModuleNotFoundError("No module named 'cftime'")
     return np.asarray(
         cftime.num2date(num_dates, units, calendar, only_use_cftime_datetimes=True)
     )
@@ -414,7 +419,8 @@ def _encode_datetime_with_cftime(dates, units, calendar):
     This method is more flexible than xarray's parsing using datetime64[ns]
     arrays but also slower because it loops over each element.
     """
-    import cftime
+    if cftime is None:
+        raise ModuleNotFoundError("No module named 'cftime'")
 
     if np.issubdtype(dates.dtype, np.datetime64):
         # numpy's broken datetime conversion only works for us precision

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -29,7 +29,6 @@ from .pycompat import is_duck_dask_array
 from .rolling_exp import RollingExp
 from .utils import Frozen, either_dict_or_kwargs, is_scalar
 
-
 try:
     import cftime
 except ImportError:

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -29,6 +29,12 @@ from .pycompat import is_duck_dask_array
 from .rolling_exp import RollingExp
 from .utils import Frozen, either_dict_or_kwargs, is_scalar
 
+
+try:
+    import cftime
+except ImportError:
+    cftime = None
+
 # Used as a sentinel value to indicate a all dimensions
 ALL_DIMS = ...
 
@@ -1820,9 +1826,7 @@ def is_np_timedelta_like(dtype: DTypeLike) -> bool:
 
 def _contains_cftime_datetimes(array) -> bool:
     """Check if an array contains cftime.datetime objects"""
-    try:
-        from cftime import datetime as cftime_datetime
-    except ImportError:
+    if cftime is None:
         return False
     else:
         if array.dtype == np.dtype("O") and array.size > 0:
@@ -1831,7 +1835,7 @@ def _contains_cftime_datetimes(array) -> bool:
                 sample = sample.compute()
                 if isinstance(sample, np.ndarray):
                     sample = sample.item()
-            return isinstance(sample, cftime_datetime)
+            return isinstance(sample, cftime.datetime)
         else:
             return False
 

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -19,6 +19,12 @@ try:
 except ImportError:
     nc_time_axis_available = False
 
+
+try:
+    import cftime
+except ImportError:
+    cftime = None
+
 ROBUST_PERCENTILE = 2.0
 
 
@@ -622,13 +628,11 @@ def _ensure_plottable(*args):
         np.str_,
     ]
     other_types = [datetime]
-    try:
-        import cftime
-
-        cftime_datetime = [cftime.datetime]
-    except ImportError:
-        cftime_datetime = []
-    other_types = other_types + cftime_datetime
+    if cftime is not None:
+        cftime_datetime_types = [cftime.datetime]
+        other_types = other_types + cftime_datetime_types
+    else:
+        cftime_datetime_types = []
     for x in args:
         if not (
             _valid_numpy_subdtype(np.array(x), numpy_types)
@@ -641,7 +645,7 @@ def _ensure_plottable(*args):
                 f"pandas.Interval. Received data of type {np.array(x).dtype} instead."
             )
         if (
-            _valid_other_type(np.array(x), cftime_datetime)
+            _valid_other_type(np.array(x), cftime_datetime_types)
             and not nc_time_axis_available
         ):
             raise ImportError(


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

No functional change, just removes a terrible perfomance bug when cftime isn't installed - previously calls to `.sel` would search your whole python path for trying to import cftime, leading to progams of mine taking 10% of time just doing this against a slow filesystem.

Tests all pass localy.
