### PR TITLE
Accessing the Exception message via e.args[0]

### DIFF
--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -86,7 +86,8 @@ def _open_scipy_netcdf(filename, mode, mmap, version):
             )
         except TypeError as e:
             # TODO: gzipped loading only works with NetCDF3 files.
-            if "is not a valid NetCDF 3 file" in e.message:
+            errmsg = e.args[0]
+            if "is not a valid NetCDF 3 file" in errmsg:
                 raise ValueError("gzipped file loading only supports NetCDF 3 files.")
             else:
                 raise


### PR DESCRIPTION
Very small fix.
When opening gz files, in the case of the TypeError exception, another exception would be raised:
AttributeError: 'TypeError' object has no attribute 'message'

As python 3 exceptions have no attribute message, I replace it for e.args[0] following the pattern a few lines below.


