### PR TITLE
Fix dark-theme in `html[data-theme=dark]`-tags

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -45,6 +45,8 @@ Bug fixes
   By `Justus Magin <https://github.com/keewis>`_.
 - Fiy static typing of tolerance arguments by allowing `str` type (:issue:`8892`, :pull:`9194`).
   By `Michael Niklas <https://github.com/headtr1ck>`_.
+- Dark themes are now properly detected for ``html[data-theme=dark]``-tags (:pull:`9200`).
+  By `Dieter Werthmüller <https://github.com/prisae>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -14,6 +14,7 @@
 }
 
 html[theme=dark],
+html[data-theme=dark],
 body[data-theme=dark],
 body.vscode-dark {
   --xr-font-color0: rgba(255, 255, 255, 1);


### PR DESCRIPTION
This is similar to https://github.com/pydata/xarray/issues/6500 and https://github.com/pydata/xarray/pull/6501 : In my docs, the dark-theme is noted in the html-part as 
```
html< ... data-theme=dark ... >
```
and xarray-tables look therefore awful with the dark theme, as they are not rendered properly, as can be seen, e.g., here: https://emsig.xyz/emg3d-gallery/gallery/tutorials/simulation.html#create-survey.

This can be fixed by extending
https://github.com/pydata/xarray/blob/fff82539c7b0f045c35ace332c4f6ecb365a0612/xarray/static/css/style.css#L16-L18

to 
```
html[theme=dark],
html[data-theme=dark],
body[data-theme=dark],
body.vscode-dark {
```

- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`