### PR TITLE
Keep attributes for "bounds" variables

### DIFF
--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -794,24 +794,4 @@ def cf_encoder(variables: T_Variables, attributes: T_Attrs):
 
     new_vars = {k: encode_cf_variable(v, name=k) for k, v in variables.items()}
 
-    # Remove attrs from bounds variables (issue #2921)
-    for var in new_vars.values():
-        bounds = var.attrs["bounds"] if "bounds" in var.attrs else None
-        if bounds and bounds in new_vars:
-            # see http://cfconventions.org/cf-conventions/cf-conventions.html#cell-boundaries
-            for attr in [
-                "units",
-                "standard_name",
-                "axis",
-                "positive",
-                "calendar",
-                "long_name",
-                "leap_month",
-                "leap_year",
-                "month_lengths",
-            ]:
-                if attr in new_vars[bounds].attrs and attr in var.attrs:
-                    if new_vars[bounds].attrs[attr] == var.attrs[attr]:
-                        new_vars[bounds].attrs.pop(attr)
-
     return new_vars, attributes


### PR DESCRIPTION
Issue #2921 is about mismatching time units between a time variable and its "bounds" companion.
However, #2965 does more than fixing #2921, it removes all double attributes from "bounds" variables which has the undesired side effect that there is currently no way to save them to netcdf with xarray. Since the mentioned link is a recommendation and not a hard requirement for CF compliance, these attributes should be left to the caller to prepare the dataset variables appropriately if required. Reduces the amount of surprise that attributes are not written to disk and fixes #8368.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #8368
- [ ] Tests added (simple round trip test would be in issue #8368) 
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst` (not sure about "user visibility" here)
