### PR TITLE
Use read1 instead of read.

### DIFF
--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -656,10 +656,10 @@ def read_magic_number_from_file(filename_or_obj, count=8) -> bytes:
     # check byte header to determine file type
     if isinstance(filename_or_obj, bytes):
         magic_number = filename_or_obj[:count]
-    elif isinstance(filename_or_obj, io.IOBase):
+    elif isinstance(filename_or_obj, io.BufferedIOBase):
         if filename_or_obj.tell() != 0:
             filename_or_obj.seek(0)
-        magic_number = filename_or_obj.read(count)
+        magic_number = filename_or_obj.read1(count)
         filename_or_obj.seek(0)
     else:
         raise TypeError(f"cannot read the magic number from {type(filename_or_obj)}")


### PR DESCRIPTION
Addresses #7697.

I changed the isinstance check because neither `read` nor `read1` are provided by IOBase. Only RawIOBase and BufferedIOBase provide `read` and `read1` respectively.

I think that there is little benefit to using `.tell()`. I suggest the following:
```python
filename_or_obj.seek(0)
magic_number = filename_or_obj.read1(count)
filename_or_obj.seek(0)
```
