### PR TITLE
Add Coordinates `set_xindex()` and `drop_indexes()` methods

### DIFF
--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Hashable, Iterator, Mapping, Sequence
+from collections.abc import Hashable, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from typing import (
     TYPE_CHECKING,
@@ -23,7 +23,7 @@ from xarray.core.indexes import (
     create_default_index_implicit,
 )
 from xarray.core.merge import merge_coordinates_without_align, merge_coords
-from xarray.core.types import Self, T_DataArray
+from xarray.core.types import ErrorOptions, Self, T_DataArray
 from xarray.core.utils import Frozen, ReprObject
 from xarray.core.variable import Variable, as_variable, calculate_dimensions
 
@@ -471,6 +471,68 @@ class Coordinates(AbstractCoordinates):
         )
 
         self._update_coords(coords, indexes)
+
+    def set_xindex(
+        self,
+        coord_names: str | Sequence[Hashable],
+        index_cls: type[Index] | None = None,
+        **options,
+    ) -> Self:
+        """Set a new, Xarray-compatible index from one or more existing
+        coordinate(s).
+
+        Parameters
+        ----------
+        coord_names : str or list
+            Name(s) of the coordinate(s) used to build the index.
+            If several names are given, their order matters.
+        index_cls : subclass of :class:`~xarray.indexes.Index`, optional
+            The type of index to create. By default, try setting
+            a ``PandasIndex`` if ``len(coord_names) == 1``,
+            otherwise a ``PandasMultiIndex``.
+        **options
+            Options passed to the index constructor.
+
+        Returns
+        -------
+        obj : Coordinates
+            Another Coordinates object with a new index.
+
+        """
+        new_obj = self._data.set_xindex(coord_names, index_cls, **options)
+
+        # TODO: remove cast once we get rid of DatasetCoordinates
+        # and DataArrayCoordinates (i.e., Dataset and DataArray encapsulate Coordinates)
+        return cast(Self, new_obj.coords)
+
+    def drop_indexes(
+        self,
+        coord_names: Hashable | Iterable[Hashable],
+        *,
+        errors: ErrorOptions = "raise",
+    ) -> Self:
+        """Drop the indexes assigned to the given coordinates.
+
+        Parameters
+        ----------
+        coord_names : hashable or iterable of hashable
+            Name(s) of the coordinate(s) for which to drop the index.
+        errors : {"raise", "ignore"}, default: "raise"
+            If 'raise', raises a ValueError error if any of the coordinates
+            passed have no index or are not in the dataset.
+            If 'ignore', no error is raised.
+
+        Returns
+        -------
+        dropped : Coordinates
+            A new Coordinates object with dropped indexes.
+
+        """
+        new_obj = self._data.drop_indexes(coord_names, errors=errors)
+
+        # TODO: remove cast once we get rid of DatasetCoordinates
+        # and DataArrayCoordinates (i.e., Dataset and DataArray encapsulate Coordinates)
+        return cast(Self, new_obj.coords)
 
     def _overwrite_indexes(
         self,


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

I don't think that we need to copy most API from Dataset / DataArray to `Coordinates`, but I find it convenient to have some relevant methods there too. For example, when building Coordinates from scratch (with custom indexes) before passing the whole coords + indexes bundle around:

```python
import dask.array as da
import numpy as np
import xarray as xr

coords = (
    xr.Coordinates(
        coords={"x": da.arange(100_000_000), "y": np.arange(100)},
        indexes={},
    )
    .set_xindex("x", DaskIndex)
    .set_xindex("y", xr.indexes.PandasIndex)
)

ds = xr.Dataset(coords=coords)

# <xarray.Dataset>
# Dimensions:  (x: 100000000, y: 100)
# Coordinates:
#   * x        (x) int64 dask.array<chunksize=(16777216,), meta=np.ndarray>
#   * y        (y) int64 0 1 2 3 4 5 6 7 8 9 10 ... 90 91 92 93 94 95 96 97 98 99
# Data variables:
#     *empty*
# Indexes:
#     x        DaskIndex
```

 