### PR TITLE
use `_repr_inline` for indexes that define it

### DIFF
--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -408,7 +408,7 @@ def coords_repr(coords, col_width=None, max_rows=None):
     )
 
 
-def summarize_index(name: Hashable, index, col_width: int, is_index: bool = False):
+def summarize_index(name: Hashable, index, col_width: int):
     if hasattr(index, "_repr_inline_"):
         repr_ = index._repr_inline_()
     else:

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -408,9 +408,7 @@ def coords_repr(coords, col_width=None, max_rows=None):
     )
 
 
-def summarize_index(
-    name: Hashable, index, col_width: int, max_width: int = None, is_index: bool = False
-):
+def summarize_index(name: Hashable, index, col_width: int, is_index: bool = False):
     if hasattr(index, "_repr_inline_"):
         repr_ = index._repr_inline_()
     else:

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -411,7 +411,12 @@ def coords_repr(coords, col_width=None, max_rows=None):
 def summarize_index(
     name: Hashable, index, col_width: int, max_width: int = None, is_index: bool = False
 ):
-    return pretty_print(f"    {name} ", col_width) + f"{repr(index)}"
+    if hasattr(index, "_repr_inline_"):
+        repr_ = index._repr_inline_()
+    else:
+        repr_ = repr(index)
+
+    return pretty_print(f"    {name} ", col_width) + f"{repr_}"
 
 
 def nondefault_indexes(indexes):

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -219,6 +219,29 @@ class TestFormatting:
         assert "\n" not in newlines
         assert "\t" not in tabs
 
+    def test_index_repr(self) -> None:
+        from xarray.core.indexes import Index
+
+        class CustomIndex(Index):
+            def __init__(self, names):
+                self.names = names
+
+            def __repr__(self):
+                return f"CustomIndex(coords={self.names})"
+
+        coord_names = ["x", "y"]
+        index = CustomIndex(coord_names)
+
+        name = "x"
+        normal = formatting.summarize_index(name, index, col_width=20)
+        assert name in normal
+        assert repr(index) in normal
+
+        CustomIndex._repr_inline_ = lambda self: f"CustomIndex[{', '.join(self.names)}]"
+        inline = formatting.summarize_index(name, index, col_width=20)
+        assert name in inline
+        assert index._repr_inline_() in inline
+
     def test_diff_array_repr(self) -> None:
         da_a = xr.DataArray(
             np.array([[1, 2, 3], [4, 5, 6]], dtype="int64"),


### PR DESCRIPTION
- [x] Follow-up to #6795
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`