### PR TITLE
fix the detection of backend entrypoints

### DIFF
--- a/ci/requirements/py37-bare-minimum.yml
+++ b/ci/requirements/py37-bare-minimum.yml
@@ -13,3 +13,4 @@ dependencies:
   - numpy=1.18
   - pandas=1.1
   - typing_extensions=3.7
+  - importlib-metadata=2.0

--- a/ci/requirements/py37-min-all-deps.yml
+++ b/ci/requirements/py37-min-all-deps.yml
@@ -24,6 +24,7 @@ dependencies:
   - hdf5=1.10
   - hypothesis
   - iris=2.4
+  - importlib-metadata=2.0
   - lxml=4.6  # Optional dep of pydap
   - matplotlib-base=3.3
   - nc-time-axis=1.2

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -31,6 +31,8 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
+- Fix a regression in the detection of the backend entrypoints (:issue:`5930`, :pull:``)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -31,7 +31,7 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
-- Fix a regression in the detection of the backend entrypoints (:issue:`5930`, :pull:``)
+- Fix a regression in the detection of the backend entrypoints (:issue:`5930`, :pull:`5931`)
   By `Justus Magin <https://github.com/keewis>`_.
 
 Internal Changes

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -6,10 +6,10 @@ import warnings
 from .common import BACKEND_ENTRYPOINTS, BackendEntrypoint
 
 try:
-    from importlib.metadata import Distribution
+    from importlib.metadata import entry_points
 except ImportError:
     # if the fallback library is missing, we are doomed.
-    from importlib_metadata import Distribution  # type: ignore[no-redef]
+    from importlib_metadata import entry_points  # type: ignore[no-redef]
 
 
 STANDARD_BACKENDS_ORDER = ["netcdf4", "h5netcdf", "scipy"]
@@ -99,11 +99,7 @@ def build_engines(entrypoints):
 
 @functools.lru_cache(maxsize=1)
 def list_engines():
-    entrypoints = (
-        entry_point
-        for entry_point in Distribution.from_name("xarray").entry_points
-        if entry_point.module == "xarray.backends"
-    )
+    entrypoints = entry_points().get("xarray.backends", ())
     return build_engines(entrypoints)
 
 


### PR DESCRIPTION
In #5845, we accidentally broke the detection of the backends. Since this has a big impact we probably need to release `v0.20.1` very soon.

I'm not sure if it's possible to add tests for this, though.

- [x] Closes #5930
- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
