### PR TITLE
Amended docstring to reflect the actual behaviour of Dataset.map

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5117,7 +5117,7 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
         keep_attrs : bool, optional
             If True, both the dataset's and variables' attributes (`attrs`) will be
             copied from the original objects to the new ones. If False, the new dataset
-            will be returned without attributes.
+            and variables will be returned without copying the attributes.
         args : tuple, optional
             Positional arguments passed on to `func`.
         **kwargs : Any

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5115,9 +5115,9 @@ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
             to transform each DataArray `x` in this dataset into another
             DataArray.
         keep_attrs : bool, optional
-            If True, the dataset's attributes (`attrs`) will be copied from
-            the original object to the new one. If False, the new object will
-            be returned without attributes.
+            If True, both the dataset's and variables' attributes (`attrs`) will be
+            copied from the original objects to the new ones. If False, the new dataset
+            will be returned without attributes.
         args : tuple, optional
             Positional arguments passed on to `func`.
         **kwargs : Any


### PR DESCRIPTION
In [MetPy/pull#2312](https://github.com/MetPy/pull/2312), I noticed that the behavior of `Dataset.map`'s kwarg `keep_attrs` was not in line with its docstring. This is because in xarray 0.16.2 (pydata/xarray#3595 & pydata/xarray#4195) this behavior was changed.

In short, `keep_attrs=True` now copies both, the Dataset's and the variables' attributes and adds them to the new objects - preventing any change to them by the mapped function. In contrast, `keep_attrs= False` discards the Dataset's attributes and does not touch the variables' attributes, enabling the mapped function to modify them.

Here, I propose an update to the `keep_attrs` docstring of `Dataset.map` which would more accurately reflect its current behavior. Please feel free to provide alternative formulations if you feel like this one misses the mark.