### PR TITLE
Use duck array ops for `around` and `round`

### DIFF
--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -662,8 +662,8 @@ class NonStringCoder(VariableCoder):
                             SerializationWarning,
                             stacklevel=10,
                         )
-                    data = np.around(data)
-                data = data.astype(dtype=dtype)
+                    data = duck_array_ops.around(data)
+                data = duck_array_ops.astype(data, dtype=dtype)
             return Variable(dims, data, attrs, encoding, fastpath=True)
         else:
             return variable

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -662,7 +662,7 @@ class NonStringCoder(VariableCoder):
                             SerializationWarning,
                             stacklevel=10,
                         )
-                    data = duck_array_ops.around(data)
+                    data = duck_array_ops.round(data)
                 data = duck_array_ops.astype(data, dtype=dtype)
             return Variable(dims, data, attrs, encoding, fastpath=True)
         else:

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -12,6 +12,7 @@ import inspect
 import warnings
 from functools import partial
 from importlib import import_module
+from typing import Callable
 
 import numpy as np
 import pandas as pd
@@ -127,7 +128,7 @@ def round(array):
     return xp.round(array)
 
 
-around = round
+around: Callable = round
 
 
 def isnull(data):

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -18,7 +18,6 @@ import pandas as pd
 from numpy import all as array_all  # noqa
 from numpy import any as array_any  # noqa
 from numpy import (  # noqa
-    around,  # noqa
     full_like,
     gradient,
     isclose,
@@ -122,37 +121,11 @@ def fail_on_dask_array_input(values, msg=None, func_name=None):
 # Requires special-casing because pandas won't automatically dispatch to dask.isnull via NEP-18
 pandas_isnull = _dask_or_eager_func("isnull", eager_module=pd, dask_module="dask.array")
 
-# np.around has failing doctests, overwrite it so they pass:
-# https://github.com/numpy/numpy/issues/19759
-around.__doc__ = str.replace(
-    around.__doc__ or "",
-    "array([0.,  2.])",
-    "array([0., 2.])",
-)
-around.__doc__ = str.replace(
-    around.__doc__ or "",
-    "array([0.,  2.])",
-    "array([0., 2.])",
-)
-around.__doc__ = str.replace(
-    around.__doc__ or "",
-    "array([0.4,  1.6])",
-    "array([0.4, 1.6])",
-)
-around.__doc__ = str.replace(
-    around.__doc__ or "",
-    "array([0.,  2.,  2.,  4.,  4.])",
-    "array([0., 2., 2., 4., 4.])",
-)
-around.__doc__ = str.replace(
-    around.__doc__ or "",
-    (
-        '    .. [2] "How Futile are Mindless Assessments of\n'
-        '           Roundoff in Floating-Point Computation?", William Kahan,\n'
-        "           https://people.eecs.berkeley.edu/~wkahan/Mindless.pdf\n"
-    ),
-    "",
-)
+def round(array):
+    xp = get_array_namespace(array)
+    return xp.round(array)
+
+around = round
 
 
 def isnull(data):

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -17,6 +17,7 @@ import numpy as np
 import pandas as pd
 from numpy import all as array_all  # noqa
 from numpy import any as array_any  # noqa
+from numpy import concatenate as _concatenate
 from numpy import (  # noqa
     full_like,
     gradient,
@@ -28,7 +29,6 @@ from numpy import (  # noqa
     transpose,
     unravel_index,
 )
-from numpy import concatenate as _concatenate
 from numpy.lib.stride_tricks import sliding_window_view  # noqa
 from packaging.version import Version
 from pandas.api.types import is_extension_array_dtype
@@ -121,9 +121,11 @@ def fail_on_dask_array_input(values, msg=None, func_name=None):
 # Requires special-casing because pandas won't automatically dispatch to dask.isnull via NEP-18
 pandas_isnull = _dask_or_eager_func("isnull", eager_module=pd, dask_module="dask.array")
 
+
 def round(array):
     xp = get_array_namespace(array)
     return xp.round(array)
+
 
 around = round
 


### PR DESCRIPTION
Another change to use `duck_array_ops` to fix the case in https://github.com/cubed-dev/cubed/issues/539

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
