### PR TITLE
Filter null values before plotting

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -44,6 +44,8 @@ Documentation
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Remove null values before plotting. (:pull:`8535`).
+  By `Jimmy Westling <https://github.com/illviljan>`_.
 
 .. _whats-new.2023.12.0:
 

--- a/xarray/plot/dataarray_plot.py
+++ b/xarray/plot/dataarray_plot.py
@@ -944,15 +944,15 @@ def _plot1d(plotfunc):
         if plotfunc.__name__ == "scatter":
             size_ = kwargs.pop("_size", markersize)
             size_r = _MARKERSIZE_RANGE
+
+            # Remove any nulls, .where(m, drop=True) doesn't work when m is
+            # a dask array, so load the array to memory.
+            # It will have to be loaded to memory at some point anyway:
+            darray = darray.load()
+            darray = darray.where(darray.notnull(), drop=True)
         else:
             size_ = kwargs.pop("_size", linewidth)
             size_r = _LINEWIDTH_RANGE
-
-        # Remove any nulls, .where(m, drop=True) doesn't work when m is a dask array,
-        # so load the array to memory.
-        # It will have to be loaded to memory at some point anyway:
-        darray = darray.load()
-        darray = darray.where(darray.notnull(), drop=True)
 
         # Get data to plot:
         coords_to_plot: MutableMapping[str, Hashable | None] = dict(

--- a/xarray/plot/dataarray_plot.py
+++ b/xarray/plot/dataarray_plot.py
@@ -948,6 +948,12 @@ def _plot1d(plotfunc):
             size_ = kwargs.pop("_size", linewidth)
             size_r = _LINEWIDTH_RANGE
 
+        # Remove any nulls, .where(m, drop=True) doesn't work when m is a dask array,
+        # so load the array to memory.
+        # It will have to be loaded to memory at some point anyway:
+        darray = darray.load()
+        darray = darray.where(darray.notnull(), drop=True)
+
         # Get data to plot:
         coords_to_plot: MutableMapping[str, Hashable | None] = dict(
             x=x, z=z, hue=hue, size=size_

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -3372,3 +3372,15 @@ def test_plot1d_default_rcparams() -> None:
         np.testing.assert_allclose(
             ax.collections[0].get_edgecolor(), mpl.colors.to_rgba_array("k")
         )
+
+
+@requires_matplotlib
+def test_plot1d_filtered_nulls():
+    ds = xr.tutorial.scatter_example_dataset(seed=42)
+    y = ds.y.where(ds.y > 0.2)
+    expected = y.notnull().sum().item()
+
+    pc = y.plot.scatter()
+    actual = pc.get_offsets().shape[0]
+
+    assert expected == actual

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -3380,7 +3380,8 @@ def test_plot1d_filtered_nulls() -> None:
     y = ds.y.where(ds.y > 0.2)
     expected = y.notnull().sum().item()
 
-    pc = y.plot.scatter()
-    actual = pc.get_offsets().shape[0]
+    with figure_context():
+        pc = y.plot.scatter()
+        actual = pc.get_offsets().shape[0]
 
-    assert expected == actual
+        assert expected == actual

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -3375,7 +3375,7 @@ def test_plot1d_default_rcparams() -> None:
 
 
 @requires_matplotlib
-def test_plot1d_filtered_nulls():
+def test_plot1d_filtered_nulls() -> None:
     ds = xr.tutorial.scatter_example_dataset(seed=42)
     y = ds.y.where(ds.y > 0.2)
     expected = y.notnull().sum().item()


### PR DESCRIPTION
I noticed that seaborn's plot was responding much faster than xarray's version with the same data. 
Turn's out seaborn drops any nulls: https://github.com/mwaskom/seaborn/blob/056413d7393e3daec597d430c076e45938d53376/seaborn/relational.py#L399

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

