### PR TITLE
Use `math` instead of `numpy`  in some places

### DIFF
--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -40,6 +40,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from __future__ import annotations
 
+import math
 import re
 import warnings
 from datetime import timedelta
@@ -249,7 +250,7 @@ def format_times(
 ):
     """Format values of cftimeindex as pd.Index."""
     n_per_row = max(max_width // (CFTIME_REPR_LENGTH + len(separator)), 1)
-    n_rows = int(np.ceil(len(index) / n_per_row))
+    n_rows = math.ceil(len(index) / n_per_row)
 
     representation = ""
     for row in range(n_rows):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4,6 +4,7 @@ import copy
 import datetime
 import inspect
 import itertools
+import math
 import sys
 import warnings
 from collections import defaultdict
@@ -5187,7 +5188,7 @@ class Dataset(
             if dim in array.dims:
                 dims = [d for d in array.dims if d != dim]
                 count += np.asarray(array.count(dims))  # type: ignore[attr-defined]
-                size += np.prod([self.dims[d] for d in dims])
+                size += math.prod([self.dims[d] for d in dims])
 
         if thresh is not None:
             mask = count >= thresh
@@ -5945,7 +5946,7 @@ class Dataset(
         # We already verified that the MultiIndex has all unique values, so
         # there are missing values if and only if the size of output arrays is
         # larger that the index.
-        missing_values = np.prod(shape) > idx.shape[0]
+        missing_values = math.prod(shape) > idx.shape[0]
 
         for name, values in arrays:
             # NumPy indexing is much faster than using DataFrame.reindex() to

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import math
 from collections import defaultdict
 from datetime import datetime, timedelta
 from itertools import chain, zip_longest
@@ -47,7 +48,7 @@ def _get_indexer_at_least_n_items(shape, n_desired, from_end):
     assert 0 < n_desired <= np.prod(shape)
     cum_items = np.cumprod(shape[::-1])
     n_steps = np.argmax(cum_items >= n_desired)
-    stop = int(np.ceil(float(n_desired) / np.r_[1, cum_items][n_steps]))
+    stop = math.ceil(float(n_desired) / np.r_[1, cum_items][n_steps])
     indexer = (
         ((-1 if from_end else 0),) * (len(shape) - 1 - n_steps)
         + ((slice(-stop, None) if from_end else slice(stop)),)
@@ -186,7 +187,7 @@ def format_array_flat(array, max_width: int):
     # every item will take up at least two characters, but we always want to
     # print at least first and last items
     max_possibly_relevant = min(
-        max(array.size, 1), max(int(np.ceil(max_width / 2.0)), 2)
+        max(array.size, 1), max(math.ceil(max_width / 2.0), 2)
     )
     relevant_front_items = format_items(
         first_n_items(array, (max_possibly_relevant + 1) // 2)

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -45,7 +45,7 @@ def wrap_indent(text, start="", length=None):
 
 
 def _get_indexer_at_least_n_items(shape, n_desired, from_end):
-    assert 0 < n_desired <= np.prod(shape)
+    assert 0 < n_desired <= math.prod(shape)
     cum_items = np.cumprod(shape[::-1])
     n_steps = np.argmax(cum_items >= n_desired)
     stop = math.ceil(float(n_desired) / np.r_[1, cum_items][n_steps])

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -5,6 +5,7 @@ import contextlib
 import functools
 import io
 import itertools
+import math
 import os
 import re
 import sys
@@ -555,8 +556,7 @@ class NdimSizeLenMixin:
 
     @property
     def size(self: Any) -> int:
-        # cast to int so that shape = () gives size = 1
-        return int(np.prod(self.shape))
+        return math.prod(self.shape)
 
     def __len__(self: Any) -> int:
         try:

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import itertools
+import math
 import numbers
 import warnings
 from datetime import timedelta
@@ -1644,7 +1645,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
                 "name as an existing dimension"
             )
 
-        if np.prod(new_dim_sizes) != self.sizes[old_dim]:
+        if math.prod(new_dim_sizes) != self.sizes[old_dim]:
             raise ValueError(
                 "the product of the new dimension sizes must "
                 "equal the size of the old dimension"
@@ -1684,7 +1685,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         new_dims = reordered.dims[: len(other_dims)] + new_dim_names
 
         if fill_value is dtypes.NA:
-            is_missing_values = np.prod(new_shape) > np.prod(self.shape)
+            is_missing_values = math.prod(new_shape) > math.prod(self.shape)
             if is_missing_values:
                 dtype, fill_value = dtypes.maybe_promote(self.dtype)
             else:

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -179,7 +179,7 @@ def _format_message(x, y, err_msg, verbose):
     abs_diff = max(abs(diff))
     rel_diff = "not implemented"
 
-    n_diff = int(np.count_nonzero(diff))
+    n_diff = np.count_nonzero(diff)
     n_total = diff.size
 
     fraction = f"{n_diff} / {n_total}"

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import inspect
+import math
 from copy import copy
 from datetime import datetime
 from typing import Any
@@ -117,7 +118,7 @@ def easy_array(shape, start=0, stop=1):
 
     shape is a tuple like (2, 3)
     """
-    a = np.linspace(start, stop, num=np.prod(shape))
+    a = np.linspace(start, stop, num=math.prod(shape))
     return a.reshape(shape)
 
 

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import pickle
 from textwrap import dedent
 
@@ -28,7 +29,7 @@ def assert_sparse_equal(a, b):
 
 
 def make_ndarray(shape):
-    return np.arange(np.prod(shape)).reshape(shape)
+    return np.arange(math.prod(shape)).reshape(shape)
 
 
 def make_sparray(shape):

--- a/xarray/tutorial.py
+++ b/xarray/tutorial.py
@@ -39,6 +39,7 @@ external_rasterio_urls = {
 file_formats = {
     "air_temperature": 3,
     "air_temperature_gradient": 4,
+    "ASE_ice_velocity": 4,
     "basin_mask": 4,
     "ersstv5": 4,
     "rasm": 3,
@@ -93,6 +94,7 @@ def open_dataset(
     * ``"air_temperature"``: NCEP reanalysis subset
     * ``"air_temperature_gradient"``: NCEP reanalysis subset with approximate x,y gradients
     * ``"basin_mask"``: Dataset with ocean basins marked using integers
+    * ``"ASE_ice_velocity"``: MEaSUREs InSAR-Based Ice Velocity of the Amundsen Sea Embayment, Antarctica, Version 1
     * ``"rasm"``: Output of the Regional Arctic System Model (RASM)
     * ``"ROMS_example"``: Regional Ocean Model System (ROMS) output
     * ``"tiny"``: small synthetic dataset with a 1D data variable


### PR DESCRIPTION
Use `math` instead of `numpy` where possible, looks better and seems faster as well. 
Idea from https://github.com/pydata/xarray/pull/6702#discussion_r903986442, https://github.com/dask/dask/pull/9232

Example:
```python
%timeit math.prod((1, 2, 3))
161 ns ± 10.5 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

%timeit int(np.prod((1, 2, 3)))
11.9 µs ± 248 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```