### PR TITLE
Add '.hdf' extension to 'netcdf4' backend

### DIFF
--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -560,7 +560,7 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
 
         if isinstance(filename_or_obj, (str, os.PathLike)):
             _, ext = os.path.splitext(filename_or_obj)
-            return ext in {".nc", ".nc4", ".cdf"}
+            return ext in {".nc", ".nc4", ".cdf", ".hdf"}
 
         return False
 


### PR DESCRIPTION
I'm helping @joleenf debug an issue where some old code that uses `xr.open_dataset` no longer works since the introduction of engines or at least as far as we can tell. The main issue is that she's using code that assumes the NetCDF4 C library was compiled with HDF4 support (ex. conda-forge builds with this functionality enabled). So in this case `netCDF4.Dataset("my_file.hdf")` can actually read the HDF4 file through the NetCDF4 C library.

However, with `xr.open_dataset("my_file.hdf")` will fail because xarray (or rather the netcdf4 engine) doesn't know that it could potentially read HDF4 files. This PR adds the `.hdf` extension to the 'netcdf4' engine to allow this to be automatic without needing `engine='netcdf4'` to be specified.

What do people think? I didn't want to put any more work into this until others weighed in.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
