### PR TITLE
refactor DaskIndexingAdapter `__getitem__` method

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -102,6 +102,9 @@ Internal Changes
 - Adds :py:func:`open_datatree` into ``xarray/backends`` (:pull:`8697`) By `Matt
   Savoie <https://github.com/flamingbear>`_.
 
+- Refactor  :py:meth:`xarray.core.indexing.DaskIndexingAdapter.__getitem__` to remove an unnecessary rewrite of the indexer key
+  (:issue: `8377`, :pull:`8758`) By `Anderson Banihirwe <https://github.com/andersy005>`
+
 .. _whats-new.2024.01.1:
 
 v2024.01.1 (23 Jan, 2024)

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -4,7 +4,7 @@ import enum
 import functools
 import operator
 from collections import Counter, defaultdict
-from collections.abc import Hashable, Iterable, Mapping
+from collections.abc import Hashable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import timedelta
@@ -1418,23 +1418,6 @@ class DaskIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
         self.array = array
 
     def __getitem__(self, key):
-        if not isinstance(key, VectorizedIndexer):
-            # if possible, short-circuit when keys are effectively slice(None)
-            # This preserves dask name and passes lazy array equivalence checks
-            # (see duck_array_ops.lazy_array_equiv)
-            rewritten_indexer = False
-            new_indexer = []
-            for idim, k in enumerate(key.tuple):
-                if isinstance(k, Iterable) and (
-                    not is_duck_dask_array(k)
-                    and duck_array_ops.array_equiv(k, np.arange(self.array.shape[idim]))
-                ):
-                    new_indexer.append(slice(None))
-                    rewritten_indexer = True
-                else:
-                    new_indexer.append(k)
-            if rewritten_indexer:
-                key = type(key)(tuple(new_indexer))
 
         if isinstance(key, BasicIndexer):
             return self.array[key.tuple]

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1654,39 +1654,6 @@ def test_lazy_array_equiv_merge(compat):
         xr.merge([da1, da2 / 2], compat=compat)
 
 
-@pytest.mark.filterwarnings("ignore::FutureWarning")  # transpose_coords
-@pytest.mark.parametrize("obj", [make_da(), make_ds()])
-@pytest.mark.parametrize(
-    "transform",
-    [
-        lambda a: a.assign_attrs(new_attr="anew"),
-        lambda a: a.assign_coords(cxy=a.cxy),
-        lambda a: a.copy(),
-        lambda a: a.isel(x=np.arange(a.sizes["x"])),
-        lambda a: a.isel(x=slice(None)),
-        lambda a: a.loc[dict(x=slice(None))],
-        lambda a: a.loc[dict(x=np.arange(a.sizes["x"]))],
-        lambda a: a.loc[dict(x=a.x)],
-        lambda a: a.sel(x=a.x),
-        lambda a: a.sel(x=a.x.values),
-        lambda a: a.transpose(...),
-        lambda a: a.squeeze(),  # no dimensions to squeeze
-        lambda a: a.sortby("x"),  # "x" is already sorted
-        lambda a: a.reindex(x=a.x),
-        lambda a: a.reindex_like(a),
-        lambda a: a.rename({"cxy": "cnew"}).rename({"cnew": "cxy"}),
-        lambda a: a.pipe(lambda x: x),
-        lambda a: xr.align(a, xr.zeros_like(a))[0],
-        # assign
-        # swap_dims
-        # set_index / reset_index
-    ],
-)
-def test_transforms_pass_lazy_array_equiv(obj, transform):
-    with raise_if_dask_computes():
-        assert_equal(obj, transform(obj))
-
-
 def test_more_transforms_pass_lazy_array_equiv(map_da, map_ds):
     with raise_if_dask_computes():
         assert_equal(map_ds.cxy.broadcast_like(map_ds.cxy), map_ds.cxy)

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1666,6 +1666,8 @@ def test_lazy_array_equiv_merge(compat):
         lambda a: a.loc[dict(x=slice(None))],
         lambda a: a.transpose(...),
         lambda a: a.squeeze(),  # no dimensions to squeeze
+        lambda a: a.reindex(x=a.x),
+        lambda a: a.reindex_like(a),
         lambda a: a.rename({"cxy": "cnew"}).rename({"cnew": "cxy"}),
         lambda a: a.pipe(lambda x: x),
         lambda a: xr.align(a, xr.zeros_like(a))[0],

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1654,6 +1654,31 @@ def test_lazy_array_equiv_merge(compat):
         xr.merge([da1, da2 / 2], compat=compat)
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")  # transpose_coords
+@pytest.mark.parametrize("obj", [make_da(), make_ds()])
+@pytest.mark.parametrize(
+    "transform",
+    [
+        lambda a: a.assign_attrs(new_attr="anew"),
+        lambda a: a.assign_coords(cxy=a.cxy),
+        lambda a: a.copy(),
+        lambda a: a.isel(x=slice(None)),
+        lambda a: a.loc[dict(x=slice(None))],
+        lambda a: a.transpose(...),
+        lambda a: a.squeeze(),  # no dimensions to squeeze
+        lambda a: a.rename({"cxy": "cnew"}).rename({"cnew": "cxy"}),
+        lambda a: a.pipe(lambda x: x),
+        lambda a: xr.align(a, xr.zeros_like(a))[0],
+        # assign
+        # swap_dims
+        # set_index / reset_index
+    ],
+)
+def test_transforms_pass_lazy_array_equiv(obj, transform):
+    with raise_if_dask_computes():
+        assert_equal(obj, transform(obj))
+
+
 def test_more_transforms_pass_lazy_array_equiv(map_da, map_ds):
     with raise_if_dask_computes():
         assert_equal(map_ds.cxy.broadcast_like(map_ds.cxy), map_ds.cxy)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

this pull request removes the ["unnecessary optimization"](https://github.com/pydata/xarray/issues/8377#issuecomment-1781406355) introduced in https://github.com/pydata/xarray/pull/3588 that attempts to rewrite the indexer key for `BasicIndexer` and `OuterIndexer`

- [x] Closes #8377
- [ ] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
