### PR TITLE
Use new importlib.metadata.entry_points interface where available

### DIFF
--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -1,6 +1,7 @@
 import functools
 import inspect
 import itertools
+import sys
 import warnings
 from importlib.metadata import entry_points
 
@@ -95,7 +96,11 @@ def build_engines(entrypoints):
 
 @functools.lru_cache(maxsize=1)
 def list_engines():
-    entrypoints = entry_points().get("xarray.backends", ())
+    # New selection mechanism introduced with Python 3.10. See GH6514.
+    if sys.version_info >= (3, 10):
+        entrypoints = entry_points(group="xarray.backends")
+    else:
+        entrypoints = entry_points().get("xarray.backends", ())
     return build_engines(entrypoints)
 
 


### PR DESCRIPTION
With Python 3.10, the entry_points() method returning a SelectableGroups dict interface was deprecated. The preferred way is to now filter by group through a keyword argument.

- [x] Closes #6514.
