### PR TITLE
Omit coordinates using False instead of None

### DIFF
--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -673,12 +673,12 @@ def _encode_coordinates(variables, attributes, non_dim_coord_names):
                 f"'coordinates' found in both attrs and encoding for variable {name!r}."
             )
 
-        # if coordinates set to None, don't write coordinates attribute
+        # if coordinates set to False, don't write coordinates attribute
         if (
             "coordinates" in attrs
-            and attrs.get("coordinates") is None
+            and attrs.get("coordinates") is False
             or "coordinates" in encoding
-            and encoding.get("coordinates") is None
+            and encoding.get("coordinates") is False
         ):
             # make sure "coordinates" is removed from attrs/encoding
             attrs.pop("coordinates", None)

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -204,38 +204,56 @@ class TestEncodeCFVariable:
         assert attrs["coordinates"] == "bar baz"
 
     @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
-    def test_emit_coordinates_attribute_in_attrs(self) -> None:
+    def test_omit_coordinates_attribute_in_attrs(self) -> None:
         orig = Dataset(
             {"a": 1, "b": 1},
             coords={"t": np.array("2004-11-01T00:00:00", dtype=np.datetime64)},
         )
 
-        orig["a"].attrs["coordinates"] = None
+        orig["a"].attrs["coordinates"] = False
         enc, _ = conventions.encode_dataset_coordinates(orig)
 
-        # check coordinate attribute emitted for 'a'
+        # check coordinate attribute omitted for 'a'
         assert "coordinates" not in enc["a"].attrs
         assert "coordinates" not in enc["a"].encoding
 
-        # check coordinate attribute not emitted for 'b'
+        # check coordinate attribute not omitted for 'b'
         assert enc["b"].attrs.get("coordinates") == "t"
         assert "coordinates" not in enc["b"].encoding
 
     @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
-    def test_emit_coordinates_attribute_in_encoding(self) -> None:
+    def test_omit_coordinates_attribute_in_assign_attrs(self) -> None:
         orig = Dataset(
             {"a": 1, "b": 1},
             coords={"t": np.array("2004-11-01T00:00:00", dtype=np.datetime64)},
         )
 
-        orig["a"].encoding["coordinates"] = None
+        orig["a"] = orig["a"].assign_attrs({"coordinates": False})
         enc, _ = conventions.encode_dataset_coordinates(orig)
 
-        # check coordinate attribute emitted for 'a'
+        # check coordinate attribute omitted for 'a'
         assert "coordinates" not in enc["a"].attrs
         assert "coordinates" not in enc["a"].encoding
 
-        # check coordinate attribute not emitted for 'b'
+        # check coordinate attribute not omitted for 'b'
+        assert enc["b"].attrs.get("coordinates") == "t"
+        assert "coordinates" not in enc["b"].encoding
+
+    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    def test_omit_coordinates_attribute_in_encoding(self) -> None:
+        orig = Dataset(
+            {"a": 1, "b": 1},
+            coords={"t": np.array("2004-11-01T00:00:00", dtype=np.datetime64)},
+        )
+
+        orig["a"].encoding["coordinates"] = False
+        enc, _ = conventions.encode_dataset_coordinates(orig)
+
+        # check coordinate attribute omitted for 'a'
+        assert "coordinates" not in enc["a"].attrs
+        assert "coordinates" not in enc["a"].encoding
+
+        # check coordinate attribute not omitted for 'b'
         assert enc["b"].attrs.get("coordinates") == "t"
         assert "coordinates" not in enc["b"].encoding
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #5510
- [x] Tests updated
- [ ] Roundtrip tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

For now this checks for False instead of None, but I'm not sure if I should have it check for both to keep it from breaking anybody's code who's using None right now.