### PR TITLE
allow skipping RTD builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     python: mambaforge-4.10
   jobs:
     post_checkout:
-      - git --no-pager log --pretty="tformat:%s" -1 | grep -vqF "[skip-rtd]"
+      - (git --no-pager log --pretty="tformat:%s" -1 | grep -viq "[skip-rtd]") || exit 183
 
 conda:
   environment: ci/requirements/doc.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,9 @@ build:
   os: ubuntu-20.04
   tools:
     python: mambaforge-4.10
+  jobs:
+    post_checkout:
+      - git --no-pager log --pretty="tformat:%s" -1 | grep -vqF "[skip-rtd]"
 
 conda:
   environment: ci/requirements/doc.yml


### PR DESCRIPTION
RTD somewhat recently introduced the [build.jobs](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-jobs) setting, which allows [skipping builds](https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition) (technically it's more of a "automated cancel" with a special error code instead of a skip) on user-defined conditions. We can use that to manually "skip" builds we don't need a documentation build for.

Edit: the only downside seems to be that the build is not actually marked as "skipped"
Edit2: apparently that's a bug that's being worked on, see readthedocs/readthedocs.org#9807