### PR TITLE
Add chunkedduckarray to _typing 

### DIFF
--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -168,15 +168,11 @@ _ArrayAPI = _arrayapi[Any, np.dtype[_ScalarType_co]]
 
 # NamedArray can most likely use both __array_function__ and __array_namespace__:
 _arrayfunction_or_api = (_arrayfunction, _arrayapi)
-# _ArrayFunctionOrAPI = Union[
-#     _arrayfunction[_ShapeType_co, _DType_co], _arrayapi[_ShapeType_co, _DType_co]
-# ]
 
 duckarray = Union[
     _arrayfunction[_ShapeType_co, _DType_co], _arrayapi[_ShapeType_co, _DType_co]
 ]
 DuckArray = _arrayfunction[Any, np.dtype[_ScalarType_co]]
-T_DuckArray = TypeVar("T_DuckArray", bound=_arrayfunction[Any, Any])
 
 
 @runtime_checkable
@@ -234,6 +230,13 @@ class _chunkedarrayapi(
 
 # Corresponds to np.typing.NDArray:
 _ChunkedArrayAPI = _chunkedarrayapi[Any, np.dtype[_ScalarType_co]]
+
+# NamedArray can most likely use both __array_function__ and __array_namespace__:
+_chunkedarrayfunction_or_api = (_arrayfunction, _arrayapi)
+
+chunkedduckarray = Union[
+    _arrayfunction[_ShapeType_co, _DType_co], _arrayapi[_ShapeType_co, _DType_co]
+]
 
 
 @runtime_checkable
@@ -295,13 +298,7 @@ _SparseArrayFunctionOrAPI = Union[
     _SparseArrayFunction[np.generic], _SparseArrayAPI[np.generic]
 ]
 
-
-# Temporary placeholder for indicating an array api compliant type.
-# hopefully in the future we can narrow this down more
-# T_DuckArray = TypeVar("T_DuckArray", bound=_ArrayFunctionOrAPI)
-
 # The chunked arrays like dask or cubed:
 _ChunkedArrayFunctionOrAPI = Union[
     _ChunkedArrayFunction[np.generic], _ChunkedArrayAPI[np.generic]
 ]
-T_ChunkedArray = TypeVar("T_ChunkedArray", bound=_ChunkedArrayFunctionOrAPI)

--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -102,10 +102,6 @@ class _array(Protocol[_ShapeType_co, _DType_co]):
         ...
 
 
-# Corresponds to np.typing.NDArray:
-_Array = _array[Any, np.dtype[_ScalarType_co]]
-
-
 @runtime_checkable
 class _arrayfunction(
     _array[_ShapeType_co, _DType_co], Protocol[_ShapeType_co, _DType_co]
@@ -147,10 +143,6 @@ class _arrayfunction(
         ...
 
 
-# Corresponds to np.typing.NDArray:
-_ArrayFunction = _arrayfunction[Any, np.dtype[_ScalarType_co]]
-
-
 @runtime_checkable
 class _arrayapi(_array[_ShapeType_co, _DType_co], Protocol[_ShapeType_co, _DType_co]):
     """
@@ -163,15 +155,14 @@ class _arrayapi(_array[_ShapeType_co, _DType_co], Protocol[_ShapeType_co, _DType
         ...
 
 
-# Corresponds to np.typing.NDArray:
-_ArrayAPI = _arrayapi[Any, np.dtype[_ScalarType_co]]
-
 # NamedArray can most likely use both __array_function__ and __array_namespace__:
 _arrayfunction_or_api = (_arrayfunction, _arrayapi)
 
 duckarray = Union[
     _arrayfunction[_ShapeType_co, _DType_co], _arrayapi[_ShapeType_co, _DType_co]
 ]
+
+# Corresponds to np.typing.NDArray:
 DuckArray = _arrayfunction[Any, np.dtype[_ScalarType_co]]
 
 
@@ -190,10 +181,6 @@ class _chunkedarray(
         ...
 
 
-# Corresponds to np.typing.NDArray:
-_ChunkedArray = _chunkedarray[Any, np.dtype[_ScalarType_co]]
-
-
 @runtime_checkable
 class _chunkedarrayfunction(
     _arrayfunction[_ShapeType_co, _DType_co], Protocol[_ShapeType_co, _DType_co]
@@ -207,10 +194,6 @@ class _chunkedarrayfunction(
     @property
     def chunks(self) -> _Chunks:
         ...
-
-
-# Corresponds to np.typing.NDArray:
-_ChunkedArrayFunction = _chunkedarrayfunction[Any, np.dtype[_ScalarType_co]]
 
 
 @runtime_checkable
@@ -228,14 +211,11 @@ class _chunkedarrayapi(
         ...
 
 
-# Corresponds to np.typing.NDArray:
-_ChunkedArrayAPI = _chunkedarrayapi[Any, np.dtype[_ScalarType_co]]
-
 # NamedArray can most likely use both __array_function__ and __array_namespace__:
-_chunkedarrayfunction_or_api = (_arrayfunction, _arrayapi)
-
+_chunkedarrayfunction_or_api = (_chunkedarrayfunction, _chunkedarrayapi)
 chunkedduckarray = Union[
-    _arrayfunction[_ShapeType_co, _DType_co], _arrayapi[_ShapeType_co, _DType_co]
+    _chunkedarrayfunction[_ShapeType_co, _DType_co],
+    _chunkedarrayapi[_ShapeType_co, _DType_co],
 ]
 
 
@@ -253,10 +233,6 @@ class _sparsearray(
         ...
 
 
-# Corresponds to np.typing.NDArray:
-_SparseArray = _sparsearray[Any, np.dtype[_ScalarType_co]]
-
-
 @runtime_checkable
 class _sparsearrayfunction(
     _arrayfunction[_ShapeType_co, _DType_co], Protocol[_ShapeType_co, _DType_co]
@@ -269,10 +245,6 @@ class _sparsearrayfunction(
 
     def todense(self) -> NDArray[_ScalarType_co]:
         ...
-
-
-# Corresponds to np.typing.NDArray:
-_SparseArrayFunction = _sparsearrayfunction[Any, np.dtype[_ScalarType_co]]
 
 
 @runtime_checkable
@@ -289,16 +261,5 @@ class _sparsearrayapi(
         ...
 
 
-# Corresponds to np.typing.NDArray:
-_SparseArrayAPI = _sparsearrayapi[Any, np.dtype[_ScalarType_co]]
-
 # NamedArray can most likely use both __array_function__ and __array_namespace__:
 _sparsearrayfunction_or_api = (_sparsearrayfunction, _sparsearrayapi)
-_SparseArrayFunctionOrAPI = Union[
-    _SparseArrayFunction[np.generic], _SparseArrayAPI[np.generic]
-]
-
-# The chunked arrays like dask or cubed:
-_ChunkedArrayFunctionOrAPI = Union[
-    _ChunkedArrayFunction[np.generic], _ChunkedArrayAPI[np.generic]
-]


### PR DESCRIPTION
Add more chunkedarray typing options.
Also clean up some ideas that didn't work out. Using TypeVar for arrays for example has turned out to not work that great because of the very common dtype changes.

If you want to check if an ArrayLike is a chunked array:
```python
if isinstance(data, _chunkedarrayfunction_or_api):
    data.chunk()
```
However try to rely on mypy in private functions over isinstance checks for better performance:
```python
def _do_compute(data: chunkedduckarray[Any, _DType]) -> duckarray[Any, _DType]:
     return data.compute()
```