### PR TITLE
add set_options link to FAQ on metadata

### DIFF
--- a/doc/getting-started-guide/faq.rst
+++ b/doc/getting-started-guide/faq.rst
@@ -140,7 +140,7 @@ conventions`_. (An exception is serialization to and from netCDF files.)
 
 An implication of this choice is that we do not propagate ``attrs`` through
 most operations unless explicitly flagged (some methods have a ``keep_attrs``
-option, and there is a global flag, accessible with :py:func:`xr.set_options`,
+option, and there is a global flag, accessible with :py:func:`xarray.set_options`,
 for setting this to be always True or False). Similarly, xarray does not check
 for conflicts between ``attrs`` when combining arrays and datasets, unless
 explicitly requested with the option ``compat='identical'``. The guiding

--- a/doc/getting-started-guide/faq.rst
+++ b/doc/getting-started-guide/faq.rst
@@ -140,14 +140,11 @@ conventions`_. (An exception is serialization to and from netCDF files.)
 
 An implication of this choice is that we do not propagate ``attrs`` through
 most operations unless explicitly flagged (some methods have a ``keep_attrs``
-option, and there is a `global flag`_ for setting this to be always True or
-False). Similarly, xarray does not check for conflicts between ``attrs`` when
-combining arrays and datasets, unless explicitly requested with the option
-``compat='identical'``. The guiding principle is that metadata should not be
-allowed to get in the way.
-
-.. _global flag: http://xarray.pydata.org/en/stable/generated/xarray.set_options.html
-
+option, and there is a global flag, accessible with :py:func:`xr.set_options`,
+for setting this to be always True or False). Similarly, xarray does not check
+for conflicts between ``attrs`` when combining arrays and datasets, unless
+explicitly requested with the option ``compat='identical'``. The guiding
+principle is that metadata should not be allowed to get in the way.
 
 What other netCDF related Python libraries should I know about?
 ---------------------------------------------------------------

--- a/doc/getting-started-guide/faq.rst
+++ b/doc/getting-started-guide/faq.rst
@@ -140,11 +140,13 @@ conventions`_. (An exception is serialization to and from netCDF files.)
 
 An implication of this choice is that we do not propagate ``attrs`` through
 most operations unless explicitly flagged (some methods have a ``keep_attrs``
-option, and there is a global flag for setting this to be always True or
+option, and there is a `global flag`__ for setting this to be always True or
 False). Similarly, xarray does not check for conflicts between ``attrs`` when
 combining arrays and datasets, unless explicitly requested with the option
 ``compat='identical'``. The guiding principle is that metadata should not be
 allowed to get in the way.
+
+.. _global flag: http://xarray.pydata.org/en/stable/generated/xarray.set_options.html
 
 
 What other netCDF related Python libraries should I know about?

--- a/doc/getting-started-guide/faq.rst
+++ b/doc/getting-started-guide/faq.rst
@@ -140,7 +140,7 @@ conventions`_. (An exception is serialization to and from netCDF files.)
 
 An implication of this choice is that we do not propagate ``attrs`` through
 most operations unless explicitly flagged (some methods have a ``keep_attrs``
-option, and there is a `global flag`__ for setting this to be always True or
+option, and there is a `global flag`_ for setting this to be always True or
 False). Similarly, xarray does not check for conflicts between ``attrs`` when
 combining arrays and datasets, unless explicitly requested with the option
 ``compat='identical'``. The guiding principle is that metadata should not be


### PR DESCRIPTION
If helpful - added a PR to adds a reference and link to `xr.set_options` in the section of the FAQ on "what is your approach to metadata?". I had to do a bit of digging to figure out what was meant by "there is a global flag" and thought others might find the direct ref useful.

Relevant section: https://github.com/pydata/xarray/blob/main/doc/getting-started-guide/faq.rst#what-is-your-approach-to-metadata

Current text:
> An implication of this choice is that we do not propagate ``attrs`` through most operations unless explicitly flagged (some methods have a ``keep_attrs`` option, and there is a global flag for setting this to be always True or False)

Proposed version:
> An implication of this choice is that we do not propagate ``attrs`` through most operations unless explicitly flagged (some methods have a ``keep_attrs`` option, and there is a global flag, **accessible with [`xr.set_options`](http://xarray.pydata.org/en/stable/generated/xarray.set_options.html),** for setting this to be always True or False).

Minor docs change only. No workflow steps needed.