### PR TITLE
Make the first argument in DataTree.from_dict positional only

### DIFF
--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1051,6 +1051,7 @@ class DataTree(
     def from_dict(
         cls,
         d: Mapping[str, Dataset | DataArray | DataTree | None],
+        /,
         name: str | None = None,
     ) -> DataTree:
         """

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -1059,7 +1059,7 @@ class TestSubset:
 
     def test_filter(self):
         simpsons: DataTree = DataTree.from_dict(
-            d={
+            {
                 "/": xr.Dataset({"age": 83}),
                 "/Herbert": xr.Dataset({"age": 40}),
                 "/Homer": xr.Dataset({"age": 39}),
@@ -1070,7 +1070,7 @@ class TestSubset:
             name="Abe",
         )
         expected = DataTree.from_dict(
-            d={
+            {
                 "/": xr.Dataset({"age": 83}),
                 "/Herbert": xr.Dataset({"age": 40}),
                 "/Homer": xr.Dataset({"age": 39}),

--- a/xarray/tests/test_datatree_mapping.py
+++ b/xarray/tests/test_datatree_mapping.py
@@ -19,8 +19,8 @@ class TestCheckTreesIsomorphic:
             check_isomorphic("s", 1)  # type: ignore[arg-type]
 
     def test_different_widths(self):
-        dt1 = DataTree.from_dict(d={"a": empty})
-        dt2 = DataTree.from_dict(d={"b": empty, "c": empty})
+        dt1 = DataTree.from_dict({"a": empty})
+        dt2 = DataTree.from_dict({"b": empty, "c": empty})
         expected_err_str = (
             "Number of children on node '/' of the left object: 1\n"
             "Number of children on node '/' of the right object: 2"
@@ -320,7 +320,7 @@ class TestMutableOperations:
 
     def test_alter_inplace_forbidden(self):
         simpsons = DataTree.from_dict(
-            d={
+            {
                 "/": xr.Dataset({"age": 83}),
                 "/Herbert": xr.Dataset({"age": 40}),
                 "/Homer": xr.Dataset({"age": 39}),


### PR DESCRIPTION
The fact that it has the non-descriptive name "d" is a good indication that users should not be supplying it as a keyword argument.

(Alternatively, we could make a more descriptive name, but I think positional only is also fine for now.)
