### PR TITLE
Remove an import fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,6 @@ module = [
   "fsspec.*",
   "h5netcdf.*",
   "h5py.*",
-  "importlib_metadata.*",
   "iris.*",
   "matplotlib.*",
   "mpl_toolkits.*",

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -1,3 +1,5 @@
+from importlib.metadata import version as _version
+
 from xarray import testing, tutorial
 from xarray.backends.api import (
     load_dataarray,
@@ -40,8 +42,6 @@ from xarray.core.options import get_options, set_options
 from xarray.core.parallel import map_blocks
 from xarray.core.variable import IndexVariable, Variable, as_variable
 from xarray.util.print_versions import show_versions
-
-from importlib.metadata import version as _version
 
 try:
     __version__ = _version("xarray")

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -41,11 +41,7 @@ from xarray.core.parallel import map_blocks
 from xarray.core.variable import IndexVariable, Variable, as_variable
 from xarray.util.print_versions import show_versions
 
-try:
-    from importlib.metadata import version as _version
-except ImportError:
-    # if the fallback library is missing, we are doomed.
-    from importlib_metadata import version as _version
+from importlib.metadata import version as _version
 
 try:
     __version__ = _version("xarray")


### PR DESCRIPTION
This is stable in 3.8, so we can remove the fallback now
