### PR TITLE
Reset file pointer to 0 when reading file stream

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -56,6 +56,8 @@ Bug fixes
 
 - Import ``nc_time_axis`` when needed (:issue:`7275`, :pull:`7276`).
   By `Michael Niklas <https://github.com/headtr1ck>`_.
+- Fix multiple reads on fsspec S3 files by resetting file pointer to 0 when reading file streams (:issue:`6813`, :pull:`7304`).
+  By `David Hoese <https://github.com/djhoese>`_ and `Wei Ji Leong <https://github.com/weiji14>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -664,7 +664,7 @@ def read_magic_number_from_file(filename_or_obj, count=8) -> bytes:
         magic_number = filename_or_obj.read(count)
         filename_or_obj.seek(0)
     else:
-        raise TypeError(f"cannot read the magic number form {type(filename_or_obj)}")
+        raise TypeError(f"cannot read the magic number from {type(filename_or_obj)}")
     return magic_number
 
 

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -654,9 +654,11 @@ def read_magic_number_from_file(filename_or_obj, count=8) -> bytes:
         magic_number = filename_or_obj[:count]
     elif isinstance(filename_or_obj, io.IOBase):
         if filename_or_obj.tell() != 0:
-            raise ValueError(
+            filename_or_obj.seek(0)
+            warnings.warn(
                 "cannot guess the engine, "
                 "file-like object read/write pointer not at the start of the file, "
+                "so resetting file pointer to zero. If this does not work, "
                 "please close and reopen, or use a context manager"
             )
         magic_number = filename_or_obj.read(count)

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -655,12 +655,6 @@ def read_magic_number_from_file(filename_or_obj, count=8) -> bytes:
     elif isinstance(filename_or_obj, io.IOBase):
         if filename_or_obj.tell() != 0:
             filename_or_obj.seek(0)
-            warnings.warn(
-                "cannot guess the engine, "
-                "file-like object read/write pointer not at the start of the file, "
-                "so resetting file pointer to zero. If this does not work, "
-                "please close and reopen, or use a context manager"
-            )
         magic_number = filename_or_obj.read(count)
         filename_or_obj.seek(0)
     else:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3159,13 +3159,12 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
     def test_open_twice(self) -> None:
         expected = create_test_data()
         expected.attrs["foo"] = "bar"
-        with pytest.warns(match=r"read/write pointer not at the start"):
-            with create_tmp_file() as tmp_file:
-                expected.to_netcdf(tmp_file, engine="h5netcdf")
-                with open(tmp_file, "rb") as f:
+        with create_tmp_file() as tmp_file:
+            expected.to_netcdf(tmp_file, engine="h5netcdf")
+            with open(tmp_file, "rb") as f:
+                with open_dataset(f, engine="h5netcdf"):
                     with open_dataset(f, engine="h5netcdf"):
-                        with open_dataset(f, engine="h5netcdf"):
-                            pass
+                        pass
 
     @requires_scipy
     def test_open_fileobj(self) -> None:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3031,7 +3031,7 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
     def test_open_twice(self) -> None:
         expected = create_test_data()
         expected.attrs["foo"] = "bar"
-        with pytest.raises(ValueError, match=r"read/write pointer not at the start"):
+        with pytest.warns(match=r"read/write pointer not at the start"):
             with create_tmp_file() as tmp_file:
                 expected.to_netcdf(tmp_file, engine="h5netcdf")
                 with open(tmp_file, "rb") as f:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3069,15 +3069,7 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
             # `raises_regex`?). Ref https://github.com/pydata/xarray/pull/5191
             with open(tmp_file, "rb") as f:
                 f.seek(8)
-                with pytest.raises(
-                    ValueError,
-                    match="match in any of xarray's currently installed IO",
-                ):
-                    with pytest.warns(
-                        RuntimeWarning,
-                        match=re.escape("'h5netcdf' fails while guessing"),
-                    ):
-                        open_dataset(f)
+                open_dataset(f)
 
 
 @requires_h5netcdf


### PR DESCRIPTION
Instead of raising a ValueError about the file pointer not being at the start of the file, reset the file pointer automatically to zero, and warn that the pointer has been reset.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #6813
- [ ] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
