### PR TITLE
tests: Update US/Eastern timezone to America/New_York

### DIFF
--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4698,7 +4698,7 @@ class TestDataset:
                 "e": [True, False, True],
                 "f": pd.Categorical(list("abc")),
                 "g": pd.date_range("20130101", periods=3),
-                "h": pd.date_range("20130101", periods=3, tz="US/Eastern"),
+                "h": pd.date_range("20130101", periods=3, tz="America/New_York"),
             }
         )
         df.index = pd.MultiIndex.from_product([["a"], range(3)], names=["one", "two"])

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -2906,7 +2906,9 @@ class TestNumpyCoercion:
         (np.array([datetime(2000, 1, 1)]), False),
         (pd.date_range("2000", periods=1, tz=pytz.timezone("America/New_York")), False),
         (
-            pd.Series(pd.date_range("2000", periods=1, tz=pytz.timezone("America/New_York"))),
+            pd.Series(
+                pd.date_range("2000", periods=1, tz=pytz.timezone("America/New_York"))
+            ),
             False,
         ),
     ],
@@ -2945,7 +2947,9 @@ def test_pandas_two_only_datetime_conversion_warnings() -> None:
             pd.DatetimeTZDtype("s", pytz.timezone("America/New_York")),
         ),
         (
-            pd.Series(pd.date_range("2000", periods=1, tz=pytz.timezone("America/New_York"))),
+            pd.Series(
+                pd.date_range("2000", periods=1, tz=pytz.timezone("America/New_York"))
+            ),
             pd.DatetimeTZDtype("s", pytz.timezone("America/New_York")),
         ),
     ]

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -2604,7 +2604,7 @@ class TestAsCompatibleData:
 
     @requires_pandas_version_two
     def test_tz_datetime(self) -> None:
-        tz = pytz.timezone("US/Eastern")
+        tz = pytz.timezone("America/New_York")
         times_ns = pd.date_range("2000", periods=1, tz=tz)
 
         times_s = times_ns.astype(pd.DatetimeTZDtype("s", tz))
@@ -2904,9 +2904,9 @@ class TestNumpyCoercion:
         (pd.date_range("2000", periods=1), False),
         (datetime(2000, 1, 1), False),
         (np.array([datetime(2000, 1, 1)]), False),
-        (pd.date_range("2000", periods=1, tz=pytz.timezone("US/Eastern")), False),
+        (pd.date_range("2000", periods=1, tz=pytz.timezone("America/New_York")), False),
         (
-            pd.Series(pd.date_range("2000", periods=1, tz=pytz.timezone("US/Eastern"))),
+            pd.Series(pd.date_range("2000", periods=1, tz=pytz.timezone("America/New_York"))),
             False,
         ),
     ],
@@ -2929,7 +2929,7 @@ def test_datetime_conversion_warning(values, warns_under_pandas_version_two) -> 
         # the case that the variable is backed by a timezone-aware
         # DatetimeIndex, and thus is hidden within the PandasIndexingAdapter class.
         assert var._data.array.dtype == pd.DatetimeTZDtype(
-            "ns", pytz.timezone("US/Eastern")
+            "ns", pytz.timezone("America/New_York")
         )
 
 
@@ -2941,12 +2941,12 @@ def test_pandas_two_only_datetime_conversion_warnings() -> None:
         (pd.date_range("2000", periods=1), "datetime64[s]"),
         (pd.Series(pd.date_range("2000", periods=1)), "datetime64[s]"),
         (
-            pd.date_range("2000", periods=1, tz=pytz.timezone("US/Eastern")),
-            pd.DatetimeTZDtype("s", pytz.timezone("US/Eastern")),
+            pd.date_range("2000", periods=1, tz=pytz.timezone("America/New_York")),
+            pd.DatetimeTZDtype("s", pytz.timezone("America/New_York")),
         ),
         (
-            pd.Series(pd.date_range("2000", periods=1, tz=pytz.timezone("US/Eastern"))),
-            pd.DatetimeTZDtype("s", pytz.timezone("US/Eastern")),
+            pd.Series(pd.date_range("2000", periods=1, tz=pytz.timezone("America/New_York"))),
+            pd.DatetimeTZDtype("s", pytz.timezone("America/New_York")),
         ),
     ]
     for data, dtype in cases:
@@ -2960,7 +2960,7 @@ def test_pandas_two_only_datetime_conversion_warnings() -> None:
         # the case that the variable is backed by a timezone-aware
         # DatetimeIndex, and thus is hidden within the PandasIndexingAdapter class.
         assert var._data.array.dtype == pd.DatetimeTZDtype(
-            "ns", pytz.timezone("US/Eastern")
+            "ns", pytz.timezone("America/New_York")
         )
 
 


### PR DESCRIPTION
Reason is that US/Eastern symlink moved from tzdata to tzdata-legacy package, causing FTBFS. Since America/New_York is better supported by tzdata, the switch makes the package stronger against future failures
