### PR TITLE
Dirty workaround for mypy 1.5 error

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -132,6 +132,7 @@ if TYPE_CHECKING:
         DatetimeLike,
         DatetimeUnitOptions,
         Dims,
+        DsCompatible,
         ErrorOptions,
         ErrorOptionsWithWarn,
         InterpOptions,
@@ -695,6 +696,11 @@ class Dataset(
         self._coord_names = coord_names
         self._dims = dims
         self._indexes = indexes
+
+    # TODO: dirty workaround for mypy 1.5 error with inherited DatasetOpsMixin vs. Mapping
+    # related to https://github.com/python/mypy/issues/9319?
+    def __eq__(self: T_Dataset, other: DsCompatible) -> T_Dataset:  # type: ignore[override]
+        return super().__eq__(other)
 
     @classmethod
     def load_store(cls: type[T_Dataset], store, decoder=None) -> T_Dataset:


### PR DESCRIPTION
I wanted to fix the following error with mypy 1.5:

```
xarray/core/dataset.py:505: error: Definition of "__eq__" in base class "DatasetOpsMixin" is incompatible with definition in base class "Mapping"  [misc]
```

Which looks similar to https://github.com/python/mypy/issues/9319. It is weird that here it worked with mypy versions < 1.5, though.

I don't know if there is a better fix, but I thought that redefining `__eq__` in `Dataset` would be a bit less dirty workaround than adding `type: ignore` in the class declaration.


