### PR TITLE
test: Fix test_write_read_select_write for Zarr V3

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2584,10 +2584,10 @@ class ZarrBase(CFEncodedBase):
             ds.to_zarr(initial_store, mode="w", **self.version_kwargs)
             ds1 = xr.open_zarr(initial_store, **self.version_kwargs)
 
-        # Combination of where+squeeze triggers error on write.
-        ds_sel = ds1.where(ds1.coords["dim3"] == "a", drop=True).squeeze("dim3")
-        with self.create_zarr_target() as final_store:
-            ds_sel.to_zarr(final_store, mode="w", **self.version_kwargs)
+            # Combination of where+squeeze triggers error on write.
+            ds_sel = ds1.where(ds1.coords["dim3"] == "a", drop=True).squeeze("dim3")
+            with self.create_zarr_target() as final_store:
+                ds_sel.to_zarr(final_store, mode="w", **self.version_kwargs)
 
     @pytest.mark.parametrize("obj", [Dataset(), DataArray(name="foo")])
     def test_attributes(self, obj) -> None:


### PR DESCRIPTION
Previously, the first context manager in this test was closed before accessing the data. This resulted in key errors when trying to access the opened dataset.

- [x] Fixes the Zarr V3 parts of https://github.com/pydata/xarray/issues/7707
