### PR TITLE
DOC: cross ref the groupby tutorial

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -6205,7 +6205,6 @@ class DataArray(
         restore_coord_dims: bool = False,
     ) -> DataArrayGroupBy:
         """Returns a DataArrayGroupBy object for performing grouped operations.
-        See more details at :ref:`groupby`.
 
         Parameters
         ----------
@@ -6250,6 +6249,7 @@ class DataArray(
 
         See Also
         --------
+        :ref:`groupby`
         DataArray.groupby_bins
         Dataset.groupby
         core.groupby.DataArrayGroupBy
@@ -6286,8 +6286,7 @@ class DataArray(
         """Returns a DataArrayGroupBy object for performing grouped operations.
 
         Rather than using all unique values of `group`, the values are discretized
-        first by applying `pandas.cut` [1]_ to `group`.  See more details at
-        :ref:`groupby`.
+        first by applying `pandas.cut` [1]_ to `group`.
 
         Parameters
         ----------
@@ -6330,6 +6329,7 @@ class DataArray(
 
         See Also
         --------
+        :ref:`groupby`
         DataArray.groupby
         Dataset.groupby_bins
         core.groupby.DataArrayGroupBy

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -6249,7 +6249,7 @@ class DataArray(
 
         See Also
         --------
-        :ref:`groupby`
+        :ref:`Users guide: group and bin data <groupby>`
         DataArray.groupby_bins
         Dataset.groupby
         core.groupby.DataArrayGroupBy
@@ -6329,7 +6329,7 @@ class DataArray(
 
         See Also
         --------
-        :ref:`groupby`
+        :ref:`Users guide: group and bin data <groupby>`
         DataArray.groupby
         Dataset.groupby_bins
         core.groupby.DataArrayGroupBy

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -6249,7 +6249,8 @@ class DataArray(
 
         See Also
         --------
-        :ref:`Users guide: group and bin data <groupby>`
+        :ref:`groupby`
+            Users guide explanation of how to group and bin data.
         DataArray.groupby_bins
         Dataset.groupby
         core.groupby.DataArrayGroupBy
@@ -6329,7 +6330,8 @@ class DataArray(
 
         See Also
         --------
-        :ref:`Users guide: group and bin data <groupby>`
+        :ref:`groupby`
+            Users guide explanation of how to group and bin data.
         DataArray.groupby
         Dataset.groupby_bins
         core.groupby.DataArrayGroupBy

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -6205,6 +6205,7 @@ class DataArray(
         restore_coord_dims: bool = False,
     ) -> DataArrayGroupBy:
         """Returns a DataArrayGroupBy object for performing grouped operations.
+        See more details at :ref:`groupby`.
 
         Parameters
         ----------
@@ -6285,7 +6286,8 @@ class DataArray(
         """Returns a DataArrayGroupBy object for performing grouped operations.
 
         Rather than using all unique values of `group`, the values are discretized
-        first by applying `pandas.cut` [1]_ to `group`.
+        first by applying `pandas.cut` [1]_ to `group`.  See more details at
+        :ref:`groupby`.
 
         Parameters
         ----------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8933,7 +8933,7 @@ class Dataset(
 
         See Also
         --------
-        :ref:`groupby`
+        :ref:`Users guide: group and bin data <groupby>`
         Dataset.groupby_bins
         DataArray.groupby
         core.groupby.DatasetGroupBy
@@ -9015,7 +9015,7 @@ class Dataset(
 
         See Also
         --------
-        :ref:`groupby`
+        :ref:`Users guide: group and bin data <groupby>`
         Dataset.groupby
         DataArray.groupby_bins
         core.groupby.DatasetGroupBy

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8933,7 +8933,8 @@ class Dataset(
 
         See Also
         --------
-        :ref:`Users guide: group and bin data <groupby>`
+        :ref:`groupby`
+            Users guide explanation of how to group and bin data.
         Dataset.groupby_bins
         DataArray.groupby
         core.groupby.DatasetGroupBy
@@ -9015,7 +9016,8 @@ class Dataset(
 
         See Also
         --------
-        :ref:`Users guide: group and bin data <groupby>`
+        :ref:`groupby`
+            Users guide explanation of how to group and bin data.
         Dataset.groupby
         DataArray.groupby_bins
         core.groupby.DatasetGroupBy

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8911,6 +8911,7 @@ class Dataset(
         restore_coord_dims: bool = False,
     ) -> DatasetGroupBy:
         """Returns a DatasetGroupBy object for performing grouped operations.
+        See more details at :ref:`groupby`.
 
         Parameters
         ----------
@@ -8969,6 +8970,7 @@ class Dataset(
         restore_coord_dims: bool = False,
     ) -> DatasetGroupBy:
         """Returns a DatasetGroupBy object for performing grouped operations.
+        See more details at :ref:`groupby`.
 
         Rather than using all unique values of `group`, the values are discretized
         first by applying `pandas.cut` [1]_ to `group`.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8911,7 +8911,6 @@ class Dataset(
         restore_coord_dims: bool = False,
     ) -> DatasetGroupBy:
         """Returns a DatasetGroupBy object for performing grouped operations.
-        See more details at :ref:`groupby`.
 
         Parameters
         ----------
@@ -8934,6 +8933,7 @@ class Dataset(
 
         See Also
         --------
+        :ref:`groupby`
         Dataset.groupby_bins
         DataArray.groupby
         core.groupby.DatasetGroupBy
@@ -8970,7 +8970,6 @@ class Dataset(
         restore_coord_dims: bool = False,
     ) -> DatasetGroupBy:
         """Returns a DatasetGroupBy object for performing grouped operations.
-        See more details at :ref:`groupby`.
 
         Rather than using all unique values of `group`, the values are discretized
         first by applying `pandas.cut` [1]_ to `group`.
@@ -9016,6 +9015,7 @@ class Dataset(
 
         See Also
         --------
+        :ref:`groupby`
         Dataset.groupby
         DataArray.groupby_bins
         core.groupby.DatasetGroupBy


### PR DESCRIPTION
There are probably many more of these that could be done, but xarray has great explainers that are not linked in the API reference.  Not sure if that is on purpose (obviously they are kind of useless if you aren't looking at the http version), but if not, this at least does them for `groupby`, which is something I always need the explainer for...