### PR TITLE
Improve error message for missing coordinate index

### DIFF
--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -89,10 +89,12 @@ def _infer_concat_order_from_coords(datasets):
             # Need to read coordinate values to do ordering
             indexes = [ds._indexes.get(dim) for ds in datasets]
             if any(index is None for index in indexes):
-                raise ValueError(
-                    "Every dimension needs a coordinate for "
-                    "inferring concatenation order"
+                error_msg = (
+                    f"Every dimension requires a corresponding 1D coordinate "
+                    f"and index for inferring concatenation order but the "
+                    f"coordinate '{dim}' has no corresponding index"
                 )
+                raise ValueError(error_msg)
 
             # TODO (benbovy, flexible indexes): support flexible indexes?
             indexes = [index.to_pandas_index() for index in indexes]

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -1163,3 +1163,16 @@ def test_combine_by_coords_raises_for_differing_types():
         TypeError, match=r"Cannot combine along dimension 'time' with mixed types."
     ):
         combine_by_coords([da_1, da_2])
+
+
+def test_combine_by_coords_raises_for_no_index():
+    # previously failed with uninformative ValueError
+
+    da1 = DataArray([1, 2, 3], dims="x", coords={"x": [1, 2, 3]})
+    da2 = DataArray([1, 2, 3], dims="x", coords={"x": [4, 5, 6]})
+    da1 = da1.drop_indexes("x")
+    with pytest.raises(
+        ValueError,
+        match=r"Every dimension requires a corresponding 1D coordinate and index for inferring concatenation order but the coordinate 'x' has no corresponding index",
+    ):
+        combine_by_coords([da1, da2])

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -728,7 +728,10 @@ class TestCombineDatasetsbyCoords:
             combine_by_coords(objs)
 
         objs = [Dataset({"x": [0], "y": [0]}), Dataset({"x": [0]})]
-        with pytest.raises(ValueError, match=r"Every dimension needs a coordinate"):
+        with pytest.raises(
+            ValueError,
+            match=r"Every dimension requires a corresponding 1D coordinate and index",
+        ):
             combine_by_coords(objs)
 
     def test_empty_input(self):
@@ -1163,16 +1166,3 @@ def test_combine_by_coords_raises_for_differing_types():
         TypeError, match=r"Cannot combine along dimension 'time' with mixed types."
     ):
         combine_by_coords([da_1, da_2])
-
-
-def test_combine_by_coords_raises_for_no_index():
-    # previously failed with uninformative ValueError
-
-    da1 = DataArray([1, 2, 3], dims="x", coords={"x": [1, 2, 3]})
-    da2 = DataArray([1, 2, 3], dims="x", coords={"x": [4, 5, 6]})
-    da1 = da1.drop_indexes("x")
-    with pytest.raises(
-        ValueError,
-        match=r"Every dimension requires a corresponding 1D coordinate and index for inferring concatenation order but the coordinate 'x' has no corresponding index",
-    ):
-        combine_by_coords([da1, da2])


### PR DESCRIPTION
This simple PR improves the error message for cases where a coordinate is missing its corresponding index. Previously, a generic ValueError was raised, but now the error message specifically mentions which coordinate is without an index. 

- [x] Closes #9201
- [x] Tests added
