### PR TITLE
Fix Dataset/DataArray.isel with drop=True and scalar DataArray indexes

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -119,6 +119,9 @@ Bug fixes
   :pull:`6489`). By `Spencer Clark <https://github.com/spencerkclark>`_.
 - Dark themes are now properly detected in Furo-themed Sphinx documents (:issue:`6500`, :pull:`6501`).
   By `Kevin Paul <https://github.com/kmpaul>`_.
+- :py:meth:`isel` with `drop=True` works as intended with scalar :py:class:`DataArray` indexers.
+  (:issue:`6554`, :pull:`6579`)
+  By `Michael Niklas <https://github.com/headtr1ck>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -44,6 +44,7 @@ New Features
 - :py:meth:`xr.polyval` now supports :py:class:`Dataset` and :py:class:`DataArray` args of any shape,
   is faster and requires less memory. (:pull:`6548`)
   By `Michael Niklas <https://github.com/headtr1ck>`_.
+- Improved overall typing.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2334,7 +2334,7 @@ class DataArray(
         self,
         *dims: Hashable,
         transpose_coords: bool = True,
-        missing_dims: str = "raise",
+        missing_dims: ErrorChoiceWithWarn = "raise",
     ) -> DataArray:
         """Return a new DataArray object with transposed dimensions.
 
@@ -2393,8 +2393,8 @@ class DataArray(
         ----------
         names : hashable or iterable of hashable
             Name(s) of variables to drop.
-        errors : {"raise", "ignore"}, optional
-            If 'raise' (default), raises a ValueError error if any of the variable
+        errors : {"raise", "ignore"}, default: "raise"
+            If 'raise', raises a ValueError error if any of the variable
             passed are not in the dataset. If 'ignore', any given names that are in the
             DataArray are dropped and no error is raised.
 
@@ -2411,7 +2411,7 @@ class DataArray(
         labels: Mapping = None,
         dim: Hashable = None,
         *,
-        errors: str = "raise",
+        errors: ErrorChoice = "raise",
         **labels_kwargs,
     ) -> DataArray:
         """Backward compatible method based on `drop_vars` and `drop_sel`
@@ -2430,7 +2430,7 @@ class DataArray(
         self,
         labels: Mapping[Any, Any] = None,
         *,
-        errors: str = "raise",
+        errors: ErrorChoice = "raise",
         **labels_kwargs,
     ) -> DataArray:
         """Drop index labels from this DataArray.
@@ -2439,8 +2439,8 @@ class DataArray(
         ----------
         labels : mapping of hashable to Any
             Index labels to drop
-        errors : {"raise", "ignore"}, optional
-            If 'raise' (default), raises a ValueError error if
+        errors : {"raise", "ignore"}, default: "raise"
+            If 'raise', raises a ValueError error if
             any of the index labels passed are not
             in the dataset. If 'ignore', any given labels that are in the
             dataset are dropped and no error is raised.

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -77,7 +77,7 @@ if TYPE_CHECKING:
     except ImportError:
         iris_Cube = None
 
-    from .types import T_DataArray, T_Xarray
+    from .types import T_DataArray, T_Xarray, ErrorChoice, ErrorChoiceWithWarn
 
 
 def _infer_coords_and_dims(
@@ -1170,7 +1170,7 @@ class DataArray(
         self,
         indexers: Mapping[Any, Any] = None,
         drop: bool = False,
-        missing_dims: str = "raise",
+        missing_dims: ErrorChoiceWithWarn = "raise",
         **indexers_kwargs: Any,
     ) -> DataArray:
         """Return a new DataArray whose data is given by integer indexing
@@ -1185,7 +1185,7 @@ class DataArray(
             If DataArrays are passed as indexers, xarray-style indexing will be
             carried out. See :ref:`indexing` for the details.
             One of indexers or indexers_kwargs must be provided.
-        drop : bool, optional
+        drop : bool, default False
             If ``drop=True``, drop coordinates variables indexed by integers
             instead of making them scalar.
         missing_dims : {"raise", "warn", "ignore"}, default: "raise"
@@ -2385,7 +2385,7 @@ class DataArray(
         return self.transpose()
 
     def drop_vars(
-        self, names: Hashable | Iterable[Hashable], *, errors: str = "raise"
+        self, names: Hashable | Iterable[Hashable], *, errors: ErrorChoice = "raise"
     ) -> DataArray:
         """Returns an array with dropped variables.
 
@@ -4586,7 +4586,7 @@ class DataArray(
         queries: Mapping[Any, Any] = None,
         parser: str = "pandas",
         engine: str = None,
-        missing_dims: str = "raise",
+        missing_dims: ErrorChoiceWithWarn = "raise",
         **queries_kwargs: Any,
     ) -> DataArray:
         """Return a new data array indexed along the specified

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -77,7 +77,7 @@ if TYPE_CHECKING:
     except ImportError:
         iris_Cube = None
 
-    from .types import T_DataArray, T_Xarray, ErrorChoice, ErrorChoiceWithWarn
+    from .types import ErrorChoice, ErrorChoiceWithWarn, T_DataArray, T_Xarray
 
 
 def _infer_coords_and_dims(

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1185,7 +1185,7 @@ class DataArray(
             If DataArrays are passed as indexers, xarray-style indexing will be
             carried out. See :ref:`indexing` for the details.
             One of indexers or indexers_kwargs must be provided.
-        drop : bool, default False
+        drop : bool, default: False
             If ``drop=True``, drop coordinates variables indexed by integers
             instead of making them scalar.
         missing_dims : {"raise", "warn", "ignore"}, default: "raise"

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -105,7 +105,7 @@ if TYPE_CHECKING:
     from ..backends import AbstractDataStore, ZarrStore
     from .dataarray import DataArray
     from .merge import CoercibleMapping
-    from .types import T_Xarray
+    from .types import T_Xarray, ErrorChoiceWithWarn
 
     try:
         from dask.delayed import Delayed
@@ -2163,7 +2163,7 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
         self,
         indexers: Mapping[Any, Any] = None,
         drop: bool = False,
-        missing_dims: str = "raise",
+        missing_dims: ErrorChoiceWithWarn = "raise",
         **indexers_kwargs: Any,
     ) -> Dataset:
         """Returns a new dataset with each array indexed along the specified
@@ -2182,14 +2182,14 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
             If DataArrays are passed as indexers, xarray-style indexing will be
             carried out. See :ref:`indexing` for the details.
             One of indexers or indexers_kwargs must be provided.
-        drop : bool, optional
+        drop : bool, default False
             If ``drop=True``, drop coordinates variables indexed by integers
             instead of making them scalar.
         missing_dims : {"raise", "warn", "ignore"}, default: "raise"
             What to do if dimensions that should be selected from are not present in the
             Dataset:
             - "raise": raise an exception
-            - "warning": raise a warning, and ignore the missing dimensions
+            - "warn": raise a warning, and ignore the missing dimensions
             - "ignore": ignore the missing dimensions
         **indexers_kwargs : {dim: indexer, ...}, optional
             The keyword arguments form of ``indexers``.
@@ -2254,7 +2254,7 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
         indexers: Mapping[Any, Any],
         *,
         drop: bool,
-        missing_dims: str = "raise",
+        missing_dims: ErrorChoiceWithWarn = "raise",
     ) -> Dataset:
         valid_indexers = dict(self._validate_indexers(indexers, missing_dims))
 
@@ -7715,7 +7715,7 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
         queries: Mapping[Any, Any] = None,
         parser: str = "pandas",
         engine: str = None,
-        missing_dims: str = "raise",
+        missing_dims: ErrorChoiceWithWarn = "raise",
         **queries_kwargs: Any,
     ) -> Dataset:
         """Return a new dataset with each array indexed along the specified
@@ -7748,7 +7748,7 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
             Dataset:
 
             - "raise": raise an exception
-            - "warning": raise a warning, and ignore the missing dimensions
+            - "warn": raise a warning, and ignore the missing dimensions
             - "ignore": ignore the missing dimensions
 
         **queries_kwargs : {dim: query, ...}, optional

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2270,6 +2270,8 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
                 }
                 if var_indexers:
                     new_var = var.isel(indexers=var_indexers)
+                    if drop and new_var.ndim == 0:
+                        continue
                 else:
                     new_var = var.copy(deep=False)
                 if name not in indexes:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4559,7 +4559,9 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
             variables, coord_names=coord_names, indexes=indexes
         )
 
-    def drop(self, labels=None, dim=None, *, errors: ErrorChoice = "raise", **labels_kwargs):
+    def drop(
+        self, labels=None, dim=None, *, errors: ErrorChoice = "raise", **labels_kwargs
+    ):
         """Backward compatible method based on `drop_vars` and `drop_sel`
 
         Using either `drop_vars` or `drop_sel` is encouraged

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -105,7 +105,7 @@ if TYPE_CHECKING:
     from ..backends import AbstractDataStore, ZarrStore
     from .dataarray import DataArray
     from .merge import CoercibleMapping
-    from .types import T_Xarray, ErrorChoiceWithWarn
+    from .types import ErrorChoiceWithWarn, T_Xarray
 
     try:
         from dask.delayed import Delayed

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2270,6 +2270,8 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
                 }
                 if var_indexers:
                     new_var = var.isel(indexers=var_indexers)
+                    # drop scalar coordinates
+                    # https://github.com/pydata/xarray/issues/6554
                     if name in self.coords and drop and new_var.ndim == 0:
                         continue
                 else:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -105,7 +105,7 @@ if TYPE_CHECKING:
     from ..backends import AbstractDataStore, ZarrStore
     from .dataarray import DataArray
     from .merge import CoercibleMapping
-    from .types import ErrorChoiceWithWarn, T_Xarray
+    from .types import ErrorChoice, ErrorChoiceWithWarn, T_Xarray
 
     try:
         from dask.delayed import Delayed
@@ -2058,7 +2058,7 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
         return self._replace(variables)
 
     def _validate_indexers(
-        self, indexers: Mapping[Any, Any], missing_dims: str = "raise"
+        self, indexers: Mapping[Any, Any], missing_dims: ErrorChoiceWithWarn = "raise"
     ) -> Iterator[tuple[Hashable, int | slice | np.ndarray | Variable]]:
         """Here we make sure
         + indexer has a valid keys
@@ -4524,7 +4524,7 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
             )
 
     def drop_vars(
-        self, names: Hashable | Iterable[Hashable], *, errors: str = "raise"
+        self, names: Hashable | Iterable[Hashable], *, errors: ErrorChoice = "raise"
     ) -> Dataset:
         """Drop variables from this dataset.
 
@@ -4532,8 +4532,8 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
         ----------
         names : hashable or iterable of hashable
             Name(s) of variables to drop.
-        errors : {"raise", "ignore"}, optional
-            If 'raise' (default), raises a ValueError error if any of the variable
+        errors : {"raise", "ignore"}, default: "raise"
+            If 'raise', raises a ValueError error if any of the variable
             passed are not in the dataset. If 'ignore', any given names that are in the
             dataset are dropped and no error is raised.
 
@@ -4559,7 +4559,7 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
             variables, coord_names=coord_names, indexes=indexes
         )
 
-    def drop(self, labels=None, dim=None, *, errors="raise", **labels_kwargs):
+    def drop(self, labels=None, dim=None, *, errors: ErrorChoice = "raise", **labels_kwargs):
         """Backward compatible method based on `drop_vars` and `drop_sel`
 
         Using either `drop_vars` or `drop_sel` is encouraged
@@ -4608,15 +4608,15 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
         )
         return self.drop_sel(labels, errors=errors)
 
-    def drop_sel(self, labels=None, *, errors="raise", **labels_kwargs):
+    def drop_sel(self, labels=None, *, errors: ErrorChoice = "raise", **labels_kwargs):
         """Drop index labels from this dataset.
 
         Parameters
         ----------
         labels : mapping of hashable to Any
             Index labels to drop
-        errors : {"raise", "ignore"}, optional
-            If 'raise' (default), raises a ValueError error if
+        errors : {"raise", "ignore"}, default: "raise"
+            If 'raise', raises a ValueError error if
             any of the index labels passed are not
             in the dataset. If 'ignore', any given labels that are in the
             dataset are dropped and no error is raised.
@@ -4743,7 +4743,7 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
         return ds
 
     def drop_dims(
-        self, drop_dims: Hashable | Iterable[Hashable], *, errors: str = "raise"
+        self, drop_dims: Hashable | Iterable[Hashable], *, errors: ErrorChoice = "raise"
     ) -> Dataset:
         """Drop dimensions and associated variables from this dataset.
 
@@ -4783,7 +4783,7 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
     def transpose(
         self,
         *dims: Hashable,
-        missing_dims: str = "raise",
+        missing_dims: ErrorChoiceWithWarn = "raise",
     ) -> Dataset:
         """Return a new Dataset object with all array dimensions transposed.
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2182,7 +2182,7 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
             If DataArrays are passed as indexers, xarray-style indexing will be
             carried out. See :ref:`indexing` for the details.
             One of indexers or indexers_kwargs must be provided.
-        drop : bool, default False
+        drop : bool, default: False
             If ``drop=True``, drop coordinates variables indexed by integers
             instead of making them scalar.
         missing_dims : {"raise", "warn", "ignore"}, default: "raise"
@@ -2270,7 +2270,7 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
                 }
                 if var_indexers:
                     new_var = var.isel(indexers=var_indexers)
-                    if drop and new_var.ndim == 0:
+                    if name in self.coords and drop and new_var.ndim == 0:
                         continue
                 else:
                     new_var = var.copy(deep=False)

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -22,11 +22,11 @@ import pandas as pd
 
 from . import formatting, nputils, utils
 from .indexing import IndexSelResult, PandasIndexingAdapter, PandasMultiIndexingAdapter
-from .types import T_Index
 from .utils import Frozen, get_valid_numpy_dtype, is_dict_like, is_scalar
 
 if TYPE_CHECKING:
     from .variable import Variable
+    from .types import ErrorChoice, T_Index
 
 IndexVars = Dict[Any, "Variable"]
 
@@ -1098,7 +1098,7 @@ class Indexes(collections.abc.Mapping, Generic[T_PandasOrXarrayIndex]):
         return len(self._id_coord_names[self._coord_name_id[key]]) > 1
 
     def get_all_coords(
-        self, key: Hashable, errors: str = "raise"
+        self, key: Hashable, errors: ErrorChoice = "raise"
     ) -> dict[Hashable, Variable]:
         """Return all coordinates having the same index.
 
@@ -1106,7 +1106,7 @@ class Indexes(collections.abc.Mapping, Generic[T_PandasOrXarrayIndex]):
         ----------
         key : hashable
             Index key.
-        errors : {"raise", "ignore"}, optional
+        errors : {"raise", "ignore"}, default: "raise"
             If "raise", raises a ValueError if `key` is not in indexes.
             If "ignore", an empty tuple is returned instead.
 
@@ -1129,7 +1129,7 @@ class Indexes(collections.abc.Mapping, Generic[T_PandasOrXarrayIndex]):
         return {k: self._variables[k] for k in all_coord_names}
 
     def get_all_dims(
-        self, key: Hashable, errors: str = "raise"
+        self, key: Hashable, errors: ErrorChoice = "raise"
     ) -> Mapping[Hashable, int]:
         """Return all dimensions shared by an index.
 
@@ -1137,7 +1137,7 @@ class Indexes(collections.abc.Mapping, Generic[T_PandasOrXarrayIndex]):
         ----------
         key : hashable
             Index key.
-        errors : {"raise", "ignore"}, optional
+        errors : {"raise", "ignore"}, default: "raise"
             If "raise", raises a ValueError if `key` is not in indexes.
             If "ignore", an empty tuple is returned instead.
 

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -25,8 +25,8 @@ from .indexing import IndexSelResult, PandasIndexingAdapter, PandasMultiIndexing
 from .utils import Frozen, get_valid_numpy_dtype, is_dict_like, is_scalar
 
 if TYPE_CHECKING:
-    from .variable import Variable
     from .types import ErrorChoice, T_Index
+    from .variable import Variable
 
 IndexVars = Dict[Any, "Variable"]
 

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, Union
+from typing import TYPE_CHECKING, TypeVar, Union, Literal
 
 import numpy as np
 
@@ -33,3 +33,6 @@ DsCompatible = Union["Dataset", "DataArray", "Variable", "GroupBy", "ScalarOrArr
 DaCompatible = Union["DataArray", "Variable", "DataArrayGroupBy", "ScalarOrArray"]
 VarCompatible = Union["Variable", "ScalarOrArray"]
 GroupByIncompatible = Union["Variable", "GroupBy"]
+
+ErrorChoice = Literal["raise", "ignore"]
+ErrorChoiceWithWarn = Literal["raise", "warn", "ignore"]

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, Union, Literal
+from typing import TYPE_CHECKING, Literal, TypeVar, Union
 
 import numpy as np
 

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -759,7 +759,9 @@ class HiddenKeyDict(MutableMapping[K, V]):
 
 
 def infix_dims(
-    dims_supplied: Collection, dims_all: Collection, missing_dims: ErrorChoiceWithWarn = "raise"
+    dims_supplied: Collection,
+    dims_all: Collection,
+    missing_dims: ErrorChoiceWithWarn = "raise",
 ) -> Iterator:
     """
     Resolves a supplied list containing an ellipsis representing other items, to

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -29,6 +29,9 @@ from typing import (
 import numpy as np
 import pandas as pd
 
+if TYPE_CHECKING:
+    from .types import ErrorChoiceWithWarn
+
 K = TypeVar("K")
 V = TypeVar("V")
 T = TypeVar("T")
@@ -756,7 +759,7 @@ class HiddenKeyDict(MutableMapping[K, V]):
 
 
 def infix_dims(
-    dims_supplied: Collection, dims_all: Collection, missing_dims: str = "raise"
+    dims_supplied: Collection, dims_all: Collection, missing_dims: ErrorChoiceWithWarn = "raise"
 ) -> Iterator:
     """
     Resolves a supplied list containing an ellipsis representing other items, to
@@ -804,7 +807,7 @@ def get_temp_dimname(dims: Container[Hashable], new_dim: Hashable) -> Hashable:
 def drop_dims_from_indexers(
     indexers: Mapping[Any, Any],
     dims: list | Mapping[Any, int],
-    missing_dims: str,
+    missing_dims: ErrorChoiceWithWarn,
 ) -> Mapping[Hashable, Any]:
     """Depending on the setting of missing_dims, drop any dimensions from indexers that
     are not present in dims.
@@ -850,7 +853,7 @@ def drop_dims_from_indexers(
 
 
 def drop_missing_dims(
-    supplied_dims: Collection, dims: Collection, missing_dims: str
+    supplied_dims: Collection, dims: Collection, missing_dims: ErrorChoiceWithWarn
 ) -> Collection:
     """Depending on the setting of missing_dims, drop any dimensions from supplied_dims that
     are not present in dims.

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -59,7 +59,7 @@ NON_NUMPY_SUPPORTED_ARRAY_TYPES = (
 BASIC_INDEXING_TYPES = integer_types + (slice,)
 
 if TYPE_CHECKING:
-    from .types import T_Variable
+    from .types import ErrorChoiceWithWarn, T_Variable
 
 
 class MissingDimensionsError(ValueError):
@@ -1159,7 +1159,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
     def isel(
         self: T_Variable,
         indexers: Mapping[Any, Any] = None,
-        missing_dims: str = "raise",
+        missing_dims: ErrorChoiceWithWarn = "raise",
         **indexers_kwargs: Any,
     ) -> T_Variable:
         """Return a new array indexed along the specified dimension(s).
@@ -1173,7 +1173,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
             What to do if dimensions that should be selected from are not present in the
             DataArray:
             - "raise": raise an exception
-            - "warning": raise a warning, and ignore the missing dimensions
+            - "warn": raise a warning, and ignore the missing dimensions
             - "ignore": ignore the missing dimensions
 
         Returns
@@ -1436,7 +1436,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
     def transpose(
         self,
         *dims,
-        missing_dims: str = "raise",
+        missing_dims: ErrorChoiceWithWarn = "raise",
     ) -> Variable:
         """Return a new Variable object with transposed dimensions.
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1175,6 +1175,18 @@ class TestDataset:
         assert_array_equal(actual["var2"], expected_var2)
         assert_array_equal(actual["var3"], expected_var3)
 
+        # test that drop works
+        ds = xr.Dataset({"a": (("x",), [1, 2, 3])}, coords={"b": (("x",), [5, 6, 7])})
+
+        actual = ds.isel({"x": 1}, drop=False)
+        expected = xr.Dataset({"a": 2}, coords={"b": 6})
+        assert_identical(actual, expected)
+
+        actual = ds.isel({"x": 1}, drop=True)
+        expected = xr.Dataset({"a": 2})
+        assert_identical(actual, expected)
+
+
     def test_isel_dataarray(self):
         """Test for indexing by DataArray"""
         data = create_test_data()

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1186,6 +1186,14 @@ class TestDataset:
         expected = xr.Dataset({"a": 2})
         assert_identical(actual, expected)
 
+        actual = ds.isel({"x": DataArray(1)}, drop=False)
+        expected = xr.Dataset({"a": 2}, coords={"b": 6})
+        assert_identical(actual, expected)
+
+        actual = ds.isel({"x": DataArray(1)}, drop=True)
+        expected = xr.Dataset({"a": 2})
+        assert_identical(actual, expected)
+
     def test_isel_dataarray(self):
         """Test for indexing by DataArray"""
         data = create_test_data()

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1186,7 +1186,6 @@ class TestDataset:
         expected = xr.Dataset({"a": 2})
         assert_identical(actual, expected)
 
-
     def test_isel_dataarray(self):
         """Test for indexing by DataArray"""
         data = create_test_data()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #6554
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Additionally I have added new literal types for error handling (Only applied to functions related to isel such that mypy stops complaining).