### PR TITLE
Allow mypy to run in vscode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ exclude_lines = ["pragma: no cover", "if TYPE_CHECKING"]
 [tool.mypy]
 enable_error_code = "redundant-self"
 exclude = [
+  'build',
   'xarray/util/generate_.*\.py',
   'xarray/datatree_/doc/.*\.py',
 ]


### PR DESCRIPTION
Seems to require adding an exclude for `build` and an `__init__.py` file in the `properties` directory...
