### PR TITLE
Fix sortby link in reshaping.rst

### DIFF
--- a/doc/user-guide/reshaping.rst
+++ b/doc/user-guide/reshaping.rst
@@ -274,7 +274,7 @@ Sort
 ----
 
 One may sort a DataArray/Dataset via :py:meth:`~xarray.DataArray.sortby` and
-:py:meth:`~xarray.DataArray.sortby`.  The input can be an individual or list of
+:py:meth:`~xarray.Dataset.sortby`.  The input can be an individual or list of
 1D ``DataArray`` objects:
 
 .. ipython:: python


### PR DESCRIPTION
The "Reshaping" document has two identical links to the `sortby()` method for DataArrays.

The proposed fix replaces one and links to the appropriate Dataset method for ease of use.