### PR TITLE
use `warnings.catch_warnings(record=True)` instead of `pytest.warns(None)`

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1814,7 +1814,7 @@ class ZarrBase(CFEncodedBase):
         good_chunks = ({"dim2": 3}, {"dim3": (6, 4)}, {})
         for chunks in good_chunks:
             kwargs = {"chunks": chunks}
-            with pytest.warns(None) as record:
+            with warnings.catch_warnings(record=True) as record:
                 with self.roundtrip(original, open_kwargs=kwargs) as actual:
                     for k, v in actual.variables.items():
                         # only index variables should be in memory
@@ -4964,7 +4964,7 @@ class TestDataArrayToNetCDF:
 @requires_scipy_or_netCDF4
 def test_no_warning_from_dask_effective_get():
     with create_tmp_file() as tmpfile:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             ds = Dataset()
             ds.to_netcdf(tmpfile)
         assert len(record) == 0
@@ -5009,7 +5009,7 @@ def test_use_cftime_standard_calendar_default_in_range(calendar):
 
     with create_tmp_file() as tmp_file:
         original.to_netcdf(tmp_file)
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             with open_dataset(tmp_file) as ds:
                 assert_identical(expected_x, ds.x)
                 assert_identical(expected_time, ds.time)
@@ -5072,7 +5072,7 @@ def test_use_cftime_true(calendar, units_year):
 
     with create_tmp_file() as tmp_file:
         original.to_netcdf(tmp_file)
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             with open_dataset(tmp_file, use_cftime=True) as ds:
                 assert_identical(expected_x, ds.x)
                 assert_identical(expected_time, ds.time)
@@ -5101,7 +5101,7 @@ def test_use_cftime_false_standard_calendar_in_range(calendar):
 
     with create_tmp_file() as tmp_file:
         original.to_netcdf(tmp_file)
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             with open_dataset(tmp_file, use_cftime=False) as ds:
                 assert_identical(expected_x, ds.x)
                 assert_identical(expected_time, ds.time)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -54,6 +54,7 @@ from . import (
     assert_array_equal,
     assert_equal,
     assert_identical,
+    assert_no_warnings,
     has_dask,
     has_h5netcdf_0_12,
     has_netCDF4,
@@ -1814,12 +1815,11 @@ class ZarrBase(CFEncodedBase):
         good_chunks = ({"dim2": 3}, {"dim3": (6, 4)}, {})
         for chunks in good_chunks:
             kwargs = {"chunks": chunks}
-            with warnings.catch_warnings(record=True) as record:
+            with assert_no_warnings():
                 with self.roundtrip(original, open_kwargs=kwargs) as actual:
                     for k, v in actual.variables.items():
                         # only index variables should be in memory
                         assert v._in_memory == (k in actual.dims)
-            assert len(record) == 0
 
     @requires_dask
     def test_deprecate_auto_chunk(self):
@@ -4964,10 +4964,9 @@ class TestDataArrayToNetCDF:
 @requires_scipy_or_netCDF4
 def test_no_warning_from_dask_effective_get():
     with create_tmp_file() as tmpfile:
-        with warnings.catch_warnings(record=True) as record:
+        with assert_no_warnings():
             ds = Dataset()
             ds.to_netcdf(tmpfile)
-        assert len(record) == 0
 
 
 @requires_scipy_or_netCDF4

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -32,6 +32,7 @@ from xarray.testing import assert_equal, assert_identical
 from . import (
     arm_xfail,
     assert_array_equal,
+    assert_no_warnings,
     has_cftime,
     has_cftime_1_4_1,
     requires_cftime,
@@ -905,10 +906,9 @@ def test_use_cftime_default_standard_calendar_in_range(calendar) -> None:
     units = "days since 2000-01-01"
     expected = pd.date_range("2000", periods=2)
 
-    with warnings.catch_warnings(record=True) as record:
+    with assert_no_warnings():
         result = decode_cf_datetime(numerical_dates, units, calendar)
         np.testing.assert_array_equal(result, expected)
-        assert not record
 
 
 @requires_cftime
@@ -942,10 +942,9 @@ def test_use_cftime_default_non_standard_calendar(calendar, units_year) -> None:
         numerical_dates, units, calendar, only_use_cftime_datetimes=True
     )
 
-    with warnings.catch_warnings(record=True) as record:
+    with assert_no_warnings():
         result = decode_cf_datetime(numerical_dates, units, calendar)
         np.testing.assert_array_equal(result, expected)
-        assert not record
 
 
 @requires_cftime
@@ -960,10 +959,9 @@ def test_use_cftime_true(calendar, units_year) -> None:
         numerical_dates, units, calendar, only_use_cftime_datetimes=True
     )
 
-    with warnings.catch_warnings(record=True) as record:
+    with assert_no_warnings():
         result = decode_cf_datetime(numerical_dates, units, calendar, use_cftime=True)
         np.testing.assert_array_equal(result, expected)
-        assert not record
 
 
 @pytest.mark.parametrize("calendar", _STANDARD_CALENDARS)
@@ -972,10 +970,9 @@ def test_use_cftime_false_standard_calendar_in_range(calendar) -> None:
     units = "days since 2000-01-01"
     expected = pd.date_range("2000", periods=2)
 
-    with warnings.catch_warnings(record=True) as record:
+    with assert_no_warnings():
         result = decode_cf_datetime(numerical_dates, units, calendar, use_cftime=False)
         np.testing.assert_array_equal(result, expected)
-        assert not record
 
 
 @pytest.mark.parametrize("calendar", _STANDARD_CALENDARS)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -905,7 +905,7 @@ def test_use_cftime_default_standard_calendar_in_range(calendar) -> None:
     units = "days since 2000-01-01"
     expected = pd.date_range("2000", periods=2)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         result = decode_cf_datetime(numerical_dates, units, calendar)
         np.testing.assert_array_equal(result, expected)
         assert not record
@@ -942,7 +942,7 @@ def test_use_cftime_default_non_standard_calendar(calendar, units_year) -> None:
         numerical_dates, units, calendar, only_use_cftime_datetimes=True
     )
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         result = decode_cf_datetime(numerical_dates, units, calendar)
         np.testing.assert_array_equal(result, expected)
         assert not record
@@ -960,7 +960,7 @@ def test_use_cftime_true(calendar, units_year) -> None:
         numerical_dates, units, calendar, only_use_cftime_datetimes=True
     )
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         result = decode_cf_datetime(numerical_dates, units, calendar, use_cftime=True)
         np.testing.assert_array_equal(result, expected)
         assert not record
@@ -972,7 +972,7 @@ def test_use_cftime_false_standard_calendar_in_range(calendar) -> None:
     units = "days since 2000-01-01"
     expected = pd.date_range("2000", periods=2)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         result = decode_cf_datetime(numerical_dates, units, calendar, use_cftime=False)
         np.testing.assert_array_equal(result, expected)
         assert not record

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6155,7 +6155,7 @@ def test_rolling_keep_attrs(funcname, argument):
 
 
 def test_raise_no_warning_for_nan_in_binary_ops():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         xr.DataArray([1, 2, np.NaN]) > 0
     assert len(record) == 0
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -33,6 +33,7 @@ from xarray.tests import (
     assert_chunks_equal,
     assert_equal,
     assert_identical,
+    assert_no_warnings,
     has_dask,
     raise_if_dask_computes,
     requires_bottleneck,
@@ -6155,9 +6156,8 @@ def test_rolling_keep_attrs(funcname, argument):
 
 
 def test_raise_no_warning_for_nan_in_binary_ops():
-    with warnings.catch_warnings(record=True) as record:
+    with assert_no_warnings():
         xr.DataArray([1, 2, np.NaN]) > 0
-    assert len(record) == 0
 
 
 @pytest.mark.filterwarnings("error")

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -38,6 +38,7 @@ from . import (
     assert_array_equal,
     assert_equal,
     assert_identical,
+    assert_no_warnings,
     create_test_data,
     has_cftime,
     has_dask,
@@ -6165,9 +6166,8 @@ def test_ndrolling_construct(center, fill_value, dask):
 
 
 def test_raise_no_warning_for_nan_in_binary_ops():
-    with warnings.catch_warnings(record=True) as record:
+    with assert_no_warnings():
         Dataset(data_vars={"x": ("y", [1, 2, np.NaN])}) > 0
-    assert len(record) == 0
 
 
 @pytest.mark.filterwarnings("error")

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1873,7 +1873,7 @@ class TestDataset:
 
         # Should not warn
         ind = xr.DataArray([0.0, 1.0], dims=["dim2"], name="ind")
-        with pytest.warns(None) as ws:
+        with warnings.catch_warnings(record=True) as ws:
             data.reindex(dim2=ind)
             assert len(ws) == 0
 
@@ -6165,7 +6165,7 @@ def test_ndrolling_construct(center, fill_value, dask):
 
 
 def test_raise_no_warning_for_nan_in_binary_ops():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         Dataset(data_vars={"x": ("y", [1, 2, np.NaN])}) > 0
     assert len(record) == 0
 

--- a/xarray/tests/test_ufuncs.py
+++ b/xarray/tests/test_ufuncs.py
@@ -1,4 +1,5 @@
 import pickle
+import warnings
 
 import numpy as np
 import pytest
@@ -164,7 +165,7 @@ def test_xarray_ufuncs_deprecation():
     with pytest.warns(FutureWarning, match="xarray.ufuncs"):
         xu.cos(xr.DataArray([0, 1]))
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         xu.angle(xr.DataArray([0, 1]))
     assert len(record) == 0
 

--- a/xarray/tests/test_ufuncs.py
+++ b/xarray/tests/test_ufuncs.py
@@ -1,5 +1,4 @@
 import pickle
-import warnings
 
 import numpy as np
 import pytest
@@ -9,7 +8,7 @@ import xarray.ufuncs as xu
 
 from . import assert_array_equal
 from . import assert_identical as assert_identical_
-from . import mock
+from . import assert_no_warnings, mock
 
 
 def assert_identical(a, b):
@@ -165,9 +164,8 @@ def test_xarray_ufuncs_deprecation():
     with pytest.warns(FutureWarning, match="xarray.ufuncs"):
         xu.cos(xr.DataArray([0, 1]))
 
-    with warnings.catch_warnings(record=True) as record:
+    with assert_no_warnings():
         xu.angle(xr.DataArray([0, 1]))
-    assert len(record) == 0
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -2537,7 +2537,7 @@ class TestAsCompatibleData:
 
 
 def test_raise_no_warning_for_nan_in_binary_ops():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         Variable("x", [1, 2, np.NaN]) > 0
     assert len(record) == 0
 

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -33,6 +33,7 @@ from . import (
     assert_array_equal,
     assert_equal,
     assert_identical,
+    assert_no_warnings,
     raise_if_dask_computes,
     requires_cupy,
     requires_dask,
@@ -2537,9 +2538,8 @@ class TestAsCompatibleData:
 
 
 def test_raise_no_warning_for_nan_in_binary_ops():
-    with warnings.catch_warnings(record=True) as record:
+    with assert_no_warnings():
         Variable("x", [1, 2, np.NaN]) > 0
-    assert len(record) == 0
 
 
 class TestBackendIndexing:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

pytest v7.0.0 no longer want's us to use ` pytest.warns(None)` to test for no warning, so we can use `warnings.catch_warnings(record=True)` instead.
