### PR TITLE
Type `shape` methods

### DIFF
--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -31,7 +31,7 @@ class PydapArrayWrapper(BackendArray):
         self.array = array
 
     @property
-    def shape(self):
+    def shape(self) -> tuple[int, ...]:
         return self.array.shape
 
     @property

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -48,7 +48,7 @@ class RasterioArrayWrapper(BackendArray):
         return self._dtype
 
     @property
-    def shape(self):
+    def shape(self) -> tuple[int, ...]:
         return self._shape
 
     def _get_indexer(self, key):

--- a/xarray/coding/strings.py
+++ b/xarray/coding/strings.py
@@ -225,7 +225,7 @@ class StackedBytesArray(indexing.ExplicitlyIndexedNDArrayMixin):
         return np.dtype("S" + str(self.array.shape[-1]))
 
     @property
-    def shape(self):
+    def shape(self) -> tuple[int, ...]:
         return self.array.shape[:-1]
 
     def __repr__(self):

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -510,7 +510,7 @@ class LazilyIndexedArray(ExplicitlyIndexedNDArrayMixin):
         return OuterIndexer(full_key)
 
     @property
-    def shape(self):
+    def shape(self) -> tuple[int, ...]:
         shape = []
         for size, k in zip(self.array.shape, self.key.tuple):
             if isinstance(k, slice):
@@ -569,7 +569,7 @@ class LazilyVectorizedIndexedArray(ExplicitlyIndexedNDArrayMixin):
         self.array = as_indexable(array)
 
     @property
-    def shape(self):
+    def shape(self) -> tuple[int, ...]:
         return np.broadcast(*self.key.tuple).shape
 
     def __array__(self, dtype=None):
@@ -1392,7 +1392,7 @@ class PandasIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
         return np.asarray(array.values, dtype=dtype)
 
     @property
-    def shape(self) -> tuple[int]:
+    def shape(self) -> tuple[int, ...]:
         return (len(self.array),)
 
     def _convert_scalar(self, item):

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -580,7 +580,7 @@ class NDArrayMixin(NdimSizeLenMixin):
         return self.array.dtype
 
     @property
-    def shape(self: Any) -> tuple[int]:
+    def shape(self: Any) -> tuple[int, ...]:
         return self.array.shape
 
     def __getitem__(self: Any, key):

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -458,7 +458,7 @@ def test_inline_variable_array_repr_custom_repr() -> None:
             return NotImplemented
 
         @property
-        def shape(self):
+        def shape(self) -> tuple[int, ...]:
             return self.value.shape
 
         @property


### PR DESCRIPTION
The shape methods can have multiple integers inside the tuple, this fixes that and adds to typing to all shape methods I found.