### PR TITLE
Warn and raise ImportError, if a DuckArrayModule is corrupted

### DIFF
--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -19,7 +19,16 @@ class DuckArrayModule:
     def __init__(self, mod):
         try:
             duck_array_module = import_module(mod)
-            duck_array_version = LooseVersion(duck_array_module.__version__)
+            try:
+                duck_array_version = LooseVersion(duck_array_module.__version__)
+            except AttributeError as err:
+                from warnings import warn
+                warn(
+                    f"Can import {mod} but its modules are missing. "
+                    "If uninstalled, ensure the package is removed from "
+                    f"{duck_array_module.__path__}."
+                )
+                raise ImportError from err
 
             if mod == "dask":
                 duck_array_type = (import_module("dask.array").Array,)

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -23,6 +23,7 @@ class DuckArrayModule:
                 duck_array_version = LooseVersion(duck_array_module.__version__)
             except AttributeError as err:
                 from warnings import warn
+
                 warn(
                     f"Can import {mod} but its modules are missing. "
                     "If uninstalled, ensure the package is removed from "


### PR DESCRIPTION
Fixes #5841

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [X] Closes #5841
- [ ] Tests added
- [X] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
