### PR TITLE
Update resample time offset FutureWarning and docs

### DIFF
--- a/doc/user-guide/time-series.rst
+++ b/doc/user-guide/time-series.rst
@@ -245,6 +245,18 @@ Data that has indices outside of the given ``tolerance`` are set to ``NaN``.
 
     ds.resample(time="1h").nearest(tolerance="1h")
 
+It is often desirable to center the time values after a resampling operation.
+That can be accomplished by updating the resampled dataset time coordinate values
+using time offset arithmetic via the `pandas.tseries.frequencies.to_offset`_ function.
+
+.. _pandas.tseries.frequencies.to_offset: https://pandas.pydata.org/docs/reference/api/pandas.tseries.frequencies.to_offset.html
+
+.. ipython:: python
+
+    resampled_ds = ds.resample(time="6h").mean()
+    offset = pd.tseries.frequencies.to_offset("6h") / 2
+    resampled_ds["time"] = resampled_ds.get_index("time") + offset
+    resampled_ds
 
 For more examples of using grouped operations on a time dimension, see
 :doc:`../examples/weather-data`.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -46,6 +46,12 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
+- Added illustration of updating the time coordinate values of a resampled dataset using
+  time offset arithmetic.
+  This is the recommended technique to replace the use of the deprecated ``loffset`` parameter
+  in ``resample`` (:pull:`8479`).
+  By `Doug Latornell <https://github.com/douglatornell>`_.
+
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1011,7 +1011,7 @@ class DataWithCoords(AttrAccessMixin):
         if loffset is not None:
             emit_user_level_warning(
                 "Following pandas, the `loffset` parameter to resample "
-                "will be deprecated in a future version of xarray.  "
+                "is deprecated in a future version of xarray.  "
                 "Switch to updating the resampled dataset time coordinate using "
                 "time offset arithmetic.",
                 FutureWarning,

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1010,10 +1010,11 @@ class DataWithCoords(AttrAccessMixin):
 
         if loffset is not None:
             emit_user_level_warning(
-                "Following pandas, the `loffset` parameter to resample "
-                "is deprecated in a future version of xarray.  "
+                "Following pandas, the `loffset` parameter to resample is deprecated.  "
                 "Switch to updating the resampled dataset time coordinate using "
-                "time offset arithmetic.",
+                "time offset arithmetic.  For example:\n"
+                "    >>> offset = pd.tseries.frequencies.to_offset(freq) / 2\n"
+                '    >>> resampled_ds["time"] = resampled_ds.get_index("time") + offset',
                 FutureWarning,
             )
 

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1010,7 +1010,7 @@ class DataWithCoords(AttrAccessMixin):
 
         if loffset is not None:
             emit_user_level_warning(
-                "FutureWarning: Following pandas, the `loffset` parameter to resample "
+                "Following pandas, the `loffset` parameter to resample "
                 "will be deprecated in a future version of xarray.  "
                 "Switch to updating the resampled dataset time coordinate using "
                 "time offset arithmetic.",

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1010,8 +1010,10 @@ class DataWithCoords(AttrAccessMixin):
 
         if loffset is not None:
             emit_user_level_warning(
-                "Following pandas, the `loffset` parameter to resample will be deprecated "
-                "in a future version of xarray.  Switch to using time offset arithmetic.",
+                "FutureWarning: Following pandas, the `loffset` parameter to resample "
+                "will be deprecated in a future version of xarray.  "
+                "Switch to updating the resampled dataset time coordinate using "
+                "time offset arithmetic.",
                 FutureWarning,
             )
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -7031,6 +7031,12 @@ class DataArray(
         loffset : timedelta or str, optional
             Offset used to adjust the resampled time labels. Some pandas date
             offset strings are supported.
+
+            .. deprecated:: 2023.03.0
+                Following pandas, the ``loffset`` parameter is deprecated in favor
+                of using time offset arithmetic, and will be removed in a future
+                version of xarray.
+
         restore_coord_dims : bool, optional
             If True, also restore the dimension order of multi-dimensional
             coordinates.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -10374,6 +10374,12 @@ class Dataset(
         loffset : timedelta or str, optional
             Offset used to adjust the resampled time labels. Some pandas date
             offset strings are supported.
+
+            .. deprecated:: 2023.03.0
+                Following pandas, the ``loffset`` parameter is deprecated in favor
+                of using time offset arithmetic, and will be removed in a future
+                version of xarray.
+
         restore_coord_dims : bool, optional
             If True, also restore the dimension order of multi-dimensional
             coordinates.


### PR DESCRIPTION
Improve the text of the `FutureWarning` re: deprecation of the `loffset` parameter in the `DataWithCoords._resample()`.
Add deprecation notices about `loffset` to the `Dataset.resample()` and DataArray.resample()` docstrings.
Add illustration of updating the time coordinate values of a resampled dataset using  time offset arithmetic to the Time series data - Resampling and grouped operations section of the user guide.

- [x] Closes #7596
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
