### PR TITLE
[skip-ci] min_deps_check: show age of required pkg on error

### DIFF
--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -23,12 +23,12 @@ IGNORE_DEPS = {
     "isort",
     "mypy",
     "pip",
-    "setuptools",
     "pytest",
     "pytest-cov",
     "pytest-env",
-    "pytest-xdist",
     "pytest-timeout",
+    "pytest-xdist",
+    "setuptools",
 }
 
 POLICY_MONTHS = {"python": 30, "numpy": 18}
@@ -162,11 +162,11 @@ def process_pkg(
         status = "<"
     elif (req_major, req_minor) > (policy_major, policy_minor):
         status = "> (!)"
-        delta = relativedelta(datetime.now(), policy_published_actual).normalized()
+        delta = relativedelta(datetime.now(), req_published).normalized()
         n_months = delta.years * 12 + delta.months
         warning(
-            f"Package is too new: {pkg}={policy_major}.{policy_minor} was "
-            f"published on {versions[policy_major, policy_minor]:%Y-%m-%d} "
+            f"Package is too new: {pkg}={req_major}.{req_minor} was "
+            f"published on {req_published:%Y-%m-%d} "
             f"which was {n_months} months ago (policy is {policy_months} months)"
         )
     else:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

I think we want to show the age of the 'user-requested' package (i.e. the one in min-all-deps.yml) and not of the 'policy-required' when running min_deps_check.py.