### PR TITLE
Ensure encoding["source"] is available for a pathlib.Path object

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -66,7 +66,7 @@ Bug fixes
 - Avoid use of random numbers in `test_weighted.test_weighted_operations_nonequal_coords` (:issue:`6504`, :pull:`6961`).
   By `Luke Conibear <https://github.com/lukeconibear>`_.
 - ``Dataset.encoding['source']`` now exists when reading from a Path object (:issue:`5888`, :pull:`6974)
-  By `Thomas Coleman <https://github.com/ColemanTom`_.
+  By `Thomas Coleman <https://github.com/ColemanTom>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -65,7 +65,7 @@ Bug fixes
   By `András Gunyhó <https://github.com/mgunyho>`_.
 - Avoid use of random numbers in `test_weighted.test_weighted_operations_nonequal_coords` (:issue:`6504`, :pull:`6961`).
   By `Luke Conibear <https://github.com/lukeconibear>`_.
-- ``Dataset.encoding['source']`` now exists when reading from a Path object (:issue:`5888`, :pull:`6974)
+- ``Dataset.encoding['source']`` now exists when reading from a Path object (:issue:`5888`, :pull:`6974`)
   By `Thomas Coleman <https://github.com/ColemanTom>`_.
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -59,6 +59,8 @@ Bug fixes
   By `András Gunyhó <https://github.com/mgunyho>`_.
 - Avoid use of random numbers in `test_weighted.test_weighted_operations_nonequal_coords` (:issue:`6504`, :pull:`6961`).
   By `Luke Conibear <https://github.com/lukeconibear>`_.
+- :py:attr:`DataSet.encoding['source']` now exists when it was created from a Path object instead of only existing when a string path is provided (:issue:`5888`, :pull:`6974)
+  By `Thomas Coleman <https://github.com/ColemanTom`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -59,7 +59,7 @@ Bug fixes
   By `András Gunyhó <https://github.com/mgunyho>`_.
 - Avoid use of random numbers in `test_weighted.test_weighted_operations_nonequal_coords` (:issue:`6504`, :pull:`6961`).
   By `Luke Conibear <https://github.com/lukeconibear>`_.
-- :py:attr:`DataSet.encoding['source']` now exists when it was created from a Path object instead of only existing when a string path is provided (:issue:`5888`, :pull:`6974)
+- ``Dataset.encoding['source']`` now exists when reading from a Path object (:issue:`5888`, :pull:`6974)
   By `Thomas Coleman <https://github.com/ColemanTom`_.
 
 Documentation

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -359,7 +359,7 @@ def _dataset_from_backend_dataset(
     ds.set_close(backend_ds._close)
 
     # Ensure source filename always stored in dataset object
-    if "source" not in ds.encoding:
+    if "source" not in ds.encoding and isinstance(filename_or_obj, (str, os.PathLike)):
         ds.encoding["source"] = _normalize_path(filename_or_obj)
 
     return ds

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -358,9 +358,9 @@ def _dataset_from_backend_dataset(
 
     ds.set_close(backend_ds._close)
 
-    # Ensure source filename always stored in dataset object (GH issue #2550)
-    if "source" not in ds.encoding and isinstance(filename_or_obj, str):
-        ds.encoding["source"] = filename_or_obj
+    # Ensure source filename always stored in dataset object
+    if "source" not in ds.encoding:
+        ds.encoding["source"] = _normalize_path(filename_or_obj)
 
     return ds
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5062,6 +5062,17 @@ def test_source_encoding_always_present() -> None:
             assert ds.encoding["source"] == tmp
 
 
+@requires_scipy_or_netCDF4
+def test_source_encoding_always_present_with_pathlib() -> None:
+    # Test for GH issue #5888.
+    rnddata = np.random.randn(10)
+    original = Dataset({"foo": ("x", rnddata)})
+    with create_tmp_file() as tmp:
+        original.to_netcdf(tmp)
+        with open_dataset(Path(tmp)) as ds:
+            assert ds.encoding["source"] == tmp
+
+
 def _assert_no_dates_out_of_range_warning(record):
     undesired_message = "dates out of range"
     for warning in record:


### PR DESCRIPTION
Closes #5888. At the moment if you pass a `Path` object, the `source` will not be encoded in, only if a string is passed in. Given there is already a function to handle this, `_normalize_path`, I've simplified the logic to just run that over the `str/Path` to ensure it is always encoded.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #5888
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

I'm not sure if this needs including in the `whats-new.rst`. I'm happy to add it if desired.
