### PR TITLE
Amended docs on how to add a new backend

### DIFF
--- a/doc/internals/how-to-add-new-backend.rst
+++ b/doc/internals/how-to-add-new-backend.rst
@@ -273,7 +273,7 @@ If you are using `Poetry <https://python-poetry.org/>`_ for your build system, y
 
 .. code-block:: toml
 
-    [tool.poetry.plugins."xarray_backends"]
+    [tool.poetry.plugins."xarray.backends"]
     "my_engine" = "my_package.my_module:MyBackendEntryClass"
 
 See https://python-poetry.org/docs/pyproject/#plugins for more information on Poetry plugins.


### PR DESCRIPTION
When trying to install a new xarray backend with poetry, I noticed that it should be `xarray.backends` instead of `xarray_backends`.