### PR TITLE
Fix example code formatting for CachingFileManager

### DIFF
--- a/xarray/backends/file_manager.py
+++ b/xarray/backends/file_manager.py
@@ -63,7 +63,7 @@ class CachingFileManager(FileManager):
     FileManager.close(), which ensures that closed files are removed from the
     cache as well.
 
-    Example usage:
+    Example usage::
 
         manager = FileManager(open, 'example.txt', mode='w')
         f = manager.acquire()
@@ -71,7 +71,7 @@ class CachingFileManager(FileManager):
         manager.close()  # ensures file is closed
 
     Note that as long as previous files are still cached, acquiring a file
-    multiple times from the same FileManager is essentially free:
+    multiple times from the same FileManager is essentially free::
 
         f1 = manager.acquire()
         f2 = manager.acquire()


### PR DESCRIPTION
While reading through the docs I noticed that the code examples for the CachingFileManager were all one block of text and not respecting the newlines in the source. This PR changes `:` to `::` to tell restruturedtext/sphinx that the code blocks are literal blocks and not new paragraphs. Alternatively I could do `.. code-block:: python`, but I feel like that hurts readability of the source, but it may be needed if sphinx doesn't format the literal block as python code (syntax highlighting).

There may be other parts of the API docs like this, but this was the first one I saw and I didn't look very hard otherwise.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
