### PR TITLE
Changed duck typing exception to: (ImportError, AttributeError)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -109,7 +109,7 @@ Internal Changes
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 
-..https://help.aei.mpg.de/ _whats-new.2023.04.2:
+.. _whats-new.2023.04.2:
 
 v2023.04.2 (April 20, 2023)
 ---------------------------

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -51,6 +51,7 @@ Internal Changes
   (:pull:`7847`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - Xarray now uploads nightly wheels to https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/.
   By `Martin Fleischmann <https://github.com/martinfleis>`_.
+- Added an exception catch for ``AttributeError`` along with ``ImportError`` when duck typing the dynamic imports in pycompat.py. This catches some name collisions between packages.
 
 .. _whats-new.2023.05.0:
 
@@ -108,7 +109,7 @@ Internal Changes
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 
-.. _whats-new.2023.04.2:
+..https://help.aei.mpg.de/ _whats-new.2023.04.2:
 
 v2023.04.2 (April 20, 2023)
 ---------------------------

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -51,7 +51,7 @@ Internal Changes
   (:pull:`7847`) By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - Xarray now uploads nightly wheels to https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/.
   By `Martin Fleischmann <https://github.com/martinfleis>`_.
-- Added an exception catch for ``AttributeError`` along with ``ImportError`` when duck typing the dynamic imports in pycompat.py. This catches some name collisions between packages.
+- Added an exception catch for ``AttributeError`` along with ``ImportError`` when duck typing the dynamic imports in pycompat.py. This catches some name collisions between packages. (:issue:`7870`, :pull:`7874`)
 
 .. _whats-new.2023.05.0:
 

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -50,7 +50,7 @@ class DuckArrayModule:
             else:
                 raise NotImplementedError
 
-        except ImportError:  # pragma: no cover
+        except (ImportError, AttributeError):  # pragma: no cover
             duck_array_module = None
             duck_array_version = Version("0.0.0")
             duck_array_type = ()


### PR DESCRIPTION
- [x] closes #7870

As described in issue #7870, there is a name-collision with the astrophysics package `pint-pulsar`, which is used to do high-precision pulsar timing. That other package would get imported as `pint`, and an `AttributeError` is thrown because that imported package is not the expected package.

By generalizing the duck typing exception to catch an `ImportError` and an `AttributeError`, we catch such name-collisions. It fits the idea and goal of duck typing.

This PR is a single-line change