### PR TITLE
Deprecate bool(ds)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -37,7 +37,7 @@ Deprecations
 
 - Coercing a dataset to bool, e.g. ``bool(ds)``, is being deprecated and will raise an
   error in a future version (not yet planned). For now, invoking ``Dataset.__bool__``
-  issues a ``PendingDeprecationWarning`` (:issue:`6124`).
+  issues a ``PendingDeprecationWarning`` (:issue:`6124`, :pull:`6126`).
   By `Michael Delgado <https://github.com/delgadom>`_.
 
 Bug fixes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,6 +35,11 @@ Deprecations
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 
+- Coercing a dataset to bool, e.g. ``bool(ds)``, is being deprecated and will raise an
+  error in a future version (not yet planned). For now, invoking ``Dataset.__bool__``
+  issues a ``PendingDeprecationWarning`` (:issue:`6124`).
+  By `Michael Delgado <https://github.com/delgadom>`_.
+
 Bug fixes
 ~~~~~~~~~
 - Fix applying function with non-xarray arguments using :py:func:`xr.map_blocks`.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1451,8 +1451,9 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
     def __bool__(self) -> bool:
         warnings.warn(
             "coercing a Dataset to a bool be deprecated in the future. Using "
-            "bool(ds.data_vars) to check for data_variables or converting to an array with "
-            "Dataset.to_array to test whether array values are true is encouraged",
+            "bool(ds.data_vars) to check for the presence of at least on data "
+            "variable or converting to an array with Dataset.to_array to test "
+            "whether array values are true is encouraged.",
             PendingDeprecationWarning,
             stacklevel=2,
         )

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1450,9 +1450,9 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
 
     def __bool__(self) -> bool:
         warnings.warn(
-            "coercing a Dataset to a bool be deprecated in the future. Using "
-            "bool(ds.data_vars) to check for the presence of at least one data "
-            "variable or converting to an array with Dataset.to_array to test "
+            "coercing a Dataset to a bool will be deprecated. "
+            "Using bool(ds.data_vars) to check for at least one "
+            "data variable or using Dataset.to_array to test "
             "whether array values are true is encouraged.",
             PendingDeprecationWarning,
             stacklevel=2,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1451,7 +1451,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
     def __bool__(self) -> bool:
         warnings.warn(
             "coercing a Dataset to a bool be deprecated in the future. Using "
-            "bool(ds.data_vars) to check for the presence of at least on data "
+            "bool(ds.data_vars) to check for the presence of at least one data "
             "variable or converting to an array with Dataset.to_array to test "
             "whether array values are true is encouraged.",
             PendingDeprecationWarning,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1449,6 +1449,13 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         return len(self.data_vars)
 
     def __bool__(self) -> bool:
+        warnings.warn(
+            "coercing a Dataset to a bool be deprecated in the future. Using "
+            "len(ds) > 0 to check for data_variables or converting to an array with "
+            "Dataset.to_array to test whether array values are true is encouraged",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
         return bool(self.data_vars)
 
     def __iter__(self) -> Iterator[Hashable]:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1451,7 +1451,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
     def __bool__(self) -> bool:
         warnings.warn(
             "coercing a Dataset to a bool be deprecated in the future. Using "
-            "len(ds) > 0 to check for data_variables or converting to an array with "
+            "bool(ds.data_vars) to check for data_variables or converting to an array with "
             "Dataset.to_array to test whether array values are true is encouraged",
             PendingDeprecationWarning,
             stacklevel=2,

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -544,7 +544,9 @@ class TestDataset:
         assert "aasldfjalskdfj" not in ds.variables
         assert "dim1" in repr(ds.variables)
         assert len(ds) == 3
-        assert bool(ds)
+
+        with pytest.warns(PendingDeprecationWarning):
+            assert bool(ds)
 
         assert list(ds.data_vars) == ["var1", "var2", "var3"]
         assert list(ds.data_vars.keys()) == ["var1", "var2", "var3"]


### PR DESCRIPTION
Issues a PendingDeprecationWarning on `Dataset.__bool__`

- [x] Closes #6124 
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst` <-- could definitely use a review
