### PR TITLE
Offer a fixture for unifying DataArray & Dataset tests

### DIFF
--- a/xarray/tests/conftest.py
+++ b/xarray/tests/conftest.py
@@ -95,14 +95,14 @@ def d(request, backend, type) -> DataArray | Dataset:
     if request.param == 1:
         ds = Dataset(
             dict(
-                a=(["x", "y"], np.arange(16).reshape(8, 2)),
-                b=(["y", "z"], np.arange(12, 32).reshape(2, 10).astype(np.float64)),
+                a=(["x", "z"], np.arange(24).reshape(2, 12)),
+                b=(["y", "z"], np.arange(100, 136).reshape(3, 12).astype(np.float64)),
             ),
             dict(
-                x=("x", np.linspace(0, 1.0, 8)),
-                y=range(2),
-                z=("z", np.linspace(0, 1.0, 10)),
-                w=("y", ["a", "b"]),
+                x=("x", np.linspace(0, 1.0, 2)),
+                y=range(3),
+                z=("z", pd.date_range("2000-01-01", periods=12)),
+                w=("x", ["a", "b"]),
             ),
         )
         if type == DataArray:

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -37,17 +37,17 @@ def compute_backend(request):
 
 
 @pytest.mark.parametrize("func", ["mean", "sum"])
-@pytest.mark.parametrize("min_periods", [1, 20])
+@pytest.mark.parametrize("min_periods", [1, 10])
 def test_cumulative(d, func, min_periods) -> None:
     # One dim
-    result = getattr(d.cumulative("x", min_periods=min_periods), func)()
-    expected = getattr(d.rolling(x=d["x"].size, min_periods=min_periods), func)()
+    result = getattr(d.cumulative("z", min_periods=min_periods), func)()
+    expected = getattr(d.rolling(z=d["z"].size, min_periods=min_periods), func)()
     assert_identical(result, expected)
 
     # Multiple dim
-    result = getattr(d.cumulative(["x", "y"], min_periods=min_periods), func)()
+    result = getattr(d.cumulative(["z", "x"], min_periods=min_periods), func)()
     expected = getattr(
-        d.rolling(x=d["x"].size, y=d["y"].size, min_periods=min_periods),
+        d.rolling(z=d["z"].size, x=d["x"].size, min_periods=min_periods),
         func,
     )()
     assert_identical(result, expected)

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -54,10 +54,10 @@ def test_cumulative(d, func, min_periods) -> None:
 
 
 def test_cumulative_vs_cum(d) -> None:
-    result = d.cumulative("x").sum()
-    expected = d.cumsum("x")
+    result = d.cumulative("z").sum()
+    expected = d.cumsum("z")
     # cumsum drops the coord of the dimension; cumulative doesn't
-    expected = expected.assign_coords(x=result["x"])
+    expected = expected.assign_coords(z=result["z"])
     assert_identical(result, expected)
 
 

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -36,6 +36,31 @@ def compute_backend(request):
         yield request.param
 
 
+@pytest.mark.parametrize("func", ["mean", "sum"])
+@pytest.mark.parametrize("min_periods", [1, 20])
+def test_cumulative(d, func, min_periods) -> None:
+    # One dim
+    result = getattr(d.cumulative("x", min_periods=min_periods), func)()
+    expected = getattr(d.rolling(x=d["x"].size, min_periods=min_periods), func)()
+    assert_identical(result, expected)
+
+    # Multiple dim
+    result = getattr(d.cumulative(["x", "y"], min_periods=min_periods), func)()
+    expected = getattr(
+        d.rolling(x=d["x"].size, y=d["y"].size, min_periods=min_periods),
+        func,
+    )()
+    assert_identical(result, expected)
+
+
+def test_cumulative_vs_cum(d) -> None:
+    result = d.cumulative("x").sum()
+    expected = d.cumsum("x")
+    # cumsum drops the coord of the dimension; cumulative doesn't
+    expected = expected.assign_coords(x=result["x"])
+    assert_identical(result, expected)
+
+
 class TestDataArrayRolling:
     @pytest.mark.parametrize("da", (1, 2), indirect=True)
     @pytest.mark.parametrize("center", [True, False])
@@ -485,29 +510,6 @@ class TestDataArrayRollingExp:
         ):
             da.rolling_exp(time=10, keep_attrs=True)
 
-    @pytest.mark.parametrize("func", ["mean", "sum"])
-    @pytest.mark.parametrize("min_periods", [1, 20])
-    def test_cumulative(self, da, func, min_periods) -> None:
-        # One dim
-        result = getattr(da.cumulative("time", min_periods=min_periods), func)()
-        expected = getattr(
-            da.rolling(time=da.time.size, min_periods=min_periods), func
-        )()
-        assert_identical(result, expected)
-
-        # Multiple dim
-        result = getattr(da.cumulative(["time", "a"], min_periods=min_periods), func)()
-        expected = getattr(
-            da.rolling(time=da.time.size, a=da.a.size, min_periods=min_periods),
-            func,
-        )()
-        assert_identical(result, expected)
-
-    def test_cumulative_vs_cum(self, da) -> None:
-        result = da.cumulative("time").sum()
-        expected = da.cumsum("time")
-        assert_identical(result, expected)
-
 
 class TestDatasetRolling:
     @pytest.mark.parametrize(
@@ -831,25 +833,6 @@ class TestDatasetRolling:
         actual = getattr(rolling_obj, name)()
         expected = getattr(getattr(ds.rolling(time=4), name)().rolling(x=3), name)()
         assert_allclose(actual, expected)
-
-    @pytest.mark.parametrize("func", ["mean", "sum"])
-    @pytest.mark.parametrize("ds", (2,), indirect=True)
-    @pytest.mark.parametrize("min_periods", [1, 10])
-    def test_cumulative(self, ds, func, min_periods) -> None:
-        # One dim
-        result = getattr(ds.cumulative("time", min_periods=min_periods), func)()
-        expected = getattr(
-            ds.rolling(time=ds.time.size, min_periods=min_periods), func
-        )()
-        assert_identical(result, expected)
-
-        # Multiple dim
-        result = getattr(ds.cumulative(["time", "x"], min_periods=min_periods), func)()
-        expected = getattr(
-            ds.rolling(time=ds.time.size, x=ds.x.size, min_periods=min_periods),
-            func,
-        )()
-        assert_identical(result, expected)
 
 
 @requires_numbagg


### PR DESCRIPTION
Some tests are literally copy & pasted between DataArray & Dataset tests. This change allows them to use a single test. Not everything will be able to use this — sometimes we want to check specifics — but some will — I've change the `.cumulative` tests to use this fixture.