### PR TITLE
Add option to define custom format of units in plots

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,6 +30,8 @@ New Features
 - :py:meth:`~xarray.DataArray.rank` now operates on dask-backed arrays, assuming
   the core dim has exactly one chunk. (:pull:`8475`).
   By `Maximilian Roos <https://github.com/max-sixty>`_.
+- Add option ``plot_unit_brackets`` to configure the enclosing brackets of units in plots (:pull:`8503`).
+  By `Michael Niklas <https://github.com/headtr1ck>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,7 +30,7 @@ New Features
 - :py:meth:`~xarray.DataArray.rank` now operates on dask-backed arrays, assuming
   the core dim has exactly one chunk. (:pull:`8475`).
   By `Maximilian Roos <https://github.com/max-sixty>`_.
-- Add option ``plot_unit_brackets`` to configure the enclosing brackets of units in plots (:pull:`8503`).
+- Add option ``plot_unit_format`` to configure how units are formatted in plots (:pull:`8503`).
   By `Michael Niklas <https://github.com/headtr1ck>`_.
 
 Breaking changes

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -251,8 +251,8 @@ class set_options:
         Whether or not to issue a warning when unclosed files are
         deallocated. This is mostly useful for debugging.
     plot_unit_brackets: tuple[str, str], default: ("[", "]")
-        Enclosing brackets for units in plots. Sometimes `(unit)`
-        is preferred over `unit`, use this option.
+        Enclosing brackets for units in plots. Use this to change
+        `[unit]` (default) to e.g. `(unit)`.
 
     Examples
     --------

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
         "use_numbagg",
         "use_opt_einsum",
         "use_flox",
-        "plot_unit_brackets",
+        "plot_unit_format",
     ]
 
     class T_Options(TypedDict):
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
         use_flox: bool
         use_numbagg: bool
         use_opt_einsum: bool
-        plot_unit_brackets: tuple[str, str]
+        plot_unit_format: str
 
 
 OPTIONS: T_Options = {
@@ -80,7 +80,7 @@ OPTIONS: T_Options = {
     "use_flox": True,
     "use_numbagg": True,
     "use_opt_einsum": True,
-    "plot_unit_brackets": ("[", "]"),
+    "plot_unit_format": "[{}]",
 }
 
 _JOIN_OPTIONS = frozenset(["inner", "outer", "left", "right", "exact"])
@@ -111,7 +111,7 @@ _VALIDATORS = {
     "use_opt_einsum": lambda value: isinstance(value, bool),
     "use_flox": lambda value: isinstance(value, bool),
     "warn_for_unclosed_files": lambda value: isinstance(value, bool),
-    "plot_unit_brackets": lambda value: isinstance(value, tuple) and len(value) == 2,
+    "plot_unit_format": lambda value: isinstance(value, str) and "{}" in value,
 }
 
 
@@ -250,8 +250,8 @@ class set_options:
     warn_for_unclosed_files : bool, default: False
         Whether or not to issue a warning when unclosed files are
         deallocated. This is mostly useful for debugging.
-    plot_unit_brackets: tuple[str, str], default: ("[", "]")
-        Enclosing brackets for units in plots. Use this to change
+    plot_unit_format: str, default: "[{}]"
+        Format units in plots. Must contain "{}". Use this to change
         `[unit]` (default) to e.g. `(unit)`.
 
     Examples

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
         "use_numbagg",
         "use_opt_einsum",
         "use_flox",
+        "plot_unit_brackets",
     ]
 
     class T_Options(TypedDict):
@@ -54,6 +55,7 @@ if TYPE_CHECKING:
         use_flox: bool
         use_numbagg: bool
         use_opt_einsum: bool
+        plot_unit_brackets: tuple[str, str]
 
 
 OPTIONS: T_Options = {
@@ -78,6 +80,7 @@ OPTIONS: T_Options = {
     "use_flox": True,
     "use_numbagg": True,
     "use_opt_einsum": True,
+    "plot_unit_brackets": ("[", "]"),
 }
 
 _JOIN_OPTIONS = frozenset(["inner", "outer", "left", "right", "exact"])
@@ -108,6 +111,7 @@ _VALIDATORS = {
     "use_opt_einsum": lambda value: isinstance(value, bool),
     "use_flox": lambda value: isinstance(value, bool),
     "warn_for_unclosed_files": lambda value: isinstance(value, bool),
+    "plot_unit_brackets": lambda value: isinstance(value, tuple) and len(value) == 2,
 }
 
 
@@ -246,6 +250,9 @@ class set_options:
     warn_for_unclosed_files : bool, default: False
         Whether or not to issue a warning when unclosed files are
         deallocated. This is mostly useful for debugging.
+    plot_unit_brackets: tuple[str, str], default: ("[", "]")
+        Enclosing brackets for units in plots. Sometimes `(unit)`
+        is preferred over `unit`, use this option.
 
     Examples
     --------

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -500,13 +500,15 @@ def _maybe_gca(**subplot_kws: Any) -> Axes:
 def _get_units_from_attrs(da: DataArray) -> str:
     """Extracts and formats the unit/units from a attributes."""
     pint_array_type = DuckArrayModule("pint").type
-    units = " [{}]"
+    _brackets = OPTIONS["plot_unit_brackets"]
+    brackets = {"left": _brackets[0], "right": _brackets[1]}
+    units = " {left}{unit}{right}"
     if isinstance(da.data, pint_array_type):
-        return units.format(str(da.data.units))
+        return units.format(unit=str(da.data.units), **brackets)
     if "units" in da.attrs:
-        return units.format(da.attrs["units"])
+        return units.format(unit=da.attrs["units"], **brackets)
     if "unit" in da.attrs:
-        return units.format(da.attrs["unit"])
+        return units.format(unit=da.attrs["unit"], **brackets)
     return ""
 
 

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -500,15 +500,13 @@ def _maybe_gca(**subplot_kws: Any) -> Axes:
 def _get_units_from_attrs(da: DataArray) -> str:
     """Extracts and formats the unit/units from a attributes."""
     pint_array_type = DuckArrayModule("pint").type
-    _brackets = OPTIONS["plot_unit_brackets"]
-    brackets = {"left": _brackets[0], "right": _brackets[1]}
-    units = " {left}{unit}{right}"
+    units = " " + OPTIONS["plot_unit_format"]
     if isinstance(da.data, pint_array_type):
-        return units.format(unit=str(da.data.units), **brackets)
+        return units.format(str(da.data.units))
     if "units" in da.attrs:
-        return units.format(unit=da.attrs["units"], **brackets)
+        return units.format(da.attrs["units"])
     if "unit" in da.attrs:
-        return units.format(unit=da.attrs["unit"], **brackets)
+        return units.format(da.attrs["unit"])
     return ""
 
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -15,6 +15,7 @@ import pytest
 import xarray as xr
 import xarray.plot as xplt
 from xarray import DataArray, Dataset
+from xarray.core.options import set_options
 from xarray.core.utils import module_available
 from xarray.plot.dataarray_plot import _infer_interval_breaks
 from xarray.plot.dataset_plot import _infer_meta_data
@@ -728,6 +729,24 @@ class TestPlot(PlotTestCase):
 
         expected = "dim_0_bins_center [m]"
         assert actual == expected
+
+    @pytest.mark.parametrize("brackets", ("()", "<>", "in ."))
+    def test_option_plot_unit_brackets(self, brackets: str) -> None:
+        """Test if options to set units works."""
+
+        bins = [-1, 0, 1, 2]
+        arr = self.darray.groupby_bins("dim_0", bins).mean(...)
+        arr.dim_0_bins.attrs["units"] = "m"
+
+        left = brackets[:-1]
+        right = brackets[-1]
+        with set_options(plot_unit_brackets=(left, right)):
+            (mappable,) = arr.plot(x="dim_0_bins")
+            ax = mappable.figure.gca()
+            actual = ax.get_xlabel()
+
+            expected = f"dim_0_bins_center {left}m{right}"
+            assert actual == expected
 
     def test_multiplot_over_length_one_dim(self) -> None:
         a = easy_array((3, 1, 1, 1))

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -730,22 +730,20 @@ class TestPlot(PlotTestCase):
         expected = "dim_0_bins_center [m]"
         assert actual == expected
 
-    @pytest.mark.parametrize("brackets", ("()", "<>", "in ."))
-    def test_option_plot_unit_brackets(self, brackets: str) -> None:
-        """Test if options to set units works."""
+    @pytest.mark.parametrize("format", ("({})", "<{}>", "in {}."))
+    def test_option_plot_unit_format(self, format: str) -> None:
+        """Test if options to set units format works."""
 
         bins = [-1, 0, 1, 2]
         arr = self.darray.groupby_bins("dim_0", bins).mean(...)
         arr.dim_0_bins.attrs["units"] = "m"
 
-        left = brackets[:-1]
-        right = brackets[-1]
-        with set_options(plot_unit_brackets=(left, right)):
+        with set_options(plot_unit_format=format):
             (mappable,) = arr.plot(x="dim_0_bins")
             ax = mappable.figure.gca()
             actual = ax.get_xlabel()
 
-            expected = f"dim_0_bins_center {left}m{right}"
+            expected = "dim_0_bins_center " + format.format("m")
             assert actual == expected
 
     def test_multiplot_over_length_one_dim(self) -> None:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

We encountered the issue that we should plot units as `(unit)` instead of `[unit]`.
This PR enables us to do exactly this, easier to change this at the source ;)

I think setting this as a global option is the correct approach, but feel free to propose alternatives :)