### PR TITLE
disable pytest-xdist (to check CI failure)

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -96,7 +96,7 @@ jobs:
           python -c "import xarray"
       - name: Run tests
         run: |
-          python -m pytest -n 4 \
+          python -m pytest \
              --cov=xarray \
              --cov-report=xml \
              $PYTEST_EXTRA_FLAGS

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
         run: |
           python -c "import xarray"
       - name: Run tests
-        run: python -m pytest -n 4
+        run: python -m pytest
           --cov=xarray
           --cov-report=xml
           --junitxml=pytest.xml


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Our CI fails with some pytest-xdist error. Let's see if we get a clearer picture when disabling parallel tests. (Maybe some interaction between dask and pytest-xdist?).
