### PR TITLE
Avoid one call to len when getting ndim of Variables

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -396,6 +396,17 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         return self._data.shape
 
     @property
+    def ndim(self) -> int:
+        """
+        Number of array dimensions.
+
+        See Also
+        --------
+        numpy.ndarray.ndim
+        """
+        return self._data.ndim
+
+    @property
     def nbytes(self) -> int:
         """
         Total bytes consumed by the elements of the data array.

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -411,6 +411,10 @@ class TestDataset:
             def __repr__(self):
                 return "Custom\nArray"
 
+            @property
+            def ndim(self):
+                return len(self.shape)
+
         dataset = Dataset({"foo": ("x", Array())})
         expected = dedent(
             """\


### PR DESCRIPTION
I admit this is a super micro optimization but it avoids in certain cases the creation of a tuple, and a call to len on it.

I hit this as I was trying to understand why Variable indexing was so much slower than numpy indexing. It seems that bounds checking in python is just slower than in C.

Feel free to close this one if you don't want this kind of optimization.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
