### PR TITLE
Use `zarr` to validate attrs when writing to zarr

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -93,6 +93,8 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- :py:meth:`Dataset.to_zarr` now allows to write all attribute types supported by `zarr-python`.
+  By `Mattia Almansi <https://github.com/malmans2>`_.
 - Set ``skipna=None`` for all ``quantile`` methods (e.g. :py:meth:`Dataset.quantile`) and
   ensure it skips missing values for float dtypes (consistent with other methods). This should
   not change the behavior (:pull:`6303`).

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1556,9 +1556,8 @@ def to_zarr(
             f"'w-', 'a' and 'r+', but mode={mode!r}"
         )
 
-    # validate Dataset keys, DataArray names, and attr keys/values
+    # validate Dataset keys, DataArray names
     _validate_dataset_names(dataset)
-    _validate_attrs(dataset)
 
     if region is not None:
         _validate_region(dataset, region)

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -325,7 +325,7 @@ def _put_attrs(zarr_obj, attrs):
     try:
         zarr_obj.attrs.put(attrs)
     except TypeError as e:
-        raise TypeError(f"Invalid attrs. {e!s}") from e
+        raise TypeError(f"Invalid attribute in Dataset.attrs.") from e
     return zarr_obj
 
 

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -325,7 +325,7 @@ def _put_attrs(zarr_obj, attrs):
     try:
         zarr_obj.attrs.put(attrs)
     except TypeError as e:
-        raise TypeError(f"Invalid attribute in Dataset.attrs.") from e
+        raise TypeError("Invalid attribute in Dataset.attrs.") from e
     return zarr_obj
 
 

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -321,11 +321,11 @@ def _validate_existing_dims(var_name, new_var, existing_var, region, append_dim)
 
 
 def _put_attrs(zarr_obj, attrs):
-    for key, value in attrs.items():
-        try:
-            zarr_obj.attrs[key] = value
-        except TypeError as e:
-            raise TypeError(f"Invalid attr {key!r}: {value!r}. {e!s}") from e
+    """Raise a more informative error message for invalid attrs."""
+    try:
+        zarr_obj.attrs.put(attrs)
+    except TypeError as e:
+        raise TypeError(f"Invalid attrs. {e!s}") from e
     return zarr_obj
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2456,7 +2456,7 @@ class ZarrBase(CFEncodedBase):
         obj.attrs["bad"] = DataArray()
         ds = obj if isinstance(obj, Dataset) else obj.to_dataset()
         with self.create_zarr_target() as store_target:
-            with pytest.raises(TypeError, match=r"Invalid attr 'bad'"):
+            with pytest.raises(TypeError, match=r"Invalid attrs."):
                 ds.to_zarr(store_target)
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2456,7 +2456,7 @@ class ZarrBase(CFEncodedBase):
         obj.attrs["bad"] = DataArray()
         ds = obj if isinstance(obj, Dataset) else obj.to_dataset()
         with self.create_zarr_target() as store_target:
-            with pytest.raises(TypeError, match=r"Invalid attrs."):
+            with pytest.raises(TypeError, match=r"Invalid attribute in Dataset.attrs."):
                 ds.to_zarr(store_target)
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2443,6 +2443,22 @@ class ZarrBase(CFEncodedBase):
         with self.create_zarr_target() as final_store:
             ds_sel.to_zarr(final_store, mode="w")
 
+    @pytest.mark.parametrize("obj", [Dataset(), DataArray(name="foo")])
+    def test_attributes(self, obj):
+        obj = obj.copy()
+
+        obj.attrs["good"] = {"key": "value"}
+        ds = obj if isinstance(obj, Dataset) else obj.to_dataset()
+        with self.create_zarr_target() as store_target:
+            ds.to_zarr(store_target)
+            assert_identical(ds, xr.open_zarr(store_target))
+
+        obj.attrs["bad"] = DataArray()
+        ds = obj if isinstance(obj, Dataset) else obj.to_dataset()
+        with self.create_zarr_target() as store_target:
+            with pytest.raises(TypeError, match=r"Invalid attr 'bad'"):
+                ds.to_zarr(store_target)
+
 
 @requires_zarr
 class TestZarrDictStore(ZarrBase):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #6448 
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- ~New functions/methods are listed in `api.rst`~

I think we can just use zarr to validate attributes, so we can support all types allowed by zarr.

Note that I removed the checks on the keys, as I believe we can rely on zarr for that as well. However, there is an issue with mixed types (e.g., `attrs={"a": "foo", 1: "foo"}`), but I think that needs to be addressed in zarr. See: https://github.com/zarr-developers/zarr-python/issues/1037

cc: @wankoelias @rabernat 