### PR TITLE
Fix errors in test_latex_name_isnt_split for min environments

### DIFF
--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2952,6 +2952,7 @@ def test_datarray_scatter(x, y, z, hue, markersize, row, col, add_legend, add_co
         )
 
 
+@requires_matplotlib
 def test_latex_name_isnt_split():
     da = xr.DataArray()
     long_latex_name = r"$Ra_s = \mathrm{mean}(\epsilon_k) / \mu M^2_\infty$"

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2952,7 +2952,7 @@ def test_datarray_scatter(x, y, z, hue, markersize, row, col, add_legend, add_co
         )
 
 
-@requires_matplotlib
+# @requires_matplotlib
 def test_latex_name_isnt_split():
     da = xr.DataArray()
     long_latex_name = r"$Ra_s = \mathrm{mean}(\epsilon_k) / \mu M^2_\infty$"

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2952,7 +2952,7 @@ def test_datarray_scatter(x, y, z, hue, markersize, row, col, add_legend, add_co
         )
 
 
-# @requires_matplotlib
+@requires_matplotlib
 def test_latex_name_isnt_split():
     da = xr.DataArray()
     long_latex_name = r"$Ra_s = \mathrm{mean}(\epsilon_k) / \mu M^2_\infty$"

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -185,6 +185,11 @@ class TestPlot(PlotTestCase):
         da.attrs.pop("units")
         assert "a" == label_from_attrs(da)
 
+        # Latex strings can be longer without needing a new line:
+        long_latex_name = r"$Ra_s = \mathrm{mean}(\epsilon_k) / \mu M^2_\infty$"
+        da.attrs = dict(long_name=long_latex_name)
+        assert label_from_attrs(da) == long_latex_name
+
     def test1d(self):
         self.darray[:, 0, 0].plot()
 
@@ -2950,11 +2955,3 @@ def test_datarray_scatter(x, y, z, hue, markersize, row, col, add_legend, add_co
             add_legend=add_legend,
             add_colorbar=add_colorbar,
         )
-
-
-@requires_matplotlib
-def test_latex_name_isnt_split():
-    da = xr.DataArray()
-    long_latex_name = r"$Ra_s = \mathrm{mean}(\epsilon_k) / \mu M^2_\infty$"
-    da.attrs = dict(long_name=long_latex_name)
-    assert label_from_attrs(da) == long_latex_name


### PR DESCRIPTION
There's some error in the minimum environments (for example `ubuntu-latest py37-bare-minimum`) introduced in #5682 but was hidden in all other errors because of #5654:
```
 =========================== short test summary info ============================
ERROR xarray/tests/test_plot.py::test_latex_name_isnt_split - NameError: name...
= 7908 passed, 4163 skipped, 202 xfailed, 42 xpassed, 89 warnings, 1 error in 279.31s (0:04:39) =
```

But when looking further in the details it mentions a completely different function crashing because matplotlib isn't installed, which is true but the function doesn't test any mpl-specific things. 
```
 ==================================== ERRORS ====================================
_______________ ERROR at teardown of test_latex_name_isnt_split ________________
[gw0] linux -- Python 3.7.10 /usr/share/miniconda/envs/xarray-tests/bin/python

    @pytest.fixture(scope="function", autouse=True)
    def test_all_figures_closed():
        """meta-test to ensure all figures are closed at the end of a test
    
        Notes:  Scope is kept to module (only invoke this function once per test
        module) else tests cannot be run in parallel (locally). Disadvantage: only
        catches one open figure per run. May still give a false positive if tests
        are run in parallel.
        """
        yield None
    
>       open_figs = len(plt.get_fignums())
E       NameError: name 'plt' is not defined

/home/runner/work/xarray/xarray/xarray/tests/test_plot.py:72: NameError
```
Might be something that pytest runs on every function. Not sure if there's a clean way of turning it off, but requiring matplotlib to be installed works of course.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Passes `pre-commit run --all-files`
