### PR TITLE
Rely on array backend for string formatting

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,6 +36,8 @@ Bug fixes
 
 - :py:attr:`DataArray.nbytes` now uses the ``nbytes`` property of the underlying array if available.
   By `Max Jones <https://github.com/maxrjones>`_.
+- Rely on the array backend for string formatting. (:pull:`xxxx`).
+  By `Jimmy Westling <https://github.com/illviljan>`_.
 
 Documentation
 ~~~~~~~~~~~~~
@@ -79,6 +81,8 @@ New Features
 - Experimental support for wrapping any array type that conforms to the python
   `array api standard <https://data-apis.org/array-api/latest/>`_. (:pull:`6804`)
   By `Tom White <https://github.com/tomwhite>`_.
+- Allow string formatting of scalar DataArrays. (:pull:`5981`)
+  By `fmaussion <https://github.com/fmaussion>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,7 +36,7 @@ Bug fixes
 
 - :py:attr:`DataArray.nbytes` now uses the ``nbytes`` property of the underlying array if available.
   By `Max Jones <https://github.com/maxrjones>`_.
-- Rely on the array backend for string formatting. (:pull:`xxxx`).
+- Rely on the array backend for string formatting. (:pull:`6823`).
   By `Jimmy Westling <https://github.com/illviljan>`_.
 
 Documentation

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -173,7 +173,8 @@ class AbstractArray:
                 # take format_spec as an input. If we'd only use self.data we
                 # lose all the information about coords for example which is
                 # important information:
-                raise NotImplementedError()
+                raise NotImplementedError("Using format_spec is only supported"
+                                          " when shape is (). Got shape = {self.shape}.")
         else:
             return self.__repr__()
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -173,8 +173,10 @@ class AbstractArray:
                 # take format_spec as an input. If we'd only use self.data we
                 # lose all the information about coords for example which is
                 # important information:
-                raise NotImplementedError("Using format_spec is only supported"
-                                          " when shape is (). Got shape = {self.shape}.")
+                raise NotImplementedError(
+                    "Using format_spec is only supported"
+                    " when shape is (). Got shape = {self.shape}."
+                )
         else:
             return self.__repr__()
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -175,7 +175,7 @@ class AbstractArray:
                 # important information:
                 raise NotImplementedError(
                     "Using format_spec is only supported"
-                    " when shape is (). Got shape = {self.shape}."
+                    f" when shape is (). Got shape = {self.shape}."
                 )
         else:
             return self.__repr__()

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -164,8 +164,7 @@ class AbstractArray:
         return formatting_html.array_repr(self)
 
     def __format__(self: Any, format_spec: str) -> str:
-        # we use numpy: scalars will print fine and arrays will raise
-        return self.values.__format__(format_spec)
+        return self.data.__format__(format_spec)
 
     def _iter(self: Any) -> Iterator[Any]:
         for n in range(len(self)):

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -163,8 +163,19 @@ class AbstractArray:
             return f"<pre>{escape(repr(self))}</pre>"
         return formatting_html.array_repr(self)
 
-    def __format__(self: Any, format_spec: str) -> str:
-        return self.data.__format__(format_spec)
+    def __format__(self: Any, format_spec: str = "") -> str:
+        if format_spec != "":
+            if self.shape == ():
+                # Scalar values might be ok use format_spec with instead of repr:
+                return self.data.__format__(format_spec)
+            else:
+                # TODO: If it's an array the formatting.array_repr(self) should
+                # take format_spec as an input. If we'd only use self.data we
+                # lose all the information about coords for example which is
+                # important information:
+                raise NotImplementedError()
+        else:
+            return self.__repr__()
 
     def _iter(self: Any) -> Iterator[Any]:
         for n in range(len(self)):

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -454,6 +454,7 @@ class TestFormatting:
             format(var, ".2f")
         assert "Using format_spec is only supported" in str(excinfo.value)
 
+
 def test_inline_variable_array_repr_custom_repr() -> None:
     class CustomArray:
         def __init__(self, value, attr):

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -391,7 +391,10 @@ class TestFormatting:
     def test_array_repr(self) -> None:
         ds = xr.Dataset(coords={"foo": [1, 2, 3], "bar": [1, 2, 3]})
         ds[(1, 2)] = xr.DataArray([0], dims="test")
-        actual = formatting.array_repr(ds[(1, 2)])
+        ds_12 = ds[(1, 2)]
+
+        # Test repr function behaves correctly:
+        actual = formatting.array_repr(ds_12)
         expected = dedent(
             """\
         <xarray.DataArray (1, 2) (test: 1)>
@@ -399,6 +402,15 @@ class TestFormatting:
         Dimensions without coordinates: test"""
         )
 
+        assert actual == expected
+
+        # Test repr, str prints returns correctly as well:
+        for func in (repr, str):
+            actual = func(ds_12)
+            assert actual == expected
+
+        # f-strings (aka format(...)) by default should use the repr:
+        actual = f"{ds_12}"
         assert actual == expected
 
         with xr.set_options(display_expand_data=False):

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -433,12 +433,14 @@ class TestFormatting:
             var.__format__(".2f")
         assert "unsupported format string passed to" in str(excinfo.value)
 
-        # also check for dask
+        # also check for dask, dask however doesn't implement __format__
+        # in the same way as numpy so results differs or errors more:
         var = var.chunk(chunks={"dim_0": 1})
-        assert var.__format__("") == "[0.1 0.2]"
-        with pytest.raises(TypeError) as excinfo:
-            var.__format__(".2f")
-        assert "unsupported format string passed to" in str(excinfo.value)
+        assert var.__format__("") == var.data.__format__("")
+        for fmt in (".2f", ":.3f"):
+            with pytest.raises(TypeError) as excinfo:
+                var.__format__(fmt)
+            assert "unsupported format string passed to" in str(excinfo.value)
 
 
 def test_inline_variable_array_repr_custom_repr() -> None:

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -405,9 +405,8 @@ class TestFormatting:
         assert actual == expected
 
         # Test repr, str prints returns correctly as well:
-        for func in (repr, str):
-            actual = func(ds_12)
-            assert actual == expected
+        assert repr(ds_12) == expected
+        assert str(ds_12) == expected
 
         # f-strings (aka format(...)) by default should use the repr:
         actual = f"{ds_12}"
@@ -436,7 +435,7 @@ class TestFormatting:
     def test_array_scalar_format(self) -> None:
         # Test numpy scalars:
         var = xr.DataArray(np.array(0))
-        assert var.__format__("") == var.__repr__()
+        assert var.__format__("") == repr(var)
         assert var.__format__("d") == "0"
         assert var.__format__(".2f") == "0.00"
 
@@ -444,7 +443,7 @@ class TestFormatting:
         import dask.array as da
 
         var = xr.DataArray(da.array(0))
-        assert var.__format__("") == var.__repr__()
+        assert var.__format__("") == repr(var)
         with pytest.raises(TypeError) as excinfo:
             var.__format__(".2f")
         assert "unsupported format string passed to" in str(excinfo.value)

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -435,24 +435,24 @@ class TestFormatting:
     def test_array_scalar_format(self) -> None:
         # Test numpy scalars:
         var = xr.DataArray(np.array(0))
-        assert var.__format__("") == repr(var)
-        assert var.__format__("d") == "0"
-        assert var.__format__(".2f") == "0.00"
+        assert format(var, "") == repr(var)
+        assert format(var, "d") == "0"
+        assert format(var, ".2f") == "0.00"
 
         # Test dask scalars, not supported however:
         import dask.array as da
 
         var = xr.DataArray(da.array(0))
-        assert var.__format__("") == repr(var)
+        assert format(var, "") == repr(var)
         with pytest.raises(TypeError) as excinfo:
-            var.__format__(".2f")
+            format(var, ".2f")
         assert "unsupported format string passed to" in str(excinfo.value)
 
         # Test numpy arrays raises:
         var = xr.DataArray([0.1, 0.2])
-        with pytest.raises(NotImplementedError) as excinfo:
-            var.__format__(".2f")
-
+        with pytest.raises(NotImplementedError) as excinfo:  # type: ignore
+            format(var, ".2f")
+        assert "Using format_spec is only supported" in str(excinfo.value)
 
 def test_inline_variable_array_repr_custom_repr() -> None:
     class CustomArray:

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -434,25 +434,25 @@ class TestFormatting:
 
     @requires_dask
     def test_array_scalar_format(self) -> None:
-        var = xr.DataArray(0)
-        assert var.__format__("") == "0"
+        # Test numpy scalars:
+        var = xr.DataArray(np.array(0))
+        assert var.__format__("") == var.__repr__()
         assert var.__format__("d") == "0"
         assert var.__format__(".2f") == "0.00"
 
-        var = xr.DataArray([0.1, 0.2])
-        assert var.__format__("") == "[0.1 0.2]"
+        # Test dask scalars, not supported however:
+        import dask.array as da
+
+        var = xr.DataArray(da.array(0))
+        assert var.__format__("") == var.__repr__()
         with pytest.raises(TypeError) as excinfo:
             var.__format__(".2f")
         assert "unsupported format string passed to" in str(excinfo.value)
 
-        # also check for dask, dask however doesn't implement __format__
-        # in the same way as numpy so results differs or errors more:
-        var = var.chunk(chunks={"dim_0": 1})
-        assert var.__format__("") == var.data.__format__("")
-        for fmt in (".2f", ":.3f"):
-            with pytest.raises(TypeError) as excinfo:
-                var.__format__(fmt)
-            assert "unsupported format string passed to" in str(excinfo.value)
+        # Test numpy arrays raises:
+        var = xr.DataArray([0.1, 0.2])
+        with pytest.raises(NotImplementedError) as excinfo:
+            var.__format__(".2f")
 
 
 def test_inline_variable_array_repr_custom_repr() -> None:


### PR DESCRIPTION
* Rely on array backend for string formatting instead of forcing to numpy arrays. The previous implementation used `.values` to force to numpy arrays which doesn't work for sparse arrays and might be scary in the case of large dask arrays.
* Only allow `format_spec` when dealing with scalar arrays, shape=(). Using f-strings is a common method to print the repr. If we want to have full support of `.__format__` we should probably add `format_spec` as input to `formatting.array_repr`. 

- [x] Closes #6822
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`


```python
import pandas as pd
import xarray as xr

s = pd.Series(
    range(4),
    index=pd.MultiIndex.from_product([list("ab"), list("cd")]),
)

da = xr.DataArray.from_series(s, sparse=True)

# Handle sparse:
print(f"Error: {da} is sparse")
Error: <xarray.DataArray (level_0: 2, level_1: 2)>
<COO: shape=(2, 2), dtype=float64, nnz=4, fill_value=nan>
Coordinates:
  * level_0  (level_0) object 'a' 'b'
  * level_1  (level_1) object 'c' 'd' is sparse

# Handle format_spec:
da = xr.DataArray([1, 2, 3])

print(f'{da[0]}')
<xarray.DataArray ()>
array(1)

print(f'{da[0]:d}')
1

print(f'{da[0]:f}')
1.000000

da = xr.DataArray([1, 2, 3])
print(f'{da:.f}')
Traceback (most recent call last):
(...)
NotImplementedError: Using format_spec is only supported when shape is (). Got shape = (3,).
```