### PR TITLE
use the `DaskIndexingAdapter` for `duck dask` arrays

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -24,7 +24,8 @@ New Features
 
 - Add a ``create_index=True`` parameter to :py:meth:`Dataset.stack` and
   :py:meth:`DataArray.stack` so that the creation of multi-indexes is optional
-  (:pull:`5692`). By `Benoît Bovy <https://github.com/benbovy>`_.
+  (:pull:`5692`).
+  By `Benoît Bovy <https://github.com/benbovy>`_.
 - Multi-index levels are now accessible through their own, regular coordinates
   instead of virtual coordinates (:pull:`5692`).
   By `Benoît Bovy <https://github.com/benbovy>`_.
@@ -33,7 +34,8 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 - The Dataset and DataArray ``rename*`` methods do not implicitly add or drop
-  indexes. (:pull:`5692`). By `Benoît Bovy <https://github.com/benbovy>`_.
+  indexes. (:pull:`5692`).
+  By `Benoît Bovy <https://github.com/benbovy>`_.
 - Many arguments like ``keep_attrs``, ``axis``, and ``skipna`` are now keyword
   only for all reduction operations like ``.mean``.
   By `Deepak Cherian <https://github.com/dcherian>`_, `Jimmy Westling <https://github.com/illviljan>`_.
@@ -47,12 +49,14 @@ Bug fixes
 
 - Set ``skipna=None`` for all ``quantile`` methods (e.g. :py:meth:`Dataset.quantile`) and
   ensure it skips missing values for float dtypes (consistent with other methods). This should
-  not change the behavior (:pull:`6303`). By `Mathias Hauser <https://github.com/mathause>`_.
+  not change the behavior (:pull:`6303`).
+  By `Mathias Hauser <https://github.com/mathause>`_.
 - Many bugs fixed by the explicit indexes refactor, mainly related to multi-index (virtual)
   coordinates. See the corresponding pull-request on GitHub for more details. (:pull:`5692`).
   By `Benoît Bovy <https://github.com/benbovy>`_.
 - Fixed "unhashable type" error trying to read NetCDF file with variable having its 'units'
-  attribute not ``str`` (e.g. ``numpy.ndarray``) (:issue:`6368`). By `Oleh Khoma <https://github.com/okhoma>`_.
+  attribute not ``str`` (e.g. ``numpy.ndarray``) (:issue:`6368`).
+  By `Oleh Khoma <https://github.com/okhoma>`_.
 
 Documentation
 ~~~~~~~~~~~~~
@@ -65,7 +69,6 @@ Internal Changes
   corresponding pull-request on GitHub for more details. (:pull:`5692`).
   By `Benoît Bovy <https://github.com/benbovy>`_.
 
-.. _whats-new.2022.02.0:
 .. _whats-new.2022.03.0:
 
 v2022.03.0 (2 March 2022)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -57,6 +57,8 @@ Bug fixes
 - Fixed "unhashable type" error trying to read NetCDF file with variable having its 'units'
   attribute not ``str`` (e.g. ``numpy.ndarray``) (:issue:`6368`).
   By `Oleh Khoma <https://github.com/okhoma>`_.
+- Allow fancy indexing of duck dask arrays along multiple dimensions. (:pull:`6414`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -25,13 +25,7 @@ from packaging.version import Version
 
 from . import duck_array_ops, nputils, utils
 from .npcompat import DTypeLike
-from .pycompat import (
-    dask_array_type,
-    dask_version,
-    integer_types,
-    is_duck_dask_array,
-    sparse_array_type,
-)
+from .pycompat import dask_version, integer_types, is_duck_dask_array, sparse_array_type
 from .types import T_Xarray
 from .utils import either_dict_or_kwargs, get_valid_numpy_dtype
 
@@ -682,7 +676,7 @@ def as_indexable(array):
         return NumpyIndexingAdapter(array)
     if isinstance(array, pd.Index):
         return PandasIndexingAdapter(array)
-    if isinstance(array, dask_array_type):
+    if is_duck_dask_array(array):
         return DaskIndexingAdapter(array)
     if hasattr(array, "__array_function__"):
         return NdArrayLikeIndexingAdapter(array)

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1837,6 +1837,7 @@ class TestVariable:
 
         assert expected == actual
 
+    @pytest.mark.parametrize("dask", [False, pytest.param(True, marks=[requires_dask])])
     @pytest.mark.parametrize(
         ["variable", "indexers"],
         (
@@ -1862,7 +1863,9 @@ class TestVariable:
             ),
         ),
     )
-    def test_isel(self, variable, indexers, dtype):
+    def test_isel(self, variable, indexers, dask, dtype):
+        if dask:
+            variable = variable.chunk({dim: 2 for dim in variable.dims})
         quantified = xr.Variable(
             variable.dims, variable.data.astype(dtype) * unit_registry.s
         )

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1838,20 +1838,39 @@ class TestVariable:
         assert expected == actual
 
     @pytest.mark.parametrize(
-        "indices",
+        ["variable", "indexers"],
         (
-            pytest.param(4, id="single index"),
-            pytest.param([5, 2, 9, 1], id="multiple indices"),
+            pytest.param(
+                xr.Variable("x", np.linspace(0, 5, 10)),
+                {"x": 4},
+                id="single value–single indexer",
+            ),
+            pytest.param(
+                xr.Variable("x", np.linspace(0, 5, 10)),
+                {"x": [5, 2, 9, 1]},
+                id="multiple values–single indexer",
+            ),
+            pytest.param(
+                xr.Variable(("x", "y"), np.linspace(0, 5, 20).reshape(4, 5)),
+                {"x": 1, "y": 4},
+                id="single value—multiple indexers",
+            ),
+            pytest.param(
+                xr.Variable(("x", "y"), np.linspace(0, 5, 20).reshape(4, 5)),
+                {"x": [0, 1, 2], "y": [0, 2, 4]},
+                id="multiple values—multiple indexers",
+            ),
         ),
     )
-    def test_isel(self, indices, dtype):
-        array = np.linspace(0, 5, 10).astype(dtype) * unit_registry.s
-        variable = xr.Variable("x", array)
+    def test_isel(self, variable, indexers, dtype):
+        quantified = xr.Variable(
+            variable.dims, variable.data.astype(dtype) * unit_registry.s
+        )
 
         expected = attach_units(
-            strip_units(variable).isel(x=indices), extract_units(variable)
+            strip_units(quantified).isel(indexers), extract_units(quantified)
         )
-        actual = variable.isel(x=indices)
+        actual = quantified.isel(indexers)
 
         assert_units_equal(expected, actual)
         assert_identical(expected, actual)

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -31,7 +31,7 @@ DimensionalityError = pint.errors.DimensionalityError
 
 # make sure scalars are converted to 0d arrays so quantities can
 # always be treated like ndarrays
-unit_registry = pint.UnitRegistry(force_ndarray=True)
+unit_registry = pint.UnitRegistry(force_ndarray_like=True)
 Quantity = unit_registry.Quantity
 
 

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1843,22 +1843,22 @@ class TestVariable:
             pytest.param(
                 xr.Variable("x", np.linspace(0, 5, 10)),
                 {"x": 4},
-                id="single value–single indexer",
+                id="single value-single indexer",
             ),
             pytest.param(
                 xr.Variable("x", np.linspace(0, 5, 10)),
                 {"x": [5, 2, 9, 1]},
-                id="multiple values–single indexer",
+                id="multiple values-single indexer",
             ),
             pytest.param(
                 xr.Variable(("x", "y"), np.linspace(0, 5, 20).reshape(4, 5)),
                 {"x": 1, "y": 4},
-                id="single value—multiple indexers",
+                id="single value-multiple indexers",
             ),
             pytest.param(
                 xr.Variable(("x", "y"), np.linspace(0, 5, 20).reshape(4, 5)),
                 {"x": [0, 1, 2], "y": [0, 2, 4]},
-                id="multiple values—multiple indexers",
+                id="multiple values-multiple indexers",
             ),
         ),
     )


### PR DESCRIPTION
(detected while trying to implement a `PintMetaIndex` in xarray-contrib/pint-xarray#163)

This fixes position-based indexing of `duck dask arrays`:
``` python

In [1]: import xarray as xr
   ...: impIn [1]: import xarray as xr
   ...: import dask.array as da
   ...: import pint
   ...: 
   ...: ureg = pint.UnitRegistry(force_ndarray_like=True)
   ...: 
   ...: a = da.zeros((20, 20), chunks=(10, 10))
   ...: q = ureg.Quantity(a, "m")
   ...: 
   ...: arr1 = xr.DataArray(a, dims=("x", "y"))
   ...: arr2 = xr.DataArray(q, dims=("x", "y"))

In [2]: arr1.isel(x=[0, 2, 4], y=[1, 3, 5])
Out[2]: 
<xarray.DataArray 'zeros_like-d81259c3a77e6dff3e60975e2afe4ff9' (x: 3, y: 3)>
dask.array<getitem, shape=(3, 3), dtype=float64, chunksize=(3, 3), chunktype=numpy.ndarray>
Dimensions without coordinates: x, y

In [3]: arr2.isel(x=[0, 2, 4], y=[1, 3, 5])
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
Input In [3], in <module>
----> 1 arr2.isel(x=[0, 2, 4], y=[1, 3, 5])

File .../xarray/core/dataarray.py:1220, in DataArray.isel(self, indexers, drop, missing_dims, **indexers_kwargs)
   1215     return self._from_temp_dataset(ds)
   1217 # Much faster algorithm for when all indexers are ints, slices, one-dimensional
   1218 # lists, or zero or one-dimensional np.ndarray's
-> 1220 variable = self._variable.isel(indexers, missing_dims=missing_dims)
   1221 indexes, index_variables = isel_indexes(self.xindexes, indexers)
   1223 coords = {}

File .../xarray/core/variable.py:1172, in Variable.isel(self, indexers, missing_dims, **indexers_kwargs)
   1169 indexers = drop_dims_from_indexers(indexers, self.dims, missing_dims)
   1171 key = tuple(indexers.get(dim, slice(None)) for dim in self.dims)
-> 1172 return self[key]

File .../xarray/core/variable.py:765, in Variable.__getitem__(self, key)
    752 """Return a new Variable object whose contents are consistent with
    753 getting the provided key from the underlying data.
    754 
   (...)
    762 array `x.values` directly.
    763 """
    764 dims, indexer, new_order = self._broadcast_indexes(key)
--> 765 data = as_indexable(self._data)[indexer]
    766 if new_order:
    767     data = np.moveaxis(data, range(len(new_order)), new_order)

File .../xarray/core/indexing.py:1269, in NumpyIndexingAdapter.__getitem__(self, key)
   1267 def __getitem__(self, key):
   1268     array, key = self._indexing_array_and_key(key)
-> 1269     return array[key]

File .../lib/python3.9/site-packages/pint/quantity.py:1899, in Quantity.__getitem__(self, key)
   1897 def __getitem__(self, key):
   1898     try:
-> 1899         return type(self)(self._magnitude[key], self._units)
   1900     except PintTypeError:
   1901         raise

File .../lib/python3.9/site-packages/dask/array/core.py:1892, in Array.__getitem__(self, index)
   1889     return self
   1891 out = "getitem-" + tokenize(self, index2)
-> 1892 dsk, chunks = slice_array(out, self.name, self.chunks, index2, self.itemsize)
   1894 graph = HighLevelGraph.from_collections(out, dsk, dependencies=[self])
   1896 meta = meta_from_array(self._meta, ndim=len(chunks))

File .../lib/python3.9/site-packages/dask/array/slicing.py:174, in slice_array(out_name, in_name, blockdims, index, itemsize)
    171 index += (slice(None, None, None),) * missing
    173 # Pass down to next function
--> 174 dsk_out, bd_out = slice_with_newaxes(out_name, in_name, blockdims, index, itemsize)
    176 bd_out = tuple(map(tuple, bd_out))
    177 return dsk_out, bd_out

File .../lib/python3.9/site-packages/dask/array/slicing.py:196, in slice_with_newaxes(out_name, in_name, blockdims, index, itemsize)
    193         where_none[i] -= n
    195 # Pass down and do work
--> 196 dsk, blockdims2 = slice_wrap_lists(out_name, in_name, blockdims, index2, itemsize)
    198 if where_none:
    199     expand = expander(where_none)

File .../lib/python3.9/site-packages/dask/array/slicing.py:242, in slice_wrap_lists(out_name, in_name, blockdims, index, itemsize)
    238 where_list = [
    239     i for i, ind in enumerate(index) if is_arraylike(ind) and ind.ndim > 0
    240 ]
    241 if len(where_list) > 1:
--> 242     raise NotImplementedError("Don't yet support nd fancy indexing")
    243 # Is the single list an empty list? In this case just treat it as a zero
    244 # length slice
    245 if where_list and not index[where_list[0]].size:

NotImplementedError: Don't yet support nd fancy indexing
```

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`