### PR TITLE
Docs: Fix url in "Contribute to xarray" guide

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -153,7 +153,7 @@ Creating a development environment
 ----------------------------------
 
 To test out code changes locally, you'll need to build *xarray* from source, which requires you to
-`create a local development environment <https://docs.xarray.dev/en/stable/contributing.html#creating-a-development-environment>`_.
+`create a local development environment <https://docs.xarray.dev/en/stable/contributing.html#contributing-dev-env>`_.
 
 Update the ``main`` branch
 --------------------------


### PR DESCRIPTION
The URL in the section about [creating a local development environment](https://docs.xarray.dev/en/stable/contributing.html#creating-a-development-environment) was pointing to itself. The new URL is pointing to the (I assume) correct section further down in the same guide. 
