### PR TITLE
Add xarray-dataclasses to ecosystem in docs

### DIFF
--- a/doc/ecosystem.rst
+++ b/doc/ecosystem.rst
@@ -68,6 +68,7 @@ Extend xarray capabilities
 - `hypothesis-gufunc <https://hypothesis-gufunc.readthedocs.io/en/latest/>`_: Extension to hypothesis. Makes it easy to write unit tests with xarray objects as input.
 - `nxarray <https://github.com/nxarray/nxarray>`_: NeXus input/output capability for xarray.
 - `xarray-compare <https://github.com/astropenguin/xarray-compare>`_: xarray extension for data comparison.
+- `xarray-dataclasses <https://github.com/astropenguin/xarray-dataclasses>`_: xarray extension for typed DataArray and Dataset creation.
 - `xarray_extras <https://github.com/crusaderky/xarray_extras>`_: Advanced algorithms for xarray objects (e.g. integrations/interpolations).
 - `xpublish <https://xpublish.readthedocs.io/>`_: Publish Xarray Datasets via a Zarr compatible REST API.
 - `xrft <https://github.com/rabernat/xrft>`_: Fourier transforms for xarray data.

--- a/doc/ecosystem.rst
+++ b/doc/ecosystem.rst
@@ -68,7 +68,6 @@ Extend xarray capabilities
 - `hypothesis-gufunc <https://hypothesis-gufunc.readthedocs.io/en/latest/>`_: Extension to hypothesis. Makes it easy to write unit tests with xarray objects as input.
 - `nxarray <https://github.com/nxarray/nxarray>`_: NeXus input/output capability for xarray.
 - `xarray-compare <https://github.com/astropenguin/xarray-compare>`_: xarray extension for data comparison.
-- `xarray-custom <https://github.com/astropenguin/xarray-custom>`_: Data classes for custom xarray creation.
 - `xarray_extras <https://github.com/crusaderky/xarray_extras>`_: Advanced algorithms for xarray objects (e.g. integrations/interpolations).
 - `xpublish <https://xpublish.readthedocs.io/>`_: Publish Xarray Datasets via a Zarr compatible REST API.
 - `xrft <https://github.com/rabernat/xrft>`_: Fourier transforms for xarray data.


### PR DESCRIPTION
We have released [xarray-dataclasses](https://github.com/astropenguin/xarray-dataclasses), an xarray extension for typed DataArray and Dataset creation.
This PR added the project to the "Extend xarray capabilities" section in `doc/ecosystem.rst`.
Plus we removed [xarray-custom](https://github.com/astropenguin/xarray-custom) (added by #4109) from the same section.
This is because it is not maintained and xarray-dataclasses is the successor.
It would be appreciated if you could merge it (if this PR fits the purpose of the xarray documentation).

