### PR TITLE
Properly closes zarr groups in zarr store

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -751,7 +751,7 @@ class ZarrStore(AbstractWritableDataStore):
             writer.add(v.data, zarr_array, region)
 
     def close(self):
-        pass
+        self.zarr_group.store.close()
 
 
 def open_zarr(


### PR DESCRIPTION
If the zarr backend is using a store which needs closing, e.g., a zip store, it should be closed with the xarray zarrstore backend.
This is occurred when i tried to save a dataset to a zarr file while giving the .zip file extension.

I have not done extensive tests on this small piece of code, so it might not cover all use cases.
Let me know if I need to add tests or more documentation!

- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
