### PR TITLE
Interpolate na: Fix #7665 and introduce arguments similar to pandas

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -96,6 +96,8 @@ if TYPE_CHECKING:
         ErrorOptions,
         ErrorOptionsWithWarn,
         InterpOptions,
+        LimitAreaOptions,
+        LimitDirectionOptions,
         PadModeOptions,
         PadReflectOptions,
         QuantileMethods,
@@ -3452,10 +3454,21 @@ class DataArray(
 
     def interpolate_na(
         self,
-        dim: Hashable | None = None,
+        dim: Hashable,
         method: InterpOptions = "linear",
-        limit: int | None = None,
-        use_coordinate: bool | str = True,
+        use_coordinate: bool | Hashable = True,
+        limit: (
+            None
+            | int
+            | float
+            | str
+            | pd.Timedelta
+            | np.timedelta64
+            | datetime.timedelta
+        ) = None,
+        limit_direction: LimitDirectionOptions = "forward",
+        limit_area: LimitAreaOptions | None = None,
+        limit_use_coordinate: bool | Hashable = False,
         max_gap: (
             None
             | int
@@ -3472,7 +3485,7 @@ class DataArray(
 
         Parameters
         ----------
-        dim : Hashable or None, optional
+        dim : Hashable
             Specifies the dimension along which to interpolate.
         method : {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "polynomial", \
             "barycentric", "krogh", "pchip", "spline", "akima"}, default: "linear"
@@ -3487,17 +3500,54 @@ class DataArray(
             - 'barycentric', 'krogh', 'pchip', 'spline', 'akima': use their
               respective :py:class:`scipy.interpolate` classes.
 
-        use_coordinate : bool or str, default: True
+        use_coordinate : bool or Hashable, default: True
             Specifies which index to use as the x values in the interpolation
-            formulated as `y = f(x)`. If False, values are treated as if
-            equally-spaced along ``dim``. If True, the IndexVariable `dim` is
-            used. If ``use_coordinate`` is a string, it specifies the name of a
-            coordinate variable to use as the index.
-        limit : int or None, default: None
-            Maximum number of consecutive NaNs to fill. Must be greater than 0
-            or None for no limit. This filling is done regardless of the size of
-            the gap in the data. To only interpolate over gaps less than a given length,
+            formulated as `y = f(x)`.
+
+            - False: a consecutive integer index is created along ``dim`` (0, 1, 2, ...).
+            - True: the IndexVariable `dim` is used.
+            - String: specifies the name of a coordinate variable to use as the index.
+
+        limit : int, float, str, pandas.Timedelta, numpy.timedelta64, datetime.timedelta, default: None
+            Maximum number or distance of consecutive NaNs to fill.
+            Use None for no limit. When interpolating along a datetime64 dimension
+            and ``limit_use_coordinate=True``, ``limit`` can be one of the following:
+
+            - a string that is valid input for pandas.to_timedelta
+            - a :py:class:`numpy.timedelta64` object
+            - a :py:class:`pandas.Timedelta` object
+            - a :py:class:`datetime.timedelta` object
+
+            Otherwise, ``limit`` must be an int or a float.
+            If ``limit_use_coordinates=True``, for ``limit_direction=forward`` distance is defined
+            as the difference between the coordinate at a NaN value and the coordinate of the next valid value
+            to the left (right for ``limit_direction=backward``).
+            For example, consider::
+
+                <xarray.DataArray (x: 9)>
+                array([nan, nan, nan,  1., nan, nan,  4., nan, nan])
+                Coordinates:
+                  * x        (x) int64 0 1 2 3 4 5 6 7 8
+
+            For ``limit_direction=forward``, distances are ``[nan, nan, nan, 0, 1, 2, 0, 1, 2]``.
+            To only interpolate over gaps less than a given length,
             see ``max_gap``.
+        limit_direction: {"forward", "backward", "both"}, default: "forward"
+            Consecutive NaNs will be filled in this direction.
+        limit_area: {"inside", "outside"} or None: default: None
+            Consecutive NaNs will be filled with this restriction.
+
+            - None: No fill restriction.
+            - "inside": Only fill NaNs surrounded by valid values (interpolate).
+            - "outside": Only fill NaNs outside valid values (extrapolate).
+
+        limit_use_coordinate : bool or Hashable, default: True
+            Specifies which index to use for the ``limit`` distance.
+
+            - False: a consecutive integer index is created along ``dim`` (0, 1, 2, ...).
+            - True: the IndexVariable `dim` is used.
+            - String: specifies the name of a coordinate variable to use as the index.
+
         max_gap : int, float, str, pandas.Timedelta, numpy.timedelta64, datetime.timedelta, default: None
             Maximum size of gap, a continuous sequence of NaNs, that will be filled.
             Use None for no limit. When interpolating along a datetime64 dimension
@@ -3508,8 +3558,8 @@ class DataArray(
             - a :py:class:`pandas.Timedelta` object
             - a :py:class:`datetime.timedelta` object
 
-            Otherwise, ``max_gap`` must be an int or a float. Use of ``max_gap`` with unlabeled
-            dimensions has not been implemented yet. Gap length is defined as the difference
+            Otherwise, ``max_gap`` must be an int or a float. If ``use_coordinate=False``, a linear integer
+            index is created. Gap length is defined as the difference
             between coordinate values at the first data point after a gap and the last value
             before a gap. For gaps at the beginning (end), gap length is defined as the difference
             between coordinate values at the first (last) valid data point and the first (last) NaN.
@@ -3533,33 +3583,62 @@ class DataArray(
         interpolated: DataArray
             Filled in DataArray.
 
+        Warning
+        --------
+        When passing fill_value as a keyword argument with method="linear", it does not use
+        ``numpy.interp`` but it uses ``scipy.interpolate.interp1d``, which provides the fill_value parameter.
+
         See Also
         --------
         numpy.interp
         scipy.interpolate
+        pandas.DataFrame.interpolate
+
+        Notes
+        -----
+        ``Limit`` and ``max_gap`` have different effects on gaps: If ``limit`` is set, *some* values in a gap will be filled (up to the given distance from the boundaries). ``max_gap`` will prevent *any* filling for gaps larger than the given distance.
 
         Examples
         --------
         >>> da = xr.DataArray(
-        ...     [np.nan, 2, 3, np.nan, 0], dims="x", coords={"x": [0, 1, 2, 3, 4]}
+        ...     [np.nan, 2, np.nan, np.nan, 5, np.nan, 0],
+        ...     dims="x",
+        ...     coords={"x": [0, 1, 2, 3, 4, 5, 6]},
         ... )
         >>> da
-        <xarray.DataArray (x: 5)> Size: 40B
-        array([nan,  2.,  3., nan,  0.])
+        <xarray.DataArray (x: 7)>
+        array([nan,  2., nan, nan,  5., nan,  0.])
         Coordinates:
-          * x        (x) int64 40B 0 1 2 3 4
-
+        * x        (x) int64 0 1 2 3 4 5 6
         >>> da.interpolate_na(dim="x", method="linear")
-        <xarray.DataArray (x: 5)> Size: 40B
-        array([nan, 2. , 3. , 1.5, 0. ])
+        <xarray.DataArray (x: 7)>
+        array([nan, 2. , 3. , 4. , 5. , 2.5, 0. ])
         Coordinates:
-          * x        (x) int64 40B 0 1 2 3 4
-
-        >>> da.interpolate_na(dim="x", method="linear", fill_value="extrapolate")
-        <xarray.DataArray (x: 5)> Size: 40B
-        array([1. , 2. , 3. , 1.5, 0. ])
+        * x        (x) int64 0 1 2 3 4 5 6
+        >>> da.interpolate_na(
+        ...     dim="x",
+        ...     method="linear",
+        ...     limit_direction="both",
+        ...     fill_value="extrapolate",
+        ... )
+        <xarray.DataArray (x: 7)>
+        array([1. , 2. , 3. , 4. , 5. , 2.5, 0. ])
         Coordinates:
-          * x        (x) int64 40B 0 1 2 3 4
+        * x        (x) int64 0 1 2 3 4 5 6
+        >>> da.interpolate_na(
+        ...     dim="x", method="linear", limit=1, limit_direction="forward"
+        ... )
+        <xarray.DataArray (x: 7)>
+        array([nan, 2. , 3. , nan, 5. , 2.5, 0. ])
+        Coordinates:
+        * x        (x) int64 0 1 2 3 4 5 6
+        >>> da.interpolate_na(
+        ...     dim="x", method="linear", max_gap=2, limit_direction="forward"
+        ... )
+        <xarray.DataArray (x: 7)>
+        array([nan, 2. , nan, nan, 5. , 2.5, 0. ])
+        Coordinates:
+        * x        (x) int64 0 1 2 3 4 5 6
         """
         from xarray.core.missing import interp_na
 
@@ -3567,8 +3646,11 @@ class DataArray(
             self,
             dim=dim,
             method=method,
-            limit=limit,
             use_coordinate=use_coordinate,
+            limit=limit,
+            limit_direction=limit_direction,
+            limit_area=limit_area,
+            limit_use_coordinate=limit_use_coordinate,
             max_gap=max_gap,
             keep_attrs=keep_attrs,
             **kwargs,

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3541,7 +3541,7 @@ class DataArray(
             - "inside": Only fill NaNs surrounded by valid values (interpolate).
             - "outside": Only fill NaNs outside valid values (extrapolate).
 
-        limit_use_coordinate : bool or Hashable, default: True
+        limit_use_coordinate : bool or Hashable, default: False
             Specifies which index to use for the ``limit`` distance.
 
             - False: a consecutive integer index is created along ``dim`` (0, 1, 2, ...).

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6620,7 +6620,7 @@ class Dataset(
             - "inside": Only fill NaNs surrounded by valid values (interpolate).
             - "outside": Only fill NaNs outside valid values (extrapolate).
 
-        limit_use_coordinate : bool or Hashable, default: True
+        limit_use_coordinate : bool or Hashable, default: False
             Specifies which index to use for the ``limit`` distance.
 
             - False: a consecutive integer index is created along ``dim`` (0, 1, 2, ...).

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -475,17 +475,14 @@ def interp_na(
     dim: Hashable | None = None,
     method: InterpOptions = "linear",
     use_coordinate: bool | str = True,
-    limit: int
-    | float
-    | str
-    | pd.Timedelta
-    | np.timedelta64
-    | dt.timedelta
-    | None = None,
+    limit: (
+        int | float | str | pd.Timedelta | np.timedelta64 | dt.timedelta | None
+    ) = None,
     limit_direction: LimitDirectionOptions = "forward",
     limit_area: LimitAreaOptions | None = None,
-    limit_use_coordinate: bool
-    | str = False,  # backward compatibility + pandas (2.1.4) compatibility
+    limit_use_coordinate: (
+        bool | str
+    ) = False,  # backward compatibility + pandas (2.1.4) compatibility
     max_gap: int | float | str | pd.Timedelta | np.timedelta64 | dt.timedelta = None,
     keep_attrs: bool | None = None,
     **kwargs,

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, get_args
 import numpy as np
 import pandas as pd
 
-from xarray.core.common import _contains_datetime_like_objects, ones_like
+from xarray.core.common import _contains_datetime_like_objects
 from xarray.core.computation import apply_ufunc
 from xarray.core.duck_array_ops import (
     datetime_to_numeric,
@@ -38,8 +38,7 @@ if TYPE_CHECKING:
 def _get_gap_left_edge(
     obj: Dataset | DataArray | Variable, dim: Hashable, index: Variable, outside=False
 ):
-    arange = ones_like(obj) * index
-    left = arange.where(~obj.isnull()).ffill(dim)
+    left = index.where(~obj.isnull()).ffill(dim).transpose(*obj.dims)
     if outside:
         return left.fillna(index[0])
     return left
@@ -48,8 +47,7 @@ def _get_gap_left_edge(
 def _get_gap_right_edge(
     obj: Dataset | DataArray | Variable, dim: Hashable, index: Variable, outside=False
 ):
-    arange = ones_like(obj) * index
-    right = arange.where(~obj.isnull()).bfill(dim)
+    right = index.where(~obj.isnull()).bfill(dim).transpose(*obj.dims)
     if outside:
         return right.fillna(index[-1])
     return right
@@ -58,15 +56,13 @@ def _get_gap_right_edge(
 def _get_gap_dist_to_left_edge(
     obj: Dataset | DataArray | Variable, dim: Hashable, index: Variable
 ):
-    arange = ones_like(obj) * index
-    return arange - _get_gap_left_edge(obj, dim, index)
+    return (index - _get_gap_left_edge(obj, dim, index)).transpose(*obj.dims)
 
 
 def _get_gap_dist_to_right_edge(
     obj: Dataset | DataArray | Variable, dim: Hashable, index: Variable
 ):
-    arange = ones_like(obj) * index
-    return _get_gap_right_edge(obj, dim, index) - arange
+    return (_get_gap_right_edge(obj, dim, index) - index).transpose(*obj.dims)
 
 
 def _get_limit_fill_mask(
@@ -174,22 +170,32 @@ def _get_gap_masks(
                 raise TypeError(
                     f"Expected integer or floating point max_gap since use_coordinate=False. Received {type(max_gap).__name__}."
                 )
+    # Which masks are really needed?
+    need_limit_mask = limit != np.inf or limit_direction != "both"
+    need_area_mask = limit_area is not None
+    need_max_gap_mask = max_gap is not None
     # Calculate indexes
-    index_limit = get_clean_interp_index(obj, dim, use_coordinate=limit_use_coordinate)
-    index_max_gap = get_clean_interp_index(
-        obj, dim, use_coordinate=max_gap_use_coordinate
-    )
+    if need_limit_mask or need_area_mask:
+        index_limit = get_clean_interp_index(
+            obj, dim, use_coordinate=limit_use_coordinate
+        )
+        # index_limit = ones_like(obj) * index_limit
+    if need_max_gap_mask:
+        index_max_gap = get_clean_interp_index(
+            obj, dim, use_coordinate=max_gap_use_coordinate
+        )
+        # index_max_gap = ones_like(obj) * index_max_gap
     # Calculate fill masks
     limit_mask = None
-    if limit != np.inf or limit_direction != "both":
+    if need_limit_mask:
         limit_mask = _get_limit_fill_mask(obj, dim, index_limit, limit, limit_direction)
 
     limit_area_mask = None
-    if limit_area is not None:
+    if need_area_mask:
         limit_area_mask = _get_limit_area_mask(obj, dim, index_limit, limit_area)
 
     max_gap_mask = None
-    if max_gap is not None:
+    if need_max_gap_mask:
         max_gap_mask = _get_max_gap_mask(obj, dim, index_max_gap, max_gap)
     return limit_mask, limit_area_mask, max_gap_mask
 

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -208,6 +208,8 @@ Interp1dOptions = Literal[
 ]
 InterpolantOptions = Literal["barycentric", "krogh", "pchip", "spline", "akima"]
 InterpOptions = Union[Interp1dOptions, InterpolantOptions]
+LimitDirectionOptions = Literal["forward", "backward", "both"]
+LimitAreaOptions = Literal["inside", "outside"]
 
 DatetimeUnitOptions = Literal[
     "Y", "M", "W", "D", "h", "m", "s", "ms", "us", "μs", "ns", "ps", "fs", "as", None

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -769,7 +769,7 @@ def test_get_gap_dist_to_right_edge():
         ],
     ],
 )
-def test_interpolate_na_nan_block_lengths(y, lengths_expected):
+def test_get_nan_block_lengths(y, lengths_expected):
     arr = [
         [np.nan, 1, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 4],
         [np.nan, np.nan, np.nan, 1, np.nan, np.nan, 4, np.nan, np.nan],
@@ -779,6 +779,42 @@ def test_interpolate_na_nan_block_lengths(y, lengths_expected):
     actual = _get_nan_block_lengths(da, dim="y", index=index)
     expected = da.copy(data=lengths_expected)
     assert_equal(actual, expected)
+
+
+def test_get_nan_block_lengths_2d():
+    n = np.nan
+    da = xr.DataArray(
+        [
+            [1, 2, 3, 4, n, 6, n, n, n, 10, 11, n],
+            [n, n, 3, n, n, 6, n, n, n, 10, n, n],
+            [n, n, 3, n, n, 6, n, n, n, 10, n, n],
+            [n, 2, 3, 4, n, 6, n, n, n, 10, 11, n],
+        ],
+        dims=["x", "y"],
+        coords={"x": np.arange(4), "y": np.arange(12) ** 2},
+    )
+    index = get_clean_interp_index(da, dim="y", use_coordinate=False)
+    actual = _get_nan_block_lengths(da, dim="y", index=index)
+    expected_y = da.copy(
+        data=[
+            [0, 0, 0, 0, 2, 0, 4, 4, 4, 0, 0, 1],
+            [2, 2, 0, 3, 3, 0, 4, 4, 4, 0, 2, 2],
+            [2, 2, 0, 3, 3, 0, 4, 4, 4, 0, 2, 2],
+            [1, 0, 0, 0, 2, 0, 4, 4, 4, 0, 0, 1],
+        ]
+    )
+    assert_equal(actual, expected_y)
+    index = get_clean_interp_index(da, dim="y", use_coordinate=True)
+    actual = _get_nan_block_lengths(da, dim="y", index=index)
+    expected_y = da.copy(
+        data=[
+            [0, 0, 0, 0, 16, 0, 56, 56, 56, 0, 0, 21],
+            [4, 4, 0, 21, 21, 0, 56, 56, 56, 0, 40, 40],
+            [4, 4, 0, 21, 21, 0, 56, 56, 56, 0, 40, 40],
+            [1, 0, 0, 0, 16, 0, 56, 56, 56, 0, 0, 21],
+        ]
+    )
+    assert_equal(actual, expected_y)
 
 
 def test_get_limit_fill_mask():


### PR DESCRIPTION
- [x] Closes #7665
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

This is an attempt to close #7665 and combine the current possibilities from xarray (max_gap) and pandas (limit_direction, limit_area) regarding interpolation of nan values. Please see also my comments in #7665 for the motivation.
This PR already involves a full implementation, documentation and corresponding tests, but before any final polishing, I want to hear your thoughts. Specifically, I think the API and default options need to be discussed. (See the proposed documentation of DataArray.interpolate_na() / Dataset.interpolate_na() for the current state)

Implementation: Basically, I use ffill and bfill to calculate the coordinate of the left/right edge for every gap in the data. Based on edge coordinates, all masks (limit, limit_area, max_gap) are created.

On the long term, it might be interesting to provide those arguments to other na-filling methods as well (ffill, bfill, fillna).

# Things to consider

## limit_direction=forward
Pros:
- Backward compatible: If limit is not None, this is the current behaviour (see #7665)
- Pandas compatible: Forward is the pandas default.

Cons:
- `limit_direction=both` feels more natural as default. If the user does `interpolate_na('x', fill_value='extrapolate')`, in my opinion they will expect all nans to be filled, including both boundaries. In contrast to pandas, this was the case in xarray before, but not anymore now if we follow pandas and set `limit_direction=forward`. `both` would also increase performance, since no restrictions need to be applied.


## limit_use_coordinates=False
Pros:
- Backward compatible
- Pandas compatible
-> Both xarray and pandas have no support for coordinate based limits so far.

Cons:
- Inconsistent with the current default of `use_coordinates=True`

Generally, one might discuss if this separate argument is necessary or only one argument `use_coordinates` is sufficient. Imo, if the grid is irregular and `use_coordinates=True`, there is not a lot of sense in specifying the limit as a fixed number of grid cells. Alternatively, we could allow a three-tuple like `use_coordinates=(True, True, False)` to specify the index for interpolation, limit and max_gap separately (or something similar).

## use_coordinates=True
So far, if there is no coordinate for `dim`, interpolation will succeed, falling silently back to a linearly increasing index. I feel, for `use_coordinate=True`, we should fail and inform the user to set use_coordinate=False if they really want a linear index. However, this is a breaking change.
Maybe we can keep this behaviour with `use_coordinate=None` as new default option (= True if coord existent, else linear).

## Performance
On my machine, the new limit implementation based on ffill/bfill seems to be a little less performant (10%) than the old one (based on rolling). There might be potential for improvements.
