### PR TITLE
extend show_versions

### DIFF
--- a/xarray/util/print_versions.py
+++ b/xarray/util/print_versions.py
@@ -118,6 +118,7 @@ def show_versions(file=sys.stdout):
         ("cartopy", lambda mod: mod.__version__),
         ("seaborn", lambda mod: mod.__version__),
         ("numbagg", lambda mod: mod.__version__),
+        ("fsspec", lambda mod: mod.__version__),
         ("sparse", lambda mod: mod.__version__),
         ("pint", lambda mod: mod.__version__),
         # xarray setup/test

--- a/xarray/util/print_versions.py
+++ b/xarray/util/print_versions.py
@@ -119,8 +119,9 @@ def show_versions(file=sys.stdout):
         ("seaborn", lambda mod: mod.__version__),
         ("numbagg", lambda mod: mod.__version__),
         ("fsspec", lambda mod: mod.__version__),
-        ("sparse", lambda mod: mod.__version__),
+        ("cupy", lambda mod: mod.__version__),
         ("pint", lambda mod: mod.__version__),
+        ("sparse", lambda mod: mod.__version__),
         # xarray setup/test
         ("setuptools", lambda mod: mod.__version__),
         ("pip", lambda mod: mod.__version__),

--- a/xarray/util/print_versions.py
+++ b/xarray/util/print_versions.py
@@ -118,6 +118,7 @@ def show_versions(file=sys.stdout):
         ("cartopy", lambda mod: mod.__version__),
         ("seaborn", lambda mod: mod.__version__),
         ("numbagg", lambda mod: mod.__version__),
+        ("sparse", lambda mod: mod.__version__),
         ("pint", lambda mod: mod.__version__),
         # xarray setup/test
         ("setuptools", lambda mod: mod.__version__),


### PR DESCRIPTION
add `cupy`, `sparse` and `fsspec` to the output of `xr.show_versions()`

- [x] Passes `pre-commit run --all-files`
