### PR TITLE
Fix PR number in what’s new

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,7 +22,7 @@ v2022.11.1 (unreleased)
 New Features
 ~~~~~~~~~~~~
 - Enable using `offset` and `origin` arguments in :py:meth:`DataArray.resample`
-  and :py:meth:`Dataset.resample` (:issue:`7266`, :pull:`6538`).  By `Spencer
+  and :py:meth:`Dataset.resample` (:issue:`7266`, :pull:`7284`).  By `Spencer
   Clark <https://github.com/spencerkclark>`_.
 - Add experimental support for Zarr's in-progress V3 specification. (:pull:`6475`).
   By `Gregory Lee  <https://github.com/grlee77>`_ and `Joe Hamman <https://github.com/jhamman>`_.


### PR DESCRIPTION
I noticed the PR number was off in my what’s new entry in #7284.  This fixes that.