### PR TITLE
Use partial function in open_mfdataset example

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -916,7 +916,7 @@ def open_mfdataset(
     >>> lon_bnds, lat_bnds = (-110, -105), (40, 45)
     >>> partial_func = partial(_preprocess, lon_bnds=lon_bnds, lat_bnds=lat_bnds)
     >>> ds = xr.open_mfdataset(
-    ...     "file_*.nc", concat_dim="time", preprocess=_preprocess
+    ...     "file_*.nc", concat_dim="time", preprocess=partial_func
     ... )  # doctest: +SKIP
 
     References


### PR DESCRIPTION
The example in `xarray.open_mfdataset` mentions usage of partial function, but does not use it correctly:
(`_preprocess` should not be used as a parameter, but `partial_func` should be used)

```python
partial_func = partial(_preprocess, lon_bnds=lon_bnds, lat_bnds=lat_bnds)
ds = xr.open_mfdataset(
    "file_*.nc", concat_dim="time", preprocess=_preprocess
) 
```

This PR fixes the example, to use `partial_func`:

```python
partial_func = partial(_preprocess, lon_bnds=lon_bnds, lat_bnds=lat_bnds)
ds = xr.open_mfdataset(
    "file_*.nc", concat_dim="time", preprocess=partial_func
) 
```



