### PR TITLE
Bump minimum numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 
 dependencies = [
-  "numpy>=1.21",
+  "numpy>=1.22",
   "packaging>=21.3",
   "pandas>=1.4",
 ]


### PR DESCRIPTION
I believe this was missed in v2023.08.0 (Aug 18, 2023).

xref: https://github.com/conda-forge/xarray-feedstock/pull/97
