### PR TITLE
Test formatting platform

### DIFF
--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -71,8 +71,6 @@ pytestmark = [
     pytest.mark.filterwarnings("error:All-NaN (slice|axis) encountered"),
 ]
 
-ON_WINDOWS = sys.platform == "win32"
-
 
 class TestDataArray:
     @pytest.fixture(autouse=True)
@@ -87,61 +85,34 @@ class TestDataArray:
         self.mindex = pd.MultiIndex.from_product(
             [["a", "b"], [1, 2]], names=("level_1", "level_2")
         )
-        self.mda = DataArray([0, 1, 2, 3], coords={"x": self.mindex}, dims="x")
+        self.mda = DataArray([0, 1, 2, 3], coords={"x": self.mindex}, dims="x").astype(
+            np.uint64
+        )
 
-    @pytest.mark.skipif(
-        ON_WINDOWS,
-        reason="Default numpy's dtypes vary according to OS",
-    )
     def test_repr(self) -> None:
         v = Variable(["time", "x"], [[1, 2, 3], [4, 5, 6]], {"foo": "bar"})
-        coords = {"x": np.arange(3, dtype=np.int64), "other": np.int64(0)}
+        v = v.astype(np.uint64)
+        coords = {"x": np.arange(3, dtype=np.uint64), "other": np.uint64(0)}
         data_array = DataArray(v, coords, name="my_variable")
         expected = dedent(
             """\
             <xarray.DataArray 'my_variable' (time: 2, x: 3)> Size: 48B
             array([[1, 2, 3],
-                   [4, 5, 6]])
+                   [4, 5, 6]], dtype=uint64)
             Coordinates:
-              * x        (x) int64 24B 0 1 2
-                other    int64 8B 0
+              * x        (x) uint64 24B 0 1 2
+                other    uint64 8B 0
             Dimensions without coordinates: time
             Attributes:
                 foo:      bar"""
         )
         assert expected == repr(data_array)
 
-    @pytest.mark.skipif(
-        not ON_WINDOWS,
-        reason="Default numpy's dtypes vary according to OS",
-    )
-    def test_repr_windows(self) -> None:
-        v = Variable(["time", "x"], [[1, 2, 3], [4, 5, 6]], {"foo": "bar"})
-        coords = {"x": np.arange(3, dtype=np.int64), "other": np.int64(0)}
-        data_array = DataArray(v, coords, name="my_variable")
-        expected = dedent(
-            """\
-            <xarray.DataArray 'my_variable' (time: 2, x: 3)> Size: 24B
-            array([[1, 2, 3],
-                   [4, 5, 6]])
-            Coordinates:
-              * x        (x) int64 24B 0 1 2
-                other    int64 8B 0
-            Dimensions without coordinates: time
-            Attributes:
-                foo:      bar"""
-        )
-        assert expected == repr(data_array)
-
-    @pytest.mark.skipif(
-        ON_WINDOWS,
-        reason="Default numpy's dtypes vary according to OS",
-    )
     def test_repr_multiindex(self) -> None:
         expected = dedent(
             """\
             <xarray.DataArray (x: 4)> Size: 32B
-            array([0, 1, 2, 3])
+            array([0, 1, 2, 3], dtype=uint64)
             Coordinates:
               * x        (x) object 32B MultiIndex
               * level_1  (x) object 32B 'a' 'a' 'b' 'b'
@@ -149,59 +120,20 @@ class TestDataArray:
         )
         assert expected == repr(self.mda)
 
-    @pytest.mark.skipif(
-        not ON_WINDOWS,
-        reason="Default numpy's dtypes vary according to OS",
-    )
-    def test_repr_multiindex_windows(self) -> None:
-        expected = dedent(
-            """\
-            <xarray.DataArray (x: 4)> Size: 16B
-            array([0, 1, 2, 3])
-            Coordinates:
-              * x        (x) object 32B MultiIndex
-              * level_1  (x) object 32B 'a' 'a' 'b' 'b'
-              * level_2  (x) int64 32B 1 2 1 2"""
-        )
-        assert expected == repr(self.mda)
-
-    @pytest.mark.skipif(
-        ON_WINDOWS,
-        reason="Default numpy's dtypes vary according to OS",
-    )
     def test_repr_multiindex_long(self) -> None:
         mindex_long = pd.MultiIndex.from_product(
             [["a", "b", "c", "d"], [1, 2, 3, 4, 5, 6, 7, 8]],
             names=("level_1", "level_2"),
         )
-        mda_long = DataArray(list(range(32)), coords={"x": mindex_long}, dims="x")
+        mda_long = DataArray(
+            list(range(32)), coords={"x": mindex_long}, dims="x"
+        ).astype(np.uint64)
         expected = dedent(
             """\
             <xarray.DataArray (x: 32)> Size: 256B
             array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
-                   17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31])
-            Coordinates:
-              * x        (x) object 256B MultiIndex
-              * level_1  (x) object 256B 'a' 'a' 'a' 'a' 'a' 'a' ... 'd' 'd' 'd' 'd' 'd' 'd'
-              * level_2  (x) int64 256B 1 2 3 4 5 6 7 8 1 2 3 4 ... 5 6 7 8 1 2 3 4 5 6 7 8"""
-        )
-        assert expected == repr(mda_long)
-
-    @pytest.mark.skipif(
-        not ON_WINDOWS,
-        reason="Default numpy's dtypes vary according to OS",
-    )
-    def test_repr_multiindex_long_windows(self) -> None:
-        mindex_long = pd.MultiIndex.from_product(
-            [["a", "b", "c", "d"], [1, 2, 3, 4, 5, 6, 7, 8]],
-            names=("level_1", "level_2"),
-        )
-        mda_long = DataArray(list(range(32)), coords={"x": mindex_long}, dims="x")
-        expected = dedent(
-            """\
-            <xarray.DataArray (x: 32)> Size: 128B
-            array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
-                   17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31])
+                   17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31],
+                  dtype=uint64)
             Coordinates:
               * x        (x) object 256B MultiIndex
               * level_1  (x) object 256B 'a' 'a' 'a' 'a' 'a' 'a' ... 'd' 'd' 'd' 'd' 'd' 'd'

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -1024,7 +1024,7 @@ Dimensions without coordinates: x
     ds = xr.DataArray(np.array([0.0]), dims="x")
     actual = repr(ds)
     expected = """
-<xarray.DataArray (x: 1)> Size: 4B
+<xarray.DataArray (x: 1)> Size: 8B
 array([0.])
 Dimensions without coordinates: x
         """.strip()
@@ -1043,7 +1043,7 @@ Dimensions without coordinates: x
     actual = repr(ds)
     expected = """
 <xarray.DataArray (x: 1)> Size: 4B
-array([0.])
+array([0.], dtype=float32)
 Dimensions without coordinates: x
         """.strip()
     assert actual == expected
@@ -1052,7 +1052,7 @@ Dimensions without coordinates: x
     actual = repr(ds)
     expected = """
 <xarray.DataArray (x: 1)> Size: 8B
-array([0.], dtype=float64)
+array([0.])
 Dimensions without coordinates: x
         """.strip()
     assert actual == expected

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -872,3 +872,187 @@ Coordinates:
   * foo      (foo) int16 2kB 0 1 2 3 4 5 6 ... 1194 1195 1196 1197 1198 1199
 """.strip()
     assert actual == expected
+
+
+@pytest.mark.skipif(
+    ON_WINDOWS,
+    reason="Default numpy's dtypes vary according to OS",
+)
+def test_array_repr_dtypes() -> None:
+
+    # Integer dtypes
+
+    ds = xr.DataArray(np.array([0]), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 8B
+array([0])
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="int8"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 1B
+array([0], dtype=int8)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="int16"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 2B
+array([0], dtype=int16)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="int32"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 4B
+array([0], dtype=int32)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="int64"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 8B
+array([0])
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    # Float dtypes
+
+    ds = xr.DataArray(np.array([0.0]), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 8B
+array([0.])
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="float16"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 2B
+array([0.], dtype=float16)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="float32"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 4B
+array([0.], dtype=float32)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="float64"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 8B
+array([0.])
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+
+@pytest.mark.skipif(
+    not ON_WINDOWS,
+    reason="Default numpy's dtypes vary according to OS",
+)
+def test_array_repr_dtypes_on_windows() -> None:
+
+    # Integer dtypes
+
+    ds = xr.DataArray(np.array([0]), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 4B
+array([0])
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="int8"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 1B
+array([0], dtype=int8)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="int16"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 2B
+array([0], dtype=int16)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="int32"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 4B
+array([0])
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="int64"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 8B
+array([0], dtype=int64)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    # Float dtypes
+
+    ds = xr.DataArray(np.array([0.0]), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 4B
+array([0.])
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="float16"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 2B
+array([0.], dtype=float16)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="float32"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 4B
+array([0.])
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="float64"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 8B
+array([0.], dtype=float64)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -466,26 +466,24 @@ class TestFormatting:
         assert actual == expected
 
     def test_array_repr(self) -> None:
-        ds = xr.Dataset(coords={"foo": [1, 2, 3], "bar": [1, 2, 3]})
+        ds = xr.Dataset(
+            coords={
+                "foo": np.array([1, 2, 3], dtype=np.uint64),
+                "bar": np.array([1, 2, 3], dtype=np.uint64),
+            }
+        )
         ds[(1, 2)] = xr.DataArray([0], dims="test")
         ds_12 = ds[(1, 2)]
 
         # Test repr function behaves correctly:
         actual = formatting.array_repr(ds_12)
-        if ON_WINDOWS:
-            expected = dedent(
-                """\
-            <xarray.DataArray (1, 2) (test: 1)> Size: 4B
-            array([0])
-            Dimensions without coordinates: test"""
-            )
-        else:
-            expected = dedent(
-                """\
-            <xarray.DataArray (1, 2) (test: 1)> Size: 8B
-            array([0])
-            Dimensions without coordinates: test"""
-            )
+
+        expected = dedent(
+            """\
+        <xarray.DataArray (1, 2) (test: 1)> Size: 8B
+        array([0])
+        Dimensions without coordinates: test"""
+        )
 
         assert actual == expected
 
@@ -499,21 +497,12 @@ class TestFormatting:
 
         with xr.set_options(display_expand_data=False):
             actual = formatting.array_repr(ds[(1, 2)])
-            if ON_WINDOWS:
-                expected = dedent(
-                    """\
-                <xarray.DataArray (1, 2) (test: 1)> Size: 4B
-                0
-                Dimensions without coordinates: test"""
-                )
-
-            else:
-                expected = dedent(
-                    """\
-                <xarray.DataArray (1, 2) (test: 1)> Size: 8B
-                0
-                Dimensions without coordinates: test"""
-                )
+            expected = dedent(
+                """\
+            <xarray.DataArray (1, 2) (test: 1)> Size: 8B
+            0
+            Dimensions without coordinates: test"""
+            )
 
             assert actual == expected
 
@@ -682,15 +671,16 @@ def test__mapping_repr(display_max_rows, n_vars, n_attr) -> None:
     b = defchararray.add("attr_", np.arange(0, n_attr).astype(str))
     c = defchararray.add("coord", np.arange(0, n_vars).astype(str))
     attrs = {k: 2 for k in b}
-    coords = {_c: np.array([0, 1]) for _c in c}
+    coords = {_c: np.array([0, 1], dtype=np.uint64) for _c in c}
     data_vars = dict()
     for v, _c in zip(a, coords.items()):
         data_vars[v] = xr.DataArray(
             name=v,
-            data=np.array([3, 4]),
+            data=np.array([3, 4], dtype=np.uint64),
             dims=[_c[0]],
             coords=dict([_c]),
         )
+
     ds = xr.Dataset(data_vars)
     ds.attrs = attrs
 
@@ -727,7 +717,7 @@ def test__mapping_repr(display_max_rows, n_vars, n_attr) -> None:
         dims_values = formatting.dim_summary_limited(
             ds, col_width=col_width + 1, max_rows=display_max_rows
         )
-        expected_size = "640B" if ON_WINDOWS else "1kB"
+        expected_size = "1kB"
         expected = f"""\
 <xarray.Dataset> Size: {expected_size}
 {dims_start}({dims_values})
@@ -875,6 +865,13 @@ Coordinates:
 
 
 def test_array_repr_dtypes():
+
+    # These dtypes are expected to be represented similarly
+    # on Ubuntu, macOS and Windows environments of the CI.
+    # Unsigned integer could be used as easy replacements
+    # for tests where the data-type does not matter,
+    # but the repr does, including the size
+    # (size of a int == size of an uint)
 
     # Signed integer dtypes
 

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -472,7 +472,7 @@ class TestFormatting:
                 "bar": np.array([1, 2, 3], dtype=np.uint64),
             }
         )
-        ds[(1, 2)] = xr.DataArray([0], dims="test")
+        ds[(1, 2)] = xr.DataArray(np.array([0], dtype=np.uint64), dims="test")
         ds_12 = ds[(1, 2)]
 
         # Test repr function behaves correctly:
@@ -481,7 +481,7 @@ class TestFormatting:
         expected = dedent(
             """\
         <xarray.DataArray (1, 2) (test: 1)> Size: 8B
-        array([0])
+        array([0], dtype=uint64)
         Dimensions without coordinates: test"""
         )
 

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -874,22 +874,9 @@ Coordinates:
     assert actual == expected
 
 
-@pytest.mark.skipif(
-    ON_WINDOWS,
-    reason="Default numpy's dtypes vary according to OS",
-)
-def test_array_repr_dtypes() -> None:
+def test_array_repr_dtypes():
 
-    # Integer dtypes
-
-    ds = xr.DataArray(np.array([0]), dims="x")
-    actual = repr(ds)
-    expected = """
-<xarray.DataArray (x: 1)> Size: 8B
-array([0])
-Dimensions without coordinates: x
-        """.strip()
-    assert actual == expected
+    # Signed integer dtypes
 
     ds = xr.DataArray(np.array([0], dtype="int8"), dims="x")
     actual = repr(ds)
@@ -905,6 +892,100 @@ Dimensions without coordinates: x
     expected = """
 <xarray.DataArray (x: 1)> Size: 2B
 array([0], dtype=int16)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    # Unsigned integer dtypes
+
+    ds = xr.DataArray(np.array([0], dtype="uint8"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 1B
+array([0], dtype=uint8)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="uint16"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 2B
+array([0], dtype=uint16)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="uint32"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 4B
+array([0], dtype=uint32)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="uint64"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 8B
+array([0], dtype=uint64)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    # Float dtypes
+
+    ds = xr.DataArray(np.array([0.0]), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 8B
+array([0.])
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="float16"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 2B
+array([0.], dtype=float16)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="float32"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 4B
+array([0.], dtype=float32)
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+    ds = xr.DataArray(np.array([0], dtype="float64"), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 8B
+array([0.])
+Dimensions without coordinates: x
+        """.strip()
+    assert actual == expected
+
+
+@pytest.mark.skipif(
+    ON_WINDOWS,
+    reason="Default numpy's dtypes vary according to OS",
+)
+def test_array_repr_dtypes_unix() -> None:
+
+    # Signed integer dtypes
+
+    ds = xr.DataArray(np.array([0]), dims="x")
+    actual = repr(ds)
+    expected = """
+<xarray.DataArray (x: 1)> Size: 8B
+array([0])
 Dimensions without coordinates: x
         """.strip()
     assert actual == expected
@@ -927,44 +1008,6 @@ Dimensions without coordinates: x
         """.strip()
     assert actual == expected
 
-    # Float dtypes
-
-    ds = xr.DataArray(np.array([0.0]), dims="x")
-    actual = repr(ds)
-    expected = """
-<xarray.DataArray (x: 1)> Size: 8B
-array([0.])
-Dimensions without coordinates: x
-        """.strip()
-    assert actual == expected
-
-    ds = xr.DataArray(np.array([0], dtype="float16"), dims="x")
-    actual = repr(ds)
-    expected = """
-<xarray.DataArray (x: 1)> Size: 2B
-array([0.], dtype=float16)
-Dimensions without coordinates: x
-        """.strip()
-    assert actual == expected
-
-    ds = xr.DataArray(np.array([0], dtype="float32"), dims="x")
-    actual = repr(ds)
-    expected = """
-<xarray.DataArray (x: 1)> Size: 4B
-array([0.], dtype=float32)
-Dimensions without coordinates: x
-        """.strip()
-    assert actual == expected
-
-    ds = xr.DataArray(np.array([0], dtype="float64"), dims="x")
-    actual = repr(ds)
-    expected = """
-<xarray.DataArray (x: 1)> Size: 8B
-array([0.])
-Dimensions without coordinates: x
-        """.strip()
-    assert actual == expected
-
 
 @pytest.mark.skipif(
     not ON_WINDOWS,
@@ -983,24 +1026,6 @@ Dimensions without coordinates: x
         """.strip()
     assert actual == expected
 
-    ds = xr.DataArray(np.array([0], dtype="int8"), dims="x")
-    actual = repr(ds)
-    expected = """
-<xarray.DataArray (x: 1)> Size: 1B
-array([0], dtype=int8)
-Dimensions without coordinates: x
-        """.strip()
-    assert actual == expected
-
-    ds = xr.DataArray(np.array([0], dtype="int16"), dims="x")
-    actual = repr(ds)
-    expected = """
-<xarray.DataArray (x: 1)> Size: 2B
-array([0], dtype=int16)
-Dimensions without coordinates: x
-        """.strip()
-    assert actual == expected
-
     ds = xr.DataArray(np.array([0], dtype="int32"), dims="x")
     actual = repr(ds)
     expected = """
@@ -1015,44 +1040,6 @@ Dimensions without coordinates: x
     expected = """
 <xarray.DataArray (x: 1)> Size: 8B
 array([0], dtype=int64)
-Dimensions without coordinates: x
-        """.strip()
-    assert actual == expected
-
-    # Float dtypes
-
-    ds = xr.DataArray(np.array([0.0]), dims="x")
-    actual = repr(ds)
-    expected = """
-<xarray.DataArray (x: 1)> Size: 8B
-array([0.])
-Dimensions without coordinates: x
-        """.strip()
-    assert actual == expected
-
-    ds = xr.DataArray(np.array([0], dtype="float16"), dims="x")
-    actual = repr(ds)
-    expected = """
-<xarray.DataArray (x: 1)> Size: 2B
-array([0.], dtype=float16)
-Dimensions without coordinates: x
-        """.strip()
-    assert actual == expected
-
-    ds = xr.DataArray(np.array([0], dtype="float32"), dims="x")
-    actual = repr(ds)
-    expected = """
-<xarray.DataArray (x: 1)> Size: 4B
-array([0.], dtype=float32)
-Dimensions without coordinates: x
-        """.strip()
-    assert actual == expected
-
-    ds = xr.DataArray(np.array([0], dtype="float64"), dims="x")
-    actual = repr(ds)
-    expected = """
-<xarray.DataArray (x: 1)> Size: 8B
-array([0.])
 Dimensions without coordinates: x
         """.strip()
     assert actual == expected

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import warnings
 from abc import ABC
 from copy import copy, deepcopy
@@ -58,8 +57,6 @@ _PAD_XR_NP_ARGS = [
     [{"x": (3, 1), "z": (2, 0)}, ((3, 1), (0, 0), (2, 0))],
     [{"x": (3, 1), "z": 2}, ((3, 1), (0, 0), (2, 2))],
 ]
-
-ON_WINDOWS = sys.platform == "win32"
 
 
 @pytest.fixture

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1231,26 +1231,16 @@ class TestVariable(VariableSubclassobjects):
 
     def test_repr(self):
         v = Variable(["time", "x"], [[1, 2, 3], [4, 5, 6]], {"foo": "bar"})
-        if ON_WINDOWS:
-            expected = dedent(
-                """
-            <xarray.Variable (time: 2, x: 3)> Size: 24B
-            array([[1, 2, 3],
-                   [4, 5, 6]])
-            Attributes:
-                foo:      bar
+        v = v.astype(np.uint64)
+        expected = dedent(
             """
-            ).strip()
-        else:
-            expected = dedent(
-                """
-            <xarray.Variable (time: 2, x: 3)> Size: 48B
-            array([[1, 2, 3],
-                   [4, 5, 6]])
-            Attributes:
-                foo:      bar
-            """
-            ).strip()
+        <xarray.Variable (time: 2, x: 3)> Size: 48B
+        array([[1, 2, 3],
+               [4, 5, 6]], dtype=uint64)
+        Attributes:
+            foo:      bar
+        """
+        ).strip()
         assert expected == repr(v)
 
     def test_repr_lazy_data(self):


### PR DESCRIPTION
Follow up #8702 / https://github.com/pydata/xarray/pull/8702#issuecomment-1932851112

The goal is to remove the not elegant OS-dependant checks introduced during the testing of #8702 

A simple way to do so is to use unsigned integer as dtypes for tests involving data array representations on multiple OSes. Indeed, this solves the issue of the default dtypes being not printed in the repr, with  default dtyps varying according to the OS. The tests show that the concerned dtypes are `int32` (for the Windows CI) and `int64` (for Ubuntu and macOS CIs). Using `uint64` should fix both the varying size and the varying numpy array repr.

~~- [ ] Closes #xxxx~~
- [x] Tests added
~~- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`~~
~~- [ ] New functions/methods are listed in `api.rst`~~
