### PR TITLE
Set dev version above released version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 ]
 
 [tool.setuptools_scm]
-fallback_version = "999"
+fallback_version = "9999"
 
 [tool.coverage.run]
 omit = [
@@ -64,7 +64,7 @@ module = [
   "sparse.*",
   "toolz.*",
   "zarr.*",
-  "numpy.exceptions.*",  # remove once support for `numpy<2.0` has been dropped
+  "numpy.exceptions.*", # remove once support for `numpy<2.0` has been dropped
 ]
 
 [[tool.mypy.overrides]]
@@ -72,31 +72,28 @@ ignore_errors = true
 module = []
 
 [tool.ruff]
-target-version = "py39"
 builtins = ["ellipsis"]
 exclude = [
-    ".eggs",
-    "doc",
-    "_typed_ops.pyi",
+  ".eggs",
+  "doc",
+  "_typed_ops.pyi",
 ]
+target-version = "py39"
 # E402: module level import not at top of file
 # E501: line too long - let black worry about that
 # E731: do not assign a lambda expression, use a def
 ignore = [
-    "E402",
-    "E501",
-    "E731",
+  "E402",
+  "E501",
+  "E731",
 ]
 select = [
-    # Pyflakes
-    "F",
-    # Pycodestyle
-    "E",
-    "W",
-    # isort
-    "I",
-    # Pyupgrade
-    "UP",
+  # Pyflakes
+  "F", # Pycodestyle
+  "E",
+  "W", # isort
+  "I", # Pyupgrade
+  "UP",
 ]
 
 [tool.ruff.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,9 +88,8 @@ ignore = [
   "E731",
 ]
 select = [
-  # Pyflakes
-  "F", # Pycodestyle
-  "E",
+  "F", # Pyflakes
+  "E", # Pycodestyle
   "W", # isort
   "I", # Pyupgrade
   "UP",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-setup(use_scm_version={"fallback_version": "999"})
+setup(use_scm_version={"fallback_version": "9999"})


### PR DESCRIPTION
Pandas asserts that the xarray version that's running is above `2022.`; locally it was set to `999` which failed this. It only applies when developing locally.