### PR TITLE
Support additional dtypes in `resample`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -60,6 +60,10 @@ Bug fixes
 - Fix deprecation warning that was raised when calling ``np.array`` on an ``xr.DataArray``
   in NumPy 2.0 (:issue:`9312`, :pull:`9393`)
   By `Andrew Scherer <https://github.com/andrew-s28>`_.
+- Fix support for using ``pandas.BaseOffset``, ``pandas.Timedelta``, and
+  ``datetime.timedelta`` objects as ``resample`` frequencies
+  (:issue:`9408`, :pull:`9413`).
+  By `Oliver Higgs <https://github.com/oliverhiggs>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -60,7 +60,7 @@ Bug fixes
 - Fix deprecation warning that was raised when calling ``np.array`` on an ``xr.DataArray``
   in NumPy 2.0 (:issue:`9312`, :pull:`9393`)
   By `Andrew Scherer <https://github.com/andrew-s28>`_.
-- Fix support for using ``pandas.BaseOffset``, ``pandas.Timedelta``, and
+- Fix support for using ``pandas.DateOffset``, ``pandas.Timedelta``, and
   ``datetime.timedelta`` objects as ``resample`` frequencies
   (:issue:`9408`, :pull:`9413`).
   By `Oliver Higgs <https://github.com/oliverhiggs>`_.

--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -784,7 +784,7 @@ def to_offset(
     if isinstance(freq, timedelta | pd.Timedelta):
         return delta_to_tick(freq)
     if isinstance(freq, pd.DateOffset):
-        freq = _new_freq(freq.freqstr)
+        freq = _legacy_to_new_freq(freq.freqstr)
 
     match = re.match(_PATTERN, freq)
     if match is None:

--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -783,7 +783,7 @@ def to_offset(
     if isinstance(freq, timedelta | pd.Timedelta):
         return delta_to_tick(freq)
     if isinstance(freq, pd.DateOffset):
-        freq = freq.freqstr
+        freq = _legacy_to_new_freq(freq.freqstr)
 
     match = re.match(_PATTERN, freq)
     if match is None:
@@ -818,7 +818,7 @@ def delta_to_tick(delta: timedelta | pd.Timedelta) -> Tick:
             else:
                 return Second(n=seconds)
     else:
-        # Regardless of the days and seconds this will always be a Millsecond
+        # Regardless of the days and seconds this will always be a Millisecond
         # or Microsecond object
         if delta.microseconds % 1_000 == 0:
             return Millisecond(n=delta.microseconds // 1_000)

--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -47,7 +47,7 @@ import warnings
 from collections.abc import Mapping
 from datetime import datetime, timedelta
 from functools import partial
-from typing import TYPE_CHECKING, ClassVar, Literal
+from typing import TYPE_CHECKING, ClassVar, Literal, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -80,6 +80,7 @@ if TYPE_CHECKING:
 
 
 DayOption: TypeAlias = Literal["start", "end"]
+T_FreqStr = TypeVar("T_FreqStr", str, None)
 
 
 def _nanosecond_precision_timestamp(*args, **kwargs):
@@ -783,7 +784,7 @@ def to_offset(
     if isinstance(freq, timedelta | pd.Timedelta):
         return delta_to_tick(freq)
     if isinstance(freq, pd.DateOffset):
-        freq = _legacy_to_new_freq(freq.freqstr)
+        freq = _new_freq(freq.freqstr)
 
     match = re.match(_PATTERN, freq)
     if match is None:
@@ -1367,7 +1368,7 @@ def _new_to_legacy_freq(freq):
     return freq
 
 
-def _legacy_to_new_freq(freq):
+def _legacy_to_new_freq(freq: T_FreqStr) -> T_FreqStr:
     # to avoid internal deprecation warnings when freq is determined using pandas < 2.2
 
     # TODO: remove once requiring pandas >= 2.2

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -14,6 +14,7 @@ import pandas as pd
 from xarray.core import dtypes, duck_array_ops, formatting, formatting_html, ops
 from xarray.core.indexing import BasicIndexer, ExplicitlyIndexed
 from xarray.core.options import OPTIONS, _get_keep_attrs
+from xarray.core.types import ResampleCompatible
 from xarray.core.utils import (
     Frozen,
     either_dict_or_kwargs,
@@ -27,9 +28,6 @@ try:
     import cftime
 except ImportError:
     cftime = None
-
-if TYPE_CHECKING:
-    from xarray.core.types import ResampleCompatible
 
 # Used as a sentinel value to indicate a all dimensions
 ALL_DIMS = ...

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -28,6 +28,9 @@ try:
 except ImportError:
     cftime = None
 
+if TYPE_CHECKING:
+    from xarray.core.types import ResampleCompatible
+
 # Used as a sentinel value to indicate a all dimensions
 ALL_DIMS = ...
 
@@ -890,7 +893,7 @@ class DataWithCoords(AttrAccessMixin):
     def _resample(
         self,
         resample_cls: type[T_Resample],
-        indexer: Mapping[Hashable, str | Resampler] | None,
+        indexer: Mapping[Hashable, ResampleCompatible | Resampler] | None,
         skipna: bool | None,
         closed: SideOptions | None,
         label: SideOptions | None,
@@ -1077,7 +1080,7 @@ class DataWithCoords(AttrAccessMixin):
         )
 
         grouper: Resampler
-        if isinstance(freq, str | datetime.timedelta | pd.Timedelta | pd.DateOffset):
+        if isinstance(freq, ResampleCompatible):
             grouper = TimeResampler(
                 freq=freq, closed=closed, label=label, origin=origin, offset=offset
             )

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1059,7 +1059,6 @@ class DataWithCoords(AttrAccessMixin):
         """
         # TODO support non-string indexer after removing the old API.
 
-        from xarray.coding.cftime_offsets import BaseCFTimeOffset
         from xarray.core.dataarray import DataArray
         from xarray.core.groupby import ResolvedGrouper
         from xarray.core.resample import RESAMPLE_DIM
@@ -1078,14 +1077,7 @@ class DataWithCoords(AttrAccessMixin):
         )
 
         grouper: Resampler
-        if isinstance(
-            freq,
-            str
-            | datetime.timedelta
-            | pd.Timedelta
-            | pd.offsets.BaseOffset
-            | BaseCFTimeOffset,
-        ):
+        if isinstance(freq, str | datetime.timedelta | pd.Timedelta | pd.DateOffset):
             grouper = TimeResampler(
                 freq=freq, closed=closed, label=label, origin=origin, offset=offset
             )
@@ -1094,8 +1086,8 @@ class DataWithCoords(AttrAccessMixin):
         else:
             raise ValueError(
                 "freq must be an object of type 'str', 'datetime.timedelta', "
-                "'pandas.Timedelta', 'pandas.offsets.BaseOffset', 'BaseCFTimeOffset', "
-                f" or 'TimeResampler'. Received {type(freq)} instead."
+                "'pandas.Timedelta', 'pandas.DateOffset', or 'TimeResampler'. "
+                f"Received {type(freq)} instead."
             )
 
         rgrouper = ResolvedGrouper(grouper, group, self)

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -900,7 +900,7 @@ class DataWithCoords(AttrAccessMixin):
         offset: pd.Timedelta | datetime.timedelta | str | None,
         origin: str | DatetimeLike,
         restore_coord_dims: bool | None,
-        **indexer_kwargs: str | Resampler,
+        **indexer_kwargs: ResampleCompatible | Resampler,
     ) -> T_Resample:
         """Returns a Resample object for performing resampling operations.
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -110,6 +110,7 @@ if TYPE_CHECKING:
         QueryEngineOptions,
         QueryParserOptions,
         ReindexMethodOptions,
+        ResampleCompatible,
         Self,
         SideOptions,
         T_ChunkDimFreq,
@@ -7244,7 +7245,7 @@ class DataArray(
     @_deprecate_positional_args("v2024.07.0")
     def resample(
         self,
-        indexer: Mapping[Hashable, str | Resampler] | None = None,
+        indexer: Mapping[Hashable, ResampleCompatible | Resampler] | None = None,
         *,
         skipna: bool | None = None,
         closed: SideOptions | None = None,
@@ -7252,11 +7253,7 @@ class DataArray(
         offset: pd.Timedelta | datetime.timedelta | str | None = None,
         origin: str | DatetimeLike = "start_day",
         restore_coord_dims: bool | None = None,
-        **indexer_kwargs: str
-        | datetime.timedelta
-        | pd.Timedelta
-        | pd.DateOffset
-        | Resampler,
+        **indexer_kwargs: ResampleCompatible | Resampler,
     ) -> DataArrayResample:
         """Returns a Resample object for performing resampling operations.
 
@@ -7267,7 +7264,7 @@ class DataArray(
 
         Parameters
         ----------
-        indexer : Mapping of Hashable to str, optional
+        indexer : Mapping of Hashable to str, datetime.timedelta, pd.Timedelta, pd.DateOffset, or Resampler, optional
             Mapping from the dimension name to resample frequency [1]_. The
             dimension must be datetime-like.
         skipna : bool, optional
@@ -7291,7 +7288,7 @@ class DataArray(
         restore_coord_dims : bool, optional
             If True, also restore the dimension order of multi-dimensional
             coordinates.
-        **indexer_kwargs : str
+        **indexer_kwargs : str, datetime.timedelta, pd.Timedelta, pd.DateOffset, or Resampler
             The keyword arguments form of ``indexer``.
             One of indexer or indexer_kwargs must be provided.
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -7252,7 +7252,11 @@ class DataArray(
         offset: pd.Timedelta | datetime.timedelta | str | None = None,
         origin: str | DatetimeLike = "start_day",
         restore_coord_dims: bool | None = None,
-        **indexer_kwargs: str | Resampler,
+        **indexer_kwargs: str
+        | datetime.timedelta
+        | pd.Timedelta
+        | pd.DateOffset
+        | Resampler,
     ) -> DataArrayResample:
         """Returns a Resample object for performing resampling operations.
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -10693,7 +10693,11 @@ class Dataset(
         offset: pd.Timedelta | datetime.timedelta | str | None = None,
         origin: str | DatetimeLike = "start_day",
         restore_coord_dims: bool | None = None,
-        **indexer_kwargs: str | Resampler,
+        **indexer_kwargs: str
+        | datetime.timedelta
+        | pd.Timedelta
+        | pd.DateOffset
+        | Resampler,
     ) -> DatasetResample:
         """Returns a Resample object for performing resampling operations.
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -162,6 +162,7 @@ if TYPE_CHECKING:
         QueryEngineOptions,
         QueryParserOptions,
         ReindexMethodOptions,
+        ResampleCompatible,
         SideOptions,
         T_ChunkDimFreq,
         T_DatasetPadConstantValues,
@@ -10685,7 +10686,7 @@ class Dataset(
     @_deprecate_positional_args("v2024.07.0")
     def resample(
         self,
-        indexer: Mapping[Any, str | Resampler] | None = None,
+        indexer: Mapping[Any, ResampleCompatible | Resampler] | None = None,
         *,
         skipna: bool | None = None,
         closed: SideOptions | None = None,
@@ -10693,11 +10694,7 @@ class Dataset(
         offset: pd.Timedelta | datetime.timedelta | str | None = None,
         origin: str | DatetimeLike = "start_day",
         restore_coord_dims: bool | None = None,
-        **indexer_kwargs: str
-        | datetime.timedelta
-        | pd.Timedelta
-        | pd.DateOffset
-        | Resampler,
+        **indexer_kwargs: ResampleCompatible | Resampler,
     ) -> DatasetResample:
         """Returns a Resample object for performing resampling operations.
 
@@ -10708,7 +10705,7 @@ class Dataset(
 
         Parameters
         ----------
-        indexer : Mapping of Hashable to str, optional
+        indexer : Mapping of Hashable to str, datetime.timedelta, pd.Timedelta, pd.DateOffset, or Resampler, optional
             Mapping from the dimension name to resample frequency [1]_. The
             dimension must be datetime-like.
         skipna : bool, optional
@@ -10732,7 +10729,7 @@ class Dataset(
         restore_coord_dims : bool, optional
             If True, also restore the dimension order of multi-dimensional
             coordinates.
-        **indexer_kwargs : str
+        **indexer_kwargs : str, datetime.timedelta, pd.Timedelta, pd.DateOffset, or Resampler
             The keyword arguments form of ``indexer``.
             One of indexer or indexer_kwargs must be provided.
 

--- a/xarray/core/resample_cftime.py
+++ b/xarray/core/resample_cftime.py
@@ -58,7 +58,7 @@ from xarray.coding.cftimeindex import CFTimeIndex
 from xarray.core.types import SideOptions
 
 if typing.TYPE_CHECKING:
-    from xarray.core.types import CFTimeDatetime
+    from xarray.core.types import CFTimeDatetime, ResampleCompatible
 
 
 class CFTimeGrouper:
@@ -75,11 +75,7 @@ class CFTimeGrouper:
 
     def __init__(
         self,
-        freq: str
-        | datetime.timedelta
-        | pd.Timedelta
-        | pd.DateOffset
-        | BaseCFTimeOffset,
+        freq: ResampleCompatible | BaseCFTimeOffset,
         closed: SideOptions | None = None,
         label: SideOptions | None = None,
         origin: str | CFTimeDatetime = "start_day",

--- a/xarray/core/resample_cftime.py
+++ b/xarray/core/resample_cftime.py
@@ -75,7 +75,11 @@ class CFTimeGrouper:
 
     def __init__(
         self,
-        freq: str | BaseCFTimeOffset,
+        freq: str
+        | datetime.timedelta
+        | pd.Timedelta
+        | pd.DateOffset
+        | BaseCFTimeOffset,
         closed: SideOptions | None = None,
         label: SideOptions | None = None,
         origin: str | CFTimeDatetime = "start_day",

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -309,3 +309,5 @@ GroupIndices = tuple[GroupIndex, ...]
 Bins = Union[
     int, Sequence[int], Sequence[float], Sequence[pd.Timestamp], np.ndarray, pd.Index
 ]
+
+ResampleCompatible = Union[str, datetime.timedelta, pd.Timedelta, pd.DateOffset]

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -310,4 +310,4 @@ Bins = Union[
     int, Sequence[int], Sequence[float], Sequence[pd.Timestamp], np.ndarray, pd.Index
 ]
 
-ResampleCompatible = Union[str, datetime.timedelta, pd.Timedelta, pd.DateOffset]
+ResampleCompatible: TypeAlias = str | datetime.timedelta | pd.Timedelta | pd.DateOffset

--- a/xarray/groupers.py
+++ b/xarray/groupers.py
@@ -380,13 +380,6 @@ class TimeResampler(Resampler):
         if isinstance(group_as_index, CFTimeIndex):
             from xarray.core.resample_cftime import CFTimeGrouper
 
-            if not isinstance(self.freq, str | BaseCFTimeOffset):
-                raise ValueError(
-                    "Resample frequency must be a string or 'BaseCFTimeOffset' "
-                    "object when resampling a 'CFTimeIndex'. Received "
-                    f"{type(self.freq)} instead."
-                )
-
             self.index_grouper = CFTimeGrouper(
                 freq=self.freq,
                 closed=self.closed,

--- a/xarray/groupers.py
+++ b/xarray/groupers.py
@@ -336,7 +336,7 @@ class TimeResampler(Resampler):
 
     Attributes
     ----------
-    freq : str, pandas.Timestamp, pandas.BaseOffset, datetime.timedelta, BaseCFTimeOffset
+    freq : str, datetime.timedelta, pandas.Timestamp, pandas.DateOffset
         Frequency to resample to. See `Pandas frequency
         aliases <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`_
         for a list of possible values.
@@ -358,7 +358,7 @@ class TimeResampler(Resampler):
         An offset timedelta added to the origin.
     """
 
-    freq: str | pd.Timedelta | pd.offsets.BaseOffset | datetime.timedelta
+    freq: str | datetime.timedelta | pd.Timedelta | pd.DateOffset
     closed: SideOptions | None = field(default=None)
     label: SideOptions | None = field(default=None)
     origin: str | DatetimeLike = field(default="start_day")

--- a/xarray/groupers.py
+++ b/xarray/groupers.py
@@ -21,7 +21,13 @@ from xarray.core.dataarray import DataArray
 from xarray.core.groupby import T_Group, _DummyGroup
 from xarray.core.indexes import safe_cast_to_index
 from xarray.core.resample_cftime import CFTimeGrouper
-from xarray.core.types import Bins, DatetimeLike, GroupIndices, SideOptions
+from xarray.core.types import (
+    Bins,
+    DatetimeLike,
+    GroupIndices,
+    ResampleCompatible,
+    SideOptions,
+)
 from xarray.core.variable import Variable
 
 __all__ = [
@@ -336,7 +342,7 @@ class TimeResampler(Resampler):
 
     Attributes
     ----------
-    freq : str, datetime.timedelta, pandas.Timestamp, pandas.DateOffset
+    freq : str, datetime.timedelta, pandas.Timestamp, or pandas.DateOffset
         Frequency to resample to. See `Pandas frequency
         aliases <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`_
         for a list of possible values.
@@ -358,7 +364,7 @@ class TimeResampler(Resampler):
         An offset timedelta added to the origin.
     """
 
-    freq: str | datetime.timedelta | pd.Timedelta | pd.DateOffset
+    freq: ResampleCompatible
     closed: SideOptions | None = field(default=None)
     label: SideOptions | None = field(default=None)
     origin: str | DatetimeLike = field(default="start_day")

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -2270,12 +2270,12 @@ class TestDatasetResample:
                 "time": times,
             }
         )
-        test_resample_freqs = [
+        test_resample_freqs = (
             "10min",
             pd.Timedelta(hours=2),
             pd.offsets.MonthBegin(),
             datetime.timedelta(days=1, hours=6),
-        ]
+        )
         for freq in test_resample_freqs:
             ds.resample(time=freq)
 

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -1773,20 +1773,18 @@ class TestDataArrayGroupBy:
 
 
 class TestDataArrayResample:
+    @pytest.mark.parametrize("use_cftime", [True, False])
     @pytest.mark.parametrize(
-        "use_cftime,resample_freq",
-        product(
-            [True, False],
-            [
-                "24h",
-                "123456s",
-                "1234567890us",
-                pd.Timedelta(hours=2),
-                pd.offsets.MonthBegin(),
-                pd.offsets.Second(123456),
-                datetime.timedelta(days=1, hours=6),
-            ],
-        ),
+        "resample_freq",
+        [
+            "24h",
+            "123456s",
+            "1234567890us",
+            pd.Timedelta(hours=2),
+            pd.offsets.MonthBegin(),
+            pd.offsets.Second(123456),
+            datetime.timedelta(days=1, hours=6),
+        ],
     )
     def test_resample(
         self, use_cftime: bool, resample_freq: ResampleCompatible
@@ -2223,20 +2221,18 @@ class TestDataArrayResample:
 
 
 class TestDatasetResample:
+    @pytest.mark.parametrize("use_cftime", [True, False])
     @pytest.mark.parametrize(
-        "use_cftime,resample_freq",
-        product(
-            [True, False],
-            [
-                "24h",
-                "123456s",
-                "1234567890us",
-                pd.Timedelta(hours=2),
-                pd.offsets.MonthBegin(),
-                pd.offsets.Second(123456),
-                datetime.timedelta(days=1, hours=6),
-            ],
-        ),
+        "resample_freq",
+        [
+            "24h",
+            "123456s",
+            "1234567890us",
+            pd.Timedelta(hours=2),
+            pd.offsets.MonthBegin(),
+            pd.offsets.Second(123456),
+            datetime.timedelta(days=1, hours=6),
+        ],
     )
     def test_resample(
         self, use_cftime: bool, resample_freq: ResampleCompatible

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime
 import operator
 import warnings
-from itertools import product
 from unittest import mock
 
 import numpy as np

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import operator
 import warnings
 from unittest import mock
@@ -1812,6 +1813,30 @@ class TestDataArrayResample:
         reverse = array.isel(time=slice(-1, None, -1))
         with pytest.raises(ValueError):
             reverse.resample(time="1D").mean()
+
+    @pytest.mark.parametrize("use_cftime", [True, False])
+    def test_resample_dtype(self, use_cftime: bool) -> None:
+        if use_cftime and not has_cftime:
+            pytest.skip()
+        array = DataArray(
+            np.arange(10),
+            [
+                (
+                    "time",
+                    xr.date_range(
+                        "2000-01-01", freq="6h", periods=10, use_cftime=use_cftime
+                    ),
+                )
+            ],
+        )
+        test_resample_freqs = [
+            "10min",
+            pd.Timedelta(hours=2),
+            pd.offsets.MonthBegin(),
+            datetime.timedelta(days=1, hours=6),
+        ]
+        for freq in test_resample_freqs:
+            array.resample(time=freq)
 
     @pytest.mark.parametrize("use_cftime", [True, False])
     def test_resample_doctest(self, use_cftime: bool) -> None:

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -1829,12 +1829,13 @@ class TestDataArrayResample:
                 )
             ],
         )
-        test_resample_freqs = [
-            "10min",
-            pd.Timedelta(hours=2),
-            pd.offsets.MonthBegin(),
-            datetime.timedelta(days=1, hours=6),
-        ]
+        test_resample_freqs = ["10min"]
+        if not use_cftime:
+            test_resample_freqs += [
+                pd.Timedelta(hours=2),
+                pd.offsets.MonthBegin(),
+                datetime.timedelta(days=1, hours=6),
+            ]
         for freq in test_resample_freqs:
             array.resample(time=freq)
 


### PR DESCRIPTION
pandas.BaseOffset, pandas.Timedelta, datetime.timedelta, and BaseCFTimeOffset are now all supported datatypes for resampling.

Closes #9408 