### PR TITLE
Add docstring example for xr.open_mfdataset

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -907,7 +907,7 @@ def open_mfdataset(
     ...
     >>> lon_bnds, lat_bnds = (-110, -105), (40, 45)
     >>> partial_func = partial(_preprocess, lon_bnds=lon_bnds, lat_bnds=lat_bnds)
-    >>> ds = xr.open_mfdataset("file_*.nc", concat_dim="time", preprocess=_preprocess)
+    >>> ds = xr.open_mfdataset("file_*.nc", concat_dim="time", preprocess=_preprocess)  # doctest: SKIP
 
     References
     ----------

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -907,7 +907,9 @@ def open_mfdataset(
     ...
     >>> lon_bnds, lat_bnds = (-110, -105), (40, 45)
     >>> partial_func = partial(_preprocess, lon_bnds=lon_bnds, lat_bnds=lat_bnds)
-    >>> ds = xr.open_mfdataset("file_*.nc", concat_dim="time", preprocess=_preprocess)  # doctest: SKIP
+    >>> ds = xr.open_mfdataset(
+    ...     "file_*.nc", concat_dim="time", preprocess=_preprocess
+    ... )  # doctest: SKIP
 
     References
     ----------

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -909,7 +909,7 @@ def open_mfdataset(
     >>> partial_func = partial(_preprocess, lon_bnds=lon_bnds, lat_bnds=lat_bnds)
     >>> ds = xr.open_mfdataset(
     ...     "file_*.nc", concat_dim="time", preprocess=_preprocess
-    ... )  # doctest: SKIP
+    ... )  # doctest: +SKIP
 
     References
     ----------

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -895,6 +895,19 @@ def open_mfdataset(
     combine_nested
     open_dataset
 
+    Examples
+    --------
+    A user might want to pass additional arguments into ``preprocess`` when
+    applying some operation to many individual files that are being opened. One route
+    to do this is through the use of ``functools.partial``.
+
+    >>> from functools import partial
+    >>> def _preprocess(x, lon_bnds, lat_bnds):
+    ...     return x.sel(lon=slice(*lon_bnds), lat=slice(*lat_bnds))
+    >>> lon_bnds, lat_bnds = (-110, -105), (40, 45)
+    >>> partial_func = partial(_preprocess, lon_bnds=lon_bnds, lat_bnds=lat_bnds)
+    >>> ds = xr.open_mfdataset("file_*.nc", concat_dim="time", preprocess=_preprocess)
+
     References
     ----------
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -904,6 +904,7 @@ def open_mfdataset(
     >>> from functools import partial
     >>> def _preprocess(x, lon_bnds, lat_bnds):
     ...     return x.sel(lon=slice(*lon_bnds), lat=slice(*lat_bnds))
+    ...
     >>> lon_bnds, lat_bnds = (-110, -105), (40, 45)
     >>> partial_func = partial(_preprocess, lon_bnds=lon_bnds, lat_bnds=lat_bnds)
     >>> ds = xr.open_mfdataset("file_*.nc", concat_dim="time", preprocess=_preprocess)


### PR DESCRIPTION
This adds a short docstring example to `xr.open_mfdataset` to showcase how to pass arguments into `preprocess` for `xr.open_mfdataset`.

It wasn't very clear before how to do this, and this hopefully will show an easy and minimal pathway to doing so.

- [X] Closes https://github.com/pydata/xarray/discussions/6820
