### PR TITLE
add timeouts for tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,7 @@ jobs:
 
       - name: Run tests
         run: python -m pytest -n 4
+          --timeout 300
           --cov=xarray
           --cov-report=xml
           --junitxml=pytest.xml

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -48,4 +48,3 @@ python -m pip install \
     git+https://github.com/SciTools/nc-time-axis \
     git+https://github.com/xarray-contrib/flox \
     git+https://github.com/h5netcdf/h5netcdf
-python -m pip install pytest-timeout

--- a/ci/requirements/environment-py311.yml
+++ b/ci/requirements/environment-py311.yml
@@ -39,6 +39,7 @@ dependencies:
   - pytest-cov
   - pytest-env
   - pytest-xdist
+  - pytest-timeout
   - rasterio
   - scipy
   - seaborn

--- a/ci/requirements/environment-windows-py311.yml
+++ b/ci/requirements/environment-windows-py311.yml
@@ -35,6 +35,7 @@ dependencies:
   - pytest-cov
   - pytest-env
   - pytest-xdist
+  - pytest-timeout
   - rasterio
   - scipy
   - seaborn

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -35,6 +35,7 @@ dependencies:
   - pytest-cov
   - pytest-env
   - pytest-xdist
+  - pytest-timeout
   - rasterio
   - scipy
   - seaborn

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -39,6 +39,7 @@ dependencies:
   - pytest-cov
   - pytest-env
   - pytest-xdist
+  - pytest-timeout
   - rasterio
   - scipy
   - seaborn


### PR DESCRIPTION
The `macos` 3.11 CI seems stall very often at the moment, which makes it hit the 6 hours mark and get cancelled. Since our tests should never run that long (the ubuntu runners usually take between 15-20 minutes), I'm introducing a pretty generous timeout of 5 minutes. By comparison, we already have a timeout of 60 seconds in the upstream-dev CI, but that's on a ubuntu runner which usually is much faster than any of the macos / windows runners.

Tests that time out raise an error, which might help us with figuring out which test it is that stalls, and also if we can do anything about that.