### PR TITLE
Implement setitem syntax for `.oindex` and `.vindex` properties

### DIFF
--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1450,24 +1450,6 @@ class NumpyIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
             )
         self.array = array
 
-    def _indexing_array_and_key(self, key):
-        if isinstance(key, OuterIndexer):
-            array = self.array
-            key = _outer_to_numpy_indexer(key, self.array.shape)
-        elif isinstance(key, VectorizedIndexer):
-            array = NumpyVIndexAdapter(self.array)
-            key = key.tuple
-        elif isinstance(key, BasicIndexer):
-            array = self.array
-            # We want 0d slices rather than scalars. This is achieved by
-            # appending an ellipsis (see
-            # https://numpy.org/doc/stable/reference/arrays.indexing.html#detailed-notes).
-            key = key.tuple + (Ellipsis,)
-        else:
-            raise TypeError(f"unexpected key type: {type(key)}")
-
-        return array, key
-
     def transpose(self, order):
         return self.array.transpose(order)
 
@@ -1481,7 +1463,12 @@ class NumpyIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
 
     def __getitem__(self, key):
         self._check_and_raise_if_non_basic_indexer(key)
-        array, key = self._indexing_array_and_key(key)
+
+        array = self.array
+        # We want 0d slices rather than scalars. This is achieved by
+        # appending an ellipsis (see
+        # https://numpy.org/doc/stable/reference/arrays.indexing.html#detailed-notes).
+        key = key.tuple + (Ellipsis,)
         return array[key]
 
     def _safe_setitem(self, array, key, value):
@@ -1507,7 +1494,11 @@ class NumpyIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
 
     def __setitem__(self, key, value):
         self._check_and_raise_if_non_basic_indexer(key)
-        array, key = self._indexing_array_and_key(key)
+        array = self.array
+        # We want 0d slices rather than scalars. This is achieved by
+        # appending an ellipsis (see
+        # https://numpy.org/doc/stable/reference/arrays.indexing.html#detailed-notes).
+        key = key.tuple + (Ellipsis,)
         self._safe_setitem(array, key, value)
 
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -330,19 +330,19 @@ class IndexCallable:
 
     __slots__ = ("getter", "setter")
 
-    def __init__(self, func_get, func_set=None):
-        self.func_get = func_get
-        self.func_set = func_set
+    def __init__(self, getter, setter=None):
+        self.getter = getter
+        self.setter = setter
 
     def __getitem__(self, key):
-        return self.func_get(key)
+        return self.getter(key)
 
     def __setitem__(self, key, value):
-        if self.func_set is None:
+        if self.setter is None:
             raise NotImplementedError(
                 "Setting values is not supported for this indexer."
             )
-        self.func_set(key, value)
+        self.setter(key, value)
 
 
 class BasicIndexer(ExplicitIndexer):

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -328,7 +328,7 @@ def as_integer_slice(value):
 class IndexCallable:
     """Provide getitem and setitem syntax for callable objects."""
 
-    __slots__ = ("func_get", "func_set")
+    __slots__ = ("getter", "setter")
 
     def __init__(self, func_get, func_set=None):
         self.func_get = func_get
@@ -643,7 +643,7 @@ class LazilyIndexedArray(ExplicitlyIndexedNDArrayMixin):
 
     def _oindex_set(self, key, value):
         full_key = self._updated_key(key)
-        self.array[full_key] = value
+        self.array.oindex[full_key] = value
 
     def __setitem__(self, key, value):
         self._check_and_raise_if_non_basic_indexer(key)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -842,7 +842,7 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
             value = np.moveaxis(value, new_order, range(len(new_order)))
 
         indexable = as_indexable(self._data)
-        indexable[index_tuple] = value
+        indexing.set_with_indexer(indexable, index_tuple, value)
 
     @property
     def encoding(self) -> dict[Any, Any]:

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -383,15 +383,8 @@ class TestLazyArray:
 
         def check_indexing(v_eager, v_lazy, indexers):
             for indexer in indexers:
-                if isinstance(indexer, indexing.VectorizedIndexer):
-                    actual = v_lazy.vindex[indexer]
-                    expected = v_eager.vindex[indexer]
-                elif isinstance(indexer, indexing.OuterIndexer):
-                    actual = v_lazy.oindex[indexer]
-                    expected = v_eager.oindex[indexer]
-                else:
-                    actual = v_lazy[indexer]
-                    expected = v_eager[indexer]
+                actual = v_lazy[indexer]
+                expected = v_eager[indexer]
                 assert expected.shape == actual.shape
                 assert isinstance(
                     actual._data,

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -23,6 +23,28 @@ from xarray.tests import (
 B = IndexerMaker(indexing.BasicIndexer)
 
 
+class TestIndexCallable:
+    def test_getitem(self):
+        def getter(key):
+            return key * 2
+
+        indexer = indexing.IndexCallable(getter)
+        assert indexer[3] == 6
+        assert indexer[0] == 0
+        assert indexer[-1] == -2
+
+    def test_setitem(self):
+        def getter(key):
+            return key * 2
+
+        def setter(key, value):
+            raise NotImplementedError("Setter not implemented")
+
+        indexer = indexing.IndexCallable(getter, setter)
+        with pytest.raises(NotImplementedError):
+            indexer[3] = 6
+
+
 class TestIndexers:
     def set_to_zero(self, x, i):
         x = x.copy()


### PR DESCRIPTION
this is another follow-up to previous Prs

- #8780
- #8750
- #8790

, continuing the proposal outlined in [plan for decoupling lazy indexing functionality from NamedArray](https://github.com/pydata/xarray/blob/main/design_notes/named_array_design_doc.md#plan-for-decoupling-lazy-indexing-functionality-from-namedarray)

Cc @maxrjones for visibility