### PR TITLE
fix test with pseudonetcdf 3.2

### DIFF
--- a/xarray/tests/data/example.ict
+++ b/xarray/tests/data/example.ict
@@ -1,13 +1,13 @@
-27, 1001
+29, 1001
 Henderson, Barron
 U.S. EPA
 Example file with artificial data
 JUST_A_TEST
 1, 1
-2018, 04, 27, 2018, 04, 27
+2018, 04, 27 2018, 04, 27
 0
 Start_UTC
-7
+5
 1, 1, 1, 1, 1
 -9999, -9999, -9999, -9999, -9999
 lat, degrees_north
@@ -16,7 +16,9 @@ elev, meters
 TEST_ppbv, ppbv
 TESTM_ppbv, ppbv
 0
-8
+9
+INDEPENDENT_VARIABLE_DEFINITION: Start_UTC
+INDEPENDENT_VARIABLE_UNITS: Start_UTC
 ULOD_FLAG: -7777
 ULOD_VALUE: N/A
 LLOD_FLAG: -8888

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3964,7 +3964,7 @@ class TestPseudoNetCDFFormat:
             "coords": {},
             "attrs": {
                 "fmt": "1001",
-                "n_header_lines": 27,
+                "n_header_lines": 29,
                 "PI_NAME": "Henderson, Barron",
                 "ORGANIZATION_NAME": "U.S. EPA",
                 "SOURCE_DESCRIPTION": "Example file with artificial data",
@@ -3973,7 +3973,9 @@ class TestPseudoNetCDFFormat:
                 "SDATE": "2018, 04, 27",
                 "WDATE": "2018, 04, 27",
                 "TIME_INTERVAL": "0",
+                "INDEPENDENT_VARIABLE_DEFINITION": "Start_UTC",
                 "INDEPENDENT_VARIABLE": "Start_UTC",
+                "INDEPENDENT_VARIABLE_UNITS": "Start_UTC",
                 "ULOD_FLAG": "-7777",
                 "ULOD_VALUE": "N/A",
                 "LLOD_FLAG": "-8888",


### PR DESCRIPTION
Fixes one part of #5872

pseudoNETCDF adds two attrs to ict files, which breaks the following two tests:

Test 1:
https://github.com/pydata/xarray/blob/07de257c5884df49335496ee6347fb633a7c302c/xarray/tests/test_backends.py#L3944
Test 2:

https://github.com/pydata/xarray/blob/07de257c5884df49335496ee6347fb633a7c302c/xarray/tests/test_backends.py#L4030

I reproduced the test file so that the tests pass again. To reproduce the file I used the following bit of code:

```python
import xarray as xr
from xarray.tests import test_backends

fN = "xarray/tests/data/example.ict"
fmtkw = {"format": "ffi1001"}

ds = xr.open_dataset(fN, engine="pseudonetcdf", backend_kwargs={"format": "ffi1001"})

c = test_backends.TestPseudoNetCDFFormat()
c.save(ds, fN, **fmtkw)
```

The `save` method is here:

https://github.com/pydata/xarray/blob/07de257c5884df49335496ee6347fb633a7c302c/xarray/tests/test_backends.py#L4124



@barronh I would appreciate your review here - I am not sure if this is the right approach.


