### PR TITLE
ADD: objects can override is_dict_like()

### DIFF
--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -246,7 +246,14 @@ def remove_incompatible_items(
 
 # It's probably OK to give this as a TypeGuard; though it's not perfectly robust.
 def is_dict_like(value: Any) -> TypeGuard[Mapping]:
-    return hasattr(value, "keys") and hasattr(value, "__getitem__")
+    """Return whether to treat value like it is a dictionary.
+    Usually, just tests whether value has 'keys' and '__getitem__' attributes.
+    However, if value._xarray_dict_like_ exists, return that instead.
+    """
+    try:
+        return value._xarray_dict_like_
+    except AttributeError:
+        return hasattr(value, "keys") and hasattr(value, "__getitem__")
 
 
 def is_full_slice(value: Any) -> bool:


### PR DESCRIPTION
By setting `obj._xarray_dict_like_`, any object `obj` can now tell xarray to treat it like it is (or is not) a dict. Note: objects without the `_xarray_dict_like_` attribute will be unaffected; this change is fully backwards-compatible.

There are no relevant issue reports, tests added, user visible changes, or new functions / methods.

This is my first contribution to xarray, I tried my best to follow the contribution guidelines; please let me know if I am missing anything essential!


### Motivation
I have been using xarray in my personal project pretty successfully (xarray is a great package, and I am very grateful for it)! However, I sometimes use dict-like objects as coordinates. xarray seems to be okay with this most of the time, but fails when it comes to things like the `DataArray.sel` method. I would really like to be able to use `sel`, since my dict-like objects are only dict-like for reasons completely unrelated to xarray.

For example, I built a PlasmaFluid class which stores information about different fluids. And, I use instances of that class as coordinates for my DataArray. E.g.:
```python
import xarray as xr
import mypackage
f0 = mypackage.PlasmaFluid(0, 'e-', q=-1, density=1e10)     # fluid composed of electrons
f1 = mypackage.PlasmaFluid(1, 'H neutral', q=0, density=1e14)     # fluid composed of neutral hydrogen
f2 = mypackage.PlasmaFluid(2, 'p', q=1, density=1e10)     # fluid composed of protons
# fluids can have many parameters, including charge, mass, density, and more.
#   so, each PlasmaFluid object has a .keys() method which tells the parameters,
#   and a __getitem__ method to get the values. E.g.:
f0['q']     # -1
f0['density']     # 1e10
# xarray seems happy enough to allow PlasmaFluid objects to be used as coordinates, e.g.:
u_x = xr.DataArray([2, 7, 3], coords=dict(fluid=[f0, f1, f2]))
density = xr.DataArray([f0['density'], f1['density'], f2['density']], coords=dict(fluid=[f0, f1, f2]))
momentum_density_x = density * u_x   # == xr.DataArray([2e10, 7e14, 3e10], coords=dict(fluid=[f0, f1, f2]))
```
This code works just fine, and produces a nicely-labeled DataArray, where the `fluid` dimension contains the actual `PlasmaFluid` objects, e.g. `u_x.isel(fluid=0) is f0`.

However, it fails when I try to use the `sel` method, e.g.:
```python
u_x.sel(fluid=f1)
# --> ValueError: cannot use a dict-like object for selection on a dimension that does not have a MultiIndex
```

After implementing the change in this PR, I am able to avoid this issue, and can use the `sel` method by updating the class I wrote to include `PlasmaFluid._xarray_dict_like_ = False`.