### PR TITLE
Add pytest-gha-annotations

### DIFF
--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -37,6 +37,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-env
+  - pytest-github-actions-annotate-failures
   - pytest-xdist
   - rasterio
   - scipy


### PR DESCRIPTION
This looks really good -- it adds an annotation to the PR inline for any failures.

I'm not sure how it will do with our many environments -- we may have to find a way of only having it run on one environment if it doesn't de-dupe them.
