### PR TITLE
unpin dask again

### DIFF
--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -8,7 +8,7 @@ dependencies:
   # - cdms2  # Not available on Windows
   # - cfgrib  # Causes Python interpreter crash on Windows: https://github.com/pydata/xarray/pull/3340
   - cftime
-  - dask-core != 2021.12.0 # https://github.com/pydata/xarray/pull/6111, can remove on next release
+  - dask-core
   - distributed
   - fsspec!=2021.7.0
   - h5netcdf

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - cdms2
   - cfgrib
   - cftime
-  - dask-core != 2021.12.0 # https://github.com/pydata/xarray/pull/6111, can remove on next release
+  - dask-core
   - distributed
   - fsspec!=2021.7.0
   - h5netcdf


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- dask 2022.01 is out, so we can remove the pin