### PR TITLE
Support **kwargs form in `.chunk()`

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 700  # start with a large number and reduce shortly
+daysUntilStale: 600 # start with a large number and reduce shortly
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
@@ -31,6 +31,9 @@ markComment: |
 
   If this issue remains relevant, please comment here or remove the `stale` label; otherwise it will be marked as closed automatically
 
+closeComment: |
+  The stalebot didn't hear anything for a while, so it closed this. Please reopen if this is still an issue.
+
 # Comment to post when removing the stale label.
 # unmarkComment: >
 #   Your comment here.
@@ -40,8 +43,7 @@ markComment: |
 #   Your comment here.
 
 # Limit the number of actions per hour, from 1-30. Default is 30
-limitPerRun: 1  # start with a small number
-
+limitPerRun: 2 # start with a small number
 
 # Limit to only `issues` or `pulls`
 # only: issues

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,6 +36,9 @@ New Features
   elements which trigger summarization rather than full repr in (numpy) array
   detailed views of the html repr (:pull:`6400`).
   By `Benoît Bovy <https://github.com/benbovy>`_.
+- Allow passing chunks in **kwargs form to :py:meth:`Dataset.chunk`, :py:meth:`DataArray.chunk`, and
+  :py:meth:`Variable.chunk`. (:pull:`6471`)
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1146,6 +1146,14 @@ class DataArray(
         -------
         chunked : xarray.DataArray
         """
+        if chunks is None:
+            warnings.warn(
+                "None value for 'chunks' is deprecated. "
+                "It will raise an error in the future. Use instead '{}'",
+                category=FutureWarning,
+            )
+            chunks = {}
+
         if isinstance(chunks, (Number, str, int)):
             chunks = dict.fromkeys(self.dims, chunks)
         elif isinstance(chunks, (tuple, list)):

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1159,7 +1159,6 @@ class DataArray(
         elif isinstance(chunks, (tuple, list)):
             chunks = dict(zip(self.dims, chunks))
         else:
-            chunks = None if chunks == {} else chunks
             chunks = either_dict_or_kwargs(chunks, chunks_kwargs, "chunk")
 
         ds = self._to_temp_dataset().chunk(

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import warnings
-from numbers import Number
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2043,7 +2043,6 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
         if isinstance(chunks, (Number, str, int)):
             chunks = dict.fromkeys(self.dims, chunks)
         else:
-            chunks = None if chunks == {} else chunks
             chunks = either_dict_or_kwargs(chunks, chunks_kwargs, "chunk")
 
         bad_dims = chunks.keys() - self.dims.keys()

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -266,7 +266,7 @@ def either_dict_or_kwargs(
     kw_kwargs: Mapping[str, T],
     func_name: str,
 ) -> Mapping[Hashable, T]:
-    if pos_kwargs is None:
+    if pos_kwargs is None or pos_kwargs == {}:
         # Need an explicit cast to appease mypy due to invariance; see
         # https://github.com/python/mypy/issues/6228
         return cast(Mapping[Hashable, T], kw_kwargs)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -5,7 +5,7 @@ import itertools
 import numbers
 import warnings
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Hashable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Hashable, Literal, Mapping, Sequence
 
 import numpy as np
 import pandas as pd
@@ -1012,7 +1012,19 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
 
     _array_counter = itertools.count()
 
-    def chunk(self, chunks={}, name=None, lock=False):
+    def chunk(
+        self,
+        chunks: (
+            int
+            | Literal["auto"]
+            | tuple[int, ...]
+            | tuple[tuple[int, ...], ...]
+            | Mapping[Any, None | int | tuple[int, ...]]
+        ) = {},
+        name: str = None,
+        lock: bool = False,
+        **chunks_kwargs: Any,
+    ) -> Variable:
         """Coerce this array's data into a dask array with the given chunks.
 
         If this variable is a non-dask array, it will be converted to dask
@@ -1034,6 +1046,9 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         lock : optional
             Passed on to :py:func:`dask.array.from_array`, if the array is not
             already as dask array.
+        **chunks_kwargs : {dim: chunks, ...}, optional
+            The keyword arguments form of ``chunks``.
+            One of chunks or chunks_kwargs must be provided.
 
         Returns
         -------
@@ -1048,6 +1063,12 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
                 category=FutureWarning,
             )
             chunks = {}
+
+        if isinstance(chunks, (numbers.Number, str, int, tuple, list)):
+            pass  # dask.array.from_array can handle these directly
+        else:
+            chunks = None if chunks == {} else chunks
+            chunks = either_dict_or_kwargs(chunks, chunks_kwargs, "chunk")
 
         if utils.is_dict_like(chunks):
             chunks = {self.get_axis_num(dim): chunk for dim, chunk in chunks.items()}

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1064,7 +1064,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
             )
             chunks = {}
 
-        if isinstance(chunks, (numbers.Number, str, int, tuple, list)):
+        if isinstance(chunks, (float, str, int, tuple, list)):
             pass  # dask.array.from_array can handle these directly
         else:
             chunks = either_dict_or_kwargs(chunks, chunks_kwargs, "chunk")

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1067,7 +1067,6 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         if isinstance(chunks, (numbers.Number, str, int, tuple, list)):
             pass  # dask.array.from_array can handle these directly
         else:
-            chunks = None if chunks == {} else chunks
             chunks = either_dict_or_kwargs(chunks, chunks_kwargs, "chunk")
 
         if utils.is_dict_like(chunks):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -804,6 +804,11 @@ class TestDataArray:
         assert isinstance(blocked.data, da.Array)
         assert "testname_" in blocked.data.name
 
+        # test kwargs form of chunks
+        blocked = unblocked.chunk(dim_0=3, dim_1=3)
+        assert blocked.chunks == ((3,), (3, 1))
+        assert blocked.data.name != first_dask_name
+
     def test_isel(self):
         assert_identical(self.dv[0], self.dv.isel(x=0))
         assert_identical(self.dv, self.dv.isel(x=slice(None)))

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -921,6 +921,9 @@ class TestDataset:
         expected_chunks = {"dim1": (8,), "dim2": (9,), "dim3": (10,)}
         assert reblocked.chunks == expected_chunks
 
+        # test kwargs form of chunks
+        assert data.chunk(**expected_chunks).chunks == expected_chunks
+
         def get_dask_names(ds):
             return {k: v.data.name for k, v in ds.items()}
 
@@ -947,12 +950,13 @@ class TestDataset:
         new_dask_names = get_dask_names(reblocked)
         assert reblocked.chunks == expected_chunks
         assert_identical(reblocked, data)
-        # recuhnking with same chunk sizes should not change names
+        # rechunking with same chunk sizes should not change names
         for k, v in new_dask_names.items():
             assert v == orig_dask_names[k]
 
         with pytest.raises(ValueError, match=r"some chunks"):
             data.chunk({"foo": 10})
+
 
     @requires_dask
     def test_dask_is_lazy(self):

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -2183,6 +2183,11 @@ class TestVariableWithDask(VariableSubclassobjects):
         assert isinstance(blocked.data, da.Array)
         assert "testname_" in blocked.data.name
 
+        # test kwargs form of chunks
+        blocked = unblocked.chunk(dim_0=3, dim_1=3)
+        assert blocked.chunks == ((3,), (3, 1))
+        assert blocked.data.name != first_dask_name
+
     @pytest.mark.xfail
     def test_0d_object_array_with_list(self):
         super().test_0d_object_array_with_list()


### PR DESCRIPTION
Also adds some explicit tests (and type hinting) for `Variable.chunk()`, as I don't think it had dedicated tests before.

- [x] Closes #6459
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
