### PR TITLE
Avoid loading entire dataset by getting the nbytes in an array

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,6 +35,9 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Accessing the property ``.nbytes`` of a DataArray, or Variable no longer
+  accidentally triggers loading the variable into memory.
+
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -403,8 +403,8 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         If the underlying data array does not include ``nbytes``, estimates
         the bytes consumed based on the ``size`` and ``dtype``.
         """
-        if hasattr(self.data, "nbytes"):
-            return self.data.nbytes
+        if hasattr(self._data, "nbytes"):
+            return self._data.nbytes
         else:
             return self.size * self.dtype.itemsize
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3261,21 +3261,6 @@ class TestDataArray:
         assert_identical(actual_sparse, actual_dense)
 
     @requires_sparse
-    def test_sparse_nbytes(self) -> None:
-        # https://github.com/pydata/xarray/issues/4842#issue-793245791
-        df = pd.DataFrame()
-        df["x"] = np.repeat(np.arange(10), 10)
-        df["y"] = np.repeat(np.arange(10), 10)
-        df["time"] = np.tile(pd.date_range("2000-01-01", "2000-03-10", freq="W"), 10)
-        df["rate"] = 10.0
-        df = df.set_index(["time", "y", "x"])
-
-        sparse_ds = xr.Dataset.from_dataframe(df, sparse=True)
-        rate = sparse_ds["rate"]
-        assert rate.nbytes < 8000
-        assert rate.size * rate.dtype.itemsize == 8000
-
-    @requires_sparse
     def test_from_multiindex_series_sparse(self) -> None:
         # regression test for GH4019
         import sparse

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -30,6 +30,7 @@ from xarray.core.indexes import Index, PandasIndex, filter_indexes_from_coords
 from xarray.core.types import QueryEngineOptions, QueryParserOptions
 from xarray.core.utils import is_scalar
 from xarray.tests import (
+    InaccessibleArray,
     ReturnItem,
     assert_allclose,
     assert_array_equal,
@@ -38,7 +39,6 @@ from xarray.tests import (
     assert_identical,
     assert_no_warnings,
     has_dask,
-    InaccessibleArray,
     raise_if_dask_computes,
     requires_bottleneck,
     requires_cupy,
@@ -3294,7 +3294,7 @@ class TestDataArray:
         np.testing.assert_equal(actual_coords, expected_coords)
 
     def test_nbytes_does_not_load_data(self) -> None:
-        array = InaccessibleArray(np.zeros((3, 3), dtype='uint8'))
+        array = InaccessibleArray(np.zeros((3, 3), dtype="uint8"))
         da = xr.DataArray(array, dims=["x", "y"])
 
         # If xarray tries to instantiate the InaccessibleArray to compute
@@ -3306,7 +3306,7 @@ class TestDataArray:
         # nbytes property, since it isn't really required by the array
         # interface. nbytes is more a property of arrays that have been
         # cast to numpy arrays.
-        assert not hasattr(array, 'nbytes')
+        assert not hasattr(array, "nbytes")
 
     def test_to_and_from_empty_series(self) -> None:
         # GH697

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3260,6 +3260,21 @@ class TestDataArray:
         assert_identical(actual_sparse, actual_dense)
 
     @requires_sparse
+    def test_sparse_nbytes(self) -> None:
+        # https://github.com/pydata/xarray/issues/4842#issue-793245791
+        df = pd.DataFrame()
+        df["x"] = np.repeat(np.arange(10), 10)
+        df["y"] = np.repeat(np.arange(10), 10)
+        df["time"] = np.tile(pd.date_range("2000-01-01", "2000-03-10", freq="W"), 10)
+        df["rate"] = 10.0
+        df = df.set_index(["time", "y", "x"])
+
+        sparse_ds = xr.Dataset.from_dataframe(df, sparse=True)
+        rate = sparse_ds["rate"]
+        assert rate.nbytes < 8000
+        assert rate.size * rate.dtype.itemsize == 8000
+
+    @requires_sparse
     def test_from_multiindex_series_sparse(self) -> None:
         # regression test for GH4019
         import sparse


### PR DESCRIPTION
Using `.data` accidentally tries to load the whole lazy arrays into memory.

Sad.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
