### PR TITLE
Avoid use of random numbers in `test_weighted.test_weighted_operations_nonequal_coords`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -55,7 +55,7 @@ Bug fixes
   By `Fabian Hofmann <https://github.com/FabianHofmann>`_.
 - Fix step plots with ``hue`` arg. (:pull:`6944`)
   By `András Gunyhó <https://github.com/mgunyho>`_.
-- Avoid use of random numbers in `test_weighted.test_weighted_operations_nonequal_coords` (:issue:`6504`, :pull:`6959`).
+- Avoid use of random numbers in `test_weighted.test_weighted_operations_nonequal_coords` (:issue:`6504`, :pull:`6961`).
   By `Luke Conibear <https://github.com/lukeconibear>`_.
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -55,6 +55,8 @@ Bug fixes
   By `Fabian Hofmann <https://github.com/FabianHofmann>`_.
 - Fix step plots with ``hue`` arg. (:pull:`6944`)
   By `András Gunyhó <https://github.com/mgunyho>`_.
+- Avoid use of random numbers in `test_weighted.test_weighted_operations_nonequal_coords` (:issue:`6504`, :pull:`6959`).
+  By `Luke Conibear <https://github.com/lukeconibear>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -691,7 +691,7 @@ def test_weighted_operations_nonequal_coords(
     da_expected = DataArray([expected_value], coords={"quantile": [quantile]}).squeeze()
     assert_allclose(da_actual, da_expected)
 
-    ds_data = da_data.to_dataset(name="data")  # type: xr.Dataset
+    ds_data = da_data.to_dataset(name="data")
     check_weighted_operations(ds_data, da_weights, dim="a", skipna=None)
 
     ds_actual = ds_data.weighted(da_weights).quantile(quantile, dim="a")

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -679,7 +679,7 @@ def test_weighted_operations_nonequal_coords(
         The coords for the weights.
     coords_data : Iterable[Any]
         The coords for the data.
-    expected : float
+    expected_value_at_weighted_quantile : float
         The expected value for the quantile of the weighted data.
     """
     da_weights = DataArray(

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -657,16 +657,17 @@ def test_weighted_quantile_3D(dim, q, add_nans, skipna):
 
 
 @pytest.mark.parametrize(
-    "nonequal_coords_for_weights_and_data, expected_value",
+    "coords_weights, coords_data, expected_value_at_weighted_quantile",
     [
-        (([0, 1, 2, 3], [1, 2, 3, 4]), 2.50),  # no weights for coord a == 4
-        (([0, 1, 2, 3], [2, 3, 4, 5]), 1.80),  # no weights for coord a == 4 or 5
-        (([2, 3, 4, 5], [0, 1, 2, 3]), 3.80),  # no weights for coord a == 0 or 1
+        ([0, 1, 2, 3], [1, 2, 3, 4], 2.5),  # no weights for coord a == 4
+        ([0, 1, 2, 3], [2, 3, 4, 5], 1.8),  # no weights for coord a == 4 or 5
+        ([2, 3, 4, 5], [0, 1, 2, 3], 3.8),  # no weights for coord a == 0 or 1
     ],
 )
 def test_weighted_operations_nonequal_coords(
-    nonequal_coords_for_weights_and_data: Iterable[Any],
-    expected_value: float,
+    coords_weights: Iterable[Any],
+    coords_data: Iterable[Any],
+    expected_value_at_weighted_quantile: float,
 ) -> None:
     """Check that weighted operations work with unequal coords.
 
@@ -674,12 +675,13 @@ def test_weighted_operations_nonequal_coords(
 
     Parameters
     ----------
-    nonequal_coords_for_weights_and_data : Iterable[Any]
-        The first list is the coords for the weights, the second for the data.
+    coords_weights : Iterable[Any]
+        The coords for the weights.
+    coords_data : Iterable[Any]
+        The coords for the data.
     expected : float
-        The expected result.
+        The expected value for the quantile of the weighted data.
     """
-    coords_weights, coords_data = nonequal_coords_for_weights_and_data
     da_weights = DataArray(
         [0.5, 1.0, 1.0, 2.0], dims=("a",), coords=dict(a=coords_weights)
     )
@@ -688,7 +690,9 @@ def test_weighted_operations_nonequal_coords(
 
     quantile = 0.5
     da_actual = da_data.weighted(da_weights).quantile(quantile, dim="a")
-    da_expected = DataArray([expected_value], coords={"quantile": [quantile]}).squeeze()
+    da_expected = DataArray(
+        [expected_value_at_weighted_quantile], coords={"quantile": [quantile]}
+    ).squeeze()
     assert_allclose(da_actual, da_expected)
 
     ds_data = da_data.to_dataset(name="data")

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -657,7 +657,7 @@ def test_weighted_quantile_3D(dim, q, add_nans, skipna):
 
 
 @pytest.mark.parametrize(
-    "nonequal_coords_for_weights_and_data, expected",
+    "nonequal_coords_for_weights_and_data, expected_value",
     [
         (([0, 1, 2, 3], [1, 2, 3, 4]), 2.50),  # no weights for coord a == 4
         (([0, 1, 2, 3], [2, 3, 4, 5]), 1.80),  # no weights for coord a == 4 or 5
@@ -666,7 +666,7 @@ def test_weighted_quantile_3D(dim, q, add_nans, skipna):
 )
 def test_weighted_operations_nonequal_coords(
     nonequal_coords_for_weights_and_data: Iterable[Any],
-    expected: float,
+    expected_value: float,
 ) -> None:
     """Check that weighted operations work with unequal coords.
 
@@ -680,22 +680,22 @@ def test_weighted_operations_nonequal_coords(
         The expected result.
     """
     coords_weights, coords_data = nonequal_coords_for_weights_and_data
-    weights = DataArray(
+    da_weights = DataArray(
         [0.5, 1.0, 1.0, 2.0], dims=("a",), coords=dict(a=coords_weights)
     )
-    data = DataArray([1, 2, 3, 4], dims=("a",), coords=dict(a=coords_data))
-    check_weighted_operations(data, weights, dim="a", skipna=None)
+    da_data = DataArray([1, 2, 3, 4], dims=("a",), coords=dict(a=coords_data))
+    check_weighted_operations(da_data, da_weights, dim="a", skipna=None)
 
     quantile = 0.5
-    actual = data.weighted(weights).quantile(quantile, dim="a")
-    expected = DataArray([expected], coords={"quantile": [quantile]}).squeeze()
-    assert_allclose(actual, expected)
+    da_actual = da_data.weighted(da_weights).quantile(quantile, dim="a")
+    da_expected = DataArray([expected_value], coords={"quantile": [quantile]}).squeeze()
+    assert_allclose(da_actual, da_expected)
 
-    data = data.to_dataset(name="data")
-    check_weighted_operations(data, weights, dim="a", skipna=None)
+    ds_data = da_data.to_dataset(name="data")  # type: xr.Dataset
+    check_weighted_operations(ds_data, da_weights, dim="a", skipna=None)
 
-    actual = data.weighted(weights).quantile(quantile, dim="a")
-    assert_allclose(actual, expected.to_dataset(name="data"))
+    ds_actual = ds_data.weighted(da_weights).quantile(quantile, dim="a")
+    assert_allclose(ds_actual, da_expected.to_dataset(name="data"))
 
 
 @pytest.mark.parametrize("shape_data", ((4,), (4, 4), (4, 4, 4)))

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -671,7 +671,6 @@ def test_weighted_operations_nonequal_coords(
 ) -> None:
     """Check that weighted operations work with unequal coords.
 
-    Expected values based on https://aakinshin.net/posts/weighted-quantiles/
 
     Parameters
     ----------


### PR DESCRIPTION
### Avoid use of random numbers in `test_weighted.test_weighted_operations_nonequal_coords`

- [x] Closes #6504 
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
