### PR TITLE
sort when encoding coordinates for deterministic outputs

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -96,6 +96,9 @@ Internal Changes
 
 - :py:func:`as_variable` now consistently includes the variable name in any exceptions
   raised. (:pull:`7995`). By `Peter Hill <https://github.com/ZedThree>`_
+- :py:func:`encode_dataset_coordinates` now sorts coordinates automatically assigned to
+  `coordinates` attributes during serialization (:pull:`8034` by
+  `Ian Carroll <https://github.com/itcarroll>`_).
 
 .. _whats-new.2023.07.0:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -97,8 +97,8 @@ Internal Changes
 - :py:func:`as_variable` now consistently includes the variable name in any exceptions
   raised. (:pull:`7995`). By `Peter Hill <https://github.com/ZedThree>`_
 - :py:func:`encode_dataset_coordinates` now sorts coordinates automatically assigned to
-  `coordinates` attributes during serialization (:pull:`8034` by
-  `Ian Carroll <https://github.com/itcarroll>`_).
+  `coordinates` attributes during serialization (:issue:`8026`, :pull:`8034`).
+  `By Ian Carroll <https://github.com/itcarroll>`_.
 
 .. _whats-new.2023.07.0:
 

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -694,7 +694,7 @@ def _encode_coordinates(variables, attributes, non_dim_coord_names):
         if not coords_str and variable_coordinates[name]:
             coordinates_text = " ".join(
                 str(coord_name)
-                for coord_name in variable_coordinates[name]
+                for coord_name in sorted(variable_coordinates[name])
                 if coord_name not in not_technically_coordinates
             )
             if coordinates_text:
@@ -719,7 +719,7 @@ def _encode_coordinates(variables, attributes, non_dim_coord_names):
                 SerializationWarning,
             )
         else:
-            attributes["coordinates"] = " ".join(map(str, global_coordinates))
+            attributes["coordinates"] = " ".join(sorted(map(str, global_coordinates)))
 
     return variables, attributes
 


### PR DESCRIPTION
- [x] Closes #8026
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- ~~[ ] New functions/methods are listed in `api.rst`~~

The PR changes `conventions._encode_coordinates` to add `sorted` during the creation of "coordinates" strings *de novo*. It does not touch user-specified coordinates attributes or encodings.

The PR adds a test, but also changes two pre-existing tests that allowed for non-deterministic ordering of the coordinates string.

In reviewing the netCDF data model and CF convenstions, I confirmed that there is no requirement on the ordering of names in the coordinates attribute. I also learned that the global coordinates attribute created by XArray for non-dimension coordinates that are not associated with a variable is not compliant with CF conventions, as was [discussed in 2014](https://mailman.cgd.ucar.edu/pipermail/cf-metadata/2014/007571.html). In 2021, CF-Conventions 1.9 added ["Domain Variables"](http://cfconventions.org/cf-conventions/cf-conventions.html#domain-variables), which appear to provide a CF compliant way to handle this situation. I will likely open an enhancement issue to weigh making that change.