### PR TITLE
Fix automatic broadcasting when wrapping array api class

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -37,6 +37,8 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Fix bug with broadcasting when wrapping array API-compliant classes. (:issue:`8665`, :pull:`8669`)
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1476,7 +1476,8 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
             tmp_shape = tuple(dims_map[d] for d in expanded_dims)
             expanded_data = duck_array_ops.broadcast_to(self.data, tmp_shape)
         else:
-            expanded_data = self.data[(None,) * (len(expanded_dims) - self.ndim)]
+            indexer = (None,) * (len(expanded_dims) - self.ndim) + (...,)
+            expanded_data = self.data[indexer]
 
         expanded_var = Variable(
             expanded_dims, expanded_data, self._attrs, self._encoding, fastpath=True

--- a/xarray/tests/test_array_api.py
+++ b/xarray/tests/test_array_api.py
@@ -77,6 +77,21 @@ def test_broadcast(arrays: tuple[xr.DataArray, xr.DataArray]) -> None:
         assert_equal(a, e)
 
 
+def test_broadcast_during_arithmetic(arrays: tuple[xr.DataArray, xr.DataArray]) -> None:
+    np_arr, xp_arr = arrays
+    np_arr2 = xr.DataArray(np.array([1.0, 2.0]), dims="x")
+    xp_arr2 = xr.DataArray(xp.asarray([1.0, 2.0]), dims="x")
+
+    expected = np_arr * np_arr2
+    actual = xp_arr * xp_arr2
+    assert isinstance(actual.data, Array)
+    assert_equal(actual, expected)
+
+    expected = np_arr2 * np_arr
+    actual = xp_arr2 * xp_arr
+    assert isinstance(actual.data, Array)
+    assert_equal(actual, expected)
+
 def test_concat(arrays: tuple[xr.DataArray, xr.DataArray]) -> None:
     np_arr, xp_arr = arrays
     expected = xr.concat((np_arr, np_arr), dim="x")

--- a/xarray/tests/test_array_api.py
+++ b/xarray/tests/test_array_api.py
@@ -92,6 +92,7 @@ def test_broadcast_during_arithmetic(arrays: tuple[xr.DataArray, xr.DataArray]) 
     assert isinstance(actual.data, Array)
     assert_equal(actual, expected)
 
+
 def test_concat(arrays: tuple[xr.DataArray, xr.DataArray]) -> None:
     np_arr, xp_arr = arrays
     expected = xr.concat((np_arr, np_arr), dim="x")


### PR DESCRIPTION
- [x] Closes #8665
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] ~~New functions/methods are listed in `api.rst`~~
