### PR TITLE
deprecate open_zarr

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -596,7 +596,6 @@ Dataset methods
    open_dataset
    open_mfdataset
    open_rasterio
-   open_zarr
    save_mfdataset
    Dataset.as_numpy
    Dataset.from_dataframe
@@ -1139,6 +1138,7 @@ Deprecated / Pending Deprecation
 .. autosummary::
    :toctree: generated/
 
+   open_zarr
    Dataset.drop
    DataArray.drop
    Dataset.apply

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -626,11 +626,11 @@ To store variable length strings, convert them to object arrays first with
 ``dtype=object``.
 
 To read back a zarr dataset that has been created this way, we use the
-:py:func:`open_zarr` method:
+:py:func:`open_dataset` function:
 
 .. ipython:: python
 
-    ds_zarr = xr.open_zarr("path/to/directory.zarr")
+    ds_zarr = xr.open_dataset("path/to/directory.zarr", engine="zarr")
     ds_zarr
 
 Cloud Storage Buckets
@@ -671,7 +671,7 @@ instance and pass this, as follows:
     # write to the bucket
     ds.to_zarr(store=gcsmap)
     # read it back
-    ds_gcs = xr.open_zarr(gcsmap)
+    ds_gcs = xr.open_dataset(gcsmap, engine="zarr")
 
 (or use the utility function ``fsspec.get_mapper()``).
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -45,7 +45,9 @@ Breaking changes
 
 Deprecations
 ~~~~~~~~~~~~
-
+- The `open_zarr` function has been deprecated in favor of `open_dataset(..., engine='zarr')`.
+  (:issue:`7495`, :pull:`7496`).
+  By `Joe Hamman <https://github.com/jhamman>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -789,7 +789,7 @@ def open_zarr(
 
     .. deprecated:: v2023.02.0
         `open_zarr` will be removed in Xarray v2023.06.0, please use
-        `open_dataset(..., engine='zarr')` from now on.
+        `open_dataset(..., engine='zarr', chunks={})` from now on.
 
     See Also
     --------

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -805,7 +805,7 @@ def open_zarr(
     from xarray.backends.api import open_dataset
 
     warnings.warn(
-        "open_zarr is Deprecated in favor of open_dataset(store, ..., engine='zarr')"
+        "open_zarr is Deprecated in favor of open_dataset(..., engine='zarr', chunks={})"
         "See https://github.com/pydata/xarray/issues/7495 for more information",
         DeprecationWarning,
     )

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -787,16 +787,28 @@ def open_zarr(
     dataset : Dataset
         The newly created dataset.
 
+    .. deprecated:: 1.6.0
+        `ndobj_old` will be removed in NumPy 2.0.0, it is replaced by
+        `ndobj_new` because the latter works also with array subclasses.
+
     See Also
     --------
     open_dataset
     open_mfdataset
+
+
 
     References
     ----------
     http://zarr.readthedocs.io/
     """
     from xarray.backends.api import open_dataset
+
+    warnings.warn(
+        "open_zarr is Deprecated in favor of open_dataset(store, ..., engine='zarr')"
+        "See https://github.com/pydata/xarray/issues/7495 for more information",
+        DeprecationWarning,
+    )
 
     if chunks == "auto":
         try:

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -787,9 +787,9 @@ def open_zarr(
     dataset : Dataset
         The newly created dataset.
 
-    .. deprecated:: 1.6.0
-        `ndobj_old` will be removed in NumPy 2.0.0, it is replaced by
-        `ndobj_new` because the latter works also with array subclasses.
+    .. deprecated:: v2023.02.0
+        `open_zarr` will be removed in Xarray v2023.06.0, please use
+        `open_dataset(..., engine='zarr')` from now on.
 
     See Also
     --------


### PR DESCRIPTION
This PR deprecates `open_zarr` in favor of `open_dataset(..., engine='zarr')`. 

- [x] Closes #7495
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`
