### PR TITLE
Enable `.rolling_exp` to work on dask arrays

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -29,6 +29,9 @@ New Features
 - :py:meth:`DataArray.sortby` & :py:meth:`Dataset.sortby` accept a callable for
   the ``variables`` parameter, passing the object as the only argument.
   By `Maximilian Roos <https://github.com/max-sixty>`_.
+- ``.rolling_exp`` functions can now operate on dask-backed arrays, assuming the
+  core dim has exactly one chunk. (:pull:`8284`).
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/rolling_exp.py
+++ b/xarray/core/rolling_exp.py
@@ -147,9 +147,9 @@ class RollingExp(Generic[T_DataWithCoords]):
             input_core_dims=[[self.dim]],
             kwargs=dict(alpha=self.alpha, axis=-1),
             output_core_dims=[[self.dim]],
-            exclude_dims={self.dim},
             keep_attrs=keep_attrs,
             on_missing_core_dim="copy",
+            dask="parallelized",
         ).transpose(*dim_order)
 
     def sum(self, keep_attrs: bool | None = None) -> T_DataWithCoords:
@@ -183,7 +183,7 @@ class RollingExp(Generic[T_DataWithCoords]):
             input_core_dims=[[self.dim]],
             kwargs=dict(alpha=self.alpha, axis=-1),
             output_core_dims=[[self.dim]],
-            exclude_dims={self.dim},
             keep_attrs=keep_attrs,
             on_missing_core_dim="copy",
+            dask="parallelized",
         ).transpose(*dim_order)

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -788,7 +788,9 @@ class TestDatasetRolling:
 
 @requires_numbagg
 class TestDatasetRollingExp:
-    @pytest.mark.parametrize("backend", ["numpy", pytest.param("dask", marks=requires_dask )], indirect=True)
+    @pytest.mark.parametrize(
+        "backend", ["numpy", pytest.param("dask", marks=requires_dask)], indirect=True
+    )
     def test_rolling_exp(self, ds) -> None:
         result = ds.rolling_exp(time=10, window_type="span").mean()
         assert isinstance(result, Dataset)

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -788,7 +788,7 @@ class TestDatasetRolling:
 
 @requires_numbagg
 class TestDatasetRollingExp:
-    @pytest.mark.parametrize("backend", ["numpy"], indirect=True)
+    @pytest.mark.parametrize("backend", ["numpy", "dask"], indirect=True)
     def test_rolling_exp(self, ds) -> None:
         result = ds.rolling_exp(time=10, window_type="span").mean()
         assert isinstance(result, Dataset)

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -788,7 +788,7 @@ class TestDatasetRolling:
 
 @requires_numbagg
 class TestDatasetRollingExp:
-    @pytest.mark.parametrize("backend", ["numpy", "dask"], indirect=True)
+    @pytest.mark.parametrize("backend", ["numpy", pytest.param("dask", marks=requires_dask )], indirect=True)
     def test_rolling_exp(self, ds) -> None:
         result = ds.rolling_exp(time=10, window_type="span").mean()
         assert isinstance(result, Dataset)


### PR DESCRIPTION
Another benefit of the move to `.apply_ufunc`...
