### PR TITLE
Set sharex/sharey to False if using 3d plots

### DIFF
--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -674,6 +674,10 @@ def _easy_facetgrid(
         size = 3
     elif figsize is not None:
         raise ValueError("cannot provide both `figsize` and `size` arguments")
+    if kwargs.get("z") is not None:
+        # 3d plots doesn't support sharex, sharey, reset to mpl defaults:
+        sharex = False
+        sharey = False
 
     g = FacetGrid(
         data=data,


### PR DESCRIPTION
Matplotlibs 3d plots appears to not support sharex/sharey. So reset to default values instead. This improves the look of the plot as axis values aren't deleted. 

Example:
```python
import matplotlib.pyplot as plt

fig = plt.figure()
subplot_kws = {"projection":"3d"}
ax1 = fig.add_subplot(211, **subplot_kws)
ax1.plot([0, 1, 2], [5,6,6])
ax2 = fig.add_subplot(212, sharex = ax1, **subplot_kws)
ax2.plot([0, 1, 2], [5,4,2])  # x axis is not linked.
```
Split up from #6778.