### PR TITLE
Improve to_dask_dataframe performance

### DIFF
--- a/asv_bench/benchmarks/pandas.py
+++ b/asv_bench/benchmarks/pandas.py
@@ -35,15 +35,14 @@ class ToDataFrame:
 
         dim1 = 10_000
         dim2 = 10_000
+
+        var = xr.Variable(
+            dims=("dim1", "dim2"), data=xp.random.random((dim1, dim2), **random_kws)
+        )
+        data_vars = {f"long_name_{v}": (("dim1", "dim2"), var) for v in range(nvars)}
+
         ds = xr.Dataset(
-            {
-                f"x_{i}": xr.DataArray(
-                    data=xp.random.random((dim1, dim2), **random_kws),
-                    dims=["dim1", "dim2"],
-                    coords={"dim1": np.arange(0, dim1), "dim2": np.arange(0, dim2)},
-                )
-                for i in range(nvars)
-            }
+            data_vars, coords={"dim1": np.arange(0, dim1), "dim2": np.arange(0, dim2)}
         )
         self.to_frame = getattr(ds, method)
 

--- a/asv_bench/benchmarks/pandas.py
+++ b/asv_bench/benchmarks/pandas.py
@@ -29,6 +29,7 @@ class MultiIndexSeries:
 class ToDataFrame:
     def setup(self, *args, **kwargs):
         xp = kwargs.get("xp", np)
+        nvars = kwargs.get("nvars", 1)
         random_kws = kwargs.get("random_kws", {})
         method = kwargs.get("method", "to_dataframe")
 
@@ -36,11 +37,12 @@ class ToDataFrame:
         dim2 = 10_000
         ds = xr.Dataset(
             {
-                "x": xr.DataArray(
+                f"x_{i}": xr.DataArray(
                     data=xp.random.random((dim1, dim2), **random_kws),
                     dims=["dim1", "dim2"],
                     coords={"dim1": np.arange(0, dim1), "dim2": np.arange(0, dim2)},
                 )
+                for i in range(nvars)
             }
         )
         self.to_frame = getattr(ds, method)
@@ -58,4 +60,6 @@ class ToDataFrameDask(ToDataFrame):
 
         import dask.array as da
 
-        super().setup(xp=da, random_kws=dict(chunks=5000), method="to_dask_dataframe")
+        super().setup(
+            xp=da, random_kws=dict(chunks=5000), method="to_dask_dataframe", nvars=500
+        )

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6465,11 +6465,7 @@ class Dataset(
         columns.extend(k for k in self.coords if k not in self.dims)
         columns.extend(self.data_vars)
 
-        has_many_dims = len(ordered_dims) > 1
-        if has_many_dims:
-            ds_chunks = self.chunks
-        else:
-            ds_chunks = {}
+        ds_chunks = self.chunks
 
         series_list = []
         df_meta = pd.DataFrame()
@@ -6491,12 +6487,10 @@ class Dataset(
             if not is_duck_dask_array(var._data):
                 var = var.chunk()
 
-            if has_many_dims:
-                # Broadcast then flatten the array:
-                var_new_dims = var.set_dims(ordered_dims).chunk(ds_chunks)
-                dask_array = var_new_dims._data.reshape(-1)
-            else:
-                dask_array = var._data
+            # Broadcast then flatten the array:
+            var_new_dims = var.set_dims(ordered_dims).chunk(ds_chunks)
+            dask_array = var_new_dims._data.reshape(-1)
+
             series = dd.from_dask_array(dask_array, columns=name, meta=df_meta)
             series_list.append(series)
 


### PR DESCRIPTION
* ds.chunks loops all the variables, do it once.
* Faster to create a meta dataframe once than letting dask guess 2000 times.
 