### PR TITLE
Attempt datetime coding using cftime when pandas fails

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -47,6 +47,8 @@ Bug fixes
   By `Sebastian Weigand <https://github.com/s-weigand>`_.
 - Fix a regression in the removal of duplicate backend entrypoints (:issue:`5944`, :pull:`5959`)
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Fix an issue that datasets from being saved when time variables with units that ``cftime`` can parse but pandas can not were present (:pull:`6049`).
+  By `Tim Heap <https://github.com/mx-moth>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -400,8 +400,9 @@ def _cleanup_netcdf_time_units(units):
     delta, ref_date = _unpack_netcdf_time_units(units)
     try:
         units = "{} since {}".format(delta, format_timestamp(ref_date))
-    except OutOfBoundsDatetime:
-        # don't worry about reifying the units if they're out of bounds
+    except (OutOfBoundsDatetime, ValueError):
+        # don't worry about reifying the units if they're out of bounds or
+        # formatted badly
         pass
     return units
 
@@ -482,7 +483,7 @@ def encode_cf_datetime(dates, units=None, calendar=None):
             num = time_deltas / time_delta
         num = num.values.reshape(dates.shape)
 
-    except (OutOfBoundsDatetime, OverflowError):
+    except (OutOfBoundsDatetime, OverflowError, ValueError):
         num = _encode_datetime_with_cftime(dates, units, calendar)
 
     num = cast_to_int_if_safe(num)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -853,6 +853,22 @@ def test_encode_cf_datetime_pandas_min() -> None:
     assert calendar == expected_calendar
 
 
+def test_encode_cf_datetime_invalid_pandas_valid_cftime() -> None:
+    num, units, calendar = encode_cf_datetime(
+        pd.date_range("2000", periods=3),
+        # Pandas fails to parse this unit, but cftime is quite happy with it
+        "days since 1970-01-01 00:00:00 00",
+        "standard",
+    )
+
+    expected_num = [10957, 10958, 10959]
+    expected_units = "days since 1970-01-01 00:00:00 00"
+    expected_calendar = "standard"
+    assert_array_equal(num, expected_num)
+    assert units == expected_units
+    assert calendar == expected_calendar
+
+
 @requires_cftime
 def test_time_units_with_timezone_roundtrip(calendar) -> None:
     # Regression test for GH 2649

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -853,6 +853,7 @@ def test_encode_cf_datetime_pandas_min() -> None:
     assert calendar == expected_calendar
 
 
+@requires_cftime
 def test_encode_cf_datetime_invalid_pandas_valid_cftime() -> None:
     num, units, calendar = encode_cf_datetime(
         pd.date_range("2000", periods=3),

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -188,6 +188,11 @@ class TestFormatting:
     def test_maybe_truncate(self) -> None:
         assert formatting.maybe_truncate("ß", 10) == "ß"
 
+    def test_format_timestamp_invalid_pandas_format(self) -> None:
+        expected = "2021-12-06 17:00:00 00"
+        with pytest.raises(ValueError):
+            formatting.format_timestamp(expected)
+
     def test_format_timestamp_out_of_bounds(self) -> None:
         from datetime import datetime
 


### PR DESCRIPTION
A netCDF4 dataset we use has a time variable defined as:
```
        double time(time) ;
                time:axis = "T" ;
                time:bounds = "time_bnds" ;
                time:calendar = "gregorian" ;
                time:long_name = "time" ;
                time:standard_name = "time" ;
                time:units = "days since 1970-01-01 00:00:00 00" ;
```

Note the `units` attribute, specifically a timezone offset of `00` without any `+-` sign.

xarray can successfully open this dataset and parse the time units, making a time variable with the expeced values. However, attempting to save this dataset (e.g. after slicing some geographic bounds or selecting a subset of variables), xarray would raise an error trying to reformat the time `units`.

This fix applies the same logic used in the decoding step to the encoding step - specifically, attempt to use `pandas` but if that fails then use `cftime`. The decoding step catches `ValueError` to do this, but `ValueError` was not caught in the encode workflow.

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`