### PR TITLE
Fix numpy 1.20 incompatibility

### DIFF
--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - netcdf4
   - numba
   - numexpr
-  - numpy
+  - numpy=1.20
   - packaging
   - pandas
   - pint

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - netcdf4
   - numba
   - numexpr
-  - numpy=1.20
+  - numpy
   - packaging
   - pandas
   - pint

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,7 +35,10 @@ Bug fixes
 ~~~~~~~~~
 
 - :py:attr:`DataArray.nbytes` now uses the ``nbytes`` property of the underlying array if available.
+  (:pull:`6797`)
   By `Max Jones <https://github.com/maxrjones>`_.
+- Fix incompatibility with numpy 1.20 (:issue:`6818`, :pull:`6821`)
+  By `Michael Niklas <https://github.com/headtr1ck>`_.
 
 Documentation
 ~~~~~~~~~~~~~


### PR DESCRIPTION
This PR removes the `_SupportsDType` dependency from numpy and introduces its own.

Closes https://github.com/pydata/xarray/issues/6818