### PR TITLE
use the `files` interface instead of the deprecated `read_binary`

### DIFF
--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -4,7 +4,7 @@ import uuid
 from collections import OrderedDict
 from functools import lru_cache, partial
 from html import escape
-from importlib.resources import read_binary
+from importlib.resources import files
 
 from xarray.core.formatting import (
     inline_index_repr,
@@ -23,7 +23,7 @@ STATIC_FILES = (
 def _load_static_files():
     """Lazily load the resource files into memory the first time they are needed"""
     return [
-        read_binary(package, resource).decode("utf-8")
+        files(package).joinpath(resource).read_bytes().decode("utf-8")
         for package, resource in STATIC_FILES
     ]
 

--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -23,7 +23,7 @@ STATIC_FILES = (
 def _load_static_files():
     """Lazily load the resource files into memory the first time they are needed"""
     return [
-        files(package).joinpath(resource).read_bytes().decode("utf-8")
+        files(package).joinpath(resource).read_text(encoding="utf-8")
         for package, resource in STATIC_FILES
     ]
 


### PR DESCRIPTION
Apparently, `read_binary` has been marked as deprecated in `python=3.11`, and is to be replaced by `importlib.resources.files`, which has been available since `python=3.9`. Since we dropped support for `python=3.8` a while ago, we can safely follow the instructions in the deprecation warning.