### PR TITLE
Reduce dask tokenization time

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -309,6 +309,7 @@ def _maybe_chunk(
             # when rechunking by different amounts, make sure dask names change
             # by providing chunks as an input to tokenize.
             # subtle bugs result otherwise. see GH3350
+            # we use str() for speed, and use the name for the final array name on the next line
             token2 = tokenize(token if token else var._data, str(chunks))
             name2 = f"{name_prefix}{name}-{token2}"
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -309,7 +309,7 @@ def _maybe_chunk(
             # when rechunking by different amounts, make sure dask names change
             # by providing chunks as an input to tokenize.
             # subtle bugs result otherwise. see GH3350
-            token2 = tokenize(name, token if token else var._data, chunks)
+            token2 = tokenize(token if token else var._data, str(chunks))
             name2 = f"{name_prefix}{name}-{token2}"
 
             from_array_kwargs = utils.consolidate_dask_from_array_kwargs(


### PR DESCRIPTION
When using dask (e.g., `chunks={}` with a zarr dataset), each dask.array gets a token. Calculating this token currently hits a recursive path within dask and is relatively slow (~10ms), which adds up for many variables. This PR makes a simpler but still unique token.

An example profile of open_dataset before: 
<img width="1049" alt="Screenshot 2023-10-19 at 13 19 43" src="https://github.com/pydata/xarray/assets/6042212/f8c4d9a8-cf63-440f-88e4-eddd6afcbb48">

and after
<img width="1030" alt="Screenshot 2023-10-19 at 13 19 52" src="https://github.com/pydata/xarray/assets/6042212/b2a7b9d9-ce08-4571-be91-b3a92c85a92f">
