### PR TITLE
Pull Request Labeler - Workaround sync-labels bug

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -54,7 +54,7 @@ topic-indexing:
   - xarray/core/indexes.py
   - xarray/core/indexing.py
 
-run-benchmark:
+run-benchmark-bot:
   - asv_bench/benchmarks/*
   - asv_bench/benchmarks/**/*
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -54,10 +54,6 @@ topic-indexing:
   - xarray/core/indexes.py
   - xarray/core/indexing.py
 
-run-benchmark-bot:
-  - asv_bench/benchmarks/*
-  - asv_bench/benchmarks/**/*
-
 topic-performance:
   - asv_bench/benchmarks/*
   - asv_bench/benchmarks/**/*

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   benchmark:
-    if: ${{ contains( github.event.pull_request.labels.*.name, 'run-benchmark') && github.event_name == 'pull_request' || contains( github.event.pull_request.labels.*.name, 'run-benchmark-bot') && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ contains( github.event.pull_request.labels.*.name, 'run-benchmark') && github.event_name == 'pull_request' || contains( github.event.pull_request.labels.*.name, 'topic-performance') && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     name: Linux
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   benchmark:
-    if: ${{ contains( github.event.pull_request.labels.*.name, 'run-benchmark') && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ contains( github.event.pull_request.labels.*.name, 'run-benchmark') && github.event_name == 'pull_request' || contains( github.event.pull_request.labels.*.name, 'run-benchmark-bot') && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     name: Linux
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -10,5 +10,6 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         # Workaround for sync-labels bug:
+
         # https://github.com/actions/labeler/issues/112
         sync-labels: ""

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -9,4 +9,6 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: false
+        # Workaround for sync-labels bug:
+        # https://github.com/actions/labeler/issues/112
+        sync-labels: ""

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -10,6 +10,5 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         # Workaround for sync-labels bug:
-
         # https://github.com/actions/labeler/issues/112
         sync-labels: ""


### PR DESCRIPTION
* Workaround for Pull Request Labeler The PR labeler keeps removing manually added labels. xref: https://github.com/actions/labeler/issues/112
* ASV benchmarks starts also when `topic-performance` label is added now. Bot is allowed to change this one, but not `run-benchmarks`. 