### PR TITLE
Update signature for _arrayfunction.__array__

### DIFF
--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -66,7 +66,7 @@ _DTypeLike = Union[
 ]
 
 # For unknown shapes Dask uses np.nan, array_api uses None:
-_IntOrUnknown = Union[int, float, None]
+_IntOrUnknown = int
 _Shape = tuple[_IntOrUnknown, ...]
 _ShapeLike = Union[SupportsIndex, Sequence[SupportsIndex]]
 _ShapeType = TypeVar("_ShapeType", bound=_Shape)

--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -218,7 +218,6 @@ duckarray = Union[
     _arrayfunction[_ShapeType_co, _DType_co], _arrayapi[_ShapeType_co, _DType_co]
 ]
 
-
 # Corresponds to np.typing.NDArray:
 DuckArray = _arrayfunction[Any, np.dtype[_ScalarType_co]]
 

--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -69,8 +69,8 @@ _DTypeLike = Union[
 _IntOrUnknown = int
 _Shape = tuple[_IntOrUnknown, ...]
 _ShapeLike = Union[SupportsIndex, Sequence[SupportsIndex]]
-_ShapeType = TypeVar("_ShapeType", bound=_Shape)
-_ShapeType_co = TypeVar("_ShapeType_co", bound=_Shape, covariant=True)
+_ShapeType = TypeVar("_ShapeType", bound=Any)
+_ShapeType_co = TypeVar("_ShapeType_co", bound=Any, covariant=True)
 
 _Axis = int
 _Axes = tuple[_Axis, ...]
@@ -118,7 +118,7 @@ class _array(Protocol[_ShapeType_co, _DType_co]):
     """
 
     @property
-    def shape(self) -> _ShapeType_co: ...
+    def shape(self) -> _Shape: ...
 
     @property
     def dtype(self) -> _DType_co: ...

--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -153,13 +153,16 @@ class _arrayfunction(
     ) -> _arrayfunction[Any, _DType_co] | Any: ...
 
     @overload
-    def __array__(self, dtype: None = ..., /) -> np.ndarray[Any, _DType_co]: ...
-
+    def __array__(
+        self, dtype: None = ..., /, *, copy: None | bool = ...
+    ) -> np.ndarray[Any, _DType_co]: ...
     @overload
-    def __array__(self, dtype: _DType, /) -> np.ndarray[Any, _DType]: ...
+    def __array__(
+        self, dtype: _DType, /, *, copy: None | bool = ...
+    ) -> np.ndarray[Any, _DType]: ...
 
     def __array__(
-        self, dtype: _DType | None = ..., /
+        self, dtype: _DType | None = ..., /, *, copy: None | bool = ...
     ) -> np.ndarray[Any, _DType] | np.ndarray[Any, _DType_co]: ...
 
     # TODO: Should return the same subclass but with a new dtype generic.
@@ -211,9 +214,9 @@ class _arrayapi(_array[_ShapeType_co, _DType_co], Protocol[_ShapeType_co, _DType
 # NamedArray can most likely use both __array_function__ and __array_namespace__:
 _arrayfunction_or_api = (_arrayfunction, _arrayapi)
 
-duckarray: TypeAlias = (
-    _arrayfunction[_ShapeType_co, _DType_co] | _arrayapi[_ShapeType_co, _DType_co]
-)
+duckarray = Union[
+    _arrayfunction[_ShapeType_co, _DType_co], _arrayapi[_ShapeType_co, _DType_co]
+]
 
 
 # Corresponds to np.typing.NDArray:

--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -211,9 +211,7 @@ class _arrayapi(_array[_ShapeType_co, _DType_co], Protocol[_ShapeType_co, _DType
 # NamedArray can most likely use both __array_function__ and __array_namespace__:
 _arrayfunction_or_api = (_arrayfunction, _arrayapi)
 
-duckarray = Union[
-    _arrayfunction[_ShapeType_co, _DType_co], _arrayapi[_ShapeType_co, _DType_co]
-]
+duckarray = Union[_arrayfunction[_ShapeType, _DType], _arrayapi[_ShapeType, _DType]]
 
 # Corresponds to np.typing.NDArray:
 DuckArray = _arrayfunction[Any, np.dtype[_ScalarType_co]]

--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -212,7 +212,7 @@ class _arrayapi(_array[_ShapeType_co, _DType_co], Protocol[_ShapeType_co, _DType
 _arrayfunction_or_api = (_arrayfunction, _arrayapi)
 
 duckarray: TypeAlias = (
-    _arrayfunction[_ShapeType, _DType] | _arrayapi[_ShapeType, _DType]
+    _arrayfunction[_ShapeType_co, _DType_co] | _arrayapi[_ShapeType_co, _DType_co]
 )
 
 

--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -8,6 +8,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Collection,
     Final,
     Literal,
     Protocol,
@@ -66,11 +67,11 @@ _DTypeLike = Union[
 ]
 
 # For unknown shapes Dask uses np.nan, array_api uses None:
-_IntOrUnknown = int
+_IntOrUnknown = Union[int, float, None]
 _Shape = tuple[_IntOrUnknown, ...]
 _ShapeLike = Union[SupportsIndex, Sequence[SupportsIndex]]
-_ShapeType = TypeVar("_ShapeType", bound=Any)
-_ShapeType_co = TypeVar("_ShapeType_co", bound=Any, covariant=True)
+_ShapeType = TypeVar("_ShapeType", bound=_Shape)
+_ShapeType_co = TypeVar("_ShapeType_co", bound=_Shape, covariant=True)
 
 _Axis = int
 _Axes = tuple[_Axis, ...]
@@ -118,7 +119,7 @@ class _array(Protocol[_ShapeType_co, _DType_co]):
     """
 
     @property
-    def shape(self) -> _Shape: ...
+    def shape(self) -> _ShapeType_co: ...
 
     @property
     def dtype(self) -> _DType_co: ...
@@ -211,7 +212,10 @@ class _arrayapi(_array[_ShapeType_co, _DType_co], Protocol[_ShapeType_co, _DType
 # NamedArray can most likely use both __array_function__ and __array_namespace__:
 _arrayfunction_or_api = (_arrayfunction, _arrayapi)
 
-duckarray = Union[_arrayfunction[_ShapeType, _DType], _arrayapi[_ShapeType, _DType]]
+duckarray: TypeAlias = (
+    _arrayfunction[_ShapeType, _DType] | _arrayapi[_ShapeType, _DType]
+)
+
 
 # Corresponds to np.typing.NDArray:
 DuckArray = _arrayfunction[Any, np.dtype[_ScalarType_co]]

--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -8,7 +8,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Collection,
     Final,
     Literal,
     Protocol,

--- a/xarray/namedarray/core.py
+++ b/xarray/namedarray/core.py
@@ -250,14 +250,14 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
 
     __slots__ = ("_data", "_dims", "_attrs")
 
-    _data: duckarray[Any, _DType_co]
+    _data: duckarray[_ShapeType_co, _DType_co]
     _dims: _Dims
     _attrs: dict[Any, Any] | None
 
     def __init__(
         self,
         dims: _DimsLike,
-        data: duckarray[Any, _DType_co],
+        data: duckarray[_ShapeType_co, _DType_co],
         attrs: _AttrsLike = None,
     ):
         self._data = data
@@ -292,7 +292,7 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
     def _new(
         self,
         dims: _DimsLike | Default = _default,
-        data: duckarray[Any, _DType] | Default = _default,
+        data: duckarray[_ShapeType, _DType] | Default = _default,
         attrs: _AttrsLike | Default = _default,
     ) -> NamedArray[_ShapeType, _DType] | NamedArray[_ShapeType_co, _DType_co]:
         """
@@ -447,7 +447,7 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
         return self._data.dtype
 
     @property
-    def shape(self) -> _Shape:
+    def shape(self) -> _ShapeType_co:
         """
         Get the shape of the array.
 
@@ -850,9 +850,9 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
         # TODO an entrypoint so array libraries can choose coercion method?
         return to_numpy(self._data)
 
-    def as_numpy(self) -> Self:
+    def as_numpy(self) -> NamedArray[Any, Any]:
         """Coerces wrapped data into a numpy array, returning a Variable."""
-        return self._replace(data=self.to_numpy())
+        return self._new(data=self.to_numpy())
 
     def reduce(
         self,

--- a/xarray/namedarray/core.py
+++ b/xarray/namedarray/core.py
@@ -250,14 +250,14 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
 
     __slots__ = ("_data", "_dims", "_attrs")
 
-    _data: duckarray[_ShapeType_co, _DType_co]
+    _data: duckarray[Any, _DType_co]
     _dims: _Dims
     _attrs: dict[Any, Any] | None
 
     def __init__(
         self,
         dims: _DimsLike,
-        data: duckarray[_ShapeType_co, _DType_co],
+        data: duckarray[Any, _DType_co],
         attrs: _AttrsLike = None,
     ):
         self._data = data
@@ -292,7 +292,7 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
     def _new(
         self,
         dims: _DimsLike | Default = _default,
-        data: duckarray[_ShapeType, _DType] | Default = _default,
+        data: duckarray[Any, _DType] | Default = _default,
         attrs: _AttrsLike | Default = _default,
     ) -> NamedArray[_ShapeType, _DType] | NamedArray[_ShapeType_co, _DType_co]:
         """
@@ -447,7 +447,7 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
         return self._data.dtype
 
     @property
-    def shape(self) -> _ShapeType_co:
+    def shape(self) -> _Shape:
         """
         Get the shape of the array.
 
@@ -850,9 +850,9 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
         # TODO an entrypoint so array libraries can choose coercion method?
         return to_numpy(self._data)
 
-    def as_numpy(self) -> NamedArray[Any, Any]:
+    def as_numpy(self) -> Self:
         """Coerces wrapped data into a numpy array, returning a Variable."""
-        return self._new(data=self.to_numpy())
+        return self._replace(data=self.to_numpy())
 
     def reduce(
         self,

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -31,21 +31,20 @@ if TYPE_CHECKING:
         _IndexKeyLike,
         _IntOrUnknown,
         _ShapeLike,
-        _ShapeType,
         duckarray,
     )
 
 
 class CustomArrayBase(Generic[_ShapeType_co, _DType_co]):
-    def __init__(self, array: duckarray[_ShapeType_co, _DType_co]) -> None:
-        self.array: duckarray[_ShapeType_co, _DType_co] = array
+    def __init__(self, array: duckarray[Any, _DType_co]) -> None:
+        self.array: duckarray[Any, _DType_co] = array
 
     @property
     def dtype(self) -> _DType_co:
         return self.array.dtype
 
     @property
-    def shape(self) -> _ShapeType_co:
+    def shape(self) -> _Shape:
         return self.array.shape
 
 
@@ -78,11 +77,9 @@ class CustomArrayIndexable(
         return np
 
 
-def check_duck_array_typevar(
-    a: duckarray[_ShapeType, _DType]
-) -> duckarray[_ShapeType, _DType]:
+def check_duck_array_typevar(a: duckarray[Any, _DType]) -> duckarray[Any, _DType]:
     # Mypy checks a is valid:
-    b: duckarray[_ShapeType, _DType] = a
+    b: duckarray[Any, _DType] = a
 
     # Runtime check if valid:
     if isinstance(b, _arrayfunction_or_api):

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
         _DType,
         _IndexKeyLike,
         _IntOrUnknown,
+        _Shape,
         _ShapeLike,
         duckarray,
     )

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -32,20 +32,21 @@ if TYPE_CHECKING:
         _IntOrUnknown,
         _Shape,
         _ShapeLike,
+        _ShapeType,
         duckarray,
     )
 
 
 class CustomArrayBase(Generic[_ShapeType_co, _DType_co]):
-    def __init__(self, array: duckarray[Any, _DType_co]) -> None:
-        self.array: duckarray[Any, _DType_co] = array
+    def __init__(self, array: duckarray[_ShapeType_co, _DType_co]) -> None:
+        self.array: duckarray[_ShapeType_co, _DType_co] = array
 
     @property
     def dtype(self) -> _DType_co:
         return self.array.dtype
 
     @property
-    def shape(self) -> _Shape:
+    def shape(self) -> _ShapeType_co:
         return self.array.shape
 
 
@@ -78,9 +79,11 @@ class CustomArrayIndexable(
         return np
 
 
-def check_duck_array_typevar(a: duckarray[Any, _DType]) -> duckarray[Any, _DType]:
+def check_duck_array_typevar(
+    a: duckarray[_ShapeType, _DType]
+) -> duckarray[_ShapeType, _DType]:
     # Mypy checks a is valid:
-    b: duckarray[Any, _DType] = a
+    b: duckarray[_ShapeType, _DType] = a
 
     # Runtime check if valid:
     if isinstance(b, _arrayfunction_or_api):
@@ -180,7 +183,7 @@ class TestNamedArray(NamedArraySubclassobjects):
             # Fail:
             (
                 ("x",),
-                NamedArray("time", np.array([1, 2, 3])),
+                NamedArray("time", np.array([1, 2, 3], dtype=np.dtype(np.int64))),
                 np.array([1, 2, 3]),
                 True,
             ),

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -79,6 +79,8 @@ class CustomArrayIndexable(
 
 
 def check_duck_array_typevar(a: duckarray[Any, _DType]) -> duckarray[Any, _DType]:
+    reveal_type(a)
+
     # Mypy checks a is valid:
     b: duckarray[Any, _DType] = a
 

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
         _DType,
         _IndexKeyLike,
         _IntOrUnknown,
-        _Shape,
         _ShapeLike,
         _ShapeType,
         duckarray,

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -180,7 +180,7 @@ class TestNamedArray(NamedArraySubclassobjects):
             # Fail:
             (
                 ("x",),
-                NamedArray("time", np.array([1, 2, 3])),  # type: ignore
+                NamedArray("time", np.array([1, 2, 3])),
                 np.array([1, 2, 3]),
                 True,
             ),
@@ -341,7 +341,7 @@ class TestNamedArray(NamedArraySubclassobjects):
     def test_duck_array_class(self) -> None:
         numpy_a: NDArray[np.int64]
         numpy_a = np.array([2.1, 4], dtype=np.dtype(np.int64))
-        check_duck_array_typevar(numpy_a)  # type: ignore
+        check_duck_array_typevar(numpy_a)
 
         masked_a: np.ma.MaskedArray[Any, np.dtype[np.int64]]
         masked_a = np.ma.asarray([2.1, 4], dtype=np.dtype(np.int64))  # type: ignore[no-untyped-call]
@@ -560,4 +560,4 @@ class TestNamedArray(NamedArraySubclassobjects):
 
     def test_warn_on_repeated_dimension_names(self) -> None:
         with pytest.warns(UserWarning, match="Duplicate dimension names"):
-            NamedArray(("x", "x"), np.arange(4).reshape(2, 2))  # type: ignore
+            NamedArray(("x", "x"), np.arange(4).reshape(2, 2))

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -79,8 +79,6 @@ class CustomArrayIndexable(
 
 
 def check_duck_array_typevar(a: duckarray[Any, _DType]) -> duckarray[Any, _DType]:
-    reveal_type(a)
-
     # Mypy checks a is valid:
     b: duckarray[Any, _DType] = a
 


### PR DESCRIPTION
I believe numpy updated the signature of `__array__` in numpy2. 
It currently looks like this now: https://github.com/numpy/numpy/blob/de1ca2676e0f1db5a1b95e1d05e86ca87321cac2/numpy/__init__.pyi#L1471-L1478

xref #9231, #9252