### PR TITLE
Convert 360 calendar, choosing random dates to drop or add

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,6 +30,8 @@ New Features
   See `netCDF4 documentation <https://unidata.github.io/netcdf4-python/#efficient-compression-of-netcdf-variables>`_ for details.
   By `Markel García-Díez <https://github.com/markelg>`_. (:issue:`6929`, :pull:`7551`) Note that some
   new compression filters needs plugins to be installed which may not be available in all netCDF distributions.
+- New "random" method for converting to and from 360_day calendars.
+  By `Pascal Bourgault <https://github.com/aulemahal>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/tests/test_calendar_ops.py
+++ b/xarray/tests/test_calendar_ops.py
@@ -108,6 +108,42 @@ def test_convert_calendar_360_days(source, target, freq, align_on):
         assert conv.size == 359 if freq == "D" else 359 * 4
 
 
+def test_convert_calendar_360_days_random():
+    da_std = DataArray(
+        np.linspace(0, 1, 366 * 2),
+        dims=("time",),
+        coords={
+            "time": date_range(
+                "2004-01-01", "2004-12-31T23:59:59", freq="12H", calendar="standard", use_cftime=False
+            )
+        },
+    )
+    da_360 = DataArray(
+        np.linspace(0, 1, 360 * 2),
+        dims=("time",),
+        coords={
+            "time": date_range(
+                "2004-01-01", "2004-12-30T23:59:59", freq="12H", calendar="360_day"
+            )
+        },
+    )
+
+    conv = convert_calendar(da_std, "360_day", align_on="random")
+    conv2 = convert_calendar(da_std, "360_day", align_on="random")
+    assert (conv != conv2).any()
+
+    conv = convert_calendar(da_360, "standard", use_cftime=False, align_on="random")
+    assert np.datetime64("2004-02-29") not in conv.time
+    conv2 = convert_calendar(da_360, "standard", use_cftime=False, align_on="random")
+    assert (conv2 != conv).any()
+
+    # Ensure that added days are evenly distributed in the 5 fifths of each year
+    conv = convert_calendar(da_360, "noleap", align_on="random", missing=np.NaN)
+    conv = conv.where(conv.isnull(), drop=True)
+    nandoys = conv.time.dt.dayofyear[::2]
+    assert all(nandoys < np.array([74, 147, 220, 293, 366]))
+    assert all(nandoys > np.array([0, 73, 146, 219, 292]))
+
 @requires_cftime
 @pytest.mark.parametrize(
     "source,target,freq",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Small PR to add a new "method" to convert to and from 360_day calendars. The current two methods (chosen with the `align_on` keyword) will always remove or add the same day-of-year for all years of the same length. 

This new option will randomly chose the days, one for each fifth of the year (72-days period). It emulates the method of the LOCA datasets (see [web page](https://loca.ucsd.edu/loca-calendar/) and [article](https://journals.ametsoc.org/view/journals/hydr/15/6/jhm-d-14-0082_1.xml) ). February 29th is always removed/added when the source/target is a leap year.

I copied the implementation from xclim (which I wrote), [see code here](https://github.com/Ouranosinc/xclim/blob/fb29b8a8e400c7d8aaf4e1233a6b37a300126257/xclim/core/calendar.py#L112-L134) .
