### PR TITLE
Only use CopyOnWriteArray wrapper on BackendArrays

### DIFF
--- a/doc/internals/how-to-add-new-backend.rst
+++ b/doc/internals/how-to-add-new-backend.rst
@@ -421,6 +421,9 @@ That implies that all the reference to open files should be dropped. For
 opening files, we therefore suggest to use the helper class provided by Xarray
 :py:class:`~xarray.backends.CachingFileManager`.
 
+Note that any ``BackendArray`` subclass will also be protected such that any attempt 
+to write to this array only writes to a copy of whatever might still be stored on disk.
+
 .. _RST indexing:
 
 Indexing examples

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -236,9 +236,16 @@ def _protect_dataset_variables_inplace(dataset, cache):
     for name, variable in dataset.variables.items():
         if name not in dataset._indexes:
             # no need to protect IndexVariable objects
-            data = indexing.CopyOnWriteArray(variable._data)
+
+            if isinstance(variable._data, backends.BackendArray):
+                # only need to protect arrays that were lazy-loaded from disk
+                data = indexing.CopyOnWriteArray(variable._data)
+            else:
+                data = variable.data
+
             if cache:
                 data = indexing.MemoryCachedArray(data)
+
             variable.data = data
 
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -652,6 +652,13 @@ def _wrap_numpy_scalars(array):
 
 
 class CopyOnWriteArray(ExplicitlyIndexedNDArrayMixin):
+    """
+    Ensures that an attempt to write to this array only writes to a copy
+    of whatever might still be stored on disk.
+
+    Used to wrap any array that inherits from BackendArray.
+    """
+
     __slots__ = ("array", "_copied")
 
     def __init__(self, array):


### PR DESCRIPTION
This makes sure we only use the `CopyOnWriteArray` wrapper on arrays that have been explicitly marked to be lazily-loaded (through being subclasses of `BackendArray`. Without this change we are implicitly assuming that any array type obtained through the BackendEntrypoint system should be treated as if it points to an on-disk array.

Motivated by https://github.com/pydata/xarray/issues/8699, which is a counterexample to that assumption. 

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
