### PR TITLE
rely on `numpy`'s version of `nanprod` and `nansum`

### DIFF
--- a/xarray/core/nanops.py
+++ b/xarray/core/nanops.py
@@ -105,8 +105,8 @@ def nanargmax(a, axis=None):
 
 
 def nansum(a, axis=None, dtype=None, out=None, min_count=None):
-    a, mask = _replace_nan(a, 0)
-    result = np.sum(a, axis=axis, dtype=dtype)
+    mask = isnull(a)
+    result = np.nansum(a, axis=axis, dtype=dtype)
     if min_count is not None:
         return _maybe_null_out(result, axis, mask, min_count)
     else:
@@ -173,7 +173,7 @@ def nanstd(a, axis=None, dtype=None, out=None, ddof=0):
 
 
 def nanprod(a, axis=None, dtype=None, out=None, min_count=None):
-    a, mask = _replace_nan(a, 1)
+    mask = isnull(a)
     result = nputils.nanprod(a, axis=axis, dtype=dtype, out=out)
     if min_count is not None:
         return _maybe_null_out(result, axis, mask, min_count)

--- a/xarray/core/nanops.py
+++ b/xarray/core/nanops.py
@@ -17,15 +17,6 @@ except ImportError:
     dask_array_compat = None  # type: ignore[assignment]
 
 
-def _replace_nan(a, val):
-    """
-    replace nan in a by val, and returns the replaced array and the nan
-    position
-    """
-    mask = isnull(a)
-    return where_method(val, mask, a), mask
-
-
 def _maybe_null_out(result, axis, mask, min_count=1):
     """
     xarray version of pandas.core.nanops._maybe_null_out

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1530,9 +1530,6 @@ class TestVariable:
         ids=repr,
     )
     def test_aggregation(self, func, dtype):
-        if func.name == "prod" and dtype.kind == "f":
-            pytest.xfail(reason="nanprod is not supported, yet")
-
         array = np.linspace(0, 1, 10).astype(dtype) * (
             unit_registry.m if func.name != "cumprod" else unit_registry.dimensionless
         )
@@ -2387,9 +2384,6 @@ class TestDataArray:
         ids=repr,
     )
     def test_aggregation(self, func, dtype):
-        if func.name == "prod" and dtype.kind == "f":
-            pytest.xfail(reason="nanprod is not supported, yet")
-
         array = np.arange(10).astype(dtype) * (
             unit_registry.m if func.name != "cumprod" else unit_registry.dimensionless
         )
@@ -4082,9 +4076,6 @@ class TestDataset:
         ids=repr,
     )
     def test_aggregation(self, func, dtype):
-        if func.name == "prod" and dtype.kind == "f":
-            pytest.xfail(reason="nanprod is not supported, yet")
-
         unit_a, unit_b = (
             (unit_registry.Pa, unit_registry.degK)
             if func.name != "cumprod"

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -6,6 +6,7 @@ import operator
 import numpy as np
 import pandas as pd
 import pytest
+from packaging import version
 
 import xarray as xr
 from xarray.core import dtypes, duck_array_ops
@@ -1530,6 +1531,13 @@ class TestVariable:
         ids=repr,
     )
     def test_aggregation(self, func, dtype):
+        if (
+            func.name == "prod"
+            and dtype.kind == "f"
+            and version.parse(pint.__version__) < version.parse("0.19")
+        ):
+            pytest.xfail(reason="nanprod is not by older `pint` versions")
+
         array = np.linspace(0, 1, 10).astype(dtype) * (
             unit_registry.m if func.name != "cumprod" else unit_registry.dimensionless
         )
@@ -2384,6 +2392,13 @@ class TestDataArray:
         ids=repr,
     )
     def test_aggregation(self, func, dtype):
+        if (
+            func.name == "prod"
+            and dtype.kind == "f"
+            and version.parse(pint.__version__) < version.parse("0.19")
+        ):
+            pytest.xfail(reason="nanprod is not by older `pint` versions")
+
         array = np.arange(10).astype(dtype) * (
             unit_registry.m if func.name != "cumprod" else unit_registry.dimensionless
         )
@@ -4076,6 +4091,13 @@ class TestDataset:
         ids=repr,
     )
     def test_aggregation(self, func, dtype):
+        if (
+            func.name == "prod"
+            and dtype.kind == "f"
+            and version.parse(pint.__version__) < version.parse("0.19")
+        ):
+            pytest.xfail(reason="nanprod is not by older `pint` versions")
+
         unit_a, unit_b = (
             (unit_registry.Pa, unit_registry.degK)
             if func.name != "cumprod"


### PR DESCRIPTION
At the moment, `nanprod` and `nansum` will replace any `nan` values with `1` for `nanprod` or `0` for `nansum`. For `pint`, inserting dimensionless values into quantities is explicitly not allowed, so our version of `nanprod` cannot be used on `pint` quantities (`0` is a exception so `nansum` does work).

I'm proposing to rely on `numpy`'s version for that, which would allow `pint` to customize the behavior.