### PR TITLE
{full,zeros,ones}_like typing

### DIFF
--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1599,6 +1599,13 @@ def full_like(other: Variable, fill_value: Any, dtype: DTypeLikeSave) -> Variabl
 
 @overload
 def full_like(
+    other: Dataset | DataArray, fill_value: Any, dtype: DTypeMaybeMapping = None
+) -> Dataset | DataArray:
+    ...
+
+
+@overload
+def full_like(
     other: Dataset | DataArray | Variable, fill_value: Any, dtype: DTypeMaybeMapping = None
 ) -> Dataset | DataArray | Variable:
     ...
@@ -1792,6 +1799,13 @@ def zeros_like(other: Variable, dtype: DTypeLikeSave) -> Variable:
 
 @overload
 def zeros_like(
+    other: Dataset | DataArray, dtype: DTypeMaybeMapping = None
+) -> Dataset | DataArray:
+    ...
+    
+
+@overload
+def zeros_like(
     other: Dataset | DataArray | Variable, dtype: DTypeMaybeMapping = None
 ) -> Dataset | DataArray | Variable:
     ...
@@ -1867,6 +1881,13 @@ def ones_like(other: Dataset, dtype: DTypeMaybeMapping) -> Dataset:
 
 @overload
 def ones_like(other: Variable, dtype: DTypeLikeSave) -> Variable:
+    ...
+
+
+@overload
+def ones_like(
+    other: Dataset | DataArray, dtype: DTypeMaybeMapping = None
+) -> Dataset | DataArray:
     ...
 
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1581,7 +1581,6 @@ class DataWithCoords(AttrAccessMixin):
 DTypeMaybeMapping = Union[DTypeLikeSave, Mapping[Any, DTypeLikeSave]]
 
 
-
 @overload
 def full_like(other: DataArray, fill_value: Any, dtype: DTypeLikeSave) -> DataArray:
     ...
@@ -1606,13 +1605,17 @@ def full_like(
 
 @overload
 def full_like(
-    other: Dataset | DataArray | Variable, fill_value: Any, dtype: DTypeMaybeMapping = None
+    other: Dataset | DataArray | Variable,
+    fill_value: Any,
+    dtype: DTypeMaybeMapping = None,
 ) -> Dataset | DataArray | Variable:
     ...
 
 
 def full_like(
-    other: Dataset | DataArray | Variable, fill_value: Any, dtype: DTypeMaybeMapping = None
+    other: Dataset | DataArray | Variable,
+    fill_value: Any,
+    dtype: DTypeMaybeMapping = None,
 ) -> Dataset | DataArray | Variable:
     """Return a new object with the same shape and type as a given object.
 
@@ -1739,7 +1742,9 @@ def full_like(
             dtype_ = dtype
 
         data_vars = {
-            k: _full_like_variable(v.variable, fill_value.get(k, dtypes.NA), dtype_.get(k, None))
+            k: _full_like_variable(
+                v.variable, fill_value.get(k, dtypes.NA), dtype_.get(k, None)
+            )
             for k, v in other.data_vars.items()
         }
         return Dataset(data_vars, coords=other.coords, attrs=other.attrs)
@@ -1761,7 +1766,9 @@ def full_like(
         raise TypeError("Expected DataArray, Dataset, or Variable")
 
 
-def _full_like_variable(other: Variable, fill_value: Any, dtype: DTypeLike = None) -> Variable:
+def _full_like_variable(
+    other: Variable, fill_value: Any, dtype: DTypeLike = None
+) -> Variable:
     """Inner function of full_like, where other must be a variable"""
     from .variable import Variable
 
@@ -1802,7 +1809,7 @@ def zeros_like(
     other: Dataset | DataArray, dtype: DTypeMaybeMapping = None
 ) -> Dataset | DataArray:
     ...
-    
+
 
 @overload
 def zeros_like(

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -13,6 +13,7 @@ from typing import (
     Iterator,
     Mapping,
     TypeVar,
+    Union,
     overload,
 )
 
@@ -20,7 +21,7 @@ import numpy as np
 import pandas as pd
 
 from . import dtypes, duck_array_ops, formatting, formatting_html, ops
-from .npcompat import DTypeLike
+from .npcompat import DTypeLike, DTypeLikeSave
 from .options import OPTIONS, _get_keep_attrs
 from .pycompat import is_duck_dask_array
 from .rolling_exp import RollingExp
@@ -1577,26 +1578,35 @@ class DataWithCoords(AttrAccessMixin):
         raise NotImplementedError()
 
 
+DTypeMaybeMapping = Union[DTypeLikeSave, Mapping[Any, DTypeLikeSave]]
+
+
+
+@overload
+def full_like(other: DataArray, fill_value: Any, dtype: DTypeLikeSave) -> DataArray:
+    ...
+
+
+@overload
+def full_like(other: Dataset, fill_value: Any, dtype: DTypeMaybeMapping) -> Dataset:
+    ...
+
+
+@overload
+def full_like(other: Variable, fill_value: Any, dtype: DTypeLikeSave) -> Variable:
+    ...
+
+
 @overload
 def full_like(
-    other: Dataset,
-    fill_value,
-    dtype: DTypeLike | Mapping[Any, DTypeLike] = None,
-) -> Dataset:
+    other: Dataset | DataArray | Variable, fill_value: Any, dtype: DTypeMaybeMapping = None
+) -> Dataset | DataArray | Variable:
     ...
 
 
-@overload
-def full_like(other: DataArray, fill_value, dtype: DTypeLike = None) -> DataArray:
-    ...
-
-
-@overload
-def full_like(other: Variable, fill_value, dtype: DTypeLike = None) -> Variable:
-    ...
-
-
-def full_like(other, fill_value, dtype=None):
+def full_like(
+    other: Dataset | DataArray | Variable, fill_value: Any, dtype: DTypeMaybeMapping = None
+) -> Dataset | DataArray | Variable:
     """Return a new object with the same shape and type as a given object.
 
     Parameters
@@ -1711,26 +1721,24 @@ def full_like(other, fill_value, dtype=None):
             f"fill_value must be scalar or, for datasets, a dict-like. Received {fill_value} instead."
         )
 
-    if not isinstance(other, Dataset) and isinstance(dtype, Mapping):
-        raise ValueError(
-            "'dtype' cannot be dict-like when passing a DataArray or Variable"
-        )
-
     if isinstance(other, Dataset):
         if not isinstance(fill_value, dict):
             fill_value = {k: fill_value for k in other.data_vars.keys()}
 
+        dtype_: Mapping[Any, DTypeLikeSave]
         if not isinstance(dtype, Mapping):
             dtype_ = {k: dtype for k in other.data_vars.keys()}
         else:
             dtype_ = dtype
 
         data_vars = {
-            k: _full_like_variable(v, fill_value.get(k, dtypes.NA), dtype_.get(k, None))
+            k: _full_like_variable(v.variable, fill_value.get(k, dtypes.NA), dtype_.get(k, None))
             for k, v in other.data_vars.items()
         }
         return Dataset(data_vars, coords=other.coords, attrs=other.attrs)
     elif isinstance(other, DataArray):
+        if isinstance(dtype, Mapping):
+            raise ValueError("'dtype' cannot be dict-like when passing a DataArray")
         return DataArray(
             _full_like_variable(other.variable, fill_value, dtype),
             dims=other.dims,
@@ -1739,12 +1747,14 @@ def full_like(other, fill_value, dtype=None):
             name=other.name,
         )
     elif isinstance(other, Variable):
+        if isinstance(dtype, Mapping):
+            raise ValueError("'dtype' cannot be dict-like when passing a Variable")
         return _full_like_variable(other, fill_value, dtype)
     else:
         raise TypeError("Expected DataArray, Dataset, or Variable")
 
 
-def _full_like_variable(other, fill_value, dtype: DTypeLike = None):
+def _full_like_variable(other: Variable, fill_value: Any, dtype: DTypeLike = None) -> Variable:
     """Inner function of full_like, where other must be a variable"""
     from .variable import Variable
 
@@ -1765,7 +1775,31 @@ def _full_like_variable(other, fill_value, dtype: DTypeLike = None):
     return Variable(dims=other.dims, data=data, attrs=other.attrs)
 
 
-def zeros_like(other, dtype: DTypeLike = None):
+@overload
+def zeros_like(other: DataArray, dtype: DTypeLikeSave) -> DataArray:
+    ...
+
+
+@overload
+def zeros_like(other: Dataset, dtype: DTypeMaybeMapping) -> Dataset:
+    ...
+
+
+@overload
+def zeros_like(other: Variable, dtype: DTypeLikeSave) -> Variable:
+    ...
+
+
+@overload
+def zeros_like(
+    other: Dataset | DataArray | Variable, dtype: DTypeMaybeMapping = None
+) -> Dataset | DataArray | Variable:
+    ...
+
+
+def zeros_like(
+    other: Dataset | DataArray | Variable, dtype: DTypeMaybeMapping = None
+) -> Dataset | DataArray | Variable:
     """Return a new object of zeros with the same shape and
     type as a given dataarray or dataset.
 
@@ -1821,7 +1855,31 @@ def zeros_like(other, dtype: DTypeLike = None):
     return full_like(other, 0, dtype)
 
 
-def ones_like(other, dtype: DTypeLike = None):
+@overload
+def ones_like(other: DataArray, dtype: DTypeLikeSave) -> DataArray:
+    ...
+
+
+@overload
+def ones_like(other: Dataset, dtype: DTypeMaybeMapping) -> Dataset:
+    ...
+
+
+@overload
+def ones_like(other: Variable, dtype: DTypeLikeSave) -> Variable:
+    ...
+
+
+@overload
+def ones_like(
+    other: Dataset | DataArray | Variable, dtype: DTypeMaybeMapping = None
+) -> Dataset | DataArray | Variable:
+    ...
+
+
+def ones_like(
+    other: Dataset | DataArray | Variable, dtype: DTypeMaybeMapping = None
+) -> Dataset | DataArray | Variable:
     """Return a new object of ones with the same shape and
     type as a given dataarray or dataset.
 

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1946,6 +1946,7 @@ def _ensure_numeric(data: Dataset | DataArray) -> Dataset | DataArray:
             # timedeltas
             return x.astype(float)
         return x
+
     if isinstance(data, Dataset):
         return data.map(to_floatable)
     else:

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1905,7 +1905,7 @@ def polyval(
     coeffs = coeffs.reindex(
         {degree_dim: np.arange(max_deg + 1)}, fill_value=0, copy=False
     )
-    coord = _ensure_numeric(coord)  # type: ignore # https://github.com/python/mypy/issues/1533 ?
+    coord = _ensure_numeric(coord)
 
     # using Horner's method
     # https://en.wikipedia.org/wiki/Horner%27s_method
@@ -1917,7 +1917,7 @@ def polyval(
     return res
 
 
-def _ensure_numeric(data: T_Xarray) -> T_Xarray:
+def _ensure_numeric(data: Dataset | DataArray) -> Dataset | DataArray:
     """Converts all datetime64 variables to float64
 
     Parameters
@@ -1942,7 +1942,6 @@ def _ensure_numeric(data: T_Xarray) -> T_Xarray:
                 ),
             )
         return x
-
     if isinstance(data, Dataset):
         return data.map(to_floatable)
     else:

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -4,15 +4,11 @@ import datetime as dt
 import warnings
 from functools import partial
 from numbers import Number
-from typing import Any, Callable, Dict, Hashable, Sequence, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Dict, Hashable, Sequence, Union
 
 import numpy as np
 import pandas as pd
 from packaging.version import Version
-
-if TYPE_CHECKING:
-    from .dataarray import DataArray
-    from .dataset import Dataset
 
 from . import utils
 from .common import _contains_datetime_like_objects, ones_like
@@ -23,8 +19,14 @@ from .pycompat import dask_version, is_duck_dask_array
 from .utils import OrderedSet, is_scalar
 from .variable import Variable, broadcast_variables
 
+if TYPE_CHECKING:
+    from .dataarray import DataArray
+    from .dataset import Dataset
 
-def _get_nan_block_lengths(obj: Dataset | DataArray | Variable, dim: Hashable, index: Variable):
+
+def _get_nan_block_lengths(
+    obj: Dataset | DataArray | Variable, dim: Hashable, index: Variable
+):
     """
     Return an object where each NaN element in 'obj' is replaced by the
     length of the gap the element is in.
@@ -54,8 +56,8 @@ def _get_nan_block_lengths(obj: Dataset | DataArray | Variable, dim: Hashable, i
 class BaseInterpolator:
     """Generic interpolator class for normalizing interpolation methods"""
 
-    cons_kwargs: Dict[str, Any]
-    call_kwargs: Dict[str, Any]
+    cons_kwargs: dict[str, Any]
+    call_kwargs: dict[str, Any]
     f: Callable
     method: str
 
@@ -219,7 +221,7 @@ def _apply_over_vars_with_dim(func, self, dim=None, **kwargs):
 
 
 def get_clean_interp_index(
-    arr, dim: Hashable, use_coordinate: Union[str, bool] = True, strict: bool = True
+    arr, dim: Hashable, use_coordinate: str | bool = True, strict: bool = True
 ):
     """Return index to use for x values in interpolation or curve fitting.
 
@@ -306,10 +308,10 @@ def get_clean_interp_index(
 def interp_na(
     self,
     dim: Hashable = None,
-    use_coordinate: Union[bool, str] = True,
+    use_coordinate: bool | str = True,
     method: str = "linear",
     limit: int = None,
-    max_gap: Union[int, float, str, pd.Timedelta, np.timedelta64, dt.timedelta] = None,
+    max_gap: int | float | str | pd.Timedelta | np.timedelta64 | dt.timedelta = None,
     keep_attrs: bool = None,
     **kwargs,
 ):

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -1,12 +1,18 @@
+from __future__ import annotations
+
 import datetime as dt
 import warnings
 from functools import partial
 from numbers import Number
-from typing import Any, Callable, Dict, Hashable, Sequence, Union
+from typing import Any, Callable, Dict, Hashable, Sequence, Union, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 from packaging.version import Version
+
+if TYPE_CHECKING:
+    from .dataarray import DataArray
+    from .dataset import Dataset
 
 from . import utils
 from .common import _contains_datetime_like_objects, ones_like
@@ -18,7 +24,7 @@ from .utils import OrderedSet, is_scalar
 from .variable import Variable, broadcast_variables
 
 
-def _get_nan_block_lengths(obj, dim: Hashable, index: Variable):
+def _get_nan_block_lengths(obj: Dataset | DataArray | Variable, dim: Hashable, index: Variable):
     """
     Return an object where each NaN element in 'obj' is replaced by the
     length of the gap the element is in.

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -4,7 +4,7 @@ import datetime as dt
 import warnings
 from functools import partial
 from numbers import Number
-from typing import TYPE_CHECKING, Any, Callable, Dict, Hashable, Sequence, Union
+from typing import TYPE_CHECKING, Any, Callable, Hashable, Sequence
 
 import numpy as np
 import pandas as pd

--- a/xarray/core/npcompat.py
+++ b/xarray/core/npcompat.py
@@ -49,7 +49,8 @@ try:
     from numpy.typing._dtype_like import _DTypeLikeNested, _ShapeLike, _SupportsDType
 
     # Xarray requires a Mapping[Hashable, dtype] in many places which
-    # conflics with numpys own DTypeLik (with dtypes for fields).
+    # conflics with numpys own DTypeLike (with dtypes for fields).
+    # https://numpy.org/devdocs/reference/typing.html#numpy.typing.DTypeLike
     # This is a copy of this DTypeLike that allows only non-Mapping dtypes.
     DTypeLikeSave = Union[
         np.dtype,

--- a/xarray/core/npcompat.py
+++ b/xarray/core/npcompat.py
@@ -36,13 +36,13 @@ from packaging.version import Version
 # Type annotations stubs
 try:
     from numpy.typing import ArrayLike, DTypeLike
-    from numpy.typing._dtype_like import _SupportsDType, _DTypeLikeNested, _ShapeLike, DType
+    from numpy.typing._dtype_like import _SupportsDType, _DTypeLikeNested, _ShapeLike
 
     # Xarray requires a Mapping[Hashable, dtype] in many places which
     # conflics with numpys own DTypeLik (with dtypes for fields).
     # This is a copy of this DTypeLike that allows only non-Mapping dtypes.
     DTypeLikeSave = Union[
-        DType[Any],
+        np.dtype,
         # default data type (float64)
         None,
         # array-scalar types and generic types
@@ -58,7 +58,7 @@ try:
         # because numpy does the same?
         list[Any],
         # anything with a dtype attribute
-        _SupportsDType[DType[Any]]
+        _SupportsDType[np.dtype]
     ]
 except ImportError:
     # fall back for numpy < 1.20, ArrayLike adapted from numpy.typing._array_like
@@ -102,7 +102,6 @@ except ImportError:
     # with the same name (ArrayLike and DTypeLike from the try block)
     ArrayLike = _ArrayLikeFallback  # type: ignore
     # fall back for numpy < 1.20
-    DTypeLike = Union[np.dtype, str, None, Type[Any]]  # type: ignore[misc]
     DTypeLikeSave = Union[  # type: ignore[misc]
         np.dtype,
         str,
@@ -112,6 +111,7 @@ except ImportError:
         list[Any],
         _SupportsDTypeFallback,
     ]
+    DTypeLike = DTypeLikeSave  # type: ignore[misc]
 
 
 if Version(np.__version__) >= Version("1.20.0"):

--- a/xarray/core/npcompat.py
+++ b/xarray/core/npcompat.py
@@ -28,7 +28,17 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from typing import TYPE_CHECKING, Any, List, Literal, Sequence, Tuple, Type, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    List,
+    Literal,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import numpy as np
 from packaging.version import Version

--- a/xarray/core/npcompat.py
+++ b/xarray/core/npcompat.py
@@ -87,7 +87,7 @@ except ImportError:
 
     else:
         _SupportsArray = Any
-        _SupportsDType = Any
+        _SupportsDTypeFallback = Any
 
     _T = TypeVar("_T")
     _NestedSequence = Union[

--- a/xarray/core/npcompat.py
+++ b/xarray/core/npcompat.py
@@ -36,7 +36,7 @@ from packaging.version import Version
 # Type annotations stubs
 try:
     from numpy.typing import ArrayLike, DTypeLike
-    from numpy.typing._dtype_like import _SupportsDType, _DTypeLikeNested, _ShapeLike
+    from numpy.typing._dtype_like import _DTypeLikeNested, _ShapeLike, _SupportsDType
 
     # Xarray requires a Mapping[Hashable, dtype] in many places which
     # conflics with numpys own DTypeLik (with dtypes for fields).
@@ -58,18 +58,18 @@ try:
         # because numpy does the same?
         list[Any],
         # anything with a dtype attribute
-        _SupportsDType[np.dtype]
+        _SupportsDType[np.dtype],
     ]
 except ImportError:
     # fall back for numpy < 1.20, ArrayLike adapted from numpy.typing._array_like
-    from typing import Protocol, SupportsIndex
+    from typing import Protocol
 
     if TYPE_CHECKING:
 
         class _SupportsArray(Protocol):
             def __array__(self) -> np.ndarray:
                 ...
-                
+
         class _SupportsDTypeFallback(Protocol):
             @property
             def dtype(self) -> np.dtype:

--- a/xarray/core/npcompat.py
+++ b/xarray/core/npcompat.py
@@ -28,7 +28,7 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from typing import TYPE_CHECKING, Any, Literal, Sequence, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, List, Literal, Sequence, Tuple, Type, TypeVar, Union
 
 import numpy as np
 from packaging.version import Version
@@ -56,7 +56,7 @@ try:
         # (base_dtype, new_dtype)
         Tuple[_DTypeLikeNested, _DTypeLikeNested],
         # because numpy does the same?
-        list[Any],
+        List[Any],
         # anything with a dtype attribute
         _SupportsDType[np.dtype],
     ]
@@ -108,7 +108,7 @@ except ImportError:
         None,
         Type[Any],
         Tuple[Any, Any],
-        list[Any],
+        List[Any],
         _SupportsDTypeFallback,
     ]
     DTypeLike = DTypeLikeSave  # type: ignore[misc]

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5559,7 +5559,7 @@ class TestDataset:
             actual = ds1 + ds2
             assert_equal(actual, expected)
 
-    def test_full_like(self):
+    def test_full_like(self) -> None:
         # For more thorough tests, see test_variable.py
         # Note: testing data_vars with mismatched dtypes
         ds = Dataset(
@@ -5572,8 +5572,9 @@ class TestDataset:
         actual = full_like(ds, 2)
 
         expected = ds.copy(deep=True)
-        expected["d1"].values = [2, 2, 2]
-        expected["d2"].values = [2.0, 2.0, 2.0]
+        # https://github.com/python/mypy/issues/3004
+        expected["d1"].values = [2, 2, 2]  # type: ignore
+        expected["d2"].values = [2.0, 2.0, 2.0]  # type: ignore
         assert expected["d1"].dtype == int
         assert expected["d2"].dtype == float
         assert_identical(expected, actual)
@@ -5581,8 +5582,8 @@ class TestDataset:
         # override dtype
         actual = full_like(ds, fill_value=True, dtype=bool)
         expected = ds.copy(deep=True)
-        expected["d1"].values = [True, True, True]
-        expected["d2"].values = [True, True, True]
+        expected["d1"].values = [True, True, True]  # type: ignore
+        expected["d2"].values = [True, True, True]  # type: ignore
         assert expected["d1"].dtype == bool
         assert expected["d2"].dtype == bool
         assert_identical(expected, actual)
@@ -5788,7 +5789,7 @@ class TestDataset:
             ds.data_vars[item]  # should not raise
         assert sorted(actual) == sorted(expected)
 
-    def test_polyfit_output(self):
+    def test_polyfit_output(self) -> None:
         ds = create_test_data(seed=1)
 
         out = ds.polyfit("dim2", 2, full=False)
@@ -5801,7 +5802,7 @@ class TestDataset:
         out = ds.polyfit("time", 2)
         assert len(out.data_vars) == 0
 
-    def test_polyfit_warnings(self):
+    def test_polyfit_warnings(self) -> None:
         ds = create_test_data(seed=1)
 
         with warnings.catch_warnings(record=True) as ws:

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -2480,7 +2480,7 @@ class TestAsCompatibleData:
         assert np.ndarray == type(actual)
         assert np.dtype("datetime64[ns]") == actual.dtype
 
-    def test_full_like(self):
+    def test_full_like(self) -> None:
         # For more thorough tests, see test_variable.py
         orig = Variable(
             dims=("x", "y"), data=[[1.5, 2.0], [3.1, 4.3]], attrs={"foo": "bar"}
@@ -2503,7 +2503,7 @@ class TestAsCompatibleData:
             full_like(orig, True, dtype={"x": bool})
 
     @requires_dask
-    def test_full_like_dask(self):
+    def test_full_like_dask(self) -> None:
         orig = Variable(
             dims=("x", "y"), data=[[1.5, 2.0], [3.1, 4.3]], attrs={"foo": "bar"}
         ).chunk(((1, 1), (2,)))
@@ -2534,14 +2534,14 @@ class TestAsCompatibleData:
             else:
                 assert not isinstance(v, np.ndarray)
 
-    def test_zeros_like(self):
+    def test_zeros_like(self) -> None:
         orig = Variable(
             dims=("x", "y"), data=[[1.5, 2.0], [3.1, 4.3]], attrs={"foo": "bar"}
         )
         assert_identical(zeros_like(orig), full_like(orig, 0))
         assert_identical(zeros_like(orig, dtype=int), full_like(orig, 0, dtype=int))
 
-    def test_ones_like(self):
+    def test_ones_like(self) -> None:
         orig = Variable(
             dims=("x", "y"), data=[[1.5, 2.0], [3.1, 4.3]], attrs={"foo": "bar"}
         )


### PR DESCRIPTION
(partial) typing for functions `full_like`, `zeros_like`, `ones_like`.

I could not figure out how to properly use TypeVars so many things are "hardcoded" with overloads.

I have added a `DTypeLikeSave` to `npcompat`, not sure that this file is supposed to be edited.

Problem1: `TypeVar["T", Dataset, DataArray, Variable]` can only be one of these three, but never with `Union[Dataset, DataArray]` which is used in several other places in xarray.
Problem2: The official mypy support says: use `TypeVar["T", bound=Union[Dataset, DataArray, Variable]` but the the `isinstance(obj, Dataset)` could not be correctly resolved (is that a mypy issue?).

So if anyone can get it to work with TypeVars, feel free to change it. :)