### PR TITLE
removed check for last dask chunk size in to_zarr

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -39,7 +39,7 @@ Bug fixes
 
 
 - Variables which are chunked using dask in larger (but aligned) chunks than the target zarr chunk size
-  can now be stored using `to_zarr()` By `Tobias Kölling <https://github.com/d70-t>`_.
+  can now be stored using `to_zarr()` (:pull:`6258`) By `Tobias Kölling <https://github.com/d70-t>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,6 +38,9 @@ Bug fixes
 ~~~~~~~~~
 
 
+- Variables which are chunked using dask in larger (but aligned) chunks than the target zarr chunk size
+  can now be stored using `to_zarr()` By `Tobias Kölling <https://github.com/d70-t>`_.
+
 Documentation
 ~~~~~~~~~~~~~
 

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -160,8 +160,6 @@ def _determine_zarr_chunks(enc_chunks, var_chunks, ndim, name, safe_chunks):
     # threads
     if var_chunks and enc_chunks_tuple:
         for zchunk, dchunks in zip(enc_chunks_tuple, var_chunks):
-            if len(dchunks) == 1:
-                continue
             for dchunk in dchunks[:-1]:
                 if dchunk % zchunk:
                     base_error = (
@@ -175,21 +173,6 @@ def _determine_zarr_chunks(enc_chunks, var_chunks, ndim, name, safe_chunks):
                             + " Consider either rechunking using `chunk()`, deleting "
                             "or modifying `encoding['chunks']`, or specify `safe_chunks=False`."
                         )
-            if dchunks[-1] > zchunk:
-                base_error = (
-                    "Final chunk of Zarr array must be the same size or "
-                    "smaller than the first. "
-                    f"Specified Zarr chunk encoding['chunks']={enc_chunks_tuple}, "
-                    f"for variable named {name!r} "
-                    f"but {dchunks} in the variable's Dask chunks {var_chunks} are "
-                    "incompatible with this encoding. "
-                )
-                if safe_chunks:
-                    raise NotImplementedError(
-                        base_error
-                        + " Consider either rechunking using `chunk()`, deleting "
-                        "or modifying `encoding['chunks']`, or specify `safe_chunks=False`."
-                    )
         return enc_chunks_tuple
 
     raise AssertionError("We should never get here. Function logic must be wrong.")

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2374,6 +2374,15 @@ class ZarrBase(CFEncodedBase):
         ) as ds1:
             assert_equal(ds1, original)
 
+    @requires_dask
+    def test_chunk_encoding_with_larger_dask_chunks(self):
+        original = xr.Dataset({"a": ("x", [1, 2, 3, 4])}).chunk({"x": 2})
+
+        with self.roundtrip(
+            original, save_kwargs={"encoding": {"a": {"chunks": [1]}}}
+        ) as ds1:
+            assert_equal(ds1, original)
+
     @requires_cftime
     def test_open_zarr_use_cftime(self):
         ds = create_test_data()

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1896,19 +1896,20 @@ class ZarrBase(CFEncodedBase):
             pass
 
         # if dask chunks (4) are an integer multiple of zarr chunks (2) it should not fail...
-        badenc.var1.encoding["chunks"] = (2,)
-        with self.roundtrip(badenc) as actual:
+        goodenc = ds.chunk({"x": 4})
+        goodenc.var1.encoding["chunks"] = (2,)
+        with self.roundtrip(goodenc) as actual:
             pass
 
         # if initial dask chunks are aligned, size of last dask chunk doesn't matter
-        badenc = badenc.chunk({"x": (3, 3, 6)})
-        badenc.var1.encoding["chunks"] = (3,)
-        with self.roundtrip(badenc) as actual:
+        goodenc = ds.chunk({"x": (3, 3, 6)})
+        goodenc.var1.encoding["chunks"] = (3,)
+        with self.roundtrip(goodenc) as actual:
             pass
 
-        badenc = badenc.chunk({"x": (3, 6, 3)})
-        badenc.var1.encoding["chunks"] = (3,)
-        with self.roundtrip(badenc) as actual:
+        goodenc = ds.chunk({"x": (3, 6, 3)})
+        goodenc.var1.encoding["chunks"] = (3,)
+        with self.roundtrip(goodenc) as actual:
             pass
 
         # ... also if the last chunk is irregular
@@ -1921,7 +1922,7 @@ class ZarrBase(CFEncodedBase):
                 assert_identical(original, actual)
 
         # but itermediate unaligned chunks are bad
-        badenc = badenc.chunk({"x": (3, 5, 3, 1)})
+        badenc = ds.chunk({"x": (3, 5, 3, 1)})
         badenc.var1.encoding["chunks"] = (3,)
         with pytest.raises(
             NotImplementedError, match=r"would overlap multiple dask chunks"


### PR DESCRIPTION
When storing a dask-chunked dataset to zarr, the size of the last chunk
in each dimension does not matter, as this single last chunk will be
written to any number of zarr chunks, but none of the zarr chunks which
are being written to will be accessed by any other dask chunk.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #6255
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

cc'ing @rabernat who seems to have worked on this lately.
