### PR TITLE
link to zarr.convenience.consolidate_metadata

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -316,22 +316,22 @@ htmlhelp_basename = "xarraydoc"
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3/", None),
-    "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
-    "iris": ("https://scitools-iris.readthedocs.io/en/latest", None),
-    "numpy": ("https://numpy.org/doc/stable", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy", None),
-    "numba": ("https://numba.readthedocs.io/en/stable/", None),
-    "matplotlib": ("https://matplotlib.org/stable/", None),
-    "dask": ("https://docs.dask.org/en/latest", None),
-    "cftime": ("https://unidata.github.io/cftime", None),
-    "sparse": ("https://sparse.pydata.org/en/latest/", None),
-    "hypothesis": ("https://hypothesis.readthedocs.io/en/latest/", None),
-    "cubed": ("https://cubed-dev.github.io/cubed/", None),
-    "datatree": ("https://xarray-datatree.readthedocs.io/en/latest/", None),
-    "xarray-tutorial": ("https://tutorial.xarray.dev/", None),
-    "flox": ("https://flox.readthedocs.io/en/latest/", None),
-    # "opt_einsum": ("https://dgasmith.github.io/opt_einsum/", None),
+    'cftime': ('https://unidata.github.io/cftime', None),
+    'cubed': ('https://cubed-dev.github.io/cubed/', None),
+    'dask': ('https://docs.dask.org/en/latest', None),
+    'datatree': ('https://xarray-datatree.readthedocs.io/en/latest/', None),
+    'flox': ('https://flox.readthedocs.io/en/latest/', None),
+    'hypothesis': ('https://hypothesis.readthedocs.io/en/latest/', None),
+    'iris': ('https://scitools-iris.readthedocs.io/en/latest', None),
+    'matplotlib': ('https://matplotlib.org/stable/', None),
+    'numba': ('https://numba.readthedocs.io/en/stable/', None),
+    'numpy': ('https://numpy.org/doc/stable', None),
+    'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
+    'python': ('https://docs.python.org/3/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy', None),
+    'sparse': ('https://sparse.pydata.org/en/latest/', None),
+    'xarray-tutorial': ('https://tutorial.xarray.dev/', None),
+    'zarr': ('https://zarr.readthedocs.io/en/latest/', None),    
 }
 
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2417,7 +2417,7 @@ class Dataset(
             ``dask.delayed.Delayed`` object that can be computed to write
             array data later. Metadata is always updated eagerly.
         consolidated : bool, optional
-            If True, apply zarr's `consolidate_metadata` function to the store
+            If True, apply :func:`zarr.convenience.consolidate_metadata`
             after writing metadata and read existing stores with consolidated
             metadata; if False, do not. The default (`consolidated=None`) means
             write consolidated metadata and attempt to read consolidated


### PR DESCRIPTION
I wanted to know what `zarr.convenience.consolidate_metadata` does which motivated me to add a link to it in the docstring to make it easier for others (and future me) to discover it.

I sorted `intersphinx_mapping` to make it easier to docs from other projects. I also added :func:`zarr.convenience.consolidate_metadata` in the doc string.

Testing if it actually works is WIP