### PR TITLE
Refer to open_zarr in open_dataset docstring

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -414,7 +414,7 @@ def open_dataset(
         arrays. ``chunks=-1`` loads the dataset with dask using a single
         chunk for all arrays. ``chunks={}`` loads the dataset with dask using
         engine preferred chunks if exposed by the backend, otherwise with
-        a single chunk for all arrays.
+        a single chunk for all arrays. In order to reproduce the default behavior of ``xr.open_zarr(...)`` use ``xr.open_dataset(..., engine='zarr', chunks={})``.
         ``chunks='auto'`` will use dask ``auto`` chunking taking into account the
         engine preferred chunks. See dask chunking for more details.
     cache : bool, optional

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -414,7 +414,7 @@ def open_dataset(
         arrays. ``chunks=-1`` loads the dataset with dask using a single
         chunk for all arrays. ``chunks={}`` loads the dataset with dask using
         engine preferred chunks if exposed by the backend, otherwise with
-        a single chunk for all arrays. In order to reproduce the default behavior 
+        a single chunk for all arrays. In order to reproduce the default behavior
         of ``xr.open_zarr(...)`` use ``xr.open_dataset(..., engine='zarr', chunks={})``.
         ``chunks='auto'`` will use dask ``auto`` chunking taking into account the
         engine preferred chunks. See dask chunking for more details.

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -414,7 +414,8 @@ def open_dataset(
         arrays. ``chunks=-1`` loads the dataset with dask using a single
         chunk for all arrays. ``chunks={}`` loads the dataset with dask using
         engine preferred chunks if exposed by the backend, otherwise with
-        a single chunk for all arrays. In order to reproduce the default behavior of ``xr.open_zarr(...)`` use ``xr.open_dataset(..., engine='zarr', chunks={})``.
+        a single chunk for all arrays. In order to reproduce the default behavior 
+        of ``xr.open_zarr(...)`` use ``xr.open_dataset(..., engine='zarr', chunks={})``.
         ``chunks='auto'`` will use dask ``auto`` chunking taking into account the
         engine preferred chunks. See dask chunking for more details.
     cache : bool, optional


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This adds a sentence (below) under "chunks" in doctoring of `open_dataset()` to clarify current usage for those who want the same behavior as `open_zarr()` used to provide:

```
In order to reproduce the default behavior of xr.open_zarr(...) use `xr.open_dataset(..., engine='zarr', chunks={})`.
```

- [ ] Closes #7293
