### PR TITLE
Update combine error

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -65,7 +65,7 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
-- Users are instructed to try ``use_cftime=True`` if they try to open a dataset and its dimensions are not all the same data type (:pull:`5776`).
+- Users are instructed to try ``use_cftime=True`` if a ``TypeError`` occurs when combining datasets and one of the types involved is a subclass of ``cftime.datetime`` (:pull:`5776`).
   By `Zeb Nicholls <https://github.com/znicholls>`_.
 
 Internal Changes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -65,7 +65,7 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
-- Users are instructed to try ``use_cftime=True`` if they try to open a dataset and its dimensions are not all the same data type (:pull:`5767`).
+- Users are instructed to try ``use_cftime=True`` if they try to open a dataset and its dimensions are not all the same data type (:pull:`5776`).
   By `Zeb Nicholls <https://github.com/znicholls>`_.
 
 Internal Changes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -65,6 +65,8 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
+- Users are instructed to try ``use_cftime=True`` if they try to open a dataset and its dimensions are not all the same data type (:pull:`5767`).
+  By `Zeb Nicholls <https://github.com/znicholls>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -2,7 +2,6 @@ import itertools
 import warnings
 from collections import Counter
 
-import cftime
 import pandas as pd
 
 from . import dtypes
@@ -51,7 +50,11 @@ def _ensure_same_types(series, dim):
     if series.dtype == object:
         types = set(series.map(type))
         if len(types) > 1:
-            cftimes = any(issubclass(t, cftime.datetime) for t in types)
+            try:
+                import cftime
+                cftimes = any(issubclass(t, cftime.datetime) for t in types)
+            except ImportError:
+                cftimes = False
 
             types = ", ".join(t.__name__ for t in types)
 

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -64,7 +64,10 @@ def _ensure_same_types(series, dim):
                 f" Found: {types}."
             )
             if cftimes:
-                error_msg = f"{error_msg} Setting `use_cftime=True` may fix this issue."
+                error_msg = (
+                    f"{error_msg} If importing data directly from a file then "
+                    f"setting `use_cftime=True` may fix this issue."
+                )
 
             raise TypeError(error_msg)
 

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -52,6 +52,7 @@ def _ensure_same_types(series, dim):
         if len(types) > 1:
             try:
                 import cftime
+
                 cftimes = any(issubclass(t, cftime.datetime) for t in types)
             except ImportError:
                 cftimes = False

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -2,6 +2,7 @@ import itertools
 import warnings
 from collections import Counter
 
+import cftime
 import pandas as pd
 
 from . import dtypes
@@ -50,12 +51,18 @@ def _ensure_same_types(series, dim):
     if series.dtype == object:
         types = set(series.map(type))
         if len(types) > 1:
+            cftimes = any(issubclass(t, cftime.datetime) for t in types)
+
             types = ", ".join(t.__name__ for t in types)
-            raise TypeError(
+
+            error_msg = (
                 f"Cannot combine along dimension '{dim}' with mixed types."
                 f" Found: {types}."
-                f" Setting `use_cftime=True` may fix this issue."
             )
+            if cftimes:
+                error_msg = f"{error_msg} Setting `use_cftime=True` may fix this issue."
+
+            raise TypeError(error_msg)
 
 
 def _infer_concat_order_from_coords(datasets):

--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -54,6 +54,7 @@ def _ensure_same_types(series, dim):
             raise TypeError(
                 f"Cannot combine along dimension '{dim}' with mixed types."
                 f" Found: {types}."
+                f" Setting `use_cftime=True` may fix this issue."
             )
 
 

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -1100,7 +1100,8 @@ def test_combine_by_coords_raises_for_differing_calendars():
         error_msg = (
             "Cannot combine along dimension 'time' with mixed types."
             " Found:.*"
-            " Setting `use_cftime=True` may fix this issue."
+            " If importing data directly from a file then setting"
+            " `use_cftime=True` may fix this issue."
         )
     else:
         error_msg = r"cannot compare .* \(different calendars\)"

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -1099,8 +1099,8 @@ def test_combine_by_coords_raises_for_differing_calendars():
     if LooseVersion(cftime.__version__) >= LooseVersion("1.5"):
         error_msg = (
             "Cannot combine along dimension 'time' with mixed types."
-            "Found:.*"
-            "Setting `use_cftime=True` may fix this issue."
+            " Found:.*"
+            " Setting `use_cftime=True` may fix this issue."
         )
     else:
         error_msg = r"cannot compare .* \(different calendars\)"

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -1097,7 +1097,11 @@ def test_combine_by_coords_raises_for_differing_calendars():
     da_2 = DataArray([1], dims=["time"], coords=[time_2], name="a").to_dataset()
 
     if LooseVersion(cftime.__version__) >= LooseVersion("1.5"):
-        error_msg = "Cannot combine along dimension 'time' with mixed types."
+        error_msg = (
+            "Cannot combine along dimension 'time' with mixed types."
+            "Found:.*"
+            "Setting `use_cftime=True` may fix this issue."
+        )
     else:
         error_msg = r"cannot compare .* \(different calendars\)"
 


### PR DESCRIPTION
The update points users in the direction of the `use_cftime` argument, which can solve issues where calendars are decoded into different time classes (see also the discussion in #5767)

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
