### PR TITLE
Try waking up stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 700  # start with a large number and reduce shortly
+daysUntilStale: 600 # start with a large number and reduce shortly
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
@@ -31,6 +31,9 @@ markComment: |
 
   If this issue remains relevant, please comment here or remove the `stale` label; otherwise it will be marked as closed automatically
 
+closeComment: |
+  The stalebot didn't hear anything for a while, so it closed this. Please reopen if this is still an issue.
+
 # Comment to post when removing the stale label.
 # unmarkComment: >
 #   Your comment here.
@@ -40,8 +43,7 @@ markComment: |
 #   Your comment here.
 
 # Limit the number of actions per hour, from 1-30. Default is 30
-limitPerRun: 1  # start with a small number
-
+limitPerRun: 2 # start with a small number
 
 # Limit to only `issues` or `pulls`
 # only: issues


### PR DESCRIPTION
We're almost at the 1000 mark of issues, and when browsing I see a non-trivial number that look stale. I'm not sure why stalebot doesn't seem to be awake; I'll try this and see if it helps
