### PR TITLE
DOC: Add "auto" to dataarray `chunk` method

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1094,6 +1094,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
         self,
         chunks: Union[
             int,
+            str,
             Tuple[int, ...],
             Tuple[Tuple[int, ...], ...],
             Mapping[Any, Union[None, int, Tuple[int, ...]]],
@@ -1114,9 +1115,9 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
 
         Parameters
         ----------
-        chunks : int, tuple of int or mapping of hashable to int, optional
-            Chunk sizes along each dimension, e.g., ``5``, ``(5, 5)`` or
-            ``{'x': 5, 'y': 5}``.
+        chunks : int, "auto", tuple of int or mapping of hashable to int, optional
+            Chunk sizes along each dimension, e.g., ``5``, ``"auto"``, ``(5, 5)`` or
+            ``{"x": 5, "y": 5}``.
         name_prefix : str, optional
             Prefix for the name of the new dask array.
         token : str, optional

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import sys
 import warnings
 from typing import (
     TYPE_CHECKING,
@@ -87,6 +88,12 @@ if TYPE_CHECKING:
         iris_Cube = None
 
     from .types import T_DataArray, T_Xarray
+
+# TODO: Remove this check once python 3.7 is not supported:
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 def _infer_coords_and_dims(
@@ -1094,7 +1101,7 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
         self,
         chunks: Union[
             int,
-            str,
+            Literal["auto"],
             Tuple[int, ...],
             Tuple[Tuple[int, ...], ...],
             Mapping[Any, Union[None, int, Tuple[int, ...]]],

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2150,8 +2150,8 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
 
         Parameters
         ----------
-        chunks : int, 'auto' or mapping, optional
-            Chunk sizes along each dimension, e.g., ``5`` or
+        chunks : int, "auto" or mapping of hashable to int, optional
+            Chunk sizes along each dimension, e.g., ``5``, ``"auto"``, or
             ``{"x": 5, "y": 5}``.
         name_prefix : str, optional
             Prefix for the name of any new dask arrays.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -104,6 +104,12 @@ from .variable import (
     broadcast_variables,
 )
 
+# TODO: Remove this check once python 3.7 is not supported:
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
 if TYPE_CHECKING:
     from ..backends import AbstractDataStore, ZarrStore
     from .dataarray import DataArray
@@ -2131,7 +2137,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         self,
         chunks: Union[
             int,
-            str,
+            Literal["auto"],
             Mapping[Any, Union[None, int, str, Tuple[int, ...]]],
         ] = {},  # {} even though it's technically unsafe, is being used intentionally here (#4667)
         name_prefix: str = "xarray-",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

This PR adds `str` type on `datarray.chunk` method the same way it is accepted on `dataset.chunk`.
The corresponding documentation has been updated.

I wanted to add a unit test for `da.chunk("auto")` but the existing tests seems to rely on zarr which I don't know at all.
