### PR TITLE
Add invariant check for #8646

### DIFF
--- a/xarray/testing/assertions.py
+++ b/xarray/testing/assertions.py
@@ -268,6 +268,10 @@ def _assert_indexes_invariants_checks(
     }
     assert indexes.keys() <= index_vars, (set(indexes), index_vars)
 
+    for k, v in possible_coord_variables.items():
+        if isinstance(v, IndexVariable):
+            assert k == v.name, (k, v.name)
+
     # check pandas index wrappers vs. coordinate data adapters
     for k, index in indexes.items():
         if isinstance(index, PandasIndex):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
@benbovy this seems to be the root cause of #8646, the variable name in `Dataset._variables` does not match `IndexVariable.name`.

A good number of tests seem to fail though, so not sure if this is a good chck.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
