### PR TITLE
Improve performance and typing in _protect_dataset_variables_inplace

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -238,9 +238,9 @@ def _protect_dataset_variables_inplace(dataset: T_Dataset, cache: bool) -> None:
             # no need to protect IndexVariable objects
             data = indexing.CopyOnWriteArray(variable._data)
             if cache:
-                variable.data = indexing.MemoryCachedArray(data)
+                variable._data = indexing.MemoryCachedArray(data)
             else:
-                variable.data = data
+                variable._data = data
 
 
 def _finalize_store(write, store):


### PR DESCRIPTION
Improve performance by removing type and shape checking in `_protect_dataset_variables_inplace` by setting directly to `self._data`. 
The function already has valid variables, there should be no need to recheck when adding small wrapper classes like CopyOnWriteArray and MemoryCachedArray.

variable.data = data does this, and `as_compatible_data` is a known performance bottleneck:
https://github.com/pydata/xarray/blob/447e5a3d16764a880387d33d0b5938393e167817/xarray/core/variable.py#L452-L456

Add some typing to make sure strange types are not input to these functions.

- [ ] Related to #9058
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`