### PR TITLE
Test: new index from dask.array computes only once

### DIFF
--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1701,3 +1701,10 @@ def test_graph_manipulation():
     # names if we were to use HighLevelGraph.cull() instead of
     # HighLevelGraph.cull_layers() in Dataset.__dask_postpersist__().
     assert_equal(ds2.d1 + ds2.d2, ds.d1 + ds.d2)
+
+
+def test_new_index_var_computes_once():
+    # regression test for GH1533
+    data = dask.array.from_array(np.array([100, 200]))
+    with raise_if_dask_computes(max_computes=1):
+        Dataset(coords={"z": ("z", data)})


### PR DESCRIPTION
Closes #1533

Seems to have been fixed by the indexes refactor