### PR TITLE
Self should be Any

### DIFF
--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     #         from typing_extensions import Self
     # except ImportError:
     #     Self: Any = None
-    Self = TypeVar("Self")
+    Self: Any = None
 
     Ellipsis = ellipsis
 


### PR DESCRIPTION
Self should be as permissive as possible until it works properly.

Using `Any` instead of `TypeVar` avoids errors like these:
`C:\users\j.w\documents\github\xarray\xarray\plot\facetgrid.py:462: error: Incompatible return value type (got "FacetGrid", expected "Self")`

xref: #6923