### PR TITLE
Fixed readme to have correct link for contributing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ notebook](https://mybinder.org/v2/gh/pydata/xarray/main?urlpath=lab/tree/doc/exa
 
 You can find information about contributing to xarray at our
 [Contributing
-page](https://docs.xarray.dev/en/latest/contributing.html#).
+page](https://docs.xarray.dev/en/stable/contributing.html).
 
 ## Get in touch
 


### PR DESCRIPTION
I updated the dead link under the contributing tab.

This is my first time contributing to any open source project, so if I have done anything wrong please let me know.

