### PR TITLE
Respect keep_attrs when using `Dataset.set_index` (#4955)

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -224,6 +224,7 @@ def merge_indexes(
     vars_to_remove: List[Hashable] = []
     dims_to_replace: Dict[Hashable, Hashable] = {}
     error_msg = "{} is not the name of an existing variable."
+    keep_attrs = _get_keep_attrs(default=True)
 
     for dim, var_names in indexes.items():
         if isinstance(var_names, str) or not isinstance(var_names, Sequence):
@@ -277,7 +278,8 @@ def merge_indexes(
             for n in names:
                 dims_to_replace[n] = dim
 
-        vars_to_replace[dim] = IndexVariable(dim, idx)
+        attrs = variables[var_names[0]].attrs if keep_attrs else None
+        vars_to_replace[dim] = IndexVariable(dim, idx, attrs=attrs)
         vars_to_remove.extend(var_names)
 
     new_variables = {k: v for k, v in variables.items() if k not in vars_to_remove}

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2976,6 +2976,15 @@ class TestDataset:
             ds.set_index(foo="bar")
         assert str(excinfo.value) == "bar is not the name of an existing variable."
 
+        # ensure attrs are kept
+        da = DataArray([1, 2], dims=["x"])
+        da.coords["x"] = (["x"], [2, 3], {"name": "coord_1"})
+        da.coords["a"] = (["x"], [0, 1], {"name": "coord_2"})
+        ds = Dataset({"x_var": da})
+        assert ds.set_index(x="a").x.attrs == {"name": "coord_2"}
+        with set_options(keep_attrs=False):
+            assert ds.set_index(x="a").x.attrs == {}
+
     def test_reset_index(self):
         ds = create_test_multiindex()
         mindex = ds["x"].to_index()


### PR DESCRIPTION
- [x] Closes #4955
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

The original issue was about `DataArray.set_index`, but since this simply calls `Dataset.set_index`, I have only added a test for the latter.  `DataArray.set_index` probably deserves a test too, please let me know what you think.