### PR TITLE
Pin pint to 0.20

### DIFF
--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -26,7 +26,7 @@ dependencies:
   - numpy<1.24
   - packaging
   - pandas
-  - pint
+  - pint<0.21
   - pip
   - pseudonetcdf
   - pydap

--- a/ci/requirements/environment-py311.yml
+++ b/ci/requirements/environment-py311.yml
@@ -28,7 +28,7 @@ dependencies:
   - numpy
   - packaging
   - pandas
-  - pint
+  - pint<0.20
   - pip
   - pooch
   - pre-commit

--- a/ci/requirements/environment-py311.yml
+++ b/ci/requirements/environment-py311.yml
@@ -28,7 +28,7 @@ dependencies:
   - numpy
   - packaging
   - pandas
-  - pint<0.20
+  - pint<0.21
   - pip
   - pooch
   - pre-commit

--- a/ci/requirements/environment-windows-py311.yml
+++ b/ci/requirements/environment-windows-py311.yml
@@ -25,7 +25,7 @@ dependencies:
   - numpy
   - packaging
   - pandas
-  - pint<0.20
+  - pint<0.21
   - pip
   - pre-commit
   - pseudonetcdf

--- a/ci/requirements/environment-windows-py311.yml
+++ b/ci/requirements/environment-windows-py311.yml
@@ -25,7 +25,7 @@ dependencies:
   - numpy
   - packaging
   - pandas
-  - pint
+  - pint<0.20
   - pip
   - pre-commit
   - pseudonetcdf

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -25,7 +25,7 @@ dependencies:
   - numpy<1.24
   - packaging
   - pandas
-  - pint<0.20
+  - pint<0.21
   - pip
   - pre-commit
   - pseudonetcdf

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -25,7 +25,7 @@ dependencies:
   - numpy<1.24
   - packaging
   - pandas
-  - pint
+  - pint<0.20
   - pip
   - pre-commit
   - pseudonetcdf

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - numpy<1.24
   - packaging
   - pandas
-  - pint<0.20
+  - pint<0.21
   - pip
   - pooch
   - pre-commit

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -28,8 +28,8 @@ dependencies:
   - numpy<1.24
   - packaging
   - pandas
-  - pint
-  - pip#
+  - pint<0.20
+  - pip
   - pooch
   - pre-commit
   - pseudonetcdf

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - packaging
   - pandas
   - pint
-  - pip
+  - pip#
   - pooch
   - pre-commit
   - pseudonetcdf


### PR DESCRIPTION
Newest pint crashes our tests for some reason, pin it for now. 

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
