### PR TITLE
Add lazy backend ASV test

### DIFF
--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -519,7 +519,7 @@ class IOReadSingleFile(IOSingleNetCDF):
             self.filepaths[engine] = f"test_single_file_with_{engine}.nc"
             self.ds.to_netcdf(self.filepaths[engine], engine=engine)
 
-    @parameterized("engine", [_ENGINES])
+    @parameterized(["engine", "chunks"], (_ENGINES, [None, {}]))
     def time_read_dataset(self, engine):
         xr.open_dataset(self.filepaths[engine], engine=engine)
 

--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 import os
+from dataclasses import dataclass
 
 import numpy as np
 import pandas as pd
 
 import xarray as xr
 
-from . import _skip_slow, randint, randn, requires_dask
+from . import _skip_slow, parameterized, randint, randn, requires_dask
 
 try:
     import dask
@@ -476,3 +479,129 @@ class IOWriteNetCDFDaskDistributed:
 
     def time_write(self):
         self.write.compute()
+
+
+class OpenDataset:
+    def setup(self):
+        """
+        The custom backend does the bare mininum to be considered a lazy backend. But
+        the data in it is still in memory so slow file reading shouldn't affect the
+        results.
+        """
+        requires_dask()
+
+        @dataclass
+        class PerformanceBackendArray(xr.backends.BackendArray):
+            filename_or_obj: str | os.PathLike | None
+            shape: tuple[int, ...]
+            dtype: np.dtype
+            lock: xr.backends.locks.SerializableLock
+
+            def __getitem__(self, key: tuple):
+                return xr.core.indexing.explicit_indexing_adapter(
+                    key,
+                    self.shape,
+                    xr.core.indexing.IndexingSupport.BASIC,
+                    self._raw_indexing_method,
+                )
+
+            def _raw_indexing_method(self, key: tuple):
+                raise NotImplementedError
+
+        @dataclass
+        class PerformanceStore(xr.backends.common.AbstractWritableDataStore):
+            manager: xr.backends.CachingFileManager
+            mode: str | None = None
+            lock: xr.backends.locks.SerializableLock | None = None
+            autoclose: bool = False
+
+            def __post_init__(self):
+                self.filename = self.manager._args[0]
+
+            @classmethod
+            def open(
+                cls,
+                filename: str | os.PathLike | None,
+                mode: str = "r",
+                lock: xr.backends.locks.SerializableLock | None = None,
+                autoclose: bool = False,
+            ):
+                if lock is None:
+                    if mode == "r":
+                        locker = xr.backends.locks.SerializableLock()
+                    else:
+                        locker = xr.backends.locks.SerializableLock()
+                else:
+                    locker = lock
+
+                manager = xr.backends.CachingFileManager(
+                    xr.backends.DummyFileManager,
+                    filename,
+                    mode=mode,
+                )
+                return cls(manager, mode=mode, lock=locker, autoclose=autoclose)
+
+            def load(self) -> tuple:
+                """
+                Load a bunch of test data quickly.
+
+                Normally this method would've opened a file and parsed it.
+                """
+                # Important to have a shape and dtype for lazy loading.
+                shape = (1,)
+                dtype = np.dtype(int)
+                variables = {
+                    f"long_variable_name_{v}": xr.Variable(
+                        data=PerformanceBackendArray(
+                            self.filename, shape, dtype, self.lock
+                        ),
+                        dims=("time",),
+                        fastpath=True,
+                    )
+                    for v in range(0, 2000)
+                }
+                attributes = {}
+
+                return variables, attributes
+
+        class PerformanceBackend(xr.backends.BackendEntrypoint):
+            def open_dataset(
+                self,
+                filename_or_obj: str | os.PathLike | None,
+                drop_variables: tuple[str] = None,
+                *,
+                mask_and_scale=True,
+                decode_times=True,
+                concat_characters=True,
+                decode_coords=True,
+                use_cftime=None,
+                decode_timedelta=None,
+                lock=None,
+                **kwargs,
+            ) -> xr.Dataset:
+                filename_or_obj = xr.backends.common._normalize_path(filename_or_obj)
+                store = PerformanceStore.open(filename_or_obj, lock=lock)
+
+                store_entrypoint = xr.backends.store.StoreBackendEntrypoint()
+
+                ds = store_entrypoint.open_dataset(
+                    store,
+                    mask_and_scale=mask_and_scale,
+                    decode_times=decode_times,
+                    concat_characters=concat_characters,
+                    decode_coords=decode_coords,
+                    drop_variables=drop_variables,
+                    use_cftime=use_cftime,
+                    decode_timedelta=decode_timedelta,
+                )
+                return ds
+
+        self.engine = PerformanceBackend
+
+    @parameterized(["chunks"], ([None, {}]))
+    def time_open_dataset(self, chunks):
+        """
+        Time how fast xr.open_dataset is without the slow data reading part.
+        Test with and without dask.
+        """
+        xr.open_dataset(None, engine=self.engine, chunks=chunks)

--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -481,7 +481,7 @@ class IOWriteNetCDFDaskDistributed:
         self.write.compute()
 
 
-class OpenDataset:
+class IOOpenDataset:
     def setup(self, *args, **kwargs):
         """
         The custom backend does the bare mininum to be considered a lazy backend. But

--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -521,7 +521,7 @@ class IOReadSingleFile(IOSingleNetCDF):
 
     @parameterized(["engine", "chunks"], (_ENGINES, [None, {}]))
     def time_read_dataset(self, engine):
-        xr.open_dataset(self.filepaths[engine], engine=engine)
+        xr.open_dataset(self.filepaths[engine], engine=engine, chunks=chunks)
 
 
 class IOReadCustomEngine:

--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -19,7 +19,7 @@ except ImportError:
 
 os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 
-_ENGINES = tuple(xr.backends.plugins.BACKEND_ENTRYPOINTS.keys())
+_ENGINES = tuple(xr.backends.list_engines().keys() - {"store"})
 
 
 class IOSingleNetCDF:

--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -482,7 +482,7 @@ class IOWriteNetCDFDaskDistributed:
 
 
 class OpenDataset:
-    def setup(self):
+    def setup(self, *args, **kwargs):
         """
         The custom backend does the bare mininum to be considered a lazy backend. But
         the data in it is still in memory so slow file reading shouldn't affect the

--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -31,10 +31,6 @@ class IOSingleNetCDF:
     number = 5
 
     def make_ds(self):
-        # TODO: Lazily skipped in CI as it is very demanding and slow.
-        # Improve times and remove errors.
-        _skip_slow()
-
         # single Dataset
         self.ds = xr.Dataset()
         self.nt = 1000
@@ -98,6 +94,10 @@ class IOSingleNetCDF:
 
 class IOWriteSingleNetCDF3(IOSingleNetCDF):
     def setup(self):
+        # TODO: Lazily skipped in CI as it is very demanding and slow.
+        # Improve times and remove errors.
+        _skip_slow()
+
         self.format = "NETCDF3_64BIT"
         self.make_ds()
 
@@ -110,6 +110,9 @@ class IOWriteSingleNetCDF3(IOSingleNetCDF):
 
 class IOReadSingleNetCDF4(IOSingleNetCDF):
     def setup(self):
+        # TODO: Lazily skipped in CI as it is very demanding and slow.
+        # Improve times and remove errors.
+        _skip_slow()
 
         self.make_ds()
 
@@ -131,6 +134,9 @@ class IOReadSingleNetCDF4(IOSingleNetCDF):
 
 class IOReadSingleNetCDF3(IOReadSingleNetCDF4):
     def setup(self):
+        # TODO: Lazily skipped in CI as it is very demanding and slow.
+        # Improve times and remove errors.
+        _skip_slow()
 
         self.make_ds()
 
@@ -152,6 +158,9 @@ class IOReadSingleNetCDF3(IOReadSingleNetCDF4):
 
 class IOReadSingleNetCDF4Dask(IOSingleNetCDF):
     def setup(self):
+        # TODO: Lazily skipped in CI as it is very demanding and slow.
+        # Improve times and remove errors.
+        _skip_slow()
 
         requires_dask()
 
@@ -192,6 +201,9 @@ class IOReadSingleNetCDF4Dask(IOSingleNetCDF):
 
 class IOReadSingleNetCDF3Dask(IOReadSingleNetCDF4Dask):
     def setup(self):
+        # TODO: Lazily skipped in CI as it is very demanding and slow.
+        # Improve times and remove errors.
+        _skip_slow()
 
         requires_dask()
 
@@ -233,10 +245,6 @@ class IOMultipleNetCDF:
     number = 5
 
     def make_ds(self, nfiles=10):
-        # TODO: Lazily skipped in CI as it is very demanding and slow.
-        # Improve times and remove errors.
-        _skip_slow()
-
         # multiple Dataset
         self.ds = xr.Dataset()
         self.nt = 1000
@@ -301,6 +309,10 @@ class IOMultipleNetCDF:
 
 class IOWriteMultipleNetCDF3(IOMultipleNetCDF):
     def setup(self):
+        # TODO: Lazily skipped in CI as it is very demanding and slow.
+        # Improve times and remove errors.
+        _skip_slow()
+
         self.make_ds()
         self.format = "NETCDF3_64BIT"
 
@@ -317,6 +329,9 @@ class IOWriteMultipleNetCDF3(IOMultipleNetCDF):
 
 class IOReadMultipleNetCDF4(IOMultipleNetCDF):
     def setup(self):
+        # TODO: Lazily skipped in CI as it is very demanding and slow.
+        # Improve times and remove errors.
+        _skip_slow()
 
         requires_dask()
 
@@ -333,6 +348,9 @@ class IOReadMultipleNetCDF4(IOMultipleNetCDF):
 
 class IOReadMultipleNetCDF3(IOReadMultipleNetCDF4):
     def setup(self):
+        # TODO: Lazily skipped in CI as it is very demanding and slow.
+        # Improve times and remove errors.
+        _skip_slow()
 
         requires_dask()
 
@@ -349,6 +367,9 @@ class IOReadMultipleNetCDF3(IOReadMultipleNetCDF4):
 
 class IOReadMultipleNetCDF4Dask(IOMultipleNetCDF):
     def setup(self):
+        # TODO: Lazily skipped in CI as it is very demanding and slow.
+        # Improve times and remove errors.
+        _skip_slow()
 
         requires_dask()
 
@@ -403,6 +424,9 @@ class IOReadMultipleNetCDF4Dask(IOMultipleNetCDF):
 
 class IOReadMultipleNetCDF3Dask(IOReadMultipleNetCDF4Dask):
     def setup(self):
+        # TODO: Lazily skipped in CI as it is very demanding and slow.
+        # Improve times and remove errors.
+        _skip_slow()
 
         requires_dask()
 
@@ -438,10 +462,6 @@ class IOReadMultipleNetCDF3Dask(IOReadMultipleNetCDF4Dask):
 def create_delayed_write():
     import dask.array as da
 
-    # TODO: Lazily skipped in CI as it is very demanding and slow.
-    # Improve times and remove errors.
-    _skip_slow()
-
     vals = da.random.random(300, chunks=(1,))
     ds = xr.Dataset({"vals": (["a"], vals)})
     return ds.to_netcdf("file.nc", engine="netcdf4", compute=False)
@@ -453,7 +473,12 @@ class IOWriteNetCDFDask:
     number = 5
 
     def setup(self):
+        # TODO: Lazily skipped in CI as it is very demanding and slow.
+        # Improve times and remove errors.
+        _skip_slow()
+
         requires_dask()
+
         self.write = create_delayed_write()
 
     def time_write(self):
@@ -462,14 +487,16 @@ class IOWriteNetCDFDask:
 
 class IOWriteNetCDFDaskDistributed:
     def setup(self):
+        # TODO: Lazily skipped in CI as it is very demanding and slow.
+        # Improve times and remove errors.
+        _skip_slow()
+
+        requires_dask()
+
         try:
             import distributed
         except ImportError:
             raise NotImplementedError()
-
-        # TODO: Lazily skipped in CI as it is very demanding and slow.
-        # Improve times and remove errors.
-        _skip_slow()
 
         self.client = distributed.Client()
         self.write = create_delayed_write()

--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -520,7 +520,7 @@ class IOReadSingleFile(IOSingleNetCDF):
             self.ds.to_netcdf(self.filepaths[engine], engine=engine)
 
     @parameterized(["engine", "chunks"], (_ENGINES, [None, {}]))
-    def time_read_dataset(self, engine):
+    def time_read_dataset(self, engine, chunks):
         xr.open_dataset(self.filepaths[engine], engine=engine, chunks=chunks)
 
 

--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -516,7 +516,7 @@ class IOReadSingleFile(IOSingleNetCDF):
 
         engine = kwargs.get("engine", None)
         self.filepath = "test_single_file.nc"
-        self.ds.to_netcdf(self.filepath, format=engine)
+        self.ds.to_netcdf(self.filepath, engine=engine)
 
     @parameterized("engine", [_ENGINES])
     def time_read_dataset(self, engine):

--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -514,13 +514,14 @@ class IOReadSingleFile(IOSingleNetCDF):
     def setup(self, *args, **kwargs):
         self.make_ds()
 
-        engine = kwargs.get("engine", None)
-        self.filepath = "test_single_file.nc"
-        self.ds.to_netcdf(self.filepath, engine=engine)
+        self.filepaths = {}
+        for engine in _ENGINES:
+            self.filepaths[engine] = f"test_single_file_with_{engine}.nc"
+            self.ds.to_netcdf(self.filepaths[engine], engine=engine)
 
     @parameterized("engine", [_ENGINES])
     def time_read_dataset(self, engine):
-        xr.open_dataset(self.filepath, engine=engine)
+        xr.open_dataset(self.filepaths[engine], engine=engine)
 
 
 class IOReadCustomEngine:


### PR DESCRIPTION
This tests xr.open_dataset without any slow file reading that can quickly become the majority of the performance time.

Related to #7374.


Timings for the new ASV-tests:
```

[ 50.85%] ··· dataset_io.IOReadCustomEngine.time_open_dataset                 ok
[ 50.85%] ··· ======== ============
               chunks              
              -------- ------------
                None     265±4ms   
                 {}     1.17±0.02s 
              ======== ============
[ 54.69%] ··· dataset_io.IOReadSingleFile.time_read_dataset                   ok
[ 54.69%] ··· ========= ============= =============
              --                   chunks          
              --------- ---------------------------
                engine       None           {}     
              ========= ============= =============
                scipy     4.81±0.1ms   6.65±0.01ms 
               netcdf4   8.41±0.08ms    10.9±0.2ms 
              ========= ============= =============
```
From the IOReadCustomEngine test we can see that chunking datasets with many variables (2000+) is considerably slower.