### PR TITLE
Doc Link to accessors list in extending-xarray.rst

### DIFF
--- a/doc/internals/extending-xarray.rst
+++ b/doc/internals/extending-xarray.rst
@@ -93,7 +93,7 @@ on ways to write new accessors and the philosophy behind the approach, see
 To help users keep things straight, please `let us know
 <https://github.com/pydata/xarray/issues>`_ if you plan to write a new accessor
 for an open source library. Existing open source accessors and the libraries 
-that implement them are available in the list on the :ref:`ecosystem` page. 
+that implement them are available in the list on the :ref:`ecosystem` page.
 
 To make documenting accessors with ``sphinx`` and ``sphinx.ext.autosummary``
 easier, you can use `sphinx-autosummary-accessors`_.

--- a/doc/internals/extending-xarray.rst
+++ b/doc/internals/extending-xarray.rst
@@ -92,8 +92,8 @@ on ways to write new accessors and the philosophy behind the approach, see
 
 To help users keep things straight, please `let us know
 <https://github.com/pydata/xarray/issues>`_ if you plan to write a new accessor
-for an open source library. In the future, we will maintain a list of accessors
-and the libraries that implement them on this page.
+for an open source library. Existing open source accessors and the libraries 
+that implement them are available in the list on the :ref:`ecosystem` page. 
 
 To make documenting accessors with ``sphinx`` and ``sphinx.ext.autosummary``
 easier, you can use `sphinx-autosummary-accessors`_.


### PR DESCRIPTION
Only documentation change, one outdated sentence. Old text states that in the future a list of accessors will me maintained on the Extending xarray page. The list of accessors are available under Xarray related projects page.

Second last paragraph on https://docs.xarray.dev/en/stable/internals/extending-xarray.html

Link to https://docs.xarray.dev/en/stable/ecosystem.html