### PR TITLE
Add test for #9155

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,6 @@ module = [
   "h5netcdf.*",
   "h5py.*",
   "iris.*",
-  "matplotlib.*",
   "mpl_toolkits.*",
   "nc_time_axis.*",
   "numbagg.*",

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -3406,3 +3406,11 @@ def test_plot1d_filtered_nulls() -> None:
         actual = pc.get_offsets().shape[0]
 
         assert expected == actual
+
+@requires_matplotlib
+def test_9155() -> None:
+    # A test for types from issue #9155
+
+    data = xr.DataArray([1, 2, 3], dims=["x"])
+    fig, ax = plt.subplots(ncols=1, nrows=1)
+    data.plot(ax=ax)

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -3407,6 +3407,7 @@ def test_plot1d_filtered_nulls() -> None:
 
         assert expected == actual
 
+
 @requires_matplotlib
 def test_9155() -> None:
     # A test for types from issue #9155

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -3412,6 +3412,7 @@ def test_plot1d_filtered_nulls() -> None:
 def test_9155() -> None:
     # A test for types from issue #9155
 
-    data = xr.DataArray([1, 2, 3], dims=["x"])
-    fig, ax = plt.subplots(ncols=1, nrows=1)
-    data.plot(ax=ax)
+    with figure_context():
+        data = xr.DataArray([1, 2, 3], dims=["x"])
+        fig, ax = plt.subplots(ncols=1, nrows=1)
+        data.plot(ax=ax)


### PR DESCRIPTION
I can't get this to fail locally, so adding a test to assess what's going on.

Alos excludes matplotlib from type exclusions
