### PR TITLE
Verbose error handling for non-valid duckarrays

### DIFF
--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -87,11 +87,15 @@ def check_duck_array_typevar(a: duckarray[Any, _DType]) -> duckarray[Any, _DType
     if isinstance(b, _arrayfunction_or_api):
         return b
     else:
-
         missing_attrs = ""
         actual_attrs = set(dir(b))
         for t in _arrayfunction_or_api:
-            if sys.version_info >= (3, 11):
+            if sys.version_info >= (3, 13):
+                # https://github.com/python/cpython/issues/104873
+                from typing import get_protocol_members
+
+                expected_attrs = get_protocol_members(t)
+            elif sys.version_info >= (3, 12):
                 expected_attrs = t.__protocol_attrs__
             else:
                 from typing import _get_protocol_attrs

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import sys
 from abc import abstractmethod
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Generic, cast, overload
@@ -90,7 +91,13 @@ def check_duck_array_typevar(a: duckarray[Any, _DType]) -> duckarray[Any, _DType
         missing_attrs = ""
         actual_attrs = set(dir(b))
         for t in _arrayfunction_or_api:
-            expected_attrs = t.__protocol_attrs__
+            if sys.version_info >= (3, 11):
+                expected_attrs = t.__protocol_attrs__
+            else:
+                from typing import _get_protocol_attrs
+
+                expected_attrs = _get_protocol_attrs(t)
+
             missing_attrs_ = expected_attrs - actual_attrs
             if missing_attrs_:
                 missing_attrs += f"{t.__name__} - {missing_attrs_}\n"

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -383,12 +383,6 @@ class TestNamedArray(NamedArraySubclassobjects):
         arrayapi_a = nxp.asarray([2.1, 4], dtype=nxp.int64)
         check_duck_array_typevar(arrayapi_a)
 
-    def test_duck_array_class_pd_index(self) -> None:
-        import pandas as pd
-
-        a: duckarray[Any, Any] = pd.Index([])
-        check_duck_array_typevar(a)
-
     def test_new_namedarray(self) -> None:
         dtype_float = np.dtype(np.float32)
         narr_float: NamedArray[Any, np.dtype[np.float32]]

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -372,6 +372,12 @@ class TestNamedArray(NamedArraySubclassobjects):
         arrayapi_a = nxp.asarray([2.1, 4], dtype=nxp.int64)
         check_duck_array_typevar(arrayapi_a)
 
+    def test_pd_index_duckarray(self) -> None:
+        import pandas as pd
+
+        a: duckarray[Any, Any] = pd.Index([])
+        check_duck_array_typevar(a)
+
     def test_new_namedarray(self) -> None:
         dtype_float = np.dtype(np.float32)
         narr_float: NamedArray[Any, np.dtype[np.float32]]

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -383,7 +383,7 @@ class TestNamedArray(NamedArraySubclassobjects):
         arrayapi_a = nxp.asarray([2.1, 4], dtype=nxp.int64)
         check_duck_array_typevar(arrayapi_a)
 
-    def test_pd_index_duckarray(self) -> None:
+    def test_duck_array_class_pd_index(self) -> None:
         import pandas as pd
 
         a: duckarray[Any, Any] = pd.Index([])

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -98,7 +98,7 @@ def check_duck_array_typevar(a: duckarray[Any, _DType]) -> duckarray[Any, _DType
             elif sys.version_info >= (3, 12):
                 expected_attrs = t.__protocol_attrs__
             else:
-                from typing import _get_protocol_attrs
+                from typing import _get_protocol_attrs  # type: ignore[attr-defined]
 
                 expected_attrs = _get_protocol_attrs(t)
 

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -86,7 +86,19 @@ def check_duck_array_typevar(a: duckarray[Any, _DType]) -> duckarray[Any, _DType
     if isinstance(b, _arrayfunction_or_api):
         return b
     else:
-        raise TypeError(f"a ({type(a)}) is not a valid _arrayfunction or _arrayapi")
+
+        missing_attrs = ""
+        actual_attrs = set(dir(b))
+        for t in _arrayfunction_or_api:
+            expected_attrs = t.__protocol_attrs__
+            missing_attrs_ = expected_attrs - actual_attrs
+            if missing_attrs_:
+                missing_attrs += f"{t.__name__} - {missing_attrs_}\n"
+        raise TypeError(
+            f"a ({type(a)}) is not a valid _arrayfunction or _arrayapi. "
+            "Missing following attrs:\n"
+            f"{missing_attrs}"
+        )
 
 
 class NamedArraySubclassobjects:


### PR DESCRIPTION
It is rather annoying trying to figure out why some arrays aren't valid duckarrays. This PR logs the missing attributes instead of just saying it isn't valid.

Example:
```python
    def test_duck_array_class_pd_index(self) -> None:
        import pandas as pd

        a: duckarray[Any, Any] = pd.Index([])
        check_duck_array_typevar(a)
```

```
FAILED xarray/tests/test_namedarray.py::TestNamedArray::test_pd_index_duckarray - TypeError: a (<class 'pandas.core.indexes.base.Index'>) is not a valid _arrayfunction or _arrayapi. Missing following attrs:
_arrayfunction - {'imag', '__array_function__', 'real'}
_arrayapi - {'__array_namespace__'}
```

Further reading: https://github.com/python/cpython/issues/104873