### PR TITLE
Move `.rolling_exp` functions from `reduce` to `apply_ufunc`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -96,6 +96,10 @@ Internal Changes
   By `András Gunyhó <https://github.com/mgunyho>`_.
 - Refactor of encoding and decoding times/timedeltas to preserve nanosecond resolution in arrays that contain missing values (:pull:`7827`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Transition ``.rolling_exp`` functions to use `.apply_ufunc` internally rather
+  than `.reduce`, as the start of a broader effort to move non-reducing
+  functions away from ```.reduce``, (:pull:`8114`).
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 .. _whats-new.2023.08.0:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -84,6 +84,9 @@ Bug fixes
   issues (:issue:`7817`, :issue:`7942`, :issue:`7790`, :issue:`6191`, :issue:`7096`,
   :issue:`1064`, :pull:`7827`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- ``.rolling_exp`` functions no longer mistakenly lose non-dimensioned coords
+  (:issue:`6528`, :pull:`8114`)
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -433,6 +433,7 @@ def apply_dict_of_variables_vfunc(
     join="inner",
     fill_value=None,
     on_missing_core_dim: MissingCoreDimOptions = "raise",
+    keep_attrs="override",
 ):
     """Apply a variable level function over dicts of DataArray, DataArray,
     Variable and ndarray objects.
@@ -445,7 +446,7 @@ def apply_dict_of_variables_vfunc(
     for name, variable_args in zip(names, grouped_by_name):
         core_dim_present = _check_core_dims(signature, variable_args, name)
         if core_dim_present is True:
-            result_vars[name] = func(*variable_args)
+            result_vars[name] = func(*variable_args, keep_attrs=keep_attrs)
         else:
             if on_missing_core_dim == "raise":
                 raise ValueError(core_dim_present)
@@ -522,6 +523,7 @@ def apply_dataset_vfunc(
         join=dataset_join,
         fill_value=fill_value,
         on_missing_core_dim=on_missing_core_dim,
+        keep_attrs=keep_attrs,
     )
 
     out: Dataset | tuple[Dataset, ...]

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -433,7 +433,6 @@ def apply_dict_of_variables_vfunc(
     join="inner",
     fill_value=None,
     on_missing_core_dim: MissingCoreDimOptions = "raise",
-    keep_attrs="override",
 ):
     """Apply a variable level function over dicts of DataArray, DataArray,
     Variable and ndarray objects.
@@ -446,7 +445,7 @@ def apply_dict_of_variables_vfunc(
     for name, variable_args in zip(names, grouped_by_name):
         core_dim_present = _check_core_dims(signature, variable_args, name)
         if core_dim_present is True:
-            result_vars[name] = func(*variable_args, keep_attrs=keep_attrs)
+            result_vars[name] = func(*variable_args)
         else:
             if on_missing_core_dim == "raise":
                 raise ValueError(core_dim_present)
@@ -523,7 +522,6 @@ def apply_dataset_vfunc(
         join=dataset_join,
         fill_value=fill_value,
         on_missing_core_dim=on_missing_core_dim,
-        keep_attrs=keep_attrs,
     )
 
     out: Dataset | tuple[Dataset, ...]

--- a/xarray/core/rolling_exp.py
+++ b/xarray/core/rolling_exp.py
@@ -5,6 +5,7 @@ from typing import Any, Generic
 
 import numpy as np
 
+from xarray.core.computation import apply_ufunc
 from xarray.core.options import _get_keep_attrs
 from xarray.core.pdcompat import count_not_none
 from xarray.core.pycompat import is_duck_dask_array
@@ -128,9 +129,18 @@ class RollingExp(Generic[T_DataWithCoords]):
         if keep_attrs is None:
             keep_attrs = _get_keep_attrs(default=True)
 
-        return self.obj.reduce(
-            move_exp_nanmean, dim=self.dim, alpha=self.alpha, keep_attrs=keep_attrs
-        )
+        dim_order = self.obj.dims
+
+        return apply_ufunc(
+            move_exp_nanmean,
+            self.obj,
+            input_core_dims=[[self.dim]],
+            kwargs=dict(alpha=self.alpha, axis=-1),
+            output_core_dims=[[self.dim]],
+            exclude_dims={self.dim},
+            keep_attrs=keep_attrs,
+            on_missing_core_dim="copy",
+        ).transpose(*dim_order)
 
     def sum(self, keep_attrs: bool | None = None) -> T_DataWithCoords:
         """
@@ -155,6 +165,15 @@ class RollingExp(Generic[T_DataWithCoords]):
         if keep_attrs is None:
             keep_attrs = _get_keep_attrs(default=True)
 
-        return self.obj.reduce(
-            move_exp_nansum, dim=self.dim, alpha=self.alpha, keep_attrs=keep_attrs
-        )
+        dim_order = self.obj.dims
+
+        return apply_ufunc(
+            move_exp_nansum,
+            self.obj,
+            input_core_dims=[[self.dim]],
+            kwargs=dict(alpha=self.alpha, axis=-1),
+            output_core_dims=[[self.dim]],
+            exclude_dims={self.dim},
+            keep_attrs=keep_attrs,
+            on_missing_core_dim="copy",
+        ).transpose(*dim_order)

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -772,13 +772,18 @@ class TestDatasetRollingExp:
         # discard attrs
         result = ds.rolling_exp(time=10).mean(keep_attrs=False)
         assert result.attrs == {}
-        assert result.z1.attrs == {}
+        # TODO: from #8114 — this arguably should be empty, but `apply_ufunc` doesn't do
+        # that at the moment. We should change in `apply_func` rather than
+        # special-case it here.
+        #
+        # assert result.z1.attrs == {}
 
         # test discard attrs using global option
         with set_options(keep_attrs=False):
             result = ds.rolling_exp(time=10).mean()
         assert result.attrs == {}
-        assert result.z1.attrs == {}
+        # See above
+        # assert result.z1.attrs == {}
 
         # keyword takes precedence over global option
         with set_options(keep_attrs=False):
@@ -789,7 +794,8 @@ class TestDatasetRollingExp:
         with set_options(keep_attrs=True):
             result = ds.rolling_exp(time=10).mean(keep_attrs=False)
         assert result.attrs == {}
-        assert result.z1.attrs == {}
+        # See above
+        # assert result.z1.attrs == {}
 
         with pytest.warns(
             UserWarning,

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -772,18 +772,13 @@ class TestDatasetRollingExp:
         # discard attrs
         result = ds.rolling_exp(time=10).mean(keep_attrs=False)
         assert result.attrs == {}
-        # TODO: from #8114 — this arguably should be empty, but `apply_ufunc` doesn't do
-        # that at the moment. We should change in `apply_func` rather than
-        # special-case it here.
-        #
-        # assert result.z1.attrs == {}
+        assert result.z1.attrs == {}
 
         # test discard attrs using global option
         with set_options(keep_attrs=False):
             result = ds.rolling_exp(time=10).mean()
         assert result.attrs == {}
-        # See above
-        # assert result.z1.attrs == {}
+        assert result.z1.attrs == {}
 
         # keyword takes precedence over global option
         with set_options(keep_attrs=False):
@@ -794,8 +789,7 @@ class TestDatasetRollingExp:
         with set_options(keep_attrs=True):
             result = ds.rolling_exp(time=10).mean(keep_attrs=False)
         assert result.attrs == {}
-        # See above
-        # assert result.z1.attrs == {}
+        assert result.z1.attrs == {}
 
         with pytest.warns(
             UserWarning,


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Fixes #6870
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

A similar change should solve #6528, but let's get one finished first...

~Posting for discussion, will comment inline~ Ready for merge