### PR TITLE
Implement multidimensional initial guess and bounds for `curvefit`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -23,6 +23,8 @@ v2023.05.1 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- Added support for multidimensional initial guess and bounds in :py:meth:`DataArray.curvefit` (:issue:`7768`, :pull:`7821`).
+  By `András Gunyhó <https://github.com/mgunyho>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -6166,10 +6166,12 @@ class DataArray(
             broadcast to the coordinates of the array. If none or only some parameters are
             passed, the rest will be assigned initial values following the default scipy
             behavior.
-        bounds : dict-like or None, optional
-            Optional dictionary of parameter names to bounding values passed to the
-            `curve_fit` `bounds` arg. If none or only some parameters are passed, the rest
-            will be unbounded following the default scipy behavior.
+        bounds : dict-like, optional
+            Optional dictionary of parameter names to tuples of bounding values passed to the
+            `curve_fit` `bounds` arg. If any of the bounds are DataArrays, they will be
+            appropriately broadcast to the coordinates of the array. If none or only some
+            parameters are passed, the rest will be unbounded following the default scipy
+            behavior.
         param_names : sequence of Hashable or None, optional
             Sequence of names for the fittable parameters of `func`. If not supplied,
             this will be automatically determined by arguments of `func`. `param_names`

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -6130,8 +6130,8 @@ class DataArray(
         func: Callable[..., Any],
         reduce_dims: Dims = None,
         skipna: bool = True,
-        p0: dict[str, Any] | None = None,
-        bounds: dict[str, Any] | None = None,
+        p0: dict[str, float | DataArray] | None = None,
+        bounds: dict[str, tuple[float | DataArray, float | DataArray]] | None = None,
         param_names: Sequence[str] | None = None,
         kwargs: dict[str, Any] | None = None,
     ) -> Dataset:

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -6240,7 +6240,7 @@ class DataArray(
           * x        (x) int64 0 1 2
             param    <U13 'amplitude'
 
-        An initial guess can also be given with the `p0` arg (although it does not make much
+        An initial guess can also be given with the ``p0`` arg (although it does not make much
         of a difference in this simple example). To have a different guess for different
         coordinate points, the guess can be a DataArray. Here we use the same initial guess
         for the amplitude but different guesses for the time constant:

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -6161,8 +6161,10 @@ class DataArray(
             Whether to skip missing values when fitting. Default is True.
         p0 : dict-like or None, optional
             Optional dictionary of parameter names to initial guesses passed to the
-            `curve_fit` `p0` arg. If none or only some parameters are passed, the rest will
-            be assigned initial values following the default scipy behavior.
+            `curve_fit` `p0` arg. If the values are DataArrays, they will be appropriately
+            broadcast to the coordinates of the array. If none or only some parameters are
+            passed, the rest will be assigned initial values following the default scipy
+            behavior.
         bounds : dict-like or None, optional
             Optional dictionary of parameter names to bounding values passed to the
             `curve_fit` `bounds` arg. If none or only some parameters are passed, the rest

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -5475,6 +5475,7 @@ class DataArray(
         numpy.polyfit
         numpy.polyval
         xarray.polyval
+        DataArray.curvefit
         """
         return self._to_temp_dataset().polyfit(
             dim, deg, skipna=skipna, rcond=rcond, w=w, full=full, cov=cov

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -6229,7 +6229,7 @@ class DataArray(
         >>> fit_result = da.curvefit("time", exp_decay)
         >>> fit_result["curvefit_coefficients"].sel(param="time_constant")
         <xarray.DataArray 'curvefit_coefficients' (x: 3)>
-        array([1.05692036, 1.73549638, 2.94215771])
+        array([1.05692036, 1.73549639, 2.94215771])
         Coordinates:
           * x        (x) int64 0 1 2
             param    <U13 'time_constant'

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8717,6 +8717,17 @@ class Dataset(
                 "in fitting on scalar data."
             )
 
+        # Check that initial guess only contains coordinates that are in preserved_dims
+        for param, guess in p0.items():
+            if isinstance(guess, DataArray):
+                unexpected = list(set(guess.dims) - set(preserved_dims))
+                if unexpected:
+                    raise ValueError(
+                        f"Initial guess for '{param}' has unexpected dimensions "
+                        f"{unexpected}. It should only have dimensions that are in data "
+                        f"dimensions {preserved_dims}."
+                    )
+
         # Broadcast all coords with each other
         coords_ = broadcast(*coords_)
         coords_ = [

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8728,7 +8728,7 @@ class Dataset(
                 "in fitting on scalar data."
             )
 
-        # Check that initial guess only contains coordinates that are in preserved_dims
+        # Check that initial guess and bounds only contain coordinates that are in preserved_dims
         for param, guess in p0.items():
             if isinstance(guess, DataArray):
                 unexpected = list(set(guess.dims) - set(preserved_dims))
@@ -8738,6 +8738,16 @@ class Dataset(
                         f"{unexpected}. It should only have dimensions that are in data "
                         f"dimensions {preserved_dims}."
                     )
+        for param, (lb, ub) in bounds.items():
+            for label, bound in zip(["Lower", "Upper"], [lb, ub]):
+                if isinstance(bound, DataArray):
+                    unexpected = list(set(bound.dims) - set(preserved_dims))
+                    if unexpected:
+                        raise ValueError(
+                            f"{label} bound for '{param}' has unexpected dimensions "
+                            f"{unexpected}. It should only have dimensions that are in data "
+                            f"dimensions {preserved_dims}."
+                        )
 
         # Broadcast all coords with each other
         coords_ = broadcast(*coords_)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8622,8 +8622,8 @@ class Dataset(
         func: Callable[..., Any],
         reduce_dims: Dims = None,
         skipna: bool = True,
-        p0: dict[str, Any] | None = None,
-        bounds: dict[str, Any] | None = None,
+        p0: dict[str, float | DataArray] | None = None,
+        bounds: dict[str, tuple[float | DataArray, float | DataArray]] | None = None,
         param_names: Sequence[str] | None = None,
         kwargs: dict[str, Any] | None = None,
     ) -> T_Dataset:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8643,8 +8643,10 @@ class Dataset(
             Whether to skip missing values when fitting. Default is True.
         p0 : dict-like, optional
             Optional dictionary of parameter names to initial guesses passed to the
-            `curve_fit` `p0` arg. If none or only some parameters are passed, the rest will
-            be assigned initial values following the default scipy behavior.
+            `curve_fit` `p0` arg. If the values are DataArrays, they will be appropriately
+            broadcast to the coordinates of the array. If none or only some parameters are
+            passed, the rest will be assigned initial values following the default scipy
+            behavior.
         bounds : dict-like, optional
             Optional dictionary of parameter names to bounding values passed to the
             `curve_fit` `bounds` arg. If none or only some parameters are passed, the rest

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -367,13 +367,18 @@ def _initialize_curvefit_params(params, p0, bounds, func_args):
         # Mimics functionality of scipy.optimize.minpack._initialize_feasible
         lb_finite = np.isfinite(lb)
         ub_finite = np.isfinite(ub)
-        p0 = np.nansum(
-            [
-                0.5 * (lb + ub) * (lb_finite & ub_finite),
-                (lb + 1) * (lb_finite & ~ub_finite),
-                (ub - 1) * (~lb_finite & ub_finite),
-            ],
-            axis=0,
+        p0 = where(
+            lb_finite,
+            where(
+                ub_finite,
+                0.5 * (lb + ub),  # both bounds finite
+                lb + 1,  # lower bound finite, upper infinite
+            ),
+            where(
+                ub_finite,
+                ub - 1,  # lower bound infinite, upper finite
+                0,  # both bounds infinite
+            ),
         )
         return p0
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8659,9 +8659,11 @@ class Dataset(
             passed, the rest will be assigned initial values following the default scipy
             behavior.
         bounds : dict-like, optional
-            Optional dictionary of parameter names to bounding values passed to the
-            `curve_fit` `bounds` arg. If none or only some parameters are passed, the rest
-            will be unbounded following the default scipy behavior.
+            Optional dictionary of parameter names to tuples of bounding values passed to the
+            `curve_fit` `bounds` arg. If any of the bounds are DataArrays, they will be
+            appropriately broadcast to the coordinates of the array. If none or only some
+            parameters are passed, the rest will be unbounded following the default scipy
+            behavior.
         param_names : sequence of hashable, optional
             Sequence of names for the fittable parameters of `func`. If not supplied,
             this will be automatically determined by arguments of `func`. `param_names`

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8733,21 +8733,21 @@ class Dataset(
         # Check that initial guess and bounds only contain coordinates that are in preserved_dims
         for param, guess in p0.items():
             if isinstance(guess, DataArray):
-                unexpected = list(set(guess.dims) - set(preserved_dims))
+                unexpected = set(guess.dims) - set(preserved_dims)
                 if unexpected:
                     raise ValueError(
                         f"Initial guess for '{param}' has unexpected dimensions "
-                        f"{unexpected}. It should only have dimensions that are in data "
+                        f"{tuple(unexpected)}. It should only have dimensions that are in data "
                         f"dimensions {preserved_dims}."
                     )
         for param, (lb, ub) in bounds.items():
-            for label, bound in zip(["Lower", "Upper"], [lb, ub]):
+            for label, bound in zip(("Lower", "Upper"), (lb, ub)):
                 if isinstance(bound, DataArray):
-                    unexpected = list(set(bound.dims) - set(preserved_dims))
+                    unexpected = set(bound.dims) - set(preserved_dims)
                     if unexpected:
                         raise ValueError(
                             f"{label} bound for '{param}' has unexpected dimensions "
-                            f"{unexpected}. It should only have dimensions that are in data "
+                            f"{tuple(unexpected)}. It should only have dimensions that are in data "
                             f"dimensions {preserved_dims}."
                         )
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4420,6 +4420,23 @@ class TestDataArray:
         assert param_defaults == {"n0": 4, "tau": 6}
         assert bounds_defaults == {"n0": (-np.inf, np.inf), "tau": (5, np.inf)}
 
+        # DataArray as bound
+        param_defaults, bounds_defaults = xr.core.dataset._initialize_curvefit_params(
+            params=params,
+            p0={"n0": 4},
+            bounds={"tau": [DataArray([3, 4], coords=[("x", [1, 2])]), np.inf]},
+            func_args=func_args,
+        )
+        assert param_defaults["n0"] == 4
+        assert (
+            param_defaults["tau"] == xr.DataArray([4, 5], coords=[("x", [1, 2])])
+        ).all()
+        assert bounds_defaults["n0"] == (-np.inf, np.inf)
+        assert (
+            bounds_defaults["tau"][0] == DataArray([3, 4], coords=[("x", [1, 2])])
+        ).all()
+        assert bounds_defaults["tau"][1] == np.inf
+
         param_names = ["a"]
         params, func_args = xr.core.dataset._get_func_args(np.power, param_names)
         assert params == param_names

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4543,6 +4543,18 @@ class TestDataArray:
         )
         assert_allclose(fit2.curvefit_coefficients, expected)
 
+        with pytest.raises(
+            ValueError,
+            match=r"Upper bound for 'a' has unexpected dimensions .* should only have "
+            "dimensions that are in data dimensions",
+        ):
+            # bounds with additional dimensions should be an error
+            da.curvefit(
+                coords=[da.t],
+                func=sine,
+                bounds={"a": (0, DataArray([1], coords={"foo": [1]}))},
+            )
+
 
 class TestReduce:
     @pytest.fixture(autouse=True)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4399,7 +4399,7 @@ class TestDataArray:
             da = da.chunk({"x": 1})
 
         fit = da.curvefit(
-            coords=[da.t], func=exp_decay, p0={"n0": 4}, bounds={"tau": [2, 6]}
+            coords=[da.t], func=exp_decay, p0={"n0": 4}, bounds={"tau": (2, 6)}
         )
         assert_allclose(fit.curvefit_coefficients, expected, rtol=1e-3)
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4464,6 +4464,18 @@ class TestDataArray:
         )
         assert_allclose(fit.curvefit_coefficients, expected)
 
+        with pytest.raises(
+            ValueError,
+            match=r"Initial guess for 'a' has unexpected dimensions .* should only have "
+            "dimensions that are in data dimensions",
+        ):
+            # initial guess with additional dimensions should be an error
+            da.curvefit(
+                coords=[da.t],
+                func=sine,
+                p0={"a": DataArray([1, 2], coords={"foo": [1, 2]})},
+            )
+
 
 class TestReduce:
     @pytest.fixture(autouse=True)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4445,7 +4445,7 @@ class TestDataArray:
 
     @requires_scipy
     @pytest.mark.parametrize("use_dask", [True, False])
-    def test_curvefit_multidimensional_guess(self, use_dask) -> None:
+    def test_curvefit_multidimensional_guess(self, use_dask: bool) -> None:
         if use_dask and not has_dask:
             pytest.skip("requires dask")
 
@@ -4495,7 +4495,7 @@ class TestDataArray:
 
     @requires_scipy
     @pytest.mark.parametrize("use_dask", [True, False])
-    def test_curvefit_multidimensional_bounds(self, use_dask) -> None:
+    def test_curvefit_multidimensional_bounds(self, use_dask: bool) -> None:
         if use_dask and not has_dask:
             pytest.skip("requires dask")
 


### PR DESCRIPTION
- [x] Closes #7768 
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

With this PR, it's possible to pass an initial guess to `curvefit` that is a DataArray, which will be broadcast to the data dimensions. This way, the initial guess can vary with the data coordinates.

I also added examples of using `curvefit` to the documentation, both a basic example and one with the multidimensional guess.

I have a couple of questions:
- Should we change the signature to `p0: dict[str, float | DataArray] | None`, instead of `dict[str, Any]` (and same for bounds)? scipy only optimizes over scalars, so I think it would be safe to assume that the values should either be those, or arrays that can be broadcast.
- The usage example of curvefit is only in the docstring for DataArray, so now the docs differ between DA and dataset. But the example uses a DataArray only, so this should be ok, right?