### PR TITLE
Add a benchmark to monitor performance for large dataset indexing

### DIFF
--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -12,6 +12,7 @@ ny = 1000
 nt = 500
 
 basic_indexes = {
+    "1scalar": {"x": 0},
     "1slice": {"x": slice(0, 3)},
     "1slice-1scalar": {"x": 0, "y": slice(None, None, 3)},
     "2slicess-1scalar": {"x": slice(3, -3, 3), "y": 1, "t": slice(None, -3, 3)},
@@ -74,6 +75,10 @@ class Base:
                 "x_coords": ("x", np.linspace(1.1, 2.1, nx)),
             },
         )
+        # Benchmark how indexing is slowed down by adding many scalar variable
+        # to the dataset
+        # https://github.com/pydata/xarray/pull/9003
+        self.ds_large = self.ds.merge({f"extra_var{i}": i for i in range(400)})
 
 
 class Indexing(Base):
@@ -88,6 +93,11 @@ class Indexing(Base):
     @parameterized(["key"], [list(vectorized_indexes.keys())])
     def time_indexing_vectorized(self, key):
         self.ds.isel(**vectorized_indexes[key]).load()
+
+    @parameterized(["key"], [list(basic_indexes.keys())])
+    def time_indexing_basic_ds_large(self, key):
+        # https://github.com/pydata/xarray/pull/9003
+        self.ds_large.isel(**basic_indexes[key]).load()
 
 
 class Assignment(Base):


### PR DESCRIPTION
See benchmark results from: https://github.com/pydata/xarray/pull/9003#issuecomment-2097169851

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
