### PR TITLE
fix the binder environment

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - pandas
   - pint
   - pip
+  - pooch
   - pydap
   - pynio
   - rasterio

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -2,7 +2,7 @@ name: xarray-examples
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
+  - python=3.9
   - boto3
   - bottleneck
   - cartopy


### PR DESCRIPTION
As far as I can tell, the examples on binder currently fail because `pooch` is not installed.

- [x] Passes `pre-commit run --all-files`

