### PR TITLE
Allow setting (or skipping) new indexes in open_dataset

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -403,6 +403,7 @@ def open_dataset(
     concat_characters: bool | None = None,
     decode_coords: Literal["coordinates", "all"] | bool | None = None,
     drop_variables: str | Iterable[str] | None = None,
+    set_indexes: bool = True,
     inline_array: bool = False,
     chunked_array_type: str | None = None,
     from_array_kwargs: dict[str, Any] | None = None,
@@ -492,6 +493,12 @@ def open_dataset(
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or
         inconsistent values.
+    set_indexes : bool, optional
+        If True (default), create new indexes from coordinates. Both the number and
+        the type(s) of those indexes depend on the backend used to open the dataset.
+        For most common backends this creates a pandas index for each
+        :term:`Dimension coordinate`, which loads the coordinate data fully in memory.
+        Set it to False if you want to avoid loading data into memory.
     inline_array: bool, default: False
         How to include the array in the dask task graph.
         By default(``inline_array=False``) the array is included in a task by
@@ -570,6 +577,7 @@ def open_dataset(
     backend_ds = backend.open_dataset(
         filename_or_obj,
         drop_variables=drop_variables,
+        set_indexes=set_indexes,
         **decoders,
         **kwargs,
     )
@@ -604,6 +612,7 @@ def open_dataarray(
     concat_characters: bool | None = None,
     decode_coords: Literal["coordinates", "all"] | bool | None = None,
     drop_variables: str | Iterable[str] | None = None,
+    set_indexes: bool = True,
     inline_array: bool = False,
     chunked_array_type: str | None = None,
     from_array_kwargs: dict[str, Any] | None = None,
@@ -695,6 +704,12 @@ def open_dataarray(
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or
         inconsistent values.
+    set_indexes : bool, optional
+        If True (default), create new indexes from coordinates. Both the number and
+        the type(s) of those indexes depend on the backend used to open the dataset.
+        For most common backends this creates a pandas index for each
+        :term:`Dimension coordinate`, which loads the coordinate data fully in memory.
+        Set it to False if you want to avoid loading data into memory.
     inline_array: bool, default: False
         How to include the array in the dask task graph.
         By default(``inline_array=False``) the array is included in a task by
@@ -752,6 +767,7 @@ def open_dataarray(
         chunks=chunks,
         cache=cache,
         drop_variables=drop_variables,
+        set_indexes=set_indexes,
         inline_array=inline_array,
         chunked_array_type=chunked_array_type,
         from_array_kwargs=from_array_kwargs,

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -490,6 +490,7 @@ class BackendEntrypoint:
         filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
         *,
         drop_variables: str | Iterable[str] | None = None,
+        set_indexes: bool = True,
         **kwargs: Any,
     ) -> Dataset:
         """

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -9,6 +9,7 @@ from xarray.backends.common import (
     AbstractDataStore,
     BackendEntrypoint,
 )
+from xarray.core.coordinates import Coordinates
 from xarray.core.dataset import Dataset
 
 if TYPE_CHECKING:
@@ -35,6 +36,7 @@ class StoreBackendEntrypoint(BackendEntrypoint):
         concat_characters=True,
         decode_coords=True,
         drop_variables: str | Iterable[str] | None = None,
+        set_indexes: bool = True,
         use_cftime=None,
         decode_timedelta=None,
     ) -> Dataset:
@@ -55,8 +57,22 @@ class StoreBackendEntrypoint(BackendEntrypoint):
             decode_timedelta=decode_timedelta,
         )
 
-        ds = Dataset(vars, attrs=attrs)
-        ds = ds.set_coords(coord_names.intersection(vars))
+        # split data and coordinate variables (promote dimension coordinates)
+        data_vars = {}
+        coord_vars = {}
+        for name, var in vars.items():
+            if name in coord_names or var.dims == (name,):
+                coord_vars[name] = var
+            else:
+                data_vars[name] = var
+
+        if set_indexes:
+            coords = coord_vars
+        else:
+            # explict Coordinates object with no index passed
+            coords = Coordinates(coord_vars)
+
+        ds = Dataset(data_vars, coords=coords, attrs=attrs)
         ds.set_close(filename_or_obj.close)
         ds.encoding = encoding
 

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -757,6 +757,7 @@ def open_zarr(
     zarr_version=None,
     chunked_array_type: str | None = None,
     from_array_kwargs: dict[str, Any] | None = None,
+    set_indexes=True,
     **kwargs,
 ):
     """Load and decode a dataset from a Zarr store.
@@ -850,6 +851,10 @@ def open_zarr(
         chunked arrays, via whichever chunk manager is specified through the `chunked_array_type` kwarg.
         Defaults to {'manager': 'dask'}, meaning additional kwargs will be passed eventually to
         :py:func:`dask.array.from_array`. Experimental API that should not be relied upon.
+    set_indexes : bool, optional
+        If True (default), create a default (pandas) index for each
+        :term:`Dimension coordinate`. Set it to False if the dataset contains
+        dimension coordinate arrays that are too large to load fully in memory.
 
     Returns
     -------
@@ -906,6 +911,7 @@ def open_zarr(
         engine="zarr",
         chunks=chunks,
         drop_variables=drop_variables,
+        set_indexes=set_indexes,
         chunked_array_type=chunked_array_type,
         from_array_kwargs=from_array_kwargs,
         backend_kwargs=backend_kwargs,
@@ -950,6 +956,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
         concat_characters=True,
         decode_coords=True,
         drop_variables: str | Iterable[str] | None = None,
+        set_indexes: bool = True,
         use_cftime=None,
         decode_timedelta=None,
         group=None,
@@ -986,6 +993,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
                 drop_variables=drop_variables,
                 use_cftime=use_cftime,
                 decode_timedelta=decode_timedelta,
+                set_indexes=set_indexes,
             )
         return ds
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #6633
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

This PR introduces a new boolean parameter `set_indexes=True` to `xr.open_dataset()`, which may be used to skip the creation of default (pandas) indexes when opening a dataset.

Currently works with the Zarr backend:

```python
import numpy as np
import xarray as xr

# example dataset (real dataset may be much larger)
arr = np.random.random(size=1_000_000)
xr.Dataset({"x": arr}).to_zarr("dataset.zarr")


xr.open_dataset("dataset.zarr", set_indexes=False, engine="zarr")
# <xarray.Dataset>
# Dimensions:  (x: 1000000)
# Coordinates:
#     x        (x) float64 ...
# Data variables:
#     *empty*


xr.open_zarr("dataset.zarr", set_indexes=False)
# <xarray.Dataset>
# Dimensions:  (x: 1000000)
# Coordinates:
#     x        (x) float64 ...
# Data variables:
#     *empty*
```


I'll add it to the other Xarray backends as well, but I'd like to get your thoughts about the API first.

1. Do we want to add yet another keyword parameter to `xr.open_dataset()`? There are already many...
2. Do we want to add this parameter to the `BackendEntrypoint.open_dataset()` API?
  - I'm afraid we must do it if we want this parameter in `xr.open_dataset()`
  - this would also make it possible skipping the creation of custom indexes (if any) in custom IO backends
  - con: if we require `set_indexes` in the signature in addition to the `drop_variables` parameter, this is a breaking change for all existing 3rd-party backends. Or should we group `set_indexes` with the other xarray decoder kwargs? This would feel a bit odd to me as setting indexes is different from decoding data.
3. Or should we leave this up to the backends?
  - pros: no breaking change, more flexible (3rd party backends may want to offer more control like choosing between custom indexes and default pandas indexes or skipping the creation of indexes by default)
  - cons: less discoverable and consistency is not enforced across 3rd party backends (although for such advanced case this is probably OK).

Currently 1 and 2 are implemented in this PR, although as I write this comment I think that I would prefer 3. I guess this depends on whether we prefer `open_***` vs. `xr.open_dataset(engine="***")` and unless I missed something there is still no real consensus about that? (e.g., #7496).

