### PR TITLE
fix grammatical typo in docs

### DIFF
--- a/doc/user-guide/computation.rst
+++ b/doc/user-guide/computation.rst
@@ -546,7 +546,7 @@ two gaussian peaks:
 Broadcasting by dimension name
 ==============================
 
-``DataArray`` objects are automatically align themselves ("broadcasting" in
+``DataArray`` objects automatically align themselves ("broadcasting" in
 the numpy parlance) by dimension name instead of axis order. With xarray, you
 do not need to transpose arrays or insert dimensions of length 1 to get array
 operations to work, as commonly done in numpy with :py:func:`numpy.reshape` or


### PR DESCRIPTION
very simple fix in the [broadcasting by dimension name](http://xarray.pydata.org/en/stable/user-guide/computation.html#broadcasting-by-dimension-name) docs:

> ``DataArray`` objects ~~are~~ automatically align themselves [...] by dimension name instead of axis order.

<!-- Feel free to remove check-list items aren't relevant to your change -->

No workflow stages - this is a very minor docs fix.
