### PR TITLE
Vectorize groupby binary ops

### DIFF
--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -63,9 +63,6 @@ class GroupByPandasDataFrame(GroupBy):
         self.ds1d = self.ds1d.to_dataframe()
         self.ds1d_mean = self.ds1d.groupby("b").mean()
 
-    def time_groupby_binary_op_1d(self):
-        self.ds1d - self.ds1d_mean
-
     def time_groupby_binary_op_2d(self):
         raise NotImplementedError
 
@@ -81,9 +78,6 @@ class GroupByDaskDataFrame(GroupBy):
         super().setup(**kwargs)
         self.ds1d = self.ds1d.chunk({"dim_0": 50}).to_dataframe()
         self.ds1d_mean = self.ds1d.groupby("b").mean()
-
-    def time_groupby_binary_op_1d(self):
-        self.ds1d - self.ds1d_mean
 
     def time_groupby_binary_op_2d(self):
         raise NotImplementedError

--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -16,6 +16,8 @@ class GroupBy:
             }
         )
         self.ds2d = self.ds1d.expand_dims(z=10)
+        self.ds1d_mean = self.ds1d.groupby("b").mean()
+        self.ds2d_mean = self.ds2d.groupby("b").mean()
 
     @parameterized(["ndim"], [(1, 2)])
     def time_init(self, ndim):
@@ -31,6 +33,12 @@ class GroupBy:
         ds = getattr(self, f"ds{ndim}d")
         getattr(ds.groupby("b"), method)()
 
+    def time_groupby_binary_op_1d(self):
+        self.ds1d - self.ds1d_mean
+
+    def time_groupby_binary_op_2d(self):
+        self.ds2d - self.ds2d_mean
+
 
 class GroupByDask(GroupBy):
     def setup(self, *args, **kwargs):
@@ -40,6 +48,8 @@ class GroupByDask(GroupBy):
         self.ds2d = self.ds2d.sel(dim_0=slice(None, None, 2)).chunk(
             {"dim_0": 50, "z": 5}
         )
+        self.ds1d_mean = self.ds1d.groupby("b").mean()
+        self.ds2d_mean = self.ds2d.groupby("b").mean()
 
 
 class GroupByPandasDataFrame(GroupBy):
@@ -51,6 +61,13 @@ class GroupByPandasDataFrame(GroupBy):
 
         super().setup(**kwargs)
         self.ds1d = self.ds1d.to_dataframe()
+        self.ds1d_mean = self.ds1d.groupby("b").mean()
+
+    def time_groupby_binary_op_1d(self):
+        self.ds1d - self.ds1d_bmean
+
+    def time_groupby_binary_op_2d(self):
+        raise NotImplementedError
 
 
 class GroupByDaskDataFrame(GroupBy):
@@ -63,6 +80,13 @@ class GroupByDaskDataFrame(GroupBy):
         requires_dask()
         super().setup(**kwargs)
         self.ds1d = self.ds1d.chunk({"dim_0": 50}).to_dataframe()
+        self.ds1d_mean = self.ds1d.groupby("b").mean()
+
+    def time_groupby_binary_op_1d(self):
+        self.ds1d - self.ds1d_bmean
+
+    def time_groupby_binary_op_2d(self):
+        raise NotImplementedError
 
 
 class Resample:
@@ -74,6 +98,8 @@ class Resample:
             coords={"time": pd.date_range("2001-01-01", freq="H", periods=365 * 24)},
         )
         self.ds2d = self.ds1d.expand_dims(z=10)
+        self.ds1d_mean = self.ds1d.resample(time="48H").mean()
+        self.ds2d_mean = self.ds2d.resample(time="48H").mean()
 
     @parameterized(["ndim"], [(1, 2)])
     def time_init(self, ndim):
@@ -88,6 +114,12 @@ class Resample:
     def time_agg_large_num_groups(self, method, ndim):
         ds = getattr(self, f"ds{ndim}d")
         getattr(ds.resample(time="48H"), method)()
+
+    def time_groupby_binary_op_1d(self):
+        self.ds1d - self.ds1d_bmean
+
+    def time_groupby_binary_op_2d(self):
+        self.ds2d - self.ds2d_mean
 
 
 class ResampleDask(Resample):

--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -64,7 +64,7 @@ class GroupByPandasDataFrame(GroupBy):
         self.ds1d_mean = self.ds1d.groupby("b").mean()
 
     def time_groupby_binary_op_1d(self):
-        self.ds1d - self.ds1d_bmean
+        self.ds1d - self.ds1d_mean
 
     def time_groupby_binary_op_2d(self):
         raise NotImplementedError
@@ -83,7 +83,7 @@ class GroupByDaskDataFrame(GroupBy):
         self.ds1d_mean = self.ds1d.groupby("b").mean()
 
     def time_groupby_binary_op_1d(self):
-        self.ds1d - self.ds1d_bmean
+        self.ds1d - self.ds1d_mean
 
     def time_groupby_binary_op_2d(self):
         raise NotImplementedError
@@ -116,7 +116,7 @@ class Resample:
         getattr(ds.resample(time="48H"), method)()
 
     def time_groupby_binary_op_1d(self):
-        self.ds1d - self.ds1d_bmean
+        self.ds1d - self.ds1d_mean
 
     def time_groupby_binary_op_2d(self):
         self.ds2d - self.ds2d_mean

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -52,6 +52,12 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
+Performance
+~~~~~~~~~~~
+
+- GroupBy binary operations are now vectorized.
+  Previously this involved looping over all groups. (:issue:`5804`,:pull:`6160`)
+  By `Deepak Cherian <https://github.com/dcherian>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -529,7 +529,7 @@ class GroupBy:
             # When binning by unindexed coordinate we need to reindex obj.
             # _full_index is IntervalIndex, so idx will be -1 where
             # a value does not belong to any bin. Using IntervalIndex
-            # accounts for  any non-default cut_kwargs passed to the constructor
+            # accounts for any non-default cut_kwargs passed to the constructor
             idx = pd.cut(group, bins=self._full_index).codes
             obj = obj.isel({dim: np.arange(group.size)[idx != -1]})
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -514,7 +514,7 @@ class GroupBy:
             # so we align by reindexing and then rename dimensions.
 
             # Broadcast out scalars for backwards compatibility
-            # TODO: get rid of this.
+            # TODO: get rid of this when fixing GH2145
             for var in other.coords:
                 if other[var].ndim == 0:
                     other[var] = (

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -518,7 +518,7 @@ class GroupBy:
             for var in other.coords:
                 if other[var].ndim == 0:
                     other[var] = (
-                        other[var].drop(var).expand_dims({name: other.sizes[name]})
+                        other[var].drop_vars(var).expand_dims({name: other.sizes[name]})
                     )
             other = (
                 other.reindex({name: group.data})
@@ -547,7 +547,10 @@ class GroupBy:
                 if set(obj[var].dims) < set(group.dims):
                     result[var] = obj[var].reset_coords(drop=True).broadcast_like(group)
 
-        result = result.transpose(*group.dims, ...)
+        if isinstance(result, Dataset) and isinstance(obj, Dataset):
+            for var in set(result):
+                if dim not in obj[var].dims:
+                    result[var] = result[var].transpose(dim, ...)
         return result
 
     def _maybe_restore_empty_groups(self, combined):

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -507,7 +507,7 @@ class GroupBy:
             )
 
         try:
-            other = other.sel({name: group})
+            expanded = other.sel({name: group})
         except KeyError:
             # some labels are absent i.e. other is not aligned
             # so we align by reindexing and then rename dimensions.
@@ -519,7 +519,7 @@ class GroupBy:
                     other[var] = (
                         other[var].drop_vars(var).expand_dims({name: other.sizes[name]})
                     )
-            other = (
+            expanded = (
                 other.reindex({name: group.data})
                 .rename({name: dim})
                 .assign_coords({dim: obj[dim]})
@@ -533,7 +533,7 @@ class GroupBy:
             idx = pd.cut(group, bins=self._full_index).codes
             obj = obj.isel({dim: np.arange(group.size)[idx != -1]})
 
-        result = g(obj, other)
+        result = g(obj, expanded)
 
         result = self._maybe_unstack(result)
         group = self._maybe_unstack(group)

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -526,16 +526,13 @@ class GroupBy:
                 .assign_coords({dim: obj[dim]})
             )
 
-        if self._bins is not None:
-            # TODO: vectorized indexing bug in .sel; name_bins is still an IndexVariable!
-            other[name] = other[name].variable.to_base_variable()
-            if name == dim and dim not in obj.xindexes:
-                # When binning by unindexed coordinate we need to reindex obj.
-                # _full_index is IntervalIndex, so idx will be -1 where
-                # a value does not belong to any bin. Using IntervalIndex
-                # accounts for  any non-default cut_kwargs passed to the constructor
-                idx = pd.cut(obj[dim], bins=self._full_index).codes
-                obj = obj.isel({dim: np.arange(obj[dim].size)[idx != -1]})
+        if self._bins is not None and name == dim and dim not in obj.xindexes:
+            # When binning by unindexed coordinate we need to reindex obj.
+            # _full_index is IntervalIndex, so idx will be -1 where
+            # a value does not belong to any bin. Using IntervalIndex
+            # accounts for  any non-default cut_kwargs passed to the constructor
+            idx = pd.cut(obj[dim], bins=self._full_index).codes
+            obj = obj.isel({dim: np.arange(obj[dim].size)[idx != -1]})
 
         result = g(obj, other)
 

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -857,6 +857,17 @@ def test_groupby_dataset_math_virtual() -> None:
     assert_identical(actual, expected)
 
 
+def test_groupby_math_dim_order() -> None:
+    da = DataArray(
+        np.ones((10, 10, 12)),
+        dims=("x", "y", "time"),
+        coords={"time": pd.date_range("2001-01-01", periods=12, freq="6H")},
+    )
+    grouped = da.groupby("time.day")
+    result = grouped - grouped.mean()
+    assert result.dims == da.dims
+
+
 def test_groupby_dataset_nan() -> None:
     # nan should be excluded from groupby
     ds = Dataset({"foo": ("x", [1, 2, 3, 4])}, {"bar": ("x", [1, 1, 2, np.nan])})

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -1133,26 +1133,28 @@ class TestDataArrayGroupBy:
         expected = change_metadata(expected)
         assert_equal(expected, actual)
 
+    @pytest.mark.parametrize("squeeze", [True, False])
+    def test_groupby_math_squeeze(self, squeeze):
+        array = self.da
+        grouped = array.groupby("x", squeeze=squeeze)
+
+        expected = array + array.coords["x"]
+        actual = grouped + array.coords["x"]
+        assert_identical(expected, actual)
+
+        actual = array.coords["x"] + grouped
+        assert_identical(expected, actual)
+
+        ds = array.coords["x"].to_dataset(name="X")
+        expected = array + ds
+        actual = grouped + ds
+        assert_identical(expected, actual)
+
+        actual = ds + grouped
+        assert_identical(expected, actual)
+
     def test_groupby_math(self):
         array = self.da
-        for squeeze in [True, False]:
-            grouped = array.groupby("x", squeeze=squeeze)
-
-            expected = array + array.coords["x"]
-            actual = grouped + array.coords["x"]
-            assert_identical(expected, actual)
-
-            actual = array.coords["x"] + grouped
-            assert_identical(expected, actual)
-
-            ds = array.coords["x"].to_dataset(name="X")
-            expected = array + ds
-            actual = grouped + ds
-            assert_identical(expected, actual)
-
-            actual = ds + grouped
-            assert_identical(expected, actual)
-
         grouped = array.groupby("abc")
         expected_agg = (grouped.mean(...) - np.arange(3)).rename(None)
         actual = grouped - DataArray(range(3), [("abc", ["a", "b", "c"])])


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #5804 
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Doing the math is  easy. Keeping backward compatibility with respect to non-dimension coordinates is hard! (e.g. #2145)
