### PR TITLE
explicitly install `ipython_genutils`

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -12,6 +12,7 @@ dependencies:
   - h5netcdf>=0.7.4
   - ipykernel
   - ipython
+  - ipython_genutils  # remove once `nbconvert` fixed its dependencies
   - iris>=2.3
   - jupyter_client
   - matplotlib-base

--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -34,7 +34,7 @@ dependencies:
   - sphinx-book-theme >= 0.0.38
   - sphinx-copybutton
   - sphinx-panels
-  - sphinx<4
+  - sphinx<5
   - zarr>=2.4
   - pip:
       - sphinxext-rediraffe

--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -34,7 +34,7 @@ dependencies:
   - sphinx-book-theme >= 0.0.38
   - sphinx-copybutton
   - sphinx-panels
-  - sphinx<5
+  - sphinx<4
   - zarr>=2.4
   - pip:
       - sphinxext-rediraffe


### PR DESCRIPTION
This can be reverted once the `nbconvert` package on `conda-forge` has been updated.