### PR TITLE
Add pre-commit hook to check CITATION.cff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,3 +63,7 @@ repos:
             typing-extensions==3.10.0.0,
             numpy,
           ]
+  - repo: https://github.com/citation-file-format/cff-converter-python
+    rev: ebf0b5e44d67f8beaa1cd13a0d0393ea04c6058d
+    hooks:
+    - id: validate-cff


### PR DESCRIPTION
Following the discussion in #6252, I am adding a pre-commit hook to check the CITATION.cff upon changes.