### PR TITLE
Add argopy to ecosystem.rst doc page

### DIFF
--- a/doc/ecosystem.rst
+++ b/doc/ecosystem.rst
@@ -13,6 +13,7 @@ Geosciences
 ~~~~~~~~~~~
 
 - `aospy <https://aospy.readthedocs.io>`_: Automated analysis and management of gridded climate data.
+- `argopy <https://github.com/euroargodev/argopy>`_: xarray-based Argo data access, manipulation and visualisation for standard users as well as Argo experts.
 - `climpred <https://climpred.readthedocs.io>`_: Analysis of ensemble forecast models for climate prediction.
 - `geocube <https://corteva.github.io/geocube>`_: Tool to convert geopandas vector data into rasterized xarray data.
 - `GeoWombat <https://github.com/jgrss/geowombat>`_: Utilities for analysis of remotely sensed and gridded raster data at scale (easily tame Landsat, Sentinel, Quickbird, and PlanetScope).


### PR DESCRIPTION
As it says, this is to add the https://github.com/euroargodev/argopy xarray related project to the documentation page.

[argopy](https://github.com/euroargodev/argopy) is a python library that aims to ease Argo data access, manipulation and visualisation for standard users as well as Argo experts.

[argopy](https://github.com/euroargodev/argopy) comes with a [xarray accessor ``argo`` for Argo dataset](https://argopy.readthedocs.io/en/latest/api.html#dataset-argo-xarray-accessor)