### PR TITLE
Add Index.load() and Index.chunk() methods

### DIFF
--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -691,12 +691,7 @@ class DatasetCoordinates(Coordinates):
         self._data._variables = variables
         self._data._coord_names.update(new_coord_names)
         self._data._dims = dims
-
-        # TODO(shoyer): once ._indexes is always populated by a dict, modify
-        # it to update inplace instead.
-        original_indexes = dict(self._data.xindexes)
-        original_indexes.update(indexes)
-        self._data._indexes = original_indexes
+        self._data._indexes.update(indexes)
 
     def _drop_coords(self, coord_names):
         # should drop indexed coordinates only
@@ -777,12 +772,7 @@ class DataArrayCoordinates(Coordinates, Generic[T_DataArray]):
                 "cannot add coordinates with new dimensions to a DataArray"
             )
         self._data._coords = coords
-
-        # TODO(shoyer): once ._indexes is always populated by a dict, modify
-        # it to update inplace instead.
-        original_indexes = dict(self._data.xindexes)
-        original_indexes.update(indexes)
-        self._data._indexes = original_indexes
+        self._data._indexes.update(indexes)
 
     def _drop_coords(self, coord_names):
         # should drop indexed coordinates only

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -67,6 +67,7 @@ from xarray.core.indexes import (
     create_default_index_implicit,
     filter_indexes_from_coords,
     isel_indexes,
+    load_indexes,
     remove_unused_levels_categories,
     roll_indexes,
 )
@@ -816,6 +817,11 @@ class Dataset(
         --------
         dask.compute
         """
+        # apply Index.load, collect new indexes and variables and replace the existing ones
+        # new index variables may still be lazy: load them here after
+        indexes, index_variables = load_indexes(self.xindexes, kwargs)
+        self.coords._update_coords(index_variables, indexes)
+
         # access .data to coerce everything to numpy or dask arrays
         lazy_data = {
             k: v._data for k, v in self.variables.items() if is_chunked_array(v._data)

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -4,7 +4,7 @@ import collections.abc
 import copy
 from collections import defaultdict
 from collections.abc import Hashable, Iterable, Iterator, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
 
 import numpy as np
 import pandas as pd
@@ -15,6 +15,7 @@ from xarray.core.indexing import (
     PandasIndexingAdapter,
     PandasMultiIndexingAdapter,
 )
+from xarray.core.parallelcompat import ChunkManagerEntrypoint
 from xarray.core.utils import (
     Frozen,
     emit_user_level_warning,
@@ -54,8 +55,6 @@ class Index:
     corresponding operation on a :py:meth:`Dataset` or :py:meth:`DataArray`
     either will raise a ``NotImplementedError`` or will simply drop/pass/copy
     the index from/to the result.
-
-    Do not use this class directly for creating index objects.
     """
 
     @classmethod
@@ -320,6 +319,55 @@ class Index:
             ``True`` if the indexes are equal, ``False`` otherwise.
         """
         raise NotImplementedError()
+
+    def load(self, **kwargs) -> Index | None:
+        """Method called when calling :py:meth:`Dataset.load` or
+        :py:meth:`Dataset.compute` (or DataArray equivalent methods).
+
+        The default implementation will simply drop the index by returning
+        ``None``.
+
+        Possible re-implementations in subclasses are:
+
+        - For an index with coordinate data fully in memory like a ``PandasIndex``:
+          return itself
+        - For an index with lazy coordinate data (e.g., a dask array):
+          return an index object of another type like ``PandasIndex``
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Additional keyword arguments passed on to ``dask.compute``.
+        """
+        return None
+
+    def chunk(
+        self,
+        chunks: Literal["auto"] | Mapping[Any, None | tuple[int, ...]],
+        name_prefix: str = "xarray-",
+        token: str | None = None,
+        lock: bool = False,
+        inline_array: bool = False,
+        chunked_array_type: ChunkManagerEntrypoint | None = None,
+        from_array_kwargs=None,
+    ) -> Index | None:
+        """Method called when calling :py:meth:`Dataset.chunk` or
+        :py:meth:`Dataset.chunk` (or DataArray equivalent methods).
+
+        The default implementation will simply drop the index by returning
+        ``None``.
+
+        Possible re-implementations in subclasses are:
+
+        - For an index with coordinate data fully in memory like a ``PandasIndex``:
+          return itself (do not chunk)
+        - For an index with lazy coordinate data (e.g., a dask array):
+          rebuild the index with an internal lookup structure that is
+          in sync with the new chunks
+
+        For more details about the parameters, see :py:meth:`Dataset.chunk`.
+        """
+        return None
 
     def roll(self: T_Index, shifts: Mapping[Any, int]) -> T_Index | None:
         """Roll this index by an offset along one or more dimensions.
@@ -820,6 +868,23 @@ class PandasIndex(Index):
             )
 
         return {self.dim: get_indexer_nd(self.index, other.index, method, tolerance)}
+
+    def load(self: T_PandasIndex, **kwargs) -> T_PandasIndex:
+        # both index and coordinate(s) already loaded in-memory
+        return self
+
+    def chunk(
+        self: T_PandasIndex,
+        chunks: Literal["auto"] | Mapping[Any, None | tuple[int, ...]],
+        name_prefix: str = "xarray-",
+        token: str | None = None,
+        lock: bool = False,
+        inline_array: bool = False,
+        chunked_array_type: ChunkManagerEntrypoint | None = None,
+        from_array_kwargs=None,
+    ) -> T_PandasIndex:
+        # skip chunk
+        return self
 
     def roll(self, shifts: Mapping[Any, int]) -> PandasIndex:
         shift = shifts[self.dim] % self.index.shape[0]
@@ -1764,19 +1829,42 @@ def indexes_all_equal(
     return not not_equal
 
 
-def _apply_indexes(
+def _apply_index_method(
     indexes: Indexes[Index],
-    args: Mapping[Any, Any],
-    func: str,
+    method_name: str,
+    dim_args: Mapping | None = None,
+    kwargs: Mapping | None = None,
 ) -> tuple[dict[Hashable, Index], dict[Hashable, Variable]]:
+    """Utility function that applies a given Index method for an Indexes
+    collection and that returns new collections of indexes and coordinate
+    variables.
+
+    Filter index method calls and arguments according to ``dim_args`` if not
+    None. Otherwise, call the method unconditionally for each index.
+
+    ``kwargs`` is passed to every method call.
+
+    """
+    if kwargs is None:
+        kwargs = {}
+
     new_indexes: dict[Hashable, Index] = {k: v for k, v in indexes.items()}
     new_index_variables: dict[Hashable, Variable] = {}
 
     for index, index_vars in indexes.group_by_index():
-        index_dims = {d for var in index_vars.values() for d in var.dims}
-        index_args = {k: v for k, v in args.items() if k in index_dims}
-        if index_args:
-            new_index = getattr(index, func)(index_args)
+        func = getattr(index, method_name)
+
+        if dim_args is not None:
+            index_dims = {d for var in index_vars.values() for d in var.dims}
+            index_args = {k: v for k, v in dim_args.items() if k in index_dims}
+        else:
+            index_args = {}
+
+        if dim_args is None or index_args:
+            if index_args:
+                new_index = func(index_args, **kwargs)
+            else:
+                new_index = func(**kwargs)
             if new_index is not None:
                 new_indexes.update({k: new_index for k in index_vars})
                 new_index_vars = new_index.create_variables(index_vars)
@@ -1790,16 +1878,23 @@ def _apply_indexes(
 
 def isel_indexes(
     indexes: Indexes[Index],
-    indexers: Mapping[Any, Any],
+    dim_indexers: Mapping,
 ) -> tuple[dict[Hashable, Index], dict[Hashable, Variable]]:
-    return _apply_indexes(indexes, indexers, "isel")
+    return _apply_index_method(indexes, "isel", dim_args=dim_indexers)
 
 
 def roll_indexes(
     indexes: Indexes[Index],
-    shifts: Mapping[Any, int],
+    dim_shifts: Mapping[Any, int],
 ) -> tuple[dict[Hashable, Index], dict[Hashable, Variable]]:
-    return _apply_indexes(indexes, shifts, "roll")
+    return _apply_index_method(indexes, "roll", dim_args=dim_shifts)
+
+
+def load_indexes(
+    indexes: Indexes[Index],
+    kwargs: Mapping,
+) -> tuple[dict[Hashable, Index], dict[Hashable, Variable]]:
+    return _apply_index_method(indexes, "load", kwargs=kwargs)
 
 
 def filter_indexes_from_coords(


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

As mentioned in #8124, it give more control to custom Xarray indexes on what to do when the Dataset / DataArray `load()` and `chunk()` counterpart methods are called.

`PandasIndex.load` and `PandasIndex.chunk` always return self (no action required).

For a DaskIndex, we might want to return a PandasIndex (or other non-lazy index) from `load` and a rebuilt DaskIndex object from `chunk` (rechunk).