### PR TITLE
docs: use the link shortener

### DIFF
--- a/doc/internals/extending-xarray.rst
+++ b/doc/internals/extending-xarray.rst
@@ -103,7 +103,7 @@ The intent here is that libraries that extend xarray could add such an accessor
 to implement subclass specific functionality rather than using actual subclasses
 or patching in a large number of domain specific methods. For further reading
 on ways to write new accessors and the philosophy behind the approach, see
-https://github.com/pydata/xarray/issues/1080`.
+https://github.com/pydata/xarray/issues/1080.
 
 To help users keep things straight, please `let us know
 <https://github.com/pydata/xarray/issues>`_ if you plan to write a new accessor

--- a/doc/internals/extending-xarray.rst
+++ b/doc/internals/extending-xarray.rst
@@ -103,7 +103,7 @@ The intent here is that libraries that extend xarray could add such an accessor
 to implement subclass specific functionality rather than using actual subclasses
 or patching in a large number of domain specific methods. For further reading
 on ways to write new accessors and the philosophy behind the approach, see
-:issue:`1080`.
+https://github.com/pydata/xarray/issues/1080`.
 
 To help users keep things straight, please `let us know
 <https://github.com/pydata/xarray/issues>`_ if you plan to write a new accessor


### PR DESCRIPTION
In the recent version of the pydata-sphinx-theme (that you use through the sphinx-book-theme) we implemented a link shortener that would (I think) be a good replacement for the custom `:issue:` role. I was passing by, I made a small adjustment so you can see the diff and if you don't like it, simply close my PR.

https://xray--8700.org.readthedocs.build/en/8700/internals/extending-xarray.html
