### PR TITLE
Allow opening datasets with nD dimenson coordinate variables.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,6 +21,10 @@ v2023.07.1 (unreleased)
 
 New Features
 ~~~~~~~~~~~~
+- Allow creating Xarray objects where a multidimensional variable shares its name
+  with a dimension. Examples include output from finite volume models like FVCOM.
+  (:issue:`2233`, :pull:`7989`)
+  By `Deepak Cherian <https://github.com/dcherian>`_ and `Benoit Bovy <https://github.com/benbovy>`_.
 
 
 Breaking changes

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -1362,7 +1362,7 @@ def default_indexes(
     coord_names = set(coords)
 
     for name, var in coords.items():
-        if name in dims:
+        if name in dims and var.ndim == 1:
             index, index_vars = create_default_index_implicit(var, coords)
             if set(index_vars) <= coord_names:
                 indexes.update({k: index for k in index_vars})

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -161,12 +161,14 @@ def as_variable(obj, name=None) -> Variable | IndexVariable:
     if name is not None and name in obj.dims:
         # convert the Variable into an Index
         if obj.ndim != 1:
-            raise MissingDimensionsError(
+            warnings.warn(
                 f"{name!r} has more than 1-dimension and the same name as one of its "
-                f"dimensions {obj.dims!r}. xarray disallows such variables because they "
-                "conflict with the coordinates used to label dimensions."
+                f"dimensions {obj.dims!r}. Xarray will not automatically"
+                "create an Index object that would allow label-based selection.",
+                RuntimeWarning,
             )
-        obj = obj.to_index_variable()
+        else:
+            obj = obj.to_index_variable()
 
     return obj
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -158,17 +158,9 @@ def as_variable(obj, name=None) -> Variable | IndexVariable:
             f"explicit list of dimensions: {obj!r}"
         )
 
-    if name is not None and name in obj.dims:
-        # convert the Variable into an Index
-        if obj.ndim != 1:
-            warnings.warn(
-                f"{name!r} has more than 1-dimension and the same name as one of its "
-                f"dimensions {obj.dims!r}. Xarray will not automatically "
-                "create an Index object that would allow label-based selection.",
-                RuntimeWarning,
-            )
-        else:
-            obj = obj.to_index_variable()
+    if name is not None and name in obj.dims and obj.ndim == 1:
+        # automatically convert the Variable into an Index
+        obj = obj.to_index_variable()
 
     return obj
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -163,7 +163,7 @@ def as_variable(obj, name=None) -> Variable | IndexVariable:
         if obj.ndim != 1:
             warnings.warn(
                 f"{name!r} has more than 1-dimension and the same name as one of its "
-                f"dimensions {obj.dims!r}. Xarray will not automatically"
+                f"dimensions {obj.dims!r}. Xarray will not automatically "
                 "create an Index object that would allow label-based selection.",
                 RuntimeWarning,
             )

--- a/xarray/testing.py
+++ b/xarray/testing.py
@@ -364,14 +364,13 @@ def _assert_dataset_invariants(ds: Dataset, check_default_indexes: bool):
     assert all(
         ds._dims[k] == v.sizes[k] for v in ds._variables.values() for k in v.sizes
     ), (ds._dims, {k: v.sizes for k, v in ds._variables.items()})
-    assert all(
-        isinstance(v, IndexVariable)
-        for (k, v) in ds._variables.items()
-        if v.dims == (k,)
-    ), {k: type(v) for k, v in ds._variables.items() if v.dims == (k,)}
-    assert all(v.dims == (k,) for (k, v) in ds._variables.items() if k in ds._dims), {
-        k: v.dims for k, v in ds._variables.items() if k in ds._dims
-    }
+
+    if check_default_indexes:
+        assert all(
+            isinstance(v, IndexVariable)
+            for (k, v) in ds._variables.items()
+            if v.dims == (k,)
+        ), {k: type(v) for k, v in ds._variables.items() if v.dims == (k,)}
 
     if ds._indexes is not None:
         _assert_indexes_invariants_checks(

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -35,6 +35,7 @@ from xarray.core.coordinates import DatasetCoordinates
 from xarray.core.indexes import Index, PandasIndex
 from xarray.core.pycompat import array_type, integer_types
 from xarray.core.utils import is_scalar
+from xarray.testing import _assert_internal_invariants
 from xarray.tests import (
     DuckArrayWrapper,
     InaccessibleArray,
@@ -475,6 +476,7 @@ class TestDataset:
         # nD coordinate variable "x" sharing name with dimension
         actual = Dataset({"a": x1, "x": z})
         assert "x" not in actual.xindexes
+        _assert_internal_invariants(actual, check_default_indexes=True)
 
         # verify handling of DataArrays
         expected = Dataset({"x": x1, "z": z})

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -472,9 +472,9 @@ class TestDataset:
         with pytest.raises(ValueError, match=r"already exists as a scalar"):
             Dataset({"x": 0, "y": ("x", [1, 2, 3])})
 
-        with pytest.warns(RuntimeWarning, match=r"will not automatically"):
-            actual = Dataset({"a": x1, "x": z})
-            assert "x" not in actual.xindexes
+        # nD coordinate variable "x" sharing name with dimension
+        actual = Dataset({"a": x1, "x": z})
+        assert "x" not in actual.xindexes
 
         # verify handling of DataArrays
         expected = Dataset({"x": x1, "z": z})

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -467,12 +467,14 @@ class TestDataset:
 
         with pytest.raises(ValueError, match=r"conflicting sizes"):
             Dataset({"a": x1, "b": x2})
-        with pytest.raises(ValueError, match=r"disallows such variables"):
-            Dataset({"a": x1, "x": z})
         with pytest.raises(TypeError, match=r"tuple of form"):
             Dataset({"x": (1, 2, 3, 4, 5, 6, 7)})
         with pytest.raises(ValueError, match=r"already exists as a scalar"):
             Dataset({"x": 0, "y": ("x", [1, 2, 3])})
+
+        with pytest.warns(RuntimeWarning, match=r"will not automatically"):
+            actual = Dataset({"a": x1, "x": z})
+            assert "x" not in actual.xindexes
 
         # verify handling of DataArrays
         expected = Dataset({"x": x1, "z": z})

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1247,8 +1247,9 @@ class TestVariable(VariableSubclassobjects):
         expected = Variable(("x", "y"), data)
         with pytest.raises(ValueError, match=r"without explicit dimension names"):
             as_variable(data, name="x")
-        with pytest.raises(ValueError, match=r"has more than 1-dimension"):
-            as_variable(expected, name="x")
+        with pytest.warns(RuntimeWarning, match=r"has more than 1-dimension"):
+            actual = as_variable(expected, name="x")
+            assert_identical(expected, actual)
 
         # test datetime, timedelta conversion
         dt = np.array([datetime(1999, 1, 1) + timedelta(days=x) for x in range(10)])

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1247,9 +1247,10 @@ class TestVariable(VariableSubclassobjects):
         expected = Variable(("x", "y"), data)
         with pytest.raises(ValueError, match=r"without explicit dimension names"):
             as_variable(data, name="x")
-        with pytest.warns(RuntimeWarning, match=r"has more than 1-dimension"):
-            actual = as_variable(expected, name="x")
-            assert_identical(expected, actual)
+
+        # name of nD variable matches dimension name
+        actual = as_variable(expected, name="x")
+        assert_identical(expected, actual)
 
         # test datetime, timedelta conversion
         dt = np.array([datetime(1999, 1, 1) + timedelta(days=x) for x in range(10)])


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2233
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`


Avoid automatic creating of Index variable when nD variable shares name with one of its dimensions.

Closes #2233

```python
url = "http://www.smast.umassd.edu:8080/thredds/dodsC/FVCOM/NECOFS/Forecasts/NECOFS_GOM3_FORECAST.nc"
ds = xr.open_dataset(url, engine="netcdf4")
display(ds)

xr.testing._assert_internal_invariants(ds, check_default_indexes=False)  ! no raise on #7368
```

~The internal invariants assert fails on `main` but succeeds on #7368~. EDIT: now fixed the invariants check.

<img width="816" alt="image" src="https://github.com/pydata/xarray/assets/2448579/f7ff8c78-11e2-42d7-beed-61d53d99557b">
