### PR TITLE
Fix FacetGrid.set_titles #6839

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,7 +40,7 @@ Bug fixes
 - :py:attr:`DataArray.nbytes` now uses the ``nbytes`` property of the underlying array if available.
   By `Max Jones <https://github.com/maxrjones>`_.
 - Make FacetGrid.set_titles send kwargs correctly using `handle.udpate(kwargs)`.
-  (:issue:`6839`)
+  (:issue:`6839`, :pull:`6843`)
   By `Oliver Lopez <https://github.com/lopezvoliver>`_.
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -39,6 +39,9 @@ Bug fixes
   By `Jimmy Westling <https://github.com/illviljan>`_.
 - :py:attr:`DataArray.nbytes` now uses the ``nbytes`` property of the underlying array if available.
   By `Max Jones <https://github.com/maxrjones>`_.
+- Make FacetGrid.set_titles send kwargs correctly using `handle.udpate(kwargs)`.
+  (:issue:`6839`)
+  By `Oliver Lopez <https://github.com/lopezvoliver>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -553,6 +553,7 @@ class FacetGrid:
                     )
                 else:
                     handle.set_text(title)
+                    handle.update(kwargs)
 
             # The column titles on the top row
             for index, (ax, col_name, handle) in enumerate(
@@ -563,6 +564,7 @@ class FacetGrid:
                     self.col_labels[index] = ax.set_title(title, size=size, **kwargs)
                 else:
                     handle.set_text(title)
+                    handle.update(kwargs)
 
         return self
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -112,6 +112,19 @@ def substring_not_in_axes(substring, ax):
     return all(check)
 
 
+def property_in_axes_text(property, property_str, target_txt, ax):
+    """
+    Return True if the specified text in an axes
+    has the property assigned to property_str
+    """
+    alltxt = ax.findobj(mpl.text.Text)
+    check = []
+    for t in alltxt:
+        if (t.get_text() == target_txt):
+            check.append(plt.getp(t,property)==property_str)
+    return all(check)
+
+
 def easy_array(shape, start=0, stop=1):
     """
     Make an array with desired shape using np.linspace
@@ -2259,6 +2272,19 @@ class TestFacetGrid4d(PlotTestCase):
         )
 
         self.darray = darray
+
+    def test_title_kwargs(self):
+        g = xplt.FacetGrid(self.darray, col="col", row="row")
+        g.set_titles(template='{value}', weight = 'bold')
+
+        # Rightmost column titles should be bold
+        for label, ax in zip(self.darray.coords["row"].values, g.axes[:, -1]):
+            assert property_in_axes_text('weight', 'bold', label, ax)       
+        
+        # Top row titles should be bold
+        for label, ax in zip(self.darray.coords["col"].values, g.axes[0, :]):
+            assert property_in_axes_text('weight', 'bold', label, ax)       
+
 
     @pytest.mark.slow
     def test_default_labels(self):

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -120,8 +120,8 @@ def property_in_axes_text(property, property_str, target_txt, ax):
     alltxt = ax.findobj(mpl.text.Text)
     check = []
     for t in alltxt:
-        if (t.get_text() == target_txt):
-            check.append(plt.getp(t,property)==property_str)
+        if t.get_text() == target_txt:
+            check.append(plt.getp(t, property) == property_str)
     return all(check)
 
 
@@ -2275,16 +2275,15 @@ class TestFacetGrid4d(PlotTestCase):
 
     def test_title_kwargs(self):
         g = xplt.FacetGrid(self.darray, col="col", row="row")
-        g.set_titles(template='{value}', weight = 'bold')
+        g.set_titles(template="{value}", weight="bold")
 
         # Rightmost column titles should be bold
         for label, ax in zip(self.darray.coords["row"].values, g.axes[:, -1]):
-            assert property_in_axes_text('weight', 'bold', label, ax)       
-        
+            assert property_in_axes_text("weight", "bold", label, ax)
+
         # Top row titles should be bold
         for label, ax in zip(self.darray.coords["col"].values, g.axes[0, :]):
-            assert property_in_axes_text('weight', 'bold', label, ax)       
-
+            assert property_in_axes_text("weight", "bold", label, ax)
 
     @pytest.mark.slow
     def test_default_labels(self):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [X] Closes #6839 
- [X] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Added `handle.update(kwargs)` after `handle.set_text(title)` so that the title properties sent using keyword arguments are also updated. 