### PR TITLE
check pytest summary - do not merge

### DIFF
--- a/xarray/tests/test_test.py
+++ b/xarray/tests/test_test.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+
+def test_a():
+
+    assert False, "a long\nmultiline\nreason"
+
+
+def test_b():
+    raise ValueError("another\nmultiline\nstring")
+
+
+def test_c():
+
+    np.testing.assert_allclose(1, 2)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

I am trying to figure out why my other package gives multiline output in the pytest short summary on GHA. It should not and I was not able to reproduce it locally, and it seems not to do that on the xarray repo (checking old failed runs). But to be sure I open this dummy PR to see if that is actually true. Sorry for the spam.


```

=========================== short test summary info ============================
FAILED regionmask/tests/test_test.py::test_a - AssertionError: a long
  multiline
eason
assert False
FAILED regionmask/tests/test_test.py::test_b - ValueError: another
multiline	hingy
FAILED regionmask/tests/test_test.py::test_c - AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0

Mismatched elements: 1 / 1 (100%)
Max absolute difference: 1
Max relative difference: 0.5
 x: array(1)
 y: array(2)
====== 3 failed, 881 passed, 22 skipped, 1 xfailed, 30 warnings in 38.21s ======
```
