### PR TITLE
Fixing issue #8770: Improved frequency parameter logic to set it to 'D' only if periods, start, or end are None.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,7 +34,9 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
-
+- The logic of the frequency parameter in :py:meth:`xr.date_range` and :py:meth:`xr.cftime_range` are
+  set to 'D' only if periods, start, or end are None. (:issue:`8770`, :pull:`8774`).
+  By `Roberto Chang <https://github.com/rjavierch>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,8 +34,8 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
-- The logic of the frequency parameter in :py:meth:`xr.date_range` and :py:meth:`xr.cftime_range` are
-  set to ``'D'`` only if periods, start, or end are ``None`` (:issue:`8770`, :pull:`8774`).
+- The default ``freq`` parameter in :py:meth:`xr.date_range` and :py:meth:`xr.cftime_range` is
+  set to ``'D'`` only if ``periods``, ``start``, or ``end`` are ``None`` (:issue:`8770`, :pull:`8774`).
   By `Roberto Chang <https://github.com/rjavierch>`_.
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,7 +35,7 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 - The logic of the frequency parameter in :py:meth:`xr.date_range` and :py:meth:`xr.cftime_range` are
-  set to 'D' only if periods, start, or end are None. (:issue:`8770`, :pull:`8774`).
+  set to ``'D'`` only if periods, start, or end are ``None`` (:issue:`8770`, :pull:`8774`).
   By `Roberto Chang <https://github.com/rjavierch>`_.
 
 Documentation

--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -1152,7 +1152,7 @@ def date_range(
     start=None,
     end=None,
     periods=None,
-    freq="D",
+    freq=None,
     tz=None,
     normalize=False,
     name=None,
@@ -1217,6 +1217,9 @@ def date_range(
     date_range_like
     """
     from xarray.coding.times import _is_standard_calendar
+
+    if freq is None and any(arg is None for arg in [periods, start, end]):
+        freq = "D"
 
     if tz is not None:
         use_cftime = False

--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -914,7 +914,7 @@ def cftime_range(
     start=None,
     end=None,
     periods=None,
-    freq="D",
+    freq=None,
     normalize=False,
     name=None,
     closed: NoDefault | SideOptions = no_default,
@@ -1100,6 +1100,10 @@ def cftime_range(
     --------
     pandas.date_range
     """
+
+    if freq is None and any(arg is None for arg in [periods, start, end]):
+        freq = "D"
+
     # Adapted from pandas.core.indexes.datetimes._generate_range.
     if count_not_none(start, end, periods, freq) != 3:
         raise ValueError(
@@ -1217,9 +1221,6 @@ def date_range(
     date_range_like
     """
     from xarray.coding.times import _is_standard_calendar
-
-    if freq is None and any(arg is None for arg in [periods, start, end]):
-        freq = "D"
 
     if tz is not None:
         use_cftime = False

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -1733,3 +1733,47 @@ def test_cftime_range_same_as_pandas(start, end, freq):
     expected = date_range(start, end, freq=freq, use_cftime=False)
 
     np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.filterwarnings("ignore:Converting a CFTimeIndex with:")
+@pytest.mark.parametrize(
+    "start, end",
+    [
+        ("2022-01-01", "2022-01-10"),
+        ("2022-02-01", "2022-02-28"),
+        ("2022-03-01", "2022-03-31"),
+    ],
+)
+def test_cftime_range_no_freq(start, end):
+    """
+    Test whether cftime_range produces the same result as Pandas
+    when freq is not provided, but start and end are.
+    """
+    # Generate date ranges using cftime_range
+    result = cftime_range(start=start, end=end)
+    result = result.to_datetimeindex()
+    expected = pd.date_range(start=start, end=end)
+
+    # Assert that the results are equal
+    np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "start, end",
+    [
+        ("2022-01-01", "2022-01-10"),
+        ("2022-02-01", "2022-02-28"),
+        ("2022-03-01", "2022-03-31"),
+    ],
+)
+def test_date_range_no_freq(start, end):
+    """
+    Test whether date_range produces the same result as Pandas
+    when freq is not provided, but start and end are.
+    """
+    # Generate date ranges using date_range
+    result = date_range(start=start, end=end)
+    expected = pd.date_range(start=start, end=end)
+
+    # Assert that the results are equal
+    np.testing.assert_array_equal(result, expected)

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -1774,5 +1774,4 @@ def test_date_range_no_freq(start, end):
     result = date_range(start=start, end=end)
     expected = pd.date_range(start=start, end=end)
 
-    # Assert that the results are equal
     np.testing.assert_array_equal(result, expected)

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -1754,7 +1754,6 @@ def test_cftime_range_no_freq(start, end):
     result = result.to_datetimeindex()
     expected = pd.date_range(start=start, end=end)
 
-    # Assert that the results are equal
     np.testing.assert_array_equal(result, expected)
 
 

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -1294,7 +1294,6 @@ def test_cftime_range_name():
         (None, None, 5, "YE", None),
         ("2000", None, None, "YE", None),
         (None, "2000", None, "YE", None),
-        ("2000", "2001", None, None, None),
         (None, None, None, None, None),
         ("2000", "2001", None, "YE", "up"),
         ("2000", "2001", 5, "YE", None),
@@ -1737,41 +1736,43 @@ def test_cftime_range_same_as_pandas(start, end, freq):
 
 @pytest.mark.filterwarnings("ignore:Converting a CFTimeIndex with:")
 @pytest.mark.parametrize(
-    "start, end",
+    "start, end, periods",
     [
-        ("2022-01-01", "2022-01-10"),
-        ("2022-02-01", "2022-02-28"),
-        ("2022-03-01", "2022-03-31"),
+        ("2022-01-01", "2022-01-10", 2),
+        ("2022-03-01", "2022-03-31", 2),
+        ("2022-01-01", "2022-01-10", None),
+        ("2022-03-01", "2022-03-31", None),
     ],
 )
-def test_cftime_range_no_freq(start, end):
+def test_cftime_range_no_freq(start, end, periods):
     """
     Test whether cftime_range produces the same result as Pandas
-    when freq is not provided, but start and end are.
+    when freq is not provided, but start, end and periods are.
     """
     # Generate date ranges using cftime_range
-    result = cftime_range(start=start, end=end)
+    result = cftime_range(start=start, end=end, periods=periods)
     result = result.to_datetimeindex()
-    expected = pd.date_range(start=start, end=end)
+    expected = pd.date_range(start=start, end=end, periods=periods)
 
     np.testing.assert_array_equal(result, expected)
 
 
 @pytest.mark.parametrize(
-    "start, end",
+    "start, end, periods",
     [
-        ("2022-01-01", "2022-01-10"),
-        ("2022-02-01", "2022-02-28"),
-        ("2022-03-01", "2022-03-31"),
+        ("2022-01-01", "2022-01-10", 2),
+        ("2022-03-01", "2022-03-31", 2),
+        ("2022-01-01", "2022-01-10", None),
+        ("2022-03-01", "2022-03-31", None),
     ],
 )
-def test_date_range_no_freq(start, end):
+def test_date_range_no_freq(start, end, periods):
     """
     Test whether date_range produces the same result as Pandas
-    when freq is not provided, but start and end are.
+    when freq is not provided, but start, end and periods are.
     """
     # Generate date ranges using date_range
-    result = date_range(start=start, end=end)
-    expected = pd.date_range(start=start, end=end)
+    result = date_range(start=start, end=end, periods=periods)
+    expected = pd.date_range(start=start, end=end, periods=periods)
 
     np.testing.assert_array_equal(result, expected)


### PR DESCRIPTION
This Pull Request addresses the issue reported regarding the default setting of the frequency (freq) parameter in Xarray. Currently, the frequency is explicitly set to "D" by default, which may not always be appropriate behavior. The proposed improvement adjusts the logic to set the frequency to "D" only if any of the parameters (periods, start, or end) are None, providing more flexibility and aligning with expected behavior.

Changes:

Updated logic for setting the frequency parameter to consider periods, start, or end values.
Added checks to ensure that the frequency is set to "D" only when necessary.

Please review and provide feedback on the proposed changes. Any suggestions for further improvements are welcome.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #8770 
