### PR TITLE
Update docstring for compute and persist

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1125,6 +1125,7 @@ class DataArray(
     def load(self, **kwargs) -> Self:
         """Manually trigger loading of this array's data from disk or a
         remote source into memory and return this array.
+
         Unlike compute, the original dataset is modified and returned.
 
         Normally, it should not be necessary to call this method in user code,

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1125,6 +1125,7 @@ class DataArray(
     def load(self, **kwargs) -> Self:
         """Manually trigger loading of this array's data from disk or a
         remote source into memory and return this array.
+        Unlike compute, the original dataset is modified and returned.
 
         Normally, it should not be necessary to call this method in user code,
         because all xarray functions should either work on deferred data or

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1151,7 +1151,7 @@ class DataArray(
     def compute(self, **kwargs) -> Self:
         """Manually trigger loading of this array's data from disk or a
         remote source into memory and return a new array.
-        
+
         Unlike load, the original is left unaltered.
 
         Normally, it should not be necessary to call this method in user code,
@@ -1192,7 +1192,7 @@ class DataArray(
         Returns
         -------
         object : DataArray
-            New object with dask-backed data and coordinates as persisted dask arrays.
+            New object with all dask-backed data and coordinates as persisted dask arrays.
 
         See Also
         --------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1182,7 +1182,7 @@ class DataArray(
         This keeps them as dask arrays but encourages them to keep data in
         memory.  This is particularly useful when on a distributed machine.
         When on a single machine consider using ``.compute()`` instead.
-        Unlike load but like compute, the original dataset is left unaltered.
+        Like compute (but unlike load), the original dataset is left unaltered.
 
         Parameters
         ----------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1165,7 +1165,7 @@ class DataArray(
         Returns
         -------
         object : DataArray
-            New object with data as in memory numpy array.
+            New object with the data and all coordinates as in-memory arrays.
 
         See Also
         --------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1150,8 +1150,9 @@ class DataArray(
 
     def compute(self, **kwargs) -> Self:
         """Manually trigger loading of this array's data from disk or a
-        remote source into memory and return a new array. Unlike load, the original is
-        left unaltered.
+        remote source into memory and return a new array.
+        
+        Unlike load, the original is left unaltered.
 
         Normally, it should not be necessary to call this method in user code,
         because all xarray functions should either work on deferred data or
@@ -1191,7 +1192,7 @@ class DataArray(
         Returns
         -------
         object : DataArray
-            New object with data as persisted dask array.
+            New object with dask-backed data and coordinates as persisted dask arrays.
 
         See Also
         --------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1148,7 +1148,7 @@ class DataArray(
 
     def compute(self, **kwargs) -> Self:
         """Manually trigger loading of this array's data from disk or a
-        remote source into memory and return a new array. The original is
+        remote source into memory and return a new array. Unlike load, the original is
         left unaltered.
 
         Normally, it should not be necessary to call this method in user code,
@@ -1160,6 +1160,11 @@ class DataArray(
         ----------
         **kwargs : dict
             Additional keyword arguments passed on to ``dask.compute``.
+
+        Returns
+        -------
+        object : DataArray
+            New object with data as in memory numpy array.
 
         See Also
         --------
@@ -1174,11 +1179,17 @@ class DataArray(
         This keeps them as dask arrays but encourages them to keep data in
         memory.  This is particularly useful when on a distributed machine.
         When on a single machine consider using ``.compute()`` instead.
+        Unlike load but like compute, the original dataset is left unaltered.
 
         Parameters
         ----------
         **kwargs : dict
             Additional keyword arguments passed on to ``dask.persist``.
+
+        Returns
+        -------
+        object : DataArray
+            New object with data as persisted dask array.
 
         See Also
         --------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1005,6 +1005,11 @@ class Dataset(
         **kwargs : dict
             Additional keyword arguments passed on to ``dask.compute``.
 
+        Returns
+        -------
+        object : Dataset
+            New object with data as numpy arrays in memory.
+
         See Also
         --------
         dask.compute
@@ -1037,11 +1042,17 @@ class Dataset(
         operation keeps the data as dask arrays. This is particularly useful
         when using the dask.distributed scheduler and you want to load a large
         amount of data into distributed memory.
+        Unlike load but like compute, the original dataset is left unaltered.
 
         Parameters
         ----------
         **kwargs : dict
             Additional keyword arguments passed on to ``dask.persist``.
+
+        Returns
+        -------
+        object : Dataset
+            New object with data as persisted dask arrays.
 
         See Also
         --------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1042,7 +1042,7 @@ class Dataset(
         operation keeps the data as dask arrays. This is particularly useful
         when using the dask.distributed scheduler and you want to load a large
         amount of data into distributed memory.
-        Unlike load but like compute, the original dataset is left unaltered.
+        Like compute (but unlike load), the original dataset is left unaltered.
 
         Parameters
         ----------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1008,7 +1008,7 @@ class Dataset(
         Returns
         -------
         object : Dataset
-            New object with data as numpy arrays in memory.
+            New object with lazy data variables and coordinates as in-memory arrays.
 
         See Also
         --------
@@ -1052,7 +1052,7 @@ class Dataset(
         Returns
         -------
         object : Dataset
-            New object with data as persisted dask arrays.
+            New object with all dask-backed coordinates and data variables as persisted dask arrays.
 
         See Also
         --------


### PR DESCRIPTION
* Updates the docstring for persist to mention that it is not altering the original object.
* Adds a return value to the docstring for compute and persist on both Dataset and DataArray

- [x] Closes #8901
