### PR TITLE
xfail another dask/pyarrow test

### DIFF
--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -1248,7 +1248,12 @@ def find_stack_level(test_mode=False) -> int:
     pkg_dir = Path(xr.__file__).parent
     test_dir = pkg_dir / "tests"
 
-    std_lib_dir = Path(sys.modules["os"].__file__).parent  # Standard library path
+    std_lib_path = sys.modules["os"].__file__
+    # Mostly to appease mypy; I don't think this can happen...
+    if std_lib_path is None:
+        return 0
+
+    std_lib_dir = Path(std_lib_path).parent  # Standard library path
 
     frame = inspect.currentframe()
     n = 0

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -1248,12 +1248,12 @@ def find_stack_level(test_mode=False) -> int:
     pkg_dir = Path(xr.__file__).parent
     test_dir = pkg_dir / "tests"
 
-    std_lib_path = sys.modules["os"].__file__
+    std_lib_init = sys.modules["os"].__file__
     # Mostly to appease mypy; I don't think this can happen...
-    if std_lib_path is None:
+    if std_lib_init is None:
         return 0
 
-    std_lib_dir = Path(std_lib_path).parent  # Standard library path
+    std_lib_dir = Path(std_lib_init).parent
 
     frame = inspect.currentframe()
     n = 0

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -867,6 +867,10 @@ class TestToDaskDataFrame:
         assert isinstance(actual, dd.DataFrame)
         assert_frame_equal(expected.compute(), actual.compute())
 
+    @pytest.mark.xfail(
+        reason="Currently pandas with pyarrow installed will return a `string[pyarrow]` type, "
+        "which causes the index to have a different type depending on whether pyarrow is installed"
+    )
     def test_to_dask_dataframe_not_daskarray(self):
         # Test if DataArray is not a dask array
         x = np.random.randn(10)


### PR DESCRIPTION
Unsure why this wasn't showing prior -- having tests fail in the good state does make it much more difficult to ensure everything is fixed before merging.
