### PR TITLE
Cut middle version from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         # Bookend python versions
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.11"]
         env: [""]
         include:
           # Minimum python version:


### PR DESCRIPTION
Testing for 3.10 seems fairly low value — is there a realistic case where 3.10 would fail but 3.9 & 3.11 would pass?

Merging this would cut the CI queue...
