### PR TITLE
Adjust sidebar font colors

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -172,11 +172,9 @@ https://github.com/bokeh/bokeh/blob/branch-2.4/sphinx/source/bokeh/static/custom
   display: block;
   padding: 0.25rem 1.5rem;
   font-size: 90%;
-  color: rgba(0, 0, 0, 0.65);
 }
 
 .bd-sidebar .nav > li > a:hover {
-  color: rgba(0, 0, 0, 0.85);
   text-decoration: none;
   background-color: transparent;
 }
@@ -184,7 +182,6 @@ https://github.com/bokeh/bokeh/blob/branch-2.4/sphinx/source/bokeh/static/custom
 .bd-sidebar .nav > .active > a,
 .bd-sidebar .nav > .active:hover > a {
   font-weight: 400;
-  color: #130654;
   /* adjusted from original
   color: rgba(0, 0, 0, 0.85);
   background-color: transparent; */
@@ -199,13 +196,11 @@ https://github.com/bokeh/bokeh/blob/branch-2.4/sphinx/source/bokeh/static/custom
   display: block;
   padding: 0.25rem 1.5rem;
   font-size: 90%;
-  color: rgba(0, 0, 0, 0.65);
 }
 
 .bd-sidebar .nav > li > ul > .active > a,
 .bd-sidebar .nav > li > ul > .active:hover > a {
   font-weight: 400;
-  color: #542437;
 }
 
 dt:target {


### PR DESCRIPTION
Closes #7661 
Removes the specified font colors for the sidebar in `/_static/style.css` to let the theme handle the dark mode styles.

The updated dark mode:
![darkmode](https://user-images.githubusercontent.com/51911758/227668285-5110ecf9-52c2-468c-8a9c-9744f17f97eb.png)
The light mode:
![lightmode](https://user-images.githubusercontent.com/51911758/227668353-b814560d-5a51-4556-9d01-711306378073.png)

I couldn't find the dark mode logo in the ` _static` folder so I only adjusted the font colors. If there is a copy, please let me know!