### PR TITLE
Update map_blocks to use chunksizes property.

### DIFF
--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -373,7 +373,7 @@ def map_blocks(
         new_indexes = template_indexes - set(input_indexes)
         indexes = {dim: input_indexes[dim] for dim in preserved_indexes}
         indexes.update({k: template._indexes[k] for k in new_indexes})
-        output_chunks = {
+        output_chunks: Mapping[Hashable, tuple[int, ...]] = {
             dim: input_chunks[dim] for dim in template.dims if dim in input_chunks
         }
 

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -380,12 +380,12 @@ def map_blocks(
     else:
         # template xarray object has been provided with proper sizes and chunk shapes
         indexes = dict(template._indexes)
-        if isinstance(template, DataArray):
-            output_chunks = dict(
-                zip(template.dims, template.chunks)  # type: ignore[arg-type]
+        output_chunks = template.chunksizes
+        if not output_chunks:
+            raise ValueError(
+                "Provided template has no dask arrays. "
+                " Please construct a template with appropriately chunked dask arrays."
             )
-        else:
-            output_chunks = dict(template.chunks)
 
     for dim in output_chunks:
         if dim in input_chunks and len(input_chunks[dim]) != len(output_chunks[dim]):

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1246,7 +1246,10 @@ def test_map_blocks_dask_args():
     # bad template: not chunked
     with pytest.raises(ValueError, match="Provided template has no dask arrays"):
         xr.map_blocks(
-            lambda a, b: (a + b).sum("x"), da1, args=[da2], template=da1.sum("x").compute()
+            lambda a, b: (a + b).sum("x"),
+            da1,
+            args=[da2],
+            template=da1.sum("x").compute(),
         )
 
 

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1243,6 +1243,12 @@ def test_map_blocks_dask_args():
         )
     xr.testing.assert_equal((da1 + da2).sum("x"), mapped)
 
+    # bad template: not chunked
+    with pytest.raises(ValueError, match="Provided template has no dask arrays"):
+        xr.map_blocks(
+            lambda a, b: (a + b).sum("x"), da1, args=[da2], template=da1.sum("x").compute()
+        )
+
 
 @pytest.mark.parametrize("obj", [make_da(), make_ds()])
 def test_map_blocks_add_attrs(obj):


### PR DESCRIPTION
Raise nicer error if provided template has no dask arrays.

- [x] Closes #6763
- [x] Tests added