### PR TITLE
test and fix empty xindexes repr

### DIFF
--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -357,7 +357,7 @@ EMPTY_REPR = "    *empty*"
 
 
 def _calculate_col_width(col_items):
-    max_name_length = max(len(str(s)) for s in col_items) if col_items else 0
+    max_name_length = max((len(str(s)) for s in col_items), default=0)
     col_width = max(max_name_length, 7) + 6
     return col_width
 
@@ -490,7 +490,7 @@ def filter_nondefault_indexes(indexes, filter_indexes: bool):
 
 
 def indexes_repr(indexes, max_rows: int | None = None) -> str:
-    col_width = _calculate_col_width(indexes)
+    col_width = _calculate_col_width(chain.from_iterable(indexes))
 
     return _mapping_repr(
         indexes,

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -490,7 +490,7 @@ def filter_nondefault_indexes(indexes, filter_indexes: bool):
 
 
 def indexes_repr(indexes, max_rows: int | None = None) -> str:
-    col_width = _calculate_col_width(chain.from_iterable(indexes))
+    col_width = _calculate_col_width(indexes)
 
     return _mapping_repr(
         indexes,

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -785,7 +785,7 @@ def test_format_xindexes_none(as_dataset: bool) -> None:
     expected = dedent(expected)
 
     obj: xr.DataArray | xr.Dataset = xr.DataArray()
-    obj = obj._to_temp_dataset() if as_dataset else obj  # type: ignore[assignment]
+    obj = obj._to_temp_dataset() if as_dataset else obj
 
     actual = repr(obj.xindexes)
     assert actual == expected
@@ -799,7 +799,7 @@ def test_format_xindexes(as_dataset: bool) -> None:
     expected = dedent(expected)
 
     obj: xr.DataArray | xr.Dataset = xr.DataArray([1], coords={"x": [1]})
-    obj = obj._to_temp_dataset() if as_dataset else obj  # type: ignore[assignment]
+    obj = obj._to_temp_dataset() if as_dataset else obj
 
     actual = repr(obj.xindexes)
     assert actual == expected

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -785,7 +785,7 @@ def test_format_xindexes_none(as_dataset):
     expected = dedent(expected)
 
     obj = xr.DataArray()
-    obj = obj._to_temp_dataset() if as_dataset else obj
+    obj = obj._to_temp_dataset() if as_dataset else obj  # type: ignore[assignment]
 
     actual = obj.xindexes.__repr__()
     assert actual == expected
@@ -799,7 +799,7 @@ def test_format_xindexes(as_dataset):
     expected = dedent(expected)
 
     obj = xr.DataArray([1], coords={"x": [1]})
-    obj = obj._to_temp_dataset() if as_dataset else obj
+    obj = obj._to_temp_dataset() if as_dataset else obj  # type: ignore[assignment]
 
     actual = obj.xindexes.__repr__()
     assert actual == expected

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -776,7 +776,7 @@ def test_lazy_array_wont_compute() -> None:
 
 
 @pytest.mark.parametrize("as_dataset", (False, True))
-def test_format_xindexes_none(as_dataset):
+def test_format_xindexes_none(as_dataset: bool) -> None:
     # ensure repr for empty xindexes can be displayed #8367
 
     expected = """\
@@ -784,22 +784,22 @@ def test_format_xindexes_none(as_dataset):
         *empty*"""
     expected = dedent(expected)
 
-    obj = xr.DataArray()
+    obj: xr.DataArray | xr.Dataset = xr.DataArray()
     obj = obj._to_temp_dataset() if as_dataset else obj  # type: ignore[assignment]
 
-    actual = obj.xindexes.__repr__()
+    actual = repr(obj.xindexes)
     assert actual == expected
 
 
 @pytest.mark.parametrize("as_dataset", (False, True))
-def test_format_xindexes(as_dataset):
+def test_format_xindexes(as_dataset: bool) -> None:
     expected = """\
     Indexes:
         x        PandasIndex"""
     expected = dedent(expected)
 
-    obj = xr.DataArray([1], coords={"x": [1]})
+    obj: xr.DataArray | xr.Dataset = xr.DataArray([1], coords={"x": [1]})
     obj = obj._to_temp_dataset() if as_dataset else obj  # type: ignore[assignment]
 
-    actual = obj.xindexes.__repr__()
+    actual = repr(obj.xindexes)
     assert actual == expected

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -795,7 +795,7 @@ def test_format_xindexes_none(as_dataset):
 def test_format_xindexes(as_dataset):
     expected = """\
     Indexes:
-        x                         PandasIndex"""
+        x        PandasIndex"""
     expected = dedent(expected)
 
     obj = xr.DataArray([1], coords={"x": [1]})

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -773,3 +773,33 @@ def test_lazy_array_wont_compute() -> None:
     # These will crash if var.data are converted to numpy arrays:
     var.__repr__()
     var._repr_html_()
+
+
+@pytest.mark.parametrize("as_dataset", (False, True))
+def test_format_xindexes_none(as_dataset):
+    # ensure repr for empty xindexes can be displayed #8367
+
+    expected = """\
+    Indexes:
+        *empty*"""
+    expected = dedent(expected)
+
+    obj = xr.DataArray()
+    obj = obj._to_temp_dataset() if as_dataset else obj
+
+    actual = obj.xindexes.__repr__()
+    assert actual == expected
+
+
+@pytest.mark.parametrize("as_dataset", (False, True))
+def test_format_xindexes(as_dataset):
+    expected = """\
+    Indexes:
+        x                         PandasIndex"""
+    expected = dedent(expected)
+
+    obj = xr.DataArray([1], coords={"x": [1]})
+    obj = obj._to_temp_dataset() if as_dataset else obj
+
+    actual = obj.xindexes.__repr__()
+    assert actual == expected


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #8367
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

Uses `max` with a default, which work with empty iterators, in contrast to `if col_items else 0`.