### PR TITLE
Don't return IndexVariable with .dt accessor

### DIFF
--- a/xarray/core/accessor_dt.py
+++ b/xarray/core/accessor_dt.py
@@ -14,7 +14,7 @@ from xarray.core.common import (
     is_np_timedelta_like,
 )
 from xarray.core.types import T_DataArray
-from xarray.core.variable import IndexVariable
+from xarray.core.variable import IndexVariable, Variable
 from xarray.namedarray.utils import is_duck_dask_array
 
 if TYPE_CHECKING:
@@ -244,12 +244,22 @@ class TimeAccessor(Generic[T_DataArray]):
         if dtype is None:
             dtype = self._obj.dtype
         result = _get_date_field(_index_or_data(self._obj), name, dtype)
-        newvar = self._obj.variable.copy(data=result, deep=False)
+        newvar = Variable(
+            dims=self._obj.dims,
+            attrs=self._obj.attrs,
+            encoding=self._obj.encoding,
+            data=result,
+        )
         return self._obj._replace(newvar, name=name)
 
     def _tslib_round_accessor(self, name: str, freq: str) -> T_DataArray:
         result = _round_field(_index_or_data(self._obj), name, freq)
-        newvar = self._obj.variable.copy(data=result, deep=False)
+        newvar = Variable(
+            dims=self._obj.dims,
+            attrs=self._obj.attrs,
+            encoding=self._obj.encoding,
+            data=result,
+        )
         return self._obj._replace(newvar, name=name)
 
     def floor(self, freq: str) -> T_DataArray:

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1550,7 +1550,7 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
             # case the destinations will be NaN / zero.
             data[(..., *indexer)] = reordered
 
-        return self._replace(dims=new_dims, data=data)
+        return self.to_base_variable()._replace(dims=new_dims, data=data)
 
     @partial(deprecate_dims, old_name="dimensions")
     def unstack(self, dim=None, **dim_kwargs):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1490,7 +1490,7 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
         dim: Hashable,
         fill_value=dtypes.NA,
         sparse: bool = False,
-    ) -> Self:
+    ) -> Variable:
         """
         Unstacks this variable given an index to unstack and the name of the
         dimension to which the index refers.
@@ -1553,7 +1553,7 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
         return self.to_base_variable()._replace(dims=new_dims, data=data)
 
     @partial(deprecate_dims, old_name="dimensions")
-    def unstack(self, dim=None, **dim_kwargs):
+    def unstack(self, dim=None, **dim_kwargs) -> Variable:
         """
         Unstack an existing dimension into multiple new dimensions.
 

--- a/xarray/testing/assertions.py
+++ b/xarray/testing/assertions.py
@@ -211,7 +211,9 @@ def assert_identical(a, b, from_root=True):
     if isinstance(a, Variable):
         assert a.identical(b), formatting.diff_array_repr(a, b, "identical")
     elif isinstance(a, DataArray):
-        assert a.name == b.name
+        assert (
+            a.name == b.name
+        ), f"DataArray names are different. L: {a.name}, R: {b.name}"
         assert a.identical(b), formatting.diff_array_repr(a, b, "identical")
     elif isinstance(a, Dataset | Variable):
         assert a.identical(b), formatting.diff_dataset_repr(a, b, "identical")

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -97,6 +97,7 @@ class TestDatetimeAccessor:
                 actual = getattr(self.data.time.dt, field)
         else:
             actual = getattr(self.data.time.dt, field)
+        assert not isinstance(actual.variable, xr.IndexVariable)
 
         assert expected.dtype == actual.dtype
         assert_identical(expected, actual)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -7209,4 +7209,10 @@ def test_unstack_index_var() -> None:
     da = source.x
     da = da.assign_coords(y=("x", ["c", "d"]), z=("x", ["e", "f"]))
     da = da.set_index(x=["y", "z"])
-    da.unstack("x")
+    actual = da.unstack("x")
+    expected = xr.DataArray(
+        np.array([["a", np.nan], [np.nan, "b"]], dtype=object),
+        coords={"y": ["c", "d"], "z": ["e", "f"]},
+        name="x",
+    )
+    assert_identical(actual, expected)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -7202,3 +7202,11 @@ def test_lazy_data_variable_not_loaded():
     da = xr.DataArray(v)
     # No data needs to be accessed, so no error should be raised
     xr.DataArray(da)
+
+
+def test_unstack_index_var() -> None:
+    source = xr.DataArray(range(2), dims=["x"], coords=[["a", "b"]])
+    da = source.x
+    da = da.assign_coords(y=("x", ["c", "d"]), z=("x", ["e", "f"]))
+    da = da.set_index(x=["y", "z"])
+    da.unstack("x")


### PR DESCRIPTION
- [x] Closes #9190
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

I *think* it makes sense to limit how much we expose IndexVariable to users so I removed it.

This PR also auto-converts IndexVariable to Variable when unstacking.
