### PR TITLE
Pass variable name to `encode_zarr_variable`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -71,7 +71,8 @@ Bug fixes
 - Warn and return bytes undecoded in case of UnicodeDecodeError in h5netcdf-backend
   (:issue:`5563`, :pull:`8874`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
-
+- Fix a regression when saving dropped multi-indexes with the zarr backend (:pull:`8809`).
+  By `Sam Levang <https://github.com/slevang>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -333,7 +333,7 @@ class AbstractWritableDataStore(AbstractDataStore):
         attributes = {k: self.encode_attribute(v) for k, v in attributes.items()}
         return variables, attributes
 
-    def encode_variable(self, v, name):
+    def encode_variable(self, v, name: str | None = None):
         """encode one variable"""
         return v
 

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -329,11 +329,11 @@ class AbstractWritableDataStore(AbstractDataStore):
         attributes : dict-like
 
         """
-        variables = {k: self.encode_variable(v) for k, v in variables.items()}
+        variables = {k: self.encode_variable(v, k) for k, v in variables.items()}
         attributes = {k: self.encode_attribute(v) for k, v in attributes.items()}
         return variables, attributes
 
-    def encode_variable(self, v):
+    def encode_variable(self, v, name):
         """encode one variable"""
         return v
 
@@ -480,7 +480,7 @@ class WritableCFDataStore(AbstractWritableDataStore):
         # All NetCDF files get CF encoded by default, without this attempting
         # to write times, for example, would fail.
         variables, attributes = cf_encoder(variables, attributes)
-        variables = {k: self.encode_variable(v) for k, v in variables.items()}
+        variables = {k: self.encode_variable(v, k) for k, v in variables.items()}
         attributes = {k: self.encode_attribute(v) for k, v in attributes.items()}
         return variables, attributes
 

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -260,7 +260,7 @@ class H5NetCDFStore(WritableCFDataStore):
     def set_attribute(self, key, value):
         self.ds.attrs[key] = value
 
-    def encode_variable(self, variable):
+    def encode_variable(self, variable, name):
         return _encode_nc4_variable(variable)
 
     def prepare_variable(

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -490,7 +490,7 @@ class NetCDF4DataStore(WritableCFDataStore):
         else:
             self.ds.setncattr(key, value)
 
-    def encode_variable(self, variable):
+    def encode_variable(self, variable, name):
         variable = _force_native_endianness(variable)
         if self.format == "NETCDF4":
             variable = _encode_nc4_variable(variable)

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -209,7 +209,7 @@ class ScipyDataStore(WritableCFDataStore):
         value = encode_nc3_attr_value(value)
         setattr(self.ds, key, value)
 
-    def encode_variable(self, variable):
+    def encode_variable(self, variable, name):
         variable = encode_nc3_variable(variable)
         return variable
 

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -569,8 +569,8 @@ class ZarrStore(AbstractWritableDataStore):
     def set_attributes(self, attributes):
         _put_attrs(self.zarr_group, attributes)
 
-    def encode_variable(self, variable):
-        variable = encode_zarr_variable(variable)
+    def encode_variable(self, variable, name):
+        variable = encode_zarr_variable(variable, name=name)
         return variable
 
     def encode_attribute(self, a):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1251,6 +1251,16 @@ class CFEncodedBase(DatasetIOBase):
         with self.roundtrip(ds_reset) as actual:
             assert_identical(actual, ds_reset)
 
+    def test_reset_multiindex_as_indexvariable(self) -> None:
+        # regression noted in https://github.com/xarray-contrib/xeofs/issues/148
+        ds = xr.Dataset(coords={"dim1": [1, 2, 3]})
+        ds = ds.stack(feature=["dim1"])
+        ds_reset = ds.reset_index("feature")
+        # Convert dim1 back to an IndexVariable, should still be able to serialize
+        ds_reset["dim1"] = ds_reset.dim1.variable.to_index_variable()
+        with self.roundtrip(ds_reset) as actual:
+            assert_identical(actual, ds_reset)
+
 
 class NetCDFBase(CFEncodedBase):
     """Tests for all netCDF3 and netCDF4 backends."""

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -449,7 +449,7 @@ class TestDecodeCF:
 
 
 class CFEncodedInMemoryStore(WritableCFDataStore, InMemoryDataStore):
-    def encode_variable(self, var):
+    def encode_variable(self, var, name):
         """encode one variable"""
         coder = coding.strings.EncodedStringCoder(allows_unicode=True)
         var = coder.encode(var)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes https://github.com/xarray-contrib/xeofs/issues/148
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

The change from https://github.com/pydata/xarray/pull/8672 mostly fixed the issue of serializing a reset multiindex in the backends, but there was an additional niche issue that turned up in xeofs that was causing serialization to still fail on the zarr backend.

The issue is that zarr is the only backend that uses a custom version of `encode_cf_variable` called `encode_zarr_variable`, and the way this gets called we don't pass through the `name` of the variable before running `ensure_not_multiindex`.

As a minimal fix, this PR just passes `name` through as an additional arg to the general `encode_variable` function. See @benbovy's [comment](https://github.com/pydata/xarray/pull/8672#issuecomment-1929837384) that maybe we should actually unwrap the level coordinate in `reset_index` and clean up the checks in `ensure_not_multiindex`, but I wasn't able to get that working easily.

The exact workflow this turned up in involves DataTree and looks like this:
```python
import numpy as np
import xarray as xr
from datatree import DataTree

# ND DataArray that gets stacked along a multiindex
da = xr.DataArray(np.ones((3, 3)), coords={"dim1": [1, 2, 3], "dim2": [4, 5, 6]})
da = da.stack(feature=["dim1", "dim2"])

# Extract just the stacked coordinates for saving in a dataset
ds = xr.Dataset(data_vars={"feature": da.feature})

# Reset the multiindex, which should make things serializable
ds = ds.reset_index("feature")
dt1 = DataTree()
dt2 = DataTree(name="feature", data=ds)
dt1["foo"] = dt2
# Somehow in this step, dt1.foo.feature.dim1.variable becomes an IndexVariable again
print(type(dt1.foo.feature.dim1.variable))

# Works
dt1.to_netcdf("test.nc", mode="w")
# Fails
dt1.to_zarr("test.zarr", mode="w")
```

But we can reproduce in xarray with the test added here.
