### PR TITLE
Fix type in benchmarks/merge.py

### DIFF
--- a/asv_bench/benchmarks/merge.py
+++ b/asv_bench/benchmarks/merge.py
@@ -13,6 +13,6 @@ class DatasetAddVariable:
             d[f"var{i}"] = i
         self.dataset = xr.merge([d])
 
-    def time_variable_insertion(self, existin_elements):
+    def time_variable_insertion(self, existing_elements):
         dataset = self.dataset
         dataset["new_var"] = 0


### PR DESCRIPTION
I don't think this affects what is displayed that is determined by param_names

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
