### PR TITLE
Don't specify a subdir in mypy CI cli

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Run mypy
         run: |
-          python -m mypy --install-types --non-interactive --cobertura-xml-report mypy_report 
+          python -m mypy --install-types --non-interactive --cobertura-xml-report mypy_report
 
       - name: Upload mypy coverage to Codecov
         uses: codecov/codecov-action@v4.5.0

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Run mypy
         run: |
-          python -m mypy --install-types --non-interactive --cobertura-xml-report mypy_report xarray/
+          python -m mypy --install-types --non-interactive --cobertura-xml-report mypy_report 
 
       - name: Upload mypy coverage to Codecov
         uses: codecov/codecov-action@v4.5.0
@@ -138,7 +138,7 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
 
-  mypy39:
+  mypy-min:
     name: Mypy 3.10
     runs-on: "ubuntu-latest"
     needs: detect-ci-trigger
@@ -181,7 +181,7 @@ jobs:
 
       - name: Run mypy
         run: |
-          python -m mypy --install-types --non-interactive --cobertura-xml-report mypy_report xarray/
+          python -m mypy --install-types --non-interactive --cobertura-xml-report mypy_report
 
       - name: Upload mypy coverage to Codecov
         uses: codecov/codecov-action@v4.5.0


### PR DESCRIPTION
We should test that a simple `mypy` invocation works, because that's what's expected to run locally, and instead move any arguments to config files

(I hit this because I'm getting type errors locally, though this doesn't fix them, it eliminates a source of difference)
