### PR TITLE
use `pytest-reportlog` to generate upstream-dev CI failure reports

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -90,6 +90,7 @@ jobs:
         if: |
           failure()
           && steps.status.outcome == 'failure'
+          && github.event_name == 'schedule'
           && github.repository == 'pydata/xarray'
         uses: actions/upload-artifact@v3
         with:
@@ -102,6 +103,7 @@ jobs:
     needs: upstream-dev
     if: |
       failure()
+      && github.event_name == 'schedule'
       && needs.upstream-dev.outputs.artifacts_availability == 'true'
     runs-on: ubuntu-latest
     defaults:
@@ -128,7 +130,6 @@ jobs:
           python .github/workflows/parse_logs.py logs/**/*-log*
           cat pytest-logs.txt
       - name: Report failures
-        if: github.event_name == 'schedule'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -62,6 +62,7 @@ jobs:
           environment-name: xarray-tests
           extra-specs: |
             python=${{ matrix.python-version }}
+            pytest-reportlog
       - name: Install upstream versions
         run: |
           bash ci/install-upstream-wheels.sh
@@ -80,10 +81,11 @@ jobs:
         if: success()
         id: status
         run: |
-          set -euo pipefail
-          python -m pytest --timeout=60 -rf | tee output-${{ matrix.python-version }}-log || (
+          python -m pytest --timeout=60 -rf \
+            --report-log output-${{ matrix.python-version }}-log.jsonl \
+            || (
               echo '::set-output name=ARTIFACTS_AVAILABLE::true' && false
-          )
+            )
       - name: Upload artifacts
         if: |
           failure()
@@ -122,7 +124,7 @@ jobs:
       - name: Parse logs
         run: |
           shopt -s globstar
-          python .github/workflows/parse_logs.py logs/**/*-log
+          python .github/workflows/parse_logs.py logs/**/*-log*
       - name: Report failures
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -126,6 +126,7 @@ jobs:
         run: |
           shopt -s globstar
           python .github/workflows/parse_logs.py logs/**/*-log*
+          cat pytest-logs.txt
       - name: Report failures
         if: github.event_name == 'schedule'
         uses: actions/github-script@v6

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -90,7 +90,6 @@ jobs:
         if: |
           failure()
           && steps.status.outcome == 'failure'
-          && github.event_name == 'schedule'
           && github.repository == 'pydata/xarray'
         uses: actions/upload-artifact@v3
         with:
@@ -103,7 +102,6 @@ jobs:
     needs: upstream-dev
     if: |
       failure()
-      && github.event_name == 'schedule'
       && needs.upstream-dev.outputs.artifacts_availability == 'true'
     runs-on: ubuntu-latest
     defaults:
@@ -129,6 +127,7 @@ jobs:
           shopt -s globstar
           python .github/workflows/parse_logs.py logs/**/*-log*
       - name: Report failures
+        if: github.event_name == 'schedule'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -93,8 +93,8 @@ jobs:
           && github.repository == 'pydata/xarray'
         uses: actions/upload-artifact@v3
         with:
-          name: output-${{ matrix.python-version }}-log
-          path: output-${{ matrix.python-version }}-log
+          name: output-${{ matrix.python-version }}-log.jsonl
+          path: output-${{ matrix.python-version }}-log.jsonl
           retention-days: 5
 
   report:

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -121,6 +121,9 @@ jobs:
         run: |
           rsync -a /tmp/workspace/logs/output-*/ ./logs
           ls -R ./logs
+      - name: install dependencies
+        run: |
+          python -m pip install pytest
       - name: Parse logs
         run: |
           shopt -s globstar


### PR DESCRIPTION
We currently use the output of `pytest` to generate our test results, which is both fragile and does not detect import errors on test collection.

Instead, we can use `pytest-reportlog` to generate a machine-readable file that is easy to parse (`junit` XML would probably work, too, but apparently does not entirely fit the different failure modes of `pytest`).

The new script will collect failure summaries like the old version, but it should be fairly easy to create a fancy report with more information.