### PR TITLE
mypy - Remove some ignored packages and modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ module = [
   "Nio.*",
   "nc_time_axis.*",
   "numbagg.*",
-  "numpy.*",
   "netCDF4.*",
   "netcdftime.*",
   "pandas.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,6 @@ module = [
   "cfgrib.*",
   "cftime.*",
   "cupy.*",
-  "dask.*",
-  "distributed.*",
   "fsspec.*",
   "h5netcdf.*",
   "h5py.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,6 @@ module = [
   "zarr.*",
 ]
 
-# version spanning code is hard to type annotate (and most of this module will
-# be going away soon anyways)
 [[tool.mypy.overrides]]
 ignore_errors = true
-module = "xarray.core.pycompat"
+module = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ module = [
   "numbagg.*",
   "netCDF4.*",
   "netcdftime.*",
-  "pandas.*",
   "pooch.*",
   "PseudoNetCDF.*",
   "pydap.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ module = [
   "numbagg.*",
   "netCDF4.*",
   "netcdftime.*",
+  "pandas.*",
   "pooch.*",
   "PseudoNetCDF.*",
   "pydap.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ module = [
   "netCDF4.*",
   "netcdftime.*",
   "pandas.*",
-  "pint.*",
   "pooch.*",
   "PseudoNetCDF.*",
   "pydap.*",

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from importlib import import_module
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Literal, Type
+from typing import TYPE_CHECKING, Any, Literal, Type, Tuple
 
 import numpy as np
 from packaging.version import Version
@@ -13,7 +13,7 @@ integer_types = (int, np.integer)
 
 if TYPE_CHECKING:
     ModType = Literal["dask", "pint", "cupy", "sparse"]
-    DuckArrayTypes = tuple[Type[Any], ...]  # TODO: improve this? maybe Generic
+    DuckArrayTypes = Tuple[Type[Any], ...]  # TODO: improve this? maybe Generic
 
 
 class DuckArrayModule:

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from importlib import import_module
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Literal, Type, Tuple
+from typing import TYPE_CHECKING, Any, Literal, Tuple, Type
 
 import numpy as np
 from packaging.version import Version


### PR DESCRIPTION
dask has added py.typed files so now the ignores shouldn't be needed anymore:
https://github.com/dask/dask/pull/8854
https://github.com/dask/distributed/pull/5328
As does numpy and pint

pycompat.py doesn't error anymore, so it's good to type check that one as well. Fixed also a python 3.8 related error in it.