### PR TITLE
raise on being passed a Dataset

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1557,6 +1557,8 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
                     self.update(dict(zip(key, value)))
 
         else:
+            if isinstance(value, Dataset):
+                raise TypeError("Cannot assign a Dataset to a single key, only a DataArray or Variable object")
             self.update({key: value})
 
     def _setitem_check(self, key, value):


### PR DESCRIPTION
Inspired by confusion in #5833, this PR slightly clarifies the error thrown when the user attempts to do `ds['var'] = xr.Dataset`. The original error is 
```
TypeError: cannot directly convert an xarray.Dataset into a numpy array. Instead, create an xarray.DataArray first, either with indexing on the Dataset or by invoking the `to_array()` method.
```
while the new error is
```
TypeError: Cannot assign a Dataset to a single key, only a DataArray or Variable object
```


- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] ~~New functions/methods are listed in `api.rst`~~
