### PR TITLE
Release summary for v2023.06.0

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -49,6 +49,10 @@ v2023.06.0 (June 21, 2023)
 
 This release adds features to ``curvefit``, improves the performance of concatenation, and fixes various bugs.
 
+Thank to our 12 contributors to this release:
+Anderson Banihirwe, Deepak Cherian, dependabot[bot], Illviljan, Justus Magin, Martin Fleischmann, Mattia Almansi,
+mgunyho, Rutger van Haasteren, Thomas Nicholas, Tom Nicholas, Tom White.
+
 
 New Features
 ~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,10 +15,40 @@ What's New
     np.random.seed(123456)
 
 
-.. _whats-new.2023.05.1:
+.. _whats-new.2023.06.1:
 
-v2023.05.1 (unreleased)
+v2023.06.0 (unreleased)
 -----------------------
+
+New Features
+~~~~~~~~~~~~
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+Deprecations
+~~~~~~~~~~~~
+
+Performance
+~~~~~~~~~~~
+
+Bug fixes
+~~~~~~~~~
+
+Documentation
+~~~~~~~~~~~~~
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+
+.. _whats-new.2023.06.0:
+
+v2023.06.0 (June 21, 2023)
+--------------------------
+
+This release adds features to ``curvefit``, improves the performance of concatenation, and fixes various bugs.
+
 
 New Features
 ~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,33 +15,6 @@ What's New
     np.random.seed(123456)
 
 
-.. _whats-new.2023.06.1:
-
-v2023.06.0 (unreleased)
------------------------
-
-New Features
-~~~~~~~~~~~~
-
-Breaking changes
-~~~~~~~~~~~~~~~~
-
-Deprecations
-~~~~~~~~~~~~
-
-Performance
-~~~~~~~~~~~
-
-Bug fixes
-~~~~~~~~~
-
-Documentation
-~~~~~~~~~~~~~
-
-Internal Changes
-~~~~~~~~~~~~~~~~
-
-
 .. _whats-new.2023.06.0:
 
 v2023.06.0 (June 21, 2023)


### PR DESCRIPTION
Release summary:

This release adds features to ``curvefit``, improves the performance of concatenation, and fixes various bugs.

---

For some reason when I try to use 
`git log "$(git tag --sort=v:refname | tail -1).." --format=%aN | sort -u | perl -pe 's/\n/$1, /'`
to return the list of all contributors since last release, it only returns Deepak :laughing: I'm not sure what's going wrong there - I definitely have all the git tags fetched, and other people have definitely contributed since the last version!


