### PR TITLE
fix the RTD build skipping feature

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     python: mambaforge-4.10
   jobs:
     post_checkout:
-      - (git --no-pager log --pretty="tformat:%s" -1 | grep -viq "[skip-rtd]") || exit 183
+      - (git --no-pager log --pretty="tformat:%s" -1 | grep -vqF "[skip-rtd]") || exit 183
 
 conda:
   environment: ci/requirements/doc.yml


### PR DESCRIPTION
We can't use the example `grep` options because we usually enclose tags with `[]`, which `grep` will interpret as character classes.