### PR TITLE
Remove code used to support h5py<2.10.0

### DIFF
--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -4,7 +4,6 @@ import functools
 import io
 import os
 
-import numpy as np
 from packaging.version import Version
 
 from ..core import indexing
@@ -46,9 +45,6 @@ class H5NetCDFArrayWrapper(BaseNetCDF4Array):
         )
 
     def _getitem(self, key):
-        # h5py requires using lists for fancy indexing:
-        # https://github.com/h5py/h5py/issues/992
-        key = tuple(list(k) if isinstance(k, np.ndarray) else k for k in key)
         with self.datastore.lock:
             array = self.get_array(needs_lock=False)
             return array[key]


### PR DESCRIPTION
It seems that the relevant issue was fixed in 2.10.0 https://github.com/h5py/h5py/commit/466181b178c1b8a5bfa6fb8f217319e021f647e0

I'm not sure how far back you want to fix things. I'm hoping to test this on the CI.

I found this since I've been auditing slowdowns in our codebase, which has caused me to review much of the reading pipeline.

Do you want to add a test for h5py>=2.10.0? Or can we assume that users won't install things together.
https://pypi.org/project/h5py/2.10.0/

I could for example set the backend to not be available if a version of h5py that is too old is detected.
One could alternatively, just keep the code here.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
