### PR TITLE
also pin `numpy` in the all-but-dask CI

### DIFF
--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -22,7 +22,7 @@ dependencies:
   - netcdf4
   - numba
   - numbagg
-  - numpy
+  - numpy<2
   - packaging
   - pandas
   - pint>=0.22


### PR DESCRIPTION
Looks like I forgot that environment in #9181.

- [x] follow-up to #9181