### PR TITLE
Exclude typechecking stuff from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,0 @@
-[run]
-omit =
-    */xarray/tests/*
-    */xarray/core/dask_array_compat.py
-    */xarray/core/npcompat.py
-    */xarray/core/pdcompat.py
-    */xarray/core/pycompat.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,22 @@
 [build-system]
-requires = [
-    "setuptools>=42",
-    "setuptools-scm[toml]>=3.4",
-    "setuptools-scm-git-archive",
-]
 build-backend = "setuptools.build_meta"
+requires = [
+  "setuptools>=42",
+  "setuptools-scm[toml]>=3.4",
+  "setuptools-scm-git-archive",
+]
 
 [tool.setuptools_scm]
 fallback_version = "999"
+
+[tool.coverage.run]
+exclude_lines = ["pragma: no cover", "if TYPE_CHECKING"]
+omit = [
+  "*/xarray/tests/*",
+  "*/xarray/core/dask_array_compat.py",
+  "*/xarray/core/npcompat.py",
+  "*/xarray/core/pdcompat.py",
+  "*/xarray/core/pycompat.py",
+  "*/xarray/core/types.py",
+]
+source = ["xarray"]


### PR DESCRIPTION
tiny PR that disables coverage on `types.py` and all typing-only imports a.la. `if TYPE_CHECKING: ...`