### PR TITLE
Fix `PeriodIndex` deprecation in xarray tests

### DIFF
--- a/asv_bench/benchmarks/pandas.py
+++ b/asv_bench/benchmarks/pandas.py
@@ -13,7 +13,7 @@ class MultiIndexSeries:
             [
                 list("abcdefhijk"),
                 list("abcdefhijk"),
-                pd.date_range(start="2000-01-01", periods=1000, freq="B"),
+                pd.date_range(start="2000-01-01", periods=1000, freq="D"),
             ]
         )
         series = pd.Series(data, index)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -380,7 +380,7 @@ class TestDataset:
 
     def test_repr_period_index(self) -> None:
         data = create_test_data(seed=456)
-        data.coords["time"] = pd.period_range("2000-01-01", periods=20, freq="B")
+        data.coords["time"] = pd.period_range("2000-01-01", periods=20, freq="D")
 
         # check that creating the repr doesn't raise an error #GH645
         repr(data)

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -338,10 +338,10 @@ class VariableSubclassobjects(ABC):
         assert v[0].values == v.values[0]
 
     def test_pandas_period_index(self):
-        v = self.cls(["x"], pd.period_range(start="2000", periods=20, freq="B"))
+        v = self.cls(["x"], pd.period_range(start="2000", periods=20, freq="D"))
         v = v.load()  # for dask-based Variable
-        assert v[0] == pd.Period("2000", freq="B")
-        assert "Period('2000-01-03', 'B')" in repr(v)
+        assert v[0] == pd.Period("2000", freq="D")
+        assert "Period('2000-01-01', 'D')" in repr(v)
 
     @pytest.mark.parametrize("dtype", [float, int])
     def test_1d_math(self, dtype: np.typing.DTypeLike) -> None:


### PR DESCRIPTION
Silences a few warnings

<!-- Feel free to remove check-list items aren't relevant to your change -->
