### PR TITLE
Fix building doc following depreciation in Pandas 2.2.0

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -7225,6 +7225,7 @@ Breaking changes
   such `'DJF'`:
 
   .. ipython:: python
+      :okwarning:
 
       ds = xray.Dataset({"t": pd.date_range("2000-01-01", periods=12, freq="M")})
       ds["t.season"]


### PR DESCRIPTION
Fixes
`./doc`
`make html` 

Following Pandas 2.2.0 release, pd.date_range [freq arguments](https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#deprecate-aliases-m-q-y-etc-in-favour-of-me-qe-ye-etc-for-offsets) were depreciated.

Question why old releases in doc/whats-new.rst are compiled and not static to avoid breaking changes for old releases.


Error from building doc:
```
WARNING:
>>>-------------------------------------------------------------------------
Warning in /Users/sam/Documents/GitHub/xarray/doc/whats-new.rst at block ending on line 7231
Specify :okwarning: as an option in the ipython:: block to suppress this message
----------------------------------------------------------------------------
<ipython-input-92-be0529fe0129>:1: FutureWarning: 'M' is deprecated and will be removed in a future version, please use 'ME' instead.
  ds = xray.Dataset({"t": pd.date_range("2000-01-01", periods=12, freq="M")})
<<<-------------------------------------------------------------------------

Exception occurred:
  File "/Users/sam/miniconda3/envs/xarray-docs/lib/python3.10/site-packages/IPython/sphinxext/ipython_directive.py", line 602, in process_input
    raise RuntimeError(
RuntimeError: Unexpected warning in `/Users/sam/Documents/GitHub/xarray/doc/whats-new.rst` line 7231
```