### PR TITLE
Do not change coordinate inplace when throwing error

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2418,6 +2418,8 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         if dims != self.dims:
             raise ValueError("dimensions cannot change for in-place operations")
         with np.errstate(all="ignore"):
+            if isinstance(self_data, np.ndarray):
+                self.values = f(self_data.copy(), other_data)
             self.values = f(self_data, other_data)
         return self
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2418,10 +2418,6 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         if dims != self.dims:
             raise ValueError("dimensions cannot change for in-place operations")
         with np.errstate(all="ignore"):
-            # Give a chance to Variable.values.setter to throw error if needed
-            # without updating self_data inplace
-            if isinstance(self_data, np.ndarray):
-                self.values = f(self_data.copy(), other_data)
             self.values = f(self_data, other_data)
         return self
 
@@ -2816,6 +2812,11 @@ class IndexVariable(Variable):
     @name.setter
     def name(self, value):
         raise AttributeError("cannot modify name of IndexVariable in-place")
+
+    def _inplace_binary_op(self, other, f):
+        raise TypeError(
+            "Values of an IndexVariable are immutable and can not be modified inplace"
+        )
 
 
 # for backwards compatibility

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2418,6 +2418,8 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         if dims != self.dims:
             raise ValueError("dimensions cannot change for in-place operations")
         with np.errstate(all="ignore"):
+            # Give a chance to Variable.values.setter to throw error if needed
+            # without updating self_data inplace
             if isinstance(self_data, np.ndarray):
                 self.values = f(self_data.copy(), other_data)
             self.values = f(self_data, other_data)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1987,6 +1987,16 @@ class TestDataArray:
         assert_array_equal(b.values, x)
         assert source_ndarray(b.values) is x
 
+    def test_inplace_math_error(self):
+        data = np.random.rand(4)
+        times = np.arange(4)
+        foo = DataArray(data, coords=[times], dims=["time"])
+        b = times.copy()
+        with pytest.raises(ValueError, match=r"Cannot assign to the .values"):
+            foo.coords["time"] += 1
+        # Check error throwing prevented inplace operation
+        assert_array_equal(foo.coords["time"], b)
+
     def test_inplace_math_automatic_alignment(self):
         a = DataArray(range(5), [("x", range(5))])
         b = DataArray(range(1, 6), [("x", range(1, 6))])

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1992,7 +1992,9 @@ class TestDataArray:
         times = np.arange(4)
         foo = DataArray(data, coords=[times], dims=["time"])
         b = times.copy()
-        with pytest.raises(ValueError, match=r"Cannot assign to the .values"):
+        with pytest.raises(
+            TypeError, match=r"Values of an IndexVariable are immutable"
+        ):
             foo.coords["time"] += 1
         # Check error throwing prevented inplace operation
         assert_array_equal(foo.coords["time"], b)

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1656,6 +1656,14 @@ class TestVariable(VariableSubclassobjects):
         with pytest.raises(ValueError, match=r"dimensions cannot change"):
             v += Variable("y", np.arange(5))
 
+    def test_inplace_math_error(self):
+        x = np.arange(5)
+        v = IndexVariable(["x"], x)
+        with pytest.raises(
+            TypeError, match=r"Values of an IndexVariable are immutable"
+        ):
+            v += 1
+
     def test_reduce(self):
         v = Variable(["x", "y"], self.d, {"ignored": "attributes"})
         assert_identical(v.reduce(np.std, "x"), Variable(["y"], self.d.std(axis=0)))


### PR DESCRIPTION
- [x] Closes #5036
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Not the prettiest of fixes, but this goes around the fact that mutable data types (e.g. when `self_data` is a  `np.ndarray`) get  updated inplace on the right-hand side of the following line, while the error is thrown during the  subsequent assignment to the left-hand side.

https://github.com/pydata/xarray/blob/20fddb7e3838d3cf1514476899e77a8a1749734b/xarray/core/variable.py#L2421
