### PR TITLE
REF: Make mypy manual stage with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,8 @@ repos:
       - id: mypy
         # Copied from setup.cfg
         exclude: "properties|asv_bench"
+        # This is slow and so we take it out of the fast-path; requires passing
+        # `--hook-stage manual` to pre-commit
         stages: [manual]
         additional_dependencies: [
             # Type stubs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,9 +48,9 @@ repos:
     rev: v0.931
     hooks:
       - id: mypy
-        # `properies` & `asv_bench` are copied from setup.cfg.
-        # `_typed_ops.py` is added since otherwise mypy will complain (but notably only in pre-commit)
-        exclude: "properties|asv_bench|_typed_ops.py"
+        # Copied from setup.cfg
+        exclude: "properties|asv_bench"
+        stages: [manual]
         additional_dependencies: [
             # Type stubs
             types-python-dateutil,


### PR DESCRIPTION
With this setup, the `mypy` hook is only added to the run if you specify it:
```
pre-commit run --all-files --hook-stage manual
```
cc: @dcherian 

https://pre-commit.com/#confining-hooks-to-run-at-certain-stages