### PR TITLE
Delete ``base`` and ``loffset`` parameters to resample

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -42,6 +42,11 @@ New Features
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
+- The ``base`` and ``loffset`` parameters to :py:meth:`Dataset.resample` and :py:meth:`DataArray.resample`
+  is now removed. These parameters has been deprecated since v2023.03.0. Using the
+  ``origin`` or ``offset`` parameters is recommended as a replacement for using
+  the ``base`` parameter and using time offset arithmetic is recommended as a
+  replacement for using the ``loffset`` parameter.
 
 
 Deprecations

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1051,18 +1051,6 @@ class DataWithCoords(AttrAccessMixin):
         from xarray.core.groupers import Resampler, TimeResampler
         from xarray.core.resample import RESAMPLE_DIM
 
-        # note: the second argument (now 'skipna') use to be 'dim'
-        if (
-            (skipna is not None and not isinstance(skipna, bool))
-            or ("how" in indexer_kwargs and "how" not in self.dims)
-            or ("dim" in indexer_kwargs and "dim" not in self.dims)
-        ):
-            raise TypeError(
-                "resample() no longer supports the `how` or "
-                "`dim` arguments. Instead call methods on resample "
-                "objects, e.g., data.resample(time='1D').mean()"
-            )
-
         indexer = either_dict_or_kwargs(indexer, indexer_kwargs, "resample")
         if len(indexer) != 1:
             raise ValueError("Resampling only supported along single dimensions.")

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1060,10 +1060,7 @@ class DataWithCoords(AttrAccessMixin):
         dim_coord = self[dim]
 
         group = DataArray(
-            dim_coord,
-            coords=dim_coord.coords,
-            dims=dim_coord.dims,
-            name=RESAMPLE_DIM,
+            dim_coord, coords=dim_coord.coords, dims=dim_coord.dims, name=RESAMPLE_DIM
         )
 
         grouper: Resampler

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -881,10 +881,8 @@ class DataWithCoords(AttrAccessMixin):
         skipna: bool | None,
         closed: SideOptions | None,
         label: SideOptions | None,
-        base: int | None,
         offset: pd.Timedelta | datetime.timedelta | str | None,
         origin: str | DatetimeLike,
-        loffset: datetime.timedelta | str | None,
         restore_coord_dims: bool | None,
         **indexer_kwargs: str | Resampler,
     ) -> T_Resample:
@@ -906,16 +904,6 @@ class DataWithCoords(AttrAccessMixin):
             Side of each interval to treat as closed.
         label : {"left", "right"}, optional
             Side of each interval to use for labeling.
-        base : int, optional
-            For frequencies that evenly subdivide 1 day, the "origin" of the
-            aggregated intervals. For example, for "24H" frequency, base could
-            range from 0 through 23.
-
-            .. deprecated:: 2023.03.0
-                Following pandas, the ``base`` parameter is deprecated in favor
-                of the ``origin`` and ``offset`` parameters, and will be removed
-                in a future version of xarray.
-
         origin : {'epoch', 'start', 'start_day', 'end', 'end_day'}, pd.Timestamp, datetime.datetime, np.datetime64, or cftime.datetime, default 'start_day'
             The datetime on which to adjust the grouping. The timezone of origin
             must match the timezone of the index.
@@ -928,15 +916,6 @@ class DataWithCoords(AttrAccessMixin):
             - 'end_day': `origin` is the ceiling midnight of the last day
         offset : pd.Timedelta, datetime.timedelta, or str, default is None
             An offset timedelta added to the origin.
-        loffset : timedelta or str, optional
-            Offset used to adjust the resampled time labels. Some pandas date
-            offset strings are supported.
-
-            .. deprecated:: 2023.03.0
-                Following pandas, the ``loffset`` parameter is deprecated in favor
-                of using time offset arithmetic, and will be removed in a future
-                version of xarray.
-
         restore_coord_dims : bool, optional
             If True, also restore the dimension order of multi-dimensional
             coordinates.
@@ -1102,13 +1081,7 @@ class DataWithCoords(AttrAccessMixin):
         grouper: Resampler
         if isinstance(freq, str):
             grouper = TimeResampler(
-                freq=freq,
-                closed=closed,
-                label=label,
-                origin=origin,
-                offset=offset,
-                loffset=loffset,
-                base=base,
+                freq=freq, closed=closed, label=label, origin=origin, offset=offset
             )
         elif isinstance(freq, Resampler):
             grouper = freq

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -7245,10 +7245,8 @@ class DataArray(
         skipna: bool | None = None,
         closed: SideOptions | None = None,
         label: SideOptions | None = None,
-        base: int | None = None,
         offset: pd.Timedelta | datetime.timedelta | str | None = None,
         origin: str | DatetimeLike = "start_day",
-        loffset: datetime.timedelta | str | None = None,
         restore_coord_dims: bool | None = None,
         **indexer_kwargs: str | Resampler,
     ) -> DataArrayResample:
@@ -7270,10 +7268,6 @@ class DataArray(
             Side of each interval to treat as closed.
         label : {"left", "right"}, optional
             Side of each interval to use for labeling.
-        base : int, optional
-            For frequencies that evenly subdivide 1 day, the "origin" of the
-            aggregated intervals. For example, for "24H" frequency, base could
-            range from 0 through 23.
         origin : {'epoch', 'start', 'start_day', 'end', 'end_day'}, pd.Timestamp, datetime.datetime, np.datetime64, or cftime.datetime, default 'start_day'
             The datetime on which to adjust the grouping. The timezone of origin
             must match the timezone of the index.
@@ -7286,15 +7280,6 @@ class DataArray(
             - 'end_day': `origin` is the ceiling midnight of the last day
         offset : pd.Timedelta, datetime.timedelta, or str, default is None
             An offset timedelta added to the origin.
-        loffset : timedelta or str, optional
-            Offset used to adjust the resampled time labels. Some pandas date
-            offset strings are supported.
-
-            .. deprecated:: 2023.03.0
-                Following pandas, the ``loffset`` parameter is deprecated in favor
-                of using time offset arithmetic, and will be removed in a future
-                version of xarray.
-
         restore_coord_dims : bool, optional
             If True, also restore the dimension order of multi-dimensional
             coordinates.
@@ -7399,10 +7384,8 @@ class DataArray(
             skipna=skipna,
             closed=closed,
             label=label,
-            base=base,
             offset=offset,
             origin=origin,
-            loffset=loffset,
             restore_coord_dims=restore_coord_dims,
             **indexer_kwargs,
         )

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -10626,10 +10626,8 @@ class Dataset(
         skipna: bool | None = None,
         closed: SideOptions | None = None,
         label: SideOptions | None = None,
-        base: int | None = None,
         offset: pd.Timedelta | datetime.timedelta | str | None = None,
         origin: str | DatetimeLike = "start_day",
-        loffset: datetime.timedelta | str | None = None,
         restore_coord_dims: bool | None = None,
         **indexer_kwargs: str | Resampler,
     ) -> DatasetResample:
@@ -10651,10 +10649,6 @@ class Dataset(
             Side of each interval to treat as closed.
         label : {"left", "right"}, optional
             Side of each interval to use for labeling.
-        base : int, optional
-            For frequencies that evenly subdivide 1 day, the "origin" of the
-            aggregated intervals. For example, for "24H" frequency, base could
-            range from 0 through 23.
         origin : {'epoch', 'start', 'start_day', 'end', 'end_day'}, pd.Timestamp, datetime.datetime, np.datetime64, or cftime.datetime, default 'start_day'
             The datetime on which to adjust the grouping. The timezone of origin
             must match the timezone of the index.
@@ -10667,15 +10661,6 @@ class Dataset(
             - 'end_day': `origin` is the ceiling midnight of the last day
         offset : pd.Timedelta, datetime.timedelta, or str, default is None
             An offset timedelta added to the origin.
-        loffset : timedelta or str, optional
-            Offset used to adjust the resampled time labels. Some pandas date
-            offset strings are supported.
-
-            .. deprecated:: 2023.03.0
-                Following pandas, the ``loffset`` parameter is deprecated in favor
-                of using time offset arithmetic, and will be removed in a future
-                version of xarray.
-
         restore_coord_dims : bool, optional
             If True, also restore the dimension order of multi-dimensional
             coordinates.
@@ -10708,10 +10693,8 @@ class Dataset(
             skipna=skipna,
             closed=closed,
             label=label,
-            base=base,
             offset=offset,
             origin=origin,
-            loffset=loffset,
             restore_coord_dims=restore_coord_dims,
             **indexer_kwargs,
         )

--- a/xarray/core/groupers.py
+++ b/xarray/core/groupers.py
@@ -360,7 +360,6 @@ class TimeResampler(Resampler):
 
     def first_items(self) -> tuple[pd.Series, np.ndarray]:
         from xarray.coding.cftimeindex import CFTimeIndex
-        from xarray.core.resample_cftime import CFTimeGrouper
 
         if isinstance(self.group_as_index, CFTimeIndex):
             return self.index_grouper.first_items(
@@ -375,8 +374,6 @@ class TimeResampler(Resampler):
             # So for _flox_reduce we avoid one reindex and copy by avoiding
             # _maybe_restore_empty_groups
             codes = np.repeat(np.arange(len(first_items)), counts)
-            if self.loffset is not None:
-                _apply_loffset(self.loffset, first_items)
             return first_items, codes
 
     def factorize(self, group: T_Group) -> EncodedGroups:

--- a/xarray/core/groupers.py
+++ b/xarray/core/groupers.py
@@ -360,8 +360,9 @@ class TimeResampler(Resampler):
 
     def first_items(self) -> tuple[pd.Series, np.ndarray]:
         from xarray.coding.cftimeindex import CFTimeIndex
+        from xarray.core.resample_cftime import CFTimeGrouper
 
-        if isinstance(self.group_as_index, CFTimeIndex):
+        if isinstance(self.index_grouper, CFTimeGrouper):
             return self.index_grouper.first_items(
                 cast(CFTimeIndex, self.group_as_index)
             )

--- a/xarray/core/pdcompat.py
+++ b/xarray/core/pdcompat.py
@@ -41,8 +41,6 @@ from typing import Literal
 import pandas as pd
 from packaging.version import Version
 
-from xarray.coding import cftime_offsets
-
 
 def count_not_none(*args) -> int:
     """Compute the number of non-None arguments.

--- a/xarray/core/pdcompat.py
+++ b/xarray/core/pdcompat.py
@@ -75,26 +75,6 @@ no_default = (
 NoDefault = Literal[_NoDefault.no_default]  # For typing following pandas
 
 
-def _convert_base_to_offset(base, freq, index):
-    """Required until we officially deprecate the base argument to resample.  This
-    translates a provided `base` argument to an `offset` argument, following logic
-    from pandas.
-    """
-    from xarray.coding.cftimeindex import CFTimeIndex
-
-    if isinstance(index, pd.DatetimeIndex):
-        freq = cftime_offsets._new_to_legacy_freq(freq)
-        freq = pd.tseries.frequencies.to_offset(freq)
-        if isinstance(freq, pd.offsets.Tick):
-            return pd.Timedelta(base * freq.nanos // freq.n)
-    elif isinstance(index, CFTimeIndex):
-        freq = cftime_offsets.to_offset(freq)
-        if isinstance(freq, cftime_offsets.Tick):
-            return base * freq.as_timedelta() // freq.n
-    else:
-        raise ValueError("Can only resample using a DatetimeIndex or CFTimeIndex.")
-
-
 def nanosecond_precision_timestamp(*args, **kwargs) -> pd.Timestamp:
     """Return a nanosecond-precision Timestamp object.
 

--- a/xarray/core/resample_cftime.py
+++ b/xarray/core/resample_cftime.py
@@ -78,12 +78,10 @@ class CFTimeGrouper:
         freq: str | BaseCFTimeOffset,
         closed: SideOptions | None = None,
         label: SideOptions | None = None,
-        loffset: str | datetime.timedelta | BaseCFTimeOffset | None = None,
         origin: str | CFTimeDatetime = "start_day",
         offset: str | datetime.timedelta | BaseCFTimeOffset | None = None,
     ):
         self.freq = to_offset(freq)
-        self.loffset = loffset
         self.origin = origin
 
         if isinstance(self.freq, (MonthEnd, QuarterEnd, YearEnd)):
@@ -145,22 +143,6 @@ class CFTimeGrouper:
         datetime_bins, labels = _get_time_bins(
             index, self.freq, self.closed, self.label, self.origin, self.offset
         )
-        if self.loffset is not None:
-            if not isinstance(
-                self.loffset, (str, datetime.timedelta, BaseCFTimeOffset)
-            ):
-                # BaseCFTimeOffset is not public API so we do not include it in
-                # the error message for now.
-                raise ValueError(
-                    f"`loffset` must be a str or datetime.timedelta object. "
-                    f"Got {self.loffset}."
-                )
-
-            if isinstance(self.loffset, datetime.timedelta):
-                labels = labels + self.loffset
-            else:
-                labels = labels + to_offset(self.loffset)
-
         # check binner fits data
         if index[0] < datetime_bins[0]:
             raise ValueError("Value falls before first bin")

--- a/xarray/tests/test_cftimeindex_resample.py
+++ b/xarray/tests/test_cftimeindex_resample.py
@@ -11,7 +11,6 @@ from packaging.version import Version
 import xarray as xr
 from xarray.coding.cftime_offsets import _new_to_legacy_freq
 from xarray.coding.cftimeindex import CFTimeIndex
-from xarray.core.pdcompat import _convert_base_to_offset
 from xarray.core.resample_cftime import CFTimeGrouper
 
 cftime = pytest.importorskip("cftime")
@@ -61,10 +60,8 @@ def compare_against_pandas(
     freq,
     closed=None,
     label=None,
-    base=None,
     offset=None,
     origin=None,
-    loffset=None,
 ) -> None:
     if isinstance(origin, tuple):
         origin_pandas = pd.Timestamp(datetime.datetime(*origin))
@@ -78,8 +75,6 @@ def compare_against_pandas(
             time=freq,
             closed=closed,
             label=label,
-            base=base,
-            loffset=loffset,
             offset=offset,
             origin=origin_pandas,
         ).mean()
@@ -89,8 +84,6 @@ def compare_against_pandas(
                 time=freq,
                 closed=closed,
                 label=label,
-                base=base,
-                loffset=loffset,
                 origin=origin_cftime,
                 offset=offset,
             ).mean()
@@ -99,8 +92,6 @@ def compare_against_pandas(
             time=freq,
             closed=closed,
             label=label,
-            base=base,
-            loffset=loffset,
             origin=origin_cftime,
             offset=offset,
         ).mean()
@@ -117,14 +108,11 @@ def da(index) -> xr.DataArray:
     )
 
 
-@pytest.mark.filterwarnings("ignore:.*the `(base|loffset)` parameter to resample")
 @pytest.mark.parametrize("freqs", FREQS, ids=lambda x: "{}->{}".format(*x))
 @pytest.mark.parametrize("closed", [None, "left", "right"])
 @pytest.mark.parametrize("label", [None, "left", "right"])
-@pytest.mark.parametrize(
-    ("base", "offset"), [(24, None), (31, None), (None, "5s")], ids=lambda x: f"{x}"
-)
-def test_resample(freqs, closed, label, base, offset) -> None:
+@pytest.mark.parametrize("offset", [None, "5s"], ids=lambda x: f"{x}")
+def test_resample(freqs, closed, label, offset) -> None:
     initial_freq, resample_freq = freqs
     if (
         resample_freq == "4001D"
@@ -137,7 +125,6 @@ def test_resample(freqs, closed, label, base, offset) -> None:
             "result as pandas for earlier pandas versions."
         )
     start = "2000-01-01T12:07:01"
-    loffset = "12h"
     origin = "start"
 
     datetime_index = pd.date_range(
@@ -147,18 +134,15 @@ def test_resample(freqs, closed, label, base, offset) -> None:
     da_datetimeindex = da(datetime_index)
     da_cftimeindex = da(cftime_index)
 
-    with pytest.warns(FutureWarning, match="`loffset` parameter"):
-        compare_against_pandas(
-            da_datetimeindex,
-            da_cftimeindex,
-            resample_freq,
-            closed=closed,
-            label=label,
-            base=base,
-            offset=offset,
-            origin=origin,
-            loffset=loffset,
-        )
+    compare_against_pandas(
+        da_datetimeindex,
+        da_cftimeindex,
+        resample_freq,
+        closed=closed,
+        label=label,
+        offset=offset,
+        origin=origin,
+    )
 
 
 @pytest.mark.parametrize(
@@ -182,28 +166,18 @@ def test_closed_label_defaults(freq, expected) -> None:
 
 
 @pytest.mark.filterwarnings("ignore:Converting a CFTimeIndex")
-@pytest.mark.filterwarnings("ignore:.*the `(base|loffset)` parameter to resample")
 @pytest.mark.parametrize(
     "calendar", ["gregorian", "noleap", "all_leap", "360_day", "julian"]
 )
 def test_calendars(calendar: str) -> None:
     # Limited testing for non-standard calendars
-    freq, closed, label, base = "8001min", None, None, 17
-    loffset = datetime.timedelta(hours=12)
+    freq, closed, label = "8001min", None, None
     xr_index = xr.cftime_range(
         start="2004-01-01T12:07:01", periods=7, freq="3D", calendar=calendar
     )
     pd_index = pd.date_range(start="2004-01-01T12:07:01", periods=7, freq="3D")
-    da_cftime = (
-        da(xr_index)
-        .resample(time=freq, closed=closed, label=label, base=base, loffset=loffset)
-        .mean()
-    )
-    da_datetime = (
-        da(pd_index)
-        .resample(time=freq, closed=closed, label=label, base=base, loffset=loffset)
-        .mean()
-    )
+    da_cftime = da(xr_index).resample(time=freq, closed=closed, label=label).mean()
+    da_datetime = da(pd_index).resample(time=freq, closed=closed, label=label).mean()
     # TODO (benbovy - flexible indexes): update when CFTimeIndex is a xarray Index subclass
     new_pd_index = da_cftime.xindexes["time"].to_pandas_index()
     assert isinstance(new_pd_index, CFTimeIndex)  # shouldn't that be a pd.Index?
@@ -217,7 +191,6 @@ class DateRangeKwargs(TypedDict):
     freq: str
 
 
-@pytest.mark.filterwarnings("ignore:.*the `(base|loffset)` parameter to resample")
 @pytest.mark.parametrize("closed", ["left", "right"])
 @pytest.mark.parametrize(
     "origin",
@@ -242,7 +215,6 @@ def test_origin(closed, origin) -> None:
     )
 
 
-@pytest.mark.filterwarnings("ignore:.*the `(base|loffset)` parameter to resample")
 def test_base_and_offset_error():
     cftime_index = xr.cftime_range("2000", periods=5)
     da_cftime = da(cftime_index)
@@ -268,46 +240,3 @@ def test_timedelta_offset() -> None:
     timedelta_result = da_cftime.resample(time="2D", offset=timedelta).mean()
     string_result = da_cftime.resample(time="2D", offset=string).mean()
     xr.testing.assert_identical(timedelta_result, string_result)
-
-
-@pytest.mark.parametrize("loffset", ["MS", "12h", datetime.timedelta(hours=-12)])
-def test_resample_loffset_cftimeindex(loffset) -> None:
-    datetimeindex = pd.date_range("2000-01-01", freq="6h", periods=10)
-    da_datetimeindex = xr.DataArray(np.arange(10), [("time", datetimeindex)])
-
-    cftimeindex = xr.cftime_range("2000-01-01", freq="6h", periods=10)
-    da_cftimeindex = xr.DataArray(np.arange(10), [("time", cftimeindex)])
-
-    with pytest.warns(FutureWarning, match="`loffset` parameter"):
-        result = da_cftimeindex.resample(time="24h", loffset=loffset).mean()
-        expected = da_datetimeindex.resample(time="24h", loffset=loffset).mean()
-
-    index = result.xindexes["time"].to_pandas_index()
-    assert isinstance(index, CFTimeIndex)
-    result["time"] = index.to_datetimeindex()
-    xr.testing.assert_identical(result, expected)
-
-
-@pytest.mark.filterwarnings("ignore:.*the `(base|loffset)` parameter to resample")
-def test_resample_invalid_loffset_cftimeindex() -> None:
-    times = xr.cftime_range("2000-01-01", freq="6h", periods=10)
-    da = xr.DataArray(np.arange(10), [("time", times)])
-
-    with pytest.raises(ValueError):
-        da.resample(time="24h", loffset=1)  # type: ignore
-
-
-@pytest.mark.parametrize(("base", "freq"), [(1, "10s"), (17, "3h"), (15, "5us")])
-def test__convert_base_to_offset(base, freq):
-    # Verify that the cftime_offset adapted version of _convert_base_to_offset
-    # produces the same result as the pandas version.
-    datetimeindex = pd.date_range("2000", periods=2)
-    cftimeindex = xr.cftime_range("2000", periods=2)
-    pandas_result = _convert_base_to_offset(base, freq, datetimeindex)
-    cftime_result = _convert_base_to_offset(base, freq, cftimeindex)
-    assert pandas_result.to_pytimedelta() == cftime_result
-
-
-def test__convert_base_to_offset_invalid_index():
-    with pytest.raises(ValueError, match="Can only resample"):
-        _convert_base_to_offset(1, "12h", pd.Index([0]))

--- a/xarray/tests/test_cftimeindex_resample.py
+++ b/xarray/tests/test_cftimeindex_resample.py
@@ -215,13 +215,6 @@ def test_origin(closed, origin) -> None:
     )
 
 
-def test_base_and_offset_error():
-    cftime_index = xr.cftime_range("2000", periods=5)
-    da_cftime = da(cftime_index)
-    with pytest.raises(ValueError, match="base and offset cannot"):
-        da_cftime.resample(time="2D", base=3, offset="5s")
-
-
 @pytest.mark.parametrize("offset", ["foo", "5MS", 10])
 def test_invalid_offset_error(offset: str | int) -> None:
     cftime_index = xr.cftime_range("2000", periods=5)

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 import operator
 import warnings
 from unittest import mock
@@ -2205,19 +2204,6 @@ class TestDataArrayResample:
             # done here due to floating point arithmetic
             assert_allclose(expected, actual, rtol=1e-16)
 
-    def test_resample_base(self) -> None:
-        times = pd.date_range("2000-01-01T02:03:01", freq="6h", periods=10)
-        array = DataArray(np.arange(10), [("time", times)])
-
-        base = 11
-
-        with pytest.warns(FutureWarning, match="the `base` parameter to resample"):
-            actual = array.resample(time="24h", base=base).mean()
-        expected = DataArray(
-            array.to_series().resample("24h", offset=f"{base}h").mean()
-        )
-        assert_identical(expected, actual)
-
     def test_resample_offset(self) -> None:
         times = pd.date_range("2000-01-01T02:03:01", freq="6h", periods=10)
         array = DataArray(np.arange(10), [("time", times)])
@@ -2235,38 +2221,6 @@ class TestDataArrayResample:
         actual = array.resample(time="24h", origin=origin).mean()
         expected = DataArray(array.to_series().resample("24h", origin=origin).mean())
         assert_identical(expected, actual)
-
-    @pytest.mark.parametrize(
-        "loffset",
-        [
-            "-12h",
-            datetime.timedelta(hours=-12),
-            pd.Timedelta(hours=-12),
-            pd.DateOffset(hours=-12),
-        ],
-    )
-    def test_resample_loffset(self, loffset) -> None:
-        times = pd.date_range("2000-01-01", freq="6h", periods=10)
-        array = DataArray(np.arange(10), [("time", times)])
-
-        with pytest.warns(FutureWarning, match="`loffset` parameter"):
-            actual = array.resample(time="24h", loffset=loffset).mean()
-        series = array.to_series().resample("24h").mean()
-        if not isinstance(loffset, pd.DateOffset):
-            loffset = pd.Timedelta(loffset)
-        series.index = series.index + loffset
-        expected = DataArray(series)
-        assert_identical(actual, expected)
-
-    def test_resample_invalid_loffset(self) -> None:
-        times = pd.date_range("2000-01-01", freq="6h", periods=10)
-        array = DataArray(np.arange(10), [("time", times)])
-
-        with pytest.warns(
-            FutureWarning, match="Following pandas, the `loffset` parameter"
-        ):
-            with pytest.raises(ValueError, match="`loffset` must be"):
-                array.resample(time="24h", loffset=1).mean()  # type: ignore
 
 
 class TestDatasetResample:
@@ -2337,17 +2291,6 @@ class TestDatasetResample:
         actual = resampled_ds.attrs
         expected = ds.attrs
         assert expected == actual
-
-    def test_resample_loffset(self) -> None:
-        times = pd.date_range("2000-01-01", freq="6h", periods=10)
-        ds = Dataset(
-            {
-                "foo": (["time", "x", "y"], np.random.randn(10, 5, 3)),
-                "bar": ("time", np.random.randn(10), {"meta": "data"}),
-                "time": times,
-            }
-        )
-        ds.attrs["dsmeta"] = "dsdata"
 
     def test_resample_by_mean_discarding_attrs(self) -> None:
         times = pd.date_range("2000-01-01", freq="6h", periods=10)

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -2351,25 +2351,6 @@ class TestDatasetResample:
         actual = ds.resample(time="1h").interpolate("linear")
         assert "tc" not in actual.coords
 
-    def test_resample_old_api(self) -> None:
-        times = pd.date_range("2000-01-01", freq="6h", periods=10)
-        ds = Dataset(
-            {
-                "foo": (["time", "x", "y"], np.random.randn(10, 5, 3)),
-                "bar": ("time", np.random.randn(10), {"meta": "data"}),
-                "time": times,
-            }
-        )
-
-        with pytest.raises(TypeError, match=r"resample\(\) no longer supports"):
-            ds.resample("1D", "time")  # type: ignore[arg-type]
-
-        with pytest.raises(TypeError, match=r"resample\(\) no longer supports"):
-            ds.resample("1D", dim="time", how="mean")  # type: ignore[arg-type]
-
-        with pytest.raises(TypeError, match=r"resample\(\) no longer supports"):
-            ds.resample("1D", dim="time")  # type: ignore[arg-type]
-
     def test_resample_ds_da_are_the_same(self) -> None:
         time = pd.date_range("2000-01-01", freq="6h", periods=365 * 4)
         ds = xr.Dataset(


### PR DESCRIPTION
Builds on #8840 

Finishes the deprecations of ``base`` and ``loffset`` parameters in resample.

- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
