### PR TITLE
Fill missing data_vars during concat by reindexing

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -78,9 +78,6 @@ Bug fixes
   By `Benoît Bovy <https://github.com/benbovy>`_.
 - Preserve original dtype on accessing MultiIndex levels (:issue:`7250`,
   :pull:`7393`). By `Ian Carroll <https://github.com/itcarroll>`_.
-- Make :py:func:`xarray.concat` more robust when concatenating variables present in some datasets but
-  not others (:issue:`508`, :pull:`7400`).
-  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_ and `Scott Chamberlin <https://github.com/scottcha>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -75,7 +75,7 @@ Bug fixes
   By `Benoît Bovy <https://github.com/benbovy>`_.
 - Preserve original dtype on accessing MultiIndex levels (:issue:`7250`,
   :pull:`7393`). By `Ian Carroll <https://github.com/itcarroll>`_.
-- Make :py:func:`xarray.concat` more robust when concatenating variables present in some datasets but
+- :py:func:`xarray.concat` can now concatenate variables present in some datasets but
   not others (:issue:`508`, :pull:`7400`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_ and `Scott Chamberlin <https://github.com/scottcha>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -78,6 +78,9 @@ Bug fixes
   By `Benoît Bovy <https://github.com/benbovy>`_.
 - Preserve original dtype on accessing MultiIndex levels (:issue:`7250`,
   :pull:`7393`). By `Ian Carroll <https://github.com/itcarroll>`_.
+- Make :py:func:`xarray.concat` more robust when concatenating variables present in some datasets but
+  not others (:issue:`508`, :pull:`7400`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_ and `Scott Chamberlin <https://github.com/scottcha>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,6 +35,9 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- :py:func:`xarray.concat` can now concatenate variables present in some datasets but
+  not others (:issue:`508`, :pull:`7400`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_ and `Scott Chamberlin <https://github.com/scottcha>`_.
 
 Documentation
 ~~~~~~~~~~~~~
@@ -75,9 +78,6 @@ Bug fixes
   By `Benoît Bovy <https://github.com/benbovy>`_.
 - Preserve original dtype on accessing MultiIndex levels (:issue:`7250`,
   :pull:`7393`). By `Ian Carroll <https://github.com/itcarroll>`_.
-- :py:func:`xarray.concat` can now concatenate variables present in some datasets but
-  not others (:issue:`508`, :pull:`7400`).
-  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_ and `Scott Chamberlin <https://github.com/scottcha>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -75,6 +75,9 @@ Bug fixes
   By `Benoît Bovy <https://github.com/benbovy>`_.
 - Preserve original dtype on accessing MultiIndex levels (:issue:`7250`,
   :pull:`7393`). By `Ian Carroll <https://github.com/itcarroll>`_.
+- Make :py:func:`xarray.concat` more robust when concatenating variables present in some datasets but
+  not others (:issue:`508`, :pull:`7400`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_ and `Scott Chamberlin <https://github.com/scottcha>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -71,7 +71,7 @@ def reindex_variables(
 
     for name, var in variables.items():
         if isinstance(fill_value, dict):
-            fill_value_ = fill_value[name]
+            fill_value_ = fill_value.get(name, dtypes.NA)
         else:
             fill_value_ = fill_value
 

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -71,7 +71,7 @@ def reindex_variables(
 
     for name, var in variables.items():
         if isinstance(fill_value, dict):
-            fill_value_ = fill_value.get(name, dtypes.NA)
+            fill_value_ = fill_value[name]
         else:
             fill_value_ = fill_value
 

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -424,7 +424,7 @@ def _parse_datasets(
     dims_sizes: dict[Hashable, int] = {}  # shared dimension sizes to expand variables
     variables_order: dict[Hashable, Variable] = {}  # variables in order of appearance
 
-    for i, ds in enumerate(datasets):
+    for ds in datasets:
         dims_sizes.update(ds.dims)
         all_coord_names.update(ds.coords)
         data_vars.update(ds.data_vars)

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -536,7 +536,7 @@ def _dataset_concat(
 
     # we've already verified everything is consistent; now, calculate
     # shared dimension sizes so we can expand the necessary variables
-    def ensure_common_dims(vars):
+    def ensure_common_dims(vars, concat_dim_lengths):
         # ensure each variable with the given name shares the same
         # dimensions and the same shape for all of them except along the
         # concat dimension
@@ -573,23 +573,24 @@ def _dataset_concat(
         if name in concat_over and name not in result_indexes:
             variables = []
             variable_index = []
+            var_concat_dim_length = []
             for i, ds in enumerate(datasets):
                 if name in ds.variables:
                     variables.append(ds[name].variable)
                     # add to variable index, needed for reindexing
-                    variable_index.extend(
-                        [
-                            sum(concat_dim_lengths[:i]) + k
-                            for k in range(concat_dim_lengths[i])
-                        ]
-                    )
+                    var_idx = [
+                        sum(concat_dim_lengths[:i]) + k
+                        for k in range(concat_dim_lengths[i])
+                    ]
+                    variable_index.extend(var_idx)
+                    var_concat_dim_length.append(len(var_idx))
                 else:
                     # raise if coordinate not in all datasets
                     if name in coord_names:
                         raise ValueError(
                             f"coordinate {name!r} not present in all datasets."
                         )
-            vars = ensure_common_dims(variables)
+            vars = ensure_common_dims(variables, var_concat_dim_length)
 
             # Try to concatenate the indexes, concatenate the variables when no index
             # is found on all datasets.

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -441,7 +441,7 @@ def _dataset_concat(
     coords: str | list[str],
     compat: CompatOptions,
     positions: Iterable[Iterable[int]] | None,
-    fill_value: object = dtypes.NA,
+    fill_value: Any = dtypes.NA,
     join: JoinOptions = "outer",
     combine_attrs: CombineAttrsOptions = "override",
 ) -> T_Dataset:

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -500,7 +500,7 @@ def _dataset_concat(
     # Make sure we're working on a copy (we'll be loading variables)
     datasets = [ds.copy() for ds in datasets]
     datasets = list(
-        align(*datasets, join=join, copy=False, exclude=[dim], fill_value=fill_value_)
+        align(*datasets, join=join, copy=False, exclude=[dim], fill_value=fill_value)
     )
 
     dim_coords, dims_sizes, coord_names, data_names, data_vars_order = _parse_datasets(

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -480,7 +480,7 @@ def _dataset_concat(
         align(*datasets, join=join, copy=False, exclude=[dim], fill_value=fill_value)
     )
 
-    dim_coords, dims_sizes, coord_names, data_names, data_vars_order = _parse_datasets(
+    dim_coords, dims_sizes, coord_names, data_names, vars_order = _parse_datasets(
         datasets
     )
     dim_names = set(dim_coords)
@@ -569,7 +569,7 @@ def _dataset_concat(
 
     # stack up each variable and/or index to fill-out the dataset (in order)
     # n.b. this loop preserves variable order, needed for groupby.
-    for name in data_vars_order:
+    for name in vars_order:
         if name in concat_over and name not in result_indexes:
             variables = []
             variable_index = []
@@ -589,7 +589,7 @@ def _dataset_concat(
                         raise ValueError(
                             f"coordinate {name!r} not present in all datasets."
                         )
-            vars = list(ensure_common_dims(variables))
+            vars = ensure_common_dims(variables)
 
             # Try to concatenate the indexes, concatenate the variables when no index
             # is found on all datasets.

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -491,17 +491,17 @@ def _dataset_concat(
 
     dim, index = _calc_concat_dim_index(dim)
 
+    # ensure dictionary for fill_value
+    if isinstance(fill_value, dict):
+        fill_value_ = fill_value.copy()
+    else:
+        fill_value_ = defaultdict(lambda: fill_value)
+
     # Make sure we're working on a copy (we'll be loading variables)
     datasets = [ds.copy() for ds in datasets]
     datasets = list(
-        align(*datasets, join=join, copy=False, exclude=[dim], fill_value=fill_value)
+        align(*datasets, join=join, copy=False, exclude=[dim], fill_value=fill_value_)
     )
-
-    # ensure dictionary for fill_value
-    if isinstance(fill_value, dict):
-        fill_value_ = defaultdict(lambda: dtypes.NA, **fill_value)
-    else:
-        fill_value_ = defaultdict(lambda: fill_value)
 
     dim_coords, dims_sizes, coord_names, data_names, data_vars_order = _parse_datasets(
         datasets

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -613,7 +613,11 @@ def _dataset_concat(
                 # do not concat if:
                 # 1. variable is only present in one dataset of multiple datasets and
                 # 2. dim is not a dimension of variable
-                if dim not in variables[0].dims and len(variables) == 1 and len(datasets) > 1:
+                if (
+                    dim not in variables[0].dims
+                    and len(variables) == 1
+                    and len(datasets) > 1
+                ):
                     combined_var = variables[0]
                 # only concat if variable is in multiple datasets
                 # or if single dataset (GH1988)

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -610,9 +610,10 @@ def _dataset_concat(
                     )
                     result_vars[k] = v
             else:
-                # if variable is only present in one dataset of multiple datasets,
-                # then do not concat
-                if len(variables) == 1 and len(datasets) > 1:
+                # do not concat if:
+                # 1. variable is only present in one dataset of multiple datasets and
+                # 2. dim is not a dimension of variable
+                if dim not in variables[0].dims and len(variables) == 1 and len(datasets) > 1:
                     combined_var = variables[0]
                 # only concat if variable is in multiple datasets
                 # or if single dataset (GH1988)

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -379,7 +379,7 @@ def _calc_concat_over(datasets, dim, dim_names, data_vars, coords, compat):
             elif opt == "all":
                 concat_over.update(
                     set().union(
-                        *list((set(getattr(d, subset)) - set(d.dims) for d in datasets))
+                        *list(set(getattr(d, subset)) - set(d.dims) for d in datasets)
                     )
                 )
             elif opt == "minimal":
@@ -573,7 +573,10 @@ def _dataset_concat(
                     variables.append(ds.variables[name])
                     # add to variable index, needed for reindexing
                     variable_index.extend(
-                        [sum(concat_dim_lengths[:i]) + k for k in range(concat_dim_lengths[i])]
+                        [
+                            sum(concat_dim_lengths[:i]) + k
+                            for k in range(concat_dim_lengths[i])
+                        ]
                     )
                 else:
                     # raise if coordinate not in all datasets

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -443,7 +443,7 @@ def _parse_datasets(
     data_vars: set[Hashable] = set()  # list of data_vars
     dim_coords: dict[Hashable, Variable] = {}  # maps dim name to variable
     dims_sizes: dict[Hashable, int] = {}  # shared dimension sizes to expand variables
-    data_vars_order: list[Hashable]  # dataset index of maximum count of variables
+    data_vars_order: list[Hashable]  # ordered list of variables
 
     data_vars_count = []
 

--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -558,6 +558,9 @@ def _dataset_concat(
     # preserve variable order for variables in first dataset
     data_var_order = list(datasets[0].variables)
     # append additional variables to the end
+    # TODO: since data_names is a set the ordering for the appended variables
+    #  is not deterministic, see also discussion in
+    #  https://github.com/pydata/xarray/pull/3545#pullrequestreview-347543738
     data_var_order += [e for e in data_names if e not in data_var_order]
     # create concatenation index, needed for later reindexing
     concat_index = list(range(sum(concat_dim_lengths)))

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -583,7 +583,7 @@ class TestConcatDataset:
                 var_names.append(l1)
             return var_names
 
-        def create_ds(var_names, dim=False, coord=False, drop_idx=False):
+        def create_ds(var_names: list[str], dim: bool =False, coord: bool =False, drop_idx: list[int] |None =None) -> list[Dataset]:
             out_ds = []
             ds = Dataset()
             ds = ds.assign_coords({"x": np.arange(2)})

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -591,7 +591,7 @@ class TestConcatDataset:
             ds = ds.assign_coords({"z": np.arange(4)})
             for i, dsl in enumerate(var_names):
                 vlist = dsl.copy()
-                if drop_idx:
+                if drop_idx is not None:
                     vlist.pop(drop_idx[i])
                 foo_data = np.arange(48, dtype=float).reshape(2, 2, 3, 4)
                 dsi = ds.copy()

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -50,8 +50,6 @@ def test_concat_compat() -> None:
         ValueError, match=r"coordinates in some datasets but not others"
     ):
         concat([ds1, ds2], dim="q")
-    with pytest.raises(ValueError, match=r"'q' is not present in all datasets"):
-        concat([ds2, ds1], dim="q")
 
 
 class TestConcatDataset:
@@ -776,7 +774,7 @@ def test_concat_merge_single_non_dim_coord():
         actual = concat([da1, da2], "x", coords=coords)
         assert_identical(actual, expected)
 
-    with pytest.raises(ValueError, match=r"'y' is not present in all datasets."):
+    with pytest.raises(ValueError, match=r"'y' not present in all datasets."):
         concat([da1, da2], dim="x", coords="all")
 
     da1 = DataArray([1, 2, 3], dims="x", coords={"x": [1, 2, 3], "y": 1})
@@ -784,7 +782,7 @@ def test_concat_merge_single_non_dim_coord():
     da3 = DataArray([7, 8, 9], dims="x", coords={"x": [7, 8, 9], "y": 1})
     for coords in ["different", "all"]:
         with pytest.raises(ValueError, match=r"'y' not present in all datasets"):
-            concat([da1, da2, da3], dim="x")
+            concat([da1, da2, da3], dim="x", coords=coords)
 
 
 def test_concat_preserve_coordinate_order() -> None:

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -576,7 +576,7 @@ class TestConcatDataset:
     def test_concat_fill_missing_variables(self, dim, coord):
         # create var names list with one missing value
         def get_var_names(var_cnt=10, list_cnt=10):
-            orig = [f'd{i:02d}' for i in range(var_cnt)]
+            orig = [f"d{i:02d}" for i in range(var_cnt)]
             var_names = []
             for i in range(0, list_cnt):
                 l1 = orig.copy()
@@ -603,15 +603,19 @@ class TestConcatDataset:
                     dsi = dsi.isel(time=0)
                 out_ds.append(dsi)
             return out_ds
+
         var_names = get_var_names()
 
         import random
+
         random.seed(42)
         drop_idx = [random.randrange(len(vlist)) for vlist in var_names]
-        expected = concat(create_ds(var_names, dim=dim, coord=coord), dim="time", data_vars="all")
+        expected = concat(
+            create_ds(var_names, dim=dim, coord=coord), dim="time", data_vars="all"
+        )
         for i, idx in enumerate(drop_idx):
             if dim:
-                expected[var_names[0][idx]][i * 2: i * 2 + 2] = np.nan
+                expected[var_names[0][idx]][i * 2 : i * 2 + 2] = np.nan
             else:
                 expected[var_names[0][idx]][i] = np.nan
 

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 def create_concat_datasets(
     num_datasets: int = 2, seed: int | None = None, include_day: bool = True
 ) -> list[Dataset]:
-    rng = default_rng(seed)
+    rng = np.random.default_rng(seed)
     lat = rng.standard_normal(size=(1, 4))
     lon = rng.standard_normal(size=(1, 4))
     result = []

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -188,14 +188,27 @@ def test_concat_second_empty() -> None:
 
     expected = Dataset(data_vars={"a": ("y", [0.1, np.nan])}, coords={"x": 0.1})
     actual = concat([ds1, ds2], dim="y")
-
     assert_identical(actual, expected)
 
     expected = Dataset(
         data_vars={"a": ("y", [0.1, np.nan])}, coords={"x": ("y", [0.1, 0.1])}
     )
     actual = concat([ds1, ds2], dim="y", coords="all")
+    assert_identical(actual, expected)
 
+    # Check concatenating scalar data_var only present in ds1
+    ds1["b"] = 0.1
+    expected = Dataset(
+        data_vars={"a": ("y", [0.1, np.nan]), "b": ("y", [0.1, np.nan])},
+        coords={"x": ("y", [0.1, 0.1])},
+    )
+    actual = concat([ds1, ds2], dim="y", coords="all", data_vars="all")
+    assert_identical(actual, expected)
+
+    expected = Dataset(
+        data_vars={"a": ("y", [0.1, np.nan]), "b": 0.1}, coords={"x": 0.1}
+    )
+    actual = concat([ds1, ds2], dim="y", coords="different", data_vars="different")
     assert_identical(actual, expected)
 
 

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -25,7 +25,9 @@ if TYPE_CHECKING:
 
 
 # helper method to create multiple tests datasets to concat
-def create_concat_datasets(num_datasets=2, seed=None, include_day=True):
+def create_concat_datasets(
+    num_datasets: int = 2, seed: [int | None] = None, include_day: bool = True
+) -> list[Dataset]:
     random.seed(seed)
     result = []
     lat = np.random.randn(1, 4)
@@ -66,7 +68,9 @@ def create_concat_datasets(num_datasets=2, seed=None, include_day=True):
 
 
 # helper method to create multiple tests datasets to concat with specific types
-def create_typed_datasets(num_datasets=2, seed=None):
+def create_typed_datasets(
+    num_datasets: int = 2, seed: [int | None] = None
+) -> list[Dataset]:
     random.seed(seed)
     var_strings = ["a", "b", "c", "d", "e", "f", "g", "h"]
     result = []
@@ -133,7 +137,7 @@ def test_concat_compat() -> None:
         concat([ds1, ds2], dim="q")
 
 
-def test_concat_missing_var():
+def test_concat_missing_var() -> None:
     datasets = create_concat_datasets(2, 123)
     vars_to_drop = ["humidity", "precipitation", "cloud cover"]
     datasets[0] = datasets[0].drop_vars(vars_to_drop)
@@ -165,7 +169,7 @@ def test_concat_missing_var():
     assert_equal(result, ds_result)
 
 
-def test_concat_missing_multiple_consecutive_var():
+def test_concat_missing_multiple_consecutive_var() -> None:
     datasets = create_concat_datasets(3, 123)
     vars_to_drop = ["pressure", "humidity"]
     datasets[0] = datasets[0].drop_vars(vars_to_drop)
@@ -236,7 +240,7 @@ def test_concat_missing_multiple_consecutive_var():
     assert_equal(result, ds_result)
 
 
-def test_concat_all_empty():
+def test_concat_all_empty() -> None:
     ds1 = Dataset()
     ds2 = Dataset()
     result = concat([ds1, ds2], dim="new_dim")
@@ -244,7 +248,7 @@ def test_concat_all_empty():
     assert_equal(result, Dataset())
 
 
-def test_concat_second_empty():
+def test_concat_second_empty() -> None:
     ds1 = Dataset(data_vars={"a": ("y", [0.1])}, coords={"x": 0.1})
     ds2 = Dataset(coords={"x": 0.1})
 
@@ -254,7 +258,7 @@ def test_concat_second_empty():
     assert_equal(result, ds_result)
 
 
-def test_multiple_missing_variables():
+def test_multiple_missing_variables() -> None:
     datasets = create_concat_datasets(2, 123)
     vars_to_drop = ["pressure", "cloud cover"]
     datasets[1] = datasets[1].drop_vars(vars_to_drop)
@@ -298,7 +302,7 @@ def test_multiple_missing_variables():
 
 
 @pytest.mark.xfail(strict=True)
-def test_concat_multiple_datasets_missing_vars_and_new_dim():
+def test_concat_multiple_datasets_missing_vars_and_new_dim() -> None:
     vars_to_drop = [
         "temperature",
         "pressure",
@@ -370,7 +374,7 @@ def test_concat_multiple_datasets_missing_vars_and_new_dim():
     assert_equal(result, ds_result)
 
 
-def test_multiple_datasets_with_missing_variables():
+def test_multiple_datasets_with_missing_variables() -> None:
     vars_to_drop = [
         "temperature",
         "pressure",
@@ -436,7 +440,7 @@ def test_multiple_datasets_with_missing_variables():
     assert_equal(result, ds_result)
 
 
-def test_multiple_datasets_with_multiple_missing_variables():
+def test_multiple_datasets_with_multiple_missing_variables() -> None:
     vars_to_drop_in_first = ["temperature", "pressure"]
     vars_to_drop_in_second = ["humidity", "precipitation", "cloud cover"]
     datasets = create_concat_datasets(2, 123)
@@ -484,7 +488,7 @@ def test_multiple_datasets_with_multiple_missing_variables():
     assert_equal(result, ds_result)
 
 
-def test_type_of_missing_fill():
+def test_type_of_missing_fill() -> None:
     datasets = create_typed_datasets(2, 123)
 
     vars = ["float", "float2", "string", "int", "datetime64", "timedelta64"]
@@ -576,7 +580,7 @@ def test_type_of_missing_fill():
     assert_equal(result_rev, ds_result_rev)
 
 
-def test_order_when_filling_missing():
+def test_order_when_filling_missing() -> None:
     vars_to_drop_in_first = []
     # drop middle
     vars_to_drop_in_second = ["humidity"]

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 # helper method to create multiple tests datasets to concat
 def create_concat_datasets(
-    num_datasets: int = 2, seed: [int | None] = None, include_day: bool = True
+    num_datasets: int = 2, seed: int | None = None, include_day: bool = True
 ) -> list[Dataset]:
     random.seed(seed)
     result = []
@@ -69,7 +69,7 @@ def create_concat_datasets(
 
 # helper method to create multiple tests datasets to concat with specific types
 def create_typed_datasets(
-    num_datasets: int = 2, seed: [int | None] = None
+    num_datasets: int = 2, seed: int | None = None
 ) -> list[Dataset]:
     random.seed(seed)
     var_strings = ["a", "b", "c", "d", "e", "f", "g", "h"]
@@ -1172,7 +1172,7 @@ class TestConcatDataset:
     @pytest.mark.parametrize("coord", [True, False])
     def test_concat_fill_missing_variables(self, dim: bool, coord: bool) -> None:
         # create var names list with one missing value
-        def get_var_names(var_cnt: int = 10, list_cnt: int = 10) -> list[str]:
+        def get_var_names(var_cnt: int = 10, list_cnt: int = 10) -> list[list[str]]:
             orig = [f"d{i:02d}" for i in range(var_cnt)]
             var_names = []
             for i in range(0, list_cnt):
@@ -1181,7 +1181,7 @@ class TestConcatDataset:
             return var_names
 
         def create_ds(
-            var_names: list[str],
+            var_names: list[list[str]],
             dim: bool = False,
             coord: bool = False,
             drop_idx: list[int] | None = None,

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -573,7 +573,7 @@ class TestConcatDataset:
 
     @pytest.mark.parametrize("dim", [True, False])
     @pytest.mark.parametrize("coord", [True, False])
-    def test_concat_fill_missing_variables(self, dim, coord):
+    def test_concat_fill_missing_variables(self, dim: bool, coord: bool) -> None:
         # create var names list with one missing value
         def get_var_names(var_cnt=10, list_cnt=10):
             orig = [f"d{i:02d}" for i in range(var_cnt)]

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -28,10 +28,10 @@ if TYPE_CHECKING:
 def create_concat_datasets(
     num_datasets: int = 2, seed: int | None = None, include_day: bool = True
 ) -> list[Dataset]:
-    random.seed(seed)
+    rng = default_rng(seed)
+    lat = rng.standard_normal(size=(1, 4))
+    lon = rng.standard_normal(size=(1, 4))
     result = []
-    lat = np.random.randn(1, 4)
-    lon = np.random.randn(1, 4)
     for i in range(num_datasets):
         if include_day:
             result.append(

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -785,7 +785,7 @@ class TestConcatDataset:
         split_data = [data.isel(dim1=slice(3)), data.isel(dim1=slice(3, None))]
         data0, data1 = deepcopy(split_data)
         data1["foo"] = ("bar", np.random.randn(10))
-        actual = concat([data0, data1], "dim1")
+        actual = concat([data0, data1], "dim1", data_vars="minimal")
         expected = data.copy().assign(foo=data1.foo)
         assert_identical(expected, actual)
 

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -662,9 +662,9 @@ def test_order_when_filling_missing() -> None:
     result_keys_rev = [
         "temperature",
         "pressure",
-        "humidity",
         "precipitation",
         "cloud cover",
+        "humidity",
     ]
     # test order when concat in reversed order
     rev_result = concat(datasets[::-1], dim="day")

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -234,6 +234,7 @@ def test_concat_missing_multiple_consecutive_var() -> None:
     r1 = [var for var in result.data_vars]
     r2 = [var for var in ds_result.data_vars]
     # check the variables orders are the same for the first three variables
+    # TODO: Can all variables become deterministic?
     assert r1[:3] == r2[:3]
     assert set(r1[3:]) == set(r2[3:])  # just check availability for the remaining vars
     assert_equal(result, ds_result)

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -145,9 +145,7 @@ def test_concat_compat() -> None:
 
     for var in ["has_x", "no_x_y"]:
         assert "y" not in result[var].dims and "y" not in result[var].coords
-    with pytest.raises(
-        ValueError, match=r"coordinates in some datasets but not others"
-    ):
+    with pytest.raises(ValueError, match=r"'q' not present in all datasets"):
         concat([ds1, ds2], dim="q")
     with pytest.raises(ValueError, match=r"'q' not present in all datasets"):
         concat([ds2, ds1], dim="q")

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -575,7 +575,7 @@ class TestConcatDataset:
     @pytest.mark.parametrize("coord", [True, False])
     def test_concat_fill_missing_variables(self, dim: bool, coord: bool) -> None:
         # create var names list with one missing value
-        def get_var_names(var_cnt=10, list_cnt=10):
+        def get_var_names(var_cnt: int=10, list_cnt: int=10) -> list[str]:
             orig = [f"d{i:02d}" for i in range(var_cnt)]
             var_names = []
             for i in range(0, list_cnt):

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -575,7 +575,7 @@ class TestConcatDataset:
     @pytest.mark.parametrize("coord", [True, False])
     def test_concat_fill_missing_variables(self, dim: bool, coord: bool) -> None:
         # create var names list with one missing value
-        def get_var_names(var_cnt: int=10, list_cnt: int=10) -> list[str]:
+        def get_var_names(var_cnt: int = 10, list_cnt: int = 10) -> list[str]:
             orig = [f"d{i:02d}" for i in range(var_cnt)]
             var_names = []
             for i in range(0, list_cnt):
@@ -583,7 +583,12 @@ class TestConcatDataset:
                 var_names.append(l1)
             return var_names
 
-        def create_ds(var_names: list[str], dim: bool =False, coord: bool =False, drop_idx: list[int] |None =None) -> list[Dataset]:
+        def create_ds(
+            var_names: list[str],
+            dim: bool = False,
+            coord: bool = False,
+            drop_idx: list[int] | None = None,
+        ) -> list[Dataset]:
             out_ds = []
             ds = Dataset()
             ds = ds.assign_coords({"x": np.arange(2)})


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #508, 
- [x] Closes #3545
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

This is another attempt to solve #508. Took inspiration from #3545 by @scottcha.

This follows along @dcherian's comment in the same above PR (https://github.com/pydata/xarray/pull/3545#issuecomment-586346637).

Update:

After review the variable order is estimated by order of appearance in the list of datasets. That keeps full backwards compatibility and is deterministic. Thanks @dcherian and @keewis for the suggestions.
