### PR TITLE
Allow configuring open_dataset via backend instances

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     T_Engine = Union[
         T_NetcdfEngine,
         Literal["pydap", "pynio", "zarr"],
+        BackendEntrypoint,
         type[BackendEntrypoint],
         str,  # no nice typing support for custom backends
         None,
@@ -421,11 +422,10 @@ def open_dataset(
         objects are opened by scipy.io.netcdf (netCDF3) or h5py (netCDF4/HDF).
     engine : {"netcdf4", "scipy", "pydap", "h5netcdf", "pynio", \
         "zarr", None}, installed backend \
-        or subclass of xarray.backends.BackendEntrypoint, optional
+        or instance or subclass of xarray.backends.BackendEntrypoint, optional
         Engine to use when reading files. If not provided, the default engine
         is chosen based on available dependencies, with a preference for
-        "netcdf4". A custom backend class (a subclass of ``BackendEntrypoint``)
-        can also be used.
+        "netcdf4".
     chunks : int, dict, 'auto' or None, optional
         If chunks is provided, it is used to load the new dataset into dask
         arrays. ``chunks=-1`` loads the dataset with dask using a single
@@ -595,8 +595,8 @@ def open_dataset(
 def open_dataarray(
     filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
     *,
-    engine: T_Engine | None = None,
-    chunks: T_Chunks | None = None,
+    engine: T_Engine = None,
+    chunks: T_Chunks = None,
     cache: bool | None = None,
     decode_cf: bool | None = None,
     mask_and_scale: bool | None = None,
@@ -628,7 +628,7 @@ def open_dataarray(
         objects are opened by scipy.io.netcdf (netCDF3) or h5py (netCDF4/HDF).
     engine : {"netcdf4", "scipy", "pydap", "h5netcdf", "pynio", \
         "zarr", None}, installed backend \
-        or subclass of xarray.backends.BackendEntrypoint, optional
+        or instance or subclass of xarray.backends.BackendEntrypoint, optional
         Engine to use when reading files. If not provided, the default engine
         is chosen based on available dependencies, with a preference for
         "netcdf4".
@@ -707,16 +707,20 @@ def open_dataarray(
         in the values of the task graph. See :py:func:`dask.array.from_array`.
     chunked_array_type: str, optional
         Which chunked array type to coerce the underlying data array to.
-        Defaults to 'dask' if installed, else whatever is registered via the `ChunkManagerEnetryPoint` system.
+        Defaults to 'dask' if installed, else whatever is registered via the
+        `ChunkManagerEnetryPoint` system.
         Experimental API that should not be relied upon.
     from_array_kwargs: dict
-        Additional keyword arguments passed on to the `ChunkManagerEntrypoint.from_array` method used to create
-        chunked arrays, via whichever chunk manager is specified through the `chunked_array_type` kwarg.
-        For example if :py:func:`dask.array.Array` objects are used for chunking, additional kwargs will be passed
-        to :py:func:`dask.array.from_array`. Experimental API that should not be relied upon.
+        Additional keyword arguments passed on to the `ChunkManagerEntrypoint.from_array`
+        method used to create chunked arrays, via whichever chunk manager is
+        specified through the `chunked_array_type` kwarg.
+        For example if :py:func:`dask.array.Array` objects are used for chunking,
+        additional kwargs will be passed to :py:func:`dask.array.from_array`.
+        Experimental API that should not be relied upon.
     backend_kwargs: dict
         Additional keyword arguments passed on to the engine open function,
-        equivalent to `**kwargs`.
+        equivalent to `**kwargs`. Alternatively pass a configured Backend object
+        as engine.
     **kwargs: dict
         Additional keyword arguments passed on to the engine open function.
         For example:
@@ -729,7 +733,8 @@ def open_dataarray(
           currently active dask scheduler. Supported by "netcdf4", "h5netcdf",
           "scipy", "pynio".
 
-        See engine open function for kwargs accepted by each specific engine.
+        See engine open function for kwargs accepted by each specific engine or
+        create an instance of the Backend and configure it in the constructor.
 
     Notes
     -----
@@ -790,7 +795,7 @@ def open_dataarray(
 
 def open_mfdataset(
     paths: str | NestedSequence[str | os.PathLike],
-    chunks: T_Chunks | None = None,
+    chunks: T_Chunks = None,
     concat_dim: str
     | DataArray
     | Index
@@ -800,7 +805,7 @@ def open_mfdataset(
     | None = None,
     compat: CompatOptions = "no_conflicts",
     preprocess: Callable[[Dataset], Dataset] | None = None,
-    engine: T_Engine | None = None,
+    engine: T_Engine = None,
     data_vars: Literal["all", "minimal", "different"] | list[str] = "all",
     coords="different",
     combine: Literal["by_coords", "nested"] = "by_coords",
@@ -868,7 +873,7 @@ def open_mfdataset(
         ``ds.encoding["source"]``.
     engine : {"netcdf4", "scipy", "pydap", "h5netcdf", "pynio", \
         "zarr", None}, installed backend \
-        or subclass of xarray.backends.BackendEntrypoint, optional
+        or instance or subclass of xarray.backends.BackendEntrypoint, optional
         Engine to use when reading files. If not provided, the default engine
         is chosen based on available dependencies, with a preference for
         "netcdf4".

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -6,7 +6,7 @@ import time
 import traceback
 from collections.abc import Iterable
 from glob import glob
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
 
@@ -17,10 +17,8 @@ from xarray.core.pycompat import is_chunked_array
 from xarray.core.utils import FrozenDict, NdimSizeLenMixin, is_remote_uri
 
 if TYPE_CHECKING:
-    from io import BufferedIOBase
-
     from xarray.core.dataset import Dataset
-    from xarray.core.types import NestedSequence
+    from xarray.core.types import NestedSequence, T_XarrayCanOpen
 
 # Create a logger object, but don't add any handlers. Leave that to user code.
 logger = logging.getLogger(__name__)
@@ -487,10 +485,9 @@ class BackendEntrypoint:
 
     def open_dataset(
         self,
-        filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
+        filename_or_obj: T_XarrayCanOpen,
         *,
         drop_variables: str | Iterable[str] | None = None,
-        **kwargs: Any,
     ) -> Dataset:
         """
         Backend open_dataset method used by Xarray in :py:func:`~xarray.open_dataset`.
@@ -500,7 +497,7 @@ class BackendEntrypoint:
 
     def guess_can_open(
         self,
-        filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
+        filename_or_obj: T_XarrayCanOpen,
     ) -> bool:
         """
         Backend open_dataset method used by Xarray in :py:func:`~xarray.open_dataset`.

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -197,21 +197,23 @@ def guess_engine(
     raise ValueError(error_msg)
 
 
-def get_backend(engine: str | type[BackendEntrypoint]) -> BackendEntrypoint:
+def get_backend(
+    engine: str | BackendEntrypoint | type[BackendEntrypoint],
+) -> BackendEntrypoint:
     """Select open_dataset method based on current engine."""
+    if isinstance(engine, BackendEntrypoint):
+        return engine
     if isinstance(engine, str):
         engines = list_engines()
         if engine not in engines:
             raise ValueError(
                 f"unrecognized engine {engine} must be one of: {list(engines)}"
             )
-        backend = engines[engine]
-    elif isinstance(engine, type) and issubclass(engine, BackendEntrypoint):
-        backend = engine()
-    else:
-        raise TypeError(
-            "engine must be a string or a subclass of "
-            f"xarray.backends.BackendEntrypoint: {engine}"
-        )
+        return engines[engine]
+    if isinstance(engine, type) and issubclass(engine, BackendEntrypoint):
+        return engine()
 
-    return backend
+    raise TypeError(
+        "engine must be a string, a subclass of xarray.backends.BackendEntrypoint"
+        f" or an object of such a subclass, got {type(engine)}"
+    )

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import datetime
+import os
 import sys
 from collections.abc import Hashable, Iterable, Iterator, Mapping, Sequence
+from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -29,10 +31,12 @@ except ImportError:
         Self: Any = None
 
 if TYPE_CHECKING:
+    from io import BufferedIOBase
+
     from numpy._typing import _SupportsDType
     from numpy.typing import ArrayLike
 
-    from xarray.backends.common import BackendEntrypoint
+    from xarray.backends.common import AbstractDataStore, BackendEntrypoint
     from xarray.core.alignment import Aligner
     from xarray.core.common import AbstractArray, DataWithCoords
     from xarray.core.coordinates import Coordinates
@@ -267,7 +271,7 @@ NestedSequence = Union[
 ]
 
 
-QuantileMethods = Literal[
+QuantileMethods: TypeAlias = Literal[
     "inverted_cdf",
     "averaged_inverted_cdf",
     "closest_observation",
@@ -283,5 +287,29 @@ QuantileMethods = Literal[
     "nearest",
 ]
 
+T_XarrayCanOpen: TypeAlias = Union[
+    str, os.PathLike[Any], "BufferedIOBase", "AbstractDataStore"
+]
+ZarrWriteModes: TypeAlias = Literal["w", "w-", "a", "a-", "r+", "r"]
 
-ZarrWriteModes = Literal["w", "w-", "a", "a-", "r+", "r"]
+
+class SupportsLock(Protocol):
+    def acquire(self, blocking: bool) -> bool:
+        ...
+
+    def release(self) -> None:
+        ...
+
+    def locked(self) -> bool:
+        ...
+
+    def __enter__(self) -> bool:
+        ...
+
+    def __exit__(
+        self,
+        type: type[BaseException] | None,
+        value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        ...


### PR DESCRIPTION
This is trial if maybe supporting instances of `BackendEntryPoints` as the `engine` argument makes sense.

Then instead of passing a long list of options to the `open_dataset` method directly, you can also configure the entrypoint in the constructor and pass it as the engine.

For now I have only changed the netcdf4 backend to see how it would work out. Tests are still failing because the argument detection fails (which we could even drop eventually with this PR).

It would look something like this:
```python
engine = NetCDF4BackendEntrypoint(mask_and_scale=False, use_cftime=True)
ds = xr.open_dataset("some_file.nc", engine=engine)
```
While this is actually even more lines of code, the main advantage is to have better discoverability of the options.
