### PR TITLE
limit lines in html repr of dataset attrs

### DIFF
--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -53,9 +53,20 @@ def format_dims(dims, dims_with_index):
     return f"<ul class='xr-dim-list'>{dims_li}</ul>"
 
 
-def summarize_attrs(attrs):
+def summarize_attrs(attrs, max_lines=15, min_lines=10):
+    def attr_cropper(obj):
+        if type(obj) is str:
+            lines = str.splitlines(obj)
+            if len(lines) > max_lines:
+                return (
+                    escape("\n".join(lines[: min_lines // 2]))
+                    + f"\n<i>... (skipped {len(lines) - min_lines} lines)</i>\n"
+                    + escape("\n".join(lines[-min_lines // 2 :]))
+                )
+        return escape(str(obj))
+
     attrs_dl = "".join(
-        f"<dt><span>{escape(str(k))} :</span></dt>" f"<dd>{escape(str(v))}</dd>"
+        f"<dt><span>{escape(str(k))} :</span></dt>" f"<dd>{attr_cropper(v)}</dd>"
         for k, v in attrs.items()
     )
 


### PR DESCRIPTION
Truncates the amount of lines output by `_html_repr_` for `DataSet`/`DataArray` objects.

Motivation is that currently, if an attribute has a larger number of line breaks, it will pollute your _Jupyter_ (etc) view. 
For example, I like to append the measurement script source file to all my measurement results. When I then load the netcdf file, the attributes will contain a file with potentially hundreds of lines. I don't want all these lines to be shown in my output cells when viewing the html representation.

In the suggested edit, `max_lines` defines above which amount of lines the output should be truncated, while `min_lines` defines how many should still be shown (like a preview). The current values of 15 and 10 are somewhat arbitrary.
