### PR TITLE
Add type definitions in prep for #6086

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -198,6 +198,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-h5py.*]
 ignore_missing_imports = True
+[mypy-importlib_metadata.*]
+ignore_missing_imports = True
 [mypy-iris.*]
 ignore_missing_imports = True
 [mypy-matplotlib.*]

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1068,11 +1068,11 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
     @classmethod
     def _construct_direct(
         cls,
-        variables: Mapping[Hashable, Variable],
+        variables: Mapping[Any, Variable],
         coord_names: Set[Hashable],
-        dims: Mapping[Hashable, int] = None,
+        dims: Mapping[Any, int] = None,
         attrs: Mapping = None,
-        indexes: Mapping[Hashable, Index] = None,
+        indexes: Mapping[Any, Index] = None,
         encoding: Mapping = None,
         close: Callable[[], None] = None,
     ) -> "Dataset":

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1068,14 +1068,14 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
     @classmethod
     def _construct_direct(
         cls,
-        variables,
-        coord_names,
-        dims=None,
-        attrs=None,
-        indexes=None,
-        encoding=None,
-        close=None,
-    ):
+        variables: Mapping[Hashable, Variable],
+        coord_names: Set[Hashable],
+        dims: Mapping[Hashable, int] = None,
+        attrs: Mapping = None,
+        indexes: Mapping[Hashable, Index] = None,
+        encoding: Mapping = None,
+        close: Callable[[], None] = None,
+    ) -> "Dataset":
         """Shortcut around __init__ for internal use when we want to skip
         costly validation
         """
@@ -2359,7 +2359,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         indexers = drop_dims_from_indexers(indexers, self.dims, missing_dims)
 
         variables = {}
-        dims: Dict[Hashable, Tuple[int, ...]] = {}
+        dims: Dict[Hashable, int] = {}
         coord_names = self._coord_names.copy()
         indexes = self._indexes.copy() if self._indexes is not None else None
 


### PR DESCRIPTION
We can add the current typing to this function, making the changes in #6086 easier.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Passes `pre-commit run --all-files`