### PR TITLE
supress namespace_package deprecation warning (doctests)

### DIFF
--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -37,6 +37,7 @@ except ImportError:
 
 # https://github.com/pydata/xarray/issues/7322
 warnings.filterwarnings("ignore", "'urllib3.contrib.pyopenssl' module is deprecated")
+warnings.filterwarnings("ignore", "Deprecated call to `pkg_resources.declare_namespace")
 
 arm_xfail = pytest.mark.xfail(
     platform.machine() == "aarch64" or "arm" in platform.machine(),


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Suppress the `pkg_resources.namespace_package` `DeprecationError` to make the doctest pass again (similar to #7322). This is reported upstream: pydap/pydap#277 and matplotlib/matplotlib#25244




