### PR TITLE
Better default behavior of the Coordinates constructor

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,6 +27,12 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- The :py:class:`Coordinates` constructor now creates a (pandas) index by
+  default for each dimension coordinate. To keep the previous behavior (no index
+  created), pass an empty dictionary to ``indexes``. The constructor now also
+  extracts and add the indexes from another :py:class:`Coordinates` object
+  passed via ``coords`` (:pull:`8107`).
+  By `Benoît Bovy <https://github.com/benbovy>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -232,7 +232,7 @@ class Coordinates(AbstractCoordinates):
     (indexes are passed):
 
     >>> ds = xr.Dataset(coords={"x": [1, 2]})
-    >>> coords = xr.Coordinates(ds.coords)
+    >>> xr.Coordinates(ds.coords)
     Coordinates:
       * x        (x) int64 1 2
 

--- a/xarray/tests/test_coordinates.py
+++ b/xarray/tests/test_coordinates.py
@@ -17,6 +17,17 @@ class TestCoordinates:
         expected = Dataset(coords={"foo": ("x", [0, 1, 2])})
         assert_identical(coords.to_dataset(), expected)
 
+    def test_init_default_index(self) -> None:
+        coords = Coordinates(coords={"x": [1, 2]})
+        expected = Dataset(coords={"x": [1, 2]})
+        assert_identical(coords.to_dataset(), expected)
+        assert "x" in coords.xindexes
+
+    def test_init_no_default_index(self) -> None:
+        # dimension coordinate with no default index (explicit)
+        coords = Coordinates(coords={"x": [1, 2]}, indexes={})
+        assert "x" not in coords.xindexes
+
     def test_init_from_coords(self) -> None:
         expected = Dataset(coords={"foo": ("x", [0, 1, 2])})
         coords = Coordinates(coords=expected.coords)
@@ -25,10 +36,19 @@ class TestCoordinates:
         # test variables copied
         assert coords.variables["foo"] is not expected.variables["foo"]
 
-        # default index
-        expected = Dataset(coords={"x": ("x", [0, 1, 2])})
-        coords = Coordinates(coords=expected.coords, indexes=expected.xindexes)
+        # test indexes are extracted
+        expected = Dataset(coords={"x": [0, 1, 2]})
+        coords = Coordinates(coords=expected.coords)
         assert_identical(coords.to_dataset(), expected)
+        assert expected.xindexes == coords.xindexes
+
+        # coords + indexes not supported
+        with pytest.raises(
+            ValueError, match="passing both.*Coordinates.*indexes.*not allowed"
+        ):
+            coords = Coordinates(
+                coords=expected.coords, indexes={"x": PandasIndex([0, 1, 2], "x")}
+            )
 
     def test_init_empty(self) -> None:
         coords = Coordinates()
@@ -60,37 +80,31 @@ class TestCoordinates:
             assert_identical(expected[name], coords.variables[name])
 
     def test_dims(self) -> None:
-        _ds = Dataset(coords={"x": [0, 1, 2]})
-        coords = Coordinates(coords=_ds.coords, indexes=_ds.xindexes)
+        coords = Coordinates(coords={"x": [0, 1, 2]})
         assert coords.dims == {"x": 3}
 
     def test_sizes(self) -> None:
-        _ds = Dataset(coords={"x": [0, 1, 2]})
-        coords = Coordinates(coords=_ds.coords, indexes=_ds.xindexes)
+        coords = Coordinates(coords={"x": [0, 1, 2]})
         assert coords.sizes == {"x": 3}
 
     def test_dtypes(self) -> None:
-        _ds = Dataset(coords={"x": [0, 1, 2]})
-        coords = Coordinates(coords=_ds.coords, indexes=_ds.xindexes)
+        coords = Coordinates(coords={"x": [0, 1, 2]})
         assert coords.dtypes == {"x": int}
 
     def test_getitem(self) -> None:
-        _ds = Dataset(coords={"x": [0, 1, 2]})
-        coords = Coordinates(coords=_ds.coords, indexes=_ds.xindexes)
+        coords = Coordinates(coords={"x": [0, 1, 2]})
         assert_identical(
             coords["x"],
             DataArray([0, 1, 2], coords={"x": [0, 1, 2]}, name="x"),
         )
 
     def test_delitem(self) -> None:
-        _ds = Dataset(coords={"x": [0, 1, 2]})
-        coords = Coordinates(coords=_ds.coords, indexes=_ds.xindexes)
+        coords = Coordinates(coords={"x": [0, 1, 2]})
         del coords["x"]
         assert "x" not in coords
 
     def test_update(self) -> None:
-        _ds = Dataset(coords={"x": [0, 1, 2]})
-        coords = Coordinates(coords=_ds.coords, indexes=_ds.xindexes)
+        coords = Coordinates(coords={"x": [0, 1, 2]})
 
         coords.update({"y": ("y", [4, 5, 6])})
         assert "y" in coords
@@ -99,18 +113,16 @@ class TestCoordinates:
         assert_identical(coords["y"], expected)
 
     def test_equals(self):
-        _ds = Dataset(coords={"x": [0, 1, 2]})
-        coords = Coordinates(coords=_ds.coords, indexes=_ds.xindexes)
+        coords = Coordinates(coords={"x": [0, 1, 2]})
 
         assert coords.equals(coords)
-        assert not coords.equals("no_a_coords")
+        assert not coords.equals("not_a_coords")
 
     def test_identical(self):
-        _ds = Dataset(coords={"x": [0, 1, 2]})
-        coords = Coordinates(coords=_ds.coords, indexes=_ds.xindexes)
+        coords = Coordinates(coords={"x": [0, 1, 2]})
 
         assert coords.identical(coords)
-        assert not coords.identical("no_a_coords")
+        assert not coords.identical("not_a_coords")
 
     def test_copy(self) -> None:
         no_index_coords = Coordinates({"foo": ("x", [1, 2, 3])})
@@ -129,8 +141,7 @@ class TestCoordinates:
         assert source_ndarray(v0.data) is not source_ndarray(v1.data)
 
     def test_align(self) -> None:
-        _ds = Dataset(coords={"x": [0, 1, 2]})
-        coords = Coordinates(coords=_ds.coords, indexes=_ds.xindexes)
+        coords = Coordinates(coords={"x": [0, 1, 2]})
 
         left = coords
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -489,7 +489,7 @@ class TestDataArray:
 
     def test_constructor_no_default_index(self) -> None:
         # explicitly passing a Coordinates object skips the creation of default index
-        da = DataArray(range(3), coords=Coordinates({"x": ("x", [1, 2, 3])}))
+        da = DataArray(range(3), coords=Coordinates({"x": [1, 2, 3]}, indexes={}))
         assert "x" in da.coords
         assert "x" not in da.xindexes
 
@@ -1585,7 +1585,7 @@ class TestDataArray:
         assert isinstance(actual.xindexes["x"], CustomIndex)
 
     def test_assign_coords_no_default_index(self) -> None:
-        coords = Coordinates({"y": ("y", [1, 2, 3])})
+        coords = Coordinates({"y": [1, 2, 3]}, indexes={})
         da = DataArray([1, 2, 3], dims="y")
         actual = da.assign_coords(coords)
         assert_identical(actual.coords, coords, check_default_indexes=False)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -636,7 +636,7 @@ class TestDataset:
 
     def test_constructor_no_default_index(self) -> None:
         # explicitly passing a Coordinates object skips the creation of default index
-        ds = Dataset(coords=Coordinates({"x": ("x", [1, 2, 3])}))
+        ds = Dataset(coords=Coordinates({"x": [1, 2, 3]}, indexes={}))
         assert "x" in ds
         assert "x" not in ds.xindexes
 
@@ -4298,7 +4298,7 @@ class TestDataset:
         assert isinstance(actual.xindexes["x"], CustomIndex)
 
     def test_assign_coords_no_default_index(self) -> None:
-        coords = Coordinates({"y": ("y", [1, 2, 3])})
+        coords = Coordinates({"y": [1, 2, 3]}, indexes={})
         ds = Dataset()
         actual = ds.assign_coords(coords)
         expected = coords.to_dataset()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

After working more on `Coordinates` I realize that the default behavior of its constructor could be more consistent with other Xarray objects. This PR changes this default behavior such that:

- Pandas indexes are created for dimension coordinates if `indexes=None` (default). To create dimension coordinates with no index, just pass `indexes={}`.
- If another `Coordinates` object is passed as input, its indexes are also added to the new created object. Since we don't support alignment / merge here, the following call raises an error: `xr.Coordinates(coords=xr.Coordinates(...), indexes={...})`.

This PR introduces a breaking change since `Coordinates` are now exposed in v2023.8.0, which has just been released. It is a bit unfortunate but I think it may be OK for a fresh feature, especially if the next release will be soon after this one.