### PR TITLE
Remove redundant check in IndexVariable

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2787,8 +2787,6 @@ class IndexVariable(Variable):
             data copied from original.
         """
         if data is None:
-            data_old = self._data
-
             ndata = self._data
 
             if deep:

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2789,11 +2789,7 @@ class IndexVariable(Variable):
         if data is None:
             data_old = self._data
 
-            if not isinstance(data_old, indexing.MemoryCachedArray):
-                ndata = data_old
-            else:
-                # don't share caching between copies
-                ndata = indexing.MemoryCachedArray(data_old.array)
+            ndata = self._data
 
             if deep:
                 ndata = copy.deepcopy(ndata, None)


### PR DESCRIPTION
Reverts a few things from #8313. An IndexVariable can only have PandasIndexAdapter as self._data, which makes the for MemoryCachedArray unnecessary. 

Seen in #8294.