### PR TITLE
unstack: require unique MultiIndex

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -74,6 +74,8 @@ Bug fixes
   lead to integer overflow or unsafe conversion from floating point to integer
   values (:issue:`8542`, :pull:`8575`).  By `Spencer Clark
   <https://github.com/spencerkclark>`_.
+- Raise an error when unstacking a MultiIndex that has duplicates as this would lead
+  to silent data loss (:issue:`7104`, :pull:`8737`). By `Mathias Hauser <https://github.com/mathause>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -1019,9 +1019,9 @@ class PandasMultiIndex(PandasIndex):
 
         if not clean_index.is_unique:
             raise ValueError(
-                "Cannot unstack a non-unique MultiIndex. To restore the previous "
-                "behavior call ``.drop_duplicates('{self.dim}', keep='last')`` before "
-                "unstacking."
+                "Cannot unstack MultiIndex containing duplicates. Make sure entries "
+                "are unique, e.g., by  calling ``.drop_duplicates('{self.dim}')``, "
+                "before unstacking."
             )
 
         new_indexes: dict[Hashable, Index] = {}

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -1017,6 +1017,13 @@ class PandasMultiIndex(PandasIndex):
     def unstack(self) -> tuple[dict[Hashable, Index], pd.MultiIndex]:
         clean_index = remove_unused_levels_categories(self.index)
 
+        if not clean_index.is_unique:
+            raise ValueError(
+                "Cannot unstack a non-unique MultiIndex. To restore the previous "
+                "behavior call ``.drop_duplicates('{self.dim}', keep='last')`` before "
+                "unstacking."
+            )
+
         new_indexes: dict[Hashable, Index] = {}
         for name, lev in zip(clean_index.names, clean_index.levels):
             idx = PandasIndex(

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -1020,7 +1020,7 @@ class PandasMultiIndex(PandasIndex):
         if not clean_index.is_unique:
             raise ValueError(
                 "Cannot unstack MultiIndex containing duplicates. Make sure entries "
-                "are unique, e.g., by  calling ``.drop_duplicates('{self.dim}')``, "
+                f"are unique, e.g., by  calling ``.drop_duplicates('{self.dim}')``, "
                 "before unstacking."
             )
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2526,7 +2526,7 @@ class TestDataArray:
         assert_identical(orig, actual)
 
     def test_unstack_pandas_consistency(self) -> None:
-        df = pd.DataFrame({"foo": range(3), "x": ["a", "b", "b"], "y": [0, 0, 1]})
+        df = pd.DataFrame({"foo": range(2), "x": ["a", "b", "b"], "y": [0, 0, 1]})
         s = df.set_index(["x", "y"])["foo"]
         expected = DataArray(s.unstack(), name="foo")
         actual = DataArray(s, dims="z").unstack("z")

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2536,7 +2536,9 @@ class TestDataArray:
         df = pd.DataFrame({"foo": range(2), "x": ["a", "a"], "y": [0, 0]})
         s = df.set_index(["x", "y"])["foo"]
 
-        with pytest.raises(ValueError, match="Cannot unstack a non-unique MultiIndex"):
+        with pytest.raises(
+            ValueError, match="Cannot unstack MultiIndex containing duplicates"
+        ):
             DataArray(s, dims="z").unstack("z")
 
     @pytest.mark.filterwarnings("error")

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2526,14 +2526,14 @@ class TestDataArray:
         assert_identical(orig, actual)
 
     def test_unstack_pandas_consistency(self) -> None:
-        df = pd.DataFrame({"foo": range(2), "x": ["a", "b", "b"], "y": [0, 0, 1]})
+        df = pd.DataFrame({"foo": range(3), "x": ["a", "b", "b"], "y": [0, 0, 1]})
         s = df.set_index(["x", "y"])["foo"]
         expected = DataArray(s.unstack(), name="foo")
         actual = DataArray(s, dims="z").unstack("z")
         assert_identical(expected, actual)
 
     def test_unstack_requires_unique(self) -> None:
-        df = pd.DataFrame({"foo": range(3), "x": ["a", "a"], "y": [0, 0]})
+        df = pd.DataFrame({"foo": range(2), "x": ["a", "a"], "y": [0, 0]})
         s = df.set_index(["x", "y"])["foo"]
 
         with pytest.raises(ValueError, match="Cannot unstack a non-unique MultiIndex"):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2532,6 +2532,13 @@ class TestDataArray:
         actual = DataArray(s, dims="z").unstack("z")
         assert_identical(expected, actual)
 
+    def test_unstack_requires_unique(self) -> None:
+        df = pd.DataFrame({"foo": range(3), "x": ["a", "a"], "y": [0, 0]})
+        s = df.set_index(["x", "y"])["foo"]
+
+        with pytest.raises(ValueError, match="Cannot unstack a non-unique MultiIndex"):
+            DataArray(s, dims="z").unstack("z")
+
     @pytest.mark.filterwarnings("error")
     def test_unstack_roundtrip_integer_array(self) -> None:
         arr = xr.DataArray(

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3764,6 +3764,12 @@ class TestDataset:
         with pytest.raises(ValueError, match=r".*do not have exactly one multi-index"):
             ds.unstack("x")
 
+        ds = Dataset({"da": [1, 2]}, coords={"y": ("x", [1, 1]), "z": ("x", [0, 0])})
+        ds = ds.set_index(x=("y", "z"))
+
+        with pytest.raises(ValueError, match="Cannot unstack a non-unique MultiIndex"):
+            ds.unstack("x")
+
     def test_unstack_fill_value(self) -> None:
         ds = xr.Dataset(
             {"var": (("x",), np.arange(6)), "other_var": (("x",), np.arange(3, 9))},

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3767,7 +3767,9 @@ class TestDataset:
         ds = Dataset({"da": [1, 2]}, coords={"y": ("x", [1, 1]), "z": ("x", [0, 0])})
         ds = ds.set_index(x=("y", "z"))
 
-        with pytest.raises(ValueError, match="Cannot unstack a non-unique MultiIndex"):
+        with pytest.raises(
+            ValueError, match="Cannot unstack MultiIndex containing duplicates"
+        ):
             ds.unstack("x")
 
     def test_unstack_fill_value(self) -> None:

--- a/xarray/tests/test_indexes.py
+++ b/xarray/tests/test_indexes.py
@@ -456,7 +456,9 @@ class TestPandasMultiIndex:
         pd_midx = pd.MultiIndex.from_product([["a", "a"], [1, 2]], names=["one", "two"])
         index = PandasMultiIndex(pd_midx, "x")
 
-        with pytest.raises(ValueError, match="Cannot unstack a non-unique MultiIndex"):
+        with pytest.raises(
+            ValueError, match="Cannot unstack MultiIndex containing duplicates"
+        ):
             index.unstack()
 
     def test_create_variables(self) -> None:

--- a/xarray/tests/test_indexes.py
+++ b/xarray/tests/test_indexes.py
@@ -452,6 +452,13 @@ class TestPandasMultiIndex:
         assert new_indexes["two"].equals(PandasIndex([1, 2, 3], "two"))
         assert new_pd_idx.equals(pd_midx)
 
+    def test_unstack_requires_unique(self) -> None:
+        pd_midx = pd.MultiIndex.from_product([["a", "a"], [1, 2]], names=["one", "two"])
+        index = PandasMultiIndex(pd_midx, "x")
+
+        with pytest.raises(ValueError, match="Cannot unstack a non-unique MultiIndex"):
+            index.unstack()
+
     def test_create_variables(self) -> None:
         foo_data = np.array([0, 0, 1], dtype="int64")
         bar_data = np.array([1.1, 1.2, 1.3], dtype="float64")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #7104
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`


Unstacking non-unique MultiIndex can lead to silent data loss, so we raise an error.