### PR TITLE
Minor Dataset.map docstr clarification

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5302,7 +5302,7 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
         args: Iterable[Any] = (),
         **kwargs: Any,
     ) -> Dataset:
-        """Apply a function to each variable in this dataset
+        """Apply a function to each data variable in this dataset
 
         Parameters
         ----------


### PR DESCRIPTION
The summary line in the docstr for `Dataset.map()` says that it operates on variables in the dataset. This is a very minor update clarifying that it operates on *data* variables, as opposed to all variables (data + coord) in the Dataset.

- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
