### PR TITLE
Align MemoryCachedArray and PandasIndexingAdapter more

### DIFF
--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -474,6 +474,13 @@ class ExplicitlyIndexedNDArrayMixin(NDArrayMixin, ExplicitlyIndexed):
         return np.asarray(self.get_duck_array(), dtype=dtype)
 
 
+class _ExplicitlyIndexedNDArrayMixinArray(ExplicitlyIndexedNDArrayMixin):
+    __slots__ = ("array",)
+
+    def __init__(self, array):
+        self.array = array
+
+
 class ImplicitToExplicitIndexingAdapter(NDArrayMixin):
     """Wrap an array, converting tuples into the indicated explicit indexer."""
 
@@ -683,7 +690,7 @@ class CopyOnWriteArray(ExplicitlyIndexedNDArrayMixin):
         return type(self)(self.array)
 
 
-class MemoryCachedArray(ExplicitlyIndexedNDArrayMixin):
+class MemoryCachedArray(_ExplicitlyIndexedNDArrayMixinArray):
     __slots__ = ("array",)
 
     def __init__(self, array):
@@ -1470,7 +1477,7 @@ class DaskIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
         return self.array.transpose(order)
 
 
-class PandasIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
+class PandasIndexingAdapter(_ExplicitlyIndexedNDArrayMixinArray):
     """Wrap a pandas.Index to preserve dtypes and handle explicit indexing."""
 
     __slots__ = ("array", "_dtype")

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -23,6 +23,7 @@ from xarray.core.indexing import (
     OuterIndexer,
     PandasIndexingAdapter,
     VectorizedIndexer,
+    _ExplicitlyIndexedNDArrayMixinArray,
     as_indexable,
 )
 from xarray.core.options import OPTIONS, _get_keep_attrs
@@ -2643,6 +2644,8 @@ class IndexVariable(Variable):
     """
 
     __slots__ = ()
+
+    _data: _ExplicitlyIndexedNDArrayMixinArray
 
     def __init__(self, dims, data, attrs=None, encoding=None, fastpath=False):
         super().__init__(dims, data, attrs, encoding, fastpath)


### PR DESCRIPTION
Seen in #8294.

The issue is the IndexVariable, ExplicitlyIndexedNDArrayMixin lacks `.array` which is required for IndexVariable, and therefore we need a new minimal class that are common between the two.