### PR TITLE
(Issue #7324) added functions that return data values in memory efficient manner

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4011,9 +4011,11 @@ class DataArray(
             lst_to_return: list
         """
         lst_to_return = []
-        the_data = self.data.values
         if 0 in self.shape:
             return lst_to_return
+
+        the_data = self.data.values
+        
         for i in range(len(the_data)):
             lst_to_return.append(the_data[0].tolist())
             the_data = np.delete(the_data, 0)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4014,7 +4014,7 @@ class DataArray(
             return lst_to_return
 
         the_data = self.data.values
-        
+
         for i in range(len(the_data)):
             lst_to_return.append(the_data[0].tolist())
             the_data = np.delete(the_data, 0)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4033,13 +4033,13 @@ class DataArray(
 
         (lst_of_dataJSON will hold all the data values in a list)
 
-        
+
 
         Returns
         --------
         generator
         """
-        
+
         if 0 in self.shape:
             return []
 
@@ -4048,7 +4048,6 @@ class DataArray(
         for i in range(len(self.data)):
             yield (the_data[0].tolist())
             the_data = np.delete(the_data, 0)
-            
 
     @classmethod
     def from_dict(cls: type[T_DataArray], d: Mapping[str, Any]) -> T_DataArray:

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4020,6 +4020,36 @@ class DataArray(
             the_data = np.delete(the_data, 0)
         return lst_to_return
 
+    def _genlist(self):
+        """
+        Covert this Xarray.DataArray to a list while freeing up memory as it rids of the original DataArray
+        Useful when returning data values in json format of large datasets after dataset no longer in use to avoid memory issues
+        More effecient than to_dict() and slighly more effiecnt than data_to_list_save_memory() regarding memory usage
+
+        to use:
+            lst_of_dataJSON = []
+            for i in _gennumpy(<Xarray.DataArray>):
+                lst_of_dataJSON.append(i)
+
+        (lst_of_dataJSON will hold all the data values in a list)
+
+        
+
+        Returns
+        --------
+        generator
+        """
+        
+        if 0 in self.shape:
+            return []
+
+        the_data = self.data.values
+
+        for i in range(len(self.data)):
+            yield (the_data[0].tolist())
+            the_data = np.delete(the_data, 0)
+            
+
     @classmethod
     def from_dict(cls: type[T_DataArray], d: Mapping[str, Any]) -> T_DataArray:
         """Convert a dictionary into an xarray.DataArray

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3999,6 +3999,29 @@ class DataArray(
             d["encoding"] = dict(self.encoding)
         return d
 
+
+    def data_to_list_save_memory(self):
+        """
+            Covert this Xarray.DataArray to a list while freeing up memory as it rids of the original DataArray
+            Useful when returning data values in json format of large datasets after dataset no longer in use to avoid memory issues
+            More effecient than to_dict() regarding memory usage
+
+            Returns
+            --------
+            lst_to_return: list
+        """
+        lst_to_return = []
+        the_data = self.data.values
+        if 0 in self.shape:
+            return lst_to_return
+        for i in range(len(the_data)):
+            lst_to_return.append(the_data[0].tolist())
+            the_data = np.delete(the_data, 0)
+        return lst_to_return
+
+
+
+       
     @classmethod
     def from_dict(cls: type[T_DataArray], d: Mapping[str, Any]) -> T_DataArray:
         """Convert a dictionary into an xarray.DataArray


### PR DESCRIPTION
added functions:
- `data_to_list_save_memory` 
- `_genlist`
 
`data_to_list_save_memory` returns a list of data values from a given Xarray.DataArray. 
Creates a list of data values as data values from the original Xarray.DataArray is removed (saving memory)

`_genlist` provides a generator (Most memory efficient)

Useful when returning data values in json format of large datasets after the dataset no longer in use to avoid memory issues. The function is more efficient than `to_dict()` regarding memory usage when calling for just the data values.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Documentation regarding tests: https://gist.github.com/adanb13/9203bcb411246267cea244bb2f29ca2d
- [x] Addressing Issue: https://github.com/pydata/xarray/issues/7324