### PR TITLE
Use canonical name for set_horizonalalignment over alias set_ha

### DIFF
--- a/xarray/plot/dataarray_plot.py
+++ b/xarray/plot/dataarray_plot.py
@@ -530,7 +530,7 @@ def line(
     if np.issubdtype(xplt.dtype, np.datetime64):
         for xlabels in ax.get_xticklabels():
             xlabels.set_rotation(30)
-            xlabels.set_ha("right")
+            xlabels.set_horizontalalignment("right")
 
     _update_axes(ax, xincrease, yincrease, xscale, yscale, xticks, yticks, xlim, ylim)
 
@@ -1099,7 +1099,7 @@ def _add_labels(
             # https://stackoverflow.com/questions/17430105/autofmt-xdate-deletes-x-axis-labels-of-all-subplots
             for labels in getattr(ax, f"get_{axis}ticklabels")():
                 labels.set_rotation(30)
-                labels.set_ha("right")
+                labels.set_horizontalalignment("right")
 
 
 @overload
@@ -1639,7 +1639,7 @@ def _plot2d(plotfunc):
         if np.issubdtype(xplt.dtype, np.datetime64):
             for xlabels in ax.get_xticklabels():
                 xlabels.set_rotation(30)
-                xlabels.set_ha("right")
+                xlabels.set_horizontalalignment("right")
 
         return primitive
 


### PR DESCRIPTION
Matplotlib has recently introduced type hints on our main version (due to be released with mpl v3.8 in a couple months) xref matplotlib/matplotlib#24976

As part of this, the dynamically generated aliases of certain functions are not included in static type hints (since they are dynamic).
So, a type hinted codebase should prefer the canonical names so that they can be type checked.

I encourage maintainers over here to run type checking with our new type hints, as this is not the only thing flagged.
Much of the remaining flags have to do with interactions with 3D axes, which are currently not type hinted in mpl (along with the rest of mpl_toolkits, for that matter).

Feel free to ping me if you have any questions regarding mpl's type hints and interactions here.
Partly opening this as a "reach out early, so you don't get surprised by a release breaking CI" (and can hopefully sort it out before that a bit more incrementally).

