### PR TITLE
Alignment: allow flexible index coordinate order

### DIFF
--- a/xarray/core/alignment.py
+++ b/xarray/core/alignment.py
@@ -84,8 +84,8 @@ def reindex_variables(
     return new_variables
 
 
-CoordNamesAndDims = tuple[tuple[Hashable, tuple[Hashable, ...]], ...]
-MatchingIndexKey = tuple[CoordNamesAndDims, type[Index]]
+SortedCoordNamesAndDims = tuple[tuple[Hashable, tuple[Hashable, ...]], ...]
+MatchingIndexKey = tuple[SortedCoordNamesAndDims, type[Index]]
 NormalizedIndexes = dict[MatchingIndexKey, Index]
 NormalizedIndexVars = dict[MatchingIndexKey, dict[Hashable, Variable]]
 
@@ -226,6 +226,10 @@ class Aligner(Generic[T_Alignable]):
                     "these are used by an index together with non-excluded dimensions "
                     f"{incl_dims_str}"
                 )
+
+            # sort by coordinate name so that finding matching indexes
+            # doesn't rely on coordinate order
+            coord_names_and_dims.sort(key=lambda i: i[0])
 
             key = (tuple(coord_names_and_dims), type(idx))
             normalized_indexes[key] = idx

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -1290,7 +1290,20 @@ class PandasMultiIndex(PandasIndex):
         else:
             return IndexSelResult({self.dim: indexer})
 
+    def equals(self, other: Index):
+        is_equal = super().equals(other)
+        if is_equal and isinstance(other, PandasMultiIndex):
+            is_equal = self.index.names == other.index.names
+        return is_equal
+
     def join(self, other, how: str = "inner"):
+        if other.index.names != self.index.names:
+            raise ValueError(
+                f"cannot join together a PandasMultiIndex with levels {tuple(self.index.names)!r} and "
+                f"another PandasMultiIndex with levels {tuple(other.index.names)!r} "
+                "(level order mismatch)."
+            )
+
         if how == "outer":
             # bug in pandas? need to reset index.name
             other_index = other.index.copy()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #7002
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

This PR relaxes some of the rules used in alignment for finding the indexes to compare or join together. Those indexes must still be of the same type and must relate to the same set of coordinates (and dimensions), but the order of coordinates is now ignored.

It is up to the index to implement the equal / join logic if it needs to care about that order.

Regarding `pandas.MultiIndex`, it seems that the level names are ignored when comparing indexes:

```python
midx = pd.MultiIndex.from_product([["a", "b"], [0, 1]], names=("one", "two")))
midx2 = pd.MultiIndex.from_product([["a", "b"], [0, 1]], names=("two", "one"))

midx.equals(midx2)  # True
```

However, in Xarray the names of the multi-index levels (and their order) matter since each level has its coordinates. In this PR, `PandasMultiIndex.equals()` and `PandasMultiIndex.join()` thus check that the level names match. 