### PR TITLE
Migrate indexing and broadcasting logic to `xarray.namedarray` (Part 1)

### DIFF
--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -56,7 +56,6 @@ from collections.abc import (
     KeysView,
     Mapping,
     MutableMapping,
-    MutableSet,
     ValuesView,
 )
 from enum import Enum
@@ -75,6 +74,7 @@ import numpy as np
 import pandas as pd
 
 from xarray.namedarray.utils import (  # noqa: F401
+    OrderedSet,
     ReprObject,
     drop_missing_dims,
     either_dict_or_kwargs,
@@ -519,48 +519,6 @@ class HybridMappingProxy(Mapping[K, V]):
 
     def __len__(self) -> int:
         return len(self._keys)
-
-
-class OrderedSet(MutableSet[T]):
-    """A simple ordered set.
-
-    The API matches the builtin set, but it preserves insertion order of elements, like
-    a dict. Note that, unlike in an OrderedDict, equality tests are not order-sensitive.
-    """
-
-    _d: dict[T, None]
-
-    __slots__ = ("_d",)
-
-    def __init__(self, values: Iterable[T] | None = None):
-        self._d = {}
-        if values is not None:
-            self.update(values)
-
-    # Required methods for MutableSet
-
-    def __contains__(self, value: Hashable) -> bool:
-        return value in self._d
-
-    def __iter__(self) -> Iterator[T]:
-        return iter(self._d)
-
-    def __len__(self) -> int:
-        return len(self._d)
-
-    def add(self, value: T) -> None:
-        self._d[value] = None
-
-    def discard(self, value: T) -> None:
-        del self._d[value]
-
-    # Additional methods
-
-    def update(self, values: Iterable[T]) -> None:
-        self._d.update(dict.fromkeys(values))
-
-    def __repr__(self) -> str:
-        return f"{type(self).__name__}({list(self)!r})"
 
 
 class NdimSizeLenMixin:

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -554,32 +554,6 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
 
         return item
 
-    def __getitem__(self, key) -> Self:
-        """Return a new Variable object whose contents are consistent with
-        getting the provided key from the underlying data.
-
-        NB. __getitem__ and __setitem__ implement xarray-style indexing,
-        where if keys are unlabeled arrays, we index the array orthogonally
-        with them. If keys are labeled array (such as Variables), they are
-        broadcasted with our usual scheme and then the array is indexed with
-        the broadcasted key, like numpy's fancy indexing.
-
-        If you really want to do indexing like `x[x > 0]`, manipulate the numpy
-        array `x.values` directly.
-        """
-        dims, indexer, new_order = self._broadcast_indexes(key)
-        indexable = as_indexable(self._data)
-
-        data = indexing.apply_indexer(indexable, indexer)
-
-        if new_order:
-            data = np.moveaxis(data, range(len(new_order)), new_order)
-        return self._finalize_indexing_result(dims, data)
-
-    def _finalize_indexing_result(self, dims, data) -> Self:
-        """Used by IndexVariable to return IndexVariable objects when possible."""
-        return self._replace(dims=dims, data=data)
-
     def _getitem_with_mask(self, key, fill_value=dtypes.NA):
         """Index this Variable with -1 remapped to fill_value."""
         # TODO(shoyer): expose this method in public API somewhere (isel?) and

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -19,15 +19,11 @@ from xarray.core import common, dtypes, duck_array_ops, indexing, nputils, ops, 
 from xarray.core.arithmetic import VariableArithmetic
 from xarray.core.common import AbstractArray
 from xarray.core.indexing import (
-    BasicIndexer,
-    OuterIndexer,
     PandasIndexingAdapter,
-    VectorizedIndexer,
     as_indexable,
 )
 from xarray.core.options import OPTIONS, _get_keep_attrs
 from xarray.core.utils import (
-    OrderedSet,
     _default,
     consolidate_dask_from_array_kwargs,
     decode_numpy_dict_values,
@@ -40,15 +36,18 @@ from xarray.core.utils import (
     is_duck_dask_array,
     maybe_coerce_to_str,
 )
-from xarray.namedarray.core import NamedArray, _raise_if_any_duplicate_dimensions
-from xarray.namedarray.pycompat import integer_types, is_0d_dask_array, to_duck_array
+from xarray.namedarray.core import (
+    NamedArray,
+    _broadcast_compat_data,
+    broadcast_variables,
+)
+from xarray.namedarray.pycompat import to_duck_array
 
 NON_NUMPY_SUPPORTED_ARRAY_TYPES = (
     indexing.ExplicitlyIndexed,
     pd.Index,
 )
-# https://github.com/python/mypy/issues/224
-BASIC_INDEXING_TYPES = integer_types + (slice,)
+
 
 if TYPE_CHECKING:
     from xarray.core.types import (
@@ -554,194 +553,6 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
             item["encoding"] = dict(self.encoding)
 
         return item
-
-    def _item_key_to_tuple(self, key):
-        if is_dict_like(key):
-            return tuple(key.get(dim, slice(None)) for dim in self.dims)
-        else:
-            return key
-
-    def _broadcast_indexes(self, key):
-        """Prepare an indexing key for an indexing operation.
-
-        Parameters
-        ----------
-        key : int, slice, array-like, dict or tuple of integer, slice and array-like
-            Any valid input for indexing.
-
-        Returns
-        -------
-        dims : tuple
-            Dimension of the resultant variable.
-        indexers : IndexingTuple subclass
-            Tuple of integer, array-like, or slices to use when indexing
-            self._data. The type of this argument indicates the type of
-            indexing to perform, either basic, outer or vectorized.
-        new_order : Optional[Sequence[int]]
-            Optional reordering to do on the result of indexing. If not None,
-            the first len(new_order) indexing should be moved to these
-            positions.
-        """
-        key = self._item_key_to_tuple(key)  # key is a tuple
-        # key is a tuple of full size
-        key = indexing.expanded_indexer(key, self.ndim)
-        # Convert a scalar Variable to a 0d-array
-        key = tuple(
-            k.data if isinstance(k, Variable) and k.ndim == 0 else k for k in key
-        )
-        # Convert a 0d numpy arrays to an integer
-        # dask 0d arrays are passed through
-        key = tuple(
-            k.item() if isinstance(k, np.ndarray) and k.ndim == 0 else k for k in key
-        )
-
-        if all(isinstance(k, BASIC_INDEXING_TYPES) for k in key):
-            return self._broadcast_indexes_basic(key)
-
-        self._validate_indexers(key)
-        # Detect it can be mapped as an outer indexer
-        # If all key is unlabeled, or
-        # key can be mapped as an OuterIndexer.
-        if all(not isinstance(k, Variable) for k in key):
-            return self._broadcast_indexes_outer(key)
-
-        # If all key is 1-dimensional and there are no duplicate labels,
-        # key can be mapped as an OuterIndexer.
-        dims = []
-        for k, d in zip(key, self.dims):
-            if isinstance(k, Variable):
-                if len(k.dims) > 1:
-                    return self._broadcast_indexes_vectorized(key)
-                dims.append(k.dims[0])
-            elif not isinstance(k, integer_types):
-                dims.append(d)
-        if len(set(dims)) == len(dims):
-            return self._broadcast_indexes_outer(key)
-
-        return self._broadcast_indexes_vectorized(key)
-
-    def _broadcast_indexes_basic(self, key):
-        dims = tuple(
-            dim for k, dim in zip(key, self.dims) if not isinstance(k, integer_types)
-        )
-        return dims, BasicIndexer(key), None
-
-    def _validate_indexers(self, key):
-        """Make sanity checks"""
-        for dim, k in zip(self.dims, key):
-            if not isinstance(k, BASIC_INDEXING_TYPES):
-                if not isinstance(k, Variable):
-                    if not is_duck_array(k):
-                        k = np.asarray(k)
-                    if k.ndim > 1:
-                        raise IndexError(
-                            "Unlabeled multi-dimensional array cannot be "
-                            f"used for indexing: {k}"
-                        )
-                if k.dtype.kind == "b":
-                    if self.shape[self.get_axis_num(dim)] != len(k):
-                        raise IndexError(
-                            f"Boolean array size {len(k):d} is used to index array "
-                            f"with shape {str(self.shape):s}."
-                        )
-                    if k.ndim > 1:
-                        raise IndexError(
-                            f"{k.ndim}-dimensional boolean indexing is "
-                            "not supported. "
-                        )
-                    if is_duck_dask_array(k.data):
-                        raise KeyError(
-                            "Indexing with a boolean dask array is not allowed. "
-                            "This will result in a dask array of unknown shape. "
-                            "Such arrays are unsupported by Xarray."
-                            "Please compute the indexer first using .compute()"
-                        )
-                    if getattr(k, "dims", (dim,)) != (dim,):
-                        raise IndexError(
-                            "Boolean indexer should be unlabeled or on the "
-                            "same dimension to the indexed array. Indexer is "
-                            f"on {str(k.dims):s} but the target dimension is {dim:s}."
-                        )
-
-    def _broadcast_indexes_outer(self, key):
-        # drop dim if k is integer or if k is a 0d dask array
-        dims = tuple(
-            k.dims[0] if isinstance(k, Variable) else dim
-            for k, dim in zip(key, self.dims)
-            if (not isinstance(k, integer_types) and not is_0d_dask_array(k))
-        )
-
-        new_key = []
-        for k in key:
-            if isinstance(k, Variable):
-                k = k.data
-            if not isinstance(k, BASIC_INDEXING_TYPES):
-                if not is_duck_array(k):
-                    k = np.asarray(k)
-                if k.size == 0:
-                    # Slice by empty list; numpy could not infer the dtype
-                    k = k.astype(int)
-                elif k.dtype.kind == "b":
-                    (k,) = np.nonzero(k)
-            new_key.append(k)
-
-        return dims, OuterIndexer(tuple(new_key)), None
-
-    def _broadcast_indexes_vectorized(self, key):
-        variables = []
-        out_dims_set = OrderedSet()
-        for dim, value in zip(self.dims, key):
-            if isinstance(value, slice):
-                out_dims_set.add(dim)
-            else:
-                variable = (
-                    value
-                    if isinstance(value, Variable)
-                    else as_variable(value, name=dim)
-                )
-                if variable.dtype.kind == "b":  # boolean indexing case
-                    (variable,) = variable._nonzero()
-
-                variables.append(variable)
-                out_dims_set.update(variable.dims)
-
-        variable_dims = set()
-        for variable in variables:
-            variable_dims.update(variable.dims)
-
-        slices = []
-        for i, (dim, value) in enumerate(zip(self.dims, key)):
-            if isinstance(value, slice):
-                if dim in variable_dims:
-                    # We only convert slice objects to variables if they share
-                    # a dimension with at least one other variable. Otherwise,
-                    # we can equivalently leave them as slices aknd transpose
-                    # the result. This is significantly faster/more efficient
-                    # for most array backends.
-                    values = np.arange(*value.indices(self.sizes[dim]))
-                    variables.insert(i - len(slices), Variable((dim,), values))
-                else:
-                    slices.append((i, value))
-
-        try:
-            variables = _broadcast_compat_variables(*variables)
-        except ValueError:
-            raise IndexError(f"Dimensions of indexers mismatch: {key}")
-
-        out_key = [variable.data for variable in variables]
-        out_dims = tuple(out_dims_set)
-        slice_positions = set()
-        for i, value in slices:
-            out_key.insert(i, value)
-            new_position = out_dims.index(self.dims[i])
-            slice_positions.add(new_position)
-
-        if slice_positions:
-            new_order = [i for i in range(len(out_dims)) if i not in slice_positions]
-        else:
-            new_order = None
-
-        return out_dims, VectorizedIndexer(tuple(out_key)), new_order
 
     def __getitem__(self, key) -> Self:
         """Return a new Variable object whose contents are consistent with
@@ -2812,76 +2623,6 @@ class IndexVariable(Variable):
         raise TypeError(
             "Values of an IndexVariable are immutable and can not be modified inplace"
         )
-
-
-def _unified_dims(variables):
-    # validate dimensions
-    all_dims = {}
-    for var in variables:
-        var_dims = var.dims
-        _raise_if_any_duplicate_dimensions(var_dims, err_context="Broadcasting")
-
-        for d, s in zip(var_dims, var.shape):
-            if d not in all_dims:
-                all_dims[d] = s
-            elif all_dims[d] != s:
-                raise ValueError(
-                    "operands cannot be broadcast together "
-                    f"with mismatched lengths for dimension {d!r}: {(all_dims[d], s)}"
-                )
-    return all_dims
-
-
-def _broadcast_compat_variables(*variables):
-    """Create broadcast compatible variables, with the same dimensions.
-
-    Unlike the result of broadcast_variables(), some variables may have
-    dimensions of size 1 instead of the size of the broadcast dimension.
-    """
-    dims = tuple(_unified_dims(variables))
-    return tuple(var.set_dims(dims) if var.dims != dims else var for var in variables)
-
-
-def broadcast_variables(*variables: Variable) -> tuple[Variable, ...]:
-    """Given any number of variables, return variables with matching dimensions
-    and broadcast data.
-
-    The data on the returned variables will be a view of the data on the
-    corresponding original arrays, but dimensions will be reordered and
-    inserted so that both broadcast arrays have the same dimensions. The new
-    dimensions are sorted in order of appearance in the first variable's
-    dimensions followed by the second variable's dimensions.
-    """
-    dims_map = _unified_dims(variables)
-    dims_tuple = tuple(dims_map)
-    return tuple(
-        var.set_dims(dims_map) if var.dims != dims_tuple else var for var in variables
-    )
-
-
-def _broadcast_compat_data(self, other):
-    if not OPTIONS["arithmetic_broadcast"]:
-        if (isinstance(other, Variable) and self.dims != other.dims) or (
-            is_duck_array(other) and self.ndim != other.ndim
-        ):
-            raise ValueError(
-                "Broadcasting is necessary but automatic broadcasting is disabled via "
-                "global option `'arithmetic_broadcast'`. "
-                "Use `xr.set_options(arithmetic_broadcast=True)` to enable automatic broadcasting."
-            )
-
-    if all(hasattr(other, attr) for attr in ["dims", "data", "shape", "encoding"]):
-        # `other` satisfies the necessary Variable API for broadcast_variables
-        new_self, new_other = _broadcast_compat_variables(self, other)
-        self_data = new_self.data
-        other_data = new_other.data
-        dims = new_self.dims
-    else:
-        # rely on numpy broadcasting rules
-        self_data = self.data
-        other_data = other
-        dims = self.dims
-    return self_data, other_data, dims
 
 
 def concat(

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -395,15 +395,6 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
             return cls_(dims_, data, attrs_)
 
     @property
-    def _in_memory(self):
-        return isinstance(
-            self._data, (np.ndarray, np.number, PandasIndexingAdapter)
-        ) or (
-            isinstance(self._data, indexing.MemoryCachedArray)
-            and isinstance(self._data.array, indexing.NumpyIndexingAdapter)
-        )
-
-    @property
     def data(self):
         """
         The Variable's data as an array. The underlying array type

--- a/xarray/namedarray/core.py
+++ b/xarray/namedarray/core.py
@@ -1128,6 +1128,19 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
 
         return expand_dims(self, dim=dim)
 
+    @property
+    def _in_memory(self) -> bool:
+        """Return whether the data is in memory."""
+        # TODO: Remove the import once the indexing adapters are moved to namedarray
+        from xarray.core import indexing
+
+        return isinstance(
+            self._data, (np.ndarray, np.number, indexing.PandasIndexingAdapter)
+        ) or (
+            isinstance(self._data, indexing.MemoryCachedArray)
+            and isinstance(self._data.array, indexing.NumpyIndexingAdapter)
+        )
+
 
 _NamedArray = NamedArray[Any, np.dtype[_ScalarType_co]]
 

--- a/xarray/namedarray/core.py
+++ b/xarray/namedarray/core.py
@@ -1148,7 +1148,7 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
         if is_dict_like(key):
             return tuple(key.get(dim, slice(None)) for dim in self.dims)
         else:
-            return tuple(key)
+            return key
 
     def _validate_indexers(self, key: Any) -> None:
         """Make sanity checks"""

--- a/xarray/namedarray/indexing.py
+++ b/xarray/namedarray/indexing.py
@@ -1,0 +1,4 @@
+from xarray.namedarray.pycompat import integer_types
+
+# https://github.com/python/mypy/issues/224
+BASIC_INDEXING_TYPES = integer_types + (slice,)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This pull request is the first part of migrating the indexing and broadcasting logic from `xarray.core.variable` to `xarray.namedarray`. I intend to open follow-up pull request to address additional changes related to this refactoring, as outlined in the [proposal for decoupling lazy indexing functionality from NamedArray](https://github.com/pydata/xarray/blob/main/design_notes/named_array_design_doc.md#plan-for-decoupling-lazy-indexing-functionality-from-namedarray).

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
