### PR TITLE
More informative error for non-existent zarr store

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -73,7 +73,8 @@ Bug fixes
 
 Documentation
 ~~~~~~~~~~~~~
-
+- Raise a more informative error when trying to open a non-existent zarr store. (:issue:`6484`, :pull:`7060`)
+  By `Sam Levang <https://github.com/slevang>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import sys
 import tempfile
+import uuid
 import warnings
 from contextlib import ExitStack
 from io import BytesIO
@@ -1733,6 +1734,10 @@ class ZarrBase(CFEncodedBase):
             ):
                 with xr.open_zarr(store) as ds:
                     assert_identical(ds, expected)
+
+    def test_non_existent_store(self):
+        with pytest.raises(FileNotFoundError, match=r"No such file or directory:"):
+            xr.open_zarr(f"{uuid.uuid4()}")
 
     def test_with_chunkstore(self):
         expected = create_test_data()


### PR DESCRIPTION
- [x] Closes #6484
- [x] Tests added

I've often been tripped up by the stack trace noted in #6484. This PR changes two things:

1. Handles the zarr `GroupNotFoundError` error with a more informative `FileNotFoundError`, displaying the path where we didn't find a zarr store.
2. Moves the consolidated metadata warning to after the step of successfully opening the zarr with non-consolidated metadata. This way the warning isn't shown if we are actually trying to open a non-existent zarr store, in which case we only get the error above and no warning.