### PR TITLE
On Windows, enable successful test of opening a dataset containing a cftime index

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,7 +40,7 @@ Bug fixes
 
 - Variables which are chunked using dask in larger (but aligned) chunks than the target zarr chunk size
   can now be stored using `to_zarr()` (:pull:`6258`) By `Tobias Kölling <https://github.com/d70-t>`_.
-- Multi-file datasets containing encoded :py:class:`cftime.datetime` objects can be read in parallel again (:issue:`6226`, :pull:`6249`).  By `Martin Bergemann <https://github.com/antarcticrainforest>`_.
+- Multi-file datasets containing encoded :py:class:`cftime.datetime` objects can be read in parallel again (:issue:`6226`, :pull:`6249`, :pull:`6305`).  By `Martin Bergemann <https://github.com/antarcticrainforest>`_ and `Stan West <https://github.com/stanwest>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -1,8 +1,6 @@
 """ isort:skip_file """
-import os
 import pickle
 import numpy as np
-import tempfile
 
 import pytest
 
@@ -113,19 +111,18 @@ def test_dask_distributed_netcdf_roundtrip(
 
 @requires_cftime
 @requires_netCDF4
-def test_open_mfdataset_can_open_files_with_cftime_index():
+def test_open_mfdataset_can_open_files_with_cftime_index(tmp_path):
     T = xr.cftime_range("20010101", "20010501", calendar="360_day")
     Lon = np.arange(100)
     data = np.random.random((T.size, Lon.size))
     da = xr.DataArray(data, coords={"time": T, "Lon": Lon}, name="test")
-    with tempfile.TemporaryDirectory() as td:
-        data_file = os.path.join(td, "test.nc")
-        da.to_netcdf(data_file)
-        with cluster() as (s, [a, b]):
-            with Client(s["address"]):
-                for parallel in (False, True):
-                    with xr.open_mfdataset(data_file, parallel=parallel) as tf:
-                        assert_identical(tf["test"], da)
+    file_path = tmp_path / "test.nc"
+    da.to_netcdf(file_path)
+    with cluster() as (s, [a, b]):
+        with Client(s["address"]):
+            for parallel in (False, True):
+                with xr.open_mfdataset(file_path, parallel=parallel) as tf:
+                    assert_identical(tf["test"], da)
 
 
 @pytest.mark.parametrize("engine,nc_format", ENGINES_AND_FORMATS)

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -118,11 +118,11 @@ def test_open_mfdataset_can_open_files_with_cftime_index():
     Lon = np.arange(100)
     data = np.random.random((T.size, Lon.size))
     da = xr.DataArray(data, coords={"time": T, "Lon": Lon}, name="test")
-    with cluster() as (s, [a, b]):
-        with Client(s["address"]):
-            with tempfile.TemporaryDirectory() as td:
-                data_file = os.path.join(td, "test.nc")
-                da.to_netcdf(data_file)
+    with tempfile.TemporaryDirectory() as td:
+        data_file = os.path.join(td, "test.nc")
+        da.to_netcdf(data_file)
+        with cluster() as (s, [a, b]):
+            with Client(s["address"]):
                 for parallel in (False, True):
                     with xr.open_mfdataset(data_file, parallel=parallel) as tf:
                         assert_identical(tf["test"], da)


### PR DESCRIPTION
- [X] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Previously, on Windows, the subject test unnecessarily failed, and the temporary directory and file remained, because the scheduler in the outer context prevented deleting the temporary directory upon exiting the inner context of the latter.

<details><summary>Example failure (with short traceback):</summary>
<p>

```
================================================ FAILURES =================================================
__________________________ test_open_mfdataset_can_open_files_with_cftime_index ___________________________
C:\Users\stan.west\Programs\Miniconda3-64\envs\xarray-dev\lib\shutil.py:616: in _rmtree_unsafe
    os.unlink(fullname)
E   PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\STAN~1.WES\\AppData\\Local\\Temp\\tmpdpdajrgc\\test.nc'

During handling of the above exception, another exception occurred:
C:\Users\stan.west\Programs\Miniconda3-64\envs\xarray-dev\lib\tempfile.py:802: in onerror
    _os.unlink(path)
E   PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\STAN~1.WES\\AppData\\Local\\Temp\\tmpdpdajrgc\\test.nc'

During handling of the above exception, another exception occurred:
C:\Users\stan.west\Documents\Repositories\xarray\xarray\tests\test_distributed.py:128: in test_open_mfdataset_can_open_files_with_cftime_index
    assert_identical(tf["test"], da)
C:\Users\stan.west\Programs\Miniconda3-64\envs\xarray-dev\lib\tempfile.py:827: in __exit__
    self.cleanup()
C:\Users\stan.west\Programs\Miniconda3-64\envs\xarray-dev\lib\tempfile.py:831: in cleanup
    self._rmtree(self.name)
C:\Users\stan.west\Programs\Miniconda3-64\envs\xarray-dev\lib\tempfile.py:813: in _rmtree
    _shutil.rmtree(name, onerror=onerror)
C:\Users\stan.west\Programs\Miniconda3-64\envs\xarray-dev\lib\shutil.py:740: in rmtree
    return _rmtree_unsafe(path, onerror)
C:\Users\stan.west\Programs\Miniconda3-64\envs\xarray-dev\lib\shutil.py:618: in _rmtree_unsafe
    onerror(os.unlink, fullname, sys.exc_info())
C:\Users\stan.west\Programs\Miniconda3-64\envs\xarray-dev\lib\tempfile.py:805: in onerror
    cls._rmtree(path)
C:\Users\stan.west\Programs\Miniconda3-64\envs\xarray-dev\lib\tempfile.py:813: in _rmtree
    _shutil.rmtree(name, onerror=onerror)
C:\Users\stan.west\Programs\Miniconda3-64\envs\xarray-dev\lib\shutil.py:740: in rmtree
    return _rmtree_unsafe(path, onerror)
C:\Users\stan.west\Programs\Miniconda3-64\envs\xarray-dev\lib\shutil.py:599: in _rmtree_unsafe
    onerror(os.scandir, path, sys.exc_info())
C:\Users\stan.west\Programs\Miniconda3-64\envs\xarray-dev\lib\shutil.py:596: in _rmtree_unsafe
    with os.scandir(path) as scandir_it:
E   NotADirectoryError: [WinError 267] The directory name is invalid: 'C:\\Users\\STAN~1.WES\\AppData\\Local\\Temp\\tmpdpdajrgc\\test.nc'
========================================= short test summary info =========================================
FAILED xarray/tests/test_distributed.py::test_open_mfdataset_can_open_files_with_cftime_index - NotADirec...

=========================================== 1 failed in 10.77s ============================================
```

</p>
</details>

The first commit swaps the two contexts to resolve the issue. The second commit replaces the `tempfile.TemporaryDirectory()` context manager with *pytest*'s `tmp_path` fixture, which slightly simplifies the test and relies on *pytest* to remove the directory on a subsequent invocation.