### PR TITLE
whats-new entry for dropping python 3.9

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -26,6 +26,7 @@ New Features
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
+- Support for ``python 3.9`` has been dropped (:pull:`8937`)
 
 
 Deprecations


### PR DESCRIPTION
- [x] follow-up to #8937