### PR TITLE
Deprecate passing pd.MultiIndex implicitly

### DIFF
--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from xarray.core import dtypes, utils
 from xarray.core.alignment import align, reindex_variables
+from xarray.core.coordinates import Coordinates
 from xarray.core.duck_array_ops import lazy_array_equiv
 from xarray.core.indexes import Index, PandasIndex
 from xarray.core.merge import (
@@ -645,29 +646,34 @@ def _dataset_concat(
             # preserves original variable order
             result_vars[name] = result_vars.pop(name)
 
-    result = type(datasets[0])(result_vars, attrs=result_attrs)
+    result_coords = Coordinates(
+        coords={k: v for k, v in result_vars.items() if k in coord_names},
+        indexes=result_indexes,
+    )
+    result_data_vars = {k: v for k, v in result_vars.items() if k not in result_coords}
+    result = type(datasets[0])(
+        result_data_vars, coords=result_coords, attrs=result_attrs
+    )
 
     absent_coord_names = coord_names - set(result.variables)
     if absent_coord_names:
         raise ValueError(
             f"Variables {absent_coord_names!r} are coordinates in some datasets but not others."
         )
-    result = result.set_coords(coord_names)
     result.encoding = result_encoding
 
     result = result.drop_vars(unlabeled_dims, errors="ignore")
 
     if index is not None:
-        # add concat index / coordinate last to ensure that its in the final Dataset
+        # add concat index / coordinate last to ensure that it is in the final Dataset
         if dim_var is not None:
             index_vars = index.create_variables({dim: dim_var})
         else:
             index_vars = index.create_variables()
-        result[dim] = index_vars[dim]
-        result_indexes[dim] = index
-
-    # TODO: add indexes at Dataset creation (when it is supported)
-    result = result._overwrite_indexes(result_indexes)
+        index_coords = Coordinates._construct_direct(
+            coords=index_vars, indexes={k: index for k in index_vars}
+        )
+        result = result.assign_coords(index_coords)
 
     return result
 

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -951,31 +951,11 @@ def create_coords_with_default_indexes(
     indexes: dict[Hashable, Index] = {}
     variables: dict[Hashable, Variable] = {}
 
-    # promote any pandas multi-index in data_vars as coordinates
-    coords_promoted: dict[Hashable, Any] = {}
-    pd_mindex_keys: list[Hashable] = []
-
-    for k, v in all_variables.items():
-        if isinstance(v, pd.MultiIndex):
-            coords_promoted[k] = v
-            pd_mindex_keys.append(k)
-        elif k in coords:
-            coords_promoted[k] = v
-
-    if pd_mindex_keys:
-        pd_mindex_keys_fmt = ",".join([f"'{k}'" for k in pd_mindex_keys])
-        emit_user_level_warning(
-            f"the `pandas.MultiIndex` object(s) passed as {pd_mindex_keys_fmt} coordinate(s) or "
-            "data variable(s) will no longer be implicitly promoted and wrapped into "
-            "multiple indexed coordinates in the future "
-            "(i.e., one coordinate for each multi-index level + one dimension coordinate). "
-            "If you want to keep this behavior, you need to first wrap it explicitly using "
-            "`mindex_coords = xarray.Coordinates.from_pandas_multiindex(mindex_obj, 'dim')` "
-            "and pass it as coordinates, e.g., `xarray.Dataset(coords=mindex_coords)`, "
-            "`dataset.assign_coords(mindex_coords)` or `dataarray.assign_coords(mindex_coords)`.",
-            FutureWarning,
-        )
-
+    coords_promoted: dict[Hashable, Any] = {
+        k: v
+        for k, v in all_variables.items()
+        if k in coords or isinstance(v, pd.MultiIndex)
+    }
     dataarray_coords: list[DataArrayCoordinates] = []
 
     for name, obj in coords_promoted.items():

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -1355,7 +1355,6 @@ def create_default_index_implicit(
 
     if isinstance(array, pd.MultiIndex):
         if warn_multi_index:
-            # raise ValueError("no pd.MultiIndex please!")
             emit_user_level_warning(
                 f"the `pandas.MultiIndex` object wrapped in variable {name} will no longer "
                 "be implicitly promoted into multiple indexed coordinates in the future. "

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from xarray import DataArray, Dataset, Variable, concat
+from xarray import Coordinates, DataArray, Dataset, Variable, concat
 from xarray.core import dtypes, merge
 from xarray.core.indexes import PandasIndex
 from xarray.tests import (
@@ -906,8 +906,9 @@ class TestConcatDataset:
         assert_identical(actual, expected)
 
     def test_concat_multiindex(self) -> None:
-        x = pd.MultiIndex.from_product([[1, 2, 3], ["a", "b"]])
-        expected = Dataset(coords={"x": x})
+        midx = pd.MultiIndex.from_product([[1, 2, 3], ["a", "b"]])
+        midx_coords = Coordinates.from_pandas_multiindex(midx, "x")
+        expected = Dataset(coords=midx_coords)
         actual = concat(
             [expected.isel(x=slice(2)), expected.isel(x=slice(2, None))], "x"
         )
@@ -917,8 +918,9 @@ class TestConcatDataset:
     def test_concat_along_new_dim_multiindex(self) -> None:
         # see https://github.com/pydata/xarray/issues/6881
         level_names = ["x_level_0", "x_level_1"]
-        x = pd.MultiIndex.from_product([[1, 2, 3], ["a", "b"]], names=level_names)
-        ds = Dataset(coords={"x": x})
+        midx = pd.MultiIndex.from_product([[1, 2, 3], ["a", "b"]], names=level_names)
+        midx_coords = Coordinates.from_pandas_multiindex(midx, "x")
+        ds = Dataset(coords=midx_coords)
         concatenated = concat([ds], "new")
         actual = list(concatenated.xindexes.get_all_coords("x"))
         expected = ["x"] + level_names

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 
 import xarray as xr
-from xarray import DataArray, Dataset, Variable
+from xarray import Coordinates, DataArray, Dataset, Variable
 from xarray.core import duck_array_ops
 from xarray.core.duck_array_ops import lazy_array_equiv
 from xarray.testing import assert_chunks_equal
@@ -639,8 +639,11 @@ class TestDataArrayAndDataset(DaskTestCase):
         data = da.random.normal(size=(2, 3, 4), chunks=(1, 3, 4))
         arr = DataArray(data, dims=("w", "x", "y"))
         stacked = arr.stack(z=("x", "y"))
-        z = pd.MultiIndex.from_product([np.arange(3), np.arange(4)], names=["x", "y"])
-        expected = DataArray(data.reshape(2, -1), {"z": z}, dims=["w", "z"])
+        midx = pd.MultiIndex.from_product(
+            [np.arange(3), np.arange(4)], names=["x", "y"]
+        )
+        midx_coords = Coordinates.from_pandas_multiindex(midx, "z")
+        expected = DataArray(data.reshape(2, -1), coords=midx_coords, dims=["w", "z"])
         assert stacked.data.chunks == expected.data.chunks
         self.assertLazyAndEqual(expected, stacked)
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -356,7 +356,8 @@ class TestDataset:
         mindex = pd.MultiIndex.from_product(
             [["a", "b"], [1, 2]], names=("a_quite_long_level_name", "level_2")
         )
-        data = Dataset({}, {"x": mindex})
+        mindex_coords = Coordinates.from_pandas_multiindex(mindex, "x")
+        data = Dataset({}, mindex_coords)
         expected = dedent(
             """\
             <xarray.Dataset>
@@ -630,9 +631,14 @@ class TestDataset:
         mindex = pd.MultiIndex.from_product(
             [["a", "b"], [1, 2]], names=("level_1", "level_2")
         )
-        with pytest.raises(ValueError, match=r"conflicting MultiIndex"):
-            Dataset({}, {"x": mindex, "y": mindex})
-            Dataset({}, {"x": mindex, "level_1": range(4)})
+
+        with pytest.warns(
+            FutureWarning,
+            match=".*`pandas.MultiIndex`.*no longer be implicitly promoted",
+        ):
+            with pytest.raises(ValueError, match=r"conflicting MultiIndex"):
+                Dataset({}, {"x": mindex, "y": mindex})
+                Dataset({}, {"x": mindex, "level_1": range(4)})
 
     def test_constructor_no_default_index(self) -> None:
         # explicitly passing a Coordinates object skips the creation of default index
@@ -1604,19 +1610,20 @@ class TestDataset:
 
     def test_sel_dataarray_mindex(self) -> None:
         midx = pd.MultiIndex.from_product([list("abc"), [0, 1]], names=("one", "two"))
+        midx_coords = Coordinates.from_pandas_multiindex(midx, "x")
         mds = xr.Dataset(
             {"var": (("x", "y"), np.random.rand(6, 3))},
-            coords={"x": midx, "y": range(3)},
+            coords=midx_coords.merge({"y": range(3)}).coords,
         )
 
         actual_isel = mds.isel(x=xr.DataArray(np.arange(3), dims="x"))
-        actual_sel = mds.sel(x=DataArray(midx[:3], dims="x"))
+        actual_sel = mds.sel(x=DataArray(np.array(midx[:3]), dims="x"))
         assert actual_isel["x"].dims == ("x",)
         assert actual_sel["x"].dims == ("x",)
         assert_identical(actual_isel, actual_sel)
 
         actual_isel = mds.isel(x=xr.DataArray(np.arange(3), dims="z"))
-        actual_sel = mds.sel(x=Variable("z", midx[:3]))
+        actual_sel = mds.sel(x=Variable("z", np.array(midx[:3])))
         assert actual_isel["x"].dims == ("z",)
         assert actual_sel["x"].dims == ("z",)
         assert_identical(actual_isel, actual_sel)
@@ -1724,7 +1731,8 @@ class TestDataset:
 
     def test_sel_drop_mindex(self) -> None:
         midx = pd.MultiIndex.from_arrays([["a", "a"], [1, 2]], names=("foo", "bar"))
-        data = Dataset(coords={"x": midx})
+        midx_coords = Coordinates.from_pandas_multiindex(midx, "x")
+        data = Dataset(coords=midx_coords)
 
         actual = data.sel(foo="a", drop=True)
         assert "foo" not in actual.coords
@@ -1948,7 +1956,8 @@ class TestDataset:
         mindex = pd.MultiIndex.from_product(
             [["a", "b"], [1, 2], [-1, -2]], names=("one", "two", "three")
         )
-        mdata = Dataset(data_vars={"var": ("x", range(8))}, coords={"x": mindex})
+        mindex_coords = Coordinates.from_pandas_multiindex(mindex, "x")
+        mdata = Dataset(data_vars={"var": ("x", range(8))}, coords=mindex_coords)
 
         def test_sel(
             lab_indexer, pos_indexer, replaced_idx=False, renamed_dim=None
@@ -2791,7 +2800,8 @@ class TestDataset:
 
         # test index corrupted
         mindex = pd.MultiIndex.from_tuples([([1, 2]), ([3, 4])], names=["a", "b"])
-        ds = Dataset(coords={"x": mindex})
+        mindex_coords = Coordinates.from_pandas_multiindex(mindex, "x")
+        ds = Dataset(coords=mindex_coords)
 
         with pytest.raises(ValueError, match=".*would corrupt the following index.*"):
             ds.drop_indexes("a")
@@ -3077,8 +3087,12 @@ class TestDataset:
 
     def test_rename_multiindex(self) -> None:
         mindex = pd.MultiIndex.from_tuples([([1, 2]), ([3, 4])], names=["a", "b"])
-        original = Dataset({}, {"x": mindex})
-        expected = Dataset({}, {"x": mindex.rename(["a", "c"])})
+        original_coords = Coordinates.from_pandas_multiindex(mindex, "x")
+        original = Dataset({}, original_coords)
+        expected_coords = Coordinates.from_pandas_multiindex(
+            mindex.rename(["a", "c"]), "x"
+        )
+        expected = Dataset({}, expected_coords)
 
         actual = original.rename({"b": "c"})
         assert_identical(expected, actual)
@@ -3188,10 +3202,17 @@ class TestDataset:
         assert_identical(expected, actual)
 
         # handle multiindex case
-        idx = pd.MultiIndex.from_arrays([list("aab"), list("yzz")], names=["y1", "y2"])
-        original = Dataset({"x": [1, 2, 3], "y": ("x", idx), "z": 42})
-        expected = Dataset({"z": 42}, {"x": ("y", [1, 2, 3]), "y": idx})
-        actual = original.swap_dims({"x": "y"})
+        midx = pd.MultiIndex.from_arrays([list("aab"), list("yzz")], names=["y1", "y2"])
+        midx_coords = xr.Coordinates.from_pandas_multiindex(midx, "y")
+
+        original = Dataset({"x": [1, 2, 3], "y": ("x", midx), "z": 42})
+        expected_coords = midx_coords.assign({"x": ("y", [1, 2, 3])})
+        expected = Dataset({"z": 42}, expected_coords)
+        with pytest.warns(
+            FutureWarning,
+            match=".*`pandas.MultiIndex`.*no longer be implicitly promoted",
+        ):
+            actual = original.swap_dims({"x": "y"})
         assert_identical(expected, actual)
         assert isinstance(actual.variables["y"], IndexVariable)
         assert isinstance(actual.variables["x"], Variable)
@@ -3423,14 +3444,18 @@ class TestDataset:
         four = [3, 4, 3, 4]
 
         mindex_12 = pd.MultiIndex.from_arrays([one, two], names=["one", "two"])
+        mindex_12_coords = Coordinates.from_pandas_multiindex(mindex_12, "x")
         mindex_34 = pd.MultiIndex.from_arrays([three, four], names=["three", "four"])
+        mindex_34_coords = Coordinates.from_pandas_multiindex(mindex_34, "x")
 
         ds = xr.Dataset(
-            coords={"x": mindex_12, "three": ("x", three), "four": ("x", four)}
+            coords=mindex_12_coords.merge(
+                {"three": ("x", three), "four": ("x", four)}
+            ).coords
         )
         actual = ds.set_index(x=["three", "four"])
         expected = xr.Dataset(
-            coords={"x": mindex_34, "one": ("x", one), "two": ("x", two)}
+            coords=mindex_34_coords.merge({"one": ("x", one), "two": ("x", two)}).coords
         )
         assert_identical(actual, expected)
 
@@ -3482,7 +3507,8 @@ class TestDataset:
         # check that multi-index dimension or level coordinates are dropped, converted
         # from IndexVariable to Variable or renamed to dimension as expected
         midx = pd.MultiIndex.from_product([["a", "b"], [1, 2]], names=("foo", "bar"))
-        ds = xr.Dataset(coords={"x": midx})
+        midx_coords = Coordinates.from_pandas_multiindex(midx, "x")
+        ds = xr.Dataset(coords=midx_coords)
         reset = ds.reset_index(arg, drop=drop)
 
         for name in dropped:
@@ -3496,7 +3522,8 @@ class TestDataset:
         ds = create_test_multiindex()
         mindex = ds["x"].to_index()
         midx = mindex.reorder_levels(["level_2", "level_1"])
-        expected = Dataset({}, coords={"x": midx})
+        midx_coords = Coordinates.from_pandas_multiindex(midx, "x")
+        expected = Dataset({}, coords=midx_coords)
 
         # check attrs propagated
         ds["level_1"].attrs["foo"] = "bar"
@@ -3564,7 +3591,7 @@ class TestDataset:
         exp_index = pd.MultiIndex.from_product([[0, 1], ["a", "b"]], names=["x", "y"])
         expected = Dataset(
             data_vars={"b": ("z", [0, 1, 2, 3])},
-            coords={"z": exp_index},
+            coords=Coordinates.from_pandas_multiindex(exp_index, "z"),
         )
         # check attrs propagated
         ds["x"].attrs["foo"] = "bar"
@@ -3588,7 +3615,7 @@ class TestDataset:
         exp_index = pd.MultiIndex.from_product([["a", "b"], [0, 1]], names=["y", "x"])
         expected = Dataset(
             data_vars={"b": ("z", [0, 2, 1, 3])},
-            coords={"z": exp_index},
+            coords=Coordinates.from_pandas_multiindex(exp_index, "z"),
         )
         expected["x"].attrs["foo"] = "bar"
 
@@ -3619,9 +3646,10 @@ class TestDataset:
     def test_stack_multi_index(self) -> None:
         # multi-index on a dimension to stack is discarded too
         midx = pd.MultiIndex.from_product([["a", "b"], [0, 1]], names=("lvl1", "lvl2"))
+        midx_coords = Coordinates.from_pandas_multiindex(midx, "x")
         ds = xr.Dataset(
             data_vars={"b": (("x", "y"), [[0, 1], [2, 3], [4, 5], [6, 7]])},
-            coords={"x": midx, "y": [0, 1]},
+            coords=midx_coords.merge({"y": [0, 1]}).coords,
         )
         expected = Dataset(
             data_vars={"b": ("z", [0, 1, 2, 3, 4, 5, 6, 7])},
@@ -3648,7 +3676,7 @@ class TestDataset:
         exp_index = pd.MultiIndex.from_product([[0, 1], ["a", "b"]], names=["xx", "y"])
         expected = Dataset(
             data_vars={"b": ("z", [0, 1, 2, 3])},
-            coords={"z": exp_index},
+            coords=Coordinates.from_pandas_multiindex(exp_index, "z"),
         )
 
         actual = ds.stack(z=["x", "y"])
@@ -3657,7 +3685,10 @@ class TestDataset:
 
     def test_unstack(self) -> None:
         index = pd.MultiIndex.from_product([[0, 1], ["a", "b"]], names=["x", "y"])
-        ds = Dataset(data_vars={"b": ("z", [0, 1, 2, 3])}, coords={"z": index})
+        ds = Dataset(
+            data_vars={"b": ("z", [0, 1, 2, 3])},
+            coords=Coordinates.from_pandas_multiindex(index, "z"),
+        )
         expected = Dataset(
             {"b": (("x", "y"), [[0, 1], [2, 3]]), "x": [0, 1], "y": ["a", "b"]}
         )
@@ -3722,9 +3753,12 @@ class TestDataset:
         mindex = pd.MultiIndex.from_arrays(
             [np.arange(3), np.arange(3)], names=["a", "b"]
         )
+        mindex_coords = Coordinates.from_pandas_multiindex(mindex, "z")
         ds_eye = Dataset(
             {"var": (("z", "foo", "bar"), np.ones((3, 4, 5)))},
-            coords={"z": mindex, "foo": np.arange(4), "bar": np.arange(5)},
+            coords=mindex_coords.merge(
+                {"foo": np.arange(4), "bar": np.arange(5)}
+            ).coords,
         )
         actual3 = ds_eye.unstack(sparse=True, fill_value=0)
         assert isinstance(actual3["var"].data, sparse_array_type)
@@ -6218,10 +6252,12 @@ class TestDataset:
         # test pandas.MultiIndex
         indices = (("b", 1), ("b", 0), ("a", 1), ("a", 0))
         midx = pd.MultiIndex.from_tuples(indices, names=["one", "two"])
+        midx_coords = Coordinates.from_pandas_multiindex(midx, "x")
         ds_midx = Dataset(
             {
                 "A": DataArray(
-                    [[1, 2], [3, 4], [5, 6], [7, 8]], [("x", midx), ("y", [1, 0])]
+                    [[1, 2], [3, 4], [5, 6], [7, 8]],
+                    coords=midx_coords.merge({"y": [1, 0]}).coords,
                 ),
                 "B": DataArray([[5, 6], [7, 8], [9, 10], [11, 12]], dims=["x", "y"]),
             }
@@ -6230,11 +6266,12 @@ class TestDataset:
         midx_reversed = pd.MultiIndex.from_tuples(
             tuple(reversed(indices)), names=["one", "two"]
         )
+        midx_reversed_coords = Coordinates.from_pandas_multiindex(midx_reversed, "x")
         expected = Dataset(
             {
                 "A": DataArray(
                     [[7, 8], [5, 6], [3, 4], [1, 2]],
-                    [("x", midx_reversed), ("y", [1, 0])],
+                    coords=midx_reversed_coords.merge({"y": [1, 0]}).coords,
                 ),
                 "B": DataArray([[11, 12], [9, 10], [7, 8], [5, 6]], dims=["x", "y"]),
             }

--- a/xarray/tests/test_formatting_html.py
+++ b/xarray/tests/test_formatting_html.py
@@ -24,7 +24,8 @@ def multiindex():
     mindex = pd.MultiIndex.from_product(
         [["a", "b"], [1, 2]], names=("level_1", "level_2")
     )
-    return xr.Dataset({}, {"x": mindex})
+    mindex_coords = xr.Coordinates.from_pandas_multiindex(mindex, "x")
+    return xr.Dataset({}, mindex_coords)
 
 
 @pytest.fixture

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from xarray import DataArray, Dataset, Variable
+from xarray import Coordinates, DataArray, Dataset, Variable
 from xarray.core import indexing, nputils
 from xarray.core.indexes import PandasIndex, PandasMultiIndex
 from xarray.core.types import T_Xarray
@@ -68,9 +68,9 @@ class TestIndexers:
 
     def test_group_indexers_by_index(self) -> None:
         mindex = pd.MultiIndex.from_product([["a", "b"], [1, 2]], names=("one", "two"))
-        data = DataArray(
-            np.zeros((4, 2, 2)), coords={"x": mindex, "y": [1, 2]}, dims=("x", "y", "z")
-        )
+        coords = Coordinates.from_pandas_multiindex(mindex, "x")
+        coords["y"] = [1, 2]
+        data = DataArray(np.zeros((4, 2, 2)), coords=coords, dims=("x", "y", "z"))
         data.coords["y2"] = ("y", [2.0, 3.0])
 
         grouped_indexers = indexing.group_indexers_by_index(
@@ -146,7 +146,8 @@ class TestIndexers:
         mindex = pd.MultiIndex.from_product(
             [["a", "b"], [1, 2], [-1, -2]], names=("one", "two", "three")
         )
-        mdata = DataArray(range(8), [("x", mindex)])
+        mindex_coords = Coordinates.from_pandas_multiindex(mindex, "x")
+        mdata = DataArray(range(8), coords=mindex_coords)
 
         test_indexer(data, 1, indexing.IndexSelResult({"x": 0}))
         test_indexer(data, np.int32(1), indexing.IndexSelResult({"x": 0}))

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -144,21 +144,28 @@ def strip_units(obj):
             strip_units(name): strip_units(value)
             for name, value in obj.data_vars.items()
         }
-        coords = {
-            strip_units(name): strip_units(value) for name, value in obj.coords.items()
-        }
+        coords = xr.Coordinates(
+            coords={
+                strip_units(name): strip_units(value)
+                for name, value in obj.coords.items()
+            },
+            indexes=dict(obj.xindexes),
+        )
 
         new_obj = xr.Dataset(data_vars=data_vars, coords=coords)
     elif isinstance(obj, xr.DataArray):
         data = array_strip_units(obj.variable._data)
-        coords = {
-            strip_units(name): (
-                (value.dims, array_strip_units(value.variable._data))
-                if isinstance(value.data, Quantity)
-                else value  # to preserve multiindexes
-            )
-            for name, value in obj.coords.items()
-        }
+        coords = xr.Coordinates(
+            coords={
+                strip_units(name): (
+                    (value.dims, array_strip_units(value.variable._data))
+                    if isinstance(value.data, Quantity)
+                    else value  # to preserve multiindexes
+                )
+                for name, value in obj.coords.items()
+            },
+            indexes=dict(obj.xindexes),
+        )
 
         new_obj = xr.DataArray(
             name=strip_units(obj.name), data=data, coords=coords, dims=obj.dims

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 import pytz
 
-from xarray import DataArray, Dataset, IndexVariable, Variable, set_options
+from xarray import Coordinates, DataArray, Dataset, IndexVariable, Variable, set_options
 from xarray.core import dtypes, duck_array_ops, indexing
 from xarray.core.common import full_like, ones_like, zeros_like
 from xarray.core.indexing import (
@@ -2376,7 +2376,8 @@ class TestIndexVariable(VariableSubclassobjects):
 
     def test_to_index_multiindex_level(self):
         midx = pd.MultiIndex.from_product([["a", "b"], [1, 2]], names=("one", "two"))
-        ds = Dataset(coords={"x": midx})
+        midx_coords = Coordinates.from_pandas_multiindex(midx, "x")
+        ds = Dataset(coords=midx_coords)
         assert ds.one.variable.to_index().equals(midx.get_level_values("one"))
 
     def test_multiindex_default_level_names(self):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- Follow-up #8094
- [x] Closes #6481
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

This PR should normally raise a warning *each time* when indexed coordinates are created implicitly from a `pd.MultiIndex` object.

I updated the tests to create coordinates explicitly using `Coordinates.from_pandas_multiindex()`.

I also refactored some parts where a `pd.MultiIndex` could still be passed and promoted internally, with the exception of:

- `swap_dims()`: it should raise a warning! Right now the warning message is a bit confusing for this case, but instead of adding a special case we should probably deprecate the whole method? As it is suggested as a TODO comment... This method was to circumvent the limitations of dimension coordinates, which isn't needed anymore (`rename_dims` and/or `set_xindex` is equivalent and less confusing).
- `xr.DataArray(pandas_obj_with_multiindex, dims=...)`: I guess it should raise a warning too?
- `da.stack(z=...).groupby("z")`: it shoudn't raise a warning, but this requires a (heavy?) refactoring of groupby. During building the "grouper" objects, `grouper.group1d` or `grouper.unique_coord` may still be built by extracting only the multi-index dimension coordinate. I'd greatly appreciate if anyone familiar with the groupby implementation could help me with this! @dcherian ?