### PR TITLE
Fix pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,8 @@ select = [
 [tool.ruff.isort]
 known-first-party = ["xarray"]
 
-[tool.pytest.ini-options]
+[tool.pytest.ini_options]
+addopts = '--strict-markers'
 filterwarnings = [
   "ignore:Using a non-tuple sequence for multidimensional indexing is deprecated:FutureWarning",
 ]


### PR DESCRIPTION
My mistake from #8183. I added `--strict-markers` so we can't make this sort of mistake again.
