### PR TITLE
remove _ensure_plottable

### DIFF
--- a/xarray/plot/plot.py
+++ b/xarray/plot/plot.py
@@ -18,7 +18,6 @@ from .utils import (
     _add_colorbar,
     _adjust_legend_subtitles,
     _assert_valid_xy,
-    _ensure_plottable,
     _infer_interval_breaks,
     _infer_xy_labels,
     _is_numeric,
@@ -434,8 +433,6 @@ def line(
     )
     xlabel = label_from_attrs(xplt, extra=x_suffix)
     ylabel = label_from_attrs(yplt, extra=y_suffix)
-
-    _ensure_plottable(xplt_val, yplt_val)
 
     primitive = ax.plot(xplt_val, yplt_val, *args, **kwargs)
 
@@ -1174,8 +1171,6 @@ def _plot2d(plotfunc):
         # Replace pd.Intervals if contained in xval or yval.
         xplt, xlab_extra = _resolve_intervals_2dplot(xval, plotfunc.__name__)
         yplt, ylab_extra = _resolve_intervals_2dplot(yval, plotfunc.__name__)
-
-        _ensure_plottable(xplt, yplt, zval)
 
         cmap_params, cbar_kwargs = _process_cmap_cbar_kwargs(
             plotfunc,

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -614,51 +614,6 @@ def _valid_numpy_subdtype(x, numpy_types):
     return any(np.issubdtype(x.dtype, t) for t in numpy_types)
 
 
-def _ensure_plottable(*args):
-    """
-    Raise exception if there is anything in args that can't be plotted on an
-    axis by matplotlib.
-    """
-    numpy_types = [
-        np.floating,
-        np.integer,
-        np.timedelta64,
-        np.datetime64,
-        np.bool_,
-        np.str_,
-    ]
-    other_types = [datetime]
-    try:
-        import cftime
-
-        cftime_datetime = [cftime.datetime]
-    except ImportError:
-        cftime_datetime = []
-    other_types = other_types + cftime_datetime
-    for x in args:
-        if not (
-            _valid_numpy_subdtype(np.array(x), numpy_types)
-            or _valid_other_type(np.array(x), other_types)
-        ):
-            raise TypeError(
-                "Plotting requires coordinates to be numeric, boolean, "
-                "or dates of type numpy.datetime64, "
-                "datetime.datetime, cftime.datetime or "
-                f"pandas.Interval. Received data of type {np.array(x).dtype} instead."
-            )
-        if (
-            _valid_other_type(np.array(x), cftime_datetime)
-            and not nc_time_axis_available
-        ):
-            raise ImportError(
-                "Plotting of arrays of cftime.datetime "
-                "objects or arrays indexed by "
-                "cftime.datetime objects requires the "
-                "optional `nc-time-axis` (v1.2.0 or later) "
-                "package."
-            )
-
-
 def _is_numeric(arr):
     numpy_types = [np.floating, np.integer]
     return _valid_numpy_subdtype(arr, numpy_types)


### PR DESCRIPTION
The plotting backend does more reliable checking and thus removing avoids
false negatives, which are causing easily avoidable plot failures

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #5762
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
