### PR TITLE
Use a bound `TypeVar` for `DataArray` and `Dataset` methods

### DIFF
--- a/xarray/core/_aggregations.py
+++ b/xarray/core/_aggregations.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Callable
 
+from typing_extensions import Self
+
 from xarray.core import duck_array_ops
 from xarray.core.options import OPTIONS
-from xarray.core.types import Dims, Self
+from xarray.core.types import Dims
 from xarray.core.utils import contains_only_chunked_or_numpy, module_available
 
 if TYPE_CHECKING:

--- a/xarray/core/_aggregations.py
+++ b/xarray/core/_aggregations.py
@@ -6,11 +6,9 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Callable
 
-from typing_extensions import Self
-
 from xarray.core import duck_array_ops
 from xarray.core.options import OPTIONS
-from xarray.core.types import Dims
+from xarray.core.types import Dims, Self
 from xarray.core.utils import contains_only_chunked_or_numpy, module_available
 
 if TYPE_CHECKING:

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union, cast, overload
 
 import numpy as np
 import pandas as pd
-from typing_extensions import Self
 
 from xarray.core import dtypes, duck_array_ops, formatting, formatting_html, ops
 from xarray.core.indexing import BasicIndexer, ExplicitlyIndexed
@@ -46,6 +45,7 @@ if TYPE_CHECKING:
         DatetimeLike,
         DTypeLikeSave,
         ScalarOrArray,
+        Self,
         SideOptions,
         T_Chunks,
         T_Variable,
@@ -848,7 +848,7 @@ class DataWithCoords(AttrAccessMixin):
 
         window = either_dict_or_kwargs(window, window_kwargs, "rolling_exp")
 
-        return rolling_exp.RollingExp(cast(T_Xarray, self), window, window_type)
+        return rolling_exp.RollingExp(cast("T_Xarray", self), window, window_type)
 
     def _resample(
         self,

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -382,7 +382,7 @@ class DataWithCoords(AttrAccessMixin):
     __slots__ = ("_close",)
 
     def squeeze(
-        self: Self,
+        self,
         dim: Hashable | Iterable[Hashable] | None = None,
         drop: bool = False,
         axis: int | Iterable[int] | None = None,

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -527,7 +527,7 @@ class Coordinates(AbstractCoordinates):
     def __setitem__(self, key: Hashable, value: Any) -> None:
         self.update({key: value})
 
-    def update(self, other: Mapping[Any, Any]) -> None:
+    def update(self: Self, other: Mapping[Any, Any]) -> None:
         """Update this Coordinates variables with other coordinate variables."""
 
         if not len(other):

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, NoReturn, cast, overlo
 
 import numpy as np
 import pandas as pd
+from typing_extensions import Self
 
 from xarray.coding.calendar_ops import convert_calendar, interp_calendar
 from xarray.coding.cftimeindex import CFTimeIndex
@@ -2986,14 +2987,12 @@ class DataArray(
     def T(self: T_DataArray) -> T_DataArray:
         return self.transpose()
 
-    # change type of self and return to T_DataArray once
-    # https://github.com/python/mypy/issues/12846 is resolved
     def drop_vars(
-        self,
+        self: Self,
         names: Hashable | Iterable[Hashable],
         *,
         errors: ErrorOptions = "raise",
-    ) -> DataArray:
+    ) -> Self:
         """Returns an array with dropped variables.
 
         Parameters

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, NoReturn, cast, overlo
 
 import numpy as np
 import pandas as pd
-from typing_extensions import Self
 
 from xarray.coding.calendar_ops import convert_calendar, interp_calendar
 from xarray.coding.cftimeindex import CFTimeIndex
@@ -101,6 +100,7 @@ if TYPE_CHECKING:
         QueryEngineOptions,
         QueryParserOptions,
         ReindexMethodOptions,
+        Self,
         SideOptions,
         T_DataArray,
         T_Xarray,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -21,9 +21,19 @@ from html import escape
 from numbers import Number
 from operator import methodcaller
 from os import PathLike
-from typing import IO, TYPE_CHECKING, Any, Callable, Generic, Literal, cast, overload
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Generic,
+    Literal,
+    cast,
+    overload,
+)
 
 import numpy as np
+from typing_extensions import Self
 
 # remove once numpy 2.0 is the oldest supported version
 try:
@@ -1114,13 +1124,13 @@ class Dataset(
         return obj
 
     def _replace_with_new_dims(
-        self: T_Dataset,
+        self: Self,
         variables: dict[Hashable, Variable],
         coord_names: set | None = None,
         attrs: dict[Hashable, Any] | None | Default = _default,
         indexes: dict[Hashable, Index] | None = None,
         inplace: bool = False,
-    ) -> T_Dataset:
+    ) -> Self:
         """Replace variables with recalculated dimensions."""
         dims = calculate_dimensions(variables)
         return self._replace(

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -33,7 +33,6 @@ from typing import (
 )
 
 import numpy as np
-from typing_extensions import Self
 
 # remove once numpy 2.0 is the oldest supported version
 try:
@@ -156,6 +155,7 @@ if TYPE_CHECKING:
         QueryEngineOptions,
         QueryParserOptions,
         ReindexMethodOptions,
+        Self,
         SideOptions,
         T_Xarray,
     )

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -358,14 +358,17 @@ def map_blocks(
 
     if template is None:
         # infer template by providing zero-shaped arrays
-        template = infer_template(func, aligned[0], *args, **kwargs)
-        template_indexes = set(template._indexes)
+        template_inferred = infer_template(func, aligned[0], *args, **kwargs)
+        template = template_inferred
+        template_indexes = set(template_inferred._indexes)
         preserved_indexes = template_indexes & set(input_indexes)
         new_indexes = template_indexes - set(input_indexes)
         indexes = {dim: input_indexes[dim] for dim in preserved_indexes}
-        indexes.update({k: template._indexes[k] for k in new_indexes})
+        indexes.update({k: template_inferred._indexes[k] for k in new_indexes})
         output_chunks: Mapping[Hashable, tuple[int, ...]] = {
-            dim: input_chunks[dim] for dim in template.dims if dim in input_chunks
+            dim: input_chunks[dim]
+            for dim in template_inferred.dims
+            if dim in input_chunks
         }
 
     else:

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Hashable, Iterable, Sequence
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, cast
+
+from typing_extensions import Self
 
 from xarray.core._aggregations import (
     DataArrayResampleAggregations,
@@ -63,10 +65,10 @@ class Resample(GroupBy[T_Xarray]):
         obj = self._obj
         for k, v in obj.coords.items():
             if k != self._dim and self._dim in v.dims:
-                obj = obj.drop_vars(k)
+                obj = cast(T_Xarray, obj.drop_vars(k))
         return obj
 
-    def pad(self, tolerance: float | Iterable[float] | None = None) -> T_Xarray:
+    def pad(self: Self, tolerance: float | Iterable[float] | None = None) -> T_Xarray:
         """Forward fill new values at up-sampled frequency.
 
         Parameters
@@ -85,13 +87,18 @@ class Resample(GroupBy[T_Xarray]):
         """
         obj = self._drop_coords()
         (grouper,) = self.groupers
-        return obj.reindex(
-            {self._dim: grouper.full_index}, method="pad", tolerance=tolerance
+        return cast(
+            T_Xarray,
+            obj.reindex(
+                {self._dim: grouper.full_index}, method="pad", tolerance=tolerance
+            ),
         )
 
     ffill = pad
 
-    def backfill(self, tolerance: float | Iterable[float] | None = None) -> T_Xarray:
+    def backfill(
+        self: Self, tolerance: float | Iterable[float] | None = None
+    ) -> T_Xarray:
         """Backward fill new values at up-sampled frequency.
 
         Parameters
@@ -110,8 +117,11 @@ class Resample(GroupBy[T_Xarray]):
         """
         obj = self._drop_coords()
         (grouper,) = self.groupers
-        return obj.reindex(
-            {self._dim: grouper.full_index}, method="backfill", tolerance=tolerance
+        return cast(
+            T_Xarray,
+            obj.reindex(
+                {self._dim: grouper.full_index}, method="backfill", tolerance=tolerance
+            ),
         )
 
     bfill = backfill
@@ -136,8 +146,11 @@ class Resample(GroupBy[T_Xarray]):
         """
         obj = self._drop_coords()
         (grouper,) = self.groupers
-        return obj.reindex(
-            {self._dim: grouper.full_index}, method="nearest", tolerance=tolerance
+        return cast(
+            T_Xarray,
+            obj.reindex(
+                {self._dim: grouper.full_index}, method="nearest", tolerance=tolerance
+            ),
         )
 
     def interpolate(self, kind: InterpOptions = "linear") -> T_Xarray:
@@ -174,11 +187,14 @@ class Resample(GroupBy[T_Xarray]):
         """Apply scipy.interpolate.interp1d along resampling dimension."""
         obj = self._drop_coords()
         (grouper,) = self.groupers
-        return obj.interp(
-            coords={self._dim: grouper.full_index},
-            assume_sorted=True,
-            method=kind,
-            kwargs={"bounds_error": False},
+        return cast(
+            T_Xarray,
+            obj.interp(
+                coords={self._dim: grouper.full_index},
+                assume_sorted=True,
+                method=kind,
+                kwargs={"bounds_error": False},
+            ),
         )
 
 

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -4,14 +4,12 @@ import warnings
 from collections.abc import Hashable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Callable, cast
 
-from typing_extensions import Self
-
 from xarray.core._aggregations import (
     DataArrayResampleAggregations,
     DatasetResampleAggregations,
 )
 from xarray.core.groupby import DataArrayGroupByBase, DatasetGroupByBase, GroupBy
-from xarray.core.types import Dims, InterpOptions, T_Xarray
+from xarray.core.types import Dims, InterpOptions, Self, T_Xarray
 
 if TYPE_CHECKING:
     from xarray.core.dataarray import DataArray

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -8,13 +8,12 @@ from collections.abc import Hashable, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, cast
 
 import numpy as np
-from typing_extensions import Self
 
 from xarray.core import dtypes, duck_array_ops, utils
 from xarray.core.arithmetic import CoarsenArithmetic
 from xarray.core.options import OPTIONS, _get_keep_attrs
 from xarray.core.pycompat import is_duck_dask_array
-from xarray.core.types import CoarsenBoundaryOptions, SideOptions, T_Xarray
+from xarray.core.types import CoarsenBoundaryOptions, Self, SideOptions, T_Xarray
 from xarray.core.utils import either_dict_or_kwargs
 
 try:

--- a/xarray/core/rolling_exp.py
+++ b/xarray/core/rolling_exp.py
@@ -9,7 +9,7 @@ from xarray.core.computation import apply_ufunc
 from xarray.core.options import _get_keep_attrs
 from xarray.core.pdcompat import count_not_none
 from xarray.core.pycompat import is_duck_dask_array
-from xarray.core.types import T_DataWithCoords
+from xarray.core.types import T_Xarray
 
 
 def _get_alpha(com=None, span=None, halflife=None, alpha=None):
@@ -73,7 +73,7 @@ def _get_center_of_mass(comass, span, halflife, alpha):
     return float(comass)
 
 
-class RollingExp(Generic[T_DataWithCoords]):
+class RollingExp(Generic[T_Xarray]):
     """
     Exponentially-weighted moving window object.
     Similar to EWM in pandas
@@ -97,16 +97,16 @@ class RollingExp(Generic[T_DataWithCoords]):
 
     def __init__(
         self,
-        obj: T_DataWithCoords,
+        obj: T_Xarray,
         windows: Mapping[Any, int | float],
         window_type: str = "span",
     ):
-        self.obj: T_DataWithCoords = obj
+        self.obj: T_Xarray = obj
         dim, window = next(iter(windows.items()))
         self.dim = dim
         self.alpha = _get_alpha(**{window_type: window})
 
-    def mean(self, keep_attrs: bool | None = None) -> T_DataWithCoords:
+    def mean(self, keep_attrs: bool | None = None) -> T_Xarray:
         """
         Exponentially weighted moving average.
 
@@ -142,7 +142,7 @@ class RollingExp(Generic[T_DataWithCoords]):
             on_missing_core_dim="copy",
         ).transpose(*dim_order)
 
-    def sum(self, keep_attrs: bool | None = None) -> T_DataWithCoords:
+    def sum(self, keep_attrs: bool | None = None) -> T_Xarray:
         """
         Exponentially weighted moving sum.
 

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
     from xarray.backends.common import BackendEntrypoint
     from xarray.core.alignment import Aligner
-    from xarray.core.common import AbstractArray, DataWithCoords
+    from xarray.core.common import AbstractArray
     from xarray.core.coordinates import Coordinates
     from xarray.core.dataarray import DataArray
     from xarray.core.dataset import Dataset

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -154,11 +154,8 @@ T_Coordinates = TypeVar("T_Coordinates", bound="Coordinates")
 T_Array = TypeVar("T_Array", bound="AbstractArray")
 T_Index = TypeVar("T_Index", bound="Index")
 
-T_DataArrayOrSet = TypeVar("T_DataArrayOrSet", bound=Union["Dataset", "DataArray"])
+T_Xarray = TypeVar("T_Xarray", bound=Union["DataArray", "Dataset"])
 
-# Maybe we rename this to T_Data or something less Fortran-y?
-T_Xarray = TypeVar("T_Xarray", "DataArray", "Dataset")
-T_DataWithCoords = TypeVar("T_DataWithCoords", bound="DataWithCoords")
 T_Alignable = TypeVar("T_Alignable", bound="Alignable")
 
 ScalarOrArray = Union["ArrayLike", np.generic, np.ndarray, "DaskArray"]

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, TypeVar, cast
 import numpy as np
 
 from xarray.core.formatting import format_item
-from xarray.core.types import HueStyleOptions, T_DataArrayOrSet
+from xarray.core.types import HueStyleOptions, T_Xarray
 from xarray.plot.utils import (
     _LINEWIDTH_RANGE,
     _MARKERSIZE_RANGE,
@@ -59,7 +59,7 @@ def _nicetitle(coord, value, maxchar, template):
 T_FacetGrid = TypeVar("T_FacetGrid", bound="FacetGrid")
 
 
-class FacetGrid(Generic[T_DataArrayOrSet]):
+class FacetGrid(Generic[T_Xarray]):
     """
     Initialize the Matplotlib figure and FacetGrid object.
 
@@ -100,7 +100,7 @@ class FacetGrid(Generic[T_DataArrayOrSet]):
         sometimes the rightmost grid positions in the bottom row.
     """
 
-    data: T_DataArrayOrSet
+    data: T_Xarray
     name_dicts: np.ndarray
     fig: Figure
     axs: np.ndarray
@@ -125,7 +125,7 @@ class FacetGrid(Generic[T_DataArrayOrSet]):
 
     def __init__(
         self,
-        data: T_DataArrayOrSet,
+        data: T_Xarray,
         col: Hashable | None = None,
         row: Hashable | None = None,
         col_wrap: int | None = None,
@@ -1009,7 +1009,7 @@ class FacetGrid(Generic[T_DataArrayOrSet]):
 
 
 def _easy_facetgrid(
-    data: T_DataArrayOrSet,
+    data: T_Xarray,
     plotfunc: Callable,
     kind: Literal["line", "dataarray", "dataset", "plot1d"],
     x: Hashable | None = None,
@@ -1025,7 +1025,7 @@ def _easy_facetgrid(
     ax: Axes | None = None,
     figsize: Iterable[float] | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArrayOrSet]:
+) -> FacetGrid[T_Xarray]:
     """
     Convenience method to call xarray.plot.FacetGrid from 2d plotting methods
 


### PR DESCRIPTION
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Edit: I added a [comment](https://github.com/pydata/xarray/pull/8208#issuecomment-1725054516) outlining a problem with this

---

I _think_ we should be using a `TypeVar(..., bound=...)` for our typing, since otherwise subtypes aren't allowed. I don't see a compelling reason to have all of `T_DataWithCoords` and `T_DataArrayOrSet` and `T_Xarray`, though I might be missing something.

So this unifies all `T_DataWithCoords`, `T_DataArrayOrSet` and `T_Xarray` to `T_Xarray`, and changes that type to be bound on a union of `DataArray` & `Dataset` (similar to the existing `T_DataArrayOrSet`). This covers the bulk of our API — functions which transform either a `DataArray` or `Dataset` and return the input type.

This does require some manual casts; I think because when there's a concrete path for both `DataArray` & `Dataset`, mypy doesn't unify them back together. It's also possible I'm missing something.

One alternative — a minor change — would be to bound on `DataWithCoords`, like the existing `T_DataWithCoords`, rather than the union. A quick comparison showed each required some additional casts / ignores over the other.
