### PR TITLE
New whatsnew section

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -14,6 +14,34 @@ What's New
 
     np.random.seed(123456)
 
+.. _whats-new.2024.09.1:
+
+v2024.09.1 (unreleased)
+-----------------------
+
+New Features
+~~~~~~~~~~~~
+
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+
+Deprecations
+~~~~~~~~~~~~
+
+
+Bug fixes
+~~~~~~~~~
+
+
+Documentation
+~~~~~~~~~~~~~
+
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+
 
 .. _whats-new.2024.09.0:
 


### PR DESCRIPTION
This PR just adds in the new section to `doc/whats-new.rst` after the v2024.09.0 release. (The instructions for a release said to push to main, but the branch was protected against that)

- ~~Closes #xxxx~~
- ~~Tests added~~
- ~~User visible changes (including notable bug fixes) are documented in `whats-new.rst`~~
- ~~New functions/methods are listed in `api.rst`~~