### PR TITLE
Add sphinx-codeautolink extension to docs build

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -36,6 +36,7 @@ dependencies:
   - sphinx!=4.4.0
   - zarr>=2.4
   - pip:
+      - sphinx-codeautolink
       - sphinxext-rediraffe
       - sphinxext-opengraph
       # relative to this file. Needs to be editable to be accepted.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -88,6 +88,7 @@ extensions = [
     "IPython.sphinxext.ipython_console_highlighting",
     "nbsphinx",
     "sphinx_autosummary_accessors",
+    "sphinx_codeautolink",
     "sphinx.ext.linkcode",
     "sphinxext.opengraph",
     "sphinx_copybutton",


### PR DESCRIPTION
I think that sphinx-codeautolink is different from `sphinx.ext.linkcode`...

- [ ] Closes #7010
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
