### PR TITLE
fix: remove Coordinate from __all__ in xarray/__init__.py

### DIFF
--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -97,7 +97,6 @@ __all__ = (
     # Classes
     "CFTimeIndex",
     "Context",
-    "Coordinate",
     "Coordinates",
     "DataArray",
     "Dataset",


### PR DESCRIPTION
`Coordinate` is in `__all__` but isn't imported.
Thus a 
```
from xarray import *
``` 
raises an error. 

IMHO, this should have been caught by ruff, but ruff doesn't catch undefined entries in `__all__`, see https://github.com/astral-sh/ruff/issues/10095 
I suggest to watch that issue for resolution to potentially adjust the ruff config of this project such that these things will be caught in the future.