### PR TITLE
decode variable with mismatched coordinate attribute

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -84,7 +84,7 @@ Bug fixes
   issues (:issue:`7817`, :issue:`7942`, :issue:`7790`, :issue:`6191`, :issue:`7096`,
   :issue:`1064`, :pull:`7827`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
-- Fixed a bug where mismatched ``coordinates`` silently failed to decode variable (:issue:`1809`, :pull:`8195`).
+- Fixed a bug where inaccurate ``coordinates`` silently failed to decode variable (:issue:`1809`, :pull:`8195`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_
 - ``.rolling_exp`` functions no longer mistakenly lose non-dimensioned coords
   (:issue:`6528`, :pull:`8114`)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -84,6 +84,8 @@ Bug fixes
   issues (:issue:`7817`, :issue:`7942`, :issue:`7790`, :issue:`6191`, :issue:`7096`,
   :issue:`1064`, :pull:`7827`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Fixed a bug where mismatched ``coordinates`` silently failed to decode variable (:issue:`1809`, :pull:`8195`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -490,8 +490,7 @@ def open_dataset(
           other attributes as coordinate variables.
 
         Only existing variables can be set as coordinates. Missing variables
-        will be silently ignored. If ``coordinates`` do not match any variable,
-        no decoding takes place.
+        will be silently ignored. 
     drop_variables: str or iterable of str, optional
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or
@@ -697,8 +696,7 @@ def open_dataarray(
           other attributes as coordinate variables.
 
         Only existing variables can be set as coordinates. Missing variables
-        will be silently ignored. If ``coordinates`` do not match any variable,
-        no decoding takes place.
+        will be silently ignored.
     drop_variables: str or iterable of str, optional
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -488,6 +488,10 @@ def open_dataset(
           as coordinate variables.
         - "all": Set variables referred to in  ``'grid_mapping'``, ``'bounds'`` and
           other attributes as coordinate variables.
+
+        Only existing variables can be set as coordinates. Missing variables
+        will be silently ignored. If ``coordinates`` do not match any variable,
+        no decoding takes place.
     drop_variables: str or iterable of str, optional
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or
@@ -691,6 +695,10 @@ def open_dataarray(
           as coordinate variables.
         - "all": Set variables referred to in  ``'grid_mapping'``, ``'bounds'`` and
           other attributes as coordinate variables.
+
+        Only existing variables can be set as coordinates. Missing variables
+        will be silently ignored. If ``coordinates`` do not match any variable,
+        no decoding takes place.
     drop_variables: str or iterable of str, optional
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -490,7 +490,7 @@ def open_dataset(
           other attributes as coordinate variables.
 
         Only existing variables can be set as coordinates. Missing variables
-        will be silently ignored. 
+        will be silently ignored.
     drop_variables: str or iterable of str, optional
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -439,31 +439,12 @@ def decode_cf_variables(
             )
         except Exception as e:
             raise type(e)(f"Failed to decode variable {k!r}: {e}")
-        if decode_coords in [
-            True,
-            "coordinates",
-            "all",
-            "coordinates_strict",
-            "all_strict",
-        ]:
+        if decode_coords in [True, "coordinates", "all"]:
             var_attrs = new_vars[k].attrs
             if "coordinates" in var_attrs:
-                var_coord_names = var_attrs["coordinates"].split()
-                if missing_coord_names := set(var_coord_names) - set(variables):
-                    # need to preserve order here
-                    var_coord_names = [c for c in var_coord_names if c in variables]
-                    msg = (
-                        f"Mismatched ``coordinates`` attribute on variable {k!r}. "
-                        f"Coordinate(s): {list(missing_coord_names)!r} missing in dataset."
-                    )
-                    if isinstance(decode_coords, str) and "strict" in decode_coords:
-                        raise ValueError(msg)
-                    else:
-                        msg_solution = (
-                            f"Decoding with new ``coordinates``: {var_coord_names}."
-                        )
-                        emit_user_level_warning(" ".join([msg, msg_solution]))
-
+                var_coord_names = [
+                    c for c in var_attrs["coordinates"].split() if c in variables
+                ]
                 new_vars[k].encoding["coordinates"] = " ".join(var_coord_names)
                 del var_attrs["coordinates"]
                 coord_names.update(var_coord_names)

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -443,10 +443,11 @@ def decode_cf_variables(
                 var_coord_names = [
                     c for c in var_attrs["coordinates"].split() if c in variables
                 ]
-                # only decode if there is at least one variable matching a coordinate
+                # propagate as is
+                new_vars[k].encoding["coordinates"] = var_attrs["coordinates"]
+                del var_attrs["coordinates"]
+                # but only use as coordinate if existing
                 if var_coord_names:
-                    new_vars[k].encoding["coordinates"] = var_attrs["coordinates"]
-                    del var_attrs["coordinates"]
                     coord_names.update(var_coord_names)
 
         if decode_coords == "all":

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from collections import defaultdict
 from collections.abc import Hashable, Iterable, Mapping, MutableMapping
 from typing import TYPE_CHECKING, Any, Union
@@ -112,13 +111,13 @@ def ensure_dtype_not_object(var: Variable, name: T_Name = None) -> Variable:
             return var
 
         if is_duck_dask_array(data):
-            warnings.warn(
+            emit_user_level_warning(
                 f"variable {name} has data in the form of a dask array with "
                 "dtype=object, which means it is being loaded into memory "
                 "to determine a data type that can be safely stored on disk. "
                 "To avoid this, coerce this variable to a fixed-size dtype "
                 "with astype() before saving it.",
-                SerializationWarning,
+                category=SerializationWarning,
             )
             data = data.compute()
 
@@ -355,15 +354,14 @@ def _update_bounds_encoding(variables: T_Variables) -> None:
             and "bounds" in attrs
             and attrs["bounds"] in variables
         ):
-            warnings.warn(
-                "Variable '{0}' has datetime type and a "
-                "bounds variable but {0}.encoding does not have "
-                "units specified. The units encodings for '{0}' "
-                "and '{1}' will be determined independently "
+            emit_user_level_warning(
+                f"Variable {name:s} has datetime type and a "
+                f"bounds variable but {name:s}.encoding does not have "
+                f"units specified. The units encodings for {name:s} "
+                f"and {attrs['bounds']} will be determined independently "
                 "and may not be equal, counter to CF-conventions. "
                 "If this is a concern, specify a units encoding for "
-                "'{0}' before writing to a file.".format(name, attrs["bounds"]),
-                UserWarning,
+                f"{name:s} before writing to a file.",
             )
 
         if has_date_units and "bounds" in attrs:
@@ -475,8 +473,8 @@ def decode_cf_variables(
                             for role_or_name in part.split()
                         ]
                         if len(roles_and_names) % 2 == 1:
-                            warnings.warn(
-                                f"Attribute {attr_name:s} malformed", stacklevel=5
+                            emit_user_level_warning(
+                                f"Attribute {attr_name:s} malformed"
                             )
                         var_names = roles_and_names[1::2]
                     if all(var_name in variables for var_name in var_names):
@@ -488,9 +486,8 @@ def decode_cf_variables(
                             for proj_name in var_names
                             if proj_name not in variables
                         ]
-                        warnings.warn(
+                        emit_user_level_warning(
                             f"Variable(s) referenced in {attr_name:s} not in variables: {referenced_vars_not_in_variables!s}",
-                            stacklevel=5,
                         )
                     del var_attrs[attr_name]
 
@@ -646,12 +643,11 @@ def _encode_coordinates(variables, attributes, non_dim_coord_names):
 
     for name in list(non_dim_coord_names):
         if isinstance(name, str) and " " in name:
-            warnings.warn(
+            emit_user_level_warning(
                 f"coordinate {name!r} has a space in its name, which means it "
                 "cannot be marked as a coordinate on disk and will be "
                 "saved as a data variable instead",
-                SerializationWarning,
-                stacklevel=6,
+                category=SerializationWarning,
             )
             non_dim_coord_names.discard(name)
 
@@ -724,11 +720,11 @@ def _encode_coordinates(variables, attributes, non_dim_coord_names):
     if global_coordinates:
         attributes = dict(attributes)
         if "coordinates" in attributes:
-            warnings.warn(
+            emit_user_level_warning(
                 f"cannot serialize global coordinates {global_coordinates!r} because the global "
                 f"attribute 'coordinates' already exists. This may prevent faithful roundtripping"
                 f"of xarray datasets",
-                SerializationWarning,
+                category=SerializationWarning,
             )
         else:
             attributes["coordinates"] = " ".join(sorted(map(str, global_coordinates)))

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -445,9 +445,11 @@ def decode_cf_variables(
                 var_coord_names = [
                     c for c in var_attrs["coordinates"].split() if c in variables
                 ]
-                new_vars[k].encoding["coordinates"] = " ".join(var_coord_names)
-                del var_attrs["coordinates"]
-                coord_names.update(var_coord_names)
+                # only decode if there is at least one variable matching a coordinate
+                if var_coord_names:
+                    new_vars[k].encoding["coordinates"] = " ".join(var_coord_names)
+                    del var_attrs["coordinates"]
+                    coord_names.update(var_coord_names)
 
         if decode_coords == "all":
             for attr_name in CF_RELATED_DATA:

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -378,9 +378,7 @@ def decode_cf_variables(
     concat_characters: bool = True,
     mask_and_scale: bool = True,
     decode_times: bool = True,
-    decode_coords: Literal[
-        True, "coordinates", "all", "coordinates_strict", "all_strict"
-    ] = True,
+    decode_coords: bool | Literal["coordinates", "all"] = True,
     drop_variables: T_DropVariables = None,
     use_cftime: bool | None = None,
     decode_timedelta: bool | None = None,
@@ -495,9 +493,7 @@ def decode_cf(
     concat_characters: bool = True,
     mask_and_scale: bool = True,
     decode_times: bool = True,
-    decode_coords: Literal[
-        True, "coordinates", "all", "coordinates_strict", "all_strict"
-    ] = True,
+    decode_coords: bool | Literal["coordinates", "all"] = True,
     drop_variables: T_DropVariables = None,
     use_cftime: bool | None = None,
     decode_timedelta: bool | None = None,

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -450,7 +450,15 @@ def decode_cf_variables(
                         raise ValueError(msg)
                     else:
                         from xarray.core.utils import emit_user_level_warning
-                        emit_user_level_warning(" ".join([msg,  f"Decoding with new ``coordinates``: {existing_coord_names}."]))
+
+                        emit_user_level_warning(
+                            " ".join(
+                                [
+                                    msg,
+                                    f"Decoding with new ``coordinates``: {existing_coord_names}.",
+                                ]
+                            )
+                        )
 
                 new_vars[k].encoding["coordinates"] = " ".join(existing_coord_names)
                 del var_attrs["coordinates"]

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -445,7 +445,7 @@ def decode_cf_variables(
                 ]
                 # only decode if there is at least one variable matching a coordinate
                 if var_coord_names:
-                    new_vars[k].encoding["coordinates"] = " ".join(var_coord_names)
+                    new_vars[k].encoding["coordinates"] = var_attrs["coordinates"]
                     del var_attrs["coordinates"]
                     coord_names.update(var_coord_names)
 
@@ -514,17 +514,14 @@ def decode_cf(
     decode_times : bool, optional
         Decode cf times (e.g., integers since "hours since 2000-01-01") to
         np.datetime64.
-    decode_coords : bool or {"coordinates", "coordinates_strict", "all", "all_strict"}, optional
+    decode_coords : bool or {"coordinates", "all"}, optional
         Controls which variables are set as coordinate variables:
 
-        - "coordinates"/"coordinates_strict" or True: Set variables referred to in the
+        - "coordinates" or True: Set variables referred to in the
           ``'coordinates'`` attribute of the datasets or individual variables
           as coordinate variables.
-        - "all"/"all_strict": Set variables referred to in  ``'grid_mapping'``, ``'bounds'`` and
+        - "all": Set variables referred to in  ``'grid_mapping'``, ``'bounds'`` and
           other attributes as coordinate variables.
-        When using the "strict"-forms an error is raised, if ``coordinates``-items are
-        missing from the dataset, otherwise a warning is issued and only the
-        available ``coordinates`items are handled.
     drop_variables : str or iterable, optional
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Hashable, Iterable, Mapping, MutableMapping
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Literal, Union
 
 import numpy as np
 import pandas as pd
@@ -378,7 +378,9 @@ def decode_cf_variables(
     concat_characters: bool = True,
     mask_and_scale: bool = True,
     decode_times: bool = True,
-    decode_coords: bool = True,
+    decode_coords: Literal[
+        True, "coordinates", "all", "coordinates_strict", "all_strict"
+    ] = True,
     drop_variables: T_DropVariables = None,
     use_cftime: bool | None = None,
     decode_timedelta: bool | None = None,
@@ -437,7 +439,13 @@ def decode_cf_variables(
             )
         except Exception as e:
             raise type(e)(f"Failed to decode variable {k!r}: {e}")
-        if decode_coords in [True, "coordinates", "all", "coordinates_strict"]:
+        if decode_coords in [
+            True,
+            "coordinates",
+            "all",
+            "coordinates_strict",
+            "all_strict",
+        ]:
             var_attrs = new_vars[k].attrs
             if "coordinates" in var_attrs:
                 var_coord_names = var_attrs["coordinates"].split()
@@ -504,7 +512,9 @@ def decode_cf(
     concat_characters: bool = True,
     mask_and_scale: bool = True,
     decode_times: bool = True,
-    decode_coords: bool = True,
+    decode_coords: Literal[
+        True, "coordinates", "all", "coordinates_strict", "all_strict"
+    ] = True,
     drop_variables: T_DropVariables = None,
     use_cftime: bool | None = None,
     decode_timedelta: bool | None = None,
@@ -525,14 +535,17 @@ def decode_cf(
     decode_times : bool, optional
         Decode cf times (e.g., integers since "hours since 2000-01-01") to
         np.datetime64.
-    decode_coords : bool or {"coordinates", "all"}, optional
+    decode_coords : bool or {"coordinates", "coordinates_strict", "all", "all_strict"}, optional
         Controls which variables are set as coordinate variables:
 
-        - "coordinates" or True: Set variables referred to in the
+        - "coordinates"/"coordinates_strict" or True: Set variables referred to in the
           ``'coordinates'`` attribute of the datasets or individual variables
           as coordinate variables.
-        - "all": Set variables referred to in  ``'grid_mapping'``, ``'bounds'`` and
+        - "all"/"all_strict": Set variables referred to in  ``'grid_mapping'``, ``'bounds'`` and
           other attributes as coordinate variables.
+        When using the "strict"-forms an error is raised, if ``coordinates``-items are
+        missing from the dataset, otherwise a warning is issued and only the
+        available ``coordinates`items are handled.
     drop_variables : str or iterable, optional
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -451,14 +451,8 @@ def decode_cf_variables(
                     else:
                         from xarray.core.utils import emit_user_level_warning
 
-                        emit_user_level_warning(
-                            " ".join(
-                                [
-                                    msg,
-                                    f"Decoding with new ``coordinates``: {existing_coord_names}.",
-                                ]
-                            )
-                        )
+                       msg_solution = f"Decoding with new ``coordinates``: {existing_coord_names}."
+                        emit_user_level_warning(" ".join([msg, msg_solution]))
 
                 new_vars[k].encoding["coordinates"] = " ".join(existing_coord_names)
                 del var_attrs["coordinates"]

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -93,11 +93,11 @@ def test_decode_cf_variable_with_mismatched_coordinates() -> None:
         }
     )
     decoded = conventions.decode_cf(orig, decode_coords=True)
-    assert decoded["foo"].encoding["coordinates"] == "XLONG XLAT"
+    assert decoded["foo"].encoding["coordinates"] == "XTIME XLONG XLAT"
     assert list(decoded.coords.keys()) == ["XLONG", "XLAT", "time"]
 
     decoded = conventions.decode_cf(orig, decode_coords=False)
-    assert decoded["foo"].encoding.get("coordinates") is None
+    assert "coordinates" not in decoded["foo"].encoding
     assert decoded["foo"].attrs.get("coordinates") == "XTIME XLONG XLAT"
     assert list(decoded.coords.keys()) == ["time"]
 

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -92,19 +92,14 @@ def test_decode_cf_variable_with_mismatched_coordinates() -> None:
             "time": ("time", [0.0], {"units": "hours since 2017-01-01"}),
         }
     )
-    k = "foo"
-    missing_coord_names = ["XTIME"]
-    existing_coord_names = ["XLONG", "XLAT"]
-    msg = f"Mismatched ``coordinates`` attribute on variable {k!r}. Coordinate(s): {missing_coord_names!r} missing in dataset."
-    with pytest.raises(ValueError) as e:
-        decoded = conventions.decode_cf(orig, decode_coords="coordinates_strict")
-        assert e.value.args[0] == msg
-    msg = " ".join([msg, f"Decoding with new ``coordinates``: {existing_coord_names}."])
-    with pytest.warns(UserWarning) as w:
-        decoded = conventions.decode_cf(orig)
-        assert w[0].message.args[0] == msg
-        assert decoded["foo"].encoding["coordinates"] == "XLONG XLAT"
-        assert list(decoded.coords.keys()) == ["XLONG", "XLAT", "time"]
+    decoded = conventions.decode_cf(orig, decode_coords=True)
+    assert decoded["foo"].encoding["coordinates"] == "XLONG XLAT"
+    assert list(decoded.coords.keys()) == ["XLONG", "XLAT", "time"]
+
+    decoded = conventions.decode_cf(orig, decode_coords=False)
+    assert decoded["foo"].encoding.get("coordinates") is None
+    assert decoded["foo"].attrs.get("coordinates") == "XTIME XLONG XLAT"
+    assert list(decoded.coords.keys()) == ["time"]
 
 
 @requires_cftime

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -268,9 +268,12 @@ class TestDecodeCF:
         assert_identical(expected, actual)
 
     def test_invalid_coordinates(self) -> None:
-        # regression test for GH308
+        # regression test for GH308, GH1809
         original = Dataset({"foo": ("t", [1, 2], {"coordinates": "invalid"})})
+        decoded = Dataset({"foo": ("t", [1, 2], {}, {"coordinates": "invalid"})})
         actual = conventions.decode_cf(original)
+        assert_identical(decoded, actual)
+        actual = conventions.decode_cf(original, decode_coords=False)
         assert_identical(original, actual)
 
     def test_decode_coordinates(self) -> None:


### PR DESCRIPTION
- decode variable with mismatched coordinate attribute
- propagate `coordinates` to encoding in any case

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #1809
- [x] Closes #5170 
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
