### PR TITLE
Handle numpy missing the array api function astype

### DIFF
--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -184,6 +184,9 @@ def cumulative_trapezoid(y, x, axis):
 def astype(data, dtype, **kwargs):
     if hasattr(data, "__array_namespace__"):
         xp = get_array_namespace(data)
+        if xp == np:
+            # numpy currently doesn't have a astype:
+            return data.astype(dtype, **kwargs)
         return xp.astype(data, dtype, **kwargs)
     return data.astype(dtype, **kwargs)
 


### PR DESCRIPTION
This is how our get_array_namespace works:
https://github.com/pydata/xarray/blob/dafd726c36e24ac77427513a4a149a6933353b66/xarray/core/duck_array_ops.py#L44-L48

Which usually works. But not for astype.

Using np.array_api doesn't work because you have to use np.array_api.Array instead of np.ndarray:

```python
import numpy.array_api as nxp
nxp.astype(np.array([1, 2,]), np.dtype(float))

Traceback (most recent call last):

  File "C:\Users\J.W\AppData\Local\Temp\ipykernel_8616\23329947.py", line 1, in <cell line: 1>
    nxp.astype(np.array([1, 2,]), np.dtype(float))

  File "C:\Users\J.W\anaconda3\envs\xarray-tests\lib\site-packages\numpy\array_api\_data_type_functions.py", line 20, in astype
    return Array._new(x._array.astype(dtype=dtype, copy=copy))

AttributeError: 'numpy.ndarray' object has no attribute '_array'
```

I found it simpler to just change astype here.

An alternative solution would be to use: https://github.com/data-apis/array-api-compat
https://github.com/tomwhite/cubed/pull/317

Seen in #8294.