### PR TITLE
Update `sparse` `test_chunk` xfail

### DIFF
--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -854,7 +854,9 @@ class TestSparseCoords:
         )
 
 
-@pytest.mark.xfail(sparse_version < "0.13.0", reason="https://github.com/pydata/xarray/issues/5654")
+@pytest.mark.xfail(
+    sparse_version < "0.13.0", reason="https://github.com/pydata/xarray/issues/5654"
+)
 @requires_dask
 def test_chunk():
     s = sparse.COO.from_numpy(np.array([0, 0, 1, 2]))

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 import pickle
 from textwrap import dedent
 
@@ -854,7 +855,7 @@ class TestSparseCoords:
         )
 
 
-@pytest.mark.xfail(reason="https://github.com/pydata/xarray/issues/5654")
+@pytest.mark.xfail(LooseVersion(sparse.__version__) < "0.13.0", reason="https://github.com/pydata/xarray/issues/5654")
 @requires_dask
 def test_chunk():
     s = sparse.COO.from_numpy(np.array([0, 0, 1, 2]))

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -1,5 +1,5 @@
-from distutils.version import LooseVersion
 import pickle
+from distutils.version import LooseVersion
 from textwrap import dedent
 
 import numpy as np
@@ -855,7 +855,10 @@ class TestSparseCoords:
         )
 
 
-@pytest.mark.xfail(LooseVersion(sparse.__version__) < "0.13.0", reason="https://github.com/pydata/xarray/issues/5654")
+@pytest.mark.xfail(
+    LooseVersion(sparse.__version__) < "0.13.0",
+    reason="https://github.com/pydata/xarray/issues/5654",
+)
 @requires_dask
 def test_chunk():
     s = sparse.COO.from_numpy(np.array([0, 0, 1, 2]))

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -1,5 +1,4 @@
 import pickle
-from distutils.version import LooseVersion
 from textwrap import dedent
 
 import numpy as np
@@ -9,7 +8,7 @@ import pytest
 import xarray as xr
 import xarray.ufuncs as xu
 from xarray import DataArray, Variable
-from xarray.core.pycompat import sparse_array_type
+from xarray.core.pycompat import sparse_array_type, sparse_version
 
 from . import assert_equal, assert_identical, requires_dask
 
@@ -855,10 +854,7 @@ class TestSparseCoords:
         )
 
 
-@pytest.mark.xfail(
-    LooseVersion(sparse.__version__) < "0.13.0",
-    reason="https://github.com/pydata/xarray/issues/5654",
-)
+@pytest.mark.xfail(sparse_version < "0.13.0", reason="https://github.com/pydata/xarray/issues/5654")
 @requires_dask
 def test_chunk():
     s = sparse.COO.from_numpy(np.array([0, 0, 1, 2]))


### PR DESCRIPTION
`xarray/tests/test_sparse.py::test_chunk` now passes with the latest `sparse=0.13.0` release

- [x] Closes https://github.com/pydata/xarray/issues/5654
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
