### PR TITLE
Fix `variables` arg typo in `Dataset.sortby()` docstring

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,7 +40,9 @@ Bug fixes
 
 Documentation
 ~~~~~~~~~~~~~
-
+- Fix `variables` arg typo in `Dataset.sortby()` docstring
+ (:issue:`8663`, :pull:`8670`)
+  By `Tom Vo <https://github.com/tomvothecoder>`_.  
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -42,7 +42,7 @@ Documentation
 ~~~~~~~~~~~~~
 - Fix `variables` arg typo in `Dataset.sortby()` docstring
  (:issue:`8663`, :pull:`8670`)
-  By `Tom Vo <https://github.com/tomvothecoder>`_.  
+  By `Tom Vo <https://github.com/tomvothecoder>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -41,7 +41,7 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 - Fix `variables` arg typo in `Dataset.sortby()` docstring
- (:issue:`8663`, :pull:`8670`)
+  (:issue:`8663`, :pull:`8670`)
   By `Tom Vo <https://github.com/tomvothecoder>`_.
 
 Internal Changes

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -7947,7 +7947,7 @@ class Dataset(
 
         Parameters
         ----------
-        kariables : Hashable, DataArray, sequence of Hashable or DataArray, or Callable
+        variables : Hashable, DataArray, sequence of Hashable or DataArray, or Callable
             1D DataArray objects or name(s) of 1D variable(s) in coords whose values are
             used to sort this array. If a callable, the callable is passed this object,
             and the result is used as the value for cond.


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

-  [x] Closes #8663 
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`