### PR TITLE
Check for py version instead of try/except when importing entry_points

### DIFF
--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -6,7 +6,7 @@ import warnings
 
 from .common import BACKEND_ENTRYPOINTS, BackendEntrypoint
 
-if sys.version_info >= (3, 8): 
+if sys.version_info >= (3, 8):
     from importlib.metadata import entry_points
 else:
     # if the fallback library is missing, we are doomed.

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -1,15 +1,16 @@
 import functools
 import inspect
 import itertools
+import sys
 import warnings
 
 from .common import BACKEND_ENTRYPOINTS, BackendEntrypoint
 
-try:
+if sys.version_info >= (3, 8): 
     from importlib.metadata import entry_points
-except ImportError:
+else:
     # if the fallback library is missing, we are doomed.
-    from importlib_metadata import entry_points  # type: ignore
+    from importlib_metadata import entry_points
 
 
 STANDARD_BACKENDS_ORDER = ["netcdf4", "h5netcdf", "scipy"]


### PR DESCRIPTION
This removes the need for the `# type: ignore` to make mypy happy. It is also clearer when this compatibillity code can be removed.