### PR TITLE
Temporarily import `loop_in_thread` fixture from `distributed`

### DIFF
--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -14,7 +14,13 @@ distributed = pytest.importorskip("distributed")  # isort:skip
 
 from dask.distributed import Client, Lock
 from distributed.client import futures_of
-from distributed.utils_test import cluster, gen_cluster, loop, cleanup  # noqa: F401
+from distributed.utils_test import (  # noqa: F401
+    cluster,
+    gen_cluster,
+    loop,
+    cleanup,
+    loop_in_thread,
+)
 
 import xarray as xr
 from xarray.backends.locks import HDF5_LOCK, CombinedLock


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes https://github.com/dask/distributed/issues/6842
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

This is a quickfix similar to https://github.com/dask/dask/pull/9337. Note there's a conversation happening over in https://github.com/dask/distributed/issues/6806 around what testing utilities in `distributed` should be considered public. 