### PR TITLE
Use the same bool validator as other inputs for use_bottleneck in xr.set_options

### DIFF
--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -56,7 +56,7 @@ _VALIDATORS = {
     FILE_CACHE_MAXSIZE: _positive_integer,
     KEEP_ATTRS: lambda choice: choice in [True, False, "default"],
     WARN_FOR_UNCLOSED_FILES: lambda value: isinstance(value, bool),
-    USE_BOTTLENECK: lambda choice: choice in [True, False],
+    USE_BOTTLENECK: lambda value: isinstance(value, bool),
 }
 
 


### PR DESCRIPTION
Minor change to align with other booleans.