### PR TITLE
Remove some warnings in tests

### DIFF
--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -587,7 +587,7 @@ def _encode_datetime_with_cftime(dates, units, calendar):
 
 
 def cast_to_int_if_safe(num):
-    int_num = np.array(num, dtype=np.int64)
+    int_num = np.asarray(num, dtype=np.int64)
     if (num == int_num).all():
         num = int_num
     return num

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -362,7 +362,7 @@ def infer_calendar_name(dates) -> CFCalendar:
     elif dates.dtype == np.dtype("O") and dates.size > 0:
         # Logic copied from core.common.contains_cftime_datetimes.
         if cftime is not None:
-            sample = dates.ravel()[0]
+            sample = np.asarray(dates).flat[0]
             if is_duck_dask_array(sample):
                 sample = sample.compute()
                 if isinstance(sample, np.ndarray):

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1076,7 +1076,9 @@ class DataWithCoords(AttrAccessMixin):
                 return cond.any(dim=(d for d in cond.dims if d != dim))
 
             def _dataset_indexer(dim: Hashable) -> DataArray:
-                cond_wdim = cond.drop(var for var in cond if dim not in cond[var].dims)
+                cond_wdim = cond.drop_vars(
+                    var for var in cond if dim not in cond[var].dims
+                )
                 keepany = cond_wdim.any(dim=(d for d in cond.dims.keys() if d != dim))
                 return keepany.to_array().any("variable")
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1758,7 +1758,7 @@ def _contains_cftime_datetimes(array) -> bool:
         return False
     else:
         if array.dtype == np.dtype("O") and array.size > 0:
-            sample = array.ravel()[0]
+            sample = np.asarray(array).flat[0]
             if is_duck_dask_array(sample):
                 sample = sample.compute()
                 if isinstance(sample, np.ndarray):

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -487,7 +487,7 @@ def coerce_pandas_values(objects: Iterable[CoercibleMapping]) -> list[DatasetLik
         else:
             variables = {}
             if isinstance(obj, PANDAS_TYPES):
-                obj = dict(obj.iteritems())
+                obj = dict(obj.items())
             for k, v in obj.items():
                 if isinstance(v, PANDAS_TYPES):
                     v = DataArray(v)

--- a/xarray/tests/test_array_api.py
+++ b/xarray/tests/test_array_api.py
@@ -1,4 +1,6 @@
-from typing import Tuple
+from __future__ import annotations
+
+import warnings
 
 import pytest
 
@@ -7,19 +9,21 @@ from xarray.testing import assert_equal
 
 np = pytest.importorskip("numpy", minversion="1.22")
 
-import numpy.array_api as xp  # isort:skip
-from numpy.array_api._array_object import Array  # isort:skip
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    import numpy.array_api as xp  # isort:skip
+    from numpy.array_api._array_object import Array  # isort:skip
 
 
 @pytest.fixture
-def arrays() -> Tuple[xr.DataArray, xr.DataArray]:
+def arrays() -> tuple[xr.DataArray, xr.DataArray]:
     np_arr = xr.DataArray(np.ones((2, 3)), dims=("x", "y"), coords={"x": [10, 20]})
     xp_arr = xr.DataArray(xp.ones((2, 3)), dims=("x", "y"), coords={"x": [10, 20]})
     assert isinstance(xp_arr.data, Array)
     return np_arr, xp_arr
 
 
-def test_arithmetic(arrays) -> None:
+def test_arithmetic(arrays: tuple[xr.DataArray, xr.DataArray]) -> None:
     np_arr, xp_arr = arrays
     expected = np_arr + 7
     actual = xp_arr + 7
@@ -27,7 +31,7 @@ def test_arithmetic(arrays) -> None:
     assert_equal(actual, expected)
 
 
-def test_aggregation(arrays) -> None:
+def test_aggregation(arrays: tuple[xr.DataArray, xr.DataArray]) -> None:
     np_arr, xp_arr = arrays
     expected = np_arr.sum(skipna=False)
     actual = xp_arr.sum(skipna=False)
@@ -35,7 +39,7 @@ def test_aggregation(arrays) -> None:
     assert_equal(actual, expected)
 
 
-def test_indexing(arrays) -> None:
+def test_indexing(arrays: tuple[xr.DataArray, xr.DataArray]) -> None:
     np_arr, xp_arr = arrays
     expected = np_arr[:, 0]
     actual = xp_arr[:, 0]
@@ -43,13 +47,13 @@ def test_indexing(arrays) -> None:
     assert_equal(actual, expected)
 
 
-def test_properties(arrays) -> None:
+def test_properties(arrays: tuple[xr.DataArray, xr.DataArray]) -> None:
     np_arr, xp_arr = arrays
     assert np_arr.nbytes == np_arr.data.nbytes
     assert xp_arr.nbytes == np_arr.data.nbytes
 
 
-def test_reorganizing_operation(arrays) -> None:
+def test_reorganizing_operation(arrays: tuple[xr.DataArray, xr.DataArray]) -> None:
     np_arr, xp_arr = arrays
     expected = np_arr.transpose()
     actual = xp_arr.transpose()

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -286,9 +286,9 @@ def assert_dask_array(da, dask):
 
 
 @arm_xfail
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:All-NaN .* encountered:RuntimeWarning")
 @pytest.mark.parametrize("dask", [False, True] if has_dask else [False])
-def test_datetime_mean(dask):
+def test_datetime_mean(dask: bool) -> None:
     # Note: only testing numpy, as dask is broken upstream
     da = DataArray(
         np.array(["2010-01-01", "NaT", "2010-01-03", "NaT", "NaT"], dtype="M8[ns]"),

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -276,7 +276,9 @@ def test_weighted_quantile_nan(skipna):
         pytest.param(
             [np.nan, np.nan, np.nan],
             id="allnan",
-            marks=pytest.mark.filterwarnings("ignore:All-NaN slice encountered"),
+            marks=pytest.mark.filterwarnings(
+                "ignore:All-NaN slice encountered:RuntimeWarning"
+            ),
         ),
     ),
 )


### PR DESCRIPTION
This PR tries to get rid of several warnings in the tests.

I could not get rid of `RuntimeWarning: All-NaN slice encountered` for tests with dask.
Does anyone know why is that? pytest.mark.filterwarnings does not seem to capture them...