### PR TITLE
Revert "Do not attempt to broadcast when global option ``arithmetic_b…

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -23,9 +23,6 @@ v2024.03.0 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
-- Do not broadcast in arithmetic operations when global option ``arithmetic_broadcast=False``
-  (:issue:`6806`, :pull:`8784`).
-  By `Etienne Schalk <https://github.com/etienneschalk>`_ and `Deepak Cherian <https://github.com/dcherian>`_.
 - Add the ``.oindex`` property to Explicitly Indexed Arrays for orthogonal indexing functionality. (:issue:`8238`, :pull:`8750`)
   By `Anderson Banihirwe <https://github.com/andersy005>`_.
 

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -34,7 +34,6 @@ if TYPE_CHECKING:
     ]
 
     class T_Options(TypedDict):
-        arithmetic_broadcast: bool
         arithmetic_join: Literal["inner", "outer", "left", "right", "exact"]
         cmap_divergent: str | Colormap
         cmap_sequential: str | Colormap
@@ -60,7 +59,6 @@ if TYPE_CHECKING:
 
 
 OPTIONS: T_Options = {
-    "arithmetic_broadcast": True,
     "arithmetic_join": "inner",
     "cmap_divergent": "RdBu_r",
     "cmap_sequential": "viridis",
@@ -94,7 +92,6 @@ def _positive_integer(value: int) -> bool:
 
 
 _VALIDATORS = {
-    "arithmetic_broadcast": lambda value: isinstance(value, bool),
     "arithmetic_join": _JOIN_OPTIONS.__contains__,
     "display_max_rows": _positive_integer,
     "display_values_threshold": _positive_integer,

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2871,16 +2871,6 @@ def broadcast_variables(*variables: Variable) -> tuple[Variable, ...]:
 
 
 def _broadcast_compat_data(self, other):
-    if not OPTIONS["arithmetic_broadcast"]:
-        if (isinstance(other, Variable) and self.dims != other.dims) or (
-            is_duck_array(other) and self.ndim != other.ndim
-        ):
-            raise ValueError(
-                "Broadcasting is necessary but automatic broadcasting is disabled via "
-                "global option `'arithmetic_broadcast'`. "
-                "Use `xr.set_options(arithmetic_broadcast=True)` to enable automatic broadcasting."
-            )
-
     if all(hasattr(other, attr) for attr in ["dims", "data", "shape", "encoding"]):
         # `other` satisfies the necessary Variable API for broadcast_variables
         new_self, new_other = _broadcast_compat_variables(self, other)

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -89,13 +89,6 @@ with warnings.catch_warnings():
 has_pynio, requires_pynio = _importorskip("Nio")
 has_cftime, requires_cftime = _importorskip("cftime")
 has_dask, requires_dask = _importorskip("dask")
-with warnings.catch_warnings():
-    warnings.filterwarnings(
-        "ignore",
-        message="The current Dask DataFrame implementation is deprecated.",
-        category=DeprecationWarning,
-    )
-    has_dask_expr, requires_dask_expr = _importorskip("dask_expr")
 has_bottleneck, requires_bottleneck = _importorskip("bottleneck")
 has_rasterio, requires_rasterio = _importorskip("rasterio")
 has_zarr, requires_zarr = _importorskip("zarr")

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -51,7 +51,6 @@ from xarray.tests import (
     requires_bottleneck,
     requires_cupy,
     requires_dask,
-    requires_dask_expr,
     requires_iris,
     requires_numexpr,
     requires_pint,
@@ -3204,42 +3203,6 @@ class TestDataArray:
         assert_identical(expected_b, actual_b)
         assert expected_b.x.dtype == actual_b.x.dtype
 
-    def test_broadcast_on_vs_off_global_option_different_dims(self) -> None:
-        xda_1 = xr.DataArray([1], dims="x1")
-        xda_2 = xr.DataArray([1], dims="x2")
-
-        with xr.set_options(arithmetic_broadcast=True):
-            expected_xda = xr.DataArray([[1.0]], dims=("x1", "x2"))
-            actual_xda = xda_1 / xda_2
-            assert_identical(actual_xda, expected_xda)
-
-        with xr.set_options(arithmetic_broadcast=False):
-            with pytest.raises(
-                ValueError,
-                match=re.escape(
-                    "Broadcasting is necessary but automatic broadcasting is disabled via "
-                    "global option `'arithmetic_broadcast'`. "
-                    "Use `xr.set_options(arithmetic_broadcast=True)` to enable automatic broadcasting."
-                ),
-            ):
-                xda_1 / xda_2
-
-    @pytest.mark.parametrize("arithmetic_broadcast", [True, False])
-    def test_broadcast_on_vs_off_global_option_same_dims(
-        self, arithmetic_broadcast: bool
-    ) -> None:
-        # Ensure that no error is raised when arithmetic broadcasting is disabled,
-        # when broadcasting is not needed. The two DataArrays have the same
-        # dimensions of the same size.
-        xda_1 = xr.DataArray([1], dims="x")
-        xda_2 = xr.DataArray([1], dims="x")
-        expected_xda = xr.DataArray([2.0], dims=("x",))
-
-        with xr.set_options(arithmetic_broadcast=arithmetic_broadcast):
-            assert_identical(xda_1 + xda_2, expected_xda)
-            assert_identical(xda_1 + np.array([1.0]), expected_xda)
-            assert_identical(np.array([1.0]) + xda_1, expected_xda)
-
     def test_broadcast_arrays(self) -> None:
         x = DataArray([1, 2], coords=[("a", [-1, -2])], name="x")
         y = DataArray([1, 2], coords=[("b", [3, 4])], name="y")
@@ -3418,7 +3381,6 @@ class TestDataArray:
         assert len(actual) == 0
         assert_array_equal(actual.index.names, list("ABC"))
 
-    @requires_dask_expr
     @requires_dask
     def test_to_dask_dataframe(self) -> None:
         arr_np = np.arange(3 * 4).reshape(3, 4)


### PR DESCRIPTION
…roadcast=False`` (#8784)"

This reverts commit 11f89ecdd41226cf93da8d1e720d2710849cd23e.

Reverting #8784 

Sadly that PR broke a lot of tests by breaking `create_test_data` with
```
from xarray.tests import create_test_data
create_test_data()
```

```
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
Cell In[3], line 2
      1 from xarray.tests import create_test_data
----> 2 create_test_data()

File [~/repos/xarray/xarray/tests/__init__.py:329](http://localhost:8888/lab/workspaces/auto-P/tree/repos/devel/arraylake/~/repos/xarray/xarray/tests/__init__.py#line=328), in create_test_data(seed, add_attrs, dim_sizes)
    327 obj.coords["numbers"] = ("dim3", numbers_values)
    328 obj.encoding = {"foo": "bar"}
--> 329 assert all(var.values.flags.writeable for var in obj.variables.values())
    330 return obj

AssertionError:
```


Somehow that code changes whether `IndexVariable.values` returns a writeable numpy array. I spent some time debugging but couldn't figure it out.

cc @etienneschalk 