### PR TITLE
Suggest `.drop_vars` rather than `.drop`

### DIFF
--- a/doc/user-guide/plotting.rst
+++ b/doc/user-guide/plotting.rst
@@ -251,7 +251,7 @@ Finally, if a dataset does not have any coordinates it enumerates all data point
 .. ipython:: python
     :okwarning:
 
-    air1d_multi = air1d_multi.drop(["date", "time", "decimal_day"])
+    air1d_multi = air1d_multi.drop_vars(["date", "time", "decimal_day"])
     air1d_multi.plot()
 
 The same applies to 2D plots below.

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1273,7 +1273,7 @@ def _validate_region(ds, region):
             f"{list(region.keys())}, but that is not "
             f"the case for some variables here. To drop these variables "
             f"from this dataset before exporting to zarr, write: "
-            f".drop({non_matching_vars!r})"
+            f".drop_vars({non_matching_vars!r})"
         )
 
 


### PR DESCRIPTION
Small tweak since I just saw this error message
