### PR TITLE
Disable unit test comments

### DIFF
--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -42,3 +42,4 @@ jobs:
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           files: "artifacts/**/*.xml"
+          comment_mode: off


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes https://github.com/pydata/xarray/issues/5940

I disable the commenting, but didn't turn it off — I'm still hoping we could get cool stuff like this:
<img width="924" alt="image" src="https://user-images.githubusercontent.com/5635139/140622602-c62ec738-c09e-462d-981f-4746f6738c6f.png">

...from https://github.com/EnricoMi/publish-unit-test-result-action, which I don't know why we don't get.

Removing the commenting removes any downside, I think

