### PR TITLE
Add typing to the OPTIONS dict

### DIFF
--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -4,6 +4,7 @@ import warnings
 # TODO: Remove this check once python 3.7 is not supported:
 if sys.version_info >= (3, 8):
     from typing import TYPE_CHECKING, Union
+
     from typing_extensions import TypedDict
 
     if TYPE_CHECKING:
@@ -25,7 +26,7 @@ if sys.version_info >= (3, 8):
         display_expand_data: str
         enable_cftimeindex: bool
         file_cache_maxsize: int
-        keep_attrs: str
+        keep_attrs: Union[str, bool]
         warn_for_unclosed_files: bool
         use_bottleneck: bool
 
@@ -36,6 +37,7 @@ else:
     #  to _run_ the code (it is required to type-check).
     try:
         from typing import TYPE_CHECKING, Union
+
         from typing_extensions import TypedDict
 
         if TYPE_CHECKING:
@@ -57,7 +59,7 @@ else:
             display_expand_data: str
             enable_cftimeindex: bool
             file_cache_maxsize: int
-            keep_attrs: str
+            keep_attrs: Union[str, bool]
             warn_for_unclosed_files: bool
             use_bottleneck: bool
 

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import TypedDict
 
 ARITHMETIC_JOIN = "arithmetic_join"
 CMAP_DIVERGENT = "cmap_divergent"
@@ -16,7 +17,24 @@ KEEP_ATTRS = "keep_attrs"
 WARN_FOR_UNCLOSED_FILES = "warn_for_unclosed_files"
 
 
-OPTIONS = {
+class TypedOptions(TypedDict):
+    ARITHMETIC_JOIN: str
+    CMAP_DIVERGENT: str
+    CMAP_SEQUENTIAL: str
+    DISPLAY_MAX_ROWS: int
+    DISPLAY_STYLE: str
+    DISPLAY_WIDTH: int
+    DISPLAY_EXPAND_ATTRS: str
+    DISPLAY_EXPAND_COORDS: str
+    DISPLAY_EXPAND_DATA_VARS: str
+    DISPLAY_EXPAND_DATA: str
+    ENABLE_CFTIMEINDEX: bool
+    FILE_CACHE_MAXSIZE: int
+    KEEP_ATTRS: str
+    WARN_FOR_UNCLOSED_FILES: bool
+
+
+OPTIONS: TypedOptions = {
     ARITHMETIC_JOIN: "inner",
     CMAP_DIVERGENT: "RdBu_r",
     CMAP_SEQUENTIAL: "viridis",

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -1,9 +1,8 @@
 import sys
 import warnings
 
-
 # TODO: Remove this check once python 3.7 is not supported:
-if sys.version_info > (3, 7):
+if sys.version_info >= (3, 8):
     from typing import TypedDict
 
     class T_Options(TypedDict):

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -17,24 +17,28 @@ KEEP_ATTRS = "keep_attrs"
 WARN_FOR_UNCLOSED_FILES = "warn_for_unclosed_files"
 
 
-class TypedOptions(TypedDict):
-    ARITHMETIC_JOIN: str
-    CMAP_DIVERGENT: str
-    CMAP_SEQUENTIAL: str
-    DISPLAY_MAX_ROWS: int
-    DISPLAY_STYLE: str
-    DISPLAY_WIDTH: int
-    DISPLAY_EXPAND_ATTRS: str
-    DISPLAY_EXPAND_COORDS: str
-    DISPLAY_EXPAND_DATA_VARS: str
-    DISPLAY_EXPAND_DATA: str
-    ENABLE_CFTIMEINDEX: bool
-    FILE_CACHE_MAXSIZE: int
-    KEEP_ATTRS: str
-    WARN_FOR_UNCLOSED_FILES: bool
+T_Options = TypedDict(
+    "T_Options",
+    {
+        ARITHMETIC_JOIN: str,
+        CMAP_DIVERGENT: str,
+        CMAP_SEQUENTIAL: str,
+        DISPLAY_MAX_ROWS: int,
+        DISPLAY_STYLE: str,
+        DISPLAY_WIDTH: int,
+        DISPLAY_EXPAND_ATTRS: str,
+        DISPLAY_EXPAND_COORDS: str,
+        DISPLAY_EXPAND_DATA_VARS: str,
+        DISPLAY_EXPAND_DATA: str,
+        ENABLE_CFTIMEINDEX: bool,
+        FILE_CACHE_MAXSIZE: int,
+        KEEP_ATTRS: str,
+        WARN_FOR_UNCLOSED_FILES: bool,
+    },
+)
 
 
-OPTIONS: TypedOptions = {
+OPTIONS: T_Options = {
     ARITHMETIC_JOIN: "inner",
     CMAP_DIVERGENT: "RdBu_r",
     CMAP_SEQUENTIAL: "viridis",

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -23,9 +23,32 @@ if sys.version_info >= (3, 8):
 
 
 else:
-    from typing import Any, Dict, Hashable
+    # See GH5624, this is a convoluted way to allow type-checking to use
+    # `TypedDict` without requiring typing_extensions as a required dependency
+    #  to _run_ the code (it is required to type-check).
+    try:
+        from typing_extensions import TypedDict
 
-    T_Options = Dict[Hashable, Any]
+        class T_Options(TypedDict):
+            arithmetic_join: str
+            cmap_divergent: str
+            cmap_sequential: str
+            display_max_rows: int
+            display_style: str
+            display_width: int
+            display_expand_attrs: str
+            display_expand_coords: str
+            display_expand_data_vars: str
+            display_expand_data: str
+            enable_cftimeindex: bool
+            file_cache_maxsize: int
+            keep_attrs: str
+            warn_for_unclosed_files: bool
+
+    except ImportError:
+        from typing import Any, Dict, Hashable
+
+        T_Options = Dict[Hashable, Any]
 
 
 OPTIONS: T_Options = {

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -3,7 +3,6 @@ from typing import TypedDict
 
 
 class T_Options(TypedDict):
-    # Can't use the variables here unfortunately:
     arithmetic_join: str
     cmap_divergent: str
     cmap_sequential: str

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -1,5 +1,6 @@
 import sys
 import warnings
+from typing import TYPE_CHECKING
 
 # TODO: Remove this check once python 3.7 is not supported:
 if sys.version_info >= (3, 8):
@@ -46,9 +47,12 @@ else:
             warn_for_unclosed_files: bool
 
     except ImportError:
-        from typing import Any, Dict, Hashable
+        if TYPE_CHECKING:
+            raise
+        else:
+            from typing import Any, Dict, Hashable
 
-        T_Options = Dict[Hashable, Any]
+            T_Options = Dict[Hashable, Any]
 
 
 OPTIONS: T_Options = {

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -1,21 +1,6 @@
 import warnings
 from typing import TypedDict
 
-ARITHMETIC_JOIN = "arithmetic_join"
-CMAP_DIVERGENT = "cmap_divergent"
-CMAP_SEQUENTIAL = "cmap_sequential"
-DISPLAY_MAX_ROWS = "display_max_rows"
-DISPLAY_STYLE = "display_style"
-DISPLAY_WIDTH = "display_width"
-DISPLAY_EXPAND_ATTRS = "display_expand_attrs"
-DISPLAY_EXPAND_COORDS = "display_expand_coords"
-DISPLAY_EXPAND_DATA_VARS = "display_expand_data_vars"
-DISPLAY_EXPAND_DATA = "display_expand_data"
-ENABLE_CFTIMEINDEX = "enable_cftimeindex"
-FILE_CACHE_MAXSIZE = "file_cache_maxsize"
-KEEP_ATTRS = "keep_attrs"
-WARN_FOR_UNCLOSED_FILES = "warn_for_unclosed_files"
-
 
 class T_Options(TypedDict):
     # Can't use the variables here unfortunately:
@@ -36,20 +21,20 @@ class T_Options(TypedDict):
 
 
 OPTIONS: T_Options = {
-    ARITHMETIC_JOIN: "inner",
-    CMAP_DIVERGENT: "RdBu_r",
-    CMAP_SEQUENTIAL: "viridis",
-    DISPLAY_MAX_ROWS: 12,
-    DISPLAY_STYLE: "html",
-    DISPLAY_WIDTH: 80,
-    DISPLAY_EXPAND_ATTRS: "default",
-    DISPLAY_EXPAND_COORDS: "default",
-    DISPLAY_EXPAND_DATA_VARS: "default",
-    DISPLAY_EXPAND_DATA: "default",
-    ENABLE_CFTIMEINDEX: True,
-    FILE_CACHE_MAXSIZE: 128,
-    KEEP_ATTRS: "default",
-    WARN_FOR_UNCLOSED_FILES: False,
+    "arithmetic_join": "inner",
+    "cmap_divergent": "RdBu_r",
+    "cmap_sequential": "viridis",
+    "display_max_rows": 12,
+    "display_style": "html",
+    "display_width": 80,
+    "display_expand_attrs": "default",
+    "display_expand_coords": "default",
+    "display_expand_data_vars": "default",
+    "display_expand_data": "default",
+    "enable_cftimeindex": True,
+    "file_cache_maxsize": 128,
+    "keep_attrs": "default",
+    "warn_for_unclosed_files": False,
 }
 
 _JOIN_OPTIONS = frozenset(["inner", "outer", "left", "right", "exact"])
@@ -61,18 +46,18 @@ def _positive_integer(value):
 
 
 _VALIDATORS = {
-    ARITHMETIC_JOIN: _JOIN_OPTIONS.__contains__,
-    DISPLAY_MAX_ROWS: _positive_integer,
-    DISPLAY_STYLE: _DISPLAY_OPTIONS.__contains__,
-    DISPLAY_WIDTH: _positive_integer,
-    DISPLAY_EXPAND_ATTRS: lambda choice: choice in [True, False, "default"],
-    DISPLAY_EXPAND_COORDS: lambda choice: choice in [True, False, "default"],
-    DISPLAY_EXPAND_DATA_VARS: lambda choice: choice in [True, False, "default"],
-    DISPLAY_EXPAND_DATA: lambda choice: choice in [True, False, "default"],
-    ENABLE_CFTIMEINDEX: lambda value: isinstance(value, bool),
-    FILE_CACHE_MAXSIZE: _positive_integer,
-    KEEP_ATTRS: lambda choice: choice in [True, False, "default"],
-    WARN_FOR_UNCLOSED_FILES: lambda value: isinstance(value, bool),
+    "arithmetic_join": _JOIN_OPTIONS.__contains__,
+    "display_max_rows": _positive_integer,
+    "display_style": _DISPLAY_OPTIONS.__contains__,
+    "display_width": _positive_integer,
+    "display_expand_attrs": lambda choice: choice in [True, False, "default"],
+    "display_expand_coords": lambda choice: choice in [True, False, "default"],
+    "display_expand_data_vars": lambda choice: choice in [True, False, "default"],
+    "display_expand_data": lambda choice: choice in [True, False, "default"],
+    "enable_cftimeindex": lambda value: isinstance(value, bool),
+    "file_cache_maxsize": _positive_integer,
+    "keep_attrs": lambda choice: choice in [True, False, "default"],
+    "warn_for_unclosed_files": lambda value: isinstance(value, bool),
 }
 
 
@@ -91,8 +76,8 @@ def _warn_on_setting_enable_cftimeindex(enable_cftimeindex):
 
 
 _SETTERS = {
-    ENABLE_CFTIMEINDEX: _warn_on_setting_enable_cftimeindex,
-    FILE_CACHE_MAXSIZE: _set_file_cache_maxsize,
+    "enable_cftimeindex": _warn_on_setting_enable_cftimeindex,
+    "file_cache_maxsize": _set_file_cache_maxsize,
 }
 
 
@@ -188,9 +173,9 @@ class set_options:
                     f"argument name {k!r} is not in the set of valid options {set(OPTIONS)!r}"
                 )
             if k in _VALIDATORS and not _VALIDATORS[k](v):
-                if k == ARITHMETIC_JOIN:
+                if k == "arithmetic_join":
                     expected = f"Expected one of {_JOIN_OPTIONS!r}"
-                elif k == DISPLAY_STYLE:
+                elif k == "display_style":
                     expected = f"Expected one of {_DISPLAY_OPTIONS!r}"
                 else:
                     expected = ""

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -3,12 +3,19 @@ import warnings
 
 # TODO: Remove this check once python 3.7 is not supported:
 if sys.version_info >= (3, 8):
-    from typing import TypedDict
+    from typing import TYPE_CHECKING, Union
+    from typing_extensions import TypedDict
+
+    if TYPE_CHECKING:
+        try:
+            from matplotlib.colors import Colormap
+        except ImportError:
+            Colormap = str
 
     class T_Options(TypedDict):
         arithmetic_join: str
-        cmap_divergent: str
-        cmap_sequential: str
+        cmap_divergent: Union[str, "Colormap"]
+        cmap_sequential: Union[str, "Colormap"]
         display_max_rows: int
         display_style: str
         display_width: int
@@ -28,12 +35,19 @@ else:
     # `TypedDict` without requiring typing_extensions as a required dependency
     #  to _run_ the code (it is required to type-check).
     try:
+        from typing import TYPE_CHECKING, Union
         from typing_extensions import TypedDict
+
+        if TYPE_CHECKING:
+            try:
+                from matplotlib.colors import Colormap
+            except ImportError:
+                Colormap = str
 
         class T_Options(TypedDict):
             arithmetic_join: str
-            cmap_divergent: str
-            cmap_sequential: str
+            cmap_divergent: Union[str, "Colormap"]
+            cmap_sequential: Union[str, "Colormap"]
             display_max_rows: int
             display_style: str
             display_width: int

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -20,10 +20,10 @@ if sys.version_info >= (3, 8):
         display_max_rows: int
         display_style: str
         display_width: int
-        display_expand_attrs: str
-        display_expand_coords: str
-        display_expand_data_vars: str
-        display_expand_data: str
+        display_expand_attrs: Union[str, bool]
+        display_expand_coords: Union[str, bool]
+        display_expand_data_vars: Union[str, bool]
+        display_expand_data: Union[str, bool]
         enable_cftimeindex: bool
         file_cache_maxsize: int
         keep_attrs: Union[str, bool]
@@ -53,10 +53,10 @@ else:
             display_max_rows: int
             display_style: str
             display_width: int
-            display_expand_attrs: str
-            display_expand_coords: str
-            display_expand_data_vars: str
-            display_expand_data: str
+            display_expand_attrs: Union[str, bool]
+            display_expand_coords: Union[str, bool]
+            display_expand_data_vars: Union[str, bool]
+            display_expand_data: Union[str, bool]
             enable_cftimeindex: bool
             file_cache_maxsize: int
             keep_attrs: Union[str, bool]

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -3,7 +3,7 @@ import sys
 
 
 # TODO: Remove this check once python 3.7 is not supported:
-if sys.version_info >= (3, 7):
+if sys.version_info > (3, 7):
     from typing import TypedDict
 
     class T_Options(TypedDict):

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -1,6 +1,5 @@
 import sys
 import warnings
-from typing import TYPE_CHECKING
 
 # TODO: Remove this check once python 3.7 is not supported:
 if sys.version_info >= (3, 8):
@@ -47,11 +46,11 @@ else:
             warn_for_unclosed_files: bool
 
     except ImportError:
+        from typing import Any, Dict, Hashable, TYPE_CHECKING
+
         if TYPE_CHECKING:
             raise
         else:
-            from typing import Any, Dict, Hashable
-
             T_Options = Dict[Hashable, Any]
 
 

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -17,25 +17,22 @@ KEEP_ATTRS = "keep_attrs"
 WARN_FOR_UNCLOSED_FILES = "warn_for_unclosed_files"
 
 
-T_Options = TypedDict(
-    "T_Options",
-    {
-        ARITHMETIC_JOIN: str,
-        CMAP_DIVERGENT: str,
-        CMAP_SEQUENTIAL: str,
-        DISPLAY_MAX_ROWS: int,
-        DISPLAY_STYLE: str,
-        DISPLAY_WIDTH: int,
-        DISPLAY_EXPAND_ATTRS: str,
-        DISPLAY_EXPAND_COORDS: str,
-        DISPLAY_EXPAND_DATA_VARS: str,
-        DISPLAY_EXPAND_DATA: str,
-        ENABLE_CFTIMEINDEX: bool,
-        FILE_CACHE_MAXSIZE: int,
-        KEEP_ATTRS: str,
-        WARN_FOR_UNCLOSED_FILES: bool,
-    },
-)
+class T_Options(TypedDict):
+    # Can't use the variables here unfortunately:
+    arithmetic_join: str
+    cmap_divergent: str
+    cmap_sequential: str
+    display_max_rows: int
+    display_style: str
+    display_width: int
+    display_expand_attrs: str
+    display_expand_coords: str
+    display_expand_data_vars: str
+    display_expand_data: str
+    enable_cftimeindex: bool
+    file_cache_maxsize: int
+    keep_attrs: str
+    warn_for_unclosed_files: bool
 
 
 OPTIONS: T_Options = {

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -1,5 +1,5 @@
-import warnings
 import sys
+import warnings
 
 
 # TODO: Remove this check once python 3.7 is not supported:
@@ -24,7 +24,7 @@ if sys.version_info > (3, 7):
 
 
 else:
-    from typing import Dict, Hashable, Any
+    from typing import Any, Dict, Hashable
 
     T_Options = Dict[Hashable, Any]
 

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -31,12 +31,12 @@ if sys.version_info >= (3, 8):
 
 else:
     # See GH5624, this is a convoluted way to allow type-checking to use
-    # `TypedDict` without requiring typing_extensions as a required dependency
-    #  to _run_ the code (it is required to type-check).
+    # `TypedDict` and `Literal` without requiring typing_extensions as a
+    #  required dependency to _run_ the code (it is required to type-check).
     try:
-        from typing import TYPE_CHECKING, Literal, Union
+        from typing import TYPE_CHECKING, Union
 
-        from typing_extensions import TypedDict
+        from typing_extensions import Literal, TypedDict
 
         if TYPE_CHECKING:
             try:

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -46,7 +46,7 @@ else:
             warn_for_unclosed_files: bool
 
     except ImportError:
-        from typing import Any, Dict, Hashable, TYPE_CHECKING
+        from typing import TYPE_CHECKING, Any, Dict, Hashable
 
         if TYPE_CHECKING:
             raise

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -1,22 +1,32 @@
 import warnings
-from typing import TypedDict
+import sys
 
 
-class T_Options(TypedDict):
-    arithmetic_join: str
-    cmap_divergent: str
-    cmap_sequential: str
-    display_max_rows: int
-    display_style: str
-    display_width: int
-    display_expand_attrs: str
-    display_expand_coords: str
-    display_expand_data_vars: str
-    display_expand_data: str
-    enable_cftimeindex: bool
-    file_cache_maxsize: int
-    keep_attrs: str
-    warn_for_unclosed_files: bool
+# TODO: Remove this check once python 3.7 is not supported:
+if sys.version_info >= (3, 7):
+    from typing import TypedDict
+
+    class T_Options(TypedDict):
+        arithmetic_join: str
+        cmap_divergent: str
+        cmap_sequential: str
+        display_max_rows: int
+        display_style: str
+        display_width: int
+        display_expand_attrs: str
+        display_expand_coords: str
+        display_expand_data_vars: str
+        display_expand_data: str
+        enable_cftimeindex: bool
+        file_cache_maxsize: int
+        keep_attrs: str
+        warn_for_unclosed_files: bool
+
+
+else:
+    from typing import Dict, Hashable, Any
+
+    T_Options = Dict[Hashable, Any]
 
 
 OPTIONS: T_Options = {

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -3,9 +3,7 @@ import warnings
 
 # TODO: Remove this check once python 3.7 is not supported:
 if sys.version_info >= (3, 8):
-    from typing import TYPE_CHECKING, Union
-
-    from typing_extensions import TypedDict
+    from typing import TYPE_CHECKING, TypedDict, Union
 
     if TYPE_CHECKING:
         try:

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -3,7 +3,7 @@ import warnings
 
 # TODO: Remove this check once python 3.7 is not supported:
 if sys.version_info >= (3, 8):
-    from typing import TYPE_CHECKING, TypedDict, Union
+    from typing import TYPE_CHECKING, Literal, TypedDict, Union
 
     if TYPE_CHECKING:
         try:
@@ -12,19 +12,19 @@ if sys.version_info >= (3, 8):
             Colormap = str
 
     class T_Options(TypedDict):
-        arithmetic_join: str
+        arithmetic_join: Literal["inner", "outer", "left", "right", "exact"]
         cmap_divergent: Union[str, "Colormap"]
         cmap_sequential: Union[str, "Colormap"]
         display_max_rows: int
-        display_style: str
+        display_style: Literal["text", "html"]
         display_width: int
-        display_expand_attrs: Union[str, bool]
-        display_expand_coords: Union[str, bool]
-        display_expand_data_vars: Union[str, bool]
-        display_expand_data: Union[str, bool]
+        display_expand_attrs: Literal["default", True, False]
+        display_expand_coords: Literal["default", True, False]
+        display_expand_data_vars: Literal["default", True, False]
+        display_expand_data: Literal["default", True, False]
         enable_cftimeindex: bool
         file_cache_maxsize: int
-        keep_attrs: Union[str, bool]
+        keep_attrs: Literal["default", True, False]
         warn_for_unclosed_files: bool
         use_bottleneck: bool
 
@@ -34,7 +34,7 @@ else:
     # `TypedDict` without requiring typing_extensions as a required dependency
     #  to _run_ the code (it is required to type-check).
     try:
-        from typing import TYPE_CHECKING, Union
+        from typing import TYPE_CHECKING, Literal, Union
 
         from typing_extensions import TypedDict
 
@@ -45,19 +45,19 @@ else:
                 Colormap = str
 
         class T_Options(TypedDict):
-            arithmetic_join: str
+            arithmetic_join: Literal["inner", "outer", "left", "right", "exact"]
             cmap_divergent: Union[str, "Colormap"]
             cmap_sequential: Union[str, "Colormap"]
             display_max_rows: int
-            display_style: str
+            display_style: Literal["text", "html"]
             display_width: int
-            display_expand_attrs: Union[str, bool]
-            display_expand_coords: Union[str, bool]
-            display_expand_data_vars: Union[str, bool]
-            display_expand_data: Union[str, bool]
+            display_expand_attrs: Literal["default", True, False]
+            display_expand_coords: Literal["default", True, False]
+            display_expand_data_vars: Literal["default", True, False]
+            display_expand_data: Literal["default", True, False]
             enable_cftimeindex: bool
             file_cache_maxsize: int
-            keep_attrs: Union[str, bool]
+            keep_attrs: Literal["default", True, False]
             warn_for_unclosed_files: bool
             use_bottleneck: bool
 


### PR DESCRIPTION
This adds typing to the dict values. Using variables as keys is apparently not permitted by mypy so that part has been removed.

Attempts to fix issues found in #5662. 
<!-- Feel free to remove check-list items aren't relevant to your change -->

