### PR TITLE
Restore ability to specify _FillValue as Python native integers

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -166,7 +166,7 @@ def create_encoded_masked_and_scaled_data(dtype: np.dtype) -> Dataset:
 
 def create_unsigned_masked_scaled_data(dtype: np.dtype) -> Dataset:
     encoding = {
-        "_FillValue": np.int8(-1),
+        "_FillValue": 255,
         "_Unsigned": "true",
         "dtype": "i1",
         "add_offset": dtype.type(10),
@@ -925,7 +925,7 @@ class CFEncodedBase(DatasetIOBase):
                 assert decoded.variables[k].dtype == actual.variables[k].dtype
             assert_allclose(decoded, actual, decode_bytes=False)
 
-    @pytest.mark.parametrize("fillvalue", [np.int8(-1), np.uint8(255)])
+    @pytest.mark.parametrize("fillvalue", [np.int8(-1), np.uint8(255), -1, 255])
     def test_roundtrip_unsigned(self, fillvalue):
         # regression/numpy2 test for
         encoding = {


### PR DESCRIPTION
See #9136 for the longer discussion of this. In #9136 numpy 2 compatibility was fixed by working around integer overflow errors when a `_FillValue` was specified in an unsigned dtype (ex. `np.uint8(255)`) but needed to be cast to the signed dtype to be stored to a NetCDF file. This is all related to the use of the special `_Unsigned` attribute. However, the referenced PR broke the ability to specify `_FillValue` with native python integers (ex. `-1`).

This PR restores this behavior by handling both primary use cases:

1. `_FillValue` corresponds to the unsigned in-memory data
2. `_FillValue` corresponds to the signed on-disk data

I'm sure there are at least 10 ways of interpreting what the best solution should be. This one I think causes the least amount of disruption and restores previous behavior as far as I can tell.

CC @dcherian @kmuehlbauer 

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
