### PR TITLE
Address latest pandas-related upstream test failures

### DIFF
--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -77,13 +77,21 @@ if TYPE_CHECKING:
     from xarray.core.types import InclusiveOptions, SideOptions
 
 
+def _nanosecond_precision_timestamp(*args, **kwargs):
+    # As of pandas version 3.0, pd.to_datetime(Timestamp(...)) will try to
+    # infer the appropriate datetime precision. Until xarray supports
+    # non-nanosecond precision times, we will use this constructor wrapper to
+    # explicitly create nanosecond-precision Timestamp objects.
+    return pd.Timestamp(*args, **kwargs).as_unit("ns")
+
+
 def get_date_type(calendar, use_cftime=True):
     """Return the cftime date type for a given calendar name."""
     if cftime is None:
         raise ImportError("cftime is required for dates with non-standard calendars")
     else:
         if _is_standard_calendar(calendar) and not use_cftime:
-            return pd.Timestamp
+            return _nanosecond_precision_timestamp
 
         calendars = {
             "noleap": cftime.DatetimeNoLeap,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -529,7 +529,7 @@ class DatasetIOBase:
             assert actual["x"].encoding["_Encoding"] == "ascii"
 
     def test_roundtrip_numpy_datetime_data(self) -> None:
-        times = pd.to_datetime(["2000-01-01", "2000-01-02", "NaT"])
+        times = pd.to_datetime(["2000-01-01", "2000-01-02", "NaT"], unit="ns")
         expected = Dataset({"t": ("t", times), "t0": times[0]})
         kwargs = {"encoding": {"t0": {"units": "days since 1950-01-01"}}}
         with self.roundtrip(expected, save_kwargs=kwargs) as actual:

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -538,11 +538,14 @@ def test_infer_datetime_units(freq, units) -> None:
     ["dates", "expected"],
     [
         (
-            pd.to_datetime(["1900-01-01", "1900-01-02", "NaT"]),
+            pd.to_datetime(["1900-01-01", "1900-01-02", "NaT"], unit="ns"),
             "days since 1900-01-01 00:00:00",
         ),
-        (pd.to_datetime(["NaT", "1900-01-01"]), "days since 1900-01-01 00:00:00"),
-        (pd.to_datetime(["NaT"]), "days since 1970-01-01 00:00:00"),
+        (
+            pd.to_datetime(["NaT", "1900-01-01"], unit="ns"),
+            "days since 1900-01-01 00:00:00",
+        ),
+        (pd.to_datetime(["NaT"], unit="ns"), "days since 1970-01-01 00:00:00"),
     ],
 )
 def test_infer_datetime_units_with_NaT(dates, expected) -> None:

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
 from itertools import product
 
 import numpy as np
@@ -229,8 +228,22 @@ class TestTileIDsFromCoords:
         assert concat_dims == ["simulation"]
 
     def test_datetime_coords(self):
-        ds0 = Dataset({"time": [datetime(2000, 3, 6), datetime(2001, 3, 7)]})
-        ds1 = Dataset({"time": [datetime(1999, 1, 1), datetime(1999, 2, 4)]})
+        ds0 = Dataset(
+            {
+                "time": [
+                    np.datetime64("2000-03-06", "ns"),
+                    np.datetime64("2000-03-07", "ns"),
+                ]
+            }
+        )
+        ds1 = Dataset(
+            {
+                "time": [
+                    np.datetime64("1999-01-01", "ns"),
+                    np.datetime64("1999-02-04", "ns"),
+                ]
+            }
+        )
 
         expected = {(0,): ds1, (1,): ds0}
         actual, concat_dims = _infer_concat_order_from_coords([ds0, ds1])

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -229,20 +229,10 @@ class TestTileIDsFromCoords:
 
     def test_datetime_coords(self):
         ds0 = Dataset(
-            {
-                "time": [
-                    np.datetime64("2000-03-06", "ns"),
-                    np.datetime64("2000-03-07", "ns"),
-                ]
-            }
+            {"time": np.array(["2000-03-06", "2000-03-07"], dtype="datetime64[ns]")}
         )
         ds1 = Dataset(
-            {
-                "time": [
-                    np.datetime64("1999-01-01", "ns"),
-                    np.datetime64("1999-02-04", "ns"),
-                ]
-            }
+            {"time": np.array(["1999-01-01", "1999-02-04"], dtype="datetime64[ns]")}
         )
 
         expected = {(0,): ds1, (1,): ds0}

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3642,16 +3642,16 @@ class TestDataArray:
         actual_no_data = da.to_dict(data=False, encoding=encoding)
         assert expected_no_data == actual_no_data
 
+    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
     def test_to_and_from_dict_with_time_dim(self) -> None:
         x = np.random.randn(10, 3)
         t = pd.date_range("20130101", periods=10)
         lat = [77.7, 83.2, 76]
         da = DataArray(x, {"t": t, "lat": lat}, dims=["t", "lat"])
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message="Converting non-nanosecond")
-            roundtripped = DataArray.from_dict(da.to_dict())
+        roundtripped = DataArray.from_dict(da.to_dict())
         assert_identical(da, roundtripped)
 
+    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
     def test_to_and_from_dict_with_nan_nat(self) -> None:
         y = np.random.randn(10, 3)
         y[2] = np.nan
@@ -3659,9 +3659,7 @@ class TestDataArray:
         t[2] = np.nan
         lat = [77.7, 83.2, 76]
         da = DataArray(y, {"t": t, "lat": lat}, dims=["t", "lat"])
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message="Converting non-nanosecond")
-            roundtripped = DataArray.from_dict(da.to_dict())
+        roundtripped = DataArray.from_dict(da.to_dict())
         assert_identical(da, roundtripped)
 
     def test_to_dict_with_numpy_attrs(self) -> None:

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3647,7 +3647,9 @@ class TestDataArray:
         t = pd.date_range("20130101", periods=10)
         lat = [77.7, 83.2, 76]
         da = DataArray(x, {"t": t, "lat": lat}, dims=["t", "lat"])
-        roundtripped = DataArray.from_dict(da.to_dict())
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Converting non-nanosecond")
+            roundtripped = DataArray.from_dict(da.to_dict())
         assert_identical(da, roundtripped)
 
     def test_to_and_from_dict_with_nan_nat(self) -> None:
@@ -3657,7 +3659,9 @@ class TestDataArray:
         t[2] = np.nan
         lat = [77.7, 83.2, 76]
         da = DataArray(y, {"t": t, "lat": lat}, dims=["t", "lat"])
-        roundtripped = DataArray.from_dict(da.to_dict())
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Converting non-nanosecond")
+            roundtripped = DataArray.from_dict(da.to_dict())
         assert_identical(da, roundtripped)
 
     def test_to_dict_with_numpy_attrs(self) -> None:

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -139,8 +139,7 @@ def test_groupby_da_datetime() -> None:
     times = pd.date_range("2000-01-01", periods=4)
     foo = xr.DataArray([1, 2, 3, 4], coords=dict(time=times), dims="time")
     # create test index
-    dd = times.to_pydatetime()
-    reference_dates = [dd[0], dd[2]]
+    reference_dates = [times[0], times[2]]
     labels = reference_dates[0:1] * 2 + reference_dates[1:2] * 2
     ind = xr.DataArray(
         labels, coords=dict(time=times), dims="time", name="reference_date"
@@ -1881,7 +1880,7 @@ class TestDataArrayResample:
         array = Dataset({"time": times})["time"]
         actual = array.resample(time="1D").last()
         expected_times = pd.to_datetime(
-            ["2000-01-01T18", "2000-01-02T18", "2000-01-03T06"]
+            ["2000-01-01T18", "2000-01-02T18", "2000-01-03T06"], unit="ns"
         )
         expected = DataArray(expected_times, [("time", times[::4])], name="time")
         assert_identical(expected, actual)

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -5,7 +5,7 @@ import inspect
 import math
 from collections.abc import Generator, Hashable
 from copy import copy
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from typing import Any, Callable, Literal
 
 import numpy as np
@@ -2912,9 +2912,8 @@ class TestDatetimePlot(PlotTestCase):
         """
         month = np.arange(1, 13, 1)
         data = np.sin(2 * np.pi * month / 12.0)
-
-        darray = DataArray(data, dims=["time"])
-        darray.coords["time"] = np.array([datetime(2017, m, 1) for m in month])
+        times = pd.date_range(start="2017-01-01", freq="ME", periods=12)
+        darray = DataArray(data, dims=["time"], coords=[times])
 
         self.darray = darray
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2912,7 +2912,7 @@ class TestDatetimePlot(PlotTestCase):
         """
         month = np.arange(1, 13, 1)
         data = np.sin(2 * np.pi * month / 12.0)
-        times = pd.date_range(start="2017-01-01", freq="ME", periods=12)
+        times = pd.date_range(start="2017-01-01", freq="MS", periods=12)
         darray = DataArray(data, dims=["time"], coords=[times])
 
         self.darray = darray

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -36,11 +36,11 @@ from xarray.tests import (
     assert_equal,
     assert_identical,
     assert_no_warnings,
+    has_pandas_3,
     raise_if_dask_computes,
     requires_bottleneck,
     requires_cupy,
     requires_dask,
-    requires_pandas_3,
     requires_pint,
     requires_sparse,
     source_ndarray,
@@ -2945,8 +2945,8 @@ class TestNumpyCoercion:
         (np.array([np.datetime64("2000-01-01", "ns")]), False),
         (np.array([np.datetime64("2000-01-01", "s")]), True),
         (pd.date_range("2000", periods=1), False),
-        pytest.param(datetime(2000, 1, 1), True, marks=requires_pandas_3),
-        pytest.param(np.array([datetime(2000, 1, 1)]), True, marks=requires_pandas_3),
+        (datetime(2000, 1, 1), has_pandas_3),
+        (np.array([datetime(2000, 1, 1)]), has_pandas_3),
         (pd.date_range("2000", periods=1, tz=pytz.timezone("America/New_York")), False),
         (
             pd.Series(

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -253,13 +253,12 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
         assert_array_equal(x[0].data, listarray.squeeze())
         assert_array_equal(x.squeeze().data, listarray.squeeze())
 
+    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
     def test_index_and_concat_datetime(self):
         # regression test for #125
         date_range = pd.date_range("2011-09-01", periods=10)
         for dates in [date_range, date_range.values, date_range.to_pydatetime()]:
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", message="Converting non-nanosecond")
-                expected = self.cls("t", dates)
+            expected = self.cls("t", dates)
             for times in [
                 [expected[i] for i in range(10)],
                 [expected[i : (i + 1)] for i in range(10)],


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This PR addresses the upstream failures described in https://github.com/pydata/xarray/issues/8844#issuecomment-2155521159 with a few minor changes to ensure that, for the time being, nanosecond precision times continue to be used in xarray.  These failures stem from https://github.com/pandas-dev/pandas/pull/55901, which causes `pandas.to_datetime` to infer the precision to use based its input instead of always using nanosecond precision.

See the review comments for an explanation of the changes.
