### PR TITLE
Ensure datetime-like variables are left unmodified by `decode_cf_variable`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -85,8 +85,8 @@ Bug fixes
   By `Michael Delgado <https://github.com/delgadom>`_.
 - Ensure dtype encoding attributes are not added or modified on variables that
   contain datetime-like values prior to being passed to
-  :py:func:`xarray.conventions.decode_cf_variable` (:issue:`6453`, :pull:``).
-  By `Spencer Clark <https://github.com/spencerkclark>`_.
+  :py:func:`xarray.conventions.decode_cf_variable` (:issue:`6453`,
+  :pull:`6489`). By `Spencer Clark <https://github.com/spencerkclark>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -83,6 +83,10 @@ Bug fixes
 - Allow passing both ``other`` and ``drop=True`` arguments to ``xr.DataArray.where``
   and ``xr.Dataset.where`` (:pull:`6466`, :pull:`6467`).
   By `Michael Delgado <https://github.com/delgadom>`_.
+- Ensure dtype encoding attributes are not added or modified on variables that
+  contain datetime-like values prior to being passed to
+  :py:func:`xarray.conventions.decode_cf_variable` (:issue:`6453`, :pull:``).
+  By `Spencer Clark <https://github.com/spencerkclark>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -7,7 +7,7 @@ import pandas as pd
 from .coding import strings, times, variables
 from .coding.variables import SerializationWarning, pop_to
 from .core import duck_array_ops, indexing
-from .core.common import contains_cftime_datetimes
+from .core.common import _contains_datetime_like_objects, contains_cftime_datetimes
 from .core.pycompat import is_duck_dask_array
 from .core.variable import IndexVariable, Variable, as_variable
 
@@ -340,6 +340,11 @@ def decode_cf_variable(
         A variable holding the decoded equivalent of var.
     """
     var = as_variable(var)
+
+    # Ensure datetime-like Variables are passed through unmodified (GH 6453)
+    if _contains_datetime_like_objects(var):
+        return var
+
     original_dtype = var.dtype
 
     if decode_timedelta is None:

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1862,7 +1862,10 @@ def _contains_cftime_datetimes(array) -> bool:
 
 def contains_cftime_datetimes(var) -> bool:
     """Check if an xarray.Variable contains cftime.datetime objects"""
-    return _contains_cftime_datetimes(var.data)
+    if var.dtype == np.dtype("O") and var.size > 0:
+        return _contains_cftime_datetimes(var.data)
+    else:
+        return False
 
 
 def _contains_datetime_like_objects(var) -> bool:

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -9,6 +9,7 @@ from xarray import (
     Dataset,
     SerializationWarning,
     Variable,
+    cftime_range,
     coding,
     conventions,
     open_dataset,
@@ -442,3 +443,22 @@ class TestDecodeCFVariableWithArrayUnits:
         v = Variable(["t"], [1, 2, 3], {"units": np.array(["foobar"], dtype=object)})
         v_decoded = conventions.decode_cf_variable("test2", v)
         assert_identical(v, v_decoded)
+
+
+def test_decode_cf_variable_timedelta64():
+    variable = Variable(["time"], pd.timedelta_range("1D", periods=2))
+    decoded = conventions.decode_cf_variable("time", variable)
+    assert decoded.encoding == {}
+
+
+def test_decode_cf_variable_datetime64():
+    variable = Variable(["time"], pd.date_range("2000", periods=2))
+    decoded = conventions.decode_cf_variable("time", variable)
+    assert decoded.encoding == {}
+
+
+@requires_cftime
+def test_decode_cf_variable_cftime():
+    variable = Variable(["time"], cftime_range("2000", periods=2))
+    decoded = conventions.decode_cf_variable("time", variable)
+    assert decoded.encoding == {}

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -449,12 +449,14 @@ def test_decode_cf_variable_timedelta64():
     variable = Variable(["time"], pd.timedelta_range("1D", periods=2))
     decoded = conventions.decode_cf_variable("time", variable)
     assert decoded.encoding == {}
+    assert_identical(decoded, variable)
 
 
 def test_decode_cf_variable_datetime64():
     variable = Variable(["time"], pd.date_range("2000", periods=2))
     decoded = conventions.decode_cf_variable("time", variable)
     assert decoded.encoding == {}
+    assert_identical(decoded, variable)
 
 
 @requires_cftime
@@ -462,3 +464,4 @@ def test_decode_cf_variable_cftime():
     variable = Variable(["time"], cftime_range("2000", periods=2))
     decoded = conventions.decode_cf_variable("time", variable)
     assert decoded.encoding == {}
+    assert_identical(decoded, variable)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

It seems rare that `decode_cf_variable` would be called on variables that contain datetime-like objects already, but in the case that it is, it seems best to let those variables pass through unmodified.

- [x] Closes #6453
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`