### PR TITLE
BUG: xarray.backends.plugins.get_backend: fix passing in a backend directly

### DIFF
--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -1,3 +1,4 @@
+from typing import Dict, Union
 import functools
 import inspect
 import itertools
@@ -80,7 +81,7 @@ def sort_backends(backend_entrypoints):
     return ordered_backends_entrypoints
 
 
-def build_engines(pkg_entrypoints):
+def build_engines(pkg_entrypoints) -> Dict[str, BackendEntrypoint]:
     backend_entrypoints = {}
     for backend_name, backend in BACKEND_ENTRYPOINTS.items():
         if backend.available:
@@ -94,7 +95,7 @@ def build_engines(pkg_entrypoints):
 
 
 @functools.lru_cache(maxsize=1)
-def list_engines():
+def list_engines() -> Dict[str, BackendEntrypoint]:
     pkg_entrypoints = pkg_resources.iter_entry_points("xarray.backends")
     return build_engines(pkg_entrypoints)
 
@@ -148,7 +149,7 @@ def guess_engine(store_spec):
     raise ValueError(error_msg)
 
 
-def get_backend(engine):
+def get_backend(engine: Union[str, type]) -> BackendEntrypoint:
     """Select open_dataset method based on current engine."""
     if isinstance(engine, str):
         engines = list_engines()
@@ -158,7 +159,7 @@ def get_backend(engine):
             )
         backend = engines[engine]
     elif isinstance(engine, type) and issubclass(engine, BackendEntrypoint):
-        backend = engine
+        backend = engine()
     else:
         raise TypeError(
             (

--- a/xarray/tests/test_backends_plugins.py
+++ b/xarray/tests/test_backends_plugins.py
@@ -1,0 +1,16 @@
+from xarray.backends.plugins import get_backend, list_engines
+
+
+def test_get_backend__engine():
+    """Test passing in a a backend name (engine) gets us an instance of the corresponding backend."""
+    engine = "netcdf4"
+    engines = list_engines()
+    backend = get_backend(engine)
+    assert backend == engines[engine]
+
+
+def test_get_backend__backend():
+    """Test passing in a backend directly gets us an instance of that backend."""
+    engine = "netcdf4"
+    given_backend = type(list_engines()[engine])
+    assert isinstance(get_backend(given_backend), given_backend)


### PR DESCRIPTION
The `open_dataset` and `open_mfdataset` functions allow a user to pass
in a (custom) backend directly. This was however not functioning.

Selecting an engine with a string was functioning as expected, however,
passing in a backend class directly failed.

An instance of the backend is now created. A test has been added, as
well as some type hints.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [x] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
