### PR TITLE
copy the data of the `DatetimeIndex` in the `Dataset.chunk`-by-frequency tests

### DIFF
--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1217,7 +1217,7 @@ class TestDataset:
         ΔN = 28
         time = xr.date_range(
             "2001-01-01", periods=N + ΔN, freq="D", calendar=calendar
-        ).to_numpy()
+        ).to_numpy(copy=True)
         if add_gap:
             # introduce an empty bin
             time[31 : 31 + ΔN] = np.datetime64("NaT")


### PR DESCRIPTION
Looks like `pd.DatetimeIndex.to_numpy` will return a immutable view by default, so we have to specify that we want a copy instead.

- [x] towards #9277

(Note: this, together with #9403, allows us to close the upstream-dev issue #9277)