### PR TITLE
Explicitly remove grids for pcolormesh

### DIFF
--- a/xarray/plot/dataarray_plot.py
+++ b/xarray/plot/dataarray_plot.py
@@ -2318,6 +2318,7 @@ def pcolormesh(
             y = _infer_interval_breaks(y, axis=1, scale=yscale)
             y = _infer_interval_breaks(y, axis=0, scale=yscale)
 
+    ax.grid(False)
     primitive = ax.pcolormesh(x, y, z, **kwargs)
 
     # by default, pcolormesh picks "round" values for bounds


### PR DESCRIPTION
Removes a warning in the plotting tests, related to https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.5.0.html#auto-removal-of-grids-by-pcolor-and-pcolormesh.

I just added `ax.grid(False)` but maybe we just want whatever is the default of matplotlib?

```python
import xarray as xr

airtemps = xr.tutorial.open_dataset("air_temperature")
air = airtemps.air - 273.15
air.attrs = airtemps.air.attrs
air.attrs["units"] = "deg C"

air2d = air.isel(time=500)
fig, axs = plt.subplots(2,1)
air2d.plot(ax=axs[0])  # No grid.
air2d.plot(ax=axs[1])  # With grid.
axs[1].grid(True)
```

![image](https://user-images.githubusercontent.com/14371165/197848951-01834aba-a260-4793-aa66-85288875498d.png)

