### PR TITLE
Add missing spacing in documentation

### DIFF
--- a/doc/user-guide/terminology.rst
+++ b/doc/user-guide/terminology.rst
@@ -223,9 +223,9 @@ complete examples, please consult the relevant documentation.*
     lazy
         Lazily-evaluated operations do not load data into memory until necessary. Instead of doing calculations
         right away, xarray lets you plan what calculations you want to do, like finding the
-        average temperature in a dataset.This planning is called "lazy evaluation." Later, when
+        average temperature in a dataset. This planning is called "lazy evaluation." Later, when
         you're ready to see the final result, you tell xarray, "Okay, go ahead and do those calculations now!"
-        That's when xarray starts working through the steps you planned and gives you the answer you wanted.This
+        That's when xarray starts working through the steps you planned and gives you the answer you wanted. This
         lazy approach helps save time and memory because xarray only does the work when you actually need the
         results.
 


### PR DESCRIPTION
Reading through the documentation and noticed some missing spaces.