### PR TITLE
Don't break users that were already using ChunkManagerEntrypoint

### DIFF
--- a/xarray/core/parallelcompat.py
+++ b/xarray/core/parallelcompat.py
@@ -1,0 +1,6 @@
+from xarray.namedarray.parallelcompat import ChunkManagerEntrypoint  # noqa
+import warnings
+
+warnings.warn("xarray.core.parallelcompat.ChunkManagerEntrypoint is deprecated. "
+              "Use xarray.namedarray.parallel.ChunkManagerEntrypoint instead.",
+               DeprecationWarning, stacklevel=2)

--- a/xarray/core/parallelcompat.py
+++ b/xarray/core/parallelcompat.py
@@ -2,9 +2,11 @@ __all__ = [
     "ChunkManagerEntrypoint",
 ]
 
+
 def __getattr__(attr):
-    if attr == 'ChunkManagerEntrypoint':
+    if attr == "ChunkManagerEntrypoint":
         import warnings
+
         warnings.warn(
             "xarray.core.parallelcompat.ChunkManagerEntrypoint is deprecated. "
             "Use xarray.namedarray.parallelcompat.ChunkManagerEntrypoint instead.",
@@ -12,10 +14,11 @@ def __getattr__(attr):
             stacklevel=2,
         )
         from xarray.namedarray.parallelcompat import ChunkManagerEntrypoint
+
         return ChunkManagerEntrypoint
     else:
-        raise AttributeError("module {!r} has no attribute "
-                             "{!r}".format(__name__, attr))
+        raise AttributeError(f"module {__name__!r} has no attribute " f"{attr!r}")
+
 
 def __dir__():
     return __all__

--- a/xarray/core/parallelcompat.py
+++ b/xarray/core/parallelcompat.py
@@ -1,6 +1,9 @@
 from xarray.namedarray.parallelcompat import ChunkManagerEntrypoint  # noqa
 import warnings
 
-warnings.warn("xarray.core.parallelcompat.ChunkManagerEntrypoint is deprecated. "
-              "Use xarray.namedarray.parallel.ChunkManagerEntrypoint instead.",
-               DeprecationWarning, stacklevel=2)
+warnings.warn(
+    "xarray.core.parallelcompat.ChunkManagerEntrypoint is deprecated. "
+    "Use xarray.namedarray.parallel.ChunkManagerEntrypoint instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/xarray/core/parallelcompat.py
+++ b/xarray/core/parallelcompat.py
@@ -1,9 +1,21 @@
-from xarray.namedarray.parallelcompat import ChunkManagerEntrypoint  # noqa
-import warnings
+__all__ = [
+    "ChunkManagerEntrypoint",
+]
 
-warnings.warn(
-    "xarray.core.parallelcompat.ChunkManagerEntrypoint is deprecated. "
-    "Use xarray.namedarray.parallel.ChunkManagerEntrypoint instead.",
-    DeprecationWarning,
-    stacklevel=2,
-)
+def __getattr__(attr):
+    if attr == 'ChunkManagerEntrypoint':
+        import warnings
+        warnings.warn(
+            "xarray.core.parallelcompat.ChunkManagerEntrypoint is deprecated. "
+            "Use xarray.namedarray.parallelcompat.ChunkManagerEntrypoint instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from xarray.namedarray.parallelcompat import ChunkManagerEntrypoint
+        return ChunkManagerEntrypoint
+    else:
+        raise AttributeError("module {!r} has no attribute "
+                             "{!r}".format(__name__, attr))
+
+def __dir__():
+    return __all__

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -3,9 +3,11 @@ __all__ = [
     "is_duck_dask_array",
 ]
 
+
 def __getattr__(attr):
-    if attr == 'is_chunked_array':
+    if attr == "is_chunked_array":
         import warnings
+
         warnings.warn(
             "xarray.core.pycompat.is_chunked_array is deprecated. "
             "Use xarray.namedarray.pycompat.is_chunked_array instead.",
@@ -13,9 +15,11 @@ def __getattr__(attr):
             stacklevel=2,
         )
         from xarray.namedarray.pycompat import is_chunked_array
+
         return is_chunked_array
-    elif attr == 'is_duck_dask_array':
+    elif attr == "is_duck_dask_array":
         import warnings
+
         warnings.warn(
             "xarray.core.pycompat.is_duck_dask_array is deprecated. "
             "Use xarray.namedarray.pycompat.is_duck_dask_array instead.",
@@ -23,10 +27,11 @@ def __getattr__(attr):
             stacklevel=2,
         )
         from xarray.namedarray.pycompat import is_duck_dask_array
+
         return is_duck_dask_array
     else:
-        raise AttributeError("module {!r} has no attribute "
-                             "{!r}".format(__name__, attr))
+        raise AttributeError(f"module {__name__!r} has no attribute " f"{attr!r}")
+
 
 def __dir__():
     return __all__

--- a/xarray/core/pycompat.py
+++ b/xarray/core/pycompat.py
@@ -1,0 +1,32 @@
+__all__ = [
+    "is_chunked_array",
+    "is_duck_dask_array",
+]
+
+def __getattr__(attr):
+    if attr == 'is_chunked_array':
+        import warnings
+        warnings.warn(
+            "xarray.core.pycompat.is_chunked_array is deprecated. "
+            "Use xarray.namedarray.pycompat.is_chunked_array instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from xarray.namedarray.pycompat import is_chunked_array
+        return is_chunked_array
+    elif attr == 'is_duck_dask_array':
+        import warnings
+        warnings.warn(
+            "xarray.core.pycompat.is_duck_dask_array is deprecated. "
+            "Use xarray.namedarray.pycompat.is_duck_dask_array instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from xarray.namedarray.pycompat import is_duck_dask_array
+        return is_duck_dask_array
+    else:
+        raise AttributeError("module {!r} has no attribute "
+                             "{!r}".format(__name__, attr))
+
+def __dir__():
+    return __all__

--- a/xarray/tests/test_core_parallelcompat.py
+++ b/xarray/tests/test_core_parallelcompat.py
@@ -1,0 +1,17 @@
+import pytest
+
+def test_parallelcompat_backward():
+    # In vesion 2024.4.1 and before
+    # These functions were located in the
+    #    xarray.core.parallelcompat
+    #    xarray.core.pycompat
+    # modules
+    # https://github.com/pydata/xarray/commit/d64460795e406bc4a998e2ddae0054a1029d52a9
+    with pytest.warns(match="xarray.core.parallelcompat.ChunkManagerEntrypoint is deprecated."):
+        from xarray.core.parallelcompat import ChunkManagerEntrypoint
+
+    with pytest.warns(match="xarray.core.pycompat.is_chunked_array is deprecated."):
+        from xarray.core.pycompat import is_chunked_array
+
+    with pytest.warns(match="xarray.core.pycompat.is_chunked_array is deprecated."):
+        from xarray.core.pycompat import is_chunked_array

--- a/xarray/tests/test_core_parallelcompat.py
+++ b/xarray/tests/test_core_parallelcompat.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 def test_parallelcompat_backward():
     # In vesion 2024.4.1 and before
     # These functions were located in the
@@ -7,11 +8,13 @@ def test_parallelcompat_backward():
     #    xarray.core.pycompat
     # modules
     # https://github.com/pydata/xarray/commit/d64460795e406bc4a998e2ddae0054a1029d52a9
-    with pytest.warns(match="xarray.core.parallelcompat.ChunkManagerEntrypoint is deprecated."):
-        from xarray.core.parallelcompat import ChunkManagerEntrypoint
+    with pytest.warns(
+        match="xarray.core.parallelcompat.ChunkManagerEntrypoint is deprecated."
+    ):
+        pass
 
     with pytest.warns(match="xarray.core.pycompat.is_chunked_array is deprecated."):
-        from xarray.core.pycompat import is_chunked_array
+        pass
 
     with pytest.warns(match="xarray.core.pycompat.is_chunked_array is deprecated."):
-        from xarray.core.pycompat import is_chunked_array
+        pass


### PR DESCRIPTION
For example, you just broke cubed

https://github.com/xarray-contrib/cubed-xarray/blob/main/cubed_xarray/cubedmanager.py#L15

Not sure how much you care, it didn't seem like anybody other than me ever tried this module on github...

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
