### PR TITLE
Allow callables to `.drop_vars`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,6 +30,10 @@ New Features
 - :py:meth:`~xarray.DataArray.rank` now operates on dask-backed arrays, assuming
   the core dim has exactly one chunk. (:pull:`8475`).
   By `Maximilian Roos <https://github.com/max-sixty>`_.
+- :py:meth:`Dataset.drop_vars` & :py:meth:`DataArray.drop_vars` allow passing a
+  callable, similar to :py:meth:`Dataset.where` & :py:meth:`Dataset.sortby` & others.
+  (:pull:`8511`).
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -6339,7 +6339,7 @@ class DataArray(
         ...     param="time_constant"
         ... )  # doctest: +NUMBER
         <xarray.DataArray 'curvefit_coefficients' (x: 3)>
-        array([1.05692035, 1.73549638, 2.9421577 ])
+        array([1.0569203, 1.7354963, 2.9421577])
         Coordinates:
           * x        (x) int64 0 1 2
             param    <U13 'time_constant'

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3041,7 +3041,7 @@ class DataArray(
 
     def drop_vars(
         self,
-        names: Hashable | Iterable[Hashable] | Callable,
+        names: str | Iterable[Hashable] | Callable[[Self], str | Iterable[Hashable]],
         *,
         errors: ErrorOptions = "raise",
     ) -> Self:
@@ -3110,6 +3110,8 @@ class DataArray(
                [ 9, 10, 11]])
         Dimensions without coordinates: x, y
         """
+        if callable(names):
+            names = names(self)
         ds = self._to_temp_dataset().drop_vars(names, errors=errors)
         return self._from_temp_dataset(ds)
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3041,7 +3041,7 @@ class DataArray(
 
     def drop_vars(
         self,
-        names: Hashable | Iterable[Hashable],
+        names: Hashable | Iterable[Hashable] | Callable,
         *,
         errors: ErrorOptions = "raise",
     ) -> Self:
@@ -3049,8 +3049,9 @@ class DataArray(
 
         Parameters
         ----------
-        names : Hashable or iterable of Hashable
-            Name(s) of variables to drop.
+        names : Hashable or iterable of Hashable or Callable
+            Name(s) of variables to drop. If a Callable, this object is passed as its
+            only argument and its result is used.
         errors : {"raise", "ignore"}, default: "raise"
             If 'raise', raises a ValueError error if any of the variable
             passed are not in the dataset. If 'ignore', any given names that are in the
@@ -3094,6 +3095,14 @@ class DataArray(
         Removing a list of variables:
 
         >>> da.drop_vars(["x", "y"])
+        <xarray.DataArray (x: 4, y: 3)>
+        array([[ 0,  1,  2],
+               [ 3,  4,  5],
+               [ 6,  7,  8],
+               [ 9, 10, 11]])
+        Dimensions without coordinates: x, y
+
+        >>> da.drop_vars(lambda x: x.coords)
         <xarray.DataArray (x: 4, y: 3)>
         array([[ 0,  1,  2],
                [ 3,  4,  5],
@@ -6328,7 +6337,7 @@ class DataArray(
         ...     param="time_constant"
         ... )  # doctest: +NUMBER
         <xarray.DataArray 'curvefit_coefficients' (x: 3)>
-        array([1.0569203, 1.7354963, 2.9421577])
+        array([1.05692035, 1.73549638, 2.9421577 ])
         Coordinates:
           * x        (x) int64 0 1 2
             param    <U13 'time_constant'

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -19,7 +19,7 @@ from collections.abc import (
 )
 from html import escape
 from numbers import Number
-from operator import methodcaller
+from operator import is_, methodcaller
 from os import PathLike
 from typing import IO, TYPE_CHECKING, Any, Callable, Generic, Literal, cast, overload
 
@@ -5723,7 +5723,7 @@ class Dataset(
 
     def drop_vars(
         self,
-        names: Hashable | Iterable[Hashable] | Callable,
+        names: str | Iterable[Hashable] | Callable[[Self], str | Iterable[Hashable]],
         *,
         errors: ErrorOptions = "raise",
     ) -> Self:
@@ -5860,7 +5860,7 @@ class Dataset(
         for var in names_set:
             maybe_midx = self._indexes.get(var, None)
             if isinstance(maybe_midx, PandasMultiIndex):
-                idx_coord_names = set(maybe_midx.index.names_set + [maybe_midx.dim])
+                idx_coord_names = set(maybe_midx.index.names + [maybe_midx.dim])
                 idx_other_names = idx_coord_names - set(names_set)
                 other_names.update(idx_other_names)
         if other_names:
@@ -5976,6 +5976,9 @@ class Dataset(
                 PendingDeprecationWarning,
                 stacklevel=2,
             )
+            # for mypy
+            if is_scalar(labels):
+                labels = [labels]
             return self.drop_vars(labels, errors=errors)
         if dim is not None:
             warnings.warn(

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5845,9 +5845,9 @@ class Dataset(
         DataArray.drop_vars
 
         """
-        # the Iterable check is required for mypy
         if callable(names):
             names = names(self)
+        # the Iterable check is required for mypy
         if is_scalar(names) or not isinstance(names, Iterable):
             names_set = {names}
         else:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -19,7 +19,7 @@ from collections.abc import (
 )
 from html import escape
 from numbers import Number
-from operator import is_, methodcaller
+from operator import methodcaller
 from os import PathLike
 from typing import IO, TYPE_CHECKING, Any, Callable, Generic, Literal, cast, overload
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5723,7 +5723,7 @@ class Dataset(
 
     def drop_vars(
         self,
-        names: Hashable | Iterable[Hashable],
+        names: Hashable | Iterable[Hashable] | Callable,
         *,
         errors: ErrorOptions = "raise",
     ) -> Self:
@@ -5731,8 +5731,9 @@ class Dataset(
 
         Parameters
         ----------
-        names : hashable or iterable of hashable
-            Name(s) of variables to drop.
+        names : Hashable or iterable of Hashable or Callable
+            Name(s) of variables to drop. If a Callable, this object is passed as its
+            only argument and its result is used.
         errors : {"raise", "ignore"}, default: "raise"
             If 'raise', raises a ValueError error if any of the variable
             passed are not in the dataset. If 'ignore', any given names that are in the
@@ -5774,7 +5775,7 @@ class Dataset(
             humidity     (time, latitude, longitude) float64 65.0 63.8 58.2 59.6
             wind_speed   (time, latitude, longitude) float64 10.2 8.5 12.1 9.8
 
-        # Drop the 'humidity' variable
+        Drop the 'humidity' variable
 
         >>> dataset.drop_vars(["humidity"])
         <xarray.Dataset>
@@ -5787,7 +5788,7 @@ class Dataset(
             temperature  (time, latitude, longitude) float64 25.5 26.3 27.1 28.0
             wind_speed   (time, latitude, longitude) float64 10.2 8.5 12.1 9.8
 
-        # Drop the 'humidity', 'temperature' variables
+        Drop the 'humidity', 'temperature' variables
 
         >>> dataset.drop_vars(["humidity", "temperature"])
         <xarray.Dataset>
@@ -5799,7 +5800,18 @@ class Dataset(
         Data variables:
             wind_speed  (time, latitude, longitude) float64 10.2 8.5 12.1 9.8
 
-        # Attempt to drop non-existent variable with errors="ignore"
+        Drop all indexes
+
+        >>> dataset.drop_vars(lambda x: x.indexes)
+        <xarray.Dataset>
+        Dimensions:      (time: 1, latitude: 2, longitude: 2)
+        Dimensions without coordinates: time, latitude, longitude
+        Data variables:
+            temperature  (time, latitude, longitude) float64 25.5 26.3 27.1 28.0
+            humidity     (time, latitude, longitude) float64 65.0 63.8 58.2 59.6
+            wind_speed   (time, latitude, longitude) float64 10.2 8.5 12.1 9.8
+
+        Attempt to drop non-existent variable with errors="ignore"
 
         >>> dataset.drop_vars(["pressure"], errors="ignore")
         <xarray.Dataset>
@@ -5813,7 +5825,7 @@ class Dataset(
             humidity     (time, latitude, longitude) float64 65.0 63.8 58.2 59.6
             wind_speed   (time, latitude, longitude) float64 10.2 8.5 12.1 9.8
 
-        # Attempt to drop non-existent variable with errors="raise"
+        Attempt to drop non-existent variable with errors="raise"
 
         >>> dataset.drop_vars(["pressure"], errors="raise")
         Traceback (most recent call last):
@@ -5834,23 +5846,25 @@ class Dataset(
 
         """
         # the Iterable check is required for mypy
+        if callable(names):
+            names = names(self)
         if is_scalar(names) or not isinstance(names, Iterable):
-            names = {names}
+            names_set = {names}
         else:
-            names = set(names)
+            names_set = set(names)
         if errors == "raise":
-            self._assert_all_in_dataset(names)
+            self._assert_all_in_dataset(names_set)
 
         # GH6505
         other_names = set()
-        for var in names:
+        for var in names_set:
             maybe_midx = self._indexes.get(var, None)
             if isinstance(maybe_midx, PandasMultiIndex):
-                idx_coord_names = set(maybe_midx.index.names + [maybe_midx.dim])
-                idx_other_names = idx_coord_names - set(names)
+                idx_coord_names = set(maybe_midx.index.names_set + [maybe_midx.dim])
+                idx_other_names = idx_coord_names - set(names_set)
                 other_names.update(idx_other_names)
         if other_names:
-            names |= set(other_names)
+            names_set |= set(other_names)
             warnings.warn(
                 f"Deleting a single level of a MultiIndex is deprecated. Previously, this deleted all levels of a MultiIndex. "
                 f"Please also drop the following variables: {other_names!r} to avoid an error in the future.",
@@ -5858,11 +5872,11 @@ class Dataset(
                 stacklevel=2,
             )
 
-        assert_no_index_corrupted(self.xindexes, names)
+        assert_no_index_corrupted(self.xindexes, names_set)
 
-        variables = {k: v for k, v in self._variables.items() if k not in names}
+        variables = {k: v for k, v in self._variables.items() if k not in names_set}
         coord_names = {k for k in self._coord_names if k in variables}
-        indexes = {k: v for k, v in self._indexes.items() if k not in names}
+        indexes = {k: v for k, v in self._indexes.items() if k not in names_set}
         return self._replace_with_new_dims(
             variables, coord_names=coord_names, indexes=indexes
         )

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -63,7 +63,7 @@ class Resample(GroupBy[T_Xarray]):
         obj = self._obj
         for k, v in obj.coords.items():
             if k != self._dim and self._dim in v.dims:
-                obj = obj.drop_vars(k)
+                obj = obj.drop_vars([k])
         return obj
 
     def pad(self, tolerance: float | Iterable[float] | None = None) -> T_Xarray:
@@ -244,7 +244,7 @@ class DataArrayResample(Resample["DataArray"], DataArrayGroupByBase, DataArrayRe
         # dimension, then we need to do so before we can rename the proxy
         # dimension we used.
         if self._dim in combined.coords:
-            combined = combined.drop_vars(self._dim)
+            combined = combined.drop_vars([self._dim])
 
         if RESAMPLE_DIM in combined.dims:
             combined = combined.rename({RESAMPLE_DIM: self._dim})

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2653,8 +2653,10 @@ class TestDataArray:
         assert_identical(actual, renamed)
 
     def test_drop_vars_callable(self) -> None:
-        A = DataArray(np.random.randn(2, 3), dims=["x", "y"], coords={"x": [1, 2], "y": [3, 4, 5]})
-        expected = A.drop_vars(['x','y'])
+        A = DataArray(
+            np.random.randn(2, 3), dims=["x", "y"], coords={"x": [1, 2], "y": [3, 4, 5]}
+        )
+        expected = A.drop_vars(["x", "y"])
         actual = A.drop_vars(lambda x: x.indexes)
         assert_identical(expected, actual)
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2652,6 +2652,12 @@ class TestDataArray:
         actual = renamed.drop_vars("foo", errors="ignore")
         assert_identical(actual, renamed)
 
+    def test_drop_vars_callable(self) -> None:
+        A = DataArray(np.random.randn(2, 3), dims=["x", "y"], coords={"x": [1, 2], "y": [3, 4, 5]})
+        expected = A.drop_vars(['x','y'])
+        actual = A.drop_vars(lambda x: x.indexes)
+        assert_identical(expected, actual)
+
     def test_drop_multiindex_level(self) -> None:
         # GH6505
         expected = self.mda.drop_vars(["x", "level_1", "level_2"])


### PR DESCRIPTION
This can be used as a nice more general alternative to `.drop_indexes` or `.reset_coords(drop=True)`
