### PR TITLE
Add support for remote string paths to `h5netcdf` engine

### DIFF
--- a/xarray/backends/file_manager.py
+++ b/xarray/backends/file_manager.py
@@ -157,11 +157,17 @@ class CachingFileManager(FileManager):
 
     def _make_key(self):
         """Make a key for caching files in the LRU cache."""
+        kwargs = self._kwargs
+        # storage_options is a non-hashable dict, so we implement special logic for hashing
+        if self._kwargs.get("storage_options", None) is not None:
+            kwargs = self._kwargs.copy()
+            kwargs["storage_options"] = tuple(sorted(kwargs["storage_options"].items()))
+
         value = (
             self._opener,
             self._args,
             "a" if self._mode == "w" else self._mode,
-            tuple(sorted(self._kwargs.items())),
+            tuple(sorted(kwargs.items())),
             self._manager_id,
         )
         return _HashedSequence(value)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2915,6 +2915,27 @@ def test_zarr_storage_options() -> None:
     assert_identical(ds, ds_a)
 
 
+@requires_h5netcdf
+@requires_fsspec
+def test_h5netcdf_storage_options() -> None:
+    with create_tmp_files(2) as (f1, f2):
+        ds1 = create_test_data()
+        ds1.to_netcdf(f1, engine="h5netcdf")
+
+        ds2 = create_test_data()
+        ds2.to_netcdf(f2, engine="h5netcdf")
+
+        files = [f"file://{f}" for f in [f1, f2]]
+        ds = xr.open_mfdataset(
+            files,
+            engine="h5netcdf",
+            concat_dim="time",
+            combine="nested",
+            storage_options={"skip_instance_cache": False},
+        )
+        assert_identical(xr.concat([ds1, ds2], dim="time"), ds)
+
+
 @requires_scipy
 class TestScipyInMemoryData(CFEncodedBase, NetCDF3Only):
     engine: T_NetcdfEngine = "scipy"


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes https://github.com/pydata/xarray/issues/8423
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

cc @dcherian as you might find this interesting 