### PR TITLE
Remove rasterio tutorial test

### DIFF
--- a/xarray/tests/test_tutorial.py
+++ b/xarray/tests/test_tutorial.py
@@ -29,16 +29,3 @@ class TestLoadDataset:
         ).load()
         ds_cache = tutorial.open_dataset(self.testfile, cache_dir=cache_dir).load()
         assert_identical(ds_cache, ds_nocache)
-
-    def test_download_rasterio_from_github_load_without_cache(
-        self, tmp_path, monkeypatch
-    ):
-        cache_dir = tmp_path / tutorial._default_cache_dir_name
-        with pytest.warns(DeprecationWarning):
-            arr_nocache = tutorial.open_rasterio(
-                "RGB.byte", cache=False, cache_dir=cache_dir
-            ).load()
-            arr_cache = tutorial.open_rasterio(
-                "RGB.byte", cache=True, cache_dir=cache_dir
-            ).load()
-        assert_identical(arr_cache, arr_nocache)

--- a/xarray/tutorial.py
+++ b/xarray/tutorial.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import pathlib
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np

--- a/xarray/tutorial.py
+++ b/xarray/tutorial.py
@@ -175,6 +175,12 @@ def open_rasterio(
     """
     Open a rasterio dataset from the online repository (requires internet).
 
+    .. deprecated:: 0.20.0
+
+        Deprecated in favor of rioxarray.
+        For information about transitioning, see:
+        https://corteva.github.io/rioxarray/stable/getting_started/getting_started.html
+
     If a local copy is found then always use that to avoid network traffic.
 
     Available datasets:
@@ -204,6 +210,13 @@ def open_rasterio(
     ----------
     .. [1] https://github.com/rasterio/rasterio
     """
+    warnings.warn(
+        "open_rasterio is Deprecated in favor of rioxarray. "
+        "For information about transitioning, see: "
+        "https://corteva.github.io/rioxarray/stable/getting_started/getting_started.html",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     try:
         import pooch
     except ImportError as e:


### PR DESCRIPTION
This test has been quite troublesome and since `.open_rasterio` has been deprecated since 0.20 I think it's fine removing the test.