### PR TITLE
deprecate pynio backend

### DIFF
--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -30,7 +30,6 @@ dependencies:
   - pip
   - pseudonetcdf
   - pydap
-  # - pynio  # not compatible with netCDF4>1.5.3, see #4491
   - pytest
   - pytest-cov
   - pytest-env

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -30,7 +30,6 @@ dependencies:
   - pre-commit
   - pseudonetcdf
   - pydap
-  # - pynio  # Not available on Windows
   - pytest
   - pytest-cov
   - pytest-env

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -34,7 +34,6 @@ dependencies:
   - pre-commit
   - pseudonetcdf
   - pydap
-  # - pynio  # not compatible with netCDF4>1.5.3, see #4491
   - pytest
   - pytest-cov
   - pytest-env

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -41,7 +41,6 @@ dependencies:
   - pip
   - pseudonetcdf=3.1
   - pydap=3.2
-  # - pynio=1.5.5
   - pytest
   - pytest-cov
   - pytest-env

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -1209,6 +1209,10 @@ We recommend installing cfgrib via conda::
 Formats supported by PyNIO
 --------------------------
 
+.. warning::
+
+    The PyNIO backend is deprecated_. PyNIO is no longer maintained_. See
+
 Xarray can also read GRIB, HDF4 and other file formats supported by PyNIO_,
 if PyNIO is installed. To use PyNIO to read such files, supply
 ``engine='pynio'`` to :py:func:`open_dataset`.
@@ -1217,12 +1221,9 @@ We recommend installing PyNIO via conda::
 
     conda install -c conda-forge pynio
 
-.. warning::
-
-    PyNIO is no longer actively maintained and conflicts with netcdf4 > 1.5.3.
-    The PyNIO backend may be moved outside of xarray in the future.
-
 .. _PyNIO: https://www.pyngl.ucar.edu/Nio.shtml
+.. _deprecated: https://github.com/pydata/xarray/issues/4491
+.. _maintained: https://github.com/NCAR/pynio/issues/53
 
 .. _io.PseudoNetCDF:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,7 +30,8 @@ Breaking changes
 
 Deprecations
 ~~~~~~~~~~~~
-
+- The PyNIO backend has been deprecated (:issue:`4491`, :pull:`7301`).
+  By `Joe Hamman <https://github.com/jhamman>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 
 from ..core import indexing
@@ -55,6 +57,12 @@ class NioDataStore(AbstractDataStore):
     def __init__(self, filename, mode="r", lock=None, **kwargs):
         import Nio
 
+        warnings.warn(
+            "The PyNIO backend is Deprecated and will be removed from Xarray in a future release. "
+            "See https://github.com/pydata/xarray/issues/4491 for more information",
+            FutureWarning,
+        )
+
         if lock is None:
             lock = PYNIO_LOCK
         self.lock = ensure_lock(lock)
@@ -94,6 +102,15 @@ class NioDataStore(AbstractDataStore):
 
 
 class PynioBackendEntrypoint(BackendEntrypoint):
+    """
+    PyNIO backend
+
+        .. deprecated:: 0.20.0
+
+        Deprecated as PyNIO is no longer supported. See
+        https://github.com/pydata/xarray/issues/4491 for more information
+    """
+
     available = module_available("Nio")
 
     def open_dataset(

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -60,7 +60,7 @@ class NioDataStore(AbstractDataStore):
         warnings.warn(
             "The PyNIO backend is Deprecated and will be removed from Xarray in a future release. "
             "See https://github.com/pydata/xarray/issues/4491 for more information",
-            FutureWarning,
+            DeprecationWarning,
         )
 
         if lock is None:


### PR DESCRIPTION
This PR finally deprecates the PyNIO backend. PyNIO is technically in maintenance mode but it hasn't had any maintenance in 4+ years. Its conda packages cannot be installed in any of our test environments. I have added a future warning to the `NioDataStore.__init__` method and noted the deprecation in the IO docs.

- [x] Closes #4491 
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
