### PR TITLE
TEST: Fix numbagg or bottlekneck skip

### DIFF
--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -145,7 +145,7 @@ requires_scipy_or_netCDF4 = pytest.mark.skipif(
 )
 has_numbagg_or_bottleneck = has_numbagg or has_bottleneck
 requires_numbagg_or_bottleneck = pytest.mark.skipif(
-    not has_scipy_or_netCDF4, reason="requires scipy or netCDF4"
+    not has_numbagg_or_bottleneck, reason="requires numbagg or bottlekneck"
 )
 has_numpy_array_api, requires_numpy_array_api = _importorskip("numpy", "1.26.0")
 has_numpy_2, requires_numpy_2 = _importorskip("numpy", "2.0.0")


### PR DESCRIPTION
It only seems to be used in 1 place:
```
$ rg requires_numbagg_or_bottleneck
xarray/tests/test_missing.py
28:    requires_numbagg_or_bottleneck,
416:@requires_numbagg_or_bottleneck

xarray/tests/__init__.py
147:requires_numbagg_or_bottleneck = pytest.mark.skipif(
```

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
