### PR TITLE
Update contourf call check for mpl 3.8

### DIFF
--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -167,7 +167,14 @@ class PlotTestCase:
 
     def contourf_called(self, plotmethod):
         plotmethod()
-        paths = plt.gca().findobj(mpl.collections.PathCollection)
+
+        # Compatible with mpl before (PathCollection) and after (QuadContourSet) 3.8
+        def matchfunc(x):
+            return isinstance(
+                x, (mpl.collections.PathCollection, mpl.contour.QuadContourSet)
+            )
+
+        paths = plt.gca().findobj(matchfunc)
         return len(paths) > 0
 
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

In doing the final checks prior to release of Matplotlib 3.8.0, we noticed that there were two test failures here
due to the return type/artist tree changing for contourf calls (while the type is reasonably back-compatible itself,
we have moved from a "QuadContourSet makes a PathCollection" to "QuadContourSet is a full artist/collection"

xref matplotlib/matplotlib#25247

Unfortunately this change is not really possible to make with deprecations/etc, so we are kind of stuck just making it.
However, in practice, it has only ever seemed to matter for test code which is pretty easy to make work (like here),r
so we have decided to go forward with the change.
