### PR TITLE
Typing of `str` and `dt` accessors

### DIFF
--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -2,6 +2,7 @@ import re
 import warnings
 from datetime import datetime, timedelta
 from functools import partial
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -26,6 +27,9 @@ try:
     import cftime
 except ImportError:
     cftime = None
+
+if TYPE_CHECKING:
+    from ..core.types import CFCalendar
 
 # standard calendars recognized by cftime
 _STANDARD_CALENDARS = {"standard", "gregorian", "proleptic_gregorian"}
@@ -344,7 +348,7 @@ def _infer_time_units_from_diff(unique_timedeltas):
     return "seconds"
 
 
-def infer_calendar_name(dates):
+def infer_calendar_name(dates) -> CFCalendar:
     """Given an array of datetimes, infer the CF calendar name"""
     if is_np_datetime_like(dates.dtype):
         return "proleptic_gregorian"

--- a/xarray/core/accessor_dt.py
+++ b/xarray/core/accessor_dt.py
@@ -199,7 +199,7 @@ def _strftime(values, date_format):
         return access_method(values, date_format)
 
 
-class TimeAccesor(Generic[T_DataArray]):
+class TimeAccessor(Generic[T_DataArray]):
 
     __slots__ = ("_obj",)
 
@@ -268,7 +268,7 @@ class TimeAccesor(Generic[T_DataArray]):
         return self._tslib_round_accessor("round", freq)
 
 
-class DatetimeAccessor(TimeAccesor[T_DataArray]):
+class DatetimeAccessor(TimeAccessor[T_DataArray]):
     """Access datetime fields for DataArrays with datetime-like dtypes.
 
     Fields can be accessed through the `.dt` attribute
@@ -505,7 +505,7 @@ class DatetimeAccessor(TimeAccesor[T_DataArray]):
         return infer_calendar_name(self._obj.data)
 
 
-class TimedeltaAccessor(TimeAccesor[T_DataArray]):
+class TimedeltaAccessor(TimeAccessor[T_DataArray]):
     """Access Timedelta fields for DataArrays with Timedelta-like dtypes.
 
     Fields can be accessed through the `.dt` attribute for applicable DataArrays.

--- a/xarray/core/accessor_dt.py
+++ b/xarray/core/accessor_dt.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import warnings
+from typing import TYPE_CHECKING, Generic
 
 import numpy as np
 import pandas as pd
@@ -11,6 +14,12 @@ from .common import (
 )
 from .npcompat import DTypeLike
 from .pycompat import is_duck_dask_array
+from .types import T_DataArray
+
+if TYPE_CHECKING:
+    from .dataarray import DataArray
+    from .dataset import Dataset
+    from .types import CFCalendar
 
 
 def _season_from_months(months):
@@ -156,7 +165,7 @@ def _round_field(values, name, freq):
         return _round_through_series_or_index(values, name, freq)
 
 
-def _strftime_through_cftimeindex(values, date_format):
+def _strftime_through_cftimeindex(values, date_format: str):
     """Coerce an array of cftime-like values to a CFTimeIndex
     and access requested datetime component
     """
@@ -168,7 +177,7 @@ def _strftime_through_cftimeindex(values, date_format):
     return field_values.values.reshape(values.shape)
 
 
-def _strftime_through_series(values, date_format):
+def _strftime_through_series(values, date_format: str):
     """Coerce an array of datetime-like values to a pandas Series and
     apply string formatting
     """
@@ -190,33 +199,26 @@ def _strftime(values, date_format):
         return access_method(values, date_format)
 
 
-class Properties:
-    def __init__(self, obj):
+class TimeAccesor(Generic[T_DataArray]):
+
+    __slots__ = ("_obj",)
+
+    def __init__(self, obj: T_DataArray) -> None:
         self._obj = obj
 
-    @staticmethod
-    def _tslib_field_accessor(
-        name: str, docstring: str = None, dtype: DTypeLike = None
-    ):
-        def f(self, dtype=dtype):
-            if dtype is None:
-                dtype = self._obj.dtype
-            obj_type = type(self._obj)
-            result = _get_date_field(self._obj.data, name, dtype)
-            return obj_type(
-                result, name=name, coords=self._obj.coords, dims=self._obj.dims
-            )
+    def _date_field(self, name: str, dtype: DTypeLike) -> T_DataArray:
+        if dtype is None:
+            dtype = self._obj.dtype
+        obj_type = type(self._obj)
+        result = _get_date_field(self._obj.data, name, dtype)
+        return obj_type(result, name=name, coords=self._obj.coords, dims=self._obj.dims)
 
-        f.__name__ = name
-        f.__doc__ = docstring
-        return property(f)
-
-    def _tslib_round_accessor(self, name, freq):
+    def _tslib_round_accessor(self, name: str, freq: str) -> T_DataArray:
         obj_type = type(self._obj)
         result = _round_field(self._obj.data, name, freq)
         return obj_type(result, name=name, coords=self._obj.coords, dims=self._obj.dims)
 
-    def floor(self, freq):
+    def floor(self, freq: str) -> T_DataArray:
         """
         Round timestamps downward to specified frequency resolution.
 
@@ -233,7 +235,7 @@ class Properties:
 
         return self._tslib_round_accessor("floor", freq)
 
-    def ceil(self, freq):
+    def ceil(self, freq: str) -> T_DataArray:
         """
         Round timestamps upward to specified frequency resolution.
 
@@ -249,7 +251,7 @@ class Properties:
         """
         return self._tslib_round_accessor("ceil", freq)
 
-    def round(self, freq):
+    def round(self, freq: str) -> T_DataArray:
         """
         Round timestamps to specified frequency resolution.
 
@@ -266,7 +268,7 @@ class Properties:
         return self._tslib_round_accessor("round", freq)
 
 
-class DatetimeAccessor(Properties):
+class DatetimeAccessor(TimeAccesor[T_DataArray]):
     """Access datetime fields for DataArrays with datetime-like dtypes.
 
     Fields can be accessed through the `.dt` attribute
@@ -301,7 +303,7 @@ class DatetimeAccessor(Properties):
 
     """
 
-    def strftime(self, date_format):
+    def strftime(self, date_format: str) -> T_DataArray:
         """
         Return an array of formatted strings specified by date_format, which
         supports the same string format as the python standard library. Details
@@ -334,7 +336,7 @@ class DatetimeAccessor(Properties):
             result, name="strftime", coords=self._obj.coords, dims=self._obj.dims
         )
 
-    def isocalendar(self):
+    def isocalendar(self) -> Dataset:
         """Dataset containing ISO year, week number, and weekday.
 
         Notes
@@ -358,31 +360,48 @@ class DatetimeAccessor(Properties):
 
         return Dataset(data_vars)
 
-    year = Properties._tslib_field_accessor(
-        "year", "The year of the datetime", np.int64
-    )
-    month = Properties._tslib_field_accessor(
-        "month", "The month as January=1, December=12", np.int64
-    )
-    day = Properties._tslib_field_accessor("day", "The days of the datetime", np.int64)
-    hour = Properties._tslib_field_accessor(
-        "hour", "The hours of the datetime", np.int64
-    )
-    minute = Properties._tslib_field_accessor(
-        "minute", "The minutes of the datetime", np.int64
-    )
-    second = Properties._tslib_field_accessor(
-        "second", "The seconds of the datetime", np.int64
-    )
-    microsecond = Properties._tslib_field_accessor(
-        "microsecond", "The microseconds of the datetime", np.int64
-    )
-    nanosecond = Properties._tslib_field_accessor(
-        "nanosecond", "The nanoseconds of the datetime", np.int64
-    )
+    @property
+    def year(self) -> T_DataArray:
+        """The year of the datetime"""
+        return self._date_field("year", np.int64)
 
     @property
-    def weekofyear(self):
+    def month(self) -> T_DataArray:
+        """The month as January=1, December=12"""
+        return self._date_field("month", np.int64)
+
+    @property
+    def day(self) -> T_DataArray:
+        """The days of the datetime"""
+        return self._date_field("day", np.int64)
+
+    @property
+    def hour(self) -> T_DataArray:
+        """The hours of the datetime"""
+        return self._date_field("hour", np.int64)
+
+    @property
+    def minute(self) -> T_DataArray:
+        """The minutes of the datetime"""
+        return self._date_field("minute", np.int64)
+
+    @property
+    def second(self) -> T_DataArray:
+        """The seconds of the datetime"""
+        return self._date_field("second", np.int64)
+
+    @property
+    def microsecond(self) -> T_DataArray:
+        """The microseconds of the datetime"""
+        return self._date_field("microsecond", np.int64)
+
+    @property
+    def nanosecond(self) -> T_DataArray:
+        """The nanoseconds of the datetime"""
+        return self._date_field("nanosecond", np.int64)
+
+    @property
+    def weekofyear(self) -> DataArray:
         "The week ordinal of the year"
 
         warnings.warn(
@@ -396,64 +415,88 @@ class DatetimeAccessor(Properties):
         return weekofyear
 
     week = weekofyear
-    dayofweek = Properties._tslib_field_accessor(
-        "dayofweek", "The day of the week with Monday=0, Sunday=6", np.int64
-    )
-    weekday = dayofweek
-
-    weekday_name = Properties._tslib_field_accessor(
-        "weekday_name", "The name of day in a week", object
-    )
-
-    dayofyear = Properties._tslib_field_accessor(
-        "dayofyear", "The ordinal day of the year", np.int64
-    )
-    quarter = Properties._tslib_field_accessor("quarter", "The quarter of the date")
-    days_in_month = Properties._tslib_field_accessor(
-        "days_in_month", "The number of days in the month", np.int64
-    )
-    daysinmonth = days_in_month
-
-    season = Properties._tslib_field_accessor("season", "Season of the year", object)
-
-    time = Properties._tslib_field_accessor(
-        "time", "Timestamps corresponding to datetimes", object
-    )
-
-    date = Properties._tslib_field_accessor(
-        "date", "Date corresponding to datetimes", object
-    )
-
-    is_month_start = Properties._tslib_field_accessor(
-        "is_month_start",
-        "Indicates whether the date is the first day of the month.",
-        bool,
-    )
-    is_month_end = Properties._tslib_field_accessor(
-        "is_month_end", "Indicates whether the date is the last day of the month.", bool
-    )
-    is_quarter_start = Properties._tslib_field_accessor(
-        "is_quarter_start",
-        "Indicator for whether the date is the first day of a quarter.",
-        bool,
-    )
-    is_quarter_end = Properties._tslib_field_accessor(
-        "is_quarter_end",
-        "Indicator for whether the date is the last day of a quarter.",
-        bool,
-    )
-    is_year_start = Properties._tslib_field_accessor(
-        "is_year_start", "Indicate whether the date is the first day of a year.", bool
-    )
-    is_year_end = Properties._tslib_field_accessor(
-        "is_year_end", "Indicate whether the date is the last day of the year.", bool
-    )
-    is_leap_year = Properties._tslib_field_accessor(
-        "is_leap_year", "Boolean indicator if the date belongs to a leap year.", bool
-    )
 
     @property
-    def calendar(self):
+    def dayofweek(self) -> T_DataArray:
+        """The day of the week with Monday=0, Sunday=6"""
+        return self._date_field("dayofweek", np.int64)
+
+    weekday = dayofweek
+
+    @property
+    def weekday_name(self) -> T_DataArray:
+        """The name of day in a week"""
+        return self._date_field("weekday_name", object)
+
+    @property
+    def dayofyear(self) -> T_DataArray:
+        """The ordinal day of the year"""
+        return self._date_field("dayofyear", np.int64)
+
+    @property
+    def quarter(self) -> T_DataArray:
+        """The quarter of the date"""
+        return self._date_field("quarter", np.int64)
+
+    @property
+    def days_in_month(self) -> T_DataArray:
+        """The number of days in the month"""
+        return self._date_field("days_in_month", np.int64)
+
+    daysinmonth = days_in_month
+
+    @property
+    def season(self) -> T_DataArray:
+        """Season of the year"""
+        return self._date_field("season", object)
+
+    @property
+    def time(self) -> T_DataArray:
+        """Timestamps corresponding to datetimes"""
+        return self._date_field("time", object)
+
+    @property
+    def date(self) -> T_DataArray:
+        """Date corresponding to datetimes"""
+        return self._date_field("date", object)
+
+    @property
+    def is_month_start(self) -> T_DataArray:
+        """Indicate whether the date is the first day of the month"""
+        return self._date_field("is_month_start", bool)
+
+    @property
+    def is_month_end(self) -> T_DataArray:
+        """Indicate whether the date is the last day of the month"""
+        return self._date_field("is_month_end", bool)
+
+    @property
+    def is_quarter_start(self) -> T_DataArray:
+        """Indicate whether the date is the first day of a quarter"""
+        return self._date_field("is_quarter_start", bool)
+
+    @property
+    def is_quarter_end(self) -> T_DataArray:
+        """Indicate whether the date is the last day of a quarter"""
+        return self._date_field("is_quarter_end", bool)
+
+    @property
+    def is_year_start(self) -> T_DataArray:
+        """Indicate whether the date is the first day of a year"""
+        return self._date_field("is_year_start", bool)
+
+    @property
+    def is_year_end(self) -> T_DataArray:
+        """Indicate whether the date is the last day of the year"""
+        return self._date_field("is_year_end", bool)
+
+    @property
+    def is_leap_year(self) -> T_DataArray:
+        """Indicate if the date belongs to a leap year"""
+        return self._date_field("is_leap_year", bool)
+
+    @property
+    def calendar(self) -> CFCalendar:
         """The name of the calendar of the dates.
 
         Only relevant for arrays of :py:class:`cftime.datetime` objects,
@@ -462,7 +505,7 @@ class DatetimeAccessor(Properties):
         return infer_calendar_name(self._obj.data)
 
 
-class TimedeltaAccessor(Properties):
+class TimedeltaAccessor(TimeAccesor[T_DataArray]):
     """Access Timedelta fields for DataArrays with Timedelta-like dtypes.
 
     Fields can be accessed through the `.dt` attribute for applicable DataArrays.
@@ -502,28 +545,31 @@ class TimedeltaAccessor(Properties):
       * time     (time) timedelta64[ns] 1 days 00:00:00 ... 5 days 18:00:00
     """
 
-    days = Properties._tslib_field_accessor(
-        "days", "Number of days for each element.", np.int64
-    )
-    seconds = Properties._tslib_field_accessor(
-        "seconds",
-        "Number of seconds (>= 0 and less than 1 day) for each element.",
-        np.int64,
-    )
-    microseconds = Properties._tslib_field_accessor(
-        "microseconds",
-        "Number of microseconds (>= 0 and less than 1 second) for each element.",
-        np.int64,
-    )
-    nanoseconds = Properties._tslib_field_accessor(
-        "nanoseconds",
-        "Number of nanoseconds (>= 0 and less than 1 microsecond) for each element.",
-        np.int64,
-    )
+    @property
+    def days(self) -> T_DataArray:
+        """Number of days for each element"""
+        return self._date_field("days", np.int64)
+
+    @property
+    def seconds(self) -> T_DataArray:
+        """Number of seconds (>= 0 and less than 1 day) for each element"""
+        return self._date_field("seconds", np.int64)
+
+    @property
+    def microseconds(self) -> T_DataArray:
+        """Number of microseconds (>= 0 and less than 1 second) for each element"""
+        return self._date_field("microseconds", np.int64)
+
+    @property
+    def nanoseconds(self) -> T_DataArray:
+        """Number of nanoseconds (>= 0 and less than 1 microsecond) for each element"""
+        return self._date_field("nanoseconds", np.int64)
 
 
-class CombinedDatetimelikeAccessor(DatetimeAccessor, TimedeltaAccessor):
-    def __new__(cls, obj):
+class CombinedDatetimelikeAccessor(
+    DatetimeAccessor[T_DataArray], TimedeltaAccessor[T_DataArray]
+):
+    def __new__(cls, obj: T_DataArray) -> CombinedDatetimelikeAccessor:
         # CombinedDatetimelikeAccessor isn't really instatiated. Instead
         # we need to choose which parent (datetime or timedelta) is
         # appropriate. Since we're checking the dtypes anyway, we'll just
@@ -537,6 +583,6 @@ class CombinedDatetimelikeAccessor(DatetimeAccessor, TimedeltaAccessor):
             )
 
         if is_np_timedelta_like(obj.dtype):
-            return TimedeltaAccessor(obj)
+            return TimedeltaAccessor(obj)  # type: ignore[return-value]
         else:
-            return DatetimeAccessor(obj)
+            return DatetimeAccessor(obj)  # type: ignore[return-value]

--- a/xarray/core/accessor_str.py
+++ b/xarray/core/accessor_str.py
@@ -37,27 +37,23 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import codecs
 import re
 import textwrap
 from functools import reduce
 from operator import or_ as set_union
-from typing import (
-    Any,
-    Callable,
-    Hashable,
-    Mapping,
-    Optional,
-    Pattern,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Generic, Hashable, Mapping, Pattern
 from unicodedata import normalize
 
 import numpy as np
 
 from .computation import apply_ufunc
+from .types import T_DataArray
+
+if TYPE_CHECKING:
+    from .dataarray import DataArray
 
 _cpython_optimized_encoders = (
     "utf-8",
@@ -112,10 +108,10 @@ def _apply_str_ufunc(
     *,
     func: Callable,
     obj: Any,
-    dtype: Union[str, np.dtype, Type] = None,
-    output_core_dims: Union[list, tuple] = ((),),
+    dtype: str | np.dtype | type = None,
+    output_core_dims: list | tuple = ((),),
     output_sizes: Mapping[Any, int] = None,
-    func_args: Tuple = (),
+    func_args: tuple = (),
     func_kwargs: Mapping = {},
 ) -> Any:
     # TODO handling of na values ?
@@ -139,7 +135,7 @@ def _apply_str_ufunc(
     )
 
 
-class StringAccessor:
+class StringAccessor(Generic[T_DataArray]):
     r"""Vectorized string functions for string-like arrays.
 
     Similar to pandas, fields can be accessed through the `.str` attribute
@@ -204,13 +200,10 @@ class StringAccessor:
 
     __slots__ = ("_obj",)
 
-    def __init__(self, obj):
+    def __init__(self, obj: T_DataArray) -> None:
         self._obj = obj
 
-    def _stringify(
-        self,
-        invar: Any,
-    ) -> Union[str, bytes, Any]:
+    def _stringify(self, invar: Any) -> str | bytes | Any:
         """
         Convert a string-like to the correct string/bytes type.
 
@@ -225,10 +218,10 @@ class StringAccessor:
         self,
         *,
         func: Callable,
-        dtype: Union[str, np.dtype, Type] = None,
-        output_core_dims: Union[list, tuple] = ((),),
+        dtype: str | np.dtype | type = None,
+        output_core_dims: list | tuple = ((),),
         output_sizes: Mapping[Any, int] = None,
-        func_args: Tuple = (),
+        func_args: tuple = (),
         func_kwargs: Mapping = {},
     ) -> Any:
         return _apply_str_ufunc(
@@ -244,10 +237,10 @@ class StringAccessor:
     def _re_compile(
         self,
         *,
-        pat: Union[str, bytes, Pattern, Any],
+        pat: str | bytes | Pattern | Any,
         flags: int = 0,
         case: bool = None,
-    ) -> Union[Pattern, Any]:
+    ) -> Pattern | Any:
         is_compiled_re = isinstance(pat, re.Pattern)
 
         if is_compiled_re and flags != 0:
@@ -281,7 +274,7 @@ class StringAccessor:
         else:
             return _apply_str_ufunc(func=func, obj=pat, dtype=np.object_)
 
-    def len(self) -> Any:
+    def len(self) -> T_DataArray:
         """
         Compute the length of each string in the array.
 
@@ -293,22 +286,19 @@ class StringAccessor:
 
     def __getitem__(
         self,
-        key: Union[int, slice],
+        key: int | slice,
     ) -> Any:
         if isinstance(key, slice):
             return self.slice(start=key.start, stop=key.stop, step=key.step)
         else:
             return self.get(key)
 
-    def __add__(
-        self,
-        other: Any,
-    ) -> Any:
+    def __add__(self, other: Any) -> T_DataArray:
         return self.cat(other, sep="")
 
     def __mul__(
         self,
-        num: Union[int, Any],
+        num: int | Any,
     ) -> Any:
         return self.repeat(num)
 
@@ -327,8 +317,8 @@ class StringAccessor:
 
     def get(
         self,
-        i: Union[int, Any],
-        default: Union[str, bytes] = "",
+        i: int | Any,
+        default: str | bytes = "",
     ) -> Any:
         """
         Extract character number `i` from each string in the array.
@@ -360,9 +350,9 @@ class StringAccessor:
 
     def slice(
         self,
-        start: Union[int, Any] = None,
-        stop: Union[int, Any] = None,
-        step: Union[int, Any] = None,
+        start: int | Any = None,
+        stop: int | Any = None,
+        step: int | Any = None,
     ) -> Any:
         """
         Slice substrings from each string in the array.
@@ -391,9 +381,9 @@ class StringAccessor:
 
     def slice_replace(
         self,
-        start: Union[int, Any] = None,
-        stop: Union[int, Any] = None,
-        repl: Union[str, bytes, Any] = "",
+        start: int | Any = None,
+        stop: int | Any = None,
+        repl: str | bytes | Any = "",
     ) -> Any:
         """
         Replace a positional slice of a string with another value.
@@ -436,11 +426,7 @@ class StringAccessor:
 
         return self._apply(func=func, func_args=(start, stop, repl))
 
-    def cat(
-        self,
-        *others,
-        sep: Union[str, bytes, Any] = "",
-    ) -> Any:
+    def cat(self, *others, sep: str | bytes | Any = "") -> T_DataArray:
         """
         Concatenate strings elementwise in the DataArray with other strings.
 
@@ -524,8 +510,8 @@ class StringAccessor:
     def join(
         self,
         dim: Hashable = None,
-        sep: Union[str, bytes, Any] = "",
-    ) -> Any:
+        sep: str | bytes | Any = "",
+    ) -> T_DataArray:
         """
         Concatenate strings in a DataArray along a particular dimension.
 
@@ -596,7 +582,7 @@ class StringAccessor:
         self,
         *args: Any,
         **kwargs: Any,
-    ) -> Any:
+    ) -> T_DataArray:
         """
         Perform python string formatting on each element of the DataArray.
 
@@ -676,7 +662,7 @@ class StringAccessor:
         )
         return self._apply(func=func, func_args=args, func_kwargs={"kwargs": kwargs})
 
-    def capitalize(self) -> Any:
+    def capitalize(self) -> T_DataArray:
         """
         Convert strings in the array to be capitalized.
 
@@ -686,7 +672,7 @@ class StringAccessor:
         """
         return self._apply(func=lambda x: x.capitalize())
 
-    def lower(self) -> Any:
+    def lower(self) -> T_DataArray:
         """
         Convert strings in the array to lowercase.
 
@@ -696,7 +682,7 @@ class StringAccessor:
         """
         return self._apply(func=lambda x: x.lower())
 
-    def swapcase(self) -> Any:
+    def swapcase(self) -> T_DataArray:
         """
         Convert strings in the array to be swapcased.
 
@@ -706,7 +692,7 @@ class StringAccessor:
         """
         return self._apply(func=lambda x: x.swapcase())
 
-    def title(self) -> Any:
+    def title(self) -> T_DataArray:
         """
         Convert strings in the array to titlecase.
 
@@ -716,7 +702,7 @@ class StringAccessor:
         """
         return self._apply(func=lambda x: x.title())
 
-    def upper(self) -> Any:
+    def upper(self) -> T_DataArray:
         """
         Convert strings in the array to uppercase.
 
@@ -726,7 +712,7 @@ class StringAccessor:
         """
         return self._apply(func=lambda x: x.upper())
 
-    def casefold(self) -> Any:
+    def casefold(self) -> T_DataArray:
         """
         Convert strings in the array to be casefolded.
 
@@ -744,7 +730,7 @@ class StringAccessor:
     def normalize(
         self,
         form: str,
-    ) -> Any:
+    ) -> T_DataArray:
         """
         Return the Unicode normal form for the strings in the datarray.
 
@@ -763,7 +749,7 @@ class StringAccessor:
         """
         return self._apply(func=lambda x: normalize(form, x))
 
-    def isalnum(self) -> Any:
+    def isalnum(self) -> T_DataArray:
         """
         Check whether all characters in each string are alphanumeric.
 
@@ -774,7 +760,7 @@ class StringAccessor:
         """
         return self._apply(func=lambda x: x.isalnum(), dtype=bool)
 
-    def isalpha(self) -> Any:
+    def isalpha(self) -> T_DataArray:
         """
         Check whether all characters in each string are alphabetic.
 
@@ -785,7 +771,7 @@ class StringAccessor:
         """
         return self._apply(func=lambda x: x.isalpha(), dtype=bool)
 
-    def isdecimal(self) -> Any:
+    def isdecimal(self) -> T_DataArray:
         """
         Check whether all characters in each string are decimal.
 
@@ -796,7 +782,7 @@ class StringAccessor:
         """
         return self._apply(func=lambda x: x.isdecimal(), dtype=bool)
 
-    def isdigit(self) -> Any:
+    def isdigit(self) -> T_DataArray:
         """
         Check whether all characters in each string are digits.
 
@@ -807,7 +793,7 @@ class StringAccessor:
         """
         return self._apply(func=lambda x: x.isdigit(), dtype=bool)
 
-    def islower(self) -> Any:
+    def islower(self) -> T_DataArray:
         """
         Check whether all characters in each string are lowercase.
 
@@ -818,7 +804,7 @@ class StringAccessor:
         """
         return self._apply(func=lambda x: x.islower(), dtype=bool)
 
-    def isnumeric(self) -> Any:
+    def isnumeric(self) -> T_DataArray:
         """
         Check whether all characters in each string are numeric.
 
@@ -829,7 +815,7 @@ class StringAccessor:
         """
         return self._apply(func=lambda x: x.isnumeric(), dtype=bool)
 
-    def isspace(self) -> Any:
+    def isspace(self) -> T_DataArray:
         """
         Check whether all characters in each string are spaces.
 
@@ -840,7 +826,7 @@ class StringAccessor:
         """
         return self._apply(func=lambda x: x.isspace(), dtype=bool)
 
-    def istitle(self) -> Any:
+    def istitle(self) -> T_DataArray:
         """
         Check whether all characters in each string are titlecase.
 
@@ -851,7 +837,7 @@ class StringAccessor:
         """
         return self._apply(func=lambda x: x.istitle(), dtype=bool)
 
-    def isupper(self) -> Any:
+    def isupper(self) -> T_DataArray:
         """
         Check whether all characters in each string are uppercase.
 
@@ -863,11 +849,8 @@ class StringAccessor:
         return self._apply(func=lambda x: x.isupper(), dtype=bool)
 
     def count(
-        self,
-        pat: Union[str, bytes, Pattern, Any],
-        flags: int = 0,
-        case: bool = None,
-    ) -> Any:
+        self, pat: str | bytes | Pattern | Any, flags: int = 0, case: bool = None
+    ) -> T_DataArray:
         """
         Count occurrences of pattern in each string of the array.
 
@@ -903,10 +886,7 @@ class StringAccessor:
         func = lambda x, ipat: len(ipat.findall(x))
         return self._apply(func=func, func_args=(pat,), dtype=int)
 
-    def startswith(
-        self,
-        pat: Union[str, bytes, Any],
-    ) -> Any:
+    def startswith(self, pat: str | bytes | Any) -> T_DataArray:
         """
         Test if the start of each string in the array matches a pattern.
 
@@ -929,10 +909,7 @@ class StringAccessor:
         func = lambda x, y: x.startswith(y)
         return self._apply(func=func, func_args=(pat,), dtype=bool)
 
-    def endswith(
-        self,
-        pat: Union[str, bytes, Any],
-    ) -> Any:
+    def endswith(self, pat: str | bytes | Any) -> T_DataArray:
         """
         Test if the end of each string in the array matches a pattern.
 
@@ -957,10 +934,10 @@ class StringAccessor:
 
     def pad(
         self,
-        width: Union[int, Any],
+        width: int | Any,
         side: str = "left",
-        fillchar: Union[str, bytes, Any] = " ",
-    ) -> Any:
+        fillchar: str | bytes | Any = " ",
+    ) -> T_DataArray:
         """
         Pad strings in the array up to width.
 
@@ -999,9 +976,9 @@ class StringAccessor:
         self,
         *,
         func: Callable,
-        width: Union[int, Any],
-        fillchar: Union[str, bytes, Any] = " ",
-    ) -> Any:
+        width: int | Any,
+        fillchar: str | bytes | Any = " ",
+    ) -> T_DataArray:
         """
         Wrapper function to handle padding operations
         """
@@ -1015,10 +992,8 @@ class StringAccessor:
         return self._apply(func=overfunc, func_args=(width, fillchar))
 
     def center(
-        self,
-        width: Union[int, Any],
-        fillchar: Union[str, bytes, Any] = " ",
-    ) -> Any:
+        self, width: int | Any, fillchar: str | bytes | Any = " "
+    ) -> T_DataArray:
         """
         Pad left and right side of each string in the array.
 
@@ -1043,9 +1018,9 @@ class StringAccessor:
 
     def ljust(
         self,
-        width: Union[int, Any],
-        fillchar: Union[str, bytes, Any] = " ",
-    ) -> Any:
+        width: int | Any,
+        fillchar: str | bytes | Any = " ",
+    ) -> T_DataArray:
         """
         Pad right side of each string in the array.
 
@@ -1070,9 +1045,9 @@ class StringAccessor:
 
     def rjust(
         self,
-        width: Union[int, Any],
-        fillchar: Union[str, bytes, Any] = " ",
-    ) -> Any:
+        width: int | Any,
+        fillchar: str | bytes | Any = " ",
+    ) -> T_DataArray:
         """
         Pad left side of each string in the array.
 
@@ -1095,7 +1070,7 @@ class StringAccessor:
         func = self._obj.dtype.type.rjust
         return self._padder(func=func, width=width, fillchar=fillchar)
 
-    def zfill(self, width: Union[int, Any]) -> Any:
+    def zfill(self, width: int | Any) -> T_DataArray:
         """
         Pad each string in the array by prepending '0' characters.
 
@@ -1120,11 +1095,11 @@ class StringAccessor:
 
     def contains(
         self,
-        pat: Union[str, bytes, Pattern, Any],
+        pat: str | bytes | Pattern | Any,
         case: bool = None,
         flags: int = 0,
         regex: bool = True,
-    ) -> Any:
+    ) -> T_DataArray:
         """
         Test if pattern or regex is contained within each string of the array.
 
@@ -1181,22 +1156,22 @@ class StringAccessor:
             if case or case is None:
                 func = lambda x, ipat: ipat in x
             elif self._obj.dtype.char == "U":
-                uppered = self._obj.str.casefold()
-                uppat = StringAccessor(pat).casefold()
-                return uppered.str.contains(uppat, regex=False)
+                uppered = self.casefold()
+                uppat = StringAccessor(pat).casefold()  # type: ignore[type-var]  # hack?
+                return uppered.str.contains(uppat, regex=False)  # type: ignore[return-value]
             else:
-                uppered = self._obj.str.upper()
-                uppat = StringAccessor(pat).upper()
-                return uppered.str.contains(uppat, regex=False)
+                uppered = self.upper()
+                uppat = StringAccessor(pat).upper()  # type: ignore[type-var]  # hack?
+                return uppered.str.contains(uppat, regex=False)  # type: ignore[return-value]
 
         return self._apply(func=func, func_args=(pat,), dtype=bool)
 
     def match(
         self,
-        pat: Union[str, bytes, Pattern, Any],
+        pat: str | bytes | Pattern | Any,
         case: bool = None,
         flags: int = 0,
-    ) -> Any:
+    ) -> T_DataArray:
         """
         Determine if each string in the array matches a regular expression.
 
@@ -1229,10 +1204,8 @@ class StringAccessor:
         return self._apply(func=func, func_args=(pat,), dtype=bool)
 
     def strip(
-        self,
-        to_strip: Union[str, bytes, Any] = None,
-        side: str = "both",
-    ) -> Any:
+        self, to_strip: str | bytes | Any = None, side: str = "both"
+    ) -> T_DataArray:
         """
         Remove leading and trailing characters.
 
@@ -1269,10 +1242,7 @@ class StringAccessor:
 
         return self._apply(func=func, func_args=(to_strip,))
 
-    def lstrip(
-        self,
-        to_strip: Union[str, bytes, Any] = None,
-    ) -> Any:
+    def lstrip(self, to_strip: str | bytes | Any = None) -> T_DataArray:
         """
         Remove leading characters.
 
@@ -1295,10 +1265,7 @@ class StringAccessor:
         """
         return self.strip(to_strip, side="left")
 
-    def rstrip(
-        self,
-        to_strip: Union[str, bytes, Any] = None,
-    ) -> Any:
+    def rstrip(self, to_strip: str | bytes | Any = None) -> T_DataArray:
         """
         Remove trailing characters.
 
@@ -1321,11 +1288,7 @@ class StringAccessor:
         """
         return self.strip(to_strip, side="right")
 
-    def wrap(
-        self,
-        width: Union[int, Any],
-        **kwargs,
-    ) -> Any:
+    def wrap(self, width: int | Any, **kwargs) -> T_DataArray:
         """
         Wrap long strings in the array in paragraphs with length less than `width`.
 
@@ -1348,14 +1311,11 @@ class StringAccessor:
         wrapped : same type as values
         """
         ifunc = lambda x: textwrap.TextWrapper(width=x, **kwargs)
-        tw = StringAccessor(width)._apply(func=ifunc, dtype=np.object_)
+        tw = StringAccessor(width)._apply(func=ifunc, dtype=np.object_)  # type: ignore[type-var]  # hack?
         func = lambda x, itw: "\n".join(itw.wrap(x))
         return self._apply(func=func, func_args=(tw,))
 
-    def translate(
-        self,
-        table: Mapping[Union[str, bytes], Union[str, bytes]],
-    ) -> Any:
+    def translate(self, table: Mapping[str | bytes, str | bytes]) -> T_DataArray:
         """
         Map characters of each string through the given mapping table.
 
@@ -1376,8 +1336,8 @@ class StringAccessor:
 
     def repeat(
         self,
-        repeats: Union[int, Any],
-    ) -> Any:
+        repeats: int | Any,
+    ) -> T_DataArray:
         """
         Repeat each string in the array.
 
@@ -1400,11 +1360,11 @@ class StringAccessor:
 
     def find(
         self,
-        sub: Union[str, bytes, Any],
-        start: Union[int, Any] = 0,
-        end: Union[int, Any] = None,
+        sub: str | bytes | Any,
+        start: int | Any = 0,
+        end: int | Any = None,
         side: str = "left",
-    ) -> Any:
+    ) -> T_DataArray:
         """
         Return lowest or highest indexes in each strings in the array
         where the substring is fully contained between [start:end].
@@ -1445,10 +1405,10 @@ class StringAccessor:
 
     def rfind(
         self,
-        sub: Union[str, bytes, Any],
-        start: Union[int, Any] = 0,
-        end: Union[int, Any] = None,
-    ) -> Any:
+        sub: str | bytes | Any,
+        start: int | Any = 0,
+        end: int | Any = None,
+    ) -> T_DataArray:
         """
         Return highest indexes in each strings in the array
         where the substring is fully contained between [start:end].
@@ -1477,11 +1437,11 @@ class StringAccessor:
 
     def index(
         self,
-        sub: Union[str, bytes, Any],
-        start: Union[int, Any] = 0,
-        end: Union[int, Any] = None,
+        sub: str | bytes | Any,
+        start: int | Any = 0,
+        end: int | Any = None,
         side: str = "left",
-    ) -> Any:
+    ) -> T_DataArray:
         """
         Return lowest or highest indexes in each strings where the substring is
         fully contained between [start:end]. This is the same as
@@ -1528,10 +1488,10 @@ class StringAccessor:
 
     def rindex(
         self,
-        sub: Union[str, bytes, Any],
-        start: Union[int, Any] = 0,
-        end: Union[int, Any] = None,
-    ) -> Any:
+        sub: str | bytes | Any,
+        start: int | Any = 0,
+        end: int | Any = None,
+    ) -> T_DataArray:
         """
         Return highest indexes in each strings where the substring is
         fully contained between [start:end]. This is the same as
@@ -1566,13 +1526,13 @@ class StringAccessor:
 
     def replace(
         self,
-        pat: Union[str, bytes, Pattern, Any],
-        repl: Union[str, bytes, Callable, Any],
-        n: Union[int, Any] = -1,
+        pat: str | bytes | Pattern | Any,
+        repl: str | bytes | Callable | Any,
+        n: int | Any = -1,
         case: bool = None,
         flags: int = 0,
         regex: bool = True,
-    ) -> Any:
+    ) -> T_DataArray:
         """
         Replace occurrences of pattern/regex in the array with some string.
 
@@ -1639,7 +1599,7 @@ class StringAccessor:
 
     def extract(
         self,
-        pat: Union[str, bytes, Pattern, Any],
+        pat: str | bytes | Pattern | Any,
         dim: Hashable,
         case: bool = None,
         flags: int = 0,
@@ -1783,7 +1743,7 @@ class StringAccessor:
 
     def extractall(
         self,
-        pat: Union[str, bytes, Pattern, Any],
+        pat: str | bytes | Pattern | Any,
         group_dim: Hashable,
         match_dim: Hashable,
         case: bool = None,
@@ -1958,7 +1918,7 @@ class StringAccessor:
 
     def findall(
         self,
-        pat: Union[str, bytes, Pattern, Any],
+        pat: str | bytes | Pattern | Any,
         case: bool = None,
         flags: int = 0,
     ) -> Any:
@@ -2053,9 +2013,9 @@ class StringAccessor:
         self,
         *,
         func: Callable,
-        dim: Hashable,
-        sep: Optional[Union[str, bytes, Any]],
-    ) -> Any:
+        dim: Hashable | None,
+        sep: str | bytes | Any | None,
+    ) -> T_DataArray:
         """
         Implements logic for `partition` and `rpartition`.
         """
@@ -2067,7 +2027,7 @@ class StringAccessor:
 
         # _apply breaks on an empty array in this case
         if not self._obj.size:
-            return self._obj.copy().expand_dims({dim: 0}, axis=-1)
+            return self._obj.copy().expand_dims({dim: 0}, axis=-1)  # type: ignore[return-value]
 
         arrfunc = lambda x, isep: np.array(func(x, isep), dtype=self._obj.dtype)
 
@@ -2083,9 +2043,9 @@ class StringAccessor:
 
     def partition(
         self,
-        dim: Optional[Hashable],
-        sep: Union[str, bytes, Any] = " ",
-    ) -> Any:
+        dim: Hashable | None,
+        sep: str | bytes | Any = " ",
+    ) -> T_DataArray:
         """
         Split the strings in the DataArray at the first occurrence of separator `sep`.
 
@@ -2103,7 +2063,7 @@ class StringAccessor:
         dim : hashable or None
             Name for the dimension to place the 3 elements in.
             If `None`, place the results as list elements in an object DataArray.
-        sep : str, default: " "
+        sep : str or bytes or array-like, default: " "
             String to split on.
             If array-like, it is broadcast.
 
@@ -2121,9 +2081,9 @@ class StringAccessor:
 
     def rpartition(
         self,
-        dim: Optional[Hashable],
-        sep: Union[str, bytes, Any] = " ",
-    ) -> Any:
+        dim: Hashable | None,
+        sep: str | bytes | Any = " ",
+    ) -> T_DataArray:
         """
         Split the strings in the DataArray at the last occurrence of separator `sep`.
 
@@ -2141,7 +2101,7 @@ class StringAccessor:
         dim : hashable or None
             Name for the dimension to place the 3 elements in.
             If `None`, place the results as list elements in an object DataArray.
-        sep : str, default: " "
+        sep : str or bytes or array-like, default: " "
             String to split on.
             If array-like, it is broadcast.
 
@@ -2163,9 +2123,9 @@ class StringAccessor:
         func: Callable,
         pre: bool,
         dim: Hashable,
-        sep: Optional[Union[str, bytes, Any]],
+        sep: str | bytes | Any | None,
         maxsplit: int,
-    ) -> Any:
+    ) -> DataArray:
         """
         Implements logic for `split` and `rsplit`.
         """
@@ -2208,10 +2168,10 @@ class StringAccessor:
 
     def split(
         self,
-        dim: Optional[Hashable],
-        sep: Union[str, bytes, Any] = None,
+        dim: Hashable | None,
+        sep: str | bytes | Any = None,
         maxsplit: int = -1,
-    ) -> Any:
+    ) -> DataArray:
         r"""
         Split strings in a DataArray around the given separator/delimiter `sep`.
 
@@ -2324,10 +2284,10 @@ class StringAccessor:
 
     def rsplit(
         self,
-        dim: Optional[Hashable],
-        sep: Union[str, bytes, Any] = None,
-        maxsplit: Union[int, Any] = -1,
-    ) -> Any:
+        dim: Hashable | None,
+        sep: str | bytes | Any = None,
+        maxsplit: int | Any = -1,
+    ) -> DataArray:
         r"""
         Split strings in a DataArray around the given separator/delimiter `sep`.
 
@@ -2443,8 +2403,8 @@ class StringAccessor:
     def get_dummies(
         self,
         dim: Hashable,
-        sep: Union[str, bytes, Any] = "|",
-    ) -> Any:
+        sep: str | bytes | Any = "|",
+    ) -> DataArray:
         """
         Return DataArray of dummy/indicator variables.
 
@@ -2519,11 +2479,7 @@ class StringAccessor:
         res.coords[dim] = vals
         return res
 
-    def decode(
-        self,
-        encoding: str,
-        errors: str = "strict",
-    ) -> Any:
+    def decode(self, encoding: str, errors: str = "strict") -> T_DataArray:
         """
         Decode character string in the array using indicated encoding.
 
@@ -2533,7 +2489,7 @@ class StringAccessor:
             The encoding to use.
             Please see the Python documentation `codecs standard encoders <https://docs.python.org/3/library/codecs.html#standard-encodings>`_
             section for a list of encodings handlers.
-        errors : str, optional
+        errors : str, default: "strict"
             The handler for encoding errors.
             Please see the Python documentation `codecs error handlers <https://docs.python.org/3/library/codecs.html#error-handlers>`_
             for a list of error handlers.
@@ -2549,11 +2505,7 @@ class StringAccessor:
             func = lambda x: decoder(x, errors)[0]
         return self._apply(func=func, dtype=np.str_)
 
-    def encode(
-        self,
-        encoding: str,
-        errors: str = "strict",
-    ) -> Any:
+    def encode(self, encoding: str, errors: str = "strict") -> T_DataArray:
         """
         Encode character string in the array using indicated encoding.
 
@@ -2563,7 +2515,7 @@ class StringAccessor:
             The encoding to use.
             Please see the Python documentation `codecs standard encoders <https://docs.python.org/3/library/codecs.html#standard-encodings>`_
             section for a list of encodings handlers.
-        errors : str, optional
+        errors : str, default: "strict"
             The handler for encoding errors.
             Please see the Python documentation `codecs error handlers <https://docs.python.org/3/library/codecs.html#error-handlers>`_
             for a list of error handlers.

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -765,7 +765,7 @@ def align(
 
 
 def deep_align(
-    objects,
+    objects: Iterable[Any],
     join: JoinOptions = "inner",
     copy=True,
     indexes=None,

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -282,7 +282,7 @@ def build_output_coords_and_indexes(
 def apply_dataarray_vfunc(
     func,
     *args,
-    signature,
+    signature: _UFuncSignature,
     join: JoinOptions = "inner",
     exclude_dims=frozenset(),
     keep_attrs="override",
@@ -405,12 +405,12 @@ def _unpack_dict_tuples(
 
 
 def apply_dict_of_variables_vfunc(
-    func, *args, signature, join="inner", fill_value=None
+    func, *args, signature: _UFuncSignature, join="inner", fill_value=None
 ):
     """Apply a variable level function over dicts of DataArray, DataArray,
     Variable and ndarray objects.
     """
-    args = [_as_variables_or_variable(arg) for arg in args]
+    args = tuple(_as_variables_or_variable(arg) for arg in args)
     names = join_dict_keys(args, how=join)
     grouped_by_name = collect_dict_values(args, names, fill_value)
 
@@ -443,13 +443,13 @@ def _fast_dataset(
 def apply_dataset_vfunc(
     func,
     *args,
-    signature,
+    signature: _UFuncSignature,
     join="inner",
     dataset_join="exact",
     fill_value=_NO_FILL_VALUE,
     exclude_dims=frozenset(),
     keep_attrs="override",
-):
+) -> Dataset | tuple[Dataset, ...]:
     """Apply a variable level function over Dataset, dict of DataArray,
     DataArray, Variable and/or ndarray objects.
     """
@@ -472,12 +472,13 @@ def apply_dataset_vfunc(
     list_of_coords, list_of_indexes = build_output_coords_and_indexes(
         args, signature, exclude_dims, combine_attrs=keep_attrs
     )
-    args = [getattr(arg, "data_vars", arg) for arg in args]
+    args = tuple(getattr(arg, "data_vars", arg) for arg in args)
 
     result_vars = apply_dict_of_variables_vfunc(
         func, *args, signature=signature, join=dataset_join, fill_value=fill_value
     )
 
+    out: Dataset | tuple[Dataset, ...]
     if signature.num_outputs > 1:
         out = tuple(
             _fast_dataset(*args)
@@ -657,14 +658,14 @@ def _vectorize(func, signature, output_dtypes, exclude_dims):
 def apply_variable_ufunc(
     func,
     *args,
-    signature,
+    signature: _UFuncSignature,
     exclude_dims=frozenset(),
     dask="forbidden",
     output_dtypes=None,
     vectorize=False,
     keep_attrs="override",
     dask_gufunc_kwargs=None,
-):
+) -> Variable | tuple[Variable, ...]:
     """Apply a ndarray level function over Variable and/or ndarray objects."""
     from .variable import Variable, as_compatible_data
 
@@ -785,7 +786,7 @@ def apply_variable_ufunc(
         combine_attrs=keep_attrs,
     )
 
-    output = []
+    output: list[Variable] = []
     for dims, data in zip(output_dims, result_data):
         data = as_compatible_data(data)
         if data.ndim != len(dims):

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -356,7 +356,7 @@ class DataArray(
     _resample_cls = resample.DataArrayResample
     _weighted_cls = weighted.DataArrayWeighted
 
-    dt = utils.UncachedAccessor(CombinedDatetimelikeAccessor)
+    dt = utils.UncachedAccessor(CombinedDatetimelikeAccessor["DataArray"])
 
     def __init__(
         self,
@@ -5077,4 +5077,4 @@ class DataArray(
 
     # this needs to be at the end, or mypy will confuse with `str`
     # https://mypy.readthedocs.io/en/latest/common_issues.html#dealing-with-conflicting-names
-    str = utils.UncachedAccessor(StringAccessor)
+    str = utils.UncachedAccessor(StringAccessor["DataArray"])

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -46,6 +46,18 @@ CombineAttrsOptions = Union[
 ]
 JoinOptions = Literal["outer", "inner", "left", "right", "exact", "override"]
 
+CFCalendar = Literal[
+    "standard",
+    "gregorian",
+    "proleptic_gregorian",
+    "noleap",
+    "365_day",
+    "360_day",
+    "julian",
+    "all_leap",
+    "366_day",
+]
+
 # TODO: Wait until mypy supports recursive objects in combination with typevars
 _T = TypeVar("_T")
 NestedSequence = Union[


### PR DESCRIPTION
This is initial try to get type hints for `str` and `dt` accessors.

I think there is no way of accessing the class at class scope (or is there?), so I had to use plain "DataArray" as the generic type of the accessors. I think that is acceptable for now.

The hack of `DatetimeAccessor` vs `TimedeltaAccessor` in the `CombinedDatetimelikeAccessor.__new__` is nothing static typing can handle, so at type-checking time all properties of both accessors are available. If someone has a better idea?

Maybe a common interface class for accessors would be also beneficial?