### PR TITLE
FIX: adapt handling of copy keyword argument in scipy backend for numpy >= 2.0dev

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -59,6 +59,8 @@ Bug fixes
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - do not cast `_FillValue`/`missing_value` in `CFMaskCoder` if `_Unsigned` is provided
   (:issue:`8844`, :pull:`8852`).
+- Adapt handling of copy keyword argument in scipy backend for numpy >= 2.0dev
+  (:issue:`8844`, :pull:`8851`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Documentation

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -28,6 +28,7 @@ from xarray.core.utils import (
     Frozen,
     FrozenDict,
     close_on_error,
+    module_available,
     try_read_magic_number_from_file_or_path,
 )
 from xarray.core.variable import Variable
@@ -37,6 +38,9 @@ if TYPE_CHECKING:
 
     from xarray.backends.common import AbstractDataStore
     from xarray.core.dataset import Dataset
+
+
+NUMPY_2_0 = module_available("numpy", minversion="2.0.0.dev0")
 
 
 def _decode_string(s):
@@ -76,6 +80,12 @@ class ScipyArrayWrapper(BackendArray):
         # with the netCDF4 library by ensuring we can safely read arrays even
         # after closing associated files.
         copy = self.datastore.ds.use_mmap
+
+        # adapt handling of copy-kwarg to numpy 2.0
+        # see https://github.com/numpy/numpy/issues/25916
+        # and https://github.com/numpy/numpy/pull/25922
+        copy = None if NUMPY_2_0 and copy is False else copy
+
         return np.array(data, dtype=self.dtype, copy=copy)
 
     def __setitem__(self, key, value):

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from xarray.core.dataset import Dataset
 
 
-NUMPY_2_0 = module_available("numpy", minversion="2.0.0.dev0")
+HAS_NUMPY_2_0 = module_available("numpy", minversion="2.0.0.dev0")
 
 
 def _decode_string(s):
@@ -84,7 +84,7 @@ class ScipyArrayWrapper(BackendArray):
         # adapt handling of copy-kwarg to numpy 2.0
         # see https://github.com/numpy/numpy/issues/25916
         # and https://github.com/numpy/numpy/pull/25922
-        copy = None if NUMPY_2_0 and copy is False else copy
+        copy = None if HAS_NUMPY_2_0 and copy is False else copy
 
         return np.array(data, dtype=self.dtype, copy=copy)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
