### PR TITLE
DRAFT: Implement `open_datatree` in BackendEntrypoint for preliminary DataTree support

### DIFF
--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -4,6 +4,7 @@ from xarray.backends.api import (
     load_dataset,
     open_dataarray,
     open_dataset,
+    open_datatree,
     open_mfdataset,
     save_mfdataset,
 )
@@ -84,6 +85,7 @@ __all__ = (
     "ones_like",
     "open_dataarray",
     "open_dataset",
+    "open_datatree",
     "open_mfdataset",
     "open_rasterio",
     "open_zarr",

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -100,6 +100,9 @@ class AbstractDataStore:
     def get_variables(self):  # pragma: no cover
         raise NotImplementedError()
 
+    def get_group_stores(self):  # pragma: no cover
+        raise NotImplementedError()
+
     def get_encoding(self):
         return {}
 

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -373,6 +373,14 @@ class BackendEntrypoint:
       ``filename_or_obj``, ``False`` otherwise. The implementation of this
       method is not mandatory.
 
+    Optionally, it shall implement:
+
+    - ``open_datatree`` method: it shall implement reading from file, variables
+      decoding and it returns an instance of :py:class:`~datatree.DataTree`.
+      It shall take in input at least ``filename_or_obj`` argument and
+      ``drop_variables`` keyword argument.
+      For more details see TODO.
+
     Attributes
     ----------
 
@@ -382,6 +390,7 @@ class BackendEntrypoint:
     open_dataset_parameters : tuple, default: None
         A list of ``open_dataset`` method parameters.
         The setting of this attribute is not mandatory.
+        TODO should datatree have a separate method, or share these parameters?
     description : str, default: ""
         A short string describing the engine.
         The setting of this attribute is not mandatory.
@@ -405,6 +414,18 @@ class BackendEntrypoint:
         return txt
 
     def open_dataset(
+        self,
+        filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
+        drop_variables: str | Iterable[str] | None = None,
+        **kwargs: Any,
+    ):
+        """
+        Backend open_dataset method used by Xarray in :py:func:`~xarray.open_dataset`.
+        """
+
+        raise NotImplementedError
+
+    def open_datatree(
         self,
         filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
         drop_variables: str | Iterable[str] | None = None,

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -438,14 +438,20 @@ class NetCDF4DataStore(WritableCFDataStore):
         }
 
     def get_group_stores(self):
-        return FrozenDict((group_name, self.select_group(group_name)) for group_name in self.ds.groups)
+        return FrozenDict(
+            (group_name, self.select_group(group_name)) for group_name in self.ds.groups
+        )
 
     def select_group(self, group):
         """Return new NetCDF4DataStore for specified group of this NetCDF4DataStore."""
         if group in self.ds.groups:
-            parent_group = self._group if self._group is not None else ''
+            parent_group = self._group if self._group is not None else ""
             return self.__class__(
-                manager=self._manager, group=f"{parent_group}{group}/", mode=self._mode, lock=self.lock, autoclose=self.autoclose
+                manager=self._manager,
+                group=f"{parent_group}{group}/",
+                mode=self._mode,
+                lock=self.lock,
+                autoclose=self.autoclose,
             )
         else:
             raise KeyError(group)

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -443,8 +443,9 @@ class NetCDF4DataStore(WritableCFDataStore):
     def select_group(self, group):
         """Return new NetCDF4DataStore for specified group of this NetCDF4DataStore."""
         if group in self.ds.groups:
-            return self.__init__(
-                manager=self._manager, group=group, mode=self._mode, lock=self.lock, autoclose=self.autoclose
+            parent_group = self._group if self._group is not None else ''
+            return self.__class__(
+                manager=self._manager, group=f"{parent_group}{group}/", mode=self._mode, lock=self.lock, autoclose=self.autoclose
             )
         else:
             raise KeyError(group)
@@ -654,7 +655,7 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
             autoclose=autoclose,
         )
 
-    def open_dataset(
+    def open_datatree(
         self,
         filename_or_obj,
         mask_and_scale=True,

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -102,16 +102,17 @@ class StoreBackendEntrypoint(BackendEntrypoint):
                 use_cftime=use_cftime,
                 decode_timedelta=decode_timedelta,
             )
+            ds.set_close(store.close)  # TODO should this be on datatree? if so, need to add to datatree API
             datasets[path] = ds
 
             # Recursively add children to collector
-            for child_name, child_store in store.get_group_stores():
+            for child_name, child_store in store.get_group_stores().items():
                 datasets = _add_node(child_store, f"{path}{child_name}/", datasets)
 
             return datasets
 
-        dt = DataTree.from_dict(_add_node(store, "/", {}))
-        dt.set_close(store.close)
+        datasets = _add_node(store, "/", {})
+        dt = DataTree.from_dict(datasets)
 
         return dt
 

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -102,7 +102,9 @@ class StoreBackendEntrypoint(BackendEntrypoint):
                 use_cftime=use_cftime,
                 decode_timedelta=decode_timedelta,
             )
-            ds.set_close(store.close)  # TODO should this be on datatree? if so, need to add to datatree API
+            ds.set_close(
+                store.close
+            )  # TODO should this be on datatree? if so, need to add to datatree API
             datasets[path] = ds
 
             # Recursively add children to collector

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -17,7 +17,7 @@ class StoreBackendEntrypoint(BackendEntrypoint):
     def guess_can_open(self, filename_or_obj):
         return isinstance(filename_or_obj, AbstractDataStore)
 
-    def open_dataset(
+    def _construct_dataset(
         self,
         store,
         *,
@@ -46,10 +46,74 @@ class StoreBackendEntrypoint(BackendEntrypoint):
 
         ds = Dataset(vars, attrs=attrs)
         ds = ds.set_coords(coord_names.intersection(vars))
-        ds.set_close(store.close)
         ds.encoding = encoding
 
         return ds
+
+    def open_dataset(
+        self,
+        store,
+        *,
+        mask_and_scale=True,
+        decode_times=True,
+        concat_characters=True,
+        decode_coords=True,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+    ):
+        ds = self._construct_dataset(
+            store,
+            mask_and_scale=mask_and_scale,
+            decode_times=decode_times,
+            concat_characters=concat_characters,
+            decode_coords=decode_coords,
+            drop_variables=drop_variables,
+            use_cftime=use_cftime,
+            decode_timedelta=decode_timedelta,
+        )
+        ds.set_close(store.close)
+
+        return ds
+
+    def open_datatree(
+        self,
+        store,
+        *,
+        mask_and_scale=True,
+        decode_times=True,
+        concat_characters=True,
+        decode_coords=True,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+    ):
+        from datatree import DataTree
+
+        def _add_node(store, path, datasets):
+            # Create dataset for this node, and add to collector
+            ds = self._construct_dataset(
+                store,
+                mask_and_scale=mask_and_scale,
+                decode_times=decode_times,
+                concat_characters=concat_characters,
+                decode_coords=decode_coords,
+                drop_variables=drop_variables,
+                use_cftime=use_cftime,
+                decode_timedelta=decode_timedelta,
+            )
+            datasets[path] = ds
+
+            # Recursively add children to collector
+            for child_name, child_store in store.get_group_stores():
+                datasets = _add_node(child_store, f"{path}{child_name}/", datasets)
+
+            return datasets
+
+        dt = DataTree.from_dict(_add_node(store, "/", {}))
+        dt.set_close(store.close)
+
+        return dt
 
 
 BACKEND_ENTRYPOINTS["store"] = StoreBackendEntrypoint

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -111,8 +111,7 @@ class StoreBackendEntrypoint(BackendEntrypoint):
 
             return datasets
 
-        datasets = _add_node(store, "/", {})
-        dt = DataTree.from_dict(datasets)
+        dt = DataTree.from_dict(_add_node(store, "/", {}))
 
         return dt
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

As discussed among folks at today's Pangeo working meeting (cc @jhamman, @TomNicholas), we are looking to try adding support for `DataTree` in the Backend API, so that backend engines can readily add `DataTree` capability. For example, with `cfgrib`, we could have

```python
import xarray as xr

dt = xr.open_datatree("path/to/gribfile.grib", engine="cfgrib")
```

given that `cfgrib` implements the appropriate method to their `BackendEntrypoint` subclass. Similarly, with NetCDF files or Zarr stores with groups, we could open as `DataTree` to obviate the need to specify a single group. 

Working Design Doc: https://hackmd.io/Oqeab-54TqOOHd5FdCb5DQ?edit

xref https://github.com/ecmwf/cfgrib/issues/327, https://github.com/openradar/xradar/issues/7

- ~~Closes #xxxx~~
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
