### PR TITLE
Pull xarray's nbytes from nbytes attribute on arrays

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -282,7 +282,6 @@ ndarray attributes
    DataArray.shape
    DataArray.size
    DataArray.dtype
-   DataArray.nbytes
    DataArray.chunks
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,6 +34,8 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- :py:attr:`DataArray.nbytes` now uses the ``nbytes`` property of the underlying array if available.
+  By `Max Jones <https://github.com/maxrjones>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -646,6 +646,12 @@ class DataArray(
 
     @property
     def nbytes(self) -> int:
+        """
+        Total bytes consumed by the elements of this DataArray's data.
+
+        If the backend data array does not include ``nbytes``, estimates
+        the bytes consumed based on the ``size`` and ``dtype``.
+        """
         return self.variable.nbytes
 
     @property

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1378,6 +1378,12 @@ class Dataset(
 
     @property
     def nbytes(self) -> int:
+        """
+        Total bytes consumed by the data arrays of all variables in this dataset.
+
+        If the backend array for any variable does not include ``nbytes``, estimates
+        the total bytes for that array based on the ``size`` and ``dtype``.
+        """
         return sum(v.nbytes for v in self.variables.values())
 
     @property

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -333,7 +333,10 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
 
     @property
     def nbytes(self):
-        return self.data.nbytes
+        if hasattr(self.data, "nbytes"):
+            return self.data.nbytes
+        else:
+            return self.size * self.dtype.itemsize
 
     @property
     def _in_memory(self):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -333,7 +333,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
 
     @property
     def nbytes(self):
-        return self.size * self.dtype.itemsize
+        return self.data.nbytes
 
     @property
     def _in_memory(self):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -335,6 +335,9 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
 
     @property
     def nbytes(self):
+        """
+        Total bytes consumed by the elements of the data array.
+        """
         if hasattr(self.data, "nbytes"):
             return self.data.nbytes
         else:

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -334,7 +334,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         return self._data.shape
 
     @property
-    def nbytes(self):
+    def nbytes(self) -> int:
         """
         Total bytes consumed by the elements of the data array.
         """

--- a/xarray/tests/test_array_api.py
+++ b/xarray/tests/test_array_api.py
@@ -45,8 +45,8 @@ def test_indexing(arrays) -> None:
 
 def test_properties(arrays) -> None:
     np_arr, xp_arr = arrays
-    assert np_arr.nbytes == 48
-    assert xp_arr.nbytes == 48
+    assert np_arr.nbytes == np_arr.data.nbytes
+    assert xp_arr.nbytes == np_arr.data.nbytes
 
 
 def test_reorganizing_operation(arrays) -> None:

--- a/xarray/tests/test_array_api.py
+++ b/xarray/tests/test_array_api.py
@@ -43,6 +43,12 @@ def test_indexing(arrays) -> None:
     assert_equal(actual, expected)
 
 
+def test_properties(arrays) -> None:
+    np_arr, xp_arr = arrays
+    assert np_arr.nbytes == 48
+    assert xp_arr.nbytes == 48
+
+
 def test_reorganizing_operation(arrays) -> None:
     np_arr, xp_arr = arrays
     expected = np_arr.transpose()

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -274,6 +274,9 @@ class TestSparseVariable:
         self.data = sparse.random((4, 6), random_state=0, density=0.5)
         self.var = xr.Variable(("x", "y"), self.data)
 
+    def test_nbytes(self):
+        assert self.var.nbytes == self.data.nbytes
+
     def test_unary_op(self):
         assert_sparse_equal(-self.var.data, -self.data)
         assert_sparse_equal(abs(self.var).data, abs(self.data))


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This implements the suggestion in https://github.com/pydata/xarray/issues/4842#issuecomment-769198581 to leave the nbytes calculation to the backend array.

Also removed the duplicate docs entry reported in #6565

- [x] Closes #6565
- [x] Closes #4842
