### PR TITLE
Fix logic bug - add_offset is in encoding, not attrs.

### DIFF
--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -269,7 +269,7 @@ class CFScaleOffsetCoder(VariableCoder):
         if "scale_factor" in attrs or "add_offset" in attrs:
             scale_factor = pop_to(attrs, encoding, "scale_factor", name=name)
             add_offset = pop_to(attrs, encoding, "add_offset", name=name)
-            dtype = _choose_float_dtype(data.dtype, "add_offset" in attrs)
+            dtype = _choose_float_dtype(data.dtype, "add_offset" in encoding)
             if np.ndim(scale_factor) > 0:
                 scale_factor = np.asarray(scale_factor).item()
             if np.ndim(add_offset) > 0:


### PR DESCRIPTION
`_pop_to` does a pop operation - it removes the key/value pair. So the line above this change will remove `add_offset` from `attrs` if it exists. The second line then checks for `add_offset` in `attrs` which should always be `False`. 

This is implemented in #6812 but the work there is significantly more involved (see for example different PR addressing the same problem, #2304), so I'm pulling this fix out and submitting it as its own PR.