### PR TITLE
Support pandas copy-on-write behaviour

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -209,7 +209,11 @@ def _possibly_convert_objects(values):
     as_series = pd.Series(values.ravel(), copy=False)
     if as_series.dtype.kind in "mM":
         as_series = _as_nanosecond_precision(as_series)
-    return np.asarray(as_series).reshape(values.shape)
+    result = np.asarray(as_series).reshape(values.shape)
+    if not result.flags.writeable:
+        # GH8843, pandas copy-on-write mode creates read-only arrays by default
+        result = result.copy()
+    return result
 
 
 def _possibly_convert_datetime_or_timedelta_index(data):

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -20,6 +20,7 @@ from xarray.core import utils
 from xarray.core.duck_array_ops import allclose_or_equiv  # noqa: F401
 from xarray.core.indexing import ExplicitlyIndexed
 from xarray.core.options import set_options
+from xarray.core.variable import IndexVariable
 from xarray.testing import (  # noqa: F401
     assert_chunks_equal,
     assert_duckarray_allclose,
@@ -36,6 +37,7 @@ try:
 except ImportError:
     pass
 
+
 # https://github.com/pydata/xarray/issues/7322
 warnings.filterwarnings("ignore", "'urllib3.contrib.pyopenssl' module is deprecated")
 warnings.filterwarnings("ignore", "Deprecated call to `pkg_resources.declare_namespace")
@@ -45,6 +47,15 @@ arm_xfail = pytest.mark.xfail(
     platform.machine() == "aarch64" or "arm" in platform.machine(),
     reason="expected failure on ARM",
 )
+
+
+def assert_writeable(ds):
+    readonly = [
+        name
+        for name, var in ds.variables.items()
+        if not isinstance(var, IndexVariable) and not var.data.flags.writeable
+    ]
+    assert not readonly, readonly
 
 
 def _importorskip(
@@ -326,7 +337,7 @@ def create_test_data(
         numbers_values = np.random.randint(0, 3, _dims["dim3"], dtype="int64")
     obj.coords["numbers"] = ("dim3", numbers_values)
     obj.encoding = {"foo": "bar"}
-    assert all(obj.data.flags.writeable for obj in obj.variables.values())
+    assert_writeable(obj)
     return obj
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2605,7 +2605,9 @@ class ZarrBase(CFEncodedBase):
             # overwrite a coordinate;
             # for mode='a-', this will not get written to the store
             # because it does not have the append_dim as a dim
-            ds_to_append.lon.data[:] = -999
+            lon = ds_to_append.lon.to_numpy().copy()
+            lon[:] = -999
+            ds_to_append["lon"] = lon
             ds_to_append.to_zarr(
                 store_target, mode="a-", append_dim="time", **self.version_kwargs
             )
@@ -2615,7 +2617,9 @@ class ZarrBase(CFEncodedBase):
             # by default, mode="a" will overwrite all coordinates.
             ds_to_append.to_zarr(store_target, append_dim="time", **self.version_kwargs)
             actual = xr.open_dataset(store_target, engine="zarr", **self.version_kwargs)
-            original2.lon.data[:] = -999
+            lon = original2.lon.to_numpy().copy()
+            lon[:] = -999
+            original2["lon"] = lon
             assert_identical(original2, actual)
 
     @requires_dask

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -51,6 +51,7 @@ from xarray.tests import (
     assert_equal,
     assert_identical,
     assert_no_warnings,
+    assert_writeable,
     create_test_data,
     has_cftime,
     has_dask,
@@ -96,11 +97,11 @@ def create_append_test_data(seed=None) -> tuple[Dataset, Dataset, Dataset]:
     nt2 = 2
     time1 = pd.date_range("2000-01-01", periods=nt1)
     time2 = pd.date_range("2000-02-01", periods=nt2)
-    string_var = np.array(["ae", "bc", "df"], dtype=object)
+    string_var = np.array(["a", "bc", "def"], dtype=object)
     string_var_to_append = np.array(["asdf", "asdfg"], dtype=object)
     string_var_fixed_length = np.array(["aa", "bb", "cc"], dtype="|S2")
     string_var_fixed_length_to_append = np.array(["dd", "ee"], dtype="|S2")
-    unicode_var = ["áó", "áó", "áó"]
+    unicode_var = np.array(["áó", "áó", "áó"])
     datetime_var = np.array(
         ["2019-01-01", "2019-01-02", "2019-01-03"], dtype="datetime64[s]"
     )
@@ -119,17 +120,11 @@ def create_append_test_data(seed=None) -> tuple[Dataset, Dataset, Dataset]:
                     coords=[lat, lon, time1],
                     dims=["lat", "lon", "time"],
                 ),
-                "string_var": xr.DataArray(string_var, coords=[time1], dims=["time"]),
-                "string_var_fixed_length": xr.DataArray(
-                    string_var_fixed_length, coords=[time1], dims=["time"]
-                ),
-                "unicode_var": xr.DataArray(
-                    unicode_var, coords=[time1], dims=["time"]
-                ).astype(np.str_),
-                "datetime_var": xr.DataArray(
-                    datetime_var, coords=[time1], dims=["time"]
-                ),
-                "bool_var": xr.DataArray(bool_var, coords=[time1], dims=["time"]),
+                "string_var": ("time", string_var),
+                "string_var_fixed_length": ("time", string_var_fixed_length),
+                "unicode_var": ("time", unicode_var),
+                "datetime_var": ("time", datetime_var),
+                "bool_var": ("time", bool_var),
             }
         )
 
@@ -140,21 +135,11 @@ def create_append_test_data(seed=None) -> tuple[Dataset, Dataset, Dataset]:
                     coords=[lat, lon, time2],
                     dims=["lat", "lon", "time"],
                 ),
-                "string_var": xr.DataArray(
-                    string_var_to_append, coords=[time2], dims=["time"]
-                ),
-                "string_var_fixed_length": xr.DataArray(
-                    string_var_fixed_length_to_append, coords=[time2], dims=["time"]
-                ),
-                "unicode_var": xr.DataArray(
-                    unicode_var[:nt2], coords=[time2], dims=["time"]
-                ).astype(np.str_),
-                "datetime_var": xr.DataArray(
-                    datetime_var_to_append, coords=[time2], dims=["time"]
-                ),
-                "bool_var": xr.DataArray(
-                    bool_var_to_append, coords=[time2], dims=["time"]
-                ),
+                "string_var": ("time", string_var_to_append),
+                "string_var_fixed_length": ("time", string_var_fixed_length_to_append),
+                "unicode_var": ("time", unicode_var[:nt2]),
+                "datetime_var": ("time", datetime_var_to_append),
+                "bool_var": ("time", bool_var_to_append),
             }
         )
 
@@ -168,8 +153,9 @@ def create_append_test_data(seed=None) -> tuple[Dataset, Dataset, Dataset]:
             }
         )
 
-    assert all(objp.data.flags.writeable for objp in ds.variables.values())
-    assert all(objp.data.flags.writeable for objp in ds_to_append.variables.values())
+    assert_writeable(ds)
+    assert_writeable(ds_to_append)
+    assert_writeable(ds_with_new_var)
     return ds, ds_to_append, ds_with_new_var
 
 
@@ -182,10 +168,8 @@ def create_append_string_length_mismatch_test_data(dtype) -> tuple[Dataset, Data
         ds_to_append = xr.Dataset(
             {"temperature": (["time"], data_to_append)}, coords={"time": [0, 1, 2]}
         )
-        assert all(objp.data.flags.writeable for objp in ds.variables.values())
-        assert all(
-            objp.data.flags.writeable for objp in ds_to_append.variables.values()
-        )
+        assert_writeable(ds)
+        assert_writeable(ds_to_append)
         return ds, ds_to_append
 
     u2_strings = ["ab", "cd", "ef"]

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -64,6 +64,21 @@ def var():
     return Variable(dims=list("xyz"), data=np.random.rand(3, 4, 5))
 
 
+@pytest.mark.parametrize(
+    "data",
+    [
+        np.array(["a", "bc", "def"], dtype=object),
+        np.array(["2019-01-01", "2019-01-02", "2019-01-03"], dtype="datetime64[ns]"),
+    ],
+)
+def test_as_compatible_data_writeable(data):
+    pd.set_option("mode.copy_on_write", True)
+    # GH8843, ensure writeable arrays for data_vars even with
+    # pandas copy-on-write mode
+    assert as_compatible_data(data).flags.writeable
+    pd.reset_option("mode.copy_on_write")
+
+
 class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
     @pytest.fixture
     def target(self, data):


### PR DESCRIPTION
- [x] Closes #8843
- [x] Tests added


```python
import numpy as np
import pandas as pd

pd.set_option("mode.copy_on_write", True)

from xarray.core.variable import _possibly_convert_objects

string_var = np.array(["a", "bc", "def"], dtype=object)
datetime_var = np.array(
    ["2019-01-01", "2019-01-02", "2019-01-03"], dtype="datetime64[ns]"
)
assert _possibly_convert_objects(string_var).flags.writeable
assert _possibly_convert_objects(datetime_var).flags.writeable
```

The core issue is that we now get read-only arrays back from pandas here:
https://github.com/pydata/xarray/blob/fbcac7611bf9a16750678f93483d3dbe0e261a0a/xarray/core/variable.py#L197-L212

@phofl is this expected?