### PR TITLE
Better attr diff for `testing.assert_identical`

### DIFF
--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -815,16 +815,30 @@ def _diff_mapping_repr(
                 )
                 for m in (a_mapping, b_mapping):
                     attr_s = "\n".join(
-                        summarize_attr(ak, av)
+                        "    " + summarize_attr(ak, av)
                         for ak, av in m[k].attrs.items()
                         if ak in attrs_to_print
                     )
+                    if attr_s:
+                        attr_s = "    Differing variable attributes:\n" + attr_s
                     attrs_summary.append(attr_s)
 
                 temp = [
                     "\n".join([var_s, attr_s]) if attr_s else var_s
                     for var_s, attr_s in zip(temp, attrs_summary)
                 ]
+
+                # TODO: It should be possible recursively use _diff_mapping_repr
+                #       instead of explicitly handling variable attrs specially.
+                #       That would require some refactoring.
+                # newdiff = _diff_mapping_repr(
+                #     {k: v for k,v in a_attrs.items() if k in attrs_to_print},
+                #     {k: v for k,v in b_attrs.items() if k in attrs_to_print},
+                #     compat=compat,
+                #     summarizer=summarize_attr,
+                #     title="Variable Attributes"
+                # )
+                # temp += [newdiff]
 
             diff_items += [ab_side + s[1:] for ab_side, s in zip(("L", "R"), temp)]
 

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -783,9 +783,9 @@ def _diff_mapping_repr(
         try:
             # compare xarray variable
             if not callable(compat):
-                compatible = getattr(a_mapping[k], compat)(b_mapping[k])
+                compatible = getattr(a_mapping[k].variable, compat)(b_mapping[k].variable)
             else:
-                compatible = compat(a_mapping[k], b_mapping[k])
+                compatible = compat(a_mapping[k].variable, b_mapping[k].variable)
             is_variable = True
         except AttributeError:
             # compare attribute value
@@ -804,10 +804,18 @@ def _diff_mapping_repr(
 
             if compat == "identical" and is_variable:
                 attrs_summary = []
+                a_attrs = a_mapping[k].attrs
+                b_attrs = b_mapping[k].attrs
 
+                attrs_to_print = set(a_attrs) ^ set(b_attrs)
+                for attr in set(a_attrs) & set(b_attrs):
+                    if a_attrs[attr] != b_attrs[attr]:
+                        attrs_to_print.update(attr)
                 for m in (a_mapping, b_mapping):
                     attr_s = "\n".join(
-                        summarize_attr(ak, av) for ak, av in m[k].attrs.items()
+                        summarize_attr(ak, av)
+                        for ak, av in m[k].attrs.items()
+                        if ak in attrs_to_print
                     )
                     attrs_summary.append(attr_s)
 

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -810,9 +810,9 @@ def _diff_mapping_repr(
                 b_attrs = b_mapping[k].attrs
 
                 attrs_to_print = set(a_attrs) ^ set(b_attrs)
-                for attr in set(a_attrs) & set(b_attrs):
-                    if a_attrs[attr] != b_attrs[attr]:
-                        attrs_to_print.update([attr])
+                attrs_to_print.update(
+                    {k for k in set(a_attrs) & set(b_attrs) if a_attrs[k] != b_attrs[k]}
+                )
                 for m in (a_mapping, b_mapping):
                     attr_s = "\n".join(
                         summarize_attr(ak, av)

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -783,7 +783,9 @@ def _diff_mapping_repr(
         try:
             # compare xarray variable
             if not callable(compat):
-                compatible = getattr(a_mapping[k].variable, compat)(b_mapping[k].variable)
+                compatible = getattr(a_mapping[k].variable, compat)(
+                    b_mapping[k].variable
+                )
             else:
                 compatible = compat(a_mapping[k].variable, b_mapping[k].variable)
             is_variable = True
@@ -810,7 +812,7 @@ def _diff_mapping_repr(
                 attrs_to_print = set(a_attrs) ^ set(b_attrs)
                 for attr in set(a_attrs) & set(b_attrs):
                     if a_attrs[attr] != b_attrs[attr]:
-                        attrs_to_print.update(attr)
+                        attrs_to_print.update([attr])
                 for m in (a_mapping, b_mapping):
                     attr_s = "\n".join(
                         summarize_attr(ak, av)

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -406,7 +406,11 @@ class TestFormatting:
                 "var2": ("x", np.array([3, 4], dtype="int64")),
             },
             coords={
-                "x": ("x", np.array(["a", "b"], dtype="U1"), {"foo": "bar"}),
+                "x": (
+                    "x",
+                    np.array(["a", "b"], dtype="U1"),
+                    {"foo": "bar", "same": "same"},
+                ),
                 "y": np.array([1, 2, 3], dtype="int64"),
             },
             attrs={"units": "m", "description": "desc"},
@@ -418,7 +422,7 @@ class TestFormatting:
                 "x": (
                     "x",
                     np.array(["a", "c"], dtype="U1"),
-                    {"source": 0, "foo": "baz"},
+                    {"source": 0, "foo": "baz", "same": "same"},
                 ),
                 "label": ("x", np.array([1, 2], dtype="int64")),
             },
@@ -433,8 +437,10 @@ class TestFormatting:
             (x: 2, y: 3) != (x: 2)
         Differing coordinates:
         L * x        (x) %cU1 'a' 'b'
+            foo: bar
         R * x        (x) %cU1 'a' 'c'
             source: 0
+            foo: baz
         Coordinates only on the left object:
           * y        (y) int64 1 2 3
         Coordinates only on the right object:

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -413,7 +413,7 @@ class TestFormatting:
                 ),
                 "y": np.array([1, 2, 3], dtype="int64"),
             },
-            attrs={"units": "m", "description": "desc"},
+            attrs={"title": "mytitle", "description": "desc"},
         )
 
         ds_b = xr.Dataset(
@@ -426,7 +426,7 @@ class TestFormatting:
                 ),
                 "label": ("x", np.array([1, 2], dtype="int64")),
             },
-            attrs={"units": "kg"},
+            attrs={"title": "newtitle"},
         )
 
         byteorder = "<" if sys.byteorder == "little" else ">"
@@ -437,10 +437,12 @@ class TestFormatting:
             (x: 2, y: 3) != (x: 2)
         Differing coordinates:
         L * x        (x) %cU1 'a' 'b'
-            foo: bar
+            Differing variable attributes:
+                foo: bar
         R * x        (x) %cU1 'a' 'c'
-            source: 0
-            foo: baz
+            Differing variable attributes:
+                source: 0
+                foo: baz
         Coordinates only on the left object:
           * y        (y) int64 1 2 3
         Coordinates only on the right object:
@@ -451,8 +453,8 @@ class TestFormatting:
         Data variables only on the left object:
             var2     (x) int64 3 4
         Differing attributes:
-        L   units: m
-        R   units: kg
+        L   title: mytitle
+        R   title: newtitle
         Attributes only on the left object:
             description: desc"""
             % (byteorder, byteorder)

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -406,7 +406,7 @@ class TestFormatting:
                 "var2": ("x", np.array([3, 4], dtype="int64")),
             },
             coords={
-                "x": np.array(["a", "b"], dtype="U1"),
+                "x": ("x", np.array(["a", "b"], dtype="U1"), {"foo": "bar"}),
                 "y": np.array([1, 2, 3], dtype="int64"),
             },
             attrs={"units": "m", "description": "desc"},
@@ -415,7 +415,11 @@ class TestFormatting:
         ds_b = xr.Dataset(
             data_vars={"var1": ("x", np.array([1, 2], dtype="int64"))},
             coords={
-                "x": ("x", np.array(["a", "c"], dtype="U1"), {"source": 0}),
+                "x": (
+                    "x",
+                    np.array(["a", "c"], dtype="U1"),
+                    {"source": 0, "foo": "baz"},
+                ),
                 "label": ("x", np.array([1, 2], dtype="int64")),
             },
             attrs={"units": "kg"},


### PR DESCRIPTION
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`


This gives us better reprs where only differing attributes are shown in the diff.

On main:
```
...
Differing coordinates:
L * x        (x) <U1 'a' 'b'
    foo: bar
    same: same
R * x        (x) <U1 'a' 'c'
    source: 0
    foo: baz
    same: same
...
```

With this PR:
```
Differing coordinates:
L * x        (x) %cU1 'a' 'b'
    Differing variable attributes:
        foo: bar
R * x        (x) %cU1 'a' 'c'
    Differing variable attributes:
        source: 0
        foo: baz

```