### PR TITLE
cf-coding

### DIFF
--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -300,7 +300,7 @@ def _scale_offset_decoding(data, scale_factor, add_offset, dtype: np.typing.DTyp
 def _choose_float_dtype(
     dtype: np.dtype, mapping: MutableMapping
 ) -> type[np.floating[Any]]:
-    # check scale/offset first to derive dtype
+    # check scale/offset first to derive wanted float dtype
     # see https://github.com/pydata/xarray/issues/5597#issuecomment-879561954
     scale_factor = mapping.get("scale_factor")
     add_offset = mapping.get("add_offset")
@@ -324,6 +324,7 @@ def _choose_float_dtype(
             return np.float32
         else:
             return np.float64
+    # If no scale_factor or add_offset is given, use some general rules.
     # Keep float32 as-is. Upcast half-precision to single-precision,
     # because float16 is "intended for storage but not computation"
     if dtype.itemsize <= 4 and np.issubdtype(dtype, np.floating):
@@ -477,7 +478,7 @@ class BooleanCoder(VariableCoder):
     def decode(self, variable: Variable, name: T_Name = None) -> Variable:
         if variable.attrs.get("dtype", False) == "bool":
             dims, data, attrs, encoding = unpack_for_decoding(variable)
-            # overwrite encoding accordingly and remove from attrs
+            # overwrite (!) encoding accordingly and remove from attrs
             encoding["dtype"] = attrs.pop("dtype")
             data = BoolTypeArray(data)
             return Variable(dims, data, attrs, encoding, fastpath=True)

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -456,7 +456,8 @@ class BooleanCoder(VariableCoder):
     def decode(self, variable: Variable, name: T_Name = None) -> Variable:
         if variable.attrs.get("dtype", False) == "bool":
             dims, data, attrs, encoding = unpack_for_decoding(variable)
-            del attrs["dtype"]
+            # overwrite encoding accordingly and remove from attrs
+            encoding["dtype"] = attrs.pop("dtype")
             data = BoolTypeArray(data)
             return Variable(dims, data, attrs, encoding, fastpath=True)
         else:

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -243,7 +243,8 @@ class CFMaskCoder(VariableCoder):
                     data = duck_array_ops.fillna(data, fill_value)
 
             if mv is not None:
-                # Only use mv if _FillValue isn't available
+                # Use _FillValue if available to align missing_value to prevent issues
+                # when decoding
                 # Ensure missing_value is cast to same dtype as data's
                 encoding["missing_value"] = attrs.get("_FillValue", dtype.type(mv))
                 fill_value = pop_to(encoding, attrs, "missing_value", name=name)

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -143,7 +143,6 @@ class BoolTypeArray(indexing.ExplicitlyIndexedNDArrayMixin):
         return np.asarray(self.array[key], dtype=self.dtype)
 
 
-
 def lazy_elemwise_func(array, func: Callable, dtype: np.typing.DTypeLike):
     """Lazily apply an element-wise function to an array.
     Parameters
@@ -444,6 +443,7 @@ class DefaultFillvalueCoder(VariableCoder):
             return Variable(dims, data, attrs, encoding, fastpath=True)
         else:
             return variable
+
     def decode(self, variable: Variable, name: T_Name = None) -> Variable:
         raise NotImplementedError()
 
@@ -523,4 +523,3 @@ class NonStringCoder(VariableCoder):
 
     def decode(self):
         raise NotImplementedError()
-

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -304,20 +304,20 @@ def _choose_float_dtype(
     # see https://github.com/pydata/xarray/issues/5597#issuecomment-879561954
     scale_factor = mapping.get("scale_factor")
     add_offset = mapping.get("add_offset")
-    if scale_factor or add_offset:
+    if scale_factor is not None or add_offset is not None:
         # get the type from scale_factor/add_offset to determine
         # the needed floating point type
-        if scale_factor:
+        if scale_factor is not None:
             scale_type = type(scale_factor)
-        if add_offset:
+        if add_offset is not None:
             offset_type = type(add_offset)
         # CF conforming, both scale_factor and add-offset are given and
-        # of same floating point type
+        # of same floating point type (float32/64)
         if (
-            add_offset
-            and scale_factor
+            add_offset is not None
+            and scale_factor is not None
             and offset_type == scale_type
-            and np.issubdtype(scale_type, np.floating)
+            and scale_type in [np.float32, np.float64]
         ):
             return np.dtype(scale_type).type
         # Not CF conforming and add_offset given:
@@ -325,7 +325,7 @@ def _choose_float_dtype(
         # but a large integer offset could lead to loss of precision.
         # Sensitivity analysis can be tricky, so we just use a float64
         # if there's any offset at all - better unoptimised than wrong!
-        if add_offset:
+        if add_offset is not None:
             return np.float64
         # return float32 in other cases where only scale_factor is given
         return np.float32

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -78,6 +78,72 @@ class _ElementwiseFunctionArray(indexing.ExplicitlyIndexedNDArrayMixin):
         )
 
 
+class NativeEndiannessArray(indexing.ExplicitlyIndexedNDArrayMixin):
+    """Decode arrays on the fly from non-native to native endianness
+
+    This is useful for decoding arrays from netCDF3 files (which are all
+    big endian) into native endianness, so they can be used with Cython
+    functions, such as those found in bottleneck and pandas.
+
+    >>> x = np.arange(5, dtype=">i2")
+
+    >>> x.dtype
+    dtype('>i2')
+
+    >>> NativeEndiannessArray(x).dtype
+    dtype('int16')
+
+    >>> indexer = indexing.BasicIndexer((slice(None),))
+    >>> NativeEndiannessArray(x)[indexer].dtype
+    dtype('int16')
+    """
+
+    __slots__ = ("array",)
+
+    def __init__(self, array):
+        self.array = indexing.as_indexable(array)
+
+    @property
+    def dtype(self):
+        return np.dtype(self.array.dtype.kind + str(self.array.dtype.itemsize))
+
+    def __getitem__(self, key):
+        return np.asarray(self.array[key], dtype=self.dtype)
+
+
+class BoolTypeArray(indexing.ExplicitlyIndexedNDArrayMixin):
+    """Decode arrays on the fly from integer to boolean datatype
+
+    This is useful for decoding boolean arrays from integer typed netCDF
+    variables.
+
+    >>> x = np.array([1, 0, 1, 1, 0], dtype="i1")
+
+    >>> x.dtype
+    dtype('int8')
+
+    >>> BoolTypeArray(x).dtype
+    dtype('bool')
+
+    >>> indexer = indexing.BasicIndexer((slice(None),))
+    >>> BoolTypeArray(x)[indexer].dtype
+    dtype('bool')
+    """
+
+    __slots__ = ("array",)
+
+    def __init__(self, array):
+        self.array = indexing.as_indexable(array)
+
+    @property
+    def dtype(self):
+        return np.dtype("bool")
+
+    def __getitem__(self, key):
+        return np.asarray(self.array[key], dtype=self.dtype)
+
+
+
 def lazy_elemwise_func(array, func: Callable, dtype: np.typing.DTypeLike):
     """Lazily apply an element-wise function to an array.
     Parameters
@@ -349,3 +415,99 @@ class UnsignedIntegerCoder(VariableCoder):
             return Variable(dims, data, attrs, encoding, fastpath=True)
         else:
             return variable
+
+
+class DefaultFillvalueCoder(VariableCoder):
+    """Encode default _FillValue if needed."""
+
+    def encode(self, variable: Variable, name: T_Name = None) -> Variable:
+        dims, data, attrs, encoding = unpack_for_encoding(variable)
+        # make NaN the fill value for float types
+        if (
+            "_FillValue" not in attrs
+            and "_FillValue" not in encoding
+            and np.issubdtype(variable.dtype, np.floating)
+        ):
+            attrs["_FillValue"] = variable.dtype.type(np.nan)
+            return Variable(dims, data, attrs, encoding, fastpath=True)
+        else:
+            return variable
+    def decode(self, variable: Variable, name: T_Name = None) -> Variable:
+        raise NotImplementedError()
+
+
+class BooleanCoder(VariableCoder):
+    """Code boolean values."""
+
+    def encode(self, variable: Variable, name: T_Name = None) -> Variable:
+        if (
+            (variable.dtype == bool)
+            and ("dtype" not in variable.encoding)
+            and ("dtype" not in variable.attrs)
+        ):
+            dims, data, attrs, encoding = unpack_for_encoding(variable)
+            attrs["dtype"] = "bool"
+            data = duck_array_ops.astype(data, dtype="i1", copy=True)
+
+            return Variable(dims, data, attrs, encoding, fastpath=True)
+        else:
+            return variable
+
+    def decode(self, variable: Variable, name: T_Name = None) -> Variable:
+        if variable.attrs.get("dtype", False) == "bool":
+            dims, data, attrs, encoding = unpack_for_decoding(variable)
+            del attrs["dtype"]
+            data = BoolTypeArray(data)
+            return Variable(dims, data, attrs, encoding, fastpath=True)
+        else:
+            return variable
+
+
+class EndianCoder(VariableCoder):
+    """Decode Endianness to native."""
+
+    def encode(self):
+        raise NotImplementedError()
+
+    def decode(self, variable: Variable, name: T_Name = None) -> Variable:
+        dims, data, attrs, encoding = unpack_for_decoding(variable)
+        if not data.dtype.isnative:
+            data = NativeEndiannessArray(data)
+            return Variable(dims, data, attrs, encoding, fastpath=True)
+        else:
+            return variable
+
+
+class NonStringCoder(VariableCoder):
+    """Encode NonString variables if dtypes differ."""
+
+    def encode(self, variable: Variable, name: T_Name = None) -> Variable:
+        if "dtype" in variable.encoding and variable.encoding["dtype"] not in (
+            "S1",
+            str,
+        ):
+            dims, data, attrs, encoding = unpack_for_encoding(variable)
+            dtype = np.dtype(encoding.pop("dtype"))
+            if dtype != variable.dtype:
+                if np.issubdtype(dtype, np.integer):
+                    if (
+                        np.issubdtype(variable.dtype, np.floating)
+                        and "_FillValue" not in variable.attrs
+                        and "missing_value" not in variable.attrs
+                    ):
+                        warnings.warn(
+                            f"saving variable {name} with floating "
+                            "point data as an integer dtype without "
+                            "any _FillValue to use for NaNs",
+                            SerializationWarning,
+                            stacklevel=10,
+                        )
+                    data = np.around(data)
+                data = data.astype(dtype=dtype)
+            return Variable(dims, data, attrs, encoding, fastpath=True)
+        else:
+            return variable
+
+    def decode(self):
+        raise NotImplementedError()
+

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -100,14 +100,14 @@ class NativeEndiannessArray(indexing.ExplicitlyIndexedNDArrayMixin):
 
     __slots__ = ("array",)
 
-    def __init__(self, array):
+    def __init__(self, array) -> None:
         self.array = indexing.as_indexable(array)
 
     @property
-    def dtype(self):
+    def dtype(self) -> np.dtype:
         return np.dtype(self.array.dtype.kind + str(self.array.dtype.itemsize))
 
-    def __getitem__(self, key):
+    def __getitem__(self, key) -> np.ndarray:
         return np.asarray(self.array[key], dtype=self.dtype)
 
 
@@ -132,14 +132,14 @@ class BoolTypeArray(indexing.ExplicitlyIndexedNDArrayMixin):
 
     __slots__ = ("array",)
 
-    def __init__(self, array):
+    def __init__(self, array) -> None:
         self.array = indexing.as_indexable(array)
 
     @property
-    def dtype(self):
+    def dtype(self) -> np.dtype:
         return np.dtype("bool")
 
-    def __getitem__(self, key):
+    def __getitem__(self, key) -> np.ndarray:
         return np.asarray(self.array[key], dtype=self.dtype)
 
 

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -319,7 +319,7 @@ def _choose_float_dtype(
             and offset_type == scale_type
             and np.issubdtype(scale_type, np.floating)
         ):
-            return np.dtype(scale_type)
+            return np.dtype(scale_type).type
         # Not CF conforming and add_offset given:
         # A scale factor is entirely safe (vanishing into the mantissa),
         # but a large integer offset could lead to loss of precision.
@@ -509,10 +509,7 @@ class NonStringCoder(VariableCoder):
     """Encode NonString variables if dtypes differ."""
 
     def encode(self, variable: Variable, name: T_Name = None) -> Variable:
-        if "dtype" in variable.encoding and variable.encoding["dtype"] not in (
-            "S1",
-            str,
-        ):
+        if "dtype" in variable.encoding and variable.encoding["dtype"] not in ("S1", str):
             dims, data, attrs, encoding = unpack_for_encoding(variable)
             dtype = np.dtype(encoding.pop("dtype"))
             if dtype != variable.dtype:

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -509,7 +509,10 @@ class NonStringCoder(VariableCoder):
     """Encode NonString variables if dtypes differ."""
 
     def encode(self, variable: Variable, name: T_Name = None) -> Variable:
-        if "dtype" in variable.encoding and variable.encoding["dtype"] not in ("S1", str):
+        if "dtype" in variable.encoding and variable.encoding["dtype"] not in (
+            "S1",
+            str,
+        ):
             dims, data, attrs, encoding = unpack_for_encoding(variable)
             dtype = np.dtype(encoding.pop("dtype"))
             if dtype != variable.dtype:

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -48,121 +48,8 @@ if TYPE_CHECKING:
     T_DatasetOrAbstractstore = Union[Dataset, AbstractDataStore]
 
 
-class NativeEndiannessArray(indexing.ExplicitlyIndexedNDArrayMixin):
-    """Decode arrays on the fly from non-native to native endianness
-
-    This is useful for decoding arrays from netCDF3 files (which are all
-    big endian) into native endianness, so they can be used with Cython
-    functions, such as those found in bottleneck and pandas.
-
-    >>> x = np.arange(5, dtype=">i2")
-
-    >>> x.dtype
-    dtype('>i2')
-
-    >>> NativeEndiannessArray(x).dtype
-    dtype('int16')
-
-    >>> indexer = indexing.BasicIndexer((slice(None),))
-    >>> NativeEndiannessArray(x)[indexer].dtype
-    dtype('int16')
-    """
-
-    __slots__ = ("array",)
-
-    def __init__(self, array):
-        self.array = indexing.as_indexable(array)
-
-    @property
-    def dtype(self):
-        return np.dtype(self.array.dtype.kind + str(self.array.dtype.itemsize))
-
-    def __getitem__(self, key):
-        return np.asarray(self.array[key], dtype=self.dtype)
-
-
-class BoolTypeArray(indexing.ExplicitlyIndexedNDArrayMixin):
-    """Decode arrays on the fly from integer to boolean datatype
-
-    This is useful for decoding boolean arrays from integer typed netCDF
-    variables.
-
-    >>> x = np.array([1, 0, 1, 1, 0], dtype="i1")
-
-    >>> x.dtype
-    dtype('int8')
-
-    >>> BoolTypeArray(x).dtype
-    dtype('bool')
-
-    >>> indexer = indexing.BasicIndexer((slice(None),))
-    >>> BoolTypeArray(x)[indexer].dtype
-    dtype('bool')
-    """
-
-    __slots__ = ("array",)
-
-    def __init__(self, array):
-        self.array = indexing.as_indexable(array)
-
-    @property
-    def dtype(self):
-        return np.dtype("bool")
-
-    def __getitem__(self, key):
-        return np.asarray(self.array[key], dtype=self.dtype)
-
-
 def _var_as_tuple(var: Variable) -> T_VarTuple:
     return var.dims, var.data, var.attrs.copy(), var.encoding.copy()
-
-
-def maybe_encode_nonstring_dtype(var: Variable, name: T_Name = None) -> Variable:
-    if "dtype" in var.encoding and var.encoding["dtype"] not in ("S1", str):
-        dims, data, attrs, encoding = _var_as_tuple(var)
-        dtype = np.dtype(encoding.pop("dtype"))
-        if dtype != var.dtype:
-            if np.issubdtype(dtype, np.integer):
-                if (
-                    np.issubdtype(var.dtype, np.floating)
-                    and "_FillValue" not in var.attrs
-                    and "missing_value" not in var.attrs
-                ):
-                    warnings.warn(
-                        f"saving variable {name} with floating "
-                        "point data as an integer dtype without "
-                        "any _FillValue to use for NaNs",
-                        SerializationWarning,
-                        stacklevel=10,
-                    )
-                data = np.around(data)
-            data = data.astype(dtype=dtype)
-        var = Variable(dims, data, attrs, encoding, fastpath=True)
-    return var
-
-
-def maybe_default_fill_value(var: Variable) -> Variable:
-    # make NaN the fill value for float types:
-    if (
-        "_FillValue" not in var.attrs
-        and "_FillValue" not in var.encoding
-        and np.issubdtype(var.dtype, np.floating)
-    ):
-        var.attrs["_FillValue"] = var.dtype.type(np.nan)
-    return var
-
-
-def maybe_encode_bools(var: Variable) -> Variable:
-    if (
-        (var.dtype == bool)
-        and ("dtype" not in var.encoding)
-        and ("dtype" not in var.attrs)
-    ):
-        dims, data, attrs, encoding = _var_as_tuple(var)
-        attrs["dtype"] = "bool"
-        data = duck_array_ops.astype(data, dtype="i1", copy=True)
-        var = Variable(dims, data, attrs, encoding, fastpath=True)
-    return var
 
 
 def _infer_dtype(array, name: T_Name = None) -> np.dtype:
@@ -292,13 +179,13 @@ def encode_cf_variable(
         variables.CFScaleOffsetCoder(),
         variables.CFMaskCoder(),
         variables.UnsignedIntegerCoder(),
+        variables.NonStringCoder(),
+        variables.DefaultFillvalueCoder(),
+        variables.BooleanCoder(),
     ]:
         var = coder.encode(var, name=name)
 
-    # TODO(shoyer): convert all of these to use coders, too:
-    var = maybe_encode_nonstring_dtype(var, name=name)
-    var = maybe_default_fill_value(var)
-    var = maybe_encode_bools(var)
+    # TODO(kmuehlbauer): check if ensure_dtype_not_object can be moved to backends:
     var = ensure_dtype_not_object(var, name=name)
 
     for attr_name in CF_RELATED_DATA:
@@ -389,19 +276,15 @@ def decode_cf_variable(
     if decode_times:
         var = times.CFDatetimeCoder(use_cftime=use_cftime).decode(var, name=name)
 
-    dimensions, data, attributes, encoding = variables.unpack_for_decoding(var)
-    # TODO(shoyer): convert everything below to use coders
+    if decode_endianness and not var.dtype.isnative:
+        var = variables.EndianCoder().decode(var)
+        original_dtype = var.dtype
 
-    if decode_endianness and not data.dtype.isnative:
-        # do this last, so it's only done if we didn't already unmask/scale
-        data = NativeEndiannessArray(data)
-        original_dtype = data.dtype
+    var = variables.BooleanCoder().decode(var)
+
+    dimensions, data, attributes, encoding = variables.unpack_for_decoding(var)
 
     encoding.setdefault("dtype", original_dtype)
-
-    if "dtype" in attributes and attributes["dtype"] == "bool":
-        del attributes["dtype"]
-        data = BoolTypeArray(data)
 
     if not is_duck_dask_array(data):
         data = indexing.LazilyIndexedArray(data)

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from xarray.coding import strings, times, variables
 from xarray.coding.variables import SerializationWarning, pop_to
-from xarray.core import duck_array_ops, indexing
+from xarray.core import indexing
 from xarray.core.common import (
     _contains_datetime_like_objects,
     contains_cftime_datetimes,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -149,14 +149,18 @@ def create_masked_and_scaled_data(dtype: np.typing.DTypeLike = np.float32) -> Da
     return Dataset({"x": ("t", x, {}, encoding)})
 
 
-def create_encoded_masked_and_scaled_data(dtype: np.typing.DTypeLike = np.float32) -> Dataset:
+def create_encoded_masked_and_scaled_data(
+    dtype: np.typing.DTypeLike = np.float32,
+) -> Dataset:
     attributes = {"_FillValue": -1, "add_offset": 10, "scale_factor": dtype(0.1)}
     return Dataset(
         {"x": ("t", np.array([-1, -1, 0, 1, 2], dtype=np.int16), attributes)}
     )
 
 
-def create_unsigned_masked_scaled_data(dtype: np.typing.DTypeLike = np.float32) -> Dataset:
+def create_unsigned_masked_scaled_data(
+    dtype: np.typing.DTypeLike = np.float32,
+) -> Dataset:
     encoding = {
         "_FillValue": 255,
         "_Unsigned": "true",
@@ -168,7 +172,9 @@ def create_unsigned_masked_scaled_data(dtype: np.typing.DTypeLike = np.float32) 
     return Dataset({"x": ("t", x, {}, encoding)})
 
 
-def create_encoded_unsigned_masked_scaled_data(dtype: np.typing.DTypeLike = np.float32) -> Dataset:
+def create_encoded_unsigned_masked_scaled_data(
+    dtype: np.typing.DTypeLike = np.float32,
+) -> Dataset:
     # These are values as written to the file: the _FillValue will
     # be represented in the signed form.
     attributes = {
@@ -182,7 +188,9 @@ def create_encoded_unsigned_masked_scaled_data(dtype: np.typing.DTypeLike = np.f
     return Dataset({"x": ("t", sb, attributes)})
 
 
-def create_bad_unsigned_masked_scaled_data(dtype: np.typing.DTypeLike = np.float32) -> Dataset:
+def create_bad_unsigned_masked_scaled_data(
+    dtype: np.typing.DTypeLike = np.float32,
+) -> Dataset:
     encoding = {
         "_FillValue": 255,
         "_Unsigned": True,
@@ -194,7 +202,9 @@ def create_bad_unsigned_masked_scaled_data(dtype: np.typing.DTypeLike = np.float
     return Dataset({"x": ("t", x, {}, encoding)})
 
 
-def create_bad_encoded_unsigned_masked_scaled_data(dtype: np.typing.DTypeLike = np.float32) -> Dataset:
+def create_bad_encoded_unsigned_masked_scaled_data(
+    dtype: np.typing.DTypeLike = np.float32,
+) -> Dataset:
     # These are values as written to the file: the _FillValue will
     # be represented in the signed form.
     attributes = {
@@ -208,7 +218,9 @@ def create_bad_encoded_unsigned_masked_scaled_data(dtype: np.typing.DTypeLike = 
     return Dataset({"x": ("t", sb, attributes)})
 
 
-def create_signed_masked_scaled_data(dtype: np.typing.DTypeLike = np.float32) -> Dataset:
+def create_signed_masked_scaled_data(
+    dtype: np.typing.DTypeLike = np.float32,
+) -> Dataset:
     encoding = {
         "_FillValue": -127,
         "_Unsigned": "false",
@@ -220,7 +232,9 @@ def create_signed_masked_scaled_data(dtype: np.typing.DTypeLike = np.float32) ->
     return Dataset({"x": ("t", x, {}, encoding)})
 
 
-def create_encoded_signed_masked_scaled_data(dtype: np.typing.DTypeLike = np.float32) -> Dataset:
+def create_encoded_signed_masked_scaled_data(
+    dtype: np.typing.DTypeLike = np.float32,
+) -> Dataset:
     # These are values as written to the file: the _FillValue will
     # be represented in the signed form.
     attributes = {

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1586,7 +1586,9 @@ class NetCDF4Base(NetCDFBase):
 
     @pytest.mark.parametrize("dtype", [np.float32, np.float64])
     @pytest.mark.parametrize("offset_cf_conforming", [True, False])
-    def test_mask_and_scale_non_cf_conforming(self, dtype, offset_cf_conforming) -> None:
+    def test_mask_and_scale_non_cf_conforming(
+        self, dtype, offset_cf_conforming
+    ) -> None:
         with create_tmp_file() as tmp_file:
             with nc4.Dataset(tmp_file, mode="w") as nc:
                 nc.createDimension("t", 5)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -644,6 +644,8 @@ class DatasetIOBase:
         with self.roundtrip(original) as actual:
             assert_identical(original, actual)
             assert actual["x"].dtype == "bool"
+            # this checks for preserving dtype during second roundtrip
+            # see https://github.com/pydata/xarray/issues/7652#issuecomment-1476956975
             with self.roundtrip(actual) as actual2:
                 assert_identical(original, actual2)
                 assert actual2["x"].dtype == "bool"

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -894,7 +894,10 @@ class CFEncodedBase(DatasetIOBase):
         ],
     )
     def test_roundtrip_mask_and_scale(
-        self, decoded_fn: Callable[[type[np.number]], Dataset], encoded_fn: Callable[[type[np.number]], Dataset], dtype: type[np.number]
+        self,
+        decoded_fn: Callable[[type[np.number]], Dataset],
+        encoded_fn: Callable[[type[np.number]], Dataset],
+        dtype: type[np.number],
     ) -> None:
         if dtype == np.float32 and isinstance(
             self, (TestZarrDirectoryStore, TestZarrDictStore)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -17,7 +17,7 @@ from collections.abc import Iterator
 from contextlib import ExitStack
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, cast
+from typing import TYPE_CHECKING, Any, Callable, Final, cast
 
 import numpy as np
 import pandas as pd
@@ -893,7 +893,7 @@ class CFEncodedBase(DatasetIOBase):
             (create_masked_and_scaled_data, create_encoded_masked_and_scaled_data),
         ],
     )
-    def test_roundtrip_mask_and_scale(self, decoded_fn, encoded_fn, dtype) -> None:
+    def test_roundtrip_mask_and_scale(self, decoded_fn: Callable, encoded_fn: Callable, dtype: type[np.number]) -> None:
         if dtype == np.float32 and isinstance(
             self, (TestZarrDirectoryStore, TestZarrDictStore)
         ):
@@ -1557,7 +1557,7 @@ class NetCDF4Base(NetCDFBase):
             assert_equal(ds, actual)
 
     @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-    def test_mask_and_scale(self, dtype) -> None:
+    def test_mask_and_scale(self, dtype: type[np.number]) -> None:
         with create_tmp_file() as tmp_file:
             with nc4.Dataset(tmp_file, mode="w") as nc:
                 nc.createDimension("t", 5)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -630,6 +630,9 @@ class DatasetIOBase:
         with self.roundtrip(original) as actual:
             assert_identical(original, actual)
             assert actual["x"].dtype == "bool"
+            with self.roundtrip(actual) as actual2:
+                assert_identical(original, actual2)
+                assert actual2["x"].dtype == "bool"
 
     def test_orthogonal_indexing(self) -> None:
         in_memory = create_test_data()

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -138,7 +138,7 @@ def open_example_mfdataset(names, *args, **kwargs) -> Dataset:
     )
 
 
-def create_masked_and_scaled_data(dtype: np.typing.DTypeLike = np.float32) -> Dataset:
+def create_masked_and_scaled_data(dtype: type[np.number] = np.float32) -> Dataset:
     x = np.array([np.nan, np.nan, 10, 10.1, 10.2], dtype=dtype)
     encoding = {
         "_FillValue": -1,
@@ -150,7 +150,7 @@ def create_masked_and_scaled_data(dtype: np.typing.DTypeLike = np.float32) -> Da
 
 
 def create_encoded_masked_and_scaled_data(
-    dtype: np.typing.DTypeLike = np.float32,
+    dtype: type[np.number] = np.float32,
 ) -> Dataset:
     attributes = {"_FillValue": -1, "add_offset": 10, "scale_factor": dtype(0.1)}
     return Dataset(
@@ -159,7 +159,7 @@ def create_encoded_masked_and_scaled_data(
 
 
 def create_unsigned_masked_scaled_data(
-    dtype: np.typing.DTypeLike = np.float32,
+    dtype: type[np.number] = np.float32,
 ) -> Dataset:
     encoding = {
         "_FillValue": 255,
@@ -173,7 +173,7 @@ def create_unsigned_masked_scaled_data(
 
 
 def create_encoded_unsigned_masked_scaled_data(
-    dtype: np.typing.DTypeLike = np.float32,
+    dtype: type[np.number] = np.float32,
 ) -> Dataset:
     # These are values as written to the file: the _FillValue will
     # be represented in the signed form.
@@ -189,7 +189,7 @@ def create_encoded_unsigned_masked_scaled_data(
 
 
 def create_bad_unsigned_masked_scaled_data(
-    dtype: np.typing.DTypeLike = np.float32,
+    dtype: type[np.number] = np.float32,
 ) -> Dataset:
     encoding = {
         "_FillValue": 255,
@@ -203,7 +203,7 @@ def create_bad_unsigned_masked_scaled_data(
 
 
 def create_bad_encoded_unsigned_masked_scaled_data(
-    dtype: np.typing.DTypeLike = np.float32,
+    dtype: type[np.number] = np.float32,
 ) -> Dataset:
     # These are values as written to the file: the _FillValue will
     # be represented in the signed form.
@@ -219,7 +219,7 @@ def create_bad_encoded_unsigned_masked_scaled_data(
 
 
 def create_signed_masked_scaled_data(
-    dtype: np.typing.DTypeLike = np.float32,
+    dtype: type[np.number] = np.float32,
 ) -> Dataset:
     encoding = {
         "_FillValue": -127,
@@ -233,7 +233,7 @@ def create_signed_masked_scaled_data(
 
 
 def create_encoded_signed_masked_scaled_data(
-    dtype: np.typing.DTypeLike = np.float32,
+    dtype: type[np.number] = np.float32,
 ) -> Dataset:
     # These are values as written to the file: the _FillValue will
     # be represented in the signed form.
@@ -903,7 +903,6 @@ class CFEncodedBase(DatasetIOBase):
 
         with self.roundtrip(decoded) as actual:
             for k in decoded.variables:
-                print(k, decoded.variables[k].dtype)
                 assert decoded.variables[k].dtype == actual.variables[k].dtype
             assert_allclose(decoded, actual, decode_bytes=False)
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -894,7 +894,7 @@ class CFEncodedBase(DatasetIOBase):
         ],
     )
     def test_roundtrip_mask_and_scale(
-        self, decoded_fn: Callable, encoded_fn: Callable, dtype: type[np.number]
+        self, decoded_fn: Callable[[type[np.number]], Dataset], encoded_fn: Callable[[type[np.number]], Dataset], dtype: type[np.number]
     ) -> None:
         if dtype == np.float32 and isinstance(
             self, (TestZarrDirectoryStore, TestZarrDictStore)
@@ -1589,7 +1589,7 @@ class NetCDF4Base(NetCDFBase):
     @pytest.mark.parametrize("dtype", [np.float32, np.float64])
     @pytest.mark.parametrize("offset_cf_conforming", [True, False])
     def test_mask_and_scale_non_cf_conforming(
-        self, dtype, offset_cf_conforming
+        self, dtype: type[np.number], offset_cf_conforming: bool
     ) -> None:
         with create_tmp_file() as tmp_file:
             with nc4.Dataset(tmp_file, mode="w") as nc:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -142,7 +142,7 @@ def create_masked_and_scaled_data(dtype: type[np.number] = np.float32) -> Datase
     x = np.array([np.nan, np.nan, 10, 10.1, 10.2], dtype=dtype)
     encoding = {
         "_FillValue": -1,
-        "add_offset": 10,
+        "add_offset": dtype(10),
         "scale_factor": dtype(0.1),
         "dtype": "i2",
     }
@@ -152,7 +152,7 @@ def create_masked_and_scaled_data(dtype: type[np.number] = np.float32) -> Datase
 def create_encoded_masked_and_scaled_data(
     dtype: type[np.number] = np.float32,
 ) -> Dataset:
-    attributes = {"_FillValue": -1, "add_offset": 10, "scale_factor": dtype(0.1)}
+    attributes = {"_FillValue": -1, "add_offset": dtype(10), "scale_factor": dtype(0.1)}
     return Dataset(
         {"x": ("t", np.array([-1, -1, 0, 1, 2], dtype=np.int16), attributes)}
     )
@@ -165,7 +165,7 @@ def create_unsigned_masked_scaled_data(
         "_FillValue": 255,
         "_Unsigned": "true",
         "dtype": "i1",
-        "add_offset": 10,
+        "add_offset": dtype(10),
         "scale_factor": dtype(0.1),
     }
     x = np.array([10.0, 10.1, 22.7, 22.8, np.nan], dtype=dtype)
@@ -180,7 +180,7 @@ def create_encoded_unsigned_masked_scaled_data(
     attributes = {
         "_FillValue": -1,
         "_Unsigned": "true",
-        "add_offset": 10,
+        "add_offset": dtype(10),
         "scale_factor": dtype(0.1),
     }
     # Create unsigned data corresponding to [0, 1, 127, 128, 255] unsigned
@@ -195,7 +195,7 @@ def create_bad_unsigned_masked_scaled_data(
         "_FillValue": 255,
         "_Unsigned": True,
         "dtype": "i1",
-        "add_offset": 10,
+        "add_offset": dtype(0),
         "scale_factor": dtype(0.1),
     }
     x = np.array([10.0, 10.1, 22.7, 22.8, np.nan], dtype=dtype)
@@ -210,7 +210,7 @@ def create_bad_encoded_unsigned_masked_scaled_data(
     attributes = {
         "_FillValue": -1,
         "_Unsigned": True,
-        "add_offset": 10,
+        "add_offset": dtype(10),
         "scale_factor": dtype(0.1),
     }
     # Create signed data corresponding to [0, 1, 127, 128, 255] unsigned
@@ -225,7 +225,7 @@ def create_signed_masked_scaled_data(
         "_FillValue": -127,
         "_Unsigned": "false",
         "dtype": "i1",
-        "add_offset": 10,
+        "add_offset": dtype(10),
         "scale_factor": dtype(0.1),
     }
     x = np.array([-1.0, 10.1, 22.7, np.nan], dtype=dtype)
@@ -240,7 +240,7 @@ def create_encoded_signed_masked_scaled_data(
     attributes = {
         "_FillValue": -127,
         "_Unsigned": "false",
-        "add_offset": 10,
+        "add_offset": dtype(10),
         "scale_factor": dtype(0.1),
     }
     # Create signed data corresponding to [0, 1, 127, 128, 255] unsigned
@@ -1564,7 +1564,7 @@ class NetCDF4Base(NetCDFBase):
                 nc.createVariable("x", "int16", ("t",), fill_value=-1)
                 v = nc.variables["x"]
                 v.set_auto_maskandscale(False)
-                v.add_offset = 10
+                v.add_offset = dtype(10)
                 v.scale_factor = dtype(0.1)
                 v[:] = np.array([-1, -1, 0, 1, 2])
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -893,7 +893,9 @@ class CFEncodedBase(DatasetIOBase):
             (create_masked_and_scaled_data, create_encoded_masked_and_scaled_data),
         ],
     )
-    def test_roundtrip_mask_and_scale(self, decoded_fn: Callable, encoded_fn: Callable, dtype: type[np.number]) -> None:
+    def test_roundtrip_mask_and_scale(
+        self, decoded_fn: Callable, encoded_fn: Callable, dtype: type[np.number]
+    ) -> None:
         if dtype == np.float32 and isinstance(
             self, (TestZarrDirectoryStore, TestZarrDictStore)
         ):

--- a/xarray/tests/test_coding.py
+++ b/xarray/tests/test_coding.py
@@ -97,7 +97,9 @@ def test_coder_roundtrip() -> None:
 
 @pytest.mark.parametrize("unpacked_dtype", [np.float32, np.float64, np.int32])
 @pytest.mark.parametrize("packed_dtype", "u1 u2 i1 i2 f2 f4".split())
-def test_scaling_converts_to_float32(packed_dtype: str, unpacked_dtype: type[np.number]) -> None:
+def test_scaling_converts_to_float32(
+    packed_dtype: str, unpacked_dtype: type[np.number]
+) -> None:
     # if scale_facor but no add_offset is given transform to float32 in any case
     # this minimizes memory usage, see #1840, #1842
     original = xr.Variable(

--- a/xarray/tests/test_coding.py
+++ b/xarray/tests/test_coding.py
@@ -99,7 +99,9 @@ def test_coder_roundtrip() -> None:
 @pytest.mark.parametrize("packed_dtype", "u1 u2 i1 i2 f2 f4".split())
 def test_scaling_converts_to_float32(packed_dtype, unpacked_dtype) -> None:
     original = xr.Variable(
-        ("x",), np.arange(10, dtype=packed_dtype), encoding=dict(scale_factor=unpacked_dtype(10))
+        ("x",),
+        np.arange(10, dtype=packed_dtype),
+        encoding=dict(scale_factor=unpacked_dtype(10)),
     )
     coder = variables.CFScaleOffsetCoder()
     encoded = coder.encode(original)

--- a/xarray/tests/test_coding.py
+++ b/xarray/tests/test_coding.py
@@ -97,7 +97,9 @@ def test_coder_roundtrip() -> None:
 
 @pytest.mark.parametrize("unpacked_dtype", [np.float32, np.float64, np.int32])
 @pytest.mark.parametrize("packed_dtype", "u1 u2 i1 i2 f2 f4".split())
-def test_scaling_converts_to_float32(packed_dtype, unpacked_dtype) -> None:
+def test_scaling_converts_to_float32(packed_dtype: str, unpacked_dtype: type[np.number]) -> None:
+    # if scale_facor but no add_offset is given transform to float32 in any case
+    # this minimizes memory usage, see #1840, #1842
     original = xr.Variable(
         ("x",),
         np.arange(10, dtype=packed_dtype),
@@ -115,6 +117,7 @@ def test_scaling_converts_to_float32(packed_dtype, unpacked_dtype) -> None:
 @pytest.mark.parametrize("add_offset", (0.1, [0.1]))
 def test_scaling_offset_as_list(scale_factor, add_offset) -> None:
     # test for #4631
+    # att: scale_factor and add_offset are not conforming to cf specs here
     encoding = dict(scale_factor=scale_factor, add_offset=add_offset)
     original = xr.Variable(("x",), np.arange(10.0), encoding=encoding)
     coder = variables.CFScaleOffsetCoder()

--- a/xarray/tests/test_coding.py
+++ b/xarray/tests/test_coding.py
@@ -100,7 +100,7 @@ def test_coder_roundtrip() -> None:
 def test_scaling_converts_to_float32(
     packed_dtype: str, unpacked_dtype: type[np.number]
 ) -> None:
-    # if scale_facor but no add_offset is given transform to float32 in any case
+    # if scale_factor but no add_offset is given transform to float32 in any case
     # this minimizes memory usage, see #1840, #1842
     original = xr.Variable(
         ("x",),
@@ -113,6 +113,26 @@ def test_scaling_converts_to_float32(
     roundtripped = coder.decode(encoded)
     assert_identical(original, roundtripped)
     assert roundtripped.dtype == np.float32
+
+
+@pytest.mark.parametrize("unpacked_dtype", [np.float32, np.float64, np.int32])
+@pytest.mark.parametrize("packed_dtype", "u1 u2 i1 i2 f2 f4".split())
+def test_scaling_converts_to_float64(
+    packed_dtype: str, unpacked_dtype: type[np.number]
+) -> None:
+    # if add_offset is given, but no scale_factor transform to float64 in any case
+    # to prevent precision issues
+    original = xr.Variable(
+        ("x",),
+        np.arange(10, dtype=packed_dtype),
+        encoding=dict(add_offset=unpacked_dtype(10)),
+    )
+    coder = variables.CFScaleOffsetCoder()
+    encoded = coder.encode(original)
+    assert encoded.dtype == np.float64
+    roundtripped = coder.decode(encoded)
+    assert_identical(original, roundtripped)
+    assert roundtripped.dtype == np.float64
 
 
 @pytest.mark.parametrize("scale_factor", (10, [10]))

--- a/xarray/tests/test_coding.py
+++ b/xarray/tests/test_coding.py
@@ -51,9 +51,15 @@ def test_CFMaskCoder_encode_missing_fill_values_conflict(data, encoding) -> None
     assert encoded.dtype == encoded.attrs["missing_value"].dtype
     assert encoded.dtype == encoded.attrs["_FillValue"].dtype
 
+
+def test_CFMaskCoder_multiple_missing_values_conflict():
+    data = np.array([0.0, -1.0, 1.0])
+    attrs = dict(_FillValue=np.float64(1e20), missing_value=np.float64(1e21))
+    original = xr.Variable(("x",), data, attrs=attrs)
     with pytest.warns(variables.SerializationWarning):
-        roundtripped = decode_cf_variable("foo", encoded)
-        assert_identical(roundtripped, original)
+        decoded = decode_cf_variable("foo", original)
+    with pytest.raises(ValueError):
+        encode_cf_variable(decoded)
 
 
 def test_CFMaskCoder_missing_value() -> None:

--- a/xarray/tests/test_coding.py
+++ b/xarray/tests/test_coding.py
@@ -95,10 +95,11 @@ def test_coder_roundtrip() -> None:
     assert_identical(original, roundtripped)
 
 
-@pytest.mark.parametrize("dtype", "u1 u2 i1 i2 f2 f4".split())
-def test_scaling_converts_to_float32(dtype) -> None:
+@pytest.mark.parametrize("unpacked_dtype", [np.float32, np.float64, np.int32])
+@pytest.mark.parametrize("packed_dtype", "u1 u2 i1 i2 f2 f4".split())
+def test_scaling_converts_to_float32(packed_dtype, unpacked_dtype) -> None:
     original = xr.Variable(
-        ("x",), np.arange(10, dtype=dtype), encoding=dict(scale_factor=10)
+        ("x",), np.arange(10, dtype=packed_dtype), encoding=dict(scale_factor=unpacked_dtype(10))
     )
     coder = variables.CFScaleOffsetCoder()
     encoded = coder.encode(original)

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -32,7 +32,7 @@ from xarray.tests.test_backends import CFEncodedBase
 class TestBoolTypeArray:
     def test_booltype_array(self) -> None:
         x = np.array([1, 0, 1, 1, 0], dtype="i1")
-        bx = conventions.BoolTypeArray(x)
+        bx = coding.variables.BoolTypeArray(x)
         assert bx.dtype == bool
         assert_array_equal(bx, np.array([True, False, True, True, False], dtype=bool))
 
@@ -41,7 +41,7 @@ class TestNativeEndiannessArray:
     def test(self) -> None:
         x = np.arange(5, dtype=">i8")
         expected = np.arange(5, dtype="int64")
-        a = conventions.NativeEndiannessArray(x)
+        a = coding.variables.NativeEndiannessArray(x)
         assert a.dtype == expected.dtype
         assert a.dtype == expected[:].dtype
         assert_array_equal(a, expected)
@@ -247,7 +247,7 @@ class TestDecodeCF:
     def test_0d_int32_encoding(self) -> None:
         original = Variable((), np.int32(0), encoding={"dtype": "int64"})
         expected = Variable((), np.int64(0))
-        actual = conventions.maybe_encode_nonstring_dtype(original)
+        actual = coding.variables.NonStringCoder().encode(original)
         assert_identical(expected, actual)
 
     def test_decode_cf_with_multiple_missing_values(self) -> None:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] xref #7652
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
- includes
    - implement coders
    - preserve boolean-dtype within encoding, adapt test
    - determine cf packed data type
    - ~transform numpy object-dtype strings (vlen) to numpy unicode strings~

This should also fix:

- Closes https://github.com/pydata/xarray/issues/7691
- Closes https://github.com/pydata/xarray/issues/2304
and possible other issues which have the float32/float64 issue