### PR TITLE
Remove default issue & PR titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugreport.yml
+++ b/.github/ISSUE_TEMPLATE/bugreport.yml
@@ -1,8 +1,6 @@
 name: Bug Report
 description: File a bug report to help us improve
-title: '[Bug]: '
-labels: [bug, 'needs triage']
-assignees: []
+labels: [bug, "needs triage"]
 body:
   - type: textarea
     id: what-happened
@@ -54,8 +52,8 @@ body:
   - type: textarea
     id: show-versions
     attributes:
-     label: Environment
-     description: |
-       Paste the output of `xr.show_versions()` here
+      label: Environment
+      description: |
+        Paste the output of `xr.show_versions()` here
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/newfeature.yml
+++ b/.github/ISSUE_TEMPLATE/newfeature.yml
@@ -1,8 +1,6 @@
 name: Feature Request
 description: Suggest an idea for xarray
-title: '[FEATURE]: '
 labels: [enhancement]
-assignees: []
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
I would vote to use labels rather than strings here -- it clutters the names

(but no strong view, feel free to close if ppl disagree)
