### PR TITLE
Use numbagg for `ffill` by default

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -56,7 +56,7 @@ Internal Changes
 ~~~~~~~~~~~~~~~~
 
 - :py:meth:`DataArray.bfill` & :py:meth:`DataArray.ffill` now use numbagg by
-  default, which is up to 5x faster on wide arrays on multi-core machines. (:pull:`8339`)
+  default, which is up to 5x faster where parallelization is possible. (:pull:`8339`)
   By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 .. _whats-new.2023.11.0:

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -50,6 +50,10 @@ Documentation
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- :py:meth:`DataArray.bfill` & :py:meth:`DataArray.ffill` now use numbagg by
+  default, which is up to 5x faster on wide arrays on multi-core machines. (:pull:`8339`)
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
+
 .. _whats-new.2023.11.0:
 
 v2023.11.0 (Nov 16, 2023)

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -177,8 +177,8 @@ def _determine_zarr_chunks(enc_chunks, var_chunks, ndim, name, safe_chunks):
     # DESIGN CHOICE: do not allow multiple dask chunks on a single zarr chunk
     # this avoids the need to get involved in zarr synchronization / locking
     # From zarr docs:
-    #  "If each worker in a parallel computation is writing to a separate
-    #   region of the array, and if region boundaries are perfectly aligned
+    #  "If each worker in a parallel computation is writing to a
+    #   separate region of the array, and if region boundaries are perfectly aligned
     #   with chunk boundaries, then no synchronization is required."
     # TODO: incorporate synchronizer to allow writes from multiple dask
     # threads

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -87,7 +87,6 @@ def push(array, n, axis):
     # The method parameter makes that the tests for python 3.7 fails.
     return da.reductions.cumreduction(
         func=_push,
-        # func=bottleneck.push,
         binop=_fill_with_last_one,
         ident=np.nan,
         x=array,

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -59,9 +59,10 @@ def push(array, n, axis):
     """
     Dask-aware bottleneck.push
     """
-    import bottleneck
     import dask.array as da
     import numpy as np
+
+    from xarray.core.duck_array_ops import _push
 
     def _fill_with_last_one(a, b):
         # cumreduction apply the push func over all the blocks first so, the only missing part is filling
@@ -85,7 +86,8 @@ def push(array, n, axis):
 
     # The method parameter makes that the tests for python 3.7 fails.
     return da.reductions.cumreduction(
-        func=bottleneck.push,
+        func=_push,
+        # func=bottleneck.push,
         binop=_fill_with_last_one,
         ident=np.nan,
         x=array,

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -700,7 +700,7 @@ def _push(array, n: int | None = None, axis: int = -1):
             "ffill & bfill requires bottleneck or numbagg to be enabled."
             " Call `xr.set_options(use_bottleneck=True)` or `xr.set_options(use_numbagg=True)` to enable one."
         )
-    if OPTIONS["use_numbagg"] and pycompat.mod_version("numbagg") != Version("0.0.0"):
+    if OPTIONS["use_numbagg"] and not module_available("numbagg"):
         import numbagg
 
         if pycompat.mod_version("numbagg") < Version("0.6.2"):

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -700,7 +700,7 @@ def _push(array, n: int | None = None, axis: int = -1):
             "ffill & bfill requires bottleneck or numbagg to be enabled."
             " Call `xr.set_options(use_bottleneck=True)` or `xr.set_options(use_numbagg=True)` to enable one."
         )
-    if OPTIONS["use_numbagg"] and not module_available("numbagg"):
+    if OPTIONS["use_numbagg"] and module_available("numbagg"):
         import numbagg
 
         if pycompat.mod_version("numbagg") < Version("0.6.2"):

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -700,7 +700,7 @@ def _push(array, n: int | None = None, axis: int = -1):
             "ffill & bfill requires bottleneck or numbagg to be enabled."
             " Call `xr.set_options(use_bottleneck=True)` or `xr.set_options(use_numbagg=True)` to enable one."
         )
-    if OPTIONS["use_numbagg"] and pycompat.mod_version("numbagg") is not None:
+    if OPTIONS["use_numbagg"] and pycompat.mod_version("numbagg") != Version("0.0.0"):
         import numbagg
 
         if pycompat.mod_version("numbagg") < Version("0.6.2"):

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -413,11 +413,6 @@ def _bfill(arr, n=None, axis=-1):
 
 def ffill(arr, dim=None, limit=None):
     """forward fill missing values"""
-    if not OPTIONS["use_bottleneck"]:
-        raise RuntimeError(
-            "ffill requires bottleneck to be enabled."
-            " Call `xr.set_options(use_bottleneck=True)` to enable it."
-        )
 
     axis = arr.get_axis_num(dim)
 
@@ -436,11 +431,6 @@ def ffill(arr, dim=None, limit=None):
 
 def bfill(arr, dim=None, limit=None):
     """backfill missing values"""
-    if not OPTIONS["use_bottleneck"]:
-        raise RuntimeError(
-            "bfill requires bottleneck to be enabled."
-            " Call `xr.set_options(use_bottleneck=True)` to enable it."
-        )
 
     axis = arr.get_axis_num(dim)
 

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -14,7 +14,7 @@ from xarray.core import utils
 from xarray.core.common import _contains_datetime_like_objects, ones_like
 from xarray.core.computation import apply_ufunc
 from xarray.core.duck_array_ops import datetime_to_numeric, push, timedelta_to_numeric
-from xarray.core.options import OPTIONS, _get_keep_attrs
+from xarray.core.options import _get_keep_attrs
 from xarray.core.parallelcompat import get_chunked_array_type, is_chunked_array
 from xarray.core.types import Interp1dOptions, InterpOptions
 from xarray.core.utils import OrderedSet, is_scalar

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -171,7 +171,7 @@ def _create_method(name, npmodule=np) -> Callable:
         bn_func = getattr(bn, name, None)
 
         if (
-            pycompat.mod_version("numbagg") is not None
+            module_available("numbagg")
             and pycompat.mod_version("numbagg") >= Version("0.5.0")
             and OPTIONS["use_numbagg"]
             and isinstance(values, np.ndarray)

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -9,6 +9,7 @@ from numpy.core.multiarray import normalize_axis_index  # type: ignore[attr-defi
 from packaging.version import Version
 
 from xarray.core import pycompat
+from xarray.core.utils import module_available
 
 # remove once numpy 2.0 is the oldest supported version
 try:

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -175,7 +175,6 @@ def _create_method(name, npmodule=np) -> Callable:
             and pycompat.mod_version("numbagg") >= Version("0.5.0")
             and OPTIONS["use_numbagg"]
             and isinstance(values, np.ndarray)
-            # and nba_func is not None
             # numbagg uses ddof=1 only, but numpy uses ddof=0 by default
             and (("var" in name or "std" in name) and kwargs.get("ddof", 0) == 1)
             # TODO: bool?

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -12,7 +12,7 @@ from xarray.core.utils import is_duck_array, is_scalar, module_available
 integer_types = (int, np.integer)
 
 if TYPE_CHECKING:
-    ModType = Literal["dask", "pint", "cupy", "sparse", "cubed"]
+    ModType = Literal["dask", "pint", "cupy", "sparse", "cubed", "numbagg"]
     DuckArrayTypes = tuple[type[Any], ...]  # TODO: improve this? maybe Generic
 
 
@@ -47,6 +47,9 @@ class DuckArrayModule:
                 duck_array_type = (duck_array_module.SparseArray,)
             elif mod == "cubed":
                 duck_array_type = (duck_array_module.Array,)
+            # Not a duck array module, but using this system regardless, to get lazy imports
+            elif mod == "numbagg":
+                duck_array_type = ()
             else:
                 raise NotImplementedError
 

--- a/xarray/core/rolling_exp.py
+++ b/xarray/core/rolling_exp.py
@@ -11,6 +11,7 @@ from xarray.core.computation import apply_ufunc
 from xarray.core.options import _get_keep_attrs
 from xarray.core.pdcompat import count_not_none
 from xarray.core.types import T_DataWithCoords
+from xarray.core.utils import module_available
 
 
 def _get_alpha(

--- a/xarray/core/rolling_exp.py
+++ b/xarray/core/rolling_exp.py
@@ -15,9 +15,9 @@ try:
     import numbagg
     from numbagg import move_exp_nanmean, move_exp_nansum
 
-    _NUMBAGG_VERSION: Version | None = Version(numbagg.__version__)
+    NUMBAGG_VERSION: Version | None = Version(numbagg.__version__)
 except ImportError:
-    _NUMBAGG_VERSION = None
+    NUMBAGG_VERSION = None
 
 
 def _get_alpha(
@@ -100,17 +100,17 @@ class RollingExp(Generic[T_DataWithCoords]):
         window_type: str = "span",
         min_weight: float = 0.0,
     ):
-        if _NUMBAGG_VERSION is None:
+        if NUMBAGG_VERSION is None:
             raise ImportError(
                 "numbagg >= 0.2.1 is required for rolling_exp but currently numbagg is not installed"
             )
-        elif _NUMBAGG_VERSION < Version("0.2.1"):
+        elif NUMBAGG_VERSION < Version("0.2.1"):
             raise ImportError(
-                f"numbagg >= 0.2.1 is required for rolling_exp but currently version {_NUMBAGG_VERSION} is installed"
+                f"numbagg >= 0.2.1 is required for rolling_exp but currently version {NUMBAGG_VERSION} is installed"
             )
-        elif _NUMBAGG_VERSION < Version("0.3.1") and min_weight > 0:
+        elif NUMBAGG_VERSION < Version("0.3.1") and min_weight > 0:
             raise ImportError(
-                f"numbagg >= 0.3.1 is required for `min_weight > 0` within `.rolling_exp` but currently version {_NUMBAGG_VERSION} is installed"
+                f"numbagg >= 0.3.1 is required for `min_weight > 0` within `.rolling_exp` but currently version {NUMBAGG_VERSION} is installed"
             )
 
         self.obj: T_DataWithCoords = obj
@@ -211,9 +211,9 @@ class RollingExp(Generic[T_DataWithCoords]):
         Dimensions without coordinates: x
         """
 
-        if _NUMBAGG_VERSION is None or _NUMBAGG_VERSION < Version("0.4.0"):
+        if NUMBAGG_VERSION is None or NUMBAGG_VERSION < Version("0.4.0"):
             raise ImportError(
-                f"numbagg >= 0.4.0 is required for rolling_exp().std(), currently {_NUMBAGG_VERSION} is installed"
+                f"numbagg >= 0.4.0 is required for rolling_exp().std(), currently {NUMBAGG_VERSION} is installed"
             )
         dim_order = self.obj.dims
 
@@ -243,9 +243,9 @@ class RollingExp(Generic[T_DataWithCoords]):
         Dimensions without coordinates: x
         """
 
-        if _NUMBAGG_VERSION is None or _NUMBAGG_VERSION < Version("0.4.0"):
+        if NUMBAGG_VERSION is None or NUMBAGG_VERSION < Version("0.4.0"):
             raise ImportError(
-                f"numbagg >= 0.4.0 is required for rolling_exp().var(), currently {_NUMBAGG_VERSION} is installed"
+                f"numbagg >= 0.4.0 is required for rolling_exp().var(), currently {NUMBAGG_VERSION} is installed"
             )
         dim_order = self.obj.dims
 
@@ -275,9 +275,9 @@ class RollingExp(Generic[T_DataWithCoords]):
         Dimensions without coordinates: x
         """
 
-        if _NUMBAGG_VERSION is None or _NUMBAGG_VERSION < Version("0.4.0"):
+        if NUMBAGG_VERSION is None or NUMBAGG_VERSION < Version("0.4.0"):
             raise ImportError(
-                f"numbagg >= 0.4.0 is required for rolling_exp().cov(), currently {_NUMBAGG_VERSION} is installed"
+                f"numbagg >= 0.4.0 is required for rolling_exp().cov(), currently {NUMBAGG_VERSION} is installed"
             )
         dim_order = self.obj.dims
 
@@ -308,9 +308,9 @@ class RollingExp(Generic[T_DataWithCoords]):
         Dimensions without coordinates: x
         """
 
-        if _NUMBAGG_VERSION is None or _NUMBAGG_VERSION < Version("0.4.0"):
+        if NUMBAGG_VERSION is None or NUMBAGG_VERSION < Version("0.4.0"):
             raise ImportError(
-                f"numbagg >= 0.4.0 is required for rolling_exp().cov(), currently {_NUMBAGG_VERSION} is installed"
+                f"numbagg >= 0.4.0 is required for rolling_exp().cov(), currently {NUMBAGG_VERSION} is installed"
             )
         dim_order = self.obj.dims
 

--- a/xarray/core/rolling_exp.py
+++ b/xarray/core/rolling_exp.py
@@ -76,7 +76,7 @@ class RollingExp(Generic[T_DataWithCoords]):
         window_type: str = "span",
         min_weight: float = 0.0,
     ):
-        if pycompat.mod_version("numbagg") == Version("0.0.0"):
+        if not module_available("numbagg"):
             raise ImportError(
                 "numbagg >= 0.2.1 is required for rolling_exp but currently numbagg is not installed"
             )

--- a/xarray/core/rolling_exp.py
+++ b/xarray/core/rolling_exp.py
@@ -76,7 +76,7 @@ class RollingExp(Generic[T_DataWithCoords]):
         window_type: str = "span",
         min_weight: float = 0.0,
     ):
-        if pycompat.mod_version("numbagg") is None:
+        if pycompat.mod_version("numbagg") == Version("0.0.0"):
             raise ImportError(
                 "numbagg >= 0.2.1 is required for rolling_exp but currently numbagg is not installed"
             )
@@ -191,9 +191,7 @@ class RollingExp(Generic[T_DataWithCoords]):
         Dimensions without coordinates: x
         """
 
-        if pycompat.mod_version("numbagg") is None or pycompat.mod_version(
-            "numbagg"
-        ) < Version("0.4.0"):
+        if pycompat.mod_version("numbagg") < Version("0.4.0"):
             raise ImportError(
                 f"numbagg >= 0.4.0 is required for rolling_exp().std(), currently {pycompat.mod_version('numbagg')} is installed"
             )
@@ -226,10 +224,7 @@ class RollingExp(Generic[T_DataWithCoords]):
         array([       nan, 0.        , 0.46153846, 0.18461538, 0.06446281])
         Dimensions without coordinates: x
         """
-
-        if pycompat.mod_version("numbagg") is None or pycompat.mod_version(
-            "numbagg"
-        ) < Version("0.4.0"):
+        if pycompat.mod_version("numbagg") < Version("0.4.0"):
             raise ImportError(
                 f"numbagg >= 0.4.0 is required for rolling_exp().std(), currently {pycompat.mod_version('numbagg')} is installed"
             )
@@ -262,9 +257,7 @@ class RollingExp(Generic[T_DataWithCoords]):
         Dimensions without coordinates: x
         """
 
-        if pycompat.mod_version("numbagg") is None or pycompat.mod_version(
-            "numbagg"
-        ) < Version("0.4.0"):
+        if pycompat.mod_version("numbagg") < Version("0.4.0"):
             raise ImportError(
                 f"numbagg >= 0.4.0 is required for rolling_exp().std(), currently {pycompat.mod_version('numbagg')} is installed"
             )
@@ -298,9 +291,7 @@ class RollingExp(Generic[T_DataWithCoords]):
         Dimensions without coordinates: x
         """
 
-        if pycompat.mod_version("numbagg") is None or pycompat.mod_version(
-            "numbagg"
-        ) < Version("0.4.0"):
+        if pycompat.mod_version("numbagg") < Version("0.4.0"):
             raise ImportError(
                 f"numbagg >= 0.4.0 is required for rolling_exp().std(), currently {pycompat.mod_version('numbagg')} is installed"
             )

--- a/xarray/core/rolling_exp.py
+++ b/xarray/core/rolling_exp.py
@@ -6,18 +6,11 @@ from typing import Any, Generic
 import numpy as np
 from packaging.version import Version
 
+from xarray.core import pycompat
 from xarray.core.computation import apply_ufunc
 from xarray.core.options import _get_keep_attrs
 from xarray.core.pdcompat import count_not_none
 from xarray.core.types import T_DataWithCoords
-
-try:
-    import numbagg
-    from numbagg import move_exp_nanmean, move_exp_nansum
-
-    NUMBAGG_VERSION: Version | None = Version(numbagg.__version__)
-except ImportError:
-    NUMBAGG_VERSION = None
 
 
 def _get_alpha(
@@ -83,17 +76,17 @@ class RollingExp(Generic[T_DataWithCoords]):
         window_type: str = "span",
         min_weight: float = 0.0,
     ):
-        if NUMBAGG_VERSION is None:
+        if pycompat.mod_version("numbagg") is None:
             raise ImportError(
                 "numbagg >= 0.2.1 is required for rolling_exp but currently numbagg is not installed"
             )
-        elif NUMBAGG_VERSION < Version("0.2.1"):
+        elif pycompat.mod_version("numbagg") < Version("0.2.1"):
             raise ImportError(
-                f"numbagg >= 0.2.1 is required for rolling_exp but currently version {NUMBAGG_VERSION} is installed"
+                f"numbagg >= 0.2.1 is required for rolling_exp but currently version {pycompat.mod_version('numbagg')} is installed"
             )
-        elif NUMBAGG_VERSION < Version("0.3.1") and min_weight > 0:
+        elif pycompat.mod_version("numbagg") < Version("0.3.1") and min_weight > 0:
             raise ImportError(
-                f"numbagg >= 0.3.1 is required for `min_weight > 0` within `.rolling_exp` but currently version {NUMBAGG_VERSION} is installed"
+                f"numbagg >= 0.3.1 is required for `min_weight > 0` within `.rolling_exp` but currently version {pycompat.mod_version('numbagg')} is installed"
             )
 
         self.obj: T_DataWithCoords = obj
@@ -127,13 +120,15 @@ class RollingExp(Generic[T_DataWithCoords]):
         Dimensions without coordinates: x
         """
 
+        import numbagg
+
         if keep_attrs is None:
             keep_attrs = _get_keep_attrs(default=True)
 
         dim_order = self.obj.dims
 
         return apply_ufunc(
-            move_exp_nanmean,
+            numbagg.move_exp_nanmean,
             self.obj,
             input_core_dims=[[self.dim]],
             kwargs=self.kwargs,
@@ -163,13 +158,15 @@ class RollingExp(Generic[T_DataWithCoords]):
         Dimensions without coordinates: x
         """
 
+        import numbagg
+
         if keep_attrs is None:
             keep_attrs = _get_keep_attrs(default=True)
 
         dim_order = self.obj.dims
 
         return apply_ufunc(
-            move_exp_nansum,
+            numbagg.move_exp_nansum,
             self.obj,
             input_core_dims=[[self.dim]],
             kwargs=self.kwargs,
@@ -194,10 +191,14 @@ class RollingExp(Generic[T_DataWithCoords]):
         Dimensions without coordinates: x
         """
 
-        if NUMBAGG_VERSION is None or NUMBAGG_VERSION < Version("0.4.0"):
+        if pycompat.mod_version("numbagg") is None or pycompat.mod_version(
+            "numbagg"
+        ) < Version("0.4.0"):
             raise ImportError(
-                f"numbagg >= 0.4.0 is required for rolling_exp().std(), currently {NUMBAGG_VERSION} is installed"
+                f"numbagg >= 0.4.0 is required for rolling_exp().std(), currently {pycompat.mod_version('numbagg')} is installed"
             )
+        import numbagg
+
         dim_order = self.obj.dims
 
         return apply_ufunc(
@@ -226,11 +227,14 @@ class RollingExp(Generic[T_DataWithCoords]):
         Dimensions without coordinates: x
         """
 
-        if NUMBAGG_VERSION is None or NUMBAGG_VERSION < Version("0.4.0"):
+        if pycompat.mod_version("numbagg") is None or pycompat.mod_version(
+            "numbagg"
+        ) < Version("0.4.0"):
             raise ImportError(
-                f"numbagg >= 0.4.0 is required for rolling_exp().var(), currently {NUMBAGG_VERSION} is installed"
+                f"numbagg >= 0.4.0 is required for rolling_exp().std(), currently {pycompat.mod_version('numbagg')} is installed"
             )
         dim_order = self.obj.dims
+        import numbagg
 
         return apply_ufunc(
             numbagg.move_exp_nanvar,
@@ -258,11 +262,14 @@ class RollingExp(Generic[T_DataWithCoords]):
         Dimensions without coordinates: x
         """
 
-        if NUMBAGG_VERSION is None or NUMBAGG_VERSION < Version("0.4.0"):
+        if pycompat.mod_version("numbagg") is None or pycompat.mod_version(
+            "numbagg"
+        ) < Version("0.4.0"):
             raise ImportError(
-                f"numbagg >= 0.4.0 is required for rolling_exp().cov(), currently {NUMBAGG_VERSION} is installed"
+                f"numbagg >= 0.4.0 is required for rolling_exp().std(), currently {pycompat.mod_version('numbagg')} is installed"
             )
         dim_order = self.obj.dims
+        import numbagg
 
         return apply_ufunc(
             numbagg.move_exp_nancov,
@@ -291,11 +298,14 @@ class RollingExp(Generic[T_DataWithCoords]):
         Dimensions without coordinates: x
         """
 
-        if NUMBAGG_VERSION is None or NUMBAGG_VERSION < Version("0.4.0"):
+        if pycompat.mod_version("numbagg") is None or pycompat.mod_version(
+            "numbagg"
+        ) < Version("0.4.0"):
             raise ImportError(
-                f"numbagg >= 0.4.0 is required for rolling_exp().cov(), currently {NUMBAGG_VERSION} is installed"
+                f"numbagg >= 0.4.0 is required for rolling_exp().std(), currently {pycompat.mod_version('numbagg')} is installed"
             )
         dim_order = self.obj.dims
+        import numbagg
 
         return apply_ufunc(
             numbagg.move_exp_nancorr,

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -53,7 +53,8 @@ def _importorskip(
         mod = importlib.import_module(modname)
         has = True
         if minversion is not None:
-            if Version(mod.__version__) < Version(minversion):
+            v = getattr(mod, "__version__", "999")
+            if Version(v) < Version(minversion):
                 raise ImportError("Minimum version not satisfied")
     except ImportError:
         has = False
@@ -87,6 +88,10 @@ has_flox, requires_flox = _importorskip("flox")
 # some special cases
 has_scipy_or_netCDF4 = has_scipy or has_netCDF4
 requires_scipy_or_netCDF4 = pytest.mark.skipif(
+    not has_scipy_or_netCDF4, reason="requires scipy or netCDF4"
+)
+has_numbagg_or_bottleneck = has_numbagg or has_bottleneck
+requires_numbagg_or_bottleneck = pytest.mark.skipif(
     not has_scipy_or_netCDF4, reason="requires scipy or netCDF4"
 )
 # _importorskip does not work for development versions

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -419,10 +419,9 @@ def test_ffill():
 
 def test_ffill_use_bottleneck_numbagg():
     da = xr.DataArray(np.array([4, 5, np.nan], dtype=np.float64), dims="x")
-    with xr.set_options(use_bottleneck=False):
-        with xr.set_options(use_numbagg=False):
-            with pytest.raises(RuntimeError):
-                da.ffill("x")
+    with xr.set_options(use_bottleneck=False, use_numbagg=False):
+        with pytest.raises(RuntimeError):
+            da.ffill("x")
 
 
 @requires_dask

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -24,6 +24,8 @@ from xarray.tests import (
     requires_bottleneck,
     requires_cftime,
     requires_dask,
+    requires_numbagg,
+    requires_numbagg_or_bottleneck,
     requires_scipy,
 )
 
@@ -407,7 +409,7 @@ def test_interpolate_dask_expected_dtype(dtype, method):
     assert da.dtype == da.compute().dtype
 
 
-@requires_bottleneck
+@requires_numbagg_or_bottleneck
 def test_ffill():
     da = xr.DataArray(np.array([4, 5, np.nan], dtype=np.float64), dims="x")
     expected = xr.DataArray(np.array([4, 5, 5], dtype=np.float64), dims="x")
@@ -415,25 +417,36 @@ def test_ffill():
     assert_equal(actual, expected)
 
 
-def test_ffill_use_bottleneck():
+def test_ffill_use_bottleneck_numbagg():
     da = xr.DataArray(np.array([4, 5, np.nan], dtype=np.float64), dims="x")
     with xr.set_options(use_bottleneck=False):
-        with pytest.raises(RuntimeError):
-            da.ffill("x")
+        with xr.set_options(use_numbagg=False):
+            with pytest.raises(RuntimeError):
+                da.ffill("x")
 
 
 @requires_dask
 def test_ffill_use_bottleneck_dask():
     da = xr.DataArray(np.array([4, 5, np.nan], dtype=np.float64), dims="x")
     da = da.chunk({"x": 1})
-    with xr.set_options(use_bottleneck=False):
+    with xr.set_options(use_bottleneck=False, use_numbagg=False):
         with pytest.raises(RuntimeError):
             da.ffill("x")
 
 
+@requires_numbagg
+@requires_dask
+def test_ffill_use_numbagg_dask():
+    with xr.set_options(use_bottleneck=False):
+        da = xr.DataArray(np.array([4, 5, np.nan], dtype=np.float64), dims="x")
+        da = da.chunk(x=-1)
+        # Succeeds with a single chunk:
+        _ = da.ffill("x").compute()
+
+
 def test_bfill_use_bottleneck():
     da = xr.DataArray(np.array([4, 5, np.nan], dtype=np.float64), dims="x")
-    with xr.set_options(use_bottleneck=False):
+    with xr.set_options(use_bottleneck=False, use_numbagg=False):
         with pytest.raises(RuntimeError):
             da.bfill("x")
 
@@ -442,7 +455,7 @@ def test_bfill_use_bottleneck():
 def test_bfill_use_bottleneck_dask():
     da = xr.DataArray(np.array([4, 5, np.nan], dtype=np.float64), dims="x")
     da = da.chunk({"x": 1})
-    with xr.set_options(use_bottleneck=False):
+    with xr.set_options(use_bottleneck=False, use_numbagg=False):
         with pytest.raises(RuntimeError):
             da.bfill("x")
 

--- a/xarray/tests/test_plugins.py
+++ b/xarray/tests/test_plugins.py
@@ -218,28 +218,29 @@ def test_lazy_import() -> None:
     When importing xarray these should not be imported as well.
     Only when running code for the first time that requires them.
     """
-    blacklisted = [
-        "h5netcdf",
-        "netCDF4",
-        "pydap",
-        "Nio",
-        "scipy",
-        "zarr",
-        "matplotlib",
-        "nc_time_axis",
-        "flox",
+    deny_list = [
+        "cubed",
+        "cupy",
         # "dask",  # TODO: backends.locks is not lazy yet :(
         "dask.array",
         "dask.distributed",
-        "sparse",
-        "cupy",
+        "flox",
+        "h5netcdf",
+        "matplotlib",
+        "nc_time_axis",
+        "netCDF4",
+        "Nio",
+        "numbagg",
         "pint",
-        "cubed",
+        "pydap",
+        "scipy",
+        "sparse",
+        "zarr",
     ]
     # ensure that none of the above modules has been imported before
     modules_backup = {}
     for pkg in list(sys.modules.keys()):
-        for mod in blacklisted + ["xarray"]:
+        for mod in deny_list + ["xarray"]:
             if pkg.startswith(mod):
                 modules_backup[pkg] = sys.modules[pkg]
                 del sys.modules[pkg]
@@ -255,7 +256,7 @@ def test_lazy_import() -> None:
         # lazy loaded are loaded when importing xarray
         is_imported = set()
         for pkg in sys.modules:
-            for mod in blacklisted:
+            for mod in deny_list:
                 if pkg.startswith(mod):
                     is_imported.add(mod)
                     break


### PR DESCRIPTION
The main perf advantage here is the array doesn't need to be unstacked & stacked, which is a huge win for large multi-dimensional arrays... (I actually was hitting a memory issue running an `ffill` on my own, and so thought I'd get this done!)

We could move these methods to `DataWithCoords`, since they're almost the same implementation between a `DataArray` & `Dataset`, and exactly the same for numbagg's implementation

---

For transparency — the logic of "check for numbagg, check for bottleneck" I wouldn't rate at my most confident. But I'm more confident that just installing numbagg will work. And if that works well enough, we could consider only supporting numbagg for some of these in the future.

I also haven't done the benchmarks here — though the functions are relatively well benchmarked at numbagg. I'm somewhat trading off getting through these (rolling functions are coming up too) vs. doing fewer slower, and leaning towards the former, but feedback welcome...

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`
