### PR TITLE
Fix flaky doctest for curvefit

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -6258,9 +6258,11 @@ class DataArray(
         Fit the exponential decay function to the data along the ``time`` dimension:
 
         >>> fit_result = da.curvefit("time", exp_decay)
-        >>> fit_result["curvefit_coefficients"].sel(param="time_constant")
+        >>> fit_result["curvefit_coefficients"].sel(
+        ...     param="time_constant"
+        ... )  # doctest: +NUMBER
         <xarray.DataArray 'curvefit_coefficients' (x: 3)>
-        array([1.05692036, 1.73549639, 2.94215771])
+        array([1.0569203, 1.7354963, 2.9421577])
         Coordinates:
           * x        (x) int64 0 1 2
             param    <U13 'time_constant'


### PR DESCRIPTION
Fix flaky doctest introduced in #7821, see https://github.com/pydata/xarray/pull/7821#issuecomment-1537142237.

This uses the `NUMBER` option to compare the output with less decimal precision. It's not part of standard doctest but an extension from pytest: https://docs.pytest.org/en/7.1.x/how-to/doctest.html#using-doctest-options

Another option would be to use `...` and the built-in `+ELLIPSIS` option, but IMO the current version is less confusing for someone reading the example.