### PR TITLE
enable pydap in tests again

### DIFF
--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -29,7 +29,7 @@ dependencies:
   - pip
   - pre-commit
   - pseudonetcdf
-  # - pydap  # https://github.com/pydap/pydap/pull/210
+  - pydap
   # - pynio  # Not available on Windows
   - pytest
   - pytest-cov

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - pooch
   - pre-commit
   - pseudonetcdf
-  # - pydap  # https://github.com/pydap/pydap/pull/210
+  - pydap
   # - pynio: not compatible with netCDF4>1.5.3; only tested in py37-bare-minimum
   - pytest
   - pytest-cov

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4000,7 +4000,13 @@ class TestPydapOnline(TestPydap):
         session = setup_session("XarrayTestUser", "Xarray2017")
         with mock.patch("pydap.client.open_url") as mock_func:
             xr.backends.PydapDataStore.open("http://test.url", session=session)
-        mock_func.assert_called_with("http://test.url", session=session)
+        mock_func.assert_called_with(
+            url="http://test.url",
+            application=None,
+            session=session,
+            output_grid=True,
+            timeout=120,
+        )
 
 
 @requires_scipy


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

#5844 excluded pydap from our tests - but the new version has been released in the meantime (on conda not on pypi, though, pydap/pydap#268) - so let's see if this still works.