### PR TITLE
Shallow copy parent and children in DataTree constructor

### DIFF
--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -500,12 +500,6 @@ class DataTree(
         """Parent of this node."""
         return self._parent
 
-    @parent.setter
-    def parent(self: DataTree, new_parent: DataTree) -> None:
-        if new_parent and self.name is None:
-            raise ValueError("Cannot set an unnamed node as a child of another node")
-        self._set_parent(new_parent, self.name)
-
     def _to_dataset_view(self, rebuild_dims: bool) -> DatasetView:
         variables = dict(self._data_variables)
         variables |= self._coord_variables
@@ -894,7 +888,7 @@ class DataTree(
             # create and assign a shallow copy here so as not to alter original name of node in grafted tree
             new_node = val.copy(deep=False)
             new_node.name = key
-            new_node.parent = self
+            new_node._set_parent(new_parent=self, child_name=key)
         else:
             if not isinstance(val, DataArray | Variable):
                 # accommodate other types that can be coerced into Variables

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -495,11 +495,6 @@ class DataTree(
     def _indexes(self) -> ChainMap[Hashable, Index]:
         return ChainMap(self._node_indexes, *(p._node_indexes for p in self.parents))
 
-    @property
-    def parent(self: DataTree) -> DataTree | None:
-        """Parent of this node."""
-        return self._parent
-
     def _to_dataset_view(self, rebuild_dims: bool) -> DatasetView:
         variables = dict(self._data_variables)
         variables |= self._coord_variables

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -463,8 +463,10 @@ class DataTree(
 
         super().__init__(name=name)
         self._set_node_data(_coerce_to_dataset(data))
-        self.parent = parent
-        self.children = children
+
+        # shallow copy to avoid modifying arguments in-place (see GH issue #9196)
+        self.parent = parent.copy() if parent is not None else None
+        self.children = {name: child.copy() for name, child in children.items()}
 
     def _set_node_data(self, ds: Dataset):
         data_vars, coord_vars = _collect_data_and_coord_variables(ds)
@@ -770,7 +772,7 @@ class DataTree(
         if data is not _default:
             self._set_node_data(ds)
 
-        self._children = children
+        self.children = children
 
     def copy(
         self: DataTree,

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -424,7 +424,6 @@ class DataTree(
     def __init__(
         self,
         data: Dataset | DataArray | None = None,
-        parent: DataTree | None = None,
         children: Mapping[str, DataTree] | None = None,
         name: str | None = None,
     ):
@@ -440,8 +439,6 @@ class DataTree(
         data : Dataset, DataArray, or None, optional
             Data to store under the .ds attribute of this node. DataArrays will
             be promoted to Datasets. Default is None.
-        parent : DataTree, optional
-            Parent node to this node. Default is None.
         children : Mapping[str, DataTree], optional
             Any child nodes of this node. Default is None.
         name : str, optional
@@ -462,7 +459,6 @@ class DataTree(
         self._set_node_data(_coerce_to_dataset(data))
 
         # shallow copy to avoid modifying arguments in-place (see GH issue #9196)
-        self.parent = parent.copy() if parent is not None else None
         self.children = {name: child.copy() for name, child in children.items()}
 
     def _set_node_data(self, ds: Dataset):
@@ -1100,7 +1096,7 @@ class DataTree(
             obj = root_data.copy()
             obj.orphan()
         else:
-            obj = cls(name=name, data=root_data, parent=None, children=None)
+            obj = cls(name=name, data=root_data, children=None)
 
         def depth(item) -> int:
             pathstr, _ = item

--- a/xarray/core/datatree_render.py
+++ b/xarray/core/datatree_render.py
@@ -51,11 +51,13 @@ class ContStyle(AbstractStyle):
 
         >>> from xarray.core.datatree import DataTree
         >>> from xarray.core.datatree_render import RenderDataTree
-        >>> root = DataTree(name="root")
-        >>> s0 = DataTree(name="sub0", parent=root)
-        >>> s0b = DataTree(name="sub0B", parent=s0)
-        >>> s0a = DataTree(name="sub0A", parent=s0)
-        >>> s1 = DataTree(name="sub1", parent=root)
+        >>> root = DataTree.from_dict({
+        ...     "/": None,
+        ...     "/sub0": None,
+        ...     "/sub0/sub0B": None,
+        ...     "/sub0/sub0A": None,
+        ...     "/sub1" : None,
+        ... }, name="root")
         >>> print(RenderDataTree(root))
         <xarray.DataTree 'root'>
         Group: /
@@ -98,11 +100,13 @@ class RenderDataTree:
         >>> from xarray import Dataset
         >>> from xarray.core.datatree import DataTree
         >>> from xarray.core.datatree_render import RenderDataTree
-        >>> root = DataTree(name="root", data=Dataset({"a": 0, "b": 1}))
-        >>> s0 = DataTree(name="sub0", parent=root, data=Dataset({"c": 2, "d": 3}))
-        >>> s0b = DataTree(name="sub0B", parent=s0, data=Dataset({"e": 4}))
-        >>> s0a = DataTree(name="sub0A", parent=s0, data=Dataset({"f": 5, "g": 6}))
-        >>> s1 = DataTree(name="sub1", parent=root, data=Dataset({"h": 7}))
+        >>> root = DataTree.from_dict({
+        ...     "/": Dataset({"a": 0, "b": 1}),
+        ...     "/sub0": Dataset({"c": 2, "d": 3}),
+        ...     "/sub0/sub0B": Dataset({"e": 4}),
+        ...     "/sub0/sub0A": Dataset({"f": 5, "g": 6}),
+        ...     "/sub1": Dataset({"h": 7})
+        ... },name="root")
 
         # Simple one line:
 
@@ -208,17 +212,13 @@ class RenderDataTree:
         >>> from xarray import Dataset
         >>> from xarray.core.datatree import DataTree
         >>> from xarray.core.datatree_render import RenderDataTree
-        >>> root = DataTree(name="root")
-        >>> s0 = DataTree(name="sub0", parent=root)
-        >>> s0b = DataTree(
-        ...     name="sub0B", parent=s0, data=Dataset({"foo": 4, "bar": 109})
-        ... )
-        >>> s0a = DataTree(name="sub0A", parent=s0)
-        >>> s1 = DataTree(name="sub1", parent=root)
-        >>> s1a = DataTree(name="sub1A", parent=s1)
-        >>> s1b = DataTree(name="sub1B", parent=s1, data=Dataset({"bar": 8}))
-        >>> s1c = DataTree(name="sub1C", parent=s1)
-        >>> s1ca = DataTree(name="sub1Ca", parent=s1c)
+        >>> root = DataTree.from_dict({
+        ...     "/sub0/sub0B": Dataset({"foo": 4, "bar": 109}),
+        ...     "/sub0/sub0A": None,
+        ...     "/sub1/sub1A" : None,
+        ...     "/sub1/sub1B": Dataset({"bar": 8}),
+        ...     "/sub1/sub1C/sub1Ca": None
+        ... }, name="root")
         >>> print(RenderDataTree(root).by_attr("name"))
         root
         ├── sub0

--- a/xarray/core/datatree_render.py
+++ b/xarray/core/datatree_render.py
@@ -51,13 +51,16 @@ class ContStyle(AbstractStyle):
 
         >>> from xarray.core.datatree import DataTree
         >>> from xarray.core.datatree_render import RenderDataTree
-        >>> root = DataTree.from_dict({
-        ...     "/": None,
-        ...     "/sub0": None,
-        ...     "/sub0/sub0B": None,
-        ...     "/sub0/sub0A": None,
-        ...     "/sub1" : None,
-        ... }, name="root")
+        >>> root = DataTree.from_dict(
+        ...     {
+        ...         "/": None,
+        ...         "/sub0": None,
+        ...         "/sub0/sub0B": None,
+        ...         "/sub0/sub0A": None,
+        ...         "/sub1": None,
+        ...     },
+        ...     name="root",
+        ... )
         >>> print(RenderDataTree(root))
         <xarray.DataTree 'root'>
         Group: /
@@ -100,13 +103,16 @@ class RenderDataTree:
         >>> from xarray import Dataset
         >>> from xarray.core.datatree import DataTree
         >>> from xarray.core.datatree_render import RenderDataTree
-        >>> root = DataTree.from_dict({
-        ...     "/": Dataset({"a": 0, "b": 1}),
-        ...     "/sub0": Dataset({"c": 2, "d": 3}),
-        ...     "/sub0/sub0B": Dataset({"e": 4}),
-        ...     "/sub0/sub0A": Dataset({"f": 5, "g": 6}),
-        ...     "/sub1": Dataset({"h": 7})
-        ... },name="root")
+        >>> root = DataTree.from_dict(
+        ...     {
+        ...         "/": Dataset({"a": 0, "b": 1}),
+        ...         "/sub0": Dataset({"c": 2, "d": 3}),
+        ...         "/sub0/sub0B": Dataset({"e": 4}),
+        ...         "/sub0/sub0A": Dataset({"f": 5, "g": 6}),
+        ...         "/sub1": Dataset({"h": 7}),
+        ...     },
+        ...     name="root",
+        ... )
 
         # Simple one line:
 
@@ -212,13 +218,16 @@ class RenderDataTree:
         >>> from xarray import Dataset
         >>> from xarray.core.datatree import DataTree
         >>> from xarray.core.datatree_render import RenderDataTree
-        >>> root = DataTree.from_dict({
-        ...     "/sub0/sub0B": Dataset({"foo": 4, "bar": 109}),
-        ...     "/sub0/sub0A": None,
-        ...     "/sub1/sub1A" : None,
-        ...     "/sub1/sub1B": Dataset({"bar": 8}),
-        ...     "/sub1/sub1C/sub1Ca": None
-        ... }, name="root")
+        >>> root = DataTree.from_dict(
+        ...     {
+        ...         "/sub0/sub0B": Dataset({"foo": 4, "bar": 109}),
+        ...         "/sub0/sub0A": None,
+        ...         "/sub1/sub1A": None,
+        ...         "/sub1/sub1B": Dataset({"bar": 8}),
+        ...         "/sub1/sub1C/sub1Ca": None,
+        ...     },
+        ...     name="root",
+        ... )
         >>> print(RenderDataTree(root).by_attr("name"))
         root
         ├── sub0

--- a/xarray/core/iterators.py
+++ b/xarray/core/iterators.py
@@ -28,12 +28,9 @@ class LevelOrderIter(Iterator):
     --------
     >>> from xarray.core.datatree import DataTree
     >>> from xarray.core.iterators import LevelOrderIter
-    >>> f = DataTree.from_dict({
-    ...     "/b/a": None,
-    ...     "/b/d/c": None,
-    ...     "/b/d/e": None,
-    ...     "/g/h/i": None
-    ... },name="f")
+    >>> f = DataTree.from_dict(
+    ...     {"/b/a": None, "/b/d/c": None, "/b/d/e": None, "/g/h/i": None}, name="f"
+    ... )
     >>> print(f)
     <xarray.DataTree 'f'>
     Group: /

--- a/xarray/core/iterators.py
+++ b/xarray/core/iterators.py
@@ -32,7 +32,7 @@ class LevelOrderIter(Iterator):
     ...     "/b/a": None,
     ...     "/b/d/c": None,
     ...     "/b/d/e": None,
-    ...     "/g/i/h": None
+    ...     "/g/h/i": None
     ... },name="f")
     >>> print(f)
     <xarray.DataTree 'f'>
@@ -43,19 +43,19 @@ class LevelOrderIter(Iterator):
     │       ├── Group: /b/d/c
     │       └── Group: /b/d/e
     └── Group: /g
-        └── Group: /g/i
-            └── Group: /g/i/h
+        └── Group: /g/h
+            └── Group: /g/h/i
     >>> [node.name for node in LevelOrderIter(f)]
-    ['f', 'b', 'g', 'a', 'd', 'i', 'c', 'e', 'h']
+    ['f', 'b', 'g', 'a', 'd', 'h', 'c', 'e', 'i']
     >>> [node.name for node in LevelOrderIter(f, maxlevel=3)]
-    ['f', 'b', 'g', 'a', 'd', 'i']
+    ['f', 'b', 'g', 'a', 'd', 'h']
     >>> [
     ...     node.name
     ...     for node in LevelOrderIter(f, filter_=lambda n: n.name not in ("e", "g"))
     ... ]
-    ['f', 'b', 'a', 'd', 'i', 'c', 'h']
+    ['f', 'b', 'a', 'd', 'h', 'c', 'i']
     >>> [node.name for node in LevelOrderIter(f, stop=lambda n: n.name == "d")]
-    ['f', 'b', 'g', 'a', 'i', 'h']
+    ['f', 'b', 'g', 'a', 'h', 'i']
     """
 
     def __init__(

--- a/xarray/core/iterators.py
+++ b/xarray/core/iterators.py
@@ -28,15 +28,12 @@ class LevelOrderIter(Iterator):
     --------
     >>> from xarray.core.datatree import DataTree
     >>> from xarray.core.iterators import LevelOrderIter
-    >>> f = DataTree(name="f")
-    >>> b = DataTree(name="b", parent=f)
-    >>> a = DataTree(name="a", parent=b)
-    >>> d = DataTree(name="d", parent=b)
-    >>> c = DataTree(name="c", parent=d)
-    >>> e = DataTree(name="e", parent=d)
-    >>> g = DataTree(name="g", parent=f)
-    >>> i = DataTree(name="i", parent=g)
-    >>> h = DataTree(name="h", parent=i)
+    >>> f = DataTree.from_dict({
+    ...     "/b/a": None,
+    ...     "/b/d/c": None,
+    ...     "/b/d/e": None,
+    ...     "/g/i/h": None
+    ... },name="f")
     >>> print(f)
     <xarray.DataTree 'f'>
     Group: /

--- a/xarray/core/treenode.py
+++ b/xarray/core/treenode.py
@@ -86,6 +86,12 @@ class TreeNode(Generic[Tree]):
         """Parent of this node."""
         return self._parent
 
+    @parent.setter
+    def parent(self: Tree, new_parent: Tree) -> None:
+        raise AttributeError(
+            "Cannot set parent attribute directly, you must modify the children attribute of the other node instead"
+        )
+
     def _set_parent(
         self, new_parent: Tree | None, child_name: str | None = None
     ) -> None:

--- a/xarray/core/treenode.py
+++ b/xarray/core/treenode.py
@@ -89,7 +89,7 @@ class TreeNode(Generic[Tree]):
     @parent.setter
     def parent(self: Tree, new_parent: Tree) -> None:
         raise AttributeError(
-            "Cannot set parent attribute directly, you must modify the children attribute of the other node instead"
+            "Cannot set parent attribute directly, you must modify the children of the other node instead using dict-like syntax"
         )
 
     def _set_parent(

--- a/xarray/tests/conftest.py
+++ b/xarray/tests/conftest.py
@@ -176,14 +176,17 @@ def create_test_datatree():
         set2_data = modify(xr.Dataset({"a": ("x", [2, 3]), "b": ("x", [0.1, 0.2])}))
         root_data = modify(xr.Dataset({"a": ("y", [6, 7, 8]), "set0": ("x", [9, 10])}))
 
-        # Avoid using __init__ so we can independently test it
-        root: DataTree = DataTree(data=root_data)
-        set1: DataTree = DataTree(name="set1", parent=root, data=set1_data)
-        DataTree(name="set1", parent=set1)
-        DataTree(name="set2", parent=set1)
-        set2: DataTree = DataTree(name="set2", parent=root, data=set2_data)
-        DataTree(name="set1", parent=set2)
-        DataTree(name="set3", parent=root)
+        root = DataTree.from_dict(
+            {
+                "/": root_data,
+                "/set1": set1_data,
+                "/set1/set1": None,
+                "/set1/set2": None,
+                "/set2": set2_data,
+                "/set2/set1": None,
+                "/set3": None,
+            }
+        )
 
         return root
 

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -57,13 +57,11 @@ class TestFamilyTree:
     def test_create_two_children(self):
         root_data = xr.Dataset({"a": ("y", [6, 7, 8]), "set0": ("x", [9, 10])})
         set1_data = xr.Dataset({"a": 0, "b": 1})
-        # root = DataTree.from_dict(
-        #     {"/": root_data, "/set1": set1_data, "/set1/set2": None}
-        # )
-        root: DataTree = DataTree(data=root_data)
-        set1: DataTree = DataTree(name="set1", parent=root, data=set1_data)
-        DataTree(name="set1", parent=root)
-        DataTree(name="set2", parent=set1)
+        root = DataTree.from_dict(
+            {"/": root_data, "/set1": set1_data, "/set1/set2": None}
+        )
+        assert root["/set1"].name == "set1"
+        assert root["/set1/set2"].name == "set2"
 
     def test_create_full_tree(self, simple_datatree):
         d = simple_datatree.to_dict()

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -37,13 +37,13 @@ class TestTreeCreation:
 class TestFamilyTree:
     def test_dont_modify_parent_inplace(self):
         # GH issue 9196
-        root = DataTree()
+        root: DataTree = DataTree()
         DataTree(name="child", parent=root)
         assert root.children == {}
 
     def test_dont_modify_children_inplace(self):
         # GH issue 9196
-        child = DataTree()
+        child: DataTree = DataTree()
         DataTree(children={"child": child})
         assert child.parent is None
 
@@ -422,7 +422,7 @@ class TestSetItem:
 
     def test_setitem_new_grandchild_node(self):
         john = DataTree.from_dict({"/Mary/Rose": DataTree()})
-        new_rose = DataTree(data=xr.Dataset({"x": 0}))
+        new_rose: DataTree = DataTree(data=xr.Dataset({"x": 0}))
         john["Mary/Rose"] = new_rose
 
         grafted_rose = john["Mary/Rose"]

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -137,7 +137,7 @@ class TestStoreDatasets:
         assert_identical(john.to_dataset(), dat)
 
         with pytest.raises(TypeError):
-            DataTree(name="mary", parent=john, data="junk")  # type: ignore[arg-type]
+            DataTree(name="mary", data="junk")  # type: ignore[arg-type]
 
     def test_set_data(self):
         john: DataTree = DataTree(name="john")

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -37,8 +37,9 @@ class TestTreeCreation:
 class TestFamilyTree:
     def test_dont_modify_parent_inplace(self):
         # GH issue 9196
-        root: DataTree = DataTree()
-        DataTree(name="child", parent=root)
+        root: DataTree = DataTree(name="root")
+        child: DataTree = DataTree(name="child")
+        child.parent = root
         assert root.children == {}
 
     def test_dont_modify_children_inplace(self):

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -82,7 +82,7 @@ class TestNames:
     def test_child_gets_named_on_attach(self):
         sue: DataTree = DataTree()
         mary: DataTree = DataTree(children={"Sue": sue})  # noqa
-        assert sue.name == "Sue"
+        assert mary.children["Sue"].name == "Sue"
 
 
 class TestPaths:
@@ -90,14 +90,14 @@ class TestPaths:
         sue: DataTree = DataTree()
         mary: DataTree = DataTree(children={"Sue": sue})
         john: DataTree = DataTree(children={"Mary": mary})
-        assert sue.path == "/Mary/Sue"
+        assert john.children["Mary"].children["Sue"].path == "/Mary/Sue"
         assert john.path == "/"
 
     def test_path_roundtrip(self):
         sue: DataTree = DataTree()
         mary: DataTree = DataTree(children={"Sue": sue})
         john: DataTree = DataTree(children={"Mary": mary})
-        assert john[sue.path] is sue
+        assert john["/Mary/Sue"].name == "Sue"
 
     def test_same_tree(self):
         mary: DataTree = DataTree()

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -35,6 +35,18 @@ class TestTreeCreation:
 
 
 class TestFamilyTree:
+    def test_dont_modify_parent_inplace(self):
+        # GH issue 9196
+        root = DataTree()
+        DataTree(name="child", parent=root)
+        assert root.children == {}
+
+    def test_dont_modify_children_inplace(self):
+        # GH issue 9196
+        child = DataTree()
+        DataTree(children={"child": child})
+        assert child.parent is None
+
     def test_setparent_unnamed_child_node_fails(self):
         john: DataTree = DataTree(name="john")
         with pytest.raises(ValueError, match="unnamed"):

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -125,7 +125,7 @@ class TestPaths:
 
         annie_result = john["Annie"]
         if isinstance(annie_result, DataTree):
-            annie : DataTree = annie_result
+            annie: DataTree = annie_result
 
         assert sue.relative_to(john) == "Mary/Sue"
         assert john.relative_to(sue) == "../.."

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -50,7 +50,8 @@ class TestFamilyTree:
     def test_setparent_unnamed_child_node_fails(self):
         john: DataTree = DataTree(name="john")
         with pytest.raises(ValueError, match="unnamed"):
-            DataTree(parent=john)
+            child = DataTree(name=None)
+            child.parent = john
 
     def test_create_two_children(self):
         root_data = xr.Dataset({"a": ("y", [6, 7, 8]), "set0": ("x", [9, 10])})

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -113,14 +113,19 @@ class TestPaths:
         assert john["/Mary"].same_tree(john["/Kate"])
 
     def test_relative_paths(self):
-        john = DataTree.from_dict(
+        john: DataTree = DataTree.from_dict(
             {
                 "/Mary/Sue": DataTree(),
                 "/Annie": DataTree(),
             }
         )
-        sue = john["Mary/Sue"]
-        annie = john["Annie"]
+        sue_result = john["Mary/Sue"]
+        if isinstance(sue_result, DataTree):
+            sue: DataTree = sue_result
+
+        annie_result = john["Annie"]
+        if isinstance(annie_result, DataTree):
+            annie : DataTree = annie_result
 
         assert sue.relative_to(john) == "Mary/Sue"
         assert john.relative_to(sue) == "../.."

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -62,20 +62,20 @@ class TestFamilyTree:
         DataTree(name="set2", parent=set1)
 
     def test_create_full_tree(self, simple_datatree):
-        root_data = xr.Dataset({"a": ("y", [6, 7, 8]), "set0": ("x", [9, 10])})
-        set1_data = xr.Dataset({"a": 0, "b": 1})
-        set2_data = xr.Dataset({"a": ("x", [2, 3]), "b": ("x", [0.1, 0.2])})
+        d = simple_datatree.to_dict()
+        d_keys = list(d.keys())
 
-        root: DataTree = DataTree(data=root_data)
-        set1: DataTree = DataTree(name="set1", parent=root, data=set1_data)
-        DataTree(name="set1", parent=set1)
-        DataTree(name="set2", parent=set1)
-        set2: DataTree = DataTree(name="set2", parent=root, data=set2_data)
-        DataTree(name="set1", parent=set2)
-        DataTree(name="set3", parent=root)
+        expected_keys = [
+            "/",
+            "/set1",
+            "/set2",
+            "/set3",
+            "/set1/set1",
+            "/set1/set2",
+            "/set2/set1",
+        ]
 
-        expected = simple_datatree
-        assert root.identical(expected)
+        assert d_keys == expected_keys
 
 
 class TestNames:

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -35,24 +35,11 @@ class TestTreeCreation:
 
 
 class TestFamilyTree:
-    def test_dont_modify_parent_inplace(self):
-        # GH issue 9196
-        root: DataTree = DataTree(name="root")
-        child: DataTree = DataTree(name="child")
-        child.parent = root
-        assert root.children == {}
-
     def test_dont_modify_children_inplace(self):
         # GH issue 9196
         child: DataTree = DataTree()
         DataTree(children={"child": child})
         assert child.parent is None
-
-    def test_setparent_unnamed_child_node_fails(self):
-        john: DataTree = DataTree(name="john")
-        with pytest.raises(ValueError, match="unnamed"):
-            child = DataTree(name=None)
-            child.parent = john
 
     def test_create_two_children(self):
         root_data = xr.Dataset({"a": ("y", [6, 7, 8]), "set0": ("x", [9, 10])})

--- a/xarray/tests/test_datatree_mapping.py
+++ b/xarray/tests/test_datatree_mapping.py
@@ -74,10 +74,9 @@ class TestCheckTreesIsomorphic:
         dt1 = create_test_datatree()
         dt2 = create_test_datatree()
         real_root: DataTree = DataTree(name="real root")
-        dt2.name = "not_real_root"
-        dt2.parent = real_root
+        real_root["not_real_root"] = dt2
         with pytest.raises(TreeIsomorphismError):
-            check_isomorphic(dt1, dt2, check_from_root=True)
+            check_isomorphic(dt1, real_root, check_from_root=True)
 
 
 class TestMapOverSubTree:

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -657,8 +657,11 @@ class TestFormatting:
 
     def test_datatree_printout_nested_node(self):
         dat = xr.Dataset({"a": [0, 2]})
-        root: DataTree = DataTree(name="root")
-        DataTree(name="results", data=dat, parent=root)
+        root = DataTree.from_dict(
+            {
+                "/results": dat,
+            }
+        )
         printout = str(root)
         assert printout.splitlines()[3].startswith("    ")
 

--- a/xarray/tests/test_treenode.py
+++ b/xarray/tests/test_treenode.py
@@ -55,6 +55,15 @@ class TestFamilyTree:
         assert steve.children["Mary"] is mary
         assert "Mary" not in john.children
 
+    def test_forbid_setting_parent_directly(self):
+        john: TreeNode = TreeNode()
+        mary: TreeNode = TreeNode()
+
+        with pytest.raises(
+            AttributeError, match="Cannot set parent attribute directly"
+        ):
+            mary.parent = john
+
     def test_multi_child_family(self):
         mary: TreeNode = TreeNode()
         kate: TreeNode = TreeNode()


### PR DESCRIPTION
This seems to fix the examples in #9196, but causes other tests to fail, which I think just reveals that we have existing tests that assume this in-place modification is desired. I will change those tests to match the new intended behaviour.

- [x] Implements suggestion (1) from https://github.com/pydata/xarray/issues/9196#issue-2382534068
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
