### PR TITLE
fix the environment setup: actually use the python version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,6 +92,8 @@ jobs:
           environment-name: xarray-tests
           cache-env: true
           cache-env-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{env.TODAY}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
+          extra-specs: |
+            python=${{matrix.python-version}}
 
       # We only want to install this on one run, because otherwise we'll have
       # duplicate annotations.


### PR DESCRIPTION
While working on #7241, I realized that I forgot to specify the python in our main CI, with the effect that we've been testing python 3.10 twice for each OS since the introduction of the `micromamba` action.