### PR TITLE
warn and return bytes undecoded in case of UnicodeDecodeError in h5netcdf-backend

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -57,15 +57,17 @@ Bug fixes
   `CFMaskCoder`/`CFScaleOffsetCoder` (:issue:`2304`, :issue:`5597`,
   :issue:`7691`, :pull:`8713`, see also discussion in :pull:`7654`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
-- do not cast `_FillValue`/`missing_value` in `CFMaskCoder` if `_Unsigned` is provided
+- Do not cast `_FillValue`/`missing_value` in `CFMaskCoder` if `_Unsigned` is provided
   (:issue:`8844`, :pull:`8852`).
 - Adapt handling of copy keyword argument for numpy >= 2.0dev
-  (:issue:`8844`, :pull:`8851`, :pull:`8865``).
+  (:issue:`8844`, :pull:`8851`, :pull:`8865`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
-- import trapz/trapezoid depending on numpy version.
+- Import trapz/trapezoid depending on numpy version
   (:issue:`8844`, :pull:`8865`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
-
+- Warn and return bytes undecoded in case of UnicodeDecodeError in h5netcdf-backend
+  (:issue:`5563`, :pull:`8874`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 
 Documentation

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -28,6 +28,7 @@ from xarray.backends.store import StoreBackendEntrypoint
 from xarray.core import indexing
 from xarray.core.utils import (
     FrozenDict,
+    emit_user_level_warning,
     is_remote_uri,
     read_magic_number_from_file,
     try_read_magic_number_from_file_or_path,
@@ -60,9 +61,14 @@ class H5NetCDFArrayWrapper(BaseNetCDF4Array):
 
 def maybe_decode_bytes(txt):
     if isinstance(txt, bytes):
-        return txt.decode("utf-8")
-    else:
-        return txt
+        try:
+            return txt.decode("utf-8")
+        except UnicodeDecodeError:
+            emit_user_level_warning(
+                "'utf-8' codec can't decode bytes, " "returning bytes undecoded.",
+                UnicodeWarning,
+            )
+    return txt
 
 
 def _read_attributes(h5netcdf_var):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3560,6 +3560,15 @@ class TestH5NetCDFData(NetCDF4Base):
             assert actual.x.encoding["compression"] == "lzf"
             assert actual.x.encoding["compression_opts"] is None
 
+    def test_decode_utf8_warning(self) -> None:
+        title = b"\xc3"
+        with create_tmp_file() as tmp_file:
+            with nc4.Dataset(tmp_file, "w") as f:
+                f.title = title
+            with pytest.warns(UnicodeWarning, match="returning bytes undecoded"):
+                ds = xr.load_dataset(tmp_file, engine="h5netcdf")
+                assert ds.title == title
+
 
 @requires_h5netcdf
 @requires_netCDF4

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3565,9 +3565,10 @@ class TestH5NetCDFData(NetCDF4Base):
         with create_tmp_file() as tmp_file:
             with nc4.Dataset(tmp_file, "w") as f:
                 f.title = title
-            with pytest.warns(UnicodeWarning, match="returning bytes undecoded"):
+            with pytest.warns(UnicodeWarning, match="returning bytes undecoded") as w:
                 ds = xr.load_dataset(tmp_file, engine="h5netcdf")
                 assert ds.title == title
+                assert "attribute 'title' of h5netcdf object '/'" in str(w[0].message)
 
 
 @requires_h5netcdf


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #5563
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
