### PR TITLE
Accommodate `OutOfBoundsTimedelta` error when decoding times

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -45,7 +45,7 @@ Bug fixes
   By `Michael Niklas <https://github.com/headtr1ck>`_.
 - Accommodate newly raised ``OutOfBoundsTimedelta`` error in the development version of
   pandas when decoding times outside the range that can be represented with
-  nanosecond-precision values (:issue:`6716`).
+  nanosecond-precision values (:issue:`6716`, :pull:`6717`).
   By `Spencer Clark <https://github.com/spencerkclark>`_.
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -43,6 +43,10 @@ Bug fixes
 - :py:meth:`Dataset.where` with ``drop=True`` now behaves correctly with mixed dimensions.
   (:issue:`6227`, :pull:`6690`)
   By `Michael Niklas <https://github.com/headtr1ck>`_.
+- Accommodate newly raised ``OutOfBoundsTimedelta`` error in the development version of
+  pandas when decoding times outside the range that can be represented with
+  nanosecond-precision values (:issue:`6716`).
+  By `Spencer Clark <https://github.com/spencerkclark>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
-from pandas.errors import OutOfBoundsDatetime
+from pandas.errors import OutOfBoundsDatetime, OutOfBoundsTimedelta
 
 from ..core import indexing
 from ..core.common import contains_cftime_datetimes, is_np_datetime_like
@@ -268,7 +268,7 @@ def decode_cf_datetime(num_dates, units, calendar=None, use_cftime=None):
     if use_cftime is None:
         try:
             dates = _decode_datetime_with_pandas(flat_num_dates, units, calendar)
-        except (KeyError, OutOfBoundsDatetime, OverflowError):
+        except (KeyError, OutOfBoundsDatetime, OutOfBoundsTimedelta, OverflowError):
             dates = _decode_datetime_with_cftime(
                 flat_num_dates.astype(float), units, calendar
             )


### PR DESCRIPTION
The development version of pandas raises an `OutOfBoundsTimedelta` error instead of an `OverflowError` in `pd.to_timedelta` if the timedelta cannot be represented with nanosecond precision.  Therefore we must also be ready to catch that when decoding times.

The `OutOfBoundsTimedelta` exception [was added](https://github.com/pandas-dev/pandas/pull/34448) in pandas version 1.1, which is prior to [our current minimum version (1.2)](https://github.com/pydata/xarray/blob/main/ci/requirements/min-all-deps.yml#L37), so it should be safe to import without a version check.

- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
