### PR TITLE
TST: check datetime converter is Matplotlibs

### DIFF
--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -4,8 +4,6 @@ from copy import copy
 from datetime import datetime
 from typing import Any, Dict, Union
 
-import matplotlib
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -2670,11 +2668,14 @@ class TestDatetimePlot(PlotTestCase):
 
     def test_datetime_line_plot(self):
         # test if line plot raises no Exception
+        self.darray.plot.line()
+
+    def test_datetime_units(self):
+        # test that matplotlib-native datetime works:
         fig, ax = plt.subplots()
-        self.darray.plot.line(ax=ax)
-        # check that motplotlib's datetlocator has been chosen
-        loc = ax.xaxis.get_major_locator()
-        assert isinstance(loc, matplotlib.dates.AutoDateLocator)
+        ax.plot(self.darray['time'], self.darray)
+        assert isinstance(ax.xaxis.get_major_locator(),
+                          mpl.dates.AutoDateLocator)
 
 
 @pytest.mark.filterwarnings("ignore:setting an array element with a sequence")

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2673,9 +2673,8 @@ class TestDatetimePlot(PlotTestCase):
     def test_datetime_units(self):
         # test that matplotlib-native datetime works:
         fig, ax = plt.subplots()
-        ax.plot(self.darray['time'], self.darray)
-        assert isinstance(ax.xaxis.get_major_locator(),
-                          mpl.dates.AutoDateLocator)
+        ax.plot(self.darray["time"], self.darray)
+        assert isinstance(ax.xaxis.get_major_locator(), mpl.dates.AutoDateLocator)
 
 
 @pytest.mark.filterwarnings("ignore:setting an array element with a sequence")

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -4,6 +4,8 @@ from copy import copy
 from datetime import datetime
 from typing import Any, Dict, Union
 
+import matplotlib
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -2668,7 +2670,11 @@ class TestDatetimePlot(PlotTestCase):
 
     def test_datetime_line_plot(self):
         # test if line plot raises no Exception
-        self.darray.plot.line()
+        fig, ax = plt.subplots()
+        self.darray.plot.line(ax=ax)
+        # check that motplotlib's datetlocator has been chosen
+        loc = ax.xaxis.get_major_locator()
+        assert isinstance(loc, matplotlib.dates.AutoDateLocator)
 
 
 @pytest.mark.filterwarnings("ignore:setting an array element with a sequence")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests added

Adds a test that says what the locator should be if the xaxis is datetime.  