### PR TITLE
Allow string formatting of scalar DataArrays

### DIFF
--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -158,6 +158,14 @@ class AbstractArray:
             return f"<pre>{escape(repr(self))}</pre>"
         return formatting_html.array_repr(self)
 
+    def __format__(self, format_spec):
+        if not format_spec:
+            # Keep backwards compatibility with earlier versions where
+            # format without specifier falls backs to the standard repr
+            return formatting.array_repr(self)
+        # Else why fall back to numpy
+        return self.values.__format__(format_spec)
+
     def _iter(self: Any) -> Iterator[Any]:
         for n in range(len(self)):
             yield self[n]

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -158,7 +158,7 @@ class AbstractArray:
             return f"<pre>{escape(repr(self))}</pre>"
         return formatting_html.array_repr(self)
 
-    def __format__(self, format_spec):
+    def __format__(self, format_spec) -> str:
         if not format_spec:
             # format without specifier falls backs to standard repr
             return formatting.array_repr(self)

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -158,7 +158,7 @@ class AbstractArray:
             return f"<pre>{escape(repr(self))}</pre>"
         return formatting_html.array_repr(self)
 
-    def __format__(self, format_spec) -> str:
+    def __format__(self: Any, format_spec: str) -> str:
         if not format_spec:
             # format without specifier falls backs to standard repr
             return formatting.array_repr(self)

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -160,10 +160,9 @@ class AbstractArray:
 
     def __format__(self, format_spec):
         if not format_spec:
-            # Keep backwards compatibility with earlier versions where
-            # format without specifier falls backs to the standard repr
+            # format without specifier falls backs to standard repr
             return formatting.array_repr(self)
-        # Else why fall back to numpy
+        # else use numpy: scalars will print fine and arrays will raise
         return self.values.__format__(format_spec)
 
     def _iter(self: Any) -> Iterator[Any]:

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -159,10 +159,7 @@ class AbstractArray:
         return formatting_html.array_repr(self)
 
     def __format__(self: Any, format_spec: str) -> str:
-        if not format_spec:
-            # format without specifier falls backs to standard repr
-            return formatting.array_repr(self)
-        # else use numpy: scalars will print fine and arrays will raise
+        # we use numpy: scalars will print fine and arrays will raise
         return self.values.__format__(format_spec)
 
     def _iter(self: Any) -> Iterator[Any]:

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -418,6 +418,19 @@ class TestFormatting:
         with xr.set_options(display_expand_data=False):
             formatting.array_repr(var)
 
+    def test_array_scalar_format(self) -> None:
+        var = xr.DataArray(0)
+        assert var.__format__("") == "<xarray.DataArray ()>\narray(0)"
+        assert var.__format__("d") == "0"
+        assert var.__format__(".2f") == "0.00"
+
+        var = xr.DataArray([0])
+        assert var.__format__("") == ("<xarray.DataArray (dim_0: 1)>\narray([0])"
+                                      "\nDimensions without coordinates: dim_0")
+        with pytest.raises(TypeError) as excinfo:
+            var.__format__(".2f")
+        assert "unsupported format string passed to" in str(excinfo.value)
+
 
 def test_inline_variable_array_repr_custom_repr() -> None:
     class CustomArray:

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -420,15 +420,12 @@ class TestFormatting:
 
     def test_array_scalar_format(self) -> None:
         var = xr.DataArray(0)
-        assert var.__format__("") == "<xarray.DataArray ()>\narray(0)"
+        assert var.__format__("") == "0"
         assert var.__format__("d") == "0"
         assert var.__format__(".2f") == "0.00"
 
-        var = xr.DataArray([0])
-        assert var.__format__("") == (
-            "<xarray.DataArray (dim_0: 1)>\narray([0])"
-            "\nDimensions without coordinates: dim_0"
-        )
+        var = xr.DataArray([0.1, 0.2])
+        assert var.__format__("") == "[0.1 0.2]"
         with pytest.raises(TypeError) as excinfo:
             var.__format__(".2f")
         assert "unsupported format string passed to" in str(excinfo.value)

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -9,10 +9,7 @@ from numpy.core import defchararray
 import xarray as xr
 from xarray.core import formatting
 
-from . import (
-    requires_netCDF4,
-    requires_dask,
-)
+from . import requires_dask, requires_netCDF4
 
 
 class TestFormatting:
@@ -435,11 +432,12 @@ class TestFormatting:
         assert "unsupported format string passed to" in str(excinfo.value)
 
         # also check for dask
-        var = var.chunk(chunks={'dim_0': 1})
+        var = var.chunk(chunks={"dim_0": 1})
         assert var.__format__("") == "[0.1 0.2]"
         with pytest.raises(TypeError) as excinfo:
             var.__format__(".2f")
         assert "unsupported format string passed to" in str(excinfo.value)
+
 
 def test_inline_variable_array_repr_custom_repr() -> None:
     class CustomArray:

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -425,8 +425,10 @@ class TestFormatting:
         assert var.__format__(".2f") == "0.00"
 
         var = xr.DataArray([0])
-        assert var.__format__("") == ("<xarray.DataArray (dim_0: 1)>\narray([0])"
-                                      "\nDimensions without coordinates: dim_0")
+        assert var.__format__("") == (
+            "<xarray.DataArray (dim_0: 1)>\narray([0])"
+            "\nDimensions without coordinates: dim_0"
+        )
         with pytest.raises(TypeError) as excinfo:
             var.__format__(".2f")
         assert "unsupported format string passed to" in str(excinfo.value)

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -9,7 +9,10 @@ from numpy.core import defchararray
 import xarray as xr
 from xarray.core import formatting
 
-from . import requires_netCDF4
+from . import (
+    requires_netCDF4,
+    requires_dask,
+)
 
 
 class TestFormatting:
@@ -418,6 +421,7 @@ class TestFormatting:
         with xr.set_options(display_expand_data=False):
             formatting.array_repr(var)
 
+    @requires_dask
     def test_array_scalar_format(self) -> None:
         var = xr.DataArray(0)
         assert var.__format__("") == "0"
@@ -430,6 +434,12 @@ class TestFormatting:
             var.__format__(".2f")
         assert "unsupported format string passed to" in str(excinfo.value)
 
+        # also check for dask
+        var = var.chunk(chunks={'dim_0': 1})
+        assert var.__format__("") == "[0.1 0.2]"
+        with pytest.raises(TypeError) as excinfo:
+            var.__format__(".2f")
+        assert "unsupported format string passed to" in str(excinfo.value)
 
 def test_inline_variable_array_repr_custom_repr() -> None:
     class CustomArray:


### PR DESCRIPTION
- [x] Closes https://github.com/pydata/xarray/issues/5976
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

This is a first try at formatting dataarray scalars. Here is the current behavior:

```python
In [1]: import xarray as xr
   ...: import numpy as np

In [2]: a = np.array(1)
   ...: da = xr.DataArray(a)

In [3]: print(a)
1

In [4]: print(da)
<xarray.DataArray ()>
array(1)

In [5]: print('{}'.format(a))
1

In [6]: print('{}'.format(da))
<xarray.DataArray ()>
array(1)

In [7]: print('{:.3f}'.format(a))
1.000

In [8]: print('{:.3f}'.format(da))
1.000

In [9]: a = np.array([1, 2])
   ...: da = xr.DataArray(a)

In [10]: print('{}'.format(a))
[1 2]

In [11]: print('{}'.format(da))
<xarray.DataArray (dim_0: 2)>
array([1, 2])
Dimensions without coordinates: dim_0

In [12]: print('{:.3f}'.format(a))
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-12-c5afc7863e89> in <module>
----> 1 print('{:.3f}'.format(a))

TypeError: unsupported format string passed to numpy.ndarray.__format__

In [13]: print('{:.3f}'.format(da))
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-13-bddebd8462bd> in <module>
----> 1 print('{:.3f}'.format(da))

~/disk/Dropbox/HomeDocs/git/xarray/xarray/core/common.py in __format__(self, format_spec)
    162             return formatting.array_repr(self)
    163         # Else why fall back to numpy
--> 164         return self.values.__format__(format_spec)
    165 
    166     def _iter(self: Any) -> Iterator[Any]:

TypeError: unsupported format string passed to numpy.ndarray.__format__
```
I don't think there is any backwards compatibility issue but lets see if the tests pass