### PR TITLE
Expand use of `.oindex` and `.vindex`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -29,6 +29,9 @@ New Features
 - Add the ``.vindex`` property to Explicitly Indexed Arrays for vectorized indexing functionality. (:issue:`8238`, :pull:`8780`)
   By `Anderson Banihirwe <https://github.com/andersy005>`_.
 
+- Expand use of ``.oindex`` and ``.vindex`` properties. (:pull: `8790`)
+  By `Anderson Banihirwe <https://github.com/andersy005>`_ and `Deepak Cherian <https://github.com/dcherian>`_.
+
 Breaking changes
 ~~~~~~~~~~~~~~~~
 

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -70,7 +70,7 @@ class ScipyArrayWrapper(BackendArray):
 
     def __getitem__(self, key):
         data = indexing.explicit_indexing_adapter(
-            key, self.shape, indexing.IndexingSupport.BASIC, self._getitem
+            key, self.shape, indexing.IndexingSupport.OUTER_1VECTOR, self._getitem
         )
         # Copy data if the source file is mmapped. This makes things consistent
         # with the netCDF4 library by ensuring we can safely read arrays even

--- a/xarray/coding/strings.py
+++ b/xarray/coding/strings.py
@@ -238,6 +238,12 @@ class StackedBytesArray(indexing.ExplicitlyIndexedNDArrayMixin):
     def __repr__(self):
         return f"{type(self).__name__}({self.array!r})"
 
+    def _vindex_get(self, key):
+        return _numpy_char_to_bytes(self.array.vindex[key])
+
+    def _oindex_get(self, key):
+        return _numpy_char_to_bytes(self.array.oindex[key])
+
     def __getitem__(self, key):
         # require slicing the last dimension completely
         key = type(key)(indexing.expanded_indexer(key.tuple, self.array.ndim))

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -68,6 +68,12 @@ class _ElementwiseFunctionArray(indexing.ExplicitlyIndexedNDArrayMixin):
     def dtype(self) -> np.dtype:
         return np.dtype(self._dtype)
 
+    def _oindex_get(self, key):
+        return type(self)(self.array.oindex[key], self.func, self.dtype)
+
+    def _vindex_get(self, key):
+        return type(self)(self.array.vindex[key], self.func, self.dtype)
+
     def __getitem__(self, key):
         return type(self)(self.array[key], self.func, self.dtype)
 

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -109,6 +109,12 @@ class NativeEndiannessArray(indexing.ExplicitlyIndexedNDArrayMixin):
     def dtype(self) -> np.dtype:
         return np.dtype(self.array.dtype.kind + str(self.array.dtype.itemsize))
 
+    def _oindex_get(self, key):
+        return np.asarray(self.array.oindex[key], dtype=self.dtype)
+
+    def _vindex_get(self, key):
+        return np.asarray(self.array.vindex[key], dtype=self.dtype)
+
     def __getitem__(self, key) -> np.ndarray:
         return np.asarray(self.array[key], dtype=self.dtype)
 
@@ -140,6 +146,12 @@ class BoolTypeArray(indexing.ExplicitlyIndexedNDArrayMixin):
     @property
     def dtype(self) -> np.dtype:
         return np.dtype("bool")
+
+    def _oindex_get(self, key):
+        return np.asarray(self.array.oindex[key], dtype=self.dtype)
+
+    def _vindex_get(self, key):
+        return np.asarray(self.array.vindex[key], dtype=self.dtype)
 
     def __getitem__(self, key) -> np.ndarray:
         return np.asarray(self.array[key], dtype=self.dtype)

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -600,6 +600,8 @@ class LazilyIndexedArray(ExplicitlyIndexedNDArrayMixin):
             else:
                 array = self.array[self.key]
         else:
+            # If the array is not an ExplicitlyIndexedNDArrayMixin,
+            # it may wrap a BackendArray so use its __getitem__
             array = self.array[self.key]
 
         # self.array[self.key] is now a numpy array when
@@ -673,6 +675,9 @@ class LazilyVectorizedIndexedArray(ExplicitlyIndexedNDArrayMixin):
                 array = self.array.oindex[self.key]
             else:
                 array = self.array[self.key]
+
+        # If the array is not an ExplicitlyIndexedNDArrayMixin,
+        # it may wrap a BackendArray so use its __getitem__
         else:
             array = self.array[self.key]
         # self.array[self.key] is now a numpy array when

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1027,10 +1027,10 @@ def _decompose_vectorized_indexer(
     >>> array = np.arange(36).reshape(6, 6)
     >>> backend_indexer = OuterIndexer((np.array([0, 1, 3]), np.array([2, 3])))
     >>> # load subslice of the array
-    ... array = NumpyIndexingAdapter(array)[backend_indexer]
+    ... array = NumpyIndexingAdapter(array).oindex[backend_indexer]
     >>> np_indexer = VectorizedIndexer((np.array([0, 2, 1]), np.array([0, 1, 0])))
     >>> # vectorized indexing for on-memory np.ndarray.
-    ... NumpyIndexingAdapter(array)[np_indexer]
+    ... NumpyIndexingAdapter(array).vindex[np_indexer]
     array([ 2, 21,  8])
     """
     assert isinstance(indexer, VectorizedIndexer)

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1112,7 +1112,7 @@ def _decompose_outer_indexer(
     ... array = NumpyIndexingAdapter(array)[backend_indexer]
     >>> np_indexer = OuterIndexer((np.array([0, 2, 1]), np.array([0, 1, 0])))
     >>> # outer indexing for on-memory np.ndarray.
-    ... NumpyIndexingAdapter(array)[np_indexer]
+    ... NumpyIndexingAdapter(array).oindex[np_indexer]
     array([[ 2,  3,  2],
            [14, 15, 14],
            [ 8,  9,  8]])

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -592,7 +592,12 @@ class LazilyIndexedArray(ExplicitlyIndexedNDArrayMixin):
         return tuple(shape)
 
     def get_duck_array(self):
-        array = self.array[self.key]
+        if isinstance(self.key, OuterIndexer):
+            array = self.array.oindex[self.key]
+        elif isinstance(self.key, VectorizedIndexer):
+            array = self.array.vindex[self.key]
+        else:
+            array = self.array[self.key]
         # self.array[self.key] is now a numpy array when
         # self.array is a BackendArray subclass
         # and self.key is BasicIndexer((slice(None, None, None),))
@@ -656,7 +661,12 @@ class LazilyVectorizedIndexedArray(ExplicitlyIndexedNDArrayMixin):
         return np.broadcast(*self.key.tuple).shape
 
     def get_duck_array(self):
-        array = self.array[self.key]
+        if isinstance(self.key, OuterIndexer):
+            array = self.array.oindex[self.key]
+        elif isinstance(self.key, VectorizedIndexer):
+            array = self.array.vindex[self.key]
+        else:
+            array = self.array[self.key]
         # self.array[self.key] is now a numpy array when
         # self.array is a BackendArray subclass
         # and self.key is BasicIndexer((slice(None, None, None),))

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -526,12 +526,7 @@ class ImplicitToExplicitIndexingAdapter(NDArrayMixin):
         key = expanded_indexer(key, self.ndim)
         indexer = self.indexer_cls(key)
 
-        if isinstance(indexer, OuterIndexer):
-            result = self.array.oindex[indexer]
-        elif isinstance(indexer, VectorizedIndexer):
-            result = self.array.vindex[indexer]
-        else:
-            result = self.array[indexer]
+        result = apply_indexer(self.array, indexer)
 
         if isinstance(result, ExplicitlyIndexed):
             return type(self)(result, self.indexer_cls)
@@ -593,12 +588,7 @@ class LazilyIndexedArray(ExplicitlyIndexedNDArrayMixin):
 
     def get_duck_array(self):
         if isinstance(self.array, ExplicitlyIndexedNDArrayMixin):
-            if isinstance(self.key, VectorizedIndexer):
-                array = self.array.vindex[self.key]
-            elif isinstance(self.key, OuterIndexer):
-                array = self.array.oindex[self.key]
-            else:
-                array = self.array[self.key]
+            array = apply_indexer(self.array, self.key)
         else:
             # If the array is not an ExplicitlyIndexedNDArrayMixin,
             # it may wrap a BackendArray so use its __getitem__
@@ -669,16 +659,10 @@ class LazilyVectorizedIndexedArray(ExplicitlyIndexedNDArrayMixin):
     def get_duck_array(self):
 
         if isinstance(self.array, ExplicitlyIndexedNDArrayMixin):
-            if isinstance(self.key, VectorizedIndexer):
-                array = self.array.vindex[self.key]
-            elif isinstance(self.key, OuterIndexer):
-                array = self.array.oindex[self.key]
-            else:
-                array = self.array[self.key]
-
-        # If the array is not an ExplicitlyIndexedNDArrayMixin,
-        # it may wrap a BackendArray so use its __getitem__
+            array = apply_indexer(self.array, self.key)
         else:
+            # If the array is not an ExplicitlyIndexedNDArrayMixin,
+            # it may wrap a BackendArray so use its __getitem__
             array = self.array[self.key]
         # self.array[self.key] is now a numpy array when
         # self.array is a BackendArray subclass

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -592,12 +592,18 @@ class LazilyIndexedArray(ExplicitlyIndexedNDArrayMixin):
         return tuple(shape)
 
     def get_duck_array(self):
-        if isinstance(self.key, OuterIndexer):
+        # TODO: Remove explicitlyIndexed special case when we implement fall back .oindex, .vindex properties on BackendArray base class
+        if not isinstance(self.array, ExplicitlyIndexed) and isinstance(
+            self.key, OuterIndexer
+        ):
             array = self.array.oindex[self.key]
-        elif isinstance(self.key, VectorizedIndexer):
+        elif not isinstance(self.array, ExplicitlyIndexed) and isinstance(
+            self.key, VectorizedIndexer
+        ):
             array = self.array.vindex[self.key]
         else:
             array = self.array[self.key]
+
         # self.array[self.key] is now a numpy array when
         # self.array is a BackendArray subclass
         # and self.key is BasicIndexer((slice(None, None, None),))
@@ -661,9 +667,14 @@ class LazilyVectorizedIndexedArray(ExplicitlyIndexedNDArrayMixin):
         return np.broadcast(*self.key.tuple).shape
 
     def get_duck_array(self):
-        if isinstance(self.key, OuterIndexer):
+        # TODO: Remove explicitlyIndexed special case when we implement fall back .oindex, .vindex properties on BackendArray base class
+        if not isinstance(self.array, ExplicitlyIndexed) and isinstance(
+            self.key, OuterIndexer
+        ):
             array = self.array.oindex[self.key]
-        elif isinstance(self.key, VectorizedIndexer):
+        elif not isinstance(self.array, ExplicitlyIndexed) and isinstance(
+            self.key, VectorizedIndexer
+        ):
             array = self.array.vindex[self.key]
         else:
             array = self.array[self.key]

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -952,13 +952,18 @@ def explicit_indexing_adapter(
     if numpy_indices.tuple:
         # index the loaded np.ndarray
         indexable = NumpyIndexingAdapter(result)
-        if isinstance(numpy_indices, VectorizedIndexer):
-            result = indexable.vindex[numpy_indices]
-        elif isinstance(numpy_indices, OuterIndexer):
-            result = indexable.oindex[numpy_indices]
-        else:
-            result = indexable[numpy_indices]
+        result = apply_indexer(indexable, numpy_indices)
     return result
+
+
+def apply_indexer(indexable, indexer):
+    """Apply an indexer to an indexable object."""
+    if isinstance(indexer, VectorizedIndexer):
+        return indexable.vindex[indexer]
+    elif isinstance(indexer, OuterIndexer):
+        return indexable.oindex[indexer]
+    else:
+        return indexable[indexer]
 
 
 def decompose_indexer(
@@ -1638,12 +1643,7 @@ class PandasIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
 
         if getattr(key, "ndim", 0) > 1:  # Return np-array if multidimensional
             indexable = NumpyIndexingAdapter(np.asarray(self))
-            if isinstance(indexer, VectorizedIndexer):
-                return indexable.vindex[indexer]
-            elif isinstance(indexer, OuterIndexer):
-                return indexable.oindex[indexer]
-            else:
-                return indexable[indexer]
+            return apply_indexer(indexable, indexer)
 
         result = self.array[key]
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -593,14 +593,13 @@ class LazilyIndexedArray(ExplicitlyIndexedNDArrayMixin):
 
     def get_duck_array(self):
         # TODO: Remove explicitlyIndexed special case when we implement fall back .oindex, .vindex properties on BackendArray base class
-        if not isinstance(self.array, ExplicitlyIndexed) and isinstance(
-            self.key, OuterIndexer
-        ):
-            array = self.array.oindex[self.key]
-        elif not isinstance(self.array, ExplicitlyIndexed) and isinstance(
-            self.key, VectorizedIndexer
-        ):
-            array = self.array.vindex[self.key]
+        if isinstance(self.array, ExplicitlyIndexedNDArrayMixin):
+            if isinstance(self.key, VectorizedIndexer):
+                array = self.array.vindex[self.key]
+            elif isinstance(self.key, OuterIndexer):
+                array = self.array.oindex[self.key]
+            else:
+                array = self.array[self.key]
         else:
             array = self.array[self.key]
 
@@ -668,14 +667,13 @@ class LazilyVectorizedIndexedArray(ExplicitlyIndexedNDArrayMixin):
 
     def get_duck_array(self):
         # TODO: Remove explicitlyIndexed special case when we implement fall back .oindex, .vindex properties on BackendArray base class
-        if not isinstance(self.array, ExplicitlyIndexed) and isinstance(
-            self.key, OuterIndexer
-        ):
-            array = self.array.oindex[self.key]
-        elif not isinstance(self.array, ExplicitlyIndexed) and isinstance(
-            self.key, VectorizedIndexer
-        ):
-            array = self.array.vindex[self.key]
+        if isinstance(self.array, ExplicitlyIndexedNDArrayMixin):
+            if isinstance(self.key, VectorizedIndexer):
+                array = self.array.vindex[self.key]
+            elif isinstance(self.key, OuterIndexer):
+                array = self.array.oindex[self.key]
+            else:
+                array = self.array[self.key]
         else:
             array = self.array[self.key]
         # self.array[self.key] is now a numpy array when

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -592,7 +592,6 @@ class LazilyIndexedArray(ExplicitlyIndexedNDArrayMixin):
         return tuple(shape)
 
     def get_duck_array(self):
-        # TODO: Remove explicitlyIndexed special case when we implement fall back .oindex, .vindex properties on BackendArray base class
         if isinstance(self.array, ExplicitlyIndexedNDArrayMixin):
             if isinstance(self.key, VectorizedIndexer):
                 array = self.array.vindex[self.key]
@@ -666,7 +665,7 @@ class LazilyVectorizedIndexedArray(ExplicitlyIndexedNDArrayMixin):
         return np.broadcast(*self.key.tuple).shape
 
     def get_duck_array(self):
-        # TODO: Remove explicitlyIndexed special case when we implement fall back .oindex, .vindex properties on BackendArray base class
+
         if isinstance(self.array, ExplicitlyIndexedNDArrayMixin):
             if isinstance(self.key, VectorizedIndexer):
                 array = self.array.vindex[self.key]

--- a/xarray/tests/test_coding_strings.py
+++ b/xarray/tests/test_coding_strings.py
@@ -181,7 +181,7 @@ def test_StackedBytesArray_vectorized_indexing() -> None:
 
     V = IndexerMaker(indexing.VectorizedIndexer)
     indexer = V[np.array([[0, 1], [1, 0]])]
-    actual = stacked[indexer]
+    actual = stacked.vindex[indexer]
     assert_array_equal(actual, expected)
 
 

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -708,7 +708,7 @@ def test_decompose_indexers(shape, indexer_mode, indexing_support) -> None:
 
     if not all(isinstance(k, indexing.integer_types) for k in np_ind.tuple):
         combined_ind = indexing._combine_indexers(backend_ind, shape, np_ind)
-        # combined_ind is a VectorizedIndexer
+        assert isinstance(combined_ind, VectorizedIndexer)
         array = indexing_adapter.vindex[combined_ind]
         np.testing.assert_array_equal(expected, array)
 

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -708,7 +708,7 @@ def test_decompose_indexers(shape, indexer_mode, indexing_support) -> None:
 
     if not all(isinstance(k, indexing.integer_types) for k in np_ind.tuple):
         combined_ind = indexing._combine_indexers(backend_ind, shape, np_ind)
-        assert isinstance(combined_ind, VectorizedIndexer)
+        assert isinstance(combined_ind, indexing.VectorizedIndexer)
         array = indexing_adapter.vindex[combined_ind]
         np.testing.assert_array_equal(expected, array)
 


### PR DESCRIPTION
this is a follow-up to previous PRs (#8780 and #8750), continuing the efforts outlined in the [plan for decoupling lazy indexing functionality from NamedArray](https://github.com/pydata/xarray/blob/main/design_notes/named_array_design_doc.md#plan-for-decoupling-lazy-indexing-functionality-from-namedarray). the primary focus of this PR is the removal of vectorized and orthogonal indexing logic from the `__getitem__` method. Now, `__getitem__` exclusively handles basic indexers, aligning with points 3 and 4 of the plan:

- as per point 3, lazy indexing arrays will now implement `__getitem__` solely for basic indexing. For orthogonal indexing, .oindex will be used, and for vectorized indexing, .vindex will be utilized.
- following point 4, IndexingAdapter classes have been updated to consistently implement `__getitem__`, `.oindex`, and `.vindex`




<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
