### PR TITLE
add dictionary-based integer assignment example (GH7043)

### DIFF
--- a/doc/user-guide/indexing.rst
+++ b/doc/user-guide/indexing.rst
@@ -528,6 +528,10 @@ __ https://numpy.org/doc/stable/user/basics.indexing.html#assigning-values-to-in
     # DO NOT do this
     da.isel(space=0) = 0
 
+  Instead, values can be assigned using dictionary-based indexing::
+
+    da[dict(space=0)] = 0
+
   Assigning values with the chained indexing using ``.sel`` or ``.isel`` fails silently.
 
   .. ipython:: python


### PR DESCRIPTION
I have attempted to add an example of dictionary-based assignment to the documentation following the discussion with @mathause and @dcherian. Any further clarifications are appreciated.