### PR TITLE
remove `numbagg` and `numba` from the upstream-dev CI

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -19,7 +19,8 @@ conda uninstall -y --force \
     h5netcdf \
     xarray
 # temporarily (?) remove numbagg and numba
-conda uninstall -y numbagg numba
+pip uninstall -y numbagg
+conda uninstall -y numba
 # to limit the runtime of Upstream CI
 python -m pip install \
     -i https://pypi.anaconda.org/scipy-wheels-nightly/simple \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -18,6 +18,8 @@ conda uninstall -y --force \
     flox \
     h5netcdf \
     xarray
+# temporarily (?) remove numbagg and numba
+conda uninstall -y numbagg numba
 # new matplotlib dependency
 python -m pip install --upgrade contourpy
 # to limit the runtime of Upstream CI

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -20,8 +20,6 @@ conda uninstall -y --force \
     xarray
 # temporarily (?) remove numbagg and numba
 conda uninstall -y numbagg numba
-# new matplotlib dependency
-python -m pip install --upgrade contourpy
 # to limit the runtime of Upstream CI
 python -m pip install \
     -i https://pypi.anaconda.org/scipy-wheels-nightly/simple \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# temporarily (?) remove numbagg and numba
+pip uninstall -y numbagg
+conda uninstall -y numba
+# forcibly remove packages to avoid artifacts
 conda uninstall -y --force \
     numpy \
     scipy \
@@ -18,9 +22,6 @@ conda uninstall -y --force \
     flox \
     h5netcdf \
     xarray
-# temporarily (?) remove numbagg and numba
-pip uninstall -y numbagg
-conda uninstall -y numba
 # to limit the runtime of Upstream CI
 python -m pip install \
     -i https://pypi.anaconda.org/scipy-wheels-nightly/simple \


### PR DESCRIPTION
- [x] opposite of #7311
- [x] closes #7306

Using the `numpy` HEAD together with `numba` is, in general, not supported (see numba/numba#8615). So in order to avoid the current failures and still be able to test `numpy` HEAD, this (temporarily) removes `numbagg` and `numba` (pulled in through `numbagg`), from the upstream-dev CI.