### PR TITLE
Only run asv benchmark when labeled

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,12 +3,11 @@ name: Benchmark
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
 
 jobs:
   benchmark:
-    if: |
-      ${{ contains( github.event.pull_request.labels.*.name, 'run-benchmark')
-      && github.event_name == 'pull_request' }}
+    if: ${{ contains( github.event.pull_request.labels.*.name, 'run-benchmark') && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     name: Linux
     runs-on: ubuntu-20.04
     env:


### PR DESCRIPTION
Small fix to #5796. The benchmark was only intended to run when the PR has the label `run-benchmark`. I split the if condition in multiple lines for better readability thinking it didn't change the function but it did.