### PR TITLE
Remove unnecessary for loop when using get_axis_num

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2162,7 +2162,7 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
                     raise ValueError(
                         f"Expected {name}={arg!r} to be a scalar like 'dim'."
                     )
-            dim = [dim]
+            dim = (dim,)
 
         # dim is now a list
         nroll = len(dim)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2193,7 +2193,7 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
                 pads[d] = (win - 1, 0)
 
         padded = var.pad(pads, mode="constant", constant_values=fill_value)
-        axis = tuple(self.get_axis_num(d) for d in dim)
+        axis = self.get_axis_num(dim)
         new_dims = self.dims + tuple(window_dim)
         return Variable(
             new_dims,


### PR DESCRIPTION
Noticed an unnecessary for loop when playing around with `self.get_axis_num` in #8344.