### PR TITLE
Use complex nan by default when interpolating out of bounds

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -26,7 +26,8 @@ New Features
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
-
+- Use complex nan when interpolating complex values out of bounds by default (instead of real nan) (:pull:`6019`).
+  By `Alexandre Poux <https://github.com/pums974>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -82,7 +82,7 @@ class NumpyInterpolator(BaseInterpolator):
         self._xi = xi
         self._yi = yi
 
-        nan = np.nan if not np.iscomplexobj(yi) else np.nan + np.nan * 1j
+        nan = np.nan if yi.dtype.kind != "c" else np.nan + np.nan * 1j
 
         if fill_value is None:
             self._left = nan
@@ -145,7 +145,7 @@ class ScipyInterpolator(BaseInterpolator):
         self.cons_kwargs = kwargs
         self.call_kwargs = {}
 
-        nan = np.nan if not np.iscomplexobj(yi) else np.nan + np.nan * 1j
+        nan = np.nan if yi.dtype.kind != "c" else np.nan + np.nan * 1j
 
         if fill_value is None and method == "linear":
             fill_value = nan, nan

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -907,3 +907,16 @@ def test_coord_attrs(x, expect_same_attrs):
 
     has_same_attrs = ds.interp(x=x).x.attrs == base_attrs
     assert expect_same_attrs == has_same_attrs
+
+
+@requires_scipy
+def test_interp1d_complex_out_of_bounds():
+    """Ensure complex nans are used by default"""
+    da = xr.DataArray(
+        np.exp(0.3j * np.arange(4)),
+        [("time", np.arange(4))],
+    )
+
+    expected = da.interp(time=3.5, kwargs=dict(fill_value=np.nan + np.nan * 1j))
+    actual = da.interp(time=3.5)
+    assert_identical(actual, expected)

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -706,6 +706,6 @@ def test_interpolators_complex_out_of_bounds():
         ("linear", ScipyInterpolator),
     ]:
 
-        f = interpolator(xi, yi, method=method, complex_data=True)
+        f = interpolator(xi, yi, method=method)
         actual = f(x)
         assert_array_equal(actual, expected)

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -687,3 +687,25 @@ def test_interpolate_na_2d(coords):
         coords=coords,
     )
     assert_equal(actual, expected_x)
+
+
+@requires_scipy
+def test_interpolators_complex_out_of_bounds():
+    """Ensure complex nans are used for complex data"""
+
+    xi = np.array([-1, 0, 1, 2, 5], dtype=np.float64)
+    yi = np.exp(1j * xi)
+    x = np.array([-2, 1, 6], dtype=np.float64)
+
+    expected = np.array(
+        [np.nan + np.nan * 1j, np.exp(1j), np.nan + np.nan * 1j], dtype=yi.dtype
+    )
+
+    for method, interpolator in [
+        ("linear", NumpyInterpolator),
+        ("linear", ScipyInterpolator),
+    ]:
+
+        f = interpolator(xi, yi, method=method, complex_data=True)
+        actual = f(x)
+        assert_array_equal(actual, expected)


### PR DESCRIPTION
- [X] Tests added
- [X] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

When using the `da.interp` to interpolate outside of the bounds, by default,  `fill_value` is set to `np.nan` to set the values to NaN.
This is completely fine with real values, but with complex values this will in fact set the values to `np.nan + 0j` which can be a source of confusion and bugs.
This PR propose to detect if values are complex, and if so, to use `np.nan + np.nan*1j` as the default `fill_value`