### PR TITLE
Port fix from pandas-dev/pandas#55283 to cftime resample

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -43,6 +43,13 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Port `bug fix from pandas <https://github.com/pandas-dev/pandas/pull/55283>`_
+  to eliminate the adjustment of resample bin edges in the case that the
+  resampling frequency has units of days and is greater than one day
+  (e.g. ``"2D"``, ``"3D"`` etc.) and the ``closed`` argument is set to
+  ``"right"`` to xarray's implementation of resample for data indexed by a
+  :py:class:`CFTimeIndex` (:pull:`8393`).  By `Spencer Clark
+      <https://github.com/spencerkclark>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -48,8 +48,8 @@ Bug fixes
   resampling frequency has units of days and is greater than one day
   (e.g. ``"2D"``, ``"3D"`` etc.) and the ``closed`` argument is set to
   ``"right"`` to xarray's implementation of resample for data indexed by a
-  :py:class:`CFTimeIndex` (:pull:`8393`).  By `Spencer Clark
-      <https://github.com/spencerkclark>`_.
+  :py:class:`CFTimeIndex` (:pull:`8393`).
+  By `Spencer Clark <https://github.com/spencerkclark>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/resample_cftime.py
+++ b/xarray/core/resample_cftime.py
@@ -45,7 +45,6 @@ import pandas as pd
 
 from xarray.coding.cftime_offsets import (
     BaseCFTimeOffset,
-    Day,
     MonthEnd,
     QuarterEnd,
     Tick,
@@ -254,8 +253,7 @@ def _adjust_bin_edges(
     labels: np.ndarray,
 ):
     """This is required for determining the bin edges resampling with
-    daily frequencies greater than one day, month end, and year end
-    frequencies.
+    month end, quarter end, and year end frequencies.
 
     Consider the following example.  Let's say you want to downsample the
     time series with the following coordinates to month end frequency:
@@ -283,14 +281,8 @@ def _adjust_bin_edges(
     The labels are still:
 
     CFTimeIndex([2000-01-31 00:00:00, 2000-02-29 00:00:00], dtype='object')
-
-    This is also required for daily frequencies longer than one day and
-    year-end frequencies.
     """
-    is_super_daily = isinstance(freq, (MonthEnd, QuarterEnd, YearEnd)) or (
-        isinstance(freq, Day) and freq.n > 1
-    )
-    if is_super_daily:
+    if isinstance(freq, (MonthEnd, QuarterEnd, YearEnd)):
         if closed == "right":
             datetime_bins = datetime_bins + datetime.timedelta(days=1, microseconds=-1)
         if datetime_bins[-2] > index.max():

--- a/xarray/tests/test_cftimeindex_resample.py
+++ b/xarray/tests/test_cftimeindex_resample.py
@@ -6,6 +6,7 @@ from typing import TypedDict
 import numpy as np
 import pandas as pd
 import pytest
+from packaging.version import Version
 
 import xarray as xr
 from xarray.core.pdcompat import _convert_base_to_offset
@@ -122,6 +123,16 @@ def da(index) -> xr.DataArray:
 )
 def test_resample(freqs, closed, label, base, offset) -> None:
     initial_freq, resample_freq = freqs
+    if (
+        resample_freq == "4001D"
+        and closed == "right"
+        and Version(pd.__version__) < Version("2.2")
+    ):
+        pytest.skip(
+            "Pandas fixed a bug in this test case in version 2.2, which we "
+            "ported to xarray, so this test no longer produces the same "
+            "result as pandas for earlier pandas versions."
+        )
     start = "2000-01-01T12:07:01"
     loffset = "12H"
     origin = "start"


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

The remaining failing cftime resample tests in https://github.com/pydata/xarray/issues/8091 happen to be related to a bug that was fixed in the pandas implementation, https://github.com/pandas-dev/pandas/pull/55283, leading answers to change in some circumstances.  This PR ports that bug fix to xarray's implementation of resample for data indexed by a `CFTimeIndex`.  

- [x] Fixes remaining failing cftime resample tests in https://github.com/pydata/xarray/issues/8091
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

A simple example where answers change in pandas is the following:

#### Previously

```
>>> import numpy as np; import pandas as pd
>>> index = pd.date_range("2000", periods=5, freq="5D")
>>> series = pd.Series(np.arange(index.size), index=index)
>>> series.resample("2D", closed="right", label="right", offset="1s").mean()
2000-01-01 00:00:01    0.0
2000-01-03 00:00:01    NaN
2000-01-05 00:00:01    1.0
2000-01-07 00:00:01    NaN
2000-01-09 00:00:01    NaN
2000-01-11 00:00:01    2.0
2000-01-13 00:00:01    NaN
2000-01-15 00:00:01    3.0
2000-01-17 00:00:01    NaN
2000-01-19 00:00:01    NaN
2000-01-21 00:00:01    4.0
Freq: 2D, dtype: float64
```

#### Currently

```
>>> import numpy as np; import pandas as pd
>>> index = pd.date_range("2000", periods=5, freq="5D")
>>> series = pd.Series(np.arange(index.size), index=index)
>>> series.resample("2D", closed="right", label="right", offset="1s").mean()
2000-01-01 00:00:01    0.0
2000-01-03 00:00:01    NaN
2000-01-05 00:00:01    NaN
2000-01-07 00:00:01    1.0
2000-01-09 00:00:01    NaN
2000-01-11 00:00:01    2.0
2000-01-13 00:00:01    NaN
2000-01-15 00:00:01    NaN
2000-01-17 00:00:01    3.0
2000-01-19 00:00:01    NaN
2000-01-21 00:00:01    4.0
Freq: 2D, dtype: float64
```

This PR allows us to reproduce this change in xarray for data indexed by a `CFTimeIndex`.  The bin edges were incorrect in the previous case; see https://github.com/pandas-dev/pandas/pull/52064#issuecomment-1785893752 for @MarcoGorelli's nice explanation as to why.