### PR TITLE
use `pd.to_timedelta` instead of `TimedeltaIndex`

### DIFF
--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -84,7 +84,7 @@ def make_interpolate_example_data(shape, frac_nan, seed=12345, non_uniform=False
 
     if non_uniform:
         # construct a datetime index that has irregular spacing
-        deltas = pd.TimedeltaIndex(unit="d", data=rs.normal(size=shape[0], scale=10))
+        deltas = pd.to_timedelta(rs.normal(size=shape[0], scale=10), unit="d")
         coords = {"time": (pd.Timestamp("2000-01-01") + deltas).sort_values()}
     else:
         coords = {"time": pd.date_range("2000-01-01", freq="D", periods=shape[0])}


### PR DESCRIPTION
`pandas` recently removed the deprecated `unit` kwarg to `TimedeltaIndex`.

- [x] towards #8844