### PR TITLE
resolve the timeouts on RTD

### DIFF
--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -1048,6 +1048,7 @@ We can convert a ``Dataset`` (or a ``DataArray``) to a dict using
 .. ipython:: python
 
     ds = xr.Dataset({"foo": ("x", np.arange(30))})
+    ds
 
     d = ds.to_dict()
     d

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -1047,6 +1047,8 @@ We can convert a ``Dataset`` (or a ``DataArray``) to a dict using
 
 .. ipython:: python
 
+    ds = xr.Dataset({"foo": ("x", np.arange(30))})
+
     d = ds.to_dict()
     d
 


### PR DESCRIPTION
The reason the changes introduced in #6542 caused timeouts is that they redefined `ds` to a bigger dataset, which would then be used to demonstrate `to_dict`.

The fix is to explicitly set the dataset before calling `to_dict`, which also makes that section a bit easier to follow.

- [x] Closes #6720