### PR TITLE
terminology.rst: fix link to Unidata's "netcdf_dataset_components"

### DIFF
--- a/doc/user-guide/terminology.rst
+++ b/doc/user-guide/terminology.rst
@@ -27,7 +27,7 @@ complete examples, please consult the relevant documentation.*
 
     Variable
         A `NetCDF-like variable
-        <https://www.unidata.ucar.edu/software/netcdf/docs/netcdf_data_set_components.html#variables>`_
+        <https://docs.unidata.ucar.edu/nug/current/netcdf_data_set_components.html#variables>`_
         consisting of dimensions, data, and attributes which describe a single
         array. The main functional difference between variables and numpy arrays
         is that numerical operations on variables implement array broadcasting


### PR DESCRIPTION
This content has been moved to the NetCDF User Guide [1] and the link 
currently points to a non-existing URL.

Fix the link.

[1] https://docs.unidata.ucar.edu/nug/current/netcdf_data_set_components.html

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes https://github.com/pydata/xarray/issues/6582
