### PR TITLE
Document drop_variables in open_mfdataset

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -929,8 +929,14 @@ def open_mfdataset(
 
         If a callable, it must expect a sequence of ``attrs`` dicts and a context object
         as its only parameters.
+    drop_variables: str or iterable of str, optional
+        A variable or list of variables to exclude from being parsed from the
+        dataset. This may be useful to drop variables with problems or
+        inconsistent values.
     **kwargs : optional
-        Additional arguments passed on to :py:func:`xarray.open_dataset`.
+        Additional arguments passed on to :py:func:`xarray.open_dataset`. For an
+        overview of some of the possible optionals, see the documentation of
+        :py:func:`xarray.open_dataset`
 
     Returns
     -------


### PR DESCRIPTION
Document ```drop_variables``` in ```open_mfdataset```. Makes it even clearer that for more information about possible additional options to ```open_mfdataset```, one can consult ```open_dataset```. Solves the comment at https://github.com/pydata/xarray/issues/8074#issuecomment-1682398773 .
