### PR TITLE
allow 1 non-null value in interpolate_na with method="nearest"

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -52,7 +52,7 @@ Bug fixes
   By `Cindy Chiao <https://github.com/tcchiao>`_.
 
 - No longer raise an error for an all-nan-but-one argument to
-  :py:meth:`DataArray.interpolate_na` (:issue:`5994`) when using `method='nearest'`.
+  :py:meth:`DataArray.interpolate_na` when using `method='nearest'` (:issue:`5994`, :pull:`6144`).
   By `Michael Delgado <https://github.com/delgadom>`_.
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,7 +30,7 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 - Improve repr readability when there are a large number of dimensions in datasets or dataarrays by
-  wrapping the text once the maximum display width has been exceeded. (:issue: `5546`, :pull:`5662`)
+  wrapping the text once the maximum display width has been exceeded. (:issue:`5546`, :pull:`5662`)
   By `Jimmy Westling <https://github.com/illviljan>`_.
 
 
@@ -50,6 +50,10 @@ Bug fixes
 
 - Fix applying function with non-xarray arguments using :py:func:`xr.map_blocks`.
   By `Cindy Chiao <https://github.com/tcchiao>`_.
+
+- No longer raise an error for an all-nan-but-one argument to
+  :py:meth:`DataArray.interpolate_na` (:issue:`5994`) when using `method='nearest'`.
+  By `Michael Delgado <https://github.com/delgadom>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -386,9 +386,9 @@ def func_interpolate_na(interpolator, y, x, **kwargs):
     nans = pd.isnull(y)
     nonans = ~nans
 
-    # fast track for no-nans and all-nans cases
+    # fast track for no-nans, all nan but one, and all-nans cases
     n_nans = nans.sum()
-    if n_nans == 0 or n_nans == len(y):
+    if n_nans == 0 or n_nans >= len(y) - 1:
         return y
 
     f = interpolator(x[nonans], y[nonans], **kwargs)

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -254,11 +254,12 @@ def test_interpolate():
 
     assert_equal(actual, expected)
 
+
 @requires_scipy
 @pytest.mark.parametrize(
-    'method,vals',
+    "method,vals",
     [
-        pytest.param(method, vals, id=f'{desc}:{method}')
+        pytest.param(method, vals, id=f"{desc}:{method}")
         for method in [
             "linear",
             "nearest",
@@ -269,11 +270,11 @@ def test_interpolate():
             "polynomial",
         ]
         for (desc, vals) in [
-            ('no nans', np.array([1, 2, 3, 4, 5, 6], dtype=np.float64)),
-            ('one nan', np.array([1, np.nan, np.nan], dtype=np.float64)),
-            ('all nans', np.full(6, np.nan, dtype=np.float64)),
+            ("no nans", np.array([1, 2, 3, 4, 5, 6], dtype=np.float64)),
+            ("one nan", np.array([1, np.nan, np.nan], dtype=np.float64)),
+            ("all nans", np.full(6, np.nan, dtype=np.float64)),
         ]
-    ]
+    ],
 )
 def test_interp1d_fastrack(method, vals):
     expected = xr.DataArray(vals, dims="x")

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -254,20 +254,30 @@ def test_interpolate():
 
     assert_equal(actual, expected)
 
-
-def test_interpolate_nonans():
-
-    vals = np.array([1, 2, 3, 4, 5, 6], dtype=np.float64)
-    expected = xr.DataArray(vals, dims="x")
-    actual = expected.interpolate_na(dim="x")
-    assert_equal(actual, expected)
-
-
 @requires_scipy
-def test_interpolate_allnans():
-    vals = np.full(6, np.nan, dtype=np.float64)
+@pytest.mark.parametrize(
+    'method,vals',
+    [
+        pytest.param(method, vals, id=f'{desc}:{method}')
+        for method in [
+            "linear",
+            "nearest",
+            "zero",
+            "slinear",
+            "quadratic",
+            "cubic",
+            "polynomial",
+        ]
+        for (desc, vals) in [
+            ('no nans', np.array([1, 2, 3, 4, 5, 6], dtype=np.float64)),
+            ('one nan', np.array([1, np.nan, np.nan], dtype=np.float64)),
+            ('all nans', np.full(6, np.nan, dtype=np.float64)),
+        ]
+    ]
+)
+def test_interp1d_fastrack(method, vals):
     expected = xr.DataArray(vals, dims="x")
-    actual = expected.interpolate_na(dim="x")
+    actual = expected.interpolate_na(dim="x", method=method)
 
     assert_equal(actual, expected)
 


### PR DESCRIPTION
- [x] Closes #5994 
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

@Skealz's great issue (#5994) highlighted that DataArrays with a single non-null value raise an error if `DataArray.interpolate_na` is called with `method='nearest'`. Note that this does not occur for the default (`method='linear'`).

In this PR:
* Uses the "fast track" to quickly return *any* 1-D slices with a single non-null value in addition to the previous all-nan or no-nan fasttrack
* Explicitly check this behavior for all 1-D interpolation methods using parametrized tests
* consolidate other fast-track tests (`interpolate_allnans` and `interpolate_nonans`) into a single parameterized test

For discussion:
* This patch may break existing workflows if they rely on the current behavior, which errors for slices with only a single value