### PR TITLE
add `.oindex` and `.vindex` to `BackendArray`

### DIFF
--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -210,12 +210,12 @@ class BackendArray(NdimSizeLenMixin, indexing.ExplicitlyIndexed):
         key = indexing.BasicIndexer((slice(None),) * self.ndim)
         return self[key]  # type: ignore [index]
 
-    def _oindex_get(self, indexer: indexing.OuterIndexer):
+    def _oindex_get(self, key: indexing.OuterIndexer):
         raise NotImplementedError(
             f"{self.__class__.__name__}._oindex_get method should be overridden"
         )
 
-    def _vindex_get(self, indexer: indexing.VectorizedIndexer):
+    def _vindex_get(self, key: indexing.VectorizedIndexer):
         raise NotImplementedError(
             f"{self.__class__.__name__}._vindex_get method should be overridden"
         )

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -210,6 +210,24 @@ class BackendArray(NdimSizeLenMixin, indexing.ExplicitlyIndexed):
         key = indexing.BasicIndexer((slice(None),) * self.ndim)
         return self[key]  # type: ignore [index]
 
+    def _oindex_get(self, indexer: indexing.OuterIndexer):
+        raise NotImplementedError(
+            f"{self.__class__.__name__}._oindex_get method should be overridden"
+        )
+
+    def _vindex_get(self, indexer: indexing.VectorizedIndexer):
+        raise NotImplementedError(
+            f"{self.__class__.__name__}._vindex_get method should be overridden"
+        )
+
+    @property
+    def oindex(self) -> indexing.IndexCallable:
+        return indexing.IndexCallable(self._oindex_get)
+
+    @property
+    def vindex(self) -> indexing.IndexCallable:
+        return indexing.IndexCallable(self._vindex_get)
+
 
 class AbstractDataStore:
     __slots__ = ()

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -48,7 +48,17 @@ class H5NetCDFArrayWrapper(BaseNetCDF4Array):
         ds = self.datastore._acquire(needs_lock)
         return ds.variables[self.variable_name]
 
-    def __getitem__(self, key):
+    def _oindex_get(self, key: indexing.OuterIndexer):
+        return indexing.explicit_indexing_adapter(
+            key, self.shape, indexing.IndexingSupport.OUTER_1VECTOR, self._getitem
+        )
+
+    def _vindex_get(self, key: indexing.VectorizedIndexer):
+        return indexing.explicit_indexing_adapter(
+            key, self.shape, indexing.IndexingSupport.OUTER_1VECTOR, self._getitem
+        )
+
+    def __getitem__(self, key: indexing.BasicIndexer):
         return indexing.explicit_indexing_adapter(
             key, self.shape, indexing.IndexingSupport.OUTER_1VECTOR, self._getitem
         )

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -97,7 +97,17 @@ class NetCDF4ArrayWrapper(BaseNetCDF4Array):
             variable.set_auto_chartostring(False)
         return variable
 
-    def __getitem__(self, key):
+    def _oindex_get(self, key: indexing.OuterIndexer):
+        return indexing.explicit_indexing_adapter(
+            key, self.shape, indexing.IndexingSupport.OUTER, self._getitem
+        )
+
+    def _vindex_get(self, key: indexing.VectorizedIndexer):
+        return indexing.explicit_indexing_adapter(
+            key, self.shape, indexing.IndexingSupport.OUTER, self._getitem
+        )
+
+    def __getitem__(self, key: indexing.BasicIndexer):
         return indexing.explicit_indexing_adapter(
             key, self.shape, indexing.IndexingSupport.OUTER, self._getitem
         )

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -43,7 +43,17 @@ class PydapArrayWrapper(BackendArray):
     def dtype(self):
         return self.array.dtype
 
-    def __getitem__(self, key):
+    def _oindex_get(self, key: indexing.OuterIndexer):
+        return indexing.explicit_indexing_adapter(
+            key, self.shape, indexing.IndexingSupport.BASIC, self._getitem
+        )
+
+    def _vindex_get(self, key: indexing.VectorizedIndexer):
+        return indexing.explicit_indexing_adapter(
+            key, self.shape, indexing.IndexingSupport.BASIC, self._getitem
+        )
+
+    def __getitem__(self, key: indexing.BasicIndexer):
         return indexing.explicit_indexing_adapter(
             key, self.shape, indexing.IndexingSupport.BASIC, self._getitem
         )

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -50,7 +50,17 @@ class NioArrayWrapper(BackendArray):
         ds = self.datastore._manager.acquire(needs_lock)
         return ds.variables[self.variable_name]
 
-    def __getitem__(self, key):
+    def _oindex_get(self, key: indexing.OuterIndexer):
+        return indexing.explicit_indexing_adapter(
+            key, self.shape, indexing.IndexingSupport.BASIC, self._getitem
+        )
+
+    def _vindex_get(self, key: indexing.VectorizedIndexer):
+        return indexing.explicit_indexing_adapter(
+            key, self.shape, indexing.IndexingSupport.BASIC, self._getitem
+        )
+
+    def __getitem__(self, key: indexing.BasicIndexer):
         return indexing.explicit_indexing_adapter(
             key, self.shape, indexing.IndexingSupport.BASIC, self._getitem
         )

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -85,15 +85,15 @@ class ScipyArrayWrapper(BackendArray):
             data = self.get_variable(needs_lock=False).data
             return data[key]
 
-    def _vindex_get(self, indexer: indexing.VectorizedIndexer):
+    def _vindex_get(self, key: indexing.VectorizedIndexer):
         data = indexing.explicit_indexing_adapter(
-            indexer, self.shape, indexing.IndexingSupport.OUTER_1VECTOR, self._getitem
+            key, self.shape, indexing.IndexingSupport.OUTER_1VECTOR, self._getitem
         )
         return self._finalize_result(data)
 
-    def _oindex_get(self, indexer: indexing.OuterIndexer):
+    def _oindex_get(self, key: indexing.OuterIndexer):
         data = indexing.explicit_indexing_adapter(
-            indexer, self.shape, indexing.IndexingSupport.OUTER_1VECTOR, self._getitem
+            key, self.shape, indexing.IndexingSupport.OUTER_1VECTOR, self._getitem
         )
         return self._finalize_result(data)
 

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -84,15 +84,6 @@ class ZarrArrayWrapper(BackendArray):
     def get_array(self):
         return self._array
 
-    def _oindex(self, key):
-        return self._array.oindex[key]
-
-    def _vindex(self, key):
-        return self._array.vindex[key]
-
-    def _getitem(self, key):
-        return self._array[key]
-
     def _oindex_get(self, key: indexing.OuterIndexer):
         def raw_indexing_method(key):
             return self._array.oindex[key]

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -93,16 +93,38 @@ class ZarrArrayWrapper(BackendArray):
     def _getitem(self, key):
         return self._array[key]
 
-    def __getitem__(self, key):
-        array = self._array
-        if isinstance(key, indexing.BasicIndexer):
-            method = self._getitem
-        elif isinstance(key, indexing.VectorizedIndexer):
-            method = self._vindex
-        elif isinstance(key, indexing.OuterIndexer):
-            method = self._oindex
+    def _oindex_get(self, key: indexing.OuterIndexer):
+        def raw_indexing_method(key):
+            return self._array.oindex[key]
+
         return indexing.explicit_indexing_adapter(
-            key, array.shape, indexing.IndexingSupport.VECTORIZED, method
+            key,
+            self._array.shape,
+            indexing.IndexingSupport.VECTORIZED,
+            raw_indexing_method,
+        )
+
+    def _vindex_get(self, key: indexing.VectorizedIndexer):
+
+        def raw_indexing_method(key):
+            return self._array.vindex[key]
+
+        return indexing.explicit_indexing_adapter(
+            key,
+            self._array.shape,
+            indexing.IndexingSupport.VECTORIZED,
+            raw_indexing_method,
+        )
+
+    def __getitem__(self, key: indexing.BasicIndexer):
+        def raw_indexing_method(key):
+            return self._array[key]
+
+        return indexing.explicit_indexing_adapter(
+            key,
+            self._array.shape,
+            indexing.IndexingSupport.VECTORIZED,
+            raw_indexing_method,
         )
 
         # if self.ndim == 0:

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -685,12 +685,8 @@ class LazilyVectorizedIndexedArray(ExplicitlyIndexedNDArrayMixin):
         return np.broadcast(*self.key.tuple).shape
 
     def get_duck_array(self):
-        if isinstance(self.array, ExplicitlyIndexedNDArrayMixin):
-            array = apply_indexer(self.array, self.key)
-        else:
-            # If the array is not an ExplicitlyIndexedNDArrayMixin,
-            # it may wrap a BackendArray so use its __getitem__
-            array = self.array[self.key]
+        array = apply_indexer(self.array, self.key)
+
         # self.array[self.key] is now a numpy array when
         # self.array is a BackendArray subclass
         # and self.key is BasicIndexer((slice(None, None, None),))

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -615,13 +615,7 @@ class LazilyIndexedArray(ExplicitlyIndexedNDArrayMixin):
         return tuple(shape)
 
     def get_duck_array(self):
-        if isinstance(self.array, ExplicitlyIndexedNDArrayMixin):
-            array = apply_indexer(self.array, self.key)
-        else:
-            # If the array is not an ExplicitlyIndexedNDArrayMixin,
-            # it may wrap a BackendArray so use its __getitem__
-            array = self.array[self.key]
-
+        array = apply_indexer(self.array, self.key)
         # self.array[self.key] is now a numpy array when
         # self.array is a BackendArray subclass
         # and self.key is BasicIndexer((slice(None, None, None),))

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -566,9 +566,9 @@ class ImplicitToExplicitIndexingAdapter(NDArrayMixin):
 
 
 BackendArray_fallback_warning_message = (
-    "The array {0} does not support indexing using the .vindex and .oindex properties. "
+    "The array `{0}` does not support indexing using the .vindex and .oindex properties. "
     "The __getitem__ method is being used instead. This fallback behavior will be "
-    "removed in a future version. Please ensure that the backend array {1} implements "
+    "removed in a future version. Please ensure that the backend array `{1}` implements "
     "support for the .vindex and .oindex properties to avoid potential issues."
 )
 
@@ -634,6 +634,7 @@ class LazilyIndexedArray(ExplicitlyIndexedNDArrayMixin):
                     self.array.__class__.__name__, self.array.__class__.__name__
                 ),
                 category=DeprecationWarning,
+                stacklevel=2,
             )
             array = self.array[self.key]
 
@@ -716,6 +717,7 @@ class LazilyVectorizedIndexedArray(ExplicitlyIndexedNDArrayMixin):
                     self.array.__class__.__name__, self.array.__class__.__name__
                 ),
                 category=DeprecationWarning,
+                stacklevel=2,
             )
             array = self.array[self.key]
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -716,7 +716,7 @@ class LazilyVectorizedIndexedArray(ExplicitlyIndexedNDArrayMixin):
                 BackendArray_fallback_warning_message.format(
                     self.array.__class__.__name__, self.array.__class__.__name__
                 ),
-                category=DeprecationWarning,
+                category=PendingDeprecationWarning,
                 stacklevel=2,
             )
             array = self.array[self.key]

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -566,9 +566,9 @@ class ImplicitToExplicitIndexingAdapter(NDArrayMixin):
 
 
 BackendArray_fallback_warning_message = (
-    "The array does not support indexing using the .vindex and .oindex properties. "
+    "The array {0} does not support indexing using the .vindex and .oindex properties. "
     "The __getitem__ method is being used instead. This fallback behavior will be "
-    "removed in a future version. Please ensure that the backend array implements "
+    "removed in a future version. Please ensure that the backend array {1} implements "
     "support for the .vindex and .oindex properties to avoid potential issues."
 )
 
@@ -626,11 +626,13 @@ class LazilyIndexedArray(ExplicitlyIndexedNDArrayMixin):
     def get_duck_array(self):
         try:
             array = apply_indexer(self.array, self.key)
-        except AttributeError as _:
+        except NotImplementedError as _:
             # If the array is not an ExplicitlyIndexedNDArrayMixin,
             # it may wrap a BackendArray subclass that doesn't implement .oindex and .vindex. so use its __getitem__
             warnings.warn(
-                BackendArray_fallback_warning_message,
+                BackendArray_fallback_warning_message.format(
+                    self.array.__class__.__name__, self.array.__class__.__name__
+                ),
                 category=DeprecationWarning,
             )
             array = self.array[self.key]
@@ -706,11 +708,13 @@ class LazilyVectorizedIndexedArray(ExplicitlyIndexedNDArrayMixin):
     def get_duck_array(self):
         try:
             array = apply_indexer(self.array, self.key)
-        except AttributeError as _:
+        except NotImplementedError as _:
             # If the array is not an ExplicitlyIndexedNDArrayMixin,
             # it may wrap a BackendArray subclass that doesn't implement .oindex and .vindex. so use its __getitem__
             warnings.warn(
-                BackendArray_fallback_warning_message,
+                BackendArray_fallback_warning_message.format(
+                    self.array.__class__.__name__, self.array.__class__.__name__
+                ),
                 category=DeprecationWarning,
             )
             array = self.array[self.key]

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5860,7 +5860,7 @@ def test_backend_array_deprecation_warning(capsys):
 
     captured = capsys.readouterr()
     assert len(w) == 1
-    assert issubclass(w[-1].category, DeprecationWarning)
+    assert issubclass(w[-1].category, PendingDeprecationWarning)
     assert (
         "The array `CustomBackendArray` does not support indexing using the .vindex and .oindex properties."
         in str(w[-1].message)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

this PR builds towards 

- https://github.com/pydata/xarray/pull/8870
- https://github.com/pydata/xarray/pull/8856

the primary objective is to partially address 

>  2. Implement fall back `.oindex`, `.vindex` properties on `BackendArray` base class. These will simply rewrap the `key` tuple with the appropriate `*Indexer` object, and pass it on to `__getitem__` or `__setitem__`. These methods will also raise DeprecationWarning so that external backends will know to migrate to `.oindex`, and `.vindex` over the next year.

----
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
