### PR TITLE
Enable running sphinx-build on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,13 +5,9 @@ __pycache__
 .hypothesis/
 
 # temp files from docs build
+doc/*.nc
 doc/auto_gallery
-doc/complex.nc
-doc/example-data.nc
-doc/example-no-leap.nc
-doc/example.nc
-doc/manipulated-example-data.nc
-doc/saved_on_disk.nc
+doc/rasm.zarr
 doc/savefig
 
 # C extensions
@@ -77,4 +73,3 @@ xarray/tests/data/*.grib.*.idx
 Icon*
 
 .ipynb_checkpoints
-doc/rasm.zarr

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,12 @@ __pycache__
 
 # temp files from docs build
 doc/auto_gallery
+doc/complex.nc
+doc/example-data.nc
+doc/example-no-leap.nc
 doc/example.nc
+doc/manipulated-example-data.nc
+doc/saved_on_disk.nc
 doc/savefig
 
 # C extensions

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,7 +30,7 @@ print("sys.path:", sys.path)
 
 if "conda" in sys.executable:
     print("conda environment:")
-    subprocess.run([os.environ["CONDA_EXE"], "list"])
+    subprocess.run([os.environ.get("CONDA_EXE", "conda"), "list"])
 else:
     print("pip environment:")
     subprocess.run([sys.executable, "-m", "pip", "list"])

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -28,7 +28,7 @@ allowed_failures = set()
 print("python exec:", sys.executable)
 print("sys.path:", sys.path)
 
-if "conda" in sys.executable:
+if "CONDA_DEFAULT_ENV" in os.environ or "conda" in sys.executable:
     print("conda environment:")
     subprocess.run([os.environ.get("CONDA_EXE", "conda"), "list"])
 else:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,7 +30,7 @@ print("sys.path:", sys.path)
 
 if "conda" in sys.executable:
     print("conda environment:")
-    subprocess.run(["conda", "list"])
+    subprocess.run([os.environ["CONDA_EXE"], "list"])
 else:
     print("pip environment:")
     subprocess.run([sys.executable, "-m", "pip", "list"])

--- a/doc/getting-started-guide/quick-overview.rst
+++ b/doc/getting-started-guide/quick-overview.rst
@@ -10,6 +10,8 @@ To begin, import numpy, pandas and xarray using their customary abbreviations:
 
 .. ipython:: python
 
+    import os
+
     import numpy as np
     import pandas as pd
     import xarray as xr
@@ -215,14 +217,13 @@ You can directly read and write xarray objects to disk using :py:meth:`~xarray.D
 .. ipython:: python
 
     ds.to_netcdf("example.nc")
-    xr.open_dataset("example.nc")
+    reopened = xr.open_dataset("example.nc")
+    reopened
 
 .. ipython:: python
-    :okexcept:
     :suppress:
 
-    import os
-
+    reopened.close()
     os.remove("example.nc")
 
 

--- a/doc/getting-started-guide/quick-overview.rst
+++ b/doc/getting-started-guide/quick-overview.rst
@@ -10,8 +10,6 @@ To begin, import numpy, pandas and xarray using their customary abbreviations:
 
 .. ipython:: python
 
-    import os
-
     import numpy as np
     import pandas as pd
     import xarray as xr
@@ -222,6 +220,8 @@ You can directly read and write xarray objects to disk using :py:meth:`~xarray.D
 
 .. ipython:: python
     :suppress:
+
+    import os
 
     reopened.close()
     os.remove("example.nc")

--- a/doc/getting-started-guide/quick-overview.rst
+++ b/doc/getting-started-guide/quick-overview.rst
@@ -218,6 +218,7 @@ You can directly read and write xarray objects to disk using :py:meth:`~xarray.D
     xr.open_dataset("example.nc")
 
 .. ipython:: python
+    :okexcept:
     :suppress:
 
     import os

--- a/doc/internals/zarr-encoding-spec.rst
+++ b/doc/internals/zarr-encoding-spec.rst
@@ -63,3 +63,10 @@ re-open it directly with Zarr:
     print(os.listdir("rasm.zarr"))
     print(zgroup.tree())
     dict(zgroup["Tair"].attrs)
+
+.. ipython:: python
+    :suppress:
+
+    import shutil
+
+    shutil.rmtree("rasm.zarr")

--- a/doc/user-guide/dask.rst
+++ b/doc/user-guide/dask.rst
@@ -148,6 +148,7 @@ A dataset can also be converted to a Dask DataFrame using :py:meth:`~xarray.Data
 Dask DataFrames do not support multi-indexes so the coordinate variables from the dataset are included as columns in the Dask DataFrame.
 
 .. ipython:: python
+    :okexcept:
     :suppress:
 
     import os

--- a/doc/user-guide/dask.rst
+++ b/doc/user-guide/dask.rst
@@ -55,6 +55,8 @@ argument to :py:func:`~xarray.open_dataset` or using the
 .. ipython:: python
     :suppress:
 
+    import os
+
     import numpy as np
     import pandas as pd
     import xarray as xr
@@ -129,6 +131,11 @@ will return a ``dask.delayed`` object that can be computed later.
     with ProgressBar():
         results = delayed_obj.compute()
 
+.. ipython:: python
+    :suppress:
+
+    os.remove("manipulated-example-data.nc")  # Was not opened.
+
 .. note::
 
     When using Dask's distributed scheduler to write NETCDF4 files,
@@ -147,14 +154,6 @@ A dataset can also be converted to a Dask DataFrame using :py:meth:`~xarray.Data
 
 Dask DataFrames do not support multi-indexes so the coordinate variables from the dataset are included as columns in the Dask DataFrame.
 
-.. ipython:: python
-    :okexcept:
-    :suppress:
-
-    import os
-
-    os.remove("example-data.nc")
-    os.remove("manipulated-example-data.nc")
 
 Using Dask with xarray
 ----------------------
@@ -211,7 +210,7 @@ Dask arrays using the :py:meth:`~xarray.Dataset.persist` method:
 
 .. ipython:: python
 
-    ds = ds.persist()
+    persisted = ds.persist()
 
 :py:meth:`~xarray.Dataset.persist` is particularly useful when using a
 distributed cluster because the data will be loaded into distributed memory
@@ -232,11 +231,6 @@ For performance you may wish to consider chunk sizes.  The correct choice of
 chunk size depends both on your data and on the operations you want to perform.
 With xarray, both converting data to a Dask arrays and converting the chunk
 sizes of Dask arrays is done with the :py:meth:`~xarray.Dataset.chunk` method:
-
-.. ipython:: python
-    :suppress:
-
-    ds = ds.chunk({"time": 10})
 
 .. ipython:: python
 
@@ -509,6 +503,11 @@ Notice that the 0-shaped sizes were not printed to screen. Since ``template`` ha
     expected = ds + 10 + 10
     mapped.identical(expected)
 
+.. ipython:: python
+    :suppress:
+
+    ds.close()  # Closes "example-data.nc".
+    os.remove("example-data.nc")
 
 .. tip::
 

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -11,6 +11,8 @@ format (recommended).
 .. ipython:: python
     :suppress:
 
+    import os
+
     import numpy as np
     import pandas as pd
     import xarray as xr
@@ -83,6 +85,13 @@ We can load netCDF files to create a new Dataset using
 
     ds_disk = xr.open_dataset("saved_on_disk.nc")
     ds_disk
+
+.. ipython:: python
+    :suppress:
+
+    # Close "saved_on_disk.nc", but retain the file until after closing or deleting other
+    # datasets that will refer to it.
+    ds_disk.close()
 
 Similarly, a DataArray can be saved to disk using the
 :py:meth:`DataArray.to_netcdf` method, and loaded
@@ -203,11 +212,6 @@ You can view this encoding information (among others) in the
 
 Note that all operations that manipulate variables other than indexing
 will remove encoding information.
-
-.. ipython:: python
-    :suppress:
-
-    ds_disk.close()
 
 
 .. _combining multiple files:
@@ -484,14 +488,13 @@ and currently raises a warning unless ``invalid_netcdf=True`` is set:
     da.to_netcdf("complex.nc", engine="h5netcdf", invalid_netcdf=True)
 
     # Reading it back
-    xr.open_dataarray("complex.nc", engine="h5netcdf")
+    reopened = xr.open_dataarray("complex.nc", engine="h5netcdf")
+    reopened
 
 .. ipython:: python
-    :okexcept:
     :suppress:
 
-    import os
-
+    reopened.close()
     os.remove("complex.nc")
 
 .. warning::
@@ -724,16 +727,18 @@ To export just the dataset schema without the data itself, use the
 
     ds.to_dict(data=False)
 
-This can be useful for generating indices of dataset contents to expose to
-search indices or other automated data discovery tools.
-
 .. ipython:: python
-    :okexcept:
     :suppress:
 
-    import os
-
+    # We're now done with the dataset named `ds`.  Although the `with` statement closed
+    # the dataset, displaying the unpickled pickle of `ds` re-opened "saved_on_disk.nc".
+    # However, `ds` (rather than the unpickled dataset) refers to the open file.  Delete
+    # `ds` to close the file.
+    del ds
     os.remove("saved_on_disk.nc")
+
+This can be useful for generating indices of dataset contents to expose to
+search indices or other automated data discovery tools.
 
 .. _io.rasterio:
 

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -487,6 +487,7 @@ and currently raises a warning unless ``invalid_netcdf=True`` is set:
     xr.open_dataarray("complex.nc", engine="h5netcdf")
 
 .. ipython:: python
+    :okexcept:
     :suppress:
 
     import os
@@ -727,6 +728,7 @@ This can be useful for generating indices of dataset contents to expose to
 search indices or other automated data discovery tools.
 
 .. ipython:: python
+    :okexcept:
     :suppress:
 
     import os

--- a/doc/user-guide/weather-climate.rst
+++ b/doc/user-guide/weather-climate.rst
@@ -218,14 +218,15 @@ For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
 .. ipython:: python
 
     da.to_netcdf("example-no-leap.nc")
-    xr.open_dataset("example-no-leap.nc")
+    reopened = xr.open_dataset("example-no-leap.nc")
+    reopened
 
 .. ipython:: python
-    :okexcept:
     :suppress:
 
     import os
 
+    reopened.close()
     os.remove("example-no-leap.nc")
 
 - And resampling along the time dimension for data indexed by a :py:class:`~xarray.CFTimeIndex`:

--- a/doc/user-guide/weather-climate.rst
+++ b/doc/user-guide/weather-climate.rst
@@ -221,6 +221,7 @@ For data indexed by a :py:class:`~xarray.CFTimeIndex` xarray currently supports:
     xr.open_dataset("example-no-leap.nc")
 
 .. ipython:: python
+    :okexcept:
     :suppress:
 
     import os

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,7 +38,8 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
-- Enable building the documentation on Windows via `sphinx-build` (:pull:`6237`).
+- Delete files of datasets saved to disk while building the documentation and enable
+  building on Windows via `sphinx-build` (:pull:`6237`).
   By `Stan West <https://github.com/stanwest>`_.
 
 Internal Changes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,6 +38,8 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
+- Enable building the documentation on Windows via `sphinx-build` (:pull:`6237`).
+  By `Stan West <https://github.com/stanwest>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

This PR enables one to build the documentation on Windows by manually invoking `sphinx-build`.

The first commit enables *sphinx* to execute the "conf.py" file. Before the commit, *sphinx* complains:

```
Configuration error:
There is a programmable error in your configuration file:
```

with the exception `FileNotFoundError: [WinError 2] The system cannot find the file specified` where it tries to invoke *conda*. On Windows, *conda* environments other than the base environment have "conda.bat" on their path rather than "conda.exe", and one must call `subprocess.run` with "conda.bat" instead of merely "conda". However, the `CONDA_EXE` environment variable correctly points to the executable and should do so across platforms; it requires *conda* version 4.5 or later for conda/conda#6923.

The second commit enables the build to tolerate exceptions when deleting temporary files and tells Git to ignore more such files. Without the commit, builds occasionally failed at the `os.remove` calls with exceptions such as `PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'example.nc'`.

Should "whats-new.rst" mention these changes, which are developer-visible but not user-visible?

I welcome any feedback.

Edit: Checked the "whats-new" task.