### PR TITLE
Add keep_variables keyword to open_dataset()

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -402,6 +402,7 @@ def open_dataset(
     concat_characters: bool | None = None,
     decode_coords: Literal["coordinates", "all"] | bool | None = None,
     drop_variables: str | Iterable[str] | None = None,
+    keep_variables: str | Iterable[str] | None = None,
     inline_array: bool = False,
     chunked_array_type: str | None = None,
     from_array_kwargs: dict[str, Any] | None = None,
@@ -493,6 +494,10 @@ def open_dataset(
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or
         inconsistent values.
+    keep_variables: str or iterable of str, optional
+        A variable or list of variables to load from the dataset. This is
+        useful if you don't need all the variables in the file and don't
+        want to spend time loading them. Default is to load all variables.
     inline_array: bool, default: False
         How to include the array in the dask task graph.
         By default(``inline_array=False``) the array is included in a task by
@@ -571,6 +576,7 @@ def open_dataset(
     backend_ds = backend.open_dataset(
         filename_or_obj,
         drop_variables=drop_variables,
+        keep_variables=keep_variables,
         **decoders,
         **kwargs,
     )
@@ -585,6 +591,7 @@ def open_dataset(
         chunked_array_type,
         from_array_kwargs,
         drop_variables=drop_variables,
+        keep_variables=keep_variables,
         **decoders,
         **kwargs,
     )
@@ -605,6 +612,7 @@ def open_dataarray(
     concat_characters: bool | None = None,
     decode_coords: Literal["coordinates", "all"] | bool | None = None,
     drop_variables: str | Iterable[str] | None = None,
+    keep_variables: str | Iterable[str] | None = None,
     inline_array: bool = False,
     chunked_array_type: str | None = None,
     from_array_kwargs: dict[str, Any] | None = None,
@@ -698,6 +706,10 @@ def open_dataarray(
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or
         inconsistent values.
+    keep_variables: str or iterable of str, optional
+        A variable or list of variables to load from the dataset. This is
+        useful if you don't need all the variables in the file and don't
+        want to spend time loading them. Default is to load all variables.
     inline_array: bool, default: False
         How to include the array in the dask task graph.
         By default(``inline_array=False``) the array is included in a task by
@@ -755,6 +767,7 @@ def open_dataarray(
         chunks=chunks,
         cache=cache,
         drop_variables=drop_variables,
+        keep_variables=keep_variables,
         inline_array=inline_array,
         chunked_array_type=chunked_array_type,
         from_array_kwargs=from_array_kwargs,

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -452,8 +452,8 @@ class BackendEntrypoint:
 
     - ``open_dataset`` method: it shall implement reading from file, variables
       decoding and it returns an instance of :py:class:`~xarray.Dataset`.
-      It shall take in input at least ``filename_or_obj`` argument and
-      ``drop_variables`` keyword argument.
+      It shall take in input at least ``filename_or_obj`` argument,
+      ``keep_variables`` argument, and ``drop_variables`` keyword argument.
       For more details see :ref:`RST open_dataset`.
     - ``guess_can_open`` method: it shall return ``True`` if the backend is able to open
       ``filename_or_obj``, ``False`` otherwise. The implementation of this
@@ -490,6 +490,7 @@ class BackendEntrypoint:
         filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
         *,
         drop_variables: str | Iterable[str] | None = None,
+        keep_variables: str | Iterable[str] | None = None,
         **kwargs: Any,
     ) -> Dataset:
         """

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -389,6 +389,7 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         concat_characters=True,
         decode_coords=True,
         drop_variables: str | Iterable[str] | None = None,
+        keep_variables: str | Iterable[str] | None = None,
         use_cftime=None,
         decode_timedelta=None,
         format=None,
@@ -418,6 +419,7 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
             concat_characters=concat_characters,
             decode_coords=decode_coords,
             drop_variables=drop_variables,
+            keep_variables=keep_variables,
             use_cftime=use_cftime,
             decode_timedelta=decode_timedelta,
         )

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -588,6 +588,7 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
         concat_characters=True,
         decode_coords=True,
         drop_variables: str | Iterable[str] | None = None,
+        keep_variables: str | Iterable[str] | None = None,
         use_cftime=None,
         decode_timedelta=None,
         group=None,
@@ -621,6 +622,7 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
                 concat_characters=concat_characters,
                 decode_coords=decode_coords,
                 drop_variables=drop_variables,
+                keep_variables=keep_variables,
                 use_cftime=use_cftime,
                 decode_timedelta=decode_timedelta,
             )

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -179,6 +179,7 @@ class PydapBackendEntrypoint(BackendEntrypoint):
         concat_characters=True,
         decode_coords=True,
         drop_variables: str | Iterable[str] | None = None,
+        keep_variables: str | Iterable[str] | None = None,
         use_cftime=None,
         decode_timedelta=None,
         application=None,
@@ -207,6 +208,7 @@ class PydapBackendEntrypoint(BackendEntrypoint):
                 concat_characters=concat_characters,
                 decode_coords=decode_coords,
                 drop_variables=drop_variables,
+                keep_variables=keep_variables,
                 use_cftime=use_cftime,
                 decode_timedelta=decode_timedelta,
             )

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -134,6 +134,7 @@ class PynioBackendEntrypoint(BackendEntrypoint):
         concat_characters=True,
         decode_coords=True,
         drop_variables: str | Iterable[str] | None = None,
+        keep_variables: str | Iterable[str] | None = None,
         use_cftime=None,
         decode_timedelta=None,
         mode="r",
@@ -155,6 +156,7 @@ class PynioBackendEntrypoint(BackendEntrypoint):
                 concat_characters=concat_characters,
                 decode_coords=decode_coords,
                 drop_variables=drop_variables,
+                keep_variables=keep_variables,
                 use_cftime=use_cftime,
                 decode_timedelta=decode_timedelta,
             )

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -297,6 +297,7 @@ class ScipyBackendEntrypoint(BackendEntrypoint):
         concat_characters=True,
         decode_coords=True,
         drop_variables: str | Iterable[str] | None = None,
+        keep_variables: str | Iterable[str] | None = None,
         use_cftime=None,
         decode_timedelta=None,
         mode="r",
@@ -319,6 +320,7 @@ class ScipyBackendEntrypoint(BackendEntrypoint):
                 concat_characters=concat_characters,
                 decode_coords=decode_coords,
                 drop_variables=drop_variables,
+                keep_variables=keep_variables,
                 use_cftime=use_cftime,
                 decode_timedelta=decode_timedelta,
             )

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -35,6 +35,7 @@ class StoreBackendEntrypoint(BackendEntrypoint):
         concat_characters=True,
         decode_coords=True,
         drop_variables: str | Iterable[str] | None = None,
+        keep_variables: str | Iterable[str] | None = None,
         use_cftime=None,
         decode_timedelta=None,
     ) -> Dataset:
@@ -51,6 +52,7 @@ class StoreBackendEntrypoint(BackendEntrypoint):
             concat_characters=concat_characters,
             decode_coords=decode_coords,
             drop_variables=drop_variables,
+            keep_variables=keep_variables,
             use_cftime=use_cftime,
             decode_timedelta=decode_timedelta,
         )

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -765,6 +765,7 @@ def open_zarr(
     concat_characters=True,
     decode_coords=True,
     drop_variables=None,
+    keep_variables=None,
     consolidated=None,
     overwrite_encoded_chunks=False,
     chunk_store=None,
@@ -826,6 +827,10 @@ def open_zarr(
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or
         inconsistent values.
+    keep_variables: str or iterable of str, optional
+        A variable or list of variables to load from the dataset. This is
+        useful if you don't need all the variables in the file and don't
+        want to spend time loading them. Default is to load all variables.
     consolidated : bool, optional
         Whether to open the store using zarr's consolidated metadata
         capability. Only works for stores that have already been consolidated.
@@ -923,6 +928,7 @@ def open_zarr(
         engine="zarr",
         chunks=chunks,
         drop_variables=drop_variables,
+        keep_variables=keep_variables,
         chunked_array_type=chunked_array_type,
         from_array_kwargs=from_array_kwargs,
         backend_kwargs=backend_kwargs,
@@ -967,6 +973,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
         concat_characters=True,
         decode_coords=True,
         drop_variables: str | Iterable[str] | None = None,
+        keep_variables: str | Iterable[str] | None = None,
         use_cftime=None,
         decode_timedelta=None,
         group=None,
@@ -1001,6 +1008,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
                 concat_characters=concat_characters,
                 decode_coords=decode_coords,
                 drop_variables=drop_variables,
+                keep_variables=keep_variables,
                 use_cftime=use_cftime,
                 decode_timedelta=decode_timedelta,
             )

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -327,6 +327,43 @@ class TestDecodeCF:
         assert_identical(expected, actual)
         assert_identical(expected, actual2)
 
+    def test_decode_cf_with_keep_variables(self) -> None:
+        original = Dataset(
+            {
+                "t": ("t", [0, 1, 2], {"units": "days since 2000-01-01"}),
+                "x": ("x", [9, 8, 7], {"units": "km"}),
+                "foo": (
+                    ("t", "x"),
+                    [[0, 0, 0], [1, 1, 1], [2, 2, 2]],
+                    {"units": "bar"},
+                ),
+                "y": ("t", [5, 10, -999], {"_FillValue": -999}),
+            }
+        )
+        expected = Dataset(
+            {
+                "t": pd.date_range("2000-01-01", periods=3),
+                "foo": (
+                    ("t", "x"),
+                    [[0, 0, 0], [1, 1, 1], [2, 2, 2]],
+                    {"units": "bar"},
+                ),
+                "y": ("t", [5, 10, np.nan]),
+            }
+        )
+        expected2 = Dataset(
+            {
+                "t": pd.date_range("2000-01-01", periods=3),
+            }
+        )
+        expected3 = Dataset()
+        actual = conventions.decode_cf(original, keep_variables=("t", "foo", "y"))
+        actual2 = conventions.decode_cf(original, keep_variables="t")
+        actual3 = conventions.decode_cf(original, keep_variables=[])
+        assert_identical(expected, actual)
+        assert_identical(expected2, actual2)
+        assert_identical(expected3, actual3)
+
     @pytest.mark.filterwarnings("ignore:Ambiguous reference date string")
     def test_invalid_time_units_raises_eagerly(self) -> None:
         ds = Dataset({"time": ("time", [0, 1], {"units": "foobar since 123"})})


### PR DESCRIPTION
This is based on #895 by @tsupinie, following the suggestions on that PR made my @shoyer, but that was so old I decided it was best to do a completely new PR. XArray has changed quite a bit since then, so I had to make changes in several more files than the original PR did in order to get tests to pass. I'm very new to working on XArray, and my approach here was to basically just mirror how the package handles `drop_variables` wherever that appears, with the necessary logical tweaks where appropriate. As such I've possibly touched something that shouldn't be (in particular I'm looking at `xarray/backends/zarr.py` and `xarray/backends/common.py` as places where I'm not quite sure if I've done things properly).

- [ ] Closes #1754 
- [ x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
