### PR TITLE
Change annotations to allow str keys

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -53,6 +53,8 @@ Internal Changes
   By `Deepak Cherian <https://github.com/dcherian>`_.
 - Explicit indexes refactor: decouple ``xarray.Index``` from ``xarray.Variable`` (:pull:`5636`).
   By `Benoit Bovy <https://github.com/benbovy>`_.
+- Fix ``Mapping`` argument typing to allow mypy to pass on ``str`` keys (:pull:`5690`).
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 - Improve the performance of reprs for large datasets or dataarrays. (:pull:`5661`)
   By `Jimmy Westling <https://github.com/illviljan>`_.
 

--- a/properties/test_pandas_roundtrip.py
+++ b/properties/test_pandas_roundtrip.py
@@ -28,7 +28,7 @@ an_array = npst.arrays(
 
 
 @st.composite
-def datasets_1d_vars(draw):
+def datasets_1d_vars(draw) -> xr.Dataset:
     """Generate datasets with only 1D variables
 
     Suitable for converting to pandas dataframes.
@@ -49,7 +49,7 @@ def datasets_1d_vars(draw):
 
 
 @given(st.data(), an_array)
-def test_roundtrip_dataarray(data, arr):
+def test_roundtrip_dataarray(data, arr) -> None:
     names = data.draw(
         st.lists(st.text(), min_size=arr.ndim, max_size=arr.ndim, unique=True).map(
             tuple
@@ -62,7 +62,7 @@ def test_roundtrip_dataarray(data, arr):
 
 
 @given(datasets_1d_vars())
-def test_roundtrip_dataset(dataset):
+def test_roundtrip_dataset(dataset) -> None:
     df = dataset.to_dataframe()
     assert isinstance(df, pd.DataFrame)
     roundtripped = xr.Dataset(df)
@@ -70,7 +70,7 @@ def test_roundtrip_dataset(dataset):
 
 
 @given(numeric_series, st.text())
-def test_roundtrip_pandas_series(ser, ix_name):
+def test_roundtrip_pandas_series(ser, ix_name) -> None:
     # Need to name the index, otherwise Xarray calls it 'dim_0'.
     ser.index.name = ix_name
     arr = xr.DataArray(ser)
@@ -87,7 +87,7 @@ numeric_homogeneous_dataframe = numeric_dtypes.flatmap(
 
 @pytest.mark.xfail
 @given(numeric_homogeneous_dataframe)
-def test_roundtrip_pandas_dataframe(df):
+def test_roundtrip_pandas_dataframe(df) -> None:
     # Need to name the indexes, otherwise Xarray names them 'dim_0', 'dim_1'.
     df.index.name = "rows"
     df.columns.name = "cols"

--- a/xarray/core/accessor_str.py
+++ b/xarray/core/accessor_str.py
@@ -114,7 +114,7 @@ def _apply_str_ufunc(
     obj: Any,
     dtype: Union[str, np.dtype, Type] = None,
     output_core_dims: Union[list, tuple] = ((),),
-    output_sizes: Mapping[Hashable, int] = None,
+    output_sizes: Mapping[Any, int] = None,
     func_args: Tuple = (),
     func_kwargs: Mapping = {},
 ) -> Any:
@@ -227,7 +227,7 @@ class StringAccessor:
         func: Callable,
         dtype: Union[str, np.dtype, Type] = None,
         output_core_dims: Union[list, tuple] = ((),),
-        output_sizes: Mapping[Hashable, int] = None,
+        output_sizes: Mapping[Any, int] = None,
         func_args: Tuple = (),
         func_kwargs: Mapping = {},
     ) -> Any:

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -818,7 +818,7 @@ class DataWithCoords(AttrAccessMixin):
 
     def rolling(
         self,
-        dim: Mapping[Hashable, int] = None,
+        dim: Mapping[Any, int] = None,
         min_periods: int = None,
         center: Union[bool, Mapping[Hashable, bool]] = False,
         **window_kwargs: int,
@@ -892,7 +892,7 @@ class DataWithCoords(AttrAccessMixin):
 
     def rolling_exp(
         self,
-        window: Mapping[Hashable, int] = None,
+        window: Mapping[Any, int] = None,
         window_type: str = "span",
         **window_kwargs,
     ):
@@ -933,7 +933,7 @@ class DataWithCoords(AttrAccessMixin):
 
     def coarsen(
         self,
-        dim: Mapping[Hashable, int] = None,
+        dim: Mapping[Any, int] = None,
         boundary: str = "exact",
         side: Union[str, Mapping[Hashable, str]] = "left",
         coord_func: str = "mean",
@@ -1009,7 +1009,7 @@ class DataWithCoords(AttrAccessMixin):
 
     def resample(
         self,
-        indexer: Mapping[Hashable, str] = None,
+        indexer: Mapping[Any, str] = None,
         skipna=None,
         closed: str = None,
         label: str = None,

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -400,7 +400,7 @@ def apply_dict_of_variables_vfunc(
 
 
 def _fast_dataset(
-    variables: Dict[Hashable, Variable], coord_variables: Mapping[Hashable, Variable]
+    variables: Dict[Hashable, Variable], coord_variables: Mapping[Any, Variable]
 ) -> "Dataset":
     """Create a dataset as quickly as possible.
 

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -158,7 +158,7 @@ class Coordinates(Mapping[Hashable, "DataArray"]):
 
         return pd.MultiIndex(level_list, code_list, names=names)
 
-    def update(self, other: Mapping[Hashable, Any]) -> None:
+    def update(self, other: Mapping[Any, Any]) -> None:
         other_vars = getattr(other, "variables", other)
         coords, indexes = merge_coords(
             [self.variables, other_vars], priority_arg=1, indexes=self.xindexes
@@ -270,7 +270,7 @@ class DatasetCoordinates(Coordinates):
         return self._data._copy_listed(names)
 
     def _update_coords(
-        self, coords: Dict[Hashable, Variable], indexes: Mapping[Hashable, Index]
+        self, coords: Dict[Hashable, Variable], indexes: Mapping[Any, Index]
     ) -> None:
         from .dataset import calculate_dimensions
 
@@ -333,7 +333,7 @@ class DataArrayCoordinates(Coordinates):
         return self._data._getitem_coord(key)
 
     def _update_coords(
-        self, coords: Dict[Hashable, Variable], indexes: Mapping[Hashable, Index]
+        self, coords: Dict[Hashable, Variable], indexes: Mapping[Any, Index]
     ) -> None:
         from .dataset import calculate_dimensions
 
@@ -376,7 +376,7 @@ class DataArrayCoordinates(Coordinates):
 
 
 def assert_coordinate_consistent(
-    obj: Union["DataArray", "Dataset"], coords: Mapping[Hashable, Variable]
+    obj: Union["DataArray", "Dataset"], coords: Mapping[Any, Variable]
 ) -> None:
     """Make sure the dimension coordinate of obj is consistent with coords.
 
@@ -394,7 +394,7 @@ def assert_coordinate_consistent(
 
 def remap_label_indexers(
     obj: Union["DataArray", "Dataset"],
-    indexers: Mapping[Hashable, Any] = None,
+    indexers: Mapping[Any, Any] = None,
     method: str = None,
     tolerance=None,
     **indexers_kwargs: Any,

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -468,7 +468,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
             )
         return self._replace(variable, coords, name, indexes=indexes)
 
-    def _overwrite_indexes(self, indexes: Mapping[Hashable, Any]) -> "DataArray":
+    def _overwrite_indexes(self, indexes: Mapping[Any, Any]) -> "DataArray":
         if not len(indexes):
             return self
         coords = self._coords.copy()
@@ -799,7 +799,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
         return self.variable.attrs
 
     @attrs.setter
-    def attrs(self, value: Mapping[Hashable, Any]) -> None:
+    def attrs(self, value: Mapping[Any, Any]) -> None:
         # Disable type checking to work around mypy bug - see mypy#4167
         self.variable.attrs = value  # type: ignore[assignment]
 
@@ -810,7 +810,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
         return self.variable.encoding
 
     @encoding.setter
-    def encoding(self, value: Mapping[Hashable, Any]) -> None:
+    def encoding(self, value: Mapping[Any, Any]) -> None:
         self.variable.encoding = value
 
     @property
@@ -1122,7 +1122,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
 
     def isel(
         self,
-        indexers: Mapping[Hashable, Any] = None,
+        indexers: Mapping[Any, Any] = None,
         drop: bool = False,
         missing_dims: str = "raise",
         **indexers_kwargs: Any,
@@ -1205,7 +1205,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
 
     def sel(
         self,
-        indexers: Mapping[Hashable, Any] = None,
+        indexers: Mapping[Any, Any] = None,
         method: str = None,
         tolerance=None,
         drop: bool = False,
@@ -1510,7 +1510,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
 
     def reindex(
         self,
-        indexers: Mapping[Hashable, Any] = None,
+        indexers: Mapping[Any, Any] = None,
         method: str = None,
         tolerance=None,
         copy: bool = True,
@@ -1603,7 +1603,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
 
     def interp(
         self,
-        coords: Mapping[Hashable, Any] = None,
+        coords: Mapping[Any, Any] = None,
         method: str = "linear",
         assume_sorted: bool = False,
         kwargs: Mapping[str, Any] = None,
@@ -1827,7 +1827,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
             return self._replace(name=new_name_or_name_dict)
 
     def swap_dims(
-        self, dims_dict: Mapping[Hashable, Hashable] = None, **dims_kwargs
+        self, dims_dict: Mapping[Any, Hashable] = None, **dims_kwargs
     ) -> "DataArray":
         """Returns a new DataArray with swapped dimensions.
 
@@ -2345,7 +2345,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
 
     def drop_sel(
         self,
-        labels: Mapping[Hashable, Any] = None,
+        labels: Mapping[Any, Any] = None,
         *,
         errors: str = "raise",
         **labels_kwargs,
@@ -3175,7 +3175,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
 
     def shift(
         self,
-        shifts: Mapping[Hashable, int] = None,
+        shifts: Mapping[Any, int] = None,
         fill_value: Any = dtypes.NA,
         **shifts_kwargs: int,
     ) -> "DataArray":
@@ -3222,7 +3222,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
 
     def roll(
         self,
-        shifts: Mapping[Hashable, int] = None,
+        shifts: Mapping[Any, int] = None,
         roll_coords: bool = None,
         **shifts_kwargs: int,
     ) -> "DataArray":
@@ -4445,7 +4445,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
 
     def query(
         self,
-        queries: Mapping[Hashable, Any] = None,
+        queries: Mapping[Any, Any] = None,
         parser: str = "pandas",
         engine: str = None,
         missing_dims: str = "raise",

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5137,7 +5137,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         return self.map(func, keep_attrs, args, **kwargs)
 
     def assign(
-        self, variables: Mapping[Hashable, Any] = None, **variables_kwargs: Hashable
+        self, variables: Mapping[Any, Any] = None, **variables_kwargs: Hashable
     ) -> "Dataset":
         """Assign new data variables to a Dataset, returning a new object
         with all the original variables in addition to the new ones.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -186,7 +186,7 @@ def _get_virtual_variable(
     return ref_name, var_name, virtual_var
 
 
-def calculate_dimensions(variables: Mapping[Hashable, Variable]) -> Dict[Hashable, int]:
+def calculate_dimensions(variables: Mapping[Any, Variable]) -> Dict[Hashable, int]:
     """Calculate the dimensions corresponding to a set of variables.
 
     Returns dictionary mapping from dimension names to sizes. Raises ValueError
@@ -214,7 +214,7 @@ def calculate_dimensions(variables: Mapping[Hashable, Variable]) -> Dict[Hashabl
 
 def merge_indexes(
     indexes: Mapping[Hashable, Union[Hashable, Sequence[Hashable]]],
-    variables: Mapping[Hashable, Variable],
+    variables: Mapping[Any, Variable],
     coord_names: Set[Hashable],
     append: bool = False,
 ) -> Tuple[Dict[Hashable, Variable], Set[Hashable]]:
@@ -298,9 +298,9 @@ def merge_indexes(
 
 def split_indexes(
     dims_or_levels: Union[Hashable, Sequence[Hashable]],
-    variables: Mapping[Hashable, Variable],
+    variables: Mapping[Any, Variable],
     coord_names: Set[Hashable],
-    level_coords: Mapping[Hashable, Hashable],
+    level_coords: Mapping[Any, Hashable],
     drop: bool = False,
 ) -> Tuple[Dict[Hashable, Variable], Set[Hashable]]:
     """Extract (multi-)indexes (levels) as variables.
@@ -560,7 +560,7 @@ class _LocIndexer:
     def __init__(self, dataset: "Dataset"):
         self.dataset = dataset
 
-    def __getitem__(self, key: Mapping[Hashable, Any]) -> "Dataset":
+    def __getitem__(self, key: Mapping[Any, Any]) -> "Dataset":
         if not utils.is_dict_like(key):
             raise TypeError("can only lookup dictionaries from Dataset.loc")
         return self.dataset.sel(key)
@@ -731,9 +731,9 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         self,
         # could make a VariableArgs to use more generally, and refine these
         # categories
-        data_vars: Mapping[Hashable, Any] = None,
-        coords: Mapping[Hashable, Any] = None,
-        attrs: Mapping[Hashable, Any] = None,
+        data_vars: Mapping[Any, Any] = None,
+        coords: Mapping[Any, Any] = None,
+        attrs: Mapping[Any, Any] = None,
     ):
         # TODO(shoyer): expose indexes as a public argument in __init__
 
@@ -794,7 +794,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         return self._attrs
 
     @attrs.setter
-    def attrs(self, value: Mapping[Hashable, Any]) -> None:
+    def attrs(self, value: Mapping[Any, Any]) -> None:
         self._attrs = dict(value)
 
     @property
@@ -2165,7 +2165,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         return self._replace(variables)
 
     def _validate_indexers(
-        self, indexers: Mapping[Hashable, Any], missing_dims: str = "raise"
+        self, indexers: Mapping[Any, Any], missing_dims: str = "raise"
     ) -> Iterator[Tuple[Hashable, Union[int, slice, np.ndarray, Variable]]]:
         """Here we make sure
         + indexer has a valid keys
@@ -2209,7 +2209,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
                 yield k, v
 
     def _validate_interp_indexers(
-        self, indexers: Mapping[Hashable, Any]
+        self, indexers: Mapping[Any, Any]
     ) -> Iterator[Tuple[Hashable, Variable]]:
         """Variant of _validate_indexers to be used for interpolation"""
         for k, v in self._validate_indexers(indexers):
@@ -2270,7 +2270,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
 
     def isel(
         self,
-        indexers: Mapping[Hashable, Any] = None,
+        indexers: Mapping[Any, Any] = None,
         drop: bool = False,
         missing_dims: str = "raise",
         **indexers_kwargs: Any,
@@ -2362,7 +2362,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
 
     def _isel_fancy(
         self,
-        indexers: Mapping[Hashable, Any],
+        indexers: Mapping[Any, Any],
         *,
         drop: bool,
         missing_dims: str = "raise",
@@ -2404,7 +2404,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
 
     def sel(
         self,
-        indexers: Mapping[Hashable, Any] = None,
+        indexers: Mapping[Any, Any] = None,
         method: str = None,
         tolerance: Number = None,
         drop: bool = False,
@@ -2708,7 +2708,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
 
     def reindex(
         self,
-        indexers: Mapping[Hashable, Any] = None,
+        indexers: Mapping[Any, Any] = None,
         method: str = None,
         tolerance: Number = None,
         copy: bool = True,
@@ -2918,7 +2918,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
 
     def _reindex(
         self,
-        indexers: Mapping[Hashable, Any] = None,
+        indexers: Mapping[Any, Any] = None,
         method: str = None,
         tolerance: Number = None,
         copy: bool = True,
@@ -2952,7 +2952,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
 
     def interp(
         self,
-        coords: Mapping[Hashable, Any] = None,
+        coords: Mapping[Any, Any] = None,
         method: str = "linear",
         assume_sorted: bool = False,
         kwargs: Mapping[str, Any] = None,
@@ -3321,7 +3321,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
 
     def rename(
         self,
-        name_dict: Mapping[Hashable, Hashable] = None,
+        name_dict: Mapping[Any, Hashable] = None,
         **names: Hashable,
     ) -> "Dataset":
         """Returns a new object with renamed variables and dimensions.
@@ -3362,7 +3362,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         return self._replace(variables, coord_names, dims=dims, indexes=indexes)
 
     def rename_dims(
-        self, dims_dict: Mapping[Hashable, Hashable] = None, **dims: Hashable
+        self, dims_dict: Mapping[Any, Hashable] = None, **dims: Hashable
     ) -> "Dataset":
         """Returns a new object with renamed dimensions only.
 
@@ -3407,7 +3407,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         return self._replace(variables, coord_names, dims=sizes, indexes=indexes)
 
     def rename_vars(
-        self, name_dict: Mapping[Hashable, Hashable] = None, **names: Hashable
+        self, name_dict: Mapping[Any, Hashable] = None, **names: Hashable
     ) -> "Dataset":
         """Returns a new object with renamed variables including coordinates
 
@@ -3445,7 +3445,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         return self._replace(variables, coord_names, dims=dims, indexes=indexes)
 
     def swap_dims(
-        self, dims_dict: Mapping[Hashable, Hashable] = None, **dims_kwargs
+        self, dims_dict: Mapping[Any, Hashable] = None, **dims_kwargs
     ) -> "Dataset":
         """Returns a new object with swapped dimensions.
 
@@ -5313,7 +5313,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
             "Please use Dataset.to_dataframe() instead." % len(self.dims)
         )
 
-    def _to_dataframe(self, ordered_dims: Mapping[Hashable, int]):
+    def _to_dataframe(self, ordered_dims: Mapping[Any, int]):
         columns = [k for k in self.variables if k not in self.dims]
         data = [
             self._variables[k].set_dims(ordered_dims).values.reshape(-1)
@@ -7373,7 +7373,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
 
     def query(
         self,
-        queries: Mapping[Hashable, Any] = None,
+        queries: Mapping[Any, Any] = None,
         parser: str = "pandas",
         engine: str = None,
         missing_dims: str = "raise",

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -170,7 +170,7 @@ MergeElement = Tuple[Variable, Optional[Index]]
 
 def merge_collected(
     grouped: Dict[Hashable, List[MergeElement]],
-    prioritized: Mapping[Hashable, MergeElement] = None,
+    prioritized: Mapping[Any, MergeElement] = None,
     compat: str = "minimal",
     combine_attrs="override",
 ) -> Tuple[Dict[Hashable, Variable], Dict[Hashable, Index]]:
@@ -319,7 +319,7 @@ def collect_from_coordinates(
 
 def merge_coordinates_without_align(
     objects: "List[Coordinates]",
-    prioritized: Mapping[Hashable, MergeElement] = None,
+    prioritized: Mapping[Any, MergeElement] = None,
     exclude_dims: AbstractSet = frozenset(),
     combine_attrs: str = "override",
 ) -> Tuple[Dict[Hashable, Variable], Dict[Hashable, Index]]:

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -816,7 +816,7 @@ def get_temp_dimname(dims: Container[Hashable], new_dim: Hashable) -> Hashable:
 
 
 def drop_dims_from_indexers(
-    indexers: Mapping[Hashable, Any],
+    indexers: Mapping[Any, Any],
     dims: Union[list, Mapping[Hashable, int]],
     missing_dims: str,
 ) -> Mapping[Hashable, Any]:

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -861,7 +861,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         return self._attrs
 
     @attrs.setter
-    def attrs(self, value: Mapping[Hashable, Any]) -> None:
+    def attrs(self, value: Mapping[Any, Any]) -> None:
         self._attrs = dict(value)
 
     @property
@@ -1122,7 +1122,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
 
     def isel(
         self: VariableType,
-        indexers: Mapping[Hashable, Any] = None,
+        indexers: Mapping[Any, Any] = None,
         missing_dims: str = "raise",
         **indexers_kwargs: Any,
     ) -> VariableType:
@@ -1557,7 +1557,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         return result
 
     def _unstack_once_full(
-        self, dims: Mapping[Hashable, int], old_dim: Hashable
+        self, dims: Mapping[Any, int], old_dim: Hashable
     ) -> "Variable":
         """
         Unstacks the variable without needing an index.

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6795,3 +6795,12 @@ class TestNumpyCoercion:
         result = ds.as_numpy()
         expected = xr.Dataset({"a": ("x", arr)}, coords={"lat": ("x", arr * 2)})
         assert_identical(result, expected)
+
+
+def test_string_keys_typing() -> None:
+    """Tests that string keys to `variables` are permitted by mypy"""
+
+    da = xr.DataArray(np.arange(10), dims=["x"])
+    ds = xr.Dataset(dict(x=da))
+    mapping = {"y": da}
+    ds.assign(variables=mapping)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

IIUC:
- [This test](https://github.com/pydata/xarray/pull/5690/files#diff-2db7f6624707083db4aaab1b62eb11352200ec9d3ac1055de84877912226d7b5R6800) below would fail mypy because the key of `Mapping` is invariant (though `Any` still lets anything through)
  - I've only seen this when the dict is defined in a different expression from the Dataset constructor
- Mypy doesn't type-check our test functions, [because the functions don't have any annotations](https://mypy.readthedocs.io/en/stable/common_issues.html#no-errors-reported-for-obviously-wrong-code).

If that's correct, we should change all our `Mapping` to use `Any` rather than `Hashable`, and add type annotations to our test functions (even just `-> None`)