### PR TITLE
Remove xfail from tests decorated by @gen_cluster

### DIFF
--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -5,14 +5,14 @@ import numpy as np
 import tempfile
 
 import pytest
+from packaging.version import Version
 
 dask = pytest.importorskip("dask")  # isort:skip
 distributed = pytest.importorskip("distributed")  # isort:skip
 
 from dask.distributed import Client, Lock
-from distributed.utils_test import cluster, gen_cluster
-from distributed.utils_test import loop
 from distributed.client import futures_of
+from distributed.utils_test import cluster, gen_cluster, loop
 
 import xarray as xr
 from xarray.backends.locks import HDF5_LOCK, CombinedLock
@@ -208,7 +208,10 @@ def test_dask_distributed_cfgrib_integration_test(loop) -> None:
                     assert_allclose(actual, expected)
 
 
-@pytest.mark.xfail(reason="https://github.com/pydata/xarray/pull/6211")
+@pytest.mark.xfail(
+    condition=Version(distributed.__version__) < Version("2022.02.0"),
+    reason="https://github.com/dask/distributed/pull/5739",
+)
 @gen_cluster(client=True)
 async def test_async(c, s, a, b) -> None:
     x = create_test_data()
@@ -241,7 +244,10 @@ def test_hdf5_lock() -> None:
     assert isinstance(HDF5_LOCK, dask.utils.SerializableLock)
 
 
-@pytest.mark.xfail(reason="https://github.com/pydata/xarray/pull/6211")
+@pytest.mark.xfail(
+    condition=Version(distributed.__version__) < Version("2022.02.0"),
+    reason="https://github.com/dask/distributed/pull/5739",
+)
 @gen_cluster(client=True)
 async def test_serializable_locks(c, s, a, b) -> None:
     def f(x, lock=None):


### PR DESCRIPTION
``@gen_cluster`` has now been fixed upstream.