### PR TITLE
pin nightly `zarr` to v2

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -28,9 +28,6 @@ $conda remove -y --force \
     flox
     # pint
 
-# dependencies new in nightly versions
-$conda install donfig zstandard typing-extensions crc32c
-
 # to limit the runtime of Upstream CI
 python -m pip install \
     -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
@@ -57,7 +54,7 @@ python -m pip install \
     git+https://github.com/dask/dask \
     git+https://github.com/dask/dask-expr \
     git+https://github.com/dask/distributed \
-    git+https://github.com/zarr-developers/zarr \
+    git+https://github.com/zarr-developers/zarr.git@main \
     git+https://github.com/Unidata/cftime \
     git+https://github.com/pypa/packaging \
     git+https://github.com/hgrecco/pint \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -19,6 +19,10 @@ micromamba remove -y --force \
     bottleneck \
     flox
     # pint
+
+# dependencies new in nightly versions
+micromamba install donfig zstandard typing-extensions crc32c
+
 # to limit the runtime of Upstream CI
 python -m pip install \
     -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
 
+if which micromamba >/dev/null; then
+    conda=micromamba
+elif which mamba >/dev/null; then
+    conda=mamba
+else
+    conda=conda
+fi
+
 # temporarily (?) remove numbagg and numba
-micromamba remove -y numba numbagg sparse
+$conda remove -y numba numbagg sparse
 # temporarily remove numexpr
-micromamba remove -y numexpr
+$conda remove -y numexpr
 # temporarily remove backends
-micromamba remove -y cf_units hdf5 h5py netcdf4 pydap
+$conda remove -y cf_units hdf5 h5py netcdf4 pydap
 # forcibly remove packages to avoid artifacts
-micromamba remove -y --force \
+$conda remove -y --force \
     numpy \
     scipy \
     pandas \
@@ -21,7 +29,7 @@ micromamba remove -y --force \
     # pint
 
 # dependencies new in nightly versions
-micromamba install donfig zstandard typing-extensions crc32c
+$conda install donfig zstandard typing-extensions crc32c
 
 # to limit the runtime of Upstream CI
 python -m pip install \


### PR DESCRIPTION
~Nightly `zarr` appears to have new dependencies we don't get from the version on `conda-forge`.~ Apparently `xarray` is not ready for `zarr` v3, yet, so this pins nightly `zarr` to v2.

Additionally, this allows using `ci/install-upstream-wheels.sh` if `micromamba` is not installed.

cc @jhamman