### PR TITLE
Disable CI runs on forks

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -119,6 +119,7 @@ jobs:
   doctest:
     name: Doctests
     runs-on: "ubuntu-latest"
+    if: needs.detect-ci-trigger.outputs.triggered == 'false'
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,6 +115,7 @@ jobs:
   event_file:
     name: "Event File"
     runs-on: ubuntu-latest
+    if: github.repository == 'pydata/xarray'
     steps:
       - name: Upload
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This PR ensures all CI workflows are only enabled on the main repository. A few workflows were still being triggered on forks. 
