### PR TITLE
Adds copy parameter to __array__ for numpy 2.0

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -52,6 +52,9 @@ Bug fixes
 - Fix issue with passing parameters to ZarrStore.open_store when opening
   datatree in zarr format (:issue:`9376`, :pull:`9377`).
   By `Alfonso Ladino <https://github.com/aladinor>`_
+- Fix deprecation warning that was raised when calling ``np.array`` on an ``xr.DataArray``
+  in NumPy 2.0 (:issue:`9312`, :pull:`9393`)
+  By `Andrew Scherer <https://github.com/andrew-s28>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -162,8 +162,22 @@ class AbstractArray:
     def __complex__(self: Any) -> complex:
         return complex(self.values)
 
-    def __array__(self: Any, dtype: DTypeLike | None = None) -> np.ndarray:
-        return np.asarray(self.values, dtype=dtype)
+    def __array__(
+        self: Any, dtype: DTypeLike | None = None, copy: bool | None = None
+    ) -> np.ndarray:
+        if not copy:
+            if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
+                copy = None
+            elif np.lib.NumpyVersion(np.__version__) <= "1.28.0":
+                copy = False
+            else:
+                # 2.0.0 dev versions, handle cases where copy may or may not exist
+                try:
+                    np.array([1]).__array__(copy=None)
+                    copy = None
+                except TypeError:
+                    copy = False
+        return np.array(self.values, dtype=dtype, copy=copy)
 
     def __repr__(self) -> str:
         return formatting.array_repr(self)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -7065,6 +7065,14 @@ class TestNumpyCoercion:
         np.testing.assert_equal(da.to_numpy(), np.array([1, 2, 3]))
         np.testing.assert_equal(da["lat"].to_numpy(), np.array([4, 5, 6]))
 
+    def test_to_numpy(self) -> None:
+        arr = np.array([1, 2, 3])
+        da = xr.DataArray(arr, dims="x", coords={"lat": ("x", [4, 5, 6])})
+
+        with assert_no_warnings():
+            np.testing.assert_equal(np.asarray(da), arr)
+            np.testing.assert_equal(np.array(da), arr)
+
     @requires_dask
     def test_from_dask(self) -> None:
         da = xr.DataArray([1, 2, 3], dims="x", coords={"lat": ("x", [4, 5, 6])})


### PR DESCRIPTION
xarray has been raising some deprecation warnings whenever `np.array` is called on an `xr.DataArray`. This is the same message as documented in #9312, but the issue is not specifically related to the `interpolate_na` method. Instead, the issue can be produced when using NumPy>=2.0.0 as:
```
>>> import xarray as xr
>>> import numpy as np
>>> da = xr.DataArray([0])
>>> np.array(da)
DeprecationWarning: __array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments.
```
It is caused by the `AbstractArray.__array__` method not containing a `copy` kwarg that NumPy 2.0 now expects.

A fix was proposed in #9312 by @kmuehlbauer, but upon testing it I found that this fix is not backwards compatible when using NumPy versions<2.0:
```
>>> import xarray as xr 
>>> import numpy as np
>>> da = xr.DataArray([0])
>>> np.array(da)
ValueError: NoneType copy mode not allowed.
```
The only way I found that would be able to address the deprecation warning and maintain backwards compatibility was to use a conditional in the `AbstractArray.__array__` method based on the installed NumPy version, which is how this PR is structured ([based on the suggested implementation from the migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword), from this [SciPy PR](https://github.com/scipy/scipy/pull/20172)). 

Using a conditional based on a version doesn't feel great, but the only other option I see is just ignoring the `copy` the kwarg argument that is passed into the `__array__` method, which is ignoring user input and also isn't great. I'd be interested to see if there are any more elegant ways to deal with this deprecation warning, though.

That said, if xarray ever drops support for NumPy<2.0, then this can be reverted to the more straightforward fix proposed in #9312.

- [x] Closes #9312 
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`


