### PR TITLE
Add `encode_cf_datetime` benchmark

### DIFF
--- a/asv_bench/benchmarks/coding.py
+++ b/asv_bench/benchmarks/coding.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+import xarray as xr
+
+from . import parameterized
+
+
+@parameterized(["calendar"], [("standard", "noleap")])
+class EncodeCFDatetime:
+    def setup(self, calendar):
+        self.units = "days since 2000-01-01"
+        self.dtype = np.dtype("int64")
+        self.times = xr.date_range(
+            "2000", freq="D", periods=10000, calendar=calendar
+        ).values
+
+    def time_encode_cf_datetime(self, calendar):
+        xr.coding.times.encode_cf_datetime(self.times, self.units, calendar, self.dtype)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Per https://github.com/pydata/xarray/pull/8324#issuecomment-2228724126 this adds a benchmark for encoding times via `encoding_cf_datetime`.  I think we'll see a nice speedup for the cftime case from #8324.

cc: @headtr1ck @antscloud