### PR TITLE
Fix words to make terminology consistent in docs

### DIFF
--- a/doc/getting-started-guide/quick-overview.rst
+++ b/doc/getting-started-guide/quick-overview.rst
@@ -78,7 +78,7 @@ While you're setting up your DataArray, it's often a good idea to set metadata a
     data.attrs["description"] = "A random variable created as an example."
     data.attrs["random_attribute"] = 123
     data.attrs
-    # you can add metadata to coordinates too
+    # you can add metadata to dimensions too
     data.x.attrs["units"] = "x units"
 
 


### PR DESCRIPTION
We have an example here of adding an attribute to a dimension, not a coordinate, and since these terms may be new to some people, we should not call it what its not. If it is possible to add attributes to a coordinate, the example should reflect that.

