### PR TITLE
`ds.to_dict` with data as arrays, not lists

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -83,8 +83,8 @@ New Features
 - Added ability to save ``DataArray`` objects directly to Zarr using :py:meth:`~xarray.DataArray.to_zarr`.
   (:issue:`7692`, :pull:`7693`) .
   By `Joe Hamman <https://github.com/jhamman>`_.
-- Added `numpy_data` keyword argument to both :py:meth:`xarray.Dataset.to_dict` and
-  :py:meth:`xarray.DataArray.to_dict` to return data as numpy objects instead of native Python objects.
+- Keyword argument `data='array'` to both :py:meth:`xarray.Dataset.to_dict` and
+  :py:meth:`xarray.DataArray.to_dict` will now return data as numpy.ndarrays. Python lists are returned for `data='list'` or `data=True`. Supplying `data=False` only returns the schema without data.
   (:issue:`1599`, :pull:`7739`) .
   By `James McCreight <https://github.com/jmccreight>`_.
 - Support `pandas>=2.0` (:pull:`7724`)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,6 +30,10 @@ New Features
 - Added ability to save ``DataArray`` objects directly to Zarr using :py:meth:`~xarray.DataArray.to_zarr`.
   (:issue:`7692`, :pull:`7693`) .
   By `Joe Hamman <https://github.com/jhamman>`_.
+- Added `numpy_data` keyword argument to both :py:meth:`xarray.Dataset.to_dict` and
+  :py:meth:`xarray.DataArray.to_dict` to return data as numpy objects instead of native Python objects.
+  (:issue:`1599`, :pull:`7739`) .
+  By `James McCreight <https://github.com/jmccreight>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -74,11 +74,9 @@ New Features
   (:issue:`7692`, :pull:`7693`) .
   By `Joe Hamman <https://github.com/jhamman>`_.
 - Keyword argument `data='array'` to both :py:meth:`xarray.Dataset.to_dict` and
-  :py:meth:`xarray.DataArray.to_dict` will now return data as numpy.ndarrays. Python lists are returned for `data='list'` or `data=True`. Supplying `data=False` only returns the schema without data.
+  :py:meth:`xarray.DataArray.to_dict` will now return data as the underlying array type. Python lists are returned for `data='list'` or `data=True`. Supplying `data=False` only returns the schema without data. ``encoding=True`` returns the encoding dictionary for the underlying variable also.
   (:issue:`1599`, :pull:`7739`) .
   By `James McCreight <https://github.com/jmccreight>`_.
-- Support `pandas>=2.0` (:pull:`7724`)
-  By `Justus Magin <https://github.com/keewis>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4193,8 +4193,7 @@ class DataArray(
         encoding : bool, default: False
             Whether to include the Dataset's encoding in the dictionary.
         numpy_data : bool, default: False
-           Whether to return data as numpy objects rather than native Python (
-           when returning data).
+           Whether to return data as numpy.ndarray rather than native Python.
 
         Returns
         -------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4175,7 +4175,7 @@ class DataArray(
         )
 
     def to_dict(
-        self, data: bool = True, encoding: bool = False, numpy_data: bool = False
+        self, data: bool | str = "list", encoding: bool = False
     ) -> dict[str, Any]:
         """
         Convert this xarray.DataArray into a dictionary following xarray
@@ -4187,13 +4187,13 @@ class DataArray(
 
         Parameters
         ----------
-        data : bool, default: True
+        data : bool | str, default: 'list'
             Whether to include the actual data in the dictionary. When set to
-            False, returns just the schema.
+            False, returns just the schema. If set to 'list' (or True for
+            backwards compatibility), returns a list of Python data types. If
+            set to 'array', returns a numpy.ndarray.
         encoding : bool, default: False
             Whether to include the Dataset's encoding in the dictionary.
-        numpy_data : bool, default: False
-           Whether to return data as numpy.ndarray rather than native Python.
 
         Returns
         -------
@@ -4204,10 +4204,10 @@ class DataArray(
         DataArray.from_dict
         Dataset.to_dict
         """
-        d = self.variable.to_dict(data=data, numpy_data=numpy_data)
+        d = self.variable.to_dict(data=data)
         d.update({"coords": {}, "name": self.name})
         for k, coord in self.coords.items():
-            d["coords"][k] = coord.variable.to_dict(data=data, numpy_data=numpy_data)
+            d["coords"][k] = coord.variable.to_dict(data=data)
         if encoding:
             d["encoding"] = dict(self.encoding)
         return d

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4174,7 +4174,9 @@ class DataArray(
             zarr_version=zarr_version,
         )
 
-    def to_dict(self, data: bool = True, encoding: bool = False) -> dict[str, Any]:
+    def to_dict(
+        self, data: bool = True, encoding: bool = False, numpy_data: bool = False
+    ) -> dict[str, Any]:
         """
         Convert this xarray.DataArray into a dictionary following xarray
         naming conventions.
@@ -4190,6 +4192,9 @@ class DataArray(
             False, returns just the schema.
         encoding : bool, default: False
             Whether to include the Dataset's encoding in the dictionary.
+        numpy_data : bool, default: False
+           Whether to return data as numpy objects rather than native Python (
+           when returning data).
 
         Returns
         -------
@@ -4200,10 +4205,10 @@ class DataArray(
         DataArray.from_dict
         Dataset.to_dict
         """
-        d = self.variable.to_dict(data=data)
+        d = self.variable.to_dict(data=data, numpy_data=numpy_data)
         d.update({"coords": {}, "name": self.name})
         for k, coord in self.coords.items():
-            d["coords"][k] = coord.variable.to_dict(data=data)
+            d["coords"][k] = coord.variable.to_dict(data=data, numpy_data=numpy_data)
         if encoding:
             d["encoding"] = dict(self.encoding)
         return d

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4189,9 +4189,12 @@ class DataArray(
         ----------
         data : bool or {"list", "array"}, default: "list"
             Whether to include the actual data in the dictionary. When set to
-            False, returns just the schema. If set to "list" (or True for
-            backwards compatibility), returns data in lists of Python data types.
-            If set to "array", returns data as in numpy.ndarrays.
+            False, returns just the schema. If set to "array", returns data as
+            underlying array type. If set to "list" (or True for backwards
+            compatibility), returns data in lists of Python data types. Note
+            that for obtaining the "list" output efficiently, use
+            `da.compute().to_dict(data="list")`.
+
         encoding : bool, default: False
             Whether to include the Dataset's encoding in the dictionary.
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4175,7 +4175,7 @@ class DataArray(
         )
 
     def to_dict(
-        self, data: bool | str = "list", encoding: bool = False
+        self, data: bool | Literal["list", "array"] = "list", encoding: bool = False
     ) -> dict[str, Any]:
         """
         Convert this xarray.DataArray into a dictionary following xarray
@@ -4187,11 +4187,11 @@ class DataArray(
 
         Parameters
         ----------
-        data : bool | str, default: 'list'
+        data : bool or {"list", "array"}, default: "list"
             Whether to include the actual data in the dictionary. When set to
-            False, returns just the schema. If set to 'list' (or True for
-            backwards compatibility), returns a list of Python data types. If
-            set to 'array', returns a numpy.ndarray.
+            False, returns just the schema. If set to "list" (or True for
+            backwards compatibility), returns data in lists of Python data types.
+            If set to "array", returns data as in numpy.ndarrays.
         encoding : bool, default: False
             Whether to include the Dataset's encoding in the dictionary.
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6441,7 +6441,9 @@ class Dataset(
 
         return df
 
-    def to_dict(self, data: bool = True, encoding: bool = False) -> dict[str, Any]:
+    def to_dict(
+        self, data: bool = True, encoding: bool = False, numpy_data: bool = False
+    ) -> dict[str, Any]:
         """
         Convert this dataset to a dictionary following xarray naming
         conventions.
@@ -6457,6 +6459,9 @@ class Dataset(
             False, returns just the schema.
         encoding : bool, default: False
             Whether to include the Dataset's encoding in the dictionary.
+        numpy_data : bool, default: False
+           Whether to return data as numpy objects rather than native Python (
+           when returning data).
 
         Returns
         -------
@@ -6477,11 +6482,19 @@ class Dataset(
         }
         for k in self.coords:
             d["coords"].update(
-                {k: self[k].variable.to_dict(data=data, encoding=encoding)}
+                {
+                    k: self[k].variable.to_dict(
+                        data=data, encoding=encoding, numpy_data=numpy_data
+                    )
+                }
             )
         for k in self.data_vars:
             d["data_vars"].update(
-                {k: self[k].variable.to_dict(data=data, encoding=encoding)}
+                {
+                    k: self[k].variable.to_dict(
+                        data=data, encoding=encoding, numpy_data=numpy_data
+                    )
+                }
             )
         if encoding:
             d["encoding"] = dict(self.encoding)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6456,9 +6456,12 @@ class Dataset(
         ----------
         data : bool or {"list", "array"}, default: "list"
             Whether to include the actual data in the dictionary. When set to
-            False, returns just the schema. If set to "list" (or True for
-            backwards compatibility), returns data in lists of Python data types.
-            If set to "array", returns data as underlying array type.
+            False, returns just the schema. If set to "array", returns data as
+            underlying array type. If set to "list" (or True for backwards
+            compatibility), returns data in lists of Python data types. Note
+            that for obtaining the "list" output efficiently, use
+            `ds.compute().to_dict(data="list")`.
+
         encoding : bool, default: False
             Whether to include the Dataset's encoding in the dictionary.
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6442,7 +6442,7 @@ class Dataset(
         return df
 
     def to_dict(
-        self, data: bool = True, encoding: bool = False, numpy_data: bool = False
+        self, data: bool | str = "list", encoding: bool = False
     ) -> dict[str, Any]:
         """
         Convert this dataset to a dictionary following xarray naming
@@ -6454,13 +6454,14 @@ class Dataset(
 
         Parameters
         ----------
-        data : bool, default: True
+        data : bool | str, default: 'list'
             Whether to include the actual data in the dictionary. When set to
-            False, returns just the schema.
+            False, returns just the schema. If set to 'list' (or True for
+            backwards compatibility), returns a list of Python data types. If
+            set to 'array', returns a numpy.ndarray.
         encoding : bool, default: False
             Whether to include the Dataset's encoding in the dictionary.
-        numpy_data : bool, default: False
-           Whether to return data as numpy.ndarray rather than native Python.
+
         -------
         d : dict
             Dict with keys: "coords", "attrs", "dims", "data_vars" and optionally
@@ -6479,19 +6480,11 @@ class Dataset(
         }
         for k in self.coords:
             d["coords"].update(
-                {
-                    k: self[k].variable.to_dict(
-                        data=data, encoding=encoding, numpy_data=numpy_data
-                    )
-                }
+                {k: self[k].variable.to_dict(data=data, encoding=encoding)}
             )
         for k in self.data_vars:
             d["data_vars"].update(
-                {
-                    k: self[k].variable.to_dict(
-                        data=data, encoding=encoding, numpy_data=numpy_data
-                    )
-                }
+                {k: self[k].variable.to_dict(data=data, encoding=encoding)}
             )
         if encoding:
             d["encoding"] = dict(self.encoding)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6442,7 +6442,7 @@ class Dataset(
         return df
 
     def to_dict(
-        self, data: bool | str = "list", encoding: bool = False
+        self, data: bool | Literal["list", "array"] = "list", encoding: bool = False
     ) -> dict[str, Any]:
         """
         Convert this dataset to a dictionary following xarray naming
@@ -6454,11 +6454,11 @@ class Dataset(
 
         Parameters
         ----------
-        data : bool | str, default: 'list'
+        data : bool or {"list", "array"}, default: "list"
             Whether to include the actual data in the dictionary. When set to
-            False, returns just the schema. If set to 'list' (or True for
-            backwards compatibility), returns a list of Python data types. If
-            set to 'array', returns a numpy.ndarray.
+            False, returns just the schema. If set to "list" (or True for
+            backwards compatibility), returns data in lists of Python data types.
+            If set to "array", returns data as in numpy.ndarrays.
         encoding : bool, default: False
             Whether to include the Dataset's encoding in the dictionary.
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6458,10 +6458,11 @@ class Dataset(
             Whether to include the actual data in the dictionary. When set to
             False, returns just the schema. If set to "list" (or True for
             backwards compatibility), returns data in lists of Python data types.
-            If set to "array", returns data as in numpy.ndarrays.
+            If set to "array", returns data as underlying array type.
         encoding : bool, default: False
             Whether to include the Dataset's encoding in the dictionary.
 
+        Returns
         -------
         d : dict
             Dict with keys: "coords", "attrs", "dims", "data_vars" and optionally

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6460,10 +6460,7 @@ class Dataset(
         encoding : bool, default: False
             Whether to include the Dataset's encoding in the dictionary.
         numpy_data : bool, default: False
-           Whether to return data as numpy objects rather than native Python (
-           when returning data).
-
-        Returns
+           Whether to return data as numpy.ndarray rather than native Python.
         -------
         d : dict
             Dict with keys: "coords", "attrs", "dims", "data_vars" and optionally

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6573,7 +6573,8 @@ class Dataset(
             )
         try:
             variable_dict = {
-                k: (v["dims"], v["data"], v.get("attrs")) for k, v in variables
+                k: (v["dims"], v["data"], v.get("attrs"), v.get("encoding"))
+                for k, v in variables
             }
         except KeyError as e:
             raise ValueError(

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -635,7 +635,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
 
     def to_dict(
         self, data: bool = True, encoding: bool = False, numpy_data: bool = False
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Dictionary representation of variable."""
         item: dict[str, Any] = {
             "dims": self.dims,

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -642,7 +642,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
             "attrs": decode_numpy_dict_values(self.attrs),
         }
         if data:
-            item["data"] = ensure_us_time_resolution(self.values)
+            item["data"] = ensure_us_time_resolution(self.to_numpy())
             if not numpy_data:
                 item["data"] = item["data"].tolist()
         else:

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -634,16 +634,16 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         return self.to_index_variable().to_index()
 
     def to_dict(
-        self, data: bool = True, encoding: bool = False, numpy_data: bool = False
+        self, data: bool | str = "list", encoding: bool = False
     ) -> dict[str, Any]:
         """Dictionary representation of variable."""
         item: dict[str, Any] = {
             "dims": self.dims,
             "attrs": decode_numpy_dict_values(self.attrs),
         }
-        if data:
+        if data is not False:
             item["data"] = ensure_us_time_resolution(self.to_numpy())
-            if not numpy_data:
+            if data is True or data == "list":
                 item["data"] = item["data"].tolist()
         else:
             item.update({"dtype": str(self.dtype), "shape": self.shape})

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -643,8 +643,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         }
         if data is not False:
             if data is True or data == "list":
-                item["data"] = ensure_us_time_resolution(self.to_numpy())
-                item["data"] = item["data"].tolist()
+                item["data"] = ensure_us_time_resolution(self.to_numpy()).tolist()
             elif data == "array":
                 item["data"] = ensure_us_time_resolution(self.data)
             else:

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -637,7 +637,10 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         self, data: bool = True, encoding: bool = False, numpy_data: bool = False
     ) -> dict:
         """Dictionary representation of variable."""
-        item = {"dims": self.dims, "attrs": decode_numpy_dict_values(self.attrs)}
+        item: dict[str, Any] = {
+            "dims": self.dims,
+            "attrs": decode_numpy_dict_values(self.attrs),
+        }
         if data:
             item["data"] = ensure_us_time_resolution(self.values)
             if not numpy_data:

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -633,11 +633,15 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         """Convert this variable to a pandas.Index"""
         return self.to_index_variable().to_index()
 
-    def to_dict(self, data: bool = True, encoding: bool = False) -> dict:
+    def to_dict(
+        self, data: bool = True, encoding: bool = False, numpy_data: bool = False
+    ) -> dict:
         """Dictionary representation of variable."""
         item = {"dims": self.dims, "attrs": decode_numpy_dict_values(self.attrs)}
         if data:
-            item["data"] = ensure_us_time_resolution(self.values).tolist()
+            item["data"] = ensure_us_time_resolution(self.values)
+            if not numpy_data:
+                item["data"] = item["data"].tolist()
         else:
             item.update({"dtype": str(self.dtype), "shape": self.shape})
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -642,9 +642,15 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
             "attrs": decode_numpy_dict_values(self.attrs),
         }
         if data is not False:
-            item["data"] = ensure_us_time_resolution(self.to_numpy())
             if data is True or data == "list":
+                item["data"] = ensure_us_time_resolution(self.to_numpy())
                 item["data"] = item["data"].tolist()
+            elif data == "array":
+                item["data"] = ensure_us_time_resolution(self.data)
+            else:
+                msg = 'data argument must be bool, "list", or "array"'
+                raise ValueError(msg)
+
         else:
             item.update({"dtype": str(self.dtype), "shape": self.shape})
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -642,7 +642,7 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
             "attrs": decode_numpy_dict_values(self.attrs),
         }
         if data is not False:
-            if data is True or data == "list":
+            if data in [True, "list"]:
                 item["data"] = ensure_us_time_resolution(self.to_numpy()).tolist()
             elif data == "array":
                 item["data"] = ensure_us_time_resolution(self.data)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3359,7 +3359,7 @@ class TestDataArray:
         )
         array.encoding = encoding_data
 
-        return_data = array.values
+        return_data = array.to_numpy()
         coords_data = np.array(["a", "b"])
         if data == "list" or data is True:
             return_data = return_data.tolist()

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3347,7 +3347,7 @@ class TestDataArray:
 
     @pytest.mark.parametrize("numpy_data", [True, False])
     @pytest.mark.parametrize("encoding", [True, False])
-    def test_to_and_from_dict(self, encoding, numpy_data) -> None:
+    def test_to_and_from_dict(self, encoding: bool, numpy_data: bool) -> None:
         encoding_data = {"bar": "spam"}
         array = DataArray(
             np.random.randn(2, 3), {"x": ["a", "b"]}, ["x", "y"], name="foo"

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3345,32 +3345,32 @@ class TestDataArray:
         arr = DataArray(s)
         assert "'a'" in repr(arr)  # should not error
 
-    @pytest.mark.parametrize("numpy_data", [True, False])
+    @pytest.mark.parametrize("data", ["list", "array", True])
     @pytest.mark.parametrize("encoding", [True, False])
-    def test_to_and_from_dict(self, encoding: bool, numpy_data: bool) -> None:
+    def test_to_and_from_dict(self, encoding: bool, data: bool | str) -> None:
         encoding_data = {"bar": "spam"}
         array = DataArray(
             np.random.randn(2, 3), {"x": ["a", "b"]}, ["x", "y"], name="foo"
         )
         array.encoding = encoding_data
 
-        data = array.values
+        return_data = array.values
         coords_data = np.array(["a", "b"])
-        if not numpy_data:
-            data = data.tolist()
+        if data == "list" or data is True:
+            return_data = return_data.tolist()
             coords_data = coords_data.tolist()
 
         expected: dict[str, Any] = {
             "name": "foo",
             "dims": ("x", "y"),
-            "data": data,
+            "data": return_data,
             "attrs": {},
             "coords": {"x": {"dims": ("x",), "data": coords_data, "attrs": {}}},
         }
         if encoding:
             expected["encoding"] = encoding_data
 
-        actual = array.to_dict(encoding=encoding, numpy_data=numpy_data)
+        actual = array.to_dict(encoding=encoding, data=data)
 
         # check that they are identical
         np.testing.assert_equal(expected, actual)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -6,7 +6,7 @@ import warnings
 from collections.abc import Hashable
 from copy import deepcopy
 from textwrap import dedent
-from typing import Any, Final, cast
+from typing import Any, Final, Literal, cast
 
 import numpy as np
 import pandas as pd
@@ -3347,7 +3347,9 @@ class TestDataArray:
 
     @pytest.mark.parametrize("data", ["list", "array", True])
     @pytest.mark.parametrize("encoding", [True, False])
-    def test_to_and_from_dict(self, encoding: bool, data: bool | str) -> None:
+    def test_to_and_from_dict(
+        self, encoding: bool, data: bool | Literal["list", "array"]
+    ) -> None:
         encoding_data = {"bar": "spam"}
         array = DataArray(
             np.random.randn(2, 3), {"x": ["a", "b"]}, ["x", "y"], name="foo"

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3339,7 +3339,7 @@ class TestDataArray:
             data = data.tolist()
             coords_data = coords_data.tolist()
 
-        expected = {
+        expected: dict[str, Any] = {
             "name": "foo",
             "dims": ("x", "y"),
             "data": data,

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4597,8 +4597,8 @@ class TestDataset:
         assert roundtripped.equals(expected)
 
     @pytest.mark.parametrize("encoding", [True, False])
-    @pytest.mark.parametrize("numpy_data", [True, False])
-    def test_to_and_from_dict(self, encoding: bool, numpy_data: bool) -> None:
+    @pytest.mark.parametrize("data", [True, "list", "array"])
+    def test_to_and_from_dict(self, encoding: bool, data: bool | str) -> None:
         # <xarray.Dataset>
         # Dimensions:  (t: 10)
         # Coordinates:
@@ -4626,7 +4626,7 @@ class TestDataset:
             for vv in ["a", "b"]:
                 expected["data_vars"][vv]["encoding"] = {}
 
-        actual = ds.to_dict(numpy_data=numpy_data, encoding=encoding)
+        actual = ds.to_dict(data=data, encoding=encoding)
 
         # check that they are identical
         np.testing.assert_equal(expected, actual)
@@ -4653,13 +4653,11 @@ class TestDataset:
 
         # verify coords are included roundtrip
         expected_ds = ds.set_coords("b")
-        actual2 = Dataset.from_dict(
-            expected_ds.to_dict(numpy_data=numpy_data, encoding=encoding)
-        )
+        actual2 = Dataset.from_dict(expected_ds.to_dict(data=data, encoding=encoding))
 
         assert_identical(expected_ds, actual2)
         if encoding:
-            assert sorted(expected_ds.variables) == sorted(actual2.variables)
+            assert set(expected_ds.variables) == set(actual2.variables)
             for vv in ds.variables:
                 np.testing.assert_equal(expected_ds[vv].encoding, actual2[vv].encoding)
 
@@ -4709,8 +4707,8 @@ class TestDataset:
         roundtripped = Dataset.from_dict(ds.to_dict())
         assert_identical(ds, roundtripped)
 
-    @pytest.mark.parametrize("numpy_data", [True, False])
-    def test_to_and_from_dict_with_nan_nat(self, numpy_data: bool) -> None:
+    @pytest.mark.parametrize("data", [True, "list", "array"])
+    def test_to_and_from_dict_with_nan_nat(self, data: bool | str) -> None:
         x = np.random.randn(10, 3)
         y = np.random.randn(10, 3)
         y[2] = np.nan
@@ -4726,7 +4724,7 @@ class TestDataset:
                 "lat": ("lat", lat),
             }
         )
-        roundtripped = Dataset.from_dict(ds.to_dict(numpy_data=numpy_data))
+        roundtripped = Dataset.from_dict(ds.to_dict(data=data))
         assert_identical(ds, roundtripped)
 
     def test_to_dict_with_numpy_attrs(self) -> None:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -8,7 +8,7 @@ from collections.abc import Hashable
 from copy import copy, deepcopy
 from io import StringIO
 from textwrap import dedent
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -4598,7 +4598,9 @@ class TestDataset:
 
     @pytest.mark.parametrize("encoding", [True, False])
     @pytest.mark.parametrize("data", [True, "list", "array"])
-    def test_to_and_from_dict(self, encoding: bool, data: bool | str) -> None:
+    def test_to_and_from_dict(
+        self, encoding: bool, data: bool | Literal["list", "array"]
+    ) -> None:
         # <xarray.Dataset>
         # Dimensions:  (t: 10)
         # Coordinates:
@@ -4623,8 +4625,8 @@ class TestDataset:
             ds.t.encoding.update({"foo": "bar"})
             expected["encoding"] = {}
             expected["coords"]["t"]["encoding"] = ds.t.encoding
-            for vv in ["a", "b"]:
-                expected["data_vars"][vv]["encoding"] = {}
+            for vvs in ["a", "b"]:
+                expected["data_vars"][vvs]["encoding"] = {}
 
         actual = ds.to_dict(data=data, encoding=encoding)
 
@@ -4636,8 +4638,7 @@ class TestDataset:
         assert_identical(ds, ds_rt)
         if encoding:
             assert set(ds_rt.variables) == set(ds.variables)
-            for vvh in ds.variables:
-                vv = str(vvh)
+            for vv in ds.variables:
                 np.testing.assert_equal(ds_rt[vv].encoding, ds[vv].encoding)
 
         # check the data=False option
@@ -4659,8 +4660,7 @@ class TestDataset:
         assert_identical(expected_ds, actual2)
         if encoding:
             assert set(expected_ds.variables) == set(actual2.variables)
-            for vvh in ds.variables:
-                vv = str(vvh)
+            for vv in ds.variables:
                 np.testing.assert_equal(expected_ds[vv].encoding, actual2[vv].encoding)
 
         # test some incomplete dicts:
@@ -4710,7 +4710,9 @@ class TestDataset:
         assert_identical(ds, roundtripped)
 
     @pytest.mark.parametrize("data", [True, "list", "array"])
-    def test_to_and_from_dict_with_nan_nat(self, data: bool | str) -> None:
+    def test_to_and_from_dict_with_nan_nat(
+        self, data: bool | Literal["list", "array"]
+    ) -> None:
         x = np.random.randn(10, 3)
         y = np.random.randn(10, 3)
         y[2] = np.nan

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4636,7 +4636,8 @@ class TestDataset:
         assert_identical(ds, ds_rt)
         if encoding:
             assert set(ds_rt.variables) == set(ds.variables)
-            for vv in ds.variables:
+            for vvh in ds.variables:
+                vv = str(vvh)
                 np.testing.assert_equal(ds_rt[vv].encoding, ds[vv].encoding)
 
         # check the data=False option
@@ -4658,7 +4659,8 @@ class TestDataset:
         assert_identical(expected_ds, actual2)
         if encoding:
             assert set(expected_ds.variables) == set(actual2.variables)
-            for vv in ds.variables:
+            for vvh in ds.variables:
+                vv = str(vvh)
                 np.testing.assert_equal(expected_ds[vv].encoding, actual2[vv].encoding)
 
         # test some incomplete dicts:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4589,7 +4589,8 @@ class TestDataset:
         expected = df.apply(np.asarray)
         assert roundtripped.equals(expected)
 
-    def test_to_and_from_dict(self) -> None:
+    @pytest.mark.parametrize("numpy_data", [True, False])
+    def test_to_and_from_dict(self, numpy_data) -> None:
         # <xarray.Dataset>
         # Dimensions:  (t: 10)
         # Coordinates:
@@ -4611,10 +4612,10 @@ class TestDataset:
             },
         }
 
-        actual = ds.to_dict()
+        actual = ds.to_dict(numpy_data=numpy_data)
 
         # check that they are identical
-        assert expected == actual
+        np.testing.assert_equal(expected, actual)
 
         # check roundtrip
         assert_identical(ds, Dataset.from_dict(actual))
@@ -4633,7 +4634,7 @@ class TestDataset:
 
         # verify coords are included roundtrip
         expected_ds = ds.set_coords("b")
-        actual2 = Dataset.from_dict(expected_ds.to_dict())
+        actual2 = Dataset.from_dict(expected_ds.to_dict(numpy_data=numpy_data))
 
         assert_identical(expected_ds, actual2)
 
@@ -4683,7 +4684,8 @@ class TestDataset:
         roundtripped = Dataset.from_dict(ds.to_dict())
         assert_identical(ds, roundtripped)
 
-    def test_to_and_from_dict_with_nan_nat(self) -> None:
+    @pytest.mark.parametrize("numpy_data", [True, False])
+    def test_to_and_from_dict_with_nan_nat(self, numpy_data) -> None:
         x = np.random.randn(10, 3)
         y = np.random.randn(10, 3)
         y[2] = np.nan
@@ -4699,7 +4701,7 @@ class TestDataset:
                 "lat": ("lat", lat),
             }
         )
-        roundtripped = Dataset.from_dict(ds.to_dict())
+        roundtripped = Dataset.from_dict(ds.to_dict(numpy_data=numpy_data))
         assert_identical(ds, roundtripped)
 
     def test_to_dict_with_numpy_attrs(self) -> None:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4591,7 +4591,7 @@ class TestDataset:
 
     @pytest.mark.parametrize("encoding", [True, False])
     @pytest.mark.parametrize("numpy_data", [True, False])
-    def test_to_and_from_dict(self, encoding, numpy_data) -> None:
+    def test_to_and_from_dict(self, encoding: bool, numpy_data: bool) -> None:
         # <xarray.Dataset>
         # Dimensions:  (t: 10)
         # Coordinates:
@@ -4628,7 +4628,7 @@ class TestDataset:
         ds_rt = Dataset.from_dict(actual)
         assert_identical(ds, ds_rt)
         if encoding:
-            assert sorted(ds_rt.variables) == sorted(ds.variables)
+            assert set(ds_rt.variables) == set(ds.variables)
             for vv in ds.variables:
                 np.testing.assert_equal(ds_rt[vv].encoding, ds[vv].encoding)
 
@@ -4703,7 +4703,7 @@ class TestDataset:
         assert_identical(ds, roundtripped)
 
     @pytest.mark.parametrize("numpy_data", [True, False])
-    def test_to_and_from_dict_with_nan_nat(self, numpy_data) -> None:
+    def test_to_and_from_dict_with_nan_nat(self, numpy_data: bool) -> None:
         x = np.random.randn(10, 3)
         y = np.random.randn(10, 3)
         y[2] = np.nan


### PR DESCRIPTION
- [x] Closes #1599
- [X] Tests added
  - Added @pytest.mark.parametrize("numpy_data", [True, False]) to existing and edited existing
- [X] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [X] New functions/methods are listed in `api.rst`
  - Extended documentation for ds.to_dict and da.to_dict

