### PR TITLE
Fix check for chunk_store in zarr backend

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -54,6 +54,8 @@ Bug fixes
   By `Tom White <https://github.com/tomwhite>`_ and `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - Ensure dtype of reindex result matches dtype of the original DataArray (:issue:`7299`, :pull:`7917`)
   By `Anderson Banihirwe <https://github.com/andersy005>`_.
+- Fix bug where empty zarr ``chunk_store``s were were ignored as if they were ``None`` (:pull:`7923`)
+  By `Juniper Tyree <https://github.com/juntyr>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -54,7 +54,7 @@ Bug fixes
   By `Tom White <https://github.com/tomwhite>`_ and `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - Ensure dtype of reindex result matches dtype of the original DataArray (:issue:`7299`, :pull:`7917`)
   By `Anderson Banihirwe <https://github.com/andersy005>`_.
-- Fix bug where empty zarr ``chunk_store``s were were ignored as if they were ``None`` (:pull:`7923`)
+- Fix bug where a zero-length zarr ``chunk_store`` was ignored as if it was ``None`` (:pull:`7923`)
   By `Juniper Tyree <https://github.com/juntyr>`_.
 
 Documentation

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -417,7 +417,7 @@ class ZarrStore(AbstractWritableDataStore):
             if consolidated is None:
                 consolidated = False
 
-        if chunk_store:
+        if chunk_store is not None:
             open_kwargs["chunk_store"] = chunk_store
             if consolidated is None:
                 consolidated = False

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1849,6 +1849,8 @@ class ZarrBase(CFEncodedBase):
         with self.create_zarr_target() as store_target, self.create_zarr_target() as chunk_store:
             save_kwargs = {"chunk_store": chunk_store}
             self.save(expected, store_target, **save_kwargs)
+            # the chunk store must have been populated with some entries
+            assert len(chunk_store) > 0
             open_kwargs = {"backend_kwargs": {"chunk_store": chunk_store}}
             with self.open(store_target, **open_kwargs) as ds:
                 assert_equal(ds, expected)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Zarr stores implement the `__len__` method and thus checking if a store is truthy returns if the store is non-empty, not if the `chunk_store` variable is still `None`. With this fix, empty stores can be passed as `chunk_store` to the `to_zarr(...)` method and will actually be used.

- [ ] Closes #xxxx
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
