### PR TITLE
Writing dimensionless variables to NetCDF

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -70,6 +70,9 @@ Bug fixes
   By `Deepak Cherian <https://github.com/dcherian>`_.
 - ``Dataset.encoding['source']`` now exists when reading from a Path object (:issue:`5888`, :pull:`6974`)
   By `Thomas Coleman <https://github.com/ColemanTom>`_.
+- Allow writing NetCDF files including only dimensionless variables using the distributed or multiprocessing scheduler
+  (:issue:`7013`, :pull:`7040`).
+  By `Francesco Nattino <https://github.com/fnattino>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1188,7 +1188,7 @@ def to_netcdf(
 
     # handle scheduler specific logic
     scheduler = _get_scheduler()
-    have_chunks = any(v.chunks for v in dataset.variables.values())
+    have_chunks = any(v.chunks is not None for v in dataset.variables.values())
 
     autoclose = have_chunks and scheduler in ["distributed", "multiprocessing"]
     if autoclose and engine == "scipy":

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -119,6 +119,21 @@ def test_dask_distributed_netcdf_roundtrip(
                 assert_allclose(original, computed)
 
 
+@requires_netCDF4
+def test_dask_distributed_write_netcdf_with_dimensionless_variables(
+    loop, tmp_netcdf_filename
+):
+
+    with cluster() as (s, [a, b]):
+        with Client(s["address"], loop=loop):
+
+            original = xr.Dataset({"x": da.zeros(())})
+            original.to_netcdf(tmp_netcdf_filename)
+
+            with xr.open_dataset(tmp_netcdf_filename) as actual:
+                assert actual.x.shape == ()
+
+
 @requires_cftime
 @requires_netCDF4
 def test_open_mfdataset_can_open_files_with_cftime_index(tmp_path):


### PR DESCRIPTION
@dcherian Writing NetCDFs containing only dimensionless variables only failed with the distributed or multiprocessing schedulers. I have thus thought a unit test would fit better in `test_distributed` rather than in `test_backends` - but let me know if you think otherwise! 

- [x] Closes #7013 
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
