### PR TITLE
Passing extra keyword arguments to curvefit throws an exception issue…

### DIFF
--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4302,7 +4302,9 @@ class TestDataArray:
         assert_allclose(fit.curvefit_coefficients, expected, rtol=1e-3)
 
         da = da.compute()
-        fit = da.curvefit(coords="t", func=np.power, reduce_dims="x", kwargs={"param_names":"a"})
+        fit = da.curvefit(
+            coords="t", func=np.power, reduce_dims="x", kwargs={"param_names": "a"}
+        )
         assert "a" in fit.param
         assert "x" not in fit.dims
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4302,7 +4302,7 @@ class TestDataArray:
         assert_allclose(fit.curvefit_coefficients, expected, rtol=1e-3)
 
         da = da.compute()
-        fit = da.curvefit(coords="t", func=np.power, reduce_dims="x", param_names=["a"])
+        fit = da.curvefit(coords="t", func=np.power, reduce_dims="x", kwargs={"param_names":"a"})
         assert "a" in fit.param
         assert "x" not in fit.dims
 


### PR DESCRIPTION
… solved

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
