### PR TITLE
adjust repr tests to account for different platforms (#9127)

### DIFF
--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -110,13 +110,14 @@ class TestDataArray:
         assert expected == repr(data_array)
 
     def test_repr_multiindex(self) -> None:
+        obj_size = np.dtype("O").itemsize
         expected = dedent(
-            """\
+            f"""\
             <xarray.DataArray (x: 4)> Size: 32B
             array([0, 1, 2, 3], dtype=uint64)
             Coordinates:
-              * x        (x) object 32B MultiIndex
-              * level_1  (x) object 32B 'a' 'a' 'b' 'b'
+              * x        (x) object {4 * obj_size}B MultiIndex
+              * level_1  (x) object {4 * obj_size}B 'a' 'a' 'b' 'b'
               * level_2  (x) int64 32B 1 2 1 2"""
         )
         assert expected == repr(self.mda)
@@ -129,15 +130,16 @@ class TestDataArray:
         mda_long = DataArray(
             list(range(32)), coords={"x": mindex_long}, dims="x"
         ).astype(np.uint64)
+        obj_size = np.dtype("O").itemsize
         expected = dedent(
-            """\
+            f"""\
             <xarray.DataArray (x: 32)> Size: 256B
             array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
                    17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31],
                   dtype=uint64)
             Coordinates:
-              * x        (x) object 256B MultiIndex
-              * level_1  (x) object 256B 'a' 'a' 'a' 'a' 'a' 'a' ... 'd' 'd' 'd' 'd' 'd' 'd'
+              * x        (x) object {32 * obj_size}B MultiIndex
+              * level_1  (x) object {32 * obj_size}B 'a' 'a' 'a' 'a' 'a' 'a' ... 'd' 'd' 'd' 'd' 'd' 'd'
               * level_2  (x) int64 256B 1 2 3 4 5 6 7 8 1 2 3 4 ... 5 6 7 8 1 2 3 4 5 6 7 8"""
         )
         assert expected == repr(mda_long)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -335,13 +335,14 @@ class TestDataset:
 
     def test_repr_multiindex(self) -> None:
         data = create_test_multiindex()
+        obj_size = np.dtype("O").itemsize
         expected = dedent(
-            """\
-            <xarray.Dataset> Size: 96B
+            f"""\
+            <xarray.Dataset> Size: {8 * obj_size + 32}B
             Dimensions:  (x: 4)
             Coordinates:
-              * x        (x) object 32B MultiIndex
-              * level_1  (x) object 32B 'a' 'a' 'b' 'b'
+              * x        (x) object {4 * obj_size}B MultiIndex
+              * level_1  (x) object {4 * obj_size}B 'a' 'a' 'b' 'b'
               * level_2  (x) int64 32B 1 2 1 2
             Data variables:
                 *empty*"""
@@ -357,12 +358,12 @@ class TestDataset:
         midx_coords = Coordinates.from_pandas_multiindex(midx, "x")
         data = Dataset({}, midx_coords)
         expected = dedent(
-            """\
-            <xarray.Dataset> Size: 96B
+            f"""\
+            <xarray.Dataset> Size: {8 * obj_size + 32}B
             Dimensions:                  (x: 4)
             Coordinates:
-              * x                        (x) object 32B MultiIndex
-              * a_quite_long_level_name  (x) object 32B 'a' 'a' 'b' 'b'
+              * x                        (x) object {4 * obj_size}B MultiIndex
+              * a_quite_long_level_name  (x) object {4 * obj_size}B 'a' 'a' 'b' 'b'
               * level_2                  (x) int64 32B 1 2 1 2
             Data variables:
                 *empty*"""

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -1080,29 +1080,32 @@ def test_array_repr_dtypes_unix() -> None:
 
     # Signed integer dtypes
 
-    ds = xr.DataArray(np.array([0]), dims="x")
+    array = np.array([0])
+    ds = xr.DataArray(array, dims="x")
     actual = repr(ds)
-    expected = """
-<xarray.DataArray (x: 1)> Size: 8B
-array([0])
+    expected = f"""
+<xarray.DataArray (x: 1)> Size: {array.dtype.itemsize}B
+{repr(array)}
 Dimensions without coordinates: x
         """.strip()
     assert actual == expected
 
-    ds = xr.DataArray(np.array([0], dtype="int32"), dims="x")
+    array = np.array([0], dtype="int32")
+    ds = xr.DataArray(array, dims="x")
     actual = repr(ds)
-    expected = """
+    expected = f"""
 <xarray.DataArray (x: 1)> Size: 4B
-array([0], dtype=int32)
+{repr(array)}
 Dimensions without coordinates: x
         """.strip()
     assert actual == expected
 
-    ds = xr.DataArray(np.array([0], dtype="int64"), dims="x")
+    array = np.array([0], dtype="int64")
+    ds = xr.DataArray(array, dims="x")
     actual = repr(ds)
-    expected = """
+    expected = f"""
 <xarray.DataArray (x: 1)> Size: 8B
-array([0])
+{repr(array)}
 Dimensions without coordinates: x
         """.strip()
     assert actual == expected

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -12,8 +12,6 @@ from xarray.core import formatting
 from xarray.core.datatree import DataTree  # TODO: Remove when can do xr.DataTree
 from xarray.tests import requires_cftime, requires_dask, requires_netCDF4
 
-ON_WINDOWS = sys.platform == "win32"
-
 
 class TestFormatting:
     def test_get_indexer_at_least_n_items(self) -> None:
@@ -1071,13 +1069,6 @@ Dimensions without coordinates: x
         """.strip()
     assert actual == expected
 
-
-@pytest.mark.skipif(
-    ON_WINDOWS,
-    reason="Default numpy's dtypes vary according to OS",
-)
-def test_array_repr_dtypes_unix() -> None:
-
     # Signed integer dtypes
 
     array = np.array([0])
@@ -1106,42 +1097,6 @@ Dimensions without coordinates: x
     expected = f"""
 <xarray.DataArray (x: 1)> Size: 8B
 {repr(array)}
-Dimensions without coordinates: x
-        """.strip()
-    assert actual == expected
-
-
-@pytest.mark.skipif(
-    not ON_WINDOWS,
-    reason="Default numpy's dtypes vary according to OS",
-)
-def test_array_repr_dtypes_on_windows() -> None:
-
-    # Integer dtypes
-
-    ds = xr.DataArray(np.array([0]), dims="x")
-    actual = repr(ds)
-    expected = """
-<xarray.DataArray (x: 1)> Size: 4B
-array([0])
-Dimensions without coordinates: x
-        """.strip()
-    assert actual == expected
-
-    ds = xr.DataArray(np.array([0], dtype="int32"), dims="x")
-    actual = repr(ds)
-    expected = """
-<xarray.DataArray (x: 1)> Size: 4B
-array([0])
-Dimensions without coordinates: x
-        """.strip()
-    assert actual == expected
-
-    ds = xr.DataArray(np.array([0], dtype="int64"), dims="x")
-    actual = repr(ds)
-    expected = """
-<xarray.DataArray (x: 1)> Size: 8B
-array([0], dtype=int64)
 Dimensions without coordinates: x
         """.strip()
     assert actual == expected


### PR DESCRIPTION
Adjust the expectations in repr tests to account for different object sizes and numpy type representations across platforms, particularly fixing the tests on 32-bit platforms.

Firstly, this involves getting the object type size from NumPy and using it to adjust the expectations in DataArray and Dataset tests.  The tests were already using int64 type consistently, so only the sizes used for Python objects needed to be adjusted.

Secondly, this involves fixing `test_array_repr_dtypes_unix`.  The test specifically focuses on testing a 32-bit, 64-bit and "native" data type, which affect both size and actual representation (NumPy skips the dtype attribute for the native data type).  Get the expected size from NumPy for the native int type, and reuse `repr()` from NumPy for all array types.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #9127