### PR TITLE
pin mypy to a known good version

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -119,7 +119,7 @@ jobs:
           python xarray/util/print_versions.py
       - name: Install mypy
         run: |
-          python -m pip install mypy
+          python -m pip install 'mypy<0.990'
 
       - name: Run mypy
         run: |


### PR DESCRIPTION
The type checking CI has started to fail with the new upgrade. In order not to disturb unrelated PRs, this pins `mypy` to a known good version (`mypy<0.990`).