### PR TITLE
assert ds errors in test_dataset.py

### DIFF
--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6497,14 +6497,14 @@ def test_deepcopy_obj_array():
 
 def test_clip(ds):
     result = ds.clip(min=0.5)
-    assert result.min(...) >= 0.5
+    assert all((result.min(...) >= 0.5).values())
 
     result = ds.clip(max=0.5)
-    assert result.max(...) <= 0.5
+    assert all((result.max(...) <= 0.5).values())
 
     result = ds.clip(min=0.25, max=0.75)
-    assert result.min(...) >= 0.25
-    assert result.max(...) <= 0.75
+    assert all((result.min(...) >= 0.25).values())
+    assert all((result.max(...) <= 0.75).values())
 
     result = ds.clip(min=ds.mean("y"), max=ds.mean("y"))
     assert result.dims == ds.dims


### PR DESCRIPTION
a number of assert statements in test_dataset.py::test_clip make assertions which will never fail as long as there is at least one data_variable:

```python
    assert result.min(...) >= 0.5
```
this evaluates to datasets with scalar True or False values in each data_variable; however, `ds.__bool__` returns true if `len(ds.data_vars) > 0`.

related: https://github.com/pydata/xarray/pull/6122

No workflow stages here - I just made the changes in the browser. Pretty simple patch that increases the effectiveness of existing tests - no changes to the xarray core code. Let me know if you'd like me to implement any of the normal checks.