### PR TITLE
Actually make the fast code path return early for Aligner.align

### DIFF
--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -549,11 +549,8 @@ class Aligner(Generic[DataAlignable]):
     def align(self) -> None:
         if not self.indexes and len(self.objects) == 1:
             # fast path for the trivial case
-            if self.copy:
-                (obj,) = self.objects
-                self.results = (obj.copy(deep=True),)
-            else:
-                self.results = self.objects
+            (obj,) = self.objects
+            self.results = (obj.copy(deep=self.copy),)
             return
 
         self.find_matching_indexes()

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -551,6 +551,7 @@ class Aligner(Generic[DataAlignable]):
             # fast path for the trivial case
             (obj,) = self.objects
             self.results = (obj.copy(deep=self.copy),)
+            return
 
         self.find_matching_indexes()
         self.find_matching_unindexed_dims()

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -549,8 +549,11 @@ class Aligner(Generic[DataAlignable]):
     def align(self) -> None:
         if not self.indexes and len(self.objects) == 1:
             # fast path for the trivial case
-            (obj,) = self.objects
-            self.results = (obj.copy(deep=self.copy),)
+            if self.copy:
+                (obj,) = self.objects
+                self.results = (obj.copy(deep=True),)
+            else:
+                self.results = self.objects
             return
 
         self.find_matching_indexes()


### PR DESCRIPTION
In relation to my other PR.

Without this PR
![image](https://user-images.githubusercontent.com/90008/197916473-0149747e-25b0-41d6-921d-1fad62a23699.png)

With the early return
![image](https://user-images.githubusercontent.com/90008/197916546-9ea9a020-2683-4d62-805a-b386835d61c0.png)

<details><summary>Removing the frivolous copy (does not pass tests)</summary>

![image](https://user-images.githubusercontent.com/90008/197916632-dbc89c21-94a9-4b92-af11-5b1fa5f5cddd.png)
</details>

<details><summary>Code for benchmark</summary>

```python
from tqdm import tqdm
import xarray as xr
from time import perf_counter
import numpy as np

N = 1000

# Everybody is lazy loading now, so lets force modules to get instantiated
dummy_dataset = xr.Dataset()
dummy_dataset['a'] = 1
dummy_dataset['b'] = 1
del dummy_dataset

time_elapsed = np.zeros(N)
dataset = xr.Dataset()

# tqdm = iter
for i in tqdm(range(N)):
    time_start = perf_counter()
    dataset[f"var{i}"] = i
    time_end = perf_counter()
    time_elapsed[i] = time_end - time_start
    
    
# %%
from matplotlib import pyplot as plt

plt.plot(np.arange(N), time_elapsed * 1E3, label='Time to add one variable')
plt.xlabel("Number of existing variables")
plt.ylabel("Time to add a variables (ms)")
plt.ylim([0, 10])
plt.grid(True)
```
</details>

xref: https://github.com/pydata/xarray/pull/7221

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
