### PR TITLE
Add modules to `check-untyped`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,12 +120,19 @@ module = [
 
 # Gradually we want to add more modules to this list, ratcheting up our total
 # coverage. Once a module is here, functions require annotations in order to
-# pass mypy. It would be especially useful to have tests here, because without
-# annotating test functions, we don't have a great way of testing our type
-# annotations — even with just `-> None` is sufficient for mypy to check them.
+# pass mypy. It would be especially useful to have test files listed here,
+# because without them being checked, we don't have a great way of testing our
+# type annotations.
 [[tool.mypy.overrides]]
-disallow_untyped_defs = true
-module = ["xarray.core.rolling_exp"]
+check_untyped_defs = true
+module = [
+  "xarray.core.accessor_dt",
+  "xarray.core.accessor_str",
+  "xarray.core.alignment",
+  "xarray.core.rolling_exp",
+  "xarray.core.computation",
+  "xarray.indexes.*",
+]
 
 [tool.ruff]
 builtins = ["ellipsis"]

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -9,7 +9,16 @@ import operator
 import warnings
 from collections import Counter
 from collections.abc import Hashable, Iterable, Mapping, Sequence, Set
-from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterator,
+    Literal,
+    TypeVar,
+    Union,
+    overload,
+)
 
 import numpy as np
 
@@ -163,7 +172,7 @@ class _UFuncSignature:
         if exclude_dims:
             exclude_dims = [self.dims_map[dim] for dim in exclude_dims]
 
-            counter = Counter()
+            counter: Counter = Counter()
 
             def _enumerate(dim):
                 if dim in exclude_dims:
@@ -571,7 +580,7 @@ def apply_groupby_func(func, *args):
     assert groupbys, "must have at least one groupby to iterate over"
     first_groupby = groupbys[0]
     (grouper,) = first_groupby.groupers
-    if any(not grouper.group.equals(gb.groupers[0].group) for gb in groupbys[1:]):
+    if any(not grouper.group.equals(gb.groupers[0].group) for gb in groupbys[1:]):  # type: ignore
         raise ValueError(
             "apply_ufunc can only perform operations over "
             "multiple GroupBy objects at once if they are all "
@@ -584,7 +593,7 @@ def apply_groupby_func(func, *args):
     iterators = []
     for arg in args:
         if isinstance(arg, GroupBy):
-            iterator = (value for _, value in arg)
+            iterator: Iterator = (value for _, value in arg)
         elif hasattr(arg, "dims") and grouped_dim in arg.dims:
             if isinstance(arg, Variable):
                 raise ValueError(
@@ -597,9 +606,9 @@ def apply_groupby_func(func, *args):
             iterator = itertools.repeat(arg)
         iterators.append(iterator)
 
-    applied = (func(*zipped_args) for zipped_args in zip(*iterators))
+    applied: Iterator = (func(*zipped_args) for zipped_args in zip(*iterators))
     applied_example, applied = peek_at(applied)
-    combine = first_groupby._combine
+    combine = first_groupby._combine  # type: ignore
     if isinstance(applied_example, tuple):
         combined = tuple(combine(output) for output in zip(*applied))
     else:


### PR DESCRIPTION
In reviewing https://github.com/pydata/xarray/pull/8241, I realize that we actually want `check-untyped-defs`, which is a bit less strict, but lets us add some more modules on. I did have to add a couple of ignores, think it's a reasonable tradeoff to add big modules like `computation` on.

Errors with this enabled are actual type errors, not just `mypy` pedanticness, so would be good to get as much as possible into this list...
