### PR TITLE
Fully parallelize CI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,7 +145,7 @@ jobs:
           save-always: true
 
       - name: Run tests
-        run: python -m pytest -n 4
+        run: python -m pytest -n auto
           --timeout 180
           --cov=xarray
           --cov-report=xml


### PR DESCRIPTION
When running tests locally I normally use `pytest -n auto`, which uses the pytest-xdist package to auto-parallelize different tests.

Currently our CI is hardcoded to only use 4 processes, but this change would automatically choose the number of processes.