### PR TITLE
Refine `chunks=None` handling

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2641,15 +2641,13 @@ class Dataset(
                 category=FutureWarning,
             )
             chunks = {}
-
+        chunks_mapping: Mapping[Any, Any]
         if not isinstance(chunks, Mapping) and chunks is not None:
-            # The ignore seems to be required because of the type change (though not
-            # completely sure, the message is somewhat confusing)
-            chunks = dict.fromkeys(self.dims, chunks)  # type: ignore[arg-type]
+            chunks_mapping = dict.fromkeys(self.dims, chunks)
         else:
-            chunks = either_dict_or_kwargs(chunks, chunks_kwargs, "chunk")
+            chunks_mapping = either_dict_or_kwargs(chunks, chunks_kwargs, "chunk")
 
-        bad_dims = chunks.keys() - self.dims.keys()
+        bad_dims = chunks_mapping.keys() - self.dims.keys()
         if bad_dims:
             raise ValueError(
                 f"chunks keys {tuple(bad_dims)} not found in data dimensions {tuple(self.dims)}"
@@ -2663,7 +2661,7 @@ class Dataset(
             k: _maybe_chunk(
                 k,
                 v,
-                chunks,
+                chunks_mapping,
                 token,
                 lock,
                 name_prefix,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2634,7 +2634,7 @@ class Dataset(
         xarray.unify_chunks
         dask.array.from_array
         """
-        if chunks is None and chunks_kwargs is None:
+        if chunks is None and not chunks_kwargs:
             warnings.warn(
                 "None value for 'chunks' is deprecated. "
                 "It will raise an error in the future. Use instead '{}'",
@@ -2642,8 +2642,9 @@ class Dataset(
             )
             chunks = {}
 
-        if not isinstance(chunks, Mapping):
-            # We need to ignore since mypy doesn't recognize this can't be `None`
+        if not isinstance(chunks, Mapping) and chunks is not None:
+            # The ignore seems to be required because of the type change (though not
+            # completely sure, the message is somewhat confusing)
             chunks = dict.fromkeys(self.dims, chunks)  # type: ignore[arg-type]
         else:
             chunks = either_dict_or_kwargs(chunks, chunks_kwargs, "chunk")


### PR DESCRIPTION
Based on comment in https://github.com/pydata/xarray/pull/8247. This doesn't make it perfect, but allows the warning to get hit and clarifies the type comment, as a stop-gap