### PR TITLE
Add `Coordinates.assign()` method

### DIFF
--- a/doc/api-hidden.rst
+++ b/doc/api-hidden.rst
@@ -22,6 +22,7 @@
    Coordinates.to_dataset
    Coordinates.to_index
    Coordinates.update
+   Coordinates.assign
    Coordinates.merge
    Coordinates.copy
    Coordinates.equals
@@ -39,8 +40,9 @@
    core.coordinates.DatasetCoordinates.to_dataset
    core.coordinates.DatasetCoordinates.to_index
    core.coordinates.DatasetCoordinates.update
+   core.coordinates.DatasetCoordinates.assign
    core.coordinates.DatasetCoordinates.merge
-   core.coordinates.DataArrayCoordinates.copy
+   core.coordinates.DatasetCoordinates.copy
    core.coordinates.DatasetCoordinates.equals
    core.coordinates.DatasetCoordinates.identical
 
@@ -79,6 +81,7 @@
    core.coordinates.DataArrayCoordinates.to_dataset
    core.coordinates.DataArrayCoordinates.to_index
    core.coordinates.DataArrayCoordinates.update
+   core.coordinates.DataArrayCoordinates.assign
    core.coordinates.DataArrayCoordinates.merge
    core.coordinates.DataArrayCoordinates.copy
    core.coordinates.DataArrayCoordinates.equals

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -23,6 +23,10 @@ v2023.08.1 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- Added the :py:meth:`Coordinates.assign` method that can be used to combine
+  different collections of coordinates prior to assign them to a Dataset or
+  DataArray (:pull:`8102`) at once.
+  By `Benoît Bovy <https://github.com/benbovy>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -24,10 +24,10 @@ from xarray.core.indexes import (
 from xarray.core.merge import merge_coordinates_without_align, merge_coords
 from xarray.core.types import Self, T_DataArray
 from xarray.core.utils import (
-  Frozen,
-  ReprObject,
-  either_dict_or_kwargs,
-  emit_user_level_warning,
+    Frozen,
+    ReprObject,
+    either_dict_or_kwargs,
+    emit_user_level_warning,
 )
 from xarray.core.variable import Variable, as_variable, calculate_dimensions
 

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -498,6 +498,7 @@ class Coordinates(AbstractCoordinates):
         Examples
         --------
         >>> coords = xr.Coordinates()
+        >>> coords
         Coordinates:
           *empty*
 

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -504,7 +504,7 @@ class Coordinates(AbstractCoordinates):
 
         >>> coords.assign(x=[1, 2])
         Coordinates:
-          * x          (x) int64 1 2
+          * x        (x) int64 1 2
 
         >>> midx = pd.MultiIndex.from_product([["a", "b"], [0, 1]])
         >>> coords.assign(xr.Coordinates.from_pandas_multiindex(midx, "y"))

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -232,7 +232,7 @@ class Coordinates(AbstractCoordinates):
         elif isinstance(coords, Coordinates):
             variables = {k: v.copy() for k, v in coords.variables.items()}
         else:
-            variables = {k: as_variable(v) for k, v in coords.items()}
+            variables = {k: as_variable(v, name=k) for k, v in coords.items()}
 
         if indexes is None:
             indexes = {}
@@ -494,6 +494,23 @@ class Coordinates(AbstractCoordinates):
         new_coords : Coordinates
             A new Coordinates object with the new coordinates (and indexes)
             in addition to all the existing coordinates.
+
+        Examples
+        --------
+        >>> coords = xr.Coordinates()
+        Coordinates:
+          *empty*
+
+        >>> coords.assign(x=[1, 2])
+        Coordinates:
+          * x          (x) int64 1 2
+
+        >>> midx = pd.MultiIndex.from_product([["a", "b"], [0, 1]])
+        >>> coords.assign(xr.Coordinates.from_pandas_multiindex(midx, "y"))
+        Coordinates:
+          * y          (y) object MultiIndex
+          * y_level_0  (y) object 'a' 'a' 'b' 'b'
+          * y_level_1  (y) int64 0 1 0 1
 
         """
         coords = either_dict_or_kwargs(coords, coords_kwargs, "assign")

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -500,7 +500,7 @@ class Coordinates(AbstractCoordinates):
         >>> coords = xr.Coordinates()
         >>> coords
         Coordinates:
-          *empty*
+            *empty*
 
         >>> coords.assign(x=[1, 2])
         Coordinates:

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -24,7 +24,7 @@ from xarray.core.indexes import (
 )
 from xarray.core.merge import merge_coordinates_without_align, merge_coords
 from xarray.core.types import Self, T_DataArray
-from xarray.core.utils import Frozen, ReprObject
+from xarray.core.utils import Frozen, ReprObject, either_dict_or_kwargs
 from xarray.core.variable import Variable, as_variable, calculate_dimensions
 
 if TYPE_CHECKING:
@@ -471,6 +471,35 @@ class Coordinates(AbstractCoordinates):
         )
 
         self._update_coords(coords, indexes)
+
+    def assign(
+        self, coords: Mapping | None = None, **coords_kwargs: Any
+    ) -> Coordinates:
+        """Assign new coordinates (and indexes) to a Coordinates object, returning
+        a new object with all the original coordinates in addition to the new ones.
+
+        Parameters
+        ----------
+        coords : :class:`Coordinates` or mapping of hashable to Any
+            Mapping from coordinate names to the new values. If a ``Coordinates``
+            object is passed, its indexes are assigned in the returned object.
+            Otherwise, a default (pandas) index is created for each dimension
+            coordinate found in the mapping.
+        **coords_kwargs
+            The keyword arguments form of ``coords``.
+            One of ``coords`` or ``coords_kwargs`` must be provided.
+
+        Returns
+        -------
+        new_coords : Coordinates
+            A new Coordinates object with the new coordinates (and indexes)
+            in addition to all the existing coordinates.
+
+        """
+        coords = either_dict_or_kwargs(coords, coords_kwargs, "assign")
+        new_coords = self.copy()
+        new_coords.update(coords)
+        return new_coords
 
     def _overwrite_indexes(
         self,

--- a/xarray/tests/test_coordinates.py
+++ b/xarray/tests/test_coordinates.py
@@ -112,7 +112,7 @@ class TestCoordinates:
         assert coords.identical(coords)
         assert not coords.identical("no_a_coords")
 
-    def test_assign(self):
+    def test_assign(self) -> None:
         _ds = Dataset(coords={"x": [0, 1, 2]})
         coords = Coordinates(coords=_ds.coords, indexes=_ds.xindexes)
 

--- a/xarray/tests/test_coordinates.py
+++ b/xarray/tests/test_coordinates.py
@@ -125,13 +125,8 @@ class TestCoordinates:
         assert not coords.identical("not_a_coords")
 
     def test_assign(self) -> None:
-        _ds = Dataset(coords={"x": [0, 1, 2]})
-        coords = Coordinates(coords=_ds.coords, indexes=_ds.xindexes)
-
-        _ds_expected = Dataset(coords={"x": [0, 1, 2], "y": [3, 4]})
-        expected = Coordinates(
-            coords=_ds_expected.coords, indexes=_ds_expected.xindexes
-        )
+        coords = Coordinates(coords={"x": [0, 1, 2]})
+        expected = Coordinates(coords={"x": [0, 1, 2], "y": [3, 4]})
 
         actual = coords.assign(y=[3, 4])
         assert_identical(actual, expected)

--- a/xarray/tests/test_coordinates.py
+++ b/xarray/tests/test_coordinates.py
@@ -112,6 +112,21 @@ class TestCoordinates:
         assert coords.identical(coords)
         assert not coords.identical("no_a_coords")
 
+    def test_assign(self):
+        _ds = Dataset(coords={"x": [0, 1, 2]})
+        coords = Coordinates(coords=_ds.coords, indexes=_ds.xindexes)
+
+        _ds_expected = Dataset(coords={"x": [0, 1, 2], "y": [3, 4]})
+        expected = Coordinates(
+            coords=_ds_expected.coords, indexes=_ds_expected.xindexes
+        )
+
+        actual = coords.assign(y=[3, 4])
+        assert_identical(actual, expected)
+
+        actual = coords.assign({"y": [3, 4]})
+        assert_identical(actual, expected)
+
     def test_copy(self) -> None:
         no_index_coords = Coordinates({"foo": ("x", [1, 2, 3])})
         copied = no_index_coords.copy()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`

This is consistent with the Dataset and DataArray `assign` methods (now that `Coordinates` is also exposed as public API).

This allows writing:

```python
midx = pd.MultiIndex.from_arrays([["a", "a", "b", "b"], [0, 1, 0, 1]])
midx_coords = xr.Coordinates.from_pandas_multiindex(midx, "x")

ds = xr.Dataset(coords=midx_coords.assign(y=[1, 2]))
```

which is quite common (at least in the tests) and a bit nicer than

```python
ds = xr.Dataset(coords=midx_coords.merge({"y": [1, 2]}).coords)
```