### PR TITLE
don't install bottleneck wheel for upstream CI

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"] # using 3.10 blocked by https://github.com/pydata/bottleneck/pull/378
+        python-version: ["3.10"]
     outputs:
       artifacts_availability: ${{ steps.status.outputs.ARTIFACTS_AVAILABLE }}
     steps:

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.9"] # using 3.10 blocked by https://github.com/pydata/bottleneck/pull/378
     outputs:
       artifacts_availability: ${{ steps.status.outputs.ARTIFACTS_AVAILABLE }}
     steps:

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -12,10 +12,10 @@ conda uninstall -y --force \
     cftime \
     rasterio \
     pint \
-    bottleneck \
     sparse \
     h5netcdf \
     xarray
+    # bottleneck \ # re-enable again, see https://github.com/pydata/bottleneck/pull/378
 # to limit the runtime of Upstream CI
 python -m pip install pytest-timeout
 python -m pip install \
@@ -41,8 +41,8 @@ python -m pip install \
     git+https://github.com/Unidata/cftime \
     git+https://github.com/mapbox/rasterio \
     git+https://github.com/hgrecco/pint \
-    git+https://github.com/pydata/bottleneck \
     git+https://github.com/pydata/sparse \
     git+https://github.com/intake/filesystem_spec \
     git+https://github.com/SciTools/nc-time-axis \
     git+https://github.com/h5netcdf/h5netcdf
+    # git+https://github.com/pydata/bottleneck \ # re-enable again, see https://github.com/pydata/bottleneck/pull/378


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] see #6186

I think it would be good to re-enable the upstream CI, even if this means we have to stick to py3.9 for the moment. I just subscribed to pydata/bottleneck#378, so I should see when we can switch to 3.10.