### PR TITLE
Add argopy to Related Projects doc page

### DIFF
--- a/doc/related-projects.rst
+++ b/doc/related-projects.rst
@@ -22,6 +22,7 @@ Geosciences
 - `PyGDX <https://pygdx.readthedocs.io/en/latest/>`_: Python 3 package for
   accessing data stored in GAMS Data eXchange (GDX) files. Also uses a custom
   subclass.
+- `pyXpcm <https://pyxpcm.readthedocs.io>`_: xarray-based Profile Classification Modelling (PCM), mostly for ocean data.
 - `Regionmask <https://regionmask.readthedocs.io/>`_: plotting and creation of masks of spatial regions
 - `salem <https://salem.readthedocs.io>`_: Adds geolocalised subsetting, masking, and plotting operations to xarray's data structures via accessors.
 - `SatPy <https://satpy.readthedocs.io/>`_ : Library for reading and manipulating meteorological remote sensing data and writing it to various image and data file formats. 

--- a/doc/related-projects.rst
+++ b/doc/related-projects.rst
@@ -11,6 +11,7 @@ Geosciences
 ~~~~~~~~~~~
 
 - `aospy <https://aospy.readthedocs.io>`_: Automated analysis and management of gridded climate data.
+- `argopy <https://github.com/euroargodev/argopy>`_: Argo data access, manipulation and visualisation for standard users as well as Argo experts.
 - `infinite-diff <https://github.com/spencerahill/infinite-diff>`_: xarray-based finite-differencing, focused on gridded climate/meterology data
 - `marc_analysis <https://github.com/darothen/marc_analysis>`_: Analysis package for CESM/MARC experiments and output.
 - `MPAS-Analysis <http://mpas-analysis.readthedocs.io>`_: Analysis for simulations produced with Model for Prediction Across Scales (MPAS) components and the Accelerated Climate Model for Energy (ACME).


### PR DESCRIPTION
As it says, this is to add the https://github.com/euroargodev/argopy xarray related project to the documentation page.

[argopy](https://github.com/euroargodev/argopy) is a python library that aims to ease Argo data access, manipulation and visualisation for standard users as well as Argo experts.

[argopy](https://github.com/euroargodev/argopy) comes with a xarray accessor ``argo`` for Argo dataset


