### PR TITLE
Set the cloud storage credentials when opening a datatree from ZarrStore (#9197)

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1223,9 +1223,11 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
         from xarray.core.treenode import NodePath
 
         filename_or_obj = _normalize_path(filename_or_obj)
+        if storage_options:
+            kwargs["backend_kwargs"] = {"storage_options": storage_options}
         if group:
             parent = NodePath("/") / NodePath(group)
-            stores = ZarrStore.open_store(filename_or_obj, group=parent)
+            stores = ZarrStore.open_store(filename_or_obj, group=parent, storage_options=storage_options)
             if not stores:
                 ds = open_dataset(
                     filename_or_obj, group=parent, engine="zarr", **kwargs
@@ -1233,7 +1235,8 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
                 return DataTree.from_dict({str(parent): ds})
         else:
             parent = NodePath("/")
-            stores = ZarrStore.open_store(filename_or_obj, group=parent)
+            stores = ZarrStore.open_store(filename_or_obj, group=parent, storage_options=storage_options)
+        
         ds = open_dataset(filename_or_obj, group=parent, engine="zarr", **kwargs)
         tree_root = DataTree.from_dict({str(parent): ds})
         for path_group, store in stores.items():


### PR DESCRIPTION

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #9197
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
