### PR TITLE
Add user survey announcement to docs

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -7,9 +7,8 @@ table.docutils td {
     word-wrap: break-word;
 }
 
-div.bd-header-announcement {
-  background-color: unset;
-  color: #000;
+.bd-header-announcement {
+  background-color: var(--pst-color-info-bg);
 }
 
 /* Reduce left and right margins */

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -242,7 +242,7 @@ html_theme_options = dict(
     Theme by the <a href="https://ebp.jupyterbook.org">Executable Book Project</a></p>""",
     twitter_url="https://twitter.com/xarray_dev",
     icon_links=[],  # workaround for pydata/pydata-sphinx-theme#1220
-    announcement="🍾 <a href='https://github.com/pydata/xarray/discussions/8462'>Xarray is now 10 years old!</a> 🎉",
+    announcement="<a href='https://forms.gle/KEq7WviCdz9xTaJX6'>Xarray's 2024 User Survey is live now. Please take ~5 minutes to fill it out and help us improve Xarray.</a>",
 )
 
 


### PR DESCRIPTION
Updating the doc announcement banner to include a link to the active user survey: https://forms.gle/pDRtaTx6GtNn91959

This is already live on our landing page: https://xarray.dev

See also #9076 