### PR TITLE
CI: Pin scientific-python/upload-nightly-action to release sha

### DIFF
--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -38,7 +38,7 @@ jobs:
           fi
 
       - name: Upload wheel
-        uses: scientific-python/upload-nightly-action@main
+        uses: scientific-python/upload-nightly-action@6e9304f7a3a5501c6f98351537493ec898728299 # 0.3.0
         with:
           anaconda_nightly_upload_token: ${{ secrets.ANACONDA_NIGHTLY }}
           artifacts_path: dist


### PR DESCRIPTION
* For security best practices, use the action from known commit shas that correspond to tagged releases. These can be updated via dependabot.
   - Amends PR https://github.com/pydata/xarray/pull/7865

c.f. https://github.com/scientific-python/upload-nightly-action/pull/13 for additional context.

I'll suggest @martinfleis and @keewis for reviewers.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [N/A] Closes #xxxx
- [N/A] Tests added
- [N/A] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [N/A] New functions/methods are listed in `api.rst`
