### PR TITLE
Fix mypy CI

### DIFF
--- a/xarray/tests/test_backends_file_manager.py
+++ b/xarray/tests/test_backends_file_manager.py
@@ -53,7 +53,7 @@ def test_file_manager_autoclose(warn_for_unclosed_files) -> None:
     if warn_for_unclosed_files:
         ctx = pytest.warns(RuntimeWarning)
     else:
-        ctx = assert_no_warnings()
+        ctx = assert_no_warnings()  # type: ignore
 
     with set_options(warn_for_unclosed_files=warn_for_unclosed_files):
         with ctx:


### PR DESCRIPTION
Fixes:
```
xarray/tests/test_backends_file_manager.py:56: error: Incompatible types in assignment (expression has type "_GeneratorContextManager[Any]", variable has type "WarningsChecker")  [assignment]
```
Just added a ignore.