### PR TITLE
Don't access data when creating DataArray from Variable.

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -247,8 +247,11 @@ def as_compatible_data(
 
     from xarray.core.dataarray import DataArray
 
-    if isinstance(data, (Variable, DataArray)):
+    if isinstance(data, Variable):
         return cast("T_DuckArray", data._data)
+
+    if isinstance(data, DataArray):
+        return cast("T_DuckArray", data._variable._data)
 
     if isinstance(data, NON_NUMPY_SUPPORTED_ARRAY_TYPES):
         data = _possibly_convert_datetime_or_timedelta_index(data)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -247,9 +247,11 @@ def as_compatible_data(
 
     from xarray.core.dataarray import DataArray
 
+    # TODO: do this uwrapping in the Variable/NamedArray constructor instead.
     if isinstance(data, Variable):
         return cast("T_DuckArray", data._data)
 
+    # TODO: do this uwrapping in the DataArray constructor instead.
     if isinstance(data, DataArray):
         return cast("T_DuckArray", data._variable._data)
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -248,7 +248,7 @@ def as_compatible_data(
     from xarray.core.dataarray import DataArray
 
     if isinstance(data, (Variable, DataArray)):
-        return data.data
+        return cast("T_DuckArray", data._data)
 
     if isinstance(data, NON_NUMPY_SUPPORTED_ARRAY_TYPES):
         data = _possibly_convert_datetime_or_timedelta_index(data)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -7128,3 +7128,11 @@ def test_nD_coord_dataarray() -> None:
     _assert_internal_invariants(da4, check_default_indexes=True)
     assert "x" not in da4.xindexes
     assert "x" in da4.coords
+
+
+def test_lazy_data_variable_not_loaded():
+    # GH8753
+    array = InaccessibleArray(np.array([1, 2, 3]))
+    v = Variable(data=array, dims="x")
+    # No data needs to be accessed, so no error should be raised
+    xr.DataArray(v)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -7135,4 +7135,6 @@ def test_lazy_data_variable_not_loaded():
     array = InaccessibleArray(np.array([1, 2, 3]))
     v = Variable(data=array, dims="x")
     # No data needs to be accessed, so no error should be raised
-    xr.DataArray(v)
+    da = xr.DataArray(v)
+    # No data needs to be accessed, so no error should be raised
+    xr.DataArray(da)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4908,7 +4908,7 @@ class TestReduce1D(TestReduce):
         with pytest.raises(ValueError):
             xr.DataArray(5).idxmin()
 
-        coordarr0 = xr.DataArray(ar0.coords["x"], dims=["x"])
+        coordarr0 = xr.DataArray(ar0.coords["x"].data, dims=["x"])
         coordarr1 = coordarr0.copy()
 
         hasna = np.isnan(minindex)
@@ -5023,7 +5023,7 @@ class TestReduce1D(TestReduce):
         with pytest.raises(ValueError):
             xr.DataArray(5).idxmax()
 
-        coordarr0 = xr.DataArray(ar0.coords["x"], dims=["x"])
+        coordarr0 = xr.DataArray(ar0.coords["x"].data, dims=["x"])
         coordarr1 = coordarr0.copy()
 
         hasna = np.isnan(maxindex)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #8753

This seems to have been around since 2016-ish, so presumably our backend code path is passing arrays around, not Variables.

cc @ilan-gold