### PR TITLE
Update whats-new.rst for new release

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -29,6 +29,7 @@ Breaking changes
 
 Deprecations
 ~~~~~~~~~~~~
+
 - `hue_style` is being deprecated for scatter plots. (:issue:`7907`, :pull:`7925`).
   By `Jimmy Westling <https://github.com/illviljan>`_.
 
@@ -44,10 +45,16 @@ Internal Changes
 ~~~~~~~~~~~~~~~~
 
 
-v2023.07.0 (July 11, 2023)
+v2023.07.0 (July 17, 2023)
 --------------------------
 
 This release brings improvements to the documentation on wrapping numpy-like arrays, improved docstrings, and bug fixes.
+
+Deprecations
+~~~~~~~~~~~~
+
+- `hue_style` is being deprecated for scatter plots. (:issue:`7907`, :pull:`7925`).
+  By `Jimmy Westling <https://github.com/illviljan>`_.
 
 Bug fixes
 ~~~~~~~~~


### PR DESCRIPTION
Needed because I started the release process earlier this week by writing a whatsnew, that apparently got merged, but the release hasn't been issued since. I'll self-merge this and release now.