### PR TITLE
Always include at least one category in random test data

### DIFF
--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -325,7 +325,7 @@ def create_test_data(
             "dim1",
             pd.Categorical(
                 np.random.choice(
-                    list(string.ascii_lowercase[: np.random.randint(5)]),
+                    list(string.ascii_lowercase[: np.random.randint(1, 5)]),
                     size=dim_sizes[0],
                 )
             ),

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -324,8 +324,8 @@ def create_test_data(
         obj["var4"] = (
             "dim1",
             pd.Categorical(
-                np.random.choice(
-                    list(string.ascii_lowercase[: np.random.randint(1, 5)]),
+                rs.choice(
+                    list(string.ascii_lowercase[: rs.randint(1, 5)]),
                     size=dim_sizes[0],
                 )
             ),
@@ -333,7 +333,7 @@ def create_test_data(
     if dim_sizes == _DEFAULT_TEST_DIM_SIZES:
         numbers_values = np.array([0, 1, 2, 0, 0, 1, 1, 2, 2, 3], dtype="int64")
     else:
-        numbers_values = np.random.randint(0, 3, _dims["dim3"], dtype="int64")
+        numbers_values = rs.randint(0, 3, _dims["dim3"], dtype="int64")
     obj.coords["numbers"] = ("dim3", numbers_values)
     obj.encoding = {"foo": "bar"}
     assert_writeable(obj)


### PR DESCRIPTION
Otherwise, creating test data can fail randomly, depending on how the random number generator is seeded.

(Note: we would ideally avoid using a random number generator or fix the random seed so test data is entirely deterministic, but that's a bigger refactor...)
