### PR TITLE
install `numbagg` from `conda-forge`

### DIFF
--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -23,6 +23,7 @@ dependencies:
   - nc-time-axis
   - netcdf4
   - numba
+  - numbagg
   - numpy
   - packaging
   - pandas
@@ -41,5 +42,3 @@ dependencies:
   - toolz
   - typing_extensions
   - zarr
-  - pip:
-      - numbagg

--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -24,7 +24,7 @@ dependencies:
   - netcdf4
   - numba
   - numbagg
-  - numpy
+  - numpy<1.24
   - packaging
   - pandas
   - pint

--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -18,7 +18,7 @@ dependencies:
   - nbsphinx
   - netcdf4>=1.5
   - numba
-  - numpy>=1.20
+  - numpy>=1.20,<1.24
   - packaging>=21.0
   - pandas>=1.3
   - pooch

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -23,7 +23,7 @@ dependencies:
   - netcdf4
   - numba
   - numbagg
-  - numpy
+  - numpy<1.24
   - packaging
   - pandas
   - pint

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -22,6 +22,7 @@ dependencies:
   - nc-time-axis
   - netcdf4
   - numba
+  - numbagg
   - numpy
   - packaging
   - pandas
@@ -41,5 +42,3 @@ dependencies:
   - toolz
   - typing_extensions
   - zarr
-  - pip:
-      - numbagg

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -24,6 +24,7 @@ dependencies:
   - nc-time-axis
   - netcdf4
   - numba
+  - numbagg
   - numexpr
   - numpy
   - packaging
@@ -45,5 +46,3 @@ dependencies:
   - toolz
   - typing_extensions
   - zarr
-  - pip:
-      - numbagg

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - numba
   - numbagg
   - numexpr
-  - numpy
+  - numpy<1.24
   - packaging
   - pandas
   - pint


### PR DESCRIPTION
It seems there is a `numbagg` package on `conda-forge` now.

Not sure what to do about the `min-all-deps` CI, but given that the most recent version of `numbagg` happened more than 12 months ago (more than 18 months, even) maybe we can just bump it to the version on `conda-forge`?