### PR TITLE
is_dask_collection: micro optimization

### DIFF
--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -43,19 +43,6 @@ class DuckArrayModule:
         self.available = duck_array_module is not None
 
 
-def is_dask_collection(x):
-    if DuckArrayModule("dask").available:
-        from dask.base import is_dask_collection
-
-        return is_dask_collection(x)
-    else:
-        return False
-
-
-def is_duck_dask_array(x):
-    return is_duck_array(x) and is_dask_collection(x)
-
-
 dsk = DuckArrayModule("dask")
 dask_version = dsk.version
 dask_array_type = dsk.type
@@ -65,3 +52,16 @@ sparse_array_type = sp.type
 sparse_version = sp.version
 
 cupy_array_type = DuckArrayModule("cupy").type
+
+
+def is_dask_collection(x):
+    if dsk.available:
+        from dask.base import is_dask_collection
+
+        return is_dask_collection(x)
+    else:
+        return False
+
+
+def is_duck_dask_array(x):
+    return is_duck_array(x) and is_dask_collection(x)


### PR DESCRIPTION
In #6096 I realized that `DuckArrayModule("dask")` is called a lot in our tests - 145'835 times. Most of those are from `is_dask_collection` (`is_duck_dask_array`)  This change avoids that the instance needs to be built every time.

```python
import xarray as xr

%timeit xr.core.pycompat.DuckArrayModule("dask").available
%timeit xr.core.pycompat.dsk.available
```

```
18.9 µs ± 97.7 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
77.1 ns ± 1.22 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
```

Which leads to an incredible speed up of our tests of about 2.7 s :grin: ((18.9 - 0.0771) * 145835 / 1e6).