### PR TITLE
Add f8 default fill value and test for it.

### DIFF
--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -3,6 +3,7 @@ import warnings
 from functools import partial
 from typing import Any, Hashable
 
+import netCDF4
 import numpy as np
 import pandas as pd
 
@@ -183,6 +184,8 @@ class CFMaskCoder(VariableCoder):
             pop_to(attrs, encoding, attr, name=name)
             for attr in ("missing_value", "_FillValue")
         ]
+
+        raw_fill_values.append(netCDF4.default_fillvals["f8"])
         if raw_fill_values:
             encoded_fill_values = {
                 fv

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -1,6 +1,7 @@
 import contextlib
 import warnings
 
+import netCDF4
 import numpy as np
 import pandas as pd
 import pytest
@@ -231,6 +232,12 @@ class TestDecodeCF:
             actual = conventions.decode_cf_variable("t", original)
             assert_identical(expected, actual)
             assert "has multiple fill" in str(w[0].message)
+
+    def test_decode_standard_missing_value(self):
+        original = Variable(["t"], [netCDF4.default_fillvals["f8"], 1, 2], {})
+        expected = Variable(["t"], [np.nan, 1, 2], {})
+        actual = conventions.decode_cf_variable("t", original)
+        assert_identical(expected, actual)
 
     def test_decode_cf_with_drop_variables(self):
         original = Dataset(


### PR DESCRIPTION
- [x] Closes #2374
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

This is a work in progress, mostly so that I can ask some clarifying questions.

I see that `netCDF4` is an optional dependency for `xarray`, so probably `import netCDF4` can't be used. Should `xarray` simply hard-code default fill values ?

From the issue's conversation, it wasn't clear to me whether an argument should control the use the default fill value. Since some tests fail now I guess the answer is yes. 