### PR TITLE
[test-upstream] fix pd skipna=None

### DIFF
--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -258,6 +258,11 @@ def from_series_or_scalar(se):
 def series_reduce(da, func, dim, **kwargs):
     """convert DataArray to pd.Series, apply pd.func, then convert back to
     a DataArray. Multiple dims cannot be specified."""
+
+    # pd no longer accepts skipna=None https://github.com/pandas-dev/pandas/issues/44178
+    if kwargs.get("skipna", True) is None:
+        kwargs["skipna"] = True
+
     if dim is None or da.ndim == 1:
         se = da.to_series()
         return from_series_or_scalar(getattr(se, func)(**kwargs))


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #5872
- [x] Passes `pre-commit run --all-files`

pandas will disallow `skipna=None` (pandas-dev/pandas#44178) - this fixes a test which relies on this. I don't think we have any user facing use of this. AFAIK we don't use pandas for reductions anywhere)