### PR TITLE
Speed-up multi-index html repr + add display_values_threshold option

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -28,6 +28,10 @@ New Features
 - Multi-index levels are now accessible through their own, regular coordinates
   instead of virtual coordinates (:pull:`5692`).
   By `Benoît Bovy <https://github.com/benbovy>`_.
+- Add a ``display_values_threshold`` option to control the total number of array
+  elements which trigger summarization rather than full repr in (numpy) array
+  detailed views of the html repr (:pull:`6400`).
+  By `Benoît Bovy <https://github.com/benbovy>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
@@ -50,7 +54,7 @@ Bug fixes
   By `Benoît Bovy <https://github.com/benbovy>`_.
 - Fixed "unhashable type" error trying to read NetCDF file with variable having its 'units'
   attribute not ``str`` (e.g. ``numpy.ndarray``) (:issue:`6368`). By `Oleh Khoma <https://github.com/okhoma>`_.
-- Fixed the poor html repr performance on large multi-indexes (:pull:`5529`).
+- Fixed the poor html repr performance on large multi-indexes (:pull:`6400`).
   By `Benoît Bovy <https://github.com/benbovy>`_.
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -50,6 +50,8 @@ Bug fixes
   By `Benoît Bovy <https://github.com/benbovy>`_.
 - Fixed "unhashable type" error trying to read NetCDF file with variable having its 'units'
   attribute not ``str`` (e.g. ``numpy.ndarray``) (:issue:`6368`). By `Oleh Khoma <https://github.com/okhoma>`_.
+- Fixed the poor html repr performance on large multi-indexes (:pull:`5529`).
+  By `Benoît Bovy <https://github.com/benbovy>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -520,7 +520,11 @@ def short_numpy_repr(array):
 
     # default to lower precision so a full (abbreviated) line can fit on
     # one line with the default display_width
-    options = {"precision": 6, "linewidth": OPTIONS["display_width"], "threshold": 200}
+    options = {
+        "precision": 6,
+        "linewidth": OPTIONS["display_width"],
+        "threshold": OPTIONS["display_values_threshold"],
+    }
     if array.ndim < 3:
         edgeitems = 3
     elif array.ndim == 3:

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -27,13 +27,7 @@ from packaging.version import Version
 from . import duck_array_ops, nputils, utils
 from .npcompat import DTypeLike
 from .options import OPTIONS
-from .pycompat import (
-    dask_array_type,
-    dask_version,
-    integer_types,
-    is_duck_dask_array,
-    sparse_array_type,
-)
+from .pycompat import dask_version, integer_types, is_duck_dask_array, sparse_array_type
 from .types import T_Xarray
 from .utils import either_dict_or_kwargs, get_valid_numpy_dtype
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1516,10 +1516,8 @@ class PandasMultiIndexingAdapter(PandasIndexingAdapter):
 
     def _get_array_subset(self, size: int) -> np.ndarray:
         # used to speed-up the repr for big multi-indexes
-
         if self.size > 200 and size < self.size:
-            n_values = size
-            indices = np.concatenate([np.arange(0, n_values), np.arange(-n_values, 0)])
+            indices = np.concatenate([np.arange(0, size), np.arange(-size, 0)])
             subset = self[OuterIndexer((indices,))]
         else:
             subset = self

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -15,6 +15,7 @@ class T_Options(TypedDict):
     cmap_divergent: Union[str, "Colormap"]
     cmap_sequential: Union[str, "Colormap"]
     display_max_rows: int
+    display_values_threshold: int
     display_style: Literal["text", "html"]
     display_width: int
     display_expand_attrs: Literal["default", True, False]
@@ -33,6 +34,7 @@ OPTIONS: T_Options = {
     "cmap_divergent": "RdBu_r",
     "cmap_sequential": "viridis",
     "display_max_rows": 12,
+    "display_values_threshold": 200,
     "display_style": "html",
     "display_width": 80,
     "display_expand_attrs": "default",
@@ -57,6 +59,7 @@ def _positive_integer(value):
 _VALIDATORS = {
     "arithmetic_join": _JOIN_OPTIONS.__contains__,
     "display_max_rows": _positive_integer,
+    "display_values_threshold": _positive_integer,
     "display_style": _DISPLAY_OPTIONS.__contains__,
     "display_width": _positive_integer,
     "display_expand_attrs": lambda choice: choice in [True, False, "default"],
@@ -154,6 +157,9 @@ class set_options:
         * ``default`` : to expand unless over a pre-defined limit
     display_max_rows : int, default: 12
         Maximum display rows.
+    display_values_threshold : int, default: 200
+        Total number of array elements which trigger summarization rather
+        than full repr for variable data views (numpy arrays).
     display_style : {"text", "html"}, default: "html"
         Display style to use in jupyter for xarray objects.
     display_width : int, default: 80

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -479,6 +479,12 @@ def test_short_numpy_repr() -> None:
         num_lines = formatting.short_numpy_repr(array).count("\n") + 1
         assert num_lines < 30
 
+    # threshold option (default: 200)
+    array = np.arange(100)
+    assert "..." not in formatting.short_numpy_repr(array)
+    with xr.set_options(display_values_threshold=10):
+        assert "..." in formatting.short_numpy_repr(array)
+
 
 def test_large_array_repr_length() -> None:
 


### PR DESCRIPTION
This adds `PandasMultiIndexingAdapter._repr_html_` that can greatly speed-up the html repr of Xarray objects with
multi-indexes.

This optimized `_repr_html_` implementation is now used for formatting the array detailed view of all multi-index coordinates in the html repr, instead of converting the full index and each levels to numpy arrays before formatting them.

```python
import xarray as xr

ds = xr.tutorial.load_dataset("air_temperature")
da = ds["air"].stack(z=[...])

da.shape 

# (3869000,)

%timeit -n 1 -r 1 da._repr_html_()

# 9.96 ms !
```

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #5529
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
