### PR TITLE
remove the `black` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,6 @@ repos:
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
-      - id: black
       - id: black-jupyter
   - repo: https://github.com/keewis/blackdoc
     rev: v0.3.8


### PR DESCRIPTION
Apparently, in addition to formatting notebooks, `black-jupyter` does exactly the same thing as `black`.