### PR TITLE
temporarily pin `numpy<2`

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -21,7 +21,7 @@ dependencies:
   - nbsphinx
   - netcdf4>=1.5
   - numba
-  - numpy>=1.21
+  - numpy>=1.21,<2
   - packaging>=21.3
   - pandas>=1.4,!=2.1.0
   - pooch

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -23,7 +23,7 @@ dependencies:
   - netcdf4
   - numba
   - numbagg
-  - numpy
+  - numpy<2
   - packaging
   - pandas
   # - pint>=0.22

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - numba
   - numbagg
   - numexpr
-  - numpy
+  - numpy<2
   - opt_einsum
   - packaging
   - pandas


### PR DESCRIPTION
To give us a bit more time while fixing the various issues related to `numpy>=2` without affecting other PRs, this temporarily pins `numpy` to below version 2 in CI.

We didn't detect these issues before `2024.06.0` because we didn't run the doctests / docs, because some dependencies didn't support it at that point, and because the tests don't cover everything. We will most likely never solve the last point, but we can at least continuously improve.