### PR TITLE
Fix whats-new for 2023.02.0

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -20,10 +20,10 @@ What's New
 v2023.02.0 (Feb 7, 2023)
 ------------------------
 
-This release brings a major upgrade to :py:func:`xarray.concat`, bug fixes and
-a bump in supported dependency versions. Thanks to our 9 contributors:
+This release brings a major upgrade to :py:func:`xarray.concat`, many bug fixes,
+and a bump in supported dependency versions. Thanks to our 11 contributors:
 Aron Gergely, Deepak Cherian, Illviljan, James Bourbeau, Joe Hamman,
-Justus Magin, Kai Mühlbauer, Ken Mankoff, Spencer Clark.
+Justus Magin, Hauke Schulz, Kai Mühlbauer, Ken Mankoff, Spencer Clark, Tom Nicholas.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -24,10 +24,6 @@ This release brings a major upgrade to :py:func:`xarray.concat`, many bug fixes,
 and a bump in supported dependency versions. Thanks to our 11 contributors:
 Aron Gergely, Deepak Cherian, Illviljan, James Bourbeau, Joe Hamman,
 Justus Magin, Hauke Schulz, Kai Mühlbauer, Ken Mankoff, Spencer Clark, Tom Nicholas.
-This release brings a major upgrade to :py:func:`xarray.concat`, bug fixes and
-a bump in supported dependency versions. Thanks to our 9 contributors:
-Aron Gergely, Deepak Cherian, Illviljan, James Bourbeau, Joe Hamman,
-Justus Magin, Kai Mühlbauer, Ken Mankoff, Spencer Clark.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -17,7 +17,7 @@ What's New
 
 .. _whats-new.2023.02.0:
 
-v2023.02.0 (Feb 7. 2023)
+v2023.02.0 (Feb 7, 2023)
 ------------------------
 
 This release brings a major upgrade to :py:func:`xarray.concat`, bug fixes and

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -20,9 +20,9 @@ What's New
 v2023.02.0 (Feb 7. 2023)
 ------------------------
 
-This release brings a major upgrade to :py:func:`xarray.concat`, bug fixes and 
-a bump in supported dependency versions. Thanks to our 9 contributors: 
-Aron Gergely, Deepak Cherian, Illviljan, James Bourbeau, Joe Hamman, 
+This release brings a major upgrade to :py:func:`xarray.concat`, bug fixes and
+a bump in supported dependency versions. Thanks to our 9 contributors:
+Aron Gergely, Deepak Cherian, Illviljan, James Bourbeau, Joe Hamman,
 Justus Magin, Kai Mühlbauer, Ken Mankoff, Spencer Clark.
 
 Breaking changes


### PR DESCRIPTION
Oops. I used "Github Codespaces" to edit whats-new, but it turns if you commit in there, it just commits to main!

This fixes the pre-commit error.