### PR TITLE
exclude the bots from the release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
As described in the [scientific-python guide on github actions](https://learn.scientific-python.org/development/guides/gha-basic/#changelog-generation), this excludes bots from the release notes. We'll still have to update the code snippet in the release guide, though.