### PR TITLE
Set copy=False when calling pd.Series

### DIFF
--- a/xarray/core/accessor_dt.py
+++ b/xarray/core/accessor_dt.py
@@ -65,7 +65,7 @@ def _access_through_series(values, name):
     """Coerce an array of datetime-like values to a pandas Series and
     access requested datetime component
     """
-    values_as_series = pd.Series(values.ravel())
+    values_as_series = pd.Series(values.ravel(), copy=False)
     if name == "season":
         months = values_as_series.dt.month.values
         field_values = _season_from_months(months)
@@ -125,7 +125,7 @@ def _round_through_series_or_index(values, name, freq):
     from xarray.coding.cftimeindex import CFTimeIndex
 
     if is_np_datetime_like(values.dtype):
-        values_as_series = pd.Series(values.ravel())
+        values_as_series = pd.Series(values.ravel(), copy=False)
         method = getattr(values_as_series.dt, name)
     else:
         values_as_cftimeindex = CFTimeIndex(values.ravel())
@@ -182,7 +182,7 @@ def _strftime_through_series(values, date_format: str):
     """Coerce an array of datetime-like values to a pandas Series and
     apply string formatting
     """
-    values_as_series = pd.Series(values.ravel())
+    values_as_series = pd.Series(values.ravel(), copy=False)
     strs = values_as_series.dt.strftime(date_format)
     return strs.values.reshape(values.shape)
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -1404,7 +1404,7 @@ class TimeResampleGrouper:
             )
             return grouper.first_items(index)
         else:
-            s = pd.Series(np.arange(index.size), index)
+            s = pd.Series(np.arange(index.size), index, copy=False)
             grouper = pd.Grouper(
                 freq=self.freq,
                 closed=self.closed,

--- a/xarray/core/resample_cftime.py
+++ b/xarray/core/resample_cftime.py
@@ -164,7 +164,7 @@ class CFTimeGrouper:
             raise ValueError("Value falls after last bin")
 
         integer_bins = np.searchsorted(index, datetime_bins, side=self.closed)[:-1]
-        first_items = pd.Series(integer_bins, labels)
+        first_items = pd.Series(integer_bins, labels, copy=False)
 
         # Mask duplicate values with NaNs, preserving the last values
         non_duplicate = ~first_items.duplicated("last")

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -214,7 +214,7 @@ def _possibly_convert_objects(values):
     within the valid date range for ns precision, as pandas will raise an error
     if they are not.
     """
-    as_series = pd.Series(values.ravel())
+    as_series = pd.Series(values.ravel(), copy=False)
     if as_series.dtype.kind in "mM":
         as_series = _as_nanosecond_precision(as_series)
     return np.asarray(as_series).reshape(values.shape)


### PR DESCRIPTION
pandas will change the default for the Series constructor to ``True`` under Copy-on-Write when getting arrays as input. Setting ``copy=False`` explicitly avoids the performance penalty. 

