### PR TITLE
Explicitly list all reductions in api.rst

### DIFF
--- a/doc/api-hidden.rst
+++ b/doc/api-hidden.rst
@@ -9,24 +9,6 @@
 .. autosummary::
    :toctree: generated/
 
-   Dataset.nbytes
-   Dataset.chunks
-
-   Dataset.all
-   Dataset.any
-   Dataset.argmax
-   Dataset.argmin
-   Dataset.idxmax
-   Dataset.idxmin
-   Dataset.max
-   Dataset.min
-   Dataset.mean
-   Dataset.median
-   Dataset.prod
-   Dataset.sum
-   Dataset.std
-   Dataset.var
-
    core.coordinates.DatasetCoordinates.get
    core.coordinates.DatasetCoordinates.items
    core.coordinates.DatasetCoordinates.keys
@@ -39,19 +21,6 @@
    core.coordinates.DatasetCoordinates.indexes
    core.coordinates.DatasetCoordinates.variables
 
-   core.rolling.DatasetCoarsen.all
-   core.rolling.DatasetCoarsen.any
-   core.rolling.DatasetCoarsen.construct
-   core.rolling.DatasetCoarsen.count
-   core.rolling.DatasetCoarsen.max
-   core.rolling.DatasetCoarsen.mean
-   core.rolling.DatasetCoarsen.median
-   core.rolling.DatasetCoarsen.min
-   core.rolling.DatasetCoarsen.prod
-   core.rolling.DatasetCoarsen.reduce
-   core.rolling.DatasetCoarsen.std
-   core.rolling.DatasetCoarsen.sum
-   core.rolling.DatasetCoarsen.var
    core.rolling.DatasetCoarsen.boundary
    core.rolling.DatasetCoarsen.coord_func
    core.rolling.DatasetCoarsen.obj
@@ -59,64 +28,6 @@
    core.rolling.DatasetCoarsen.trim_excess
    core.rolling.DatasetCoarsen.windows
 
-   core.groupby.DatasetGroupBy.assign
-   core.groupby.DatasetGroupBy.assign_coords
-   core.groupby.DatasetGroupBy.first
-   core.groupby.DatasetGroupBy.last
-   core.groupby.DatasetGroupBy.fillna
-   core.groupby.DatasetGroupBy.quantile
-   core.groupby.DatasetGroupBy.where
-   core.groupby.DatasetGroupBy.all
-   core.groupby.DatasetGroupBy.any
-   core.groupby.DatasetGroupBy.count
-   core.groupby.DatasetGroupBy.max
-   core.groupby.DatasetGroupBy.mean
-   core.groupby.DatasetGroupBy.median
-   core.groupby.DatasetGroupBy.min
-   core.groupby.DatasetGroupBy.prod
-   core.groupby.DatasetGroupBy.std
-   core.groupby.DatasetGroupBy.sum
-   core.groupby.DatasetGroupBy.var
-   core.groupby.DatasetGroupBy.dims
-   core.groupby.DatasetGroupBy.groups
-
-   core.resample.DatasetResample.all
-   core.resample.DatasetResample.any
-   core.resample.DatasetResample.apply
-   core.resample.DatasetResample.assign
-   core.resample.DatasetResample.assign_coords
-   core.resample.DatasetResample.bfill
-   core.resample.DatasetResample.count
-   core.resample.DatasetResample.ffill
-   core.resample.DatasetResample.fillna
-   core.resample.DatasetResample.first
-   core.resample.DatasetResample.last
-   core.resample.DatasetResample.map
-   core.resample.DatasetResample.max
-   core.resample.DatasetResample.mean
-   core.resample.DatasetResample.median
-   core.resample.DatasetResample.min
-   core.resample.DatasetResample.prod
-   core.resample.DatasetResample.quantile
-   core.resample.DatasetResample.reduce
-   core.resample.DatasetResample.std
-   core.resample.DatasetResample.sum
-   core.resample.DatasetResample.var
-   core.resample.DatasetResample.where
-   core.resample.DatasetResample.dims
-   core.resample.DatasetResample.groups
-
-   core.rolling.DatasetRolling.argmax
-   core.rolling.DatasetRolling.argmin
-   core.rolling.DatasetRolling.count
-   core.rolling.DatasetRolling.max
-   core.rolling.DatasetRolling.mean
-   core.rolling.DatasetRolling.median
-   core.rolling.DatasetRolling.min
-   core.rolling.DatasetRolling.prod
-   core.rolling.DatasetRolling.std
-   core.rolling.DatasetRolling.sum
-   core.rolling.DatasetRolling.var
    core.rolling.DatasetRolling.center
    core.rolling.DatasetRolling.dim
    core.rolling.DatasetRolling.min_periods
@@ -127,48 +38,11 @@
    core.weighted.DatasetWeighted.obj
    core.weighted.DatasetWeighted.weights
 
-   core.rolling_exp.RollingExp.mean
-
-   Dataset.argsort
-   Dataset.astype
-   Dataset.clip
-   Dataset.conj
-   Dataset.conjugate
-   Dataset.imag
-   Dataset.round
-   Dataset.real
-   Dataset.cumsum
-   Dataset.cumprod
-   Dataset.rank
-
    Dataset.load_store
    Dataset.dump_to_store
 
-   DataArray.ndim
-   DataArray.nbytes
-   DataArray.shape
-   DataArray.size
-   DataArray.dtype
-   DataArray.nbytes
-   DataArray.chunks
-
    DataArray.astype
    DataArray.item
-
-   DataArray.all
-   DataArray.any
-   DataArray.argmax
-   DataArray.argmin
-   DataArray.idxmax
-   DataArray.idxmin
-   DataArray.max
-   DataArray.min
-   DataArray.mean
-   DataArray.median
-   DataArray.prod
-   DataArray.sum
-   DataArray.std
-   DataArray.var
 
    core.coordinates.DataArrayCoordinates.get
    core.coordinates.DataArrayCoordinates.items
@@ -182,19 +56,6 @@
    core.coordinates.DataArrayCoordinates.indexes
    core.coordinates.DataArrayCoordinates.variables
 
-   core.rolling.DataArrayCoarsen.all
-   core.rolling.DataArrayCoarsen.any
-   core.rolling.DataArrayCoarsen.construct
-   core.rolling.DataArrayCoarsen.count
-   core.rolling.DataArrayCoarsen.max
-   core.rolling.DataArrayCoarsen.mean
-   core.rolling.DataArrayCoarsen.median
-   core.rolling.DataArrayCoarsen.min
-   core.rolling.DataArrayCoarsen.prod
-   core.rolling.DataArrayCoarsen.reduce
-   core.rolling.DataArrayCoarsen.std
-   core.rolling.DataArrayCoarsen.sum
-   core.rolling.DataArrayCoarsen.var
    core.rolling.DataArrayCoarsen.boundary
    core.rolling.DataArrayCoarsen.coord_func
    core.rolling.DataArrayCoarsen.obj
@@ -202,62 +63,6 @@
    core.rolling.DataArrayCoarsen.trim_excess
    core.rolling.DataArrayCoarsen.windows
 
-   core.groupby.DataArrayGroupBy.assign_coords
-   core.groupby.DataArrayGroupBy.first
-   core.groupby.DataArrayGroupBy.last
-   core.groupby.DataArrayGroupBy.fillna
-   core.groupby.DataArrayGroupBy.quantile
-   core.groupby.DataArrayGroupBy.where
-   core.groupby.DataArrayGroupBy.all
-   core.groupby.DataArrayGroupBy.any
-   core.groupby.DataArrayGroupBy.count
-   core.groupby.DataArrayGroupBy.max
-   core.groupby.DataArrayGroupBy.mean
-   core.groupby.DataArrayGroupBy.median
-   core.groupby.DataArrayGroupBy.min
-   core.groupby.DataArrayGroupBy.prod
-   core.groupby.DataArrayGroupBy.std
-   core.groupby.DataArrayGroupBy.sum
-   core.groupby.DataArrayGroupBy.var
-   core.groupby.DataArrayGroupBy.dims
-   core.groupby.DataArrayGroupBy.groups
-
-   core.resample.DataArrayResample.all
-   core.resample.DataArrayResample.any
-   core.resample.DataArrayResample.apply
-   core.resample.DataArrayResample.assign_coords
-   core.resample.DataArrayResample.bfill
-   core.resample.DataArrayResample.count
-   core.resample.DataArrayResample.ffill
-   core.resample.DataArrayResample.fillna
-   core.resample.DataArrayResample.first
-   core.resample.DataArrayResample.last
-   core.resample.DataArrayResample.map
-   core.resample.DataArrayResample.max
-   core.resample.DataArrayResample.mean
-   core.resample.DataArrayResample.median
-   core.resample.DataArrayResample.min
-   core.resample.DataArrayResample.prod
-   core.resample.DataArrayResample.quantile
-   core.resample.DataArrayResample.reduce
-   core.resample.DataArrayResample.std
-   core.resample.DataArrayResample.sum
-   core.resample.DataArrayResample.var
-   core.resample.DataArrayResample.where
-   core.resample.DataArrayResample.dims
-   core.resample.DataArrayResample.groups
-
-   core.rolling.DataArrayRolling.argmax
-   core.rolling.DataArrayRolling.argmin
-   core.rolling.DataArrayRolling.count
-   core.rolling.DataArrayRolling.max
-   core.rolling.DataArrayRolling.mean
-   core.rolling.DataArrayRolling.median
-   core.rolling.DataArrayRolling.min
-   core.rolling.DataArrayRolling.prod
-   core.rolling.DataArrayRolling.std
-   core.rolling.DataArrayRolling.sum
-   core.rolling.DataArrayRolling.var
    core.rolling.DataArrayRolling.center
    core.rolling.DataArrayRolling.dim
    core.rolling.DataArrayRolling.min_periods
@@ -267,19 +72,6 @@
 
    core.weighted.DataArrayWeighted.obj
    core.weighted.DataArrayWeighted.weights
-
-   DataArray.argsort
-   DataArray.clip
-   DataArray.conj
-   DataArray.conjugate
-   DataArray.imag
-   DataArray.searchsorted
-   DataArray.round
-   DataArray.real
-   DataArray.T
-   DataArray.cumsum
-   DataArray.cumprod
-   DataArray.rank
 
    core.accessor_dt.DatetimeAccessor.ceil
    core.accessor_dt.DatetimeAccessor.floor

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -934,7 +934,10 @@ Dataset
    DatasetWeighted
    DatasetWeighted.mean
    DatasetWeighted.sum
+   DatasetWeighted.std
+   DatasetWeighted.var
    DatasetWeighted.sum_of_weights
+   DatasetWeighted.sum_of_squares
 
 DataArray
 ---------
@@ -945,7 +948,10 @@ DataArray
    DataArrayWeighted
    DataArrayWeighted.mean
    DataArrayWeighted.sum
+   DataArrayWeighted.std
+   DataArrayWeighted.var
    DataArrayWeighted.sum_of_weights
+   DataArrayWeighted.sum_of_squares
 
 Resample objects
 ================

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1,5 +1,7 @@
 .. currentmodule:: xarray
 
+.. _api:
+
 #############
 API reference
 #############

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -63,7 +63,6 @@ Attributes
    Dataset.attrs
    Dataset.encoding
    Dataset.indexes
-   Dataset.get_index
    Dataset.chunks
    Dataset.nbytes
 
@@ -106,6 +105,7 @@ Dataset contents
    Dataset.drop_dims
    Dataset.set_coords
    Dataset.reset_coords
+   Dataset.get_index
 
 Comparisons
 -----------
@@ -182,43 +182,44 @@ Computation
    Dataset.polyfit
    Dataset.curvefit
 
-**Aggregation**:
-:py:attr:`~Dataset.all`
-:py:attr:`~Dataset.any`
-:py:attr:`~Dataset.argmax`
-:py:attr:`~Dataset.argmin`
-:py:attr:`~Dataset.idxmax`
-:py:attr:`~Dataset.idxmin`
-:py:attr:`~Dataset.max`
-:py:attr:`~Dataset.mean`
-:py:attr:`~Dataset.median`
-:py:attr:`~Dataset.min`
-:py:attr:`~Dataset.prod`
-:py:attr:`~Dataset.sum`
-:py:attr:`~Dataset.std`
-:py:attr:`~Dataset.var`
+Aggregation
+-----------
 
-**ndarray methods**:
-:py:attr:`~Dataset.astype`
-:py:attr:`~Dataset.argsort`
-:py:attr:`~Dataset.clip`
-:py:attr:`~Dataset.conj`
-:py:attr:`~Dataset.conjugate`
-:py:attr:`~Dataset.imag`
-:py:attr:`~Dataset.round`
-:py:attr:`~Dataset.real`
-:py:attr:`~Dataset.cumsum`
-:py:attr:`~Dataset.cumprod`
-:py:attr:`~Dataset.rank`
+.. autosummary::
+   :toctree: generated/
 
-**Grouped operations**:
-:py:attr:`~core.groupby.DatasetGroupBy.assign`
-:py:attr:`~core.groupby.DatasetGroupBy.assign_coords`
-:py:attr:`~core.groupby.DatasetGroupBy.first`
-:py:attr:`~core.groupby.DatasetGroupBy.last`
-:py:attr:`~core.groupby.DatasetGroupBy.fillna`
-:py:attr:`~core.groupby.DatasetGroupBy.where`
-:py:attr:`~core.groupby.DatasetGroupBy.quantile`
+   Dataset.all
+   Dataset.any
+   Dataset.argmax
+   Dataset.argmin
+   Dataset.idxmax
+   Dataset.idxmin
+   Dataset.max
+   Dataset.min
+   Dataset.mean
+   Dataset.median
+   Dataset.prod
+   Dataset.sum
+   Dataset.std
+   Dataset.var
+   Dataset.cumsum
+   Dataset.cumprod
+
+ndarray methods
+---------------
+
+.. autosummary::
+   :toctree: generated/
+
+   Dataset.argsort
+   Dataset.astype
+   Dataset.clip
+   Dataset.conj
+   Dataset.conjugate
+   Dataset.imag
+   Dataset.round
+   Dataset.real
+   Dataset.rank
 
 Reshaping and reorganizing
 --------------------------
@@ -270,15 +271,21 @@ Attributes
    DataArray.attrs
    DataArray.encoding
    DataArray.indexes
-   DataArray.get_index
 
-**ndarray attributes**:
-:py:attr:`~DataArray.ndim`
-:py:attr:`~DataArray.shape`
-:py:attr:`~DataArray.size`
-:py:attr:`~DataArray.dtype`
-:py:attr:`~DataArray.nbytes`
-:py:attr:`~DataArray.chunks`
+ndarray attributes
+------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   DataArray.ndim
+   DataArray.nbytes
+   DataArray.shape
+   DataArray.size
+   DataArray.dtype
+   DataArray.nbytes
+   DataArray.chunks
+
 
 DataArray contents
 ------------------
@@ -296,11 +303,9 @@ DataArray contents
    DataArray.drop_duplicates
    DataArray.reset_coords
    DataArray.copy
-
-**ndarray methods**:
-:py:attr:`~DataArray.astype`
-:py:attr:`~DataArray.item`
-
+   DataArray.get_index
+   DataArray.astype
+   DataArray.item
 
 Indexing
 --------
@@ -380,43 +385,45 @@ Computation
    DataArray.map_blocks
    DataArray.curvefit
 
-**Aggregation**:
-:py:attr:`~DataArray.all`
-:py:attr:`~DataArray.any`
-:py:attr:`~DataArray.argmax`
-:py:attr:`~DataArray.argmin`
-:py:attr:`~DataArray.idxmax`
-:py:attr:`~DataArray.idxmin`
-:py:attr:`~DataArray.max`
-:py:attr:`~DataArray.mean`
-:py:attr:`~DataArray.median`
-:py:attr:`~DataArray.min`
-:py:attr:`~DataArray.prod`
-:py:attr:`~DataArray.sum`
-:py:attr:`~DataArray.std`
-:py:attr:`~DataArray.var`
+Aggregation
+-----------
 
-**ndarray methods**:
-:py:attr:`~DataArray.argsort`
-:py:attr:`~DataArray.clip`
-:py:attr:`~DataArray.conj`
-:py:attr:`~DataArray.conjugate`
-:py:attr:`~DataArray.imag`
-:py:attr:`~DataArray.searchsorted`
-:py:attr:`~DataArray.round`
-:py:attr:`~DataArray.real`
-:py:attr:`~DataArray.T`
-:py:attr:`~DataArray.cumsum`
-:py:attr:`~DataArray.cumprod`
-:py:attr:`~DataArray.rank`
+.. autosummary::
+   :toctree: generated/
 
-**Grouped operations**:
-:py:attr:`~core.groupby.DataArrayGroupBy.assign_coords`
-:py:attr:`~core.groupby.DataArrayGroupBy.first`
-:py:attr:`~core.groupby.DataArrayGroupBy.last`
-:py:attr:`~core.groupby.DataArrayGroupBy.fillna`
-:py:attr:`~core.groupby.DataArrayGroupBy.where`
-:py:attr:`~core.groupby.DataArrayGroupBy.quantile`
+   DataArray.all
+   DataArray.any
+   DataArray.argmax
+   DataArray.argmin
+   DataArray.idxmax
+   DataArray.idxmin
+   DataArray.max
+   DataArray.min
+   DataArray.mean
+   DataArray.median
+   DataArray.prod
+   DataArray.sum
+   DataArray.std
+   DataArray.var
+   DataArray.cumsum
+   DataArray.cumprod
+
+ndarray methods
+---------------
+
+.. autosummary::
+   :toctree: generated/
+
+   DataArray.argsort
+   DataArray.clip
+   DataArray.conj
+   DataArray.conjugate
+   DataArray.imag
+   DataArray.searchsorted
+   DataArray.round
+   DataArray.real
+   DataArray.T
+   DataArray.rank
 
 
 String manipulation
@@ -747,80 +754,284 @@ Coordinates objects
 GroupBy objects
 ===============
 
+.. currentmodule:: xarray.core.groupby
+
+Dataset
+-------
+
 .. autosummary::
    :toctree: generated/
 
-   core.groupby.DataArrayGroupBy
-   core.groupby.DataArrayGroupBy.map
-   core.groupby.DataArrayGroupBy.reduce
-   core.groupby.DatasetGroupBy
-   core.groupby.DatasetGroupBy.map
-   core.groupby.DatasetGroupBy.reduce
+   DatasetGroupBy
+   DatasetGroupBy.map
+   DatasetGroupBy.reduce
+   DatasetGroupBy.assign
+   DatasetGroupBy.assign_coords
+   DatasetGroupBy.first
+   DatasetGroupBy.last
+   DatasetGroupBy.fillna
+   DatasetGroupBy.quantile
+   DatasetGroupBy.where
+   DatasetGroupBy.all
+   DatasetGroupBy.any
+   DatasetGroupBy.count
+   DatasetGroupBy.max
+   DatasetGroupBy.mean
+   DatasetGroupBy.median
+   DatasetGroupBy.min
+   DatasetGroupBy.prod
+   DatasetGroupBy.std
+   DatasetGroupBy.sum
+   DatasetGroupBy.var
+   DatasetGroupBy.dims
+   DatasetGroupBy.groups
+
+DataArray
+---------
+
+.. autosummary::
+   :toctree: generated/
+
+   DataArrayGroupBy
+   DataArrayGroupBy.map
+   DataArrayGroupBy.reduce
+   DataArrayGroupBy.assign_coords
+   DataArrayGroupBy.first
+   DataArrayGroupBy.last
+   DataArrayGroupBy.fillna
+   DataArrayGroupBy.quantile
+   DataArrayGroupBy.where
+   DataArrayGroupBy.all
+   DataArrayGroupBy.any
+   DataArrayGroupBy.count
+   DataArrayGroupBy.max
+   DataArrayGroupBy.mean
+   DataArrayGroupBy.median
+   DataArrayGroupBy.min
+   DataArrayGroupBy.prod
+   DataArrayGroupBy.std
+   DataArrayGroupBy.sum
+   DataArrayGroupBy.var
+   DataArrayGroupBy.dims
+   DataArrayGroupBy.groups
+
 
 Rolling objects
 ===============
 
-.. autosummary::
-   :toctree: generated/
+.. currentmodule:: xarray.core.rolling
 
-   core.rolling.DataArrayRolling
-   core.rolling.DataArrayRolling.construct
-   core.rolling.DataArrayRolling.reduce
-   core.rolling.DatasetRolling
-   core.rolling.DatasetRolling.construct
-   core.rolling.DatasetRolling.reduce
-   core.rolling_exp.RollingExp
-
-Weighted objects
-================
+Dataset
+-------
 
 .. autosummary::
    :toctree: generated/
 
-   core.weighted.DataArrayWeighted
-   core.weighted.DataArrayWeighted.mean
-   core.weighted.DataArrayWeighted.sum
-   core.weighted.DataArrayWeighted.sum_of_weights
-   core.weighted.DatasetWeighted
-   core.weighted.DatasetWeighted.mean
-   core.weighted.DatasetWeighted.sum
-   core.weighted.DatasetWeighted.sum_of_weights
+   DatasetRolling
+   DatasetRolling.construct
+   DatasetRolling.reduce
+   DatasetRolling.argmax
+   DatasetRolling.argmin
+   DatasetRolling.count
+   DatasetRolling.max
+   DatasetRolling.mean
+   DatasetRolling.median
+   DatasetRolling.min
+   DatasetRolling.prod
+   DatasetRolling.std
+   DatasetRolling.sum
+   DatasetRolling.var
 
+DataArray
+---------
+
+.. autosummary::
+   :toctree: generated/
+
+   DataArrayRolling
+   DataArrayRolling.construct
+   DataArrayRolling.reduce
+   DataArrayRolling.argmax
+   DataArrayRolling.argmin
+   DataArrayRolling.count
+   DataArrayRolling.max
+   DataArrayRolling.mean
+   DataArrayRolling.median
+   DataArrayRolling.min
+   DataArrayRolling.prod
+   DataArrayRolling.std
+   DataArrayRolling.sum
+   DataArrayRolling.var
 
 Coarsen objects
 ===============
 
+Dataset
+-------
+
 .. autosummary::
    :toctree: generated/
 
-   core.rolling.DataArrayCoarsen
-   core.rolling.DatasetCoarsen
+   DatasetCoarsen
+   DatasetCoarsen.all
+   DatasetCoarsen.any
+   DatasetCoarsen.construct
+   DatasetCoarsen.count
+   DatasetCoarsen.max
+   DatasetCoarsen.mean
+   DatasetCoarsen.median
+   DatasetCoarsen.min
+   DatasetCoarsen.prod
+   DatasetCoarsen.reduce
+   DatasetCoarsen.std
+   DatasetCoarsen.sum
+   DatasetCoarsen.var
 
+DataArray
+---------
+
+.. autosummary::
+   :toctree: generated/
+
+   DataArrayCoarsen
+   DataArrayCoarsen.all
+   DataArrayCoarsen.any
+   DataArrayCoarsen.construct
+   DataArrayCoarsen.count
+   DataArrayCoarsen.max
+   DataArrayCoarsen.mean
+   DataArrayCoarsen.median
+   DataArrayCoarsen.min
+   DataArrayCoarsen.prod
+   DataArrayCoarsen.reduce
+   DataArrayCoarsen.std
+   DataArrayCoarsen.sum
+   DataArrayCoarsen.var
+
+Exponential rolling objects
+===========================
+
+.. currentmodule:: xarray.core.rolling_exp
+
+.. autosummary::
+   :toctree: generated/
+
+   RollingExp
+   RollingExp.mean
+   RollingExp.sum
+
+Weighted objects
+================
+
+.. currentmodule:: xarray.core.weighted
+
+Dataset
+-------
+
+.. autosummary::
+   :toctree: generated/
+
+   DatasetWeighted
+   DatasetWeighted.mean
+   DatasetWeighted.sum
+   DatasetWeighted.sum_of_weights
+
+DataArray
+---------
+
+.. autosummary::
+   :toctree: generated/
+
+   DataArrayWeighted
+   DataArrayWeighted.mean
+   DataArrayWeighted.sum
+   DataArrayWeighted.sum_of_weights
 
 Resample objects
 ================
 
-Resample objects also implement the GroupBy interface
-(methods like ``map()``, ``reduce()``, ``mean()``, ``sum()``, etc.).
+.. currentmodule:: xarray.core.resample
+
+Dataset
+-------
 
 .. autosummary::
    :toctree: generated/
 
-   core.resample.DataArrayResample
-   core.resample.DataArrayResample.asfreq
-   core.resample.DataArrayResample.backfill
-   core.resample.DataArrayResample.interpolate
-   core.resample.DataArrayResample.nearest
-   core.resample.DataArrayResample.pad
-   core.resample.DatasetResample
-   core.resample.DatasetResample.asfreq
-   core.resample.DatasetResample.backfill
-   core.resample.DatasetResample.interpolate
-   core.resample.DatasetResample.nearest
-   core.resample.DatasetResample.pad
+   DatasetResample
+   DatasetResample.asfreq
+   DatasetResample.backfill
+   DatasetResample.interpolate
+   DatasetResample.nearest
+   DatasetResample.pad
+   DatasetResample.all
+   DatasetResample.any
+   DatasetResample.apply
+   DatasetResample.assign
+   DatasetResample.assign_coords
+   DatasetResample.bfill
+   DatasetResample.count
+   DatasetResample.ffill
+   DatasetResample.fillna
+   DatasetResample.first
+   DatasetResample.last
+   DatasetResample.map
+   DatasetResample.max
+   DatasetResample.mean
+   DatasetResample.median
+   DatasetResample.min
+   DatasetResample.prod
+   DatasetResample.quantile
+   DatasetResample.reduce
+   DatasetResample.std
+   DatasetResample.sum
+   DatasetResample.var
+   DatasetResample.where
+   DatasetResample.dims
+   DatasetResample.groups
+
+
+DataArray
+---------
+
+.. autosummary::
+   :toctree: generated/
+
+   DataArrayResample
+   DataArrayResample.asfreq
+   DataArrayResample.backfill
+   DataArrayResample.interpolate
+   DataArrayResample.nearest
+   DataArrayResample.pad
+   DataArrayResample.all
+   DataArrayResample.any
+   DataArrayResample.apply
+   DataArrayResample.assign_coords
+   DataArrayResample.bfill
+   DataArrayResample.count
+   DataArrayResample.ffill
+   DataArrayResample.fillna
+   DataArrayResample.first
+   DataArrayResample.last
+   DataArrayResample.map
+   DataArrayResample.max
+   DataArrayResample.mean
+   DataArrayResample.median
+   DataArrayResample.min
+   DataArrayResample.prod
+   DataArrayResample.quantile
+   DataArrayResample.reduce
+   DataArrayResample.std
+   DataArrayResample.sum
+   DataArrayResample.var
+   DataArrayResample.where
+   DataArrayResample.dims
+   DataArrayResample.groups
 
 Accessors
 =========
+
+.. currentmodule:: xarray
 
 .. autosummary::
    :toctree: generated/

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -32,6 +32,11 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+Documentation
+~~~~~~~~~~~~~
+
+- Significant improvements to  :ref:`api`. By `Deepak Cherian <https://github.com/dcherian>`_.
+
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
@@ -151,7 +156,6 @@ Documentation
 - A clearer error is now raised if a user attempts to assign a Dataset to a single key of
   another Dataset. (:pull:`5839`)
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
-- Significant improvements to  :ref:`api`. By `Deepak Cherian <https://github.com/dcherian>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -96,6 +96,7 @@ Documentation
 - A clearer error is now raised if a user attempts to assign a Dataset to a single key of
   another Dataset. (:pull:`5839`)
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
+- Significant improvements to  :ref:`api`. By `Deepak Cherian <https://github.com/dcherian>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This PR makes a number of updates to `api.rst`. The main goal is to make it easier to navigate using the right-side "Contents" menu. By moving things from `api-hidden.rst` to `api.rst` many methods are now easier-to-discover.

### list all reduction methods in their own subsection under "Dataset" and "DataArray".

**before**

<img width="697" alt="image" src="https://user-images.githubusercontent.com/2448579/139241878-c8cd14da-7690-4dca-9598-7d1debfd49d8.png">

**after**
<img width="762" alt="image" src="https://user-images.githubusercontent.com/2448579/139242316-43d9b2b3-392a-4b6f-b292-ca1cad85af4e.png">


### List reductions for groupby etc

I've also added sections for rolling, coarsen, groupby, resample that again list available reductions. These were previously hidden

<img width="989" alt="image" src="https://user-images.githubusercontent.com/2448579/139242483-4f61326e-a798-4953-9b45-4f1ec53f8c08.png">


### Class method names are much more readable.

**Before**
<img width="697" alt="image" src="https://user-images.githubusercontent.com/2448579/139242056-c8ec9b02-dfa5-480b-8a5a-54f11eddea4f.png">

**after**
<img width="697" alt="image" src="https://user-images.githubusercontent.com/2448579/139242158-fcb4d019-c81b-4f3c-82b9-c1cd43496e4c.png">



