### PR TITLE
Improve explanation in example "Working with Multidimensional Coordinates"

### DIFF
--- a/doc/examples/multidimensional-coords.ipynb
+++ b/doc/examples/multidimensional-coords.ipynb
@@ -56,7 +56,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example, the _logical coordinates_ are `x` and `y`, while the _physical coordinates_ are `xc` and `yc`, which represent the latitudes and longitude of the data."
+    "In this example, the _logical coordinates_ are `x` and `y`, while the _physical coordinates_ are `xc` and `yc`, which represent the longitude and latitude of the data."
    ]
   },
   {

--- a/doc/examples/multidimensional-coords.ipynb
+++ b/doc/examples/multidimensional-coords.ipynb
@@ -56,7 +56,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example, the _logical coordinates_ are `x` and `y`, while the _physical coordinates_ are `xc` and `yc`, which represent the longitude and latitude of the data."
+    "In this example, the _logical coordinates_ are `x` and `y`, while the _physical coordinates_ are `xc` and `yc`, which represent the longitudes and latitudes of the data."
    ]
   },
   {


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
This PR aims to clarify that `xc` represents the longitudes of the data and `yc` the latitudes in the example [Working with Multidimensional Coordinates](https://docs.xarray.dev/en/stable/examples/multidimensional-coords.html).
