### PR TITLE
Pull Request Labeler - Undo workaround sync-labels bug

### DIFF
--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -9,4 +9,4 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: true
+        sync-labels: false

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -9,4 +9,4 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: "False"
+        sync-labels: 'false'

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -9,4 +9,4 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: False
+        sync-labels: false

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -9,4 +9,4 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: false
+        sync-labels: "False"

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -9,4 +9,4 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: 'false'
+        sync-labels: false

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -9,6 +9,4 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        # Workaround for sync-labels bug:
-        # https://github.com/actions/labeler/issues/112
-        sync-labels: ""
+        sync-labels: False

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -9,4 +9,4 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: false
+        sync-labels: true


### PR DESCRIPTION
Seems https://github.com/actions/labeler/issues/112 is fixed. So using false should work.

 xref: #7431