### PR TITLE
fix {full,zeros,ones}_like overloads

### DIFF
--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1582,17 +1582,23 @@ DTypeMaybeMapping = Union[DTypeLikeSave, Mapping[Any, DTypeLikeSave]]
 
 
 @overload
-def full_like(other: DataArray, fill_value: Any, dtype: DTypeLikeSave = None) -> DataArray:
+def full_like(
+    other: DataArray, fill_value: Any, dtype: DTypeLikeSave = None
+) -> DataArray:
     ...
 
 
 @overload
-def full_like(other: Dataset, fill_value: Any, dtype: DTypeMaybeMapping = None) -> Dataset:
+def full_like(
+    other: Dataset, fill_value: Any, dtype: DTypeMaybeMapping = None
+) -> Dataset:
     ...
 
 
 @overload
-def full_like(other: Variable, fill_value: Any, dtype: DTypeLikeSave = None) -> Variable:
+def full_like(
+    other: Variable, fill_value: Any, dtype: DTypeLikeSave = None
+) -> Variable:
     ...
 
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1582,17 +1582,17 @@ DTypeMaybeMapping = Union[DTypeLikeSave, Mapping[Any, DTypeLikeSave]]
 
 
 @overload
-def full_like(other: DataArray, fill_value: Any, dtype: DTypeLikeSave) -> DataArray:
+def full_like(other: DataArray, fill_value: Any, dtype: DTypeLikeSave = None) -> DataArray:
     ...
 
 
 @overload
-def full_like(other: Dataset, fill_value: Any, dtype: DTypeMaybeMapping) -> Dataset:
+def full_like(other: Dataset, fill_value: Any, dtype: DTypeMaybeMapping = None) -> Dataset:
     ...
 
 
 @overload
-def full_like(other: Variable, fill_value: Any, dtype: DTypeLikeSave) -> Variable:
+def full_like(other: Variable, fill_value: Any, dtype: DTypeLikeSave = None) -> Variable:
     ...
 
 
@@ -1790,17 +1790,17 @@ def _full_like_variable(
 
 
 @overload
-def zeros_like(other: DataArray, dtype: DTypeLikeSave) -> DataArray:
+def zeros_like(other: DataArray, dtype: DTypeLikeSave = None) -> DataArray:
     ...
 
 
 @overload
-def zeros_like(other: Dataset, dtype: DTypeMaybeMapping) -> Dataset:
+def zeros_like(other: Dataset, dtype: DTypeMaybeMapping = None) -> Dataset:
     ...
 
 
 @overload
-def zeros_like(other: Variable, dtype: DTypeLikeSave) -> Variable:
+def zeros_like(other: Variable, dtype: DTypeLikeSave = None) -> Variable:
     ...
 
 
@@ -1877,17 +1877,17 @@ def zeros_like(
 
 
 @overload
-def ones_like(other: DataArray, dtype: DTypeLikeSave) -> DataArray:
+def ones_like(other: DataArray, dtype: DTypeLikeSave = None) -> DataArray:
     ...
 
 
 @overload
-def ones_like(other: Dataset, dtype: DTypeMaybeMapping) -> Dataset:
+def ones_like(other: Dataset, dtype: DTypeMaybeMapping = None) -> Dataset:
     ...
 
 
 @overload
-def ones_like(other: Variable, dtype: DTypeLikeSave) -> Variable:
+def ones_like(other: Variable, dtype: DTypeLikeSave = None) -> Variable:
     ...
 
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3566,7 +3566,7 @@ class TestDataArray:
         with pytest.raises(AttributeError, match=r"cannot set attr"):
             array.other = 2
 
-    def test_full_like(self):
+    def test_full_like(self) -> None:
         # For more thorough tests, see test_variable.py
         da = DataArray(
             np.random.random(size=(2, 2)),
@@ -3578,12 +3578,12 @@ class TestDataArray:
 
         actual = full_like(da, 2)
         expect = da.copy(deep=True)
-        expect.values = [[2.0, 2.0], [2.0, 2.0]]
+        expect.values = np.array([[2.0, 2.0], [2.0, 2.0]])
         assert_identical(expect, actual)
 
         # override dtype
         actual = full_like(da, fill_value=True, dtype=bool)
-        expect.values = [[True, True], [True, True]]
+        expect.values = np.array([[True, True], [True, True]])
         assert expect.dtype == bool
         assert_identical(expect, actual)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #6628
- [x] Tests added

forgot to add defaults to the dtype argument, so the typing defaulted back to the Union definition...