### PR TITLE
try to get the `upstream-dev` CI to complete again

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -41,7 +41,7 @@ python -m pip install \
     --upgrade \
     pyarrow
 # without build isolation for packages compiling against numpy
-# TODO: remove once there are `numpy>=2.0` builds for numcodecs and cftime
+# TODO: remove once there are `numpy>=2.0` builds for these
 python -m pip install \
     --no-deps \
     --upgrade \
@@ -52,6 +52,11 @@ python -m pip install \
     --upgrade \
     --no-build-isolation \
     git+https://github.com/zarr-developers/numcodecs
+python -m pip install \
+    --no-deps \
+    --upgrade \
+    --no-build-isolation \
+    git+https://github.com/pydata/numexpr
 python -m pip install \
     --no-deps \
     --upgrade \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -28,7 +28,6 @@ python -m pip install \
     --upgrade \
     numpy \
     scipy \
-    h5py \
     matplotlib \
     pandas
 # for some reason pandas depends on pyarrow already.

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -31,6 +31,15 @@ python -m pip install \
     h5py \
     matplotlib \
     pandas
+# for some reason pandas depends on pyarrow already.
+# Remove once a `pyarrow` version compiled with `numpy>=2.0` is on `conda-forge`
+python -m pip install \
+    -i https://pypi.fury.io/arrow-nightlies/ \
+    --prefer-binary \
+    --no-deps \
+    --pre \
+    --upgrade \
+    pyarrow
 # without build isolation for packages compiling against numpy
 # TODO: remove once there are `numpy>=2.0` builds for numcodecs and cftime
 python -m pip install \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -5,7 +5,7 @@ micromamba install "cython>=0.29.20" py-cpuinfo
 # temporarily (?) remove numbagg and numba
 micromamba remove -y numba numbagg
 # temporarily remove backends
-micromamba remove -y cf_units netcdf4
+micromamba remove -y cf_units hdf5 h5py netcdf4
 # forcibly remove packages to avoid artifacts
 micromamba remove -y --force \
     numpy \
@@ -69,5 +69,5 @@ python -m pip install \
     git+https://github.com/intake/filesystem_spec \
     git+https://github.com/SciTools/nc-time-axis \
     git+https://github.com/xarray-contrib/flox \
-    git+https://github.com/dgasmith/opt_einsum \
-    git+https://github.com/h5netcdf/h5netcdf
+    git+https://github.com/dgasmith/opt_einsum
+    # git+https://github.com/h5netcdf/h5netcdf

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -69,5 +69,5 @@ python -m pip install \
     git+https://github.com/intake/filesystem_spec \
     git+https://github.com/SciTools/nc-time-axis \
     git+https://github.com/xarray-contrib/flox \
-    git+https://github.com/dgasmith/opt_einsum
+    git+https://github.com/dgasmith/opt_einsum \
     git+https://github.com/h5netcdf/h5netcdf

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -4,6 +4,8 @@
 micromamba install "cython>=0.29.20" py-cpuinfo
 # temporarily (?) remove numbagg and numba
 micromamba remove -y numba numbagg
+# temporarily remove numexpr
+micromamba remove -y numexpr
 # temporarily remove backends
 micromamba remove -y cf_units hdf5 h5py netcdf4
 # forcibly remove packages to avoid artifacts
@@ -51,11 +53,6 @@ python -m pip install \
     --upgrade \
     --no-build-isolation \
     git+https://github.com/zarr-developers/numcodecs
-python -m pip install \
-    --no-deps \
-    --upgrade \
-    --no-build-isolation \
-    git+https://github.com/pydata/numexpr
 python -m pip install \
     --no-deps \
     --upgrade \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -5,7 +5,7 @@ micromamba install "cython>=0.29.20" py-cpuinfo
 # temporarily (?) remove numbagg and numba
 micromamba remove -y numba numbagg
 # temporarily remove backends
-micromamba remove -y cf_units h5py hdf5 netcdf4
+micromamba remove -y cf_units netcdf4
 # forcibly remove packages to avoid artifacts
 conda uninstall -y --force \
     numpy \
@@ -28,6 +28,7 @@ python -m pip install \
     --upgrade \
     numpy \
     scipy \
+    h5py \
     matplotlib \
     pandas
 # without build isolation for packages compiling against numpy
@@ -60,4 +61,4 @@ python -m pip install \
     git+https://github.com/SciTools/nc-time-axis \
     git+https://github.com/xarray-contrib/flox \
     git+https://github.com/dgasmith/opt_einsum
-    # git+https://github.com/h5netcdf/h5netcdf
+    git+https://github.com/h5netcdf/h5netcdf

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -7,7 +7,7 @@ micromamba remove -y numba numbagg
 # temporarily remove backends
 micromamba remove -y cf_units netcdf4
 # forcibly remove packages to avoid artifacts
-conda uninstall -y --force \
+micromamba remove -y --force \
     numpy \
     scipy \
     pandas \

--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - black
   - aiobotocore
+  - array-api-strict
   - boto3
   - bottleneck
   - cartopy

--- a/ci/requirements/environment-3.12.yml
+++ b/ci/requirements/environment-3.12.yml
@@ -4,6 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - aiobotocore
+  - array-api-strict
   - boto3
   - bottleneck
   - cartopy

--- a/ci/requirements/environment-windows-3.12.yml
+++ b/ci/requirements/environment-windows-3.12.yml
@@ -2,6 +2,7 @@ name: xarray-tests
 channels:
   - conda-forge
 dependencies:
+  - array-api-strict
   - boto3
   - bottleneck
   - cartopy

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -2,6 +2,7 @@ name: xarray-tests
 channels:
   - conda-forge
 dependencies:
+  - array-api-strict
   - boto3
   - bottleneck
   - cartopy

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -4,6 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - aiobotocore
+  - array-api-strict
   - boto3
   - bottleneck
   - cartopy

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -8,6 +8,7 @@ dependencies:
   # When upgrading python, numpy, or pandas, must also change
   # doc/user-guide/installing.rst, doc/user-guide/plotting.rst and setup.py.
   - python=3.9
+  - array-api-strict=1.0  # dependency for testing the array api compat
   - boto3=1.24
   - bottleneck=1.3
   - cartopy=0.21

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ module = [
   "toolz.*",
   "zarr.*",
   "numpy.exceptions.*", # remove once support for `numpy<2.0` has been dropped
+  "array_api_strict.*",
 ]
 
 # Gradually we want to add more modules to this list, ratcheting up our total

--- a/xarray/tests/test_array_api.py
+++ b/xarray/tests/test_array_api.py
@@ -1,18 +1,14 @@
 from __future__ import annotations
 
-import warnings
-
 import pytest
 
 import xarray as xr
 from xarray.testing import assert_equal
 
 np = pytest.importorskip("numpy", minversion="1.22")
+xp = pytest.importorskip("array_api_strict")
 
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    import numpy.array_api as xp  # isort:skip
-    from numpy.array_api._array_object import Array  # isort:skip
+from array_api_strict._array_object import Array  # isort:skip
 
 
 @pytest.fixture

--- a/xarray/tests/test_array_api.py
+++ b/xarray/tests/test_array_api.py
@@ -6,9 +6,20 @@ import xarray as xr
 from xarray.testing import assert_equal
 
 np = pytest.importorskip("numpy", minversion="1.22")
-xp = pytest.importorskip("array_api_strict")
 
-from array_api_strict._array_object import Array  # isort:skip
+try:
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        import numpy.array_api as xp  # isort:skip
+        from numpy.array_api._array_object import Array  # isort:skip
+except ImportError:
+    # for `numpy>=2.0`
+    xp = pytest.importorskip("array_api_strict")
+
+    from array_api_strict._array_object import Array  # isort:skip
 
 
 @pytest.fixture

--- a/xarray/tests/test_array_api.py
+++ b/xarray/tests/test_array_api.py
@@ -13,13 +13,13 @@ try:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 
-        import numpy.array_api as xp  # isort:skip
-        from numpy.array_api._array_object import Array  # isort:skip
+        import numpy.array_api as xp
+        from numpy.array_api._array_object import Array
 except ImportError:
     # for `numpy>=2.0`
     xp = pytest.importorskip("array_api_strict")
 
-    from array_api_strict._array_object import Array  # isort:skip
+    from array_api_strict._array_object import Array  # type: ignore[no-redef]
 
 
 @pytest.fixture


### PR DESCRIPTION
There's a couple of accumulated failures now, including a crash because `pandas` apparently depends on `pyarrow` now, which on `conda-forge` is not built for `numpy>=2.0`.