### PR TITLE
Initialize custom backends

### DIFF
--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -158,7 +158,7 @@ def get_backend(engine):
             )
         backend = engines[engine]
     elif isinstance(engine, type) and issubclass(engine, BackendEntrypoint):
-        backend = engine
+        backend = engine()
     else:
         raise TypeError(
             (

--- a/xarray/tests/test_backends_api.py
+++ b/xarray/tests/test_backends_api.py
@@ -26,6 +26,7 @@ def test_custom_engine():
 
     class CustomBackend(xr.backends.BackendEntrypoint):
         def open_dataset(
+            self,
             filename_or_obj,
             drop_variables=None,
             **kwargs,


### PR DESCRIPTION
The backend classes are initialized in the `build_engine` function.
https://github.com/pydata/xarray/blob/8b95da8e21a9d31de9f79cb0506720595f49e1dd/xarray/backends/plugins.py#L93

This wasn't the case for custom backends so I made it initialize.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
