### PR TITLE
Typing of GroupBy & Co.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,14 +22,13 @@ v2022.06.0 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
-- Initial typing support for :py:meth:`groupby`, :py:meth:`rolling`, :py:meth:`rolling_exp`,
-  :py:meth:`coarsen`, :py:meth:`weighted`, :py:meth:`resample`,
-  (:pull:`6702`)
-  By `Michael Niklas <https://github.com/headtr1ck>`_.
-
 - Add :py:meth:`Dataset.dtypes`, :py:meth:`DatasetCoordinates.dtypes`,
   :py:meth:`DataArrayCoordinates.dtypes` properties: Mapping from variable names to dtypes.
   (:pull:`6706`)
+  By `Michael Niklas <https://github.com/headtr1ck>`_.
+- Initial typing support for :py:meth:`groupby`, :py:meth:`rolling`, :py:meth:`rolling_exp`,
+  :py:meth:`coarsen`, :py:meth:`weighted`, :py:meth:`resample`,
+  (:pull:`6702`)
   By `Michael Niklas <https://github.com/headtr1ck>`_.
 
 Deprecations

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,6 +22,11 @@ v2022.06.0 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- Initial typing support for :py:meth:`groupby`, :py:meth:`rolling`, :py:meth:`rolling_exp`,
+  :py:meth:`coarsen`, :py:meth:`weighted`, :py:meth:`resample`,
+  (:pull:`6702`)
+  By `Michael Niklas <https://github.com/headtr1ck>`_.
+
 
 Deprecations
 ~~~~~~~~~~~~

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -215,7 +215,7 @@ class Aligner(Generic[DataAlignable]):
         normalized_index_vars = {}
         for idx, index_vars in Indexes(xr_indexes, xr_variables).group_by_index():
             coord_names_and_dims = []
-            all_dims = set()
+            all_dims: set[Hashable] = set()
 
             for name, var in index_vars.items():
                 dims = var.dims

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -36,14 +36,18 @@ ALL_DIMS = ...
 
 
 if TYPE_CHECKING:
+    import datetime
+
     from .dataarray import DataArray
     from .dataset import Dataset
     from .indexes import Index
+    from .resample import Resample
     from .rolling_exp import RollingExp
-    from .types import ScalarOrArray, T_DataWithCoords
+    from .types import ScalarOrArray, SideOptions, T_DataWithCoords
     from .variable import Variable
 
 
+T_Resample = TypeVar("T_Resample", bound="Resample")
 C = TypeVar("C")
 T = TypeVar("T")
 
@@ -788,111 +792,19 @@ class DataWithCoords(AttrAccessMixin):
 
         return RollingExp(self, window, window_type)
 
-    def resample(
+    def _resample(
         self,
-        indexer: Mapping[Any, str] = None,
-        skipna=None,
-        closed: str = None,
-        label: str = None,
-        base: int = 0,
-        keep_attrs: bool = None,
-        loffset=None,
-        restore_coord_dims: bool = None,
+        resample_cls: type[T_Resample],
+        indexer: Mapping[Any, str] | None,
+        skipna: bool | None,
+        closed: SideOptions | None,
+        label: SideOptions | None,
+        base: int,
+        keep_attrs: bool | None,
+        loffset: datetime.timedelta | str | None,
+        restore_coord_dims: bool | None,
         **indexer_kwargs: str,
-    ):
-        """Returns a Resample object for performing resampling operations.
-
-        Handles both downsampling and upsampling. The resampled
-        dimension must be a datetime-like coordinate. If any intervals
-        contain no values from the original object, they will be given
-        the value ``NaN``.
-
-        Parameters
-        ----------
-        indexer : {dim: freq}, optional
-            Mapping from the dimension name to resample frequency [1]_. The
-            dimension must be datetime-like.
-        skipna : bool, optional
-            Whether to skip missing values when aggregating in downsampling.
-        closed : {"left", "right"}, optional
-            Side of each interval to treat as closed.
-        label : {"left", "right"}, optional
-            Side of each interval to use for labeling.
-        base : int, optional
-            For frequencies that evenly subdivide 1 day, the "origin" of the
-            aggregated intervals. For example, for "24H" frequency, base could
-            range from 0 through 23.
-        loffset : timedelta or str, optional
-            Offset used to adjust the resampled time labels. Some pandas date
-            offset strings are supported.
-        restore_coord_dims : bool, optional
-            If True, also restore the dimension order of multi-dimensional
-            coordinates.
-        **indexer_kwargs : {dim: freq}
-            The keyword arguments form of ``indexer``.
-            One of indexer or indexer_kwargs must be provided.
-
-        Returns
-        -------
-        resampled : same type as caller
-            This object resampled.
-
-        Examples
-        --------
-        Downsample monthly time-series data to seasonal data:
-
-        >>> da = xr.DataArray(
-        ...     np.linspace(0, 11, num=12),
-        ...     coords=[
-        ...         pd.date_range(
-        ...             "1999-12-15",
-        ...             periods=12,
-        ...             freq=pd.DateOffset(months=1),
-        ...         )
-        ...     ],
-        ...     dims="time",
-        ... )
-        >>> da
-        <xarray.DataArray (time: 12)>
-        array([ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10., 11.])
-        Coordinates:
-          * time     (time) datetime64[ns] 1999-12-15 2000-01-15 ... 2000-11-15
-        >>> da.resample(time="QS-DEC").mean()
-        <xarray.DataArray (time: 4)>
-        array([ 1.,  4.,  7., 10.])
-        Coordinates:
-          * time     (time) datetime64[ns] 1999-12-01 2000-03-01 2000-06-01 2000-09-01
-
-        Upsample monthly time-series data to daily data:
-
-        >>> da.resample(time="1D").interpolate("linear")  # +doctest: ELLIPSIS
-        <xarray.DataArray (time: 337)>
-        array([ 0.        ,  0.03225806,  0.06451613,  0.09677419,  0.12903226,
-                0.16129032,  0.19354839,  0.22580645,  0.25806452,  0.29032258,
-                0.32258065,  0.35483871,  0.38709677,  0.41935484,  0.4516129 ,
-        ...
-               10.80645161, 10.83870968, 10.87096774, 10.90322581, 10.93548387,
-               10.96774194, 11.        ])
-        Coordinates:
-          * time     (time) datetime64[ns] 1999-12-15 1999-12-16 ... 2000-11-15
-
-        Limit scope of upsampling method
-
-        >>> da.resample(time="1D").nearest(tolerance="1D")
-        <xarray.DataArray (time: 337)>
-        array([ 0.,  0., nan, ..., nan, 11., 11.])
-        Coordinates:
-          * time     (time) datetime64[ns] 1999-12-15 1999-12-16 ... 2000-11-15
-
-        See Also
-        --------
-        pandas.Series.resample
-        pandas.DataFrame.resample
-
-        References
-        ----------
-        .. [1] http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
-        """
+    ) -> T_Resample:
         # TODO support non-string indexer after removing the old API.
 
         from ..coding.cftimeindex import CFTimeIndex
@@ -923,7 +835,7 @@ class DataWithCoords(AttrAccessMixin):
             raise ValueError("Resampling only supported along single dimensions.")
         dim, freq = next(iter(indexer.items()))
 
-        dim_name = dim
+        dim_name: Hashable = dim
         dim_coord = self[dim]
 
         # TODO: remove once pandas=1.1 is the minimum required version
@@ -945,7 +857,7 @@ class DataWithCoords(AttrAccessMixin):
         group = DataArray(
             dim_coord, coords=dim_coord.coords, dims=dim_coord.dims, name=RESAMPLE_DIM
         )
-        resampler = self._resample_cls(
+        return resample_cls(
             self,
             group=group,
             dim=dim_name,
@@ -953,8 +865,6 @@ class DataWithCoords(AttrAccessMixin):
             resample_dim=RESAMPLE_DIM,
             restore_coord_dims=restore_coord_dims,
         )
-
-        return resampler
 
     def where(
         self: T_DataWithCoords, cond: Any, other: Any = dtypes.NA, drop: bool = False

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -39,9 +39,10 @@ ALL_DIMS = ...
 if TYPE_CHECKING:
     from .dataarray import DataArray
     from .dataset import Dataset
+    from .groupby import GroupBy
     from .indexes import Index
     from .types import ScalarOrArray, T_DataWithCoords, T_Xarray
-    from .variable import Variable
+    from .variable import IndexVariable, Variable
     from .weighted import Weighted
 
 
@@ -355,6 +356,7 @@ class DataWithCoords(AttrAccessMixin):
 
     _close: Callable[[], None] | None
     _indexes: dict[Hashable, Index]
+    _groupby_cls: type[GroupBy]
 
     __slots__ = ("_close",)
 
@@ -749,26 +751,29 @@ class DataWithCoords(AttrAccessMixin):
             return func(self, *args, **kwargs)
 
     def groupby(
-        self, group: Any, squeeze: bool = True, restore_coord_dims: bool | None = None
-    ):
+        self,
+        group: Hashable | DataArray | IndexVariable,
+        squeeze: bool = True,
+        restore_coord_dims: bool = False,
+    ) -> GroupBy:
         """Returns a GroupBy object for performing grouped operations.
 
         Parameters
         ----------
-        group : str, DataArray or IndexVariable
+        group : Hashable, DataArray or IndexVariable
             Array whose unique values should be used to group this array. If a
             string, must be the name of a variable contained in this dataset.
         squeeze : bool, default: True
             If "group" is a dimension of any arrays in this dataset, `squeeze`
             controls whether the subarrays have a dimension of length 1 along
             that dimension or if the dimension is squeezed out.
-        restore_coord_dims : bool, optional
+        restore_coord_dims : bool, default: False
             If True, also restore the dimension order of multi-dimensional
             coordinates.
 
         Returns
         -------
-        grouped
+        grouped : GroupBy
             A `GroupBy` object patterned after `pandas.GroupBy` that can be
             iterated over in the form of `(unique_value, grouped_array)` pairs.
 
@@ -816,15 +821,15 @@ class DataWithCoords(AttrAccessMixin):
 
     def groupby_bins(
         self,
-        group,
+        group: Hashable | DataArray | IndexVariable,
         bins,
         right: bool = True,
         labels=None,
         precision: int = 3,
         include_lowest: bool = False,
         squeeze: bool = True,
-        restore_coord_dims: bool = None,
-    ):
+        restore_coord_dims: bool = False,
+    ) -> GroupBy:
         """Returns a GroupBy object for performing grouped operations.
 
         Rather than using all unique values of `group`, the values are discretized
@@ -832,7 +837,7 @@ class DataWithCoords(AttrAccessMixin):
 
         Parameters
         ----------
-        group : str, DataArray or IndexVariable
+        group : Hashable, DataArray or IndexVariable
             Array whose binned values should be used to group this array. If a
             string, must be the name of a variable contained in this dataset.
         bins : int or array-like
@@ -849,15 +854,15 @@ class DataWithCoords(AttrAccessMixin):
             Used as labels for the resulting bins. Must be of the same length as
             the resulting bins. If False, string bin labels are assigned by
             `pandas.cut`.
-        precision : int
+        precision : int, default: 3
             The precision at which to store and display the bins labels.
-        include_lowest : bool
+        include_lowest : bool, default: False
             Whether the first interval should be left-inclusive or not.
         squeeze : bool, default: True
             If "group" is a dimension of any arrays in this dataset, `squeeze`
             controls whether the subarrays have a dimension of length 1 along
             that dimension or if the dimension is squeezed out.
-        restore_coord_dims : bool, optional
+        restore_coord_dims : bool, default: False
             If True, also restore the dimension order of multi-dimensional
             coordinates.
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -198,7 +198,7 @@ class AbstractArray:
             raise ValueError(f"{dim!r} not found in array dimensions {self.dims!r}")
 
     @property
-    def sizes(self: Any) -> Mapping[Hashable, int]:
+    def sizes(self: Any) -> Frozen[Hashable, int]:
         """Ordered mapping from dimension names to lengths.
 
         Immutable.

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -780,6 +780,7 @@ class DataWithCoords(AttrAccessMixin):
         --------
         core.rolling_exp.RollingExp
         """
+        from . import rolling_exp
 
         if "keep_attrs" in window_kwargs:
             warnings.warn(
@@ -790,7 +791,7 @@ class DataWithCoords(AttrAccessMixin):
 
         window = either_dict_or_kwargs(window, window_kwargs, "rolling_exp")
 
-        return RollingExp(self, window, window_type)
+        return rolling_exp.RollingExp(self, window, window_type)
 
     def _resample(
         self,

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 _THIS_ARRAY = ReprObject("<this-array>")
 
 
-class Coordinates(Mapping[Any, "DataArray"]):
+class Coordinates(Mapping[Hashable, "DataArray"]):
     __slots__ = ()
 
     def __getitem__(self, key: Hashable) -> DataArray:

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -24,17 +24,7 @@ from ..coding.calendar_ops import convert_calendar, interp_calendar
 from ..coding.cftimeindex import CFTimeIndex
 from ..plot.plot import _PlotMethods
 from ..plot.utils import _get_units_from_attrs
-from . import (
-    alignment,
-    computation,
-    dtypes,
-    indexing,
-    ops,
-    resample,
-    rolling,
-    utils,
-    weighted,
-)
+from . import alignment, computation, dtypes, indexing, ops, resample, utils
 from ._reductions import DataArrayReductions
 from .accessor_dt import CombinedDatetimelikeAccessor
 from .accessor_str import StringAccessor
@@ -83,7 +73,9 @@ if TYPE_CHECKING:
 
     from ..backends.api import T_NetcdfEngine, T_NetcdfTypes
     from .groupby import DataArrayGroupBy
+    from .rolling import DataArrayCoarsen, DataArrayRolling
     from .types import (
+        CoarsenBoundaryOptions,
         DatetimeUnitOptions,
         ErrorOptions,
         ErrorOptionsWithWarn,
@@ -93,9 +85,11 @@ if TYPE_CHECKING:
         QueryEngineOptions,
         QueryParserOptions,
         ReindexMethodOptions,
+        SideOptions,
         T_DataArray,
         T_Xarray,
     )
+    from .weighted import DataArrayWeighted
 
     T_XarrayOther = TypeVar("T_XarrayOther", bound=Union["DataArray", Dataset])
 
@@ -367,10 +361,7 @@ class DataArray(
         "__weakref__",
     )
 
-    _rolling_cls = rolling.DataArrayRolling
-    _coarsen_cls = rolling.DataArrayCoarsen
     _resample_cls = resample.DataArrayResample
-    _weighted_cls = weighted.DataArrayWeighted
 
     dt = utils.UncachedAccessor(CombinedDatetimelikeAccessor["DataArray"])
 
@@ -5466,6 +5457,184 @@ class DataArray(
                 "precision": precision,
                 "include_lowest": include_lowest,
             },
+        )
+
+    def weighted(self, weights: DataArray) -> DataArrayWeighted:
+        """
+        Weighted DataArray operations.
+
+        Parameters
+        ----------
+        weights : DataArray
+            An array of weights associated with the values in this Dataset.
+            Each value in the data contributes to the reduction operation
+            according to its associated weight.
+
+        Notes
+        -----
+        ``weights`` must be a DataArray and cannot contain missing values.
+        Missing values can be replaced by ``weights.fillna(0)``.
+
+        Returns
+        -------
+        core.weighted.DataArrayWeighted
+
+        See Also
+        --------
+        Dataset.weighted
+        """
+        from . import weighted
+
+        return weighted.DataArrayWeighted(self, weights)
+
+    def rolling(
+        self,
+        dim: Mapping[Any, int] | None = None,
+        min_periods: int | None = None,
+        center: bool | Mapping[Any, bool] = False,
+        **window_kwargs: int,
+    ) -> DataArrayRolling:
+        """
+        Rolling window object for DataArrays.
+
+        Parameters
+        ----------
+        dim : dict, optional
+            Mapping from the dimension name to create the rolling iterator
+            along (e.g. `time`) to its moving window size.
+        min_periods : int or None, default: None
+            Minimum number of observations in window required to have a value
+            (otherwise result is NA). The default, None, is equivalent to
+            setting min_periods equal to the size of the window.
+        center : bool or Mapping to int, default: False
+            Set the labels at the center of the window.
+        **window_kwargs : optional
+            The keyword arguments form of ``dim``.
+            One of dim or window_kwargs must be provided.
+
+        Returns
+        -------
+        core.rolling.DataArrayRolling
+
+        Examples
+        --------
+        Create rolling seasonal average of monthly data e.g. DJF, JFM, ..., SON:
+
+        >>> da = xr.DataArray(
+        ...     np.linspace(0, 11, num=12),
+        ...     coords=[
+        ...         pd.date_range(
+        ...             "1999-12-15",
+        ...             periods=12,
+        ...             freq=pd.DateOffset(months=1),
+        ...         )
+        ...     ],
+        ...     dims="time",
+        ... )
+        >>> da
+        <xarray.DataArray (time: 12)>
+        array([ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10., 11.])
+        Coordinates:
+          * time     (time) datetime64[ns] 1999-12-15 2000-01-15 ... 2000-11-15
+        >>> da.rolling(time=3, center=True).mean()
+        <xarray.DataArray (time: 12)>
+        array([nan,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10., nan])
+        Coordinates:
+          * time     (time) datetime64[ns] 1999-12-15 2000-01-15 ... 2000-11-15
+
+        Remove the NaNs using ``dropna()``:
+
+        >>> da.rolling(time=3, center=True).mean().dropna("time")
+        <xarray.DataArray (time: 10)>
+        array([ 1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10.])
+        Coordinates:
+          * time     (time) datetime64[ns] 2000-01-15 2000-02-15 ... 2000-10-15
+
+        See Also
+        --------
+        core.rolling.DataArrayRolling
+        Dataset.rolling
+        """
+        from . import rolling
+
+        dim = either_dict_or_kwargs(dim, window_kwargs, "rolling")
+        return rolling.DataArrayRolling(
+            self, dim, min_periods=min_periods, center=center
+        )
+
+    def coarsen(
+        self,
+        dim: Mapping[Any, int] | None = None,
+        boundary: CoarsenBoundaryOptions = "exact",
+        side: SideOptions | Mapping[Any, SideOptions] = "left",
+        coord_func: str | Callable | Mapping[Any, str | Callable] = "mean",
+        **window_kwargs: int,
+    ) -> DataArrayCoarsen:
+        """
+        Coarsen object for DataArrays.
+
+        Parameters
+        ----------
+        dim : mapping of hashable to int, optional
+            Mapping from the dimension name to the window size.
+        boundary : {"exact", "trim", "pad"}, default: "exact"
+            If 'exact', a ValueError will be raised if dimension size is not a
+            multiple of the window size. If 'trim', the excess entries are
+            dropped. If 'pad', NA will be padded.
+        side : {"left", "right"} or mapping of str to {"left", "right"}, default: "left"
+        coord_func : str or mapping of hashable to str, default: "mean"
+            function (name) that is applied to the coordinates,
+            or a mapping from coordinate name to function (name).
+
+        Returns
+        -------
+        core.rolling.DataArrayCoarsen
+
+        Examples
+        --------
+        Coarsen the long time series by averaging over every four days.
+
+        >>> da = xr.DataArray(
+        ...     np.linspace(0, 364, num=364),
+        ...     dims="time",
+        ...     coords={"time": pd.date_range("1999-12-15", periods=364)},
+        ... )
+        >>> da  # +doctest: ELLIPSIS
+        <xarray.DataArray (time: 364)>
+        array([  0.        ,   1.00275482,   2.00550964,   3.00826446,
+                 4.01101928,   5.0137741 ,   6.01652893,   7.01928375,
+                 8.02203857,   9.02479339,  10.02754821,  11.03030303,
+        ...
+               356.98071625, 357.98347107, 358.9862259 , 359.98898072,
+               360.99173554, 361.99449036, 362.99724518, 364.        ])
+        Coordinates:
+          * time     (time) datetime64[ns] 1999-12-15 1999-12-16 ... 2000-12-12
+        >>> da.coarsen(time=3, boundary="trim").mean()  # +doctest: ELLIPSIS
+        <xarray.DataArray (time: 121)>
+        array([  1.00275482,   4.01101928,   7.01928375,  10.02754821,
+                13.03581267,  16.04407713,  19.0523416 ,  22.06060606,
+                25.06887052,  28.07713499,  31.08539945,  34.09366391,
+        ...
+               349.96143251, 352.96969697, 355.97796143, 358.9862259 ,
+               361.99449036])
+        Coordinates:
+          * time     (time) datetime64[ns] 1999-12-16 1999-12-19 ... 2000-12-10
+        >>>
+
+        See Also
+        --------
+        core.rolling.DataArrayCoarsen
+        Dataset.coarsen
+        """
+        from . import rolling
+
+        dim = either_dict_or_kwargs(dim, window_kwargs, "coarsen")
+        return rolling.DataArrayCoarsen(
+            self,
+            dim,
+            boundary=boundary,
+            side=side,
+            coord_func=coord_func,
         )
 
     # this needs to be at the end, or mypy will confuse with `str`

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3879,7 +3879,7 @@ class DataArray(
     def quantile(
         self: T_DataArray,
         q: ArrayLike,
-        dim: str | Sequence[Hashable] | None = None,
+        dim: str | Iterable[Hashable] | None = None,
         method: QUANTILE_METHODS = "linear",
         keep_attrs: bool | None = None,
         skipna: bool | None = None,
@@ -3893,7 +3893,7 @@ class DataArray(
         ----------
         q : float or array-like of float
             Quantile to compute, which must be between 0 and 1 inclusive.
-        dim : Hashable or sequence of Hashable, optional
+        dim : str or Iterable of Hashable, optional
             Dimension(s) over which to apply quantile.
         method : str, default: "linear"
             This optional parameter specifies the interpolation method to use when the

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -5315,7 +5315,7 @@ class DataArray(
         ----------
         group : Hashable, DataArray or IndexVariable
             Array whose unique values should be used to group this array. If a
-            string, must be the name of a variable contained in this dataset.
+            Hashable, must be the name of a coordinate contained in this dataarray.
         squeeze : bool, default: True
             If "group" is a dimension of any arrays in this dataset, `squeeze`
             controls whether the subarrays have a dimension of length 1 along
@@ -5379,9 +5379,9 @@ class DataArray(
     def groupby_bins(
         self,
         group: Hashable | DataArray | IndexVariable,
-        bins,
+        bins: ArrayLike,
         right: bool = True,
-        labels=None,
+        labels: ArrayLike | Literal[False] | None = None,
         precision: int = 3,
         include_lowest: bool = False,
         squeeze: bool = True,
@@ -5396,7 +5396,7 @@ class DataArray(
         ----------
         group : Hashable, DataArray or IndexVariable
             Array whose binned values should be used to group this array. If a
-            string, must be the name of a variable contained in this dataset.
+            Hashable, must be the name of a coordinate contained in this dataarray.
         bins : int or array-like
             If bins is an int, it defines the number of equal-width bins in the
             range of x. However, in this case, the range of x is extended by .1%
@@ -5407,7 +5407,7 @@ class DataArray(
             Indicates whether the bins include the rightmost edge or not. If
             right == True (the default), then the bins [1,2,3,4] indicate
             (1,2], (2,3], (3,4].
-        labels : array-like or bool, default: None
+        labels : array-like, False or None, default: None
             Used as labels for the resulting bins. Must be of the same length as
             the resulting bins. If False, string bin labels are assigned by
             `pandas.cut`.

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -742,6 +742,11 @@ class DataArray(
         Note that the type of this property is inconsistent with
         `Dataset.dims`.  See `Dataset.sizes` and `DataArray.sizes` for
         consistently named properties.
+
+        See Also
+        --------
+        DataArray.sizes
+        Dataset.dims
         """
         return self.variable.dims
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -5482,9 +5482,9 @@ class DataArray(
         --------
         Dataset.weighted
         """
-        from . import weighted
+        from .weighted import DataArrayWeighted
 
-        return weighted.DataArrayWeighted(self, weights)
+        return DataArrayWeighted(self, weights)
 
     def rolling(
         self,
@@ -5554,12 +5554,10 @@ class DataArray(
         core.rolling.DataArrayRolling
         Dataset.rolling
         """
-        from . import rolling
+        from .rolling import DataArrayRolling
 
         dim = either_dict_or_kwargs(dim, window_kwargs, "rolling")
-        return rolling.DataArrayRolling(
-            self, dim, min_periods=min_periods, center=center
-        )
+        return DataArrayRolling(self, dim, min_periods=min_periods, center=center)
 
     def coarsen(
         self,
@@ -5625,10 +5623,10 @@ class DataArray(
         core.rolling.DataArrayCoarsen
         Dataset.coarsen
         """
-        from . import rolling
+        from .rolling import DataArrayCoarsen
 
         dim = either_dict_or_kwargs(dim, window_kwargs, "coarsen")
-        return rolling.DataArrayCoarsen(
+        return DataArrayCoarsen(
             self,
             dim,
             boundary=boundary,
@@ -5742,10 +5740,10 @@ class DataArray(
         ----------
         .. [1] http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
         """
-        from . import resample
+        from .resample import DataArrayResample
 
         return self._resample(
-            resample_cls=resample.DataArrayResample,
+            resample_cls=DataArrayResample,
             indexer=indexer,
             skipna=skipna,
             closed=closed,

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2877,7 +2877,7 @@ class DataArray(
     def reduce(
         self: T_DataArray,
         func: Callable[..., Any],
-        dim: None | Hashable | Sequence[Hashable] = None,
+        dim: None | Hashable | Iterable[Hashable] = None,
         *,
         axis: None | int | Sequence[int] = None,
         keep_attrs: bool | None = None,
@@ -2892,7 +2892,7 @@ class DataArray(
             Function which can be called in the form
             `f(x, axis=axis, **kwargs)` to return the result of reducing an
             np.ndarray over an integer valued axis.
-        dim : Hashable or sequence of Hashable, optional
+        dim : Hashable or Iterable of Hashable, optional
             Dimension(s) over which to apply `func`.
         axis : int or sequence of int, optional
             Axis(es) over which to repeatedly apply `func`. Only one of the

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -28,7 +28,6 @@ from . import (
     alignment,
     computation,
     dtypes,
-    groupby,
     indexing,
     ops,
     resample,
@@ -83,6 +82,7 @@ if TYPE_CHECKING:
         iris_Cube = None
 
     from ..backends.api import T_NetcdfEngine, T_NetcdfTypes
+    from .groupby import DataArrayGroupBy
     from .types import (
         DatetimeUnitOptions,
         ErrorOptions,
@@ -367,7 +367,6 @@ class DataArray(
         "__weakref__",
     )
 
-    _groupby_cls = groupby.DataArrayGroupBy
     _rolling_cls = rolling.DataArrayRolling
     _coarsen_cls = rolling.DataArrayCoarsen
     _resample_cls = resample.DataArrayResample
@@ -3517,7 +3516,9 @@ class DataArray(
         f: Callable,
         reflexive: bool = False,
     ) -> T_DataArray:
-        if isinstance(other, (Dataset, groupby.GroupBy)):
+        from .groupby import GroupBy
+
+        if isinstance(other, (Dataset, GroupBy)):
             return NotImplemented
         if isinstance(other, DataArray):
             align_type = OPTIONS["arithmetic_join"]
@@ -3536,7 +3537,9 @@ class DataArray(
         return self._replace(variable, coords, name, indexes=indexes)
 
     def _inplace_binary_op(self: T_DataArray, other: Any, f: Callable) -> T_DataArray:
-        if isinstance(other, groupby.GroupBy):
+        from .groupby import GroupBy
+
+        if isinstance(other, GroupBy):
             raise TypeError(
                 "in-place operations between a DataArray and "
                 "a grouped object are not permitted"
@@ -5304,6 +5307,161 @@ class DataArray(
             The source interpolated on the decimal years of target,
         """
         return interp_calendar(self, target, dim=dim)
+
+    def groupby(
+        self,
+        group: Hashable | DataArray | IndexVariable,
+        squeeze: bool = True,
+        restore_coord_dims: bool = False,
+    ) -> DataArrayGroupBy:
+        """Returns a DataArrayGroupBy object for performing grouped operations.
+
+        Parameters
+        ----------
+        group : Hashable, DataArray or IndexVariable
+            Array whose unique values should be used to group this array. If a
+            string, must be the name of a variable contained in this dataset.
+        squeeze : bool, default: True
+            If "group" is a dimension of any arrays in this dataset, `squeeze`
+            controls whether the subarrays have a dimension of length 1 along
+            that dimension or if the dimension is squeezed out.
+        restore_coord_dims : bool, default: False
+            If True, also restore the dimension order of multi-dimensional
+            coordinates.
+
+        Returns
+        -------
+        grouped : DataArrayGroupBy
+            A `DataArrayGroupBy` object patterned after `pandas.GroupBy` that can be
+            iterated over in the form of `(unique_value, grouped_array)` pairs.
+
+        Examples
+        --------
+        Calculate daily anomalies for daily data:
+
+        >>> da = xr.DataArray(
+        ...     np.linspace(0, 1826, num=1827),
+        ...     coords=[pd.date_range("1/1/2000", "31/12/2004", freq="D")],
+        ...     dims="time",
+        ... )
+        >>> da
+        <xarray.DataArray (time: 1827)>
+        array([0.000e+00, 1.000e+00, 2.000e+00, ..., 1.824e+03, 1.825e+03,
+               1.826e+03])
+        Coordinates:
+          * time     (time) datetime64[ns] 2000-01-01 2000-01-02 ... 2004-12-31
+        >>> da.groupby("time.dayofyear") - da.groupby("time.dayofyear").mean("time")
+        <xarray.DataArray (time: 1827)>
+        array([-730.8, -730.8, -730.8, ...,  730.2,  730.2,  730.5])
+        Coordinates:
+          * time       (time) datetime64[ns] 2000-01-01 2000-01-02 ... 2004-12-31
+            dayofyear  (time) int64 1 2 3 4 5 6 7 8 ... 359 360 361 362 363 364 365 366
+
+        See Also
+        --------
+        DataArray.groupby_bins
+        Dataset.groupby
+        core.groupby.DataArrayGroupBy
+        pandas.DataFrame.groupby
+        """
+        from .groupby import DataArrayGroupBy
+
+        # While we don't generally check the type of every arg, passing
+        # multiple dimensions as multiple arguments is common enough, and the
+        # consequences hidden enough (strings evaluate as true) to warrant
+        # checking here.
+        # A future version could make squeeze kwarg only, but would face
+        # backward-compat issues.
+        if not isinstance(squeeze, bool):
+            raise TypeError(
+                f"`squeeze` must be True or False, but {squeeze} was supplied"
+            )
+
+        return DataArrayGroupBy(
+            self, group, squeeze=squeeze, restore_coord_dims=restore_coord_dims
+        )
+
+    def groupby_bins(
+        self,
+        group: Hashable | DataArray | IndexVariable,
+        bins,
+        right: bool = True,
+        labels=None,
+        precision: int = 3,
+        include_lowest: bool = False,
+        squeeze: bool = True,
+        restore_coord_dims: bool = False,
+    ) -> DataArrayGroupBy:
+        """Returns a DataArrayGroupBy object for performing grouped operations.
+
+        Rather than using all unique values of `group`, the values are discretized
+        first by applying `pandas.cut` [1]_ to `group`.
+
+        Parameters
+        ----------
+        group : Hashable, DataArray or IndexVariable
+            Array whose binned values should be used to group this array. If a
+            string, must be the name of a variable contained in this dataset.
+        bins : int or array-like
+            If bins is an int, it defines the number of equal-width bins in the
+            range of x. However, in this case, the range of x is extended by .1%
+            on each side to include the min or max values of x. If bins is a
+            sequence it defines the bin edges allowing for non-uniform bin
+            width. No extension of the range of x is done in this case.
+        right : bool, default: True
+            Indicates whether the bins include the rightmost edge or not. If
+            right == True (the default), then the bins [1,2,3,4] indicate
+            (1,2], (2,3], (3,4].
+        labels : array-like or bool, default: None
+            Used as labels for the resulting bins. Must be of the same length as
+            the resulting bins. If False, string bin labels are assigned by
+            `pandas.cut`.
+        precision : int, default: 3
+            The precision at which to store and display the bins labels.
+        include_lowest : bool, default: False
+            Whether the first interval should be left-inclusive or not.
+        squeeze : bool, default: True
+            If "group" is a dimension of any arrays in this dataset, `squeeze`
+            controls whether the subarrays have a dimension of length 1 along
+            that dimension or if the dimension is squeezed out.
+        restore_coord_dims : bool, default: False
+            If True, also restore the dimension order of multi-dimensional
+            coordinates.
+
+        Returns
+        -------
+        grouped : DataArrayGroupBy
+            A `DataArrayGroupBy` object patterned after `pandas.GroupBy` that can be
+            iterated over in the form of `(unique_value, grouped_array)` pairs.
+            The name of the group has the added suffix `_bins` in order to
+            distinguish it from the original variable.
+
+        See Also
+        --------
+        DataArray.groupby
+        Dataset.groupby_bins
+        core.groupby.DataArrayGroupBy
+        pandas.DataFrame.groupby
+
+        References
+        ----------
+        .. [1] http://pandas.pydata.org/pandas-docs/stable/generated/pandas.cut.html
+        """
+        from .groupby import DataArrayGroupBy
+
+        return DataArrayGroupBy(
+            self,
+            group,
+            squeeze=squeeze,
+            bins=bins,
+            restore_coord_dims=restore_coord_dims,
+            cut_kwargs={
+                "right": right,
+                "labels": labels,
+                "precision": precision,
+                "include_lowest": include_lowest,
+            },
+        )
 
     # this needs to be at the end, or mypy will confuse with `str`
     # https://mypy.readthedocs.io/en/latest/common_issues.html#dealing-with-conflicting-names

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1690,7 +1690,7 @@ class DataArray(
         self: T_DataArray,
         indexers: Mapping[Any, Any] = None,
         method: ReindexMethodOptions = None,
-        tolerance: int | float | Iterable[int | float] | None = None,
+        tolerance: float | Iterable[float] | None = None,
         copy: bool = True,
         fill_value=dtypes.NA,
         **indexers_kwargs: Any,
@@ -1720,7 +1720,7 @@ class DataArray(
             - backfill / bfill: propagate next valid index value backward
             - nearest: use nearest valid index value
 
-        tolerance : optional
+        tolerance : float | Iterable[float] | None, default: None
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8572,9 +8572,9 @@ class Dataset(
     def groupby_bins(
         self,
         group: Hashable | DataArray | IndexVariable,
-        bins,
+        bins: ArrayLike,
         right: bool = True,
-        labels=None,
+        labels: ArrayLike | None = None,
         precision: int = 3,
         include_lowest: bool = False,
         squeeze: bool = True,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6670,7 +6670,7 @@ class Dataset(
         ----------
         q : float or array-like of float
             Quantile to compute, which must be between 0 and 1 inclusive.
-        dim : str or sequence of str, optional
+        dim : str or Iterable of Hashable, optional
             Dimension(s) over which to apply quantile.
         method : str, default: "linear"
             This optional parameter specifies the interpolation method to use when the

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5532,18 +5532,21 @@ class Dataset(
                     or np.issubdtype(var.dtype, np.number)
                     or (var.dtype == np.bool_)
                 ):
+                    reduce_maybe_single: Hashable | None | list[Hashable]
                     if len(reduce_dims) == 1:
                         # unpack dimensions for the benefit of functions
                         # like np.argmin which can't handle tuple arguments
-                        (reduce_dims,) = reduce_dims  # type: ignore[assignment]
+                        (reduce_maybe_single,) = reduce_dims
                     elif len(reduce_dims) == var.ndim:
                         # prefer to aggregate over axis=None rather than
                         # axis=(0, 1) if they will be equivalent, because
                         # the former is often more efficient
-                        reduce_dims = None  # type: ignore[assignment]
+                        reduce_maybe_single = None
+                    else:
+                        reduce_maybe_single = reduce_dims
                     variables[name] = var.reduce(
                         func,
-                        dim=reduce_dims,
+                        dim=reduce_maybe_single,
                         keep_attrs=keep_attrs,
                         keepdims=keepdims,
                         **kwargs,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -658,6 +658,11 @@ class Dataset(
         Note that type of this object differs from `DataArray.dims`.
         See `Dataset.sizes` and `DataArray.sizes` for consistently named
         properties.
+
+        See Also
+        --------
+        Dataset.sizes
+        DataArray.dims
         """
         return Frozen(self._dims)
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8675,9 +8675,9 @@ class Dataset(
         --------
         DataArray.weighted
         """
-        from . import weighted
+        from .weighted import DatasetWeighted
 
-        return weighted.DatasetWeighted(self, weights)
+        return DatasetWeighted(self, weights)
 
     def rolling(
         self,
@@ -8713,10 +8713,10 @@ class Dataset(
         core.rolling.DatasetRolling
         DataArray.rolling
         """
-        from . import rolling
+        from .rolling import DatasetRolling
 
         dim = either_dict_or_kwargs(dim, window_kwargs, "rolling")
-        return rolling.DatasetRolling(self, dim, min_periods=min_periods, center=center)
+        return DatasetRolling(self, dim, min_periods=min_periods, center=center)
 
     def coarsen(
         self,
@@ -8751,10 +8751,10 @@ class Dataset(
         core.rolling.DatasetCoarsen
         DataArray.coarsen
         """
-        from . import rolling
+        from .rolling import DatasetCoarsen
 
         dim = either_dict_or_kwargs(dim, window_kwargs, "coarsen")
-        return rolling.DatasetCoarsen(
+        return DatasetCoarsen(
             self,
             dim,
             boundary=boundary,
@@ -8821,10 +8821,10 @@ class Dataset(
         ----------
         .. [1] http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
         """
-        from . import resample
+        from .resample import DatasetResample
 
         return self._resample(
-            resample_cls=resample.DatasetResample,
+            resample_cls=DatasetResample,
             indexer=indexer,
             skipna=skipna,
             closed=closed,

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -295,6 +295,7 @@ class GroupBy(Generic[T_Xarray]):
         "_stacked_dim",
         "_unique_coord",
         "_dims",
+        "_sizes",
         "_squeeze",
         # Save unstacked object for flox
         "_original_obj",

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -197,6 +197,10 @@ class _DummyGroup:
         return range(self.size)
 
     @property
+    def data(self) -> range:
+        return range(self.size)
+
+    @property
     def shape(self) -> tuple[int]:
         return (self.size,)
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -266,9 +266,6 @@ def _apply_loffset(grouper, result):
     grouper.loffset = None
 
 
-T_GroupBy = TypeVar("T_GroupBy", bound="GroupBy")
-
-
 class GroupBy(Generic[T_Xarray]):
     """A object that implements the split-apply-combine pattern.
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -11,6 +11,7 @@ from typing import (
     Iterable,
     Iterator,
     Literal,
+    Mapping,
     Sequence,
     TypeVar,
     Union,
@@ -319,9 +320,9 @@ class GroupBy(Generic[T_Xarray]):
         group: Hashable | DataArray | IndexVariable,
         squeeze: bool = False,
         grouper: pd.Grouper | None = None,
-        bins=None,
+        bins: ArrayLike | None = None,
         restore_coord_dims: bool = True,
-        cut_kwargs=None,
+        cut_kwargs: Mapping[Any, Any] | None = None,
     ) -> None:
         """Create a GroupBy object
 
@@ -343,7 +344,7 @@ class GroupBy(Generic[T_Xarray]):
         restore_coord_dims : bool, default: True
             If True, also restore the dimension order of multi-dimensional
             coordinates.
-        cut_kwargs : dict, optional
+        cut_kwargs : dict-like, optional
             Extra keyword arguments to pass to `pandas.cut`
 
         """

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -93,7 +93,7 @@ def _dummy_copy(xarray_obj):
     from . import dataarray, dataset
 
     if isinstance(xarray_obj, dataset.Dataset):
-        res = Dataset(
+        res = dataset.Dataset(
             {
                 k: dtypes.get_fill_value(v.dtype)
                 for k, v in xarray_obj.data_vars.items()
@@ -106,7 +106,7 @@ def _dummy_copy(xarray_obj):
             xarray_obj.attrs,
         )
     elif isinstance(xarray_obj, dataarray.DataArray):
-        res = DataArray(
+        res = dataarray.DataArray(
             dtypes.get_fill_value(xarray_obj.dtype),
             {
                 k: dtypes.get_fill_value(v.dtype)

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -45,6 +45,8 @@ if TYPE_CHECKING:
     from .dataset import Dataset
     from .utils import Frozen
 
+    GroupKey = Any
+
 
 def check_reduce_dims(reduce_dims, dimensions):
 
@@ -455,7 +457,7 @@ class GroupBy(Generic[T_Xarray]):
         self._squeeze = squeeze
 
         # cached attributes
-        self._groups: dict[Any, slice | int | list[int]] | None = None
+        self._groups: dict[GroupKey, slice | int | list[int]] | None = None
         self._dims = None
         self._sizes: Frozen[Hashable, int] | None = None
 
@@ -500,7 +502,7 @@ class GroupBy(Generic[T_Xarray]):
         raise NotImplementedError()
 
     @property
-    def groups(self) -> dict[Any, slice | int | list[int]]:
+    def groups(self) -> dict[GroupKey, slice | int | list[int]]:
         """
         Mapping from group labels to indices. The indices can be used to index the underlying object.
         """
@@ -509,7 +511,7 @@ class GroupBy(Generic[T_Xarray]):
             self._groups = dict(zip(self._unique_coord.values, self._group_indices))
         return self._groups
 
-    def __getitem__(self, key: Any) -> T_Xarray:
+    def __getitem__(self, key: GroupKey) -> T_Xarray:
         """
         Get DataArray or Dataset corresponding to a particular group label.
         """
@@ -518,7 +520,7 @@ class GroupBy(Generic[T_Xarray]):
     def __len__(self) -> int:
         return self._unique_coord.size
 
-    def __iter__(self) -> Iterator[tuple[Any, T_Xarray]]:
+    def __iter__(self) -> Iterator[tuple[GroupKey, T_Xarray]]:
         return zip(self._unique_coord.values, self._iter_grouped())
 
     def __repr__(self) -> str:

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -217,10 +217,12 @@ def _ensure_1d(
     group: T_Group, obj: T_Xarray
 ) -> tuple[T_Group, T_Xarray, Hashable | None, list[Hashable]]:
     # 1D cases: do nothing
+    from . import dataarray
+
     if isinstance(group, (IndexVariable, _DummyGroup)) or group.ndim == 1:
         return group, obj, None, []
 
-    if isinstance(group, DataArray):
+    if isinstance(group, dataarray.DataArray):
         # try to stack the dims of the group into a single dim
         orig_dims = group.dims
         stacked_dim = "stacked_" + "_".join(map(str, orig_dims))
@@ -623,7 +625,7 @@ class GroupBy(Generic[T_Xarray]):
                 if set(obj[var].dims) < set(group.dims):
                     result[var] = obj[var].reset_coords(drop=True).broadcast_like(group)
 
-        if isinstance(result, Dataset) and isinstance(obj, Dataset):
+        if isinstance(result, dataset.Dataset) and isinstance(obj, dataset.Dataset):
             for var in set(result):
                 if dim not in obj[var].dims:
                     result[var] = result[var].transpose(dim, ...)

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -82,17 +82,6 @@ class Resample(GroupBy[T_Xarray]):
                 obj = obj.drop_vars(k)
         return obj
 
-    def asfreq(self) -> T_Xarray:
-        """Return values of original object at the new up-sampling frequency;
-        essentially a re-index with new times set to NaN.
-
-        Returns
-        -------
-        resampled : DataArray or Dataset
-        """
-        # requires mean, which is only available for Reduction Mixins
-        raise NotImplementedError
-
     def pad(self, tolerance: float | Iterable[float] | None = None) -> T_Xarray:
         """Forward fill new values at up-sampled frequency.
 

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Callable, Hashable, Sequence
+from typing import Any, Callable, Hashable, Iterable, Sequence
 
 import numpy as np
 
@@ -349,11 +349,12 @@ class DatasetResample(Resample, DatasetGroupByBase, DatasetResampleReductions): 
     def reduce(
         self,
         func: Callable[..., Any],
-        dim: None | Hashable | Sequence[Hashable] = None,
+        dim: None | Hashable | Iterable[Hashable] = None,
         *,
         axis: None | int | Sequence[int] = None,
         keep_attrs: bool = None,
         keepdims: bool = False,
+        shortcut: bool = True,
         **kwargs: Any,
     ):
         """Reduce the items in this group by applying `func` along the
@@ -365,7 +366,7 @@ class DatasetResample(Resample, DatasetGroupByBase, DatasetResampleReductions): 
             Function which can be called in the form
             `func(x, axis=axis, **kwargs)` to return the result of collapsing
             an np.ndarray over an integer valued axis.
-        dim : str or sequence of str, optional
+        dim : Hashable or Iterable of Hashable, optional
             Dimension(s) over which to apply `func`.
         keep_attrs : bool, optional
             If True, the datasets's attributes (`attrs`) will be copied from

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -90,8 +90,8 @@ class Resample(GroupBy[T_Xarray]):
         -------
         resampled : DataArray or Dataset
         """
-        self._obj = self._drop_coords()
-        return self.mean(self._dim)  # type: ignore[attr-defined]
+        # requires mean, which is only available for Reduction Mixins
+        raise NotImplementedError
 
     def pad(self, tolerance: float | Iterable[float] | None = None) -> T_Xarray:
         """Forward fill new values at up-sampled frequency.
@@ -289,6 +289,17 @@ class DataArrayResample(Resample["DataArray"], DataArrayGroupByBase, DataArrayRe
         )
         return self.map(func=func, shortcut=shortcut, args=args, **kwargs)
 
+    def asfreq(self) -> DataArray:
+        """Return values of original object at the new up-sampling frequency;
+        essentially a re-index with new times set to NaN.
+
+        Returns
+        -------
+        resampled : DataArray
+        """
+        self._obj = self._drop_coords()
+        return self.mean(self._dim)
+
 
 # https://github.com/python/mypy/issues/9031
 class DatasetResample(Resample["Dataset"], DatasetGroupByBase, DatasetResampleReductions):  # type: ignore[misc]
@@ -396,3 +407,14 @@ class DatasetResample(Resample["Dataset"], DatasetGroupByBase, DatasetResampleRe
             shortcut=shortcut,
             **kwargs,
         )
+
+    def asfreq(self) -> Dataset:
+        """Return values of original object at the new up-sampling frequency;
+        essentially a re-index with new times set to NaN.
+
+        Returns
+        -------
+        resampled : Dataset
+        """
+        self._obj = self._drop_coords()
+        return self.mean(self._dim)

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -185,7 +185,8 @@ class Resample(GroupBy):
         )
 
 
-class DataArrayResample(Resample, DataArrayGroupByBase, DataArrayResampleReductions):
+# https://github.com/python/mypy/issues/9031
+class DataArrayResample(Resample, DataArrayGroupByBase, DataArrayResampleReductions):  # type: ignore[misc]
     """DataArrayGroupBy object specialized to time resampling operations over a
     specified dimension
     """
@@ -276,7 +277,8 @@ class DataArrayResample(Resample, DataArrayGroupByBase, DataArrayResampleReducti
         return self.map(func=func, shortcut=shortcut, args=args, **kwargs)
 
 
-class DatasetResample(Resample, DatasetGroupByBase, DatasetResampleReductions):
+# https://github.com/python/mypy/issues/9031
+class DatasetResample(Resample, DatasetGroupByBase, DatasetResampleReductions):  # type: ignore[misc]
     """DatasetGroupBy object specialized to resampling a specified dimension"""
 
     def __init__(self, *args, dim=None, resample_dim=None, **kwargs):

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -49,16 +49,6 @@ class Resample(GroupBy[T_Xarray]):
 
         super().__init__(*args, **kwargs)
 
-    def mean(
-        self,
-        dim: None | Hashable | Sequence[Hashable] = None,
-        *,
-        skipna: bool | None = None,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
-    ) -> T_Xarray:
-        raise NotImplementedError()
-
     def _flox_reduce(self, dim, keep_attrs: bool | None = None, **kwargs) -> T_Xarray:
 
         from .dataarray import DataArray
@@ -117,7 +107,7 @@ class Resample(GroupBy[T_Xarray]):
                 self._obj = self._obj.drop_vars(k)
 
         if method == "asfreq":
-            return self.mean(self._dim)
+            return self.mean(self._dim)  # type: ignore[attr-defined]
 
         elif method in ["pad", "ffill", "backfill", "bfill", "nearest"]:
             kwargs = kwargs.copy()

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -40,9 +40,8 @@ class Resample(GroupBy[T_Xarray]):
 
         if dim == resample_dim:
             raise ValueError(
-                "Proxy resampling dimension ('{}') "
-                "cannot have the same name as actual dimension "
-                "('{}')! ".format(resample_dim, dim)
+                f"Proxy resampling dimension ('{resample_dim}') "
+                f"cannot have the same name as actual dimension ('{dim}')!"
             )
         self._dim = dim
         self._resample_dim = resample_dim

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -116,7 +116,8 @@ class Resample(GroupBy[T_Xarray]):
                     "Only str dimensions supported by now. Please raise an issue on Github."
                 )
             kwargs[self._dim] = upsampled_index
-            return self._obj.reindex(method=method, *args, **kwargs)  # type: ignore[misc]
+            kwargs["method"] = method
+            return self._obj.reindex(*args, **kwargs)
 
         elif method == "interpolate":
             return self._interpolate(*args, **kwargs)

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -753,7 +753,7 @@ class DatasetRolling(Rolling["Dataset"]):
             window_dim = {d: window_dim_kwargs[str(d)] for d in self.dim}
 
         window_dims = self._mapping_to_list(
-            window_dim, allow_default=False, allow_allsame=False  # type: ignore[arg-type]  # ??
+            window_dim, allow_default=False, allow_allsame=False  # type: ignore[arg-type]  # https://github.com/python/mypy/issues/12506
         )
         strides = self._mapping_to_list(stride, default=1)
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -376,7 +376,7 @@ class DataArrayRolling(Rolling["DataArray"]):
             window_dim = {d: window_dim_kwargs[str(d)] for d in self.dim}
 
         window_dims = self._mapping_to_list(
-            window_dim, allow_default=False, allow_allsame=False  # type: ignore[arg-type]  # ??
+            window_dim, allow_default=False, allow_allsame=False  # type: ignore[arg-type]  # https://github.com/python/mypy/issues/12506
         )
         strides = self._mapping_to_list(stride, default=1)
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import itertools
+import math
 import warnings
 from typing import (
     TYPE_CHECKING,
@@ -114,7 +115,7 @@ class Rolling(Generic[T_Xarray]):
             raise ValueError("min_periods must be greater than zero or None")
 
         self.min_periods = (
-            int(np.prod(self.window)) if min_periods is None else min_periods
+            math.prod(self.window) if min_periods is None else min_periods
         )
 
     def __repr__(self) -> str:
@@ -129,7 +130,7 @@ class Rolling(Generic[T_Xarray]):
         )
 
     def __len__(self) -> int:
-        return int(np.prod([self.obj.sizes[d] for d in self.dim]))
+        return math.prod(self.obj.sizes[d] for d in self.dim)
 
     @property
     def ndim(self) -> int:

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 import functools
 import itertools
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Generic, Hashable, Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Generic,
+    Hashable,
+    Iterator,
+    Mapping,
+    TypeVar,
+)
 
 import numpy as np
 
@@ -24,6 +33,9 @@ if TYPE_CHECKING:
     from .dataarray import DataArray
     from .dataset import Dataset
 
+    RollingKey = Any
+    _T = TypeVar("_T")
+
 _ROLLING_REDUCE_DOCSTRING_TEMPLATE = """\
 Reduce this object's data windows by applying `{name}` along its dimension.
 
@@ -43,7 +55,7 @@ reduced : same type as caller
 """
 
 
-class Rolling:
+class Rolling(Generic[T_Xarray]):
     """A object that implements the moving window pattern.
 
     See Also
@@ -57,7 +69,13 @@ class Rolling:
     __slots__ = ("obj", "window", "min_periods", "center", "dim")
     _attributes = ("window", "min_periods", "center", "dim")
 
-    def __init__(self, obj, windows, min_periods=None, center=False):
+    def __init__(
+        self,
+        obj: T_Xarray,
+        windows: Mapping[Any, int],
+        min_periods: int | None = None,
+        center: bool | Mapping[Any, bool] = False,
+    ) -> None:
         """
         Moving window object.
 
@@ -68,18 +86,20 @@ class Rolling:
         windows : mapping of hashable to int
             A mapping from the name of the dimension to create the rolling
             window along (e.g. `time`) to the size of the moving window.
-        min_periods : int, default: None
+        min_periods : int or None, default: None
             Minimum number of observations in window required to have a value
             (otherwise result is NA). The default, None, is equivalent to
             setting min_periods equal to the size of the window.
-        center : bool, default: False
-            Set the labels at the center of the window.
+        center : bool or dict-like Hashable to bool, default: False
+            Set the labels at the center of the window. If dict-like, set this
+            property per rolling dimension.
 
         Returns
         -------
         rolling : type of input argument
         """
-        self.dim, self.window = [], []
+        self.dim: list[Hashable] = []
+        self.window: list[int] = []
         for d, w in windows.items():
             self.dim.append(d)
             if w <= 0:
@@ -87,15 +107,17 @@ class Rolling:
             self.window.append(w)
 
         self.center = self._mapping_to_list(center, default=False)
-        self.obj = obj
+        self.obj: T_Xarray = obj
 
         # attributes
         if min_periods is not None and min_periods <= 0:
             raise ValueError("min_periods must be greater than zero or None")
 
-        self.min_periods = np.prod(self.window) if min_periods is None else min_periods
+        self.min_periods = (
+            int(np.prod(self.window)) if min_periods is None else min_periods
+        )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """provide a nice str repr of our rolling object"""
 
         attrs = [
@@ -106,12 +128,16 @@ class Rolling:
             klass=self.__class__.__name__, attrs=",".join(attrs)
         )
 
-    def __len__(self):
-        return self.obj.sizes[self.dim]
+    def __len__(self) -> int:
+        return int(np.prod([self.obj.sizes[d] for d in self.dim]))
+
+    @property
+    def ndim(self) -> int:
+        return len(self.dim)
 
     def _reduce_method(  # type: ignore[misc]
-        name: str, fillna, rolling_agg_func: Callable = None
-    ) -> Callable:
+        name: str, fillna: Any, rolling_agg_func: Callable | None = None
+    ) -> Callable[..., T_Xarray]:
         """Constructs reduction methods built on a numpy reduction function (e.g. sum),
         a bottleneck reduction function (e.g. move_sum), or a Rolling reduction (_mean)."""
         if rolling_agg_func:
@@ -157,7 +183,10 @@ class Rolling:
     var = _reduce_method("var", None)
     median = _reduce_method("median", None)
 
-    def count(self, keep_attrs=None):
+    def _counts(self, keep_attrs: bool | None) -> T_Xarray:
+        raise NotImplementedError()
+
+    def count(self, keep_attrs: bool | None = None) -> T_Xarray:
         keep_attrs = self._get_keep_attrs(keep_attrs)
         rolling_count = self._counts(keep_attrs=keep_attrs)
         enough_periods = rolling_count >= self.min_periods
@@ -166,23 +195,24 @@ class Rolling:
     count.__doc__ = _ROLLING_REDUCE_DOCSTRING_TEMPLATE.format(name="count")
 
     def _mapping_to_list(
-        self, arg, default=None, allow_default=True, allow_allsame=True
-    ):
+        self,
+        arg: _T | Mapping[Any, _T],
+        default: _T | None = None,
+        allow_default: bool = True,
+        allow_allsame: bool = True,
+    ) -> list[_T]:
         if utils.is_dict_like(arg):
             if allow_default:
                 return [arg.get(d, default) for d in self.dim]
             for d in self.dim:
                 if d not in arg:
-                    raise KeyError(f"argument has no key {d}.")
+                    raise KeyError(f"Argument has no dimension key {d}.")
             return [arg[d] for d in self.dim]
-        elif allow_allsame:  # for single argument
-            return [arg] * len(self.dim)
-        elif len(self.dim) == 1:
-            return [arg]
-        else:
-            raise ValueError(
-                f"Mapping argument is necessary for {len(self.dim)}d-rolling."
-            )
+        if allow_allsame:  # for single argument
+            return [arg] * self.ndim  # type: ignore[list-item]  # no check for negatives
+        if self.ndim == 1:
+            return [arg]  # type: ignore[list-item]  # no check for negatives
+        raise ValueError(f"Mapping argument is necessary for {self.ndim}d-rolling.")
 
     def _get_keep_attrs(self, keep_attrs):
         if keep_attrs is None:
@@ -191,10 +221,16 @@ class Rolling:
         return keep_attrs
 
 
-class DataArrayRolling(Rolling):
+class DataArrayRolling(Rolling["DataArray"]):
     __slots__ = ("window_labels",)
 
-    def __init__(self, obj, windows, min_periods=None, center=False):
+    def __init__(
+        self,
+        obj: DataArray,
+        windows: Mapping[Any, int],
+        min_periods: int | None = None,
+        center: bool | Mapping[Any, bool] = False,
+    ) -> None:
         """
         Moving window object for DataArray.
         You should use DataArray.rolling() method to construct this object
@@ -230,14 +266,14 @@ class DataArrayRolling(Rolling):
         # TODO legacy attribute
         self.window_labels = self.obj[self.dim[0]]
 
-    def __iter__(self):
-        if len(self.dim) > 1:
+    def __iter__(self) -> Iterator[tuple[RollingKey, DataArray]]:
+        if self.ndim > 1:
             raise ValueError("__iter__ is only supported for 1d-rolling")
         stops = np.arange(1, len(self.window_labels) + 1)
         starts = stops - int(self.window[0])
         starts[: int(self.window[0])] = 0
         for (label, start, stop) in zip(self.window_labels, starts, stops):
-            window = self.obj.isel(**{self.dim[0]: slice(start, stop)})
+            window = self.obj.isel({self.dim[0]: slice(start, stop)})
 
             counts = window.count(dim=self.dim[0])
             window = window.where(counts >= self.min_periods)
@@ -246,19 +282,19 @@ class DataArrayRolling(Rolling):
 
     def construct(
         self,
-        window_dim=None,
-        stride=1,
-        fill_value=dtypes.NA,
-        keep_attrs=None,
-        **window_dim_kwargs,
-    ):
+        window_dim: Hashable | Mapping[Any, Hashable] | None = None,
+        stride: int | Mapping[Any, int] = 1,
+        fill_value: Any = dtypes.NA,
+        keep_attrs: bool | None = None,
+        **window_dim_kwargs: Hashable,
+    ) -> DataArray:
         """
         Convert this rolling object to xr.DataArray,
         where the window dimension is stacked as a new dimension
 
         Parameters
         ----------
-        window_dim : str or mapping, optional
+        window_dim : Hashable or dict-like to Hashable, optional
             A mapping from dimension name to the new window dimension names.
         stride : int or mapping of int, default: 1
             Size of stride for the rolling window.
@@ -268,8 +304,8 @@ class DataArrayRolling(Rolling):
             If True, the attributes (``attrs``) will be copied from the original
             object to the new one. If False, the new object will be returned
             without attributes. If None uses the global default.
-        **window_dim_kwargs : {dim: new_name, ...}, optional
-            The keyword arguments form of ``window_dim``.
+        **window_dim_kwargs : Hashable, optional
+            The keyword arguments form of ``window_dim`` {dim: new_name, ...}.
 
         Returns
         -------
@@ -321,13 +357,13 @@ class DataArrayRolling(Rolling):
 
     def _construct(
         self,
-        obj,
-        window_dim=None,
-        stride=1,
-        fill_value=dtypes.NA,
-        keep_attrs=None,
-        **window_dim_kwargs,
-    ):
+        obj: DataArray,
+        window_dim: Hashable | Mapping[Any, Hashable] | None = None,
+        stride: int | Mapping[Any, int] = 1,
+        fill_value: Any = dtypes.NA,
+        keep_attrs: bool | None = None,
+        **window_dim_kwargs: Hashable,
+    ) -> DataArray:
         from .dataarray import DataArray
 
         keep_attrs = self._get_keep_attrs(keep_attrs)
@@ -337,31 +373,31 @@ class DataArrayRolling(Rolling):
                 raise ValueError(
                     "Either window_dim or window_dim_kwargs need to be specified."
                 )
-            window_dim = {d: window_dim_kwargs[d] for d in self.dim}
+            window_dim = {d: window_dim_kwargs[str(d)] for d in self.dim}
 
-        window_dim = self._mapping_to_list(
-            window_dim, allow_default=False, allow_allsame=False
+        window_dims = self._mapping_to_list(
+            window_dim, allow_default=False, allow_allsame=False  # type: ignore[arg-type]  # ??
         )
-        stride = self._mapping_to_list(stride, default=1)
+        strides = self._mapping_to_list(stride, default=1)
 
         window = obj.variable.rolling_window(
-            self.dim, self.window, window_dim, self.center, fill_value=fill_value
+            self.dim, self.window, window_dims, self.center, fill_value=fill_value
         )
 
         attrs = obj.attrs if keep_attrs else {}
 
         result = DataArray(
             window,
-            dims=obj.dims + tuple(window_dim),
+            dims=obj.dims + tuple(window_dims),
             coords=obj.coords,
             attrs=attrs,
             name=obj.name,
         )
-        return result.isel(
-            **{d: slice(None, None, s) for d, s in zip(self.dim, stride)}
-        )
+        return result.isel({d: slice(None, None, s) for d, s in zip(self.dim, strides)})
 
-    def reduce(self, func, keep_attrs=None, **kwargs):
+    def reduce(
+        self, func: Callable, keep_attrs: bool | None = None, **kwargs: Any
+    ) -> DataArray:
         """Reduce the items in this group by applying `func` along some
         dimension(s).
 
@@ -439,7 +475,7 @@ class DataArrayRolling(Rolling):
         counts = self._counts(keep_attrs=False)
         return result.where(counts >= self.min_periods)
 
-    def _counts(self, keep_attrs):
+    def _counts(self, keep_attrs: bool | None) -> DataArray:
         """Number of non-nan entries in each rolling window."""
 
         rolling_dim = {
@@ -453,8 +489,8 @@ class DataArrayRolling(Rolling):
         counts = (
             self.obj.notnull(keep_attrs=keep_attrs)
             .rolling(
+                {d: w for d, w in zip(self.dim, self.window)},
                 center={d: self.center[i] for i, d in enumerate(self.dim)},
-                **{d: w for d, w in zip(self.dim, self.window)},
             )
             .construct(rolling_dim, fill_value=False, keep_attrs=keep_attrs)
             .sum(dim=list(rolling_dim.values()), skipna=False, keep_attrs=keep_attrs)
@@ -526,7 +562,7 @@ class DataArrayRolling(Rolling):
             OPTIONS["use_bottleneck"]
             and bottleneck_move_func is not None
             and not is_duck_dask_array(self.obj.data)
-            and len(self.dim) == 1
+            and self.ndim == 1
         ):
             # TODO: renable bottleneck with dask after the issues
             # underlying https://github.com/pydata/xarray/issues/2940 are
@@ -547,10 +583,16 @@ class DataArrayRolling(Rolling):
         return self.reduce(array_agg_func, keep_attrs=keep_attrs, **kwargs)
 
 
-class DatasetRolling(Rolling):
+class DatasetRolling(Rolling["Dataset"]):
     __slots__ = ("rollings",)
 
-    def __init__(self, obj, windows, min_periods=None, center=False):
+    def __init__(
+        self,
+        obj: Dataset,
+        windows: Mapping[Any, int],
+        min_periods: int | None = None,
+        center: bool | Mapping[Any, bool] = False,
+    ) -> None:
         """
         Moving window object for Dataset.
         You should use Dataset.rolling() method to construct this object
@@ -616,7 +658,9 @@ class DatasetRolling(Rolling):
         attrs = self.obj.attrs if keep_attrs else {}
         return Dataset(reduced, coords=self.obj.coords, attrs=attrs)
 
-    def reduce(self, func, keep_attrs=None, **kwargs):
+    def reduce(
+        self, func: Callable, keep_attrs: bool | None = None, **kwargs: Any
+    ) -> DataArray:
         """Reduce the items in this group by applying `func` along some
         dimension(s).
 
@@ -644,7 +688,7 @@ class DatasetRolling(Rolling):
             **kwargs,
         )
 
-    def _counts(self, keep_attrs):
+    def _counts(self, keep_attrs: bool | None) -> Dataset:
         return self._dataset_implementation(
             DataArrayRolling._counts, keep_attrs=keep_attrs
         )
@@ -670,12 +714,12 @@ class DatasetRolling(Rolling):
 
     def construct(
         self,
-        window_dim=None,
-        stride=1,
-        fill_value=dtypes.NA,
-        keep_attrs=None,
-        **window_dim_kwargs,
-    ):
+        window_dim: Hashable | Mapping[Any, Hashable] | None = None,
+        stride: int | Mapping[Any, int] = 1,
+        fill_value: Any = dtypes.NA,
+        keep_attrs: bool | None = None,
+        **window_dim_kwargs: Hashable,
+    ) -> Dataset:
         """
         Convert this rolling object to xr.Dataset,
         where the window dimension is stacked as a new dimension
@@ -706,20 +750,20 @@ class DatasetRolling(Rolling):
                 raise ValueError(
                     "Either window_dim or window_dim_kwargs need to be specified."
                 )
-            window_dim = {d: window_dim_kwargs[d] for d in self.dim}
+            window_dim = {d: window_dim_kwargs[str(d)] for d in self.dim}
 
-        window_dim = self._mapping_to_list(
-            window_dim, allow_default=False, allow_allsame=False
+        window_dims = self._mapping_to_list(
+            window_dim, allow_default=False, allow_allsame=False  # type: ignore[arg-type]  # ??
         )
-        stride = self._mapping_to_list(stride, default=1)
+        strides = self._mapping_to_list(stride, default=1)
 
         dataset = {}
         for key, da in self.obj.data_vars.items():
             # keeps rollings only for the dataset depending on self.dim
             dims = [d for d in self.dim if d in da.dims]
             if dims:
-                wi = {d: window_dim[i] for i, d in enumerate(self.dim) if d in da.dims}
-                st = {d: stride[i] for i, d in enumerate(self.dim) if d in da.dims}
+                wi = {d: window_dims[i] for i, d in enumerate(self.dim) if d in da.dims}
+                st = {d: strides[i] for i, d in enumerate(self.dim) if d in da.dims}
 
                 dataset[key] = self.rollings[key].construct(
                     window_dim=wi,
@@ -737,7 +781,7 @@ class DatasetRolling(Rolling):
         attrs = self.obj.attrs if keep_attrs else {}
 
         return Dataset(dataset, coords=self.obj.coords, attrs=attrs).isel(
-            **{d: slice(None, None, s) for d, s in zip(self.dim, stride)}
+            {d: slice(None, None, s) for d, s in zip(self.dim, strides)}
         )
 
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -11,6 +11,7 @@ from . import dtypes, duck_array_ops, utils
 from .arithmetic import CoarsenArithmetic
 from .options import OPTIONS, _get_keep_attrs
 from .pycompat import is_duck_dask_array
+from .types import CoarsenBoundaryOptions, SideOptions, T_Xarray
 from .utils import either_dict_or_kwargs
 
 try:
@@ -22,7 +23,6 @@ except ImportError:
 if TYPE_CHECKING:
     from .dataarray import DataArray
     from .dataset import Dataset
-    from .types import CoarsenBoundaryOptions, SideOptions, T_Xarray
 
 _ROLLING_REDUCE_DOCSTRING_TEMPLATE = """\
 Reduce this object's data windows by applying `{name}` along its dimension.

--- a/xarray/core/rolling_exp.py
+++ b/xarray/core/rolling_exp.py
@@ -8,7 +8,7 @@ from packaging.version import Version
 from .options import _get_keep_attrs
 from .pdcompat import count_not_none
 from .pycompat import is_duck_dask_array
-from .types import T_Xarray
+from .types import T_DataWithCoords
 
 
 def _get_alpha(com=None, span=None, halflife=None, alpha=None):
@@ -76,7 +76,7 @@ def _get_center_of_mass(comass, span, halflife, alpha):
     return float(comass)
 
 
-class RollingExp(Generic[T_Xarray]):
+class RollingExp(Generic[T_DataWithCoords]):
     """
     Exponentially-weighted moving window object.
     Similar to EWM in pandas
@@ -100,16 +100,16 @@ class RollingExp(Generic[T_Xarray]):
 
     def __init__(
         self,
-        obj: T_Xarray,
+        obj: T_DataWithCoords,
         windows: Mapping[Any, int | float],
         window_type: str = "span",
     ):
-        self.obj: T_Xarray = obj
+        self.obj: T_DataWithCoords = obj
         dim, window = next(iter(windows.items()))
         self.dim = dim
         self.alpha = _get_alpha(**{window_type: window})
 
-    def mean(self, keep_attrs: bool = None) -> T_Xarray:
+    def mean(self, keep_attrs: bool | None = None) -> T_DataWithCoords:
         """
         Exponentially weighted moving average.
 
@@ -136,7 +136,7 @@ class RollingExp(Generic[T_Xarray]):
             move_exp_nanmean, dim=self.dim, alpha=self.alpha, keep_attrs=keep_attrs
         )
 
-    def sum(self, keep_attrs: bool = None) -> T_Xarray:
+    def sum(self, keep_attrs: bool | None = None) -> T_DataWithCoords:
         """
         Exponentially weighted moving sum.
 

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -90,6 +90,9 @@ CFCalendar = Literal[
     "366_day",
 ]
 
+CoarsenBoundaryOptions = Literal["exact", "trim", "pad"]
+SideOptions = Literal["left", "right"]
+
 # TODO: Wait until mypy supports recursive objects in combination with typevars
 _T = TypeVar("_T")
 NestedSequence = Union[

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -828,7 +828,7 @@ def get_temp_dimname(dims: Container[Hashable], new_dim: Hashable) -> Hashable:
 
 def drop_dims_from_indexers(
     indexers: Mapping[Any, Any],
-    dims: list | Mapping[Any, int],
+    dims: Iterable[Hashable] | Mapping[Any, int],
     missing_dims: ErrorOptionsWithWarn,
 ) -> Mapping[Hashable, Any]:
     """Depending on the setting of missing_dims, drop any dimensions from indexers that

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -5,7 +5,16 @@ import itertools
 import numbers
 import warnings
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Hashable, Iterable, Literal, Mapping, Sequence
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Hashable,
+    Iterable,
+    Literal,
+    Mapping,
+    Sequence,
+)
 
 import numpy as np
 import pandas as pd
@@ -1780,13 +1789,13 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
 
     def reduce(
         self,
-        func,
-        dim=None,
-        axis=None,
-        keep_attrs=None,
-        keepdims=False,
+        func: Callable[..., Any],
+        dim: Hashable | Iterable[Hashable] | None = None,
+        axis: int | Sequence[int] | None = None,
+        keep_attrs: bool | None = None,
+        keepdims: bool = False,
         **kwargs,
-    ):
+    ) -> Variable:
         """Reduce this array by applying `func` along some dimension(s).
 
         Parameters
@@ -1795,9 +1804,9 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
             Function which can be called in the form
             `func(x, axis=axis, **kwargs)` to return the result of reducing an
             np.ndarray over an integer valued axis.
-        dim : str or sequence of str, optional
+        dim : Hashable or Iterable of Hashable, optional
             Dimension(s) over which to apply `func`.
-        axis : int or sequence of int, optional
+        axis : int or Iterable of int, optional
             Axis(es) over which to apply `func`. Only one of the 'dim'
             and 'axis' arguments can be supplied. If neither are supplied, then
             the reduction is calculated over the flattened array (by calling
@@ -1838,8 +1847,8 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         if getattr(data, "shape", ()) == self.shape:
             dims = self.dims
         else:
-            removed_axes = (
-                range(self.ndim) if axis is None else np.atleast_1d(axis) % self.ndim
+            removed_axes: Sequence[int] = (
+                range(self.ndim) if axis is None else np.atleast_1d(axis) % self.ndim  # type: ignore[assignment]
             )
             if keepdims:
                 # Insert np.newaxis for removed dims
@@ -1854,9 +1863,9 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
                     data = data[slices]
                 dims = self.dims
             else:
-                dims = [
+                dims = tuple(
                     adim for n, adim in enumerate(self.dims) if n not in removed_axes
-                ]
+                )
 
         if keep_attrs is None:
             keep_attrs = _get_keep_attrs(default=False)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1847,9 +1847,11 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         if getattr(data, "shape", ()) == self.shape:
             dims = self.dims
         else:
-            removed_axes: Sequence[int] = (
-                range(self.ndim) if axis is None else np.atleast_1d(axis) % self.ndim  # type: ignore[assignment]
-            )
+            removed_axes: Iterable[int]
+            if axis is None:
+                removed_axes = range(self.ndim)
+            else:
+                removed_axes = np.atleast_1d(axis) % self.ndim
             if keepdims:
                 # Insert np.newaxis for removed dims
                 slices = tuple(

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1806,7 +1806,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
             np.ndarray over an integer valued axis.
         dim : Hashable or Iterable of Hashable, optional
             Dimension(s) over which to apply `func`.
-        axis : int or Iterable of int, optional
+        axis : int or Sequence of int, optional
             Axis(es) over which to apply `func`. Only one of the 'dim'
             and 'axis' arguments can be supplied. If neither are supplied, then
             the reduction is calculated over the flattened array (by calling

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -5,7 +5,7 @@ import itertools
 import numbers
 import warnings
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Hashable, Literal, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Hashable, Iterable, Literal, Mapping, Sequence
 
 import numpy as np
 import pandas as pd
@@ -552,15 +552,15 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         return item
 
     @property
-    def dims(self):
+    def dims(self) -> tuple[Hashable, ...]:
         """Tuple of dimension names with which this variable is associated."""
         return self._dims
 
     @dims.setter
-    def dims(self, value):
+    def dims(self, value: str | Iterable[Hashable]) -> None:
         self._dims = self._parse_dimensions(value)
 
-    def _parse_dimensions(self, dims):
+    def _parse_dimensions(self, dims: str | Iterable[Hashable]) -> tuple[Hashable, ...]:
         if isinstance(dims, str):
             dims = (dims,)
         dims = tuple(dims)

--- a/xarray/core/weighted.py
+++ b/xarray/core/weighted.py
@@ -143,7 +143,7 @@ class Weighted(Generic[T_Xarray]):
 
     __slots__ = ("obj", "weights")
 
-    def __init__(self, obj: T_Xarray, weights: DataArray):
+    def __init__(self, obj: T_Xarray, weights: DataArray) -> None:
         """
         Create a Weighted object
 
@@ -525,11 +525,11 @@ class Weighted(Generic[T_Xarray]):
             self._weighted_quantile, q=q, dim=dim, skipna=skipna, keep_attrs=keep_attrs
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """provide a nice str repr of our Weighted object"""
 
         klass = self.__class__.__name__
-        weight_dims = ", ".join(self.weights.dims)
+        weight_dims = ", ".join(map(str, self.weights.dims))
         return f"{klass} with weights along dimensions: {weight_dims}"
 
 

--- a/xarray/core/weighted.py
+++ b/xarray/core/weighted.py
@@ -26,14 +26,14 @@ _WEIGHTED_REDUCE_DOCSTRING_TEMPLATE = """
 
     Parameters
     ----------
-    dim : str or sequence of str, optional
+    dim : Hashable or Iterable of Hashable, optional
         Dimension(s) over which to apply the weighted ``{fcn}``.
-    skipna : bool, optional
+    skipna : bool or None, optional
         If True, skip missing values (as marked by NaN). By default, only
         skips missing values for float dtypes; other dtypes either do not
         have a sentinel missing value (int) or skipna=True has not been
         implemented (object, datetime64 or timedelta64).
-    keep_attrs : bool, optional
+    keep_attrs : bool or None, optional
         If True, the attributes (``attrs``) will be copied from the original
         object to the new one.  If False (default), the new object will be
         returned without attributes.

--- a/xarray/tests/test_coarsen.py
+++ b/xarray/tests/test_coarsen.py
@@ -26,35 +26,35 @@ def test_coarsen_absent_dims_error(ds: Dataset) -> None:
 
 @pytest.mark.parametrize("dask", [True, False])
 @pytest.mark.parametrize(("boundary", "side"), [("trim", "left"), ("pad", "right")])
-def test_coarsen_dataset(ds: Dataset, dask: bool, boundary, side) -> None:
+def test_coarsen_dataset(ds, dask, boundary, side):
     if dask and has_dask:
         ds = ds.chunk({"x": 4})
 
-    actual = ds.coarsen(time=2, x=3, boundary=boundary, side=side).max()  # type: ignore[attr-defined]
+    actual = ds.coarsen(time=2, x=3, boundary=boundary, side=side).max()
     assert_equal(
-        actual["z1"], ds["z1"].coarsen(x=3, boundary=boundary, side=side).max()  # type: ignore[attr-defined]
+        actual["z1"], ds["z1"].coarsen(x=3, boundary=boundary, side=side).max()
     )
     # coordinate should be mean by default
     assert_equal(
-        actual["time"], ds["time"].coarsen(time=2, boundary=boundary, side=side).mean()  # type: ignore[attr-defined]
+        actual["time"], ds["time"].coarsen(time=2, boundary=boundary, side=side).mean()
     )
 
 
 @pytest.mark.parametrize("dask", [True, False])
-def test_coarsen_coords(ds: Dataset, dask: bool) -> None:
+def test_coarsen_coords(ds, dask):
     if dask and has_dask:
         ds = ds.chunk({"x": 4})
 
     # check if coord_func works
-    actual = ds.coarsen(time=2, x=3, boundary="trim", coord_func={"time": "max"}).max()  # type: ignore[attr-defined]
-    assert_equal(actual["z1"], ds["z1"].coarsen(x=3, boundary="trim").max())  # type: ignore[attr-defined]
-    assert_equal(actual["time"], ds["time"].coarsen(time=2, boundary="trim").max())  # type: ignore[attr-defined]
+    actual = ds.coarsen(time=2, x=3, boundary="trim", coord_func={"time": "max"}).max()
+    assert_equal(actual["z1"], ds["z1"].coarsen(x=3, boundary="trim").max())
+    assert_equal(actual["time"], ds["time"].coarsen(time=2, boundary="trim").max())
 
     # raise if exact
     with pytest.raises(ValueError):
-        ds.coarsen(x=3).mean()  # type: ignore[attr-defined]
+        ds.coarsen(x=3).mean()
     # should be no error
-    ds.isel(x=slice(0, 3 * (len(ds["x"]) // 3))).coarsen(x=3).mean()  # type: ignore[attr-defined]
+    ds.isel(x=slice(0, 3 * (len(ds["x"]) // 3))).coarsen(x=3).mean()
 
     # working test with pd.time
     da = xr.DataArray(
@@ -62,14 +62,14 @@ def test_coarsen_coords(ds: Dataset, dask: bool) -> None:
         dims="time",
         coords={"time": pd.date_range("1999-12-15", periods=364)},
     )
-    actual = da.coarsen(time=2).mean()  # type: ignore[attr-defined]
+    actual = da.coarsen(time=2).mean()
 
 
 @requires_cftime
-def test_coarsen_coords_cftime() -> None:
+def test_coarsen_coords_cftime():
     times = xr.cftime_range("2000", periods=6)
     da = xr.DataArray(range(6), [("time", times)])
-    actual = da.coarsen(time=3).mean()  # type: ignore[attr-defined]
+    actual = da.coarsen(time=3).mean()
     expected_times = xr.cftime_range("2000-01-02", freq="3D", periods=2)
     np.testing.assert_array_equal(actual.time, expected_times)
 

--- a/xarray/tests/test_coarsen.py
+++ b/xarray/tests/test_coarsen.py
@@ -19,42 +19,42 @@ from .test_dataarray import da
 from .test_dataset import ds
 
 
-def test_coarsen_absent_dims_error(ds) -> None:
+def test_coarsen_absent_dims_error(ds: Dataset) -> None:
     with pytest.raises(ValueError, match=r"not found in Dataset."):
         ds.coarsen(foo=2)
 
 
 @pytest.mark.parametrize("dask", [True, False])
 @pytest.mark.parametrize(("boundary", "side"), [("trim", "left"), ("pad", "right")])
-def test_coarsen_dataset(ds, dask, boundary, side) -> None:
+def test_coarsen_dataset(ds: Dataset, dask: bool, boundary, side) -> None:
     if dask and has_dask:
         ds = ds.chunk({"x": 4})
 
-    actual = ds.coarsen(time=2, x=3, boundary=boundary, side=side).max()
+    actual = ds.coarsen(time=2, x=3, boundary=boundary, side=side).max()  # type: ignore[attr-defined]
     assert_equal(
-        actual["z1"], ds["z1"].coarsen(x=3, boundary=boundary, side=side).max()
+        actual["z1"], ds["z1"].coarsen(x=3, boundary=boundary, side=side).max()  # type: ignore[attr-defined]
     )
     # coordinate should be mean by default
     assert_equal(
-        actual["time"], ds["time"].coarsen(time=2, boundary=boundary, side=side).mean()
+        actual["time"], ds["time"].coarsen(time=2, boundary=boundary, side=side).mean()  # type: ignore[attr-defined]
     )
 
 
 @pytest.mark.parametrize("dask", [True, False])
-def test_coarsen_coords(ds, dask) -> None:
+def test_coarsen_coords(ds: Dataset, dask: bool) -> None:
     if dask and has_dask:
         ds = ds.chunk({"x": 4})
 
     # check if coord_func works
-    actual = ds.coarsen(time=2, x=3, boundary="trim", coord_func={"time": "max"}).max()
-    assert_equal(actual["z1"], ds["z1"].coarsen(x=3, boundary="trim").max())
-    assert_equal(actual["time"], ds["time"].coarsen(time=2, boundary="trim").max())
+    actual = ds.coarsen(time=2, x=3, boundary="trim", coord_func={"time": "max"}).max()  # type: ignore[attr-defined]
+    assert_equal(actual["z1"], ds["z1"].coarsen(x=3, boundary="trim").max())  # type: ignore[attr-defined]
+    assert_equal(actual["time"], ds["time"].coarsen(time=2, boundary="trim").max())  # type: ignore[attr-defined]
 
     # raise if exact
     with pytest.raises(ValueError):
-        ds.coarsen(x=3).mean()
+        ds.coarsen(x=3).mean()  # type: ignore[attr-defined]
     # should be no error
-    ds.isel(x=slice(0, 3 * (len(ds["x"]) // 3))).coarsen(x=3).mean()
+    ds.isel(x=slice(0, 3 * (len(ds["x"]) // 3))).coarsen(x=3).mean()  # type: ignore[attr-defined]
 
     # working test with pd.time
     da = xr.DataArray(
@@ -62,14 +62,14 @@ def test_coarsen_coords(ds, dask) -> None:
         dims="time",
         coords={"time": pd.date_range("1999-12-15", periods=364)},
     )
-    actual = da.coarsen(time=2).mean()
+    actual = da.coarsen(time=2).mean()  # type: ignore[attr-defined]
 
 
 @requires_cftime
 def test_coarsen_coords_cftime() -> None:
     times = xr.cftime_range("2000", periods=6)
     da = xr.DataArray(range(6), [("time", times)])
-    actual = da.coarsen(time=3).mean()
+    actual = da.coarsen(time=3).mean()  # type: ignore[attr-defined]
     expected_times = xr.cftime_range("2000-01-02", freq="3D", periods=2)
     np.testing.assert_array_equal(actual.time, expected_times)
 
@@ -159,7 +159,7 @@ def test_coarsen_keep_attrs(funcname, argument) -> None:
 @pytest.mark.parametrize("ds", (1, 2), indirect=True)
 @pytest.mark.parametrize("window", (1, 2, 3, 4))
 @pytest.mark.parametrize("name", ("sum", "mean", "std", "var", "min", "max", "median"))
-def test_coarsen_reduce(ds, window, name) -> None:
+def test_coarsen_reduce(ds: Dataset, window, name) -> None:
     # Use boundary="trim" to accommodate all window sizes used in tests
     coarsen_obj = ds.coarsen(time=window, boundary="trim")
 
@@ -253,7 +253,7 @@ def test_coarsen_da_reduce(da, window, name) -> None:
 
 
 @pytest.mark.parametrize("dask", [True, False])
-def test_coarsen_construct(dask) -> None:
+def test_coarsen_construct(dask: bool) -> None:
 
     ds = Dataset(
         {

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -360,7 +360,7 @@ def test_ds_groupby_quantile() -> None:
     expected_x = xr.Dataset({"a": ("x", [1, 4])}, coords={"x": [1, 2], "quantile": 0})
     assert_identical(expected_x, actual_x)
 
-    actual_y = ds.groupby("y").quantile(0, dim=...)  # type: ignore[arg-type]
+    actual_y = ds.groupby("y").quantile(0, dim=...)  # type: ignore[arg-type]  # https://github.com/python/mypy/issues/7818
     expected_y = xr.Dataset({"a": ("y", [1, 22])}, coords={"y": [0, 1], "quantile": 0})
     assert_identical(expected_y, actual_y)
 

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -356,7 +356,7 @@ def test_ds_groupby_quantile() -> None:
         coords={"x": [1, 1, 1, 2, 2], "y": [0, 0, 1]},
     )
 
-    actual_x = ds.groupby("x").quantile(0, dim=...)  # type: ignore[arg-type]
+    actual_x = ds.groupby("x").quantile(0, dim=...)  # type: ignore[arg-type]  # https://github.com/python/mypy/issues/7818
     expected_x = xr.Dataset({"a": ("x", [1, 4])}, coords={"x": [1, 2], "quantile": 0})
     assert_identical(expected_x, actual_x)
 

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -241,7 +241,7 @@ def test_da_groupby_quantile() -> None:
     )
     assert_identical(expected_x, actual_x)
 
-    actual_y = array.groupby("y").quantile(0, dim=...)  # type: ignore[arg-type]
+    actual_y = array.groupby("y").quantile(0, dim=...)  # type: ignore[arg-type]  # https://github.com/python/mypy/issues/7818
     expected_y = xr.DataArray(
         data=[1, 22], coords={"y": [0, 1], "quantile": 0}, dims="y"
     )

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -235,13 +235,13 @@ def test_da_groupby_quantile() -> None:
         dims=("x", "y"),
     )
 
-    actual_x = array.groupby("x").quantile(0, dim=...)
+    actual_x = array.groupby("x").quantile(0, dim=...)  # type: ignore[arg-type]
     expected_x = xr.DataArray(
         data=[1, 4], coords={"x": [1, 2], "quantile": 0}, dims="x"
     )
     assert_identical(expected_x, actual_x)
 
-    actual_y = array.groupby("y").quantile(0, dim=...)
+    actual_y = array.groupby("y").quantile(0, dim=...)  # type: ignore[arg-type]
     expected_y = xr.DataArray(
         data=[1, 22], coords={"y": [0, 1], "quantile": 0}, dims="y"
     )
@@ -272,7 +272,7 @@ def test_da_groupby_quantile() -> None:
     )
     g = foo.groupby(foo.time.dt.month)
 
-    actual = g.quantile(0, dim=...)
+    actual = g.quantile(0, dim=...)  # type: ignore[arg-type]
     expected = xr.DataArray(
         data=[
             0.0,
@@ -356,11 +356,11 @@ def test_ds_groupby_quantile() -> None:
         coords={"x": [1, 1, 1, 2, 2], "y": [0, 0, 1]},
     )
 
-    actual_x = ds.groupby("x").quantile(0, dim=...)
+    actual_x = ds.groupby("x").quantile(0, dim=...)  # type: ignore[arg-type]
     expected_x = xr.Dataset({"a": ("x", [1, 4])}, coords={"x": [1, 2], "quantile": 0})
     assert_identical(expected_x, actual_x)
 
-    actual_y = ds.groupby("y").quantile(0, dim=...)
+    actual_y = ds.groupby("y").quantile(0, dim=...)  # type: ignore[arg-type]
     expected_y = xr.Dataset({"a": ("y", [1, 22])}, coords={"y": [0, 1], "quantile": 0})
     assert_identical(expected_y, actual_y)
 
@@ -386,7 +386,7 @@ def test_ds_groupby_quantile() -> None:
     )
     g = foo.groupby(foo.time.dt.month)
 
-    actual = g.quantile(0, dim=...)
+    actual = g.quantile(0, dim=...)  # type: ignore[arg-type]
     expected = xr.Dataset(
         {
             "a": (
@@ -522,17 +522,17 @@ def test_groupby_drops_nans() -> None:
     grouped = ds.groupby(ds.id)
 
     # non reduction operation
-    expected = ds.copy()
-    expected.variable.values[0, 0, :] = np.nan
-    expected.variable.values[-1, -1, :] = np.nan
-    expected.variable.values[3, 0, :] = np.nan
-    actual = grouped.map(lambda x: x).transpose(*ds.variable.dims)
-    assert_identical(actual, expected)
+    expected1 = ds.copy()
+    expected1.variable.values[0, 0, :] = np.nan
+    expected1.variable.values[-1, -1, :] = np.nan
+    expected1.variable.values[3, 0, :] = np.nan
+    actual1 = grouped.map(lambda x: x).transpose(*ds.variable.dims)
+    assert_identical(actual1, expected1)
 
     # reduction along grouped dimension
-    actual = grouped.mean()
+    actual2 = grouped.mean()
     stacked = ds.stack({"xy": ["lat", "lon"]})
-    expected = (
+    expected2 = (
         stacked.variable.where(stacked.id.notnull())
         .rename({"xy": "id"})
         .to_dataset()
@@ -540,21 +540,21 @@ def test_groupby_drops_nans() -> None:
         .drop_vars(["lon", "lat"])
         .assign(id=stacked.id.values)
         .dropna("id")
-        .transpose(*actual.dims)
+        .transpose(*actual2.dims)
     )
-    assert_identical(actual, expected)
+    assert_identical(actual2, expected2)
 
     # reduction operation along a different dimension
-    actual = grouped.mean("time")
-    expected = ds.mean("time").where(ds.id.notnull())
-    assert_identical(actual, expected)
+    actual3 = grouped.mean("time")
+    expected3 = ds.mean("time").where(ds.id.notnull())
+    assert_identical(actual3, expected3)
 
     # NaN in non-dimensional coordinate
     array = xr.DataArray([1, 2, 3], [("x", [1, 2, 3])])
     array["x1"] = ("x", [1, 1, np.nan])
-    expected_da = xr.DataArray(3, [("x1", [1])])
-    actual = array.groupby("x1").sum()
-    assert_equal(expected_da, actual)
+    expected4 = xr.DataArray(3, [("x1", [1])])
+    actual4 = array.groupby("x1").sum()
+    assert_equal(expected4, actual4)
 
     # NaT in non-dimensional coordinate
     array["t"] = (
@@ -565,15 +565,15 @@ def test_groupby_drops_nans() -> None:
             np.datetime64("NaT"),
         ],
     )
-    expected_da = xr.DataArray(3, [("t", [np.datetime64("2001-01-01")])])
-    actual = array.groupby("t").sum()
-    assert_equal(expected_da, actual)
+    expected5 = xr.DataArray(3, [("t", [np.datetime64("2001-01-01")])])
+    actual5 = array.groupby("t").sum()
+    assert_equal(expected5, actual5)
 
     # test for repeated coordinate labels
     array = xr.DataArray([0, 1, 2, 4, 3, 4], [("x", [np.nan, 1, 1, np.nan, 2, np.nan])])
-    expected_da = xr.DataArray([3, 3], [("x", [1, 2])])
-    actual = array.groupby("x").sum()
-    assert_equal(expected_da, actual)
+    expected6 = xr.DataArray([3, 3], [("x", [1, 2])])
+    actual6 = array.groupby("x").sum()
+    assert_equal(expected6, actual6)
 
 
 def test_groupby_grouping_errors() -> None:
@@ -679,28 +679,28 @@ def test_groupby_dataset() -> None:
         ("b", data.isel(x=1)),
         ("c", data.isel(x=2)),
     ]
-    for actual, expected in zip(groupby, expected_items):
-        assert actual[0] == expected[0]
-        assert_equal(actual[1], expected[1])
+    for actual1, expected1 in zip(groupby, expected_items):
+        assert actual1[0] == expected1[0]
+        assert_equal(actual1[1], expected1[1])
 
     def identity(x):
         return x
 
     for k in ["x", "c", "y"]:
-        actual = data.groupby(k, squeeze=False).map(identity)
-        assert_equal(data, actual)
+        actual2 = data.groupby(k, squeeze=False).map(identity)
+        assert_equal(data, actual2)
 
 
 def test_groupby_dataset_returns_new_type() -> None:
     data = Dataset({"z": (["x", "y"], np.random.randn(3, 5))})
 
-    actual = data.groupby("x").map(lambda ds: ds["z"])
-    expected = data["z"]
-    assert_identical(expected, actual)
+    actual1 = data.groupby("x").map(lambda ds: ds["z"])
+    expected1 = data["z"]
+    assert_identical(expected1, actual1)
 
-    actual = data["z"].groupby("x").map(lambda x: x.to_dataset())
-    expected_ds = data
-    assert_identical(expected_ds, actual)
+    actual2 = data["z"].groupby("x").map(lambda x: x.to_dataset())
+    expected2 = data
+    assert_identical(expected2, actual2)
 
 
 def test_groupby_dataset_iter() -> None:

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -386,7 +386,7 @@ def test_ds_groupby_quantile() -> None:
     )
     g = foo.groupby(foo.time.dt.month)
 
-    actual = g.quantile(0, dim=...)  # type: ignore[arg-type]
+    actual = g.quantile(0, dim=...)  # type: ignore[arg-type]  # https://github.com/python/mypy/issues/7818
     expected = xr.Dataset(
         {
             "a": (

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -272,7 +272,7 @@ def test_da_groupby_quantile() -> None:
     )
     g = foo.groupby(foo.time.dt.month)
 
-    actual = g.quantile(0, dim=...)  # type: ignore[arg-type]
+    actual = g.quantile(0, dim=...)  # type: ignore[arg-type]  # https://github.com/python/mypy/issues/7818
     expected = xr.DataArray(
         data=[
             0.0,

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -235,7 +235,7 @@ def test_da_groupby_quantile() -> None:
         dims=("x", "y"),
     )
 
-    actual_x = array.groupby("x").quantile(0, dim=...)  # type: ignore[arg-type]
+    actual_x = array.groupby("x").quantile(0, dim=...)  # type: ignore[arg-type]  # https://github.com/python/mypy/issues/7818
     expected_x = xr.DataArray(
         data=[1, 4], coords={"x": [1, 2], "quantile": 0}, dims="x"
     )


### PR DESCRIPTION
This PR adds typing support for groupby, coarsen, rolling, weighted and resample.

There are several open points:

1. Coarsen is missing type annotations for reductions like `max`, they get added dynamically.
2. The `Groupby` group-key type is quite wide. Does anyone have any idea on how to type it correctly? For now it is still Any.
3. Several function signatures were inconsistent between the DataArray and Dataset versions (looking at you: `map`). I took the freedom to align them (required for mypy), hopefully this does not break too much.
4. I was moving the generation functions from `DataWithCoords` to `DataArray` and `Dataset`, which adds some copy-paste of code (I tried to keep it minimal) but was unavoidable for typing support. (Adds the bonus that the corresponding modules are now only imported when required).