### PR TITLE
 #5740 follow up: supress xr.ufunc warnings in tests

### DIFF
--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -255,13 +255,13 @@ class TestVariable(DaskTestCase):
         except NotImplementedError as err:
             assert "dask" in str(err)
 
-    @pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
     def test_univariate_ufunc(self):
         u = self.eager_var
         v = self.lazy_var
         self.assertLazyAndAllClose(np.sin(u), xu.sin(v))
 
-    @pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
     def test_bivariate_ufunc(self):
         u = self.eager_var
         v = self.lazy_var
@@ -563,7 +563,7 @@ class TestDataArrayAndDataset(DaskTestCase):
         actual = duplicate_and_merge(self.lazy_array)
         self.assertLazyAndEqual(expected, actual)
 
-    @pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
     def test_ufuncs(self):
         u = self.eager_array
         v = self.lazy_array

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -276,11 +276,11 @@ class TestSparseVariable:
         assert_sparse_equal(abs(self.var).data, abs(self.data))
         assert_sparse_equal(self.var.round().data, self.data.round())
 
-    @pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
     def test_univariate_ufunc(self):
         assert_sparse_equal(np.sin(self.data), xu.sin(self.var).data)
 
-    @pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
     def test_bivariate_ufunc(self):
         assert_sparse_equal(np.maximum(self.data, 0), xu.maximum(self.var, 0).data)
         assert_sparse_equal(np.maximum(self.data, 0), xu.maximum(0, self.var).data)
@@ -664,7 +664,7 @@ class TestSparseDataArrayAndDataset:
         roundtripped = stacked.unstack()
         assert_identical(arr, roundtripped)
 
-    @pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
     def test_ufuncs(self):
         x = self.sp_xr
         assert_equal(np.sin(x), xu.sin(x))


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

#5740 changed `PendingDeprecationWarning` to `FutureWarning` - suppress the warnings again in the test suite.

https://github.com/pydata/xarray/blob/36f05d70c864ee7c61603c8a43ba721bf7f434b3/xarray/ufuncs.py#L47-L49
