### PR TITLE
infer_freq: return 'YE' (#8629 follow-up)

### DIFF
--- a/xarray/coding/frequencies.py
+++ b/xarray/coding/frequencies.py
@@ -183,7 +183,7 @@ class _CFTimeFrequencyInferer:  # (pd.tseries.frequencies._FrequencyInferer):
         if len(np.unique(self.index.month)) > 1:
             return None
 
-        return {"cs": "YS", "ce": "Y"}.get(month_anchor_check(self.index))
+        return {"cs": "YS", "ce": "YE"}.get(month_anchor_check(self.index))
 
     def _get_quartely_rule(self):
         if len(self.month_deltas) > 1:

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -1353,7 +1353,7 @@ def test_infer_freq_invalid_inputs():
     "freq",
     [
         "300YS-JAN",
-        "Y-DEC",
+        "YE-DEC",
         "YS-JUL",
         "2YS-FEB",
         "QE-NOV",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

I realized that the return value of `infer_freq` was not updated. #8627 will try to suppress all warnings in the test suite, so this is just the minimal PR.

Sorry for all the spam @spencerkclark 