### PR TITLE
Add xarray-einstats to ecosystem page

### DIFF
--- a/doc/ecosystem.rst
+++ b/doc/ecosystem.rst
@@ -74,6 +74,7 @@ Extend xarray capabilities
 - `nxarray <https://github.com/nxarray/nxarray>`_: NeXus input/output capability for xarray.
 - `xarray-compare <https://github.com/astropenguin/xarray-compare>`_: xarray extension for data comparison.
 - `xarray-dataclasses <https://github.com/astropenguin/xarray-dataclasses>`_: xarray extension for typed DataArray and Dataset creation.
+- `xarray_einstats <https://xarray-einstats.readthedocs.io>`_: Statistics, linear algebra and einops for xarray
 - `xarray_extras <https://github.com/crusaderky/xarray_extras>`_: Advanced algorithms for xarray objects (e.g. integrations/interpolations).
 - `xpublish <https://xpublish.readthedocs.io/>`_: Publish Xarray Datasets via a Zarr compatible REST API.
 - `xrft <https://github.com/rabernat/xrft>`_: Fourier transforms for xarray data.


### PR DESCRIPTION
Adds a mention of [xarray-einstats](https://xarray-einstats.readthedocs.io/en/latest/) to the ecosystem page. Related to #3322.
