### PR TITLE
Add mypy version to xr.show_versions

### DIFF
--- a/xarray/util/print_versions.py
+++ b/xarray/util/print_versions.py
@@ -129,7 +129,7 @@ def show_versions(file=sys.stdout):
         ("pip", lambda mod: mod.__version__),
         ("conda", lambda mod: mod.__version__),
         ("pytest", lambda mod: mod.__version__),
-        ("mypy", lambda mod: importlib.metadata.version("mypy")),
+        ("mypy", lambda mod: importlib.metadata.version(mod.__name__)),
         # Misc.
         ("IPython", lambda mod: mod.__version__),
         ("sphinx", lambda mod: mod.__version__),

--- a/xarray/util/print_versions.py
+++ b/xarray/util/print_versions.py
@@ -129,6 +129,7 @@ def show_versions(file=sys.stdout):
         ("pip", lambda mod: mod.__version__),
         ("conda", lambda mod: mod.__version__),
         ("pytest", lambda mod: mod.__version__),
+        ("mypy", lambda mod: importlib.metadata.version("mypy")),
         # Misc.
         ("IPython", lambda mod: mod.__version__),
         ("sphinx", lambda mod: mod.__version__),


### PR DESCRIPTION
It's a little tricky getting the mypy version, so adding it to the show_versions function as well.