### PR TITLE
Update dataset.py

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -193,10 +193,10 @@ def calculate_dimensions(variables: Mapping[Any, Variable]) -> dict[Hashable, in
     scalar_vars = {k for k, v in variables.items() if not v.dims}
     for k, var in variables.items():
         for dim, size in zip(var.dims, var.shape):
-            if dim in scalar_vars:
-                raise ValueError(
-                    f"dimension {dim!r} already exists as a scalar variable"
-                )
+            # if dim in scalar_vars:
+            #     raise ValueError(
+            #         f"dimension {dim!r} already exists as a scalar variable"
+            #     )
             if dim not in dims:
                 dims[dim] = size
                 last_used[dim] = k


### PR DESCRIPTION
When try to load a grib file with multiple parameters having different dimention the sclar valriable raise error is terminating execution
example for failure case:
	grib with ['surface_pressure','skin_temprature'] date : '2020-12-29' time ['10:00', '11:00']
this grib file will fail to load in xarray dataset because
skin_temprature variable have Dimensions: (time: 2, latitude: 1801, longitude: 3600)
surface_pressure have Dimensions: (step: 2, latitude: 1801, longitude: 3600)

Traceback (most recent call last):
  File "/home/bharat/PycharmProjects/bugReproduce/main.py", line 98, in <module>
    ds = xr.open_dataset(gribFileName, engine="cfgrib")
  File "/home/bharat/PycharmProjects/bugReproduce/venv/lib/python3.8/site-packages/xarray/backends/api.py", line 495, in open_dataset
    backend_ds = backend.open_dataset(
  File "/home/bharat/PycharmProjects/bugReproduce/venv/lib/python3.8/site-packages/cfgrib/xarray_plugin.py", line 126, in open_dataset
    ds = xr.Dataset(vars, attrs=attrs)
  File "/home/bharat/PycharmProjects/bugReproduce/venv/lib/python3.8/site-packages/xarray/core/dataset.py", line 750, in __init__
    variables, coord_names, dims, indexes, _ = merge_data_and_coords(
  File "/home/bharat/PycharmProjects/bugReproduce/venv/lib/python3.8/site-packages/xarray/core/merge.py", line 483, in merge_data_and_coords
    return merge_core(
  File "/home/bharat/PycharmProjects/bugReproduce/venv/lib/python3.8/site-packages/xarray/core/merge.py", line 640, in merge_core
    dims = calculate_dimensions(variables)
  File "/home/bharat/PycharmProjects/bugReproduce/venv/lib/python3.8/site-packages/xarray/core/dataset.py", line 197, in calculate_dimensions
    raise ValueError(
ValueError: dimension 'time' already exists as a scalar variable

to load a grib file the scaler variable check is creating issues.

if we skip raising valueError then the result of the above grib file looks like

Dimensions:     (step: 2, latitude: 1801, longitude: 3600, time: 2)
Coordinates:
    number      int64 ...
    time        datetime64[ns] ...
  * step        (step) timedelta64[ns] 10:00:00 11:00:00
    surface     float64 ...
  * latitude    (latitude) float64 90.0 89.9 89.8 89.7 ... -89.8 -89.9 -90.0
  * longitude   (longitude) float64 0.0 0.1 0.2 0.3 ... 359.6 359.7 359.8 359.9
    valid_time  (step) datetime64[ns] ...
Data variables:
    sp          (step, latitude, longitude) float32 ...
    skt         (time, latitude, longitude) float32 ...
Attributes:
    GRIB_edition:            1
    GRIB_centre:             ecmf
    GRIB_centreDescription:  European Centre for Medium-Range Weather Forecasts
    GRIB_subCentre:          0
    Conventions:             CF-1.7
    institution:             European Centre for Medium-Range Weather Forecasts
    history:                 2022-03-04T01:05 GRIB to CDM+CF via cfgrib-0.9.1...
Create Xarray Dataset End: 2022-03-04 01:05:31.684416

Load into Dataframe Start: 2022-03-04 01:05:31.684486
                    step  latitude  longitude  time  number  surface  \
0        0 days 10:00:00      90.0        0.0     0       0      0.0
1        0 days 10:00:00      90.0        0.0     1       0      0.0
2        0 days 10:00:00      90.0        0.1     0       0      0.0
3        0 days 10:00:00      90.0        0.1     1       0      0.0
4        0 days 10:00:00      90.0        0.2     0       0      0.0
...                  ...       ...        ...   ...     ...      ...
25934395 0 days 11:00:00     -90.0      359.7     1       0      0.0
25934396 0 days 11:00:00     -90.0      359.8     0       0      0.0
25934397 0 days 11:00:00     -90.0      359.8     1       0      0.0
25934398 0 days 11:00:00     -90.0      359.9     0       0      0.0
25934399 0 days 11:00:00     -90.0      359.9     1       0      0.0

                  valid_time       sp         skt
0        2021-12-31 10:00:00      NaN         NaN
1        2021-12-31 10:00:00      NaN         NaN
2        2021-12-31 10:00:00      NaN         NaN
3        2021-12-31 10:00:00      NaN         NaN
4        2021-12-31 10:00:00      NaN         NaN
...                      ...      ...         ...
25934395 2021-12-31 11:00:00  69046.0  250.095261
25934396 2021-12-31 11:00:00  69046.0  249.989456
25934397 2021-12-31 11:00:00  69046.0  250.095261
25934398 2021-12-31 11:00:00  69046.0  249.989456
25934399 2021-12-31 11:00:00  69046.0  250.095261

[25934400 rows x 9 columns]

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
