### PR TITLE
FIX: use "krogh" as interpolator method-string instead of "krog"

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3380,7 +3380,7 @@ class DataArray(
         dim : Hashable or None, optional
             Specifies the dimension along which to interpolate.
         method : {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "polynomial", \
-            "barycentric", "krog", "pchip", "spline", "akima"}, default: "linear"
+            "barycentric", "krogh", "pchip", "spline", "akima"}, default: "linear"
             String indicating which method to use for interpolation:
 
             - 'linear': linear interpolation. Additional keyword
@@ -3389,7 +3389,7 @@ class DataArray(
               are passed to :py:func:`scipy.interpolate.interp1d`. If
               ``method='polynomial'``, the ``order`` keyword argument must also be
               provided.
-            - 'barycentric', 'krog', 'pchip', 'spline', 'akima': use their
+            - 'barycentric', 'krogh', 'pchip', 'spline', 'akima': use their
               respective :py:class:`scipy.interpolate` classes.
 
         use_coordinate : bool or str, default: True

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3730,7 +3730,7 @@ class Dataset(
             If DataArrays are passed as new coordinates, their dimensions are
             used for the broadcasting. Missing values are skipped.
         method : {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "polynomial", \
-            "barycentric", "krog", "pchip", "spline", "akima"}, default: "linear"
+            "barycentric", "krogh", "pchip", "spline", "akima"}, default: "linear"
             String indicating which method to use for interpolation:
 
             - 'linear': linear interpolation. Additional keyword
@@ -3739,7 +3739,7 @@ class Dataset(
               are passed to :py:func:`scipy.interpolate.interp1d`. If
               ``method='polynomial'``, the ``order`` keyword argument must also be
               provided.
-            - 'barycentric', 'krog', 'pchip', 'spline', 'akima': use their
+            - 'barycentric', 'krogh', 'pchip', 'spline', 'akima': use their
               respective :py:class:`scipy.interpolate` classes.
 
         assume_sorted : bool, default: False
@@ -4006,7 +4006,7 @@ class Dataset(
             names to an 1d array-like, which provides coordinates upon
             which to index the variables in this dataset. Missing values are skipped.
         method : {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "polynomial", \
-            "barycentric", "krog", "pchip", "spline", "akima"}, default: "linear"
+            "barycentric", "krogh", "pchip", "spline", "akima"}, default: "linear"
             String indicating which method to use for interpolation:
 
             - 'linear': linear interpolation. Additional keyword
@@ -4015,7 +4015,7 @@ class Dataset(
               are passed to :py:func:`scipy.interpolate.interp1d`. If
               ``method='polynomial'``, the ``order`` keyword argument must also be
               provided.
-            - 'barycentric', 'krog', 'pchip', 'spline', 'akima': use their
+            - 'barycentric', 'krogh', 'pchip', 'spline', 'akima': use their
               respective :py:class:`scipy.interpolate` classes.
 
         assume_sorted : bool, default: False
@@ -6371,7 +6371,7 @@ class Dataset(
         dim : Hashable or None, optional
             Specifies the dimension along which to interpolate.
         method : {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "polynomial", \
-            "barycentric", "krog", "pchip", "spline", "akima"}, default: "linear"
+            "barycentric", "krogh", "pchip", "spline", "akima"}, default: "linear"
             String indicating which method to use for interpolation:
 
             - 'linear': linear interpolation. Additional keyword
@@ -6380,7 +6380,7 @@ class Dataset(
               are passed to :py:func:`scipy.interpolate.interp1d`. If
               ``method='polynomial'``, the ``order`` keyword argument must also be
               provided.
-            - 'barycentric', 'krog', 'pchip', 'spline', 'akima': use their
+            - 'barycentric', 'krogh', 'pchip', 'spline', 'akima': use their
               respective :py:class:`scipy.interpolate` classes.
 
         use_coordinate : bool or Hashable, default: True

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -501,7 +501,7 @@ def _get_interpolator(
             )
         elif method == "barycentric":
             interp_class = _import_interpolant("BarycentricInterpolator", method)
-        elif method == "krog":
+        elif method == "krogh":
             interp_class = _import_interpolant("KroghInterpolator", method)
         elif method == "pchip":
             interp_class = _import_interpolant("PchipInterpolator", method)

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -501,7 +501,7 @@ def _get_interpolator(
             )
         elif method == "barycentric":
             interp_class = _import_interpolant("BarycentricInterpolator", method)
-        elif method == "krogh":
+        elif method in ["krogh", "krog"]:
             interp_class = _import_interpolant("KroghInterpolator", method)
         elif method == "pchip":
             interp_class = _import_interpolant("PchipInterpolator", method)

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -189,7 +189,7 @@ JoinOptions = Literal["outer", "inner", "left", "right", "exact", "override"]
 Interp1dOptions = Literal[
     "linear", "nearest", "zero", "slinear", "quadratic", "cubic", "polynomial"
 ]
-InterpolantOptions = Literal["barycentric", "krog", "pchip", "spline", "akima"]
+InterpolantOptions = Literal["barycentric", "krogh", "pchip", "spline", "akima"]
 InterpOptions = Union[Interp1dOptions, InterpolantOptions]
 
 DatetimeUnitOptions = Literal[

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -118,7 +118,7 @@ def test_interpolate_pd_compat():
 
 @requires_scipy
 @pytest.mark.parametrize("method", ["barycentric", "krogh", "pchip", "spline", "akima"])
-def test_scipy_methods_function(method):
+def test_scipy_methods_function(method) -> None:
     # Note: Pandas does some wacky things with these methods and the full
     # integration tests won't work.
     da, _ = make_interpolate_example_data((25, 25), 0.4, non_uniform=True)

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -117,7 +117,7 @@ def test_interpolate_pd_compat():
 
 
 @requires_scipy
-@pytest.mark.parametrize("method", ["barycentric", "krog", "pchip", "spline", "akima"])
+@pytest.mark.parametrize("method", ["barycentric", "krogh", "pchip", "spline", "akima"])
 def test_scipy_methods_function(method):
     # Note: Pandas does some wacky things with these methods and the full
     # integration tests won't work.


### PR DESCRIPTION
While working on #8146 this came up. Aligning with upstream naming convention.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
