### PR TITLE
DOC: improve name and intro to groupby

### DIFF
--- a/doc/user-guide/groupby.rst
+++ b/doc/user-guide/groupby.rst
@@ -1,10 +1,12 @@
 .. _groupby:
 
-GroupBy: split-apply-combine
-----------------------------
+GroupBy: Group and Bin Data
+---------------------------
 
-Xarray supports `"group by"`__ operations with the same API as pandas to
-implement the `split-apply-combine`__ strategy:
+Often we want to bin or group data, produce statistics (mean, variance) on
+the groups, and then return a reduced data set. To do this, Xarray supports
+`"group by"`__ operations with the same API as pandas to implement the
+`split-apply-combine`__ strategy:
 
 __ https://pandas.pydata.org/pandas-docs/stable/groupby.html
 __ https://www.jstatsoft.org/v40/i01/paper


### PR DESCRIPTION
This is a very small change to the group-by title and an intro sentence.   I think sometimes the user docs assume knowledge of pandas GroupBy, whereas I think a decent chunk of xarray users don't have background with pandas.  The rest of the tutorial is a really nice overview, but if you are scanning docs, its nice to have the end goal explained.   