### PR TITLE
Fixed broken link in Issue 7556

### DIFF
--- a/doc/user-guide/time-series.rst
+++ b/doc/user-guide/time-series.rst
@@ -101,7 +101,7 @@ You can also select a particular time by indexing with a
 
     ds.sel(time=datetime.time(12))
 
-For more details, read the pandas documentation and the section on `Indexing Using Datetime Components <datetime_component_indexing>`_ (i.e. using the ``.dt`` accessor).
+For more details, read the pandas documentation and the section on :ref:`datetime_component_indexing` (i.e. using the ``.dt`` accessor).
 
 .. _dt_accessor:
 


### PR DESCRIPTION
Fixed the link to [Indexing using Datetime Components](https://docs.xarray.dev/en/stable/user-guide/time-series.html#datetime-component-indexing) under the [Datetime Indexing](https://docs.xarray.dev/en/stable/user-guide/time-series.html#datetime-indexing) section.


- [x] Closes #7556
