### PR TITLE
Simplify missing value handling in xarray.corr

### DIFF
--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1346,24 +1346,9 @@ def _cov_corr(da_a, da_b, dim=None, ddof=0, method=None):
 
     # 2. Ignore the nans
     valid_values = da_a.notnull() & da_b.notnull()
+    da_a = da_a.where(valid_values)
+    da_b = da_b.where(valid_values)
     valid_count = valid_values.sum(dim) - ddof
-
-    def _get_valid_values(da, other):
-        """
-        Function to lazily mask da_a and da_b
-        following a similar approach to
-        https://github.com/pydata/xarray/pull/4559
-        """
-        missing_vals = np.logical_or(da.isnull(), other.isnull())
-        if missing_vals.any():
-            da = da.where(~missing_vals)
-            return da
-        else:
-            # ensure consistent return dtype
-            return da.astype(float)
-
-    da_a = da_a.map_blocks(_get_valid_values, args=[da_b])
-    da_b = da_b.map_blocks(_get_valid_values, args=[da_a])
 
     # 3. Detrend along the given dim
     demeaned_da_a = da_a - da_a.mean(dim=dim)


### PR DESCRIPTION
This PR simplifies the fix from https://github.com/pydata/xarray/pull/5731, specifically for the benefit of xarray.corr. There is no need to use `map_blocks` instead of using `where` directly.

It is a basically an alternative version of https://github.com/pydata/xarray/pull/5284. It is potentially slightly less efficient to do this masking step when unnecessary, but I doubt this makes a noticeable performance difference in practice (and I doubt this optimization is useful insdie `map_blocks`, anyways).