### PR TITLE
Implementation of rust based cftime 

### DIFF
--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - hdf5
   - hypothesis
   - iris
-  - lxml  # Optional dep of pydap
+  - lxml # Optional dep of pydap
   - matplotlib-base
   - nc-time-axis
   - netcdf4
@@ -46,3 +46,5 @@ dependencies:
   - toolz
   - typing_extensions
   - zarr
+  - pip:
+      - cftime_rs


### PR DESCRIPTION
As discussed in #8302, here is a first attempt to implement `cftime_rs`.

There are a lot of tests and I struggle to understand all the processing in `coding/times.py`. 
However, with this first attempt I've been able to  make the `test_cf_datetime` work (ignoring one test)

https://github.com/pydata/xarray/blob/8423f2c47306cc3a4a52990818964f278179491f/xarray/tests/test_coding_times.py#L127-L131

Also there are some key differences betwwen `cftime` and `cftime-rs` : 
- A long int is used to represent the timestamp internally, so `cftime-rs` will not overflow as soon as `numpy`, `python `or `cftime`. It can go from -291,672,107,014 BC to 291,672,107,014 AD approximately and this depends on calendar.
- There is no `only_use_python_datetimes` argument. Instead there are 4 distinct functions : 
    - [date2num()](https://cftime-rs.readthedocs.io/en/latest/api_documentation/index.html#cftime_rs.date2num)
    - [num2date()](https://cftime-rs.readthedocs.io/en/latest/api_documentation/index.html#cftime_rs.num2date)
    - [num2pydate()](https://cftime-rs.readthedocs.io/en/latest/api_documentation/index.html#cftime_rs.num2pydate)
    - [pydate2num()](https://cftime-rs.readthedocs.io/en/latest/api_documentation/index.html#cftime_rs.pydate2num)
- These functions only take a python list of one dimension and return a list of one dimension. A conversion should be done before.
- There is no multiple datetime type (there are hidden) but instead a single object `PyCFDatetime`
- There is no conda repository at the moment

Finally, and regardless of this PR, I guess there could be a speed improvement by vectorizing operations by replacing this : 
https://github.com/pydata/xarray/blob/df0ddaf2e68a6b033b4e39990d7006dc346fcc8c/xarray/coding/times.py#L622-L649

by something like this : 

https://github.com/pydata/xarray/blob/8423f2c47306cc3a4a52990818964f278179491f/xarray/coding/times.py#L631-L670

We can use numpy instead of list comprehensions. It takes a bit more of memory though. 