### PR TITLE
Silence another warning in test_backends.py

### DIFF
--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -414,7 +414,7 @@ class CFScaleOffsetCoder(VariableCoder):
 class UnsignedIntegerCoder(VariableCoder):
     def encode(self, variable: Variable, name: T_Name = None) -> Variable:
         # from netCDF best practices
-        # https://www.unidata.ucar.edu/software/netcdf/docs/BestPractices.html
+        # https://docs.unidata.ucar.edu/nug/current/best_practices.html#bp_Unsigned-Data
         #     "_Unsigned = "true" to indicate that
         #      integer data should be treated as unsigned"
         if variable.encoding.get("_Unsigned", "false") == "true":

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -161,7 +161,7 @@ def create_encoded_masked_and_scaled_data() -> Dataset:
 
 def create_unsigned_masked_scaled_data() -> Dataset:
     encoding = {
-        "_FillValue": 255,
+        "_FillValue": -1,
         "_Unsigned": "true",
         "dtype": "i1",
         "add_offset": 10,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -161,7 +161,7 @@ def create_encoded_masked_and_scaled_data() -> Dataset:
 
 def create_unsigned_masked_scaled_data() -> Dataset:
     encoding = {
-        "_FillValue": -1,
+        "_FillValue": 255,
         "_Unsigned": "true",
         "dtype": "i1",
         "add_offset": 10,

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -52,10 +52,9 @@ def test_decode_cf_with_conflicting_fill_missing_value() -> None:
     var = Variable(
         ["t"], np.arange(3), {"units": "foobar", "missing_value": 0, "_FillValue": 1}
     )
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(SerializationWarning, match="has multiple fill"):
         actual = conventions.decode_cf_variable("t", var)
         assert_identical(actual, expected)
-        assert "has multiple fill" in str(w[0].message)
 
     expected = Variable(["t"], np.arange(10), {"units": "foobar"})
 
@@ -293,10 +292,9 @@ class TestDecodeCF:
     def test_decode_cf_with_multiple_missing_values(self) -> None:
         original = Variable(["t"], [0, 1, 2], {"missing_value": np.array([0, 1])})
         expected = Variable(["t"], [np.nan, np.nan, 2], {})
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.warns(SerializationWarning, match="has multiple fill"):
             actual = conventions.decode_cf_variable("t", original)
             assert_identical(expected, actual)
-            assert "has multiple fill" in str(w[0].message)
 
     def test_decode_cf_with_drop_variables(self) -> None:
         original = Dataset(
@@ -387,7 +385,6 @@ class TestDecodeCF:
             }
         ).chunk()
         decoded = conventions.decode_cf(original)
-        print(decoded)
         assert all(
             isinstance(var.data, da.Array)
             for name, var in decoded.variables.items()


### PR DESCRIPTION
Using 255 as fillvalue for int8 arrays will not be allowed any more. Previously this overflowed to -1. Now specify that instead.

On numpy 1.24.4
```
>>> np.array([255], dtype="i1")
    DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of 255 to int8 will fail in the future.

array([-1], dtype=int8)
```
