### PR TITLE
Release summary for v2024.05.0

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,7 +21,7 @@ v2024.05.0 (May 10, 2024)
 -------------------------
 
 This release brings support for pandas ExtensionArray objects, optimizations when reading Zarr, the ability to concatenate datasets without pandas indexes,
-more compatibility fixed for upcoming numpy 2.0, and the migration of most of the xarray-datatree project code into xarray `main`!
+more compatibility fixes for the upcoming numpy 2.0, and the migration of most of the xarray-datatree project code into xarray ``main``!
 
 Thanks to the 18 contributors to this release:
 Aimilios Tsouvelekakis, Andrey Akinshin, Deepak Cherian, Eni Awowale, Ilan Gold, Illviljan, Justus Magin, Mark Harfouche, Matt Savoie, Maximilian Roos, Noah C. Benson, Pascal Bourgault, Ray Bell, Spencer Clark, Tom Nicholas, ignamv, owenlittlejohns, and saschahofmann.
@@ -31,8 +31,8 @@ New Features
 - New "random" method for converting to and from 360_day calendars (:pull:`8603`).
   By `Pascal Bourgault <https://github.com/aulemahal>`_.
 - Xarray now makes a best attempt not to coerce :py:class:`pandas.api.extensions.ExtensionArray` to a numpy array
-  by supporting 1D `ExtensionArray` objects internally where possible.  Thus, `Dataset`s initialized with a `pd.Categorical`,
-  for example, will retain the object.  However, one cannot do operations that are not possible on the `ExtensionArray`
+  by supporting 1D ``ExtensionArray`` objects internally where possible.  Thus, :py:class:`Dataset` objects initialized with a ``pd.Categorical``,
+  for example, will retain the object.  However, one cannot do operations that are not possible on the ``ExtensionArray``
   then, such as broadcasting. (:issue:`5287`, :issue:`8463`, :pull:`8723`)
   By `Ilan Gold <https://github.com/ilan-gold>`_.
 - :py:func:`testing.assert_allclose`/:py:func:`testing.assert_equal` now accept a new argument `check_dims="transpose"`, controlling whether a transposed array is considered equal. (:issue:`5733`, :pull:`8991`)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -89,6 +89,9 @@ Internal Changes
   `Tom Nicholas <https://github.com/TomNicholas>`_.
 - Migrates ``ops.py`` functionality into ``xarray/core/datatree_ops.py`` (:pull:`8976`)
   By `Matt Savoie <https://github.com/flamingbear>`_ and `Tom Nicholas <https://github.com/TomNicholas>`_.
+- Migrates ``iterator`` functionality into ``xarray/core`` (:pull: `8879`)
+  By `Owen Littlejohns <https://github.com/owenlittlejohns>`_, `Matt Savoie
+  <https://github.com/flamingbear>`_ and `Tom Nicholas <https://github.com/TomNicholas>`_.
 - ``transpose``, ``set_dims``, ``stack`` & ``unstack`` now use a ``dim`` kwarg
   rather than ``dims`` or ``dimensions``. This is the final change to make xarray methods
   consistent with their use of ``dim``. Using the existing kwarg will raise a
@@ -169,9 +172,6 @@ Internal Changes
   By `Matt Savoie <https://github.com/flamingbear>`_ and `Tom Nicholas
   <https://github.com/TomNicholas>`_.
 - Migrates ``datatree`` functionality into ``xarray/core``. (:pull: `8789`)
-  By `Owen Littlejohns <https://github.com/owenlittlejohns>`_, `Matt Savoie
-  <https://github.com/flamingbear>`_ and `Tom Nicholas <https://github.com/TomNicholas>`_.
-- Migrates ``iterator`` functionality into ``xarray/core`` (:pull: `8879`)
   By `Owen Littlejohns <https://github.com/owenlittlejohns>`_, `Matt Savoie
   <https://github.com/flamingbear>`_ and `Tom Nicholas <https://github.com/TomNicholas>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,7 +21,7 @@ v2024.05.0 (May 10, 2024)
 -------------------------
 
 This release brings support for pandas ExtensionArray objects, optimizations when reading Zarr, the ability to concatenate datasets without pandas indexes,
-and the migration of most of the xarray-datatree project code into xarray `main`!
+more compatibility fixed for upcoming numpy 2.0, and the migration of most of the xarray-datatree project code into xarray `main`!
 
 Thanks to the 18 contributors to this release:
 Aimilios Tsouvelekakis, Andrey Akinshin, Deepak Cherian, Eni Awowale, Ilan Gold, Illviljan, Justus Magin, Mark Harfouche, Matt Savoie, Maximilian Roos, Noah C. Benson, Pascal Bourgault, Ray Bell, Spencer Clark, Tom Nicholas, ignamv, owenlittlejohns, and saschahofmann.
@@ -31,9 +31,9 @@ New Features
 - New "random" method for converting to and from 360_day calendars (:pull:`8603`).
   By `Pascal Bourgault <https://github.com/aulemahal>`_.
 - Xarray now makes a best attempt not to coerce :py:class:`pandas.api.extensions.ExtensionArray` to a numpy array
-  by supporting 1D `ExtensionArray` objects internally where possible.  Thus, `Dataset`s initialized with a `pd.Catgeorical`,
+  by supporting 1D `ExtensionArray` objects internally where possible.  Thus, `Dataset`s initialized with a `pd.Categorical`,
   for example, will retain the object.  However, one cannot do operations that are not possible on the `ExtensionArray`
-  then, such as broadcasting.
+  then, such as broadcasting. (:issue:`5287`, :issue:`8463`, :pull:`8723`)
   By `Ilan Gold <https://github.com/ilan-gold>`_.
 - :py:func:`testing.assert_allclose`/:py:func:`testing.assert_equal` now accept a new argument `check_dims="transpose"`, controlling whether a transposed array is considered equal. (:issue:`5733`, :pull:`8991`)
   By `Ignacio Martinez Vazquez <https://github.com/ignamv>`_.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,10 +15,16 @@ What's New
     np.random.seed(123456)
 
 
-.. _whats-new.2024.04.0:
+.. _whats-new.2024.05.0:
 
-v2024.04.0 (unreleased)
------------------------
+v2024.05.0 (May 10, 2024)
+-------------------------
+
+This release brings support for pandas ExtensionArray objects, optimizations when reading Zarr, the ability to concatenate datasets without pandas indexes,
+and the migration of most of the xarray-datatree project code into xarray `main`!
+
+Thanks to the 18 contributors to this release:
+Aimilios Tsouvelekakis, Andrey Akinshin, Deepak Cherian, Eni Awowale, Ilan Gold, Illviljan, Justus Magin, Mark Harfouche, Matt Savoie, Maximilian Roos, Noah C. Benson, Pascal Bourgault, Ray Bell, Spencer Clark, Tom Nicholas, ignamv, owenlittlejohns, and saschahofmann.
 
 New Features
 ~~~~~~~~~~~~
@@ -42,7 +48,6 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 - The PyNIO backend has been deleted (:issue:`4491`, :pull:`7301`).
   By `Deepak Cherian <https://github.com/dcherian>`_.
-
 - The minimum versions of some dependencies were changed, in particular our minimum supported pandas version is now Pandas 2.
 
   ===================== =========  =======
@@ -60,7 +65,6 @@ Breaking changes
    zarr                      2.13     2.14
   ===================== =========  =======
 
-
 Bug fixes
 ~~~~~~~~~
 - Following `an upstream bug fix
@@ -69,7 +73,6 @@ Bug fixes
   :py:func:`xarray.cftime_range` with negative frequencies will now fall fully
   within the bounds of the provided start and end dates (:pull:`8999`). By
   `Spencer Clark <https://github.com/spencerkclark>`_.
-
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
@@ -90,7 +93,6 @@ Internal Changes
   rather than ``dims`` or ``dimensions``. This is the final change to make xarray methods
   consistent with their use of ``dim``. Using the existing kwarg will raise a
   warning. By `Maximilian Roos <https://github.com/max-sixty>`_
-
 
 .. _whats-new.2024.03.0:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -17,7 +17,7 @@ What's New
 
 .. _whats-new.2024.05.0:
 
-v2024.05.0 (May 10, 2024)
+v2024.05.0 (May 12, 2024)
 -------------------------
 
 This release brings support for pandas ExtensionArray objects, optimizations when reading Zarr, the ability to concatenate datasets without pandas indexes,


### PR DESCRIPTION
Towards #9018

I noticed that we've gotten quite lax at writing `whatsnew` entries for PRs, meaning that when you go to write the release summary it looks like we've added much less since the last release than we actually have! I would say maybe half the PRs merged since the last release don't have whatsnew entries.
