### PR TITLE
Correct typing for _sparsearray

### DIFF
--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -15,7 +15,6 @@ from typing import (
 
 import numpy as np
 
-
 # https://stackoverflow.com/questions/74633074/how-to-type-hint-a-generic-numpy-array
 _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)

--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -17,7 +17,7 @@ from typing import (
 import numpy as np
 
 if TYPE_CHECKING:
-    from numpy.typing import NDArray
+    pass
 
 
 # https://stackoverflow.com/questions/74633074/how-to-type-hint-a-generic-numpy-array

--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -234,7 +234,7 @@ class _sparsearray(
     Corresponds to np.ndarray.
     """
 
-    def todense(self) -> NDArray[_ScalarType_co]:
+    def todense(self) -> np.ndarray[Any, _DType_co]:
         ...
 
 

--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Hashable, Iterable, Mapping, Sequence
 from types import ModuleType
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Protocol,
@@ -15,9 +14,6 @@ from typing import (
 )
 
 import numpy as np
-
-if TYPE_CHECKING:
-    pass
 
 
 # https://stackoverflow.com/questions/74633074/how-to-type-hint-a-generic-numpy-array


### PR DESCRIPTION
Use _DType_co instead, otherwise the dtype wont be correctly passed along.
Quick follow up to #8387.