### PR TITLE
Raise PermissionError when insufficient permissions

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -37,6 +37,8 @@ Bug fixes
 
 - Fix :py:meth:`xr.polyval` with non-system standard integer coeffs (:pull:`7619`).
   By `Shreyal Gupta <https://github.com/Ravenin7>`_ and `Michael Niklas <https://github.com/headtr1ck>`_.
+- Improve error message when trying to open a file which you do not have permission to read (:issue:`6523`, :pull:`7629`).
+  By `Thomas Coleman <https://github.com/ColemanTom>`_.
 
 Documentation
 ~~~~~~~~~~~~~
@@ -98,8 +100,6 @@ Bug fixes
   By `Paul Ockenfuß <https://github.com/Ockenfuss>`_.
 - Fix :py:meth:`DataArray.plot.pcolormesh` which now works if one of the coordinates has str dtype  (:issue:`6775`, :pull:`7612`).
   By `Michael Niklas <https://github.com/headtr1ck>`_.
-- Improve error message when trying to open a file which you do not have permission to read (:issue:`6523`, :pull:`7629`).
-  By `Thomas Coleman <https://github.com/ColemanTom>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -98,6 +98,8 @@ Bug fixes
   By `Paul Ockenfuß <https://github.com/Ockenfuss>`_.
 - Fix :py:meth:`DataArray.plot.pcolormesh` which now works if one of the coordinates has str dtype  (:issue:`6775`, :pull:`7612`).
   By `Michael Niklas <https://github.com/headtr1ck>`_.
+- Improve error message when trying to open a file which you do not have permission to read (:issue:`6523`, :pull:`7629`).
+  By `Thomas Coleman <https://github.com/ColemanTom>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -135,6 +135,8 @@ def guess_engine(
         try:
             if backend.guess_can_open(store_spec):
                 return engine
+        except PermissionError:
+            raise
         except Exception:
             warnings.warn(f"{engine!r} fails while guessing", RuntimeWarning)
 


### PR DESCRIPTION
- [x] Closes #6523
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

### Previously

```bash
(xr) $ chmod 000 testfile.nc
(xr) $ python -c 'import xarray as xr
f=xr.open_dataarray("testfile.nc").load()'
MY_HOME/miniconda3/envs/xr/lib/python3.9/site-packages/xarray/backends/plugins.py:139: RuntimeWarning: 'netcdf4' fails while guessing
  warnings.warn(f"{engine!r} fails while guessing", RuntimeWarning)
MY_HOME/miniconda3/envs/xr/lib/python3.9/site-packages/xarray/backends/plugins.py:148: RuntimeWarning: 'netcdf4' fails while guessing
  warnings.warn(f"{engine!r} fails while guessing", RuntimeWarning)
MY_HOME/miniconda3/envs/xr/lib/python3.9/site-packages/xarray/backends/plugins.py:148: RuntimeWarning: 'h5netcdf' fails while guessing
  warnings.warn(f"{engine!r} fails while guessing", RuntimeWarning)
MY_HOME/miniconda3/envs/xr/lib/python3.9/site-packages/xarray/backends/plugins.py:148: RuntimeWarning: 'scipy' fails while guessing
  warnings.warn(f"{engine!r} fails while guessing", RuntimeWarning)
Traceback (most recent call last):
  File "<string>", line 2, in <module>
  File "MY_HOME/miniconda3/envs/xr/lib/python3.9/site-packages/xarray/backends/api.py", line 687, in open_dataarray
    dataset = open_dataset(
  File "MY_HOME/miniconda3/envs/xr/lib/python3.9/site-packages/xarray/backends/api.py", line 510, in open_dataset
    engine = plugins.guess_engine(filename_or_obj)
  File "MY_HOME/miniconda3/envs/xr/lib/python3.9/site-packages/xarray/backends/plugins.py", line 177, in guess_engine
    raise ValueError(error_msg)
ValueError: did not find a match in any of xarray's currently installed IO backends ['netcdf4']. Consider explicitly selecting one of the installed engines via the ``engine`` parameter, or installing additional IO dependencies, see:
https://docs.xarray.dev/en/stable/getting-started-guide/installing.html
https://docs.xarray.dev/en/stable/user-guide/io.html
```

### Now

```bash
(xr) $ chmod 000 testfile.nc
(xr) $ python -c 'import xarray as xr
f=xr.open_dataarray("testfile.nc").load()'
Traceback (most recent call last):
  File "<string>", line 2, in <module>
  File "MY_HOME/miniconda3/envs/xr/lib/python3.9/site-packages/xarray/backends/api.py", line 687, in open_dataarray
    dataset = open_dataset(
  File "MY_HOME/miniconda3/envs/xr/lib/python3.9/site-packages/xarray/backends/api.py", line 510, in open_dataset
    engine = plugins.guess_engine(filename_or_obj)
  File "MY_HOME/miniconda3/envs/xr/lib/python3.9/site-packages/xarray/backends/plugins.py", line 136, in guess_engine
    if backend.guess_can_open(store_spec):
  File "MY_HOME/miniconda3/envs/xr/lib/python3.9/site-packages/xarray/backends/netCDF4_.py", line 547, in guess_can_open
    magic_number = try_read_magic_number_from_path(filename_or_obj)
  File "MY_HOME/miniconda3/envs/xr/lib/python3.9/site-packages/xarray/core/utils.py", line 673, in try_read_magic_number_from_path
    with open(path, "rb") as f:
PermissionError: [Errno 13] Permission denied: 'testfile.nc'
```