### PR TITLE
Avoid redundant metadata reads in `ZarrArrayWrapper`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -54,6 +54,7 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
+
 - :py:meth:`DataArray.rename` & :py:meth:`Dataset.rename` would emit a warning
   when the operation was a no-op. (:issue:`8266`)
   By `Simon Hansen <https://github.com/hoxbro>`_.
@@ -63,6 +64,12 @@ Bug fixes
   a reference date not equal to the first value of the datetime array
   (:issue:`8271`, :pull:`8272`). By `Spencer Clark
   <https://github.com/spencerkclark>`_.
+
+- Fix excess metadata requests when using a Zarr store. Prior to this, metadata
+  was re-read every time data was retrieved from the array, now metadata is retrieved only once
+  when they array is initialized.
+  (:issue:`8290`, :pull:`8297`).
+  By `Oliver McCormack <https://github.com/olimcc>`_.
 
 
 Documentation

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2877,7 +2877,7 @@ class TestZarrArrayWrapperCalls(TestZarrKVStoreV3):
 
         import zarr
 
-        ds = xr.Dataset(data_vars={"test": (("Z"), np.array([np.nan]).reshape(1))})
+        ds = xr.Dataset(data_vars={"test": (("Z", ), np.array([123]).reshape(1))})
 
         # The call to retrieve metadata performs a group lookup. We patch Group.__getitem__
         # so that we can inspect calls to this method - specifically count of calls.

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2877,7 +2877,7 @@ class TestZarrArrayWrapperCalls(TestZarrKVStoreV3):
 
         import zarr
 
-        ds = xr.Dataset(data_vars={"test": (("Z", ), np.array([123]).reshape(1))})
+        ds = xr.Dataset(data_vars={"test": (("Z",), np.array([123]).reshape(1))})
 
         # The call to retrieve metadata performs a group lookup. We patch Group.__getitem__
         # so that we can inspect calls to this method - specifically count of calls.


### PR DESCRIPTION
Modify ZarrArrayWrapper to avoid re-reading metadata each time data is read from the array.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #8290
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
