### PR TITLE
Avoid in-place multiplication of a large value to an array with small integer dtype

### DIFF
--- a/xarray/plot/dataarray_plot.py
+++ b/xarray/plot/dataarray_plot.py
@@ -333,7 +333,8 @@ def line(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     add_legend: bool = True,
     _labels: bool = True,
     **kwargs: Any,
-) -> list[Line3D]: ...
+) -> list[Line3D]:
+    ...
 
 
 @overload
@@ -360,7 +361,8 @@ def line(
     add_legend: bool = True,
     _labels: bool = True,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @overload
@@ -387,7 +389,8 @@ def line(
     add_legend: bool = True,
     _labels: bool = True,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 # This function signature should not change so that it can use
@@ -541,7 +544,8 @@ def step(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     row: None = None,  # no wrap -> primitive
     col: None = None,  # no wrap -> primitive
     **kwargs: Any,
-) -> list[Line3D]: ...
+) -> list[Line3D]:
+    ...
 
 
 @overload
@@ -554,7 +558,8 @@ def step(
     row: Hashable,  # wrap -> FacetGrid
     col: Hashable | None = None,
     **kwargs: Any,
-) -> FacetGrid[DataArray]: ...
+) -> FacetGrid[DataArray]:
+    ...
 
 
 @overload
@@ -567,7 +572,8 @@ def step(
     row: Hashable | None = None,
     col: Hashable,  # wrap -> FacetGrid
     **kwargs: Any,
-) -> FacetGrid[DataArray]: ...
+) -> FacetGrid[DataArray]:
+    ...
 
 
 def step(
@@ -1140,7 +1146,8 @@ def scatter(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     extend: ExtendOptions = None,
     levels: ArrayLike | None = None,
     **kwargs,
-) -> PathCollection: ...
+) -> PathCollection:
+    ...
 
 
 @overload
@@ -1181,7 +1188,8 @@ def scatter(
     extend: ExtendOptions = None,
     levels: ArrayLike | None = None,
     **kwargs,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @overload
@@ -1222,7 +1230,8 @@ def scatter(
     extend: ExtendOptions = None,
     levels: ArrayLike | None = None,
     **kwargs,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @_plot1d
@@ -1689,7 +1698,8 @@ def imshow(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> AxesImage: ...
+) -> AxesImage:
+    ...
 
 
 @overload
@@ -1729,7 +1739,8 @@ def imshow(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @overload
@@ -1769,7 +1780,8 @@ def imshow(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @_plot2d
@@ -1850,7 +1862,7 @@ def imshow(
         if z.shape[-1] == 3:
             alpha = np.ma.ones(z.shape[:2] + (1,), dtype=z.dtype)
             if np.issubdtype(z.dtype, np.integer):
-                alpha *= 255
+                alpha = 255 * alpha
             z = np.ma.concatenate((z, alpha), axis=2)
         else:
             z = z.copy()
@@ -1905,7 +1917,8 @@ def contour(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> QuadContourSet: ...
+) -> QuadContourSet:
+    ...
 
 
 @overload
@@ -1945,7 +1958,8 @@ def contour(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @overload
@@ -1985,7 +1999,8 @@ def contour(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @_plot2d
@@ -2038,7 +2053,8 @@ def contourf(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> QuadContourSet: ...
+) -> QuadContourSet:
+    ...
 
 
 @overload
@@ -2078,7 +2094,8 @@ def contourf(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @overload
@@ -2118,7 +2135,8 @@ def contourf(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @_plot2d
@@ -2171,7 +2189,8 @@ def pcolormesh(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> QuadMesh: ...
+) -> QuadMesh:
+    ...
 
 
 @overload
@@ -2211,7 +2230,8 @@ def pcolormesh(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @overload
@@ -2251,7 +2271,8 @@ def pcolormesh(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @_plot2d
@@ -2355,7 +2376,8 @@ def surface(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> Poly3DCollection: ...
+) -> Poly3DCollection:
+    ...
 
 
 @overload
@@ -2395,7 +2417,8 @@ def surface(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @overload
@@ -2435,7 +2458,8 @@ def surface(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @_plot2d

--- a/xarray/plot/dataarray_plot.py
+++ b/xarray/plot/dataarray_plot.py
@@ -333,8 +333,7 @@ def line(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     add_legend: bool = True,
     _labels: bool = True,
     **kwargs: Any,
-) -> list[Line3D]:
-    ...
+) -> list[Line3D]: ...
 
 
 @overload
@@ -361,8 +360,7 @@ def line(
     add_legend: bool = True,
     _labels: bool = True,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @overload
@@ -389,8 +387,7 @@ def line(
     add_legend: bool = True,
     _labels: bool = True,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 # This function signature should not change so that it can use
@@ -544,8 +541,7 @@ def step(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     row: None = None,  # no wrap -> primitive
     col: None = None,  # no wrap -> primitive
     **kwargs: Any,
-) -> list[Line3D]:
-    ...
+) -> list[Line3D]: ...
 
 
 @overload
@@ -558,8 +554,7 @@ def step(
     row: Hashable,  # wrap -> FacetGrid
     col: Hashable | None = None,
     **kwargs: Any,
-) -> FacetGrid[DataArray]:
-    ...
+) -> FacetGrid[DataArray]: ...
 
 
 @overload
@@ -572,8 +567,7 @@ def step(
     row: Hashable | None = None,
     col: Hashable,  # wrap -> FacetGrid
     **kwargs: Any,
-) -> FacetGrid[DataArray]:
-    ...
+) -> FacetGrid[DataArray]: ...
 
 
 def step(
@@ -1146,8 +1140,7 @@ def scatter(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     extend: ExtendOptions = None,
     levels: ArrayLike | None = None,
     **kwargs,
-) -> PathCollection:
-    ...
+) -> PathCollection: ...
 
 
 @overload
@@ -1188,8 +1181,7 @@ def scatter(
     extend: ExtendOptions = None,
     levels: ArrayLike | None = None,
     **kwargs,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @overload
@@ -1230,8 +1222,7 @@ def scatter(
     extend: ExtendOptions = None,
     levels: ArrayLike | None = None,
     **kwargs,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @_plot1d
@@ -1698,8 +1689,7 @@ def imshow(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> AxesImage:
-    ...
+) -> AxesImage: ...
 
 
 @overload
@@ -1739,8 +1729,7 @@ def imshow(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @overload
@@ -1780,8 +1769,7 @@ def imshow(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @_plot2d
@@ -1917,8 +1905,7 @@ def contour(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> QuadContourSet:
-    ...
+) -> QuadContourSet: ...
 
 
 @overload
@@ -1958,8 +1945,7 @@ def contour(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @overload
@@ -1999,8 +1985,7 @@ def contour(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @_plot2d
@@ -2053,8 +2038,7 @@ def contourf(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> QuadContourSet:
-    ...
+) -> QuadContourSet: ...
 
 
 @overload
@@ -2094,8 +2078,7 @@ def contourf(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @overload
@@ -2135,8 +2118,7 @@ def contourf(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @_plot2d
@@ -2189,8 +2171,7 @@ def pcolormesh(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> QuadMesh:
-    ...
+) -> QuadMesh: ...
 
 
 @overload
@@ -2230,8 +2211,7 @@ def pcolormesh(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @overload
@@ -2271,8 +2251,7 @@ def pcolormesh(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @_plot2d
@@ -2376,8 +2355,7 @@ def surface(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> Poly3DCollection:
-    ...
+) -> Poly3DCollection: ...
 
 
 @overload
@@ -2417,8 +2395,7 @@ def surface(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @overload
@@ -2458,8 +2435,7 @@ def surface(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @_plot2d

--- a/xarray/plot/dataarray_plot.py
+++ b/xarray/plot/dataarray_plot.py
@@ -333,7 +333,8 @@ def line(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     add_legend: bool = True,
     _labels: bool = True,
     **kwargs: Any,
-) -> list[Line3D]: ...
+) -> list[Line3D]:
+    ...
 
 
 @overload
@@ -360,7 +361,8 @@ def line(
     add_legend: bool = True,
     _labels: bool = True,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @overload
@@ -387,7 +389,8 @@ def line(
     add_legend: bool = True,
     _labels: bool = True,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 # This function signature should not change so that it can use
@@ -541,7 +544,8 @@ def step(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     row: None = None,  # no wrap -> primitive
     col: None = None,  # no wrap -> primitive
     **kwargs: Any,
-) -> list[Line3D]: ...
+) -> list[Line3D]:
+    ...
 
 
 @overload
@@ -554,7 +558,8 @@ def step(
     row: Hashable,  # wrap -> FacetGrid
     col: Hashable | None = None,
     **kwargs: Any,
-) -> FacetGrid[DataArray]: ...
+) -> FacetGrid[DataArray]:
+    ...
 
 
 @overload
@@ -567,7 +572,8 @@ def step(
     row: Hashable | None = None,
     col: Hashable,  # wrap -> FacetGrid
     **kwargs: Any,
-) -> FacetGrid[DataArray]: ...
+) -> FacetGrid[DataArray]:
+    ...
 
 
 def step(
@@ -1140,7 +1146,8 @@ def scatter(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     extend: ExtendOptions = None,
     levels: ArrayLike | None = None,
     **kwargs,
-) -> PathCollection: ...
+) -> PathCollection:
+    ...
 
 
 @overload
@@ -1181,7 +1188,8 @@ def scatter(
     extend: ExtendOptions = None,
     levels: ArrayLike | None = None,
     **kwargs,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @overload
@@ -1222,7 +1230,8 @@ def scatter(
     extend: ExtendOptions = None,
     levels: ArrayLike | None = None,
     **kwargs,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @_plot1d
@@ -1689,7 +1698,8 @@ def imshow(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> AxesImage: ...
+) -> AxesImage:
+    ...
 
 
 @overload
@@ -1729,7 +1739,8 @@ def imshow(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @overload
@@ -1769,7 +1780,8 @@ def imshow(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @_plot2d
@@ -1848,9 +1860,10 @@ def imshow(
         # missing data transparent.  We therefore add an alpha channel if
         # there isn't one, and set it to transparent where data is masked.
         if z.shape[-1] == 3:
-            alpha = np.ma.ones(z.shape[:2] + (1,), dtype=z.dtype)
+            safe_dtype = np.promote_types(z.dtype, np.uint8)
+            alpha = np.ma.ones(z.shape[:2] + (1,), dtype=safe_dtype)
             if np.issubdtype(z.dtype, np.integer):
-                alpha = 255 * alpha
+                alpha[:] = 255
             z = np.ma.concatenate((z, alpha), axis=2)
         else:
             z = z.copy()
@@ -1905,7 +1918,8 @@ def contour(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> QuadContourSet: ...
+) -> QuadContourSet:
+    ...
 
 
 @overload
@@ -1945,7 +1959,8 @@ def contour(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @overload
@@ -1985,7 +2000,8 @@ def contour(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @_plot2d
@@ -2038,7 +2054,8 @@ def contourf(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> QuadContourSet: ...
+) -> QuadContourSet:
+    ...
 
 
 @overload
@@ -2078,7 +2095,8 @@ def contourf(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @overload
@@ -2118,7 +2136,8 @@ def contourf(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @_plot2d
@@ -2171,7 +2190,8 @@ def pcolormesh(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> QuadMesh: ...
+) -> QuadMesh:
+    ...
 
 
 @overload
@@ -2211,7 +2231,8 @@ def pcolormesh(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @overload
@@ -2251,7 +2272,8 @@ def pcolormesh(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @_plot2d
@@ -2355,7 +2377,8 @@ def surface(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> Poly3DCollection: ...
+) -> Poly3DCollection:
+    ...
 
 
 @overload
@@ -2395,7 +2418,8 @@ def surface(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @overload
@@ -2435,7 +2459,8 @@ def surface(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]: ...
+) -> FacetGrid[T_DataArray]:
+    ...
 
 
 @_plot2d

--- a/xarray/plot/dataarray_plot.py
+++ b/xarray/plot/dataarray_plot.py
@@ -333,8 +333,7 @@ def line(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     add_legend: bool = True,
     _labels: bool = True,
     **kwargs: Any,
-) -> list[Line3D]:
-    ...
+) -> list[Line3D]: ...
 
 
 @overload
@@ -361,8 +360,7 @@ def line(
     add_legend: bool = True,
     _labels: bool = True,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @overload
@@ -389,8 +387,7 @@ def line(
     add_legend: bool = True,
     _labels: bool = True,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 # This function signature should not change so that it can use
@@ -544,8 +541,7 @@ def step(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     row: None = None,  # no wrap -> primitive
     col: None = None,  # no wrap -> primitive
     **kwargs: Any,
-) -> list[Line3D]:
-    ...
+) -> list[Line3D]: ...
 
 
 @overload
@@ -558,8 +554,7 @@ def step(
     row: Hashable,  # wrap -> FacetGrid
     col: Hashable | None = None,
     **kwargs: Any,
-) -> FacetGrid[DataArray]:
-    ...
+) -> FacetGrid[DataArray]: ...
 
 
 @overload
@@ -572,8 +567,7 @@ def step(
     row: Hashable | None = None,
     col: Hashable,  # wrap -> FacetGrid
     **kwargs: Any,
-) -> FacetGrid[DataArray]:
-    ...
+) -> FacetGrid[DataArray]: ...
 
 
 def step(
@@ -1146,8 +1140,7 @@ def scatter(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     extend: ExtendOptions = None,
     levels: ArrayLike | None = None,
     **kwargs,
-) -> PathCollection:
-    ...
+) -> PathCollection: ...
 
 
 @overload
@@ -1188,8 +1181,7 @@ def scatter(
     extend: ExtendOptions = None,
     levels: ArrayLike | None = None,
     **kwargs,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @overload
@@ -1230,8 +1222,7 @@ def scatter(
     extend: ExtendOptions = None,
     levels: ArrayLike | None = None,
     **kwargs,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @_plot1d
@@ -1698,8 +1689,7 @@ def imshow(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> AxesImage:
-    ...
+) -> AxesImage: ...
 
 
 @overload
@@ -1739,8 +1729,7 @@ def imshow(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @overload
@@ -1780,8 +1769,7 @@ def imshow(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @_plot2d
@@ -1918,8 +1906,7 @@ def contour(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> QuadContourSet:
-    ...
+) -> QuadContourSet: ...
 
 
 @overload
@@ -1959,8 +1946,7 @@ def contour(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @overload
@@ -2000,8 +1986,7 @@ def contour(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @_plot2d
@@ -2054,8 +2039,7 @@ def contourf(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> QuadContourSet:
-    ...
+) -> QuadContourSet: ...
 
 
 @overload
@@ -2095,8 +2079,7 @@ def contourf(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @overload
@@ -2136,8 +2119,7 @@ def contourf(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @_plot2d
@@ -2190,8 +2172,7 @@ def pcolormesh(  # type: ignore[misc,unused-ignore]  # None is hashable :(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> QuadMesh:
-    ...
+) -> QuadMesh: ...
 
 
 @overload
@@ -2231,8 +2212,7 @@ def pcolormesh(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @overload
@@ -2272,8 +2252,7 @@ def pcolormesh(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @_plot2d
@@ -2377,8 +2356,7 @@ def surface(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> Poly3DCollection:
-    ...
+) -> Poly3DCollection: ...
 
 
 @overload
@@ -2418,8 +2396,7 @@ def surface(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @overload
@@ -2459,8 +2436,7 @@ def surface(
     ylim: ArrayLike | None = None,
     norm: Normalize | None = None,
     **kwargs: Any,
-) -> FacetGrid[T_DataArray]:
-    ...
+) -> FacetGrid[T_DataArray]: ...
 
 
 @_plot2d

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2028,15 +2028,17 @@ class TestImshow(Common2dMixin, PlotTestCase):
         for vmin2, vmax2 in ((-1.2, -1), (2, 2.1)):
             da.plot.imshow(vmin=vmin2, vmax=vmax2)
 
-    def test_imshow_rgb_values_in_valid_range(self) -> None:
-        da = DataArray(np.arange(75, dtype="uint8").reshape((5, 5, 3)))
+    @pytest.mark.parametrize(["dtype"], [(np.uint8, np.int8, np.int16)])
+    def test_imshow_rgb_values_in_valid_range(self, dtype) -> None:
+        da = DataArray(np.arange(75, dtype=dtype).reshape((5, 5, 3)))
         _, ax = plt.subplots()
         out = da.plot.imshow(ax=ax).get_array()
         assert out is not None
-        dtype = out.dtype
-        assert dtype is not None
-        assert dtype == np.uint8
+        actual_dtype = out.dtype
+        assert actual_dtype is not None
+        assert actual_dtype == np.uint8
         assert (out[..., :3] == da.values).all()  # Compare without added alpha
+        assert (out[..., -1] == 255).all()  # Compare alpha
 
     @pytest.mark.filterwarnings("ignore:Several dimensions of this array")
     def test_regression_rgb_imshow_dim_size_one(self) -> None:

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2028,7 +2028,7 @@ class TestImshow(Common2dMixin, PlotTestCase):
         for vmin2, vmax2 in ((-1.2, -1), (2, 2.1)):
             da.plot.imshow(vmin=vmin2, vmax=vmax2)
 
-    @pytest.mark.parametrize(["dtype"], [(np.uint8, np.int8, np.int16)])
+    @pytest.mark.parametrize("dtype", [np.uint8, np.int8, np.int16])
     def test_imshow_rgb_values_in_valid_range(self, dtype) -> None:
         da = DataArray(np.arange(75, dtype=dtype).reshape((5, 5, 3)))
         _, ax = plt.subplots()


### PR DESCRIPTION
Upstream numpy has become a bit more particular with which types you can use for inplace operations. This PR fixes
```
_______________ TestImshow.test_imshow_rgb_values_in_valid_range _______________

self = <xarray.tests.test_plot.TestImshow object at 0x7f88320c2780>

    def test_imshow_rgb_values_in_valid_range(self) -> None:
        da = DataArray(np.arange(75, dtype="uint8").reshape((5, 5, 3)))
        _, ax = plt.subplots()
>       out = da.plot.imshow(ax=ax).get_array()

/home/runner/work/xarray/xarray/xarray/tests/test_plot.py:2034: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/runner/work/xarray/xarray/xarray/plot/accessor.py:421: in imshow
    return dataarray_plot.imshow(self._da, *args, **kwargs)
/home/runner/work/xarray/xarray/xarray/plot/dataarray_plot.py:1601: in newplotfunc
    primitive = plotfunc(
/home/runner/work/xarray/xarray/xarray/plot/dataarray_plot.py:1853: in imshow
    alpha *= 255
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = masked_array(
  data=[[[1],
         [1],
         [1],
         [1],
         [1]],

        [[1],
         [1],
    ...,
         [1],
         [1],
         [1],
         [1]]],
  mask=False,
  fill_value=np.int64(999999),
  dtype=uint8)
other = 255

    def __imul__(self, other):
        """
        Multiply self by other in-place.
    
        """
        m = getmask(other)
        if self._mask is nomask:
            if m is not nomask and m.any():
                self._mask = make_mask_none(self.shape, self.dtype)
                self._mask += m
        elif m is not nomask:
            self._mask += m
        other_data = getdata(other)
        other_data = np.where(self._mask, other_data.dtype.type(1), other_data)
>       self._data.__imul__(other_data)
E       numpy._core._exceptions._UFuncOutputCastingError: Cannot cast ufunc 'multiply' output from dtype('int64') to dtype('uint8') with casting rule 'same_kind'

/home/runner/micromamba/envs/xarray-tests/lib/python3.12/site-packages/numpy/ma/core.py:4415: UFuncTypeError
```

Some curious behaviors seen while debugging:
```python
alpha = np.array([1], dtype=np.int8)
alpha *= 255
repr(alpha) # 'array([-1], dtype=int8)'

alpha = np.array([1], dtype=np.int16)
alpha *= 255
repr(alpha) # 'array([255], dtype=int16)'
```



xref: #8844