### PR TITLE
Correct save_mfdataset docstring

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1416,8 +1416,6 @@ def save_mfdataset(
         these locations will be overwritten.
     format : {"NETCDF4", "NETCDF4_CLASSIC", "NETCDF3_64BIT", \
               "NETCDF3_CLASSIC"}, optional
-    **kwargs : additional arguments are passed along to ``to_netcdf``
-
         File format for the resulting netCDF file:
 
         * NETCDF4: Data is stored in an HDF5 file, using netCDF4 API
@@ -1449,10 +1447,10 @@ def save_mfdataset(
     compute : bool
         If true compute immediately, otherwise return a
         ``dask.delayed.Delayed`` object that can be computed later.
+    **kwargs : additional arguments are passed along to ``to_netcdf``
 
     Examples
     --------
-
     Save a dataset into one netCDF per year of data:
 
     >>> ds = xr.Dataset(

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1447,7 +1447,8 @@ def save_mfdataset(
     compute : bool
         If true compute immediately, otherwise return a
         ``dask.delayed.Delayed`` object that can be computed later.
-    **kwargs : additional arguments are passed along to ``to_netcdf``
+    **kwargs : dict, optional
+        Additional arguments are passed along to ``to_netcdf``.
 
     Examples
     --------


### PR DESCRIPTION
Noticed the `**kwargs` part of the docstring was mangled - [see here](https://docs.xarray.dev/en/latest/generated/xarray.save_mfdataset.html)

- [ ] ~~Closes #xxxx~~
- [ ] ~~Tests added~~
- [ ] ~~User visible changes (including notable bug fixes) are documented in `whats-new.rst`~~
- [ ] ~~New functions/methods are listed in `api.rst`~~
