### PR TITLE
Add encodings to save_mfdataset 

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,6 +33,8 @@ New Features
 - Added ``storage_options`` argument to :py:meth:`to_zarr` (:issue:`5601`).
   By `Ray Bell <https://github.com/raybellwaves>`_, `Zachary Blackwood <https://github.com/blackary>`_ and
   `Nathan Lis <https://github.com/wxman22>`_.
+- Added ``encodings`` argument to :py:func:`save_mfdataset`.
+  By `Pascal Bourgault <https://github.com/aulemahal>`_.
 
 
 Breaking changes

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1125,7 +1125,14 @@ def dump_to_store(
 
 
 def save_mfdataset(
-    datasets, paths, mode="w", format=None, groups=None, engine=None, compute=True
+    datasets,
+    paths,
+    mode="w",
+    format=None,
+    groups=None,
+    engine=None,
+    encodings=None,
+    compute=True,
 ):
     """Write multiple datasets to disk as netCDF files simultaneously.
 
@@ -1176,6 +1183,9 @@ def save_mfdataset(
         default engine is chosen based on available dependencies, with a
         preference for "netcdf4" if writing to a file on disk.
         See `Dataset.to_netcdf` for additional information.
+    encodings : list of dict, optional
+        List of nested dictionary with variable names as keys and dictionaries of
+        variable specific encodings as values. See `Dataset.to_netcdf` for additional information.
     compute : bool
         If true compute immediately, otherwise return a
         ``dask.delayed.Delayed`` object that can be computed later.
@@ -1215,19 +1225,30 @@ def save_mfdataset(
     if groups is None:
         groups = [None] * len(datasets)
 
-    if len({len(datasets), len(paths), len(groups)}) > 1:
+    if encodings is None:
+        encodings = [None] * len(datasets)
+
+    if len({len(datasets), len(paths), len(groups), len(encodings)}) > 1:
         raise ValueError(
             "must supply lists of the same length for the "
-            "datasets, paths and groups arguments to "
+            "datasets, paths, encodings and groups arguments to "
             "save_mfdataset"
         )
 
     writers, stores = zip(
         *[
             to_netcdf(
-                ds, path, mode, format, group, engine, compute=compute, multifile=True
+                ds,
+                path,
+                mode,
+                format,
+                group,
+                engine,
+                encoding,
+                compute=compute,
+                multifile=True,
             )
-            for ds, path, group in zip(datasets, paths, groups)
+            for ds, path, group, encoding in zip(datasets, paths, groups, encodings)
         ]
     )
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3557,6 +3557,20 @@ class TestDask(DatasetIOBase):
                     [tmp1, tmp2], concat_dim="x", combine="nested"
                 ) as actual:
                     assert_identical(actual, original)
+                    assert actual.foo.dtype == "float64"
+
+        # Passing encodings
+        with create_tmp_file() as tmp1:
+            with create_tmp_file() as tmp2:
+                save_mfdataset(
+                    datasets,
+                    [tmp1, tmp2],
+                    encodings=[{"foo": {"dtype": "float32"}}] * 2,
+                )
+                with open_mfdataset(
+                    [tmp1, tmp2], concat_dim="x", combine="nested"
+                ) as actual:
+                    assert actual.foo.dtype == "float32"
 
     def test_save_mfdataset_invalid(self):
         ds = Dataset()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

Simply add a `encodings` argument to `save_mfdataset`. As for the other args, it expects a list of dictionaries, with encoding information to be passed to `to_netcdf` for each dataset. 
Added a minimal test, simply to see if the argument was taken into account.