### PR TITLE
Fix for #7030

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -83,6 +83,9 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Fix bug where :py:class:`DataArray` instances on the right-hand side
+  of :py:meth:`Variable.__setitem__` lose dimension names.
+  (:issue:`7030`) By `Darsh Ranjan <https://github.com/dranjan>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -943,7 +943,12 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
 
         See __getitem__ for more details.
         """
+        from xarray.core.dataarray import DataArray
+
         dims, index_tuple, new_order = self._broadcast_indexes(key)
+
+        if isinstance(value, DataArray):
+            value = value.variable
 
         if not isinstance(value, Variable):
             value = as_compatible_data(value)

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -2140,6 +2140,15 @@ class TestVariable(VariableSubclassobjects):
         expected = Variable(["x", "y"], [[2, 3], [3, 4], [4, 5]])
         assert_identical(v, expected)
 
+    def test_setitem_with_dataarray(self):
+        v = Variable(["a", "b", "c", "d"], np.r_[:120].reshape(2, 3, 4, 5))
+        b = Variable(["u", "v"], [[0, 0], [1, 0]])
+        c = Variable(["u", "v"], [[0, 1], [2, 3]])
+        w = DataArray([-1, -2], dims=["u"])
+        index = dict(b=b, c=c)
+        v[index] = w
+        assert (v[index] == w).all()
+
     def test_coarsen(self):
         v = self.cls(["x"], [0, 1, 2, 3, 4])
         actual = v.coarsen({"x": 2}, boundary="pad", func="mean")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #7030
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Apparently `DataArray` instances on the right-hand side of `Variable.__setitem__` were being stripped of their `xarray` metadata, leading to the incorrect broadcasting noted in #7030. My proposed fix is to add an explicit if-clause for this case.