### PR TITLE
attempt to get colour output in CI

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -77,6 +77,8 @@ jobs:
           conda list
           python xarray/util/print_versions.py
       - name: Run doctests
+        env:
+          TERM: xterm-256color
         run: |
           # Raise an error if there are warnings in the doctests, with `-Werror`.
           # This is a trial; if it presents an problem, feel free to remove.
@@ -129,6 +131,8 @@ jobs:
           python -m pip install "mypy<1.9" --force-reinstall
 
       - name: Run mypy
+        env:
+          TERM: xterm-256color
         run: |
           python -m mypy --install-types --non-interactive --cobertura-xml-report mypy_report xarray/
 
@@ -179,6 +183,8 @@ jobs:
           conda list
           python xarray/util/print_versions.py
       - name: Install mypy
+        env:
+          TERM: xterm-256color
         run: |
           python -m pip install "mypy<1.9" --force-reinstall
 
@@ -342,9 +348,13 @@ jobs:
             python-dateutil
 
       - name: All-deps minimum versions policy
+        env:
+          TERM: xterm-256color
         run: |
           python ci/min_deps_check.py ci/requirements/min-all-deps.yml
 
       - name: Bare minimum versions policy
+        env:
+          TERM: xterm-256color
         run: |
           python ci/min_deps_check.py ci/requirements/bare-minimum.yml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,6 +148,8 @@ jobs:
           save-always: true
 
       - name: Run tests
+        env:
+          TERM: xterm-256color
         run: python -m pytest -n 4
           --timeout 180
           --cov=xarray

--- a/.github/workflows/hypothesis.yaml
+++ b/.github/workflows/hypothesis.yaml
@@ -90,6 +90,8 @@ jobs:
       - name: Run slow Hypothesis tests
         if: success()
         id: status
+        env:
+          TERM: xterm-256color
         run: |
            python -m pytest --hypothesis-show-statistics --run-slow-hypothesis properties/*.py \
              --report-log output-${{ matrix.python-version }}-log.jsonl

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -83,6 +83,8 @@ jobs:
       - name: Run Tests
         if: success()
         id: status
+        env:
+          TERM: xterm-256color
         run: |
           python -m pytest --timeout=60 -rf \
             --report-log output-${{ matrix.python-version }}-log.jsonl
@@ -140,6 +142,8 @@ jobs:
         run: |
           python -m pip install mypy --force-reinstall
       - name: Run mypy
+        env:
+          TERM: xterm-256color
         run: |
           python -m mypy --install-types --non-interactive --cobertura-xml-report mypy_report
       - name: Upload mypy coverage to Codecov


### PR DESCRIPTION
Github Actions don't set the TERM variable in CI, which makes `pytest` (and other CI tools) not colour the output. This tries to set the environment variable to see if that gives us colour output.