### PR TITLE
Point users to where in their code they should make mods for Dataset.dims

### DIFF
--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -491,12 +491,11 @@ class FrozenMappingWarningOnValuesAccess(Frozen[K, V]):
     __slots__ = ("mapping",)
 
     def _warn(self) -> None:
-        warnings.warn(
+        emit_user_level_warning(
             "The return type of `Dataset.dims` will be changed to return a set of dimension names in future, "
             "in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, "
             "please use `Dataset.sizes`.",
             FutureWarning,
-            stacklevel=3,
         )
 
     def __getitem__(self, key: K) -> V:

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -496,6 +496,7 @@ class FrozenMappingWarningOnValuesAccess(Frozen[K, V]):
             "in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, "
             "please use `Dataset.sizes`.",
             FutureWarning,
+            stacklevel=3,
         )
 
     def __getitem__(self, key: K) -> V:


### PR DESCRIPTION
Its somewhat annoying to get warnings that point to a line within a library where the warning is issued. It really makes it unclear what one needs to change.

This points to the user's access of the `dims` attribute.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
