### PR TITLE
Fix comment alignment in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,9 +139,9 @@ ignore = [
 select = [
   "F", # Pyflakes
   "E", # Pycodestyle
-  "W", # isort
-  "I", # Pyupgrade
-  "UP",
+  "W",
+  "I", # isort
+  "UP", # Pyupgrade
 ]
 
 [tool.ruff.isort]


### PR DESCRIPTION
I wasn't sufficiently careful in #8181...