### PR TITLE
Raise an error if you pass an invalid key in `chunks`

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -535,7 +535,9 @@ def open_dataset(
         **kwargs,
     )
     if isinstance(chunks, dict) and not set(chunks).issubset(backend_ds.dims):
-        raise ValueError(f"Invalid chunk argument. Key {set(chunks)!r} not contained in dims.")
+        raise ValueError(
+            f"Invalid chunk argument. Key {set(chunks)!r} not contained in dims."
+        )
 
     ds = _dataset_from_backend_dataset(
         backend_ds,

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -534,6 +534,9 @@ def open_dataset(
         **decoders,
         **kwargs,
     )
+    if isinstance(chunks, dict) and not set(chunks).issubset(backend_ds.dims):
+        raise ValueError(f"Invalid chunk argument. Key {set(chunks)!r} not contained in dims.")
+
     ds = _dataset_from_backend_dataset(
         backend_ds,
         filename_or_obj,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5370,6 +5370,9 @@ def test_open_dataset_chunking_zarr(chunks, tmp_path: Path) -> None:
         ) as actual:
             xr.testing.assert_chunks_equal(actual, expected)
 
+    with pytest.raises(ValueError, match="Invalid chunk argument"):
+        open_dataset(tmp_path / "test.zarr", engine="zarr", chunks={"test": 1})
+
 
 @requires_zarr
 @requires_dask

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3888,7 +3888,7 @@ class TestDask(DatasetIOBase):
         with create_tmp_file() as tmp:
             original = Dataset({"foo": ("x", np.random.randn(10))})
             original.to_netcdf(tmp)
-            chunks = {"time": 10}
+            chunks = {"x": 10}
 
             def num_graph_nodes(obj):
                 return len(obj.__dask_graph__())


### PR DESCRIPTION
- [x] Tests added

This was a minor issue that came up at the Dask BOF. Currently if the key of chunks dict isn't included in the dims then it gets silently ignored. This PR makes xarray raise an error instead. 

I'm not sure if this is the right place to put this change. So just let me know if it should go somewhere else.

I changed an existing test. I am _pretty_ sure it was not intentionally using a key that isn't in the dims. 