### PR TITLE
Update minimum version of typing extensions in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
             types-pkg_resources,
             types-PyYAML,
             types-pytz,
-            typing-extensions==3.10.0.0,
+            typing-extensions>=4.1.0,
             numpy,
           ]
   - repo: https://github.com/citation-file-format/cff-converter-python


### PR DESCRIPTION
Attempt to fix the pre-commit build failure I keep seeing in the CI (e.g. [this failure](https://results.pre-commit.ci/run/github/13221727/1688407091.YvAQyUabR0mkXgYloCyiVQ) from https://github.com/pydata/xarray/pull/7881)
