### PR TITLE
Pin pandas < 2

### DIFF
--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -26,7 +26,7 @@ dependencies:
   - numbagg
   - numpy<1.24
   - packaging
-  - pandas
+  - pandas<2
   - pint
   - pip
   - pseudonetcdf

--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -20,7 +20,7 @@ dependencies:
   - numba
   - numpy>=1.21,<1.24
   - packaging>=21.3
-  - pandas>=1.4
+  - pandas>=1.4,<2
   - pooch
   - pip
   - pre-commit

--- a/ci/requirements/environment-py311.yml
+++ b/ci/requirements/environment-py311.yml
@@ -28,7 +28,7 @@ dependencies:
   - numexpr
   - numpy
   - packaging
-  - pandas
+  - pandas<2
   - pint
   - pip
   - pooch

--- a/ci/requirements/environment-windows-py311.yml
+++ b/ci/requirements/environment-windows-py311.yml
@@ -25,7 +25,7 @@ dependencies:
   # - numbagg
   - numpy
   - packaging
-  - pandas
+  - pandas<2
   - pint
   - pip
   - pre-commit

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -25,7 +25,7 @@ dependencies:
   - numbagg
   - numpy<1.24
   - packaging
-  - pandas
+  - pandas<2
   - pint
   - pip
   - pre-commit

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - numexpr
   - numpy<1.24
   - packaging
-  - pandas
+  - pandas<2
   - pint
   - pip
   - pooch

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 
 numpy >= 1.21
 packaging >= 21.3
-pandas >= 1.4
+pandas >= 1.4, <2

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ include_package_data = True
 python_requires = >=3.9
 install_requires =
     numpy >= 1.21  # recommended to use >= 1.22 for full quantile method support
-    pandas >= 1.4
+    pandas >= 1.4, <2
     packaging >= 21.3
 
 [options.extras_require]


### PR DESCRIPTION
Pandas is expecting to release v2 in two weeks (pandas-dev/pandas#46776 (comment)). But we are still incompatible with their main branch: 
- #7441 
- #7420

This PR pins pandas to `<2`