### PR TITLE
DOC: cd command in build documentation

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -320,7 +320,7 @@ Building the documentation
 
 To build the documentation run::
 
-    cd xarray/doc/
+    cd doc/
     make html
 
 Then you can find the HTML output in the folder ``xarray/doc/_build/html/``.

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -318,8 +318,9 @@ to build the docs you need to use the environment file ``ci/requirements/doc.yml
 Building the documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Navigate to your local ``xarray/doc/`` directory in the console and run::
+To build the documentation run::
 
+    cd xarray/doc/
     make html
 
 Then you can find the HTML output in the folder ``xarray/doc/_build/html/``.


### PR DESCRIPTION
In the section above (http://xarray.pydata.org/en/stable/contributing.html#how-to-build-the-xarray-documentation) i.e. build the env, it assumes you are in the root directory. This holds that assumptions and makes it easier for a user to copy-paste to build the docs