### PR TITLE
Restrict annotations to a single run in GHA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
       # We only want to install this on one run, because otherwise we'll have
       # duplicate annotations.
       - name: Install error reporter
-        if: ${{ matrix.os }} == 'ubuntu-latest' and ${{ python-version }} == '3.10'
+        if: ${{ matrix.os }} == 'ubuntu-latest' and ${{ matrix.python-version }} == '3.10'
         run: |
           python -m pip install pytest-github-actions-annotate-failures
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,11 @@ jobs:
         run: |
           mamba env update -f $CONDA_ENV_FILE
 
+      # We only want to install this on one run, because otherwise we'll have
+      # duplicate annotations.
+      - name: Install error reporter
+        if: ${{ matrix.os }} == 'ubuntu-latest' and ${{ python-version }} == '3.10'
+
       - name: Install xarray
         run: |
           python -m pip install --no-deps -e .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,8 @@ jobs:
       # duplicate annotations.
       - name: Install error reporter
         if: ${{ matrix.os }} == 'ubuntu-latest' and ${{ python-version }} == '3.10'
+        run: |
+          python -m pip install pytest-github-actions-annotate-failures
 
       - name: Install xarray
         run: |

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -37,7 +37,6 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-env
-  - pytest-github-actions-annotate-failures
   - pytest-xdist
   - rasterio
   - scipy


### PR DESCRIPTION
Currently we get a lot of duplicates:

<img width="1036" alt="image" src="https://user-images.githubusercontent.com/5635139/165658310-947342c6-dea4-4a01-b2f6-b3a7264c981e.png">
