### PR TITLE
refactor GroupBy internals

### DIFF
--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -352,7 +352,7 @@ class Coordinates(AbstractCoordinates):
         return obj
 
     @classmethod
-    def from_pandas_multiindex(cls, midx: pd.MultiIndex, dim: str) -> Self:
+    def from_pandas_multiindex(cls, midx: pd.MultiIndex, dim: Hashable) -> Self:
         """Wrap a pandas multi-index as Xarray coordinates (dimension + levels).
 
         The returned coordinates can be directly assigned to a

--- a/xarray/groupers.py
+++ b/xarray/groupers.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 import datetime
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
 import pandas as pd
 
 from xarray.coding.cftime_offsets import _new_to_legacy_freq
 from xarray.core import duck_array_ops
+from xarray.core.coordinates import Coordinates
 from xarray.core.dataarray import DataArray
 from xarray.core.groupby import T_Group, _DummyGroup
 from xarray.core.indexes import safe_cast_to_index
@@ -35,7 +36,18 @@ __all__ = [
 RESAMPLE_DIM = "__resample_dim__"
 
 
-@dataclass
+def _coordinates_from_variable(variable: Variable) -> Coordinates:
+    from xarray.core.indexes import create_default_index_implicit
+
+    (name,) = variable.dims
+    new_index, index_vars = create_default_index_implicit(variable)
+    indexes = {k: new_index for k in index_vars}
+    new_vars = new_index.create_variables()
+    new_vars[name].attrs = variable.attrs
+    return Coordinates(new_vars, indexes)
+
+
+@dataclass(init=False)
 class EncodedGroups:
     """
     Dataclass for storing intermediate values for GroupBy operation.
@@ -57,18 +69,49 @@ class EncodedGroups:
 
     codes: DataArray
     full_index: pd.Index
-    group_indices: GroupIndices | None = field(default=None)
-    unique_coord: Variable | _DummyGroup | None = field(default=None)
+    group_indices: GroupIndices
+    unique_coord: Variable | _DummyGroup
+    coords: Coordinates
 
-    def __post_init__(self):
-        assert isinstance(self.codes, DataArray)
-        if self.codes.name is None:
+    def __init__(
+        self,
+        codes: DataArray,
+        full_index: pd.Index,
+        group_indices: GroupIndices | None = None,
+        unique_coord: Variable | _DummyGroup | None = None,
+        coords: Coordinates | None = None,
+    ):
+        from xarray.core.groupby import _codes_to_group_indices
+
+        assert isinstance(codes, DataArray)
+        if codes.name is None:
             raise ValueError("Please set a name on the array you are grouping by.")
-        assert isinstance(self.full_index, pd.Index)
-        assert (
-            isinstance(self.unique_coord, Variable | _DummyGroup)
-            or self.unique_coord is None
-        )
+        self.codes = codes
+        assert isinstance(full_index, pd.Index)
+        self.full_index = full_index
+
+        if group_indices is None:
+            self.group_indices = tuple(
+                g
+                for g in _codes_to_group_indices(codes.data.ravel(), len(full_index))
+                if g
+            )
+        else:
+            self.group_indices = group_indices
+
+        if unique_coord is None:
+            unique_values = full_index[np.unique(codes)]
+            self.unique_coord = Variable(
+                dims=codes.name, data=unique_values, attrs=codes.attrs
+            )
+        else:
+            self.unique_coord = unique_coord
+
+        if coords is None:
+            assert not isinstance(self.unique_coord, _DummyGroup)
+            self.coords = _coordinates_from_variable(self.unique_coord)
+        else:
+            self.coords = coords
 
 
 class Grouper(ABC):
@@ -111,11 +154,14 @@ class UniqueGrouper(Grouper):
     def group_as_index(self) -> pd.Index:
         """Caches the group DataArray as a pandas Index."""
         if self._group_as_index is None:
-            self._group_as_index = self.group.to_index()
+            if self.group.ndim == 1:
+                self._group_as_index = self.group.to_index()
+            else:
+                self._group_as_index = pd.Index(np.array(self.group).ravel())
         return self._group_as_index
 
-    def factorize(self, group1d: T_Group) -> EncodedGroups:
-        self.group = group1d
+    def factorize(self, group: T_Group) -> EncodedGroups:
+        self.group = group
 
         index = self.group_as_index
         is_unique_and_monotonic = isinstance(self.group, _DummyGroup) or (
@@ -138,14 +184,17 @@ class UniqueGrouper(Grouper):
             raise ValueError(
                 "Failed to group data. Are you grouping by a variable that is all NaN?"
             )
-        codes = self.group.copy(data=codes_)
+        codes = self.group.copy(data=codes_.reshape(self.group.shape))
         unique_coord = Variable(
             dims=codes.name, data=unique_values, attrs=self.group.attrs
         )
         full_index = pd.Index(unique_values)
 
         return EncodedGroups(
-            codes=codes, full_index=full_index, unique_coord=unique_coord
+            codes=codes,
+            full_index=full_index,
+            unique_coord=unique_coord,
+            coords=_coordinates_from_variable(unique_coord),
         )
 
     def _factorize_dummy(self) -> EncodedGroups:
@@ -156,20 +205,31 @@ class UniqueGrouper(Grouper):
         group_indices: GroupIndices = tuple(slice(i, i + 1) for i in range(size))
         size_range = np.arange(size)
         full_index: pd.Index
+        unique_coord: _DummyGroup | Variable
         if isinstance(self.group, _DummyGroup):
             codes = self.group.to_dataarray().copy(data=size_range)
             unique_coord = self.group
             full_index = pd.RangeIndex(self.group.size)
+            coords = Coordinates()
         else:
             codes = self.group.copy(data=size_range)
             unique_coord = self.group.variable.to_base_variable()
-            full_index = pd.Index(unique_coord.data)
+            full_index = self.group_as_index
+            if isinstance(full_index, pd.MultiIndex):
+                coords = Coordinates.from_pandas_multiindex(
+                    full_index, dim=self.group.name
+                )
+            else:
+                if TYPE_CHECKING:
+                    assert isinstance(unique_coord, Variable)
+                coords = _coordinates_from_variable(unique_coord)
 
         return EncodedGroups(
             codes=codes,
             group_indices=group_indices,
             full_index=full_index,
             unique_coord=unique_coord,
+            coords=coords,
         )
 
 
@@ -231,7 +291,7 @@ class BinGrouper(Grouper):
         data = np.asarray(group.data)  # Cast _DummyGroup data to array
 
         binned, self.bins = pd.cut(  # type: ignore [call-overload]
-            data,
+            data.ravel(),
             bins=self.bins,
             right=self.right,
             labels=self.labels,
@@ -254,13 +314,18 @@ class BinGrouper(Grouper):
         unique_values = full_index[uniques[uniques != -1]]
 
         codes = DataArray(
-            binned_codes, getattr(group, "coords", None), name=new_dim_name
+            binned_codes.reshape(group.shape),
+            getattr(group, "coords", None),
+            name=new_dim_name,
         )
         unique_coord = Variable(
             dims=new_dim_name, data=unique_values, attrs=group.attrs
         )
         return EncodedGroups(
-            codes=codes, full_index=full_index, unique_coord=unique_coord
+            codes=codes,
+            full_index=full_index,
+            unique_coord=unique_coord,
+            coords=_coordinates_from_variable(unique_coord),
         )
 
 
@@ -373,13 +438,14 @@ class TimeResampler(Resampler):
         unique_coord = Variable(
             dims=group.name, data=first_items.index, attrs=group.attrs
         )
-        codes = group.copy(data=codes_)
+        codes = group.copy(data=codes_.reshape(group.shape))
 
         return EncodedGroups(
             codes=codes,
             group_indices=group_indices,
             full_index=full_index,
             unique_coord=unique_coord,
+            coords=_coordinates_from_variable(unique_coord),
         )
 
 

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -134,6 +134,7 @@ has_cartopy, requires_cartopy = _importorskip("cartopy")
 has_pint, requires_pint = _importorskip("pint")
 has_numexpr, requires_numexpr = _importorskip("numexpr")
 has_flox, requires_flox = _importorskip("flox")
+has_pandas_ge_2_1, __ = _importorskip("pandas", "2.1")
 has_pandas_ge_2_2, __ = _importorskip("pandas", "2.2")
 has_pandas_3, requires_pandas_3 = _importorskip("pandas", "3.0.0.dev0")
 

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -22,6 +22,7 @@ from xarray.tests import (
     create_test_data,
     has_cftime,
     has_flox,
+    has_pandas_ge_2_1,
     requires_cftime,
     requires_dask,
     requires_flox,
@@ -117,6 +118,10 @@ def test_multi_index_groupby_sum() -> None:
     expected = ds.sum("z")
     actual = ds.stack(space=["x", "y"]).groupby("space").sum("z").unstack("space")
     assert_equal(expected, actual)
+
+    if not has_pandas_ge_2_1:
+        # the next line triggers a mysterious multiindex error on pandas 2.0
+        return
 
     actual = ds.stack(space=["x", "y"]).groupby("space").sum(...).unstack("space")
     assert_equal(expected, actual)


### PR DESCRIPTION
1. Simplify ResolvedGrouper by moving logic to EncodedGroups
2. Stack outside ResolvedGrouper in GroupBy.__init__ to prepare for
   multi-variable GroupBy

Broken out form #9372 

- [x] Tests added