### PR TITLE
Make zarr ArrayWriter customizable when writing dataset to zarr

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1624,6 +1624,7 @@ def to_zarr(
     zarr_version: int | None = None,
     write_empty_chunks: bool | None = None,
     chunkmanager_store_kwargs: dict[str, Any] | None = None,
+    writer: ArrayWriter | None = None,
 ) -> backends.ZarrStore: ...
 
 
@@ -1647,6 +1648,7 @@ def to_zarr(
     zarr_version: int | None = None,
     write_empty_chunks: bool | None = None,
     chunkmanager_store_kwargs: dict[str, Any] | None = None,
+    writer: ArrayWriter | None = None,
 ) -> Delayed: ...
 
 
@@ -1668,6 +1670,7 @@ def to_zarr(
     zarr_version: int | None = None,
     write_empty_chunks: bool | None = None,
     chunkmanager_store_kwargs: dict[str, Any] | None = None,
+    writer: ArrayWriter | None = None,
 ) -> backends.ZarrStore | Delayed:
     """This function creates an appropriate datastore for writing a dataset to
     a zarr ztore
@@ -1775,7 +1778,6 @@ def to_zarr(
                     f"variable {var_name!r} already exists, but encoding was provided"
                 )
 
-    writer = ArrayWriter()
     # TODO: figure out how to properly handle unlimited_dims
     dump_to_store(dataset, zstore, writer, encoding=encoding)
     writes = writer.sync(

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -138,6 +138,7 @@ if TYPE_CHECKING:
 
     from xarray.backends import AbstractDataStore, ZarrStore
     from xarray.backends.api import T_NetcdfEngine, T_NetcdfTypes
+    from xarray.backends.common import ArrayWriter
     from xarray.core.dataarray import DataArray
     from xarray.core.groupby import DatasetGroupBy
     from xarray.core.merge import CoercibleMapping, CoercibleValue, _MergeResult
@@ -2367,6 +2368,7 @@ class Dataset(
         zarr_version: int | None = None,
         write_empty_chunks: bool | None = None,
         chunkmanager_store_kwargs: dict[str, Any] | None = None,
+        writer: ArrayWriter | None = None,
     ) -> ZarrStore: ...
 
     # compute=False returns dask.Delayed
@@ -2389,6 +2391,7 @@ class Dataset(
         zarr_version: int | None = None,
         write_empty_chunks: bool | None = None,
         chunkmanager_store_kwargs: dict[str, Any] | None = None,
+        writer: ArrayWriter | None = None,
     ) -> Delayed: ...
 
     def to_zarr(
@@ -2409,6 +2412,7 @@ class Dataset(
         zarr_version: int | None = None,
         write_empty_chunks: bool | None = None,
         chunkmanager_store_kwargs: dict[str, Any] | None = None,
+        writer: ArrayWriter | None = None,
     ) -> ZarrStore | Delayed:
         """Write dataset contents to a zarr group.
 
@@ -2527,6 +2531,8 @@ class Dataset(
             Additional keyword arguments passed on to the `ChunkManager.store` method used to store
             chunked arrays. For example for a dask array additional kwargs will be passed eventually to
             :py:func:`dask.array.store()`. Experimental API that should not be relied upon.
+        writer : ArrayWriter, optional
+            Override the ArrayWriter used to write variables to the Zarr Store.
 
         Returns
         -------
@@ -2574,6 +2580,7 @@ class Dataset(
             zarr_version=zarr_version,
             write_empty_chunks=write_empty_chunks,
             chunkmanager_store_kwargs=chunkmanager_store_kwargs,
+            writer=writer,
         )
 
     def __repr__(self) -> str:


### PR DESCRIPTION

- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

The `dump_to_store` function was already exposing the ability to specify a writer, but this was never exposed on any of the `to_zarr` function, and was simply hardcoded to `ArrayWriter`.

This PR adds the optional keyword argument to override it, and just pass it to the dump function.

Let me know if you need me to add documentation on it.

Thanks!