### PR TITLE
defer to `numpy` for the expected result

### DIFF
--- a/xarray/tests/test_ufuncs.py
+++ b/xarray/tests/test_ufuncs.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import xarray as xr
-from xarray.tests import assert_array_equal, mock
+from xarray.tests import assert_allclose, assert_array_equal, mock
 from xarray.tests import assert_identical as assert_identical_
 
 
@@ -16,16 +16,16 @@ def assert_identical(a, b):
         assert_array_equal(a, b)
 
 
-def test_unary():
-    args = [
-        0,
-        np.zeros(2),
+@pytest.mark.parametrize(
+    "a",
+    [
         xr.Variable(["x"], [0, 0]),
         xr.DataArray([0, 0], dims="x"),
         xr.Dataset({"y": ("x", [0, 0])}),
-    ]
-    for a in args:
-        assert_identical(a + 1, np.cos(a))
+    ],
+)
+def test_unary(a):
+    assert_allclose(a + 1, np.cos(a))
 
 
 def test_binary():

--- a/xarray/tests/test_ufuncs.py
+++ b/xarray/tests/test_ufuncs.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import xarray as xr
-from xarray.tests import assert_allclose, assert_array_equal, mock
+from xarray.tests import assert_array_equal, mock
 from xarray.tests import assert_identical as assert_identical_
 
 
@@ -25,7 +25,12 @@ def assert_identical(a, b):
     ],
 )
 def test_unary(a):
-    assert_allclose(a + 1, np.cos(a))
+    fill_value = np.cos(0)
+
+    expected = xr.full_like(a, fill_value=fill_value, dtype=fill_value.dtype)
+    actual = np.cos(a)
+
+    assert_identical(actual, expected)
 
 
 def test_binary():

--- a/xarray/tests/test_ufuncs.py
+++ b/xarray/tests/test_ufuncs.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import xarray as xr
-from xarray.tests import assert_array_equal, mock
+from xarray.tests import assert_allclose, assert_array_equal, mock
 from xarray.tests import assert_identical as assert_identical_
 
 
@@ -25,12 +25,7 @@ def assert_identical(a, b):
     ],
 )
 def test_unary(a):
-    fill_value = np.cos(0)
-
-    expected = xr.full_like(a, fill_value=fill_value, dtype=fill_value.dtype)
-    actual = np.cos(a)
-
-    assert_identical(actual, expected)
+    assert_allclose(a + 1, np.cos(a))
 
 
 def test_binary():


### PR DESCRIPTION
`numpy` has recently changed the result of `np.cos(0)` by a very small value, which makes our tests break.

I'm not really sure what the best fix is, so I split the changes into two parts: the first commit uses
```python
xr.testing.assert_allclose(a + 1, np.cos(a))
```
to test the result, while the second commit uses
```python
expected = xr.full_like(a, fill_value=np.cos(0), dtype=float)
actual = np.cos(a)
xr.testing.assert_identical(actual, expected)
```

- [x] towards #7707