### PR TITLE
Check for just `...`, rather than `[...]` in `da.stack`

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3856,6 +3856,8 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         return self._replace(variables, indexes=indexes)
 
     def _stack_once(self, dims, new_dim):
+        if dims == ...:
+            raise ValueError("Please use [...] for dims, rather than just ...")
         if ... in dims:
             dims = list(infix_dims(dims, self.dims))
         variables = {}

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6678,3 +6678,17 @@ class TestNumpyCoercion:
         expected = xr.DataArray(arr, dims="x", coords={"lat": ("x", arr * 2)})
         assert_identical(result, expected)
         np.testing.assert_equal(da.to_numpy(), arr)
+
+
+class TestStackEllipsis:
+    # https://github.com/pydata/xarray/issues/6051
+    def test_result_as_expected(self):
+        da = DataArray([[1, 2], [1, 2]], dims=("x", "y"))
+        result = da.stack(flat=[...])
+        expected = da.stack(flat=da.dims)
+        assert_identical(result, expected)
+
+    def test_error_on_ellipsis_without_list(self):
+        da = DataArray([[1, 2], [1, 2]], dims=("x", "y"))
+        with pytest.raises(ValueError):
+            da.stack(flat=...)


### PR DESCRIPTION
- [x] Closes #6051
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst` - not quite just yet, as I'm not 100% sure in what category you'd put it!

`_stack_once` seemed like a reasonable place to put this check, just going from the trace of where the test failed. 

I also saw mypy failures during the local pre-commit step, but chose to ignore them for now given #6024. They seemed to pop up in unrelated areas, anyway.