### PR TITLE
Harmonize returned multi-indexed indexes when applying `concat` along new dimension 

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -52,7 +52,7 @@ Bug fixes
 - Fix bug where index variables would be changed inplace (:issue:`6931`, :pull:`6938`)
   By `Michael Niklas <https://github.com/headtr1ck>`_.
 - Harmonize returned multi-indexed indexes when applying ``concat`` along new dimension (:issue:`6881`, :pull:`6889`)
-  By `Fabian Hofmann <https://github.com/fabianhofmann>`_.
+  By `Fabian Hofmann <https://github.com/FabianHofmann>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -51,6 +51,8 @@ Bug fixes
   By `Oliver Lopez <https://github.com/lopezvoliver>`_.
 - Fix bug where index variables would be changed inplace (:issue:`6931`, :pull:`6938`)
   By `Michael Niklas <https://github.com/headtr1ck>`_.
+- Harmonize returned multi-indexed indexes when applying ``concat`` along new dimension (:issue:`6881`, :pull:`6889`)
+  By `Fabian Hofmann <https://github.com/fabianhofmann>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -490,7 +490,7 @@ def _dataset_concat(
     )
 
     # determine which variables to merge, and then merge them according to compat
-    variables_to_merge = (coord_names | data_names) - concat_over - dim_names
+    variables_to_merge = (coord_names | data_names) - concat_over - unlabeled_dims
 
     result_vars = {}
     result_indexes = {}

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -517,7 +517,7 @@ class TestConcatDataset:
         # see https://github.com/pydata/xarray/issues/6881
         x = pd.MultiIndex.from_product([[1, 2, 3], ["a", "b"]])
         ds = Dataset(coords={"x": x})
-        concatenated = xr.concat([ds], "new")
+        concatenated = concat([ds], "new")
         actual = list(concatenated.xindexes.get_all_coords("x"))
         expected = ["x", "a", "b"]
         assert actual == expected

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -516,12 +516,10 @@ class TestConcatDataset:
     def test_concat_along_new_dim_multiindex(self) -> None:
         x = pd.MultiIndex.from_product([[1, 2, 3], ["a", "b"]])
         ds = Dataset(coords={"x": x})
-        actual = concat(
-            [ds], "new"
-        )
+        actual = concat([ds], "new")
         assert isinstance(actual.x.to_index(), pd.MultiIndex)
         for k, idx in actual.indexes.items():
-            assert idx is actual.indexes['x']
+            assert idx is actual.indexes["x"]
 
     @pytest.mark.parametrize("fill_value", [dtypes.NA, 2, 2.0, {"a": 2, "b": 1}])
     def test_concat_fill_value(self, fill_value) -> None:

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -515,11 +515,12 @@ class TestConcatDataset:
 
     def test_concat_along_new_dim_multiindex(self) -> None:
         # see https://github.com/pydata/xarray/issues/6881
-        x = pd.MultiIndex.from_product([[1, 2, 3], ["a", "b"]])
+        level_names = ["x_level_0", "x_level_1"]
+        x = pd.MultiIndex.from_product([[1, 2, 3], ["a", "b"]], names=level_names)
         ds = Dataset(coords={"x": x})
         concatenated = concat([ds], "new")
         actual = list(concatenated.xindexes.get_all_coords("x"))
-        expected = ["x", "a", "b"]
+        expected = ["x"] + level_names
         assert actual == expected
 
     @pytest.mark.parametrize("fill_value", [dtypes.NA, 2, 2.0, {"a": 2, "b": 1}])

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -513,6 +513,16 @@ class TestConcatDataset:
         assert expected.equals(actual)
         assert isinstance(actual.x.to_index(), pd.MultiIndex)
 
+    def test_concat_along_new_dim_multiindex(self) -> None:
+        x = pd.MultiIndex.from_product([[1, 2, 3], ["a", "b"]])
+        ds = Dataset(coords={"x": x})
+        actual = concat(
+            [ds], "new"
+        )
+        assert isinstance(actual.x.to_index(), pd.MultiIndex)
+        for k, idx in actual.indexes.items():
+            assert idx is actual.indexes['x']
+
     @pytest.mark.parametrize("fill_value", [dtypes.NA, 2, 2.0, {"a": 2, "b": 1}])
     def test_concat_fill_value(self, fill_value) -> None:
         datasets = [

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -514,12 +514,13 @@ class TestConcatDataset:
         assert isinstance(actual.x.to_index(), pd.MultiIndex)
 
     def test_concat_along_new_dim_multiindex(self) -> None:
+        # see https://github.com/pydata/xarray/issues/6881
         x = pd.MultiIndex.from_product([[1, 2, 3], ["a", "b"]])
         ds = Dataset(coords={"x": x})
-        actual = concat([ds], "new")
-        assert isinstance(actual.x.to_index(), pd.MultiIndex)
-        for k, idx in actual.indexes.items():
-            assert idx is actual.indexes["x"]
+        concatenated = xr.concat([ds], "new")
+        actual = list(concatenated.xindexes.get_all_coords("x"))
+        expected = ["x", "a", "b"]
+        assert actual == expected
 
     @pytest.mark.parametrize("fill_value", [dtypes.NA, 2, 2.0, {"a": 2, "b": 1}])
     def test_concat_fill_value(self, fill_value) -> None:


### PR DESCRIPTION
- [x] Closes #6881 
- [x] Tests added

In the current implementation, the `concat` function does not ensure that the indexes that belong to the same `MultiIndex` relate to the same `MultiIndex` object in `Dataset.indexes` when concatenating along a new dimension. This becomes a problem as soon as the returned dataset needs to be aligned (for broadcasting, reindexing etc.), see #6881 for example. As far as I understand, this bug was introduced in https://github.com/pydata/xarray/pull/5692 following the idea that the `concat` function should disentangle indexes and dimensions. 

It can be fixed by not removing the index name from the list of indexes which should be merged, see https://github.com/pydata/xarray/blob/9050a8b9efc28142b762475c7285603a87b00e83/xarray/core/concat.py#L493. All indexes contained in this list will get a new index object. Currently, this list only contains the **levels** of a multi-indexed index, not the index name itself. This is removed as it is contained in `dim_names`. Instead of removing all dimension names from this list, I suggest to only remove unlabeled dimensions from this list.