### PR TITLE
MAINT: pandas 1.4: no longer use get_loc with method

### DIFF
--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -231,9 +231,14 @@ class PandasIndex(Index):
                         )
                     indexer = self.index.get_loc(label_value)
                 else:
-                    indexer = self.index.get_loc(
-                        label_value, method=method, tolerance=tolerance
-                    )
+                    if method is not None:
+                        indexer = get_indexer_nd(self.index, label, method, tolerance)
+                        if np.any(indexer < 0):
+                            raise KeyError(
+                                f"not all values found in index {coord_name!r}"
+                            )
+                    else:
+                        indexer = self.index.get_loc(label_value)
             elif label.dtype.kind == "b":
                 indexer = label
             else:

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -564,9 +564,8 @@ def _localize(var, indexes_coords):
         minval = np.nanmin(new_x.values)
         maxval = np.nanmax(new_x.values)
         index = x.to_index()
-        imin = index.get_loc(minval, method="nearest")
-        imax = index.get_loc(maxval, method="nearest")
-
+        imin = index.get_indexer([minval], method="nearest").item()
+        imax = index.get_indexer([maxval], method="nearest").item()
         indexes[dim] = slice(max(imin - 2, 0), imax + 2)
         indexes_coords[dim] = (x[indexes[dim]], new_x)
     return var.isel(**indexes), indexes_coords


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #5721
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Fixed as per @shoyer & @spencerkclark suggestion from https://github.com/pydata/xarray/issues/5721#issuecomment-903095007

Now that pandas 1.4 is out it would be good to get this fixed (there are about 5000 warnings in our tests, mostly because of `interp`, though). Also leads to a warning in our docs which breaks them (although that can also be fixed with an `:okwarning:` directive).
