### PR TITLE
Fixes for pytest-8.0.0 compatibility

### DIFF
--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2724,8 +2724,7 @@ class TestDataset:
         assert_identical(data, actual)
 
         with pytest.raises(ValueError):
-            with pytest.warns(DeprecationWarning):
-                data.drop(["c"], dim="x", errors="wrong_value")  # type: ignore[arg-type]
+            data.drop(["c"], dim="x", errors="wrong_value")  # type: ignore[arg-type]
 
         with pytest.warns(DeprecationWarning):
             actual = data.drop(["a", "b", "c"], "x", errors="ignore")
@@ -3159,8 +3158,7 @@ class TestDataset:
                 original.rename({"a": "x"})
 
         with pytest.raises(ValueError, match=r"'b' conflicts"):
-            with pytest.warns(UserWarning, match="does not create an index anymore"):
-                original.rename({"a": "b"})
+            original.rename({"a": "b"})
 
     def test_rename_perserve_attrs_encoding(self) -> None:
         # test propagate attrs/encoding to new variable(s) created from Index object

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -67,6 +67,8 @@ def test_groupby_dims_property(dataset, recwarn) -> None:
     with pytest.warns(UserWarning, match="The `squeeze` kwarg"):
         assert dataset.groupby("x").dims == dataset.isel(x=1).dims
         assert dataset.groupby("y").dims == dataset.isel(y=1).dims
+    # in pytest-8, pytest.warns() no longer clears all warnings
+    recwarn.clear()
 
     # when squeeze=False, no warning should be raised
     assert tuple(dataset.groupby("x", squeeze=False).dims) == tuple(


### PR DESCRIPTION
Two fixes for compatibility with pytest 8.0.0:
1. Removed `pytest.warns()` inside `pytest.raises()` where no warnings are actually raised.
2. Cleared recorded warnings after `pytest.warns()` invocation where the function expected all warnings to be captured.

Explained in detail in commit messages.

- [x] Closes #8681
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
