### PR TITLE
allow coordinates to be independent of `region` selection in to_zarr

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1263,7 +1263,7 @@ def _validate_region(ds, region):
             )
 
     non_matching_vars = [
-        k for k, v in ds.variables.items() if not set(region).intersection(v.dims)
+        k for k, v in ds.data_vars.items() if not set(region).intersection(v.dims)
     ]
     if non_matching_vars:
         raise ValueError(

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2347,6 +2347,30 @@ class ZarrBase(CFEncodedBase):
             ):
                 data2.to_zarr(store, region={"x": slice(3)})
 
+    def test_write_region_w_coords(self):
+        data = Dataset(
+            {"u": (("x","y",), np.array([[10], [11], [12]]))},
+            coords={'x':[0,1,2],'y':[0]}
+        )
+        data2 = Dataset(
+            {"u": (("x","y",), np.array([[13], [14]]))},
+            coords={'x':[3,4],'y':[0]}
+        )
+
+        @contextlib.contextmanager
+        def setup_and_verify_store(expected=data):
+            with self.create_zarr_target() as store:
+                data.to_zarr(store)
+                yield store
+                with self.open(store) as actual:
+                    assert_identical(actual, expected)
+
+        # verify the base case works
+        expected = Dataset({"u": (("x","y"), np.array([[13], [14], [12]]))},
+            coords={'x':[3,4,2],'y':[0]})
+        with setup_and_verify_store(expected) as store:
+            data2.to_zarr(store, region={"x": slice(2)})
+
     @requires_dask
     def test_encoding_chunksizes(self):
         # regression test for GH2278


### PR DESCRIPTION
The ``region`` argument has been validated too strictly as coordinates needed to have a common dimension with the selected dimensions in ``region``. The validation is now restricted to data variables.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [X] Closes #6069 
- [X] Tests added
- [X] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
