### PR TITLE
fix regression in time-like check when decoding masked data

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -49,6 +49,9 @@ Bug fixes
 - :py:meth:`DataArray.rename` & :py:meth:`Dataset.rename` would emit a warning
   when the operation was a no-op. (:issue:`8266`)
   By `Simon Hansen <https://github.com/hoxbro>`_.
+- Fixed a regression introduced in the previous release checking time-like units
+  when encoding/decoding masked data (:issue:`8269`, :pull:`8277`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 
 Documentation

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -217,6 +217,8 @@ def _apply_mask(
 
 def _is_time_like(units):
     # test for time-like
+    if units is None:
+        return False
     time_strings = [
         "days",
         "hours",
@@ -230,7 +232,13 @@ def _is_time_like(units):
     # to prevent detecting units like `days accumulated` as time-like
     # special casing for datetime-units and timedelta-units (GH-8269)
     if "since" in units:
-        return any(tstr in units for tstr in time_strings)
+        from xarray.coding.times import _unpack_netcdf_time_units
+
+        try:
+            _unpack_netcdf_time_units(units)
+        except ValueError:
+            return False
+        return True
     else:
         return any(tstr == units for tstr in time_strings)
 

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -218,7 +218,6 @@ def _apply_mask(
 def _is_time_like(units):
     # test for time-like
     time_strings = [
-        "since",
         "days",
         "hours",
         "minutes",
@@ -227,7 +226,13 @@ def _is_time_like(units):
         "microseconds",
         "nanoseconds",
     ]
-    return any(tstr in str(units) for tstr in time_strings)
+    units = str(units)
+    # to prevent detecting units like `days accumulated` as time-like
+    # special casing for datetime-units and timedelta-units (GH-8269)
+    if "since" in units:
+        return any(tstr in units for tstr in time_strings)
+    else:
+        return any(tstr == units for tstr in time_strings)
 
 
 class CFMaskCoder(VariableCoder):

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -333,7 +333,8 @@ class TestDecodeCF:
         with pytest.raises(ValueError, match=r"unable to decode time"):
             decode_cf(ds)
 
-    def test_invalid_timedelta_units_do_not_decode(self) -> None:
+    @pytest.mark.parametrize("decode_times", [True, False])
+    def test_invalid_timedelta_units_do_not_decode(self, decode_times) -> None:
         # regression test for #8269
         ds = Dataset(
             {"time": ("time", [0, 1, 20], {"units": "days invalid", "_FillValue": 20})}
@@ -341,7 +342,7 @@ class TestDecodeCF:
         expected = Dataset(
             {"time": ("time", [0.0, 1.0, np.nan], {"units": "days invalid"})}
         )
-        assert_identical(expected, decode_cf(ds))
+        assert_identical(expected, decode_cf(ds, decode_times=decode_times))
 
     @requires_cftime
     def test_dataset_repr_with_netcdf4_datetimes(self) -> None:

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -333,6 +333,16 @@ class TestDecodeCF:
         with pytest.raises(ValueError, match=r"unable to decode time"):
             decode_cf(ds)
 
+    def test_invalid_timedelta_units_do_not_decode(self) -> None:
+        # regression test for #8269
+        ds = Dataset(
+            {"time": ("time", [0, 1, 20], {"units": "days invalid", "_FillValue": 20})}
+        )
+        expected = Dataset(
+            {"time": ("time", [0.0, 1.0, np.nan], {"units": "days invalid"})}
+        )
+        assert_identical(expected, decode_cf(ds))
+
     @requires_cftime
     def test_dataset_repr_with_netcdf4_datetimes(self) -> None:
         # regression test for #347


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #8269
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
