### PR TITLE
In backends, support expressing a dimension's preferred chunk sizes as a tuple of integers

### DIFF
--- a/doc/internals/how-to-add-new-backend.rst
+++ b/doc/internals/how-to-add-new-backend.rst
@@ -440,8 +440,8 @@ define the preferred chunk size inside the variable’s encoding
 ``var.encoding["preferred_chunks"]``. The ``preferred_chunks`` may be useful
 to improve performances with lazy loading. ``preferred_chunks`` shall be a
 dictionary specifying chunk size per dimension like
-``{“dim1”: 1000, “dim2”: 2000}``  or
-``{“dim1”: [1000, 100], “dim2”: [2000, 2000, 2000]]}``.
+``{"dim1": 1000, "dim2": 2000}``  or
+``{"dim1": (1000, 100), "dim2": (2000, 2000, 2000)}``.
 
 The ``preferred_chunks`` is used by Xarray to define the chunk size in some
 special cases:

--- a/doc/internals/how-to-add-new-backend.rst
+++ b/doc/internals/how-to-add-new-backend.rst
@@ -431,27 +431,25 @@ currently available in :py:mod:`~xarray.backends` module.
 
 .. _RST preferred_chunks:
 
-Backend preferred chunks
-^^^^^^^^^^^^^^^^^^^^^^^^
+Preferred chunk sizes
+^^^^^^^^^^^^^^^^^^^^^
 
-The backend is not directly involved in `Dask <https://dask.org/>`__
-chunking, since it is internally managed by Xarray. However, the backend can
-define the preferred chunk size inside the variable’s encoding
-``var.encoding["preferred_chunks"]``. The ``preferred_chunks`` may be useful
-to improve performances with lazy loading. ``preferred_chunks`` shall be a
-dictionary specifying chunk size per dimension like
-``{"dim1": 1000, "dim2": 2000}``  or
-``{"dim1": (1000, 100), "dim2": (2000, 2000, 2000)}``.
+To potentially improve performance with lazy loading, the backend may define for each
+variable the chunk sizes that it prefers---that is, sizes that align with how the
+variable is stored. (Note that the backend is not directly involved in `Dask
+<https://dask.org/>`__ chunking, because Xarray internally manages chunking.) To define
+the preferred chunk sizes, store a mapping within the variable's encoding under the key
+``"preferred_chunks"`` (that is, ``var.encoding["preferred_chunks"]``). The mapping's
+keys shall be the names of dimensions with preferred chunk sizes, and each value shall
+be the corresponding dimension's preferred chunk sizes expressed as either an integer
+(such as ``{"dim1": 1000, "dim2": 2000}``) or a tuple of integers (such as ``{"dim1":
+(1000, 100), "dim2": (2000, 2000, 2000)}``).
 
-The ``preferred_chunks`` is used by Xarray to define the chunk size in some
-special cases:
-
-- if ``chunks`` along a dimension is ``None`` or not defined
-- if ``chunks`` is ``"auto"``.
-
-In the first case Xarray uses the chunks size specified in
-``preferred_chunks``.
-In the second case Xarray accommodates ideal chunk sizes, preserving if
-possible the "preferred_chunks". The ideal chunk size is computed using
-:py:func:`dask.array.core.normalize_chunks`, setting
-``previous_chunks = preferred_chunks``.
+Xarray uses the preferred chunk sizes in some special cases of the ``chunks`` argument
+of the :py:func:`~xarray.open_dataset` and :py:func:`~xarray.open_mfdataset` functions.
+If ``chunks`` is a ``dict``, then for any dimensions missing from the keys or whose
+value is ``None``, Xarray sets the chunk sizes to the preferred sizes. If ``chunks``
+equals ``"auto"``, then Xarray seeks ideal chunk sizes informed by the preferred chunk
+sizes. Specifically, it determines the chunk sizes using
+:py:func:`dask.array.core.normalize_chunks` with the ``previous_chunks`` argument set
+according to the preferred chunk sizes.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,8 +38,18 @@ Bug fixes
   ensure it skips missing values for float dtypes (consistent with other methods). This should
   not change the behavior (:pull:`6303`). By `Mathias Hauser <https://github.com/mathause>`_.
 
+- In the API for backends, support dimensions that express their preferred chunk sizes
+  as a tuple of integers. (:issue:`6333`, :pull:`6334`)
+  By `Stan West <https://github.com/stanwest>`_.
+
+
 Documentation
 ~~~~~~~~~~~~~
+
+- Revise the documentation for developers on specifying a backend's preferred chunk
+  sizes. In particular, correct the syntax and replace lists with tuples in the
+  examples. (:issue:`6333`, :pull:`6334`)
+  By `Stan West <https://github.com/stanwest>`_.
 
 
 Internal Changes

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -357,48 +357,50 @@ def _assert_empty(args: tuple, msg: str = "%s") -> None:
 
 
 def _get_chunk(var, chunks):
-    # chunks need to be explicitly computed to take correctly into account
-    # backend preferred chunking
+    """
+    Return map from each dim to chunk sizes, accounting for backend's preferred chunks.
+    """
+
     import dask.array as da
 
     if isinstance(var, IndexVariable):
         return {}
+    dims = var.dims
+    shape = var.shape
 
-    if isinstance(chunks, int) or (chunks == "auto"):
-        chunks = dict.fromkeys(var.dims, chunks)
-
+    # Determine the explicit requested chunks.
     preferred_chunks = var.encoding.get("preferred_chunks", {})
-    preferred_chunks_list = [
-        preferred_chunks.get(dim, shape) for dim, shape in zip(var.dims, var.shape)
-    ]
-
-    chunks_list = [
-        chunks.get(dim, None) or preferred_chunks.get(dim, None) for dim in var.dims
-    ]
-
-    output_chunks_list = da.core.normalize_chunks(
-        chunks_list,
-        shape=var.shape,
-        dtype=var.dtype,
-        previous_chunks=preferred_chunks_list,
+    preferred_chunk_shape = tuple(
+        preferred_chunks.get(dim, size) for dim, size in zip(dims, shape)
+    )
+    if isinstance(chunks, Number) or (chunks == "auto"):
+        chunks = dict.fromkeys(dims, chunks)
+    chunk_shape = tuple(
+        chunks.get(dim, None) or preferred_chunk_sizes
+        for dim, preferred_chunk_sizes in zip(dims, preferred_chunk_shape)
+    )
+    chunk_shape = da.core.normalize_chunks(
+        chunk_shape, shape=shape, dtype=var.dtype, previous_chunks=preferred_chunk_shape
     )
 
-    for dim, size, chunks_dim in zip(var.dims, var.shape, output_chunks_list):
-        if dim not in preferred_chunks:
+    # Warn where requested chunks break preferred chunks.
+    for dim, size, chunk_sizes in zip(dims, shape, chunk_shape):
+        try:
+            preferred_chunk_sizes = preferred_chunks[dim]
+        except KeyError:
             continue
-        preferred_chunks_dim = preferred_chunks.get(dim)
         # Determine the stop indices of the preferred chunks, but omit the last stop
         # (equal to the dim size).  In particular, assume that when a sequence expresses
         # the preferred chunks, the sequence sums to the size.
         preferred_stops = (
-            range(preferred_chunks_dim, size, preferred_chunks_dim)
-            if isinstance(preferred_chunks_dim, Number)
-            else itertools.accumulate(preferred_chunks_dim[:-1])
+            range(preferred_chunk_sizes, size, preferred_chunk_sizes)
+            if isinstance(preferred_chunk_sizes, Number)
+            else itertools.accumulate(preferred_chunk_sizes[:-1])
         )
         # Gather any stop indices of the specified chunks that are not a stop index of a
         # preferred chunk.  Again, omit the last stop, assuming that it equals the dim
         # size.
-        breaks = set(itertools.accumulate(chunks_dim[:-1])).difference(preferred_stops)
+        breaks = set(itertools.accumulate(chunk_sizes[:-1])).difference(preferred_stops)
         if breaks:
             warnings.warn(
                 "The specified Dask chunks separate the stored chunks along dimension "
@@ -406,8 +408,7 @@ def _get_chunk(var, chunks):
                 "performance. Instead, consider rechunking after loading."
             )
 
-    output_chunks = dict(zip(var.dims, output_chunks_list))
-    return output_chunks
+    return dict(zip(dims, chunk_shape))
 
 
 def _maybe_chunk(

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1756,7 +1756,7 @@ class ZarrBase(CFEncodedBase):
                 assert v.chunks == original[k].chunks
 
     @requires_dask
-    @pytest.mark.filterwarnings("ignore:Specified Dask chunks")
+    @pytest.mark.filterwarnings("ignore:The specified Dask chunks separate")
     def test_manual_chunk(self):
         original = create_test_data().chunk({"dim1": 3, "dim2": 4, "dim3": 3})
 
@@ -5320,7 +5320,7 @@ def test_open_dataset_chunking_zarr(chunks, tmp_path):
 @pytest.mark.parametrize(
     "chunks", ["auto", -1, {}, {"x": "auto"}, {"x": -1}, {"x": "auto", "y": -1}]
 )
-@pytest.mark.filterwarnings("ignore:Specified Dask chunks")
+@pytest.mark.filterwarnings("ignore:The specified Dask chunks separate")
 def test_chunking_consintency(chunks, tmp_path):
     encoded_chunks = {}
     dask_arr = da.from_array(

--- a/xarray/tests/test_backends_api.py
+++ b/xarray/tests/test_backends_api.py
@@ -97,19 +97,11 @@ class TestPreferredChunks:
             # Represent preferred chunking with int.
             ((5,), (2,)),
             # Represent preferred chunking with tuple.
-            pytest.param(
-                (5,),
-                ((2, 2, 1),),
-                marks=pytest.mark.xfail(raises=TypeError, strict=True),
-            ),
+            ((5,), ((2, 2, 1),)),
             # Represent preferred chunking with int in two dims.
             ((5, 6), (4, 2)),
             # Represent preferred chunking with tuple in second dim.
-            pytest.param(
-                (5, 6),
-                (4, (2, 2, 2)),
-                marks=pytest.mark.xfail(raises=TypeError, strict=True),
-            ),
+            ((5, 6), (4, (2, 2, 2))),
         ],
     )
     @pytest.mark.parametrize("request_with_empty_map", [False, True])
@@ -136,19 +128,9 @@ class TestPreferredChunks:
             # Preferred chunking is int; requested chunking is tuple.
             ((5,), (2,), ((2, 1, 1, 1),)),
             # Preferred chunking is tuple; requested chunking is int.
-            pytest.param(
-                (5,),
-                ((2, 2, 1),),
-                (3,),
-                marks=pytest.mark.xfail(raises=TypeError, strict=True),
-            ),
+            ((5,), ((2, 2, 1),), (3,)),
             # Preferred chunking is tuple; requested chunking is tuple.
-            pytest.param(
-                (5,),
-                ((2, 2, 1),),
-                ((2, 1, 1, 1),),
-                marks=pytest.mark.xfail(raises=TypeError, strict=True),
-            ),
+            ((5,), ((2, 2, 1),), ((2, 1, 1, 1),)),
             # Split chunks along a dimension other than the first.
             ((1, 5), (1, 2), (1, 3)),
         ],
@@ -178,26 +160,11 @@ class TestPreferredChunks:
             # Join one chunk using tuple representation.
             ((5,), (1,), ((1, 1, 2, 1),)),
             # Join one chunk using int representation.
-            pytest.param(
-                (5,),
-                ((1, 1, 2, 1),),
-                (2,),
-                marks=pytest.mark.xfail(raises=TypeError, strict=True),
-            ),
+            ((5,), ((1, 1, 2, 1),), (2,)),
             # Join multiple chunks using tuple representation.
-            pytest.param(
-                (5,),
-                ((1, 1, 2, 1),),
-                ((2, 3),),
-                marks=pytest.mark.xfail(raises=TypeError, strict=True),
-            ),
+            ((5,), ((1, 1, 2, 1),), ((2, 3),)),
             # Join chunks in multiple dimensions.
-            pytest.param(
-                (5, 5),
-                (2, (1, 1, 2, 1)),
-                (4, (2, 3)),
-                marks=pytest.mark.xfail(raises=TypeError, strict=True),
-            ),
+            ((5, 5), (2, (1, 1, 2, 1)), (4, (2, 3))),
         ],
     )
     def test_join_chunks(self, shape, pref_chunks, req_chunks):

--- a/xarray/tests/test_backends_api.py
+++ b/xarray/tests/test_backends_api.py
@@ -1,9 +1,18 @@
+from numbers import Number
+
 import numpy as np
+import pytest
 
 import xarray as xr
 from xarray.backends.api import _get_default_engine
 
-from . import assert_identical, requires_netCDF4, requires_scipy
+from . import (
+    assert_identical,
+    assert_no_warnings,
+    requires_dask,
+    requires_netCDF4,
+    requires_scipy,
+)
 
 
 @requires_netCDF4
@@ -35,3 +44,169 @@ def test_custom_engine() -> None:
 
     actual = xr.open_dataset("fake_filename", engine=CustomBackend)
     assert_identical(expected, actual)
+
+
+class PassThroughBackendEntrypoint(xr.backends.BackendEntrypoint):
+    """Access an object passed to the `open_dataset` method."""
+
+    def open_dataset(self, dataset, *, drop_variables=None):
+        """Return the first argument."""
+        return dataset
+
+
+def explicit_chunks(chunks, shape):
+    """Return explicit chunks, expanding any integer member to a tuple of integers."""
+    # Emulate `dask.array.core.normalize_chunks` but for simpler inputs.
+    return tuple(
+        (
+            (size // chunk) * (chunk,)
+            + ((size % chunk,) if size % chunk or size == 0 else ())
+        )
+        if isinstance(chunk, Number)
+        else chunk
+        for chunk, size in zip(chunks, shape)
+    )
+
+
+@requires_dask
+class TestPreferredChunks:
+    """Test behaviors related to the backend's preferred chunks."""
+
+    var_name = "data"
+
+    def create_dataset(self, shape, pref_chunks):
+        """Return a dataset with a variable with the given shape and preferred chunks."""
+        dims = tuple(f"dim_{idx}" for idx in range(len(shape)))
+        return xr.Dataset(
+            {
+                self.var_name: xr.Variable(
+                    dims,
+                    np.empty(shape, dtype=np.dtype("V1")),
+                    encoding={"preferred_chunks": dict(zip(dims, pref_chunks))},
+                )
+            }
+        )
+
+    def check_dataset(self, initial, final, expected_chunks):
+        assert_identical(initial, final)
+        assert final[self.var_name].chunks == expected_chunks
+
+    @pytest.mark.parametrize(
+        "shape,pref_chunks",
+        [
+            # Represent preferred chunking with int.
+            ((5,), (2,)),
+            # Represent preferred chunking with tuple.
+            pytest.param(
+                (5,),
+                ((2, 2, 1),),
+                marks=pytest.mark.xfail(raises=TypeError, strict=True),
+            ),
+            # Represent preferred chunking with int in two dims.
+            ((5, 6), (4, 2)),
+            # Represent preferred chunking with tuple in second dim.
+            pytest.param(
+                (5, 6),
+                (4, (2, 2, 2)),
+                marks=pytest.mark.xfail(raises=TypeError, strict=True),
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("request_with_empty_map", [False, True])
+    def test_honor_chunks(self, shape, pref_chunks, request_with_empty_map):
+        """Honor the backend's preferred chunks when opening a dataset."""
+        initial = self.create_dataset(shape, pref_chunks)
+        # To keep the backend's preferred chunks, the `chunks` argument must be an
+        # empty mapping or map dimensions to `None`.
+        chunks = (
+            {}
+            if request_with_empty_map
+            else dict.fromkeys(initial[self.var_name].dims, None)
+        )
+        final = xr.open_dataset(
+            initial, engine=PassThroughBackendEntrypoint, chunks=chunks
+        )
+        self.check_dataset(initial, final, explicit_chunks(pref_chunks, shape))
+
+    @pytest.mark.parametrize(
+        "shape,pref_chunks,req_chunks",
+        [
+            # Preferred chunking is int; requested chunking is int.
+            ((5,), (2,), (3,)),
+            # Preferred chunking is int; requested chunking is tuple.
+            ((5,), (2,), ((2, 1, 1, 1),)),
+            # Preferred chunking is tuple; requested chunking is int.
+            pytest.param(
+                (5,),
+                ((2, 2, 1),),
+                (3,),
+                marks=pytest.mark.xfail(raises=TypeError, strict=True),
+            ),
+            # Preferred chunking is tuple; requested chunking is tuple.
+            pytest.param(
+                (5,),
+                ((2, 2, 1),),
+                ((2, 1, 1, 1),),
+                marks=pytest.mark.xfail(raises=TypeError, strict=True),
+            ),
+            # Split chunks along a dimension other than the first.
+            ((1, 5), (1, 2), (1, 3)),
+        ],
+    )
+    def test_split_chunks(self, shape, pref_chunks, req_chunks):
+        """Warn when the requested chunks separate the backend's preferred chunks."""
+        initial = self.create_dataset(shape, pref_chunks)
+        with pytest.warns(UserWarning):
+            final = xr.open_dataset(
+                initial,
+                engine=PassThroughBackendEntrypoint,
+                chunks=dict(zip(initial[self.var_name].dims, req_chunks)),
+            )
+        self.check_dataset(initial, final, explicit_chunks(req_chunks, shape))
+
+    @pytest.mark.parametrize(
+        "shape,pref_chunks,req_chunks",
+        [
+            # Keep preferred chunks using int representation.
+            ((5,), (2,), (2,)),
+            # Keep preferred chunks using tuple representation.
+            ((5,), (2,), ((2, 2, 1),)),
+            # Join chunks, leaving a final short chunk.
+            ((5,), (2,), (4,)),
+            # Join all chunks with an int larger than the dimension size.
+            ((5,), (2,), (6,)),
+            # Join one chunk using tuple representation.
+            ((5,), (1,), ((1, 1, 2, 1),)),
+            # Join one chunk using int representation.
+            pytest.param(
+                (5,),
+                ((1, 1, 2, 1),),
+                (2,),
+                marks=pytest.mark.xfail(raises=TypeError, strict=True),
+            ),
+            # Join multiple chunks using tuple representation.
+            pytest.param(
+                (5,),
+                ((1, 1, 2, 1),),
+                ((2, 3),),
+                marks=pytest.mark.xfail(raises=TypeError, strict=True),
+            ),
+            # Join chunks in multiple dimensions.
+            pytest.param(
+                (5, 5),
+                (2, (1, 1, 2, 1)),
+                (4, (2, 3)),
+                marks=pytest.mark.xfail(raises=TypeError, strict=True),
+            ),
+        ],
+    )
+    def test_join_chunks(self, shape, pref_chunks, req_chunks):
+        """Don't warn when the requested chunks join or keep the preferred chunks."""
+        initial = self.create_dataset(shape, pref_chunks)
+        with assert_no_warnings():
+            final = xr.open_dataset(
+                initial,
+                engine=PassThroughBackendEntrypoint,
+                chunks=dict(zip(initial[self.var_name].dims, req_chunks)),
+            )
+        self.check_dataset(initial, final, explicit_chunks(req_chunks, shape))


### PR DESCRIPTION
- [X] Closes #6333
- [X] Tests added
- [X] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
