### PR TITLE
Remove use of deprecated kind argument in `CFTimeIndex` tests

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -59,6 +59,9 @@ Internal Changes
   By `Jimmy Westling <https://github.com/illviljan>`_.
 - Use isort's `float_to_top` config. (:pull:`5695`).
   By `Maximilian Roos <https://github.com/max-sixty>`_.
+- Remove use of the deprecated ``kind`` argument in
+  :py:meth:`pandas.Index.get_slice_bound` inside :py:class:`xarray.CFTimeIndex`
+  tests (:pull:`5722`).  By `Spencer Clark <https://github.com/spencerkclark>`_.
 
 .. _whats-new.0.19.0:
 

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -345,65 +345,58 @@ def test_get_loc(date_type, index):
 
 
 @requires_cftime
-@pytest.mark.parametrize("kind", ["loc", "getitem"])
-def test_get_slice_bound(date_type, index, kind):
-    result = index.get_slice_bound("0001", "left", kind)
+def test_get_slice_bound(date_type, index):
+    result = index.get_slice_bound("0001", "left")
     expected = 0
     assert result == expected
 
-    result = index.get_slice_bound("0001", "right", kind)
+    result = index.get_slice_bound("0001", "right")
     expected = 2
     assert result == expected
 
-    result = index.get_slice_bound(date_type(1, 3, 1), "left", kind)
+    result = index.get_slice_bound(date_type(1, 3, 1), "left")
     expected = 2
     assert result == expected
 
-    result = index.get_slice_bound(date_type(1, 3, 1), "right", kind)
+    result = index.get_slice_bound(date_type(1, 3, 1), "right")
     expected = 2
     assert result == expected
 
 
 @requires_cftime
-@pytest.mark.parametrize("kind", ["loc", "getitem"])
-def test_get_slice_bound_decreasing_index(date_type, monotonic_decreasing_index, kind):
-    result = monotonic_decreasing_index.get_slice_bound("0001", "left", kind)
+def test_get_slice_bound_decreasing_index(date_type, monotonic_decreasing_index):
+    result = monotonic_decreasing_index.get_slice_bound("0001", "left")
     expected = 2
     assert result == expected
 
-    result = monotonic_decreasing_index.get_slice_bound("0001", "right", kind)
+    result = monotonic_decreasing_index.get_slice_bound("0001", "right")
     expected = 4
     assert result == expected
 
-    result = monotonic_decreasing_index.get_slice_bound(
-        date_type(1, 3, 1), "left", kind
-    )
+    result = monotonic_decreasing_index.get_slice_bound(date_type(1, 3, 1), "left")
     expected = 2
     assert result == expected
 
-    result = monotonic_decreasing_index.get_slice_bound(
-        date_type(1, 3, 1), "right", kind
-    )
+    result = monotonic_decreasing_index.get_slice_bound(date_type(1, 3, 1), "right")
     expected = 2
     assert result == expected
 
 
 @requires_cftime
-@pytest.mark.parametrize("kind", ["loc", "getitem"])
-def test_get_slice_bound_length_one_index(date_type, length_one_index, kind):
-    result = length_one_index.get_slice_bound("0001", "left", kind)
+def test_get_slice_bound_length_one_index(date_type, length_one_index):
+    result = length_one_index.get_slice_bound("0001", "left")
     expected = 0
     assert result == expected
 
-    result = length_one_index.get_slice_bound("0001", "right", kind)
+    result = length_one_index.get_slice_bound("0001", "right")
     expected = 1
     assert result == expected
 
-    result = length_one_index.get_slice_bound(date_type(1, 3, 1), "left", kind)
+    result = length_one_index.get_slice_bound(date_type(1, 3, 1), "left")
     expected = 1
     assert result == expected
 
-    result = length_one_index.get_slice_bound(date_type(1, 3, 1), "right", kind)
+    result = length_one_index.get_slice_bound(date_type(1, 3, 1), "right")
     expected = 1
     assert result == expected
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
On the topic of FutureWarning's related to indexing in pandas (#5721), I noticed some another kind of warning in the `CFTimeIndex` tests:
```
/Users/spencer/software/xarray/xarray/tests/test_cftimeindex.py:350: FutureWarning: 'kind' argument in get_slice_bound is deprecated and will be removed in a future version.  Do not pass it.
    result = index.get_slice_bound("0001", "left", kind)
```
I think it's safe to silence these by removing the `kind` argument from these tests.  We never used it anyway in `CFTimeIndex`.  This is sort of a follow-up to #5359.

- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
