### PR TITLE
Improve error message on `ds['x', 'y']`

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -115,7 +115,6 @@ from xarray.core.utils import (
     is_dict_like,
     is_duck_array,
     is_duck_dask_array,
-    is_list_like,
     is_scalar,
     maybe_wrap_array,
 )

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4134,6 +4134,11 @@ class TestDataset:
             data["notfound"]
         with pytest.raises(KeyError):
             data[["var1", "notfound"]]
+        with pytest.raises(
+            KeyError,
+            match=r"Hint: use a list to select multiple variables, for example `ds\[\['var1', 'var2'\]\]`",
+        ):
+            data["var1", "var2"]
 
         actual1 = data[["var1", "var2"]]
         expected1 = Dataset({"var1": data["var1"], "var2": data["var2"]})


### PR DESCRIPTION
While trying to help with #9372, I realize the error message for this could be much better, and so putting this PR in as some penance for my tardiness in helping there
