### PR TITLE
automate extracting the contributors

### DIFF
--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -27,7 +27,7 @@ upstream        https://github.com/pydata/xarray (push)
     ```sh
     python ci/release_contributors.py
     ```
-    (needs `gitpython`)
+    (needs `gitpython` and `toolz` / `cytoolz`)
 
     and copy the output.
  3. Write a release summary: ~50 words describing the high level features. This

--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -23,14 +23,13 @@ upstream        https://github.com/pydata/xarray (push)
     ```sh
     git fetch upstream --tags
     ```
-    This will return a list of all the contributors since the last release:
+    Then run
     ```sh
-    git log "$(git tag --sort=v:refname | tail -1).." --format=%aN | sort -u | perl -pe 's/\n/$1, /'
+    python ci/release_contributors.py
     ```
-    This will return the total number of contributors:
-    ```sh
-    git log "$(git tag --sort=v:refname | tail -1).." --format=%aN | sort -u | wc -l
-    ```
+    (needs `gitpython`)
+
+    and copy the output.
  3. Write a release summary: ~50 words describing the high level features. This
     will be used in the release emails, tweets, GitHub release notes, etc.
  4. Look over whats-new.rst and the docs. Make sure "What's New" is complete

--- a/ci/release_contributors.py
+++ b/ci/release_contributors.py
@@ -1,0 +1,49 @@
+import re
+import textwrap
+
+import git
+from tlz.itertoolz import last, unique
+
+co_author_re = re.compile(r"Co-authored-by: (?P<name>[^<]+?) <(?P<email>.+)>")
+
+
+def main():
+    repo = git.Repo(".")
+
+    most_recent_release = last(repo.tags)
+
+    # extract information from commits
+    contributors = {}
+    for commit in repo.iter_commits(f"{most_recent_release.name}.."):
+        matches = co_author_re.findall(commit.message)
+        if matches:
+            contributors.update({email: name for name, email in matches})
+        contributors[commit.author.email] = commit.author.name
+
+    # deduplicate and ignore
+    # TODO: extract ignores from .github/release.yml
+    ignored = ["dependabot", "pre-commit-ci"]
+    unique_contributors = unique(
+        contributor
+        for contributor in contributors.values()
+        if contributor.removesuffix("[bot]") not in ignored
+    )
+
+    sorted_ = sorted(unique_contributors)
+    if len(sorted_) > 1:
+        names = f"{', '.join(sorted_[:-1])} and {sorted_[-1]}"
+    else:
+        names = "".join(sorted_)
+
+    statement = textwrap.dedent(
+        f"""\
+    Thanks to the {len(sorted_)} contributors to this release:
+    {names}
+    """.rstrip()
+    )
+
+    print(statement)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Since I've been doing a few releases recently, I noticed that the code snippets in the release guide to produce the list of contributors is inaccurate (we credit bots by default), there's a trailing comma, and, most importantly, we don't include co-authors.

In an attempt to fix this, here's a script that searches the commit messages for any `Co-authored-by:` lines and adds them to the set of contributors. As an example, for #9287 the old snippets would exclude @kmuehlbauer.