### PR TITLE
Handle division by zero in _Normalize._calc_widths

### DIFF
--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -1518,6 +1518,12 @@ class _Normalize(Sequence):
         <xarray.DataArray (dim_0: 6)>
         array([27., 18., 18., 27., 54., 72.])
         Dimensions without coordinates: dim_0
+
+        >>> _Normalize(a * 0, width=[18, 72]).values
+        <xarray.DataArray (dim_0: 6)>
+        array([27., 18., 18., 27., 54., 72.])
+        Dimensions without coordinates: dim_0
+
         """
         if self.data is None:
             return None

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -1521,7 +1521,7 @@ class _Normalize(Sequence):
 
         >>> _Normalize(a * 0, width=[18, 72]).values
         <xarray.DataArray (dim_0: 6)>
-        array([27., 18., 18., 27., 54., 72.])
+        array([18., 18., 18., 18., 18., 18.])
         Dimensions without coordinates: dim_0
 
         """

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -1459,12 +1459,18 @@ class _Normalize(Sequence):
         ...
 
     def _calc_widths(self, y: np.ndarray | DataArray) -> np.ndarray | DataArray:
+        """
+        Normalize the values so they're inbetween self._width.
+        """
         if self._width is None:
             return y
 
         x0, x1 = self._width
 
-        k = (y - np.min(y)) / (np.max(y) - np.min(y))
+        # If y is constant, then add a small number to avoid division with zero:
+        diff_maxy_miny = np.max(y) - np.min(y)
+        eps = np.finfo(np.float64).eps if diff_maxy_miny == 0 else 0
+        k = (y - np.min(y)) / (diff_maxy_miny + eps)
         widths = x0 + k * (x1 - x0)
 
         return widths


### PR DESCRIPTION
Found an issue when constant values was used. Now if constant values are found it'll default to the minimum width value instead.