### PR TITLE
Lazy import dask.distributed to reduce import time of xarray

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -51,6 +51,8 @@ Documentation
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Improve import time by lazy loading ``dask.distributed`` (:pull: `7172`).
+
 
 .. _whats-new.2022.10.0:
 

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -1,3 +1,4 @@
+from . import testing, tutorial
 from .backends.api import (
     load_dataarray,
     load_dataset,
@@ -107,16 +108,3 @@ __all__ = (
     "__version__",
     "ALL_DIMS",
 )
-
-
-def __getattr__(attr):
-    # lazy import testing and tutorial since they aren't necessary
-    # for most end users of the library
-    if attr == 'testing':
-        import xarray.testing as testing
-        return testing
-    elif attr == 'tutorial':
-        import xarray.tutorial as tutorial
-        return tutorial
-
-    raise AttributeError(f"module {__name__} has no attribute {attr}")

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -1,4 +1,3 @@
-from . import testing, tutorial
 from .backends.api import (
     load_dataarray,
     load_dataset,
@@ -108,3 +107,16 @@ __all__ = (
     "__version__",
     "ALL_DIMS",
 )
+
+
+def __getattr__(attr):
+    # lazy import testing and tutorial since they aren't necessary
+    # for most end users of the library
+    if attr == 'testing':
+        import xarray.testing as testing
+        return testing
+    elif attr == 'tutorial':
+        import xarray.tutorial as tutorial
+        return tutorial
+
+    raise AttributeError(f"module {__name__} has no attribute {attr}")

--- a/xarray/backends/locks.py
+++ b/xarray/backends/locks.py
@@ -56,6 +56,8 @@ def _get_lock_maker(scheduler=None):
     elif scheduler == "multiprocessing":
         return _get_multiprocessing_lock
     elif scheduler == "distributed":
+        # Lazy import distributed since it is can add a significant
+        # amount of time to import
         try:
             from dask.distributed import Lock as DistributedLock
         except ImportError:

--- a/xarray/backends/locks.py
+++ b/xarray/backends/locks.py
@@ -131,15 +131,12 @@ def acquire(lock, blocking=True):
     if blocking:
         # no arguments needed
         return lock.acquire()
-    elif DistributedLock is not None and isinstance(lock, DistributedLock):
-        # distributed.Lock doesn't support the blocking argument yet:
-        # https://github.com/dask/distributed/pull/2412
-        return lock.acquire(timeout=0)
     else:
         # "blocking" keyword argument not supported for:
         # - threading.Lock on Python 2.
         # - dask.SerializableLock with dask v1.0.0 or earlier.
         # - multiprocessing.Lock calls the argument "block" instead.
+        # - dask.distributed.Lock uses the blocking argument as the first one
         return lock.acquire(blocking)
 
 


### PR DESCRIPTION
I was auditing the import time of my software and found that distributed added a non insignificant amount of time to the import of xarray:

Using `tuna`, one can find that the following are sources of delay in import time for xarray:

To audit, one can use the the command
```
python -X importtime -c "import numpy as np; import pandas as pd; import dask.array; import xarray as xr" 2>import.log && tuna import.lo
```
The command as is, breaks out the import time of numpy, pandas, and dask.array to allow you to focus on "other" costs within xarray.
Main branch:
![image](https://user-images.githubusercontent.com/90008/196051640-8bb182a9-fbb0-4b83-a39d-a576fec25249.png)

Proposed:
![image](https://user-images.githubusercontent.com/90008/196051596-34d87232-5cb9-4f3d-84f9-d2ec969c95ce.png)

One would be tempted to think that this is due to xarray.testing and xarray.tutorial but those just move the imports one level down in tuna graphs.
![image](https://user-images.githubusercontent.com/90008/196051584-7895b64c-319a-4f9f-8327-b254b6571551.png)

- [x] ~~Closes~~
- [x] ~~Tests added~~
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] ~~New functions/methods are listed in `api.rst`~~