### PR TITLE
COMPAT: Adjust CFTimeIndex.get_loc for pandas 2.0 deprecation enforcement

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,6 +27,9 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- :py:meth:`CFTimeIndex.get_loc` has removed the ``method`` and ``tolerance`` keyword arguments.
+  Use ``.get_indexer([key], method=..., tolerance=...)`` instead (:pull:`7361`).
+  By `Matthew Roeschke <https://github.com/mroeschke>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -463,16 +463,12 @@ class CFTimeIndex(pd.Index):
         indexer = np.where(distance <= tolerance, indexer, -1)
         return indexer
 
-    def get_loc(self, key, method=None, tolerance=None):
+    def get_loc(self, key):
         """Adapted from pandas.tseries.index.DatetimeIndex.get_loc"""
         if isinstance(key, str):
             return self._get_string_slice(key)
-        elif method is not None and tolerance is not None:
-            return super().get_loc(key)
-        elif Version(pd.__version__) < Version("2.0"):
-            return super().get_loc(key, method=method, tolerance=tolerance)
         else:
-            return super().get_indexer(self, [key], method=method, tolerance=tolerance)
+            return super().get_loc(key)
 
     def _maybe_cast_slice_bound(self, label, side, kind=None):
         """Adapted from

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -465,11 +465,11 @@ class CFTimeIndex(pd.Index):
         if isinstance(key, str):
             return self._get_string_slice(key)
         elif method is not None and tolerance is not None:
-            return pd.Index.get_loc(self, key)
+            return super().get_loc(key)
         elif Version(pd.__version__) < Version("2.0"):
-            return pd.Index.get_loc(self, key, method=method, tolerance=tolerance)
+            return super().get_loc(key, method=method, tolerance=tolerance)
         else:
-            return pd.Index.get_indexer(self, [key], method=method, tolerance=tolerance)
+            return super().get_indexer(self, [key], method=method, tolerance=tolerance)
 
     def _maybe_cast_slice_bound(self, label, side, kind=None):
         """Adapted from

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -464,8 +464,12 @@ class CFTimeIndex(pd.Index):
         """Adapted from pandas.tseries.index.DatetimeIndex.get_loc"""
         if isinstance(key, str):
             return self._get_string_slice(key)
-        else:
+        elif method is not None and tolerance is not None:
+            return pd.Index.get_loc(self, key)
+        elif Version(pd.__version__) < Version("2.0"):
             return pd.Index.get_loc(self, key, method=method, tolerance=tolerance)
+        else:
+            return pd.Index.get_indexer(self, [key], method=method, tolerance=tolerance)
 
     def _maybe_cast_slice_bound(self, label, side, kind=None):
         """Adapted from


### PR DESCRIPTION
With the upcoming pandas 2.0 release, we are enforcing a deprecation in `pd.Index.get_loc` to remove `method` and `tolerance`.  Just in case `get_loc` isn't 100% compatible with `get_indexer`, I structured the `elif` to use `get_loc` as much as possible. Let me know if any other adjustments are needed
