### PR TITLE
Fix `map_blocks` docs' formatting

### DIFF
--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -186,8 +186,9 @@ def map_blocks(
 
     Returns
     -------
-    A single DataArray or Dataset with dask backend, reassembled from the outputs of the
-    function.
+    obj : same as obj
+        A single DataArray or Dataset with dask backend, reassembled from the outputs of the
+        function.
 
     Notes
     -----


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Was looking funky. Not 100% sure this is correct but seems consistent with the others

<img width="416" alt="image" src="https://github.com/pydata/xarray/assets/5635139/1f67a5bd-0d1c-47aa-bbdc-670383547792">
