### PR TITLE
adapted the docstring of xarray.DataArray.differentiate

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -5193,9 +5193,10 @@ class DataArray(
             The coordinate to be used to compute the gradient.
         edge_order : {1, 2}, default: 1
             N-th order accurate differences at the boundaries.
-        datetime_unit : {"Y", "M", "W", "D", "h", "m", "s", "ms", \
+        datetime_unit : {"W", "D", "h", "m", "s", "ms", \
                          "us", "ns", "ps", "fs", "as", None}, optional
-            Unit to compute gradient. Only valid for datetime coordinate.
+            Unit to compute gradient. Only valid for datetime coordinate. "Y" and "M" are not available as
+            datetime_unit.
 
         Returns
         -------


### PR DESCRIPTION
Changed the docstring of `xarray.DataArray.differentiate`, according to #8006,  to only list available datetime_units(excluded `"Y"` and `"M"`) and additionally noting that `"Y"` and `"M"` can not be used.


<!-- Feel free to remove check-list items aren't relevant to your change -->

- [X] Closes #8000
- [x] Closes #8006 
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
