### PR TITLE
FIX: use str dtype without size information

### DIFF
--- a/xarray/core/accessor_str.py
+++ b/xarray/core/accessor_str.py
@@ -121,7 +121,9 @@ def _apply_str_ufunc(
 ) -> Any:
     # TODO handling of na values ?
     if dtype is None:
-        dtype = obj.dtype
+        # need to strip length information from dtype
+        # otherwise changes in output size are not reflected
+        dtype = np.dtype(f"{obj.dtype.byteorder}{obj.dtype.char}")
 
     dask_gufunc_kwargs = dict()
     if output_sizes is not None:


### PR DESCRIPTION
Aims to resolve parts of #8844.

```python
xarray/tests/test_accessor_str.py::test_case_str: AssertionError: assert dtype('<U26') == dtype('<U30')
```
I'm not sure this is the right location for the fix, at least it fixes those errors. AFAICT this is some issue somewhere inside `apply_ufunc` where the string dtype size is kept. So this fix removes the size information from the dtype (actually recreating it).


<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`



