### PR TITLE
temporarily remove `pydap` from CI

### DIFF
--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -27,7 +27,7 @@ dependencies:
   - pandas
   - pint>=0.22
   - pip
-  - pydap
+  # - pydap
   - pytest
   - pytest-cov
   - pytest-env

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -29,7 +29,7 @@ dependencies:
   # - pint>=0.22
   - pip
   - pre-commit
-  - pydap
+  # - pydap
   - pytest
   - pytest-cov
   - pytest-env

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -35,7 +35,7 @@ dependencies:
   - pooch
   - pre-commit
   - pyarrow # pandas raises a deprecation warning without this, breaking doctests
-  - pydap
+  # - pydap
   - pytest
   - pytest-cov
   - pytest-env


### PR DESCRIPTION
The issue is that with `numpy>=2` `import pydap` works, but `import pydap.lib` raises.

Still left to do: open an issue [upstream](https://github.com/pydap/pydap) (and maybe on `conda-forge`, too?).