### PR TITLE
ruff: use extend-exclude

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,8 +227,7 @@ reportMissingTypeStubs = false
 
 [tool.ruff]
 builtins = ["ellipsis"]
-exclude = [
-  ".eggs",
+extend-exclude = [
   "doc",
   "_typed_ops.pyi",
 ]


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

I think we should use `extend-exclude` instead of `exclude` for ruff. We can then also remove `".eggs"` as this is in the default.


From https://docs.astral.sh/ruff/settings/#exclude:

> Note that you'll typically want to use [extend-exclude](https://docs.astral.sh/ruff/settings/#extend-exclude) to modify the excluded paths.
> 
> Default value: [".bzr", ".direnv", ".eggs", ".git", ".git-rewrite", ".hg", ".mypy_cache", ".nox", ".pants.d", ".pytype", ".ruff_cache", ".svn", ".tox", ".venv", "__pypackages__", "_build", "buck-out", "build", "dist", "node_modules", "venv"]


(I really dislike how github formats toml files... What would be the correct syntax, then?)