### PR TITLE
Include variable name in message if `decode_cf_variable` raises an error

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,6 +25,9 @@ New Features
 - Add scatter plot for datarrays. Scatter plots now also supports 3d plots with
   the z argument. (:pull:`6778`)
   By `Jimmy Westling <https://github.com/illviljan>`_.
+- Include the variable name in the error message when CF decoding fails to allow
+  for easier identification of problematic variables (:issue:`7145`,
+  :pull:`7147`). By `Spencer Clark <https://github.com/spencerkclark>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -519,16 +519,19 @@ def decode_cf_variables(
             and v.ndim > 0
             and stackable(v.dims[-1])
         )
-        new_vars[k] = decode_cf_variable(
-            k,
-            v,
-            concat_characters=concat_characters,
-            mask_and_scale=mask_and_scale,
-            decode_times=decode_times,
-            stack_char_dim=stack_char_dim,
-            use_cftime=use_cftime,
-            decode_timedelta=decode_timedelta,
-        )
+        try:
+            new_vars[k] = decode_cf_variable(
+                k,
+                v,
+                concat_characters=concat_characters,
+                mask_and_scale=mask_and_scale,
+                decode_times=decode_times,
+                stack_char_dim=stack_char_dim,
+                use_cftime=use_cftime,
+                decode_timedelta=decode_timedelta,
+            )
+        except Exception as e:
+            raise type(e)(f"Failed to decode variable {k!r}: {e}")
         if decode_coords in [True, "coordinates", "all"]:
             var_attrs = new_vars[k].attrs
             if "coordinates" in var_attrs:

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 from xarray import (
+    DataArray,
     Dataset,
     SerializationWarning,
     Variable,
@@ -475,3 +476,9 @@ def test_scalar_units() -> None:
 
     actual = conventions.decode_cf_variable("t", var)
     assert_identical(actual, var)
+
+
+def test_decode_cf_error_includes_variable_name():
+    ds = Dataset({"invalid": ([], 1e36, {"units": "days since 2000-01-01"})})
+    with pytest.raises(ValueError, match="Failed to decode variable 'invalid'"):
+        decode_cf(ds)

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -8,7 +8,6 @@ import pandas as pd
 import pytest
 
 from xarray import (
-    DataArray,
     Dataset,
     SerializationWarning,
     Variable,


### PR DESCRIPTION
- [x] Closes #7145
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

I'm not sure if there is a better way to do this, but this is one way to address #7145.  The error message for the example now looks like:

```
>>> xr.decode_cf(ds)
Traceback (most recent call last):
  File "/Users/spencer/software/xarray/xarray/coding/times.py", line 275, in decode_cf_datetime
    dates = _decode_datetime_with_pandas(flat_num_dates, units, calendar)
  File "/Users/spencer/software/xarray/xarray/coding/times.py", line 210, in _decode_datetime_with_pandas
    raise OutOfBoundsDatetime(
pandas._libs.tslibs.np_datetime.OutOfBoundsDatetime: Cannot decode times from a non-standard calendar, 'noleap', using pandas.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/spencer/software/xarray/xarray/coding/times.py", line 180, in _decode_cf_datetime_dtype
    result = decode_cf_datetime(example_value, units, calendar, use_cftime)
  File "/Users/spencer/software/xarray/xarray/coding/times.py", line 277, in decode_cf_datetime
    dates = _decode_datetime_with_cftime(
  File "/Users/spencer/software/xarray/xarray/coding/times.py", line 202, in _decode_datetime_with_cftime
    cftime.num2date(num_dates, units, calendar, only_use_cftime_datetimes=True)
  File "src/cftime/_cftime.pyx", line 605, in cftime._cftime.num2date
  File "src/cftime/_cftime.pyx", line 404, in cftime._cftime.cast_to_int
OverflowError: time values outside range of 64 bit signed integers

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/spencer/software/xarray/xarray/conventions.py", line 523, in decode_cf_variables
    new_vars[k] = decode_cf_variable(
  File "/Users/spencer/software/xarray/xarray/conventions.py", line 369, in decode_cf_variable
    var = times.CFDatetimeCoder(use_cftime=use_cftime).decode(var, name=name)
  File "/Users/spencer/software/xarray/xarray/coding/times.py", line 688, in decode
    dtype = _decode_cf_datetime_dtype(data, units, calendar, self.use_cftime)
  File "/Users/spencer/software/xarray/xarray/coding/times.py", line 190, in _decode_cf_datetime_dtype
    raise ValueError(msg)
ValueError: unable to decode time units 'days since 0001-01-01' with "calendar 'noleap'". Try opening your dataset with decode_times=False or installing cftime if it is not installed.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/spencer/software/xarray/xarray/conventions.py", line 659, in decode_cf
    vars, attrs, coord_names = decode_cf_variables(
  File "/Users/spencer/software/xarray/xarray/conventions.py", line 534, in decode_cf_variables
    raise type(e)(f"Failed to decode variable {k!r}: {e}")
ValueError: Failed to decode variable 'invalid_times': unable to decode time units 'days since 0001-01-01' with "calendar 'noleap'". Try opening your dataset with decode_times=False or installing cftime if it is not installed.
```