### PR TITLE
Add `Dataset.dtypes` property

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -61,6 +61,7 @@ Attributes
 
    Dataset.dims
    Dataset.sizes
+   Dataset.dtypes
    Dataset.data_vars
    Dataset.coords
    Dataset.attrs

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,6 +22,9 @@ v2022.06.0 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- Add :py:meth:`Dataset.dtypes` property: Mapping from variable names to dtypes.
+  (:pull:`6706`)
+  By `Michael Niklas <https://github.com/headtr1ck>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,7 +22,8 @@ v2022.06.0 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
-- Add :py:meth:`Dataset.dtypes` property: Mapping from variable names to dtypes.
+- Add :py:meth:`Dataset.dtypes`, :py:meth:`DatasetCoordinates.dtypes`,
+  :py:meth:`DataArrayCoordinates.dtypes` properties: Mapping from variable names to dtypes.
   (:pull:`6706`)
   By `Michael Niklas <https://github.com/headtr1ck>`_.
 

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -39,6 +39,10 @@ class Coordinates(Mapping[Any, "DataArray"]):
         raise NotImplementedError()
 
     @property
+    def dtypes(self) -> Frozen[Hashable, np.dtype]:
+        raise NotImplementedError()
+
+    @property
     def indexes(self) -> Indexes[pd.Index]:
         return self._data.indexes  # type: ignore[attr-defined]
 
@@ -243,6 +247,24 @@ class DatasetCoordinates(Coordinates):
         return self._data.dims
 
     @property
+    def dtypes(self) -> Frozen[Hashable, np.dtype]:
+        """Mapping from coordinate names to dtypes.
+
+        Cannot be modified directly, but is updated when adding new variables.
+
+        See Also
+        --------
+        Dataset.dtypes
+        """
+        return Frozen(
+            {
+                n: v.dtype
+                for n, v in self._data._variables.items()
+                if n in self._data._coord_names
+            }
+        )
+
+    @property
     def variables(self) -> Mapping[Hashable, Variable]:
         return Frozen(
             {k: v for k, v in self._data.variables.items() if k in self._names}
@@ -312,6 +334,18 @@ class DataArrayCoordinates(Coordinates):
     @property
     def dims(self) -> tuple[Hashable, ...]:
         return self._data.dims
+
+    @property
+    def dtypes(self) -> Frozen[Hashable, np.dtype]:
+        """Mapping from coordinate names to dtypes.
+
+        Cannot be modified directly, but is updated when adding new variables.
+
+        See Also
+        --------
+        DataArray.dtype
+        """
+        return Frozen({n: v.dtype for n, v in self._data._coords.items()})
 
     @property
     def _names(self) -> set[Hashable]:

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -102,7 +102,7 @@ if TYPE_CHECKING:
 
 def _infer_coords_and_dims(
     shape, coords, dims
-) -> tuple[dict[Any, Variable], tuple[Hashable, ...]]:
+) -> tuple[dict[Hashable, Variable], tuple[Hashable, ...]]:
     """All the logic for creating a new DataArray"""
 
     if (
@@ -140,7 +140,7 @@ def _infer_coords_and_dims(
             if not isinstance(d, str):
                 raise TypeError(f"dimension {d} is not a string")
 
-    new_coords: dict[Any, Variable] = {}
+    new_coords: dict[Hashable, Variable] = {}
 
     if utils.is_dict_like(coords):
         for k, v in coords.items():

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -679,7 +679,7 @@ class Dataset(
 
     @property
     def dtypes(self) -> Frozen[Hashable, np.dtype]:
-        """Mapping from variable names to xrdtypes.
+        """Mapping from variable names to dtypes.
 
         Cannot be modified directly, but is updated when adding new variables.
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6942,7 +6942,9 @@ class Dataset(
         dim = coord_var.dims[0]
         if _contains_datetime_like_objects(coord_var):
             if coord_var.dtype.kind in "mM" and datetime_unit is None:
-                datetime_unit, _ = np.datetime_data(coord_var.dtype)
+                datetime_unit = cast(
+                    "DatetimeUnitOptions", np.datetime_data(coord_var.dtype)[0]
+                )
             elif datetime_unit is None:
                 datetime_unit = "s"  # Default to seconds for cftime objects
             coord_var = coord_var._to_numeric(datetime_unit=datetime_unit)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -385,6 +385,18 @@ class DataVariables(Mapping[Any, "DataArray"]):
         all_variables = self._dataset.variables
         return Frozen({k: all_variables[k] for k in self})
 
+    @property
+    def dtypes(self) -> Frozen[Hashable, np.dtype]:
+        """Mapping from data variable names to dtypes.
+
+        Cannot be modified directly, but is updated when adding new variables.
+
+        See Also
+        --------
+        Dataset.dtype
+        """
+        return self._dataset.dtypes
+
     def _ipython_key_completions_(self):
         """Provide method for the key-autocompletions in IPython."""
         return [
@@ -679,7 +691,7 @@ class Dataset(
 
     @property
     def dtypes(self) -> Frozen[Hashable, np.dtype]:
-        """Mapping from variable names to dtypes.
+        """Mapping from data variable names to dtypes.
 
         Cannot be modified directly, but is updated when adding new variables.
 
@@ -687,7 +699,13 @@ class Dataset(
         --------
         DataArray.dtype
         """
-        return Frozen({n: v.dtype for n, v in self._variables.items()})
+        return Frozen(
+            {
+                n: v.dtype
+                for n, v in self._variables.items()
+                if n not in self._coord_names
+            }
+        )
 
     def load(self: T_Dataset, **kwargs) -> T_Dataset:
         """Manually trigger loading and/or computation of this dataset's data

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -35,9 +35,9 @@ import pandas as pd
 from ..coding.calendar_ops import convert_calendar, interp_calendar
 from ..coding.cftimeindex import CFTimeIndex, _parse_array_of_cftime_strings
 from ..plot.dataset_plot import _Dataset_PlotMethods
+from . import alignment
+from . import dtypes as xrdtypes
 from . import (
-    alignment,
-    dtypes,
     duck_array_ops,
     formatting,
     formatting_html,
@@ -676,6 +676,18 @@ class Dataset(
         DataArray.sizes
         """
         return self.dims
+
+    @property
+    def dtypes(self) -> Frozen[Hashable, np.dtype]:
+        """Mapping from variable names to xrdtypes.
+
+        Cannot be modified directly, but is updated when adding new variables.
+
+        See Also
+        --------
+        DataArray.dtype
+        """
+        return Frozen({n: v.dtype for n, v in self._variables.items()})
 
     def load(self: T_Dataset, **kwargs) -> T_Dataset:
         """Manually trigger loading and/or computation of this dataset's data
@@ -2791,7 +2803,7 @@ class Dataset(
         method: ReindexMethodOptions = None,
         tolerance: int | float | Iterable[int | float] | None = None,
         copy: bool = True,
-        fill_value: Any = dtypes.NA,
+        fill_value: Any = xrdtypes.NA,
     ) -> T_Dataset:
         """Conform this object onto the indexes of another object, filling in
         missing values with ``fill_value``. The default fill value is NaN.
@@ -2857,7 +2869,7 @@ class Dataset(
         method: ReindexMethodOptions = None,
         tolerance: int | float | Iterable[int | float] | None = None,
         copy: bool = True,
-        fill_value: Any = dtypes.NA,
+        fill_value: Any = xrdtypes.NA,
         **indexers_kwargs: Any,
     ) -> T_Dataset:
         """Conform this object onto a new set of indexes, filling in
@@ -3073,7 +3085,7 @@ class Dataset(
         method: str = None,
         tolerance: int | float | Iterable[int | float] | None = None,
         copy: bool = True,
-        fill_value: Any = dtypes.NA,
+        fill_value: Any = xrdtypes.NA,
         sparse: bool = False,
         **indexers_kwargs: Any,
     ) -> T_Dataset:
@@ -4531,7 +4543,7 @@ class Dataset(
     def unstack(
         self: T_Dataset,
         dim: Hashable | Iterable[Hashable] | None = None,
-        fill_value: Any = dtypes.NA,
+        fill_value: Any = xrdtypes.NA,
         sparse: bool = False,
     ) -> T_Dataset:
         """
@@ -4676,7 +4688,7 @@ class Dataset(
         overwrite_vars: Hashable | Iterable[Hashable] = frozenset(),
         compat: CompatOptions = "no_conflicts",
         join: JoinOptions = "outer",
-        fill_value: Any = dtypes.NA,
+        fill_value: Any = xrdtypes.NA,
         combine_attrs: CombineAttrsOptions = "override",
     ) -> T_Dataset:
         """Merge the arrays of two datasets into a single dataset.
@@ -5885,7 +5897,7 @@ class Dataset(
             # missing values and needs a fill_value. For consistency, don't
             # special case the rare exceptions (e.g., dtype=int without a
             # MultiIndex).
-            dtype, fill_value = dtypes.maybe_promote(values.dtype)
+            dtype, fill_value = xrdtypes.maybe_promote(values.dtype)
             values = np.asarray(values, dtype=dtype)
 
             data = COO(
@@ -5923,7 +5935,7 @@ class Dataset(
             # fill in missing values:
             # https://stackoverflow.com/a/35049899/809705
             if missing_values:
-                dtype, fill_value = dtypes.maybe_promote(values.dtype)
+                dtype, fill_value = xrdtypes.maybe_promote(values.dtype)
                 data = np.full(shape, fill_value, dtype)
             else:
                 # If there are no missing values, keep the existing dtype
@@ -6414,7 +6426,7 @@ class Dataset(
     def shift(
         self: T_Dataset,
         shifts: Mapping[Any, int] | None = None,
-        fill_value: Any = dtypes.NA,
+        fill_value: Any = xrdtypes.NA,
         **shifts_kwargs: int,
     ) -> T_Dataset:
 
@@ -6469,7 +6481,7 @@ class Dataset(
         for name, var in self.variables.items():
             if name in self.data_vars:
                 fill_value_ = (
-                    fill_value.get(name, dtypes.NA)
+                    fill_value.get(name, xrdtypes.NA)
                     if isinstance(fill_value, dict)
                     else fill_value
                 )
@@ -7743,7 +7755,7 @@ class Dataset(
         self: T_Dataset,
         dim: Hashable | None = None,
         skipna: bool | None = None,
-        fill_value: Any = dtypes.NA,
+        fill_value: Any = xrdtypes.NA,
         keep_attrs: bool | None = None,
     ) -> T_Dataset:
         """Return the coordinate label of the minimum value along a dimension.
@@ -7840,7 +7852,7 @@ class Dataset(
         self: T_Dataset,
         dim: Hashable | None = None,
         skipna: bool | None = None,
-        fill_value: Any = dtypes.NA,
+        fill_value: Any = xrdtypes.NA,
         keep_attrs: bool | None = None,
     ) -> T_Dataset:
         """Return the coordinate label of the maximum value along a dimension.

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1321,9 +1321,11 @@ class TestDataArray:
         ]
         da = DataArray(np.random.randn(2, 3), coords, name="foo")
 
-        assert 2 == len(da.coords)
+        # len
+        assert len(da.coords) == 2
 
-        assert ["x", "y"] == list(da.coords)
+        # iter
+        assert list(da.coords) == ["x", "y"]
 
         assert coords[0].identical(da.coords["x"])
         assert coords[1].identical(da.coords["y"])
@@ -1337,6 +1339,7 @@ class TestDataArray:
         with pytest.raises(KeyError):
             da.coords["foo"]
 
+        # repr
         expected_repr = dedent(
             """\
         Coordinates:
@@ -1345,6 +1348,9 @@ class TestDataArray:
         )
         actual = repr(da.coords)
         assert expected_repr == actual
+
+        # dtypes
+        assert da.coords.dtypes == {"x": np.dtype("int64"), "y": np.dtype("int64")}
 
         del da.coords["x"]
         da._indexes = filter_indexes_from_coords(da.xindexes, set(da.coords))

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -571,15 +571,30 @@ class TestDataset:
 
     def test_properties(self) -> None:
         ds = create_test_data()
-        assert ds.dims == {"dim1": 8, "dim2": 9, "dim3": 10, "time": 20}
-        assert ds.sizes == ds.dims
 
+        # dims / sizes
         # These exact types aren't public API, but this makes sure we don't
         # change them inadvertently:
         assert isinstance(ds.dims, utils.Frozen)
         assert isinstance(ds.dims.mapping, dict)
         assert type(ds.dims.mapping) is dict
+        assert ds.dims == {"dim1": 8, "dim2": 9, "dim3": 10, "time": 20}
+        assert ds.sizes == ds.dims
 
+        # dtypes
+        assert isinstance(ds.dtypes, utils.Frozen)
+        assert isinstance(ds.dtypes.mapping, dict)
+        assert ds.dtypes == {
+            "dim2": np.dtype("float64"),
+            "dim3": np.dtype("<U1"),
+            "time": np.dtype("<M8[ns]"),
+            "var1": np.dtype("float64"),
+            "var2": np.dtype("float64"),
+            "var3": np.dtype("float64"),
+            "numbers": np.dtype("int64"),
+        }
+
+        # data_vars
         assert list(ds) == list(ds.data_vars)
         assert list(ds.keys()) == list(ds.data_vars)
         assert "aasldfjalskdfj" not in ds.variables
@@ -594,16 +609,19 @@ class TestDataset:
         assert "numbers" not in ds.data_vars
         assert len(ds.data_vars) == 3
 
+        # xindexes
         assert set(ds.xindexes) == {"dim2", "dim3", "time"}
         assert len(ds.xindexes) == 3
         assert "dim2" in repr(ds.xindexes)
         assert all([isinstance(idx, Index) for idx in ds.xindexes.values()])
 
+        # indexes
         assert set(ds.indexes) == {"dim2", "dim3", "time"}
         assert len(ds.indexes) == 3
         assert "dim2" in repr(ds.indexes)
         assert all([isinstance(idx, pd.Index) for idx in ds.indexes.values()])
 
+        # coords
         assert list(ds.coords) == ["dim2", "dim3", "time", "numbers"]
         assert "dim2" in ds.coords
         assert "numbers" in ds.coords
@@ -611,6 +629,7 @@ class TestDataset:
         assert "dim1" not in ds.coords
         assert len(ds.coords) == 4
 
+        # nbytes
         assert (
             Dataset({"x": np.int64(1), "y": np.array([1, 2], dtype=np.float32)}).nbytes
             == 16


### PR DESCRIPTION
- [x] Closes #6714
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`

Currently returns a Mapping from variable names to dtypes for ALL variables in the Dataset, including coordinates.
Possibly better to only return data_vars dtypes? Give me your thoughts on that, it is easy to change.
