### PR TITLE
Add typing to some interval functions

### DIFF
--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -502,7 +502,7 @@ def label_from_attrs(da, extra: str = "") -> str:
         return "\n".join(textwrap.wrap(name + extra + units, 30))
 
 
-def _interval_to_mid_points(array):
+def _interval_to_mid_points(array: Iterable[pd.Interval]) -> np.ndarray:
     """
     Helper function which returns an array
     with the Intervals' mid points.
@@ -511,7 +511,7 @@ def _interval_to_mid_points(array):
     return np.array([x.mid for x in array])
 
 
-def _interval_to_bound_points(array):
+def _interval_to_bound_points(array: Sequence[pd.Interval]) -> np.ndarray:
     """
     Helper function which returns an array
     with the Intervals' boundaries.
@@ -523,7 +523,9 @@ def _interval_to_bound_points(array):
     return array_boundaries
 
 
-def _interval_to_double_bound_points(xarray, yarray):
+def _interval_to_double_bound_points(
+    xarray: Iterable[pd.Interval], yarray: Iterable
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Helper function to deal with a xarray consisting of pd.Intervals. Each
     interval is replaced with both boundaries. I.e. the length of xarray
@@ -533,13 +535,15 @@ def _interval_to_double_bound_points(xarray, yarray):
     xarray1 = np.array([x.left for x in xarray])
     xarray2 = np.array([x.right for x in xarray])
 
-    xarray = list(itertools.chain.from_iterable(zip(xarray1, xarray2)))
-    yarray = list(itertools.chain.from_iterable(zip(yarray, yarray)))
+    xarray_out = np.array(list(itertools.chain.from_iterable(zip(xarray1, xarray2))))
+    yarray_out = np.array(list(itertools.chain.from_iterable(zip(yarray, yarray))))
 
-    return xarray, yarray
+    return xarray_out, yarray_out
 
 
-def _resolve_intervals_1dplot(xval, yval, kwargs):
+def _resolve_intervals_1dplot(
+    xval: np.ndarray, yval: np.ndarray, kwargs: dict
+) -> tuple[np.ndarray, np.ndarray, str, str, dict]:
     """
     Helper function to replace the values of x and/or y coordinate arrays
     containing pd.Interval with their mid-points or - for step plots - double

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -5,7 +5,7 @@ import textwrap
 import warnings
 from datetime import datetime
 from inspect import getfullargspec
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, Sequence
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
Reduce diffs in #6778. `_interval_to_double_bound_points` was returning a `list` instead of `ndarray` which I had some issues with.

