### PR TITLE
`numpy 2` compatibility in the `pydap` backend

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -12,8 +12,6 @@ fi
 $conda remove -y numba numbagg sparse
 # temporarily remove numexpr
 $conda remove -y numexpr
-# temporarily remove backends
-$conda remove -y pydap
 # forcibly remove packages to avoid artifacts
 $conda remove -y --force \
     numpy \

--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -27,7 +27,7 @@ dependencies:
   - pandas
   - pint>=0.22
   - pip
-  # - pydap
+  - pydap
   - pytest
   - pytest-cov
   - pytest-env

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -29,7 +29,7 @@ dependencies:
   # - pint>=0.22
   - pip
   - pre-commit
-  # - pydap
+  - pydap
   - pytest
   - pytest-cov
   - pytest-env

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -35,7 +35,7 @@ dependencies:
   - pooch
   - pre-commit
   - pyarrow # pandas raises a deprecation warning without this, breaking doctests
-  # - pydap
+  - pydap
   - pytest
   - pytest-cov
   - pytest-env

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -50,8 +50,6 @@ Bug fixes
 - Fix issue with passing parameters to ZarrStore.open_store when opening
   datatree in zarr format (:issue:`9376`, :pull:`9377`).
   By `Alfonso Ladino <https://github.com/aladinor>`_
-- ``numpy>=2`` compatibility in the ``pydap`` backend (:pull:`9391`).
-  By `Miguel Jimenez <https://github.com/Mikejmnez>`_ .
 
 Documentation
 ~~~~~~~~~~~~~
@@ -59,6 +57,9 @@ Documentation
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
+
+- Re-enable testing ``pydap`` backend with ``numpy>=2`` (:pull:`9391`).
+  By `Miguel Jimenez <https://github.com/Mikejmnez>`_ .
 
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -50,6 +50,8 @@ Bug fixes
 - Fix issue with passing parameters to ZarrStore.open_store when opening
   datatree in zarr format (:issue:`9376`, :pull:`9377`).
   By `Alfonso Ladino <https://github.com/aladinor>`_
+- ``numpy>=2`` compatibility in the ``pydap`` backend (:pull:`9391`).
+  By `Miguel Jimenez <https://github.com/Mikejmnez>`_ .
 
 Documentation
 ~~~~~~~~~~~~~


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

`pydap=3.5` has a been released that is compatible with numpy 2 (among other features).
- This PR largely reverses [pydata/xarray#9183](https://github.com/pydata/xarray/pull/9183).
- [x] User visible changes (~including notable bug fixes~ internal changes) are documented in `whats-new.rst`

Don't know if I have the right permissions to push this PR, but at the very least this will bring up the attention that pydap is compatible with numpy>=2.0. Also, this has the potential to bring up additional issues to fix (even though tests on my local computer ran smoothly). Feel free to close/comment/etc etc.






