### PR TITLE
Fix Zarr region transpose

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -43,6 +43,8 @@ Bug fixes
 ~~~~~~~~~
 
 - Fix dtype inference for ``pd.CategoricalIndex`` when categories are backed by a ``pd.ExtensionDtype`` (:pull:`8481`)
+- Fix writing a variable that requires transposing when not writing to a region (:pull:`8484`)
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 
 Documentation

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -624,12 +624,10 @@ class ZarrStore(AbstractWritableDataStore):
             variables_encoded.update(vars_with_encoding)
 
             for var_name in existing_variable_names:
-                new_var = variables_encoded[var_name]
-                existing_var = existing_vars[var_name]
-                new_var = _validate_and_transpose_existing_dims(
+                variables_encoded[var_name] = _validate_and_transpose_existing_dims(
                     var_name,
-                    new_var,
-                    existing_var,
+                    variables_encoded[var_name],
+                    existing_vars[var_name],
                     self._write_region,
                     self._append_dim,
                 )

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5438,7 +5438,7 @@ def test_zarr_region_transpose(tmp_path):
     )
     ds.to_zarr(tmp_path / "test.zarr")
 
-    ds_transposed = ds.transpose('y','x')
+    ds_transposed = ds.transpose("y", "x")
 
     ds_region = 1 + ds_transposed.isel(x=[0], y=[0])
     ds_region.to_zarr(
@@ -5447,5 +5447,3 @@ def test_zarr_region_transpose(tmp_path):
 
     # Write without region
     ds_transposed.to_zarr(tmp_path / "test.zarr", mode="r+")
-
-

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5423,7 +5423,7 @@ class TestZarrRegionAuto:
 
 
 @requires_zarr
-def test_zarr_region_transpose(tmp_path):
+def test_zarr_region(tmp_path):
     x = np.arange(0, 50, 10)
     y = np.arange(0, 20, 2)
     data = np.ones((5, 10))

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5438,7 +5438,14 @@ def test_zarr_region_transpose(tmp_path):
     )
     ds.to_zarr(tmp_path / "test.zarr")
 
-    ds_region = 1 + ds.isel(x=[0], y=[0]).transpose()
+    ds_transposed = ds.transpose('y','x')
+
+    ds_region = 1 + ds_transposed.isel(x=[0], y=[0])
     ds_region.to_zarr(
         tmp_path / "test.zarr", region={"x": slice(0, 1), "y": slice(0, 1)}
     )
+
+    # Write without region
+    ds_transposed.to_zarr(tmp_path / "test.zarr", mode="r+")
+
+


### PR DESCRIPTION
This wasn't working on an unregion-ed write; I think because `new_var` was being lost.
