### PR TITLE
cftime: 'gregorian' -> 'standard' [test-upstream]

### DIFF
--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -17,12 +17,22 @@ from xarray.coding.cftimeindex import (
 )
 from xarray.tests import assert_array_equal, assert_identical
 
-from . import requires_cftime
+from . import has_cftime, requires_cftime
 from .test_coding_times import (
     _ALL_CALENDARS,
     _NON_STANDARD_CALENDARS,
     _all_cftime_date_types,
 )
+
+# cftime 1.5.2 renames "gregorian" to "standard"
+standard_or_gregorian = ""
+if has_cftime:
+    import cftime
+
+    if LooseVersion(cftime.__version__) >= LooseVersion("1.5.2"):
+        standard_or_gregorian = "standard"
+    else:
+        standard_or_gregorian = "gregorian"
 
 
 def date_dict(year=None, month=None, day=None, hour=None, minute=None, second=None):
@@ -929,7 +939,8 @@ def test_cftimeindex_shift_invalid_freq():
         ("365_day", "noleap"),
         ("360_day", "360_day"),
         ("julian", "julian"),
-        ("gregorian", "gregorian"),
+        ("gregorian", standard_or_gregorian),
+        ("standard", standard_or_gregorian),
         ("proleptic_gregorian", "proleptic_gregorian"),
     ],
 )
@@ -946,7 +957,8 @@ def test_cftimeindex_calendar_property(calendar, expected):
         ("365_day", "noleap"),
         ("360_day", "360_day"),
         ("julian", "julian"),
-        ("gregorian", "gregorian"),
+        ("gregorian", standard_or_gregorian),
+        ("standard", standard_or_gregorian),
         ("proleptic_gregorian", "proleptic_gregorian"),
     ],
 )
@@ -983,20 +995,20 @@ def test_cftimeindex_freq_in_repr(freq, calendar):
     [
         (
             2,
-            """\
+            f"""\
 CFTimeIndex([2000-01-01 00:00:00, 2000-01-02 00:00:00],
-            dtype='object', length=2, calendar='gregorian', freq=None)""",
+            dtype='object', length=2, calendar='{standard_or_gregorian}', freq=None)""",
         ),
         (
             4,
-            """\
+            f"""\
 CFTimeIndex([2000-01-01 00:00:00, 2000-01-02 00:00:00, 2000-01-03 00:00:00,
              2000-01-04 00:00:00],
-            dtype='object', length=4, calendar='gregorian', freq='D')""",
+            dtype='object', length=4, calendar='{standard_or_gregorian}', freq='D')""",
         ),
         (
             101,
-            """\
+            f"""\
 CFTimeIndex([2000-01-01 00:00:00, 2000-01-02 00:00:00, 2000-01-03 00:00:00,
              2000-01-04 00:00:00, 2000-01-05 00:00:00, 2000-01-06 00:00:00,
              2000-01-07 00:00:00, 2000-01-08 00:00:00, 2000-01-09 00:00:00,
@@ -1006,7 +1018,7 @@ CFTimeIndex([2000-01-01 00:00:00, 2000-01-02 00:00:00, 2000-01-03 00:00:00,
              2000-04-04 00:00:00, 2000-04-05 00:00:00, 2000-04-06 00:00:00,
              2000-04-07 00:00:00, 2000-04-08 00:00:00, 2000-04-09 00:00:00,
              2000-04-10 00:00:00],
-            dtype='object', length=101, calendar='gregorian', freq='D')""",
+            dtype='object', length=101, calendar='{standard_or_gregorian}', freq='D')""",
         ),
     ],
 )


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #6016

cftime 1.5.2 renames "gregorian" to "standard". AFAIK this only changes the repr of cftime indices and does not seem to influence the creation of cftime indices.