### PR TITLE
fix the python version for the TestPyPI release workflow

### DIFF
--- a/.github/workflows/testpypi-release.yaml
+++ b/.github/workflows/testpypi-release.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-python@v3
         name: Install Python
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-python@v3
         name: Install Python
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: actions/download-artifact@v3
         with:
           name: releases


### PR DESCRIPTION
follow-up to #6660