### PR TITLE
Improves rendering of complex LaTeX expressions as `long_name`s when plotting

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,7 +22,8 @@ v0.19.1 (unreleased)
 
 New Features
 ~~~~~~~~~~~~
-
+- Xarray now does a better job rendering variable names that are long LaTeX sequences when plotting (:issue:`5681`, :pull:`5682`).
+  By `Tomas Chor <https://github.com/tomchor>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -492,7 +492,8 @@ def label_from_attrs(da, extra=""):
 
     # Treat `name` differently if it's a latex sequence
     if name.startswith("$") and (name.count("$") % 2 == 0):
-        return "$\n$".join(textwrap.wrap(name + extra + units, 60, break_long_words=False))
+        return "$\n$".join(textwrap.wrap(name + extra + units, 60, 
+                                         break_long_words=False))
     else:
         return "\n".join(textwrap.wrap(name + extra + units, 30))
 

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -492,8 +492,9 @@ def label_from_attrs(da, extra=""):
 
     # Treat `name` differently if it's a latex sequence
     if name.startswith("$") and (name.count("$") % 2 == 0):
-        return "$\n$".join(textwrap.wrap(name + extra + units, 60, 
-                                         break_long_words=False))
+        return "$\n$".join(textwrap.wrap(
+            name + extra + units, 60, break_long_words=False)
+        )
     else:
         return "\n".join(textwrap.wrap(name + extra + units, 30))
 

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -490,7 +490,10 @@ def label_from_attrs(da, extra=""):
     else:
         units = _get_units_from_attrs(da)
 
-    return "\n".join(textwrap.wrap(name + extra + units, 30))
+    if name.startswith("$") and name.count("$")%2==0:
+        return "$\n$".join(textwrap.wrap(name + extra + units, 60))
+    else:
+        return "\n".join(textwrap.wrap(name + extra + units, 30))
 
 
 def _interval_to_mid_points(array):

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -492,8 +492,8 @@ def label_from_attrs(da, extra=""):
 
     # Treat `name` differently if it's a latex sequence
     if name.startswith("$") and (name.count("$") % 2 == 0):
-        return "$\n$".join(textwrap.wrap(
-            name + extra + units, 60, break_long_words=False)
+        return "$\n$".join(
+            textwrap.wrap(name + extra + units, 60, break_long_words=False)
         )
     else:
         return "\n".join(textwrap.wrap(name + extra + units, 30))

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -490,7 +490,7 @@ def label_from_attrs(da, extra=""):
     else:
         units = _get_units_from_attrs(da)
 
-    if name.startswith("$") and name.count("$")%2==0:
+    if name.startswith("$") and (name.count("$") % 2 == 0):
         return "$\n$".join(textwrap.wrap(name + extra + units, 60))
     else:
         return "\n".join(textwrap.wrap(name + extra + units, 30))

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -490,8 +490,9 @@ def label_from_attrs(da, extra=""):
     else:
         units = _get_units_from_attrs(da)
 
+    # Treat `name` differently if it's a latex sequence
     if name.startswith("$") and (name.count("$") % 2 == 0):
-        return "$\n$".join(textwrap.wrap(name + extra + units, 60))
+        return "$\n$".join(textwrap.wrap(name + extra + units, 60, break_long_words=False))
     else:
         return "\n".join(textwrap.wrap(name + extra + units, 30))
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2953,7 +2953,7 @@ def test_datarray_scatter(x, y, z, hue, markersize, row, col, add_legend, add_co
 
 
 def test_latex_name_isnt_split():
-    da = xarray.DataArray()
+    da = xr.DataArray()
     long_latex_name = r"$Ra_s = \mathrm{mean}(\epsilon_k) / \mu M^2_\infty$"
     da.attrs = dict(long_name = long_latex_name)
     assert label_from_attrs(da) == long_latex_name

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2955,6 +2955,5 @@ def test_datarray_scatter(x, y, z, hue, markersize, row, col, add_legend, add_co
 def test_latex_name_isnt_split():
     da = xr.DataArray()
     long_latex_name = r"$Ra_s = \mathrm{mean}(\epsilon_k) / \mu M^2_\infty$"
-    da.attrs = dict(long_name = long_latex_name)
+    da.attrs = dict(long_name=long_latex_name)
     assert label_from_attrs(da) == long_latex_name
-

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2952,7 +2952,6 @@ def test_datarray_scatter(x, y, z, hue, markersize, row, col, add_legend, add_co
         )
 
 
-
 def test_latex_name_isnt_split():
     da = xarray.DataArray()
     long_latex_name = r"$Ra_s = \mathrm{mean}(\epsilon_k) / \mu M^2_\infty$"

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2950,3 +2950,12 @@ def test_datarray_scatter(x, y, z, hue, markersize, row, col, add_legend, add_co
             add_legend=add_legend,
             add_colorbar=add_colorbar,
         )
+
+
+
+def test_latex_name_isnt_split():
+    da = xarray.DataArray()
+    long_latex_name = r"$Ra_s = \mathrm{mean}(\epsilon_k) / \mu M^2_\infty$"
+    da.attrs = dict(long_name = long_latex_name)
+    assert label_from_attrs(da) == long_latex_name
+

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -42,7 +42,6 @@ def test_safe_cast_to_index():
         assert expected.dtype == actual.dtype
 
 
-
 @pytest.mark.parametrize(
     "a, b, expected", [["a", "b", np.array(["a", "b"])], [1, 2, pd.Index([1, 2])]]
 )

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -46,7 +46,7 @@ def test_safe_cast_to_index():
 def test_latex_name_isnt_split():
     da = xr.DataArray()
     long_latex_name = r"$Ra_s = \mathrm{mean}(\epsilon_k) / \mu M^2_\infty$"
-    da.attrs = dict(long_name = long_latex_name)
+    da.attrs = dict(long_name=long_latex_name)
     assert label_from_attrs(da) == long_latex_name
 
 

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -9,6 +9,7 @@ from xarray.coding.cftimeindex import CFTimeIndex
 from xarray.core import duck_array_ops, utils
 from xarray.core.indexes import PandasIndex
 from xarray.core.utils import either_dict_or_kwargs, iterate_nested
+from xarray.plot.utils import label_from_attrs
 
 from . import assert_array_equal, requires_cftime, requires_dask
 from .test_coding_times import _all_cftime_date_types
@@ -40,6 +41,14 @@ def test_safe_cast_to_index():
         actual = utils.safe_cast_to_index(array)
         assert_array_equal(expected, actual)
         assert expected.dtype == actual.dtype
+
+
+def test_latex_name_isnt_split():
+    da = xr.DataArray()
+    long_latex_name = r"$Ra_s = \mathrm{mean}(\epsilon_k) / \mu M^2_\infty$"
+    da.attrs = dict(long_name = long_latex_name)
+    assert label_from_attrs(da) == long_latex_name
+
 
 
 @pytest.mark.parametrize(

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -9,7 +9,6 @@ from xarray.coding.cftimeindex import CFTimeIndex
 from xarray.core import duck_array_ops, utils
 from xarray.core.indexes import PandasIndex
 from xarray.core.utils import either_dict_or_kwargs, iterate_nested
-from xarray.plot.utils import label_from_attrs
 
 from . import assert_array_equal, requires_cftime, requires_dask
 from .test_coding_times import _all_cftime_date_types
@@ -41,13 +40,6 @@ def test_safe_cast_to_index():
         actual = utils.safe_cast_to_index(array)
         assert_array_equal(expected, actual)
         assert expected.dtype == actual.dtype
-
-
-def test_latex_name_isnt_split():
-    da = xr.DataArray()
-    long_latex_name = r"$Ra_s = \mathrm{mean}(\epsilon_k) / \mu M^2_\infty$"
-    da.attrs = dict(long_name=long_latex_name)
-    assert label_from_attrs(da) == long_latex_name
 
 
 


### PR DESCRIPTION
This PR changes the function `label_from_attrs()` to wrap text differently if we think it's a LaTeX sequence. This prevents long LaTeX names from not being rendered properly.

I tried to identify if it's a latex code if the string starts with `$` and if it has an even number of `$` in it. But I'm open to suggestions. I also increased the number of allowed columns for latex code since it generally renders to fewer characters.

- [x] Closes https://github.com/pydata/xarray/issues/5681
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`

CC: @dcherian @Illviljan 