### PR TITLE
Add lru_cache to module_available

### DIFF
--- a/xarray/namedarray/utils.py
+++ b/xarray/namedarray/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import warnings
 from collections.abc import Hashable, Iterable, Iterator, Mapping
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import numpy as np
@@ -32,6 +33,7 @@ V = TypeVar("V")
 T = TypeVar("T")
 
 
+@lru_cache
 def module_available(module: str) -> bool:
     """Checks whether a module is installed without importing it.
 


### PR DESCRIPTION
Our application creates many small netcdf3 files: https://github.com/equinor/ert/blob/9c2b60099a54eeb5bb40013acef721e30558a86c/src/ert/storage/local_ensemble.py#L593 .

A significant time in xarray.backends.common.py:AbstractWriteableDataStore.set_variables is spent on common.py:is_dask_collection as it checks for the presence of the module dask which takes about 0.3 ms.

This time becomes significant in the case of many small files. This PR uses lru_cache to avoid rechecking for the presence of dask as it should not change for the lifetime of the application.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
