### PR TITLE
Fix CI: temporary pin pytest version to 7.4.*

### DIFF
--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -27,7 +27,7 @@ dependencies:
   - pint>=0.22
   - pip
   - pydap
-  - pytest
+  - pytest==7.4.*
   - pytest-cov
   - pytest-env
   - pytest-xdist

--- a/ci/requirements/bare-minimum.yml
+++ b/ci/requirements/bare-minimum.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.9
   - coveralls
   - pip
-  - pytest
+  - pytest==7.4.*
   - pytest-cov
   - pytest-env
   - pytest-xdist

--- a/ci/requirements/environment-3.12.yml
+++ b/ci/requirements/environment-3.12.yml
@@ -33,7 +33,7 @@ dependencies:
   - pooch
   - pre-commit
   - pydap
-  - pytest
+  - pytest==7.4.*
   - pytest-cov
   - pytest-env
   - pytest-xdist

--- a/ci/requirements/environment-windows-3.12.yml
+++ b/ci/requirements/environment-windows-3.12.yml
@@ -28,7 +28,7 @@ dependencies:
   - pip
   - pre-commit
   - pydap
-  - pytest
+  - pytest==7.4.*
   - pytest-cov
   - pytest-env
   - pytest-xdist

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -28,7 +28,7 @@ dependencies:
   - pip
   - pre-commit
   - pydap
-  - pytest
+  - pytest==7.4.*
   - pytest-cov
   - pytest-env
   - pytest-xdist

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -34,7 +34,7 @@ dependencies:
   - pre-commit
   - pyarrow # pandas makes a deprecation warning without this, breaking doctests
   - pydap
-  - pytest
+  - pytest==7.4.*
   - pytest-cov
   - pytest-env
   - pytest-xdist

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -42,7 +42,7 @@ dependencies:
   - pint=0.22
   - pip
   - pydap=3.3
-  - pytest
+  - pytest==7.4.*
   - pytest-cov
   - pytest-env
   - pytest-xdist


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] towards fixing #8681
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
