### PR TITLE
clean up the upstream-dev setup script

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# install cython for building cftime without build isolation
-micromamba install "cython>=0.29.20" py-cpuinfo setuptools-scm
 # temporarily (?) remove numbagg and numba
 micromamba remove -y numba numbagg sparse
 # temporarily remove numexpr

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -30,15 +30,6 @@ python -m pip install \
     matplotlib \
     pandas \
     h5py
-# for some reason pandas depends on pyarrow already.
-# Remove once a `pyarrow` version compiled with `numpy>=2.0` is on `conda-forge`
-python -m pip install \
-    -i https://pypi.fury.io/arrow-nightlies/ \
-    --prefer-binary \
-    --no-deps \
-    --pre \
-    --upgrade \
-    pyarrow
 python -m pip install \
     --no-deps \
     --upgrade \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -18,9 +18,9 @@ micromamba remove -y --force \
     zarr \
     cftime \
     packaging \
-    pint \
     bottleneck \
     flox
+    # pint
 # to limit the runtime of Upstream CI
 python -m pip install \
     -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -20,8 +20,7 @@ micromamba remove -y --force \
     packaging \
     pint \
     bottleneck \
-    flox \
-    numcodecs
+    flox
 # to limit the runtime of Upstream CI
 python -m pip install \
     -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -30,6 +30,15 @@ python -m pip install \
     matplotlib \
     pandas \
     h5py
+# for some reason pandas depends on pyarrow already.
+# Remove once a `pyarrow` version compiled with `numpy>=2.0` is on `conda-forge`
+python -m pip install \
+    -i https://pypi.fury.io/arrow-nightlies/ \
+    --prefer-binary \
+    --no-deps \
+    --pre \
+    --upgrade \
+    pyarrow
 python -m pip install \
     --no-deps \
     --upgrade \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -51,17 +51,13 @@ python -m pip install \
 python -m pip install \
     --no-deps \
     --upgrade \
-    --no-build-isolation \
-    git+https://github.com/pydata/bottleneck
-python -m pip install \
-    --no-deps \
-    --upgrade \
     git+https://github.com/dask/dask \
     git+https://github.com/dask/dask-expr \
     git+https://github.com/dask/distributed \
     git+https://github.com/zarr-developers/zarr \
     git+https://github.com/pypa/packaging \
     git+https://github.com/hgrecco/pint \
+    git+https://github.com/pydata/bottleneck \
     git+https://github.com/intake/filesystem_spec \
     git+https://github.com/SciTools/nc-time-axis \
     git+https://github.com/xarray-contrib/flox \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -41,13 +41,6 @@ python -m pip install \
     --pre \
     --upgrade \
     pyarrow
-# without build isolation for packages compiling against numpy
-# TODO: remove once there are `numpy>=2.0` builds for these
-python -m pip install \
-    --no-deps \
-    --upgrade \
-    --no-build-isolation \
-    git+https://github.com/Unidata/cftime
 python -m pip install \
     --no-deps \
     --upgrade \
@@ -55,6 +48,7 @@ python -m pip install \
     git+https://github.com/dask/dask-expr \
     git+https://github.com/dask/distributed \
     git+https://github.com/zarr-developers/zarr \
+    git+https://github.com/Unidata/cftime \
     git+https://github.com/pypa/packaging \
     git+https://github.com/hgrecco/pint \
     git+https://github.com/pydata/bottleneck \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -53,11 +53,6 @@ python -m pip install \
     --no-deps \
     --upgrade \
     --no-build-isolation \
-    git+https://github.com/zarr-developers/numcodecs
-python -m pip install \
-    --no-deps \
-    --upgrade \
-    --no-build-isolation \
     git+https://github.com/pydata/bottleneck
 python -m pip install \
     --no-deps \


### PR DESCRIPTION
In trying to install packages that are compatible with `numpy>=2` I added several projects that are built in CI without build isolation (so that they will be built with the nightly version of `numpy`). That was a temporary workaround, so we should start thinking about cleaning this up.

As it seems `numcodecs` is now compatible (or uses less of `numpy` in compiled code, not sure), this is an attempt to see if CI works if we use the version from `conda-forge`.

`bottleneck` and `cftime` now build against `numpy>=2.0.0rc1`, so we can stop building them without build isolation.