### PR TITLE
unpin `numpy`

### DIFF
--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -23,7 +23,7 @@ dependencies:
   - netcdf4
   - numba
   - numbagg
-  - numpy<1.24
+  - numpy
   - packaging
   - pandas
   - pint<0.21

--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -19,7 +19,7 @@ dependencies:
   - nbsphinx
   - netcdf4>=1.5
   - numba
-  - numpy>=1.21,<1.24
+  - numpy>=1.21
   - packaging>=21.3
   - pandas>=1.4
   - pooch

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -22,7 +22,7 @@ dependencies:
   - netcdf4
   - numba
   - numbagg
-  - numpy<1.24
+  - numpy
   - packaging
   - pandas
   - pint<0.21

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - numba
   - numbagg
   - numexpr
-  - numpy<1.24
+  - numpy
   - packaging
   - pandas
   - pint<0.21


### PR DESCRIPTION
- [x] follow-up to #7415

It seems in a previous PR I "temporarily" pinned `numpy` to get CI to pass, but then forgot to unpin later and merged it as-is. As a result, we have not been running the main CI with `numpy>=1.24` ever since, even though now `numpy=1.25` has been around for a while.