### PR TITLE
Ensure TreeNode doesn't copy in-place

### DIFF
--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -771,67 +771,21 @@ class DataTree(
 
         self.children = children
 
-    def copy(
-        self: DataTree,
-        deep: bool = False,
-    ) -> DataTree:
-        """
-        Returns a copy of this subtree.
-
-        Copies this node and all child nodes.
-
-        If `deep=True`, a deep copy is made of each of the component variables.
-        Otherwise, a shallow copy of each of the component variable is made, so
-        that the underlying memory region of the new datatree is the same as in
-        the original datatree.
-
-        Parameters
-        ----------
-        deep : bool, default: False
-            Whether each component variable is loaded into memory and copied onto
-            the new object. Default is False.
-
-        Returns
-        -------
-        object : DataTree
-            New object with dimensions, attributes, coordinates, name, encoding,
-            and data of this node and all child nodes copied from original.
-
-        See Also
-        --------
-        xarray.Dataset.copy
-        pandas.DataFrame.copy
-        """
-        return self._copy_subtree(deep=deep)
-
-    def _copy_subtree(
-        self: DataTree,
-        deep: bool = False,
-        memo: dict[int, Any] | None = None,
-    ) -> DataTree:
-        """Copy entire subtree"""
-        new_tree = self._copy_node(deep=deep)
-        for node in self.descendants:
-            path = node.relative_to(self)
-            new_tree[path] = node._copy_node(deep=deep)
-        return new_tree
-
     def _copy_node(
         self: DataTree,
         deep: bool = False,
     ) -> DataTree:
         """Copy just one node of a tree"""
+
+        new_node = super()._copy_node()
+        new_node._name = self.name
+
         data = self._to_dataset_view(rebuild_dims=False, inherited=False)
         if deep:
             data = data.copy(deep=True)
-        new_node = DataTree(data, name=self.name)
+        new_node._set_node_data(data)
+
         return new_node
-
-    def __copy__(self: DataTree) -> DataTree:
-        return self._copy_subtree(deep=False)
-
-    def __deepcopy__(self: DataTree, memo: dict[int, Any] | None = None) -> DataTree:
-        return self._copy_subtree(deep=True, memo=memo)
 
     def get(  # type: ignore[override]
         self: DataTree, key: str, default: DataTree | DataArray | None = None

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -778,7 +778,6 @@ class DataTree(
         """Copy just one node of a tree"""
 
         new_node = super()._copy_node()
-        new_node._name = self.name
 
         data = self._to_dataset_view(rebuild_dims=False, inherited=False)
         if deep:

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -447,14 +447,10 @@ class DataTree(
         --------
         DataTree.from_dict
         """
-        if children is None:
-            children = {}
+        # TODO set after setting node data as this will check for name conflicts?
+        super().__init__(name=name, children=children)
 
-        super().__init__(name=name)
         self._set_node_data(_to_new_dataset(dataset))
-
-        # shallow copy to avoid modifying arguments in-place (see GH issue #9196)
-        self.children = {name: child.copy() for name, child in children.items()}
 
     def _set_node_data(self, dataset: Dataset):
         data_vars, coord_vars = _collect_data_and_coord_variables(dataset)

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -447,10 +447,10 @@ class DataTree(
         --------
         DataTree.from_dict
         """
-        # TODO set after setting node data as this will check for name conflicts?
-        super().__init__(name=name, children=children)
-
         self._set_node_data(_to_new_dataset(dataset))
+
+        # comes after setting node data as this will check for clashes between child names and existing variable names
+        super().__init__(name=name, children=children)
 
     def _set_node_data(self, dataset: Dataset):
         data_vars, coord_vars = _collect_data_and_coord_variables(dataset)

--- a/xarray/core/treenode.py
+++ b/xarray/core/treenode.py
@@ -78,8 +78,10 @@ class TreeNode(Generic[Tree]):
         """Create a parentless node."""
         self._parent = None
         self._children = {}
-        if children is not None:
-            self.children = children
+
+        if children:
+            # shallow copy to avoid modifying arguments in-place (see GH issue #9196)
+            self.children = {name: child.copy() for name, child in children.items()}
 
     @property
     def parent(self) -> Tree | None:

--- a/xarray/core/treenode.py
+++ b/xarray/core/treenode.py
@@ -290,12 +290,6 @@ class TreeNode(Generic[Tree]):
         deep: bool = False,
     ) -> Tree:
         """Copy just one node of a tree"""
-
-        # TODO could I just do this and then not have to override this class?
-        # new_instance = type(self).__new__(type(self))
-        # new_instance.__dict__.update(self.__dict__)
-        # return new_instance
-
         new_empty_node = type(self)()
         return new_empty_node
 
@@ -690,9 +684,9 @@ class NamedNode(TreeNode, Generic[Tree]):
         self.name = name
 
     def _copy_node(
-        self: NamedNode,
+        self: AnyNamedNode,
         deep: bool = False,
-    ) -> NamedNode:
+    ) -> AnyNamedNode:
         """Copy just one node of a tree"""
         new_node = super()._copy_node()
         new_node._name = self.name

--- a/xarray/tests/test_treenode.py
+++ b/xarray/tests/test_treenode.py
@@ -71,17 +71,21 @@ class TestFamilyTree:
         assert child.parent is None
 
     def test_multi_child_family(self):
-        mary: TreeNode = TreeNode()
-        kate: TreeNode = TreeNode()
-        john: TreeNode = TreeNode(children={"Mary": mary, "Kate": kate})
-        assert john.children["Mary"] is mary
-        assert john.children["Kate"] is kate
+        john: TreeNode = TreeNode(children={"Mary": TreeNode(), "Kate": TreeNode()})
+
+        assert "Mary" in john.children
+        mary = john.children["Mary"]
+        assert isinstance(mary, TreeNode)
         assert mary.parent is john
+
+        assert "Kate" in john.children
+        kate = john.children["Kate"]
+        assert isinstance(kate, TreeNode)
         assert kate.parent is john
 
     def test_disown_child(self):
-        mary: TreeNode = TreeNode()
-        john: TreeNode = TreeNode(children={"Mary": mary})
+        john: TreeNode = TreeNode(children={"Mary": TreeNode()})
+        mary = john.children["Mary"]
         mary.orphan()
         assert mary.parent is None
         assert "Mary" not in john.children
@@ -102,12 +106,11 @@ class TestFamilyTree:
         assert john.children["Kate"] is evil_kate
 
     def test_sibling_relationships(self):
-        mary: TreeNode = TreeNode()
-        kate: TreeNode = TreeNode()
-        ashley: TreeNode = TreeNode()
-        TreeNode(children={"Mary": mary, "Kate": kate, "Ashley": ashley})
-        assert kate.siblings["Mary"] is mary
-        assert kate.siblings["Ashley"] is ashley
+        john = TreeNode(
+            children={"Mary": TreeNode(), "Kate": TreeNode(), "Ashley": TreeNode()}
+        )
+        kate = john.children["Kate"]
+        assert list(kate.siblings) == ["Mary", "Ashley"]
         assert "Kate" not in kate.siblings
 
     def test_ancestors(self):

--- a/xarray/tests/test_treenode.py
+++ b/xarray/tests/test_treenode.py
@@ -64,6 +64,12 @@ class TestFamilyTree:
         ):
             mary.parent = john
 
+    def test_dont_modify_children_inplace(self):
+        # GH issue 9196
+        child = TreeNode()
+        TreeNode(children={"child": child})
+        assert child.parent is None
+
     def test_multi_child_family(self):
         mary: TreeNode = TreeNode()
         kate: TreeNode = TreeNode()

--- a/xarray/tests/test_treenode.py
+++ b/xarray/tests/test_treenode.py
@@ -122,21 +122,29 @@ class TestFamilyTree:
         copied_tony = vito.children["Michael"].children["Tony"]
         assert copied_tony is not tony
 
-    def test_ancestors(self):
-        tony: TreeNode = TreeNode()
-        michael: TreeNode = TreeNode(children={"Tony": tony})
-        vito = TreeNode(children={"Michael": michael})
+    def test_parents(self):
+        vito = TreeNode(
+            children={"Michael": TreeNode(children={"Tony": TreeNode()})},
+        )
+        michael = vito.children["Michael"]
+        tony = michael.children["Tony"]
+
         assert tony.root is vito
         assert tony.parents == (michael, vito)
-        assert tony.ancestors == (vito, michael, tony)
 
 
 class TestGetNodes:
     def test_get_child(self):
-        steven: TreeNode = TreeNode()
-        sue = TreeNode(children={"Steven": steven})
-        mary = TreeNode(children={"Sue": sue})
-        john = TreeNode(children={"Mary": mary})
+        john = TreeNode(
+            children={
+                "Mary": TreeNode(
+                    children={"Sue": TreeNode(children={"Steven": TreeNode()})}
+                )
+            }
+        )
+        mary = john.children["Mary"]
+        sue = mary.children["Sue"]
+        steven = sue.children["Steven"]
 
         # get child
         assert john._get_item("Mary") is mary
@@ -156,10 +164,14 @@ class TestGetNodes:
         assert mary._get_item("Sue/Steven") is steven
 
     def test_get_upwards(self):
-        sue: TreeNode = TreeNode()
-        kate: TreeNode = TreeNode()
-        mary = TreeNode(children={"Sue": sue, "Kate": kate})
-        john = TreeNode(children={"Mary": mary})
+        john = TreeNode(
+            children={
+                "Mary": TreeNode(children={"Sue": TreeNode(), "Kate": TreeNode()})
+            }
+        )
+        mary = john.children["Mary"]
+        sue = mary.children["Sue"]
+        kate = mary.children["Kate"]
 
         assert sue._get_item("../") is mary
         assert sue._get_item("../../") is john
@@ -168,9 +180,9 @@ class TestGetNodes:
         assert sue._get_item("../Kate") is kate
 
     def test_get_from_root(self):
-        sue: TreeNode = TreeNode()
-        mary = TreeNode(children={"Sue": sue})
-        john = TreeNode(children={"Mary": mary})  # noqa
+        john = TreeNode(children={"Mary": TreeNode(children={"Sue": TreeNode()})})
+        mary = john.children["Mary"]
+        sue = mary.children["Sue"]
 
         assert sue._get_item("/Mary") is mary
 
@@ -385,11 +397,14 @@ class TestAncestry:
 
 class TestRenderTree:
     def test_render_nodetree(self):
-        sam: NamedNode = NamedNode()
-        ben: NamedNode = NamedNode()
-        mary: NamedNode = NamedNode(children={"Sam": sam, "Ben": ben})
-        kate: NamedNode = NamedNode()
-        john: NamedNode = NamedNode(children={"Mary": mary, "Kate": kate})
+        john: NamedNode = NamedNode(
+            children={
+                "Mary": NamedNode(children={"Sam": NamedNode(), "Ben": NamedNode()}),
+                "Kate": NamedNode(),
+            }
+        )
+        mary = john.children["Mary"]
+
         expected_nodes = [
             "NamedNode()",
             "\tNamedNode('Mary')",

--- a/xarray/tests/test_treenode.py
+++ b/xarray/tests/test_treenode.py
@@ -66,7 +66,7 @@ class TestFamilyTree:
 
     def test_dont_modify_children_inplace(self):
         # GH issue 9196
-        child = TreeNode()
+        child: TreeNode = TreeNode()
         TreeNode(children={"child": child})
         assert child.parent is None
 
@@ -106,7 +106,7 @@ class TestFamilyTree:
         assert john.children["Kate"] is evil_kate
 
     def test_sibling_relationships(self):
-        john = TreeNode(
+        john: TreeNode = TreeNode(
             children={"Mary": TreeNode(), "Kate": TreeNode(), "Ashley": TreeNode()}
         )
         kate = john.children["Kate"]
@@ -123,7 +123,7 @@ class TestFamilyTree:
         assert copied_tony is not tony
 
     def test_parents(self):
-        vito = TreeNode(
+        vito: TreeNode = TreeNode(
             children={"Michael": TreeNode(children={"Tony": TreeNode()})},
         )
         michael = vito.children["Michael"]
@@ -135,7 +135,7 @@ class TestFamilyTree:
 
 class TestGetNodes:
     def test_get_child(self):
-        john = TreeNode(
+        john: TreeNode = TreeNode(
             children={
                 "Mary": TreeNode(
                     children={"Sue": TreeNode(children={"Steven": TreeNode()})}
@@ -164,7 +164,7 @@ class TestGetNodes:
         assert mary._get_item("Sue/Steven") is steven
 
     def test_get_upwards(self):
-        john = TreeNode(
+        john: TreeNode = TreeNode(
             children={
                 "Mary": TreeNode(children={"Sue": TreeNode(), "Kate": TreeNode()})
             }
@@ -180,7 +180,9 @@ class TestGetNodes:
         assert sue._get_item("../Kate") is kate
 
     def test_get_from_root(self):
-        john = TreeNode(children={"Mary": TreeNode(children={"Sue": TreeNode()})})
+        john: TreeNode = TreeNode(
+            children={"Mary": TreeNode(children={"Sue": TreeNode()})}
+        )
         mary = john.children["Mary"]
         sue = mary.children["Sue"]
 

--- a/xarray/tests/test_treenode.py
+++ b/xarray/tests/test_treenode.py
@@ -113,6 +113,15 @@ class TestFamilyTree:
         assert list(kate.siblings) == ["Mary", "Ashley"]
         assert "Kate" not in kate.siblings
 
+    def test_copy_subtree(self):
+        tony: TreeNode = TreeNode()
+        michael: TreeNode = TreeNode(children={"Tony": tony})
+        vito = TreeNode(children={"Michael": michael})
+
+        # check that children of assigned children are also copied (i.e. that ._copy_subtree works)
+        copied_tony = vito.children["Michael"].children["Tony"]
+        assert copied_tony is not tony
+
     def test_ancestors(self):
         tony: TreeNode = TreeNode()
         michael: TreeNode = TreeNode(children={"Tony": tony})


### PR DESCRIPTION
Solves #9478 by implementing steps 1 through 4 of https://github.com/pydata/xarray/issues/9478#issue-2519949243. Steps 5 and 6 were not necessary, so `TreeNode` and `NamedNode` are still separate.

Changes the in-place behaviour of `TreeNode` in a way that is now consistent with the changes made to `DataTree` in #9297. The tests for treenode are changed but as the tests for datatree are not changed, there are no changes to user API.

- [x] Closes #9478
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
