### PR TITLE
Xfail failing test on main

### DIFF
--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -854,6 +854,7 @@ class TestSparseCoords:
         )
 
 
+@pytest.mark.xfail(reason="https://github.com/pydata/xarray/issues/5654")
 @requires_dask
 def test_chunk():
     s = sparse.COO.from_numpy(np.array([0, 0, 1, 2]))


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

ref https://github.com/pydata/xarray/issues/5654

I vote to always do this when a dependency changes, if we can't immediately fix the code. Having main be green means it's easy to see the difference between passing and failing.