### PR TITLE
Fix a missing @requires_zarr in tests

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2398,6 +2398,7 @@ class TestZarrDirectoryStore(ZarrBase):
             yield tmp
 
 
+@requires_zarr
 @requires_fsspec
 def test_zarr_storage_options():
     pytest.importorskip("aiobotocore")


### PR DESCRIPTION
When zarr is not available, this test fails with `NameError: name 'zarr' is not defined`.

<details>
<summary>Full trace</summary>

```
__________________________ test_zarr_storage_options ___________________________

    @requires_fsspec
    def test_zarr_storage_options():
        pytest.importorskip("aiobotocore")
        ds = create_test_data()
        store_target = "memory://test.zarr"
>       ds.to_zarr(store_target, storage_options={"test": "zarr_write"})

/build/python-xarray/src/xarray-0.20.0/xarray/tests/test_backends.py:2406: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/build/python-xarray/src/xarray-0.20.0/xarray/core/dataset.py:2037: in to_zarr
    return to_zarr(
/build/python-xarray/src/xarray-0.20.0/xarray/backends/api.py:1391: in to_zarr
    zstore = backends.ZarrStore.open_group(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cls = <class 'xarray.backends.zarr.ZarrStore'>
store = <fsspec.mapping.FSMap object at 0x7f074691cfd0>, mode = 'w-'
synchronizer = None, group = None, consolidated = False
consolidate_on_close = True, chunk_store = None, storage_options = None
append_dim = None, write_region = None, safe_chunks = True, stacklevel = 4

    @classmethod
    def open_group(
        cls,
        store,
        mode="r",
        synchronizer=None,
        group=None,
        consolidated=False,
        consolidate_on_close=False,
        chunk_store=None,
        storage_options=None,
        append_dim=None,
        write_region=None,
        safe_chunks=True,
        stacklevel=2,
    ):
    
        # zarr doesn't support pathlib.Path objects yet. zarr-python#601
        if isinstance(store, os.PathLike):
            store = os.fspath(store)
    
        open_kwargs = dict(
            mode=mode,
            synchronizer=synchronizer,
            path=group,
        )
        open_kwargs["storage_options"] = storage_options
    
        if chunk_store:
            open_kwargs["chunk_store"] = chunk_store
            if consolidated is None:
                consolidated = False
    
        if consolidated is None:
            try:
                zarr_group = zarr.open_consolidated(store, **open_kwargs)
            except KeyError:
                warnings.warn(
                    "Failed to open Zarr store with consolidated metadata, "
                    "falling back to try reading non-consolidated metadata. "
                    "This is typically much slower for opening a dataset. "
                    "To silence this warning, consider:\n"
                    "1. Consolidating metadata in this existing store with "
                    "zarr.consolidate_metadata().\n"
                    "2. Explicitly setting consolidated=False, to avoid trying "
                    "to read consolidate metadata, or\n"
                    "3. Explicitly setting consolidated=True, to raise an "
                    "error in this case instead of falling back to try "
                    "reading non-consolidated metadata.",
                    RuntimeWarning,
                    stacklevel=stacklevel,
                )
                zarr_group = zarr.open_group(store, **open_kwargs)
        elif consolidated:
            # TODO: an option to pass the metadata_key keyword
            zarr_group = zarr.open_consolidated(store, **open_kwargs)
        else:
>           zarr_group = zarr.open_group(store, **open_kwargs)
E           NameError: name 'zarr' is not defined

/build/python-xarray/src/xarray-0.20.0/xarray/backends/zarr.py:386: NameError
```
</details>