### PR TITLE
DOC: note of how `chunks` can be defined

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1926,6 +1926,7 @@ class Dataset(
         Zarr chunks are determined in the following way:
 
         - From the ``chunks`` attribute in each variable's ``encoding``
+          (can be set via `Dataset.chunk`).
         - If the variable is a Dask array, from the dask chunks
         - If neither Dask chunks nor encoding chunks are present, chunks will
           be determined automatically by Zarr


### PR DESCRIPTION
Some tiny overlap with https://github.com/pydata/xarray/pull/6542.

I feel this minor changes helps it easy to navigate to other parts of the docs.

Some motivation behind the PR here: https://github.com/pydata/xarray/discussions/6697

Note: i've forgotten the syntax for how to create a link to https://xarray.pydata.org/en/stable/generated/xarray.Dataset.chunk.html