### PR TITLE
Fix copybutton for multi line examples in double digit ipython cells

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -97,7 +97,7 @@ extlinks = {
 }
 
 # sphinx-copybutton configurations
-copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.{3,}: | {5,8}: "
 copybutton_prompt_is_regexp = True
 
 # nbsphinx configurations


### PR DESCRIPTION
This PR suggests an adapted regular expression to fix the copy button for multi line examples in ipython cells with higher cell numbers.

- [ ] Closes #9263
