### PR TITLE
Move absolute path finder from open_mfdataset to own function

### DIFF
--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -45,8 +45,8 @@ def _normalize_path(path):
     >>> directory = Path(xr.backends.common.__file__).parent
     >>> paths_path = Path(directory).joinpath("comm*n.py")
     >>> paths_str = xr.backends.common._normalize_path(paths_path)
-    >>> [isinstance(p, str) for p in (paths_str,)]
-    [True]
+    >>> [type(p) for p in (paths_str,)]
+    [str]
     """
     if isinstance(path, os.PathLike):
         path = os.fspath(path)

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -45,8 +45,8 @@ def _normalize_path(path):
     >>> directory = Path(xr.backends.common.__file__).parent
     >>> paths_path = Path(directory).joinpath("comm*n.py")
     >>> paths_str = xr.backends.common._normalize_path(paths_path)
-    >>> [type(p) for p in (paths_str,)]
-    [str]
+    >>> print([type(p) for p in (paths_str,)])
+    [<class 'str'>]
     """
     if isinstance(path, os.PathLike):
         path = os.fspath(path)

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -40,7 +40,6 @@ def _normalize_path(path):
 
     Examples
     --------
-    >>> import os
     >>> from pathlib import Path
 
     >>> directory = Path(xr.backends.common.__file__).parent

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -43,7 +43,7 @@ def _normalize_path(path):
     >>> import os
     >>> from pathlib import Path
 
-    >>> directory = os.getcwd()
+    >>> directory = Path(xr.backends.common.__file__).parent
     >>> paths_path = Path(directory).joinpath("comm*n.py")
     >>> paths_str = xr.backends.common._normalize_path(paths_path)
     >>> [isinstance(p, str) for p in (paths_str,)]
@@ -73,11 +73,10 @@ def _find_absolute_paths(
 
     Examples
     --------
-    >>> import os
     >>> from pathlib import Path
 
-    >>> directory = os.getcwd()
-    >>> paths = str(Path(directory).joinpath("comm*n.py"))
+    >>> directory = Path(xr.backends.common.__file__).parent
+    >>> paths = str(Path(directory).joinpath("comm*n.py"))  # Find common with wildcard
     >>> paths = xr.backends.common._find_absolute_paths(paths)
     >>> [Path(p).name for p in paths]
     ['common.py']

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -58,7 +58,7 @@ def _normalize_path(path):
 
 
 def _find_absolute_paths(
-    paths: str | NestedSequence[str | os.PathLike], **kwargs
+    paths: str | os.PathLike | NestedSequence[str | os.PathLike], **kwargs
 ) -> list[str]:
     """
     Find absolute paths from the pattern.

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -67,7 +67,7 @@ def _find_absolute_paths(
     ----------
     paths :
         Path(s) to file(s). Can include wildcards like * .
-    **kwargs : TYPE
+    **kwargs :
         Extra kwargs. Mainly for fsspec.
 
     Examples

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -5,6 +5,7 @@ import os
 import time
 import traceback
 from collections.abc import Iterable
+from glob import glob
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
@@ -19,6 +20,7 @@ if TYPE_CHECKING:
     from io import BufferedIOBase
 
     from xarray.core.dataset import Dataset
+    from xarray.core.types import NestedSequence
 
 # Create a logger object, but don't add any handlers. Leave that to user code.
 logger = logging.getLogger(__name__)
@@ -27,7 +29,26 @@ logger = logging.getLogger(__name__)
 NONE_VAR_NAME = "__values__"
 
 
-def _normalize_path(path):
+def _normalize_path(path: str | os.PathLike) -> str:
+    """
+    Normalize pathlikes to string.
+
+    Parameters
+    ----------
+    path :
+        Path to file.
+
+    Examples
+    --------
+    >>> import os
+    >>> from pathlib import Path
+
+    >>> directory = os.getcwd()
+    >>> paths_path = Path(f"{directory}\\comm*n.py")
+    >>> paths_str = xr.backends.common._normalize_path(paths_path)
+    >>> [isinstance(p, str) for p in (paths_str,)]
+    [True]
+    """
     if isinstance(path, os.PathLike):
         path = os.fspath(path)
 
@@ -35,6 +56,65 @@ def _normalize_path(path):
         path = os.path.abspath(os.path.expanduser(path))
 
     return path
+
+
+def _find_absolute_paths(
+    paths: str | NestedSequence[str | os.PathLike], **kwargs
+) -> list[str]:
+    """
+    Find absolute paths from the pattern.
+
+    Parameters
+    ----------
+    paths :
+        Path(s) to file(s). Can include wildcards like * .
+    **kwargs : TYPE
+        Extra kwargs. Mainly for fsspec.
+
+    Examples
+    --------
+    >>> import os
+    >>> from pathlib import Path
+
+    >>> directory = os.getcwd()
+    >>> paths = f"{directory}\\comm*n.py"
+    >>> paths = xr.backends.common._find_absolute_paths(paths)
+    >>> [Path(p).name for p in paths]
+    ['common.py']
+    """
+    if isinstance(paths, str):
+        if is_remote_uri(paths) and kwargs.get("engine", None) == "zarr":
+            try:
+                from fsspec.core import get_fs_token_paths
+            except ImportError as e:
+                raise ImportError(
+                    "The use of remote URLs for opening zarr requires the package fsspec"
+                ) from e
+
+            fs, _, _ = get_fs_token_paths(
+                paths,
+                mode="rb",
+                storage_options=kwargs.get("backend_kwargs", {}).get(
+                    "storage_options", {}
+                ),
+                expand=False,
+            )
+            tmp_paths = fs.glob(fs._strip_protocol(paths))  # finds directories
+            paths = [fs.get_mapper(path) for path in tmp_paths]
+        elif is_remote_uri(paths):
+            raise ValueError(
+                "cannot do wild-card matching for paths that are remote URLs "
+                f"unless engine='zarr' is specified. Got paths: {paths}. "
+                "Instead, supply paths as an explicit list of strings."
+            )
+        else:
+            paths = sorted(glob(_normalize_path(paths)))
+    elif isinstance(paths, os.PathLike):
+        paths = [os.fspath(paths)]
+    else:
+        paths = [os.fspath(p) if isinstance(p, os.PathLike) else p for p in paths]
+
+    return paths
 
 
 def _encode_variable_name(name):

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -44,7 +44,7 @@ def _normalize_path(path):
     >>> from pathlib import Path
 
     >>> directory = os.getcwd()
-    >>> paths_path = Path(f"{directory}\\comm*n.py")
+    >>> paths_path = Path(directory).joinpath("comm*n.py")
     >>> paths_str = xr.backends.common._normalize_path(paths_path)
     >>> [isinstance(p, str) for p in (paths_str,)]
     [True]
@@ -77,7 +77,7 @@ def _find_absolute_paths(
     >>> from pathlib import Path
 
     >>> directory = os.getcwd()
-    >>> paths = f"{directory}\\comm*n.py"
+    >>> paths = str(Path(directory).joinpath("comm*n.py"))
     >>> paths = xr.backends.common._find_absolute_paths(paths)
     >>> [Path(p).name for p in paths]
     ['common.py']

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 NONE_VAR_NAME = "__values__"
 
 
-def _normalize_path(path: str | os.PathLike) -> str:
+def _normalize_path(path):
     """
     Normalize pathlikes to string.
 


### PR DESCRIPTION
A simple refactor to make it easier to retrieve the proper paths that `open_mfdataset` uses and passes on the engine.

I've been thinking how to make use of DataTree and one idea I wanted to try was:
* Open file (using` _find_absolute_path`).
* Get all groups in the file.
* For each group run `xr.open_mfdataset(..., group=group)`