### PR TITLE
Align naming convention with plt.subplots

### DIFF
--- a/doc/user-guide/plotting.rst
+++ b/doc/user-guide/plotting.rst
@@ -156,18 +156,18 @@ Keyword arguments work the same way, and are more explicit.
 
 To add the plot to an existing axis pass in the axis as a keyword argument
 ``ax``. This works for all xarray plotting methods.
-In this example ``axes`` is an array consisting of the left and right
+In this example ``axs`` is an array consisting of the left and right
 axes created by ``plt.subplots``.
 
 .. ipython:: python
     :okwarning:
 
-    fig, axes = plt.subplots(ncols=2)
+    fig, axs = plt.subplots(ncols=2)
 
-    axes
+    axs
 
-    air1d.plot(ax=axes[0])
-    air1d.plot.hist(ax=axes[1])
+    air1d.plot(ax=axs[0])
+    air1d.plot.hist(ax=axs[1])
 
     plt.tight_layout()
 
@@ -958,11 +958,11 @@ These are provided for user convenience; they all call the same code.
     import xarray.plot as xplt
 
     da = xr.DataArray(range(5))
-    fig, axes = plt.subplots(ncols=2, nrows=2)
-    da.plot(ax=axes[0, 0])
-    da.plot.line(ax=axes[0, 1])
-    xplt.plot(da, ax=axes[1, 0])
-    xplt.line(da, ax=axes[1, 1])
+    fig, axs = plt.subplots(ncols=2, nrows=2)
+    da.plot(ax=axs[0, 0])
+    da.plot.line(ax=axs[0, 1])
+    xplt.plot(da, ax=axs[1, 0])
+    xplt.line(da, ax=axs[1, 1])
     plt.tight_layout()
     @savefig plotting_ways_to_use.png width=6in
     plt.draw()

--- a/doc/user-guide/plotting.rst
+++ b/doc/user-guide/plotting.rst
@@ -348,8 +348,8 @@ The keyword arguments ``xincrease`` and ``yincrease`` let you control the axes d
 
 In addition, one can use ``xscale, yscale`` to set axes scaling;
 ``xticks, yticks`` to set axes ticks and ``xlim, ylim`` to set axes limits.
-These accept the same values as the matplotlib methods ``Axes.set_(x,y)scale()``,
-``Axes.set_(x,y)ticks()``, ``Axes.set_(x,y)lim()`` respectively.
+These accept the same values as the matplotlib methods ``ax.set_(x,y)scale()``,
+``ax.set_(x,y)ticks()``, ``ax.set_(x,y)lim()`` respectively.
 
 
 Two Dimensions
@@ -701,12 +701,12 @@ that links a :py:class:`DataArray` to a matplotlib figure with a particular stru
 This object can be used to control the behavior of the multiple plots.
 It borrows an API and code from `Seaborn's FacetGrid
 <https://seaborn.pydata.org/tutorial/axis_grids.html>`_.
-The structure is contained within the ``axes`` and ``name_dicts``
+The structure is contained within the ``axs`` and ``name_dicts``
 attributes, both 2d NumPy object arrays.
 
 .. ipython:: python
 
-    g.axes
+    g.axs
 
     g.name_dicts
 
@@ -726,10 +726,10 @@ they have been plotted.
 
     g = t.plot.imshow(x="lon", y="lat", col="time", col_wrap=3, robust=True)
 
-    for i, ax in enumerate(g.axes.flat):
+    for i, ax in enumerate(g.axs.flat):
         ax.set_title("Air Temperature %d" % i)
 
-    bottomright = g.axes[-1, -1]
+    bottomright = g.axs[-1, -1]
     bottomright.annotate("bottom right", (240, 40))
 
     @savefig plot_facet_iterator.png
@@ -928,7 +928,7 @@ by faceting are accessible in the object returned by ``plot``:
         col="time",
         subplot_kws={"projection": ccrs.Orthographic(-80, 35)},
     )
-    for ax in p.axes.flat:
+    for ax in p.axs.flat:
         ax.coastlines()
         ax.gridlines()
     @savefig plotting_maps_cartopy_facetting.png width=100%

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -42,6 +42,10 @@ Deprecations
 
 - Positional arguments for all plot methods have been deprecated (:issue:`6949`, :pull:`7052`).
   By `Michael Niklas <https://github.com/headtr1ck>`_.
+- ``xarray.plot.FacetGrid.axes`` has been renamed to ``xarray.plot.FacetGrid.axs``
+  because it's not clear if ``axes`` refers to single or multiple ``Axes`` instances.
+  This aligns with ``matplotlib.pyplot.subplots``. (:pull:`7194`)
+  By `Jimmy Westling <https://github.com/illviljan>`_.
 
 Bug fixes
 ~~~~~~~~~
@@ -60,7 +64,8 @@ Documentation
   By `Jessica Scheick <https://github.com/jessicas11>`_.
 - Add example of using :py:meth:`DataArray.coarsen.construct` to User Guide. (:pull:`7192`)
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
-
+- Rename ``axes`` to ``axs`` in plotting to align with ``matplotlib.pyplot.subplots``. (:pull:`7194`)
+  By `Jimmy Westling <https://github.com/illviljan>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -293,7 +293,7 @@ class FacetGrid(Generic[T_Xarray]):
         return self.axs
 
     @axes.setter
-    def axes(self, axs) -> None:
+    def axes(self, axs: np.ndarray) -> None:
         warnings.warn(
             "self.axes is deprecated, use self.axs instead.",
             DeprecationWarning,
@@ -800,7 +800,7 @@ class FacetGrid(Generic[T_Xarray]):
         >>> ds = xr.tutorial.scatter_example_dataset(seed=42)
         >>> fg = ds.plot.scatter(x="A", y="B", hue="y", row="x", col="w")
         >>> fg._set_lims(x=(-0.3, 0.3), y=(0, 2), z=(0, 4))
-        >>> fg.axes[0, 0].get_xlim(), fg.axes[0, 0].get_ylim()
+        >>> fg.axs[0, 0].get_xlim(), fg.axs[0, 0].get_ylim()
         ((-0.3, 0.3), (0.0, 2.0))
         """
         lims_largest = self._get_largest_lims()

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -286,8 +286,8 @@ class FacetGrid(Generic[T_Xarray]):
     def axes(self) -> np.ndarray:
         warnings.warn(
             (
-                "self.axes is deprecated in order to align with plt.subplots,"
-                " use self.axs instead."
+                "self.axes is deprecated since 2022.11 in order to align with "
+                "matplotlibs plt.subplots, use self.axs instead."
             ),
             DeprecationWarning,
             stacklevel=2,
@@ -298,8 +298,8 @@ class FacetGrid(Generic[T_Xarray]):
     def axes(self, axs: np.ndarray) -> None:
         warnings.warn(
             (
-                "self.axes is deprecated in order to align with plt.subplots,"
-                " use self.axs instead."
+                "self.axes is deprecated since 2022.11 in order to align with "
+                "matplotlibs plt.subplots, use self.axs instead."
             ),
             DeprecationWarning,
             stacklevel=2,

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -94,7 +94,7 @@ class FacetGrid(Generic[T_Xarray]):
 
     Attributes
     ----------
-    axes : ndarray of matplotlib.axes.Axes
+    axs : ndarray of matplotlib.axes.Axes
         Array containing axes in corresponding position, as returned from
         :py:func:`matplotlib.pyplot.subplots`.
     col_labels : list of matplotlib.text.Annotation
@@ -286,7 +286,7 @@ class FacetGrid(Generic[T_Xarray]):
     @property
     def axes(self) -> np.ndarray:
         warnings.warn(
-            "self.axes is deprecated, self.axs instead.",
+            "self.axes is deprecated, use self.axs instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -295,7 +295,7 @@ class FacetGrid(Generic[T_Xarray]):
     @axes.setter
     def axes(self, axs) -> None:
         warnings.warn(
-            "self.axes is deprecated, self.axs instead.",
+            "self.axes is deprecated, use self.axs instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -112,8 +112,7 @@ class FacetGrid(Generic[T_Xarray]):
     data: T_Xarray
     name_dicts: np.ndarray
     fig: Figure
-    # axes: np.ndarray
-    axs = np.ndarray
+    axs: np.ndarray
     row_names: list[np.ndarray]
     col_names: list[np.ndarray]
     figlegend: Legend | None
@@ -286,7 +285,10 @@ class FacetGrid(Generic[T_Xarray]):
     @property
     def axes(self) -> np.ndarray:
         warnings.warn(
-            "self.axes is deprecated, use self.axs instead.",
+            (
+                "self.axes is deprecated in order to align with plt.subplots,"
+                " use self.axs instead."
+            ),
             DeprecationWarning,
             stacklevel=2,
         )
@@ -295,7 +297,10 @@ class FacetGrid(Generic[T_Xarray]):
     @axes.setter
     def axes(self, axs: np.ndarray) -> None:
         warnings.warn(
-            "self.axes is deprecated, use self.axs instead.",
+            (
+                "self.axes is deprecated in order to align with plt.subplots,"
+                " use self.axs instead."
+            ),
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
I noticed that the normal notation for `fig, axs = plt.subplots(2, 1)` wasn't used in facetgrid so did a quick find replace to change that.
This feels better for my pedantic brain at least but I'm not sure it's worth the effort?