### PR TITLE
Deprecate tuples of chunks?

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,6 +30,13 @@ Breaking changes
 Deprecations
 ~~~~~~~~~~~~
 
+- Supplying dimension-ordered sequences to :py:meth:`DataArray.chunk` &
+  :py:meth:`Dataset.chunk` is deprecated in favor of supplying a dictionary of
+  dimensions, or a single ``int`` or ``"auto"`` argument covering all
+  dimensions. Xarray favors using dimensions names rather than positions, and
+  this was one place in the API where dimension positions were used.
+  (:pull:`8341`)
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1373,7 +1373,7 @@ class DataArray(
         elif isinstance(chunks, (tuple, list)):
             utils.emit_user_level_warning(
                 "Supplying chunks as dimension-order tuples is deprecated. "
-                "It will raise an error in the future. Instead use a dict with dimensions as keys.",
+                "It will raise an error in the future. Instead use a dict with dimension names as keys.",
                 category=DeprecationWarning,
             )
             chunks = dict(zip(self.dims, chunks))

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1371,11 +1371,10 @@ class DataArray(
             # ignoring type; unclear why it won't accept a Literal into the value.
             chunks = dict.fromkeys(self.dims, chunks)
         elif isinstance(chunks, (tuple, list)):
-            warnings.warn(
+            utils.emit_user_level_warning(
                 "Supplying chunks as dimension-order tuples is deprecated. "
                 "It will raise an error in the future. Instead use a dict with dimensions as keys.",
                 category=DeprecationWarning,
-                stacklevel=2,
             )
             chunks = dict(zip(self.dims, chunks))
         else:

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1371,6 +1371,11 @@ class DataArray(
             # ignoring type; unclear why it won't accept a Literal into the value.
             chunks = dict.fromkeys(self.dims, chunks)
         elif isinstance(chunks, (tuple, list)):
+            warnings.warn(
+                "Supplying chunks as dimension-order tuples is deprecated. "
+                "It will raise an error in the future. Instead use a dict with dimensions as keys.",
+                category=DeprecationWarning,
+            )
             chunks = dict(zip(self.dims, chunks))
         else:
             chunks = either_dict_or_kwargs(chunks, chunks_kwargs, "chunk")

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1375,6 +1375,7 @@ class DataArray(
                 "Supplying chunks as dimension-order tuples is deprecated. "
                 "It will raise an error in the future. Instead use a dict with dimensions as keys.",
                 category=DeprecationWarning,
+                stacklevel=2,
             )
             chunks = dict(zip(self.dims, chunks))
         else:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2653,7 +2653,7 @@ class Dataset(
         chunks_mapping: Mapping[Any, Any]
         if not isinstance(chunks, Mapping) and chunks is not None:
             if isinstance(chunks, (tuple, list)):
-                warnings.warn(
+                utils.emit_user_level_warning(
                     "Supplying chunks as dimension-order tuples is deprecated. "
                     "It will raise an error in the future. Instead use a dict with dimensions as keys.",
                     category=DeprecationWarning,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2647,11 +2647,17 @@ class Dataset(
             warnings.warn(
                 "None value for 'chunks' is deprecated. "
                 "It will raise an error in the future. Use instead '{}'",
-                category=FutureWarning,
+                category=DeprecationWarning,
             )
             chunks = {}
         chunks_mapping: Mapping[Any, Any]
         if not isinstance(chunks, Mapping) and chunks is not None:
+            if isinstance(chunks, (tuple, list)):
+                warnings.warn(
+                    "Supplying chunks as dimension-order tuples is deprecated. "
+                    "It will raise an error in the future. Instead use a dict with dimensions as keys.",
+                    category=DeprecationWarning,
+                )
             chunks_mapping = dict.fromkeys(self.dims, chunks)
         else:
             chunks_mapping = either_dict_or_kwargs(chunks, chunks_kwargs, "chunk")

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -187,9 +187,7 @@ OrderedDims = Union[str, Sequence[Union[Hashable, "ellipsis"]], "ellipsis", None
 # FYI in some cases we don't allow `None`, which this doesn't take account of.
 T_ChunkDim: TypeAlias = Union[int, Literal["auto"], None, tuple[int, ...]]
 # We allow the tuple form of this (though arguably we could transition to named dims only)
-T_Chunks: TypeAlias = Union[
-    T_ChunkDim, Mapping[Any, T_ChunkDim], tuple[T_ChunkDim, ...]
-]
+T_Chunks: TypeAlias = Union[T_ChunkDim, Mapping[Any, T_ChunkDim]]
 T_NormalizedChunks = tuple[tuple[int, ...], ...]
 
 DataVars = Mapping[Any, Any]

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -8,7 +8,7 @@ import warnings
 from collections.abc import Hashable, Mapping, Sequence
 from datetime import timedelta
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Literal, NoReturn, cast
+from typing import TYPE_CHECKING, Any, Callable, NoReturn, cast
 
 import numpy as np
 import pandas as pd

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -34,6 +34,7 @@ from xarray.core.pycompat import (
     is_duck_dask_array,
     to_numpy,
 )
+from xarray.core.types import T_Chunks
 from xarray.core.utils import (
     OrderedSet,
     _default,
@@ -965,13 +966,7 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
 
     def chunk(
         self,
-        chunks: (
-            int
-            | Literal["auto"]
-            | tuple[int, ...]
-            | tuple[tuple[int, ...], ...]
-            | Mapping[Any, None | int | tuple[int, ...]]
-        ) = {},
+        chunks: T_Chunks = {},
         name: str | None = None,
         lock: bool | None = None,
         inline_array: bool | None = None,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2798,7 +2798,7 @@ class TestZarrWriteEmpty(TestZarrDirectoryStore):
         )
 
         if has_dask:
-            ds["test"] = ds["test"].chunk((1, 1, 1))
+            ds["test"] = ds["test"].chunk(1)
             encoding = None
         else:
             encoding = {"test": {"chunks": (1, 1, 1)}}

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -879,13 +879,14 @@ class TestDataArray:
         assert blocked.chunks == ((3,), (4,))
         first_dask_name = blocked.data.name
 
-        blocked = unblocked.chunk(chunks=((2, 1), (2, 2)))
-        assert blocked.chunks == ((2, 1), (2, 2))
-        assert blocked.data.name != first_dask_name
+        with pytest.warns(DeprecationWarning):
+            blocked = unblocked.chunk(chunks=((2, 1), (2, 2)))  # type: ignore 
+            assert blocked.chunks == ((2, 1), (2, 2))
+            assert blocked.data.name != first_dask_name
 
-        blocked = unblocked.chunk(chunks=(3, 3))
-        assert blocked.chunks == ((3,), (3, 1))
-        assert blocked.data.name != first_dask_name
+            blocked = unblocked.chunk(chunks=(3, 3))
+            assert blocked.chunks == ((3,), (3, 1))
+            assert blocked.data.name != first_dask_name
 
         # name doesn't change when rechunking by same amount
         # this fails if ReprObject doesn't have __dask_tokenize__ defined

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -880,7 +880,7 @@ class TestDataArray:
         first_dask_name = blocked.data.name
 
         with pytest.warns(DeprecationWarning):
-            blocked = unblocked.chunk(chunks=((2, 1), (2, 2)))  # type: ignore 
+            blocked = unblocked.chunk(chunks=((2, 1), (2, 2)))  # type: ignore
             assert blocked.chunks == ((2, 1), (2, 2))
             assert blocked.data.name != first_dask_name
 

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -2663,7 +2663,7 @@ class TestAsCompatibleData(Generic[T_DuckArray]):
     def test_full_like_dask(self) -> None:
         orig = Variable(
             dims=("x", "y"), data=[[1.5, 2.0], [3.1, 4.3]], attrs={"foo": "bar"}
-        ).chunk(((1, 1), (2,)))
+        ).chunk(dict(x=(1, 1), y=(2,)))
 
         def check(actual, expect_dtype, expect_values):
             assert actual.dtype == expect_dtype


### PR DESCRIPTION
(I was planning on putting an issue in, but then thought it wasn't much more difficult to make the PR. But it's totally fine if we don't think this is a good idea...)

Allowing a tuple of dims means we're reliant on dimension order, which we really try and not be reliant on. It also makes the type signature even more complicated.

So are we OK to encourage a dict of `dim: chunksize`, rather than a tuple of chunksizes?
