### PR TITLE
Add numba to nightly upstream

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -18,7 +18,7 @@ conda uninstall -y --force \
     scipy \
     sparse \
     xarray
-    zarr \
+    zarr
 # new matplotlib dependency
 python -m pip install --upgrade contourpy
 # to limit the runtime of Upstream CI
@@ -47,5 +47,5 @@ python -m pip install \
     git+https://github.com/SciTools/nc-time-axis \
     git+https://github.com/Unidata/cftime \
     git+https://github.com/xarray-contrib/flox \
-    git+https://github.com/zarr-developers/zarr \
+    git+https://github.com/zarr-developers/zarr
 python -m pip install pytest-timeout

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
 
 conda uninstall -y --force \
-    numpy \
-    scipy \
-    pandas \
-    matplotlib \
+    bottleneck \
+    cftime \
     dask \
     distributed \
-    fsspec \
-    zarr \
-    cftime \
-    rasterio \
-    packaging \
-    pint \
-    bottleneck \
-    sparse \
     flox \
+    fsspec \
     h5netcdf \
+    matplotlib \
+    numpy \
+    numba \
+    packaging \
+    pandas \
+    pint \
+    rasterio \
+    scipy \
+    sparse \
     xarray
+    zarr \
 # new matplotlib dependency
 python -m pip install --upgrade contourpy
 # to limit the runtime of Upstream CI
@@ -35,15 +36,16 @@ python -m pip install \
     --upgrade \
     git+https://github.com/dask/dask \
     git+https://github.com/dask/distributed \
-    git+https://github.com/zarr-developers/zarr \
-    git+https://github.com/Unidata/cftime \
-    git+https://github.com/rasterio/rasterio \
-    git+https://github.com/pypa/packaging \
+    git+https://github.com/h5netcdf/h5netcdf
     git+https://github.com/hgrecco/pint \
+    git+https://github.com/numba/numba \
+    git+https://github.com/intake/filesystem_spec \
     git+https://github.com/pydata/bottleneck \
     git+https://github.com/pydata/sparse \
-    git+https://github.com/intake/filesystem_spec \
+    git+https://github.com/pypa/packaging \
+    git+https://github.com/rasterio/rasterio \
     git+https://github.com/SciTools/nc-time-axis \
+    git+https://github.com/Unidata/cftime \
     git+https://github.com/xarray-contrib/flox \
-    git+https://github.com/h5netcdf/h5netcdf
+    git+https://github.com/zarr-developers/zarr \
 python -m pip install pytest-timeout


### PR DESCRIPTION
I saw that we didn't have this while investigating https://github.com/numba/numba/issues/8615. We should probably wait until that's resolved before merging this (this doesn't solve that issue).
