### PR TITLE
create the context objects passed to custom `combine_attrs` functions

### DIFF
--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -63,6 +63,9 @@ class Context:
     def __init__(self, func):
         self.func = func
 
+    def __repr__(self):
+        return f"Context('{self.func}')"
+
 
 def broadcast_dimension_size(variables: List[Variable]) -> Dict[Hashable, int]:
     """Extract dimension sizes from a dictionary of variables.

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -52,7 +52,7 @@ _VALIDATORS = {
     DISPLAY_EXPAND_DATA: lambda choice: choice in [True, False, "default"],
     ENABLE_CFTIMEINDEX: lambda value: isinstance(value, bool),
     FILE_CACHE_MAXSIZE: _positive_integer,
-    KEEP_ATTRS: lambda choice: choice in [True, False, "default"],
+    KEEP_ATTRS: lambda choice: choice in [True, False, "default"] or callable(choice),
     WARN_FOR_UNCLOSED_FILES: lambda value: isinstance(value, bool),
 }
 
@@ -82,11 +82,13 @@ def _get_boolean_with_default(option, default):
 
     if global_choice == "default":
         return default
-    elif global_choice in [True, False]:
+    elif global_choice in [True, False] or callable(global_choice):
+        return global_choice
+    elif callable(global_choice):
         return global_choice
     else:
         raise ValueError(
-            f"The global option {option} must be one of True, False or 'default'."
+            f"The global option {option} must be one of True, False or 'default' or a callable."
         )
 
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1740,6 +1740,8 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
             Array with summarized data and the indicated dimension(s)
             removed.
         """
+        from .merge import Context, merge_attrs
+
         if dim == ...:
             dim = None
         if dim is not None and axis is not None:
@@ -1782,7 +1784,13 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
 
         if keep_attrs is None:
             keep_attrs = _get_keep_attrs(default=False)
-        attrs = self._attrs if keep_attrs else None
+
+        if isinstance(keep_attrs, bool):
+            keep_attrs = "override" if keep_attrs else "drop"
+
+        attrs = merge_attrs(
+            [self._attrs], combine_attrs=keep_attrs, context=Context(func.__name__)
+        )
 
         return Variable(dims, data, attrs=attrs)
 


### PR DESCRIPTION
Follow-up to #4896: this creates the context object in reduce methods and passes it to `merge_attrs`, with more planned.

- [ ] might help with xarray-contrib/cf-xarray#228
- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

Note that for now this is a bit inconvenient to use for provenance tracking (as discussed in the `cf-xarray` issue) because functions implementing that would still have to deal with merging the `attrs`.
