### PR TITLE
Added test_deepcopy_nested_attrs() (#2835).

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -85,7 +85,8 @@ Documentation
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-
+- Added test for DataArray attrs deepcopy recursion/nested attrs (:issue:`2835`).
+  By `Paul hockett <https://github.com/phockett>`_.
 
 .. _whats-new.2022.06.0:
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6458,17 +6458,20 @@ def test_delete_coords() -> None:
     assert set(a1.coords.keys()) == {"x"}
 
 
+@pytest.mark.xfail
 def test_deepcopy_nested_attrs() -> None:
     """Check attrs deep copy, see :issue:`2835`"""
-    da1 = xr.DataArray(np.random.randn(2, 3), dims=("x", "y"), coords={"x": [10, 20]})
+    da1 = xr.DataArray([[1, 2], [3, 4]], dims=("x", "y"), coords={"x": [10, 20]})
     da1.attrs["flat"] = "0"
-    da1.attrs["nested"] = {"level1": "1"}
+    da1.attrs["nested"] = {"level1a": "1", "level1b": "1"}
 
     da2 = da1.copy(deep=True)
 
-    da2.attrs["flat"] = "2"  # Test base level
-    # data2.attrs['nested']['level1'] = '2'  # Fails - overwrites data
-    da2.attrs["nested"].update({"level1": "2"})  # Fails in 2022.3.0 - overwrites da1.
+    da2.attrs["new"] = "2"
+    da2.attrs.update({"new2": "2"})
+    da2.attrs["flat"] = "2"
+    da2.attrs["nested"]["level1a"] = "2"
+    da2.attrs["nested"].update({"level1b": "2"})
 
     # Coarse test
     assert not da1.identical(da2)
@@ -6476,15 +6479,8 @@ def test_deepcopy_nested_attrs() -> None:
     # Check attrs levels
     assert da1.attrs["flat"] != da2.attrs["flat"]
     assert da1.attrs["nested"] != da2.attrs["nested"]
-
-    # # Explicit deepcopy of attrs - this should alway work and can be used as an additional test case
-    # da3 = da1.copy(deep=True)
-    # da3.attrs = deepcopy(da1.attrs)
-    # da3.attrs['flat']='3'  # OK
-    # da3.attrs['nested'].update({'level1':'3'})
-    # assert not da1.identical(da3)
-    # assert da1.attrs['flat'] != da3.attrs['flat']
-    # assert da1.attrs['nested'] != da3.attrs['nested']
+    assert "new" not in da1.attrs
+    assert "new2" not in da1.attrs
 
 
 def test_deepcopy_obj_array() -> None:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests for #2835 in case of nested DataArray attrs.
- [x] Tests added
- [x] Documented in `whats-new.rst` ('internals' section).

