### PR TITLE
Fix some typing errors in DuckArrayModule

### DIFF
--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from importlib import import_module
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Type
 
 import numpy as np
 from packaging.version import Version
@@ -13,7 +13,7 @@ integer_types = (int, np.integer)
 
 if TYPE_CHECKING:
     ModType = Literal["dask", "pint", "cupy", "sparse"]
-    DuckArrayTypes = tuple[type[Any], ...]  # TODO: improve this? maybe Generic
+    DuckArrayTypes = tuple[Type[Any], ...]  # TODO: improve this? maybe Generic
 
 
 class DuckArrayModule:

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from importlib import import_module
 from types import ModuleType
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 from packaging.version import Version
@@ -11,8 +11,9 @@ from .utils import is_duck_array, module_available
 
 integer_types = (int, np.integer)
 
-ModType = Literal["dask", "pint", "cupy", "sparse"]
-DuckArrayTypes = tuple[type[Any], ...]  # TODO: improve this? maybe Generic
+if TYPE_CHECKING:
+    ModType = Literal["dask", "pint", "cupy", "sparse"]
+    DuckArrayTypes = tuple[type[Any], ...]  # TODO: improve this? maybe Generic
 
 
 class DuckArrayModule:

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from importlib import import_module
+from types import ModuleType
 from typing import Any, Literal
 
 import numpy as np
@@ -11,6 +12,7 @@ from .utils import is_duck_array, module_available
 integer_types = (int, np.integer)
 
 ModType = Literal["dask", "pint", "cupy", "sparse"]
+DuckArrayTypes = tuple[type[Any], ...]  # TODO: improve this? maybe Generic
 
 
 class DuckArrayModule:
@@ -21,12 +23,15 @@ class DuckArrayModule:
     https://github.com/pydata/xarray/pull/5561#discussion_r664815718
     """
 
-    module: ModType | None
+    module: ModuleType | None
     version: Version
-    type: tuple[type[Any]]  # TODO: improve this? maybe Generic
+    type: DuckArrayTypes
     available: bool
 
     def __init__(self, mod: ModType) -> None:
+        duck_array_module: ModuleType | None = None
+        duck_array_version: Version
+        duck_array_type: DuckArrayTypes
         try:
             duck_array_module = import_module(mod)
             duck_array_version = Version(duck_array_module.__version__)
@@ -53,7 +58,7 @@ class DuckArrayModule:
         self.available = duck_array_module is not None
 
 
-def array_type(mod: ModType) -> tuple[type[Any]]:
+def array_type(mod: ModType) -> DuckArrayTypes:
     """Quick wrapper to get the array class of the module."""
     return DuckArrayModule(mod).type
 


### PR DESCRIPTION
Fixes these errors that I've been seeing locally for a while:

```python
!mypy C:\Users\J.W\Documents\GitHub\xarray\xarray\core\coordinates.py --ignore-missing-imports
C:\Users\J.W\Documents\GitHub\xarray\xarray\core\pycompat.py:48: error: Incompatible types in assignment (expression has type "Tuple[]", variable has type "Tuple[Any]")
C:\Users\J.W\Documents\GitHub\xarray\xarray\core\pycompat.py:50: error: Incompatible types in assignment (expression has type "Optional[Module]", variable has type "Optional[Literal['dask', 'pint', 'cupy', 'sparse']]")
Found 2 errors in 1 file (checked 1 source file)
```

Not sure why the CI isn't catching these?