### PR TITLE
fix or suppress test warnings

### DIFF
--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -1,17 +1,10 @@
 import functools
 import inspect
 import itertools
-import sys
 import warnings
+from importlib.metadata import entry_points
 
 from .common import BACKEND_ENTRYPOINTS, BackendEntrypoint
-
-if sys.version_info >= (3, 8):
-    from importlib.metadata import entry_points
-else:
-    # if the fallback library is missing, we are doomed.
-    from importlib_metadata import entry_points
-
 
 STANDARD_BACKENDS_ORDER = ["netcdf4", "h5netcdf", "scipy"]
 

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -407,7 +407,7 @@ class CFTimeIndex(pd.Index):
 
         times = self._data
 
-        if self.is_monotonic:
+        if self.is_monotonic_increasing:
             if len(times) and (
                 (start < times[0] and end < times[0])
                 or (start > times[-1] and end > times[-1])

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -853,7 +853,7 @@ class DataWithCoords(AttrAccessMixin):
         ...     np.linspace(0, 11, num=12),
         ...     coords=[
         ...         pd.date_range(
-        ...             "15/12/1999",
+        ...             "1999-12-15",
         ...             periods=12,
         ...             freq=pd.DateOffset(months=1),
         ...         )
@@ -966,7 +966,7 @@ class DataWithCoords(AttrAccessMixin):
         >>> da = xr.DataArray(
         ...     np.linspace(0, 364, num=364),
         ...     dims="time",
-        ...     coords={"time": pd.date_range("15/12/1999", periods=364)},
+        ...     coords={"time": pd.date_range("1999-12-15", periods=364)},
         ... )
         >>> da  # +doctest: ELLIPSIS
         <xarray.DataArray (time: 364)>
@@ -1062,7 +1062,7 @@ class DataWithCoords(AttrAccessMixin):
         ...     np.linspace(0, 11, num=12),
         ...     coords=[
         ...         pd.date_range(
-        ...             "15/12/1999",
+        ...             "1999-12-15",
         ...             periods=12,
         ...             freq=pd.DateOffset(months=1),
         ...         )

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -201,7 +201,7 @@ def _unique_and_monotonic(group):
     if isinstance(group, _DummyGroup):
         return True
     index = safe_cast_to_index(group)
-    return index.is_unique and index.is_monotonic
+    return index.is_unique and index.is_monotonic_increasing
 
 
 def _apply_loffset(grouper, result):
@@ -343,7 +343,7 @@ class GroupBy:
 
         if grouper is not None:
             index = safe_cast_to_index(group)
-            if not index.is_monotonic:
+            if not index.is_monotonic_increasing:
                 # TODO: sort instead of raising an error
                 raise ValueError("index must be monotonic for resampling")
             full_index, first_items = self._get_index_and_items(index, grouper)

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -407,7 +407,7 @@ def coerce_pandas_values(objects: Iterable[CoercibleMapping]) -> list[DatasetLik
         else:
             variables = {}
             if isinstance(obj, PANDAS_TYPES):
-                obj = dict(obj.iter())
+                obj = dict(obj.iteritems())
             for k, v in obj.items():
                 if isinstance(v, PANDAS_TYPES):
                     v = DataArray(v)

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -407,7 +407,7 @@ def coerce_pandas_values(objects: Iterable[CoercibleMapping]) -> list[DatasetLik
         else:
             variables = {}
             if isinstance(obj, PANDAS_TYPES):
-                obj = dict(obj.iteritems())
+                obj = dict(obj.iter())
             for k, v in obj.items():
                 if isinstance(v, PANDAS_TYPES):
                     v = DataArray(v)

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -266,7 +266,7 @@ def get_clean_interp_index(
         index.name = dim
 
     if strict:
-        if not index.is_monotonic:
+        if not index.is_monotonic_increasing:
             raise ValueError(f"Index {index.name!r} must be monotonically increasing")
 
         if not index.is_unique:

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -1036,7 +1036,8 @@ def legend_elements(
     if label_values_are_numeric:
         label_values_min = label_values.min()
         label_values_max = label_values.max()
-        fmt.set_bounds(label_values_min, label_values_max)
+        fmt.axis.set_view_interval(label_values_min, label_values_max)
+        fmt.axis.set_data_interval(label_values_min, label_values_max)
 
         if num is not None:
             # Labels are numerical but larger than the target

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -97,7 +97,7 @@ class TestDatetimeAccessor:
     def test_isocalendar(self, field, pandas_field) -> None:
 
         # pandas isocalendar has dtypy UInt32Dtype, convert to Int64
-        expected = pd.Int64Index(getattr(self.times.isocalendar(), pandas_field))
+        expected = pd.Index(getattr(self.times.isocalendar(), pandas_field), np.int64)
         expected = xr.DataArray(
             expected, name=field, coords=[self.times], dims=["time"]
         )
@@ -435,7 +435,7 @@ def test_calendar_dask() -> None:
 
     # 3D lazy dask - np
     data = xr.DataArray(
-        da.random.random_integers(1, 1000000, size=(4, 5, 6)).astype("<M8[h]"),
+        da.random.randint(1, 1000000 + 1, size=(4, 5, 6)).astype("<M8[h]"),
         dims=("x", "y", "z"),
     )
     with raise_if_dask_computes():

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -97,7 +97,7 @@ class TestDatetimeAccessor:
     def test_isocalendar(self, field, pandas_field) -> None:
 
         # pandas isocalendar has dtypy UInt32Dtype, convert to Int64
-        expected = pd.Index(getattr(self.times.isocalendar(), pandas_field), np.int64)
+        expected = pd.Index(getattr(self.times.isocalendar(), pandas_field).astype(int))
         expected = xr.DataArray(
             expected, name=field, coords=[self.times], dims=["time"]
         )

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -437,6 +437,7 @@ class DatasetIOBase:
             actual.foo.values  # no caching
             assert not actual.foo.variable._in_memory
 
+    @pytest.mark.filterwarnings("ignore:deallocating CachingFileManager")
     def test_roundtrip_None_variable(self):
         expected = Dataset({None: (("x", "y"), [[0, 1], [2, 3]])})
         with self.roundtrip(expected) as actual:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -517,7 +517,7 @@ class DatasetIOBase:
             expected_calendar = times[0].calendar
 
             with warnings.catch_warnings():
-                if expected_calendar in {"proleptic_gregorian", "gregorian"}:
+                if expected_calendar in {"proleptic_gregorian", "standard"}:
                     warnings.filterwarnings("ignore", "Unable to decode time axis")
 
                 with self.roundtrip(expected, save_kwargs=kwargs) as actual:
@@ -4703,6 +4703,9 @@ class TestRasterio:
                         assert actual_shape == expected_shape
                         assert expected_val.all() == actual_val.all()
 
+    @pytest.mark.filterwarnings(
+        "ignore:open_rasterio is Deprecated in favor of rioxarray."
+    )
     def test_rasterio_vrt_with_transform_and_size(self):
         # Test open_rasterio() support of WarpedVRT with transform, width and
         # height (issue #2864)

--- a/xarray/tests/test_coarsen.py
+++ b/xarray/tests/test_coarsen.py
@@ -58,7 +58,7 @@ def test_coarsen_coords(ds, dask) -> None:
     da = xr.DataArray(
         np.linspace(0, 365, num=364),
         dims="time",
-        coords={"time": pd.date_range("15/12/1999", periods=364)},
+        coords={"time": pd.date_range("1999-12-15", periods=364)},
     )
     actual = da.coarsen(time=2).mean()
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -1557,6 +1557,7 @@ def test_covcorr_consistency(da_a, da_b, dim) -> None:
 @requires_dask
 @pytest.mark.parametrize("da_a, da_b", arrays_w_tuples()[1])
 @pytest.mark.parametrize("dim", [None, "time", "x"])
+@pytest.mark.filterwarnings("ignore:invalid value encountered in .*divide")
 def test_corr_lazycorr_consistency(da_a, da_b, dim) -> None:
     da_al = da_a.chunk()
     da_bl = da_b.chunk()

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2162,7 +2162,7 @@ class TestDataArray:
         # test GH3000
         a = orig[:0, :1].stack(dim=("x", "y")).dim.to_index()
         b = pd.MultiIndex(
-            levels=[pd.Int64Index([]), pd.Int64Index([0])],
+            levels=[pd.Index([], np.int64), pd.Index([0], np.int64)],
             codes=[[], []],
             names=["x", "y"],
         )

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -160,6 +160,7 @@ def test_dask_distributed_zarr_integration_test(loop, consolidated, compute) -> 
 
 
 @requires_rasterio
+@pytest.mark.filterwarnings("ignore:deallocating CachingFileManager")
 def test_dask_distributed_rasterio_integration_test(loop) -> None:
     with create_tmp_geotiff() as (tmp_file, expected):
         with cluster() as (s, [a, b]):

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -765,7 +765,7 @@ def test_groupby_math_nD_group() -> None:
     g = da.groupby_bins("num2d", bins=[0, 4, 6])
     mean = g.mean()
     idxr = np.digitize(da.num2d, bins=(0, 4, 6), right=True)[:30, :] - 1
-    expanded_mean = mean.drop("num2d_bins").isel(num2d_bins=(("x", "y"), idxr))
+    expanded_mean = mean.drop_vars("num2d_bins").isel(num2d_bins=(("x", "y"), idxr))
     expected = da.isel(x=slice(30)) - expanded_mean
     expected["labels"] = expected.labels.broadcast_like(expected.labels2d)
     expected["num"] = expected.num.broadcast_like(expected.num2d)
@@ -1251,7 +1251,7 @@ class TestDataArrayGroupBy:
             np.arange(100), dims="x", coords={"x": np.linspace(-100, 100, num=100)}
         )
         binned_mean = data.groupby_bins("x", bins=11).mean()
-        assert binned_mean.to_index().is_monotonic
+        assert binned_mean.to_index().is_monotonic_increasing
 
     def test_groupby_assign_coords(self):
 
@@ -1426,7 +1426,7 @@ class TestDataArrayResample:
 
         # Pad
         actual = array.resample(time="3H").pad()
-        expected = DataArray(array.to_series().resample("3H").pad())
+        expected = DataArray(array.to_series().resample("3H").ffill())
         assert_identical(expected, actual)
 
         # Nearest

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -800,7 +800,7 @@ class TestSparseDataArrayAndDataset:
         t1 = xr.DataArray(
             np.linspace(0, 11, num=12),
             coords=[
-                pd.date_range("15/12/1999", periods=12, freq=pd.DateOffset(months=1))
+                pd.date_range("1999-12-15", periods=12, freq=pd.DateOffset(months=1))
             ],
             dims="time",
         )

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -2612,12 +2612,15 @@ class TestNumpyCoercion:
         np.testing.assert_equal(v.to_numpy(), np.array([1, 2, 3]))
 
     @requires_pint
-    @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
     def test_from_pint(self, Var):
-        from pint import Quantity
+        import pint
 
         arr = np.array([1, 2, 3])
-        v = Var("x", Quantity(arr, units="m"))
+
+        # IndexVariable strips the unit
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=pint.UnitStrippedWarning)
+            v = Var("x", pint.Quantity(arr, units="m"))
 
         assert_identical(v.as_numpy(), Var("x", arr))
         np.testing.assert_equal(v.to_numpy(), arr)
@@ -2648,14 +2651,17 @@ class TestNumpyCoercion:
 
     @requires_dask
     @requires_pint
-    @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
     def test_from_pint_wrapping_dask(self, Var):
         import dask
-        from pint import Quantity
+        import pint
 
         arr = np.array([1, 2, 3])
         d = dask.array.from_array(np.array([1, 2, 3]))
-        v = Var("x", Quantity(d, units="m"))
+
+        # IndexVariable strips the unit
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=pint.UnitStrippedWarning)
+            v = Var("x", pint.Quantity(d, units="m"))
 
         result = v.as_numpy()
         assert_identical(result, Var("x", arr))

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -2606,6 +2606,7 @@ class TestNumpyCoercion:
         np.testing.assert_equal(v.to_numpy(), np.array([1, 2, 3]))
 
     @requires_pint
+    @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
     def test_from_pint(self, Var):
         from pint import Quantity
 
@@ -2641,6 +2642,7 @@ class TestNumpyCoercion:
 
     @requires_dask
     @requires_pint
+    @pytest.mark.filterwarnings("ignore::pint.UnitStrippedWarning")
     def test_from_pint_wrapping_dask(self, Var):
         import dask
         from pint import Quantity

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -443,6 +443,7 @@ def check_weighted_operations(data, weights, dim, skipna):
 @pytest.mark.parametrize("dim", ("a", "b", "c", ("a", "b"), ("a", "b", "c"), None))
 @pytest.mark.parametrize("add_nans", (True, False))
 @pytest.mark.parametrize("skipna", (None, True, False))
+@pytest.mark.filterwarnings("ignore:invalid value encountered in sqrt")
 def test_weighted_operations_3D(dim, add_nans, skipna):
 
     dims = ("a", "b", "c")
@@ -480,6 +481,7 @@ def test_weighted_operations_nonequal_coords():
 @pytest.mark.parametrize("shape_weights", ((4,), (4, 4), (4, 4, 4)))
 @pytest.mark.parametrize("add_nans", (True, False))
 @pytest.mark.parametrize("skipna", (None, True, False))
+@pytest.mark.filterwarnings("ignore:invalid value encountered in sqrt")
 def test_weighted_operations_different_shapes(
     shape_data, shape_weights, add_nans, skipna
 ):


### PR DESCRIPTION
Fixes or suppresses a number of warnings that turn up in our upstream CI.

`pd.Index.is_monotonic` is an alias for `pd.Index.is_monotonic_increasing` and does _not_ stand for `pd.Index.is_monotonic_increasing or pd.Index.is_monotonic_decreasing`.
