### PR TITLE
Add xeofs to ecosystem.rst

### DIFF
--- a/doc/ecosystem.rst
+++ b/doc/ecosystem.rst
@@ -78,6 +78,7 @@ Extend xarray capabilities
 - `xarray-dataclasses <https://github.com/astropenguin/xarray-dataclasses>`_: xarray extension for typed DataArray and Dataset creation.
 - `xarray_einstats <https://xarray-einstats.readthedocs.io>`_: Statistics, linear algebra and einops for xarray
 - `xarray_extras <https://github.com/crusaderky/xarray_extras>`_: Advanced algorithms for xarray objects (e.g. integrations/interpolations).
+- `xeofs <https://github.com/nicrie/xeofs>`_: PCA/EOF analysis and related techniques, integrated with xarray and Dask for efficient handling of large-scale data.
 - `xpublish <https://xpublish.readthedocs.io/>`_: Publish Xarray Datasets via a Zarr compatible REST API.
 - `xrft <https://github.com/rabernat/xrft>`_: Fourier transforms for xarray data.
 - `xr-scipy <https://xr-scipy.readthedocs.io>`_: A lightweight scipy wrapper for xarray.


### PR DESCRIPTION
Suggestion to include [xeofs](https://github.com/nicrie/xeofs) in the xarray ecosystem documentation.

xeofs enables fully multidimensional PCA / EOF analysis and related techniques with large datasets, thanks to the integration of xarray and dask.

References:
- [Github repository](https://github.com/nicrie/xeofs)
- [Documentation](https://xeofs.readthedocs.io/en/latest/)
- [JOSS review](https://github.com/openjournals/joss-reviews/issues/6060)
