### PR TITLE
Remove parent argument from DataTree.__init__

### DIFF
--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -418,7 +418,6 @@ class DataTree(
     def __init__(
         self,
         data: Dataset | None = None,
-        parent: DataTree | None = None,
         children: Mapping[str, DataTree] | None = None,
         name: str | None = None,
     ):


### PR DESCRIPTION
This somehow got missed from #9297, see https://github.com/pydata/xarray/pull/9297#issuecomment-2335347554.
