### PR TITLE
Use condas dask-core in ci instead of dask to speedup ci and reduce dependencies

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -8,7 +8,7 @@ dependencies:
   - bottleneck
   - cartopy
   - cfgrib>=0.9
-  - dask>=2.10
+  - dask-core>=2.10
   - h5netcdf>=0.7.4
   - ipykernel
   - ipython

--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -8,7 +8,7 @@ dependencies:
   - bottleneck
   - cartopy
   - cfgrib>=0.9
-  - dask-core>=2.10
+  - dask-core>=2.30
   - h5netcdf>=0.7.4
   - ipykernel
   - ipython

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -8,7 +8,7 @@ dependencies:
   # - cdms2  # Not available on Windows
   # - cfgrib  # Causes Python interpreter crash on Windows: https://github.com/pydata/xarray/pull/3340
   - cftime
-  - dask
+  - dask-core
   - distributed
   - fsspec!=2021.7.0
   - h5netcdf

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - h5py
   - hdf5
   - hypothesis
-  - iris
+  #- iris
   - lxml    # Optional dep of pydap
   - matplotlib-base
   - nc-time-axis

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - h5py
   - hdf5
   - hypothesis
-  #- iris
+  #- iris  # just testing for now, include again once iris-feedstock uses dask-core
   - lxml    # Optional dep of pydap
   - matplotlib-base
   - nc-time-axis

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - h5py
   - hdf5
   - hypothesis
-  #- iris  # just testing for now, include again once iris-feedstock uses dask-core
+  - iris
   - lxml    # Optional dep of pydap
   - matplotlib-base
   - nc-time-axis

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - cdms2
   - cfgrib
   - cftime
-  - dask
+  - dask-core
   - distributed
   - fsspec!=2021.7.0
   - h5netcdf

--- a/ci/requirements/py37-min-all-deps.yml
+++ b/ci/requirements/py37-min-all-deps.yml
@@ -23,7 +23,7 @@ dependencies:
   # hdf5 1.12 conflicts with h5py=2.10
   - hdf5=1.10
   - hypothesis
-  - iris=2.4
+  # - iris=2.4 # just testing
   - importlib-metadata=2.0
   - lxml=4.6  # Optional dep of pydap
   - matplotlib-base=3.3

--- a/ci/requirements/py37-min-all-deps.yml
+++ b/ci/requirements/py37-min-all-deps.yml
@@ -16,7 +16,7 @@ dependencies:
   - cfgrib=0.9
   - cftime=1.2
   - coveralls
-  - dask=2.30
+  - dask-core=2.30
   - distributed=2.30
   - h5netcdf=0.8
   - h5py=2.10

--- a/ci/requirements/py37-min-all-deps.yml
+++ b/ci/requirements/py37-min-all-deps.yml
@@ -23,7 +23,7 @@ dependencies:
   # hdf5 1.12 conflicts with h5py=2.10
   - hdf5=1.10
   - hypothesis
-  # - iris=2.4 # just testing
+  # - iris=2.4 # just testing for now, include again once iris-feedstock uses dask-core
   - importlib-metadata=2.0
   - lxml=4.6  # Optional dep of pydap
   - matplotlib-base=3.3

--- a/ci/requirements/py37-min-all-deps.yml
+++ b/ci/requirements/py37-min-all-deps.yml
@@ -23,7 +23,7 @@ dependencies:
   # hdf5 1.12 conflicts with h5py=2.10
   - hdf5=1.10
   - hypothesis
-  # - iris=2.4 # just testing for now, include again once iris-feedstock uses dask-core
+  - iris=2.4
   - importlib-metadata=2.0
   - lxml=4.6  # Optional dep of pydap
   - matplotlib-base=3.3


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

Tried to reduce dependencies from installing dask via conda which installs like pip install dask[complete]. dask-core is like pip install dask. https://github.com/xgcm/xhistogram/pull/71#discussion_r752738286

Why? dask[complete] includes bokeh etc which are not needed here and likely speed up CI setup/install times

but now dask and dask-core are conda installed :( seems like iris installs dask https://github.com/conda-forge/iris-feedstock/blob/master/recipe/meta.yaml, so this would require an iris-feedstock PR first

linking https://github.com/SciTools/iris/pull/4434 and https://github.com/conda-forge/iris-feedstock/pull/77
