### PR TITLE
Better error message when trying to set an index from a scalar coordinate

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4698,7 +4698,9 @@ class Dataset(
             if len(var_names) == 1 and (not append or dim not in self._indexes):
                 var_name = var_names[0]
                 var = self._variables[var_name]
-                if var.dims != (dim,):
+                # an error with a better message will be raised for scalar variables
+                # when creating the PandasIndex
+                if var.ndim > 0 and var.dims != (dim,):
                     raise ValueError(
                         f"dimension mismatch: try setting an index for dimension {dim!r} with "
                         f"variable {var_name!r} that has dimensions {var.dims}"

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -616,7 +616,14 @@ class PandasIndex(Index):
 
         name, var = next(iter(variables.items()))
 
-        if var.ndim != 1:
+        if var.ndim == 0:
+            raise ValueError(
+                f"cannot set a PandasIndex from the scalar variable {name!r}, "
+                "only 1-dimensional variables are supported. "
+                f"Note: you might want to use `obj.expand_dims({name!r})` to create a "
+                f"new dimension and turn {name!r} as an indexed dimension coordinate."
+            )
+        elif var.ndim != 1:
             raise ValueError(
                 "PandasIndex only accepts a 1-dimensional variable, "
                 f"variable {name!r} has {var.ndim} dimensions"

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3392,6 +3392,12 @@ class TestDataset:
         with pytest.raises(ValueError, match=r"dimension mismatch.*"):
             ds.set_index(y="x_var")
 
+        ds = Dataset(coords={"x": 1})
+        with pytest.raises(
+            ValueError, match=r".*cannot set a PandasIndex.*scalar variable.*"
+        ):
+            ds.set_index(x="x")
+
     def test_set_index_deindexed_coords(self) -> None:
         # test de-indexed coordinates are converted to base variable
         # https://github.com/pydata/xarray/issues/6969

--- a/xarray/tests/test_indexes.py
+++ b/xarray/tests/test_indexes.py
@@ -146,6 +146,11 @@ class TestPandasIndex:
             PandasIndex.from_variables({"x": var, "foo": var2}, options={})
 
         with pytest.raises(
+            ValueError, match=r".*cannot set a PandasIndex.*scalar variable.*"
+        ):
+            PandasIndex.from_variables({"foo": xr.Variable((), 1)}, options={})
+
+        with pytest.raises(
             ValueError, match=r".*only accepts a 1-dimensional variable.*"
         ):
             PandasIndex.from_variables({"foo": var2}, options={})


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #4091
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

The message suggests using `.expand_dims()`.