### PR TITLE
DOC: add names of missing contributors to 0.20.0

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -64,7 +64,7 @@ New Features
   By `Justus Magin <https://github.com/keewis>`_.
 - Added ``**kwargs`` argument to :py:meth:`open_rasterio` to access overviews (:issue:`3269`).
   By `Pushkar Kopparla <https://github.com/pkopparla>`_.
-- Added ``storage_options`` argument to :py:meth:`to_zarr` (:issue:`5601`).
+- Added ``storage_options`` argument to :py:meth:`to_zarr` (:issue:`5601`, :pull:`5615`).
   By `Ray Bell <https://github.com/raybellwaves>`_, `Zachary Blackwood <https://github.com/blackary>`_ and
   `Nathan Lis <https://github.com/wxman22>`_.
 - Histogram plots are set with a title displaying the scalar coords if any, similarly to the other plots (:issue:`5791`, :pull:`5792`).

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -44,13 +44,13 @@ This release brings improved support for pint arrays, methods for weighted stand
 and sum of squares, the option to disable the use of the bottleneck library, significantly improved performance of
 unstack, as well as many bugfixes and internal changes.
 
-Many thanks to the 38 contributors to this release!:
+Many thanks to the 40 contributors to this release!:
 
 Aaron Spring, Akio Taniguchi, Alan D. Snow, arfy slowy, Benoit Bovy, Christian Jauvin, crusaderky, Deepak Cherian,
 Giacomo Caria, Illviljan, James Bourbeau, Joe Hamman, Joseph K Aicher, Julien Herzen, Kai Mühlbauer,
-keewis, lusewell, Martin K. Scherer, Mathias Hauser, Max Grover, Maxime Liquet, Maximilian Roos, Mike Taves, pmav99,
-Pushkar Kopparla, Ray Bell, Rio McMahon, Scott Staniewicz, Spencer Clark, Stefan Bender, Taher Chegini, Thomas Nicholas,
-Tomas Chor, Tom Augspurger, Victor Negîrneac, Zachary Moon, and Zeb Nicholls.
+keewis, lusewell, Martin K. Scherer, Mathias Hauser, Max Grover, Maxime Liquet, Maximilian Roos, Mike Taves, Nathan Lis,
+pmav99, Pushkar Kopparla, Ray Bell, Rio McMahon, Scott Staniewicz, Spencer Clark, Stefan Bender, Taher Chegini,
+Thomas Nicholas, Tomas Chor, Tom Augspurger, Victor Negîrneac, Zachary Blackwood, Zachary Moon, and Zeb Nicholls.
 
 New Features
 ~~~~~~~~~~~~


### PR DESCRIPTION
When I worked on https://github.com/pydata/xarray/pull/5615 I did so with a couple of team mates. I added them in the commit message: https://github.com/pydata/xarray/pull/5615/commits/67ccce2f9b31eebf38fffb5dc86b90810299111c

Want to make sure they get a shout out here :)