### PR TITLE
Fix pickling issue

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,8 +40,7 @@ Bug fixes
 
 - Variables which are chunked using dask in larger (but aligned) chunks than the target zarr chunk size
   can now be stored using `to_zarr()` (:pull:`6258`) By `Tobias Kölling <https://github.com/d70-t>`_.
-- Multi file datasets containing CFTime DatetimeIndx ojbects can be read in parallel again (:pull:`6249`),
-  by `Martin Bergemann <https://github.com/antarcticrainforest>`_.
+- Multi-file datasets containing encoded :py:class:`cftime.datetime` objects can be read in parallel again (:issue:`6226`, :pull:`6249`).  By `Martin Bergemann <https://github.com/antarcticrainforest>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,6 +40,8 @@ Bug fixes
 
 - Variables which are chunked using dask in larger (but aligned) chunks than the target zarr chunk size
   can now be stored using `to_zarr()` (:pull:`6258`) By `Tobias Kölling <https://github.com/d70-t>`_.
+- Multi file datasets containing CFTime DatetimeIndx ojbects can be read in parallel again (:pull:`6249`),
+  by `Martin Bergemann <https://github.com/antarcticrainforest>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -310,7 +310,7 @@ class CFTimeIndex(pd.Index):
     )
     date_type = property(get_date_type)
 
-    def __new__(cls, data, name=None):
+    def __new__(cls, data, name=None, **kwargs):
         assert_all_valid_date_type(data)
         if name is None and hasattr(data, "name"):
             name = data.name

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -1,5 +1,5 @@
-from datetime import timedelta
 import pickle
+from datetime import timedelta
 from textwrap import dedent
 
 import numpy as np
@@ -1291,11 +1291,10 @@ def test_infer_freq(freq, calendar):
     out = xr.infer_freq(indx)
     assert out == freq
 
+
 @pytest.mark.parametrize("calendar", _CFTIME_CALENDARS)
 def test_pickle_cftimeindex(calendar):
 
     idx = xr.cftime_range("2000-01-01", periods=3, freq="D", calendar=calendar)
     idx_pkl = pickle.loads(pickle.dumps(idx))
     assert (idx == idx_pkl).all()
-
-

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -1291,7 +1291,7 @@ def test_infer_freq(freq, calendar):
     out = xr.infer_freq(indx)
     assert out == freq
 
-
+@requires_cftime
 @pytest.mark.parametrize("calendar", _CFTIME_CALENDARS)
 def test_pickle_cftimeindex(calendar):
 

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+import pickle
 from textwrap import dedent
 
 import numpy as np
@@ -1289,3 +1290,12 @@ def test_infer_freq(freq, calendar):
     indx = xr.cftime_range("2000-01-01", periods=3, freq=freq, calendar=calendar)
     out = xr.infer_freq(indx)
     assert out == freq
+
+@pytest.mark.parametrize("calendar", _CFTIME_CALENDARS)
+def test_pickle_cftimeindex(calendar):
+
+    idx = xr.cftime_range("2000-01-01", periods=3, freq="D", calendar=calendar)
+    idx_pkl = pickle.loads(pickle.dumps(idx))
+    assert (idx == idx_pkl).all()
+
+

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -1291,6 +1291,7 @@ def test_infer_freq(freq, calendar):
     out = xr.infer_freq(indx)
     assert out == freq
 
+
 @requires_cftime
 @pytest.mark.parametrize("calendar", _CFTIME_CALENDARS)
 def test_pickle_cftimeindex(calendar):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #6226
- [x] Added tests for opening netcdf files with cftime axis in parallel

This PR tries to address some updates in the pandas library on how datetime objects are pickled. Since I was told that the datatype of the CFtimeIndex object will always be `object` I just instructed the `__new__` method to receive any additional arguments but not to evaluate them. Which feels a little awkward but does the job. If there are better ways to deal with this please let me know.  @spencerkclark @aidanheerdegen @mathause 