### PR TITLE
Remove duplicated navigation_with_keys in docs config

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -237,7 +237,6 @@ html_theme_options = dict(
     use_repository_button=True,
     use_issues_button=True,
     home_page_in_toc=False,
-    navigation_with_keys=False,
     extra_footer="""<p>Xarray is a fiscally sponsored project of <a href="https://numfocus.org">NumFOCUS</a>,
     a nonprofit dedicated to supporting the open-source scientific computing community.<br>
     Theme by the <a href="https://ebp.jupyterbook.org">Executable Book Project</a></p>""",


### PR DESCRIPTION
Fixes:

```
Running Sphinx v6.2.1

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/xray/conda/8387/lib/python3.10/site-packages/sphinx/config.py", line 353, in eval_config_file
    code = compile(f.read(), filename.encode(fs_encoding), 'exec')
  File "/home/docs/checkouts/readthedocs.org/user_builds/xray/checkouts/8387/doc/conf.py", line 240
    navigation_with_keys=False,
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: keyword argument repeated: navigation_with_keys

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/xray/conda/8387/lib/python3.10/site-packages/sphinx/cmd/build.py", line 280, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/home/docs/checkouts/readthedocs.org/user_builds/xray/conda/8387/lib/python3.10/site-packages/sphinx/application.py", line 207, in __init__
    self.config = Config.read(self.confdir, confoverrides or {}, self.tags)
  File "/home/docs/checkouts/readthedocs.org/user_builds/xray/conda/8387/lib/python3.10/site-packages/sphinx/config.py", line 177, in read
    namespace = eval_config_file(filename, tags)
  File "/home/docs/checkouts/readthedocs.org/user_builds/xray/conda/8387/lib/python3.10/site-packages/sphinx/config.py", line 357, in eval_config_file
    raise ConfigError(msg % err) from err
sphinx.errors.ConfigError: There is a syntax error in your configuration file: keyword argument repeated: navigation_with_keys (conf.py, line 240)


Configuration error:
There is a syntax error in your configuration file: keyword argument repeated: navigation_with_keys (conf.py, line 240)
Command time: 0s Return: 2

```

Seen in #8387