### PR TITLE
Fix docstrings for `combine_by_coords`

### DIFF
--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -739,7 +739,7 @@ def combine_by_coords(
           dimension must have the same size in all objects.
 
     combine_attrs : {"drop", "identical", "no_conflicts", "drop_conflicts", \
-                     "override"} or callable, default: "drop"
+                     "override"} or callable, default: "no_conflicts"
         A callable or a string indicating how to combine attrs of the objects being
         merged:
 


### PR DESCRIPTION
Docstrings for `combine_attrs` parameter show a wrong default value, which is `no_conflicts`, not `drop`.

https://github.com/pydata/xarray/blob/014ab8113c9397848853bf87069efffb7e22bdb2/xarray/core/combine.py#L653-L661