### PR TITLE
Zarr: drop "source" and  "original_shape" from encoding

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -55,6 +55,9 @@ Bug fixes
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_ and `Scott Chamberlin <https://github.com/scottcha>`_.
 - Handle ``keep_attrs`` option in binary operators of :py:meth:`Dataset` (:issue:`7390`, :pull:`7391`).
   By `Aron Gergely <https://github.com/arongergely>`_.
+- :py:func:`xarray.Dataset.to_zarr` drops now variable encodings that have been added by xarray during reading
+  a dataset. (:issue:`7129`, :pull:`7500`).
+  By `Hauke Schulz <https://github.com/observingClouds>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -55,7 +55,7 @@ Bug fixes
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_ and `Scott Chamberlin <https://github.com/scottcha>`_.
 - Handle ``keep_attrs`` option in binary operators of :py:meth:`Dataset` (:issue:`7390`, :pull:`7391`).
   By `Aron Gergely <https://github.com/arongergely>`_.
-- :py:func:`xarray.Dataset.to_zarr` drops now variable encodings that have been added by xarray during reading
+- :py:func:`xarray.Dataset.to_zarr` now drops variable encodings that have been added by xarray during reading
   a dataset. (:issue:`7129`, :pull:`7500`).
   By `Hauke Schulz <https://github.com/observingClouds>`_.
 

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -230,6 +230,7 @@ def extract_zarr_variable_encoding(
     """
     encoding = variable.encoding.copy()
 
+    safe_to_drop = {"source", "original_shape"}
     valid_encodings = {
         "chunks",
         "compressor",
@@ -237,6 +238,10 @@ def extract_zarr_variable_encoding(
         "cache_metadata",
         "write_empty_chunks",
     }
+
+    for k in safe_to_drop:
+        if k in encoding:
+            del encoding[k]
 
     if raise_on_invalid:
         invalid = [k for k in encoding if k not in valid_encodings]

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2039,6 +2039,12 @@ class ZarrBase(CFEncodedBase):
             # don't actually check equality because the data could be corrupted
             pass
 
+    def test_drop_encoding(self):
+        ds = open_example_dataset("example_1.nc")
+        encodings = {v: {**ds[v].encoding} for v in ds.data_vars}
+        with self.create_zarr_target() as store:
+            ds.to_zarr(store, encoding=encodings)
+
     def test_hidden_zarr_keys(self) -> None:
         expected = create_test_data()
         with self.create_store() as store:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #7129 
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
