### PR TITLE
add `numba` to the py3.11 environment

### DIFF
--- a/ci/requirements/environment-py311.yml
+++ b/ci/requirements/environment-py311.yml
@@ -7,7 +7,7 @@ dependencies:
   - boto3
   - bottleneck
   - cartopy
-  - cdms2
+  # - cdms2
   - cftime
   - dask-core
   - distributed

--- a/ci/requirements/environment-py311.yml
+++ b/ci/requirements/environment-py311.yml
@@ -7,7 +7,7 @@ dependencies:
   - boto3
   - bottleneck
   - cartopy
-  # - cdms2
+  - cdms2
   - cftime
   - dask-core
   - distributed

--- a/ci/requirements/environment-py311.yml
+++ b/ci/requirements/environment-py311.yml
@@ -22,8 +22,8 @@ dependencies:
   - matplotlib-base
   - nc-time-axis
   - netcdf4
-  # - numba
-  # - numbagg
+  - numba
+  - numbagg
   - numexpr
   - numpy
   - packaging
@@ -42,7 +42,7 @@ dependencies:
   - rasterio
   - scipy
   - seaborn
-  # - sparse
+  - sparse
   - toolz
   - typing_extensions
   - zarr


### PR DESCRIPTION
`numba=0.57.0` has been out for quite some time already and is available on `conda-forge` as-of last week, which means we can almost retire the separate `python=3.11` environment file.

I'm not sure what to do about `cdms2` (we will see if that fails in CI), but in any case we should just deprecate and remove any functions that use it: if I understand correctly, `cdms2` is in maintenance mode until the end of the year and will be discontinued afterwards.