### PR TITLE
Use base ImportError not MoudleNotFoundError when testing for plugins

### DIFF
--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -35,7 +35,10 @@ try:
     import h5netcdf
 
     has_h5netcdf = True
-except ModuleNotFoundError:
+except ImportError:
+    # Except a base ImportError (not ModuleNotFoundError) to catch usecases
+    # where errors have mismatched versions of c-dependencies. This can happen
+    # when developers are making changes them.
     has_h5netcdf = False
 
 

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -33,7 +33,10 @@ try:
     import netCDF4
 
     has_netcdf4 = True
-except ModuleNotFoundError:
+except ImportError:
+    # Except a base ImportError (not ModuleNotFoundError) to catch usecases
+    # where errors have mismatched versions of c-dependencies. This can happen
+    # when developers are making changes them.
     has_netcdf4 = False
 
 


### PR DESCRIPTION
Admittedly i had a pretty broken environment (I manually uninstalled C dependencies for python packages installed with conda), but I still expected xarray to "work" with a different backend.

I hope the comments in the code explain why `ImportError` is preferred to `ModuleNotFoundError`.

Thank you for considering.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
