### PR TITLE
Remove unnecessary build dependencies, use build defaults, strict twine check

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -23,17 +23,17 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install setuptools setuptools-scm wheel twine check-manifest
+          python -m pip install build twine
 
       - name: Build tarball and wheels
         run: |
           git clean -xdf
           git restore -SW .
-          python -m build --sdist --wheel .
+          python -m build
 
       - name: Check built artifacts
         run: |
-          python -m twine check dist/*
+          python -m twine check --strict dist/*
           pwd
           if [ -f dist/xarray-0.0.0.tar.gz ]; then
             echo "❌ INVALID VERSION NUMBER"

--- a/.github/workflows/testpypi-release.yaml
+++ b/.github/workflows/testpypi-release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build setuptools setuptools-scm wheel twine check-manifest
+          python -m pip install build twine
           python -m pip install tomli tomli_w
 
       - name: Disable local versions
@@ -35,12 +35,11 @@ jobs:
       - name: Build tarball and wheels
         run: |
           git clean -xdf
-          python -m build --sdist --wheel .
+          python -m build
 
       - name: Check built artifacts
         run: |
-          python -m twine check dist/*
-          pwd
+          python -m twine check --strict dist/*
           if [ -f dist/xarray-0.0.0.tar.gz ]; then
             echo "❌ INVALID VERSION NUMBER"
             exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,8 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "wheel",
-    "setuptools_scm[toml]>=3.4",
-    "setuptools_scm_git_archive",
+    "setuptools-scm[toml]>=3.4",
+    "setuptools-scm-git-archive",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
This PR does a few related things:

- Remove `wheel` from `pyproject.toml`, since it is no longer needed/documented (e.g. [here](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html)), and rename other dependencies to their names in PyPI
- Remove `pip install` build dependencies already specified in `pyproject.toml`
- Remove [`check-manifest`](https://pypi.org/project/check-manifest/), since it isn't used
- The command `python -m build` has defaults to build both sdist and wheel outputs
- Use `twine check --strict` to return non-zero status on warnings