### PR TITLE
Make illegal path-like variable names when constructing a DataTree from a Dataset

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -37,6 +37,9 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Make illegal path-like variable names when constructing a DataTree from a Dataset
+  (:issue:`311`, :pull:`314`)
+  By `Etienne Schalk <https://github.com/etienneschalk>`_.
 - Fix bug with rechunking to a frequency when some periods contain no data (:issue:`9360`).
   By `Deepak Cherian <https://github.com/dcherian>`_.
 - Fix bug causing `DataTree.from_dict` to be sensitive to insertion order (:issue:`9276`, :pull:`9292`).

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,7 +38,7 @@ Bug fixes
 ~~~~~~~~~
 
 - Make illegal path-like variable names when constructing a DataTree from a Dataset
-  (:issue:`311`, :pull:`314`)
+  (:issue:`9339`, :pull:`9378`)
   By `Etienne Schalk <https://github.com/etienneschalk>`_.
 - Fix bug with rechunking to a frequency when some periods contain no data (:issue:`9360`).
   By `Deepak Cherian <https://github.com/dcherian>`_.

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -160,10 +160,9 @@ def _check_for_slashes_in_names(variables: Iterable[Hashable]) -> None:
     ]
     if len(offending_variable_names) > 0:
         raise KeyError(
-            "Given Dataset contains variable names with '/': "
+            "Given variables have names containing the '/' character: "
             f"{offending_variable_names}. "
-            "A Dataset represents a group, and a single group "
-            "cannot have path-like variable names with '/' characters in them. "
+            "Variables stored in DataTree objects cannot have names containing '/' characters, as this would make path-like access to variables ambiguous."
         )
 
 

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -469,7 +469,7 @@ class DataTree(
         self.children = {name: child.copy() for name, child in children.items()}
 
     def _set_node_data(self, dataset: Dataset):
-        _check_for_slashes_in_names(ds.variables)
+        _check_for_slashes_in_names(dataset.variables)
         data_vars, coord_vars = _collect_data_and_coord_variables(dataset)
         self._data_variables = data_vars
         self._node_coord_variables = coord_vars

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -472,8 +472,7 @@ class DataTree(
             children = {}
 
         super().__init__(name=name)
-        ds = _coerce_to_dataset(data)
-        self._set_node_data(ds)
+        self._set_node_data(_coerce_to_dataset(data))
         self.parent = parent
         self.children = children
 

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -164,9 +164,10 @@ def _check_for_slashes_in_names(variables: Iterable[Hashable]) -> None:
     ]
     if len(offending_variable_names) > 0:
         raise KeyError(
-            f"Given Dataset contains path-like variable names: {offending_variable_names}. "
+            "Given Dataset contains variable names with '/': "
+            f"{offending_variable_names}. "
             "A Dataset represents a group, and a single group "
-            "cannot have path-like variable names. "
+            "cannot have path-like variable names with '/' characters in them. "
         )
 
 
@@ -473,11 +474,11 @@ class DataTree(
         super().__init__(name=name)
         ds = _coerce_to_dataset(data)
         self._set_node_data(ds)
-        _check_for_slashes_in_names(ds.variables)
         self.parent = parent
         self.children = children
 
     def _set_node_data(self, ds: Dataset):
+        _check_for_slashes_in_names(ds.variables)
         data_vars, coord_vars = _collect_data_and_coord_variables(ds)
         self._data_variables = data_vars
         self._node_coord_variables = coord_vars

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -468,14 +468,9 @@ class DataTree(
         # shallow copy to avoid modifying arguments in-place (see GH issue #9196)
         self.children = {name: child.copy() for name, child in children.items()}
 
-<<<<<<< eschalk/make-illegal-path-like-variable-names-when-dt-from-ds
-    def _set_node_data(self, ds: Dataset):
-        _check_for_slashes_in_names(ds.variables)
-        data_vars, coord_vars = _collect_data_and_coord_variables(ds)
-=======
     def _set_node_data(self, dataset: Dataset):
+        _check_for_slashes_in_names(ds.variables)
         data_vars, coord_vars = _collect_data_and_coord_variables(dataset)
->>>>>>> main
         self._data_variables = data_vars
         self._node_coord_variables = coord_vars
         self._node_dims = dataset._dims

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -159,7 +159,7 @@ def _check_for_slashes_in_names(variables: Iterable[Hashable]) -> None:
         name for name in variables if isinstance(name, str) and "/" in name
     ]
     if len(offending_variable_names) > 0:
-        raise KeyError(
+        raise ValueError(
             "Given variables have names containing the '/' character: "
             f"{offending_variable_names}. "
             "Variables stored in DataTree objects cannot have names containing '/' characters, as this would make path-like access to variables ambiguous."

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -158,6 +158,18 @@ def _check_alignment(
             _check_alignment(child_path, child_ds, base_ds, child.children)
 
 
+def _check_for_slashes_in_names(variables: Iterable[Hashable]) -> None:
+    offending_variable_names = [
+        name for name in variables if isinstance(name, str) and "/" in name
+    ]
+    if len(offending_variable_names) > 0:
+        raise KeyError(
+            f"Given Dataset contains path-like variable names: {offending_variable_names}. "
+            "A Dataset represents a group, and a single group "
+            "cannot have path-like variable names. "
+        )
+
+
 class DatasetView(Dataset):
     """
     An immutable Dataset-like view onto the data in a single DataTree node.
@@ -459,7 +471,9 @@ class DataTree(
             children = {}
 
         super().__init__(name=name)
-        self._set_node_data(_coerce_to_dataset(data))
+        ds = _coerce_to_dataset(data)
+        self._set_node_data(ds)
+        _check_for_slashes_in_names(ds.variables)
         self.parent = parent
         self.children = children
 

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -72,6 +72,23 @@ class TestNames:
         mary: DataTree = DataTree(children={"Sue": sue})  # noqa
         assert sue.name == "Sue"
 
+    def test_dataset_containing_slashes(self):
+        xda: xr.DataArray = xr.DataArray(
+            [[1, 2]],
+            coords={"label": ["a"], "R30m/y": [30, 60]},
+        )
+        xds: xr.Dataset = xr.Dataset({"group/subgroup/my_variable": xda})
+        with pytest.raises(
+            KeyError,
+            match=re.escape(
+                "Given Dataset contains path-like variable names: "
+                "['R30m/y', 'group/subgroup/my_variable']. "
+                "A Dataset represents a group, and a single group cannot "
+                "have path-like variable names. "
+            ),
+        ):
+            DataTree(xds)
+
 
 class TestPaths:
     def test_path_property(self):

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -81,10 +81,10 @@ class TestNames:
         with pytest.raises(
             KeyError,
             match=re.escape(
-                "Given Dataset contains path-like variable names: "
+                "Given Dataset contains variable names with '/': "
                 "['R30m/y', 'group/subgroup/my_variable']. "
-                "A Dataset represents a group, and a single group cannot "
-                "have path-like variable names. "
+                "A Dataset represents a group, and a single group "
+                "cannot have path-like variable names with '/' characters in them. "
             ),
         ):
             DataTree(xds)

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -89,7 +89,7 @@ class TestNames:
         )
         xds: xr.Dataset = xr.Dataset({"group/subgroup/my_variable": xda})
         with pytest.raises(
-            KeyError,
+            ValueError,
             match=re.escape(
                 "Given Dataset contains variable names with '/': "
                 "['R30m/y', 'group/subgroup/my_variable']. "

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -91,10 +91,10 @@ class TestNames:
         with pytest.raises(
             ValueError,
             match=re.escape(
-                "Given Dataset contains variable names with '/': "
+                "Given variables have names containing the '/' character: "
                 "['R30m/y', 'group/subgroup/my_variable']. "
-                "A Dataset represents a group, and a single group "
-                "cannot have path-like variable names with '/' characters in them. "
+                "Variables stored in DataTree objects cannot have names containing '/' characters, "
+                "as this would make path-like access to variables ambiguous."
             ),
         ):
             DataTree(xds)


### PR DESCRIPTION
- [x] Closes https://github.com/pydata/xarray/issues/9339
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] ~~New functions/methods are listed in `api.rst`~~


- Original issue on the DataTree repository : https://github.com/xarray-contrib/datatree/issues/311
- Original PR on the DataTree repository : https://github.com/xarray-contrib/datatree/pull/314 

## Technical Note

### Regarding `Hashable` vs `str` Dataset keys 

Note: DataTree keys are `Hashable`. I only check for slashes in the variable names if they are instance of `str`. 
I never encountered a case (yet) where a Dataset keys are not `str` but `Hashable` in the broader case. 
We can imagine corner-cases where keys would be other types of `Hashable`, eg `Path` from `pathlib`

```python
In [2]: from pathlib import Path

In [3]: hash(Path("/"))
Out[3]: -3809984204556177651
```

The choice I made is (1): only apply the check of slashes in the key if the key is an instance of `str`.
Another choice  (2)would be to project the `Hashable` space onto `str` space: `str(variable_name)` 
(1) seems more conservative than (2) as I do not pretend to be able to get a string representation for any `Hashable`.
