### PR TITLE
Set `longdouble=False` in `cftime.date2num` within the date encoding context

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -51,6 +51,10 @@ Documentation
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Explicitly specify ``longdouble=False`` in :py:func:`cftime.date2num` when
+  encoding times to preserve existing behavior and prevent future errors when it
+  is eventually set to ``True`` by default in cftime (:pull:`7171`).  By
+  `Spencer Clark <https://github.com/spencerkclark>`_.
 
 .. _whats-new.2022.10.0:
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -581,7 +581,14 @@ def _encode_datetime_with_cftime(dates, units, calendar):
         dates = dates.astype("M8[us]").astype(datetime)
 
     def encode_datetime(d):
-        return np.nan if d is None else cftime.date2num(d, units, calendar)
+        # Since netCDF files do not support storing float128 values, we ensure
+        # that float64 values are used by setting longdouble=False in num2date.
+        # This try except logic can be removed when xarray's minimum version of
+        # cftime is at least 1.6.2.
+        try:
+            return np.nan if d is None else cftime.date2num(d, units, calendar, longdouble=False)
+        except TypeError:
+            return np.nan if d is None else cftime.date2num(d, units, calendar)
 
     return np.array([encode_datetime(d) for d in dates.ravel()]).reshape(dates.shape)
 

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -1080,7 +1080,14 @@ def test__encode_datetime_with_cftime() -> None:
     times = cftime.num2date([0, 1], "hours since 2000-01-01", calendar)
 
     encoding_units = "days since 2000-01-01"
-    expected = cftime.date2num(times, encoding_units, calendar)
+    # Since netCDF files do not support storing float128 values, we ensure that
+    # float64 values are used by setting longdouble=False in num2date.  This try
+    # except logic can be removed when xarray's minimum version of cftime is at
+    # least 1.6.2.
+    try:
+        expected = cftime.date2num(times, encoding_units, calendar, longdouble=False)
+    except TypeError:
+        expected = cftime.date2num(times, encoding_units, calendar)
     result = _encode_datetime_with_cftime(times, encoding_units, calendar)
     np.testing.assert_equal(result, expected)
 


### PR DESCRIPTION
Currently, the default behavior of `cftime.date2num` is to return integer values when possible (i.e. when the encoding units allow), and fall back to returning float64 values when that is not possible.  Recently, [cftime added the option to use float128 as the fallback dtype](https://github.com/Unidata/cftime/pull/284#issuecomment-1176098280), which enables greater potential roundtrip precision.  This is through the `longdouble` flag to `cftime.date2num`, which currently defaults to `False`.  It was intentionally set to `False` by default, because netCDF does not support storing float128 values in files, and so, without any changes, would otherwise break xarray's encoding procedure. 

The desire in cftime, however, is to eventually set this flag to `True` by default (https://github.com/Unidata/cftime/issues/297).  This PR makes the necessary changes in xarray to adapt to this eventual new default. Essentially if the `longdouble` argument is allowed in the user's version of `cftime.date2num`, we explicitly set it to `False` to preserve the current float64 fallback behavior within the context of encoding times.  There are a few more places where `date2num` is used (some additional places in the tests, and [in `calendar_ops.py`](https://github.com/pydata/xarray/blob/93f1ba226086d5a916f54653e870a2943fe09ab7/xarray/coding/calendar_ops.py#L277)), but in those places using float128 values would not present a problem.

At some point we might consider relaxing this behavior in xarray, since it is possible to store float128 values in zarr stores for example, but for the time being the simplest approach seems to be to stick with float64 for all backends (it would be complicated to have backend-specific defaults).

cc: @jswhit