### PR TITLE
Allow `rank` to run on dask arrays

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2063,6 +2063,7 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
         --------
         Dataset.rank, DataArray.rank
         """
+        # This could / should arguably be implemented at the DataArray & Dataset level
         if not OPTIONS["use_bottleneck"]:
             raise RuntimeError(
                 "rank requires bottleneck to be enabled."
@@ -2071,24 +2072,20 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
 
         import bottleneck as bn
 
-        data = self.data
-
-        if is_duck_dask_array(data):
-            raise TypeError(
-                "rank does not work for arrays stored as dask "
-                "arrays. Load the data via .compute() or .load() "
-                "prior to calling this method."
-            )
-        elif not isinstance(data, np.ndarray):
-            raise TypeError(f"rank is not implemented for {type(data)} objects.")
-
-        axis = self.get_axis_num(dim)
         func = bn.nanrankdata if self.dtype.kind == "f" else bn.rankdata
-        ranked = func(data, axis=axis)
+        ranked = xr.apply_ufunc(
+            func,
+            self,
+            input_core_dims=[[dim]],
+            output_core_dims=[[dim]],
+            dask="allowed",
+            kwargs=dict(axis=-1),
+        ).transpose(*self.dims)
+
         if pct:
-            count = np.sum(~np.isnan(data), axis=axis, keepdims=True)
+            count = self.notnull().sum(dim)
             ranked /= count
-        return Variable(self.dims, ranked)
+        return ranked
 
     def rolling_window(
         self, dim, window, window_dim, center=False, fill_value=dtypes.NA

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2078,7 +2078,7 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
             self,
             input_core_dims=[[dim]],
             output_core_dims=[[dim]],
-            dask="allowed",
+            dask="parallelized",
             kwargs=dict(axis=-1),
         ).transpose(*self.dims)
 

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1881,9 +1881,18 @@ class TestVariable(VariableSubclassobjects):
     def test_rank_dask(self):
         # Instead of a single test here, we could parameterize the other tests for both
         # arrays. But this is sufficient.
-        v = Variable(["x"], [30.0, 1.0, np.nan, 20.0, 4.0]).chunk(2)
-        expected = Variable(["x"], [4.0, 1.0, np.nan, 3.0, 2.0])
-        assert_equal(v.rank("x"), expected)
+        v = Variable(
+            ["x", "y"], [[30.0, 1.0, np.nan, 20.0, 4.0], [30.0, 1.0, np.nan, 20.0, 4.0]]
+        ).chunk(x=1)
+        expected = Variable(
+            ["x", "y"], [[4.0, 1.0, np.nan, 3.0, 2.0], [4.0, 1.0, np.nan, 3.0, 2.0]]
+        )
+        assert_equal(v.rank("y").compute(), expected)
+
+        with pytest.raises(
+            ValueError, match=r" with dask='parallelized' consists of multiple chunks"
+        ):
+            v.rank("x")
 
     def test_rank_use_bottleneck(self):
         v = Variable(["x"], [3.0, 1.0, np.nan, 2.0, 4.0])

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1878,10 +1878,12 @@ class TestVariable(VariableSubclassobjects):
 
     @requires_dask
     @requires_bottleneck
-    def test_rank_dask_raises(self):
-        v = Variable(["x"], [3.0, 1.0, np.nan, 2.0, 4.0]).chunk(2)
-        with pytest.raises(TypeError, match=r"arrays stored as dask"):
-            v.rank("x")
+    def test_rank_dask(self):
+        # Instead of a single test here, we could parameterize the other tests for both
+        # arrays. But this is sufficient.
+        v = Variable(["x"], [30.0, 1.0, np.nan, 20.0, 4.0]).chunk(2)
+        expected = Variable(["x"], [4.0, 1.0, np.nan, 3.0, 2.0])
+        assert_equal(v.rank("x"), expected)
 
     def test_rank_use_bottleneck(self):
         v = Variable(["x"], [3.0, 1.0, np.nan, 2.0, 4.0])
@@ -1912,7 +1914,8 @@ class TestVariable(VariableSubclassobjects):
         v_expect = Variable(["x"], [0.75, 0.25, np.nan, 0.5, 1.0])
         assert_equal(v.rank("x", pct=True), v_expect)
         # invalid dim
-        with pytest.raises(ValueError, match=r"not found"):
+        with pytest.raises(ValueError):
+            # apply_ufunc error message isn't great here — `ValueError: tuple.index(x): x not in tuple`
             v.rank("y")
 
     def test_big_endian_reduce(self):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
