### PR TITLE
FIX: reverse index output of bottleneck move_argmax/move_argmin functions

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,6 +38,9 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Reverse index output of bottleneck's rolling move_argmax/move_argmin functions (:issue:`8541`, :pull:`8552`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -596,6 +596,11 @@ class DataArrayRolling(Rolling["DataArray"]):
             values = func(
                 padded.data, window=self.window[0], min_count=min_count, axis=axis
             )
+            # index 0 is at the rightmost edge of the window
+            # need to reverse index here
+            # see GH #8541
+            if func in [bottleneck.move_argmin, bottleneck.move_argmax]:
+                values = self.window[0] - 1 - values
 
         if self.center[0]:
             values = values[valid]


### PR DESCRIPTION
- reverse index output of bottleneck move_argmax/move_argmin functions
- add move_argmax/move_argmin to bottleneck tests

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #8541
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
