### PR TITLE
Check that compat is equal to identical only once in dataset concat

### DIFF
--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -536,9 +536,10 @@ def _dataset_concat(
     result_encoding = datasets[0].encoding
 
     # check that global attributes are fixed across all datasets if necessary
-    for ds in datasets[1:]:
-        if compat == "identical" and not utils.dict_equiv(ds.attrs, result_attrs):
-            raise ValueError("Dataset global attributes not equal.")
+    if compat == "identical":
+        for ds in datasets[1:]:
+            if not utils.dict_equiv(ds.attrs, result_attrs):
+                raise ValueError("Dataset global attributes not equal.")
 
     # we've already verified everything is consistent; now, calculate
     # shared dimension sizes so we can expand the necessary variables


### PR DESCRIPTION
Small change to avoid triggering several if-checks unnecessarily. 