### PR TITLE
use `nested_duck_arrays` to detect the innermost layer of duck arrays

### DIFF
--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -51,6 +51,13 @@ else:
         normalize_axis_index,
     )
 
+try:
+    from nested_duck_arrays import first_layer
+except ImportError:
+
+    def first_layer(x):
+        return type(x)
+
 
 dask_available = module_available("dask")
 
@@ -268,7 +275,7 @@ def as_shared_dtype(scalars_or_arrays, xp=None):
 
     # Avoid calling array_type("cupy") repeatidely in the any check
     array_type_cupy = array_type("cupy")
-    if any(isinstance(x, array_type_cupy) for x in scalars_or_arrays):
+    if any(first_layer(x) is array_type_cupy for x in scalars_or_arrays):
         import cupy as cp
 
         xp = cp

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -275,7 +275,7 @@ def as_shared_dtype(scalars_or_arrays, xp=None):
 
     # Avoid calling array_type("cupy") repeatedly in the any check
     array_type_cupy = array_type("cupy")
-    if any(first_layer(x) is array_type_cupy for x in scalars_or_arrays):
+    if any(issubclass(first_layer(x), array_type_cupy) for x in scalars_or_arrays):
         import cupy as cp
 
         xp = cp

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -273,7 +273,7 @@ def as_shared_dtype(scalars_or_arrays, xp=None):
             f" array types {[x.dtype for x in scalars_or_arrays]}"
         )
 
-    # Avoid calling array_type("cupy") repeatidely in the any check
+    # Avoid calling array_type("cupy") repeatedly in the any check
     array_type_cupy = array_type("cupy")
     if any(first_layer(x) is array_type_cupy for x in scalars_or_arrays):
         import cupy as cp

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -113,6 +113,9 @@ with warnings.catch_warnings():
         category=DeprecationWarning,
     )
     has_dask_expr, requires_dask_expr = _importorskip("dask_expr")
+has_nested_duck_arrays, requires_nested_duck_arrays = _importorskip(
+    "nested_duck_arrays"
+)
 has_bottleneck, requires_bottleneck = _importorskip("bottleneck")
 has_rasterio, requires_rasterio = _importorskip("rasterio")
 has_zarr, requires_zarr = _importorskip("zarr")

--- a/xarray/tests/test_cupy.py
+++ b/xarray/tests/test_cupy.py
@@ -5,9 +5,9 @@ import pandas as pd
 import pytest
 
 import xarray as xr
+from xarray.tests import requires_dask, requires_nested_duck_arrays
 
 cp = pytest.importorskip("cupy")
-from xarray.tests import requires_dask
 
 
 @pytest.fixture
@@ -63,6 +63,7 @@ def test_where() -> None:
     assert isinstance(output, cp.ndarray)
 
 
+@requires_nested_duck_arrays
 @requires_dask
 def test_where_dask() -> None:
     import dask.array as da

--- a/xarray/tests/test_cupy.py
+++ b/xarray/tests/test_cupy.py
@@ -7,6 +7,7 @@ import pytest
 import xarray as xr
 
 cp = pytest.importorskip("cupy")
+from xarray.tests import requires_dask
 
 
 @pytest.fixture
@@ -58,5 +59,22 @@ def test_where() -> None:
     data = cp.zeros(10)
 
     output = where(data < 1, 1, data).all()
+    assert output
+    assert isinstance(output, cp.ndarray)
+
+
+@requires_dask
+def test_where_dask() -> None:
+    import dask.array as da
+
+    from xarray.core.duck_array_ops import where
+
+    data = cp.zeros(10)
+    chunked = da.from_array(data, chunks=(2,))
+
+    chunked_output = where(chunked < 1, 1, chunked).all()
+    assert isinstance(chunked_output, da.Array)
+
+    output = chunked_output.compute()
     assert output
     assert isinstance(output, cp.ndarray)

--- a/xarray/tests/test_cupy.py
+++ b/xarray/tests/test_cupy.py
@@ -67,6 +67,7 @@ def test_where() -> None:
 @requires_dask
 def test_where_dask() -> None:
     import dask.array as da
+    import nested_duck_arrays.dask  # noqa: F401
 
     from xarray.core.duck_array_ops import where
 


### PR DESCRIPTION
- [x] Closes #7721
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

As described in https://github.com/pydata/xarray/issues/7721#issuecomment-2199668914, this uses `nested_duck_arrays.first_layer` (or should that be called `innermost_layer`? Not sure) to detect `cupy` under one or more layers of duck arrays.

This is highly experimental, and before merging this, I'd like to:
- settle on the API in `nested_duck_arrays` – the name of the protocol, and the names of the functions in `nested_duck_arrays` are not set, yet.
- in general: get feedback on the idea
- get `pint` and `dask` (the most common duck arrays that create layers) to implement the protocol
- publish `nested_duck_arrays` to PyPI and `conda-forge`