### PR TITLE
Fix kwargs used for extrapolation in docs

### DIFF
--- a/doc/user-guide/interpolation.rst
+++ b/doc/user-guide/interpolation.rst
@@ -169,7 +169,9 @@ Additional keyword arguments can be passed to scipy's functions.
         [("time", np.arange(4)), ("space", [0.1, 0.2, 0.3])],
     )
 
-    da.interp(time=4, space=np.linspace(-0.1, 0.5, 10), kwargs={"fill_value": "extrapolate"})
+    da.interp(
+        time=4, space=np.linspace(-0.1, 0.5, 10), kwargs={"fill_value": "extrapolate"}
+    )
 
 
 Advanced Interpolation
@@ -220,7 +222,9 @@ by passing additional arguments to SciPy's ``interpnd`` function,
 .. ipython:: python
 
     x = xr.DataArray([0.5, 1.5, 2.5, 3.5], dims="z", coords={"z": ["a", "b", "c", "d"]})
-    y = xr.DataArray([0.15, 0.25, 0.35, 0.45], dims="z", coords={"z": ["a", "b", "c", "d"]})
+    y = xr.DataArray(
+        [0.15, 0.25, 0.35, 0.45], dims="z", coords={"z": ["a", "b", "c", "d"]}
+    )
     da.interp(x=x, y=y, kwargs={"fill_value": None})
 
 For the details of the advanced indexing,

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1732,9 +1732,11 @@ class DataArray(
             the scipy interpolator:
 
             - ``interp1d``: {"linear", "nearest", "zero", "slinear",
-              "quadratic", "cubic"}
+              "quadratic", "cubic", "polynomial"}
             - ``interpn``: {"linear", "nearest"}
 
+            If ``"polynomial"`` is passed, the ``order`` keyword argument must
+            also be provided.
         assume_sorted : bool, optional
             If False, values of x can be in any order and they are sorted
             first. If True, x has to be an array of monotonically increasing
@@ -1870,10 +1872,12 @@ class DataArray(
             The method used to interpolate. The method should be supported by
             the scipy interpolator:
 
-            - {"linear", "nearest", "zero", "slinear", "quadratic", "cubic"}
-              when ``interp1d`` is called.
+            - {"linear", "nearest", "zero", "slinear", "quadratic", "cubic",
+              "polynomial"} when ``interp1d`` is called.
             - {"linear", "nearest"} when ``interpn`` is called.
 
+            If ``"polynomial"`` is passed, the ``order`` keyword argument must
+            also be provided.
         assume_sorted : bool, optional
             If False, values of coordinates that are interpolated over can be
             in any order and they are sorted first. If True, interpolated

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1709,28 +1709,40 @@ class DataArray(
         kwargs: Mapping[str, Any] = None,
         **coords_kwargs: Any,
     ) -> DataArray:
-        """Multidimensional interpolation of variables.
+        """Interpolate a DataArray onto new coordinates
+
+        Performs univariate or multivariate interpolation of a DataArray onto
+        new coordinates using scipy's interpolation routines. If interpolating
+        along an existing dimension, :py:class:`scipy.interpolate.interp1d` is
+        called. When interpolating along multiple existing dimensions, an
+        attempt is made to decompose the interpolation into multiple
+        1-dimensional interpolations. If this is possible,
+        :py:class:`scipy.interpolate.interp1d` is called. Otherwise,
+        :py:func:`scipy.interpolate.interpn` is called.
 
         Parameters
         ----------
         coords : dict, optional
             Mapping from dimension names to the new coordinates.
-            New coordinate can be an scalar, array-like or DataArray.
+            New coordinate can be a scalar, array-like or DataArray.
             If DataArrays are passed as new coordinates, their dimensions are
             used for the broadcasting. Missing values are skipped.
         method : str, default: "linear"
-            The method used to interpolate. Choose from
+            The method used to interpolate. The method should be supported by
+            the scipy interpolator:
 
-            - {"linear", "nearest"} for multidimensional array,
-            - {"linear", "nearest", "zero", "slinear", "quadratic", "cubic"} for 1-dimensional array.
+            - ``interp1d``: {"linear", "nearest", "zero", "slinear",
+              "quadratic", "cubic"}
+            - ``interpn``: {"linear", "nearest"}
+
         assume_sorted : bool, optional
             If False, values of x can be in any order and they are sorted
             first. If True, x has to be an array of monotonically increasing
             values.
         kwargs : dict
             Additional keyword arguments passed to scipy's interpolator. Valid
-            options and their behavior depend on if 1-dimensional or
-            multi-dimensional interpolation is used.
+            options and their behavior depend whether ``interp1d`` or
+            ``interpn`` is used.
         **coords_kwargs : {dim: coordinate, ...}, optional
             The keyword arguments form of ``coords``.
             One of coords or coords_kwargs must be provided.

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1853,6 +1853,13 @@ class DataArray(
         """Interpolate this object onto the coordinates of another object,
         filling out of range values with NaN.
 
+        If interpolating along a single existing dimension,
+        :py:class:`scipy.interpolate.interp1d` is called. When interpolating
+        along multiple existing dimensions, an attempt is made to decompose the
+        interpolation into multiple 1-dimensional interpolations. If this is
+        possible, :py:class:`scipy.interpolate.interp1d` is called. Otherwise,
+        :py:func:`scipy.interpolate.interpn` is called.
+
         Parameters
         ----------
         other : Dataset or DataArray
@@ -1860,10 +1867,13 @@ class DataArray(
             names to an 1d array-like, which provides coordinates upon
             which to index the variables in this dataset. Missing values are skipped.
         method : str, default: "linear"
-            The method used to interpolate. Choose from
+            The method used to interpolate. The method should be supported by
+            the scipy interpolator:
 
-            - {"linear", "nearest"} for multidimensional array,
-            - {"linear", "nearest", "zero", "slinear", "quadratic", "cubic"} for 1-dimensional array.
+            - {"linear", "nearest", "zero", "slinear", "quadratic", "cubic"}
+              when ``interp1d`` is called.
+            - {"linear", "nearest"} when ``interpn`` is called.
+
         assume_sorted : bool, optional
             If False, values of coordinates that are interpolated over can be
             in any order and they are sorted first. If True, interpolated

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3311,6 +3311,13 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
         """Interpolate this object onto the coordinates of another object,
         filling the out of range values with NaN.
 
+        If interpolating along a single existing dimension,
+        :py:class:`scipy.interpolate.interp1d` is called. When interpolating
+        along multiple existing dimensions, an attempt is made to decompose the
+        interpolation into multiple 1-dimensional interpolations. If this is
+        possible, :py:class:`scipy.interpolate.interp1d` is called. Otherwise,
+        :py:func:`scipy.interpolate.interpn` is called.
+
         Parameters
         ----------
         other : Dataset or DataArray
@@ -3318,9 +3325,12 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
             names to an 1d array-like, which provides coordinates upon
             which to index the variables in this dataset. Missing values are skipped.
         method : str, optional
-            {"linear", "nearest"} for multidimensional array,
-            {"linear", "nearest", "zero", "slinear", "quadratic", "cubic"}
-            for 1-dimensional array. 'linear' is used by default.
+            The method used to interpolate. The method should be supported by
+            the scipy interpolator:
+
+            - {"linear", "nearest", "zero", "slinear", "quadratic", "cubic"}
+              when ``interp1d`` is called.
+            - {"linear", "nearest"} when ``interpn`` is called.
         assume_sorted : bool, optional
             If False, values of coordinates that are interpolated over can be
             in any order and they are sorted first. If True, interpolated

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3036,7 +3036,16 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
         method_non_numeric: str = "nearest",
         **coords_kwargs: Any,
     ) -> Dataset:
-        """Multidimensional interpolation of Dataset.
+        """Interpolate a Dataset onto new coordinates
+
+        Performs univariate or multivariate interpolation of a Dataset onto
+        new coordinates using scipy's interpolation routines. If interpolating
+        along an existing dimension, :py:class:`scipy.interpolate.interp1d` is
+        called.  When interpolating along multiple existing dimensions, an
+        attempt is made to decompose the interpolation into multiple
+        1-dimensional interpolations. If this is possible,
+        :py:class:`scipy.interpolate.interp1d` is called. Otherwise,
+        :py:func:`scipy.interpolate.interpn` is called.
 
         Parameters
         ----------
@@ -3046,9 +3055,12 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
             If DataArrays are passed as new coordinates, their dimensions are
             used for the broadcasting. Missing values are skipped.
         method : str, optional
-            {"linear", "nearest"} for multidimensional array,
-            {"linear", "nearest", "zero", "slinear", "quadratic", "cubic"}
-            for 1-dimensional array. "linear" is used by default.
+            The method used to interpolate. The method should be supported by
+            the scipy interpolator:
+
+            - ``interp1d``: {"linear", "nearest", "zero", "slinear",
+              "quadratic", "cubic"}
+            - ``interpn``: {"linear", "nearest"}
         assume_sorted : bool, optional
             If False, values of coordinates that are interpolated over can be
             in any order and they are sorted first. If True, interpolated
@@ -3056,8 +3068,8 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
             values.
         kwargs : dict, optional
             Additional keyword arguments passed to scipy's interpolator. Valid
-            options and their behavior depend on if 1-dimensional or
-            multi-dimensional interpolation is used.
+            options and their behavior depend whether ``interp1d`` or
+            ``interpn`` is used.
         method_non_numeric : {"nearest", "pad", "ffill", "backfill", "bfill"}, optional
             Method for non-numeric types. Passed on to :py:meth:`Dataset.reindex`.
             ``"nearest"`` is used by default.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3059,8 +3059,11 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
             the scipy interpolator:
 
             - ``interp1d``: {"linear", "nearest", "zero", "slinear",
-              "quadratic", "cubic"}
+              "quadratic", "cubic", "polynomial"}
             - ``interpn``: {"linear", "nearest"}
+
+            If ``"polynomial"`` is passed, the ``order`` keyword argument must
+            also be provided.
         assume_sorted : bool, optional
             If False, values of coordinates that are interpolated over can be
             in any order and they are sorted first. If True, interpolated
@@ -3328,9 +3331,12 @@ class Dataset(DataWithCoords, DatasetReductions, DatasetArithmetic, Mapping):
             The method used to interpolate. The method should be supported by
             the scipy interpolator:
 
-            - {"linear", "nearest", "zero", "slinear", "quadratic", "cubic"}
-              when ``interp1d`` is called.
+            - {"linear", "nearest", "zero", "slinear", "quadratic", "cubic",
+              "polynomial"} when ``interp1d`` is called.
             - {"linear", "nearest"} when ``interpn`` is called.
+
+            If ``"polynomial"`` is passed, the ``order`` keyword argument must
+            also be provided.
         assume_sorted : bool, optional
             If False, values of coordinates that are interpolated over can be
             in any order and they are sorted first. If True, interpolated


### PR DESCRIPTION
The current version of xarray tries to call scipy's interp1d whenever
possible, and kwargs used in the user guide should reflect this.

Closes #6617
