### PR TITLE
Fixed a mispelling of dimension in dataarray documentation for from_dict

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2887,7 +2887,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
                 "name": "a",
             }
 
-        where "t" is the name of the dimesion, "a" is the name of the array,
+        where "t" is the name of the dimension, "a" is the name of the array,
         and x and t are lists, numpy.arrays, or pandas objects.
 
         Parameters


### PR DESCRIPTION
Single character change just fixing a misspelling of dimension in the from_dict method of dataarray. 
