### PR TITLE
Warn when grouping by dask array.

### DIFF
--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -377,7 +377,7 @@ class GroupBy(Generic[T_Xarray]):
         self._unstacked_group = group
         self._bins = bins
 
-        if is_duck_dask_array(group.data):
+        if not isinstance(group, _DummyGroup) and is_duck_dask_array(group.data):
             warnings.warn(
                 "Grouping by a dask array computes that array. "
                 "This will raise an error in the future. "

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -504,6 +504,13 @@ def test_groupby_repr_datetime(obj) -> None:
     assert actual == expected
 
 
+@requires_dask
+def test_groupby_dask_array_raises_warning():
+    ds = Dataset({"foo": ("x", np.arange(10)), "baz": ("x", np.arange(10))}).chunk()
+    with pytest.warns(UserWarning):
+        ds.groupby("baz")
+
+
 def test_groupby_drops_nans() -> None:
     # GH2383
     # nan in 2D data variable (requires stacking)


### PR DESCRIPTION
Currently computes eagerly; we want to not do that in the future

(broken out from #6689)
