### PR TITLE
remove deprecated xshape from ecosystem documentation

### DIFF
--- a/doc/ecosystem.rst
+++ b/doc/ecosystem.rst
@@ -46,7 +46,6 @@ Geosciences
 - `xESMF <https://pangeo-xesmf.readthedocs.io/>`_: Universal regridder for geospatial data.
 - `xgcm <https://xgcm.readthedocs.io/>`_: Extends the xarray data model to understand finite volume grid cells (common in General Circulation Models) and provides interpolation and difference operations for such grids.
 - `xmitgcm <http://xgcm.readthedocs.io/>`_: a python package for reading `MITgcm <http://mitgcm.org/>`_ binary MDS files into xarray data structures.
-- `xshape <https://xshape.readthedocs.io/>`_: Tools for working with shapefiles, topographies, and polygons in xarray.
 
 Machine Learning
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Updating documentation to remove https://github.com/ClimateImpactLab/xshape , which says "deprecated. Use geopandas".

<!-- Feel free to remove check-list items aren't relevant to your change -->
