### PR TITLE
Enable blacks `skip_magic_trailing_comma` options

### DIFF
--- a/asv_bench/benchmarks/dataarray_missing.py
+++ b/asv_bench/benchmarks/dataarray_missing.py
@@ -24,11 +24,7 @@ class DataArrayMissingInterpolateNA:
 
     @parameterized(
         ["shape", "chunks", "limit"],
-        (
-            [(365, 75, 75)],
-            [None, {"x": 25, "y": 25}],
-            [None, 3],
-        ),
+        ([(365, 75, 75)], [None, {"x": 25, "y": 25}], [None, 3]),
     )
     def time_interpolate_na(self, shape, chunks, limit):
         actual = self.da.interpolate_na(dim="time", method="linear", limit=limit)
@@ -45,11 +41,7 @@ class DataArrayMissingBottleneck:
 
     @parameterized(
         ["shape", "chunks", "limit"],
-        (
-            [(365, 75, 75)],
-            [None, {"x": 25, "y": 25}],
-            [None, 3],
-        ),
+        ([(365, 75, 75)], [None, {"x": 25, "y": 25}], [None, 3]),
     )
     def time_ffill(self, shape, chunks, limit):
         actual = self.da.ffill(dim="time", limit=limit)
@@ -59,11 +51,7 @@ class DataArrayMissingBottleneck:
 
     @parameterized(
         ["shape", "chunks", "limit"],
-        (
-            [(365, 75, 75)],
-            [None, {"x": 25, "y": 25}],
-            [None, 3],
-        ),
+        ([(365, 75, 75)], [None, {"x": 25, "y": 25}], [None, 3]),
     )
     def time_bfill(self, shape, chunks, limit):
         actual = self.da.ffill(dim="time", limit=limit)

--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -578,9 +578,7 @@ class IOReadCustomEngine:
                     locker = lock
 
                 manager = xr.backends.CachingFileManager(
-                    xr.backends.DummyFileManager,
-                    filename,
-                    mode=mode,
+                    xr.backends.DummyFileManager, filename, mode=mode
                 )
                 return cls(manager, mode=mode, lock=locker, autoclose=autoclose)
 

--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -100,9 +100,7 @@ class GroupByDaskDataFrame(GroupBy):
 class Resample:
     def setup(self, *args, **kwargs):
         self.ds1d = xr.Dataset(
-            {
-                "b": ("time", np.arange(365.0 * 24)),
-            },
+            {"b": ("time", np.arange(365.0 * 24))},
             coords={"time": pd.date_range("2001-01-01", freq="H", periods=365 * 24)},
         )
         self.ds2d = self.ds1d.expand_dims(z=10)

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -136,8 +136,7 @@ class HugeAxisSmallSliceIndexing:
         self.filepath = "test_indexing_huge_axis_small_slice.nc"
         if not os.path.isfile(self.filepath):
             xr.Dataset(
-                {"a": ("x", np.arange(10_000_000))},
-                coords={"x": np.arange(10_000_000)},
+                {"a": ("x", np.arange(10_000_000))}, coords={"x": np.arange(10_000_000)}
             ).to_netcdf(self.filepath, format="NETCDF4")
 
         self.ds = xr.open_dataset(self.filepath)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,32 +71,31 @@ ignore_errors = true
 module = []
 
 [tool.ruff]
-target-version = "py39"
 builtins = ["ellipsis"]
 exclude = [
-    ".eggs",
-    "doc",
-    "_typed_ops.pyi",
+  ".eggs",
+  "doc",
+  "_typed_ops.pyi",
 ]
+target-version = "py39"
 # E402: module level import not at top of file
 # E501: line too long - let black worry about that
 # E731: do not assign a lambda expression, use a def
 ignore = [
-    "E402",
-    "E501",
-    "E731",
+  "E402",
+  "E501",
+  "E731",
 ]
 select = [
-    # Pyflakes
-    "F",
-    # Pycodestyle
-    "E",
-    "W",
-    # isort
-    "I",
-    # Pyupgrade
-    "UP",
+  "F", # Pyflakes
+  "E", # Pycodestyle Error
+  "W", # Pycodestyle Warning
+  "I", # isort
+  "UP", # Pyupgrade
 ]
 
 [tool.ruff.isort]
 known-first-party = ["xarray"]
+
+[tool.black]
+skip_magic_trailing_comma = true

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -524,10 +524,7 @@ def open_dataset(
 
     overwrite_encoded_chunks = kwargs.pop("overwrite_encoded_chunks", None)
     backend_ds = backend.open_dataset(
-        filename_or_obj,
-        drop_variables=drop_variables,
-        **decoders,
-        **kwargs,
+        filename_or_obj, drop_variables=drop_variables, **decoders, **kwargs
     )
     ds = _dataset_from_backend_dataset(
         backend_ds,
@@ -963,7 +960,7 @@ def open_mfdataset(
         raise ValueError(
             "When combine='by_coords', passing a value for `concat_dim` has no "
             "effect. To manually combine along a specific dimension you should "
-            "instead specify combine='nested' along with a value for `concat_dim`.",
+            "instead specify combine='nested' along with a value for `concat_dim`."
         )
 
     open_kwargs = dict(engine=engine, chunks=chunks or {}, **kwargs)

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -133,11 +133,7 @@ class PynioBackendEntrypoint(BackendEntrypoint):
         lock=None,
     ):
         filename_or_obj = _normalize_path(filename_or_obj)
-        store = NioDataStore(
-            filename_or_obj,
-            mode=mode,
-            lock=lock,
-        )
+        store = NioDataStore(filename_or_obj, mode=mode, lock=lock)
 
         store_entrypoint = StoreBackendEntrypoint()
         with close_on_error(store):

--- a/xarray/backends/rasterio_.py
+++ b/xarray/backends/rasterio_.py
@@ -165,12 +165,7 @@ def _parse_envi(meta):
 
 
 def open_rasterio(
-    filename,
-    parse_coordinates=None,
-    chunks=None,
-    cache=None,
-    lock=None,
-    **kwargs,
+    filename, parse_coordinates=None, chunks=None, cache=None, lock=None, **kwargs
 ):
     """Open a file with rasterio.
 
@@ -252,11 +247,7 @@ def open_rasterio(
         lock = RASTERIO_LOCK
 
     manager = CachingFileManager(
-        rasterio.open,
-        filename,
-        lock=lock,
-        mode="r",
-        kwargs=kwargs,
+        rasterio.open, filename, lock=lock, mode="r", kwargs=kwargs
     )
     riods = manager.acquire()
     if vrt_params is not None:

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -375,11 +375,7 @@ class ZarrStore(AbstractWritableDataStore):
             # default to 2 if store doesn't specify it's version (e.g. a path)
             zarr_version = getattr(store, "_store_version", 2)
 
-        open_kwargs = dict(
-            mode=mode,
-            synchronizer=synchronizer,
-            path=group,
-        )
+        open_kwargs = dict(mode=mode, synchronizer=synchronizer, path=group)
         open_kwargs["storage_options"] = storage_options
         if zarr_version > 2:
             open_kwargs["zarr_version"] = zarr_version

--- a/xarray/coding/calendar_ops.py
+++ b/xarray/coding/calendar_ops.py
@@ -33,12 +33,7 @@ def _days_in_year(year, calendar, use_cftime=True):
 
 
 def convert_calendar(
-    obj,
-    calendar,
-    dim="time",
-    align_on=None,
-    missing=None,
-    use_cftime=None,
+    obj, calendar, dim="time", align_on=None, missing=None, use_cftime=None
 ):
     """Transform a time-indexed Dataset or DataArray to one that uses another calendar.
 

--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -1308,8 +1308,5 @@ def date_range_like(source, calendar, use_cftime=None):
         end = end.replace(day=end.daysinmonth)
 
     return date_range(
-        start=start.isoformat(),
-        end=end.isoformat(),
-        freq=freq,
-        calendar=calendar,
+        start=start.isoformat(), end=end.isoformat(), freq=freq, calendar=calendar
     )

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -30,10 +30,7 @@ CF_RELATED_DATA = (
     "cell_measures",
     "formula_terms",
 )
-CF_RELATED_DATA_NEEDS_PARSING = (
-    "cell_measures",
-    "formula_terms",
-)
+CF_RELATED_DATA_NEEDS_PARSING = ("cell_measures", "formula_terms")
 
 
 if TYPE_CHECKING:

--- a/xarray/core/_aggregations.py
+++ b/xarray/core/_aggregations.py
@@ -34,11 +34,7 @@ class DatasetAggregations:
         raise NotImplementedError()
 
     def count(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> Dataset:
         """
         Reduce this Dataset's data by applying ``count`` along some dimension(s).
@@ -106,11 +102,7 @@ class DatasetAggregations:
         )
 
     def all(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> Dataset:
         """
         Reduce this Dataset's data by applying ``all`` along some dimension(s).
@@ -178,11 +170,7 @@ class DatasetAggregations:
         )
 
     def any(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> Dataset:
         """
         Reduce this Dataset's data by applying ``any`` along some dimension(s).
@@ -1230,11 +1218,7 @@ class DataArrayAggregations:
         raise NotImplementedError()
 
     def count(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> DataArray:
         """
         Reduce this DataArray's data by applying ``count`` along some dimension(s).
@@ -1289,18 +1273,11 @@ class DataArrayAggregations:
         array(5)
         """
         return self.reduce(
-            duck_array_ops.count,
-            dim=dim,
-            keep_attrs=keep_attrs,
-            **kwargs,
+            duck_array_ops.count, dim=dim, keep_attrs=keep_attrs, **kwargs
         )
 
     def all(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> DataArray:
         """
         Reduce this DataArray's data by applying ``all`` along some dimension(s).
@@ -1355,18 +1332,11 @@ class DataArrayAggregations:
         array(False)
         """
         return self.reduce(
-            duck_array_ops.array_all,
-            dim=dim,
-            keep_attrs=keep_attrs,
-            **kwargs,
+            duck_array_ops.array_all, dim=dim, keep_attrs=keep_attrs, **kwargs
         )
 
     def any(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> DataArray:
         """
         Reduce this DataArray's data by applying ``any`` along some dimension(s).
@@ -1421,10 +1391,7 @@ class DataArrayAggregations:
         array(True)
         """
         return self.reduce(
-            duck_array_ops.array_any,
-            dim=dim,
-            keep_attrs=keep_attrs,
-            **kwargs,
+            duck_array_ops.array_any, dim=dim, keep_attrs=keep_attrs, **kwargs
         )
 
     def max(
@@ -1499,11 +1466,7 @@ class DataArrayAggregations:
         array(nan)
         """
         return self.reduce(
-            duck_array_ops.max,
-            dim=dim,
-            skipna=skipna,
-            keep_attrs=keep_attrs,
-            **kwargs,
+            duck_array_ops.max, dim=dim, skipna=skipna, keep_attrs=keep_attrs, **kwargs
         )
 
     def min(
@@ -1578,11 +1541,7 @@ class DataArrayAggregations:
         array(nan)
         """
         return self.reduce(
-            duck_array_ops.min,
-            dim=dim,
-            skipna=skipna,
-            keep_attrs=keep_attrs,
-            **kwargs,
+            duck_array_ops.min, dim=dim, skipna=skipna, keep_attrs=keep_attrs, **kwargs
         )
 
     def mean(
@@ -1661,11 +1620,7 @@ class DataArrayAggregations:
         array(nan)
         """
         return self.reduce(
-            duck_array_ops.mean,
-            dim=dim,
-            skipna=skipna,
-            keep_attrs=keep_attrs,
-            **kwargs,
+            duck_array_ops.mean, dim=dim, skipna=skipna, keep_attrs=keep_attrs, **kwargs
         )
 
     def prod(
@@ -2327,19 +2282,11 @@ class DatasetGroupByAggregations:
     ) -> Dataset:
         raise NotImplementedError()
 
-    def _flox_reduce(
-        self,
-        dim: Dims,
-        **kwargs: Any,
-    ) -> Dataset:
+    def _flox_reduce(self, dim: Dims, **kwargs: Any) -> Dataset:
         raise NotImplementedError()
 
     def count(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> Dataset:
         """
         Reduce this Dataset's data by applying ``count`` along some dimension(s).
@@ -2433,11 +2380,7 @@ class DatasetGroupByAggregations:
             )
 
     def all(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> Dataset:
         """
         Reduce this Dataset's data by applying ``all`` along some dimension(s).
@@ -2531,11 +2474,7 @@ class DatasetGroupByAggregations:
             )
 
     def any(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> Dataset:
         """
         Reduce this Dataset's data by applying ``any`` along some dimension(s).
@@ -3841,19 +3780,11 @@ class DatasetResampleAggregations:
     ) -> Dataset:
         raise NotImplementedError()
 
-    def _flox_reduce(
-        self,
-        dim: Dims,
-        **kwargs: Any,
-    ) -> Dataset:
+    def _flox_reduce(self, dim: Dims, **kwargs: Any) -> Dataset:
         raise NotImplementedError()
 
     def count(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> Dataset:
         """
         Reduce this Dataset's data by applying ``count`` along some dimension(s).
@@ -3947,11 +3878,7 @@ class DatasetResampleAggregations:
             )
 
     def all(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> Dataset:
         """
         Reduce this Dataset's data by applying ``all`` along some dimension(s).
@@ -4045,11 +3972,7 @@ class DatasetResampleAggregations:
             )
 
     def any(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> Dataset:
         """
         Reduce this Dataset's data by applying ``any`` along some dimension(s).
@@ -5355,19 +5278,11 @@ class DataArrayGroupByAggregations:
     ) -> DataArray:
         raise NotImplementedError()
 
-    def _flox_reduce(
-        self,
-        dim: Dims,
-        **kwargs: Any,
-    ) -> DataArray:
+    def _flox_reduce(self, dim: Dims, **kwargs: Any) -> DataArray:
         raise NotImplementedError()
 
     def count(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> DataArray:
         """
         Reduce this DataArray's data by applying ``count`` along some dimension(s).
@@ -5447,18 +5362,11 @@ class DataArrayGroupByAggregations:
             )
         else:
             return self.reduce(
-                duck_array_ops.count,
-                dim=dim,
-                keep_attrs=keep_attrs,
-                **kwargs,
+                duck_array_ops.count, dim=dim, keep_attrs=keep_attrs, **kwargs
             )
 
     def all(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> DataArray:
         """
         Reduce this DataArray's data by applying ``all`` along some dimension(s).
@@ -5538,18 +5446,11 @@ class DataArrayGroupByAggregations:
             )
         else:
             return self.reduce(
-                duck_array_ops.array_all,
-                dim=dim,
-                keep_attrs=keep_attrs,
-                **kwargs,
+                duck_array_ops.array_all, dim=dim, keep_attrs=keep_attrs, **kwargs
             )
 
     def any(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> DataArray:
         """
         Reduce this DataArray's data by applying ``any`` along some dimension(s).
@@ -5629,10 +5530,7 @@ class DataArrayGroupByAggregations:
             )
         else:
             return self.reduce(
-                duck_array_ops.array_any,
-                dim=dim,
-                keep_attrs=keep_attrs,
-                **kwargs,
+                duck_array_ops.array_any, dim=dim, keep_attrs=keep_attrs, **kwargs
             )
 
     def max(
@@ -6761,19 +6659,11 @@ class DataArrayResampleAggregations:
     ) -> DataArray:
         raise NotImplementedError()
 
-    def _flox_reduce(
-        self,
-        dim: Dims,
-        **kwargs: Any,
-    ) -> DataArray:
+    def _flox_reduce(self, dim: Dims, **kwargs: Any) -> DataArray:
         raise NotImplementedError()
 
     def count(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> DataArray:
         """
         Reduce this DataArray's data by applying ``count`` along some dimension(s).
@@ -6853,18 +6743,11 @@ class DataArrayResampleAggregations:
             )
         else:
             return self.reduce(
-                duck_array_ops.count,
-                dim=dim,
-                keep_attrs=keep_attrs,
-                **kwargs,
+                duck_array_ops.count, dim=dim, keep_attrs=keep_attrs, **kwargs
             )
 
     def all(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> DataArray:
         """
         Reduce this DataArray's data by applying ``all`` along some dimension(s).
@@ -6944,18 +6827,11 @@ class DataArrayResampleAggregations:
             )
         else:
             return self.reduce(
-                duck_array_ops.array_all,
-                dim=dim,
-                keep_attrs=keep_attrs,
-                **kwargs,
+                duck_array_ops.array_all, dim=dim, keep_attrs=keep_attrs, **kwargs
             )
 
     def any(
-        self,
-        dim: Dims = None,
-        *,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
+        self, dim: Dims = None, *, keep_attrs: bool | None = None, **kwargs: Any
     ) -> DataArray:
         """
         Reduce this DataArray's data by applying ``any`` along some dimension(s).
@@ -7035,10 +6911,7 @@ class DataArrayResampleAggregations:
             )
         else:
             return self.reduce(
-                duck_array_ops.array_any,
-                dim=dim,
-                keep_attrs=keep_attrs,
-                **kwargs,
+                duck_array_ops.array_any, dim=dim, keep_attrs=keep_attrs, **kwargs
             )
 
     def max(

--- a/xarray/core/accessor_str.py
+++ b/xarray/core/accessor_str.py
@@ -288,10 +288,7 @@ class StringAccessor(Generic[T_DataArray]):
         """
         return self._apply(func=len, dtype=int)
 
-    def __getitem__(
-        self,
-        key: int | slice,
-    ) -> T_DataArray:
+    def __getitem__(self, key: int | slice) -> T_DataArray:
         if isinstance(key, slice):
             return self.slice(start=key.start, stop=key.stop, step=key.step)
         else:
@@ -300,16 +297,10 @@ class StringAccessor(Generic[T_DataArray]):
     def __add__(self, other: Any) -> T_DataArray:
         return self.cat(other, sep="")
 
-    def __mul__(
-        self,
-        num: int | Any,
-    ) -> T_DataArray:
+    def __mul__(self, num: int | Any) -> T_DataArray:
         return self.repeat(num)
 
-    def __mod__(
-        self,
-        other: Any,
-    ) -> T_DataArray:
+    def __mod__(self, other: Any) -> T_DataArray:
         if isinstance(other, dict):
             other = {key: self._stringify(val) for key, val in other.items()}
             return self._apply(func=lambda x: x % other)
@@ -319,11 +310,7 @@ class StringAccessor(Generic[T_DataArray]):
         else:
             return self._apply(func=lambda x, y: x % y, func_args=(other,))
 
-    def get(
-        self,
-        i: int | Any,
-        default: str | bytes = "",
-    ) -> T_DataArray:
+    def get(self, i: int | Any, default: str | bytes = "") -> T_DataArray:
         """
         Extract character number `i` from each string in the array.
 
@@ -504,17 +491,9 @@ class StringAccessor(Generic[T_DataArray]):
         # sep will go at the end of the input arguments.
         func = lambda *x: x[-1].join(x[:-1])
 
-        return self._apply(
-            func=func,
-            func_args=others,
-            dtype=self._obj.dtype.kind,
-        )
+        return self._apply(func=func, func_args=others, dtype=self._obj.dtype.kind)
 
-    def join(
-        self,
-        dim: Hashable = None,
-        sep: str | bytes | Any = "",
-    ) -> T_DataArray:
+    def join(self, dim: Hashable = None, sep: str | bytes | Any = "") -> T_DataArray:
         """
         Concatenate strings in a DataArray along a particular dimension.
 
@@ -581,11 +560,7 @@ class StringAccessor(Generic[T_DataArray]):
         # concatenate the resulting arrays
         return start.str.cat(*others, sep=sep)
 
-    def format(
-        self,
-        *args: Any,
-        **kwargs: Any,
-    ) -> T_DataArray:
+    def format(self, *args: Any, **kwargs: Any) -> T_DataArray:
         """
         Perform python string formatting on each element of the DataArray.
 
@@ -730,10 +705,7 @@ class StringAccessor(Generic[T_DataArray]):
         """
         return self._apply(func=lambda x: x.casefold())
 
-    def normalize(
-        self,
-        form: str,
-    ) -> T_DataArray:
+    def normalize(self, form: str) -> T_DataArray:
         """
         Return the Unicode normal form for the strings in the datarray.
 
@@ -936,10 +908,7 @@ class StringAccessor(Generic[T_DataArray]):
         return self._apply(func=func, func_args=(pat,), dtype=bool)
 
     def pad(
-        self,
-        width: int | Any,
-        side: str = "left",
-        fillchar: str | bytes | Any = " ",
+        self, width: int | Any, side: str = "left", fillchar: str | bytes | Any = " "
     ) -> T_DataArray:
         """
         Pad strings in the array up to width.
@@ -976,11 +945,7 @@ class StringAccessor(Generic[T_DataArray]):
         return func(width=width, fillchar=fillchar)
 
     def _padder(
-        self,
-        *,
-        func: Callable,
-        width: int | Any,
-        fillchar: str | bytes | Any = " ",
+        self, *, func: Callable, width: int | Any, fillchar: str | bytes | Any = " "
     ) -> T_DataArray:
         """
         Wrapper function to handle padding operations
@@ -1019,11 +984,7 @@ class StringAccessor(Generic[T_DataArray]):
         func = self._obj.dtype.type.center
         return self._padder(func=func, width=width, fillchar=fillchar)
 
-    def ljust(
-        self,
-        width: int | Any,
-        fillchar: str | bytes | Any = " ",
-    ) -> T_DataArray:
+    def ljust(self, width: int | Any, fillchar: str | bytes | Any = " ") -> T_DataArray:
         """
         Pad right side of each string in the array.
 
@@ -1046,11 +1007,7 @@ class StringAccessor(Generic[T_DataArray]):
         func = self._obj.dtype.type.ljust
         return self._padder(func=func, width=width, fillchar=fillchar)
 
-    def rjust(
-        self,
-        width: int | Any,
-        fillchar: str | bytes | Any = " ",
-    ) -> T_DataArray:
+    def rjust(self, width: int | Any, fillchar: str | bytes | Any = " ") -> T_DataArray:
         """
         Pad left side of each string in the array.
 
@@ -1170,10 +1127,7 @@ class StringAccessor(Generic[T_DataArray]):
         return self._apply(func=func, func_args=(pat,), dtype=bool)
 
     def match(
-        self,
-        pat: str | bytes | Pattern | Any,
-        case: bool | None = None,
-        flags: int = 0,
+        self, pat: str | bytes | Pattern | Any, case: bool | None = None, flags: int = 0
     ) -> T_DataArray:
         """
         Determine if each string in the array matches a regular expression.
@@ -1338,10 +1292,7 @@ class StringAccessor(Generic[T_DataArray]):
         func = lambda x: x.translate(table)
         return self._apply(func=func)
 
-    def repeat(
-        self,
-        repeats: int | Any,
-    ) -> T_DataArray:
+    def repeat(self, repeats: int | Any) -> T_DataArray:
         """
         Repeat each string in the array.
 
@@ -1408,10 +1359,7 @@ class StringAccessor(Generic[T_DataArray]):
         return self._apply(func=func, func_args=(sub, start, end), dtype=int)
 
     def rfind(
-        self,
-        sub: str | bytes | Any,
-        start: int | Any = 0,
-        end: int | Any = None,
+        self, sub: str | bytes | Any, start: int | Any = 0, end: int | Any = None
     ) -> T_DataArray:
         """
         Return highest indexes in each strings in the array
@@ -1491,10 +1439,7 @@ class StringAccessor(Generic[T_DataArray]):
         return self._apply(func=func, func_args=(sub, start, end), dtype=int)
 
     def rindex(
-        self,
-        sub: str | bytes | Any,
-        start: int | Any = 0,
-        end: int | Any = None,
+        self, sub: str | bytes | Any, start: int | Any = 0, end: int | Any = None
     ) -> T_DataArray:
         """
         Return highest indexes in each strings where the substring is
@@ -1921,10 +1866,7 @@ class StringAccessor(Generic[T_DataArray]):
         ).astype(self._obj.dtype.kind)
 
     def findall(
-        self,
-        pat: str | bytes | Pattern | Any,
-        case: bool | None = None,
-        flags: int = 0,
+        self, pat: str | bytes | Pattern | Any, case: bool | None = None, flags: int = 0
     ) -> T_DataArray:
         r"""
         Find all occurrences of pattern or regular expression in the DataArray.
@@ -2014,11 +1956,7 @@ class StringAccessor(Generic[T_DataArray]):
         return self._apply(func=func, func_args=(pat,), dtype=np.object_)
 
     def _partitioner(
-        self,
-        *,
-        func: Callable,
-        dim: Hashable | None,
-        sep: str | bytes | Any | None,
+        self, *, func: Callable, dim: Hashable | None, sep: str | bytes | Any | None
     ) -> T_DataArray:
         """
         Implements logic for `partition` and `rpartition`.
@@ -2046,9 +1984,7 @@ class StringAccessor(Generic[T_DataArray]):
         ).astype(self._obj.dtype.kind)
 
     def partition(
-        self,
-        dim: Hashable | None,
-        sep: str | bytes | Any = " ",
+        self, dim: Hashable | None, sep: str | bytes | Any = " "
     ) -> T_DataArray:
         """
         Split the strings in the DataArray at the first occurrence of separator `sep`.
@@ -2084,9 +2020,7 @@ class StringAccessor(Generic[T_DataArray]):
         return self._partitioner(func=self._obj.dtype.type.partition, dim=dim, sep=sep)
 
     def rpartition(
-        self,
-        dim: Hashable | None,
-        sep: str | bytes | Any = " ",
+        self, dim: Hashable | None, sep: str | bytes | Any = " "
     ) -> T_DataArray:
         """
         Split the strings in the DataArray at the last occurrence of separator `sep`.
@@ -2171,10 +2105,7 @@ class StringAccessor(Generic[T_DataArray]):
         ).astype(self._obj.dtype.kind)
 
     def split(
-        self,
-        dim: Hashable | None,
-        sep: str | bytes | Any = None,
-        maxsplit: int = -1,
+        self, dim: Hashable | None, sep: str | bytes | Any = None, maxsplit: int = -1
     ) -> DataArray:
         r"""
         Split strings in a DataArray around the given separator/delimiter `sep`.
@@ -2404,11 +2335,7 @@ class StringAccessor(Generic[T_DataArray]):
             maxsplit=maxsplit,
         )
 
-    def get_dummies(
-        self,
-        dim: Hashable,
-        sep: str | bytes | Any = "|",
-    ) -> DataArray:
+    def get_dummies(self, dim: Hashable, sep: str | bytes | Any = "|") -> DataArray:
         """
         Return DataArray of dummy/indicator variables.
 

--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -174,8 +174,7 @@ class Aligner(Generic[DataAlignable]):
         self.results = tuple()
 
     def _normalize_indexes(
-        self,
-        indexes: Mapping[Any, Any],
+        self, indexes: Mapping[Any, Any]
     ) -> tuple[NormalizedIndexes, NormalizedIndexVars]:
         """Normalize the indexes/indexers used for re-indexing or alignment.
 
@@ -362,8 +361,7 @@ class Aligner(Generic[DataAlignable]):
     def _get_index_joiner(self, index_cls) -> Callable:
         if self.join in ["outer", "inner"]:
             return functools.partial(
-                functools.reduce,
-                functools.partial(index_cls.join, how=self.join),
+                functools.reduce, functools.partial(index_cls.join, how=self.join)
             )
         elif self.join == "left":
             return operator.itemgetter(0)
@@ -407,8 +405,7 @@ class Aligner(Generic[DataAlignable]):
             else:
                 if len(matching_indexes) > 1:
                     need_reindex = self._need_reindex(
-                        dims,
-                        list(zip(matching_indexes, matching_index_vars)),
+                        dims, list(zip(matching_indexes, matching_index_vars))
                     )
                 else:
                     need_reindex = False
@@ -494,8 +491,7 @@ class Aligner(Generic[DataAlignable]):
         self.results = tuple(objects)
 
     def _get_dim_pos_indexers(
-        self,
-        matching_indexes: dict[MatchingIndexKey, Index],
+        self, matching_indexes: dict[MatchingIndexKey, Index]
     ) -> dict[Hashable, Any]:
         dim_pos_indexers = {}
 
@@ -509,9 +505,7 @@ class Aligner(Generic[DataAlignable]):
         return dim_pos_indexers
 
     def _get_indexes_and_vars(
-        self,
-        obj: DataAlignable,
-        matching_indexes: dict[MatchingIndexKey, Index],
+        self, obj: DataAlignable, matching_indexes: dict[MatchingIndexKey, Index]
     ) -> tuple[dict[Hashable, Index], dict[Hashable, Variable]]:
         new_indexes = {}
         new_variables = {}
@@ -532,9 +526,7 @@ class Aligner(Generic[DataAlignable]):
         return new_indexes, new_variables
 
     def _reindex_one(
-        self,
-        obj: DataAlignable,
-        matching_indexes: dict[MatchingIndexKey, Index],
+        self, obj: DataAlignable, matching_indexes: dict[MatchingIndexKey, Index]
     ) -> DataAlignable:
         new_indexes, new_variables = self._get_indexes_and_vars(obj, matching_indexes)
         dim_pos_indexers = self._get_dim_pos_indexers(matching_indexes)

--- a/xarray/core/arithmetic.py
+++ b/xarray/core/arithmetic.py
@@ -36,12 +36,7 @@ class SupportsArithmetic:
     # numpy.lib.mixins.NDArrayOperatorsMixin.
 
     # TODO: allow extending this with some sort of registration system
-    _HANDLED_TYPES = (
-        np.generic,
-        numbers.Number,
-        bytes,
-        str,
-    )
+    _HANDLED_TYPES = (np.generic, numbers.Number, bytes, str)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         from xarray.core.computation import apply_ufunc
@@ -110,11 +105,7 @@ class VariableArithmetic(
     __array_priority__ = 50
 
 
-class DatasetArithmetic(
-    ImplementsDatasetReduce,
-    SupportsArithmetic,
-    DatasetOpsMixin,
-):
+class DatasetArithmetic(ImplementsDatasetReduce, SupportsArithmetic, DatasetOpsMixin):
     __slots__ = ()
     __array_priority__ = 50
 
@@ -130,17 +121,11 @@ class DataArrayArithmetic(
     __array_priority__ = 60
 
 
-class DataArrayGroupbyArithmetic(
-    SupportsArithmetic,
-    DataArrayGroupByOpsMixin,
-):
+class DataArrayGroupbyArithmetic(SupportsArithmetic, DataArrayGroupByOpsMixin):
     __slots__ = ()
 
 
-class DatasetGroupbyArithmetic(
-    SupportsArithmetic,
-    DatasetGroupByOpsMixin,
-):
+class DatasetGroupbyArithmetic(SupportsArithmetic, DatasetGroupByOpsMixin):
     __slots__ = ()
 
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1204,10 +1204,7 @@ class DataWithCoords(AttrAccessMixin):
             keep_attrs = _get_keep_attrs(default=False)
 
         return apply_ufunc(
-            duck_array_ops.isnull,
-            self,
-            dask="allowed",
-            keep_attrs=keep_attrs,
+            duck_array_ops.isnull, self, dask="allowed", keep_attrs=keep_attrs
         )
 
     def notnull(
@@ -1249,10 +1246,7 @@ class DataWithCoords(AttrAccessMixin):
             keep_attrs = _get_keep_attrs(default=False)
 
         return apply_ufunc(
-            duck_array_ops.notnull,
-            self,
-            dask="allowed",
-            keep_attrs=keep_attrs,
+            duck_array_ops.notnull, self, dask="allowed", keep_attrs=keep_attrs
         )
 
     def isin(self: T_DataWithCoords, test_elements: Any) -> T_DataWithCoords:
@@ -1772,9 +1766,7 @@ def ones_like(
     return full_like(other, 1, dtype)
 
 
-def get_chunksizes(
-    variables: Iterable[Variable],
-) -> Mapping[Any, tuple[int, ...]]:
+def get_chunksizes(variables: Iterable[Variable]) -> Mapping[Any, tuple[int, ...]]:
     chunks: dict[Any, tuple[int, ...]] = {}
     for v in variables:
         if hasattr(v._data, "chunks"):

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -136,9 +136,7 @@ class _UFuncSignature:
 
     def __repr__(self):
         return "{}({!r}, {!r})".format(
-            type(self).__name__,
-            list(self.input_core_dims),
-            list(self.output_core_dims),
+            type(self).__name__, list(self.input_core_dims), list(self.output_core_dims)
         )
 
     def __str__(self):
@@ -782,10 +780,7 @@ def apply_variable_ufunc(
         )
 
     objs = _all_of_type(args, Variable)
-    attrs = merge_attrs(
-        [obj.attrs for obj in objs],
-        combine_attrs=keep_attrs,
-    )
+    attrs = merge_attrs([obj.attrs for obj in objs], combine_attrs=keep_attrs)
 
     output: list[Variable] = []
     for dims, data in zip(output_dims, result_data):
@@ -1589,11 +1584,7 @@ def cross(
             # If the arrays have coords we know which indexes to fill
             # with zeros:
             a, b = align(
-                a,
-                b,
-                fill_value=0,
-                join="outer",
-                exclude=set(all_dims) - {dim},
+                a, b, fill_value=0, join="outer", exclude=set(all_dims) - {dim}
             )
         elif min(a.sizes[dim], b.sizes[dim]) == 2:
             # If the array doesn't have coords we can only infer
@@ -1628,11 +1619,7 @@ def cross(
     return c
 
 
-def dot(
-    *arrays,
-    dims: Dims = None,
-    **kwargs: Any,
-):
+def dot(*arrays, dims: Dims = None, **kwargs: Any):
     """Generalized dot product for xarray objects. Like np.einsum, but
     provides a simpler interface based on array dimensions.
 
@@ -2017,7 +2004,7 @@ def _ensure_numeric(data: Dataset | DataArray) -> Dataset | DataArray:
                 np.datetime64("1970-01-01") if x.dtype.kind == "M" else _cfoffset(x)
             )
             return x.copy(
-                data=datetime_to_numeric(x.data, offset=offset, datetime_unit="ns"),
+                data=datetime_to_numeric(x.data, offset=offset, datetime_unit="ns")
             )
         elif x.dtype.kind == "m":
             # timedeltas

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -222,10 +222,7 @@ _THIS_ARRAY = ReprObject("<this-array>")
 
 
 class DataArray(
-    AbstractArray,
-    DataWithCoords,
-    DataArrayArithmetic,
-    DataArrayAggregations,
+    AbstractArray, DataWithCoords, DataArrayArithmetic, DataArrayAggregations
 ):
     """N-dimensional array with labeled coordinates and dimensions.
 
@@ -903,25 +900,18 @@ class DataArray(
 
     @overload
     def reset_coords(
-        self: T_DataArray,
-        names: Dims = None,
-        drop: Literal[False] = False,
+        self: T_DataArray, names: Dims = None, drop: Literal[False] = False
     ) -> Dataset:
         ...
 
     @overload
     def reset_coords(
-        self: T_DataArray,
-        names: Dims = None,
-        *,
-        drop: Literal[True],
+        self: T_DataArray, names: Dims = None, *, drop: Literal[True]
     ) -> T_DataArray:
         ...
 
     def reset_coords(
-        self: T_DataArray,
-        names: Dims = None,
-        drop: bool = False,
+        self: T_DataArray, names: Dims = None, drop: bool = False
     ) -> T_DataArray | Dataset:
         """Given names of coordinates, reset them to become variables.
 
@@ -2577,9 +2567,7 @@ class DataArray(
     # change type of self and return to T_DataArray once
     # https://github.com/python/mypy/issues/12846 is resolved
     def reset_index(
-        self,
-        dims_or_levels: Hashable | Sequence[Hashable],
-        drop: bool = False,
+        self, dims_or_levels: Hashable | Sequence[Hashable], drop: bool = False
     ) -> DataArray:
         """Reset the specified index(es) or multi-index level(s).
 
@@ -2744,10 +2732,7 @@ class DataArray(
     # change type of self and return to T_DataArray once
     # https://github.com/python/mypy/issues/12846 is resolved
     def unstack(
-        self,
-        dim: Dims = None,
-        fill_value: Any = dtypes.NA,
-        sparse: bool = False,
+        self, dim: Dims = None, fill_value: Any = dtypes.NA, sparse: bool = False
     ) -> DataArray:
         """
         Unstack existing dimensions corresponding to MultiIndexes into
@@ -2928,10 +2913,7 @@ class DataArray(
     # change type of self and return to T_DataArray once
     # https://github.com/python/mypy/issues/12846 is resolved
     def drop_vars(
-        self,
-        names: Hashable | Iterable[Hashable],
-        *,
-        errors: ErrorOptions = "raise",
+        self, names: Hashable | Iterable[Hashable], *, errors: ErrorOptions = "raise"
     ) -> DataArray:
         """Returns an array with dropped variables.
 
@@ -4336,10 +4318,7 @@ class DataArray(
             return da
 
     def _binary_op(
-        self: T_DataArray,
-        other: Any,
-        f: Callable,
-        reflexive: bool = False,
+        self: T_DataArray, other: Any, f: Callable, reflexive: bool = False
     ) -> T_DataArray:
         from xarray.core.groupby import GroupBy
 
@@ -4595,11 +4574,7 @@ class DataArray(
         """
         return self._replace(self.variable.imag)
 
-    def dot(
-        self: T_DataArray,
-        other: T_DataArray,
-        dims: Dims = None,
-    ) -> T_DataArray:
+    def dot(self: T_DataArray, other: T_DataArray, dims: Dims = None) -> T_DataArray:
         """Perform dot product of two DataArrays along their shared dims.
 
         Equivalent to taking taking tensordot over all shared dims.
@@ -6168,9 +6143,7 @@ class DataArray(
         )
 
     def interp_calendar(
-        self,
-        target: pd.DatetimeIndex | CFTimeIndex | DataArray,
-        dim: str = "time",
+        self, target: pd.DatetimeIndex | CFTimeIndex | DataArray, dim: str = "time"
     ) -> DataArray:
         """Interpolates the DataArray to another calendar based on decimal year measure.
 
@@ -6526,11 +6499,7 @@ class DataArray(
 
         dim = either_dict_or_kwargs(dim, window_kwargs, "coarsen")
         return DataArrayCoarsen(
-            self,
-            dim,
-            boundary=boundary,
-            side=side,
-            coord_func=coord_func,
+            self, dim, boundary=boundary, side=side, coord_func=coord_func
         )
 
     def resample(

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1719,9 +1719,7 @@ class Dataset(
         return obj
 
     def reset_coords(
-        self: T_Dataset,
-        names: Dims = None,
-        drop: bool = False,
+        self: T_Dataset, names: Dims = None, drop: bool = False
     ) -> T_Dataset:
         """Given names of coordinates, reset them to become variables
 
@@ -4123,9 +4121,7 @@ class Dataset(
                 else:
                     current_variables = {}
                 idx, idx_vars = PandasMultiIndex.from_variables_maybe_expand(
-                    dim,
-                    current_variables,
-                    {k: self._variables[k] for k in var_names},
+                    dim, current_variables, {k: self._variables[k] for k in var_names}
                 )
                 for n in idx.index.names:
                     replace_dims[n] = dim
@@ -4437,10 +4433,7 @@ class Dataset(
         return self._replace(variables, indexes=indexes)
 
     def _get_stack_index(
-        self,
-        dim,
-        multi=False,
-        create_index=False,
+        self, dim, multi=False, create_index=False
     ) -> tuple[Index | None, dict[Hashable, Variable]]:
         """Used by stack and unstack to get one pandas (multi-)index among
         the indexed coordinates along dimension `dim`.
@@ -5399,9 +5392,7 @@ class Dataset(
         return self.drop_vars(drop_vars)
 
     def transpose(
-        self: T_Dataset,
-        *dims: Hashable,
-        missing_dims: ErrorOptionsWithWarn = "raise",
+        self: T_Dataset, *dims: Hashable, missing_dims: ErrorOptionsWithWarn = "raise"
     ) -> T_Dataset:
         """Return a new Dataset object with all array dimensions transposed.
 
@@ -8693,7 +8684,7 @@ class Dataset(
                         "param": n_params,
                         "cov_i": n_params,
                         "cov_j": n_params,
-                    },
+                    }
                 },
                 output_dtypes=(np.float64, np.float64),
                 exclude_dims=set(reduce_dims_),
@@ -9147,11 +9138,7 @@ class Dataset(
 
         dim = either_dict_or_kwargs(dim, window_kwargs, "coarsen")
         return DatasetCoarsen(
-            self,
-            dim,
-            boundary=boundary,
-            side=side,
-            coord_func=coord_func,
+            self, dim, boundary=boundary, side=side, coord_func=coord_func
         )
 
     def resample(

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -46,11 +46,7 @@ def get_array_namespace(x):
         return np
 
 
-def _dask_or_eager_func(
-    name,
-    eager_module=np,
-    dask_module="dask.array",
-):
+def _dask_or_eager_func(name, eager_module=np, dask_module="dask.array"):
     """Create a function that dispatches to dask for dask array inputs."""
 
     def f(*args, **kwargs):
@@ -83,19 +79,13 @@ pandas_isnull = _dask_or_eager_func("isnull", eager_module=pd, dask_module="dask
 # np.around has failing doctests, overwrite it so they pass:
 # https://github.com/numpy/numpy/issues/19759
 around.__doc__ = str.replace(
-    around.__doc__ or "",
-    "array([0.,  2.])",
-    "array([0., 2.])",
+    around.__doc__ or "", "array([0.,  2.])", "array([0., 2.])"
 )
 around.__doc__ = str.replace(
-    around.__doc__ or "",
-    "array([0.,  2.])",
-    "array([0., 2.])",
+    around.__doc__ or "", "array([0.,  2.])", "array([0., 2.])"
 )
 around.__doc__ = str.replace(
-    around.__doc__ or "",
-    "array([0.4,  1.6])",
-    "array([0.4, 1.6])",
+    around.__doc__ or "", "array([0.4,  1.6])", "array([0.4, 1.6])"
 )
 around.__doc__ = str.replace(
     around.__doc__ or "",

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -615,10 +615,7 @@ def array_repr(arr):
 
     start = f"<xarray.{type(arr).__name__} {name_str}"
     dims = dim_summary_limited(arr, col_width=len(start) + 1, max_rows=max_rows)
-    summary = [
-        f"{start}({dims})>",
-        data_repr,
-    ]
+    summary = [f"{start}({dims})>", data_repr]
 
     if hasattr(arr, "coords"):
         if arr.coords:

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -651,12 +651,7 @@ class GroupBy(Generic[T_Xarray]):
             obj._indexes = filter_indexes_from_coords(obj._indexes, set(obj.coords))
         return obj
 
-    def _flox_reduce(
-        self,
-        dim: Dims,
-        keep_attrs: bool | None = None,
-        **kwargs: Any,
-    ):
+    def _flox_reduce(self, dim: Dims, keep_attrs: bool | None = None, **kwargs: Any):
         """Adaptor function that translates our groupby API to that of flox."""
         from flox.xarray import xarray_reduce
 
@@ -1204,9 +1199,7 @@ class DataArrayGroupByBase(GroupBy["DataArray"], DataArrayGroupbyArithmetic):
 
 # https://github.com/python/mypy/issues/9031
 class DataArrayGroupBy(  # type: ignore[misc]
-    DataArrayGroupByBase,
-    DataArrayGroupByAggregations,
-    ImplementsArrayReduce,
+    DataArrayGroupByBase, DataArrayGroupByAggregations, ImplementsArrayReduce
 ):
     __slots__ = ()
 
@@ -1365,9 +1358,7 @@ class DatasetGroupByBase(GroupBy["Dataset"], DatasetGroupbyArithmetic):
 
 # https://github.com/python/mypy/issues/9031
 class DatasetGroupBy(  # type: ignore[misc]
-    DatasetGroupByBase,
-    DatasetGroupByAggregations,
-    ImplementsDatasetReduce,
+    DatasetGroupByBase, DatasetGroupByAggregations, ImplementsDatasetReduce
 ):
     __slots__ = ()
 

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -33,10 +33,7 @@ class Index:
 
     @classmethod
     def from_variables(
-        cls,
-        variables: Mapping[Any, Variable],
-        *,
-        options: Mapping[str, Any],
+        cls, variables: Mapping[Any, Variable], *, options: Mapping[str, Any]
     ) -> Index:
         raise NotImplementedError()
 
@@ -301,10 +298,7 @@ class PandasIndex(Index):
 
     @classmethod
     def from_variables(
-        cls,
-        variables: Mapping[Any, Variable],
-        *,
-        options: Mapping[str, Any],
+        cls, variables: Mapping[Any, Variable], *, options: Mapping[str, Any]
     ) -> PandasIndex:
         if len(variables) != 1:
             raise ValueError(
@@ -635,10 +629,7 @@ class PandasMultiIndex(PandasIndex):
 
     @classmethod
     def from_variables(
-        cls,
-        variables: Mapping[Any, Variable],
-        *,
-        options: Mapping[str, Any],
+        cls, variables: Mapping[Any, Variable], *, options: Mapping[str, Any]
     ) -> PandasMultiIndex:
         _check_dim_compat(variables)
         dim = next(iter(variables.values())).dims[0]
@@ -831,11 +822,7 @@ class PandasMultiIndex(PandasIndex):
 
             data = PandasMultiIndexingAdapter(self.index, dtype=dtype, level=level)
             index_vars[name] = IndexVariable(
-                self.dim,
-                data,
-                attrs=attrs,
-                encoding=encoding,
-                fastpath=True,
+                self.dim, data, attrs=attrs, encoding=encoding, fastpath=True
             )
 
         return index_vars
@@ -1023,8 +1010,7 @@ class PandasMultiIndex(PandasIndex):
 
 
 def create_default_index_implicit(
-    dim_variable: Variable,
-    all_variables: Mapping | Iterable[Hashable] | None = None,
+    dim_variable: Variable, all_variables: Mapping | Iterable[Hashable] | None = None
 ) -> tuple[PandasIndex, IndexVars]:
     """Create a default index from a dimension variable.
 
@@ -1100,9 +1086,7 @@ class Indexes(collections.abc.Mapping, Generic[T_PandasOrXarrayIndex]):
     )
 
     def __init__(
-        self,
-        indexes: dict[Any, T_PandasOrXarrayIndex],
-        variables: dict[Any, Variable],
+        self, indexes: dict[Any, T_PandasOrXarrayIndex], variables: dict[Any, Variable]
     ):
         """Constructor not for public consumption.
 
@@ -1428,9 +1412,7 @@ def indexes_all_equal(
 
 
 def _apply_indexes(
-    indexes: Indexes[Index],
-    args: Mapping[Any, Any],
-    func: str,
+    indexes: Indexes[Index], args: Mapping[Any, Any], func: str
 ) -> tuple[dict[Hashable, Index], dict[Hashable, Variable]]:
     new_indexes: dict[Hashable, Index] = {k: v for k, v in indexes.items()}
     new_index_variables: dict[Hashable, Variable] = {}
@@ -1452,22 +1434,19 @@ def _apply_indexes(
 
 
 def isel_indexes(
-    indexes: Indexes[Index],
-    indexers: Mapping[Any, Any],
+    indexes: Indexes[Index], indexers: Mapping[Any, Any]
 ) -> tuple[dict[Hashable, Index], dict[Hashable, Variable]]:
     return _apply_indexes(indexes, indexers, "isel")
 
 
 def roll_indexes(
-    indexes: Indexes[Index],
-    shifts: Mapping[Any, int],
+    indexes: Indexes[Index], shifts: Mapping[Any, int]
 ) -> tuple[dict[Hashable, Index], dict[Hashable, Variable]]:
     return _apply_indexes(indexes, shifts, "roll")
 
 
 def filter_indexes_from_coords(
-    indexes: Mapping[Any, Index],
-    filtered_coord_names: set,
+    indexes: Mapping[Any, Index], filtered_coord_names: set
 ) -> dict[Hashable, Index]:
     """Filter index items given a (sub)set of coordinate names.
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -118,9 +118,7 @@ def merge_sel_results(results: list[IndexSelResult]) -> IndexSelResult:
 
 
 def group_indexers_by_index(
-    obj: T_Xarray,
-    indexers: Mapping[Any, Any],
-    options: Mapping[str, Any],
+    obj: T_Xarray, indexers: Mapping[Any, Any], options: Mapping[str, Any]
 ) -> list[tuple[Index, dict[Any, Any]]]:
     """Returns a list of unique indexes and their corresponding indexers."""
     unique_indexes = {}
@@ -1504,10 +1502,7 @@ class PandasMultiIndexingAdapter(PandasIndexingAdapter):
     __slots__ = ("array", "_dtype", "level", "adapter")
 
     def __init__(
-        self,
-        array: pd.MultiIndex,
-        dtype: DTypeLike = None,
-        level: str | None = None,
+        self, array: pd.MultiIndex, dtype: DTypeLike = None, level: str | None = None
     ):
         super().__init__(array, dtype)
         self.level = level

--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -163,8 +163,7 @@ MergeElement = tuple[Variable, Optional[Index]]
 
 
 def _assert_prioritized_valid(
-    grouped: dict[Hashable, list[MergeElement]],
-    prioritized: Mapping[Any, MergeElement],
+    grouped: dict[Hashable, list[MergeElement]], prioritized: Mapping[Any, MergeElement]
 ) -> None:
     """Make sure that elements given in prioritized will not corrupt any
     index given in grouped.
@@ -306,8 +305,7 @@ def merge_collected(
 
 
 def collect_variables_and_indexes(
-    list_of_mappings: list[DatasetLike],
-    indexes: Mapping[Any, Any] | None = None,
+    list_of_mappings: list[DatasetLike], indexes: Mapping[Any, Any] | None = None
 ) -> dict[Hashable, list[MergeElement]]:
     """Collect variables and indexes from list of mappings of xarray objects.
 

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -709,12 +709,7 @@ def interp_func(var, x, new_x, method: InterpOptions, kwargs):
         ]
         new_x_arginds = [item for pair in new_x_arginds for item in pair]
 
-        args = (
-            var,
-            range(ndim),
-            *x_arginds,
-            *new_x_arginds,
-        )
+        args = (var, range(ndim), *x_arginds, *new_x_arginds)
 
         _, rechunked = da.unify_chunks(*args)
 

--- a/xarray/core/ops.py
+++ b/xarray/core/ops.py
@@ -41,16 +41,7 @@ NUMPY_SAME_METHODS = ["item", "searchsorted"]
 
 # methods which remove an axis
 REDUCE_METHODS = ["all", "any"]
-NAN_REDUCE_METHODS = [
-    "max",
-    "min",
-    "mean",
-    "prod",
-    "sum",
-    "std",
-    "var",
-    "median",
-]
+NAN_REDUCE_METHODS = ["max", "min", "mean", "prod", "sum", "std", "var", "median"]
 NAN_CUM_METHODS = ["cumsum", "cumprod"]
 # TODO: wrap take, dot, sort
 

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -51,10 +51,7 @@ class Resample(GroupBy[T_Xarray]):
         super().__init__(*args, **kwargs)
 
     def _flox_reduce(
-        self,
-        dim: Dims,
-        keep_attrs: bool | None = None,
-        **kwargs,
+        self, dim: Dims, keep_attrs: bool | None = None, **kwargs
     ) -> T_Xarray:
         from xarray.core.dataarray import DataArray
 

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -794,14 +794,7 @@ class Coarsen(CoarsenArithmetic, Generic[T_Xarray]):
     DataArray.coarsen
     """
 
-    __slots__ = (
-        "obj",
-        "boundary",
-        "coord_func",
-        "windows",
-        "side",
-        "trim_excess",
-    )
+    __slots__ = ("obj", "boundary", "coord_func", "windows", "side", "trim_excess")
     _attributes = ("windows", "side", "trim_excess")
     obj: T_Xarray
 
@@ -870,10 +863,7 @@ class Coarsen(CoarsenArithmetic, Generic[T_Xarray]):
         )
 
     def construct(
-        self,
-        window_dim=None,
-        keep_attrs=None,
-        **window_dim_kwargs,
+        self, window_dim=None, keep_attrs=None, **window_dim_kwargs
     ) -> T_Xarray:
         """
         Convert this Coarsen object to a DataArray or Dataset,

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -2,15 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Hashable, Iterable, Sequence
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Literal,
-    SupportsIndex,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Literal, SupportsIndex, TypeVar, Union
 
 import numpy as np
 import pandas as pd
@@ -197,9 +189,5 @@ if Version(np.__version__) >= Version("1.22.0"):
     ]
 else:
     QuantileMethods = Literal[  # type: ignore[misc]
-        "linear",
-        "lower",
-        "higher",
-        "midpoint",
-        "nearest",
+        "linear", "lower", "higher", "midpoint", "nearest"
     ]

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -268,9 +268,7 @@ def is_duck_array(value: Any) -> bool:
 
 
 def either_dict_or_kwargs(
-    pos_kwargs: Mapping[Any, T] | None,
-    kw_kwargs: Mapping[str, T],
-    func_name: str,
+    pos_kwargs: Mapping[Any, T] | None, kw_kwargs: Mapping[str, T], func_name: str
 ) -> Mapping[Hashable, T]:
     if pos_kwargs is None or pos_kwargs == {}:
         # Need an explicit cast to appease mypy due to invariance; see

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -41,10 +41,7 @@ from xarray.core.utils import (
     maybe_coerce_to_str,
 )
 
-NON_NUMPY_SUPPORTED_ARRAY_TYPES = (
-    indexing.ExplicitlyIndexed,
-    pd.Index,
-)
+NON_NUMPY_SUPPORTED_ARRAY_TYPES = (indexing.ExplicitlyIndexed, pd.Index)
 # https://github.com/python/mypy/issues/224
 BASIC_INDEXING_TYPES = integer_types + (slice,)
 
@@ -1398,9 +1395,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         return result
 
     def _pad_options_dim_to_index(
-        self,
-        pad_option: Mapping[Any, int | tuple[int, int]],
-        fill_with_shape=False,
+        self, pad_option: Mapping[Any, int | tuple[int, int]], fill_with_shape=False
     ):
         if fill_with_shape:
             return [
@@ -1565,9 +1560,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         return result
 
     def transpose(
-        self,
-        *dims: Hashable | ellipsis,
-        missing_dims: ErrorOptionsWithWarn = "raise",
+        self, *dims: Hashable | ellipsis, missing_dims: ErrorOptionsWithWarn = "raise"
     ) -> Variable:
         """Return a new Variable object with transposed dimensions.
 
@@ -1813,10 +1806,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
 
         else:
             data = np.full_like(
-                self.data,
-                fill_value=fill_value,
-                shape=new_shape,
-                dtype=dtype,
+                self.data, fill_value=fill_value, shape=new_shape, dtype=dtype
             )
 
             # Indexer is a list of lists of locations. Each list is the locations
@@ -2549,10 +2539,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
             keep_attrs = _get_keep_attrs(default=False)
 
         return apply_ufunc(
-            duck_array_ops.isnull,
-            self,
-            dask="allowed",
-            keep_attrs=keep_attrs,
+            duck_array_ops.isnull, self, dask="allowed", keep_attrs=keep_attrs
         )
 
     def notnull(self, keep_attrs: bool | None = None):
@@ -2583,10 +2570,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
             keep_attrs = _get_keep_attrs(default=False)
 
         return apply_ufunc(
-            duck_array_ops.notnull,
-            self,
-            dask="allowed",
-            keep_attrs=keep_attrs,
+            duck_array_ops.notnull, self, dask="allowed", keep_attrs=keep_attrs
         )
 
     @property

--- a/xarray/core/weighted.py
+++ b/xarray/core/weighted.py
@@ -206,10 +206,7 @@ class Weighted(Generic[T_Xarray]):
 
     @staticmethod
     def _reduce(
-        da: DataArray,
-        weights: DataArray,
-        dim: Dims = None,
-        skipna: bool | None = None,
+        da: DataArray, weights: DataArray, dim: Dims = None, skipna: bool | None = None
     ) -> DataArray:
         """reduce using dot; equivalent to (da * weights).sum(dim, skipna)
 
@@ -249,10 +246,7 @@ class Weighted(Generic[T_Xarray]):
         return sum_of_weights.where(valid_weights)
 
     def _sum_of_squares(
-        self,
-        da: DataArray,
-        dim: Dims = None,
-        skipna: bool | None = None,
+        self, da: DataArray, dim: Dims = None, skipna: bool | None = None
     ) -> DataArray:
         """Reduce a DataArray by a weighted ``sum_of_squares`` along some dimension(s)."""
 
@@ -261,20 +255,14 @@ class Weighted(Generic[T_Xarray]):
         return self._reduce((demeaned**2), self.weights, dim=dim, skipna=skipna)
 
     def _weighted_sum(
-        self,
-        da: DataArray,
-        dim: Dims = None,
-        skipna: bool | None = None,
+        self, da: DataArray, dim: Dims = None, skipna: bool | None = None
     ) -> DataArray:
         """Reduce a DataArray by a weighted ``sum`` along some dimension(s)."""
 
         return self._reduce(da, self.weights, dim=dim, skipna=skipna)
 
     def _weighted_mean(
-        self,
-        da: DataArray,
-        dim: Dims = None,
-        skipna: bool | None = None,
+        self, da: DataArray, dim: Dims = None, skipna: bool | None = None
     ) -> DataArray:
         """Reduce a DataArray by a weighted ``mean`` along some dimension(s)."""
 
@@ -285,10 +273,7 @@ class Weighted(Generic[T_Xarray]):
         return weighted_sum / sum_of_weights
 
     def _weighted_var(
-        self,
-        da: DataArray,
-        dim: Dims = None,
-        skipna: bool | None = None,
+        self, da: DataArray, dim: Dims = None, skipna: bool | None = None
     ) -> DataArray:
         """Reduce a DataArray by a weighted ``var`` along some dimension(s)."""
 
@@ -299,21 +284,14 @@ class Weighted(Generic[T_Xarray]):
         return sum_of_squares / sum_of_weights
 
     def _weighted_std(
-        self,
-        da: DataArray,
-        dim: Dims = None,
-        skipna: bool | None = None,
+        self, da: DataArray, dim: Dims = None, skipna: bool | None = None
     ) -> DataArray:
         """Reduce a DataArray by a weighted ``std`` along some dimension(s)."""
 
         return cast("DataArray", np.sqrt(self._weighted_var(da, dim, skipna)))
 
     def _weighted_quantile(
-        self,
-        da: DataArray,
-        q: ArrayLike,
-        dim: Dims = None,
-        skipna: bool | None = None,
+        self, da: DataArray, q: ArrayLike, dim: Dims = None, skipna: bool | None = None
     ) -> DataArray:
         """Apply a weighted ``quantile`` to a DataArray along some dimension(s)."""
 
@@ -446,9 +424,7 @@ class Weighted(Generic[T_Xarray]):
         raise NotImplementedError("Use `Dataset.weighted` or `DataArray.weighted`")
 
     def sum_of_weights(
-        self,
-        dim: Dims = None,
-        keep_attrs: bool | None = None,
+        self, dim: Dims = None, keep_attrs: bool | None = None
     ) -> T_Xarray:
         return self._implementation(
             self._sum_of_weights, dim=dim, keep_attrs=keep_attrs

--- a/xarray/plot/dataarray_plot.py
+++ b/xarray/plot/dataarray_plot.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 
 _styles: MutableMapping[str, Any] = {
     # Add a white border to make it easier seeing overlapping markers:
-    "scatter.edgecolors": "w",
+    "scatter.edgecolors": "w"
 }
 
 
@@ -976,9 +976,7 @@ def _plot1d(plotfunc):
                 levels = kwargs.get("levels", hueplt_norm.levels)
 
             cmap_params, cbar_kwargs = _process_cmap_cbar_kwargs(
-                plotfunc,
-                cast("DataArray", hueplt_norm.values).data,
-                **locals(),
+                plotfunc, cast("DataArray", hueplt_norm.values).data, **locals()
             )
 
             # subset that can be passed to scatter, hist2d
@@ -998,12 +996,7 @@ def _plot1d(plotfunc):
                 ax = get_axis(figsize, size, aspect, ax, **subplot_kws)
 
             primitive = plotfunc(
-                xplt,
-                yplt,
-                ax=ax,
-                add_labels=add_labels,
-                **cmap_params_subset,
-                **kwargs,
+                xplt, yplt, ax=ax, add_labels=add_labels, **cmap_params_subset, **kwargs
             )
 
         if np.any(np.asarray(add_labels)) and add_title:

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -1296,16 +1296,14 @@ def _infer_meta_data(ds, x, y, hue, hue_style, add_guide, funcname):
 
 @overload
 def _parse_size(
-    data: None,
-    norm: tuple[float | None, float | None, bool] | Normalize | None,
+    data: None, norm: tuple[float | None, float | None, bool] | Normalize | None
 ) -> None:
     ...
 
 
 @overload
 def _parse_size(
-    data: DataArray,
-    norm: tuple[float | None, float | None, bool] | Normalize | None,
+    data: DataArray, norm: tuple[float | None, float | None, bool] | Normalize | None
 ) -> pd.Series:
     ...
 
@@ -1706,10 +1704,7 @@ def _add_legend(
     primitive = primitive if isinstance(primitive, list) else [primitive]
 
     handles, labels = [], []
-    for huesizeplt, prop in [
-        (hueplt_norm, "colors"),
-        (sizeplt_norm, "sizes"),
-    ]:
+    for huesizeplt, prop in [(hueplt_norm, "colors"), (sizeplt_norm, "sizes")]:
         if huesizeplt.data is not None:
             # Get legend handles and labels that displays the
             # values correctly. Order might be different because

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -195,10 +195,7 @@ def _format_message(x, y, err_msg, verbose):
         f"Max relative difference: {rel_diff}",
     ]
     if verbose:
-        parts += [
-            f" x: {x!r}",
-            f" y: {y!r}",
-        ]
+        parts += [f" x: {x!r}", f" y: {y!r}"]
 
     return "\n".join(parts)
 

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -87,12 +87,7 @@ class TestDatetimeAccessor:
         assert_equal(expected, actual)
 
     @pytest.mark.parametrize(
-        "field, pandas_field",
-        [
-            ("year", "year"),
-            ("week", "week"),
-            ("weekday", "day"),
-        ],
+        "field, pandas_field", [("year", "year"), ("week", "week"), ("weekday", "day")]
     )
     def test_isocalendar(self, field, pandas_field) -> None:
         # pandas isocalendar has dtypy UInt32Dtype, convert to Int64
@@ -168,14 +163,7 @@ class TestDatetimeAccessor:
         assert_equal(actual.compute(), expected.compute())
 
     @requires_dask
-    @pytest.mark.parametrize(
-        "field",
-        [
-            "year",
-            "week",
-            "weekday",
-        ],
-    )
+    @pytest.mark.parametrize("field", ["year", "week", "weekday"])
     def test_isocalendar_dask(self, field) -> None:
         import dask.array as da
 

--- a/xarray/tests/test_accessor_str.py
+++ b/xarray/tests/test_accessor_str.py
@@ -845,15 +845,11 @@ def test_extract_multi_nocase(dtype) -> None:
 
 
 def test_extract_broadcast(dtype) -> None:
-    value = xr.DataArray(
-        ["a_Xy_0", "ab_xY_10", "abc_Xy_01"],
-        dims=["X"],
-    ).astype(dtype)
+    value = xr.DataArray(["a_Xy_0", "ab_xY_10", "abc_Xy_01"], dims=["X"]).astype(dtype)
 
-    pat_str = xr.DataArray(
-        [r"(\w+)_Xy_(\d*)", r"(\w+)_xY_(\d*)"],
-        dims=["Y"],
-    ).astype(dtype)
+    pat_str = xr.DataArray([r"(\w+)_Xy_(\d*)", r"(\w+)_xY_(\d*)"], dims=["Y"]).astype(
+        dtype
+    )
     pat_compiled = value.str._re_compile(pat=pat_str)
 
     expected_list = [
@@ -1192,15 +1188,11 @@ def test_extractall_multi_multi_nocase(dtype) -> None:
 
 
 def test_extractall_broadcast(dtype) -> None:
-    value = xr.DataArray(
-        ["a_Xy_0", "ab_xY_10", "abc_Xy_01"],
-        dims=["X"],
-    ).astype(dtype)
+    value = xr.DataArray(["a_Xy_0", "ab_xY_10", "abc_Xy_01"], dims=["X"]).astype(dtype)
 
-    pat_str = xr.DataArray(
-        [r"(\w+)_Xy_(\d*)", r"(\w+)_xY_(\d*)"],
-        dims=["Y"],
-    ).astype(dtype)
+    pat_str = xr.DataArray([r"(\w+)_Xy_(\d*)", r"(\w+)_xY_(\d*)"], dims=["Y"]).astype(
+        dtype
+    )
     pat_re = value.str._re_compile(pat=pat_str)
 
     expected_list = [
@@ -1292,11 +1284,7 @@ def test_findall_single_multi_case(dtype) -> None:
 
     expected_list: list[list[list]] = [
         [["a"], ["bab", "baab"], ["abc", "cbc"]],
-        [
-            ["abcd", "dcd", "dccd"],
-            [],
-            ["abcdef", "fef"],
-        ],
+        [["abcd", "dcd", "dccd"], [], ["abcdef", "fef"]],
     ]
     expected_dtype = [[[dtype(x) for x in y] for y in z] for z in expected_list]
     expected_np = np.array(expected_dtype, dtype=np.object_)
@@ -1332,16 +1320,8 @@ def test_findall_single_multi_nocase(dtype) -> None:
     ).astype(dtype)
 
     expected_list: list[list[list]] = [
-        [
-            ["a"],
-            ["ab", "bab", "baab"],
-            ["abc", "cbc"],
-        ],
-        [
-            ["abcd", "dcd", "dccd"],
-            [],
-            ["abcdef", "fef"],
-        ],
+        [["a"], ["ab", "bab", "baab"], ["abc", "cbc"]],
+        [["abcd", "dcd", "dccd"], [], ["abcdef", "fef"]],
     ]
     expected_dtype = [[[dtype(x) for x in y] for y in z] for z in expected_list]
     expected_np = np.array(expected_dtype, dtype=np.object_)
@@ -1510,15 +1490,9 @@ def test_findall_multi_multi_nocase(dtype) -> None:
 
 
 def test_findall_broadcast(dtype) -> None:
-    value = xr.DataArray(
-        ["a_Xy_0", "ab_xY_10", "abc_Xy_01"],
-        dims=["X"],
-    ).astype(dtype)
+    value = xr.DataArray(["a_Xy_0", "ab_xY_10", "abc_Xy_01"], dims=["X"]).astype(dtype)
 
-    pat_str = xr.DataArray(
-        [r"(\w+)_Xy_\d*", r"\w+_Xy_(\d*)"],
-        dims=["Y"],
-    ).astype(dtype)
+    pat_str = xr.DataArray([r"(\w+)_Xy_\d*", r"\w+_Xy_(\d*)"], dims=["Y"]).astype(dtype)
     pat_re = value.str._re_compile(pat=pat_str)
 
     expected_list: list[list[list]] = [[["a"], ["0"]], [[], []], [["abc"], ["01"]]]
@@ -2471,29 +2445,13 @@ def test_partition_whitespace(dtype) -> None:
     ).astype(dtype)
 
     exp_part_dim_list = [
-        [
-            ["abc", " ", "def"],
-            ["spam", " ", "eggs swallow"],
-            ["red_blue", "", ""],
-        ],
-        [
-            ["test0", " ", "test1 test2 test3"],
-            ["", "", ""],
-            ["abra", " ", "ka da bra"],
-        ],
+        [["abc", " ", "def"], ["spam", " ", "eggs swallow"], ["red_blue", "", ""]],
+        [["test0", " ", "test1 test2 test3"], ["", "", ""], ["abra", " ", "ka da bra"]],
     ]
 
     exp_rpart_dim_list = [
-        [
-            ["abc", " ", "def"],
-            ["spam eggs", " ", "swallow"],
-            ["", "", "red_blue"],
-        ],
-        [
-            ["test0 test1 test2", " ", "test3"],
-            ["", "", ""],
-            ["abra ka da", " ", "bra"],
-        ],
+        [["abc", " ", "def"], ["spam eggs", " ", "swallow"], ["", "", "red_blue"]],
+        [["test0 test1 test2", " ", "test3"], ["", "", ""], ["abra ka da", " ", "bra"]],
     ]
 
     exp_part_dim = xr.DataArray(exp_part_dim_list, dims=["X", "Y", "ZZ"]).astype(dtype)
@@ -2521,11 +2479,7 @@ def test_partition_comma(dtype) -> None:
     ).astype(dtype)
 
     exp_part_dim_list = [
-        [
-            ["abc", ", ", "def"],
-            ["spam", ", ", "eggs, swallow"],
-            ["red_blue", "", ""],
-        ],
+        [["abc", ", ", "def"], ["spam", ", ", "eggs, swallow"], ["red_blue", "", ""]],
         [
             ["test0", ", ", "test1, test2, test3"],
             ["", "", ""],
@@ -2534,11 +2488,7 @@ def test_partition_comma(dtype) -> None:
     ]
 
     exp_rpart_dim_list = [
-        [
-            ["abc", ", ", "def"],
-            ["spam, eggs", ", ", "swallow"],
-            ["", "", "red_blue"],
-        ],
+        [["abc", ", ", "def"], ["spam, eggs", ", ", "swallow"], ["", "", "red_blue"]],
         [
             ["test0, test1, test2", ", ", "test3"],
             ["", "", ""],
@@ -2901,14 +2851,10 @@ def test_split_comma_dim(
 
 def test_splitters_broadcast(dtype) -> None:
     values = xr.DataArray(
-        ["ab cd,de fg", "spam, ,eggs swallow", "red_blue"],
-        dims=["X"],
+        ["ab cd,de fg", "spam, ,eggs swallow", "red_blue"], dims=["X"]
     ).astype(dtype)
 
-    sep = xr.DataArray(
-        [" ", ","],
-        dims=["Y"],
-    ).astype(dtype)
+    sep = xr.DataArray([" ", ","], dims=["Y"]).astype(dtype)
 
     expected_left = xr.DataArray(
         [
@@ -3018,15 +2964,9 @@ def test_get_dummies(dtype) -> None:
 
 
 def test_get_dummies_broadcast(dtype) -> None:
-    values = xr.DataArray(
-        ["x~x|x~x", "x", "x|x~x", "x~x"],
-        dims=["X"],
-    ).astype(dtype)
+    values = xr.DataArray(["x~x|x~x", "x", "x|x~x", "x~x"], dims=["X"]).astype(dtype)
 
-    sep = xr.DataArray(
-        ["|", "~"],
-        dims=["Y"],
-    ).astype(dtype)
+    sep = xr.DataArray(["|", "~"], dims=["Y"]).astype(dtype)
 
     expected_list = [
         [[False, False, True], [True, True, False]],
@@ -3056,10 +2996,7 @@ def test_get_dummies_empty(dtype) -> None:
 
 
 def test_splitters_empty_str(dtype) -> None:
-    values = xr.DataArray(
-        [["", "", ""], ["", "", ""]],
-        dims=["X", "Y"],
-    ).astype(dtype)
+    values = xr.DataArray([["", "", ""], ["", "", ""]], dims=["X", "Y"]).astype(dtype)
 
     targ_partition_dim = xr.DataArray(
         [
@@ -3078,18 +3015,13 @@ def test_splitters_empty_str(dtype) -> None:
     ]
     targ_partition_none_np = np.array(targ_partition_none_list, dtype=np.object_)
     del targ_partition_none_np[-1, -1][-1]
-    targ_partition_none = xr.DataArray(
-        targ_partition_none_np,
-        dims=["X", "Y"],
-    )
+    targ_partition_none = xr.DataArray(targ_partition_none_np, dims=["X", "Y"])
 
     targ_split_dim = xr.DataArray(
-        [[[""], [""], [""]], [[""], [""], [""]]],
-        dims=["X", "Y", "ZZ"],
+        [[[""], [""], [""]], [[""], [""], [""]]], dims=["X", "Y", "ZZ"]
     ).astype(dtype)
     targ_split_none = xr.DataArray(
-        np.array([[[], [], []], [[], [], [""]]], dtype=np.object_),
-        dims=["X", "Y"],
+        np.array([[[], [], []], [[], [], [""]]], dtype=np.object_), dims=["X", "Y"]
     )
     del targ_split_none.data[-1, -1][-1]
 
@@ -3132,8 +3064,7 @@ def test_splitters_empty_str(dtype) -> None:
 
 def test_cat_str(dtype) -> None:
     values_1 = xr.DataArray(
-        [["a", "bb", "cccc"], ["ddddd", "eeee", "fff"]],
-        dims=["X", "Y"],
+        [["a", "bb", "cccc"], ["ddddd", "eeee", "fff"]], dims=["X", "Y"]
     ).astype(dtype)
     values_2 = "111"
 
@@ -3178,12 +3109,10 @@ def test_cat_str(dtype) -> None:
 
 def test_cat_uniform(dtype) -> None:
     values_1 = xr.DataArray(
-        [["a", "bb", "cccc"], ["ddddd", "eeee", "fff"]],
-        dims=["X", "Y"],
+        [["a", "bb", "cccc"], ["ddddd", "eeee", "fff"]], dims=["X", "Y"]
     ).astype(dtype)
     values_2 = xr.DataArray(
-        [["11111", "222", "33"], ["4", "5555", "66"]],
-        dims=["X", "Y"],
+        [["11111", "222", "33"], ["4", "5555", "66"]], dims=["X", "Y"]
     )
 
     targ_blank = xr.DataArray(
@@ -3227,13 +3156,9 @@ def test_cat_uniform(dtype) -> None:
 
 def test_cat_broadcast_right(dtype) -> None:
     values_1 = xr.DataArray(
-        [["a", "bb", "cccc"], ["ddddd", "eeee", "fff"]],
-        dims=["X", "Y"],
+        [["a", "bb", "cccc"], ["ddddd", "eeee", "fff"]], dims=["X", "Y"]
     ).astype(dtype)
-    values_2 = xr.DataArray(
-        ["11111", "222", "33"],
-        dims=["Y"],
-    )
+    values_2 = xr.DataArray(["11111", "222", "33"], dims=["Y"])
 
     targ_blank = xr.DataArray(
         [["a11111", "bb222", "cccc33"], ["ddddd11111", "eeee222", "fff33"]],
@@ -3275,19 +3200,14 @@ def test_cat_broadcast_right(dtype) -> None:
 
 
 def test_cat_broadcast_left(dtype) -> None:
-    values_1 = xr.DataArray(
-        ["a", "bb", "cccc"],
-        dims=["Y"],
-    ).astype(dtype)
+    values_1 = xr.DataArray(["a", "bb", "cccc"], dims=["Y"]).astype(dtype)
     values_2 = xr.DataArray(
-        [["11111", "222", "33"], ["4", "5555", "66"]],
-        dims=["X", "Y"],
+        [["11111", "222", "33"], ["4", "5555", "66"]], dims=["X", "Y"]
     )
 
     targ_blank = (
         xr.DataArray(
-            [["a11111", "bb222", "cccc33"], ["a4", "bb5555", "cccc66"]],
-            dims=["X", "Y"],
+            [["a11111", "bb222", "cccc33"], ["a4", "bb5555", "cccc66"]], dims=["X", "Y"]
         )
         .astype(dtype)
         .T
@@ -3340,14 +3260,8 @@ def test_cat_broadcast_left(dtype) -> None:
 
 
 def test_cat_broadcast_both(dtype) -> None:
-    values_1 = xr.DataArray(
-        ["a", "bb", "cccc"],
-        dims=["Y"],
-    ).astype(dtype)
-    values_2 = xr.DataArray(
-        ["11111", "4"],
-        dims=["X"],
-    )
+    values_1 = xr.DataArray(["a", "bb", "cccc"], dims=["Y"]).astype(dtype)
+    values_2 = xr.DataArray(["11111", "4"], dims=["X"])
 
     targ_blank = (
         xr.DataArray(
@@ -3405,15 +3319,9 @@ def test_cat_broadcast_both(dtype) -> None:
 
 
 def test_cat_multi() -> None:
-    values_1 = xr.DataArray(
-        ["11111", "4"],
-        dims=["X"],
-    )
+    values_1 = xr.DataArray(["11111", "4"], dims=["X"])
 
-    values_2 = xr.DataArray(
-        ["a", "bb", "cccc"],
-        dims=["Y"],
-    ).astype(np.bytes_)
+    values_2 = xr.DataArray(["a", "bb", "cccc"], dims=["Y"]).astype(np.bytes_)
 
     values_3 = np.array(3.4)
 
@@ -3421,10 +3329,7 @@ def test_cat_multi() -> None:
 
     values_5 = np.array("", dtype=np.unicode_)
 
-    sep = xr.DataArray(
-        [" ", ", "],
-        dims=["ZZ"],
-    ).astype(np.unicode_)
+    sep = xr.DataArray([" ", ", "], dims=["ZZ"]).astype(np.unicode_)
 
     expected = xr.DataArray(
         [
@@ -3464,10 +3369,7 @@ def test_join_scalar(dtype) -> None:
 
 
 def test_join_vector(dtype) -> None:
-    values = xr.DataArray(
-        ["a", "bb", "cccc"],
-        dims=["Y"],
-    ).astype(dtype)
+    values = xr.DataArray(["a", "bb", "cccc"], dims=["Y"]).astype(dtype)
 
     targ_blank = xr.DataArray("abbcccc").astype(dtype)
     targ_space = xr.DataArray("a bb cccc").astype(dtype)
@@ -3491,27 +3393,20 @@ def test_join_vector(dtype) -> None:
 
 def test_join_2d(dtype) -> None:
     values = xr.DataArray(
-        [["a", "bb", "cccc"], ["ddddd", "eeee", "fff"]],
-        dims=["X", "Y"],
+        [["a", "bb", "cccc"], ["ddddd", "eeee", "fff"]], dims=["X", "Y"]
     ).astype(dtype)
 
-    targ_blank_x = xr.DataArray(
-        ["addddd", "bbeeee", "ccccfff"],
-        dims=["Y"],
-    ).astype(dtype)
-    targ_space_x = xr.DataArray(
-        ["a ddddd", "bb eeee", "cccc fff"],
-        dims=["Y"],
-    ).astype(dtype)
+    targ_blank_x = xr.DataArray(["addddd", "bbeeee", "ccccfff"], dims=["Y"]).astype(
+        dtype
+    )
+    targ_space_x = xr.DataArray(["a ddddd", "bb eeee", "cccc fff"], dims=["Y"]).astype(
+        dtype
+    )
 
-    targ_blank_y = xr.DataArray(
-        ["abbcccc", "dddddeeeefff"],
-        dims=["X"],
-    ).astype(dtype)
-    targ_space_y = xr.DataArray(
-        ["a bb cccc", "ddddd eeee fff"],
-        dims=["X"],
-    ).astype(dtype)
+    targ_blank_y = xr.DataArray(["abbcccc", "dddddeeeefff"], dims=["X"]).astype(dtype)
+    targ_space_y = xr.DataArray(["a bb cccc", "ddddd eeee fff"], dims=["X"]).astype(
+        dtype
+    )
 
     res_blank_x = values.str.join(dim="X")
     res_blank_y = values.str.join(dim="Y")
@@ -3536,20 +3431,11 @@ def test_join_2d(dtype) -> None:
 
 
 def test_join_broadcast(dtype) -> None:
-    values = xr.DataArray(
-        ["a", "bb", "cccc"],
-        dims=["X"],
-    ).astype(dtype)
+    values = xr.DataArray(["a", "bb", "cccc"], dims=["X"]).astype(dtype)
 
-    sep = xr.DataArray(
-        [" ", ", "],
-        dims=["ZZ"],
-    ).astype(dtype)
+    sep = xr.DataArray([" ", ", "], dims=["ZZ"]).astype(dtype)
 
-    expected = xr.DataArray(
-        ["a bb cccc", "a, bb, cccc"],
-        dims=["ZZ"],
-    ).astype(dtype)
+    expected = xr.DataArray(["a bb cccc", "a, bb, cccc"], dims=["ZZ"]).astype(dtype)
 
     res = values.str.join(sep=sep)
 
@@ -3559,8 +3445,7 @@ def test_join_broadcast(dtype) -> None:
 
 def test_format_scalar() -> None:
     values = xr.DataArray(
-        ["{}.{Y}.{ZZ}", "{},{},{X},{X}", "{X}-{Y}-{ZZ}"],
-        dims=["X"],
+        ["{}.{Y}.{ZZ}", "{},{},{X},{X}", "{X}-{Y}-{ZZ}"], dims=["X"]
     ).astype(np.unicode_)
 
     pos0 = 1
@@ -3572,8 +3457,7 @@ def test_format_scalar() -> None:
     W = "NO!"
 
     expected = xr.DataArray(
-        ["1.X.None", "1,1.2,'test','test'", "'test'-X-None"],
-        dims=["X"],
+        ["1.X.None", "1,1.2,'test','test'", "'test'-X-None"], dims=["X"]
     ).astype(np.unicode_)
 
     res = values.str.format(pos0, pos1, pos2, X=X, Y=Y, ZZ=ZZ, W=W)
@@ -3584,17 +3468,13 @@ def test_format_scalar() -> None:
 
 def test_format_broadcast() -> None:
     values = xr.DataArray(
-        ["{}.{Y}.{ZZ}", "{},{},{X},{X}", "{X}-{Y}-{ZZ}"],
-        dims=["X"],
+        ["{}.{Y}.{ZZ}", "{},{},{X},{X}", "{X}-{Y}-{ZZ}"], dims=["X"]
     ).astype(np.unicode_)
 
     pos0 = 1
     pos1 = 1.2
 
-    pos2 = xr.DataArray(
-        ["2.3", "3.44444"],
-        dims=["YY"],
-    )
+    pos2 = xr.DataArray(["2.3", "3.44444"], dims=["YY"])
 
     X = "'test'"
     Y = "X"
@@ -3617,19 +3497,17 @@ def test_format_broadcast() -> None:
 
 
 def test_mod_scalar() -> None:
-    values = xr.DataArray(
-        ["%s.%s.%s", "%s,%s,%s", "%s-%s-%s"],
-        dims=["X"],
-    ).astype(np.unicode_)
+    values = xr.DataArray(["%s.%s.%s", "%s,%s,%s", "%s-%s-%s"], dims=["X"]).astype(
+        np.unicode_
+    )
 
     pos0 = 1
     pos1 = 1.2
     pos2 = "2.3"
 
-    expected = xr.DataArray(
-        ["1.1.2.2.3", "1,1.2,2.3", "1-1.2-2.3"],
-        dims=["X"],
-    ).astype(np.unicode_)
+    expected = xr.DataArray(["1.1.2.2.3", "1,1.2,2.3", "1-1.2-2.3"], dims=["X"]).astype(
+        np.unicode_
+    )
 
     res = values.str % (pos0, pos1, pos2)
 
@@ -3639,18 +3517,16 @@ def test_mod_scalar() -> None:
 
 def test_mod_dict() -> None:
     values = xr.DataArray(
-        ["%(a)s.%(a)s.%(b)s", "%(b)s,%(c)s,%(b)s", "%(c)s-%(b)s-%(a)s"],
-        dims=["X"],
+        ["%(a)s.%(a)s.%(b)s", "%(b)s,%(c)s,%(b)s", "%(c)s-%(b)s-%(a)s"], dims=["X"]
     ).astype(np.unicode_)
 
     a = 1
     b = 1.2
     c = "2.3"
 
-    expected = xr.DataArray(
-        ["1.1.1.2", "1.2,2.3,1.2", "2.3-1.2-1"],
-        dims=["X"],
-    ).astype(np.unicode_)
+    expected = xr.DataArray(["1.1.1.2", "1.2,2.3,1.2", "2.3-1.2-1"], dims=["X"]).astype(
+        np.unicode_
+    )
 
     res = values.str % {"a": a, "b": b, "c": c}
 
@@ -3659,15 +3535,9 @@ def test_mod_dict() -> None:
 
 
 def test_mod_broadcast_single() -> None:
-    values = xr.DataArray(
-        ["%s_1", "%s_2", "%s_3"],
-        dims=["X"],
-    ).astype(np.unicode_)
+    values = xr.DataArray(["%s_1", "%s_2", "%s_3"], dims=["X"]).astype(np.unicode_)
 
-    pos = xr.DataArray(
-        ["2.3", "3.44444"],
-        dims=["YY"],
-    )
+    pos = xr.DataArray(["2.3", "3.44444"], dims=["YY"])
 
     expected = xr.DataArray(
         [["2.3_1", "3.44444_1"], ["2.3_2", "3.44444_2"], ["2.3_3", "3.44444_3"]],
@@ -3681,18 +3551,14 @@ def test_mod_broadcast_single() -> None:
 
 
 def test_mod_broadcast_multi() -> None:
-    values = xr.DataArray(
-        ["%s.%s.%s", "%s,%s,%s", "%s-%s-%s"],
-        dims=["X"],
-    ).astype(np.unicode_)
+    values = xr.DataArray(["%s.%s.%s", "%s,%s,%s", "%s-%s-%s"], dims=["X"]).astype(
+        np.unicode_
+    )
 
     pos0 = 1
     pos1 = 1.2
 
-    pos2 = xr.DataArray(
-        ["2.3", "3.44444"],
-        dims=["YY"],
-    )
+    pos2 = xr.DataArray(["2.3", "3.44444"], dims=["YY"])
 
     expected = xr.DataArray(
         [

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -712,7 +712,7 @@ class DatasetIOBase:
         multiple_indexing(indexers5)
 
     @pytest.mark.xfail(
-        reason="zarr without dask handles negative steps in slices incorrectly",
+        reason="zarr without dask handles negative steps in slices incorrectly"
     )
     def test_vectorized_indexing_negative_step(self) -> None:
         # use dask explicitly when present
@@ -909,11 +909,7 @@ class CFEncodedBase(DatasetIOBase):
                     np.arange(0.1, 0.9, 0.1).reshape(2, 2, 2),
                     {"standard_name": "standard_error"},
                 ),
-                det_lim=(
-                    (),
-                    0.1,
-                    {"standard_name": "detection_minimum"},
-                ),
+                det_lim=((), 0.1, {"standard_name": "detection_minimum"}),
             ),
             dict(
                 latitude=("latitude", [0, 1], {"units": "degrees_north"}),
@@ -938,7 +934,7 @@ class CFEncodedBase(DatasetIOBase):
             ),
         )
         original["variable"].encoding.update(
-            {"cell_measures": "area: areas", "grid_mapping": "latlon"},
+            {"cell_measures": "area: areas", "grid_mapping": "latlon"}
         )
         original.coords["latitude"].encoding.update(
             dict(grid_mapping="latlon", bounds="latitude_bnds")
@@ -1806,8 +1802,7 @@ class ZarrBase(CFEncodedBase):
         with self.create_zarr_target() as store:
             expected.to_zarr(store, consolidated=False, **self.version_kwargs)
             with pytest.warns(
-                RuntimeWarning,
-                match="Failed to open Zarr store with consolidated",
+                RuntimeWarning, match="Failed to open Zarr store with consolidated"
             ):
                 with xr.open_zarr(store, **self.version_kwargs) as ds:
                     assert_identical(ds, expected)
@@ -3420,10 +3415,7 @@ class TestOpenMFDatasetWithDataVarsAndCoordsKw:
                     )
             else:
                 with xr.open_mfdataset(
-                    files,
-                    combine="nested",
-                    concat_dim="t",
-                    combine_attrs=combine_attrs,
+                    files, combine="nested", concat_dim="t", combine_attrs=combine_attrs
                 ) as ds:
                     assert ds.attrs == expected
 
@@ -5503,14 +5495,7 @@ def test_open_dataset_chunking_zarr(chunks, tmp_path: Path) -> None:
     dask_arr = da.from_array(
         np.ones((500, 500), dtype="float64"), chunks=encoded_chunks
     )
-    ds = xr.Dataset(
-        {
-            "test": xr.DataArray(
-                dask_arr,
-                dims=("x", "y"),
-            )
-        }
-    )
+    ds = xr.Dataset({"test": xr.DataArray(dask_arr, dims=("x", "y"))})
     ds["test"].encoding["chunks"] = encoded_chunks
     ds.to_zarr(tmp_path / "test.zarr")
 
@@ -5533,14 +5518,7 @@ def test_chunking_consintency(chunks, tmp_path: Path) -> None:
     dask_arr = da.from_array(
         np.ones((500, 500), dtype="float64"), chunks=encoded_chunks
     )
-    ds = xr.Dataset(
-        {
-            "test": xr.DataArray(
-                dask_arr,
-                dims=("x", "y"),
-            )
-        }
-    )
+    ds = xr.Dataset({"test": xr.DataArray(dask_arr, dims=("x", "y"))})
     ds["test"].encoding["chunks"] = encoded_chunks
     ds.to_zarr(tmp_path / "test.zarr")
     ds.to_netcdf(tmp_path / "test.nc")

--- a/xarray/tests/test_backends_api.py
+++ b/xarray/tests/test_backends_api.py
@@ -36,10 +36,7 @@ def test_custom_engine() -> None:
 
     class CustomBackend(xr.backends.BackendEntrypoint):
         def open_dataset(
-            self,
-            filename_or_obj,
-            drop_variables=None,
-            **kwargs,
+            self, filename_or_obj, drop_variables=None, **kwargs
         ) -> xr.Dataset:
             return expected.copy(deep=True)
 
@@ -55,10 +52,7 @@ def test_multiindex() -> None:
 
     class MultiindexBackend(xr.backends.BackendEntrypoint):
         def open_dataset(
-            self,
-            filename_or_obj,
-            drop_variables=None,
-            **kwargs,
+            self, filename_or_obj, drop_variables=None, **kwargs
         ) -> xr.Dataset:
             return dataset.copy(deep=True)
 

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -1017,15 +1017,7 @@ def test_rollback(calendar, offset, initial_date_args, partial_expected_date_arg
 
 
 _CFTIME_RANGE_TESTS = [
-    (
-        "0001-01-01",
-        "0001-01-04",
-        None,
-        "D",
-        "neither",
-        False,
-        [(1, 1, 2), (1, 1, 3)],
-    ),
+    ("0001-01-01", "0001-01-04", None, "D", "neither", False, [(1, 1, 2), (1, 1, 3)]),
     (
         "0001-01-01",
         "0001-01-04",

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -744,14 +744,7 @@ def test_cftimeindex_add_timedeltaindex(calendar) -> None:
 @requires_cftime
 @pytest.mark.parametrize("n", [2.0, 1.5])
 @pytest.mark.parametrize(
-    "freq,units",
-    [
-        ("D", "D"),
-        ("H", "H"),
-        ("T", "min"),
-        ("S", "S"),
-        ("L", "ms"),
-    ],
+    "freq,units", [("D", "D"), ("H", "H"), ("T", "min"), ("S", "S"), ("L", "ms")]
 )
 @pytest.mark.parametrize("calendar", _CFTIME_CALENDARS)
 def test_cftimeindex_shift_float(n, freq, units, calendar) -> None:

--- a/xarray/tests/test_cftimeindex_resample.py
+++ b/xarray/tests/test_cftimeindex_resample.py
@@ -214,11 +214,7 @@ def test_origin(closed, origin) -> None:
     da_cftimeindex = da(cftime_index)
 
     compare_against_pandas(
-        da_datetimeindex,
-        da_cftimeindex,
-        resample_freq,
-        closed=closed,
-        origin=origin,
+        da_datetimeindex, da_cftimeindex, resample_freq, closed=closed, origin=origin
     )
 
 

--- a/xarray/tests/test_coarsen.py
+++ b/xarray/tests/test_coarsen.py
@@ -71,13 +71,7 @@ def test_coarsen_coords_cftime():
     np.testing.assert_array_equal(actual.time, expected_times)
 
 
-@pytest.mark.parametrize(
-    "funcname, argument",
-    [
-        ("reduce", (np.mean,)),
-        ("mean", ()),
-    ],
-)
+@pytest.mark.parametrize("funcname, argument", [("reduce", (np.mean,)), ("mean", ())])
 def test_coarsen_keep_attrs(funcname, argument) -> None:
     global_attrs = {"units": "test", "long_name": "testing"}
     da_attrs = {"da_attr": "test"}
@@ -173,13 +167,7 @@ def test_coarsen_reduce(ds: Dataset, window, name) -> None:
         assert src_var.dims == actual[key].dims
 
 
-@pytest.mark.parametrize(
-    "funcname, argument",
-    [
-        ("reduce", (np.mean,)),
-        ("mean", ()),
-    ],
-)
+@pytest.mark.parametrize("funcname, argument", [("reduce", (np.mean,)), ("mean", ())])
 def test_coarsen_da_keep_attrs(funcname, argument) -> None:
     attrs_da = {"da_attr": "test"}
     attrs_coords = {"attrs_coords": "test"}

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -1048,8 +1048,7 @@ class TestCombineMixedObjectsbyCoords:
         da = DataArray([0, 1], dims="x", coords=({"x": [0, 1]}))
         ds = Dataset({"x": [2, 3]})
         with pytest.raises(
-            ValueError,
-            match="Can't automatically combine unnamed DataArrays with",
+            ValueError, match="Can't automatically combine unnamed DataArrays with"
         ):
             combine_by_coords([da, ds])
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -567,41 +567,13 @@ def test_keep_attrs() -> None:
 @pytest.mark.parametrize(
     ["strategy", "attrs", "expected", "error"],
     (
+        pytest.param(None, [{"a": 1}, {"a": 2}, {"a": 3}], {}, False, id="default"),
+        pytest.param(False, [{"a": 1}, {"a": 2}, {"a": 3}], {}, False, id="False"),
+        pytest.param(True, [{"a": 1}, {"a": 2}, {"a": 3}], {"a": 1}, False, id="True"),
         pytest.param(
-            None,
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {},
-            False,
-            id="default",
+            "override", [{"a": 1}, {"a": 2}, {"a": 3}], {"a": 1}, False, id="override"
         ),
-        pytest.param(
-            False,
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {},
-            False,
-            id="False",
-        ),
-        pytest.param(
-            True,
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {"a": 1},
-            False,
-            id="True",
-        ),
-        pytest.param(
-            "override",
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {"a": 1},
-            False,
-            id="override",
-        ),
-        pytest.param(
-            "drop",
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {},
-            False,
-            id="drop",
-        ),
+        pytest.param("drop", [{"a": 1}, {"a": 2}, {"a": 3}], {}, False, id="drop"),
         pytest.param(
             "drop_conflicts",
             [{"a": 1, "b": 2}, {"b": 1, "c": 3}, {"c": 3, "d": 4}],
@@ -636,41 +608,13 @@ def test_keep_attrs_strategies_variable(strategy, attrs, expected, error) -> Non
 @pytest.mark.parametrize(
     ["strategy", "attrs", "expected", "error"],
     (
+        pytest.param(None, [{"a": 1}, {"a": 2}, {"a": 3}], {}, False, id="default"),
+        pytest.param(False, [{"a": 1}, {"a": 2}, {"a": 3}], {}, False, id="False"),
+        pytest.param(True, [{"a": 1}, {"a": 2}, {"a": 3}], {"a": 1}, False, id="True"),
         pytest.param(
-            None,
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {},
-            False,
-            id="default",
+            "override", [{"a": 1}, {"a": 2}, {"a": 3}], {"a": 1}, False, id="override"
         ),
-        pytest.param(
-            False,
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {},
-            False,
-            id="False",
-        ),
-        pytest.param(
-            True,
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {"a": 1},
-            False,
-            id="True",
-        ),
-        pytest.param(
-            "override",
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {"a": 1},
-            False,
-            id="override",
-        ),
-        pytest.param(
-            "drop",
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {},
-            False,
-            id="drop",
-        ),
+        pytest.param("drop", [{"a": 1}, {"a": 2}, {"a": 3}], {}, False, id="drop"),
         pytest.param(
             "drop_conflicts",
             [{"a": 1, "b": 2}, {"b": 1, "c": 3}, {"c": 3, "d": 4}],
@@ -706,41 +650,13 @@ def test_keep_attrs_strategies_dataarray(strategy, attrs, expected, error) -> No
 @pytest.mark.parametrize(
     ["strategy", "attrs", "expected", "error"],
     (
+        pytest.param(None, [{"a": 1}, {"a": 2}, {"a": 3}], {}, False, id="default"),
+        pytest.param(False, [{"a": 1}, {"a": 2}, {"a": 3}], {}, False, id="False"),
+        pytest.param(True, [{"a": 1}, {"a": 2}, {"a": 3}], {"a": 1}, False, id="True"),
         pytest.param(
-            None,
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {},
-            False,
-            id="default",
+            "override", [{"a": 1}, {"a": 2}, {"a": 3}], {"a": 1}, False, id="override"
         ),
-        pytest.param(
-            False,
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {},
-            False,
-            id="False",
-        ),
-        pytest.param(
-            True,
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {"a": 1},
-            False,
-            id="True",
-        ),
-        pytest.param(
-            "override",
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {"a": 1},
-            False,
-            id="override",
-        ),
-        pytest.param(
-            "drop",
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {},
-            False,
-            id="drop",
-        ),
+        pytest.param("drop", [{"a": 1}, {"a": 2}, {"a": 3}], {}, False, id="drop"),
         pytest.param(
             "drop_conflicts",
             [{"a": 1, "b": 2}, {"b": 1, "c": 3}, {"c": 3, "d": 4}],
@@ -801,41 +717,13 @@ def test_keep_attrs_strategies_dataarray_variables(
 @pytest.mark.parametrize(
     ["strategy", "attrs", "expected", "error"],
     (
+        pytest.param(None, [{"a": 1}, {"a": 2}, {"a": 3}], {}, False, id="default"),
+        pytest.param(False, [{"a": 1}, {"a": 2}, {"a": 3}], {}, False, id="False"),
+        pytest.param(True, [{"a": 1}, {"a": 2}, {"a": 3}], {"a": 1}, False, id="True"),
         pytest.param(
-            None,
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {},
-            False,
-            id="default",
+            "override", [{"a": 1}, {"a": 2}, {"a": 3}], {"a": 1}, False, id="override"
         ),
-        pytest.param(
-            False,
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {},
-            False,
-            id="False",
-        ),
-        pytest.param(
-            True,
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {"a": 1},
-            False,
-            id="True",
-        ),
-        pytest.param(
-            "override",
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {"a": 1},
-            False,
-            id="override",
-        ),
-        pytest.param(
-            "drop",
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {},
-            False,
-            id="drop",
-        ),
+        pytest.param("drop", [{"a": 1}, {"a": 2}, {"a": 3}], {}, False, id="drop"),
         pytest.param(
             "drop_conflicts",
             [{"a": 1, "b": 2}, {"b": 1, "c": 3}, {"c": 3, "d": 4}],
@@ -871,41 +759,13 @@ def test_keep_attrs_strategies_dataset(strategy, attrs, expected, error) -> None
 @pytest.mark.parametrize(
     ["strategy", "attrs", "expected", "error"],
     (
+        pytest.param(None, [{"a": 1}, {"a": 2}, {"a": 3}], {}, False, id="default"),
+        pytest.param(False, [{"a": 1}, {"a": 2}, {"a": 3}], {}, False, id="False"),
+        pytest.param(True, [{"a": 1}, {"a": 2}, {"a": 3}], {"a": 1}, False, id="True"),
         pytest.param(
-            None,
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {},
-            False,
-            id="default",
+            "override", [{"a": 1}, {"a": 2}, {"a": 3}], {"a": 1}, False, id="override"
         ),
-        pytest.param(
-            False,
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {},
-            False,
-            id="False",
-        ),
-        pytest.param(
-            True,
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {"a": 1},
-            False,
-            id="True",
-        ),
-        pytest.param(
-            "override",
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {"a": 1},
-            False,
-            id="override",
-        ),
-        pytest.param(
-            "drop",
-            [{"a": 1}, {"a": 2}, {"a": 3}],
-            {},
-            False,
-            id="drop",
-        ),
+        pytest.param("drop", [{"a": 1}, {"a": 2}, {"a": 3}], {}, False, id="drop"),
         pytest.param(
             "drop_conflicts",
             [{"a": 1, "b": 2}, {"b": 1, "c": 3}, {"c": 3, "d": 4}],
@@ -1315,10 +1175,7 @@ def test_vectorize_dask_dtype_without_output_dtypes(data_array) -> None:
 
     expected = data_array.copy()
     actual = apply_ufunc(
-        identity,
-        data_array.chunk({"x": 1}),
-        vectorize=True,
-        dask="parallelized",
+        identity, data_array.chunk({"x": 1}), vectorize=True, dask="parallelized"
     )
 
     assert_identical(expected, actual)
@@ -2002,7 +1859,7 @@ def test_where_attrs() -> None:
     ds_expected = xr.Dataset(
         data_vars={
             "x": xr.DataArray([1, 0], coords={"a": [0, 1]}, attrs={"attr": "x_da"})
-        },
+        }
     )
     ds_expected["a"].attrs = {"attr": "x_coord"}
     assert_identical(ds_expected, ds_actual)
@@ -2121,8 +1978,7 @@ def test_polyval_cftime(use_dask: bool, date: str) -> None:
     import cftime
 
     x = xr.DataArray(
-        xr.date_range(date, freq="1S", periods=3, use_cftime=True),
-        dims="x",
+        xr.date_range(date, freq="1S", periods=3, use_cftime=True), dims="x"
     )
     coeffs = xr.DataArray([0, 1], dims="degree", coords={"degree": [0, 1]})
 
@@ -2210,14 +2066,7 @@ def test_polyfit_polyval_integration(
             "dim_0",
             -1,
         ],
-        [
-            xr.DataArray([1, 2]),
-            xr.DataArray([4, 5, 6]),
-            [1, 2],
-            [4, 5, 6],
-            "dim_0",
-            -1,
-        ],
+        [xr.DataArray([1, 2]), xr.DataArray([4, 5, 6]), [1, 2], [4, 5, 6], "dim_0", -1],
         [
             xr.Variable(dims=["dim_0"], data=[1, 2, 3]),
             xr.Variable(dims=["dim_0"], data=[4, 5, 6]),

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -34,10 +34,7 @@ def create_concat_datasets(
     variables = ["temperature", "pressure", "humidity", "precipitation", "cloud_cover"]
     for i in range(num_datasets):
         if include_day:
-            data_tuple = (
-                ["x", "y", "day"],
-                rng.standard_normal(size=(1, 4, 2)),
-            )
+            data_tuple = (["x", "y", "day"], rng.standard_normal(size=(1, 4, 2)))
             data_vars = {v: data_tuple for v in variables}
             result.append(
                 Dataset(
@@ -50,10 +47,7 @@ def create_concat_datasets(
                 )
             )
         else:
-            data_tuple = (
-                ["x", "y"],
-                rng.standard_normal(size=(1, 4)),
-            )
+            data_tuple = (["x", "y"], rng.standard_normal(size=(1, 4)))
             data_vars = {v: data_tuple for v in variables}
             result.append(
                 Dataset(
@@ -1199,8 +1193,7 @@ def test_concat_preserve_coordinate_order() -> None:
     )
 
     expected = Dataset(
-        {"data": (["time", "y", "x"], data)},
-        coords={"time": time, "y": y, "x": x},
+        {"data": (["time", "y", "x"], data)}, coords={"time": time, "y": y, "x": x}
     )
 
     actual = concat([ds1, ds2], dim="time")

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -381,7 +381,7 @@ class TestDecodeCF:
                 },
                 "dims": {"time": 3, "timedelta": 3},
                 "data_vars": {
-                    "a": {"dims": ("time", "timedelta"), "data": np.ones((3, 3))},
+                    "a": {"dims": ("time", "timedelta"), "data": np.ones((3, 3))}
                 },
             }
         )

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2335,11 +2335,7 @@ class TestDataArray:
         assert_identical(actual7, expected6)
 
     def test_stack_unstack(self) -> None:
-        orig = DataArray(
-            [[0, 1], [2, 3]],
-            dims=["x", "y"],
-            attrs={"foo": 2},
-        )
+        orig = DataArray([[0, 1], [2, 3]], dims=["x", "y"], attrs={"foo": 2})
         assert_identical(orig, orig.unstack())
 
         # test GH3000
@@ -2358,13 +2354,7 @@ class TestDataArray:
         assert_identical(orig, actual)
 
         dims = ["a", "b", "c", "d", "e"]
-        coords = {
-            "a": [0],
-            "b": [1, 2],
-            "c": [3, 4, 5],
-            "d": [6, 7],
-            "e": [8],
-        }
+        coords = {"a": [0], "b": [1, 2], "c": [3, 4, 5], "d": [6, 7], "e": [8]}
         orig = xr.DataArray(np.random.rand(1, 2, 3, 2, 1), coords=coords, dims=dims)
         stacked = orig.stack(ab=["a", "b"], cd=["c", "d"])
 
@@ -2994,14 +2984,12 @@ class TestDataArray:
 
     def test_align_without_indexes_errors(self) -> None:
         with pytest.raises(
-            ValueError,
-            match=r"cannot.*align.*dimension.*conflicting.*sizes.*",
+            ValueError, match=r"cannot.*align.*dimension.*conflicting.*sizes.*"
         ):
             align(DataArray([1, 2, 3], dims=["x"]), DataArray([1, 2], dims=["x"]))
 
         with pytest.raises(
-            ValueError,
-            match=r"cannot.*align.*dimension.*conflicting.*sizes.*",
+            ValueError, match=r"cannot.*align.*dimension.*conflicting.*sizes.*"
         ):
             align(
                 DataArray([1, 2, 3], dims=["x"]),

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -159,10 +159,7 @@ def create_append_test_data(seed=None) -> tuple[Dataset, Dataset, Dataset]:
 
 def create_append_string_length_mismatch_test_data(dtype) -> tuple[Dataset, Dataset]:
     def make_datasets(data, data_to_append) -> tuple[Dataset, Dataset]:
-        ds = xr.Dataset(
-            {"temperature": (["time"], data)},
-            coords={"time": [0, 1, 2]},
-        )
+        ds = xr.Dataset({"temperature": (["time"], data)}, coords={"time": [0, 1, 2]})
         ds_to_append = xr.Dataset(
             {"temperature": (["time"], data_to_append)}, coords={"time": [0, 1, 2]}
         )
@@ -2823,10 +2820,7 @@ class TestDataset:
 
     def test_rename(self) -> None:
         data = create_test_data()
-        newnames = {
-            "var1": "renamed_var1",
-            "dim2": "renamed_dim2",
-        }
+        newnames = {"var1": "renamed_var1", "dim2": "renamed_dim2"}
         renamed = data.rename(newnames)
 
         variables = dict(data.variables)
@@ -3432,8 +3426,7 @@ class TestDataset:
 
         exp_index = pd.MultiIndex.from_product([[0, 1], ["a", "b"]], names=["x", "y"])
         expected = Dataset(
-            data_vars={"b": ("z", [0, 1, 2, 3])},
-            coords={"z": exp_index},
+            data_vars={"b": ("z", [0, 1, 2, 3])}, coords={"z": exp_index}
         )
         # check attrs propagated
         ds["x"].attrs["foo"] = "bar"
@@ -3456,8 +3449,7 @@ class TestDataset:
 
         exp_index = pd.MultiIndex.from_product([["a", "b"], [0, 1]], names=["y", "x"])
         expected = Dataset(
-            data_vars={"b": ("z", [0, 2, 1, 3])},
-            coords={"z": exp_index},
+            data_vars={"b": ("z", [0, 2, 1, 3])}, coords={"z": exp_index}
         )
         expected["x"].attrs["foo"] = "bar"
 
@@ -3467,11 +3459,7 @@ class TestDataset:
 
     @pytest.mark.parametrize(
         "create_index,expected_keys",
-        [
-            (True, ["z", "x", "y"]),
-            (False, []),
-            (None, ["z", "x", "y"]),
-        ],
+        [(True, ["z", "x", "y"]), (False, []), (None, ["z", "x", "y"])],
     )
     def test_stack_create_index(self, create_index, expected_keys) -> None:
         ds = Dataset(
@@ -3516,8 +3504,7 @@ class TestDataset:
 
         exp_index = pd.MultiIndex.from_product([[0, 1], ["a", "b"]], names=["xx", "y"])
         expected = Dataset(
-            data_vars={"b": ("z", [0, 1, 2, 3])},
-            coords={"z": exp_index},
+            data_vars={"b": ("z", [0, 1, 2, 3])}, coords={"z": exp_index}
         )
 
         actual = ds.stack(z=["x", "y"])
@@ -3631,10 +3618,7 @@ class TestDataset:
 
     def test_stack_unstack_slow(self) -> None:
         ds = Dataset(
-            data_vars={
-                "a": ("x", [0, 1]),
-                "b": (("x", "y"), [[0, 1], [2, 3]]),
-            },
+            data_vars={"a": ("x", [0, 1]), "b": (("x", "y"), [[0, 1], [2, 3]])},
             coords={"x": [0, 1], "y": ["a", "b"]},
         )
         stacked = ds.stack(z=["x", "y"])
@@ -6619,8 +6603,7 @@ def test_cumulative_integrate(dask) -> None:
     )
     assert_allclose(expected_x, actual.compute())
     assert_equal(
-        ds["var"].cumulative_integrate("x"),
-        ds.cumulative_integrate("x")["var"],
+        ds["var"].cumulative_integrate("x"), ds.cumulative_integrate("x")["var"]
     )
 
     # make sure result is also a dask array (if the source is dask array)
@@ -6629,15 +6612,12 @@ def test_cumulative_integrate(dask) -> None:
     # along y
     actual = da.cumulative_integrate("y")
     expected_y = xr.DataArray(
-        cumtrapz(da, da["y"], axis=1, initial=0.0),
-        dims=["x", "y"],
-        coords=da.coords,
+        cumtrapz(da, da["y"], axis=1, initial=0.0), dims=["x", "y"], coords=da.coords
     )
     assert_allclose(expected_y, actual.compute())
     assert_equal(actual, ds.cumulative_integrate("y")["var"])
     assert_equal(
-        ds["var"].cumulative_integrate("y"),
-        ds.cumulative_integrate("y")["var"],
+        ds["var"].cumulative_integrate("y"), ds.cumulative_integrate("y")["var"]
     )
 
     # along x and y

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -48,11 +48,7 @@ class TestOps:
     def setUp(self):
         self.x = array(
             [
-                [
-                    [nan, nan, 2.0, nan],
-                    [nan, 5.0, 6.0, nan],
-                    [8.0, 9.0, 10.0, nan],
-                ],
+                [[nan, nan, 2.0, nan], [nan, 5.0, 6.0, nan], [8.0, 9.0, 10.0, nan]],
                 [
                     [nan, 13.0, 14.0, 15.0],
                     [nan, 17.0, 18.0, nan],
@@ -140,11 +136,7 @@ class TestDaskOps(TestOps):
 
         self.x = dask.array.from_array(
             [
-                [
-                    [nan, nan, 2.0, nan],
-                    [nan, 5.0, 6.0, nan],
-                    [8.0, 9.0, 10.0, nan],
-                ],
+                [[nan, nan, 2.0, nan], [nan, 5.0, 6.0, nan], [8.0, 9.0, 10.0, nan]],
                 [
                     [nan, 13.0, 14.0, 15.0],
                     [nan, 17.0, 18.0, nan],

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -615,10 +615,7 @@ def test__mapping_repr(display_max_rows, n_vars, n_attr) -> None:
     data_vars = dict()
     for v, _c in zip(a, coords.items()):
         data_vars[v] = xr.DataArray(
-            name=v,
-            data=np.array([3, 4]),
-            dims=[_c[0]],
-            coords=dict([_c]),
+            name=v, data=np.array([3, 4]), dims=[_c[0]], coords=dict([_c])
         )
     ds = xr.Dataset(data_vars)
     ds.attrs = attrs

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -830,7 +830,7 @@ def test_groupby_math_nD_group() -> None:
             "labels": (
                 "x",
                 np.repeat(["a", "b", "c", "d", "e", "f", "g", "h"], repeats=N // 8),
-            ),
+            )
         },
     )
     da["labels2d"] = xr.broadcast(da.labels, da)[0]
@@ -842,10 +842,7 @@ def test_groupby_math_nD_group() -> None:
     actual = g - mean
     assert_identical(expected, actual)
 
-    da["num"] = (
-        "x",
-        np.repeat([1, 2, 3, 4, 5, 6, 7, 8], repeats=N // 8),
-    )
+    da["num"] = ("x", np.repeat([1, 2, 3, 4, 5, 6, 7, 8], repeats=N // 8))
     da["num2d"] = xr.broadcast(da.num, da)[0]
     g = da.groupby_bins("num2d", bins=[0, 4, 6])
     mean = g.mean()
@@ -2055,13 +2052,8 @@ def test_groupby_cumsum() -> None:
     )
     actual = ds.groupby("group_id").cumsum(dim="x")
     expected = xr.Dataset(
-        {
-            "foo": (("x",), [7, 10, 1, 2, 1, 2, 3]),
-        },
-        coords={
-            "x": [0, 1, 2, 3, 4, 5, 6],
-            "group_id": ds.group_id,
-        },
+        {"foo": (("x",), [7, 10, 1, 2, 1, 2, 3])},
+        coords={"x": [0, 1, 2, 3, 4, 5, 6], "group_id": ds.group_id},
     )
     # TODO: Remove drop_vars when GH6528 is fixed
     # when Dataset.cumsum propagates indexes, and the group variable?
@@ -2080,13 +2072,8 @@ def test_groupby_cumprod() -> None:
     )
     actual = ds.groupby("group_id").cumprod(dim="x")
     expected = xr.Dataset(
-        {
-            "foo": (("x",), [7, 21, 0, 0, 1, 2, 2]),
-        },
-        coords={
-            "x": [0, 1, 2, 3, 4, 5, 6],
-            "group_id": ds.group_id,
-        },
+        {"foo": (("x",), [7, 21, 0, 0, 1, 2, 2])},
+        coords={"x": [0, 1, 2, 3, 4, 5, 6], "group_id": ds.group_id},
     )
     # TODO: Remove drop_vars when GH6528 is fixed
     # when Dataset.cumsum propagates indexes, and the group variable?
@@ -2108,16 +2095,12 @@ def test_groupby_cumprod() -> None:
 def test_resample_cumsum(method: str, expected_array: list[float]) -> None:
     ds = xr.Dataset(
         {"foo": ("time", [1, 2, 3, 1, 2, np.nan])},
-        coords={
-            "time": pd.date_range("01-01-2001", freq="M", periods=6),
-        },
+        coords={"time": pd.date_range("01-01-2001", freq="M", periods=6)},
     )
     actual = getattr(ds.resample(time="3M"), method)(dim="time")
     expected = xr.Dataset(
         {"foo": (("time",), expected_array)},
-        coords={
-            "time": pd.date_range("01-01-2001", freq="M", periods=6),
-        },
+        coords={"time": pd.date_range("01-01-2001", freq="M", periods=6)},
     )
     # TODO: Remove drop_vars when GH6528 is fixed
     # when Dataset.cumsum propagates indexes, and the group variable?

--- a/xarray/tests/test_indexes.py
+++ b/xarray/tests/test_indexes.py
@@ -417,8 +417,7 @@ class TestPandasMultiIndex:
             ValueError, match=r"conflicting dimensions for multi-index product.*"
         ):
             PandasMultiIndex.stack(
-                {"x": xr.Variable("x", ["a", "b"]), "x2": xr.Variable("x", [1, 2])},
-                "z",
+                {"x": xr.Variable("x", ["a", "b"]), "x2": xr.Variable("x", [1, 2])}, "z"
             )
 
     def test_stack_non_unique(self) -> None:

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -90,12 +90,7 @@ class TestIndexers:
 
     def test_map_index_queries(self) -> None:
         def create_sel_results(
-            x_indexer,
-            x_index,
-            other_vars,
-            drop_coords,
-            drop_indexes,
-            rename_dims,
+            x_indexer, x_index, other_vars, drop_coords, drop_indexes, rename_dims
         ):
             dim_indexers = {"x": x_indexer}
             index_vars = x_index.create_variables()
@@ -114,9 +109,7 @@ class TestIndexers:
             )
 
         def test_indexer(
-            data: T_Xarray,
-            x: Any,
-            expected: indexing.IndexSelResult,
+            data: T_Xarray, x: Any, expected: indexing.IndexSelResult
         ) -> None:
             results = indexing.map_index_queries(data, {"x": x})
 

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -874,15 +874,13 @@ def test_interpolate_chunk_advanced(method: InterpOptions) -> None:
     theta = np.linspace(0, 2 * np.pi, 5)
     w = np.linspace(-0.25, 0.25, 7)
     r = xr.DataArray(
-        data=1 + w[:, np.newaxis] * np.cos(theta),
-        coords=[("w", w), ("theta", theta)],
+        data=1 + w[:, np.newaxis] * np.cos(theta), coords=[("w", w), ("theta", theta)]
     )
 
     xda = r * np.cos(theta)
     yda = r * np.sin(theta)
     zda = xr.DataArray(
-        data=w[:, np.newaxis] * np.sin(theta),
-        coords=[("w", w), ("theta", theta)],
+        data=w[:, np.newaxis] * np.sin(theta), coords=[("w", w), ("theta", theta)]
     )
 
     kwargs = {"fill_value": None}
@@ -898,10 +896,7 @@ def test_interpolate_chunk_advanced(method: InterpOptions) -> None:
 @requires_scipy
 def test_interp1d_bounds_error() -> None:
     """Ensure exception on bounds error is raised if requested"""
-    da = xr.DataArray(
-        np.sin(0.3 * np.arange(4)),
-        [("time", np.arange(4))],
-    )
+    da = xr.DataArray(np.sin(0.3 * np.arange(4)), [("time", np.arange(4))])
 
     with pytest.raises(ValueError):
         da.interp(time=3.5, kwargs=dict(bounds_error=True))
@@ -933,10 +928,7 @@ def test_coord_attrs(x, expect_same_attrs: bool) -> None:
 @requires_scipy
 def test_interp1d_complex_out_of_bounds() -> None:
     """Ensure complex nans are used by default"""
-    da = xr.DataArray(
-        np.exp(0.3j * np.arange(4)),
-        [("time", np.arange(4))],
-    )
+    da = xr.DataArray(np.exp(0.3j * np.arange(4)), [("time", np.arange(4))])
 
     expected = da.interp(time=3.5, kwargs=dict(fill_value=np.nan + np.nan * 1j))
     actual = da.interp(time=3.5)

--- a/xarray/tests/test_options.py
+++ b/xarray/tests/test_options.py
@@ -207,10 +207,7 @@ class TestAttrRetention:
             assert "#x27;nested&#x27;" in html
 
 
-@pytest.mark.parametrize(
-    "set_value",
-    [("left"), ("exact")],
-)
+@pytest.mark.parametrize("set_value", [("left"), ("exact")])
 def test_get_options_retention(set_value):
     """Test to check if get_options will return changes made by set_options"""
     with xarray.set_options(arithmetic_join=set_value):

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -298,10 +298,7 @@ class TestPlot(PlotTestCase):
         assert_array_equal(line.get_ydata(), da.coords["time"].values)
 
     def test_line_plot_wrong_hue(self) -> None:
-        da = xr.DataArray(
-            data=np.array([[0, 1], [5, 9]]),
-            dims=["x", "t"],
-        )
+        da = xr.DataArray(data=np.array([[0, 1], [5, 9]]), dims=["x", "t"])
 
         with pytest.raises(ValueError, match="hue must be one of"):
             da.plot(x="t", hue="wrong_coord")

--- a/xarray/tests/test_plugins.py
+++ b/xarray/tests/test_plugins.py
@@ -52,9 +52,7 @@ def test_remove_duplicates(dummy_duplicated_entrypoints) -> None:
 
 def test_broken_plugin() -> None:
     broken_backend = EntryPoint(
-        "broken_backend",
-        "xarray.tests.test_plugins:backend_1",
-        "xarray.backends",
+        "broken_backend", "xarray.tests.test_plugins:backend_1", "xarray.backends"
     )
     with pytest.warns(RuntimeWarning) as record:
         _ = plugins.build_engines([broken_backend])
@@ -173,10 +171,7 @@ def test_no_matching_engine_found() -> None:
         plugins.guess_engine("foo.nc")
 
 
-@mock.patch(
-    "xarray.backends.plugins.list_engines",
-    mock.MagicMock(return_value={}),
-)
+@mock.patch("xarray.backends.plugins.list_engines", mock.MagicMock(return_value={}))
 def test_engines_not_installed() -> None:
     with pytest.raises(ValueError, match=r"xarray is unable to open"):
         plugins.guess_engine("not-valid")

--- a/xarray/tests/test_testing.py
+++ b/xarray/tests/test_testing.py
@@ -96,10 +96,7 @@ def test_assert_duckarray_equal_failing(duckarray, obj1, obj2) -> None:
 @pytest.mark.parametrize(
     "duckarray",
     (
-        pytest.param(
-            np.array,
-            id="numpy",
-        ),
+        pytest.param(np.array, id="numpy"),
         pytest.param(
             dask_from_array,
             id="dask",

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -37,9 +37,7 @@ unit_registry = pint.UnitRegistry(force_ndarray_like=True)
 Quantity = unit_registry.Quantity
 
 
-pytestmark = [
-    pytest.mark.filterwarnings("error::pint.UnitStrippedWarning"),
-]
+pytestmark = [pytest.mark.filterwarnings("error::pint.UnitStrippedWarning")]
 
 
 def is_compatible(unit1, unit2):
@@ -637,9 +635,7 @@ def test_align_dataset(value, unit, variant, error, dtype):
     units_a = extract_units(ds1)
     units_b = extract_units(ds2)
     expected_a, expected_b = func(
-        strip_units(ds1),
-        strip_units(convert_units(ds2, units_a)),
-        **stripped_kwargs,
+        strip_units(ds1), strip_units(convert_units(ds2, units_a)), **stripped_kwargs
     )
     expected_a = attach_units(expected_a, units_a)
     if isinstance(array2, Quantity):
@@ -1238,11 +1234,7 @@ def test_merge_dataset(variant, unit, error, dtype):
 def test_replication_dataarray(func, variant, dtype):
     unit = unit_registry.m
 
-    variants = {
-        "data": (unit, 1, 1),
-        "dims": (1, unit, 1),
-        "coords": (1, 1, unit),
-    }
+    variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
     data_unit, dim_unit, coord_unit = variants.get(variant)
 
     array = np.linspace(0, 10, 20).astype(dtype) * data_unit
@@ -1323,11 +1315,7 @@ def test_replication_full_like_dataarray(variant, dtype):
     # fill value, we don't need to try multiple units
     unit = unit_registry.m
 
-    variants = {
-        "data": (unit, 1, 1),
-        "dims": (1, unit, 1),
-        "coords": (1, 1, unit),
-    }
+    variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
     data_unit, dim_unit, coord_unit = variants.get(variant)
 
     array = np.linspace(0, 5, 10) * data_unit
@@ -1385,10 +1373,7 @@ def test_replication_full_like_dataset(variant, dtype):
 
     fill_value = -1 * unit_registry.degK
 
-    units = {
-        **extract_units(ds),
-        **{name: unit_registry.degK for name in ds.data_vars},
-    }
+    units = {**extract_units(ds), **{name: unit_registry.degK for name in ds.data_vars}}
     expected = attach_units(
         xr.full_like(strip_units(ds), fill_value=strip_units(fill_value)), units
     )
@@ -1754,10 +1739,7 @@ class TestVariable:
             pytest.param(1, id="no_unit"),
             pytest.param(unit_registry.dimensionless, id="dimensionless"),
             pytest.param(unit_registry.s, id="incompatible_unit"),
-            pytest.param(
-                unit_registry.cm,
-                id="compatible_unit",
-            ),
+            pytest.param(unit_registry.cm, id="compatible_unit"),
             pytest.param(unit_registry.m, id="identical_unit"),
         ),
     )
@@ -2225,8 +2207,7 @@ class TestVariable:
         v = xr.Variable(["x", "y", "z"], data)
 
         expected = attach_units(
-            strip_units(v).pad(mode=mode, **xr_arg),
-            extract_units(v),
+            strip_units(v).pad(mode=mode, **xr_arg), extract_units(v)
         )
         actual = v.pad(mode=mode, **xr_arg)
 
@@ -2952,16 +2933,8 @@ class TestDataArray:
                 unit_registry.dimensionless, DimensionalityError, id="dimensionless"
             ),
             pytest.param(unit_registry.s, DimensionalityError, id="incompatible_unit"),
-            pytest.param(
-                unit_registry.cm,
-                None,
-                id="compatible_unit",
-            ),
-            pytest.param(
-                unit_registry.m,
-                None,
-                id="identical_unit",
-            ),
+            pytest.param(unit_registry.cm, None, id="compatible_unit"),
+            pytest.param(unit_registry.m, None, id="identical_unit"),
         ),
     )
     def test_combine_first(self, unit, error, dtype):
@@ -3209,11 +3182,7 @@ class TestDataArray:
     def test_content_manipulation(self, func, variant, dtype):
         unit = unit_registry.m
 
-        variants = {
-            "data": (unit, 1, 1),
-            "dims": (1, unit, 1),
-            "coords": (1, 1, unit),
-        }
+        variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
         data_unit, dim_unit, coord_unit = variants.get(variant)
 
         quantity = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
@@ -3479,10 +3448,7 @@ class TestDataArray:
         ids=repr,
     )
     def test_interp_reindex(self, variant, func, dtype):
-        variants = {
-            "data": (unit_registry.m, 1),
-            "coords": (1, unit_registry.m),
-        }
+        variants = {"data": (unit_registry.m, 1), "coords": (1, unit_registry.m)}
         data_unit, coord_unit = variants.get(variant)
 
         array = np.linspace(1, 2, 10).astype(dtype) * data_unit
@@ -3512,11 +3478,7 @@ class TestDataArray:
             pytest.param(unit_registry.m, None, id="identical_unit"),
         ),
     )
-    @pytest.mark.parametrize(
-        "func",
-        (method("interp"), method("reindex")),
-        ids=repr,
-    )
+    @pytest.mark.parametrize("func", (method("interp"), method("reindex")), ids=repr)
     def test_interp_reindex_indexing(self, func, unit, error, dtype):
         array = np.linspace(1, 2, 10).astype(dtype)
         x = np.arange(10) * unit_registry.m
@@ -3554,10 +3516,7 @@ class TestDataArray:
         ids=repr,
     )
     def test_interp_reindex_like(self, variant, func, dtype):
-        variants = {
-            "data": (unit_registry.m, 1),
-            "coords": (1, unit_registry.m),
-        }
+        variants = {"data": (unit_registry.m, 1), "coords": (1, unit_registry.m)}
         data_unit, coord_unit = variants.get(variant)
 
         array = np.linspace(1, 2, 10).astype(dtype) * data_unit
@@ -3589,9 +3548,7 @@ class TestDataArray:
         ),
     )
     @pytest.mark.parametrize(
-        "func",
-        (method("interp_like"), method("reindex_like")),
-        ids=repr,
+        "func", (method("interp_like"), method("reindex_like")), ids=repr
     )
     def test_interp_reindex_like_indexing(self, func, unit, error, dtype):
         array = np.linspace(1, 2, 10).astype(dtype)
@@ -3731,10 +3688,7 @@ class TestDataArray:
         data_unit = unit_registry.m
         unit = unit_registry.s
 
-        variants = {
-            "dims": ("x", unit, 1),
-            "coords": ("u", 1, unit),
-        }
+        variants = {"dims": ("x", unit, 1), "coords": ("u", 1, unit)}
         coord, dim_unit, coord_unit = variants.get(variant)
 
         array = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
@@ -3751,17 +3705,12 @@ class TestDataArray:
         units = extract_units(data_array)
         units.update(
             extract_units(
-                func(
-                    data_array.data,
-                    getattr(data_array, coord).data,
-                    axis=0,
-                )
+                func(data_array.data, getattr(data_array, coord).data, axis=0)
             )
         )
 
         expected = attach_units(
-            func(strip_units(data_array), coord=strip_units(coord)),
-            units,
+            func(strip_units(data_array), coord=strip_units(coord)), units
         )
         actual = func(data_array, coord=coord)
 
@@ -3791,11 +3740,7 @@ class TestDataArray:
     def test_computation(self, func, variant, dtype):
         unit = unit_registry.m
 
-        variants = {
-            "data": (unit, 1, 1),
-            "dims": (1, unit, 1),
-            "coords": (1, 1, unit),
-        }
+        variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
         data_unit, dim_unit, coord_unit = variants.get(variant)
 
         array = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
@@ -3855,11 +3800,7 @@ class TestDataArray:
     def test_computation_objects(self, func, variant, dtype):
         unit = unit_registry.m
 
-        variants = {
-            "data": (unit, 1, 1),
-            "dims": (1, unit, 1),
-            "coords": (1, 1, unit),
-        }
+        variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
         data_unit, dim_unit, coord_unit = variants.get(variant)
 
         array = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
@@ -3918,11 +3859,7 @@ class TestDataArray:
     def test_grouped_operations(self, func, variant, dtype):
         unit = unit_registry.m
 
-        variants = {
-            "data": (unit, 1, 1),
-            "dims": (1, unit, 1),
-            "coords": (1, 1, unit),
-        }
+        variants = {"data": (unit, 1, 1), "dims": (1, unit, 1), "coords": (1, 1, unit)}
         data_unit, dim_unit, coord_unit = variants.get(variant)
         array = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
 
@@ -4037,8 +3974,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims",
-                marks=pytest.mark.skip(reason="indexes don't support units"),
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
             "coords",
         ),
@@ -4054,11 +3990,7 @@ class TestDataset:
         x = np.arange(len(array1)) * unit_registry.s
         y = x.to(unit_registry.ms)
 
-        variants = {
-            "dims": {"x": x},
-            "coords": {"y": ("x", y)},
-            "data": {},
-        }
+        variants = {"dims": {"x": x}, "coords": {"y": ("x", y)}, "data": {}}
 
         ds = xr.Dataset(
             data_vars={"a": ("x", array1), "b": ("x", array2)},
@@ -4278,11 +4210,7 @@ class TestDataset:
                 unit_registry.dimensionless, DimensionalityError, id="dimensionless"
             ),
             pytest.param(unit_registry.s, DimensionalityError, id="incompatible_unit"),
-            pytest.param(
-                unit_registry.cm,
-                None,
-                id="compatible_unit",
-            ),
+            pytest.param(unit_registry.cm, None, id="compatible_unit"),
             pytest.param(unit_registry.m, None, id="identical_unit"),
         ),
     )
@@ -4427,10 +4355,7 @@ class TestDataset:
             for key, value in kwargs.items()
         }
 
-        expected = attach_units(
-            strip_units(ds).where(**kwargs_without_units),
-            units,
-        )
+        expected = attach_units(strip_units(ds).where(**kwargs_without_units), units)
         actual = ds.where(**kwargs)
 
         assert_units_equal(expected, actual)
@@ -4449,10 +4374,7 @@ class TestDataset:
         ds = xr.Dataset({"a": ("x", array1), "b": ("x", array2)})
         units = extract_units(ds)
 
-        expected = attach_units(
-            strip_units(ds).interpolate_na(dim="x"),
-            units,
-        )
+        expected = attach_units(strip_units(ds).interpolate_na(dim="x"), units)
         actual = ds.interpolate_na(dim="x")
 
         assert_units_equal(expected, actual)
@@ -4475,8 +4397,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims",
-                marks=pytest.mark.skip(reason="indexes don't support units"),
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
         ),
     )
@@ -4495,8 +4416,7 @@ class TestDataset:
         )
         x = np.arange(len(array1)) * dims_unit
         ds = xr.Dataset(
-            data_vars={"a": ("x", array1), "b": ("x", array2)},
-            coords={"x": x},
+            data_vars={"a": ("x", array1), "b": ("x", array2)}, coords={"x": x}
         )
         units = extract_units(ds)
 
@@ -4573,8 +4493,7 @@ class TestDataset:
         y = coord * coord_unit
 
         ds = xr.Dataset(
-            data_vars={"a": ("x", a), "b": ("x", b)},
-            coords={"x": x, "y": ("x", y)},
+            data_vars={"a": ("x", a), "b": ("x", b)}, coords={"x": x, "y": ("x", y)}
         )
         units = extract_units(ds)
 
@@ -4631,8 +4550,7 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims",
-                marks=pytest.mark.skip(reason="indexes don't support units"),
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
         ),
     )
@@ -4685,7 +4603,7 @@ class TestDataset:
         right_array2 = np.zeros(shape=(3,)) * unit
 
         left = xr.Dataset(
-            {"a": (("x", "y"), left_array1), "b": (("y", "z"), left_array2)},
+            {"a": (("x", "y"), left_array1), "b": (("y", "z"), left_array2)}
         )
         right = xr.Dataset({"a": ("x", right_array1), "b": ("y", right_array2)})
 
@@ -4723,16 +4641,12 @@ class TestDataset:
         (
             "data",
             pytest.param(
-                "dims",
-                marks=pytest.mark.skip(reason="indexes don't support units"),
+                "dims", marks=pytest.mark.skip(reason="indexes don't support units")
             ),
         ),
     )
     def test_stacking_stacked(self, variant, func, dtype):
-        variants = {
-            "data": (unit_registry.m, 1),
-            "dims": (1, unit_registry.m),
-        }
+        variants = {"data": (unit_registry.m, 1), "dims": (1, unit_registry.m)}
         data_unit, dim_unit = variants.get(variant)
 
         array1 = np.linspace(0, 10, 5 * 10).reshape(5, 10).astype(dtype) * data_unit
@@ -4778,10 +4692,7 @@ class TestDataset:
         func = method("to_stacked_array", "z", variable_dim="y", sample_dims=["x"])
 
         actual = func(ds).rename(None)
-        expected = attach_units(
-            func(strip_units(ds)).rename(None),
-            units,
-        )
+        expected = attach_units(func(strip_units(ds)).rename(None), units)
 
         assert_units_equal(expected, actual)
         assert_equal(expected, actual)
@@ -5091,7 +5002,7 @@ class TestDataset:
             data_vars={
                 "a": (tuple(names[: len(shape)]), array1),
                 "b": (tuple(names[: len(shape)]), array2),
-            },
+            }
         )
         units = extract_units(ds)
 
@@ -5116,10 +5027,7 @@ class TestDataset:
         ids=repr,
     )
     def test_interp_reindex(self, func, variant, dtype):
-        variants = {
-            "data": (unit_registry.m, 1),
-            "coords": (1, unit_registry.m),
-        }
+        variants = {"data": (unit_registry.m, 1), "coords": (1, unit_registry.m)}
         data_unit, coord_unit = variants.get(variant)
 
         array1 = np.linspace(-1, 0, 10).astype(dtype) * data_unit
@@ -5189,10 +5097,7 @@ class TestDataset:
         ids=repr,
     )
     def test_interp_reindex_like(self, func, variant, dtype):
-        variants = {
-            "data": (unit_registry.m, 1),
-            "coords": (1, unit_registry.m),
-        }
+        variants = {"data": (unit_registry.m, 1), "coords": (1, unit_registry.m)}
         data_unit, coord_unit = variants.get(variant)
 
         array1 = np.linspace(-1, 0, 10).astype(dtype) * data_unit

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -263,8 +263,7 @@ def test_infix_dims_errors(supplied, all_):
     ],
 )
 def test_parse_dims(
-    dim: str | Iterable[Hashable] | None,
-    expected: tuple[Hashable, ...],
+    dim: str | Iterable[Hashable] | None, expected: tuple[Hashable, ...]
 ) -> None:
     all_dims = ("a", "b", 1, ("b", "c"))  # selection of different Hashables
     actual = utils.parse_dims(dim, all_dims, replace_none=False)
@@ -312,8 +311,7 @@ def test_parse_dims_raises(dim: str | Iterable[Hashable]) -> None:
     ],
 )
 def test_parse_ordered_dims(
-    dim: str | Sequence[Hashable | ellipsis],
-    expected: tuple[Hashable, ...],
+    dim: str | Sequence[Hashable | ellipsis], expected: tuple[Hashable, ...]
 ) -> None:
     all_dims = ("a", "b", "c")
     actual = utils.parse_ordered_dims(dim, all_dims)

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -988,8 +988,7 @@ class VariableSubclassobjects:
     @pytest.mark.parametrize("dims", [("x", "y"), ("y", "z"), ("z", "x")])
     def test_nd_rolling(self, center, dims):
         x = self.cls(
-            ("x", "y", "z"),
-            np.arange(7 * 6 * 8).reshape(7, 6, 8).astype(float),
+            ("x", "y", "z"), np.arange(7 * 6 * 8).reshape(7, 6, 8).astype(float)
         )
         window = [3, 3]
         actual = x.rolling_window(
@@ -1020,15 +1019,11 @@ class VariableSubclassobjects:
     )
     def test_rolling_window_errors(self, dim, window, window_dim, center):
         x = self.cls(
-            ("x", "y", "z"),
-            np.arange(7 * 6 * 8).reshape(7, 6, 8).astype(float),
+            ("x", "y", "z"), np.arange(7 * 6 * 8).reshape(7, 6, 8).astype(float)
         )
         with pytest.raises(ValueError):
             x.rolling_window(
-                dim=dim,
-                window=window,
-                window_dim=window_dim,
-                center=center,
+                dim=dim, window=window, window_dim=window_dim, center=center
             )
 
 
@@ -2193,10 +2188,7 @@ class TestVariable(VariableSubclassobjects):
         # Test kept attrs
         with set_options(keep_attrs=True):
             new = Variable(["coord"], np.linspace(1, 10, 100), attrs=_attrs).coarsen(
-                windows={"coord": 1},
-                func=test_func,
-                boundary="exact",
-                side="left",
+                windows={"coord": 1}, func=test_func, boundary="exact", side="left"
             )
         assert new.attrs == _attrs
 
@@ -2696,8 +2688,7 @@ class TestBackendIndexing:
         self.check_vectorized_indexing(v)
         # doubly wrapping
         v = Variable(
-            dims=("x", "y"),
-            data=LazilyIndexedArray(LazilyIndexedArray(self.d)),
+            dims=("x", "y"), data=LazilyIndexedArray(LazilyIndexedArray(self.d))
         )
         self.check_orthogonal_indexing(v)
         # hierarchical wrapping

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -385,8 +385,7 @@ def test_weighted_mean_bool():
 
 
 @pytest.mark.parametrize(
-    ("weights", "expected"),
-    (([1, 2], 2 / 3), ([2, 0], 0), ([0, 0], 0), ([-1, 1], 0)),
+    ("weights", "expected"), (([1, 2], 2 / 3), ([2, 0], 0), ([0, 0], 0), ([-1, 1], 0))
 )
 def test_weighted_sum_of_squares_no_nan(weights, expected):
     da = DataArray([1, 2])
@@ -399,8 +398,7 @@ def test_weighted_sum_of_squares_no_nan(weights, expected):
 
 
 @pytest.mark.parametrize(
-    ("weights", "expected"),
-    (([1, 2], 0), ([2, 0], 0), ([0, 0], 0), ([-1, 1], 0)),
+    ("weights", "expected"), (([1, 2], 0), ([2, 0], 0), ([0, 0], 0), ([-1, 1], 0))
 )
 def test_weighted_sum_of_squares_nan(weights, expected):
     da = DataArray([np.nan, 2])

--- a/xarray/tutorial.py
+++ b/xarray/tutorial.py
@@ -166,13 +166,7 @@ def open_dataset(
     return ds
 
 
-def open_rasterio(
-    name,
-    engine=None,
-    cache=True,
-    cache_dir=None,
-    **kws,
-):
+def open_rasterio(name, engine=None, cache=True, cache_dir=None, **kws):
     """
     Open a rasterio dataset from the online repository (requires internet).
 

--- a/xarray/util/generate_aggregations.py
+++ b/xarray/util/generate_aggregations.py
@@ -230,11 +230,7 @@ ddof = ExtraKwarg(
 
 class Method:
     def __init__(
-        self,
-        name,
-        bool_reduce=False,
-        extra_kwargs=tuple(),
-        numeric_only=False,
+        self, name, bool_reduce=False, extra_kwargs=tuple(), numeric_only=False
     ):
         self.name = name
         self.extra_kwargs = extra_kwargs
@@ -296,8 +292,7 @@ class AggregationGenerator:
             extra_kwargs = ""
 
         yield self._template_signature.format(
-            **template_kwargs,
-            extra_kwargs=extra_kwargs,
+            **template_kwargs, extra_kwargs=extra_kwargs
         )
 
         for text in [


### PR DESCRIPTION
This little config change will make black remove trailing commas when they are not necessary to fit something into a single line.

It is a pure design choice but personally I like the clean up it does when function signatures simplify (although this happens rarely with more and more type hints added).

I can understand that some people prefer the manual control over what is multiline and what is not.
Feel free to vote on it :)

For me it adds cheap LOCs so it looks like I am working hard, haha.