### PR TITLE
Fix Typo in Bfill benchmark

### DIFF
--- a/asv_bench/benchmarks/dataarray_missing.py
+++ b/asv_bench/benchmarks/dataarray_missing.py
@@ -66,7 +66,7 @@ class DataArrayMissingBottleneck:
         ),
     )
     def time_bfill(self, shape, chunks, limit):
-        actual = self.da.ffill(dim="time", limit=limit)
+        actual = self.da.bfill(dim="time", limit=limit)
 
         if chunks is not None:
             actual = actual.compute()


### PR DESCRIPTION
Fix a small typo, where ffill was tested twice in asv benchmarks instead of bfill