### PR TITLE
fix cftime doctests

### DIFF
--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -537,10 +537,10 @@ class CFTimeIndex(pd.Index):
         >>> index = xr.cftime_range("2000", periods=1, freq="M")
         >>> index
         CFTimeIndex([2000-01-31 00:00:00],
-                    dtype='object', length=1, calendar='gregorian', freq=None)
+                    dtype='object', length=1, calendar='standard', freq=None)
         >>> index.shift(1, "M")
         CFTimeIndex([2000-02-29 00:00:00],
-                    dtype='object', length=1, calendar='gregorian', freq=None)
+                    dtype='object', length=1, calendar='standard', freq=None)
         """
         from .cftime_offsets import to_offset
 
@@ -626,7 +626,7 @@ class CFTimeIndex(pd.Index):
         >>> times = xr.cftime_range("2000", periods=2, calendar="gregorian")
         >>> times
         CFTimeIndex([2000-01-01 00:00:00, 2000-01-02 00:00:00],
-                    dtype='object', length=2, calendar='gregorian', freq=None)
+                    dtype='object', length=2, calendar='standard', freq=None)
         >>> times.to_datetimeindex()
         DatetimeIndex(['2000-01-01', '2000-01-02'], dtype='datetime64[ns]', freq=None)
         """


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Fixes the doctests for the newest version of cftime. @spencerkclark

This of course means that the doctests will fail for environments with older versions of cftime present. I don't think there is anything we can do.

Thanks for pytest-accept b.t.w @max-sixty 

