### PR TITLE
Use `opt_einsum` by default if installed.

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -45,4 +45,5 @@ python -m pip install \
     git+https://github.com/intake/filesystem_spec \
     git+https://github.com/SciTools/nc-time-axis \
     git+https://github.com/xarray-contrib/flox \
-    git+https://github.com/h5netcdf/h5netcdf
+    git+https://github.com/h5netcdf/h5netcdf \
+    git+https://github.com/dgasmith/opt_einsum

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - numbagg
   - numexpr
   - numpy
+  - opt_einsum
   - packaging
   - pandas
   - pint<0.21

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -327,7 +327,7 @@ intersphinx_mapping = {
     "sparse": ("https://sparse.pydata.org/en/latest/", None),
     "cubed": ("https://tom-e-white.com/cubed/", None),
     "datatree": ("https://xarray-datatree.readthedocs.io/en/latest/", None),
-    "opt_einsum": ("https://dgasmith.github.io/opt_einsum/", None),
+    # "opt_einsum": ("https://dgasmith.github.io/opt_einsum/", None),
 }
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -326,6 +326,7 @@ intersphinx_mapping = {
     "sparse": ("https://sparse.pydata.org/en/latest/", None),
     "cubed": ("https://tom-e-white.com/cubed/", None),
     "datatree": ("https://xarray-datatree.readthedocs.io/en/latest/", None),
+    "opt_einsum": ("https://dgasmith.github.io/opt_einsum/", None),
 }
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -236,6 +236,7 @@ html_theme_options = dict(
     use_repository_button=True,
     use_issues_button=True,
     home_page_in_toc=False,
+    navigation_with_keys=False,
     extra_footer="""<p>Xarray is a fiscally sponsored project of <a href="https://numfocus.org">NumFOCUS</a>,
     a nonprofit dedicated to supporting the open-source scientific computing community.<br>
     Theme by the <a href="https://ebp.jupyterbook.org">Executable Book Project</a></p>""",

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -23,7 +23,7 @@ New Features
 ~~~~~~~~~~~~
 
 - Use `opt_einsum <https://optimized-einsum.readthedocs.io/en/stable/>`_ for :py:func:`xarray.dot` by default if installed.
-  By `Deepak Cherian <https://github.com/dcherian/>`_.
+  By `Deepak Cherian <https://github.com/dcherian>`_. (:issue:`7764`, :pull:`8373`).
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,6 +22,8 @@ v2023.10.2 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- Use `opt_einsum <https://optimized-einsum.readthedocs.io/en/stable/>`_ for :py:func:`xarray.dot` by default if installed.
+  By `Deepak Cherian <https://github.com/dcherian/>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ module = [
   "numbagg.*",
   "netCDF4.*",
   "netcdftime.*",
+  "opt_einsum.*",
   "pandas.*",
   "pooch.*",
   "PseudoNetCDF.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ source-code = "https://github.com/pydata/xarray"
 dask = "xarray.core.daskmanager:DaskManager"
 
 [project.optional-dependencies]
-accel = ["scipy", "bottleneck", "numbagg", "flox"]
+accel = ["scipy", "bottleneck", "numbagg", "flox", "opt_einsum"]
 complete = ["xarray[accel,io,parallel,viz]"]
 io = ["netCDF4", "h5netcdf", "scipy", 'pydap; python_version<"3.10"', "zarr", "fsspec", "cftime", "pooch"]
 parallel = ["dask[complete]"]

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1708,6 +1708,13 @@ def dot(
     -------
     DataArray
 
+
+    See Also
+    --------
+    numpy.einsum
+    dask.array.einsum
+    opt_einsum.contract
+
     Notes
     -----
     We recommend either passing `optimize=True` or installing the optional

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1716,8 +1716,8 @@ def dot(
 
     Notes
     -----
-    We recommend either passing ``optimize=True`` in ``kwargs`` or installing the optional
-    ``opt_einsum`` packages. Note that not all array packages support this however,
+    We recommend installing the optional ``opt_einsum`` package, or alternatively passing `optimize=True`,
+    which is passed through to ``np.einsum``, and works for most array backends.
 
     Examples
     --------

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1716,7 +1716,7 @@ def dot(
 
     Notes
     -----
-    We recommend installing the optional ``opt_einsum`` package, or alternatively passing `optimize=True`,
+    We recommend installing the optional ``opt_einsum`` package, or alternatively passing ``optimize=True``,
     which is passed through to ``np.einsum``, and works for most array backends.
 
     Examples

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1690,7 +1690,7 @@ def dot(
     dims: Dims = None,
     **kwargs: Any,
 ):
-    """Generalized dot product for xarray objects. Uses ``np.einsum``, but
+    """Generalized dot product for xarray objects. Like ``np.einsum``, but
     provides a simpler interface based on array dimension names.
 
     Parameters
@@ -1708,7 +1708,6 @@ def dot(
     -------
     DataArray
 
-
     See Also
     --------
     numpy.einsum
@@ -1717,7 +1716,7 @@ def dot(
 
     Notes
     -----
-    We recommend either passing `optimize=True` or installing the optional
+    We recommend either passing ``optimize=True`` in ``kwargs`` or installing the optional
     ``opt_einsum`` packages. Note that not all array packages support this however,
 
     Examples

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1690,8 +1690,8 @@ def dot(
     dims: Dims = None,
     **kwargs: Any,
 ):
-    """Generalized dot product for xarray objects. Like np.einsum, but
-    provides a simpler interface based on array dimensions.
+    """Generalized dot product for xarray objects. Uses ``np.einsum``, but
+    provides a simpler interface based on array dimension names.
 
     Parameters
     ----------
@@ -1701,12 +1701,17 @@ def dot(
         Which dimensions to sum over. Ellipsis ('...') sums over all dimensions.
         If not specified, then all the common dimensions are summed over.
     **kwargs : dict
-        Additional keyword arguments passed to numpy.einsum or
-        dask.array.einsum
+        Additional keyword arguments passed to ``numpy.einsum`` or
+        ``dask.array.einsum``
 
     Returns
     -------
     DataArray
+
+    Notes
+    -----
+    We recommend either passing `optimize=True` or installing the optional
+    ``opt_einsum`` packages. Note that not all array packages support this however,
 
     Examples
     --------

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -18,7 +18,6 @@ from numpy import all as array_all  # noqa
 from numpy import any as array_any  # noqa
 from numpy import (  # noqa
     around,  # noqa
-    einsum,
     gradient,
     isclose,
     isin,
@@ -46,6 +45,15 @@ def get_array_namespace(x):
         return x.__array_namespace__()
     else:
         return np
+
+
+def einsum(*args, **kwargs):
+    if module_available("opt_einsum"):
+        import opt_einsum
+
+        return opt_einsum.contract(*args, **kwargs)
+    else:
+        return np.einsum(*args, **kwargs)
 
 
 def _dask_or_eager_func(

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -48,7 +48,9 @@ def get_array_namespace(x):
 
 
 def einsum(*args, **kwargs):
-    if module_available("opt_einsum"):
+    from xarray.core.options import OPTIONS
+
+    if OPTIONS["use_opt_einsum"] and module_available("opt_einsum"):
         import opt_einsum
 
         return opt_einsum.contract(*args, **kwargs)

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
         "warn_for_unclosed_files",
         "use_bottleneck",
         "use_numbagg",
+        "use_opt_einsum",
         "use_flox",
     ]
 
@@ -52,6 +53,7 @@ if TYPE_CHECKING:
         use_bottleneck: bool
         use_flox: bool
         use_numbagg: bool
+        use_opt_einsum: bool
 
 
 OPTIONS: T_Options = {
@@ -75,6 +77,7 @@ OPTIONS: T_Options = {
     "use_bottleneck": True,
     "use_flox": True,
     "use_numbagg": True,
+    "use_opt_einsum": True,
 }
 
 _JOIN_OPTIONS = frozenset(["inner", "outer", "left", "right", "exact"])
@@ -102,6 +105,7 @@ _VALIDATORS = {
     "keep_attrs": lambda choice: choice in [True, False, "default"],
     "use_bottleneck": lambda value: isinstance(value, bool),
     "use_numbagg": lambda value: isinstance(value, bool),
+    "use_opt_einsum": lambda value: isinstance(value, bool),
     "use_flox": lambda value: isinstance(value, bool),
     "warn_for_unclosed_files": lambda value: isinstance(value, bool),
 }
@@ -237,6 +241,8 @@ class set_options:
     use_numbagg : bool, default: True
         Whether to use ``numbagg`` to accelerate reductions.
         Takes precedence over ``use_bottleneck`` when both are True.
+    use_opt_einsum : bool, default: True
+        Whether to use ``opt_einsum`` to accelerate dot products.
     warn_for_unclosed_files : bool, default: False
         Whether or not to issue a warning when unclosed files are
         deallocated. This is mostly useful for debugging.

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -2467,7 +2467,8 @@ class TestDataArray:
 
         units = extract_units(func(array))
         expected = attach_units(func(strip_units(data_array)), units)
-        actual = func(data_array)
+        with xr.set_options(use_opt_einsum=False):
+            actual = func(data_array)
 
         assert_units_equal(expected, actual)
         assert_identical(expected, actual)

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1502,10 +1502,10 @@ def test_dot_dataarray(dtype):
     data_array = xr.DataArray(data=array1, dims=("x", "y"))
     other = xr.DataArray(data=array2, dims=("y", "z"))
 
-    expected = attach_units(
-        xr.dot(strip_units(data_array), strip_units(other)), {None: unit_registry.m}
-    )
     with xr.set_options(use_opt_einsum=False):
+        expected = attach_units(
+            xr.dot(strip_units(data_array), strip_units(other)), {None: unit_registry.m}
+        )
         actual = xr.dot(data_array, other)
 
     assert_units_equal(expected, actual)
@@ -2466,8 +2466,8 @@ class TestDataArray:
         data_array = xr.DataArray(data=array)
 
         units = extract_units(func(array))
-        expected = attach_units(func(strip_units(data_array)), units)
         with xr.set_options(use_opt_einsum=False):
+            expected = attach_units(func(strip_units(data_array)), units)
             actual = func(data_array)
 
         assert_units_equal(expected, actual)
@@ -3831,8 +3831,9 @@ class TestDataArray:
         if not isinstance(func, (function, method)):
             units.update(extract_units(func(array.reshape(-1))))
 
-        expected = attach_units(func(strip_units(data_array)), units)
-        actual = func(data_array)
+        with xr.set_options(use_opt_einsum=False):
+            expected = attach_units(func(strip_units(data_array)), units)
+            actual = func(data_array)
 
         assert_units_equal(expected, actual)
         assert_identical(expected, actual)

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -1505,7 +1505,8 @@ def test_dot_dataarray(dtype):
     expected = attach_units(
         xr.dot(strip_units(data_array), strip_units(other)), {None: unit_registry.m}
     )
-    actual = xr.dot(data_array, other)
+    with xr.set_options(use_opt_einsum=False):
+        actual = xr.dot(data_array, other)
 
     assert_units_equal(expected, actual)
     assert_identical(expected, actual)


### PR DESCRIPTION


<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #7764
- [x] Closes #8017
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
