### PR TITLE
Start making unit testing more general

### DIFF
--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -80,8 +80,8 @@ class PintInfo(UnitInfo):
     incompatible_unit = unit_registry.s
     dimensionless = unit_registry.dimensionless
 
-    unit_type = pint.Unit
-    quantity_type = pint.Quantity
+    unit_type = unit_registry.Unit
+    quantity_type = unit_registry.Quantity
 
     @staticmethod
     def strip_units(quantity):

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -226,12 +226,8 @@ def extract_units(obj):
         vars_units = {None: array_extract_units(obj.data)}
         units = {**vars_units}
     else:
-        units = {}
-        for unit_lib in unit_libs:
-            if isinstance(obj, unit_lib.quantity_type):
-                vars_units = {None: array_extract_units(obj)}
-                units = {**vars_units}
-                break
+        vars_units = {None: array_extract_units(obj)}
+        units = {**vars_units}
 
     return units
 

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -122,6 +122,13 @@ unit_libs = [PintInfo]  # + [AstropyInfo]
 known_quantity_types = tuple(lib.quantity_type for lib in unit_libs)
 known_unit_types = tuple(lib.unit_type for lib in unit_libs)
 
+def get_unit_lib(obj):
+    for unit_lib in unit_libs:
+        if isinstance(obj, unit_lib.quantity_type):
+            return unit_lib
+
+    return None
+
 
 @pytest.fixture(params=unit_libs)
 def unit_lib(request):
@@ -167,19 +174,19 @@ def array_extract_units(obj):
     if isinstance(obj, (xr.Variable, xr.DataArray, xr.Dataset)):
         obj = obj.data
 
-    for unit_lib in unit_libs:
-        if isinstance(obj, unit_lib.quantity_type):
-            return unit_lib.get_unit(obj)
-
-    return None
+    lib = get_unit_lib(obj)
+    if lib is not None:
+        return lib.get_unit(obj)
+    else:
+        return None
 
 
 def array_strip_units(array):
-    for unit_lib in unit_libs:
-        if isinstance(array, unit_lib.quantity_type):
-            return unit_lib.strip_units(array)
-
-    return array
+    lib = get_unit_lib(array)
+    if lib is not None:
+        return lib.strip_units(array)
+    else:
+        return array
 
 
 def array_attach_units(data, unit):

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -75,13 +75,15 @@ pytestmark = [
 
 
 class PintInfo(UnitInfo):
-    unit = unit_registry.m
-    compatible_unit = unit_registry.mm
-    incompatible_unit = unit_registry.s
-    dimensionless = unit_registry.dimensionless
+    ureg = unit_registry
 
-    unit_type = unit_registry.Unit
-    quantity_type = unit_registry.Quantity
+    unit = ureg.m
+    compatible_unit = ureg.mm
+    incompatible_unit = ureg.s
+    dimensionless = ureg.dimensionless
+
+    unit_type = ureg.Unit
+    quantity_type = ureg.Quantity
 
     @staticmethod
     def strip_units(quantity):

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -122,6 +122,7 @@ unit_libs = [PintInfo]  # + [AstropyInfo]
 known_quantity_types = tuple(lib.quantity_type for lib in unit_libs)
 known_unit_types = tuple(lib.unit_type for lib in unit_libs)
 
+
 def get_unit_lib(obj):
     for unit_lib in unit_libs:
         if isinstance(obj, unit_lib.quantity_type):

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -93,7 +93,7 @@ class PintInfo(UnitInfo):
 
     @staticmethod
     def assert_equal(q1, q2):
-        assert (q1 == q2).all()
+        assert np.all(q1 == q2)
 
 
 """

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -682,9 +682,9 @@ def test_align_dataarray(value, variant, unit, error, dtype, unit_lib):
     actual_a, actual_b = func(data_array1, data_array2)
 
     assert_units_equal(expected_a, actual_a)
-    assert_allclose(expected_a, actual_a)
+    assert_allclose(expected_a, actual_a, atol=0)
     assert_units_equal(expected_b, actual_b)
-    assert_allclose(expected_b, actual_b)
+    assert_allclose(expected_b, actual_b, atol=0)
 
 
 @pytest.mark.parametrize(
@@ -786,9 +786,9 @@ def test_align_dataset(value, unit, variant, error, dtype):
     actual_a, actual_b = func(ds1, ds2)
 
     assert_units_equal(expected_a, actual_a)
-    assert_allclose(expected_a, actual_a)
+    assert_allclose(expected_a, actual_a, atol=0)
     assert_units_equal(expected_b, actual_b)
-    assert_allclose(expected_b, actual_b)
+    assert_allclose(expected_b, actual_b, atol=0)
 
 
 def test_broadcast_dataarray(dtype, unit_lib):
@@ -1270,7 +1270,7 @@ def test_merge_dataarray(variant, unit, error, dtype):
     actual = xr.merge([arr1, arr2, arr3])
 
     assert_units_equal(expected, actual)
-    assert_allclose(expected, actual)
+    assert_allclose(expected, actual, atol=0)
 
 
 @pytest.mark.parametrize(
@@ -1360,7 +1360,7 @@ def test_merge_dataset(variant, unit, error, dtype):
     actual = func([ds1, ds2, ds3])
 
     assert_units_equal(expected, actual)
-    assert_allclose(expected, actual)
+    assert_allclose(expected, actual, atol=0)
 
 
 @pytest.mark.parametrize(
@@ -1690,7 +1690,7 @@ class TestVariable:
         actual = func(variable)
 
         assert_units_equal(expected, actual)
-        assert_allclose(expected, actual)
+        assert_allclose(expected, actual, atol=0)
 
     def test_aggregate_complex(self):
         variable = xr.Variable("x", [1, 2j, np.nan] * unit_registry.m)
@@ -1698,7 +1698,7 @@ class TestVariable:
         actual = variable.mean()
 
         assert_units_equal(expected, actual)
-        assert_allclose(expected, actual)
+        assert_allclose(expected, actual, atol=0)
 
     @pytest.mark.parametrize(
         "func",
@@ -1756,7 +1756,7 @@ class TestVariable:
         actual = func(variable, *args, **kwargs)
 
         assert_units_equal(expected, actual)
-        assert_allclose(expected, actual)
+        assert_allclose(expected, actual, atol=0)
 
     @pytest.mark.parametrize(
         "func", (method("item", 5), method("searchsorted", 5)), ids=repr
@@ -2079,7 +2079,7 @@ class TestVariable:
         actual = func(variable, y)
 
         assert_units_equal(expected, actual)
-        assert_allclose(expected, actual)
+        assert_allclose(expected, actual, atol=0)
 
     @pytest.mark.parametrize(
         "unit,error",
@@ -2553,7 +2553,7 @@ class TestDataArray:
         actual = func(data_array)
 
         assert_units_equal(expected, actual)
-        assert_allclose(expected, actual)
+        assert_allclose(expected, actual, atol=0)
 
     @pytest.mark.parametrize(
         "func",
@@ -3636,7 +3636,7 @@ class TestDataArray:
         actual = func(data_array, x=new_x)
 
         assert_units_equal(expected, actual)
-        assert_allclose(expected, actual)
+        assert_allclose(expected, actual, atol=0)
 
     @pytest.mark.skip(reason="indexes don't support units")
     @pytest.mark.parametrize(
@@ -3712,7 +3712,7 @@ class TestDataArray:
         actual = func(data_array, other)
 
         assert_units_equal(expected, actual)
-        assert_allclose(expected, actual)
+        assert_allclose(expected, actual, atol=0)
 
     @pytest.mark.skip(reason="indexes don't support units")
     @pytest.mark.parametrize(
@@ -4017,7 +4017,7 @@ class TestDataArray:
         actual = func(data_array).mean()
 
         assert_units_equal(expected, actual)
-        assert_allclose(expected, actual)
+        assert_allclose(expected, actual, atol=0)
 
     def test_resample(self, dtype):
         array = np.linspace(0, 5, 10).astype(dtype) * unit_registry.m
@@ -4270,7 +4270,7 @@ class TestDataset:
         expected = attach_units(func(strip_units(ds)), units)
 
         assert_units_equal(expected, actual)
-        assert_allclose(expected, actual)
+        assert_allclose(expected, actual, atol=0)
 
     @pytest.mark.parametrize("property", ("imag", "real"))
     def test_numpy_properties(self, property, dtype):
@@ -5505,7 +5505,7 @@ class TestDataset:
         actual = func(ds).mean(*args, **kwargs)
 
         assert_units_equal(expected, actual)
-        assert_allclose(expected, actual)
+        assert_allclose(expected, actual, atol=0)
 
     @pytest.mark.parametrize(
         "variant",


### PR DESCRIPTION
As part of https://github.com/pydata/xarray/issues/525, I would like to start running the same tests already implemented for `pint` on other unit libraries - the one I'm specifically interested in is `astropy`.

This PR is a proof of concept to start making the tests in `test_units.py` more general, so it's easy to implement tests against other unit libraries. Important bits of this PR:

- The `UnitInfo` base class, which defines an interface against which additional unit libraries can be implemented.
- Concrete implementations of this for `pint` and `astropy` (the astropy one is commented out for now)
- Modifications that make `test_apply_ufunc_dataarray` run for both `astropy` and `pint`.
- A few new tests for helper functions, that I needed to fix issues with `astropy` testing

Would be greatful for feedback - is this worthwhile? If so, I can roll this approach out to more tests in `test_units.py` (there's certainly a lot of them!), either in this PR or a subsequent one.