### PR TITLE
Disallow passing a DataArray as data into the DataTree constructor

### DIFF
--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1047,7 +1047,6 @@ class DataTree(
     def from_dict(
         cls,
         d: Mapping[str, Dataset | DataTree | None],
-        /,
         name: str | None = None,
     ) -> DataTree:
         """

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1047,6 +1047,7 @@ class DataTree(
     def from_dict(
         cls,
         d: Mapping[str, Dataset | DataTree | None],
+        /,
         name: str | None = None,
     ) -> DataTree:
         """

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1046,7 +1046,7 @@ class DataTree(
     @classmethod
     def from_dict(
         cls,
-        d: Mapping[str, Dataset | DataArray | DataTree | None],
+        d: Mapping[str, Dataset | DataTree | None],
         name: str | None = None,
     ) -> DataTree:
         """
@@ -1055,10 +1055,10 @@ class DataTree(
         Parameters
         ----------
         d : dict-like
-            A mapping from path names to xarray.Dataset, xarray.DataArray, or DataTree objects.
+            A mapping from path names to xarray.Dataset or DataTree objects.
 
-            Path names are to be given as unix-like path. If path names containing more than one part are given, new
-            tree nodes will be constructed as necessary.
+            Path names are to be given as unix-like path. If path names containing more than one
+            part are given, new tree nodes will be constructed as necessary.
 
             To assign data to the root node of the tree use "/" as the path.
         name : Hashable | None, optional

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -33,6 +33,14 @@ class TestTreeCreation:
         with pytest.raises(ValueError):
             DataTree(name="folder/data")
 
+    def test_data_arg(self):
+        ds = xr.Dataset({"foo": 42})
+        tree: DataTree = DataTree(data=ds)
+        assert_identical(tree.to_dataset(), ds)
+
+        with pytest.raises(TypeError):
+            DataTree(data=xr.DataArray(42, name="foo"))  # type: ignore
+
 
 class TestFamilyTree:
     def test_setparent_unnamed_child_node_fails(self):
@@ -585,6 +593,11 @@ class TestTreeFromDict:
         # Check that Bart and Lisa's order is still preserved within the group,
         # despite 'Bart' coming before 'Lisa' when sorted alphabetically
         assert list(reversed["Homer"].children.keys()) == ["Lisa", "Bart"]
+
+    def test_array_values(self):
+        data = {"foo": xr.DataArray(1, name="bar")}
+        with pytest.raises(TypeError):
+            DataTree.from_dict(data)  # type: ignore
 
 
 class TestDatasetView:


### PR DESCRIPTION
I don't think there's a good reason to support syntax like `DataTree(DataArray(...))`, when it's easy enough to explicitly convert with `to_dataset()`. `Dataset(DataArray(...))` currently raises an error, so this feels a bit inconsistent.

If this was intended for the sake of usability, then I think supporting a dict (that gets coerced into a Dataset) in the DataTree constructor would be much helpful. We can consider adding this later.

@TomNicholas 