### PR TITLE
Fix non-nanosecond casting behavior for `expand_dims`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,6 +40,11 @@ Bug fixes
 - The default ``freq`` parameter in :py:meth:`xr.date_range` and :py:meth:`xr.cftime_range` is
   set to ``'D'`` only if ``periods``, ``start``, or ``end`` are ``None`` (:issue:`8770`, :pull:`8774`).
   By `Roberto Chang <https://github.com/rjavierch>`_.
+- Ensure that non-nanosecond precision :py:class:`numpy.datetime64` and
+  :py:class:`numpy.timedelta64` values are cast to nanosecond precision values
+  when used in :py:meth:`DataArray.expand_dims` and
+  ::py:meth:`Dataset.expand_dims` (:pull:`8781`).  By `Spencer
+  Clark <https://github.com/spencerkclark>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -218,10 +218,12 @@ def _possibly_convert_datetime_or_timedelta_index(data):
     this in version 2.0.0, in xarray we will need to make sure we are ready to
     handle non-nanosecond precision datetimes or timedeltas in our code
     before allowing such values to pass through unchanged."""
-    if isinstance(data, (pd.DatetimeIndex, pd.TimedeltaIndex)):
-        return _as_nanosecond_precision(data)
-    else:
-        return data
+    if isinstance(data, PandasIndexingAdapter):
+        if isinstance(data.array, (pd.DatetimeIndex, pd.TimedeltaIndex)):
+            data = PandasIndexingAdapter(_as_nanosecond_precision(data.array))
+    elif isinstance(data, (pd.DatetimeIndex, pd.TimedeltaIndex)):
+        data = _as_nanosecond_precision(data)
+    return data
 
 
 def as_compatible_data(

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -60,6 +60,7 @@ from xarray.tests import (
     requires_cupy,
     requires_dask,
     requires_numexpr,
+    requires_pandas_version_two,
     requires_pint,
     requires_scipy,
     requires_sparse,
@@ -3445,6 +3446,13 @@ class TestDataset:
             attrs={"key": "entry"},
         )
         assert_identical(other_way_expected, other_way)
+
+    @requires_pandas_version_two
+    def test_expand_dims_non_nanosecond_conversion(self) -> None:
+        # Regression test for https://github.com/pydata/xarray/issues/7493#issuecomment-1953091000
+        with pytest.warns(UserWarning, match="non-nanosecond precision"):
+            ds = Dataset().expand_dims({"time": [np.datetime64("2018-01-01", "s")]})
+        assert ds.time.dtype == np.dtype("datetime64[ns]")
 
     def test_set_index(self) -> None:
         expected = create_test_multiindex()

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -3011,3 +3011,19 @@ def test_pandas_two_only_timedelta_conversion_warning() -> None:
         var = Variable(["time"], data)
 
     assert var.dtype == np.dtype("timedelta64[ns]")
+
+
+@requires_pandas_version_two
+@pytest.mark.parametrize(
+    ("index", "dtype"),
+    [
+        (pd.date_range("2000", periods=1), "datetime64"),
+        (pd.timedelta_range("1", periods=1), "timedelta64"),
+    ],
+    ids=lambda x: f"{x}",
+)
+def test_pandas_indexing_adapter_non_nanosecond_conversion(index, dtype) -> None:
+    data = PandasIndexingAdapter(index.astype(f"{dtype}[s]"))
+    with pytest.warns(UserWarning, match="non-nanosecond precision"):
+        var = Variable(["time"], data)
+    assert var.dtype == np.dtype(f"{dtype}[ns]")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This PR fixes the issue noted in https://github.com/pydata/xarray/issues/7493#issuecomment-1953091000 that non-nanosecond precision datetime or timedelta values passed to `expand_dims` would not be cast to nanosecond precision.  The underlying issue was that the `_possibly_convert_datetime_or_timedelta_index` function did not appropriately handle being passed `PandasIndexingAdapter` objects.

- [x] Fixes https://github.com/pydata/xarray/issues/7493#issuecomment-1953091000
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
