### PR TITLE
Allow chunks=None for dask-less lazy loading

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -691,7 +691,7 @@ def open_dataarray(
 
 def open_mfdataset(
     paths,
-    chunks=None,
+    chunks={},
     concat_dim=None,
     compat="no_conflicts",
     preprocess=None,
@@ -891,7 +891,7 @@ def open_mfdataset(
             "instead specify combine='nested' along with a value for `concat_dim`.",
         )
 
-    open_kwargs = dict(engine=engine, chunks=chunks or {}, **kwargs)
+    open_kwargs = dict(engine=engine, chunks=chunks, **kwargs)
 
     if parallel:
         import dask


### PR DESCRIPTION
Otherwise, the preprocess step always gets a single chunk for each variable instead of the xarray lazy accessors; dask can't change the order of slicing / computing in most cases. The default is changed to {} to maintain the default behavior.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
