### PR TITLE
Fix typo in zarr.py

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -812,7 +812,7 @@ def open_zarr(
         possible, otherwise defaulting to 2.
     chunked_array_type: str, optional
         Which chunked array type to coerce this datasets' arrays to.
-        Defaults to 'dask' if installed, else whatever is registered via the `ChunkManagerEnetryPoint` system.
+        Defaults to 'dask' if installed, else whatever is registered via the `ChunkManagerEntryPoint` system.
         Experimental API that should not be relied upon.
     from_array_kwargs: dict, optional
         Additional keyword arguments passed on to the `ChunkManagerEntrypoint.from_array` method used to create


### PR DESCRIPTION
Fix typo in zarr.py documentation.
