### PR TITLE
Improve CITATION.cff, specify license version in metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -76,8 +76,11 @@ authors:
   given-names: "Phillip J."
   orcid: "https://orcid.org/0000-0001-5971-4241"
 title: "xarray"
+abstract: "N-D labeled arrays and datasets in Python."
+license: Apache-2.0
 doi: 10.5281/zenodo.598201
-url: "https://github.com/pydata/xarray"
+url: "https://xarray.dev/"
+repository-code: "https://github.com/pydata/xarray"
 preferred-citation:
   type: article
   authors:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = xarray
 author = xarray Developers
 author_email = xarray@googlegroups.com
-license = Apache
+license = Apache-2.0
 description = N-D labeled arrays and datasets in Python
 long_description_content_type=text/x-rst
 long_description =


### PR DESCRIPTION
This PR improves CITATION.cff to add abstract, license and repository-code fields, and to modify url to https://xarray.dev/

Also, update the metadata licence from "Apache", to "[Apache-2.0](https://spdx.org/licenses/Apache-2.0.html)", which is the short identifier defined by SPDX.