### PR TITLE
Add some more mypy checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,8 @@ exclude_lines = ["pragma: no cover", "if TYPE_CHECKING"]
 exclude = 'xarray/util/generate_.*\.py'
 files = "xarray"
 show_error_codes = true
+show_error_context = true
+warn_redundant_casts = true
 warn_unused_ignores = true
 
 # Most of the numerical computing stack doesn't have type annotations yet.
@@ -115,10 +117,6 @@ module = [
   "zarr.*",
   "numpy.exceptions.*", # remove once support for `numpy<2.0` has been dropped
 ]
-
-[[tool.mypy.overrides]]
-ignore_errors = true
-module = []
 
 [tool.ruff]
 builtins = ["ellipsis"]

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2564,7 +2564,7 @@ class DataArray(
                 raise ValueError("dims should not contain duplicate values.")
             dim = dict.fromkeys(dim, 1)
         elif dim is not None and not isinstance(dim, Mapping):
-            dim = {cast(Hashable, dim): 1}
+            dim = {dim: 1}
 
         dim = either_dict_or_kwargs(dim, dim_kwargs, "expand_dims")
         ds = self._to_temp_dataset().expand_dims(dim, axis)
@@ -4362,7 +4362,7 @@ class DataArray(
         temp_name = "__temporary_name"
         df = pd.DataFrame({temp_name: series})
         ds = Dataset.from_dataframe(df, sparse=sparse)
-        result = cast(DataArray, ds[temp_name])
+        result = ds[temp_name]
         result.name = series.name
         return result
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -27,7 +27,7 @@ import numpy as np
 
 # remove once numpy 2.0 is the oldest supported version
 try:
-    from numpy.exceptions import RankWarning
+    from numpy.exceptions import RankWarning  # type: ignore
 except ImportError:
     from numpy import RankWarning
 
@@ -447,7 +447,7 @@ class DataVariables(Mapping[Any, "DataArray"]):
 
     def __getitem__(self, key: Hashable) -> DataArray:
         if key not in self._dataset._coord_names:
-            return cast("DataArray", self._dataset[key])
+            return  self._dataset[key]
         raise KeyError(key)
 
     def __repr__(self) -> str:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -447,7 +447,7 @@ class DataVariables(Mapping[Any, "DataArray"]):
 
     def __getitem__(self, key: Hashable) -> DataArray:
         if key not in self._dataset._coord_names:
-            return  self._dataset[key]
+            return self._dataset[key]
         raise KeyError(key)
 
     def __repr__(self) -> str:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -27,7 +27,7 @@ import numpy as np
 
 # remove once numpy 2.0 is the oldest supported version
 try:
-    from numpy.exceptions import RankWarning  # type: ignore
+    from numpy.exceptions import RankWarning  # type: ignore[attr-defined,unused-ignore]
 except ImportError:
     from numpy import RankWarning
 

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -8,7 +8,7 @@ from numpy.core.multiarray import normalize_axis_index  # type: ignore[attr-defi
 
 # remove once numpy 2.0 is the oldest supported version
 try:
-    from numpy.exceptions import RankWarning
+    from numpy.exceptions import RankWarning  # type: ignore
 except ImportError:
     from numpy import RankWarning
 

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -8,7 +8,7 @@ from numpy.core.multiarray import normalize_axis_index  # type: ignore[attr-defi
 
 # remove once numpy 2.0 is the oldest supported version
 try:
-    from numpy.exceptions import RankWarning  # type: ignore
+    from numpy.exceptions import RankWarning  # type: ignore[attr-defined,unused-ignore]
 except ImportError:
     from numpy import RankWarning
 

--- a/xarray/plot/dataarray_plot.py
+++ b/xarray/plot/dataarray_plot.py
@@ -1043,9 +1043,7 @@ def _plot1d(plotfunc):
             else:
                 hueplt_norm_values: list[np.ndarray | None]
                 if hueplt_norm.data is not None:
-                    hueplt_norm_values = list(
-                        cast("DataArray", hueplt_norm.data).to_numpy()
-                    )
+                    hueplt_norm_values = list(hueplt_norm.data.to_numpy())
                 else:
                     hueplt_norm_values = [hueplt_norm.data]
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -16,7 +16,7 @@ from packaging.version import Version
 
 # remove once numpy 2.0 is the oldest supported version
 try:
-    from numpy.exceptions import RankWarning
+    from numpy.exceptions import RankWarning  # type: ignore
 except ImportError:
     from numpy import RankWarning
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -16,7 +16,7 @@ from packaging.version import Version
 
 # remove once numpy 2.0 is the oldest supported version
 try:
-    from numpy.exceptions import RankWarning  # type: ignore
+    from numpy.exceptions import RankWarning  # type: ignore[attr-defined,unused-ignore]
 except ImportError:
     from numpy import RankWarning
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -17,7 +17,7 @@ from pandas.core.indexes.datetimes import DatetimeIndex
 
 # remove once numpy 2.0 is the oldest supported version
 try:
-    from numpy.exceptions import RankWarning  # type: ignore
+    from numpy.exceptions import RankWarning  # type: ignore[attr-defined,unused-ignore]
 except ImportError:
     from numpy import RankWarning
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -17,7 +17,7 @@ from pandas.core.indexes.datetimes import DatetimeIndex
 
 # remove once numpy 2.0 is the oldest supported version
 try:
-    from numpy.exceptions import RankWarning
+    from numpy.exceptions import RankWarning  # type: ignore
 except ImportError:
     from numpy import RankWarning
 


### PR DESCRIPTION
This disallows redundant casts

FWIW I thought we had gone through many of the tests and forced them to have typed defs, maybe with the intention of turning on some elements of strict mode. But then I don't think we have any strictness checks at the moment, and I see many functions in the tests which don't have typing. Am I mis-rembering?? Or maybe we started but didn't get far enough (it is a big project...)
