### PR TITLE
Fix & normalize typing for chunks

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -111,6 +111,7 @@ if TYPE_CHECKING:
         ReindexMethodOptions,
         Self,
         SideOptions,
+        T_Chunks,
         T_Xarray,
     )
     from xarray.core.weighted import DataArrayWeighted
@@ -1288,13 +1289,7 @@ class DataArray(
 
     def chunk(
         self,
-        chunks: (
-            int
-            | Literal["auto"]
-            | tuple[int, ...]
-            | tuple[tuple[int, ...], ...]
-            | Mapping[Any, None | int | tuple[int, ...]]
-        ) = {},  # {} even though it's technically unsafe, is being used intentionally here (#4667)
+        chunks: T_Chunks = {},  # {} even though it's technically unsafe, is being used intentionally here (#4667)
         name_prefix: str = "xarray-",
         token: str | None = None,
         lock: bool = False,
@@ -1362,7 +1357,7 @@ class DataArray(
 
         if isinstance(chunks, (float, str, int)):
             # ignoring type; unclear why it won't accept a Literal into the value.
-            chunks = dict.fromkeys(self.dims, chunks)  # type: ignore
+            chunks = dict.fromkeys(self.dims, chunks)
         elif isinstance(chunks, (tuple, list)):
             chunks = dict(zip(self.dims, chunks))
         else:

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -16,13 +16,12 @@ from typing import (
 
 import numpy as np
 import pandas as pd
-from typing_extensions import TypeAlias
 
 try:
     if sys.version_info >= (3, 11):
-        from typing import Self
+        from typing import Self, TypeAlias
     else:
-        from typing_extensions import Self
+        from typing_extensions import Self, TypeAlias
 except ImportError:
     if TYPE_CHECKING:
         raise

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -16,6 +16,7 @@ from typing import (
 
 import numpy as np
 import pandas as pd
+from typing_extensions import TypeAlias
 
 try:
     if sys.version_info >= (3, 11):
@@ -183,7 +184,13 @@ GroupByCompatible = Union["Dataset", "DataArray"]
 Dims = Union[str, Iterable[Hashable], "ellipsis", None]
 OrderedDims = Union[str, Sequence[Union[Hashable, "ellipsis"]], "ellipsis", None]
 
-T_Chunks = Union[int, dict[Any, Any], Literal["auto"], None]
+# int, Literal["auto"], None, tuple[int, ...], tuple[tuple[int, ...], ...]
+# In some cases we don't allow `None`, which this doesn't take account of.
+T_ChunkDim: TypeAlias = Union[int, Literal["auto"], None, tuple[int, ...]]
+# We allow the tuple form of this (though arguably we could transition to named dims only)
+T_Chunks: TypeAlias = Union[
+    T_ChunkDim, Mapping[Any, T_ChunkDim], tuple[T_ChunkDim, ...]
+]
 T_NormalizedChunks = tuple[tuple[int, ...], ...]
 
 DataVars = Mapping[Any, Any]

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -183,8 +183,7 @@ GroupByCompatible = Union["Dataset", "DataArray"]
 Dims = Union[str, Iterable[Hashable], "ellipsis", None]
 OrderedDims = Union[str, Sequence[Union[Hashable, "ellipsis"]], "ellipsis", None]
 
-# int, Literal["auto"], None, tuple[int, ...], tuple[tuple[int, ...], ...]
-# In some cases we don't allow `None`, which this doesn't take account of.
+# FYI in some cases we don't allow `None`, which this doesn't take account of.
 T_ChunkDim: TypeAlias = Union[int, Literal["auto"], None, tuple[int, ...]]
 # We allow the tuple form of this (though arguably we could transition to named dims only)
 T_Chunks: TypeAlias = Union[

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1035,7 +1035,7 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
 
         data_old = self._data
         if chunkmanager.is_chunked_array(data_old):
-            data_chunked = chunkmanager.rechunk(data_old, chunks)  # type: ignore[arg-type]
+            data_chunked = chunkmanager.rechunk(data_old, chunks)
         else:
             if isinstance(data_old, indexing.ExplicitlyIndexed):
                 # Unambiguously handle array storage backends (like NetCDF4 and h5py)
@@ -1057,7 +1057,7 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
 
             data_chunked = chunkmanager.from_array(
                 ndata,
-                chunks,  # type: ignore[arg-type]
+                chunks,
                 **_from_array_kwargs,
             )
 


### PR DESCRIPTION
I noticed that `"auto"` wasn't allowed as a value in a dict. So this normalizes all chunk types, and defines the mapping as containing the inner type.

Allows removing some ignores (though also adds one).

One question — not necessary to answer now — is whether we should allow a tuple of definitions, for each dimension. Generally we use names, which helps prevent mistakes, and allows us to be less concerned about dimension ordering.
