### PR TITLE
Don't try to sort hashable, map to string

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5284,7 +5284,7 @@ class Dataset(
             if missing_sample_dims:
                 raise ValueError(
                     "Variables in the dataset must contain all ``sample_dims`` "
-                    f"({sample_dims!r}) but '{key}' misses {missing_sample_dims}"
+                    f"({sample_dims!r}) but '{key}' misses {tuple(missing_sample_dims)}"
                 )
 
         def stack_dataarray(da):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5285,7 +5285,7 @@ class Dataset(
                 raise ValueError(
                     "Variables in the dataset must contain all ``sample_dims`` "
                     f"({sample_dims!r}) but '{key}' misses {sorted(missing_sample_dims)}"
-                )
+                )  # add str
 
         def stack_dataarray(da):
             # add missing dims/ coords and the name of the variable

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5284,8 +5284,8 @@ class Dataset(
             if missing_sample_dims:
                 raise ValueError(
                     "Variables in the dataset must contain all ``sample_dims`` "
-                    f"({sample_dims!r}) but '{key}' misses {sorted(missing_sample_dims)}"
-                )  # add str
+                    f"({sample_dims!r}) but '{key}' misses {sorted(list(missing_sample_dims))}"
+                )
 
         def stack_dataarray(da):
             # add missing dims/ coords and the name of the variable

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5284,7 +5284,7 @@ class Dataset(
             if missing_sample_dims:
                 raise ValueError(
                     "Variables in the dataset must contain all ``sample_dims`` "
-                    f"({sample_dims!r}) but '{key}' misses {sorted(map(str, missing_sample_dims))}"
+                    f"({sample_dims!r}) but '{key}' misses {missing_sample_dims}"
                 )
 
         def stack_dataarray(da):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5284,7 +5284,7 @@ class Dataset(
             if missing_sample_dims:
                 raise ValueError(
                     "Variables in the dataset must contain all ``sample_dims`` "
-                    f"({sample_dims!r}) but '{key}' misses {tuple(missing_sample_dims)}"
+                    f"({sample_dims!r}) but '{key}' misses {sorted(map(str, missing_sample_dims))}"
                 )
 
         def stack_dataarray(da):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5284,7 +5284,7 @@ class Dataset(
             if missing_sample_dims:
                 raise ValueError(
                     "Variables in the dataset must contain all ``sample_dims`` "
-                    f"({sample_dims!r}) but '{key}' misses {sorted(list(missing_sample_dims))}"
+                    f"({sample_dims!r}) but '{key}' misses {sorted(map(str, missing_sample_dims))}"
                 )
 
         def stack_dataarray(da):


### PR DESCRIPTION
Fixes the mypy error we're seeing in the CI at the moment:

```
xarray/core/dataset.py:5286: error: Value of type variable "SupportsRichComparisonT" of "sorted" cannot be "Hashable"  [type-var]
```

Can't sort Hashables apparently.
