### PR TITLE
use a hook to synchronize the versions of `black`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,8 @@ repos:
     hooks:
       - id: blackdoc
         exclude: "generate_reductions.py"
-        additional_dependencies: ["black==22.3.0"]
+        additional_dependencies: ["black==22.8.0"]
+      - id: blackdoc-autoupdate-black
   - repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
     hooks:


### PR DESCRIPTION
We started to pin the version of `black` used in the environment of `blackdoc`, but the version becomes out-of-date pretty quickly. The new hook I'm adding here is still experimental, but pretty limited in what it can destroy (the `pre-commit` configuration) so for now we can just review any new autoupdate PRs from the `pre-commit-ci` a bit more thoroughly.