### PR TITLE
ignore the `pkg_resources` deprecation warning

### DIFF
--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -38,6 +38,7 @@ except ImportError:
 # https://github.com/pydata/xarray/issues/7322
 warnings.filterwarnings("ignore", "'urllib3.contrib.pyopenssl' module is deprecated")
 warnings.filterwarnings("ignore", "Deprecated call to `pkg_resources.declare_namespace")
+warnings.filterwarnings("ignore", "pkg_resources is deprecated as an API")
 
 arm_xfail = pytest.mark.xfail(
     platform.machine() == "aarch64" or "arm" in platform.machine(),


### PR DESCRIPTION
In one of the recent `setuptools` releases `pkg_resources` finally got deprecated in favor of the `importlib.*` modules. We don't use `pkg_resources` directly, so the `DeprecationWarning` that causes the doctest CI to fail is from a dependency. As such, the only way to get it to work again is to ignore the warning until the upstream packages have released versions that don't use/import `pkg_resources`.