### PR TITLE
Add setuptools as dependency in ASV benchmark CI

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -58,6 +58,9 @@
     //     "pip+emcee": [""],   // emcee is only available for install with pip.
     // },
     "matrix": {
+        // gh6606:
+        "setuptools": [""],
+        "setuptools_scm[toml]": [""],
         "numpy": [""],
         "pandas": [""],
         "netcdf4": [""],

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -58,9 +58,10 @@
     //     "pip+emcee": [""],   // emcee is only available for install with pip.
     // },
     "matrix": {
-        // gh6606:
-        "setuptools": [""],
+        // GH6606:
+        // "setuptools": [""],
         "setuptools_scm[toml]": [""],
+        "setuptools_scm_git_archive": [""],
         "numpy": [""],
         "pandas": [""],
         "netcdf4": [""],

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -58,10 +58,8 @@
     //     "pip+emcee": [""],   // emcee is only available for install with pip.
     // },
     "matrix": {
-        // GH6606:
-        // "setuptools": [""],
-        "setuptools_scm[toml]": [""],
-        "setuptools_scm_git_archive": [""],
+        "setuptools_scm[toml]": [""],  // GH6609
+        "setuptools_scm_git_archive": [""],  // GH6609
         "numpy": [""],
         "pandas": [""],
         "netcdf4": [""],


### PR DESCRIPTION
Adding `setuptools_scm[toml]` and `setuptools_scm_git_archive` appears to fix the issue.
Not sure why this is needed though.

- [x] Closes #6606

