### PR TITLE
Fix typing of backends

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -43,6 +43,8 @@ if TYPE_CHECKING:
         from dask.delayed import Delayed
     except ImportError:
         Delayed = None  # type: ignore
+    from io import BufferedIOBase
+
     from ..core.types import (
         CombineAttrsOptions,
         CompatOptions,
@@ -366,7 +368,7 @@ def _dataset_from_backend_dataset(
 
 
 def open_dataset(
-    filename_or_obj: str | os.PathLike | AbstractDataStore,
+    filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
     *,
     engine: T_Engine = None,
     chunks: T_Chunks = None,
@@ -550,7 +552,7 @@ def open_dataset(
 
 
 def open_dataarray(
-    filename_or_obj: str | os.PathLike,
+    filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
     *,
     engine: T_Engine = None,
     chunks: T_Chunks = None,

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -4,7 +4,7 @@ import logging
 import os
 import time
 import traceback
-from typing import Any
+from typing import TYPE_CHECKING, Any, ClassVar, Iterable
 
 import numpy as np
 
@@ -12,6 +12,9 @@ from ..conventions import cf_encoder
 from ..core import indexing
 from ..core.pycompat import is_duck_dask_array
 from ..core.utils import FrozenDict, NdimSizeLenMixin, is_remote_uri
+
+if TYPE_CHECKING:
+    from io import BufferedIOBase
 
 # Create a logger object, but don't add any handlers. Leave that to user code.
 logger = logging.getLogger(__name__)
@@ -371,13 +374,15 @@ class BackendEntrypoint:
       method is not mandatory.
     """
 
+    available: ClassVar[bool] = True
+
     open_dataset_parameters: tuple | None = None
     """list of ``open_dataset`` method parameters"""
 
     def open_dataset(
         self,
-        filename_or_obj: str | os.PathLike,
-        drop_variables: tuple[str] | None = None,
+        filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
+        drop_variables: str | Iterable[str] | None = None,
         **kwargs: Any,
     ):
         """
@@ -386,7 +391,10 @@ class BackendEntrypoint:
 
         raise NotImplementedError
 
-    def guess_can_open(self, filename_or_obj: str | os.PathLike):
+    def guess_can_open(
+        self,
+        filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
+    ):
         """
         Backend open_dataset method used by Xarray in :py:func:`~xarray.open_dataset`.
         """

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -6,8 +6,15 @@ import itertools
 import sys
 import warnings
 from importlib.metadata import entry_points
+from typing import TYPE_CHECKING, Any
 
 from .common import BACKEND_ENTRYPOINTS, BackendEntrypoint
+
+if TYPE_CHECKING:
+    import os
+    from io import BufferedIOBase
+
+    from .common import AbstractDataStore
 
 STANDARD_BACKENDS_ORDER = ["netcdf4", "h5netcdf", "scipy"]
 
@@ -83,7 +90,7 @@ def sort_backends(backend_entrypoints):
     return ordered_backends_entrypoints
 
 
-def build_engines(entrypoints):
+def build_engines(entrypoints) -> dict[str, BackendEntrypoint]:
     backend_entrypoints = {}
     for backend_name, backend in BACKEND_ENTRYPOINTS.items():
         if backend.available:
@@ -97,7 +104,7 @@ def build_engines(entrypoints):
 
 
 @functools.lru_cache(maxsize=1)
-def list_engines():
+def list_engines() -> dict[str, BackendEntrypoint]:
     # New selection mechanism introduced with Python 3.10. See GH6514.
     if sys.version_info >= (3, 10):
         entrypoints = entry_points(group="xarray.backends")
@@ -106,7 +113,9 @@ def list_engines():
     return build_engines(entrypoints)
 
 
-def guess_engine(store_spec):
+def guess_engine(
+    store_spec: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
+):
     engines = list_engines()
 
     for engine, backend in engines.items():
@@ -155,7 +164,7 @@ def guess_engine(store_spec):
     raise ValueError(error_msg)
 
 
-def get_backend(engine):
+def get_backend(engine: str | type[BackendEntrypoint]) -> BackendEntrypoint:
     """Select open_dataset method based on current engine."""
     if isinstance(engine, str):
         engines = list_engines()

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2167,7 +2167,7 @@ class Dataset(
         token: str | None = None,
         lock: bool = False,
         inline_array: bool = False,
-        **chunks_kwargs: Any,
+        **chunks_kwargs: None | int | str | tuple[int, ...],
     ) -> T_Dataset:
         """Coerce all arrays in this dataset into dask arrays with the given
         chunks.

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -203,7 +203,7 @@ def assert_allclose(a, b, check_default_indexes=True, **kwargs):
     xarray.testing._assert_internal_invariants(b, check_default_indexes)
 
 
-def create_test_data(seed=None, add_attrs=True):
+def create_test_data(seed: int | None = None, add_attrs: bool = True) -> Dataset:
     rs = np.random.RandomState(seed)
     _vars = {
         "var1": ["dim1", "dim2"],

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -974,9 +974,9 @@ class TestDataset:
 
     def test_equals_failures(self) -> None:
         data = create_test_data()
-        assert not data.equals("foo")
-        assert not data.identical(123)
-        assert not data.broadcast_equals({1: 2})
+        assert not data.equals("foo")  # type: ignore[arg-type]
+        assert not data.identical(123)  # type: ignore[arg-type]
+        assert not data.broadcast_equals({1: 2})  # type: ignore[arg-type]
 
     def test_broadcast_equals(self) -> None:
         data1 = Dataset(coords={"x": 0})
@@ -1020,7 +1020,7 @@ class TestDataset:
         assert reblocked.chunks == expected_chunks
 
         # test kwargs form of chunks
-        assert data.chunk(**expected_chunks).chunks == expected_chunks
+        assert data.chunk(expected_chunks).chunks == expected_chunks
 
         def get_dask_names(ds):
             return {k: v.data.name for k, v in ds.items()}
@@ -1079,8 +1079,11 @@ class TestDataset:
 
     def test_isel(self) -> None:
         data = create_test_data()
-        slicers = {"dim1": slice(None, None, 2), "dim2": slice(0, 2)}
-        ret = data.isel(**slicers)
+        slicers: dict[Hashable, slice] = {
+            "dim1": slice(None, None, 2),
+            "dim2": slice(0, 2),
+        }
+        ret = data.isel(slicers)
 
         # Verify that only the specified dimension was altered
         assert list(data.dims) == list(ret.dims)
@@ -1308,10 +1311,10 @@ class TestDataset:
             np.arange(1, 4), dims=["dim2"], coords={"dim2": np.random.randn(3)}
         )
         with pytest.raises(IndexError, match=r"dimension coordinate 'dim2'"):
-            actual = data.isel(dim2=indexing_da)
+            data.isel(dim2=indexing_da)
         # Also the case for DataArray
         with pytest.raises(IndexError, match=r"dimension coordinate 'dim2'"):
-            actual = data["var2"].isel(dim2=indexing_da)
+            data["var2"].isel(dim2=indexing_da)
         with pytest.raises(IndexError, match=r"dimension coordinate 'dim2'"):
             data["dim2"].isel(dim2=indexing_da)
 
@@ -1399,7 +1402,7 @@ class TestDataset:
             "dim2": slice(0, 0.5),
             "dim3": slice("a", "c"),
         }
-        assert_equal(data.isel(**int_slicers), data.sel(**loc_slicers))
+        assert_equal(data.isel(int_slicers), data.sel(loc_slicers))
         data["time"] = ("time", pd.date_range("2000-01-01", periods=20))
         assert_equal(data.isel(time=0), data.sel(time="2000-01-01"))
         assert_equal(
@@ -1653,7 +1656,7 @@ class TestDataset:
         assert_equal(expected, actual)
 
         with pytest.raises(TypeError, match=r"either dict-like or a single int"):
-            data.head([3])
+            data.head([3])  # type: ignore[arg-type]
         with pytest.raises(TypeError, match=r"expected integer type"):
             data.head(dim2=3.1)
         with pytest.raises(ValueError, match=r"expected positive int"):
@@ -1679,7 +1682,7 @@ class TestDataset:
         assert_equal(expected, actual)
 
         with pytest.raises(TypeError, match=r"either dict-like or a single int"):
-            data.tail([3])
+            data.tail([3])  # type: ignore[arg-type]
         with pytest.raises(TypeError, match=r"expected integer type"):
             data.tail(dim2=3.1)
         with pytest.raises(ValueError, match=r"expected positive int"):
@@ -1697,7 +1700,7 @@ class TestDataset:
         assert_equal(expected, actual)
 
         with pytest.raises(TypeError, match=r"either dict-like or a single int"):
-            data.thin([3])
+            data.thin([3])  # type: ignore[arg-type]
         with pytest.raises(TypeError, match=r"expected integer type"):
             data.thin(dim2=3.1)
         with pytest.raises(ValueError, match=r"cannot be zero"):
@@ -1821,7 +1824,7 @@ class TestDataset:
 
         with pytest.raises(TypeError, match=r"``method``"):
             # this should not pass silently
-            data.sel(dim2=1, method=data)
+            data.sel(dim2=1, method=data)  # type: ignore[arg-type]
 
         # cannot pass method if there is no associated coordinate
         with pytest.raises(ValueError, match=r"cannot supply"):
@@ -1833,7 +1836,7 @@ class TestDataset:
         actual = data.loc[dict(dim3="a")]
         assert_identical(expected, actual)
         with pytest.raises(TypeError, match=r"can only lookup dict"):
-            data.loc["a"]
+            data.loc["a"]  # type: ignore[index]
 
     def test_selection_multiindex(self) -> None:
         mindex = pd.MultiIndex.from_product(
@@ -1960,7 +1963,7 @@ class TestDataset:
         with pytest.raises(ValueError, match=r"cannot specify both"):
             data.reindex({"x": 0}, x=0)
         with pytest.raises(ValueError, match=r"dictionary"):
-            data.reindex("foo")
+            data.reindex("foo")  # type: ignore[arg-type]
 
         # invalid dimension
         # TODO: (benbovy - explicit indexes): uncomment?
@@ -2812,7 +2815,7 @@ class TestDataset:
         orig = create_test_data()
         new_var1 = np.arange(orig["var1"].size).reshape(orig["var1"].shape)
         with pytest.raises(ValueError, match=r"Data must be dict-like"):
-            orig.copy(data=new_var1)
+            orig.copy(data=new_var1)  # type: ignore[arg-type]
         with pytest.raises(ValueError, match=r"only contain variables in original"):
             orig.copy(data={"not_in_original": new_var1})
         with pytest.raises(ValueError, match=r"contain all variables in original"):
@@ -2820,15 +2823,15 @@ class TestDataset:
 
     def test_rename(self) -> None:
         data = create_test_data()
-        newnames: dict[Hashable, Hashable] = {
+        newnames = {
             "var1": "renamed_var1",
             "dim2": "renamed_dim2",
         }
         renamed = data.rename(newnames)
 
-        variables: dict[Hashable, Variable] = dict(data.variables)
-        for k, v in newnames.items():
-            variables[v] = variables.pop(k)
+        variables = dict(data.variables)
+        for nk, nv in newnames.items():
+            variables[nv] = variables.pop(nk)
 
         for k, v in variables.items():
             dims = list(v.dims)
@@ -2859,7 +2862,8 @@ class TestDataset:
         with pytest.raises(UnexpectedDataAccess):
             renamed["renamed_var1"].values
 
-        renamed_kwargs = data.rename(**newnames)
+        # https://github.com/python/mypy/issues/10008
+        renamed_kwargs = data.rename(**newnames)  # type: ignore[arg-type]
         assert_identical(renamed, renamed_kwargs)
 
     def test_rename_old_name(self) -> None:
@@ -5640,7 +5644,7 @@ class TestDataset:
     def test_dataset_diff_exception_label_str(self) -> None:
         ds = create_test_data(seed=1)
         with pytest.raises(ValueError, match=r"'label' argument has to"):
-            ds.diff("dim2", label="raise_me")
+            ds.diff("dim2", label="raise_me")  # type: ignore[arg-type]
 
     @pytest.mark.parametrize("fill_value", [dtypes.NA, 2, 2.0, {"foo": -10}])
     def test_shift(self, fill_value) -> None:

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 import pickle
 import numpy as np
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import pytest
 from packaging.version import Version
 
-dask = pytest.importorskip("dask")  # isort:skip
-distributed = pytest.importorskip("distributed")  # isort:skip
+if TYPE_CHECKING:
+    import dask
+    import distributed
+else:
+    dask = pytest.importorskip("dask")
+    distributed = pytest.importorskip("distributed")
 
 from dask.distributed import Client, Lock
 from distributed.client import futures_of

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -177,10 +177,12 @@ def test_dask_distributed_read_netcdf_integration_test(
 @requires_zarr
 @pytest.mark.parametrize("consolidated", [True, False])
 @pytest.mark.parametrize("compute", [True, False])
-def test_dask_distributed_zarr_integration_test(loop, consolidated, compute) -> None:
+def test_dask_distributed_zarr_integration_test(
+    loop, consolidated: bool, compute: bool
+) -> None:
     if consolidated:
         pytest.importorskip("zarr", minversion="2.2.1.dev2")
-        write_kwargs = {"consolidated": True}
+        write_kwargs: dict[str, Any] = {"consolidated": True}
         read_kwargs: dict[str, Any] = {"backend_kwargs": {"consolidated": True}}
     else:
         write_kwargs = read_kwargs = {}  # type: ignore
@@ -191,7 +193,7 @@ def test_dask_distributed_zarr_integration_test(loop, consolidated, compute) -> 
             with create_tmp_file(
                 allow_cleanup_failure=ON_WINDOWS, suffix=".zarrc"
             ) as filename:
-                maybe_futures = original.to_zarr(
+                maybe_futures = original.to_zarr(  # type: ignore[call-overload]  #mypy bug?
                     filename, compute=compute, **write_kwargs
                 )
                 if not compute:

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -795,7 +795,7 @@ def test_groupby_math_more() -> None:
     with pytest.raises(ValueError, match=r"incompat.* grouped binary"):
         ds + grouped
     with pytest.raises(TypeError, match=r"only support binary ops"):
-        grouped + 1
+        grouped + 1  # type: ignore[operator]
     with pytest.raises(TypeError, match=r"only support binary ops"):
         grouped + grouped
     with pytest.raises(TypeError, match=r"in-place operations"):

--- a/xarray/tests/test_plugins.py
+++ b/xarray/tests/test_plugins.py
@@ -147,8 +147,7 @@ def test_build_engines_sorted() -> None:
         EntryPoint("dummy2", "xarray.tests.test_plugins:backend_1", "xarray.backends"),
         EntryPoint("dummy1", "xarray.tests.test_plugins:backend_1", "xarray.backends"),
     ]
-    backend_entrypoints = plugins.build_engines(dummy_pkg_entrypoints)
-    backend_entrypoints = list(backend_entrypoints)
+    backend_entrypoints = list(plugins.build_engines(dummy_pkg_entrypoints))
 
     indices = []
     for be in plugins.STANDARD_BACKENDS_ORDER:


### PR DESCRIPTION
While adding type hints to `test_backends` I noticed that the `open_dataset` method and the abstract `BackendEntrypoint` were missing stream types as inputs.
