### PR TITLE
Speed up netCDF4, h5netcdf backends

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -23,6 +23,12 @@ v2024.05.1 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+Performance
+~~~~~~~~~~~
+
+- Small optimization to the netCDF4 backend (:issue:`9058`).
+  By `Deepak Cherian <https://github.com/dcherian>`_.
+
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -26,7 +26,7 @@ New Features
 Performance
 ~~~~~~~~~~~
 
-- Small optimization to the netCDF4 backend (:issue:`9058`).
+- Small optimization to the netCDF4 and h5netcdf backends (:issue:`9058`, :pull:`9067`).
   By `Deepak Cherian <https://github.com/dcherian>`_.
 
 

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -221,7 +221,7 @@ class H5NetCDFStore(WritableCFDataStore):
 
         # save source so __repr__ can detect if it's local or not
         encoding["source"] = self._filename
-        encoding["original_shape"] = var.shape
+        encoding["original_shape"] = data.shape
 
         vlen_dtype = h5py.check_dtype(vlen=var.dtype)
         if vlen_dtype is str:

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -454,7 +454,7 @@ class NetCDF4DataStore(WritableCFDataStore):
         pop_to(attributes, encoding, "least_significant_digit")
         # save source so __repr__ can detect if it's local or not
         encoding["source"] = self._filename
-        encoding["original_shape"] = var.shape
+        encoding["original_shape"] = data.shape
 
         return Variable(dimensions, data, attributes, encoding)
 


### PR DESCRIPTION
Accessing `.shape` on a netCDF4 variable is ~20-40ms. This can add up for large numbers of variables, e.g.: https://github.com/pydata/xarray/discussions/9058

We already request the shape when creating NetCDF4ArrayWrapper, so we can reuse that.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #9058
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
