### PR TITLE
Skip flaky `test_open_mfdataset_manyfiles` test

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3815,7 +3815,9 @@ def skip_if_not_engine(engine):
 
 @requires_dask
 @pytest.mark.filterwarnings("ignore:use make_scale(name) instead")
-@pytest.mark.skip(reason="Flaky test which can cause the worker to crash (so don't xfail). Very open to contributions fixing this")
+@pytest.mark.skip(
+    reason="Flaky test which can cause the worker to crash (so don't xfail). Very open to contributions fixing this"
+)
 def test_open_mfdataset_manyfiles(
     readengine, nfiles, parallel, chunks, file_cache_maxsize
 ):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3813,11 +3813,9 @@ def skip_if_not_engine(engine):
         pytest.importorskip(engine)
 
 
-# Flaky test. Very open to contributions on fixing this
 @requires_dask
 @pytest.mark.filterwarnings("ignore:use make_scale(name) instead")
-@pytest.mark.xfail(reason="Flaky test. Very open to contributions on fixing this")
-@pytest.mark.skipif(ON_WINDOWS, reason="Skipping on Windows")
+@pytest.mark.skip(reason="Flaky test which can cause the worker to crash (so don't xfail). Very open to contributions fixing this")
 def test_open_mfdataset_manyfiles(
     readengine, nfiles, parallel, chunks, file_cache_maxsize
 ):


### PR DESCRIPTION
Don't just xfail, and not only on windows, since it can crash the worked
