### PR TITLE
Don't overwrite user-defined coordinates attributes

### DIFF
--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -770,7 +770,7 @@ def _encode_coordinates(variables, attributes, non_dim_coord_names):
         # this will copy coordinates from encoding to attrs if "coordinates" in attrs
         # after the next line, "coordinates" is never in encoding
         # we get support for attrs["coordinates"] for free.
-        coords_str = pop_to(encoding, attrs, "coordinates")
+        coords_str = pop_to(encoding, attrs, "coordinates") or attrs.get("coordinates")
         if not coords_str and variable_coordinates[name]:
             coordinates_text = " ".join(
                 str(coord_name)

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -132,14 +132,12 @@ class TestEncodeCFVariable:
         # regression test for GH6310
         # don't overwrite user-defined "coordinates" attributes
         orig = Dataset(
-            {
-                "values": ('time', np.zeros(2), {"coordinates": "time lon lat"})
-            },
+            {"values": ("time", np.zeros(2), {"coordinates": "time lon lat"})},
             coords={
-               'time': ('time', np.zeros(2)),
-               'lat': ('time', np.zeros(2)),
-               'lon': ('time', np.zeros(2))
-            }
+                "time": ("time", np.zeros(2)),
+                "lat": ("time", np.zeros(2)),
+                "lon": ("time", np.zeros(2)),
+            },
         )
         # Encode the coordinates, as they would be in a netCDF output file.
         enc, attrs = conventions.encode_dataset_coordinates(orig)

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -128,6 +128,27 @@ class TestEncodeCFVariable:
         # Should not have any global coordinates.
         assert "coordinates" not in attrs
 
+    def test_var_with_coord_attr(self) -> None:
+        # regression test for GH6310
+        # don't overwrite user-defined "coordinates" attributes
+        orig = Dataset(
+            {
+                "values": ('time', np.zeros(2), {"coordinates": "time lon lat"})
+            },
+            coords={
+               'time': ('time', np.zeros(2)),
+               'lat': ('time', np.zeros(2)),
+               'lon': ('time', np.zeros(2))
+            }
+        )
+        # Encode the coordinates, as they would be in a netCDF output file.
+        enc, attrs = conventions.encode_dataset_coordinates(orig)
+        # Make sure we have the right coordinates for each variable.
+        values_coords = enc["values"].attrs.get("coordinates", "")
+        assert set(values_coords.split()) == {"time", "lat", "lon"}
+        # Should not have any global coordinates.
+        assert "coordinates" not in attrs
+
     def test_do_not_overwrite_user_coordinates(self) -> None:
         orig = Dataset(
             coords={"x": [0, 1, 2], "y": ("x", [5, 6, 7]), "z": ("x", [8, 9, 10])},


### PR DESCRIPTION
- [x] Closes #6310
- [x] Tests added
- [x] Doesn't include user visible changes or notable bug fixes for `whats-new.rst`
- [x] No new functions/methods for `api.rst`

As discussed in #6310, when setting "coordinates" as a variable attribute instead of as an encoding, the value of that variable attribute is overwritten when writing to a NetCDF file. This PR fixes it.