### PR TITLE
use `nan` instead of `NaN`

### DIFF
--- a/xarray/tests/test_calendar_ops.py
+++ b/xarray/tests/test_calendar_ops.py
@@ -138,7 +138,7 @@ def test_convert_calendar_360_days_random():
     assert (conv2 != conv).any()
 
     # Ensure that added days are evenly distributed in the 5 fifths of each year
-    conv = convert_calendar(da_360, "noleap", align_on="random", missing=np.NaN)
+    conv = convert_calendar(da_360, "noleap", align_on="random", missing=np.nan)
     conv = conv.where(conv.isnull(), drop=True)
     nandoys = conv.time.dt.dayofyear[:366]
     assert all(nandoys < np.array([74, 147, 220, 293, 366]))


### PR DESCRIPTION
FYI @aulemahal, `numpy.NaN` will be removed in the upcoming `numpy=2.0` release.

- [x] follow-up to #8603