### PR TITLE
Fix `GroupBy` import

### DIFF
--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -305,11 +305,13 @@ class method:
         all_args = merge_args(self.args, args)
         all_kwargs = {**self.kwargs, **kwargs}
 
+        from xarray.core.groupby import GroupBy
+
         xarray_classes = (
             xr.Variable,
             xr.DataArray,
             xr.Dataset,
-            xr.core.groupby.GroupBy,
+            GroupBy,
         )
 
         if not isinstance(obj, xarray_classes):


### PR DESCRIPTION
Not sure why this only breaks tests for me, vs. in CI, but hopefully no downside to this change...
