### PR TITLE
"Xarray" and "xarray"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ to support our efforts.
 History
 -------
 
-xarray is an evolution of an internal tool developed at `The Climate
+Xarray is an evolution of an internal tool developed at `The Climate
 Corporation`__. It was originally written by Climate Corp researchers Stephan
 Hoyer, Alex Kleeman and Eugene Brevdo and was released as open source in
 May 2014. The project was renamed from "xray" in January 2016. Xarray became a
@@ -131,16 +131,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-xarray bundles portions of pandas, NumPy and Seaborn, all of which are available
+Xarray bundles portions of pandas, NumPy and Seaborn, all of which are available
 under a "3-clause BSD" license:
 - pandas: setup.py, xarray/util/print_versions.py
 - NumPy: xarray/core/npcompat.py
 - Seaborn: _determine_cmap_params in xarray/core/plot/utils.py
 
-xarray also bundles portions of CPython, which is available under the "Python
+Xarray also bundles portions of CPython, which is available under the "Python
 Software Foundation License" in xarray/core/pycompat.py.
 
-xarray uses icons from the icomoon package (free version), which is
+Xarray uses icons from the icomoon package (free version), which is
 available under the "CC BY 4.0" license.
 
 The full text of these licenses are included in the licenses directory.

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -599,8 +599,8 @@ Universal functions
 
 .. warning::
 
-   With recent versions of numpy, dask and xarray, NumPy ufuncs are now
-   supported directly on all xarray and dask objects. This obviates the need
+   With recent versions of NumPy, Dask and xarray, NumPy ufuncs are now
+   supported directly on all xarray and Dask objects. This obviates the need
    for the ``xarray.ufuncs`` module, which should not be used for new code
    unless compatibility with versions of NumPy prior to v1.13 is
    required. They will be removed once support for NumPy prior to

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -257,7 +257,7 @@ Some other important things to know about the docs:
   tutorial-like overviews per topic together with some other information
   (what's new, installation, etc).
 
-- The docstrings follow the **Numpy Docstring Standard**, which is used widely
+- The docstrings follow the **NumPy Docstring Standard**, which is used widely
   in the Scientific Python community. This standard specifies the format of
   the different sections of the docstring. See `this document
   <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_

--- a/doc/examples/ERA5-GRIB-example.ipynb
+++ b/doc/examples/ERA5-GRIB-example.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "GRIB format is commonly used to disseminate atmospheric model data. With Xarray and the cfgrib engine, GRIB data can easily be analyzed and visualized."
+    "GRIB format is commonly used to disseminate atmospheric model data. With xarray and the cfgrib engine, GRIB data can easily be analyzed and visualized."
    ]
   },
   {

--- a/doc/examples/multidimensional-coords.ipynb
+++ b/doc/examples/multidimensional-coords.ipynb
@@ -184,7 +184,7 @@
    "source": [
     "The resulting coordinate for the `groupby_bins` operation got the `_bins` suffix appended: `xc_bins`. This help us distinguish it from the original multidimensional variable `xc`.\n",
     "\n",
-    "**Note**: This group-by-latitude approach does not take into account the finite-size geometry of grid cells. It simply bins each value according to the coordinates at the cell center. Xarray has no understanding of grid cells and their geometry. More precise geographic regridding for Xarray data is available via the [xesmf](https://xesmf.readthedocs.io) package."
+    "**Note**: This group-by-latitude approach does not take into account the finite-size geometry of grid cells. It simply bins each value according to the coordinates at the cell center. Xarray has no understanding of grid cells and their geometry. More precise geographic regridding for xarray data is available via the [xesmf](https://xesmf.readthedocs.io) package."
    ]
   },
   {

--- a/doc/examples/visualization_gallery.ipynb
+++ b/doc/examples/visualization_gallery.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Visualization Gallery\n",
     "\n",
-    "This notebook shows common visualization issues encountered in Xarray."
+    "This notebook shows common visualization issues encountered in xarray."
    ]
   },
   {

--- a/doc/getting-started-guide/faq.rst
+++ b/doc/getting-started-guide/faq.rst
@@ -73,7 +73,7 @@ if you were using Panels:
   xarray ``Dataset``.
 
 You can :ref:`read about switching from Panels to xarray here <panel transition>`.
-Pandas gets a lot of things right, but many science, engineering and complex
+pandas gets a lot of things right, but many science, engineering and complex
 analytics use cases need fully multi-dimensional data structures.
 
 How do xarray data structures differ from those found in pandas?

--- a/doc/getting-started-guide/faq.rst
+++ b/doc/getting-started-guide/faq.rst
@@ -55,9 +55,9 @@ rows) shouldn't really matter. For example, the images of a movie can be
 natively represented as an array with four dimensions: time, row, column and
 color.
 
-Pandas has historically supported N-dimensional panels, but deprecated them in
-version 0.20 in favor of Xarray data structures. There are now built-in methods
-on both sides to convert between pandas and Xarray, allowing for more focused
+pandas has historically supported N-dimensional panels, but deprecated them in
+version 0.20 in favor of xarray data structures. There are now built-in methods
+on both sides to convert between pandas and xarray, allowing for more focused
 development effort. Xarray objects have a much richer model of dimensionality -
 if you were using Panels:
 
@@ -72,7 +72,7 @@ if you were using Panels:
   In contrast, this sort of data structure fits very naturally in an
   xarray ``Dataset``.
 
-You can :ref:`read about switching from Panels to Xarray here <panel transition>`.
+You can :ref:`read about switching from Panels to xarray here <panel transition>`.
 Pandas gets a lot of things right, but many science, engineering and complex
 analytics use cases need fully multi-dimensional data structures.
 
@@ -92,7 +92,7 @@ of the "time" dimension. You never need to reshape arrays (e.g., with
 Why don't aggregations return Python scalars?
 ---------------------------------------------
 
-xarray tries hard to be self-consistent: operations on a ``DataArray`` (resp.
+Xarray tries hard to be self-consistent: operations on a ``DataArray`` (resp.
 ``Dataset``) return another ``DataArray`` (resp. ``Dataset``) object. In
 particular, operations returning scalar values (e.g. indexing or aggregations
 like ``mean`` or ``sum`` applied to all axes) will also return xarray objects.
@@ -152,7 +152,7 @@ What other netCDF related Python libraries should I know about?
 
 `netCDF4-python`__ provides a lower level interface for working with
 netCDF and OpenDAP datasets in Python. We use netCDF4-python internally in
-xarray, and have contributed a number of improvements and fixes upstream. xarray
+xarray, and have contributed a number of improvements and fixes upstream. Xarray
 does not yet support all of netCDF4-python's features, such as modifying files
 on-disk.
 
@@ -161,7 +161,7 @@ __ https://github.com/Unidata/netcdf4-python
 Iris_ (supported by the UK Met office) provides similar tools for in-
 memory manipulation of labeled arrays, aimed specifically at weather and
 climate data needs. Indeed, the Iris :py:class:`~iris.cube.Cube` was direct
-inspiration for xarray's :py:class:`~xarray.DataArray`. xarray and Iris take very
+inspiration for xarray's :py:class:`~xarray.DataArray`. Xarray and Iris take very
 different approaches to handling metadata: Iris strictly interprets
 `CF conventions`_. Iris particularly shines at mapping, thanks to its
 integration with Cartopy_.

--- a/doc/getting-started-guide/installing.rst
+++ b/doc/getting-started-guide/installing.rst
@@ -87,7 +87,7 @@ Alternative data containers
 
 Minimum dependency versions
 ---------------------------
-xarray adopts a rolling policy regarding the minimum supported version of its
+Xarray adopts a rolling policy regarding the minimum supported version of its
 dependencies:
 
 - **Python:** 24 months
@@ -110,7 +110,7 @@ You can see the actual minimum tested versions:
 Instructions
 ------------
 
-xarray itself is a pure Python package, but its dependencies are not. The
+Xarray itself is a pure Python package, but its dependencies are not. The
 easiest way to get everything installed is to use conda_. To install xarray
 with its recommended dependencies using the conda command line tool::
 

--- a/doc/getting-started-guide/quick-overview.rst
+++ b/doc/getting-started-guide/quick-overview.rst
@@ -46,7 +46,7 @@ Here are the key properties for a ``DataArray``:
 Indexing
 --------
 
-xarray supports four kinds of indexing. Since we have assigned coordinate labels to the x dimension we can use label-based indexing along that dimension just like pandas. The four examples below all yield the same result (the value at `x=10`) but at varying levels of convenience and intuitiveness.
+Xarray supports four kinds of indexing. Since we have assigned coordinate labels to the x dimension we can use label-based indexing along that dimension just like pandas. The four examples below all yield the same result (the value at `x=10`) but at varying levels of convenience and intuitiveness.
 
 .. ipython:: python
 
@@ -133,7 +133,7 @@ For more, see :ref:`comput`.
 GroupBy
 -------
 
-xarray supports grouped operations using a very similar API to pandas (see :ref:`groupby`):
+Xarray supports grouped operations using a very similar API to pandas (see :ref:`groupby`):
 
 .. ipython:: python
 
@@ -225,4 +225,4 @@ You can directly read and write xarray objects to disk using :py:meth:`~xarray.D
     os.remove("example.nc")
 
 
-It is common for datasets to be distributed across multiple files (commonly one file per timestep). xarray supports this use-case by providing the :py:meth:`~xarray.open_mfdataset` and the :py:meth:`~xarray.save_mfdataset` methods. For more, see :ref:`io`.
+It is common for datasets to be distributed across multiple files (commonly one file per timestep). Xarray supports this use-case by providing the :py:meth:`~xarray.open_mfdataset` and the :py:meth:`~xarray.save_mfdataset` methods. For more, see :ref:`io`.

--- a/doc/getting-started-guide/why-xarray.rst
+++ b/doc/getting-started-guide/why-xarray.rst
@@ -48,7 +48,7 @@ back to look at it weeks or months later.
 Core data structures
 --------------------
 
-xarray has two core data structures, which build upon and extend the core
+Xarray has two core data structures, which build upon and extend the core
 strengths of NumPy_ and pandas_. Both data structures are fundamentally N-dimensional:
 
 - :py:class:`~xarray.DataArray` is our implementation of a labeled, N-dimensional
@@ -75,7 +75,7 @@ xarray with a natural and portable serialization format. NetCDF is very popular
 in the geosciences, and there are existing libraries for reading and writing
 netCDF in many programming languages, including Python.
 
-xarray distinguishes itself from many tools for working with netCDF data
+Xarray distinguishes itself from many tools for working with netCDF data
 in-so-far as it provides data structures for in-memory analytics that both
 utilize and preserve labels. You only need to do the tedious work of adding
 metadata once, not every time you save a file.

--- a/doc/howdoi.rst
+++ b/doc/howdoi.rst
@@ -39,9 +39,9 @@ How do I ...
      - :py:meth:`DataArray.to_dataset`, :py:meth:`Dataset.to_array`, :py:meth:`Dataset.to_stacked_array`, :py:meth:`DataArray.to_unstacked_dataset`
    * - extract variables that have certain attributes
      - :py:meth:`Dataset.filter_by_attrs`
-   * - extract the underlying array (e.g. numpy or Dask arrays)
+   * - extract the underlying array (e.g. NumPy or Dask arrays)
      - :py:attr:`DataArray.data`
-   * - convert to and extract the underlying numpy array
+   * - convert to and extract the underlying NumPy array
      - :py:attr:`DataArray.values`
    * - find out if my xarray object is wrapping a Dask Array
      - :py:func:`dask.is_dask_collection`

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -91,7 +91,7 @@ to support our efforts.
 History
 -------
 
-xarray is an evolution of an internal tool developed at `The Climate
+Xarray is an evolution of an internal tool developed at `The Climate
 Corporation`__. It was originally written by Climate Corp researchers Stephan
 Hoyer, Alex Kleeman and Eugene Brevdo and was released as open source in
 May 2014. The project was renamed from "xray" in January 2016. Xarray became a
@@ -103,6 +103,6 @@ __ http://climate.com/
 License
 -------
 
-xarray is available under the open source `Apache License`__.
+Xarray is available under the open source `Apache License`__.
 
 __ http://www.apache.org/licenses/LICENSE-2.0.html

--- a/doc/internals/duck-arrays-integration.rst
+++ b/doc/internals/duck-arrays-integration.rst
@@ -8,7 +8,7 @@ Integrating with duck arrays
 
     This is a experimental feature.
 
-xarray can wrap custom :term:`duck array` objects as long as they define numpy's
+Xarray can wrap custom :term:`duck array` objects as long as they define numpy's
 ``shape``, ``dtype`` and ``ndim`` properties and the ``__array__``,
 ``__array_ufunc__`` and ``__array_function__`` methods.
 

--- a/doc/internals/extending-xarray.rst
+++ b/doc/internals/extending-xarray.rst
@@ -8,7 +8,7 @@ Extending xarray
     import xarray as xr
 
 
-xarray is designed as a general purpose library, and hence tries to avoid
+Xarray is designed as a general purpose library, and hence tries to avoid
 including overly domain specific functionality. But inevitably, the need for more
 domain specific logic arises.
 

--- a/doc/internals/index.rst
+++ b/doc/internals/index.rst
@@ -3,7 +3,7 @@
 xarray Internals
 ================
 
-xarray builds upon two of the foundational libraries of the scientific Python
+Xarray builds upon two of the foundational libraries of the scientific Python
 stack, NumPy and pandas. It is written in pure Python (no C or Cython
 extensions), which makes it easy to develop and extend. Instead, we push
 compiled code to :ref:`optional dependencies<installing>`.

--- a/doc/roadmap.rst
+++ b/doc/roadmap.rst
@@ -205,7 +205,7 @@ Tree-like data structure
 ++++++++++++++++++++++++
 
 .. note::
-   Work on developing a hierarchical data structure in Xarray is just
+   Work on developing a hierarchical data structure in xarray is just
    beginning. See `Datatree <https://github.com/TomNicholas/datatree>`__
    for an early prototype.
 
@@ -237,20 +237,20 @@ Labeled array without coordinates
 
 There is a need for a lightweight array structure with named dimensions for
 convenient indexing and broadcasting. Xarray includes such a structure internally
-(``xarray.Variable``). We want to factor out Xarray's “Variable”  object into a
+(``xarray.Variable``). We want to factor out xarray's “Variable”  object into a
 standalone package with minimal dependencies for integration with libraries that
-don't want to inherit Xarray's dependency on Pandas (e.g. scikit-learn).
+don't want to inherit xarray's dependency on pandas (e.g. scikit-learn).
 The new “Variable” class will follow established array protocols and the new
 data-apis standard. It will be capable of wrapping multiple array-like objects
 (e.g. NumPy, Dask, Sparse, Pint, CuPy, Pytorch). While “DataArray” fits some of
 these requirements, it offers a more complex data model than is desired for
-many applications and depends on Pandas.
+many applications and depends on pandas.
 
 Engaging more users
 -------------------
 
 .. note::
-   Work on improving Xarray’s documentation and user engagement is
+   Work on improving xarray’s documentation and user engagement is
    currently underway. See `GH Project #4 <https://github.com/pydata/xarray/projects/4>`__
    for more detail.
 

--- a/doc/roadmap.rst
+++ b/doc/roadmap.rst
@@ -267,7 +267,7 @@ In order to lower this adoption barrier, we propose to:
 
 -  Develop entry-level tutorials for users with different backgrounds. For
    example, we would like to develop tutorials for users with or without
-   previous knowledge of pandas, numpy, netCDF, etc. These tutorials may be
+   previous knowledge of pandas, NumPy, netCDF, etc. These tutorials may be
    built as part of xarray's documentation or included in a separate repository
    to enable interactive use (e.g. mybinder.org).
 -  Document typical user workflows in a dedicated website, following the example

--- a/doc/tutorials-and-videos.rst
+++ b/doc/tutorials-and-videos.rst
@@ -19,7 +19,7 @@ Videos
   :card: text-center
 
   ---
-  Xdev Python Tutorial Seminar Series 2021 seminar introducing Xarray (1 of 2) | Anderson Banihirwe
+  Xdev Python Tutorial Seminar Series 2021 seminar introducing xarray (1 of 2) | Anderson Banihirwe
   ^^^
   .. raw:: html
 

--- a/doc/user-guide/combining.rst
+++ b/doc/user-guide/combining.rst
@@ -179,7 +179,7 @@ syntax:
 Equals and identical
 ~~~~~~~~~~~~~~~~~~~~
 
-xarray objects can be compared by using the :py:meth:`~xarray.Dataset.equals`,
+Xarray objects can be compared by using the :py:meth:`~xarray.Dataset.equals`,
 :py:meth:`~xarray.Dataset.identical` and
 :py:meth:`~xarray.Dataset.broadcast_equals` methods. These methods are used by
 the optional ``compat`` argument on ``concat`` and ``merge``.

--- a/doc/user-guide/computation.rst
+++ b/doc/user-guide/computation.rst
@@ -68,7 +68,7 @@ Data arrays also implement many :py:class:`numpy.ndarray` methods:
 Missing values
 ==============
 
-xarray objects borrow the :py:meth:`~xarray.DataArray.isnull`,
+Xarray objects borrow the :py:meth:`~xarray.DataArray.isnull`,
 :py:meth:`~xarray.DataArray.notnull`, :py:meth:`~xarray.DataArray.count`,
 :py:meth:`~xarray.DataArray.dropna`, :py:meth:`~xarray.DataArray.fillna`,
 :py:meth:`~xarray.DataArray.ffill`, and :py:meth:`~xarray.DataArray.bfill`
@@ -88,7 +88,7 @@ methods for working with missing data from pandas:
 Like pandas, xarray uses the float value ``np.nan`` (not-a-number) to represent
 missing values.
 
-xarray objects also have an :py:meth:`~xarray.DataArray.interpolate_na` method
+Xarray objects also have an :py:meth:`~xarray.DataArray.interpolate_na` method
 for filling missing values via 1D interpolation.
 
 .. ipython:: python
@@ -103,7 +103,7 @@ for filling missing values via 1D interpolation.
 Note that xarray slightly diverges from the pandas ``interpolate`` syntax by
 providing the ``use_coordinate`` keyword which facilitates a clear specification
 of which values to use as the index in the interpolation.
-xarray also provides the ``max_gap`` keyword argument to limit the interpolation to
+Xarray also provides the ``max_gap`` keyword argument to limit the interpolation to
 data gaps of length ``max_gap`` or smaller. See :py:meth:`~xarray.DataArray.interpolate_na`
 for more.
 
@@ -584,7 +584,7 @@ You can explicitly broadcast xarray data structures by using the
 Automatic alignment
 ===================
 
-xarray enforces alignment between *index* :ref:`coordinates` (that is,
+Xarray enforces alignment between *index* :ref:`coordinates` (that is,
 coordinates with the same name as a dimension, marked by ``*``) on objects used
 in binary operations.
 

--- a/doc/user-guide/dask.rst
+++ b/doc/user-guide/dask.rst
@@ -5,7 +5,7 @@
 Parallel computing with Dask
 ============================
 
-xarray integrates with `Dask <http://dask.pydata.org/>`__ to support parallel
+Xarray integrates with `Dask <http://dask.pydata.org/>`__ to support parallel
 computations and streaming computation on datasets that don't fit into memory.
 Currently, Dask is an entirely optional feature for xarray. However, the
 benefits of using Dask are sufficiently strong that Dask may become a required

--- a/doc/user-guide/data-structures.rst
+++ b/doc/user-guide/data-structures.rst
@@ -26,7 +26,7 @@ multi-dimensional array. It has several key properties:
   strings)
 - ``attrs``: :py:class:`dict` to hold arbitrary metadata (*attributes*)
 
-xarray uses ``dims`` and ``coords`` to enable its core metadata aware operations.
+Xarray uses ``dims`` and ``coords`` to enable its core metadata aware operations.
 Dimensions provide names that xarray uses instead of the ``axis`` argument found
 in many numpy functions. Coordinates enable fast label based indexing and
 alignment, building on the functionality of the ``index`` found on a pandas
@@ -360,7 +360,7 @@ of `attributes`:
     ds.attrs["title"] = "example attribute"
     ds
 
-xarray does not enforce any restrictions on attributes, but serialization to
+Xarray does not enforce any restrictions on attributes, but serialization to
 some file formats may fail if you use objects that are not strings, numbers
 or :py:class:`numpy.ndarray` objects.
 
@@ -515,7 +515,7 @@ in xarray:
 
 .. note::
 
-  xarray's terminology differs from the `CF terminology`_, where the
+  Xarray's terminology differs from the `CF terminology`_, where the
   "dimension coordinates" are called "coordinate variables", and the
   "non-dimension coordinates" are called "auxiliary coordinate variables"
   (see :issue:`1295` for more details).
@@ -620,7 +620,7 @@ It also can't be used to replace one particular level.
 Because in a ``DataArray`` or ``Dataset`` object each multi-index level is
 accessible as a "virtual" coordinate, its name must not conflict with the names
 of the other levels, coordinates and data variables of the same object.
-Even though Xarray set default names for multi-indexes with unnamed levels,
+Even though xarray sets default names for multi-indexes with unnamed levels,
 it is recommended that you explicitly set the names of the levels.
 
 .. [1] Latitude and longitude are 2D arrays because the dataset uses

--- a/doc/user-guide/duckarrays.rst
+++ b/doc/user-guide/duckarrays.rst
@@ -8,7 +8,7 @@ Working with numpy-like arrays
    This feature should be considered experimental. Please report any bug you may find on
    xarray’s github repository.
 
-Numpy-like arrays (:term:`duck array`) extend the :py:class:`numpy.ndarray` with
+NumPy-like arrays (:term:`duck array`) extend the :py:class:`numpy.ndarray` with
 additional features, like propagating physical units or a different layout in memory.
 
 :py:class:`DataArray` and :py:class:`Dataset` objects can wrap these duck arrays, as

--- a/doc/user-guide/groupby.rst
+++ b/doc/user-guide/groupby.rst
@@ -3,7 +3,7 @@
 GroupBy: split-apply-combine
 ----------------------------
 
-xarray supports `"group by"`__ operations with the same API as pandas to
+Xarray supports `"group by"`__ operations with the same API as pandas to
 implement the `split-apply-combine`__ strategy:
 
 __ http://pandas.pydata.org/pandas-docs/stable/groupby.html

--- a/doc/user-guide/indexing.rst
+++ b/doc/user-guide/indexing.rst
@@ -12,7 +12,7 @@ Indexing and selecting data
 
     np.random.seed(123456)
 
-xarray offers extremely flexible indexing routines that combine the best
+Xarray offers extremely flexible indexing routines that combine the best
 features of NumPy and pandas for data selection.
 
 The most basic way to access elements of a :py:class:`~xarray.DataArray`
@@ -80,7 +80,7 @@ Attributes are persisted in all indexing operations.
     arrays like ``da[[0, 1], [0, 1]]``, as described in
     :ref:`vectorized_indexing`.
 
-xarray also supports label-based indexing, just like pandas. Because
+Xarray also supports label-based indexing, just like pandas. Because
 we use a :py:class:`pandas.Index` under the hood, label based indexing is very
 fast. To do label based indexing, use the :py:attr:`~xarray.DataArray.loc` attribute:
 
@@ -612,13 +612,13 @@ method:
 Align and reindex
 -----------------
 
-xarray's ``reindex``, ``reindex_like`` and ``align`` impose a ``DataArray`` or
+Xarray's ``reindex``, ``reindex_like`` and ``align`` impose a ``DataArray`` or
 ``Dataset`` onto a new set of coordinates corresponding to dimensions. The
 original values are subset to the index labels still found in the new labels,
 and values corresponding to new labels not found in the original object are
 in-filled with `NaN`.
 
-xarray operations that combine multiple objects generally automatically align
+Xarray operations that combine multiple objects generally automatically align
 their arguments to share the same indexes. However, manual alignment can be
 useful for greater control and for increased performance.
 
@@ -697,7 +697,7 @@ Otherwise, it raises an informative error:
 Underlying Indexes
 ------------------
 
-xarray uses the :py:class:`pandas.Index` internally to perform indexing
+Xarray uses the :py:class:`pandas.Index` internally to perform indexing
 operations.  If you need to access the underlying indexes, they are available
 through the :py:attr:`~xarray.DataArray.indexes` attribute.
 

--- a/doc/user-guide/interpolation.rst
+++ b/doc/user-guide/interpolation.rst
@@ -12,7 +12,7 @@ Interpolating data
 
     np.random.seed(123456)
 
-xarray offers flexible interpolation routines, which have a similar interface
+Xarray offers flexible interpolation routines, which have a similar interface
 to our :ref:`indexing <indexing>`.
 
 .. note::

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -4,7 +4,7 @@
 Reading and writing files
 =========================
 
-xarray supports direct serialization and IO to several file formats, from
+Xarray supports direct serialization and IO to several file formats, from
 simple :ref:`io.pickle` files to the more flexible :ref:`io.netcdf`
 format (recommended).
 
@@ -24,7 +24,7 @@ netCDF
 
 The recommended way to store xarray data structures is `netCDF`__, which
 is a binary file format for self-described datasets that originated
-in the geosciences. xarray is based on the netCDF data model, so netCDF files
+in the geosciences. Xarray is based on the netCDF data model, so netCDF files
 on disk directly correspond to :py:class:`Dataset` objects (more accurately,
 a group in a netCDF file directly corresponds to a :py:class:`Dataset` object.
 See :ref:`io.netcdf_groups` for more.)
@@ -117,7 +117,7 @@ is modified: the original file on disk is never touched.
 
 .. tip::
 
-    xarray's lazy loading of remote or on-disk datasets is often but not always
+    Xarray's lazy loading of remote or on-disk datasets is often but not always
     desirable. Before performing computationally intense operations, it is
     often a good idea to load a Dataset (or DataArray) entirely into memory by
     invoking the :py:meth:`Dataset.load` method.
@@ -217,7 +217,7 @@ Reading multi-file datasets
 
 NetCDF files are often encountered in collections, e.g., with different files
 corresponding to different model runs or one file per timestamp.
-xarray can straightforwardly combine such files into a single Dataset by making use of
+Xarray can straightforwardly combine such files into a single Dataset by making use of
 :py:func:`concat`, :py:func:`merge`, :py:func:`combine_nested` and
 :py:func:`combine_by_coords`. For details on the difference between these
 functions see :ref:`combining data`.
@@ -382,7 +382,7 @@ Compression and decompression with such discretization is extremely fast.
 String encoding
 ...............
 
-xarray can write unicode strings to netCDF files in two ways:
+Xarray can write unicode strings to netCDF files in two ways:
 
 - As variable length strings. This is only supported on netCDF4 (HDF5) files.
 - By encoding strings into bytes, and writing encoded bytes as a character
@@ -535,7 +535,7 @@ Conversely, we can create a new ``DataArray`` object from a ``Cube`` using
 OPeNDAP
 -------
 
-xarray includes support for `OPeNDAP`__ (via the netCDF4 library or Pydap), which
+Xarray includes support for `OPeNDAP`__ (via the netCDF4 library or Pydap), which
 lets us access large datasets over HTTP.
 
 __ http://www.opendap.org/
@@ -963,15 +963,15 @@ Xarray needs to read all of the zarr metadata when it opens a dataset.
 In some storage mediums, such as with cloud object storage (e.g. amazon S3),
 this can introduce significant overhead, because two separate HTTP calls to the
 object store must be made for each variable in the dataset.
-As of Xarray version 0.18, Xarray by default uses a feature called
+As of xarray version 0.18, xarray by default uses a feature called
 *consolidated metadata*, storing all metadata for the entire dataset with a
 single key (by default called ``.zmetadata``). This typically drastically speeds
 up opening the store. (For more information on this feature, consult the
 `zarr docs <https://zarr.readthedocs.io/en/latest/tutorial.html#consolidating-metadata>`_.)
 
-By default, Xarray writes consolidated metadata and attempts to read stores
+By default, xarray writes consolidated metadata and attempts to read stores
 with consolidated metadata, falling back to use non-consolidated metadata for
-reads. Because this fall-back option is so much slower, Xarray issues a
+reads. Because this fall-back option is so much slower, xarray issues a
 ``RuntimeWarning`` with guidance when reading with consolidated metadata fails:
 
     Failed to open Zarr store with consolidated metadata, falling back to try
@@ -1102,7 +1102,7 @@ with ``mode='a'``.
 GRIB format via cfgrib
 ----------------------
 
-xarray supports reading GRIB files via ECMWF cfgrib_ python driver,
+Xarray supports reading GRIB files via ECMWF cfgrib_ python driver,
 if it is installed. To open a GRIB file supply ``engine='cfgrib'``
 to :py:func:`open_dataset`:
 
@@ -1122,7 +1122,7 @@ We recommend installing cfgrib via conda::
 Formats supported by PyNIO
 --------------------------
 
-xarray can also read GRIB, HDF4 and other file formats supported by PyNIO_,
+Xarray can also read GRIB, HDF4 and other file formats supported by PyNIO_,
 if PyNIO is installed. To use PyNIO to read such files, supply
 ``engine='pynio'`` to :py:func:`open_dataset`.
 
@@ -1142,7 +1142,7 @@ We recommend installing PyNIO via conda::
 Formats supported by PseudoNetCDF
 ---------------------------------
 
-xarray can also read CAMx, BPCH, ARL PACKED BIT, and many other file
+Xarray can also read CAMx, BPCH, ARL PACKED BIT, and many other file
 formats supported by PseudoNetCDF_, if PseudoNetCDF is installed.
 PseudoNetCDF can also provide Climate Forecasting Conventions to
 CMAQ files. In addition, PseudoNetCDF can automatically register custom

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -1159,7 +1159,7 @@ options are listed on the PseudoNetCDF page.
 .. _PseudoNetCDF: http://github.com/barronh/PseudoNetCDF
 
 
-CSV and other formats supported by Pandas
+CSV and other formats supported by pandas
 -----------------------------------------
 
 For more options (tabular formats and CSV files in particular), consider

--- a/doc/user-guide/plotting.rst
+++ b/doc/user-guide/plotting.rst
@@ -689,7 +689,7 @@ This object can be used to control the behavior of the multiple plots.
 It borrows an API and code from `Seaborn's FacetGrid
 <http://seaborn.pydata.org/tutorial/axis_grids.html>`_.
 The structure is contained within the ``axes`` and ``name_dicts``
-attributes, both 2d Numpy object arrays.
+attributes, both 2d NumPy object arrays.
 
 .. ipython:: python
 

--- a/doc/user-guide/plotting.rst
+++ b/doc/user-guide/plotting.rst
@@ -10,7 +10,7 @@ Introduction
 Labeled data enables expressive computations. These same
 labels can also be used to easily create informative plots.
 
-xarray's plotting capabilities are centered around
+Xarray's plotting capabilities are centered around
 :py:class:`DataArray` objects.
 To plot :py:class:`Dataset` objects
 simply access the relevant DataArrays, i.e. ``dset['var1']``.
@@ -19,7 +19,7 @@ Here we focus mostly on arrays 2d or larger. If your data fits
 nicely into a pandas DataFrame then you're better off using one of the more
 developed tools there.
 
-xarray plotting functionality is a thin wrapper around the popular
+Xarray plotting functionality is a thin wrapper around the popular
 `matplotlib <http://matplotlib.org/>`_ library.
 Matplotlib syntax and function names were copied as much as possible, which
 makes for an easy transition between the two.
@@ -106,7 +106,7 @@ The simplest way to make a plot is to call the :py:func:`DataArray.plot()` metho
     @savefig plotting_1d_simple.png width=4in
     air1d.plot()
 
-xarray uses the coordinate name along with metadata ``attrs.long_name``, ``attrs.standard_name``, ``DataArray.name`` and ``attrs.units`` (if available) to label the axes. The names ``long_name``, ``standard_name`` and ``units`` are copied from the `CF-conventions spec <http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/ch03s03.html>`_. When choosing names, the order of precedence is ``long_name``, ``standard_name`` and finally ``DataArray.name``. The y-axis label in the above plot was constructed from the ``long_name`` and ``units`` attributes of ``air1d``.
+Xarray uses the coordinate name along with metadata ``attrs.long_name``, ``attrs.standard_name``, ``DataArray.name`` and ``attrs.units`` (if available) to label the axes. The names ``long_name``, ``standard_name`` and ``units`` are copied from the `CF-conventions spec <http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/ch03s03.html>`_. When choosing names, the order of precedence is ``long_name``, ``standard_name`` and finally ``DataArray.name``. The y-axis label in the above plot was constructed from the ``long_name`` and ``units`` attributes of ``air1d``.
 
 .. ipython:: python
 
@@ -381,7 +381,7 @@ and ``xincrease``.
  Missing Values
 ================
 
-xarray plots data with :ref:`missing_values`.
+Xarray plots data with :ref:`missing_values`.
 
 .. ipython:: python
     :okwarning:
@@ -463,7 +463,7 @@ matplotlib is available.
 
 .. note::
 
-    xarray methods update label information and generally play around with the
+    Xarray methods update label information and generally play around with the
     axes. So any kind of updates to the plot
     should be done *after* the call to the xarray's plot.
     In the example below, ``plt.xlabel`` effectively does nothing, since
@@ -482,7 +482,7 @@ matplotlib is available.
  Colormaps
 ===========
 
-xarray borrows logic from Seaborn to infer what kind of color map to use. For
+Xarray borrows logic from Seaborn to infer what kind of color map to use. For
 example, consider the original data in Kelvins rather than Celsius:
 
 .. ipython:: python
@@ -583,7 +583,7 @@ Faceting
 
 Faceting here refers to splitting an array along one or two dimensions and
 plotting each group.
-xarray's basic plotting is useful for plotting two dimensional arrays. What
+Xarray's basic plotting is useful for plotting two dimensional arrays. What
 about three or four dimensional arrays? That's where facets become helpful.
 The general approach to plotting here is called “small multiples”, where the same kind of plot is repeated multiple times, and the specific use of small multiples to display the same relationship conditioned on one ore more other variables is often called a “trellis plot”.
 
@@ -737,7 +737,7 @@ TODO: add an example of using the ``map`` method to plot dataset variables
 Datasets
 --------
 
-``xarray`` has limited support for plotting Dataset variables against each other.
+Xarray has limited support for plotting Dataset variables against each other.
 Consider this dataset
 
 .. ipython:: python

--- a/doc/user-guide/time-series.rst
+++ b/doc/user-guide/time-series.rst
@@ -21,7 +21,7 @@ core functionality.
 Creating datetime64 data
 ------------------------
 
-xarray uses the numpy dtypes ``datetime64[ns]`` and ``timedelta64[ns]`` to
+Xarray uses the numpy dtypes ``datetime64[ns]`` and ``timedelta64[ns]`` to
 represent datetime data, which offer vectorized (if sometimes buggy) operations
 with numpy and smooth integration with pandas.
 
@@ -81,7 +81,7 @@ information.
 Datetime indexing
 -----------------
 
-xarray borrows powerful indexing machinery from pandas (see :ref:`indexing`).
+Xarray borrows powerful indexing machinery from pandas (see :ref:`indexing`).
 
 This allows for several useful and succinct forms of indexing, particularly for
 `datetime64` data. For example, we support indexing with strings for single
@@ -123,7 +123,7 @@ given ``DataArray`` can be quickly computed using a special ``.dt`` accessor.
 The ``.dt`` accessor works on both coordinate dimensions as well as
 multi-dimensional data.
 
-xarray also supports a notion of "virtual" or "derived" coordinates for
+Xarray also supports a notion of "virtual" or "derived" coordinates for
 `datetime components`__ implemented by pandas, including "year", "month",
 "day", "hour", "minute", "second", "dayofyear", "week", "dayofweek", "weekday"
 and "quarter":

--- a/doc/user-guide/weather-climate.rst
+++ b/doc/user-guide/weather-climate.rst
@@ -10,7 +10,7 @@ Weather and climate data
 
     import xarray as xr
 
-``xarray`` can leverage metadata that follows the `Climate and Forecast (CF) conventions`_ if present. Examples include automatic labelling of plots with descriptive names and units if proper metadata is present (see :ref:`plotting`) and support for non-standard calendars used in climate science through the ``cftime`` module (see :ref:`CFTimeIndex`). There are also a number of geosciences-focused projects that build on xarray (see :ref:`ecosystem`).
+Xarray can leverage metadata that follows the `Climate and Forecast (CF) conventions`_ if present. Examples include automatic labelling of plots with descriptive names and units if proper metadata is present (see :ref:`plotting`) and support for non-standard calendars used in climate science through the ``cftime`` module (see :ref:`CFTimeIndex`). There are also a number of geosciences-focused projects that build on xarray (see :ref:`ecosystem`).
 
 .. _Climate and Forecast (CF) conventions: http://cfconventions.org
 
@@ -97,7 +97,7 @@ coordinate with dates from a no-leap calendar and a
     ]
     da = xr.DataArray(np.arange(24), coords=[dates], dims=["time"], name="foo")
 
-xarray also includes a :py:func:`~xarray.cftime_range` function, which enables
+Xarray also includes a :py:func:`~xarray.cftime_range` function, which enables
 creating a :py:class:`~xarray.CFTimeIndex` with regularly-spaced dates.  For
 instance, we can create the same dates and DataArray we created above using:
 

--- a/doc/user-guide/weather-climate.rst
+++ b/doc/user-guide/weather-climate.rst
@@ -21,7 +21,7 @@ Related Variables
 
 Several CF variable attributes contain lists of other variables
 associated with the variable with the attribute.  A few of these are
-now parsed by XArray, with the attribute value popped to encoding on
+now parsed by xarray, with the attribute value popped to encoding on
 read and the variables in that value interpreted as non-dimension
 coordinates:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -1732,7 +1732,7 @@ Breaking changes
   By `Guido Imperiale <https://github.com/crusaderky>`_.
 
 - Remove internal usage of :py:class:`collections.OrderedDict`. After dropping support for
-  Python <=3.5, most uses of ``OrderedDict`` in Xarray were no longer necessary. We
+  Python <=3.5, most uses of ``OrderedDict`` in xarray were no longer necessary. We
   have removed the internal use of the ``OrderedDict`` in favor of Python's builtin
   ``dict`` object which is now ordered itself. This change will be most obvious when
   interacting with the ``attrs`` property on Dataset and DataArray objects.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -1153,7 +1153,7 @@ Bug fixes
   By `Phil Butcher <https://github.com/pjbutcher>`_.
 - Support dark mode in VS code (:issue:`4024`)
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
-- Fix bug when converting multiindexed Pandas objects to sparse xarray objects. (:issue:`4019`)
+- Fix bug when converting multiindexed pandas objects to sparse xarray objects. (:issue:`4019`)
   By `Deepak Cherian <https://github.com/dcherian>`_.
 - ``ValueError`` is raised when ``fill_value`` is not a scalar in :py:meth:`full_like`. (:issue:`3977`)
   By `Huite Bootsma <https://github.com/huite>`_.
@@ -2428,7 +2428,7 @@ Enhancements
   By `Stephan Hoyer <https://github.com/shoyer>`_
 - Support Dask ``HighLevelGraphs`` by `Matthew Rocklin <https://github.com/mrocklin>`_.
 - :py:meth:`DataArray.resample` and :py:meth:`Dataset.resample` now supports the
-  ``loffset`` kwarg just like Pandas.
+  ``loffset`` kwarg just like pandas.
   By `Deepak Cherian <https://github.com/dcherian>`_
 - Datasets are now guaranteed to have a ``'source'`` encoding, so the source
   file name is always stored (:issue:`2550`).
@@ -2657,7 +2657,7 @@ Enhancements
   By `Keisuke Fujii <https://github.com/fujiisoup>`_.
 
 - :py:func:`~plot.plot()` now accepts the kwargs
-  ``xscale, yscale, xlim, ylim, xticks, yticks`` just like Pandas. Also ``xincrease=False, yincrease=False`` now use matplotlib's axis inverting methods instead of setting limits.
+  ``xscale, yscale, xlim, ylim, xticks, yticks`` just like pandas. Also ``xincrease=False, yincrease=False`` now use matplotlib's axis inverting methods instead of setting limits.
   By `Deepak Cherian <https://github.com/dcherian>`_. (:issue:`2224`)
 
 - DataArray coordinates and Dataset coordinates and data variables are
@@ -2745,7 +2745,7 @@ Breaking changes
 - Xarray no longer supports python 3.4. Additionally, the minimum supported
   versions of the following dependencies has been updated and/or clarified:
 
-  - Pandas: 0.18 -> 0.19
+  - pandas: 0.18 -> 0.19
   - NumPy: 1.11 -> 1.12
   - Dask: 0.9 -> 0.16
   - Matplotlib: unspecified -> 1.5
@@ -3264,7 +3264,7 @@ Bug fixes
   unintentionally loading the datastores data and attributes repeatedly during
   writes (:issue:`1798`).
   By `Joe Hamman <https://github.com/jhamman>`_.
-- Compatibility fixes to plotting module for Numpy 1.14 and Pandas 0.22
+- Compatibility fixes to plotting module for NumPy 1.14 and pandas 0.22
   (:issue:`1813`).
   By `Joe Hamman <https://github.com/jhamman>`_.
 - Bug fix in encoding coordinates with ``{'_FillValue': None}`` in netCDF
@@ -3540,7 +3540,7 @@ Bug fixes
 ~~~~~~~~~
 
 - Suppress ``RuntimeWarning`` issued by ``numpy`` for "invalid value comparisons"
-  (e.g. ``NaN``). Xarray now behaves similarly to Pandas in its treatment of
+  (e.g. ``NaN``). Xarray now behaves similarly to pandas in its treatment of
   binary and unary operations on objects with NaNs (:issue:`1657`).
   By `Joe Hamman <https://github.com/jhamman>`_.
 
@@ -3683,7 +3683,7 @@ Bug fixes after rc2
 ~~~~~~~~~~~~~~~~~~~
 
 - Fixed unexpected behavior in ``Dataset.set_index()`` and
-  ``DataArray.set_index()`` introduced by Pandas 0.21.0. Setting a new
+  ``DataArray.set_index()`` introduced by pandas 0.21.0. Setting a new
   index with a single variable resulted in 1-level
   ``pandas.MultiIndex`` instead of a simple ``pandas.Index``
   (:issue:`1722`).  By `Benoit Bovy <https://github.com/benbovy>`_.


### PR DESCRIPTION
Updating readme and user-facing docs according to https://github.com/pydata/xarray/issues/1306 ([final comment](https://github.com/pydata/xarray/issues/1306#issuecomment-457881189))

- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Notes:
* I didn't yet change the contributing page, since it seems to have its own convention (though not used everywhere): **xarray** (bold and lowercase). 
* I mostly didn't touch internal docs pages / docstrings.
* Also modified some cases of NumPy, pandas, and Dask according to their conventions, but could do more there, especially with NumPy.

