### PR TITLE
Install development version of nc-time-axis in upstream build

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -42,4 +42,5 @@ python -m pip install \
     git+https://github.com/hgrecco/pint \
     git+https://github.com/pydata/bottleneck \
     git+https://github.com/pydata/sparse \
-    git+https://github.com/intake/filesystem_spec
+    git+https://github.com/intake/filesystem_spec \
+    git+https://github.com/SciTools/nc-time-axis


### PR DESCRIPTION
I think this would be good to do anyway, but I'm also curious to see if it fixes the cftime plotting tests in #5743.
