### PR TITLE
Run pyupgrade on core/utils

### DIFF
--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -190,7 +190,7 @@ def list_equiv(first, second):
     return equiv
 
 
-def peek_at(iterable: Iterable[T]) -> Tuple[T, Iterator[T]]:
+def peek_at(iterable: Iterable[T]) -> tuple[T, Iterator[T]]:
     """Returns the first value from iterable, as well as a new iterator with
     the same content as the original iterable
     """
@@ -275,7 +275,7 @@ def is_duck_array(value: Any) -> bool:
 
 
 def either_dict_or_kwargs(
-    pos_kwargs: Optional[Mapping[Any, T]],
+    pos_kwargs: Mapping[Any, T] | None,
     kw_kwargs: Mapping[str, T],
     func_name: str,
 ) -> Mapping[Hashable, T]:
@@ -513,7 +513,7 @@ class OrderedSet(MutableSet[T]):
     a dict. Note that, unlike in an OrderedDict, equality tests are not order-sensitive.
     """
 
-    _d: Dict[T, None]
+    _d: dict[T, None]
 
     __slots__ = ("_d",)
 
@@ -587,7 +587,7 @@ class NDArrayMixin(NdimSizeLenMixin):
         return self.array.dtype
 
     @property
-    def shape(self: Any) -> Tuple[int]:
+    def shape(self: Any) -> tuple[int]:
         return self.array.shape
 
     def __getitem__(self: Any, key):
@@ -661,7 +661,7 @@ def read_magic_number_from_file(filename_or_obj, count=8) -> bytes:
     return magic_number
 
 
-def try_read_magic_number_from_path(pathlike, count=8) -> Optional[bytes]:
+def try_read_magic_number_from_path(pathlike, count=8) -> bytes | None:
     if isinstance(pathlike, str) or hasattr(pathlike, "__fspath__"):
         path = os.fspath(pathlike)
         try:
@@ -672,9 +672,7 @@ def try_read_magic_number_from_path(pathlike, count=8) -> Optional[bytes]:
     return None
 
 
-def try_read_magic_number_from_file_or_path(
-    filename_or_obj, count=8
-) -> Optional[bytes]:
+def try_read_magic_number_from_file_or_path(filename_or_obj, count=8) -> bytes | None:
     magic_number = try_read_magic_number_from_path(filename_or_obj, count)
     if magic_number is None:
         try:
@@ -708,7 +706,7 @@ def hashable(v: Any) -> bool:
     return True
 
 
-def decode_numpy_dict_values(attrs: Mapping[K, V]) -> Dict[K, V]:
+def decode_numpy_dict_values(attrs: Mapping[K, V]) -> dict[K, V]:
     """Convert attribute values from numpy objects to native Python objects,
     for use in to_dict
     """
@@ -817,7 +815,7 @@ def get_temp_dimname(dims: Container[Hashable], new_dim: Hashable) -> Hashable:
 
 def drop_dims_from_indexers(
     indexers: Mapping[Any, Any],
-    dims: Union[list, Mapping[Any, int]],
+    dims: list | Mapping[Any, int],
     missing_dims: str,
 ) -> Mapping[Hashable, Any]:
     """Depending on the setting of missing_dims, drop any dimensions from indexers that

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -1,4 +1,6 @@
 """Internal utilities; not for external use"""
+from __future__ import annotations
+
 import contextlib
 import functools
 import io

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -16,18 +16,14 @@ from typing import (
     Callable,
     Collection,
     Container,
-    Dict,
     Hashable,
     Iterable,
     Iterator,
     Mapping,
     MutableMapping,
     MutableSet,
-    Optional,
     Sequence,
-    Tuple,
     TypeVar,
-    Union,
     cast,
 )
 


### PR DESCRIPTION
Make #6239 cleaner by running pyupgrade separately.

pyupgrade fixes typing only if `from __future__ import annotations` has been manually added to the file. Could probably do this in other files as well.

