### PR TITLE
Request to adjust pyright config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,9 @@ defineConstant = {DEBUG = true}
 # stubPath = "src/stubs"
 # venv = "env367"
 
-reportMissingImports = true
+# Enabling this means that developers who have disabled the warning locally —
+# because not all dependencies are installable — are overridden
+# reportMissingImports = true
 reportMissingTypeStubs = false
 
 # pythonVersion = "3.6"


### PR DESCRIPTION
Would it be possible to not have this config? It overrides the local VS Code config, and means VS Code constantly is reporting errors for me.

Totally open to other approaches ofc. Or that we decide that the tradeoff is worthwhile
