### PR TITLE
Convert name to string in label_from_attrs

### DIFF
--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -463,7 +463,7 @@ def _maybe_gca(**kwargs):
     return plt.axes(**kwargs)
 
 
-def _get_units_from_attrs(da):
+def _get_units_from_attrs(da) -> str:
     """Extracts and formats the unit/units from a attributes."""
     pint_array_type = DuckArrayModule("pint").type
     units = " [{}]"
@@ -478,16 +478,16 @@ def _get_units_from_attrs(da):
     return units
 
 
-def label_from_attrs(da, extra=""):
+def label_from_attrs(da, extra: str ="") -> str:
     """Makes informative labels if variable metadata (attrs) follows
     CF conventions."""
-
+    name: str = "{}"
     if da.attrs.get("long_name"):
-        name = da.attrs["long_name"]
+        name = name.format(da.attrs["long_name"])
     elif da.attrs.get("standard_name"):
-        name = da.attrs["standard_name"]
+        name = name.format(da.attrs["standard_name"])
     elif da.name is not None:
-        name = da.name
+        name = name.format(da.name)
     else:
         name = ""
 

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -478,7 +478,7 @@ def _get_units_from_attrs(da) -> str:
     return units
 
 
-def label_from_attrs(da, extra: str ="") -> str:
+def label_from_attrs(da, extra: str = "") -> str:
     """Makes informative labels if variable metadata (attrs) follows
     CF conventions."""
     name: str = "{}"

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -169,6 +169,9 @@ class TestPlot(PlotTestCase):
         da = self.darray.copy()
         assert "" == label_from_attrs(da)
 
+        da.name = 0
+        assert "0" == label_from_attrs(da)
+
         da.name = "a"
         da.attrs["units"] = "a_units"
         da.attrs["long_name"] = "a_long_name"


### PR DESCRIPTION
Make sure name is a string. Use the same `.format` method as in `_get_units_from_attrs` to convert to string.

- [x] Closes #6826
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
