### PR TITLE
assert ds errors in test_backends

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5209,22 +5209,22 @@ def test_open_fsspec():
     # single dataset
     url = "memory://out2.zarr"
     ds2 = open_dataset(url, engine="zarr")
-    assert ds0 == ds2
+    xr.testing.assert_equal(ds0, ds2)
 
     # single dataset with caching
     url = "simplecache::memory://out2.zarr"
     ds2 = open_dataset(url, engine="zarr")
-    assert ds0 == ds2
+    xr.testing.assert_equal(ds0, ds2)
 
     # multi dataset
     url = "memory://out*.zarr"
     ds2 = open_mfdataset(url, engine="zarr")
-    assert xr.concat([ds, ds0], dim="time") == ds2
+    xr.testing.assert_equal(xr.concat([ds, ds0], dim="time"), ds2)
 
     # multi dataset with caching
     url = "simplecache::memory://out*.zarr"
     ds2 = open_mfdataset(url, engine="zarr")
-    assert xr.concat([ds, ds0], dim="time") == ds2
+    xr.testing.assert_equal(xr.concat([ds, ds0], dim="time"), ds2)
 
 
 @requires_h5netcdf


### PR DESCRIPTION
Makes four changes to xarray/tests/test_backends.py::test_open_fsspec

Previously, there were four inequality tests which will always pass regardless of whether the read was successful.

`assert ds0 == ds2` will always evaluate to True if the datasets have at least one data variable. Instead, xr.testing.assert_equal should be used to test data variable equality.

No workflow stages here - I just made the changes in the browser. Pretty simple patch that increases the effectiveness of existing tests - no changes to the xarray core code.