### PR TITLE
Migrate datatree.py module into xarray.core.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -57,7 +57,7 @@ Internal Changes
 - Migrates ``treenode`` functionality into ``xarray/core`` (:pull:`8757`)
   By `Matt Savoie <https://github.com/flamingbear>`_ and `Tom Nicholas
   <https://github.com/TomNicholas>`_.
-- Migrates ``datatree`` functionality into ``xarray/core``. (:pull: `8786`)
+- Migrates ``datatree`` functionality into ``xarray/core``. (:pull: `8789`)
   By `Owen Littlejohns <https://github.com/owenlittlejohns`_ and `Tom Nicholas
   <https://github.com/TomNicholas>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -57,6 +57,9 @@ Internal Changes
 - Migrates ``treenode`` functionality into ``xarray/core`` (:pull:`8757`)
   By `Matt Savoie <https://github.com/flamingbear>`_ and `Tom Nicholas
   <https://github.com/TomNicholas>`_.
+- Migrates ``datatree`` functionality into ``xarray/core``. (:pull: `8786`)
+  By `Owen Littlejohns <https://github.com/owenlittlejohns`_ and `Tom Nicholas
+  <https://github.com/TomNicholas>`_.
 
 
 .. _whats-new.2024.02.0:

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -74,7 +74,7 @@ Internal Changes
   <https://github.com/TomNicholas>`_.
 - Migrates ``datatree`` functionality into ``xarray/core``. (:pull: `8789`)
   By `Owen Littlejohns <https://github.com/owenlittlejohns>`_, `Matt Savoie
-  <https:/github.com/flamingbear>`_ and `Tom Nicholas <https://github.com/TomNicholas>`_.
+  <https://github.com/flamingbear>`_ and `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 
 .. _whats-new.2024.02.0:

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -68,8 +68,8 @@ Internal Changes
   By `Matt Savoie <https://github.com/flamingbear>`_ and `Tom Nicholas
   <https://github.com/TomNicholas>`_.
 - Migrates ``datatree`` functionality into ``xarray/core``. (:pull: `8789`)
-  By `Owen Littlejohns <https://github.com/owenlittlejohns>`_ and `Tom Nicholas
-  <https://github.com/TomNicholas>`_.
+  By `Owen Littlejohns <https://github.com/owenlittlejohns>`_, `Matt Savoie
+  <https:/github.com/flamingbear>`_ and `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 
 .. _whats-new.2024.02.0:

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -32,10 +32,6 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-- ``Datatree``'s ``as_array`` renamed ``to_dataarray`` to align with ``Dataset``. (:pull:`8789`)
-  By `Owen Littlejohns <https://github.com/owenlittlejohns>`_ and `Matt Savoie
-  <https://github.com/flamingbear>`_
-
 
 Deprecations
 ~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -32,6 +32,10 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- ``Datatree``'s ``as_array`` renamed ``to_dataarray`` to align with ``Dataset``. (:pull:`8789`)
+  By `Owen Littlejohns <https://github.com/owenlittlejohns>`_ and `Matt Savoie
+  <https://github.com/flamingbear>`_
+
 
 Deprecations
 ~~~~~~~~~~~~
@@ -58,7 +62,7 @@ Internal Changes
   By `Matt Savoie <https://github.com/flamingbear>`_ and `Tom Nicholas
   <https://github.com/TomNicholas>`_.
 - Migrates ``datatree`` functionality into ``xarray/core``. (:pull: `8789`)
-  By `Owen Littlejohns <https://github.com/owenlittlejohns`_ and `Tom Nicholas
+  By `Owen Littlejohns <https://github.com/owenlittlejohns>`_ and `Tom Nicholas
   <https://github.com/TomNicholas>`_.
 
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:
     T_NetcdfTypes = Literal[
         "NETCDF4", "NETCDF4_CLASSIC", "NETCDF3_64BIT", "NETCDF3_CLASSIC"
     ]
-    from xarray.datatree_.datatree import DataTree
+    from xarray.core.datatree import DataTree
 
 DATAARRAY_NAME = "__xarray_dataarray_name__"
 DATAARRAY_VARIABLE = "__xarray_dataarray_variable__"

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
     from netCDF4 import Dataset as ncDataset
 
     from xarray.core.dataset import Dataset
+    from xarray.core.datatree import DataTree
     from xarray.core.types import NestedSequence
-    from xarray.datatree_.datatree import DataTree
 
 # Create a logger object, but don't add any handlers. Leave that to user code.
 logger = logging.getLogger(__name__)
@@ -137,8 +137,8 @@ def _open_datatree_netcdf(
     **kwargs,
 ) -> DataTree:
     from xarray.backends.api import open_dataset
+    from xarray.core.datatree import DataTree
     from xarray.core.treenode import NodePath
-    from xarray.datatree_.datatree import DataTree
 
     ds = open_dataset(filename_or_obj, **kwargs)
     tree_root = DataTree.from_dict({"/": ds})

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 
     from xarray.backends.common import AbstractDataStore
     from xarray.core.dataset import Dataset
-    from xarray.datatree_.datatree import DataTree
+    from xarray.core.datatree import DataTree
 
 
 class H5NetCDFArrayWrapper(BaseNetCDF4Array):

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
     from xarray.backends.common import AbstractDataStore
     from xarray.core.dataset import Dataset
-    from xarray.datatree_.datatree import DataTree
+    from xarray.core.datatree import DataTree
 
 # This lookup table maps from dtype.byteorder to a readable endian
 # string used by netCDF4.

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
     from xarray.backends.common import AbstractDataStore
     from xarray.core.dataset import Dataset
-    from xarray.datatree_.datatree import DataTree
+    from xarray.core.datatree import DataTree
 
 
 # need some special secret attributes to tell us the dimensions
@@ -1048,8 +1048,8 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
         import zarr
 
         from xarray.backends.api import open_dataset
+        from xarray.core.datatree import DataTree
         from xarray.core.treenode import NodePath
-        from xarray.datatree_.datatree import DataTree
 
         zds = zarr.open_group(filename_or_obj, mode="r")
         ds = open_dataset(filename_or_obj, engine="zarr", **kwargs)

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -822,7 +822,7 @@ class DataTree(
     def __deepcopy__(self: DataTree, memo: dict[int, Any] | None = None) -> DataTree:
         return self._copy_subtree(deep=True, memo=memo)
 
-    def get(
+    def get(  # type: ignore[override]
         self: DataTree, key: str, default: DataTree | DataArray | None = None
     ) -> DataTree | DataArray | None:
         """

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -10,6 +10,7 @@ from typing import (
     Callable,
     Generic,
     NoReturn,
+    Union,
     overload,
 )
 
@@ -73,7 +74,7 @@ if TYPE_CHECKING:
 # """
 
 
-T_Path = str | NodePath
+T_Path = Union[str, NodePath]
 
 
 def _coerce_to_dataset(data: Dataset | DataArray | None) -> Dataset:

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -919,8 +919,20 @@ class DataTree(
         else:
             raise ValueError("Invalid format for key")
 
+    @overload
+    def update(self, other: Dataset) -> None: ...
+
+    @overload
+    def update(self, other: Mapping[Hashable, DataArray | Variable]) -> None: ...
+
+    @overload
+    def update(self, other: Mapping[str, DataTree]) -> None: ...
+
     def update(
-        self, other: Dataset | Mapping[str, DataTree | DataArray | Variable]
+        self,
+        other: (
+            Dataset | Mapping[Hashable, DataArray | Variable] | Mapping[str, DataTree]
+        ),
     ) -> None:
         """
         Update this node's children and / or variables.
@@ -934,7 +946,8 @@ class DataTree(
             if isinstance(v, DataTree):
                 # avoid named node being stored under inconsistent key
                 new_child = v.copy()
-                new_child.name = k
+                # Datatree's name is always a string until we fix that (#8836)
+                new_child.name = k  # type: ignore[assignment]
                 new_children[k] = new_child
             elif isinstance(v, (DataArray, Variable)):
                 # TODO this should also accommodate other types that can be coerced into Variables

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -174,6 +174,7 @@ class DatasetView(Dataset):
     def __getitem__(self, key: Hashable) -> DataArray:  # type: ignore[overload-overlap]
         ...
 
+    # See: https://github.com/pydata/xarray/issues/8855
     @overload
     def __getitem__(self, key: Any) -> Dataset: ...
 
@@ -441,6 +442,8 @@ class DataTree(
 
     @ds.setter
     def ds(self, data: Dataset | DataArray | None = None) -> None:
+        # Known mypy issue for setters with different type to property:
+        # https://github.com/python/mypy/issues/3004
         ds = _coerce_to_dataset(data)
 
         _check_for_name_collisions(self.children, ds.variables)
@@ -810,7 +813,7 @@ class DataTree(
         """Copy just one node of a tree"""
         new_node: DataTree = DataTree()
         new_node.name = self.name
-        new_node.ds = self.to_dataset().copy(deep=deep)
+        new_node.ds = self.to_dataset().copy(deep=deep)  # type: ignore[assignment]
         return new_node
 
     def __copy__(self: DataTree) -> DataTree:

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -929,12 +929,14 @@ class DataTree(
     def update(self, other: Mapping[Hashable, DataArray | Variable]) -> None: ...
 
     @overload
-    def update(self, other: Mapping[str, DataTree]) -> None: ...
+    def update(self, other: Mapping[str, DataTree | DataArray | Variable]) -> None: ...
 
     def update(
         self,
         other: (
-            Dataset | Mapping[Hashable, DataArray | Variable] | Mapping[str, DataTree]
+            Dataset
+            | Mapping[Hashable, DataArray | Variable]
+            | Mapping[str, DataTree | DataArray | Variable]
         ),
     ) -> None:
         """

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -921,7 +921,9 @@ class DataTree(
         else:
             raise ValueError("Invalid format for key")
 
-    def update(self, other: Dataset | Mapping[str, DataTree | DataArray]) -> None:
+    def update(
+        self, other: Dataset | Mapping[str, DataTree | DataArray | Variable]
+    ) -> None:
         """
         Update this node's children and / or variables.
 

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -289,7 +289,7 @@ class DatasetView(Dataset):
             bar      (x) float64 16B 1.0 2.0
         """
 
-        # Copied from xarray.Dataset so as not to call type(self), which causes problems (see datatree GH188).
+        # Copied from xarray.Dataset so as not to call type(self), which causes problems (see https://github.com/xarray-contrib/datatree/issues/188).
         # TODO Refactor xarray upstream to avoid needing to overwrite this.
         # TODO This copied version will drop all attrs - the keep_attrs stuff should be re-instated
         variables = {
@@ -328,8 +328,6 @@ class DataTree(
     # TODO all groupby classes
 
     # TODO a lot of properties like .variables could be defined in a DataMapping class which both Dataset and DataTree inherit from
-
-    # TODO __slots__
 
     # TODO all groupby classes
 

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -944,7 +944,7 @@ class DataTree(
 
         vars_merge_result = dataset_update_method(self.to_dataset(), new_variables)
         # TODO are there any subtleties with preserving order of children like this?
-        merged_children = dict({**self.children, **new_children})
+        merged_children = {**self.children, **new_children}
         self._replace(
             inplace=True, children=merged_children, **vars_merge_result._asdict()
         )

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1448,7 +1448,7 @@ class DataTree(
 
     # TODO some kind of .collapse() or .flatten() method to merge a subtree
 
-    def as_dataarray(self) -> DataArray:
+    def to_dataarray(self) -> DataArray:
         return self.ds.as_dataarray()
 
     @property

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -167,11 +167,11 @@ class DatasetView(Dataset):
 
     # FIXME https://github.com/python/mypy/issues/7328
     @overload
-    def __getitem__(self, key: Mapping) -> Dataset:  # type: ignore[misc]
+    def __getitem__(self, key: Mapping) -> Dataset:  # type: ignore[overload-overlap]
         ...
 
     @overload
-    def __getitem__(self, key: Hashable) -> DataArray:  # type: ignore[misc]
+    def __getitem__(self, key: Hashable) -> DataArray:  # type: ignore[overload-overlap]
         ...
 
     @overload
@@ -361,7 +361,7 @@ class DataTree(
 
     def __init__(
         self,
-        data: Dataset | DataArray | None = None,
+        data: Dataset | DataArray | DataTree | None = None,
         parent: DataTree | None = None,
         children: Mapping[str, DataTree] | None = None,
         name: str | None = None,
@@ -1337,7 +1337,7 @@ class DataTree(
         # TODO this signature means that func has no way to know which node it is being called upon - change?
 
         # TODO fix this typing error
-        return map_over_subtree(func)(self, *args, **kwargs)  # type: ignore[operator]
+        return map_over_subtree(func)(self, *args, **kwargs)
 
     def map_over_subtree_inplace(
         self,

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1449,7 +1449,7 @@ class DataTree(
     # TODO some kind of .collapse() or .flatten() method to merge a subtree
 
     def to_dataarray(self) -> DataArray:
-        return self.ds.as_dataarray()
+        return self.ds.to_dataarray()
 
     @property
     def groups(self):

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1514,7 +1514,7 @@ class DataTree(
             Persistence mode: “w” means create (overwrite if exists); “w-” means create (fail if exists);
             “a” means override existing variables (create if does not exist); “r+” means modify existing
             array values only (raise an error if any metadata or shapes would change). The default mode
-            is “a” if append_dim is set. Otherwise, it is “r+” if region is set and w- otherwise.
+            is “w-”.
         encoding : dict, optional
             Nested dictionary with variable names as keys and dictionaries of
             variable specific encodings as values, e.g.,

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -940,15 +940,15 @@ class DataTree(
         Just like `dict.update` this is an in-place operation.
         """
         # TODO separate by type
-        new_children = {}
+        new_children: dict[str, DataTree] = {}
         new_variables = {}
         for k, v in other.items():
             if isinstance(v, DataTree):
                 # avoid named node being stored under inconsistent key
-                new_child = v.copy()
+                new_child: DataTree = v.copy()
                 # Datatree's name is always a string until we fix that (#8836)
-                new_child.name = k  # type: ignore[assignment]
-                new_children[k] = new_child
+                new_child.name = str(k)
+                new_children[str(k)] = new_child
             elif isinstance(v, (DataArray, Variable)):
                 # TODO this should also accommodate other types that can be coerced into Variables
                 new_variables[k] = v

--- a/xarray/core/treenode.py
+++ b/xarray/core/treenode.py
@@ -230,7 +230,7 @@ class TreeNode(Generic[Tree]):
         pass
 
     def _iter_parents(self: Tree) -> Iterator[Tree]:
-        """Iterate up the tree, starting from the current node."""
+        """Iterate up the tree, starting from the current node's parent."""
         node: Tree | None = self.parent
         while node is not None:
             yield node

--- a/xarray/datatree_/datatree/__init__.py
+++ b/xarray/datatree_/datatree/__init__.py
@@ -1,15 +1,11 @@
 # import public API
-from .datatree import DataTree
-from .extensions import register_datatree_accessor
 from .mapping import TreeIsomorphismError, map_over_subtree
 from xarray.core.treenode import InvalidTreeError, NotFoundInTreeError
 
 
 __all__ = (
-    "DataTree",
     "TreeIsomorphismError",
     "InvalidTreeError",
     "NotFoundInTreeError",
     "map_over_subtree",
-    "register_datatree_accessor",
 )

--- a/xarray/datatree_/datatree/extensions.py
+++ b/xarray/datatree_/datatree/extensions.py
@@ -1,6 +1,6 @@
 from xarray.core.extensions import _register_accessor
 
-from .datatree import DataTree
+from xarray.core.datatree import DataTree
 
 
 def register_datatree_accessor(name):

--- a/xarray/datatree_/datatree/formatting.py
+++ b/xarray/datatree_/datatree/formatting.py
@@ -2,11 +2,11 @@ from typing import TYPE_CHECKING
 
 from xarray.core.formatting import _compat_to_str, diff_dataset_repr
 
-from .mapping import diff_treestructure
-from .render import RenderTree
+from xarray.datatree_.datatree.mapping import diff_treestructure
+from xarray.datatree_.datatree.render import RenderTree
 
 if TYPE_CHECKING:
-    from .datatree import DataTree
+    from xarray.core.datatree import DataTree
 
 
 def diff_nodewise_summary(a, b, compat):

--- a/xarray/datatree_/datatree/io.py
+++ b/xarray/datatree_/datatree/io.py
@@ -1,4 +1,4 @@
-from xarray.datatree_.datatree import DataTree
+from xarray.core.datatree import DataTree
 
 
 def _get_nc_dataset_class(engine):

--- a/xarray/datatree_/datatree/mapping.py
+++ b/xarray/datatree_/datatree/mapping.py
@@ -156,7 +156,7 @@ def map_over_subtree(func: Callable) -> Callable:
     @functools.wraps(func)
     def _map_over_subtree(*args, **kwargs) -> DataTree | Tuple[DataTree, ...]:
         """Internal function which maps func over every node in tree, returning a tree of the results."""
-        from .datatree import DataTree
+        from xarray.core.datatree import DataTree
 
         all_tree_inputs = [a for a in args if isinstance(a, DataTree)] + [
             a for a in kwargs.values() if isinstance(a, DataTree)

--- a/xarray/datatree_/datatree/render.py
+++ b/xarray/datatree_/datatree/render.py
@@ -6,7 +6,7 @@ import collections
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .datatree import DataTree
+    from xarray.core.datatree import DataTree
 
 Row = collections.namedtuple("Row", ("pre", "fill", "node"))
 

--- a/xarray/datatree_/datatree/testing.py
+++ b/xarray/datatree_/datatree/testing.py
@@ -1,6 +1,6 @@
 from xarray.testing.assertions import ensure_warnings
 
-from .datatree import DataTree
+from xarray.core.datatree import DataTree
 from .formatting import diff_tree_repr
 
 

--- a/xarray/datatree_/datatree/tests/conftest.py
+++ b/xarray/datatree_/datatree/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import xarray as xr
 
-from xarray.datatree_.datatree import DataTree
+from xarray.core.datatree import DataTree
 
 
 @pytest.fixture(scope="module")

--- a/xarray/datatree_/datatree/tests/test_dataset_api.py
+++ b/xarray/datatree_/datatree/tests/test_dataset_api.py
@@ -1,7 +1,7 @@
 import numpy as np
 import xarray as xr
 
-from xarray.datatree_.datatree import DataTree
+from xarray.core.datatree import DataTree
 from xarray.datatree_.datatree.testing import assert_equal
 
 

--- a/xarray/datatree_/datatree/tests/test_extensions.py
+++ b/xarray/datatree_/datatree/tests/test_extensions.py
@@ -1,6 +1,7 @@
 import pytest
 
-from xarray.datatree_.datatree import DataTree, register_datatree_accessor
+from xarray.core.datatree import DataTree
+from xarray.datatree_.datatree.extensions import register_datatree_accessor
 
 
 class TestAccessor:

--- a/xarray/datatree_/datatree/tests/test_formatting.py
+++ b/xarray/datatree_/datatree/tests/test_formatting.py
@@ -2,7 +2,7 @@ from textwrap import dedent
 
 from xarray import Dataset
 
-from xarray.datatree_.datatree import DataTree
+from xarray.core.datatree import DataTree
 from xarray.datatree_.datatree.formatting import diff_tree_repr
 
 

--- a/xarray/datatree_/datatree/tests/test_formatting_html.py
+++ b/xarray/datatree_/datatree/tests/test_formatting_html.py
@@ -1,7 +1,8 @@
 import pytest
 import xarray as xr
 
-from xarray.datatree_.datatree import DataTree, formatting_html
+from xarray.core.datatree import DataTree
+from xarray.datatree_.datatree import formatting_html
 
 
 @pytest.fixture(scope="module", params=["some html", "some other html"])

--- a/xarray/datatree_/datatree/tests/test_mapping.py
+++ b/xarray/datatree_/datatree/tests/test_mapping.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xarray.datatree_.datatree.datatree import DataTree
+from xarray.core.datatree import DataTree
 from xarray.datatree_.datatree.mapping import TreeIsomorphismError, check_isomorphic, map_over_subtree
 from xarray.datatree_.datatree.testing import assert_equal
 

--- a/xarray/tests/conftest.py
+++ b/xarray/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 
 import xarray as xr
 from xarray import DataArray, Dataset
-from xarray.datatree_.datatree import DataTree
+from xarray.core.datatree import DataTree
 from xarray.tests import create_test_data, requires_dask
 
 

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -13,19 +13,19 @@ from xarray.tests import create_test_data, source_ndarray
 
 class TestTreeCreation:
     def test_empty(self):
-        dt = DataTree(name="root")
+        dt: DataTree = DataTree(name="root")
         assert dt.name == "root"
         assert dt.parent is None
         assert dt.children == {}
         xrt.assert_identical(dt.to_dataset(), xr.Dataset())
 
     def test_unnamed(self):
-        dt = DataTree()
+        dt: DataTree = DataTree()
         assert dt.name is None
 
     def test_bad_names(self):
         with pytest.raises(TypeError):
-            DataTree(name=5)
+            DataTree(name=5)  # type: ignore[arg-type]
 
         with pytest.raises(ValueError):
             DataTree(name="folder/data")
@@ -33,7 +33,7 @@ class TestTreeCreation:
 
 class TestFamilyTree:
     def test_setparent_unnamed_child_node_fails(self):
-        john = DataTree(name="john")
+        john: DataTree = DataTree(name="john")
         with pytest.raises(ValueError, match="unnamed"):
             DataTree(parent=john)
 
@@ -41,8 +41,8 @@ class TestFamilyTree:
         root_data = xr.Dataset({"a": ("y", [6, 7, 8]), "set0": ("x", [9, 10])})
         set1_data = xr.Dataset({"a": 0, "b": 1})
 
-        root = DataTree(data=root_data)
-        set1 = DataTree(name="set1", parent=root, data=set1_data)
+        root: DataTree = DataTree(data=root_data)
+        set1: DataTree = DataTree(name="set1", parent=root, data=set1_data)
         DataTree(name="set1", parent=root)
         DataTree(name="set2", parent=set1)
 
@@ -51,11 +51,11 @@ class TestFamilyTree:
         set1_data = xr.Dataset({"a": 0, "b": 1})
         set2_data = xr.Dataset({"a": ("x", [2, 3]), "b": ("x", [0.1, 0.2])})
 
-        root = DataTree(data=root_data)
-        set1 = DataTree(name="set1", parent=root, data=set1_data)
+        root: DataTree = DataTree(data=root_data)
+        set1: DataTree = DataTree(name="set1", parent=root, data=set1_data)
         DataTree(name="set1", parent=set1)
         DataTree(name="set2", parent=set1)
-        set2 = DataTree(name="set2", parent=root, data=set2_data)
+        set2: DataTree = DataTree(name="set2", parent=root, data=set2_data)
         DataTree(name="set1", parent=set2)
         DataTree(name="set3", parent=root)
 
@@ -65,36 +65,36 @@ class TestFamilyTree:
 
 class TestNames:
     def test_child_gets_named_on_attach(self):
-        sue = DataTree()
-        mary = DataTree(children={"Sue": sue})  # noqa
+        sue: DataTree = DataTree()
+        mary: DataTree = DataTree(children={"Sue": sue})  # noqa
         assert sue.name == "Sue"
 
 
 class TestPaths:
     def test_path_property(self):
-        sue = DataTree()
-        mary = DataTree(children={"Sue": sue})
-        john = DataTree(children={"Mary": mary})  # noqa
+        sue: DataTree = DataTree()
+        mary: DataTree = DataTree(children={"Sue": sue})
+        john: DataTree = DataTree(children={"Mary": mary})
         assert sue.path == "/Mary/Sue"
         assert john.path == "/"
 
     def test_path_roundtrip(self):
-        sue = DataTree()
-        mary = DataTree(children={"Sue": sue})
-        john = DataTree(children={"Mary": mary})  # noqa
+        sue: DataTree = DataTree()
+        mary: DataTree = DataTree(children={"Sue": sue})
+        john: DataTree = DataTree(children={"Mary": mary})
         assert john[sue.path] is sue
 
     def test_same_tree(self):
-        mary = DataTree()
-        kate = DataTree()
-        john = DataTree(children={"Mary": mary, "Kate": kate})  # noqa
+        mary: DataTree = DataTree()
+        kate: DataTree = DataTree()
+        john: DataTree = DataTree(children={"Mary": mary, "Kate": kate})  # noqa
         assert mary.same_tree(kate)
 
     def test_relative_paths(self):
-        sue = DataTree()
-        mary = DataTree(children={"Sue": sue})
-        annie = DataTree()
-        john = DataTree(children={"Mary": mary, "Annie": annie})
+        sue: DataTree = DataTree()
+        mary: DataTree = DataTree(children={"Sue": sue})
+        annie: DataTree = DataTree()
+        john: DataTree = DataTree(children={"Mary": mary, "Annie": annie})
 
         result = sue.relative_to(john)
         assert result == "Mary/Sue"
@@ -103,7 +103,7 @@ class TestPaths:
         assert sue.relative_to(annie) == "../Mary/Sue"
         assert sue.relative_to(sue) == "."
 
-        evil_kate = DataTree()
+        evil_kate: DataTree = DataTree()
         with pytest.raises(
             NotFoundInTreeError, match="nodes do not lie within the same tree"
         ):
@@ -113,35 +113,35 @@ class TestPaths:
 class TestStoreDatasets:
     def test_create_with_data(self):
         dat = xr.Dataset({"a": 0})
-        john = DataTree(name="john", data=dat)
+        john: DataTree = DataTree(name="john", data=dat)
 
         xrt.assert_identical(john.to_dataset(), dat)
 
         with pytest.raises(TypeError):
-            DataTree(name="mary", parent=john, data="junk")  # noqa
+            DataTree(name="mary", parent=john, data="junk")  # type: ignore[arg-type]
 
     def test_set_data(self):
-        john = DataTree(name="john")
+        john: DataTree = DataTree(name="john")
         dat = xr.Dataset({"a": 0})
         john.ds = dat
 
         xrt.assert_identical(john.to_dataset(), dat)
 
         with pytest.raises(TypeError):
-            john.ds = "junk"
+            john.ds = "junk"  # type: ignore[assignment]
 
     def test_has_data(self):
-        john = DataTree(name="john", data=xr.Dataset({"a": 0}))
+        john: DataTree = DataTree(name="john", data=xr.Dataset({"a": 0}))
         assert john.has_data
 
-        john = DataTree(name="john", data=None)
-        assert not john.has_data
+        john_no_data: DataTree = DataTree(name="john", data=None)
+        assert not john_no_data.has_data
 
     def test_is_hollow(self):
-        john = DataTree(data=xr.Dataset({"a": 0}))
+        john: DataTree = DataTree(data=xr.Dataset({"a": 0}))
         assert john.is_hollow
 
-        eve = DataTree(children={"john": john})
+        eve: DataTree = DataTree(children={"john": john})
         assert eve.is_hollow
 
         eve.ds = xr.Dataset({"a": 1})
@@ -150,12 +150,12 @@ class TestStoreDatasets:
 
 class TestVariablesChildrenNameCollisions:
     def test_parent_already_has_variable_with_childs_name(self):
-        dt = DataTree(data=xr.Dataset({"a": [0], "b": 1}))
+        dt: DataTree = DataTree(data=xr.Dataset({"a": [0], "b": 1}))
         with pytest.raises(KeyError, match="already contains a data variable named a"):
             DataTree(name="a", data=None, parent=dt)
 
     def test_assign_when_already_child_with_variables_name(self):
-        dt = DataTree(data=None)
+        dt: DataTree = DataTree(data=None)
         DataTree(name="a", data=None, parent=dt)
         with pytest.raises(KeyError, match="names would collide"):
             dt.ds = xr.Dataset({"a": 0})
@@ -172,44 +172,44 @@ class TestGet: ...
 
 class TestGetItem:
     def test_getitem_node(self):
-        folder1 = DataTree(name="folder1")
-        results = DataTree(name="results", parent=folder1)
-        highres = DataTree(name="highres", parent=results)
+        folder1: DataTree = DataTree(name="folder1")
+        results: DataTree = DataTree(name="results", parent=folder1)
+        highres: DataTree = DataTree(name="highres", parent=results)
         assert folder1["results"] is results
         assert folder1["results/highres"] is highres
 
     def test_getitem_self(self):
-        dt = DataTree()
+        dt: DataTree = DataTree()
         assert dt["."] is dt
 
     def test_getitem_single_data_variable(self):
         data = xr.Dataset({"temp": [0, 50]})
-        results = DataTree(name="results", data=data)
+        results: DataTree = DataTree(name="results", data=data)
         xrt.assert_identical(results["temp"], data["temp"])
 
     def test_getitem_single_data_variable_from_node(self):
         data = xr.Dataset({"temp": [0, 50]})
-        folder1 = DataTree(name="folder1")
-        results = DataTree(name="results", parent=folder1)
+        folder1: DataTree = DataTree(name="folder1")
+        results: DataTree = DataTree(name="results", parent=folder1)
         DataTree(name="highres", parent=results, data=data)
         xrt.assert_identical(folder1["results/highres/temp"], data["temp"])
 
     def test_getitem_nonexistent_node(self):
-        folder1 = DataTree(name="folder1")
+        folder1: DataTree = DataTree(name="folder1")
         DataTree(name="results", parent=folder1)
         with pytest.raises(KeyError):
             folder1["results/highres"]
 
     def test_getitem_nonexistent_variable(self):
         data = xr.Dataset({"temp": [0, 50]})
-        results = DataTree(name="results", data=data)
+        results: DataTree = DataTree(name="results", data=data)
         with pytest.raises(KeyError):
             results["pressure"]
 
     @pytest.mark.xfail(reason="Should be deprecated in favour of .subset")
     def test_getitem_multiple_data_variables(self):
         data = xr.Dataset({"temp": [0, 50], "p": [5, 8, 7]})
-        results = DataTree(name="results", data=data)
+        results: DataTree = DataTree(name="results", data=data)
         xrt.assert_identical(results[["temp", "p"]], data[["temp", "p"]])
 
     @pytest.mark.xfail(
@@ -217,13 +217,13 @@ class TestGetItem:
     )
     def test_getitem_dict_like_selection_access_to_dataset(self):
         data = xr.Dataset({"temp": [0, 50]})
-        results = DataTree(name="results", data=data)
+        results: DataTree = DataTree(name="results", data=data)
         xrt.assert_identical(results[{"temp": 1}], data[{"temp": 1}])
 
 
 class TestUpdate:
     def test_update(self):
-        dt = DataTree()
+        dt: DataTree = DataTree()
         dt.update({"foo": xr.DataArray(0), "a": DataTree()})
         expected = DataTree.from_dict({"/": xr.Dataset({"foo": 0}), "a": None})
         print(dt)
@@ -235,13 +235,13 @@ class TestUpdate:
 
     def test_update_new_named_dataarray(self):
         da = xr.DataArray(name="temp", data=[0, 50])
-        folder1 = DataTree(name="folder1")
+        folder1: DataTree = DataTree(name="folder1")
         folder1.update({"results": da})
         expected = da.rename("results")
         xrt.assert_equal(folder1["results"], expected)
 
     def test_update_doesnt_alter_child_name(self):
-        dt = DataTree()
+        dt: DataTree = DataTree()
         dt.update({"foo": xr.DataArray(0), "a": DataTree(name="b")})
         assert "a" in dt.children
         child = dt["a"]
@@ -338,8 +338,8 @@ class TestCopy:
 
 class TestSetItem:
     def test_setitem_new_child_node(self):
-        john = DataTree(name="john")
-        mary = DataTree(name="mary")
+        john: DataTree = DataTree(name="john")
+        mary: DataTree = DataTree(name="mary")
         john["mary"] = mary
 
         grafted_mary = john["mary"]
@@ -347,14 +347,14 @@ class TestSetItem:
         assert grafted_mary.name == "mary"
 
     def test_setitem_unnamed_child_node_becomes_named(self):
-        john2 = DataTree(name="john2")
+        john2: DataTree = DataTree(name="john2")
         john2["sonny"] = DataTree()
         assert john2["sonny"].name == "sonny"
 
     def test_setitem_new_grandchild_node(self):
-        john = DataTree(name="john")
-        mary = DataTree(name="mary", parent=john)
-        rose = DataTree(name="rose")
+        john: DataTree = DataTree(name="john")
+        mary: DataTree = DataTree(name="mary", parent=john)
+        rose: DataTree = DataTree(name="rose")
         john["mary/rose"] = rose
 
         grafted_rose = john["mary/rose"]
@@ -362,21 +362,21 @@ class TestSetItem:
         assert grafted_rose.name == "rose"
 
     def test_grafted_subtree_retains_name(self):
-        subtree = DataTree(name="original_subtree_name")
-        root = DataTree(name="root")
+        subtree: DataTree = DataTree(name="original_subtree_name")
+        root: DataTree = DataTree(name="root")
         root["new_subtree_name"] = subtree  # noqa
         assert subtree.name == "original_subtree_name"
 
     def test_setitem_new_empty_node(self):
-        john = DataTree(name="john")
+        john: DataTree = DataTree(name="john")
         john["mary"] = DataTree()
         mary = john["mary"]
         assert isinstance(mary, DataTree)
         xrt.assert_identical(mary.to_dataset(), xr.Dataset())
 
     def test_setitem_overwrite_data_in_node_with_none(self):
-        john = DataTree(name="john")
-        mary = DataTree(name="mary", parent=john, data=xr.Dataset())
+        john: DataTree = DataTree(name="john")
+        mary: DataTree = DataTree(name="mary", parent=john, data=xr.Dataset())
         john["mary"] = DataTree()
         xrt.assert_identical(mary.to_dataset(), xr.Dataset())
 
@@ -387,65 +387,65 @@ class TestSetItem:
     @pytest.mark.xfail(reason="assigning Datasets doesn't yet create new nodes")
     def test_setitem_dataset_on_this_node(self):
         data = xr.Dataset({"temp": [0, 50]})
-        results = DataTree(name="results")
+        results: DataTree = DataTree(name="results")
         results["."] = data
         xrt.assert_identical(results.to_dataset(), data)
 
     @pytest.mark.xfail(reason="assigning Datasets doesn't yet create new nodes")
     def test_setitem_dataset_as_new_node(self):
         data = xr.Dataset({"temp": [0, 50]})
-        folder1 = DataTree(name="folder1")
+        folder1: DataTree = DataTree(name="folder1")
         folder1["results"] = data
         xrt.assert_identical(folder1["results"].to_dataset(), data)
 
     @pytest.mark.xfail(reason="assigning Datasets doesn't yet create new nodes")
     def test_setitem_dataset_as_new_node_requiring_intermediate_nodes(self):
         data = xr.Dataset({"temp": [0, 50]})
-        folder1 = DataTree(name="folder1")
+        folder1: DataTree = DataTree(name="folder1")
         folder1["results/highres"] = data
         xrt.assert_identical(folder1["results/highres"].to_dataset(), data)
 
     def test_setitem_named_dataarray(self):
         da = xr.DataArray(name="temp", data=[0, 50])
-        folder1 = DataTree(name="folder1")
+        folder1: DataTree = DataTree(name="folder1")
         folder1["results"] = da
         expected = da.rename("results")
         xrt.assert_equal(folder1["results"], expected)
 
     def test_setitem_unnamed_dataarray(self):
         data = xr.DataArray([0, 50])
-        folder1 = DataTree(name="folder1")
+        folder1: DataTree = DataTree(name="folder1")
         folder1["results"] = data
         xrt.assert_equal(folder1["results"], data)
 
     def test_setitem_variable(self):
         var = xr.Variable(data=[0, 50], dims="x")
-        folder1 = DataTree(name="folder1")
+        folder1: DataTree = DataTree(name="folder1")
         folder1["results"] = var
         xrt.assert_equal(folder1["results"], xr.DataArray(var))
 
     def test_setitem_coerce_to_dataarray(self):
-        folder1 = DataTree(name="folder1")
+        folder1: DataTree = DataTree(name="folder1")
         folder1["results"] = 0
         xrt.assert_equal(folder1["results"], xr.DataArray(0))
 
     def test_setitem_add_new_variable_to_empty_node(self):
-        results = DataTree(name="results")
+        results: DataTree = DataTree(name="results")
         results["pressure"] = xr.DataArray(data=[2, 3])
         assert "pressure" in results.ds
         results["temp"] = xr.Variable(data=[10, 11], dims=["x"])
         assert "temp" in results.ds
 
         # What if there is a path to traverse first?
-        results = DataTree(name="results")
-        results["highres/pressure"] = xr.DataArray(data=[2, 3])
-        assert "pressure" in results["highres"].ds
-        results["highres/temp"] = xr.Variable(data=[10, 11], dims=["x"])
-        assert "temp" in results["highres"].ds
+        results_with_path: DataTree = DataTree(name="results")
+        results_with_path["highres/pressure"] = xr.DataArray(data=[2, 3])
+        assert "pressure" in results_with_path["highres"].ds
+        results_with_path["highres/temp"] = xr.Variable(data=[10, 11], dims=["x"])
+        assert "temp" in results_with_path["highres"].ds
 
     def test_setitem_dataarray_replace_existing_node(self):
         t = xr.Dataset({"temp": [0, 50]})
-        results = DataTree(name="results", data=t)
+        results: DataTree = DataTree(name="results", data=t)
         p = xr.DataArray(data=[2, 3])
         results["pressure"] = p
         expected = t.assign(pressure=p)
@@ -502,8 +502,8 @@ class TestTreeFromDict:
         ]
 
     def test_datatree_values(self):
-        dat1 = DataTree(data=xr.Dataset({"a": 1}))
-        expected = DataTree()
+        dat1: DataTree = DataTree(data=xr.Dataset({"a": 1}))
+        expected: DataTree = DataTree()
         expected["a"] = dat1
 
         actual = DataTree.from_dict({"a": dat1})
@@ -528,7 +528,7 @@ class TestTreeFromDict:
 class TestDatasetView:
     def test_view_contents(self):
         ds = create_test_data()
-        dt = DataTree(data=ds)
+        dt: DataTree = DataTree(data=ds)
         assert ds.identical(
             dt.ds
         )  # this only works because Dataset.identical doesn't check types
@@ -536,7 +536,7 @@ class TestDatasetView:
 
     def test_immutability(self):
         # See issue https://github.com/xarray-contrib/datatree/issues/38
-        dt = DataTree(name="root", data=None)
+        dt: DataTree = DataTree(name="root", data=None)
         DataTree(name="a", data=None, parent=dt)
 
         with pytest.raises(
@@ -554,7 +554,7 @@ class TestDatasetView:
 
     def test_methods(self):
         ds = create_test_data()
-        dt = DataTree(data=ds)
+        dt: DataTree = DataTree(data=ds)
         assert ds.mean().identical(dt.ds.mean())
         assert type(dt.ds.mean()) == xr.Dataset
 
@@ -573,7 +573,7 @@ class TestDatasetView:
             dims=["x", "y", "time"],
             coords={"area": (["x", "y"], np.random.rand(3, 4))},
         ).to_dataset(name="data")
-        dt = DataTree(data=a)
+        dt: DataTree = DataTree(data=a)
 
         def weighted_mean(ds):
             return ds.weighted(ds.area).mean(["x", "y"])
@@ -644,7 +644,7 @@ class TestRestructuring:
         assert childless.children == {}
 
     def test_assign(self):
-        dt = DataTree()
+        dt: DataTree = DataTree()
         expected = DataTree.from_dict({"/": xr.Dataset({"foo": 0}), "/a": None})
 
         # kwargs form

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -123,7 +123,7 @@ class TestStoreDatasets:
     def test_set_data(self):
         john: DataTree = DataTree(name="john")
         dat = xr.Dataset({"a": 0})
-        john.ds = dat
+        john.ds = dat  # type: ignore[assignment]
 
         xrt.assert_identical(john.to_dataset(), dat)
 
@@ -144,7 +144,7 @@ class TestStoreDatasets:
         eve: DataTree = DataTree(children={"john": john})
         assert eve.is_hollow
 
-        eve.ds = xr.Dataset({"a": 1})
+        eve.ds = xr.Dataset({"a": 1})  # type: ignore[assignment]
         assert not eve.is_hollow
 
 
@@ -158,13 +158,13 @@ class TestVariablesChildrenNameCollisions:
         dt: DataTree = DataTree(data=None)
         DataTree(name="a", data=None, parent=dt)
         with pytest.raises(KeyError, match="names would collide"):
-            dt.ds = xr.Dataset({"a": 0})
+            dt.ds = xr.Dataset({"a": 0})  # type: ignore[assignment]
 
-        dt.ds = xr.Dataset()
+        dt.ds = xr.Dataset()  # type: ignore[assignment]
 
         new_ds = dt.to_dataset().assign(a=xr.DataArray(0))
         with pytest.raises(KeyError, match="names would collide"):
-            dt.ds = new_ds
+            dt.ds = new_ds  # type: ignore[assignment]
 
 
 class TestGet: ...
@@ -380,7 +380,7 @@ class TestSetItem:
         john["mary"] = DataTree()
         xrt.assert_identical(mary.to_dataset(), xr.Dataset())
 
-        john.ds = xr.Dataset()
+        john.ds = xr.Dataset()  # type: ignore[assignment]
         with pytest.raises(ValueError, match="has no name"):
             john["."] = DataTree()
 

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -2,12 +2,13 @@ from copy import copy, deepcopy
 
 import numpy as np
 import pytest
-import xarray as xr
-import xarray.testing as xrt
-from xarray.tests import create_test_data, source_ndarray
 
+import xarray as xr
 import xarray.datatree_.datatree.testing as dtt
-from xarray.datatree_.datatree import DataTree, NotFoundInTreeError
+import xarray.testing as xrt
+from xarray.core.datatree import DataTree
+from xarray.core.treenode import NotFoundInTreeError
+from xarray.tests import create_test_data, source_ndarray
 
 
 class TestTreeCreation:
@@ -166,8 +167,7 @@ class TestVariablesChildrenNameCollisions:
             dt.ds = new_ds
 
 
-class TestGet:
-    ...
+class TestGet: ...
 
 
 class TestGetItem:
@@ -212,7 +212,9 @@ class TestGetItem:
         results = DataTree(name="results", data=data)
         xrt.assert_identical(results[["temp", "p"]], data[["temp", "p"]])
 
-    @pytest.mark.xfail(reason="Indexing needs to return whole tree (GH https://github.com/xarray-contrib/datatree/issues/77)")
+    @pytest.mark.xfail(
+        reason="Indexing needs to return whole tree (GH https://github.com/xarray-contrib/datatree/issues/77)"
+    )
     def test_getitem_dict_like_selection_access_to_dataset(self):
         data = xr.Dataset({"temp": [0, 50]})
         results = DataTree(name="results", data=data)
@@ -450,8 +452,7 @@ class TestSetItem:
         xrt.assert_identical(results.to_dataset(), expected)
 
 
-class TestDictionaryInterface:
-    ...
+class TestDictionaryInterface: ...
 
 
 class TestTreeFromDict:

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -210,7 +210,7 @@ class TestGetItem:
     def test_getitem_multiple_data_variables(self):
         data = xr.Dataset({"temp": [0, 50], "p": [5, 8, 7]})
         results: DataTree = DataTree(name="results", data=data)
-        xrt.assert_identical(results[["temp", "p"]], data[["temp", "p"]])
+        xrt.assert_identical(results[["temp", "p"]], data[["temp", "p"]])  # type: ignore[index]
 
     @pytest.mark.xfail(
         reason="Indexing needs to return whole tree (GH https://github.com/xarray-contrib/datatree/issues/77)"
@@ -218,7 +218,7 @@ class TestGetItem:
     def test_getitem_dict_like_selection_access_to_dataset(self):
         data = xr.Dataset({"temp": [0, 50]})
         results: DataTree = DataTree(name="results", data=data)
-        xrt.assert_identical(results[{"temp": 1}], data[{"temp": 1}])
+        xrt.assert_identical(results[{"temp": 1}], data[{"temp": 1}])  # type: ignore[index]
 
 
 class TestUpdate:
@@ -728,5 +728,5 @@ class TestSubset:
             },
             name="Abe",
         )
-        elders = simpsons.filter(lambda node: node["age"] > 18)
+        elders = simpsons.filter(lambda node: node["age"].item() > 18)
         dtt.assert_identical(elders, expected)


### PR DESCRIPTION
This PR migrates the `datatree.py` module to `xarray/core/datatree.py`, as part of the on-going effort to merge `xarray-datatree` into `xarray` itself.

Most of the changes are import path changes, and type-hints, but there is one minor change to the methods available on the `DataTree` class: `to_array` has been converted to `to_dataarray`, to align with the method on `Dataset`. (See conversation [here](https://github.com/flamingbear/xarray/pull/6#discussion_r1504959971))

This PR was initially published as a draft [here](https://github.com/flamingbear/xarray/pull/6).

- [x] Completes migration step for `datatree/datatree.py` https://github.com/pydata/xarray/issues/8572
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`