### PR TITLE
use the new action to create an issue from the output of reportlog

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -72,7 +72,7 @@ jobs:
           conda info -a
           conda list
           python xarray/util/print_versions.py
-      - name: import xarray
+      - name: Import xarray
         run: |
           python -c 'import xarray'
       - name: Run Tests
@@ -81,7 +81,7 @@ jobs:
         run: |
           python -m pytest --timeout=60 -rf \
             --report-log output-${{ matrix.python-version }}-log.jsonl
-      - name: generate and publish the report
+      - name: Generate and publish the report
         if: |
           failure()
           && steps.status.outcome == 'failure'

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -87,6 +87,6 @@ jobs:
           && steps.status.outcome == 'failure'
           && github.event_name == 'schedule'
           && github.repository_owner == 'pydata'
-        uses: xarray-contrib/issue-from-pytest-log
+        uses: xarray-contrib/issue-from-pytest-log@v0.1
         with:
           log-path: output-${{ matrix.python-version }}-log.jsonl

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -83,43 +83,13 @@ jobs:
         id: status
         run: |
           python -m pytest --timeout=60 -rf \
-            --report-log output-${{ matrix.python-version }}-log.jsonl \
-            || (
-              echo 'ARTIFACTS_AVAILABLE=true' >> $GITHUB_OUTPUT
-              && echo 'ARTIFACT_NAME=output-${{ matrix.python-version }}-log.jsonl' >> $GITHUB_OUTPUT
-              && false
-            )
-      - name: Upload artifacts
+            --report-log output-${{ matrix.python-version }}-log.jsonl
+      - name: generate and publish the report
         if: |
           failure()
           && steps.status.outcome == 'failure'
           && github.event_name == 'schedule'
-          && github.repository == 'pydata/xarray'
-        uses: actions/upload-artifact@v3
+          && github.repository_owner == 'pydata'
+        uses: xarray-contrib/issue-from-pytest-log
         with:
-          name: output-${{ matrix.python-version }}-log.jsonl
-          path: output-${{ matrix.python-version }}-log.jsonl
-          retention-days: 5
-
-  report:
-    name: report
-    needs: upstream-dev
-    if: |
-      failure()
-      && github.event_name == 'schedule'
-      && needs.upstream-dev.outputs.artifacts_availability == 'true'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-      - uses: actions/download-artifact@v3
-        with:
-          path: /tmp/workspace/logs
-      - uses: xarray-contrib/issue-from-pytest-log@v0.1
-        with:
-          log-path: /tmp/workspace/logs/${{ needs.upstream-dev.outputs.artifact_name }}
+          log-path: output-${{ matrix.python-version }}-log.jsonl

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -49,9 +49,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-    outputs:
-      artifacts_availability: ${{ steps.status.outputs.ARTIFACTS_AVAILABLE }}
-      artifact_name: ${{ steps.status.outputs.ARTIFACT_NAME }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -51,6 +51,7 @@ jobs:
         python-version: ["3.10"]
     outputs:
       artifacts_availability: ${{ steps.status.outputs.ARTIFACTS_AVAILABLE }}
+      artifact_name: ${{ steps.status.outputs.ARTIFACT_NAME }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -84,7 +85,9 @@ jobs:
           python -m pytest --timeout=60 -rf \
             --report-log output-${{ matrix.python-version }}-log.jsonl \
             || (
-              echo '::set-output name=ARTIFACTS_AVAILABLE::true' && false
+              echo 'ARTIFACTS_AVAILABLE=true' >> $GITHUB_OUTPUT
+              && echo 'ARTIFACT_NAME=output-${{ matrix.python-version }}-log.jsonl' >> $GITHUB_OUTPUT
+              && false
             )
       - name: Upload artifacts
         if: |
@@ -117,67 +120,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           path: /tmp/workspace/logs
-      - name: Move all log files into a single directory
-        run: |
-          rsync -a /tmp/workspace/logs/output-*/ ./logs
-          ls -R ./logs
-      - name: install dependencies
-        run: |
-          python -m pip install pytest
-      - name: Parse logs
-        run: |
-          shopt -s globstar
-          python .github/workflows/parse_logs.py logs/**/*-log*
-          cat pytest-logs.txt
-      - name: Report failures
-        uses: actions/github-script@v6
+      - uses: xarray-contrib/issue-from-pytest-log@v0.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const pytest_logs = fs.readFileSync('pytest-logs.txt', 'utf8');
-            const title = "⚠️ Nightly upstream-dev CI failed ⚠️"
-            const workflow_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
-            const issue_body = `[Workflow Run URL](${workflow_url})\n${pytest_logs}`
-
-            // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
-            const query = `query($owner:String!, $name:String!, $creator:String!, $label:String!){
-              repository(owner: $owner, name: $name) {
-                issues(first: 1, states: OPEN, filterBy: {createdBy: $creator, labels: [$label]}, orderBy: {field: CREATED_AT, direction: DESC}) {
-                  edges {
-                    node {
-                      body
-                      id
-                      number
-                    }
-                  }
-                }
-              }
-            }`;
-
-            const variables = {
-                owner: context.repo.owner,
-                name: context.repo.repo,
-                label: 'CI',
-                creator: "github-actions[bot]"
-            }
-            const result = await github.graphql(query, variables)
-
-            // If no issue is open, create a new issue,
-            // else update the body of the existing issue.
-            if (result.repository.issues.edges.length === 0) {
-                github.rest.issues.create({
-                    owner: variables.owner,
-                    repo: variables.name,
-                    body: issue_body,
-                    title: title,
-                    labels: [variables.label]
-                })
-            } else {
-                github.rest.issues.update({
-                    owner: variables.owner,
-                    repo: variables.name,
-                    issue_number: result.repository.issues.edges[0].node.number,
-                    body: issue_body
-                })
-            }
+          log-path: /tmp/workspace/logs/${{ needs.upstream-dev.outputs.artifact_name }}


### PR DESCRIPTION
I'm not sure if we actually need the dedicated "report" job, or whether adding an additional step to the main ci job would suffice?

I can see two reasons for a separate job:
1. we get to control the python version independently from the version of the main job
2. we upload the reportlog files as artifacts

I think if we can change the action to abort if it is run on a python version it does not support the first concern would not matter anymore, and for 2 we might just keep the "upload artifact" action (but is it even possible to manually access artifacts? If not we might not even need the upload).

Since I don't think either is a major concern, I went ahead and joined the jobs.


- [x] Closes #6810