### PR TITLE
Sketch of datatree.inherit method

### DIFF
--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -971,7 +971,7 @@ class DataTree(
     def inherit(self) -> DataTree:
         """
         Returns a copy of this node additionally containing all coordinates that can be inherited from parent nodes.
-       
+
         Inspired by the CF conventions' "search by proximity" [1]_.
 
         References
@@ -993,7 +993,7 @@ class DataTree(
                 explicit_coords=list(candidate_variables.keys())
                 combine_attrs="override",
             )
-        
+
         # TODO this will call merge for every parent up to the root. Is there an alternative design which only calls merge once?
 
         # TODO use _MergeResult instead?


### PR DESCRIPTION
(This is just pseudocode that I'm showing to compare against #9063)

- [x] Alternative approach to closing #9056, contrasts with #9063
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
