### PR TITLE
unpin `jinja2`

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -13,7 +13,6 @@ dependencies:
   - ipykernel
   - ipython
   - iris>=2.3
-  - jinja2<3.1  # remove once nbconvert fixed the use of removed functions
   - jupyter_client
   - matplotlib-base
   - nbsphinx


### PR DESCRIPTION
`nbconvert` released a fixed version today, so we can remove the pin of `jinja2`.

- [x] Follow-up to #6415