### PR TITLE
Pin pint to >=0.22

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -2,7 +2,7 @@ name: xarray-examples
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python=3.10
   - boto3
   - bottleneck
   - cartopy
@@ -25,7 +25,7 @@ dependencies:
   - numpy
   - packaging
   - pandas
-  - pint
+  - pint>=0.22
   - pip
   - pooch
   - pydap

--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -26,7 +26,7 @@ dependencies:
   - numpy
   - packaging
   - pandas
-  - pint
+  - pint>=0.22
   - pip
   - pseudonetcdf
   - pydap

--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -26,7 +26,7 @@ dependencies:
   - numpy
   - packaging
   - pandas
-  - pint<0.21
+  - pint
   - pip
   - pseudonetcdf
   - pydap

--- a/ci/requirements/environment-py311.yml
+++ b/ci/requirements/environment-py311.yml
@@ -28,7 +28,7 @@ dependencies:
   - numpy
   - packaging
   - pandas
-  - pint<0.21
+  - pint
   - pip
   - pooch
   - pre-commit

--- a/ci/requirements/environment-py311.yml
+++ b/ci/requirements/environment-py311.yml
@@ -28,7 +28,7 @@ dependencies:
   - numpy
   - packaging
   - pandas
-  - pint
+  - pint>=0.22
   - pip
   - pooch
   - pre-commit

--- a/ci/requirements/environment-windows-py311.yml
+++ b/ci/requirements/environment-windows-py311.yml
@@ -25,7 +25,7 @@ dependencies:
   - numpy
   - packaging
   - pandas
-  - pint
+  - pint>=0.22
   - pip
   - pre-commit
   - pseudonetcdf

--- a/ci/requirements/environment-windows-py311.yml
+++ b/ci/requirements/environment-windows-py311.yml
@@ -25,7 +25,7 @@ dependencies:
   - numpy
   - packaging
   - pandas
-  - pint<0.21
+  - pint
   - pip
   - pre-commit
   - pseudonetcdf

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -25,7 +25,7 @@ dependencies:
   - numpy
   - packaging
   - pandas
-  - pint
+  - pint>=0.22
   - pip
   - pre-commit
   - pseudonetcdf

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -25,7 +25,7 @@ dependencies:
   - numpy
   - packaging
   - pandas
-  - pint<0.21
+  - pint
   - pip
   - pre-commit
   - pseudonetcdf

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - opt_einsum
   - packaging
   - pandas
-  - pint>=0.21
+  - pint>=0.22
   - pip
   - pooch
   - pre-commit

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - opt_einsum
   - packaging
   - pandas
-  - pint
+  - pint>=0.21
   - pip
   - pooch
   - pre-commit

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - opt_einsum
   - packaging
   - pandas
-  - pint<0.21
+  - pint
   - pip
   - pooch
   - pre-commit

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -35,7 +35,7 @@ dependencies:
   - numpy=1.22
   - packaging=21.3
   - pandas=1.4
-  - pint>=0.22
+  - pint=0.22
   - pip
   - pseudonetcdf=3.2
   - pydap=3.3

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -35,7 +35,7 @@ dependencies:
   - numpy=1.22
   - packaging=21.3
   - pandas=1.4
-  - pint=0.19
+  - pint>=0.22
   - pip
   - pseudonetcdf=3.2
   - pydap=3.3

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,6 +30,7 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- Bump minimum tested pint version to ``>=0.22``. By `Deepak Cherian <https://github.com/dcherian>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import functools
 import operator
-import sys
 
 import numpy as np
 import pandas as pd
@@ -1513,10 +1512,6 @@ def test_dot_dataarray(dtype):
 
 
 class TestVariable:
-    @pytest.mark.skipif(
-        (sys.version_info >= (3, 11)) and sys.platform.startswith("win"),
-        reason="fails for some reason on win and 3.11, GH7971",
-    )
     @pytest.mark.parametrize(
         "func",
         (
@@ -2348,10 +2343,6 @@ class TestDataArray:
         # warnings or errors, but does not check the result
         func(data_array)
 
-    @pytest.mark.skipif(
-        (sys.version_info >= (3, 11)) and sys.platform.startswith("win"),
-        reason="fails for some reason on win and 3.11, GH7971",
-    )
     @pytest.mark.parametrize(
         "func",
         (
@@ -2429,10 +2420,6 @@ class TestDataArray:
         assert_units_equal(expected, actual)
         assert_allclose(expected, actual)
 
-    @pytest.mark.skipif(
-        (sys.version_info >= (3, 11)) and sys.platform.startswith("win"),
-        reason="fails for some reason on win and 3.11, GH7971",
-    )
     @pytest.mark.parametrize(
         "func",
         (
@@ -4085,10 +4072,6 @@ class TestDataset:
         # warnings or errors, but does not check the result
         func(ds)
 
-    @pytest.mark.skipif(
-        (sys.version_info >= (3, 11)) and sys.platform.startswith("win"),
-        reason="fails for some reason on win and 3.11, GH7971",
-    )
     @pytest.mark.parametrize(
         "func",
         (
@@ -5647,10 +5630,6 @@ class TestDataset:
 
 @requires_dask
 class TestPintWrappingDask:
-    @pytest.mark.skipif(
-        version.parse(pint.__version__) <= version.parse("0.21"),
-        reason="pint didn't support dask properly before 0.21",
-    )
     def test_duck_array_ops(self):
         import dask.array
 

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -6,7 +6,6 @@ import operator
 import numpy as np
 import pandas as pd
 import pytest
-from packaging import version
 
 import xarray as xr
 from xarray.core import dtypes, duck_array_ops
@@ -1534,13 +1533,6 @@ class TestVariable:
         ids=repr,
     )
     def test_aggregation(self, func, dtype):
-        if (
-            func.name == "prod"
-            and dtype.kind == "f"
-            and version.parse(pint.__version__) < version.parse("0.19")
-        ):
-            pytest.xfail(reason="nanprod is not by older `pint` versions")
-
         array = np.linspace(0, 1, 10).astype(dtype) * (
             unit_registry.m if func.name != "cumprod" else unit_registry.dimensionless
         )
@@ -2395,13 +2387,6 @@ class TestDataArray:
         ids=repr,
     )
     def test_aggregation(self, func, dtype):
-        if (
-            func.name == "prod"
-            and dtype.kind == "f"
-            and version.parse(pint.__version__) < version.parse("0.19")
-        ):
-            pytest.xfail(reason="nanprod is not by older `pint` versions")
-
         array = np.arange(10).astype(dtype) * (
             unit_registry.m if func.name != "cumprod" else unit_registry.dimensionless
         )
@@ -4093,13 +4078,6 @@ class TestDataset:
         ids=repr,
     )
     def test_aggregation(self, func, dtype):
-        if (
-            func.name == "prod"
-            and dtype.kind == "f"
-            and version.parse(pint.__version__) < version.parse("0.19")
-        ):
-            pytest.xfail(reason="nanprod is not by older `pint` versions")
-
         unit_a, unit_b = (
             (unit_registry.Pa, unit_registry.degK)
             if func.name != "cumprod"


### PR DESCRIPTION
- [x] Closes https://github.com/pydata/xarray/issues/7971
- [x] Closes https://github.com/pydata/xarray/issues/8437.

We were previously pinned to `<0.21`
Removing the pin didn't change the env but with `>=0.21` we get `0.22` which works.
