### PR TITLE
Deprecate the multi-index dimension coordinate

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from xarray import set_options
+
 
 def pytest_addoption(parser):
     """Add command-line flags for pytest."""
@@ -39,3 +41,10 @@ def add_standard_imports(doctest_namespace, tmpdir):
 
     # always switch to the temporary directory, so files get written there
     tmpdir.chdir()
+
+
+@pytest.fixture(scope="function", params=[True, False])
+def mindex_dim_coord(request):
+    set_options(future_no_mindex_dim_coord=not request.param)
+    yield request.param
+    set_options(future_no_mindex_dim_coord=request.param)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5008,6 +5008,15 @@ class Dataset(
             Another dataset, with this dataset's data but replaced
             coordinates.
         """
+        warnings.warn(
+            "The `reorder_levels` method will be removed in the future, "
+            "when dimension coordinates with a PandasMultiIndex are removed.\n"
+            "Instead of `ds.reorder_levels(x=['two', 'one'])`, you could do:\n"
+            "`new_midx = ds.xindexes['one'].index.reorder_levels(['two', 'one'])`\n"
+            "`ds.assign_coords(xr.Coordinates.from_pandas_multiindex(new_midx, 'x'))`",
+            FutureWarning,
+            stacklevel=2,
+        )
         dim_order = either_dict_or_kwargs(dim_order, dim_order_kwargs, "reorder_levels")
         variables = self._variables.copy()
         indexes = dict(self._indexes)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5132,7 +5132,8 @@ class Dataset(
 
             if len(product_vars) == len(dims):
                 idx = index_cls.stack(product_vars, new_dim)
-                new_indexes[new_dim] = idx
+                if not OPTIONS["future_no_mindex_dim_coord"]:
+                    new_indexes[new_dim] = idx
                 new_indexes.update({k: idx for k in product_vars})
                 idx_vars = idx.create_variables(product_vars)
                 # keep consistent multi-index coordinate order
@@ -5779,7 +5780,7 @@ class Dataset(
         for var in names:
             maybe_midx = self._indexes.get(var, None)
             if isinstance(maybe_midx, PandasMultiIndex):
-                idx_coord_names = set(maybe_midx.index.names + [maybe_midx.dim])
+                idx_coord_names = set(self.xindexes.get_all_coords(var))
                 idx_other_names = idx_coord_names - set(names)
                 other_names.update(idx_other_names)
         if other_names:

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -15,6 +15,7 @@ from xarray.core.indexing import (
     PandasIndexingAdapter,
     PandasMultiIndexingAdapter,
 )
+from xarray.core.options import OPTIONS
 from xarray.core.utils import (
     Frozen,
     emit_user_level_warning,
@@ -1123,7 +1124,13 @@ class PandasMultiIndex(PandasIndex):
             variables = {}
 
         index_vars: IndexVars = {}
-        for name in (self.dim,) + self.index.names:
+
+        if OPTIONS["future_no_mindex_dim_coord"]:
+            names = self.index.names
+        else:
+            names = (self.dim,) + self.index.names
+
+        for name in names:
             if name == self.dim:
                 level = None
                 dtype = None

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
         "display_default_indexes",
         "enable_cftimeindex",
         "file_cache_maxsize",
+        "future_no_mindex_dim_coord",
         "keep_attrs",
         "warn_for_unclosed_files",
         "use_bottleneck",
@@ -48,6 +49,7 @@ if TYPE_CHECKING:
         display_default_indexes: Literal["default", True, False]
         enable_cftimeindex: bool
         file_cache_maxsize: int
+        future_no_mindex_dim_coord: bool
         keep_attrs: Literal["default", True, False]
         warn_for_unclosed_files: bool
         use_bottleneck: bool
@@ -70,6 +72,7 @@ OPTIONS: T_Options = {
     "display_default_indexes": False,
     "enable_cftimeindex": True,
     "file_cache_maxsize": 128,
+    "future_no_mindex_dim_coord": False,
     "keep_attrs": "default",
     "warn_for_unclosed_files": False,
     "use_bottleneck": True,
@@ -98,6 +101,7 @@ _VALIDATORS = {
     "display_default_indexes": lambda choice: choice in [True, False, "default"],
     "enable_cftimeindex": lambda value: isinstance(value, bool),
     "file_cache_maxsize": _positive_integer,
+    "future_no_mindex_dim_coord": lambda value: isinstance(value, bool),
     "keep_attrs": lambda choice: choice in [True, False, "default"],
     "use_bottleneck": lambda value: isinstance(value, bool),
     "use_flox": lambda value: isinstance(value, bool),
@@ -218,6 +222,10 @@ class set_options:
         global least-recently-usage cached. This should be smaller than
         your system's per-process file descriptor limit, e.g.,
         ``ulimit -n`` on Linux.
+    future_no_mindex_dim_coord : bool, default: False
+        If True, no dimension coordinate with tuple values is be created
+        for a pandas multi-index. This is currently deactivated but
+        it will be the default behavior in the future.
     keep_attrs : {"default", True, False}
         Whether to keep attributes on xarray Datasets/dataarrays after
         operations. Can be


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

This PR adds a `future_no_mindex_dim_coord=False` option that, if set to True, enables the future behavior of `PandasMultiIndex` (i.e., no added dimension coordinate with tuple values):

```python
import xarray as xr

ds = xr.Dataset(coords={"x": ["a", "b"], "y": [1, 2]})

ds.stack(z=["x", "y"])

# <xarray.Dataset>
# Dimensions:  (z: 4)
# Coordinates:
#   * z        (z) object MultiIndex
#   * x        (z) <U1 'a' 'a' 'b' 'b'
#   * y        (z) int64 1 2 1 2
# Data variables:
#     *empty*

with xr.set_options(future_no_mindex_dim_coord=True):
    ds.stack(z=["x", "y"])

# <xarray.Dataset>
# Dimensions:  (z: 4)
# Coordinates:
#   * x        (z) <U1 'a' 'a' 'b' 'b'
#   * y        (z) int64 1 2 1 2
# Dimensions without coordinates: z
# Data variables:
#     *empty*
```

There are a few other things that we'll need to adapt or deprecate:

- Dropping multi-index dimension coordinate *de-facto* allows having several multi-indexes along the same dimension. Normally `stack` should already take this into account, but there may be other places where this is not yet supported or where we should raise an explicit error.
- Deprecate `Dataset.reorder_levels`: API is not compatible with the absence of dimension coordinate and several multi-indexes along the same dimension. I think it is OK to deprecate such edge case, which alternatively could be done by extracting the pandas index, updating it and then re-assign it to a the dataset with `assign_coords(xr.Coordinates.from_pandas_multiindex(...))`
- The text-based repr: in the example above, `Dimensions without coordinate: z` doesn't make much sense
- ... ?

I started updating the tests, although this will be much easier once #8140 is merged. This is something that we could also easily split into multiple PRs. It is probably OK if some features are (temporarily) breaking badly when setting `future_no_mindex_dim_coord=True`.

