### PR TITLE
Fix `xr.where(..., keep_attrs=True)` bug

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -73,6 +73,8 @@ Bug fixes
 - In the API for backends, support dimensions that express their preferred chunk sizes
   as a tuple of integers. (:issue:`6333`, :pull:`6334`)
   By `Stan West <https://github.com/stanwest>`_.
+- Fix bug in :py:func:`where` when passing non-xarray objects with ``keep_attrs=True``. (:issue:`6444`, :pull:`6461`)
+  By `Sam Levang <https://github.com/slevang>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1825,11 +1825,10 @@ def where(cond, x, y, keep_attrs=None):
     """
     if keep_attrs is None:
         keep_attrs = _get_keep_attrs(default=False)
-
-    if keep_attrs is True and hasattr(x, "attrs"):
+    if keep_attrs is True:
         # keep the attributes of x, the second parameter, by default to
         # be consistent with the `where` method of `DataArray` and `Dataset`
-        keep_attrs = lambda attrs, context: attrs[1]
+        keep_attrs = lambda attrs, context: getattr(x, "attrs", {})
 
     # alignment for three arguments is complicated, so don't support it yet
     return apply_ufunc(

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1826,7 +1826,7 @@ def where(cond, x, y, keep_attrs=None):
     if keep_attrs is None:
         keep_attrs = _get_keep_attrs(default=False)
 
-    if keep_attrs is True:
+    if keep_attrs is True and hasattr(x, "attrs"):
         # keep the attributes of x, the second parameter, by default to
         # be consistent with the `where` method of `DataArray` and `Dataset`
         keep_attrs = lambda attrs, context: attrs[1]

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -1928,6 +1928,10 @@ def test_where_attrs() -> None:
     expected = xr.DataArray([1, 0], dims="x", attrs={"attr": "x"})
     assert_identical(expected, actual)
 
+    # ensure keep_attrs can handle scalar values
+    actual = xr.where(cond, 1, 0, keep_attrs=True)
+    assert actual.attrs == {}
+
 
 @pytest.mark.parametrize("use_dask", [True, False])
 @pytest.mark.parametrize("use_datetime", [True, False])


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #6444
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Fixes a bug introduced by #4687 where passing a non-xarray object to `x` in `xr.where(cond, x, y, keep_attrs=True)` caused a failure. The `keep_attrs` callable passed to `merge_attrs()` tries to access the attributes of `x` which do not exist in this case. This fix just checks to make sure `x` has attributes, and if not will pass through `keep_attrs=True`.