### PR TITLE
Forbid slashes in child & coord names

### DIFF
--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -846,10 +846,11 @@ class DataTreeCoordinates(Coordinates):
     def _update_coords(
         self, coords: dict[Hashable, Variable], indexes: Mapping[Any, Index]
     ) -> None:
-        from xarray.core.datatree import check_alignment
+        from xarray.core.datatree import check_alignment, check_for_slashes_in_names
 
         # create updated node (`.to_dataset` makes a copy so this doesn't modify in-place)
         node_ds = self._data.to_dataset(inherited=False)
+        check_for_slashes_in_names(list(coords.keys()))
         node_ds.coords._update_coords(coords, indexes)
 
         # check consistency *before* modifying anything in-place

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -156,7 +156,7 @@ def check_alignment(
             check_alignment(child_path, child_ds, base_ds, child.children)
 
 
-def _check_for_slashes_in_names(variables: Iterable[Hashable]) -> None:
+def check_for_slashes_in_names(variables: Iterable[Hashable]) -> None:
     offending_variable_names = [
         name for name in variables if isinstance(name, str) and "/" in name
     ]
@@ -465,7 +465,7 @@ class DataTree(
         super().__init__(name=name, children=children)
 
     def _set_node_data(self, dataset: Dataset):
-        _check_for_slashes_in_names(dataset.variables)
+        check_for_slashes_in_names(dataset.variables)
         data_vars, coord_vars = _collect_data_and_coord_variables(dataset)
         self._data_variables = data_vars
         self._node_coord_variables = coord_vars

--- a/xarray/core/treenode.py
+++ b/xarray/core/treenode.py
@@ -205,6 +205,8 @@ class TreeNode(Generic[Tree]):
 
         seen = set()
         for name, child in children.items():
+            if not isinstance(name, str):
+                raise TypeError("child name must be a string or None")
             if "/" in name:
                 raise ValueError("child names cannot contain forward slashes")
 

--- a/xarray/core/treenode.py
+++ b/xarray/core/treenode.py
@@ -205,6 +205,9 @@ class TreeNode(Generic[Tree]):
 
         seen = set()
         for name, child in children.items():
+            if "/" in name:
+                raise ValueError("child names cannot contain forward slashes")
+
             if not isinstance(child, TreeNode):
                 raise TypeError(
                     f"Cannot add object {name}. It is of type {type(child)}, "

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -718,6 +718,12 @@ class TestCoords:
         # expected = child.assign_coords({"c": 11})
         # assert_identical(expected, actual)
 
+    def test_forbid_paths_as_names(self):
+        # regression test for GH issue #9485
+        dt = DataTree(Dataset(coords={"x": 0}), children={"child": DataTree()})
+        with pytest.raises(ValueError, match="cannot have names containing"):
+            dt.coords["/child/y"] = 2
+
 
 def test_delitem():
     ds = Dataset({"a": 0}, coords={"x": ("x", [1, 2]), "z": "a"})

--- a/xarray/tests/test_treenode.py
+++ b/xarray/tests/test_treenode.py
@@ -270,15 +270,22 @@ class TestPruning:
             del john["Mary"]
 
 
-class TestNamesCannotContainSlashes:
+class TestValidNames:
     def test_child_keys(self):
         parent = TreeNode()
         with pytest.raises(ValueError, match="cannot contain forward slashes"):
             parent.children = {"a/b": TreeNode()}
 
+        parent = TreeNode()
+        with pytest.raises(TypeError, match="must be a string or None"):
+            parent.children = {0: TreeNode()}
+
     def test_node_names(self):
         with pytest.raises(ValueError, match="cannot contain forward slashes"):
             NamedNode(name="a/b")
+
+        with pytest.raises(TypeError, match="must be a string or None"):
+            NamedNode(name=0)
 
 
 def create_test_tree() -> tuple[NamedNode, NamedNode]:

--- a/xarray/tests/test_treenode.py
+++ b/xarray/tests/test_treenode.py
@@ -270,6 +270,17 @@ class TestPruning:
             del john["Mary"]
 
 
+class TestNamesCannotContainSlashes:
+    def test_child_keys(self):
+        parent = TreeNode()
+        with pytest.raises(ValueError, match="cannot contain forward slashes"):
+            parent.children = {"a/b": TreeNode()}
+
+    def test_node_names(self):
+        with pytest.raises(ValueError, match="cannot contain forward slashes"):
+            NamedNode(name="a/b")
+
+
 def create_test_tree() -> tuple[NamedNode, NamedNode]:
     # a
     # ├── b


### PR DESCRIPTION
Follow-up to #9378 (cc @etienneschalk ) which also forbids forward slashes in child names, and in coordinate variable names set via `.coords.__setitem__`.

Not the cleanest PR ever (we raise basically the same error message in 4 different places in the code...) but the point is to prevent inconsistent state now (so that we don't release something broken), and then I can make sure to get the obviously-needed refactor mentioned in https://github.com/pydata/xarray/issues/9485#issuecomment-2345203393 right.

- [x] Prevents reaching state shown in #9485
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

cc @shoyer 
