### PR TITLE
Fix typos

### DIFF
--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -527,7 +527,7 @@ class IOReadSingleFile(IOSingleNetCDF):
 class IOReadCustomEngine:
     def setup(self, *args, **kwargs):
         """
-        The custom backend does the bare mininum to be considered a lazy backend. But
+        The custom backend does the bare minimum to be considered a lazy backend. But
         the data in it is still in memory so slow file reading shouldn't affect the
         results.
         """

--- a/asv_bench/benchmarks/merge.py
+++ b/asv_bench/benchmarks/merge.py
@@ -41,7 +41,7 @@ class DatasetCreation:
         data = np.array(["0", "b"], dtype=str)
         self.dataset_coords = dict(time=np.array([0, 1]))
         self.dataset_attrs = dict(description="Test data")
-        attrs = dict(units="Celcius")
+        attrs = dict(units="Celsius")
         if strategy == "dict_of_DataArrays":
 
             def create_data_vars():

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -565,7 +565,7 @@ HDF5
 ----
 `HDF5`_ is both a file format and a data model for storing information. HDF5 stores
 data hierarchically, using groups to create a nested structure. HDF5 is a more
-general verion of the netCDF4 data model, so the nested structure is one of many
+general version of the netCDF4 data model, so the nested structure is one of many
 similarities between the two data formats.
 
 Reading HDF5 files in xarray requires the ``h5netcdf`` engine, which can be installed

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -888,7 +888,7 @@ Bug fixes
   By `Michael Niklas <https://github.com/headtr1ck>`_.
 - Fix side effects on index coordinate metadata after aligning objects. (:issue:`6852`, :pull:`6857`)
   By `Benoît Bovy <https://github.com/benbovy>`_.
-- Make FacetGrid.set_titles send kwargs correctly using `handle.udpate(kwargs)`. (:issue:`6839`, :pull:`6843`)
+- Make FacetGrid.set_titles send kwargs correctly using `handle.update(kwargs)`. (:issue:`6839`, :pull:`6843`)
   By `Oliver Lopez <https://github.com/lopezvoliver>`_.
 - Fix bug where index variables would be changed inplace. (:issue:`6931`, :pull:`6938`)
   By `Michael Niklas <https://github.com/headtr1ck>`_.
@@ -4751,7 +4751,7 @@ Bug fixes
 - Corrected a bug with incorrect coordinates for non-georeferenced geotiff
   files (:issue:`1686`). Internally, we now use the rasterio coordinate
   transform tool instead of doing the computations ourselves. A
-  ``parse_coordinates`` kwarg has beed added to :py:func:`~open_rasterio`
+  ``parse_coordinates`` kwarg has been added to :py:func:`~open_rasterio`
   (set to ``True`` per default).
   By `Fabien Maussion <https://github.com/fmaussion>`_.
 - The colors of discrete colormaps are now the same regardless if `seaborn`

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -538,7 +538,7 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
     """
     Backend for netCDF files based on the netCDF4 package.
 
-    It can open ".nc", ".nc4", ".cdf" files and will be choosen
+    It can open ".nc", ".nc4", ".cdf" files and will be chosen
     as default for these files.
 
     Additionally it can open valid HDF5 files, see

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4463,7 +4463,7 @@ class DataArray(
                [2, 2]])
         Dimensions without coordinates: X, Y
 
-        .equals returns True if two DataArrays have the same values, dimensions, and coordinates. .broadcast_equals returns True if the results of broadcasting two DataArrays against eachother have the same values, dimensions, and coordinates.
+        .equals returns True if two DataArrays have the same values, dimensions, and coordinates. .broadcast_equals returns True if the results of broadcasting two DataArrays against each other have the same values, dimensions, and coordinates.
 
         >>> a.equals(b)
         False

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -307,7 +307,7 @@ class Index:
     def equals(self: T_Index, other: T_Index) -> bool:
         """Compare this index with another index of the same type.
 
-        Implemenation is optional but required in order to support alignment.
+        Implementation is optional but required in order to support alignment.
 
         Parameters
         ----------

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -572,7 +572,7 @@ class DataArrayRolling(Rolling["DataArray"]):
             and not is_duck_dask_array(self.obj.data)
             and self.ndim == 1
         ):
-            # TODO: renable bottleneck with dask after the issues
+            # TODO: re-enable bottleneck with dask after the issues
             # underlying https://github.com/pydata/xarray/issues/2940 are
             # fixed.
             return self._bottleneck_reduce(

--- a/xarray/plot/dataarray_plot.py
+++ b/xarray/plot/dataarray_plot.py
@@ -186,7 +186,7 @@ def _prepare_plot1d_data(
     # dimensions so the plotter can plot anything:
     if darray.ndim > 1:
         # When stacking dims the lines will continue connecting. For floats
-        # this can be solved by adding a nan element inbetween the flattening
+        # this can be solved by adding a nan element in between the flattening
         # points:
         dims_T = []
         if np.issubdtype(darray.dtype, np.floating):

--- a/xarray/plot/dataset_plot.py
+++ b/xarray/plot/dataset_plot.py
@@ -730,7 +730,7 @@ def _temp_dataarray(ds: Dataset, y: Hashable, locals_: dict[str, Any]) -> DataAr
     coords = dict(ds.coords)
 
     # Add extra coords to the DataArray from valid kwargs, if using all
-    # kwargs there is a risk that we add unneccessary dataarrays as
+    # kwargs there is a risk that we add unnecessary dataarrays as
     # coords straining RAM further for example:
     # ds.both and extend="both" would add ds.both to the coords:
     valid_coord_kwargs = {"x", "z", "markersize", "hue", "row", "col", "u", "v"}

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -76,7 +76,7 @@ class FacetGrid(Generic[T_Xarray]):
     The general approach to plotting here is called "small multiples",
     where the same kind of plot is repeated multiple times, and the
     specific use of small multiples to display the same relationship
-    conditioned on one ore more other variables is often called a "trellis
+    conditioned on one or more other variables is often called a "trellis
     plot".
 
     The basic workflow is to initialize the :class:`FacetGrid` object with

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -1461,7 +1461,7 @@ class _Normalize(Sequence):
 
     def _calc_widths(self, y: np.ndarray | DataArray) -> np.ndarray | DataArray:
         """
-        Normalize the values so they're inbetween self._width.
+        Normalize the values so they're in between self._width.
         """
         if self._width is None:
             return y
@@ -1473,7 +1473,7 @@ class _Normalize(Sequence):
             # Use default with if y is constant:
             widths = xdefault + 0 * y
         else:
-            # Normalize inbetween xmin and xmax:
+            # Normalize in between xmin and xmax:
             k = (y - np.min(y)) / diff_maxy_miny
             widths = xmin + k * (xmax - xmin)
         return widths
@@ -1821,8 +1821,8 @@ def _guess_coords_to_plot(
     )
 
     # If dims_plot[k] isn't defined then fill with one of the available dims, unless
-    # one of related mpl kwargs has been used. This should have similiar behaviour as
-    # * plt.plot(x, y) -> Multple lines with different colors if y is 2d.
+    # one of related mpl kwargs has been used. This should have similar behaviour as
+    # * plt.plot(x, y) -> Multiple lines with different colors if y is 2d.
     # * plt.plot(x, y, color="red") -> Multiple red lines if y is 2d.
     for k, dim, ign_kws in zip(default_guess, available_coords, ignore_guess_kwargs):
         if coords_to_plot.get(k, None) is None and all(


### PR DESCRIPTION
Found via `codespell -S tests -L splitted,coo,fo,nd,ser,slowy,soler,tung,secondy,nin`

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
