### PR TITLE
Improve perf of xr.corr

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3399,8 +3399,8 @@ class DataArray(
         return self._replace(self.variable.imag)
 
     def dot(
-        self, other: DataArray, dims: Hashable | Sequence[Hashable] | None = None
-    ) -> DataArray:
+        self, other: T_DataArray, dims: Hashable | Sequence[Hashable] | None = None
+    ) -> T_DataArray:
         """Perform dot product of two DataArrays along their shared dims.
 
         Equivalent to taking taking tensordot over all shared dims.


### PR DESCRIPTION
I think this should improve the performance of `xr.corr` & `xr.cov`, but I'm not sure about dask arrays. I haven't been able to do tests on them, but I can do that soon unless anyone has an a priori view.
