### PR TITLE
Fix for date offset strings with resample loffset 

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -50,6 +50,9 @@ Bug fixes
   ``"right"`` to xarray's implementation of resample for data indexed by a
   :py:class:`CFTimeIndex` (:pull:`8393`).
   By `Spencer Clark <https://github.com/spencerkclark>`_.
+- Fix to once again support date offset strings as input to the loffset
+  parameter of resample and test this functionality (:pull:`8422`, :issue:`8399`).
+  By `Katelyn FitzGerald <https://github.com/kafitzgerald>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/resample_cftime.py
+++ b/xarray/core/resample_cftime.py
@@ -151,7 +151,10 @@ class CFTimeGrouper:
                     f"Got {self.loffset}."
                 )
 
-            labels = labels + pd.to_timedelta(self.loffset)
+            if isinstance(self.loffset, datetime.timedelta):
+                labels = labels + self.loffset
+            else:
+                labels = labels + to_offset(self.loffset)
 
         # check binner fits data
         if index[0] < datetime_bins[0]:

--- a/xarray/tests/test_cftimeindex_resample.py
+++ b/xarray/tests/test_cftimeindex_resample.py
@@ -260,7 +260,7 @@ def test_timedelta_offset() -> None:
     xr.testing.assert_identical(timedelta_result, string_result)
 
 
-@pytest.mark.parametrize("loffset", ["12H", datetime.timedelta(hours=-12)])
+@pytest.mark.parametrize("loffset", ["MS", "12H", datetime.timedelta(hours=-12)])
 def test_resample_loffset_cftimeindex(loffset) -> None:
     datetimeindex = pd.date_range("2000-01-01", freq="6H", periods=10)
     da_datetimeindex = xr.DataArray(np.arange(10), [("time", datetimeindex)])


### PR DESCRIPTION
Closes #8399.

Reverting this minor change from #7206 allows for [offset aliases](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects) to again be used with the `loffset` argument to `resample`.

Hopefully this doesn't break anything from that older PR (all tests pass).  It wasn't entirely clear to me why the change was made initially.  Perhaps just to simplify and this was an oversight?   