### PR TITLE
Fix missing 'dim' argument in _get_nan_block_lengths

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -44,6 +44,10 @@ Bug fixes
 - Fix matplotlib raising a UserWarning when plotting a scatter plot
   with an unfilled marker (:issue:`7313`, :pull:`7318`).
   By `Jimmy Westling <https://github.com/illviljan>`_.
+- Fix issue with ``max_gap`` in ``interpolate_na``, when applied to
+  multidimensional arrays. (:issue:`7597`, :pull:`7598`).
+  By `Paul Ockenfuß <https://github.com/Ockenfuss>`_.
+
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -48,7 +48,7 @@ def _get_nan_block_lengths(
         .where(valid)
         .bfill(dim=dim)
         .where(~valid, 0)
-        .fillna(index[-1] - valid_arange.max())
+        .fillna(index[-1] - valid_arange.max(dim))
     )
 
     return nan_block_lengths

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -48,7 +48,7 @@ def _get_nan_block_lengths(
         .where(valid)
         .bfill(dim=dim)
         .where(~valid, 0)
-        .fillna(index[-1] - valid_arange.max(dim=dim))
+        .fillna(index[-1] - valid_arange.max(dim=[dim]))
     )
 
     return nan_block_lengths

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -48,7 +48,7 @@ def _get_nan_block_lengths(
         .where(valid)
         .bfill(dim=dim)
         .where(~valid, 0)
-        .fillna(index[-1] - valid_arange.max(dim))
+        .fillna(index[-1] - valid_arange.max(dim=dim))
     )
 
     return nan_block_lengths

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -676,7 +676,7 @@ def test_interpolate_na_2d(coords):
     n = np.nan
     da = xr.DataArray(
         [
-            [n, 2, 3, 4, n, 6, n, n, n, 10, 11, n],
+            [1, 2, 3, 4, n, 6, n, n, n, 10, 11, n],
             [n, n, 3, n, n, 6, n, n, n, 10, n, n],
             [n, n, 3, n, n, 6, n, n, n, 10, n, n],
             [n, 2, 3, 4, n, 6, n, n, n, 10, 11, n],
@@ -688,7 +688,7 @@ def test_interpolate_na_2d(coords):
     actual = da.interpolate_na("y", max_gap=2)
     expected_y = da.copy(
         data=[
-            [n, 2, 3, 4, 5, 6, n, n, n, 10, 11, n],
+            [1, 2, 3, 4, 5, 6, n, n, n, 10, 11, n],
             [n, n, 3, n, n, 6, n, n, n, 10, n, n],
             [n, n, 3, n, n, 6, n, n, n, 10, n, n],
             [n, 2, 3, 4, 5, 6, n, n, n, 10, 11, n],
@@ -710,7 +710,7 @@ def test_interpolate_na_2d(coords):
     actual = da.interpolate_na("x", max_gap=3)
     expected_x = xr.DataArray(
         [
-            [n, 2, 3, 4, n, 6, n, n, n, 10, 11, n],
+            [1, 2, 3, 4, n, 6, n, n, n, 10, 11, n],
             [n, 2, 3, 4, n, 6, n, n, n, 10, 11, n],
             [n, 2, 3, 4, n, 6, n, n, n, 10, 11, n],
             [n, 2, 3, 4, n, 6, n, n, n, 10, 11, n],


### PR DESCRIPTION
* Add missing dim argument (GH7597)
* Append a nan gap at the end of existing tests cases

- [x] Closes #7597 
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
