### PR TITLE
DOC: Add note to docs on DataTree root-group naming conventions

### DIFF
--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1546,7 +1546,7 @@ class DataTree(
             ``dask.delayed.Delayed`` object that can be computed later.
             Currently, ``compute=False`` is not supported.
         kwargs :
-            Additonal keyword arguments to be passed to ``xarray.Dataset.to_netcdf``
+            Additional keyword arguments to be passed to ``xarray.Dataset.to_netcdf``
 
         .. note::
             Due to file format specifications the on-disk root group name

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1548,9 +1548,10 @@ class DataTree(
         kwargs :
             Additional keyword arguments to be passed to ``xarray.Dataset.to_netcdf``
 
-        .. note::
+        Note
+        ----
             Due to file format specifications the on-disk root group name
-            is always `/` overriding any given ``DataTree`` root node name.
+            is always ``"/"`` overriding any given ``DataTree`` root node name.
         """
         from xarray.core.datatree_io import _datatree_to_netcdf
 

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1546,7 +1546,11 @@ class DataTree(
             ``dask.delayed.Delayed`` object that can be computed later.
             Currently, ``compute=False`` is not supported.
         kwargs :
-            Addional keyword arguments to be passed to ``xarray.Dataset.to_netcdf``
+            Additonal keyword arguments to be passed to ``xarray.Dataset.to_netcdf``
+
+        .. note::
+            Due to file format specifications the on-disk root group name
+            is always `/` overriding any given ``DataTree`` root node name.
         """
         from xarray.core.datatree_io import _datatree_to_netcdf
 
@@ -1602,6 +1606,10 @@ class DataTree(
             supported.
         kwargs :
             Additional keyword arguments to be passed to ``xarray.Dataset.to_zarr``
+
+        .. note::
+            Due to file format specifications the on-disk root group name
+            is always `/` overriding any given ``DataTree`` root node name.
         """
         from xarray.core.datatree_io import _datatree_to_zarr
 

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1608,9 +1608,10 @@ class DataTree(
         kwargs :
             Additional keyword arguments to be passed to ``xarray.Dataset.to_zarr``
 
-        .. note::
+        Note
+        ----
             Due to file format specifications the on-disk root group name
-            is always `/` overriding any given ``DataTree`` root node name.
+            is always ``"/"`` overriding any given ``DataTree`` root node name.
         """
         from xarray.core.datatree_io import _datatree_to_zarr
 

--- a/xarray/datatree_/docs/source/io.rst
+++ b/xarray/datatree_/docs/source/io.rst
@@ -24,6 +24,12 @@ To open a whole netCDF file as a tree of groups use the :py:func:`open_datatree`
 To save a DataTree object as a netCDF file containing many groups, use the :py:meth:`DataTree.to_netcdf` method.
 
 
+.. _netcdf.root_group.note:
+
+.. note::
+    Due to file format specifications the on-disk root group name is always `/`,
+    overriding any given ``DataTree`` root node name.
+
 .. _netcdf.group.warning:
 
 .. warning::
@@ -52,3 +58,8 @@ To save a DataTree object as a zarr store containing many groups, use the :py:me
 .. note::
     Note that perfect round-tripping should always be possible with a zarr store (:ref:`unlike for netCDF files <netcdf.group.warning>`),
     as zarr does not support "unused" dimensions.
+
+    For the root group the same restrictions (:ref:`as for netCDF files <netcdf.root_group.note>`) apply.
+    Due to file format specifications the on-disk root group name is always `/`
+    overriding any given ``DataTree`` root node name.
+

--- a/xarray/datatree_/docs/source/io.rst
+++ b/xarray/datatree_/docs/source/io.rst
@@ -60,6 +60,6 @@ To save a DataTree object as a zarr store containing many groups, use the :py:me
     as zarr does not support "unused" dimensions.
 
     For the root group the same restrictions (:ref:`as for netCDF files <netcdf.root_group.note>`) apply.
-    Due to file format specifications the on-disk root group name is always `/`
+    Due to file format specifications the on-disk root group name is always ``"/"``
     overriding any given ``DataTree`` root node name.
 

--- a/xarray/datatree_/docs/source/io.rst
+++ b/xarray/datatree_/docs/source/io.rst
@@ -27,7 +27,7 @@ To save a DataTree object as a netCDF file containing many groups, use the :py:m
 .. _netcdf.root_group.note:
 
 .. note::
-    Due to file format specifications the on-disk root group name is always `/`,
+    Due to file format specifications the on-disk root group name is always ``"/"``,
     overriding any given ``DataTree`` root node name.
 
 .. _netcdf.group.warning:


### PR DESCRIPTION
root group name is always "/"

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #9293
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
