### PR TITLE
Fix `DataTree.from_dict` to be insensitive to insertion order

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,6 +35,8 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Fix bug causing `DataTree.from_dict` to be sensitive to insertion order (:issue:`9276`, :pull:`9292`).
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1102,10 +1102,14 @@ class DataTree(
         else:
             obj = cls(name=name, data=root_data, parent=None, children=None)
 
+        def depth(item) -> int:
+            pathstr, _ = item
+            return len(NodePath(pathstr).parts)
+
         if d:
             # Populate tree with children determined from data_objects mapping
-            # Sort keys so as to insert nodes from root first (see GH issue #9276)
-            for path, data in sorted(d.items()):
+            # Sort keys by depth so as to insert nodes from root first (see GH issue #9276)
+            for path, data in sorted(d.items(), key=depth):
                 # Create and set new node
                 node_name = NodePath(path).name
                 if isinstance(data, DataTree):

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1104,7 +1104,8 @@ class DataTree(
 
         if d:
             # Populate tree with children determined from data_objects mapping
-            for path, data in d.items():
+            # Sort keys so as to insert nodes from root first (see GH issue #9276)
+            for path, data in sorted(d.items()):
                 # Create and set new node
                 node_name = NodePath(path).name
                 if isinstance(data, DataTree):

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -565,6 +565,7 @@ class TestTreeFromDict:
         # regression test for GH issue #9276
         reversed = DataTree.from_dict(
             {
+                "/Homer/Lisa": xr.Dataset({"age": 8}),
                 "/Homer/Bart": xr.Dataset({"age": 10}),
                 "/Homer": xr.Dataset({"age": 39}),
                 "/": xr.Dataset({"age": 83}),
@@ -574,10 +575,15 @@ class TestTreeFromDict:
             {
                 "/": xr.Dataset({"age": 83}),
                 "/Homer": xr.Dataset({"age": 39}),
+                "/Homer/Lisa": xr.Dataset({"age": 8}),
                 "/Homer/Bart": xr.Dataset({"age": 10}),
             }
         )
         assert reversed.equals(expected)
+
+        # Check that Bart and Lisa's order is still preserved within the group,
+        # despite 'Bart' coming before 'Lisa' when sorted alphabetically
+        assert list(reversed["Homer"].children.keys()) == ["Lisa", "Bart"]
 
 
 class TestDatasetView:

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -561,6 +561,24 @@ class TestTreeFromDict:
         roundtrip = DataTree.from_dict(dt.to_dict())
         assert roundtrip.equals(dt)
 
+    def test_insertion_order(self):
+        # regression test for GH issue #9276
+        reversed = DataTree.from_dict(
+            {
+                "/Homer/Bart": xr.Dataset({"age": 10}),
+                "/Homer": xr.Dataset({"age": 39}),
+                "/": xr.Dataset({"age": 83}),
+            }
+        )
+        expected = DataTree.from_dict(
+            {
+                "/": xr.Dataset({"age": 83}),
+                "/Homer": xr.Dataset({"age": 39}),
+                "/Homer/Bart": xr.Dataset({"age": 10}),
+            }
+        )
+        assert reversed.equals(expected)
+
 
 class TestDatasetView:
     def test_view_contents(self):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #9276
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] ~New functions/methods are listed in `api.rst`~
