### PR TITLE
Revert "explicitly install `ipython_genutils`"

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -12,7 +12,6 @@ dependencies:
   - h5netcdf>=0.7.4
   - ipykernel
   - ipython
-  - ipython_genutils  # remove once `nbconvert` fixed its dependencies
   - iris>=2.3
   - jupyter_client
   - matplotlib-base


### PR DESCRIPTION
Since the dependency issue has been fixed upstream, this reverts pydata/xarray#6350