### PR TITLE
Bump minimum versions for dependencies

### DIFF
--- a/ci/requirements/bare-minimum.yml
+++ b/ci/requirements/bare-minimum.yml
@@ -11,6 +11,6 @@ dependencies:
   - pytest-env
   - pytest-xdist
   - pytest-timeout
-  - numpy=1.23
+  - numpy=1.24
   - packaging=23.1
-  - pandas=2.0
+  - pandas=2.1

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -34,7 +34,7 @@ dependencies:
   - nc-time-axis=1.4
   # netcdf follows a 1.major.minor[.patch] convention
   # (see https://github.com/Unidata/netcdf4-python/issues/1090)
-  - netcdf4=1.6.0
+  - netcdf4=1.6.4
   - numba=0.57
   - numbagg=0.2.1
   - numpy=1.24

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -34,7 +34,7 @@ dependencies:
   - nc-time-axis=1.4
   # netcdf follows a 1.major.minor[.patch] convention
   # (see https://github.com/Unidata/netcdf4-python/issues/1090)
-  - netcdf4=1.6.4
+  - netcdf4=1.6.0
   - numba=0.57
   - numbagg=0.2.1
   - numpy=1.24

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -9,37 +9,37 @@ dependencies:
   # doc/user-guide/installing.rst, doc/user-guide/plotting.rst and setup.py.
   - python=3.10
   - array-api-strict=1.0  # dependency for testing the array api compat
-  - boto3=1.26
+  - boto3=1.28
   - bottleneck=1.3
-  - cartopy=0.21
+  - cartopy=0.22
   - cftime=1.6
   - coveralls
-  - dask-core=2023.4
-  - distributed=2023.4
+  - dask-core=2023.9
+  - distributed=2023.9
   # Flox > 0.8 has a bug with numbagg versions
   # It will require numbagg > 0.6
   # so we should just skip that series eventually
   # or keep flox pinned for longer than necessary
   - flox=0.7
-  - h5netcdf=1.1
+  - h5netcdf=1.2
   # h5py and hdf5 tend to cause conflicts
   # for e.g. hdf5 1.12 conflicts with h5py=3.1
   # prioritize bumping other packages instead
   - h5py=3.8
   - hdf5=1.12
   - hypothesis
-  - iris=3.4
+  - iris=3.7
   - lxml=4.9  # Optional dep of pydap
   - matplotlib-base=3.7
   - nc-time-axis=1.4
   # netcdf follows a 1.major.minor[.patch] convention
   # (see https://github.com/Unidata/netcdf4-python/issues/1090)
   - netcdf4=1.6.0
-  - numba=0.56
+  - numba=0.57
   - numbagg=0.2.1
-  - numpy=1.23
+  - numpy=1.24
   - packaging=23.1
-  - pandas=2.0
+  - pandas=2.1
   - pint=0.22
   - pip
   - pydap=3.4
@@ -49,9 +49,9 @@ dependencies:
   - pytest-xdist
   - pytest-timeout
   - rasterio=1.3
-  - scipy=1.10
+  - scipy=1.11
   - seaborn=0.12
   - sparse=0.14
   - toolz=0.12
-  - typing_extensions=4.5
-  - zarr=2.14
+  - typing_extensions=4.7
+  - zarr=2.16

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,6 +35,24 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 - Support for ``python 3.9`` has been dropped (:pull:`8937`)
+- The minimum versions of some dependencies were changed, in particular our minimum supported pandas version is now Pandas 2.
+
+  ===================== =========  =======
+   Package                    Old      New
+  ===================== =========  =======
+    boto3                   1.26     1.28
+    cartopy                 0.21     0.22
+    dask-core               2023.4   2023.9
+    distributed             2023.4   2023.9
+    h5netcdf                1.1      1.2
+    iris                    3.4      3.7
+    numba                   0.56     0.57
+    numpy                   1.23     1.24
+    pandas                  2.0      2.1
+    scipy                   1.10     1.11
+    typing_extensions       4.5      4.7
+    zarr                    2.14     2.16
+  ===================== =========  =======
 
 
 Deprecations

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,18 +40,18 @@ Breaking changes
   ===================== =========  =======
    Package                    Old      New
   ===================== =========  =======
-    boto3                   1.26     1.28
-    cartopy                 0.21     0.22
-    dask-core               2023.4   2023.9
-    distributed             2023.4   2023.9
-    h5netcdf                1.1      1.2
-    iris                    3.4      3.7
-    numba                   0.56     0.57
-    numpy                   1.23     1.24
-    pandas                  2.0      2.1
-    scipy                   1.10     1.11
-    typing_extensions       4.5      4.7
-    zarr                    2.14     2.16
+    boto3                   1.26      1.28
+    cartopy                 0.21      0.22
+    dask-core             2023.4    2023.9
+    distributed           2023.4    2023.9
+    h5netcdf                1.1        1.2
+    iris                    3.4        3.7
+    numba                   0.56      0.57
+    numpy                   1.23      1.24
+    pandas                  2.0        2.1
+    scipy                   1.10      1.11
+    typing_extensions       4.5        4.7
+    zarr                    2.14      2.16
   ===================== =========  =======
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,7 +35,7 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 - Support for ``python 3.9`` has been dropped (:pull:`8937`)
-- The minimum versions of some dependencies were changed, in particular our minimum supported pandas version is now Pandas 2.
+- The minimum versions of some dependencies were changed
 
   ===================== =========  =======
    Package                    Old      New

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ readme = "README.md"
 requires-python = ">=3.10"
 
 dependencies = [
-  "numpy>=1.23",
+  "numpy>=1.24",
   "packaging>=23.1",
-  "pandas>=2.0",
+  "pandas>=2.1",
 ]
 
 [project.optional-dependencies]

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -134,7 +134,6 @@ has_cartopy, requires_cartopy = _importorskip("cartopy")
 has_pint, requires_pint = _importorskip("pint")
 has_numexpr, requires_numexpr = _importorskip("numexpr")
 has_flox, requires_flox = _importorskip("flox")
-has_pandas_ge_2_1, __ = _importorskip("pandas", "2.1")
 has_pandas_ge_2_2, __ = _importorskip("pandas", "2.2")
 has_pandas_3, requires_pandas_3 = _importorskip("pandas", "3.0.0.dev0")
 

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -29,7 +29,7 @@ from xarray.tests import (
     create_test_data,
     has_cftime,
     has_flox,
-    has_pandas_ge_2_1,
+    has_pandas_ge_2_2,
     requires_cftime,
     requires_dask,
     requires_flox,
@@ -135,7 +135,7 @@ def test_multi_index_groupby_sum() -> None:
         )
         assert_equal(expected, ds)
 
-    if not has_pandas_ge_2_1:
+    if not has_pandas_ge_2_2:
         # the next line triggers a mysterious multiindex error on pandas 2.0
         return
 


### PR DESCRIPTION

- [x] Closes #9363
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
