### PR TITLE
move da and ds fixtures to conftest.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -152,8 +152,6 @@ ignore =
     E501 # line too long - let black worry about that
     E731 # do not assign a lambda expression, use a def
     W503 # line break before binary operator
-per-file-ignores =
-    xarray/tests/*.py:F401,F811
 exclude=
     .eggs
     doc

--- a/xarray/tests/conftest.py
+++ b/xarray/tests/conftest.py
@@ -1,8 +1,80 @@
+import numpy as np
+import pandas as pd
 import pytest
 
-from . import requires_dask
+from xarray import DataArray, Dataset
+
+from . import create_test_data, requires_dask
 
 
 @pytest.fixture(params=["numpy", pytest.param("dask", marks=requires_dask)])
 def backend(request):
     return request.param
+
+
+@pytest.fixture(params=[1])
+def ds_fixture(request, backend):
+    if request.param == 1:
+        ds = Dataset(
+            dict(
+                z1=(["y", "x"], np.random.randn(2, 8)),
+                z2=(["time", "y"], np.random.randn(10, 2)),
+            ),
+            dict(
+                x=("x", np.linspace(0, 1.0, 8)),
+                time=("time", np.linspace(0, 1.0, 10)),
+                c=("y", ["a", "b"]),
+                y=range(2),
+            ),
+        )
+    elif request.param == 2:
+        ds = Dataset(
+            dict(
+                z1=(["time", "y"], np.random.randn(10, 2)),
+                z2=(["time"], np.random.randn(10)),
+                z3=(["x", "time"], np.random.randn(8, 10)),
+            ),
+            dict(
+                x=("x", np.linspace(0, 1.0, 8)),
+                time=("time", np.linspace(0, 1.0, 10)),
+                c=("y", ["a", "b"]),
+                y=range(2),
+            ),
+        )
+    elif request.param == 3:
+        ds = create_test_data()
+    else:
+        raise ValueError
+
+    if backend == "dask":
+        return ds.chunk()
+
+    return ds
+
+
+@pytest.fixture(params=[1])
+def da_fixture(request, backend):
+    if request.param == 1:
+        times = pd.date_range("2000-01-01", freq="1D", periods=21)
+        da = DataArray(
+            np.random.random((3, 21, 4)),
+            dims=("a", "time", "x"),
+            coords=dict(time=times),
+        )
+
+    if request.param == 2:
+        da = DataArray([0, np.nan, 1, 2, np.nan, 3, 4, 5, np.nan, 6, 7], dims="time")
+
+    if request.param == "repeating_ints":
+        da = DataArray(
+            np.tile(np.arange(12), 5).reshape(5, 4, 3),
+            coords={"x": list("abc"), "y": list("defg")},
+            dims=list("zyx"),
+        )
+
+    if backend == "dask":
+        return da.chunk()
+    elif backend == "numpy":
+        return da
+    else:
+        raise ValueError

--- a/xarray/tests/conftest.py
+++ b/xarray/tests/conftest.py
@@ -13,7 +13,7 @@ def backend(request):
 
 
 @pytest.fixture(params=[1])
-def ds_fixture(request, backend):
+def dataset(request, backend):
     if request.param == 1:
         ds = Dataset(
             dict(
@@ -53,7 +53,7 @@ def ds_fixture(request, backend):
 
 
 @pytest.fixture(params=[1])
-def da_fixture(request, backend):
+def dataarray(request, backend):
     if request.param == 1:
         times = pd.date_range("2000-01-01", freq="1D", periods=21)
         da = DataArray(

--- a/xarray/tests/conftest.py
+++ b/xarray/tests/conftest.py
@@ -13,7 +13,7 @@ def backend(request):
 
 
 @pytest.fixture(params=[1])
-def dataset(request, backend):
+def ds(request, backend):
     if request.param == 1:
         ds = Dataset(
             dict(
@@ -53,7 +53,7 @@ def dataset(request, backend):
 
 
 @pytest.fixture(params=[1])
-def dataarray(request, backend):
+def da(request, backend):
     if request.param == 1:
         times = pd.date_range("2000-01-01", freq="1D", periods=21)
         da = DataArray(

--- a/xarray/tests/test_coarsen.py
+++ b/xarray/tests/test_coarsen.py
@@ -24,7 +24,7 @@ def test_coarsen_absent_dims_error(dataset: Dataset) -> None:
 
 @pytest.mark.parametrize("dask", [True, False])
 @pytest.mark.parametrize(("boundary", "side"), [("trim", "left"), ("pad", "right")])
-def test_coarsen_dataset(dataset, dask, boundary, side) -> None:
+def test_coarsen_dataset(dataset, dask, boundary, side):
 
     if dask and has_dask:
         dataset = dataset.chunk({"x": 4})
@@ -41,7 +41,7 @@ def test_coarsen_dataset(dataset, dask, boundary, side) -> None:
 
 
 @pytest.mark.parametrize("dask", [True, False])
-def test_coarsen_coords(dataset, dask) -> None:
+def test_coarsen_coords(dataset, dask):
 
     if dask and has_dask:
         dataset = dataset.chunk({"x": 4})

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -24,15 +24,8 @@ from xarray.core.computation import (
     unified_dim_sizes,
 )
 from xarray.core.pycompat import dask_version
-from xarray.core.types import T_Xarray
 
-from . import (
-    has_cftime,
-    has_dask,
-    raise_if_dask_computes,
-    requires_cftime,
-    requires_dask,
-)
+from . import has_dask, raise_if_dask_computes, requires_cftime, requires_dask
 
 
 def assert_identical(a, b):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2279,10 +2279,10 @@ class TestDataArray:
         actual = DataArray(s, dims="z").unstack("z")
         assert_identical(expected, actual)
 
-    def test_stack_nonunique_consistency(self, dataarray) -> None:
-        dataarray = dataarray.isel(time=0, drop=True)  # 2D
-        actual = dataarray.stack(z=["a", "x"])
-        expected = DataArray(dataarray.to_pandas().stack(), dims="z")
+    def test_stack_nonunique_consistency(self, da) -> None:
+        da = da.isel(time=0, drop=True)  # 2D
+        actual = da.stack(z=["a", "x"])
+        expected = DataArray(da.to_pandas().stack(), dims="z")
         assert_identical(expected, actual)
 
     def test_to_unstacked_dataset_raises_value_error(self) -> None:
@@ -5859,16 +5859,15 @@ class TestReduceND(TestReduce):
         assert_equal(getattr(ar0_dsk, op)(dim="x"), getattr(ar0_raw, op)(dim="x"))
 
 
-@pytest.mark.parametrize("dataarray", ("repeating_ints",), indirect=True)
-def test_isin(dataarray) -> None:
-
+@pytest.mark.parametrize("da", ("repeating_ints",), indirect=True)
+def test_isin(da) -> None:
     expected = DataArray(
         np.asarray([[0, 0, 0], [1, 0, 0]]),
         dims=list("yx"),
         coords={"x": list("abc"), "y": list("de")},
     ).astype("bool")
 
-    result = dataarray.isin([3]).sel(y=list("de"), z=0)
+    result = da.isin([3]).sel(y=list("de"), z=0)
     assert_equal(result, expected)
 
     expected = DataArray(
@@ -5876,20 +5875,20 @@ def test_isin(dataarray) -> None:
         dims=list("yx"),
         coords={"x": list("abc"), "y": list("de")},
     ).astype("bool")
-    result = dataarray.isin([2, 3]).sel(y=list("de"), z=0)
+    result = da.isin([2, 3]).sel(y=list("de"), z=0)
     assert_equal(result, expected)
 
 
-@pytest.mark.parametrize("dataarray", (1, 2), indirect=True)
-def test_rolling_iter(dataarray) -> None:
-    rolling_obj = dataarray.rolling(time=7)
+@pytest.mark.parametrize("da", (1, 2), indirect=True)
+def test_rolling_iter(da) -> None:
+    rolling_obj = da.rolling(time=7)
     rolling_obj_mean = rolling_obj.mean()
 
-    assert len(rolling_obj.window_labels) == len(dataarray["time"])
-    assert_identical(rolling_obj.window_labels, dataarray["time"])
+    assert len(rolling_obj.window_labels) == len(da["time"])
+    assert_identical(rolling_obj.window_labels, da["time"])
 
     for i, (label, window_da) in enumerate(rolling_obj):
-        assert label == dataarray["time"].isel(time=i)
+        assert label == da["time"].isel(time=i)
 
         actual = rolling_obj_mean.isel(time=i)
         expected = window_da.mean("time")
@@ -5904,14 +5903,13 @@ def test_rolling_iter(dataarray) -> None:
             )
 
 
-@pytest.mark.parametrize("dataarray", (1,), indirect=True)
-def test_rolling_repr(dataarray) -> None:
-
-    rolling_obj = dataarray.rolling(time=7)
+@pytest.mark.parametrize("da", (1,), indirect=True)
+def test_rolling_repr(da) -> None:
+    rolling_obj = da.rolling(time=7)
     assert repr(rolling_obj) == "DataArrayRolling [time->7]"
-    rolling_obj = dataarray.rolling(time=7, center=True)
+    rolling_obj = da.rolling(time=7, center=True)
     assert repr(rolling_obj) == "DataArrayRolling [time->7(center)]"
-    rolling_obj = dataarray.rolling(time=7, x=3, center=True)
+    rolling_obj = da.rolling(time=7, x=3, center=True)
     assert repr(rolling_obj) == "DataArrayRolling [time->7(center),x->3(center)]"
 
 
@@ -5924,40 +5922,40 @@ def test_repeated_rolling_rechunks() -> None:
     dat_chunk.rolling(day=10).mean().rolling(day=250).std()
 
 
-def test_rolling_doc(dataarray) -> None:
-    rolling_obj = dataarray.rolling(time=7)
+def test_rolling_doc(da) -> None:
+    rolling_obj = da.rolling(time=7)
 
     # argument substitution worked
     assert "`mean`" in rolling_obj.mean.__doc__
 
 
-def test_rolling_properties(dataarray) -> None:
-    rolling_obj = dataarray.rolling(time=4)
+def test_rolling_properties(da) -> None:
+    rolling_obj = da.rolling(time=4)
 
     assert rolling_obj.obj.get_axis_num("time") == 1
 
     # catching invalid args
     with pytest.raises(ValueError, match="window must be > 0"):
-        dataarray.rolling(time=-2)
+        da.rolling(time=-2)
 
     with pytest.raises(ValueError, match="min_periods must be greater than zero"):
-        dataarray.rolling(time=2, min_periods=0)
+        da.rolling(time=2, min_periods=0)
 
 
 @pytest.mark.parametrize("name", ("sum", "mean", "std", "min", "max", "median"))
 @pytest.mark.parametrize("center", (True, False, None))
 @pytest.mark.parametrize("min_periods", (1, None))
 @pytest.mark.parametrize("backend", ["numpy"], indirect=True)
-def test_rolling_wrapped_bottleneck(dataarray, name, center, min_periods) -> None:
+def test_rolling_wrapped_bottleneck(da, name, center, min_periods) -> None:
     bn = pytest.importorskip("bottleneck", minversion="1.1")
 
     # Test all bottleneck functions
-    rolling_obj = dataarray.rolling(time=7, min_periods=min_periods)
+    rolling_obj = da.rolling(time=7, min_periods=min_periods)
 
     func_name = f"move_{name}"
     actual = getattr(rolling_obj, name)()
     expected = getattr(bn, func_name)(
-        dataarray.values, window=7, axis=1, min_count=min_periods
+        da.values, window=7, axis=1, min_count=min_periods
     )
     assert_array_equal(actual.values, expected)
 
@@ -5965,9 +5963,9 @@ def test_rolling_wrapped_bottleneck(dataarray, name, center, min_periods) -> Non
         getattr(rolling_obj, name)(dim="time")
 
     # Test center
-    rolling_obj = dataarray.rolling(time=7, center=center)
+    rolling_obj = da.rolling(time=7, center=center)
     actual = getattr(rolling_obj, name)()["time"]
-    assert_equal(actual, dataarray["time"])
+    assert_equal(actual, da["time"])
 
 
 @requires_dask
@@ -5976,18 +5974,15 @@ def test_rolling_wrapped_bottleneck(dataarray, name, center, min_periods) -> Non
 @pytest.mark.parametrize("min_periods", (1, None))
 @pytest.mark.parametrize("window", (7, 8))
 @pytest.mark.parametrize("backend", ["dask"], indirect=True)
-def test_rolling_wrapped_dask(dataarray, name, center, min_periods, window) -> None:
-
+def test_rolling_wrapped_dask(da, name, center, min_periods, window) -> None:
     # dask version
-    rolling_obj = dataarray.rolling(time=window, min_periods=min_periods, center=center)
+    rolling_obj = da.rolling(time=window, min_periods=min_periods, center=center)
     actual = getattr(rolling_obj, name)().load()
     if name != "count":
         with pytest.warns(DeprecationWarning, match="Reductions are applied"):
             getattr(rolling_obj, name)(dim="time")
     # numpy version
-    rolling_obj = dataarray.load().rolling(
-        time=window, min_periods=min_periods, center=center
-    )
+    rolling_obj = da.load().rolling(time=window, min_periods=min_periods, center=center)
     expected = getattr(rolling_obj, name)()
 
     # using all-close because rolling over ghost cells introduces some
@@ -5995,7 +5990,7 @@ def test_rolling_wrapped_dask(dataarray, name, center, min_periods, window) -> N
     assert_allclose(actual, expected)
 
     # with zero chunked array GH:2113
-    rolling_obj = dataarray.chunk().rolling(
+    rolling_obj = da.chunk().rolling(
         time=window, min_periods=min_periods, center=center
     )
     actual = getattr(rolling_obj, name)().load()
@@ -6063,21 +6058,20 @@ def test_rolling_construct(center, window) -> None:
     assert (da_rolling_mean == 0.0).sum() >= 0
 
 
-@pytest.mark.parametrize("dataarray", (1, 2), indirect=True)
+@pytest.mark.parametrize("da", (1, 2), indirect=True)
 @pytest.mark.parametrize("center", (True, False))
 @pytest.mark.parametrize("min_periods", (None, 1, 2, 3))
 @pytest.mark.parametrize("window", (1, 2, 3, 4))
 @pytest.mark.parametrize("name", ("sum", "mean", "std", "max"))
-def test_rolling_reduce(dataarray, center, min_periods, window, name) -> None:
-
+def test_rolling_reduce(da, center, min_periods, window, name) -> None:
     if min_periods is not None and window < min_periods:
         min_periods = window
 
-    if dataarray.isnull().sum() > 1 and window == 1:
+    if da.isnull().sum() > 1 and window == 1:
         # this causes all nan slices
         window = 2
 
-    rolling_obj = dataarray.rolling(time=window, center=center, min_periods=min_periods)
+    rolling_obj = da.rolling(time=window, center=center, min_periods=min_periods)
 
     # add nan prefix to numpy methods to get similar # behavior as bottleneck
     actual = rolling_obj.reduce(getattr(np, "nan%s" % name))
@@ -6144,17 +6138,17 @@ def test_rolling_count_correct() -> None:
         assert_equal(result, expected)
 
 
-@pytest.mark.parametrize("dataarray", (1,), indirect=True)
+@pytest.mark.parametrize("da", (1,), indirect=True)
 @pytest.mark.parametrize("center", (True, False))
 @pytest.mark.parametrize("min_periods", (None, 1))
 @pytest.mark.parametrize("name", ("sum", "mean", "max"))
-def test_ndrolling_reduce(dataarray, center, min_periods, name) -> None:
-    rolling_obj = dataarray.rolling(time=3, x=2, center=center, min_periods=min_periods)
+def test_ndrolling_reduce(da, center, min_periods, name) -> None:
+    rolling_obj = da.rolling(time=3, x=2, center=center, min_periods=min_periods)
 
     actual = getattr(rolling_obj, name)()
     expected = getattr(
         getattr(
-            dataarray.rolling(time=3, center=center, min_periods=min_periods), name
+            da.rolling(time=3, center=center, min_periods=min_periods), name
         )().rolling(x=2, center=center, min_periods=min_periods),
         name,
     )()
@@ -6531,7 +6525,7 @@ class TestIrisConversion:
 )
 @pytest.mark.parametrize("backend", ["numpy"], indirect=True)
 @pytest.mark.parametrize("func", ["mean", "sum"])
-def test_rolling_exp_runs(dataarray, dim, window_type, window, func) -> None:
+def test_rolling_exp_runs(da, dim, window_type, window, func) -> None:
     import numbagg
 
     if (
@@ -6540,9 +6534,9 @@ def test_rolling_exp_runs(dataarray, dim, window_type, window, func) -> None:
     ):
         pytest.skip("rolling_exp.sum requires numbagg 0.2.1")
 
-    dataarray = dataarray.where(dataarray > 0.2)
+    da = da.where(da > 0.2)
 
-    rolling_exp = dataarray.rolling_exp(window_type=window_type, **{dim: window})
+    rolling_exp = da.rolling_exp(window_type=window_type, **{dim: window})
     result = getattr(rolling_exp, func)()
     assert isinstance(result, DataArray)
 
@@ -6553,18 +6547,18 @@ def test_rolling_exp_runs(dataarray, dim, window_type, window, func) -> None:
     "window_type, window", [["span", 5], ["alpha", 0.5], ["com", 0.5], ["halflife", 5]]
 )
 @pytest.mark.parametrize("backend", ["numpy"], indirect=True)
-def test_rolling_exp_mean_pandas(dataarray, dim, window_type, window) -> None:
-    dataarray = dataarray.isel(a=0).where(lambda x: x > 0.2)
+def test_rolling_exp_mean_pandas(da, dim, window_type, window) -> None:
+    da = da.isel(a=0).where(lambda x: x > 0.2)
 
-    result = dataarray.rolling_exp(window_type=window_type, **{dim: window}).mean()
+    result = da.rolling_exp(window_type=window_type, **{dim: window}).mean()
     assert isinstance(result, DataArray)
 
-    pandas_array = dataarray.to_pandas()
+    pandas_array = da.to_pandas()
     assert pandas_array.index.name == "time"
     if dim == "x":
         pandas_array = pandas_array.T
     expected = xr.DataArray(pandas_array.ewm(**{window_type: window}).mean()).transpose(
-        *dataarray.dims
+        *da.dims
     )
 
     assert_allclose(expected.variable, result.variable)
@@ -6573,7 +6567,7 @@ def test_rolling_exp_mean_pandas(dataarray, dim, window_type, window) -> None:
 @requires_numbagg
 @pytest.mark.parametrize("backend", ["numpy"], indirect=True)
 @pytest.mark.parametrize("func", ["mean", "sum"])
-def test_rolling_exp_keep_attrs(dataarray, func) -> None:
+def test_rolling_exp_keep_attrs(da, func) -> None:
     import numbagg
 
     if (
@@ -6583,10 +6577,10 @@ def test_rolling_exp_keep_attrs(dataarray, func) -> None:
         pytest.skip("rolling_exp.sum requires numbagg 0.2.1")
 
     attrs = {"attrs": "da"}
-    dataarray.attrs = attrs
+    da.attrs = attrs
 
-    # Equivalent of `dataarray.rolling_exp(time=10).mean`
-    rolling_exp_func = getattr(dataarray.rolling_exp(time=10), func)
+    # Equivalent of `da.rolling_exp(time=10).mean`
+    rolling_exp_func = getattr(da.rolling_exp(time=10), func)
 
     # attrs are kept per default
     result = rolling_exp_func()
@@ -6613,7 +6607,7 @@ def test_rolling_exp_keep_attrs(dataarray, func) -> None:
     with pytest.warns(
         UserWarning, match="Passing ``keep_attrs`` to ``rolling_exp`` has no effect."
     ):
-        dataarray.rolling_exp(time=10, keep_attrs=True)
+        da.rolling_exp(time=10, keep_attrs=True)
 
 
 def test_no_dict() -> None:
@@ -6679,43 +6673,36 @@ def test_deepcopy_obj_array() -> None:
     assert x0.values[0] is not x1.values[0]
 
 
-def test_clip(dataarray) -> None:
-
+def test_clip(da) -> None:
     with raise_if_dask_computes():
-        result = dataarray.clip(min=0.5)
+        result = da.clip(min=0.5)
     assert result.min(...) >= 0.5
 
-    result = dataarray.clip(max=0.5)
+    result = da.clip(max=0.5)
     assert result.max(...) <= 0.5
 
-    result = dataarray.clip(min=0.25, max=0.75)
+    result = da.clip(min=0.25, max=0.75)
     assert result.min(...) >= 0.25
     assert result.max(...) <= 0.75
 
     with raise_if_dask_computes():
-        result = dataarray.clip(min=dataarray.mean("x"), max=dataarray.mean("a"))
-    assert result.dims == dataarray.dims
+        result = da.clip(min=da.mean("x"), max=da.mean("a"))
+    assert result.dims == da.dims
     assert_array_equal(
         result.data,
-        np.clip(
-            dataarray.data,
-            dataarray.mean("x").data[:, :, np.newaxis],
-            dataarray.mean("a").data,
-        ),
+        np.clip(da.data, da.mean("x").data[:, :, np.newaxis], da.mean("a").data),
     )
 
-    with_nans = dataarray.isel(time=[0, 1]).reindex_like(dataarray)
+    with_nans = da.isel(time=[0, 1]).reindex_like(da)
     with raise_if_dask_computes():
-        result = dataarray.clip(min=dataarray.mean("x"), max=dataarray.mean("a"))
-    result = dataarray.clip(with_nans)
+        result = da.clip(min=da.mean("x"), max=da.mean("a"))
+    result = da.clip(with_nans)
     # The values should be the same where there were NaNs.
     assert_array_equal(result.isel(time=[0, 1]), with_nans.isel(time=[0, 1]))
 
     # Unclear whether we want this work, OK to adjust the test when we have decided.
     with pytest.raises(ValueError, match="cannot reindex or align along dimension.*"):
-        result = dataarray.clip(
-            min=dataarray.mean("x"), max=dataarray.mean("a").isel(x=[0, 1])
-        )
+        result = da.clip(min=da.mean("x"), max=da.mean("a").isel(x=[0, 1]))
 
 
 class TestDropDuplicates:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6124,18 +6124,18 @@ def test_constructor_raises_with_invalid_coords(unaligned_coords) -> None:
         xr.DataArray([1, 2, 3], dims=["x"], coords=unaligned_coords)
 
 
-@pytest.mark.parametrize("dataset", [3], indirect=True)
-def test_dir_expected_attrs(dataset) -> None:
+@pytest.mark.parametrize("ds", [3], indirect=True)
+def test_dir_expected_attrs(ds) -> None:
 
     some_expected_attrs = {"pipe", "mean", "isnull", "var1", "dim2", "numbers"}
-    result = dir(dataset)
+    result = dir(ds)
     assert set(result) >= some_expected_attrs
 
 
-def test_dir_non_string(dataset) -> None:
+def test_dir_non_string(ds) -> None:
     # add a numbered key to ensure this doesn't break dir
-    dataset[5] = "foo"
-    result = dir(dataset)
+    ds[5] = "foo"
+    result = dir(ds)
     assert 5 not in result
 
     # GH2172
@@ -6145,9 +6145,9 @@ def test_dir_non_string(dataset) -> None:
     dir(x2)
 
 
-def test_dir_unicode(dataset) -> None:
-    dataset["unicode"] = "uni"
-    result = dir(dataset)
+def test_dir_unicode(ds) -> None:
+    ds["unicode"] = "uni"
+    result = dir(ds)
     assert "unicode" in result
 
 
@@ -6227,9 +6227,7 @@ def test_rolling_keep_attrs(funcname, argument) -> None:
     assert result.da_not_rolled.name == "da_not_rolled"
 
 
-def test_rolling_properties(dataset) -> None:
-    ds = dataset
-
+def test_rolling_properties(ds) -> None:
     # catching invalid args
     with pytest.raises(ValueError, match="window must be > 0"):
         ds.rolling(time=-2)
@@ -6244,10 +6242,8 @@ def test_rolling_properties(dataset) -> None:
 @pytest.mark.parametrize("min_periods", (1, None))
 @pytest.mark.parametrize("key", ("z1", "z2"))
 @pytest.mark.parametrize("backend", ["numpy"], indirect=True)
-def test_rolling_wrapped_bottleneck(dataset, name, center, min_periods, key) -> None:
+def test_rolling_wrapped_bottleneck(ds, name, center, min_periods, key) -> None:
     bn = pytest.importorskip("bottleneck", minversion="1.1")
-
-    ds = dataset
 
     # Test all bottleneck functions
     rolling_obj = ds.rolling(time=7, min_periods=min_periods)
@@ -6272,17 +6268,16 @@ def test_rolling_wrapped_bottleneck(dataset, name, center, min_periods, key) -> 
 
 @requires_numbagg
 @pytest.mark.parametrize("backend", ["numpy"], indirect=True)
-def test_rolling_exp(dataset) -> None:
+def test_rolling_exp(ds) -> None:
 
-    result = dataset.rolling_exp(time=10, window_type="span").mean()
+    result = ds.rolling_exp(time=10, window_type="span").mean()
     assert isinstance(result, Dataset)
 
 
 @requires_numbagg
 @pytest.mark.parametrize("backend", ["numpy"], indirect=True)
-def test_rolling_exp_keep_attrs(dataset) -> None:
+def test_rolling_exp_keep_attrs(ds) -> None:
 
-    ds = dataset
     attrs_global = {"attrs": "global"}
     attrs_z1 = {"attr": "z1"}
 
@@ -6377,14 +6372,12 @@ def test_rolling_construct(center, window) -> None:
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("dataset", (1, 2), indirect=True)
+@pytest.mark.parametrize("ds", (1, 2), indirect=True)
 @pytest.mark.parametrize("center", (True, False))
 @pytest.mark.parametrize("min_periods", (None, 1, 2, 3))
 @pytest.mark.parametrize("window", (1, 2, 3, 4))
 @pytest.mark.parametrize("name", ("sum", "mean", "std", "var", "min", "max", "median"))
-def test_rolling_reduce(dataset, center, min_periods, window, name) -> None:
-
-    ds = dataset
+def test_rolling_reduce(ds, center, min_periods, window, name) -> None:
 
     if min_periods is not None and window < min_periods:
         min_periods = window
@@ -6407,14 +6400,12 @@ def test_rolling_reduce(dataset, center, min_periods, window, name) -> None:
         assert src_var.dims == actual[key].dims
 
 
-@pytest.mark.parametrize("dataset", (2,), indirect=True)
+@pytest.mark.parametrize("ds", (2,), indirect=True)
 @pytest.mark.parametrize("center", (True, False))
 @pytest.mark.parametrize("min_periods", (None, 1))
 @pytest.mark.parametrize("name", ("sum", "max"))
 @pytest.mark.parametrize("dask", (True, False))
-def test_ndrolling_reduce(dataset, center, min_periods, name, dask) -> None:
-
-    ds = dataset
+def test_ndrolling_reduce(ds, center, min_periods, name, dask) -> None:
     if dask and has_dask:
         ds = ds.chunk({"x": 4})
 
@@ -6475,23 +6466,22 @@ def test_raise_no_warning_for_nan_in_binary_ops() -> None:
 
 
 @pytest.mark.filterwarnings("error")
-@pytest.mark.parametrize("dataset", (2,), indirect=True)
-def test_raise_no_warning_assert_close(dataset) -> None:
-    assert_allclose(dataset, dataset)
+@pytest.mark.parametrize("ds", (2,), indirect=True)
+def test_raise_no_warning_assert_close(ds) -> None:
+    assert_allclose(ds, ds)
 
 
 @pytest.mark.xfail(reason="See https://github.com/pydata/xarray/pull/4369 or docstring")
 @pytest.mark.filterwarnings("error")
-@pytest.mark.parametrize("dataset", (2,), indirect=True)
+@pytest.mark.parametrize("ds", (2,), indirect=True)
 @pytest.mark.parametrize("name", ("mean", "max"))
-def test_raise_no_warning_dask_rolling_assert_close(dataset, name) -> None:
+def test_raise_no_warning_dask_rolling_assert_close(ds, name) -> None:
     """
     This is a puzzle — I can't easily find the source of the warning. It
     requires `assert_allclose` to be run, for the `ds` param to be 2, and is
     different for `mean` and `max`. `sum` raises no warning.
     """
 
-    ds = dataset
     ds = ds.chunk({"x": 4})
 
     rolling_obj = ds.rolling(time=4, x=3)
@@ -6836,9 +6826,7 @@ def test_deepcopy_obj_array() -> None:
     assert x0["foo"].values[0] is not x1["foo"].values[0]
 
 
-def test_clip(dataset) -> None:
-    ds = dataset
-
+def test_clip(ds) -> None:
     result = ds.clip(min=0.5)
     assert all((result.min(...) >= 0.5).values())
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6117,18 +6117,18 @@ def test_constructor_raises_with_invalid_coords(unaligned_coords) -> None:
         xr.DataArray([1, 2, 3], dims=["x"], coords=unaligned_coords)
 
 
-@pytest.mark.parametrize("ds_fixture", [3], indirect=True)
-def test_dir_expected_attrs(ds_fixture) -> None:
+@pytest.mark.parametrize("dataset", [3], indirect=True)
+def test_dir_expected_attrs(dataset) -> None:
 
     some_expected_attrs = {"pipe", "mean", "isnull", "var1", "dim2", "numbers"}
-    result = dir(ds_fixture)
+    result = dir(dataset)
     assert set(result) >= some_expected_attrs
 
 
-def test_dir_non_string(ds_fixture) -> None:
+def test_dir_non_string(dataset) -> None:
     # add a numbered key to ensure this doesn't break dir
-    ds_fixture[5] = "foo"
-    result = dir(ds_fixture)
+    dataset[5] = "foo"
+    result = dir(dataset)
     assert 5 not in result
 
     # GH2172
@@ -6138,9 +6138,9 @@ def test_dir_non_string(ds_fixture) -> None:
     dir(x2)
 
 
-def test_dir_unicode(ds_fixture) -> None:
-    ds_fixture["unicode"] = "uni"
-    result = dir(ds_fixture)
+def test_dir_unicode(dataset) -> None:
+    dataset["unicode"] = "uni"
+    result = dir(dataset)
     assert "unicode" in result
 
 
@@ -6220,8 +6220,8 @@ def test_rolling_keep_attrs(funcname, argument) -> None:
     assert result.da_not_rolled.name == "da_not_rolled"
 
 
-def test_rolling_properties(ds_fixture) -> None:
-    ds = ds_fixture
+def test_rolling_properties(dataset) -> None:
+    ds = dataset
 
     # catching invalid args
     with pytest.raises(ValueError, match="window must be > 0"):
@@ -6237,10 +6237,10 @@ def test_rolling_properties(ds_fixture) -> None:
 @pytest.mark.parametrize("min_periods", (1, None))
 @pytest.mark.parametrize("key", ("z1", "z2"))
 @pytest.mark.parametrize("backend", ["numpy"], indirect=True)
-def test_rolling_wrapped_bottleneck(ds_fixture, name, center, min_periods, key) -> None:
+def test_rolling_wrapped_bottleneck(dataset, name, center, min_periods, key) -> None:
     bn = pytest.importorskip("bottleneck", minversion="1.1")
 
-    ds = ds_fixture
+    ds = dataset
 
     # Test all bottleneck functions
     rolling_obj = ds.rolling(time=7, min_periods=min_periods)
@@ -6265,17 +6265,17 @@ def test_rolling_wrapped_bottleneck(ds_fixture, name, center, min_periods, key) 
 
 @requires_numbagg
 @pytest.mark.parametrize("backend", ["numpy"], indirect=True)
-def test_rolling_exp(ds_fixture) -> None:
+def test_rolling_exp(dataset) -> None:
 
-    result = ds_fixture.rolling_exp(time=10, window_type="span").mean()
+    result = dataset.rolling_exp(time=10, window_type="span").mean()
     assert isinstance(result, Dataset)
 
 
 @requires_numbagg
 @pytest.mark.parametrize("backend", ["numpy"], indirect=True)
-def test_rolling_exp_keep_attrs(ds_fixture) -> None:
+def test_rolling_exp_keep_attrs(dataset) -> None:
 
-    ds = ds_fixture
+    ds = dataset
     attrs_global = {"attrs": "global"}
     attrs_z1 = {"attr": "z1"}
 
@@ -6370,14 +6370,14 @@ def test_rolling_construct(center, window) -> None:
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("ds_fixture", (1, 2), indirect=True)
+@pytest.mark.parametrize("dataset", (1, 2), indirect=True)
 @pytest.mark.parametrize("center", (True, False))
 @pytest.mark.parametrize("min_periods", (None, 1, 2, 3))
 @pytest.mark.parametrize("window", (1, 2, 3, 4))
 @pytest.mark.parametrize("name", ("sum", "mean", "std", "var", "min", "max", "median"))
-def test_rolling_reduce(ds_fixture, center, min_periods, window, name) -> None:
+def test_rolling_reduce(dataset, center, min_periods, window, name) -> None:
 
-    ds = ds_fixture
+    ds = dataset
 
     if min_periods is not None and window < min_periods:
         min_periods = window
@@ -6400,14 +6400,14 @@ def test_rolling_reduce(ds_fixture, center, min_periods, window, name) -> None:
         assert src_var.dims == actual[key].dims
 
 
-@pytest.mark.parametrize("ds_fixture", (2,), indirect=True)
+@pytest.mark.parametrize("dataset", (2,), indirect=True)
 @pytest.mark.parametrize("center", (True, False))
 @pytest.mark.parametrize("min_periods", (None, 1))
 @pytest.mark.parametrize("name", ("sum", "max"))
 @pytest.mark.parametrize("dask", (True, False))
-def test_ndrolling_reduce(ds_fixture, center, min_periods, name, dask) -> None:
+def test_ndrolling_reduce(dataset, center, min_periods, name, dask) -> None:
 
-    ds = ds_fixture
+    ds = dataset
     if dask and has_dask:
         ds = ds.chunk({"x": 4})
 
@@ -6468,23 +6468,23 @@ def test_raise_no_warning_for_nan_in_binary_ops() -> None:
 
 
 @pytest.mark.filterwarnings("error")
-@pytest.mark.parametrize("ds_fixture", (2,), indirect=True)
-def test_raise_no_warning_assert_close(ds_fixture) -> None:
-    assert_allclose(ds_fixture, ds_fixture)
+@pytest.mark.parametrize("dataset", (2,), indirect=True)
+def test_raise_no_warning_assert_close(dataset) -> None:
+    assert_allclose(dataset, dataset)
 
 
 @pytest.mark.xfail(reason="See https://github.com/pydata/xarray/pull/4369 or docstring")
 @pytest.mark.filterwarnings("error")
-@pytest.mark.parametrize("ds_fixture", (2,), indirect=True)
+@pytest.mark.parametrize("dataset", (2,), indirect=True)
 @pytest.mark.parametrize("name", ("mean", "max"))
-def test_raise_no_warning_dask_rolling_assert_close(ds_fixture, name) -> None:
+def test_raise_no_warning_dask_rolling_assert_close(dataset, name) -> None:
     """
     This is a puzzle — I can't easily find the source of the warning. It
     requires `assert_allclose` to be run, for the `ds` param to be 2, and is
     different for `mean` and `max`. `sum` raises no warning.
     """
 
-    ds = ds_fixture
+    ds = dataset
     ds = ds.chunk({"x": 4})
 
     rolling_obj = ds.rolling(time=4, x=3)
@@ -6829,8 +6829,8 @@ def test_deepcopy_obj_array() -> None:
     assert x0["foo"].values[0] is not x1["foo"].values[0]
 
 
-def test_clip(ds_fixture) -> None:
-    ds = ds_fixture
+def test_clip(dataset) -> None:
+    ds = dataset
 
     result = ds.clip(min=0.5)
     assert all((result.min(...) >= 0.5).values())

--- a/xarray/tests/test_indexes.py
+++ b/xarray/tests/test_indexes.py
@@ -17,7 +17,7 @@ from xarray.core.indexes import (
 )
 from xarray.core.variable import IndexVariable, Variable
 
-from . import assert_equal, assert_identical
+from . import assert_identical
 
 
 def test_asarray_tuplesafe() -> None:

--- a/xarray/tests/test_ufuncs.py
+++ b/xarray/tests/test_ufuncs.py
@@ -7,7 +7,7 @@ import xarray as xr
 
 from . import assert_array_equal
 from . import assert_identical as assert_identical_
-from . import assert_no_warnings, mock
+from . import mock
 
 
 def assert_identical(a, b):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This PR renames the `da` and `ds` fixtures (to `da_fixture` and `ds_fixture`) and moves them to conftest.py. This allows to remove the flake8 error suppression for the tests and seems more how the fixtures are [intended to be used](https://docs.pytest.org/en/6.2.x/fixture.html#conftest-py-sharing-fixtures-across-multiple-files) (from the pytest side). I think the name changes makes it a bit more obvious what happens but moving them to may make it a bit less obvious (if you don't know where to look).

Removing the flake8 error ignores also unearthed some unused imports:

https://github.com/pydata/xarray/blob/787a96c15161c9025182291b672b3d3c5548a6c7/setup.cfg#L155-L156

(What I actually wanted to do is move the tests for `rolling` to it's own file - but I think it makes sense to do this first.)