### PR TITLE
Avoid explicit loop when updating OrderedSet

### DIFF
--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -536,8 +536,7 @@ class OrderedSet(MutableSet[T]):
     # Additional methods
 
     def update(self, values: Iterable[T]) -> None:
-        for v in values:
-            self._d[v] = None
+        self._d.update(dict.fromkeys(values))
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({list(self)!r})"


### PR DESCRIPTION
Following recommendation from: https://github.com/pydata/xarray/pull/7824#discussion_r1196114696

```python
# main:
a = tuple(f"dim_{i}" for i in range(500))
%timeit OrderedSet(a)
46 µs ± 2.26 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

# This PR:
a = tuple(f"dim_{i}" for i in range(500))
%timeit OrderedSet(a)
28.9 µs ± 476 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```
