### PR TITLE
Add link to xarray binder to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ powerful and concise interface. For example:
 Documentation
 -------------
 
-Learn more about xarray in its official documentation at https://docs.xarray.dev/. 
+Learn more about xarray in its official documentation at https://docs.xarray.dev/.
 
 Try out an `interactive Jupyter notebook <https://mybinder.org/v2/gh/pydata/xarray/main?urlpath=lab/tree/doc/examples/weather-data.ipynb>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,9 @@ powerful and concise interface. For example:
 Documentation
 -------------
 
-Learn more about xarray in its official documentation at https://docs.xarray.dev/
+Learn more about xarray in its official documentation at https://docs.xarray.dev/. 
+
+Try out an `interactive Jupyter notebook <https://mybinder.org/v2/gh/pydata/xarray/main?urlpath=lab/tree/doc/examples/weather-data.ipynb>`_.
 
 Contributing
 ------------


### PR DESCRIPTION
I'm not sure this is the best place to put a link, but binder is great,
and we could advertise it more prominently (I couldn't find a hit to
`binder` in the docs either — probably it's under something else?). Any
thoughts on how to do that?

Just now, my M1 Mac seems to have its netcdf installation failing, so I used this
to repro an example — very fast & easy!

