### PR TITLE
use ruff.flake8-tidy-imports to enforce absolute imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,12 +10,6 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: mixed-line-ending
-  - repo: https://github.com/MarcoGorelli/absolufy-imports
-    rev: v0.3.1
-    hooks:
-      - id: absolufy-imports
-        name: absolufy-imports
-        files: ^xarray/
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: 'v0.1.9'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,6 +242,9 @@ extend-exclude = [
   "doc",
   "_typed_ops.pyi",
 ]
+extend-safe-fixes = [
+  "TID252", # absolute imports
+]
 target-version = "py39"
 
 [tool.ruff.lint]
@@ -257,12 +260,17 @@ select = [
   "F", # Pyflakes
   "E", # Pycodestyle
   "W",
+  "TID", # flake8-tidy-imports (absolute imports)
   "I", # isort
   "UP", # Pyupgrade
 ]
 
 [tool.ruff.lint.isort]
 known-first-party = ["xarray"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+# Disallow all relative imports.
+ban-relative-imports = "all"
 
 [tool.pytest.ini_options]
 addopts = ["--strict-config", "--strict-markers"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,6 +247,10 @@ extend-safe-fixes = [
 ]
 target-version = "py39"
 
+[tool.ruff.per-file-ignores]
+# don't enforce absolute imports
+"asv_bench/**" = ["TID252"]
+
 [tool.ruff.lint]
 # E402: module level import not at top of file
 # E501: line too long - let black worry about that


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

use ruff.flake8-tidy-imports to enforce absolute imports

- https://github.com/MarcoGorelli/absolufy-imports has been archived (no reason given)
- removes a pre-commit hook which should make it faster locally
