### PR TITLE
NamedArray.ndim can only be int

### DIFF
--- a/xarray/namedarray/core.py
+++ b/xarray/namedarray/core.py
@@ -395,7 +395,7 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
         return self._copy(deep=deep, data=data)
 
     @property
-    def ndim(self) -> _IntOrUnknown:
+    def ndim(self) -> int:
         """
         Number of array dimensions.
 


### PR DESCRIPTION
ndim is usually defined as `len(self.shape)`, which does not care about the values in the shape-tuple. 
So there's no risk when getting unknown shape sizes from for example a masked dask array.

Reference:
https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.ndim.html

