### PR TITLE
Simplify datetime64 `dt.calendar` tests

### DIFF
--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -432,7 +432,9 @@ def test_calendar_datetime64_2d() -> None:
 def test_calendar_datetime64_3d_dask() -> None:
     import dask.array as da
 
-    data = xr.DataArray(da.zeros((4, 5, 6), dtype="datetime64[ns]"), dims=("x", "y", "z"))
+    data = xr.DataArray(
+        da.zeros((4, 5, 6), dtype="datetime64[ns]"), dims=("x", "y", "z")
+    )
     with raise_if_dask_computes():
         assert data.dt.calendar == "proleptic_gregorian"
 

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -423,23 +423,16 @@ def test_calendar_cftime(data) -> None:
 
 
 @requires_cftime
-def test_calendar_cftime_2D(data) -> None:
-    # 2D np datetime:
-    data = xr.DataArray(
-        np.random.randint(1, 1000000, size=(4, 5)).astype("<M8[h]"), dims=("x", "y")
-    )
+def test_calendar_datetime64_2d() -> None:
+    data = xr.DataArray(np.zeros((4, 5), dtype="datetime64[ns]"), dims=("x", "y"))
     assert data.dt.calendar == "proleptic_gregorian"
 
 
 @requires_dask
-def test_calendar_dask() -> None:
+def test_calendar_datetime64_3d_dask() -> None:
     import dask.array as da
 
-    # 3D lazy dask - np
-    data = xr.DataArray(
-        da.random.randint(1, 1000000 + 1, size=(4, 5, 6)).astype("<M8[h]"),
-        dims=("x", "y", "z"),
-    )
+    data = xr.DataArray(da.zeros((4, 5, 6), dtype="datetime64[ns]"), dims=("x", "y", "z"))
     with raise_if_dask_computes():
         assert data.dt.calendar == "proleptic_gregorian"
 


### PR DESCRIPTION
This PR simplifies the tests for the calendar attribute on the `dt` accessor when using a `datetime64[ns]`-dtype DataArray.  Instead of creating random-valued datetime arrays, we can use arrays of zeros (i.e. 1970-01-01), since the values of the datetimes should not be relevant to these tests (only their type matters).

I suspect this should address #6906, because it eliminates the need to convert to `datetime64[ns]`, though I still feel as though there is a more fundamental pandas issue lurking there.
