### PR TITLE
Remove Dask single-threaded setting in tests

### DIFF
--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -101,8 +101,6 @@ set_options(warn_for_unclosed_files=True)
 if has_dask:
     import dask
 
-    dask.config.set(scheduler="single-threaded")
-
 
 class CountingScheduler:
     """Simple dask scheduler counting the number of computes.


### PR DESCRIPTION
I'm not totally sure why `single-threaded` was being set to begin with, so I might be missing some important context here 

Closes https://github.com/pydata/xarray/issues/7483 