### PR TITLE
install the development version of `matplotlib` into the upstream-dev CI

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -19,7 +19,6 @@ conda uninstall -y --force \
     h5netcdf \
     xarray
 # to limit the runtime of Upstream CI
-python -m pip install pytest-timeout
 python -m pip install \
     -i https://pypi.anaconda.org/scipy-wheels-nightly/simple \
     --no-deps \
@@ -45,3 +44,4 @@ python -m pip install \
     git+https://github.com/SciTools/nc-time-axis \
     git+https://github.com/dcherian/flox \
     git+https://github.com/h5netcdf/h5netcdf
+python -m pip install pytest-timeout

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -18,6 +18,8 @@ conda uninstall -y --force \
     flox \
     h5netcdf \
     xarray
+# new matplotlib dependency
+python -m pip install --upgrade contourpy
 # to limit the runtime of Upstream CI
 python -m pip install \
     -i https://pypi.anaconda.org/scipy-wheels-nightly/simple \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -26,8 +26,8 @@ python -m pip install \
     --upgrade \
     numpy \
     scipy \
-    pandas \
-    matplotlib
+    matplotlib \
+    pandas
 python -m pip install \
     --no-deps \
     --upgrade \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -27,12 +27,7 @@ python -m pip install \
     --upgrade \
     numpy \
     scipy \
-    pandas
-python -m pip install \
-    -f https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com \
-    --no-deps \
-    --pre \
-    --upgrade \
+    pandas \
     matplotlib
 python -m pip install \
     --no-deps \


### PR DESCRIPTION
- [x] follow-up to #4947