### PR TITLE
preserve boolean dtype in encoding

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -54,7 +54,8 @@ Bug fixes
   (:issue:`7420`, :pull:`7441`).
   By `Justus Magin <https://github.com/keewis>`_ and
   `Spencer Clark  <https://github.com/spencerkclark>`_.
-
+- Preserve boolean dtype within encoding (:issue:`7652`, :pull:`7720`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -458,7 +458,9 @@ class BooleanCoder(VariableCoder):
     def decode(self, variable: Variable, name: T_Name = None) -> Variable:
         if variable.attrs.get("dtype", False) == "bool":
             dims, data, attrs, encoding = unpack_for_decoding(variable)
-            del attrs["dtype"]
+            # overwrite (!) dtype in encoding, and remove from attrs
+            # needed for correct subsequent encoding
+            encoding["dtype"] = attrs.pop("dtype")
             data = BoolTypeArray(data)
             return Variable(dims, data, attrs, encoding, fastpath=True)
         else:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -630,6 +630,8 @@ class DatasetIOBase:
         with self.roundtrip(original) as actual:
             assert_identical(original, actual)
             assert actual["x"].dtype == "bool"
+            # this checks for preserving dtype during second roundtrip
+            # see https://github.com/pydata/xarray/issues/7652#issuecomment-1476956975
             with self.roundtrip(actual) as actual2:
                 assert_identical(original, actual2)
                 assert actual2["x"].dtype == "bool"

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -630,6 +630,9 @@ class DatasetIOBase:
         with self.roundtrip(original) as actual:
             assert_identical(original, actual)
             assert actual["x"].dtype == "bool"
+            with self.roundtrip(actual) as actual2:
+                assert_identical(original, actual2)
+                assert actual2["x"].dtype == "bool"
 
     def test_orthogonal_indexing(self) -> None:
         in_memory = create_test_data()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #4826
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Split out of #7654. Follow up to #7719. Needs rebase after #7719 is merged.
