### PR TITLE
Add invert option to DataArray/Dataset.stack()

### DIFF
--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2547,6 +2547,13 @@ class TestDataArray:
         expected = DataArray(da.to_pandas().stack(), dims="z")
         assert_identical(expected, actual)
 
+    def test_stack_inverted_consistency(self) -> None:
+        da = DataArray(
+            [[0, 1], [2, 3]],
+            dims=["x", "y"],
+        )
+        assert_identical(da.stack(z=["x"]), da.stack({"z": ["y"]}, invert=True))
+
     def test_to_unstacked_dataset_raises_value_error(self) -> None:
         data = DataArray([0, 1], dims="x", coords={"x": [0, 1]})
         with pytest.raises(ValueError, match="'x' is not a stacked coordinate"):


### PR DESCRIPTION
This brings in the option to stack all dimensions *except* for one or more dimensions listed. I find this very useful for quickly iterating over all the combinations of dimensions except for one (i.e. you have a number of input parameters that are parameterized and one time dimension, and you want to calculate some time response for all the combinations of these input parameters and store them in the time-row corresponding to the appropriate combination of inputs).

I played around with implementing `to_stacked_array()` for `DataArray`, but this made less sense in the end since that method was really designed for Datasets.

- [x] Addresses #8278
- [ ] Tests added (added one for DataArray, just now realizing I should have one for Dataset)
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
