### PR TITLE
fix the failing `pre-commit.ci` runs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         additional_dependencies: [
             # Type stubs
             types-python-dateutil,
-            types-pkg_resources,
+            types-setuptools,
             types-PyYAML,
             types-pytz,
             typing-extensions>=4.1.0,


### PR DESCRIPTION
In the disabled `mypy` hook we explicitly install `types-pkg_resources`. This project has been yanked on PyPI, with the notice that instead we should use `types-setuptools`. This applies that change, but if I remember correctly, we stopped depending on `setuptools` / `pkg_resources` a while ago, so we might also be able to just remove that?