### PR TITLE
fix: typo spelling grammar

### DIFF
--- a/doc/ecosystem.rst
+++ b/doc/ecosystem.rst
@@ -16,7 +16,7 @@ Geosciences
 - `climpred <https://climpred.readthedocs.io>`_: Analysis of ensemble forecast models for climate prediction.
 - `geocube <https://corteva.github.io/geocube>`_: Tool to convert geopandas vector data into rasterized xarray data.
 - `GeoWombat <https://github.com/jgrss/geowombat>`_: Utilities for analysis of remotely sensed and gridded raster data at scale (easily tame Landsat, Sentinel, Quickbird, and PlanetScope).
-- `infinite-diff <https://github.com/spencerahill/infinite-diff>`_: xarray-based finite-differencing, focused on gridded climate/meterology data
+- `infinite-diff <https://github.com/spencerahill/infinite-diff>`_: xarray-based finite-differencing, focused on gridded climate/meteorology data
 - `marc_analysis <https://github.com/darothen/marc_analysis>`_: Analysis package for CESM/MARC experiments and output.
 - `MetPy <https://unidata.github.io/MetPy/dev/index.html>`_: A collection of tools in Python for reading, visualizing, and performing calculations with weather data.
 - `MPAS-Analysis <http://mpas-analysis.readthedocs.io>`_: Analysis for simulations produced with Model for Prediction Across Scales (MPAS) components and the Accelerated Climate Model for Energy (ACME).

--- a/doc/roadmap.rst
+++ b/doc/roadmap.rst
@@ -37,7 +37,7 @@ Why has xarray been successful? In our opinion:
       labeled multidimensional arrays, rather than solving particular
       problems.
    -  This facilitates collaboration between users with different needs,
-      and helps us attract a broad community of contributers.
+      and helps us attract a broad community of contributors.
    -  Importantly, this retains flexibility, for use cases that don't
       fit particularly well into existing frameworks.
 
@@ -82,7 +82,7 @@ We think the right approach to extending xarray's user community and the
 usefulness of the project is to focus on improving key interfaces that
 can be used externally to meet domain-specific needs.
 
-We can generalize the community's needs into three main catagories:
+We can generalize the community's needs into three main caeagories:
 
 -  More flexible grids/indexing.
 -  More flexible arrays/computing.

--- a/doc/user-guide/computation.rst
+++ b/doc/user-guide/computation.rst
@@ -214,7 +214,7 @@ We can also manually iterate through ``Rolling`` objects:
 
 While ``rolling`` provides a simple moving average, ``DataArray`` also supports
 an exponential moving average with :py:meth:`~xarray.DataArray.rolling_exp`.
-This is similiar to pandas' ``ewm`` method. numbagg_ is required.
+This is similar to pandas' ``ewm`` method. numbagg_ is required.
 
 .. _numbagg: https://github.com/shoyer/numbagg
 

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -360,7 +360,7 @@ Scaling and type conversions
 
 These encoding options work on any version of the netCDF file format:
 
-- ``dtype``: Any valid NumPy dtype or string convertable to a dtype, e.g., ``'int16'``
+- ``dtype``: Any valid NumPy dtype or string convertible to a dtype, e.g., ``'int16'``
   or ``'float32'``. This controls the type of the data written on disk.
 - ``_FillValue``:  Values of ``NaN`` in xarray variables are remapped to this value when
   saved on disk. This is important when converting floating point with missing values
@@ -405,7 +405,7 @@ If character arrays are used:
   `any string encoding recognized by Python <https://docs.python.org/3/library/codecs.html#standard-encodings>`_ if you feel the need to deviate from UTF-8,
   by setting the ``_Encoding`` field in ``encoding``. But
   `we don't recommend it <http://utf8everywhere.org/>`_.
-- The character dimension name can be specifed by the ``char_dim_name`` field of a variable's
+- The character dimension name can be specified by the ``char_dim_name`` field of a variable's
   ``encoding``. If the name of the character dimension is not specified, the default is
   ``f'string{data.shape[-1]}'``. When decoding character arrays from existing files, the
   ``char_dim_name`` is added to the variables ``encoding`` to preserve if encoding happens, but
@@ -472,7 +472,7 @@ Invalid netCDF files
 The library ``h5netcdf`` allows writing some dtypes (booleans, complex, ...) that aren't
 allowed in netCDF4 (see
 `h5netcdf documentation <https://github.com/shoyer/h5netcdf#invalid-netcdf-files>`_).
-This feature is availabe through :py:meth:`DataArray.to_netcdf` and
+This feature is available through :py:meth:`DataArray.to_netcdf` and
 :py:meth:`Dataset.to_netcdf` when used with ``engine="h5netcdf"``
 and currently raises a warning unless ``invalid_netcdf=True`` is set:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -369,7 +369,7 @@ New Features
 - Added :py:meth:`DataArray.curvefit` and :py:meth:`Dataset.curvefit` for general curve fitting applications. (:issue:`4300`, :pull:`4849`)
   By `Sam Levang <https://github.com/slevang>`_.
 - Add options to control expand/collapse of sections in display of Dataset and
-  DataArray. The function :py:func:`set_options` now takes keyword aguments
+  DataArray. The function :py:func:`set_options` now takes keyword arguments
   ``display_expand_attrs``, ``display_expand_coords``, ``display_expand_data``,
   ``display_expand_data_vars``, all of which can be one of ``True`` to always
   expand, ``False`` to always collapse, or ``default`` to expand unless over a
@@ -2628,7 +2628,7 @@ This minor release contains a number of backwards compatible enhancements.
 Announcements of note:
 
 - Xarray is now a NumFOCUS fiscally sponsored project! Read
-  `the anouncement <https://numfocus.org/blog/xarray-joins-numfocus-sponsored-projects>`_
+  `the announcement <https://numfocus.org/blog/xarray-joins-numfocus-sponsored-projects>`_
   for more details.
 - We have a new :doc:`roadmap` that outlines our future development plans.
 
@@ -3481,7 +3481,7 @@ Enhancements
   By `Willi Rath <https://github.com/willirath>`_.
 
 - You can now explicitly disable any default ``_FillValue`` (``NaN`` for
-  floating point values) by passing the enconding ``{'_FillValue': None}``
+  floating point values) by passing the encoding ``{'_FillValue': None}``
   (:issue:`1598`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
 
@@ -5056,7 +5056,7 @@ Enhancements
   These methods return a new Dataset (or DataArray) with updated data or
   coordinate variables.
 - ``xray.Dataset.sel`` now supports the ``method`` parameter, which works
-  like the paramter of the same name on ``xray.Dataset.reindex``. It
+  like the parameter of the same name on ``xray.Dataset.reindex``. It
   provides a simple interface for doing nearest-neighbor interpolation:
 
   .. use verbatim because I can't seem to install pandas 0.16.1 on RTD :(
@@ -5253,7 +5253,7 @@ Breaking changes
 
       xray.DataArray([1, 2, np.nan, 3]).mean()
 
-  You can turn this behavior off by supplying the keyword arugment
+  You can turn this behavior off by supplying the keyword argument
   ``skipna=False``.
 
   These operations are lightning fast thanks to integration with bottleneck_,


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
fixing typo spelling grammar and replace to correct words with reference from [merriam webster](merriam-webster.com)
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] Fix typo