### PR TITLE
DOC: Added examples to docstrings of DataArray methods (#7123)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -73,6 +73,8 @@ Documentation
   By `Jimmy Westling <https://github.com/illviljan>`_.
 - Add documentation of specific BackendEntrypoints (:pull:`7200`).
   By `Michael Niklas <https://github.com/headtr1ck>`_.
+- Add examples to docstring for :py:meth:`DataArray.drop_vars`, :py:meth:`DataArray.reindex_like`, :py:meth:`DataArray.interp_like`. (:issue:`6793`, :pull:`7123`)
+  By `Daniel Goman <https://github.com/DanielGoman>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1865,7 +1865,9 @@ class DataArray(
         Coordinates:
           * x        (x) int64 40 30 20 10
           * y        (y) int64 90 80 70
-        Reindexing with both DataArrays having the same coordinates set, but in different order
+
+        Reindexing with both DataArrays having the same coordinates set, but in different order:
+
         >>> da1.reindex_like(da2)
         <xarray.DataArray (x: 4, y: 3)>
         array([[11, 10,  9],
@@ -1875,7 +1877,9 @@ class DataArray(
         Coordinates:
           * x        (x) int64 40 30 20 10
           * y        (y) int64 90 80 70
-        Reindexing with the other array having coordinates which the source array doesn't have
+
+        Reindexing with the other array having coordinates which the source array doesn't have:
+
         >>> data = np.arange(12).reshape(4, 3)
         >>> da1 = xr.DataArray(
         ...     data=data,
@@ -1896,7 +1900,9 @@ class DataArray(
         Coordinates:
           * x        (x) int64 20 10 29 39
           * y        (y) int64 70 80 90
-        Filling missing values with the previous valid index with respect to the coordinates' value
+
+        Filling missing values with the previous valid index with respect to the coordinates' value:
+
         >>> da1.reindex_like(da2, method="ffill")
         <xarray.DataArray (x: 4, y: 3)>
         array([[3, 4, 5],
@@ -1906,7 +1912,9 @@ class DataArray(
         Coordinates:
           * x        (x) int64 20 10 29 39
           * y        (y) int64 70 80 90
-        Filling missing values while tolerating specified error for inexact matches
+
+        Filling missing values while tolerating specified error for inexact matches:
+
         >>> da1.reindex_like(da2, method="ffill", tolerance=5)
         <xarray.DataArray (x: 4, y: 3)>
         array([[ 3.,  4.,  5.],
@@ -1916,7 +1924,9 @@ class DataArray(
         Coordinates:
           * x        (x) int64 20 10 29 39
           * y        (y) int64 70 80 90
-        Filling missing values with manually specified values
+
+        Filling missing values with manually specified values:
+
         >>> da1.reindex_like(da2, fill_value=19)
         <xarray.DataArray (x: 4, y: 3)>
         array([[ 3,  4,  5],
@@ -2254,7 +2264,9 @@ class DataArray(
         Coordinates:
           * x        (x) int64 10 20 29 39
           * y        (y) int64 70 80 90
-        Interpolate the values in the coordinates of the other DataArray with respect to the source's values
+
+        Interpolate the values in the coordinates of the other DataArray with respect to the source's values:
+
         >>> da2.interp_like(da1)
         <xarray.DataArray (x: 4, y: 3)>
         array([[0. , 1. , 2. ],
@@ -2264,7 +2276,9 @@ class DataArray(
         Coordinates:
           * x        (x) int64 10 20 30 40
           * y        (y) int64 70 80 90
-        Could also extrapolate missing values
+
+        Could also extrapolate missing values:
+
         >>> da2.interp_like(da1, kwargs={"fill_value": "extrapolate"})
         <xarray.DataArray (x: 4, y: 3)>
         array([[ 0. ,  1. ,  2. ],
@@ -2954,7 +2968,9 @@ class DataArray(
         Coordinates:
           * x        (x) int64 10 20 30 40
           * y        (y) int64 70 80 90
-        Removing a single variable
+
+        Removing a single variable:
+
         >>> da.drop_vars("x")
         <xarray.DataArray (x: 4, y: 3)>
         array([[ 0,  1,  2],
@@ -2964,7 +2980,9 @@ class DataArray(
         Coordinates:
           * y        (y) int64 70 80 90
         Dimensions without coordinates: x
-        Removing a list of variables
+
+        Removing a list of variables:
+
         >>> da.drop_vars(["x", "y"])
         <xarray.DataArray (x: 4, y: 3)>
         array([[ 0,  1,  2],

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1834,6 +1834,99 @@ class DataArray(
             Another dataset array, with this array's data but coordinates from
             the other object.
 
+        Examples
+        --------
+        >>> data = np.arange(12).reshape(4, 3)
+        >>> da1 = xr.DataArray(
+        ...     data=data,
+        ...     dims=["x", "y"],
+        ...     coords={"x": [10, 20, 30, 40], "y": [70, 80, 90]},
+        ... )
+        >>> da1
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[ 0,  1,  2],
+               [ 3,  4,  5],
+               [ 6,  7,  8],
+               [ 9, 10, 11]])
+        Coordinates:
+          * x        (x) int64 10 20 30 40
+          * y        (y) int64 70 80 90
+        >>> da2 = xr.DataArray(
+        ...     data=data,
+        ...     dims=["x", "y"],
+        ...     coords={"x": [40, 30, 20, 10], "y": [90, 80, 70]},
+        ... )
+        >>> da2
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[ 0,  1,  2],
+               [ 3,  4,  5],
+               [ 6,  7,  8],
+               [ 9, 10, 11]])
+        Coordinates:
+          * x        (x) int64 40 30 20 10
+          * y        (y) int64 90 80 70
+        Reindexing with both DataArrays having the same coordinates set, but in different order
+        >>> da1.reindex_like(da2)
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[11, 10,  9],
+               [ 8,  7,  6],
+               [ 5,  4,  3],
+               [ 2,  1,  0]])
+        Coordinates:
+          * x        (x) int64 40 30 20 10
+          * y        (y) int64 90 80 70
+        Reindexing with the other array having coordinates which the source array doesn't have
+        >>> data = np.arange(12).reshape(4, 3)
+        >>> da1 = xr.DataArray(
+        ...     data=data,
+        ...     dims=["x", "y"],
+        ...     coords={"x": [10, 20, 30, 40], "y": [70, 80, 90]},
+        ... )
+        >>> da2 = xr.DataArray(
+        ...     data=data,
+        ...     dims=["x", "y"],
+        ...     coords={"x": [20, 10, 29, 39], "y": [70, 80, 90]},
+        ... )
+        >>> da1.reindex_like(da2)
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[ 3.,  4.,  5.],
+               [ 0.,  1.,  2.],
+               [nan, nan, nan],
+               [nan, nan, nan]])
+        Coordinates:
+          * x        (x) int64 20 10 29 39
+          * y        (y) int64 70 80 90
+        Filling missing values with the previous valid index with respect to the coordinates' value
+        >>> da1.reindex_like(da2, method="ffill")
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[3, 4, 5],
+               [0, 1, 2],
+               [3, 4, 5],
+               [6, 7, 8]])
+        Coordinates:
+          * x        (x) int64 20 10 29 39
+          * y        (y) int64 70 80 90
+        Filling missing values while tolerating specified error for inexact matches
+        >>> da1.reindex_like(da2, method="ffill", tolerance=5)
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[ 3.,  4.,  5.],
+               [ 0.,  1.,  2.],
+               [nan, nan, nan],
+               [nan, nan, nan]])
+        Coordinates:
+          * x        (x) int64 20 10 29 39
+          * y        (y) int64 70 80 90
+        Filling missing values with manually specified values
+        >>> da1.reindex_like(da2, fill_value=19)
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[ 3,  4,  5],
+               [ 0,  1,  2],
+               [19, 19, 19],
+               [19, 19, 19]])
+        Coordinates:
+          * x        (x) int64 20 10 29 39
+          * y        (y) int64 70 80 90
+
         See Also
         --------
         DataArray.reindex
@@ -2129,6 +2222,58 @@ class DataArray(
         interpolated : DataArray
             Another dataarray by interpolating this dataarray's data along the
             coordinates of the other object.
+
+        Examples
+        --------
+        >>> data = np.arange(12).reshape(4, 3)
+        >>> da1 = xr.DataArray(
+        ...     data=data,
+        ...     dims=["x", "y"],
+        ...     coords={"x": [10, 20, 30, 40], "y": [70, 80, 90]},
+        ... )
+        >>> da1
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[ 0,  1,  2],
+               [ 3,  4,  5],
+               [ 6,  7,  8],
+               [ 9, 10, 11]])
+        Coordinates:
+          * x        (x) int64 10 20 30 40
+          * y        (y) int64 70 80 90
+        >>> da2 = xr.DataArray(
+        ...     data=data,
+        ...     dims=["x", "y"],
+        ...     coords={"x": [10, 20, 29, 39], "y": [70, 80, 90]},
+        ... )
+        >>> da2
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[ 0,  1,  2],
+               [ 3,  4,  5],
+               [ 6,  7,  8],
+               [ 9, 10, 11]])
+        Coordinates:
+          * x        (x) int64 10 20 29 39
+          * y        (y) int64 70 80 90
+        Interpolate the values in the coordinates of the other DataArray with respect to the source's values
+        >>> da2.interp_like(da1)
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[0. , 1. , 2. ],
+               [3. , 4. , 5. ],
+               [6.3, 7.3, 8.3],
+               [nan, nan, nan]])
+        Coordinates:
+          * x        (x) int64 10 20 30 40
+          * y        (y) int64 70 80 90
+        Could also extrapolate missing values
+        >>> da2.interp_like(da1, kwargs={"fill_value": "extrapolate"})
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[ 0. ,  1. ,  2. ],
+               [ 3. ,  4. ,  5. ],
+               [ 6.3,  7.3,  8.3],
+               [ 9.3, 10.3, 11.3]])
+        Coordinates:
+          * x        (x) int64 10 20 30 40
+          * y        (y) int64 70 80 90
 
         Notes
         -----
@@ -2791,6 +2936,42 @@ class DataArray(
         -------
         dropped : Dataset
             New Dataset copied from `self` with variables removed.
+
+        Examples
+        -------
+        >>> data = np.arange(12).reshape(4, 3)
+        >>> da = xr.DataArray(
+        ...     data=data,
+        ...     dims=["x", "y"],
+        ...     coords={"x": [10, 20, 30, 40], "y": [70, 80, 90]},
+        ... )
+        >>> da
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[ 0,  1,  2],
+               [ 3,  4,  5],
+               [ 6,  7,  8],
+               [ 9, 10, 11]])
+        Coordinates:
+          * x        (x) int64 10 20 30 40
+          * y        (y) int64 70 80 90
+        Removing a single variable
+        >>> da.drop_vars("x")
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[ 0,  1,  2],
+               [ 3,  4,  5],
+               [ 6,  7,  8],
+               [ 9, 10, 11]])
+        Coordinates:
+          * y        (y) int64 70 80 90
+        Dimensions without coordinates: x
+        Removing a list of variables
+        >>> da.drop_vars(["x", "y"])
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[ 0,  1,  2],
+               [ 3,  4,  5],
+               [ 6,  7,  8],
+               [ 9, 10, 11]])
+        Dimensions without coordinates: x, y
         """
         ds = self._to_temp_dataset().drop_vars(names, errors=errors)
         return self._from_temp_dataset(ds)


### PR DESCRIPTION
Added examples to the docstring of the following methods:

`DataArray.drop_vars()`
`DataArray.reindex_like()`
`DataArray.interp_like()`

I will gradually edit this PR and add more examples to other methods.
I'll gladly accept feedback to improve upon my work :)