### PR TITLE
Use `numpy.can_cast` instead of casting and checking

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -44,6 +44,7 @@ Bug fixes
   By `Deepak Cherian <https://github.com/dcherian>`_.
 - Fix groupby sum, prod for all-NaN groups with ``flox``. (:issue:`7808`).
   By `Deepak Cherian <https://github.com/dcherian>`_.
+- Use `numpy.can_cast` to avoid a RuntimeWarning from numpy. (:pull:`7834`).
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -615,7 +615,7 @@ def _encode_datetime_with_cftime(dates, units: str, calendar: str) -> np.ndarray
 
 
 def cast_to_int_if_safe(num) -> np.ndarray:
-    if np.can_cast(num, to=np.int64, casting='safe'):
+    if np.can_cast(num, to=np.int64, casting="safe"):
         return np.asarray(num, dtype=np.int64)
     return num
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -615,9 +615,8 @@ def _encode_datetime_with_cftime(dates, units: str, calendar: str) -> np.ndarray
 
 
 def cast_to_int_if_safe(num) -> np.ndarray:
-    int_num = np.asarray(num, dtype=np.int64)
-    if (num == int_num).all():
-        num = int_num
+    if np.can_cast(num, to=np.int64, casting='safe'):
+        return np.asarray(num, dtype=np.int64)
     return num
 
 


### PR DESCRIPTION
In numpy >= 1.24 unsafe casting raises a RuntimeWarning for an operation that xarray does often to check if casting is safe. `numpy.can_cast` looks like an alternative approach designed for this exact case.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
