### PR TITLE
Better dtype preservation for rolling mean on dask array

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -70,6 +70,8 @@ Bug fixes
   By `Deepak Cherian <https://github.com/dcherian>`_.
 - ``Dataset.encoding['source']`` now exists when reading from a Path object (:issue:`5888`, :pull:`6974`)
   By `Thomas Coleman <https://github.com/ColemanTom>`_.
+- Better dtype consistency for ``rolling.mean()``. (:issue:`7062`, :pull:`7063`)
+  By `Sam Levang <https://github.com/slevang>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -168,7 +168,7 @@ class Rolling(Generic[T_Xarray]):
     def _mean(self, keep_attrs, **kwargs):
         result = self.sum(keep_attrs=False, **kwargs) / self.count(
             keep_attrs=False
-        ).astype(self.obj.dtype)
+        ).astype(self.obj.dtype, copy=False)
         if keep_attrs:
             result.attrs = self.obj.attrs
         return result

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -166,7 +166,9 @@ class Rolling(Generic[T_Xarray]):
         return method
 
     def _mean(self, keep_attrs, **kwargs):
-        result = self.sum(keep_attrs=False, **kwargs) / self.count(keep_attrs=False)
+        result = self.sum(keep_attrs=False, **kwargs) / self.count(
+            keep_attrs=False
+        ).astype(self.obj.dtype)
         if keep_attrs:
             result.attrs = self.obj.attrs
         return result

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -371,6 +371,16 @@ class TestDataArrayRolling:
         assert result.attrs == {}
         assert result.name == "name"
 
+    @requires_dask
+    @pytest.mark.parametrize("dtype", ["int", "float32", "float64"])
+    def test_rolling_dask_dtype(self, dtype) -> None:
+        data = DataArray(
+            np.array([1, 2, 3], dtype=dtype), dims="x", coords={"x": [1, 2, 3]}
+        )
+        unchunked_result = data.rolling(x=3, min_periods=1).mean()
+        chunked_result = data.chunk({"x": 1}).rolling(x=3, min_periods=1).mean()
+        assert chunked_result.dtype == unchunked_result.dtype
+
 
 @requires_numbagg
 class TestDataArrayRollingExp:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #7062
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

This just tests to make sure we at least get the same dtype whether we have a numpy or dask array.