### PR TITLE
Revert "Attempt to improve CI caching"

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -69,7 +69,6 @@ jobs:
           else
             echo "CONDA_ENV_FILE=ci/requirements/${{ matrix.env }}.yml" >> $GITHUB_ENV
           fi
-
       - name: Cache conda
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,15 +82,12 @@ jobs:
 
           echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
 
-        # This and the next few are based on https://github.com/conda-incubator/setup-miniconda#caching-environments
       - name: Cache conda
-        id: cache-conda
         uses: actions/cache@v3
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-py${{ matrix.python-version }}-${{
             hashFiles('ci/requirements/**.yml') }}
-
       - uses: conda-incubator/setup-miniconda@v2
         with:
           channels: conda-forge
@@ -101,18 +98,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           use-only-tar-bz2: true
 
-      - name: Cache conda env
-        id: cache-env
-        uses: actions/cache@v3
-        with:
-          path: /usr/share/miniconda/envs/xarray-tests
-          key: ${{ runner.os }}-conda-py${{ matrix.python-version }}-${{
-            hashFiles('ci/requirements/**.yml') }}
-
       - name: Install conda dependencies
         run: |
           mamba env update -f $CONDA_ENV_FILE
-        if: steps.cache-env.outputs.cache-hit != 'true'
 
       # We only want to install this on one run, because otherwise we'll have
       # duplicate annotations.


### PR DESCRIPTION
Unfortunately this seems to have failed in https://github.com/pydata/xarray/runs/6232061193?check_suite_focus=true — the cache seems to have thought it was hit, but there's nothing in the cache, so it didn't install dependencies

<img width="908" alt="image" src="https://user-images.githubusercontent.com/5635139/166005581-74a4f07f-c7f5-49db-ac12-dd06d681de1a.png">

To ensure nothing is blocked, I'm reverting this — fast merges and fast reverts make for a good combo. I'll try and figure it out (but will be out for a few days so likely not until then — though if anyone can see the problem and wants to have a go, please feel free to go ahead)

Reverts pydata/xarray#6534