### PR TITLE
no longer install pydap for 'io' extras in py3.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ io =
     netCDF4
     h5netcdf
     scipy
-    pydap; python_version<"3.10" # see https://github.com/pydap/pydap/issues/267
+    pydap; python_version<"3.10" # see https://github.com/pydap/pydap/issues/268
     zarr
     fsspec
     cftime

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ io =
     netCDF4
     h5netcdf
     scipy
-    pydap
+    pydap; python_version<"3.10" # see https://github.com/pydap/pydap/issues/267
     zarr
     fsspec
     cftime


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #6960
- [ ] Tests added - tested manually

