### PR TITLE
RTD maintenance

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,11 @@ build:
   os: ubuntu-22.04
   tools:
     python: mambaforge-4.10
+  jobs:
+    post_checkout:
+      - git fetch --unshallow --tags  # to allow setuptools_scm to work properly
+    pre_install:
+      - git update-index --assume-unchanged doc/conf.py ci/requirements/doc.yml
 
 conda:
   environment: ci/requirements/doc.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: mambaforge-4.10
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,7 @@ build:
     python: mambaforge-4.10
   jobs:
     post_checkout:
+      - git log --pretty=oneline HEAD~5..
       - git fetch --unshallow --tags  # to allow setuptools_scm to work properly
       - (git --no-pager log --pretty="tformat:%s" -1 | grep -viq "[skip-rtd]") || exit 183
     pre_install:


### PR DESCRIPTION
Since the last time the RTD configuration was updated, a few things have changed:
- the OS image is now a bit old
- we can tell git (and thus `setuptools_scm`) to ignore changes by RTD

If I read the documentation / history of RTD correctly, they removed the `DONT_SHALLOW_CLONE` feature flag from documentation (it still is enabled and works for this repository, though), so we might have to migrate to adding a `post_checkout` build job that does that soon. The additional "unshallow" *should* be almost a no-op, but I'll remove it before merging.