### PR TITLE
Mark `test_use_cftime_false_standard_calendar_in_range` as an expected failure

### DIFF
--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -142,6 +142,7 @@ requires_numbagg_or_bottleneck = pytest.mark.skipif(
     not has_scipy_or_netCDF4, reason="requires scipy or netCDF4"
 )
 has_numpy_array_api, requires_numpy_array_api = _importorskip("numpy", "1.26.0")
+has_numpy_2, requires_numpy_2 = _importorskip("numpy", "2.0.0")
 
 
 def _importorskip_h5netcdf_ros3():

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -63,6 +63,7 @@ from xarray.tests import (
     assert_no_warnings,
     has_dask,
     has_netCDF4,
+    has_numpy_2,
     has_scipy,
     mock,
     network,
@@ -5088,6 +5089,9 @@ def test_use_cftime_true(calendar, units_year) -> None:
 
 @requires_scipy_or_netCDF4
 @pytest.mark.parametrize("calendar", _STANDARD_CALENDARS)
+@pytest.mark.xfail(
+    has_numpy_2, reason="https://github.com/pandas-dev/pandas/issues/56996"
+)
 def test_use_cftime_false_standard_calendar_in_range(calendar) -> None:
     x = [0, 1]
     time = [0, 720]


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Per https://github.com/pydata/xarray/issues/8844#issuecomment-2089427222, for the time being this marks `test_use_cftime_false_standard_calendar_in_range` as an expected failure under NumPy 2.  Hopefully we'll be able to fix the upstream issue in pandas eventually.