### PR TITLE
Fix plot.line crash for data of shape (1, N) in _title_for_slice on format_item

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,7 +34,8 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
-
+- Fix plot.line crash for data of shape ``(1, N)`` in _title_for_slice on format_item (:pull:`5948`).
+  By `Sebastian Weigand <https://github.com/s-weigand>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -143,7 +143,7 @@ def format_item(x, timedelta_format=None, quote_strings=True):
     elif isinstance(x, (str, bytes)):
         return repr(x) if quote_strings else x
     elif hasattr(x, "dtype") and np.issubdtype(x.dtype, np.floating):
-        return f"{x:.4}"
+        return f"{x.item():.4}"
     else:
         return str(x)
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -754,6 +754,13 @@ class TestPlot1D(PlotTestCase):
         title = plt.gca().get_title()
         assert "d = 10.01" == title
 
+    def test_slice_in_title_single_item_array(self):
+        """Edge case for data of shape (1, N) or (N, 1)."""
+        darray = self.darray.expand_dims({"d": np.array([10.009])})
+        darray.plot.line(x="period")
+        title = plt.gca().get_title()
+        assert "d = 10.01" == title
+
 
 class TestPlotStep(PlotTestCase):
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
Affected `xarray` versions `0.20.0`+

When dependabot recently made a PR to update  `xarray` to `0.20.0` our integration test CI failed with
```
....
    File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/xarray/plot/plot.py", line 447, in line
      ax.set_title(darray._title_for_slice())
    File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/xarray/core/dataarray.py", line 3140, in _title_for_slice
      v=format_item(coord.values),
    File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/xarray/core/formatting.py", line 146, in format_item
      return f"{x:.4}"
  TypeError: unsupported format string passed to numpy.ndarray.__format__
```

We use `xarray.Dataarray.plot.line(x="<dim_name>")` to plot data of shape `(N, M)` where `N` and `M` are `>=1`.

The crash is caused because the following line

https://github.com/pydata/xarray/blob/402a9b398868bd9bd385210138d6f8ea610c8c40/xarray/core/dataarray.py#L3136

allows arrays of shape `()` and `(1,)` to be passed into `format_item`, where both pass this check

https://github.com/pydata/xarray/blob/402a9b398868bd9bd385210138d6f8ea610c8c40/xarray/core/formatting.py#L145-L146

But `f"{x:.4}"` only works for arrays of shape `()` and crashes on arrays of shape `(1,)`

Before the check was
https://github.com/pydata/xarray/blob/a78c1e0115d38cb4461fd1aba93334d440cff49c/xarray/core/formatting.py#L145-L146

Which didn't allow any arrays and caused the float formatting issue.


<details>
 <summary>Code showing the differences</summary>

```python
In [1]: import numpy as np

In [2]: x = np.array(0.1)

In [3]: x.shape
Out[3]: ()

In [4]: np.issubdtype(type(x), np.floating)
Out[4]: False

In [5]: hasattr(x, "dtype") and np.issubdtype(x.dtype, np.floating)
Out[5]: True

In [6]: f"{x:.4}"
Out[6]: '0.1'

In [7]: f"{x.item():.4}"
Out[7]: '0.1'

In [8]: x = np.array([0.1])

In [9]: x.shape
Out[9]: (1,)

In [10]: np.issubdtype(type(x), np.floating)
Out[10]: False

In [11]: hasattr(x, "dtype") and np.issubdtype(x.dtype, np.floating)
Out[11]: True

In [12]: f"{x:.4}"
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~\AppData\Local\Temp/ipykernel_32644/2490801713.py in <module>
----> 1 f"{x:.4}"

TypeError: unsupported format string passed to numpy.ndarray.__format__

In [13]: f"{x.item():.4}"
Out[13]: '0.1'
```
</details>

I hope `TestPlot1D` was the correct place to put the test since the plot itself is 1D but the data which are plotted have a second dimension with size 1 (naming thing and where to put things... 😅).

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

PS: Thanks for the awesome package ❤️ 