### PR TITLE
Fix typos found by codespell

### DIFF
--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -790,7 +790,7 @@ Chunk sizes may be specified in one of three ways when writing to a zarr store:
 The resulting chunks will be determined based on the order of the above list; dask
 chunks will be overridden by manually-specified chunks in the encoding argument,
 and the presence of either dask chunks or chunks in the ``encoding`` attribute will
-supercede the default chunking heuristics in zarr.
+supersede the default chunking heuristics in zarr.
 
 Importantly, this logic applies to every array in the zarr store individually,
 including coordinate arrays. Therefore, if a dataset contains one or more dask

--- a/doc/user-guide/plotting.rst
+++ b/doc/user-guide/plotting.rst
@@ -585,7 +585,7 @@ Faceting here refers to splitting an array along one or two dimensions and
 plotting each group.
 Xarray's basic plotting is useful for plotting two dimensional arrays. What
 about three or four dimensional arrays? That's where facets become helpful.
-The general approach to plotting here is called “small multiples”, where the same kind of plot is repeated multiple times, and the specific use of small multiples to display the same relationship conditioned on one ore more other variables is often called a “trellis plot”.
+The general approach to plotting here is called “small multiples”, where the same kind of plot is repeated multiple times, and the specific use of small multiples to display the same relationship conditioned on one or more other variables is often called a “trellis plot”.
 
 Consider the temperature data set. There are 4 observations per day for two
 years which makes for 2920 values along the time dimension.

--- a/xarray/coding/calendar_ops.py
+++ b/xarray/coding/calendar_ops.py
@@ -98,7 +98,7 @@ def convert_calendar(
     Notes
     -----
     Passing a value to `missing` is only usable if the source's time coordinate as an
-    inferrable frequencies (see :py:func:`~xarray.infer_freq`) and is only appropriate
+    inferable frequencies (see :py:func:`~xarray.infer_freq`) and is only appropriate
     if the target coordinate, generated from this frequency, has dates equivalent to the
     source. It is usually **not** appropriate to use this mode with:
 

--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -1200,7 +1200,7 @@ def date_range_like(source, calendar, use_cftime=None):
     freq = infer_freq(source)
     if freq is None:
         raise ValueError(
-            "`date_range_like` was unable to generate a range as the source frequency was not inferrable."
+            "`date_range_like` was unable to generate a range as the source frequency was not inferable."
         )
 
     use_cftime = _should_cftime_be_used(source, calendar, use_cftime)

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -285,7 +285,7 @@ class Aligner(Generic[DataAlignable]):
         self.unindexed_dim_sizes = unindexed_dim_sizes
 
     def assert_no_index_conflict(self) -> None:
-        """Check for uniqueness of both coordinate and dimension names accross all sets
+        """Check for uniqueness of both coordinate and dimension names across all sets
         of matching indexes.
 
         We need to make sure that all indexes used for re-indexing or alignment

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -535,7 +535,7 @@ def _dataset_concat(
 
     # get the indexes to concatenate together, create a PandasIndex
     # for any scalar coordinate variable found with ``name`` matching ``dim``.
-    # TODO: depreciate concat a mix of scalar and dimensional indexed coodinates?
+    # TODO: depreciate concat a mix of scalar and dimensional indexed coordinates?
     # TODO: (benbovy - explicit indexes): check index types and/or coordinates
     # of all datasets?
     def get_indexes(name):

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -5215,7 +5215,7 @@ class DataArray(
         Notes
         -----
         Passing a value to `missing` is only usable if the source's time coordinate as an
-        inferrable frequencies (see :py:func:`~xarray.infer_freq`) and is only appropriate
+        inferable frequencies (see :py:func:`~xarray.infer_freq`) and is only appropriate
         if the target coordinate, generated from this frequency, has dates equivalent to the
         source. It is usually **not** appropriate to use this mode with:
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8464,7 +8464,7 @@ class Dataset(
         Notes
         -----
         Passing a value to `missing` is only usable if the source's time coordinate as an
-        inferrable frequencies (see :py:func:`~xarray.infer_freq`) and is only appropriate
+        inferable frequencies (see :py:func:`~xarray.infer_freq`) and is only appropriate
         if the target coordinate, generated from this frequency, has dates equivalent to the
         source. It is usually **not** appropriate to use this mode with:
 

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -958,7 +958,7 @@ def create_default_index_implicit(
 
     Create a PandasMultiIndex if the given variable wraps a pandas.MultiIndex,
     otherwise create a PandasIndex (note that this will become obsolete once we
-    depreciate implcitly passing a pandas.MultiIndex as a coordinate).
+    depreciate implicitly passing a pandas.MultiIndex as a coordinate).
 
     """
     if all_variables is None:

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -834,7 +834,7 @@ class Coarsen(CoarsenArithmetic, Generic[T_Xarray]):
             multiple of window size. If 'trim', the excess indexes are trimmed.
             If 'pad', NA will be padded.
         side : 'left' or 'right' or mapping from dimension to 'left' or 'right'
-        coord_func : function (name) or mapping from coordinate name to funcion (name).
+        coord_func : function (name) or mapping from coordinate name to function (name).
 
         Returns
         -------

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -1358,11 +1358,11 @@ def test_date_range_like_same_calendar():
 
 def test_date_range_like_errors():
     src = date_range("1899-02-03", periods=20, freq="D", use_cftime=False)
-    src = src[np.arange(20) != 10]  # Remove 1 day so the frequency is not inferrable.
+    src = src[np.arange(20) != 10]  # Remove 1 day so the frequency is not inferable.
 
     with pytest.raises(
         ValueError,
-        match="`date_range_like` was unable to generate a range as the source frequency was not inferrable.",
+        match="`date_range_like` was unable to generate a range as the source frequency was not inferable.",
     ):
         date_range_like(src, "gregorian")
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2834,7 +2834,7 @@ class TestDataset:
             {"x": ("x_new", [0, 1, 2]), "y": ("x_new", [10, 11, 12]), "z": 42}
         )
         # TODO: (benbovy - explicit indexes) update when set_index supports
-        # seeting index for non-dimension variables
+        # setting index for non-dimension variables
         expected = expected.set_coords("x")
         actual = original.rename_dims({"x": "x_new"})
         assert_identical(expected, actual, check_default_indexes=False)
@@ -2855,7 +2855,7 @@ class TestDataset:
             {"x_new": ("x", [0, 1, 2]), "y": ("x", [10, 11, 12]), "z": 42}
         )
         # TODO: (benbovy - explicit indexes) update when set_index supports
-        # seeting index for non-dimension variables
+        # setting index for non-dimension variables
         expected = expected.set_coords("x_new")
         actual = original.rename_vars({"x": "x_new"})
         assert_identical(expected, actual, check_default_indexes=False)

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -1175,7 +1175,7 @@ class TestDataArrayGroupBy:
         with xr.set_options(use_flox=True):
             actual = array.groupby("abc").mean(keep_attrs=keep_attrs)
 
-        # values are tested elsewhere, here we jsut check data
+        # values are tested elsewhere, here we just check data
         # TODO: add check_attrs kwarg to assert_allclose
         actual.data = expected.data
         assert_identical(expected, actual)


### PR DESCRIPTION
The `inferrable` → `inferable` change is debatable, but the most common spelling does appear to be the latter (Google hits support that):
* [Merriam-Webster](https://www.merriam-webster.com/dictionary/inferable)
* [Collins](https://www.collinsdictionary.com/dictionary/english/infer)
* [Wiktionary](https://en.wiktionary.org/wiki/inferable)
* [Lexico](https://www.lexico.com/definition/inferable)

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
