### PR TITLE
cast `numpy` scalars to arrays in `as_compatible_data`

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -309,7 +309,7 @@ def as_compatible_data(
         else:
             data = np.asarray(data)
 
-    if not isinstance(data, np.ndarray) and (
+    if not isinstance(data, np.ndarray | np.generic) and (
         hasattr(data, "__array_function__") or hasattr(data, "__array_namespace__")
     ):
         return cast("T_DuckArray", data)

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -2584,10 +2584,15 @@ class TestAsCompatibleData(Generic[T_DuckArray]):
                 assert source_ndarray(x) is source_ndarray(as_compatible_data(x))
 
     def test_converted_types(self):
-        for input_array in [[[0, 1, 2]], pd.DataFrame([[0, 1, 2]])]:
+        for input_array in [
+            [[0, 1, 2]],
+            pd.DataFrame([[0, 1, 2]]),
+            np.float64(1.4),
+            np.str_("abc"),
+        ]:
             actual = as_compatible_data(input_array)
             assert_array_equal(np.asarray(input_array), actual)
-            assert np.ndarray == type(actual)
+            assert isinstance(actual, np.ndarray)
             assert np.asarray(input_array).dtype == actual.dtype
 
     def test_masked_array(self):


### PR DESCRIPTION
- [x] Closes #9399
- [x] Tests added

As mentioned in #9399, `numpy` recently added `__array_namespace__` to scalars, which will cause `Variable` to wrap the scalar. This also casts `numpy` scalars to `numpy.ndarray` if it ever reaches `as_compatible_data`.

This will most likely also pop up in `NamedArray` / `xarray.namedarray.from_array`, so we might have to figure out what to do there. cc @andersy005 and @Illviljan for awareness