### PR TITLE
Add helper for setting axis limits in facetgrid

### DIFF
--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -492,14 +492,15 @@ class FacetGrid:
         )
         for k in ("x", "y", "z"):
             # Find the plot with the largest xlim values:
+            l0, l1 = (np.inf, -np.inf)
             for ax in self.axes.flat:
                 get_lim: None | Callable[[], tuple[float, float]] = getattr(
                     ax, f"get_{k}lim", None
                 )
                 if get_lim:
-                    l0, l1 = get_lim()
-                    l0_old, l1_old = lims_largest[k]
-                    lims_largest[k] = (min(l0, l0_old), max(l1, l1_old))
+                    l0_new, l1_new = get_lim()
+                    l0, l1 = (min(l0, l0_new), max(l1, l1_new))
+            lims_largest[k] = (l0, l1)
 
         return lims_largest
 

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -492,7 +492,7 @@ class FacetGrid:
         )
         for k in ("x", "y", "z"):
             # Find the plot with the largest xlim values:
-            l0, l1 = (np.inf, -np.inf)
+            l0, l1 = lims_largest[k]
             for ax in self.axes.flat:
                 get_lim: None | Callable[[], tuple[float, float]] = getattr(
                     ax, f"get_{k}lim", None

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -471,7 +471,7 @@ class FacetGrid:
         # self._adjust_fig_for_guide(self.quiverkey.text)
         return self
 
-    def _get_largest_lims(self) -> dict[str, tuple[int | float, int | float]]:
+    def _get_largest_lims(self) -> dict[str, tuple[float, float]]:
         """
         Get largest limits in the facetgrid.
 
@@ -506,9 +506,9 @@ class FacetGrid:
 
     def _set_lims(
         self,
-        x: None | tuple[int | float, int | float] = None,
-        y: None | tuple[int | float, int | float] = None,
-        z: None | tuple[int | float, int | float] = None,
+        x: None | tuple[float, float] = None,
+        y: None | tuple[float, float] = None,
+        z: None | tuple[float, float] = None,
     ) -> None:
         """
         Set the same limits for all the subplots in the facetgrid.

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -483,9 +483,9 @@ class FacetGrid:
         Examples
         --------
         >>> ds = xr.tutorial.scatter_example_dataset(seed=42)
-        >>> fg = ds.plot.scatter("A", "B", z="z", hue="y", row="x", col="w")
+        >>> fg = ds.plot.scatter("A", "B", hue="y", row="x", col="w")
         >>> round(fg._get_largest_lims()["x"][0], 3)
-        -0.314
+        -0.334
         """
         lims_largest: dict[str, tuple[float, float]] = dict(
             x=(np.inf, -np.inf), y=(np.inf, -np.inf), z=(np.inf, -np.inf)
@@ -526,8 +526,8 @@ class FacetGrid:
         >>> ds = xr.tutorial.scatter_example_dataset(seed=42)
         >>> fg = ds.plot.scatter("A", "B", z="z", hue="y", row="x", col="w")
         >>> fg._set_lims(x=(-0.3, 0.3), y=(0, 2), z=(0, 4))
-        >>> fg.axes[0, 0].get_xlim(), fg.axes[0, 0].get_ylim(), fg.axes[0, 0].get_zlim()
-        ((-0.3, 0.3), (0.0, 2.0), (0.0, 4.0))
+        >>> fg.axes[0, 0].get_xlim(), fg.axes[0, 0].get_ylim()
+        ((-0.3, 0.3), (0.0, 2.0))
         """
         lims_largest = self._get_largest_lims()
 

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import itertools
 import warnings
-from typing import Iterable
+from typing import Callable, Iterable
 
 import numpy as np
 
@@ -470,6 +470,73 @@ class FacetGrid:
         # https://github.com/matplotlib/matplotlib/issues/18530
         # self._adjust_fig_for_guide(self.quiverkey.text)
         return self
+
+    def _get_largest_lims(self) -> dict[str, tuple[int | float, int | float]]:
+        """
+        Get largest limits in the facetgrid.
+
+        Returns
+        -------
+        lims_largest : dict[str, tuple[int | float, int | float]]
+            Dictionary with the largest limits along each axis.
+
+        Examples
+        --------
+        >>> ds = xr.tutorial.scatter_example_dataset(seed=42)
+        >>> fg = ds.plot.scatter("A", "B", z="z", hue="y", row="x", col="w")
+        >>> round(fg._get_largest_lims()["x"][0], 3)
+        -0.314
+        """
+        lims_largest: dict[str, tuple[float, float]] = dict(
+            x=(np.inf, -np.inf), y=(np.inf, -np.inf), z=(np.inf, -np.inf)
+        )
+        for k in ("x", "y", "z"):
+            # Find the plot with the largest xlim values:
+            for ax in self.axes.flat:
+                get_lim: None | Callable[[], tuple[float, float]] = getattr(
+                    ax, f"get_{k}lim", None
+                )
+                if get_lim:
+                    l0, l1 = get_lim()
+                    l0_old, l1_old = lims_largest[k]
+                    lims_largest[k] = (min(l0, l0_old), max(l1, l1_old))
+
+        return lims_largest
+
+    def _set_lims(
+        self,
+        x: None | tuple[int | float, int | float] = None,
+        y: None | tuple[int | float, int | float] = None,
+        z: None | tuple[int | float, int | float] = None,
+    ) -> None:
+        """
+        Set the same limits for all the subplots in the facetgrid.
+
+        Parameters
+        ----------
+        x : None | tuple[int | float, int | float]
+            x axis limits.
+        y : None | tuple[int | float, int | float]
+            y axis limits.
+        z : None | tuple[int | float, int | float]
+            z axis limits.
+
+        Examples
+        --------
+        >>> ds = xr.tutorial.scatter_example_dataset(seed=42)
+        >>> fg = ds.plot.scatter("A", "B", z="z", hue="y", row="x", col="w")
+        >>> fg._set_lims(x=(-0.3, 0.3), y=(0, 2), z=(0, 4))
+        >>> fg.axes[0, 0].get_xlim(), fg.axes[0, 0].get_ylim(), fg.axes[0, 0].get_zlim()
+        ((-0.3, 0.3), (0.0, 2.0), (0.0, 4.0))
+        """
+        lims_largest = self._get_largest_lims()
+
+        # Set limits:
+        for ax in self.axes.flat:
+            for (k, v), vv in zip(lims_largest.items(), (x, y, z)):
+                set_lim = getattr(ax, f"set_{k}lim", None)
+                if set_lim:
+                    set_lim(v if vv is None else vv)
 
     def set_axis_labels(self, *axlabels):
         """Set axis labels on the left column and bottom row of the grid."""

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -524,7 +524,7 @@ class FacetGrid:
         Examples
         --------
         >>> ds = xr.tutorial.scatter_example_dataset(seed=42)
-        >>> fg = ds.plot.scatter("A", "B", z="z", hue="y", row="x", col="w")
+        >>> fg = ds.plot.scatter("A", "B", hue="y", row="x", col="w")
         >>> fg._set_lims(x=(-0.3, 0.3), y=(0, 2), z=(0, 4))
         >>> fg.axes[0, 0].get_xlim(), fg.axes[0, 0].get_ylim()
         ((-0.3, 0.3), (0.0, 2.0))


### PR DESCRIPTION
This PR adds a helper method that sets the same axis limits for all plots in a facetgrid.
Helpful when
* wanting specific limits for all plots.
* you want to make sure all data is visible by simply using the method without any inputs. Which is not certain if sharex/sharey isn't used, relevant when using 3d plots as they don't work.

Split up from #6778.