### PR TITLE
Use importlib.resources to load files

### DIFF
--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -2,8 +2,7 @@ import uuid
 from collections import OrderedDict
 from functools import lru_cache, partial
 from html import escape
-
-import pkg_resources
+from importlib import resources
 
 from .formatting import inline_variable_array_repr, short_data_repr
 from .options import _get_boolean_with_default
@@ -15,7 +14,7 @@ STATIC_FILES = ("static/html/icons-svg-inline.html", "static/css/style.css")
 def _load_static_files():
     """Lazily load the resource files into memory the first time they are needed"""
     return [
-        pkg_resources.resource_string("xarray", fname).decode("utf8")
+        resources.files("xarray").joinpath(fname).read_bytes().decode("utf8")
         for fname in STATIC_FILES
     ]
 


### PR DESCRIPTION
Following: https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-string

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
