### PR TITLE
Remove pd.Panel checks

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -61,6 +61,9 @@ Internal Changes
 - Replace ``distutils.version`` with ``packaging.version``  (:issue:`6092`).
   By `Mathias Hauser <https://github.com/mathause>`_.
 
+- Removed internal checks for ``pd.Panel`` (:issue:`6145`).
+  By `Matthew Roeschke <https://github.com/mroeschke>`_.
+
 
 .. _whats-new.0.20.2:
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -32,7 +32,6 @@ from . import (
     groupby,
     indexing,
     ops,
-    pdcompat,
     resample,
     rolling,
     utils,

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -400,8 +400,6 @@ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
                     coords = [data.index, data.columns]
                 elif isinstance(data, (pd.Index, IndexVariable)):
                     coords = [data]
-                elif isinstance(data, pdcompat.Panel):
-                    coords = [data.items, data.major_axis, data.minor_axis]
 
             if dims is None:
                 dims = getattr(data, "dims", getattr(coords, "dims", None))

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     CoercibleMapping = Union[Dataset, Mapping[Any, CoercibleValue]]
 
 
-PANDAS_TYPES = (pd.Series, pd.DataFrame, pdcompat.Panel)
+PANDAS_TYPES = (pd.Series, pd.DataFrame)
 
 _VALID_COMPAT = Frozen(
     {

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -19,7 +19,7 @@ from typing import (
 
 import pandas as pd
 
-from . import dtypes, pdcompat
+from . import dtypes
 from .alignment import deep_align
 from .duck_array_ops import lazy_array_equiv
 from .indexes import Index, PandasIndex

--- a/xarray/core/pdcompat.py
+++ b/xarray/core/pdcompat.py
@@ -1,6 +1,3 @@
-# The remove_unused_levels defined here was copied based on the source code
-# defined in pandas.core.indexes.muli.py
-
 # For reference, here is a copy of the pandas copyright notice:
 
 # (c) 2011-2012, Lambda Foundry, Inc. and PyData Development Team
@@ -36,17 +33,6 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-import pandas as pd
-from packaging.version import Version
-
-# allow ourselves to type checks for Panel even after it's removed
-if Version(pd.__version__) < Version("0.25.0"):
-    Panel = pd.Panel
-else:
-
-    class Panel:  # type: ignore[no-redef]
-        pass
 
 
 def count_not_none(*args) -> int:


### PR DESCRIPTION
Since it appears the min pandas version is 1.1, these `Panel` checks should never be true.
