### PR TITLE
Improve "variable not found" error message

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -41,6 +41,9 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
+- Improved error message when getting a variable from a Dataset which doesn't
+  exist. (:pull:`8474`)
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -41,8 +41,8 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
-- Improved error message when getting a variable from a Dataset which doesn't
-  exist. (:pull:`8474`)
+- Improved error message when attempting to get a variable which doesn't exist from a Dataset.
+  (:pull:`8474`)
   By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 Internal Changes

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1539,7 +1539,7 @@ class Dataset(
 
         Indexing with a list of names will return a new ``Dataset`` object.
         """
-        from .formatting import shorten_list_repr
+        from xarray.core.formatting import shorten_list_repr
 
         if utils.is_dict_like(key):
             return self.isel(**key)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1539,10 +1539,18 @@ class Dataset(
 
         Indexing with a list of names will return a new ``Dataset`` object.
         """
+        from .formatting import shorten_list_repr
+
         if utils.is_dict_like(key):
             return self.isel(**key)
         if utils.hashable(key):
-            return self._construct_dataarray(key)
+            try:
+                return self._construct_dataarray(key)
+            except KeyError as e:
+                raise KeyError(
+                    f"No variable named {key!r}. Variables on the dataset include {shorten_list_repr(list(self.variables.keys()), max_items=10)}"
+                ) from e
+
         if utils.iterable_of_hashable(key):
             return self._copy_listed(key)
         raise ValueError(f"Unsupported key-type {type(key)}")

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -941,13 +941,13 @@ def diff_dataset_repr(a, b, compat):
 
 
 def shorten_list_repr(items: Sequence, max_items: int) -> str:
-    if len(items) < max_items:
+    if len(items) <= max_items:
         return repr(items)
     else:
-        return repr(
-            list(
-                itertools.chain(
-                    items[: max_items // 2], ["..."], items[-max_items // 2 :]
-                )
-            )
-        )
+        first_half = repr(items[: max_items // 2])[
+            1:-1
+        ]  # Convert to string and remove brackets
+        second_half = repr(items[-max_items // 2 :])[
+            1:-1
+        ]  # Convert to string and remove brackets
+        return f"[{first_half}, ..., {second_half}]"

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import contextlib
 import functools
-import itertools
 import math
 from collections import defaultdict
 from collections.abc import Collection, Hashable, Sequence

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import itertools
 import math
 from collections import defaultdict
-from collections.abc import Collection, Hashable
+from collections.abc import Collection, Hashable, Sequence
 from datetime import datetime, timedelta
 from itertools import chain, zip_longest
 from reprlib import recursive_repr
@@ -937,3 +938,16 @@ def diff_dataset_repr(a, b, compat):
         summary.append(diff_attrs_repr(a.attrs, b.attrs, compat))
 
     return "\n".join(summary)
+
+
+def shorten_list_repr(items: Sequence, max_items: int) -> str:
+    if len(items) < max_items:
+        return repr(items)
+    else:
+        return repr(
+            list(
+                itertools.chain(
+                    items[: max_items // 2], ["..."], items[-max_items // 2 :]
+                )
+            )
+        )

--- a/xarray/tests/test_error_messages.py
+++ b/xarray/tests/test_error_messages.py
@@ -1,0 +1,17 @@
+"""
+This new file is intended to test the quality & friendliness of error messages that are
+raised by xarray. It's currently separate from the standard tests, which are more
+focused on the functions working (though we could consider integrating them.).
+"""
+
+import pytest
+
+
+def test_no_var_in_dataset(ds):
+    with pytest.raises(
+        KeyError,
+        match=(
+            r"No variable named 'foo'. Variables on the dataset include \['z1', 'z2', 'x', 'time', 'c', 'y'\]"
+        ),
+    ):
+        ds["foo"]


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

One very small step as part of https://github.com/pydata/xarray/issues/8264.

The existing error is just `KeyError: 'foo`, which is annoyingly terse. Future improvements include searching for similar variable names, or even rewriting the user's calling code if there's a close variable name.

This PR creates a new test file. I don't love the format here — it's difficult to snapshot an error message, so it requires copying & pasting things, which doesn't scale well, and the traceback contains environment-specific lines such that it wouldn't be feasible to paste tracebacks.

([here's](https://github.com/PRQL/prql/blob/7ef5ba9a074772fc26e8fcdf12a2a05768071948/prqlc/prql-compiler/tests/sql/error_messages.rs) what we do in PRQL, which is (immodestly) great)

An alternative is just to put these in the mix of all the other tests; am open to that (and not difficult to change later)