### PR TITLE
deprecate the `cdms2` conversion methods

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,6 +30,8 @@ Breaking changes
 
 Deprecations
 ~~~~~~~~~~~~
+- Deprecate the `cdms2 <https://github.com/CDAT/cdms>`_ conversion functions (:pull:`7876`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Performance
 ~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,7 +30,7 @@ Breaking changes
 
 Deprecations
 ~~~~~~~~~~~~
-- Deprecate the `cdms2 <https://github.com/CDAT/cdms>`_ conversion functions (:pull:`7876`)
+- Deprecate the `cdms2 <https://github.com/CDAT/cdms>`_ conversion methods (:pull:`7876`)
   By `Justus Magin <https://github.com/keewis>`_.
 
 Performance

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -42,6 +42,7 @@ from xarray.core.utils import (
     ReprObject,
     _default,
     either_dict_or_kwargs,
+    emit_user_level_warning,
 )
 from xarray.core.variable import (
     IndexVariable,
@@ -4334,12 +4335,24 @@ class DataArray(
         """Convert this array into a cdms2.Variable"""
         from xarray.convert import to_cdms2
 
+        emit_user_level_warning(
+            "The cdms2 library has been put into maintenance mode and will be"
+            " discontinued in the future. Please use the xcdat library instead.",
+            DeprecationWarning,
+        )
+
         return to_cdms2(self)
 
     @classmethod
     def from_cdms2(cls, variable: cdms2_Variable) -> DataArray:
         """Convert a cdms2.Variable into an xarray.DataArray"""
         from xarray.convert import from_cdms2
+
+        emit_user_level_warning(
+            "The cdms2 library has been put into maintenance mode and will be"
+            " discontinued in the future. Please use the xcdat library instead.",
+            DeprecationWarning,
+        )
 
         return from_cdms2(variable)
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4335,8 +4335,8 @@ class DataArray(
         """Convert this array into a cdms2.Variable
 
         .. deprecated:: 2023.06.0
-            The `cdms2`_ library has been put into maintenance mode. Please consider
-            using the `xcdat`_ library instead.
+            The `cdms2`_ library has been deprecated. Please consider using the
+            `xcdat`_ library instead.
 
         .. _cdms2: https://github.com/CDAT/cdms
         .. _xcdat: https://github.com/xCDAT/xcdat
@@ -4344,8 +4344,8 @@ class DataArray(
         from xarray.convert import to_cdms2
 
         emit_user_level_warning(
-            "The cdms2 library has been put into maintenance mode and will be"
-            " discontinued in the future. Please consider using the xcdat library instead.",
+            "The cdms2 library has been deprecated."
+            " Please consider using the xcdat library instead.",
             DeprecationWarning,
         )
 
@@ -4356,8 +4356,8 @@ class DataArray(
         """Convert a cdms2.Variable into an xarray.DataArray
 
         .. deprecated:: 2023.06.0
-            The `cdms2`_ library has been put into maintenance mode. Please consider
-            using the `xcdat`_ library instead.
+            The `cdms2`_ library has been deprecated. Please consider using the
+            `xcdat`_ library instead.
 
         .. _cdms2: https://github.com/CDAT/cdms
         .. _xcdat: https://github.com/xCDAT/xcdat
@@ -4365,8 +4365,8 @@ class DataArray(
         from xarray.convert import from_cdms2
 
         emit_user_level_warning(
-            "The cdms2 library has been put into maintenance mode and will be"
-            " discontinued in the future. Please consider using the xcdat library instead.",
+            "The cdms2 library has been deprecated."
+            " Please consider using the xcdat library instead.",
             DeprecationWarning,
         )
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4332,7 +4332,13 @@ class DataArray(
         return result
 
     def to_cdms2(self) -> cdms2_Variable:
-        """Convert this array into a cdms2.Variable"""
+        """Convert this array into a cdms2.Variable
+
+        .. deprecated:: 2023.06.0
+            The `cdms2`_ library has been put into maintenance mode.
+
+        .. _cdms2: https://github.com/CDAT/cdms
+        """
         from xarray.convert import to_cdms2
 
         emit_user_level_warning(
@@ -4345,7 +4351,13 @@ class DataArray(
 
     @classmethod
     def from_cdms2(cls, variable: cdms2_Variable) -> DataArray:
-        """Convert a cdms2.Variable into an xarray.DataArray"""
+        """Convert a cdms2.Variable into an xarray.DataArray
+
+        .. deprecated:: 2023.06.0
+            The `cdms2`_ library has been put into maintenance mode.
+
+        .. _cdms2: https://github.com/CDAT/cdms
+        """
         from xarray.convert import from_cdms2
 
         emit_user_level_warning(

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4335,15 +4335,17 @@ class DataArray(
         """Convert this array into a cdms2.Variable
 
         .. deprecated:: 2023.06.0
-            The `cdms2`_ library has been put into maintenance mode.
+            The `cdms2`_ library has been put into maintenance mode. Please consider
+            using the `xcdat`_ library instead.
 
         .. _cdms2: https://github.com/CDAT/cdms
+        .. _xcdat: https://github.com/xCDAT/xcdat
         """
         from xarray.convert import to_cdms2
 
         emit_user_level_warning(
             "The cdms2 library has been put into maintenance mode and will be"
-            " discontinued in the future. Please use the xcdat library instead.",
+            " discontinued in the future. Please consider using the xcdat library instead.",
             DeprecationWarning,
         )
 
@@ -4354,15 +4356,17 @@ class DataArray(
         """Convert a cdms2.Variable into an xarray.DataArray
 
         .. deprecated:: 2023.06.0
-            The `cdms2`_ library has been put into maintenance mode.
+            The `cdms2`_ library has been put into maintenance mode. Please consider
+            using the `xcdat`_ library instead.
 
         .. _cdms2: https://github.com/CDAT/cdms
+        .. _xcdat: https://github.com/xCDAT/xcdat
         """
         from xarray.convert import from_cdms2
 
         emit_user_level_warning(
             "The cdms2 library has been put into maintenance mode and will be"
-            " discontinued in the future. Please use the xcdat library instead.",
+            " discontinued in the future. Please consider using the xcdat library instead.",
             DeprecationWarning,
         )
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3549,7 +3549,7 @@ class TestDataArray:
         assert len(ma.mask) == N
 
     @pytest.mark.skipif(
-        Version(np.__version__) >= Version("1.25") or sys.version_info[:2] > (3, 10),
+        Version(np.__version__) > Version("1.24") or sys.version_info[:2] > (3, 10),
         reason="cdms2 is unmaintained and does not support newer `numpy` or python versions",
     )
     def test_to_and_from_cdms2_classic(self) -> None:
@@ -3594,7 +3594,7 @@ class TestDataArray:
             assert_array_equal(original.coords[coord_name], back.coords[coord_name])
 
     @pytest.mark.skipif(
-        Version(np.__version__) >= Version("1.25") or sys.version_info[:2] > (3, 10),
+        Version(np.__version__) > Version("1.24") or sys.version_info[:2] > (3, 10),
         reason="cdms2 is unmaintained and does not support newer `numpy` or python versions",
     )
     def test_to_and_from_cdms2_sgrid(self) -> None:
@@ -3628,7 +3628,7 @@ class TestDataArray:
         assert_array_equal(original.coords["lon"], back.coords["lon"])
 
     @pytest.mark.skipif(
-        Version(np.__version__) >= Version("1.25") or sys.version_info[:2] > (3, 10),
+        Version(np.__version__) > Version("1.24") or sys.version_info[:2] > (3, 10),
         reason="cdms2 is unmaintained and does not support newer `numpy` or python versions",
     )
     def test_to_and_from_cdms2_ugrid(self) -> None:

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3565,7 +3565,8 @@ class TestDataArray:
             IndexVariable("distance", [-2, 2]),
             IndexVariable("time", [0, 1, 2]),
         ]
-        actual = original.to_cdms2()
+        with pytest.deprecated_call():
+            actual = original.to_cdms2()
         assert_array_equal(actual.asma(), original)
         assert actual.id == original.name
         assert tuple(actual.getAxisIds()) == original.dims
@@ -3578,7 +3579,8 @@ class TestDataArray:
         assert len(component_times) == 3
         assert str(component_times[0]) == "2000-1-1 0:0:0.0"
 
-        roundtripped = DataArray.from_cdms2(actual)
+        with pytest.deprecated_call():
+            roundtripped = DataArray.from_cdms2(actual)
         assert_identical(original, roundtripped)
 
         back = from_cdms2(actual)
@@ -3605,7 +3607,8 @@ class TestDataArray:
             coords=dict(x=x, y=y, lon=lon, lat=lat),
             name="sst",
         )
-        actual = original.to_cdms2()
+        with pytest.deprecated_call():
+            actual = original.to_cdms2()
         assert tuple(actual.getAxisIds()) == original.dims
         assert_array_equal(original.coords["lon"], actual.getLongitude().asma())
         assert_array_equal(original.coords["lat"], actual.getLatitude().asma())
@@ -3626,7 +3629,8 @@ class TestDataArray:
         original = DataArray(
             np.arange(5), dims=["cell"], coords={"lon": lon, "lat": lat, "cell": cell}
         )
-        actual = original.to_cdms2()
+        with pytest.deprecated_call():
+            actual = original.to_cdms2()
         assert tuple(actual.getAxisIds()) == original.dims
         assert_array_equal(original.coords["lon"], actual.getLongitude().getValue())
         assert_array_equal(original.coords["lat"], actual.getLatitude().getValue())

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3565,7 +3565,7 @@ class TestDataArray:
             IndexVariable("distance", [-2, 2]),
             IndexVariable("time", [0, 1, 2]),
         ]
-        with pytest.deprecated_call():
+        with pytest.deprecated_call(match=".*cdms2"):
             actual = original.to_cdms2()
         assert_array_equal(actual.asma(), original)
         assert actual.id == original.name
@@ -3579,7 +3579,7 @@ class TestDataArray:
         assert len(component_times) == 3
         assert str(component_times[0]) == "2000-1-1 0:0:0.0"
 
-        with pytest.deprecated_call():
+        with pytest.deprecated_call(match=".*cdms2"):
             roundtripped = DataArray.from_cdms2(actual)
         assert_identical(original, roundtripped)
 
@@ -3629,7 +3629,7 @@ class TestDataArray:
         original = DataArray(
             np.arange(5), dims=["cell"], coords={"lon": lon, "lat": lat, "cell": cell}
         )
-        with pytest.deprecated_call():
+        with pytest.deprecated_call(match=".*cdms2"):
             actual = original.to_cdms2()
         assert tuple(actual.getAxisIds()) == original.dims
         assert_array_equal(original.coords["lon"], actual.getLongitude().getValue())

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3548,6 +3548,10 @@ class TestDataArray:
         ma = da.to_masked_array()
         assert len(ma.mask) == N
 
+    @pytest.mark.skipif(
+        Version(np.__version__) >= Version("1.25") or sys.version_info[:2] > (3, 10),
+        reason="cdms2 is unmaintained and does not support newer `numpy` or python versions",
+    )
     def test_to_and_from_cdms2_classic(self) -> None:
         """Classic with 1D axes"""
         pytest.importorskip("cdms2")
@@ -3589,6 +3593,10 @@ class TestDataArray:
         for coord_name in original.coords.keys():
             assert_array_equal(original.coords[coord_name], back.coords[coord_name])
 
+    @pytest.mark.skipif(
+        Version(np.__version__) >= Version("1.25") or sys.version_info[:2] > (3, 10),
+        reason="cdms2 is unmaintained and does not support newer `numpy` or python versions",
+    )
     def test_to_and_from_cdms2_sgrid(self) -> None:
         """Curvilinear (structured) grid
 
@@ -3619,6 +3627,10 @@ class TestDataArray:
         assert_array_equal(original.coords["lat"], back.coords["lat"])
         assert_array_equal(original.coords["lon"], back.coords["lon"])
 
+    @pytest.mark.skipif(
+        Version(np.__version__) >= Version("1.25") or sys.version_info[:2] > (3, 10),
+        reason="cdms2 is unmaintained and does not support newer `numpy` or python versions",
+    )
     def test_to_and_from_cdms2_ugrid(self) -> None:
         """Unstructured grid"""
         pytest.importorskip("cdms2")


### PR DESCRIPTION
As the `cdms2` library has been deprecated and will be retired at the end of this year, maintaining conversion functions does not make sense anymore. Additionally, one of the tests is currently failing on the upstream-dev CI (`cdms2` is incompatible with a recent change to `numpy`), and it seems unlikely this will ever be fixed (*and* there's no `python=3.11` release, blocking us from merging the `py311` environment with the default one).

cc @tomvothecoder for visibility

- [x] Closes #7707
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`