### PR TITLE
Adding `open_datatree` backend-specific keyword arguments

### DIFF
--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -438,7 +438,14 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         drop_variables: str | Iterable[str] | None = None,
         use_cftime=None,
         decode_timedelta=None,
+        format=None,
         group: str | Iterable[str] | Callable | None = None,
+        lock=None,
+        invalid_netcdf=None,
+        phony_dims=None,
+        decode_vlen_strings=True,
+        driver=None,
+        driver_kwds=None,
         **kwargs,
     ) -> DataTree:
         from xarray.backends.api import open_dataset
@@ -450,7 +457,14 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         filename_or_obj = _normalize_path(filename_or_obj)
         store = H5NetCDFStore.open(
             filename_or_obj,
+            format=format,
             group=group,
+            lock=lock,
+            invalid_netcdf=invalid_netcdf,
+            phony_dims=phony_dims,
+            decode_vlen_strings=decode_vlen_strings,
+            driver=driver,
+            driver_kwds=driver_kwds,
         )
         if group:
             parent = NodePath("/") / NodePath(group)

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -680,6 +680,12 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
         use_cftime=None,
         decode_timedelta=None,
         group: str | Iterable[str] | Callable | None = None,
+        format="NETCDF4",
+        clobber=True,
+        diskless=False,
+        persist=False,
+        lock=None,
+        autoclose=False,
         **kwargs,
     ) -> DataTree:
         from xarray.backends.api import open_dataset
@@ -691,6 +697,12 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
         store = NetCDF4DataStore.open(
             filename_or_obj,
             group=group,
+            format=format,
+            clobber=clobber,
+            diskless=diskless,
+            persist=persist,
+            lock=lock,
+            autoclose=autoclose,
         )
         if group:
             parent = NodePath("/") / NodePath(group)


### PR DESCRIPTION
- [x] Closes ##9135
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
