### PR TITLE
Change np.core.defchararray to np.char (#9165)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,7 +35,7 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
-- Make `testing.assert_allclose` work with numpy 2.0 (:issue:`9165`, :pull:`9166`).
+- Make :py:func:`testing.assert_allclose` work with numpy 2.0 (:issue:`9165`, :pull:`9166`).
   By `Pontus Lurcock <https://github.com/pont-us>`_
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,7 +36,7 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 - Make :py:func:`testing.assert_allclose` work with numpy 2.0 (:issue:`9165`, :pull:`9166`).
-  By `Pontus Lurcock <https://github.com/pont-us>`_
+  By `Pontus Lurcock <https://github.com/pont-us>`_.
 
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,6 +35,8 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
+- Make `testing.assert_allclose` work with numpy 2.0 (:issue:`9165`, :pull:`9166`).
+  By `Pontus Lurcock <https://github.com/pont-us>`_
 
 
 Documentation

--- a/xarray/testing/assertions.py
+++ b/xarray/testing/assertions.py
@@ -36,7 +36,7 @@ def ensure_warnings(func):
 
 def _decode_string_data(data):
     if data.dtype.kind == "S":
-        return np.char.chararray.decode(data, "utf-8", "replace")
+        return np.char.decode(data, "utf-8", "replace")
     return data
 
 

--- a/xarray/testing/assertions.py
+++ b/xarray/testing/assertions.py
@@ -36,7 +36,7 @@ def ensure_warnings(func):
 
 def _decode_string_data(data):
     if data.dtype.kind == "S":
-        return np.core.defchararray.decode(data, "utf-8", "replace")
+        return np.char.chararray.decode(data, "utf-8", "replace")
     return data
 
 

--- a/xarray/tests/test_assertions.py
+++ b/xarray/tests/test_assertions.py
@@ -52,6 +52,11 @@ def test_allclose_regression() -> None:
             xr.Dataset({"a": ("x", [0, 2]), "b": ("y", [0, 1])}),
             id="Dataset",
         ),
+        pytest.param(
+            xr.DataArray(np.array("a", dtype="|S1")),
+            xr.DataArray(np.array("b", dtype="|S1")),
+            id="DataArray_dtypeS",
+        ),
     ),
 )
 def test_assert_allclose(obj1, obj2) -> None:

--- a/xarray/tests/test_assertions.py
+++ b/xarray/tests/test_assertions.py
@@ -55,7 +55,7 @@ def test_allclose_regression() -> None:
         pytest.param(
             xr.DataArray(np.array("a", dtype="|S1")),
             xr.DataArray(np.array("b", dtype="|S1")),
-            id="DataArray_dtypeS",
+            id="DataArray_with_character_dtype",
         ),
     ),
 )


### PR DESCRIPTION
Replace a reference to np.core.defchararray with np.char.chararray in xarray.testing.assertions, since the former no longer works on NumPy 2.0.0 and the latter is the "preferred alias" according to NumPy docs. See Issue #9165.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #9165
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

