### PR TITLE
Forbid modifying names of DataTree objects with parents

### DIFF
--- a/xarray/core/treenode.py
+++ b/xarray/core/treenode.py
@@ -673,8 +673,8 @@ class NamedNode(TreeNode, Generic[Tree]):
     def name(self, name: str | None) -> None:
         if self.parent is not None:
             raise ValueError(
-                "cannot set the name of a node with a parent. Consider creating "
-                "a detached copy of this node via .copy(), or using .rename() "
+                "cannot set the name of a node which already has a parent. Consider creating "
+                "a detached copy of this node via .copy()."
                 "on the parent node."
             )
         _validate_name(name)

--- a/xarray/core/treenode.py
+++ b/xarray/core/treenode.py
@@ -205,8 +205,6 @@ class TreeNode(Generic[Tree]):
 
         seen = set()
         for name, child in children.items():
-            _validate_name(name)
-
             if not isinstance(child, TreeNode):
                 raise TypeError(
                     f"Cannot add object {name}. It is of type {type(child)}, "
@@ -691,6 +689,11 @@ class NamedNode(TreeNode, Generic[Tree]):
     def __str__(self) -> str:
         name_repr = repr(self.name) if self.name is not None else ""
         return f"NamedNode({name_repr})"
+
+    def _post_attach(self: AnyNamedNode, parent: AnyNamedNode, name: str) -> None:
+        """Ensures child has name attribute corresponding to key under which it has been stored."""
+        _validate_name(name)  # is this check redundant?
+        self._name = name
 
     def _copy_node(
         self: AnyNamedNode,

--- a/xarray/core/treenode.py
+++ b/xarray/core/treenode.py
@@ -205,6 +205,8 @@ class TreeNode(Generic[Tree]):
 
         seen = set()
         for name, child in children.items():
+            _validate_name(name)
+
             if not isinstance(child, TreeNode):
                 raise TypeError(
                     f"Cannot add object {name}. It is of type {type(child)}, "
@@ -673,8 +675,8 @@ class NamedNode(TreeNode, Generic[Tree]):
     def name(self, name: str | None) -> None:
         if self.parent is not None:
             raise ValueError(
-                "cannot set the name of a node which already has a parent. Consider creating "
-                "a detached copy of this node via .copy()."
+                "cannot set the name of a node which already has a parent. "
+                "Consider creating a detached copy of this node via .copy() "
                 "on the parent node."
             )
         _validate_name(name)
@@ -687,12 +689,8 @@ class NamedNode(TreeNode, Generic[Tree]):
         return repr_value
 
     def __str__(self) -> str:
-        return f"NamedNode('{self.name}')" if self.name else "NamedNode()"
-
-    def _post_attach(self: AnyNamedNode, parent: AnyNamedNode, name: str) -> None:
-        """Ensures child has name attribute corresponding to key under which it has been stored."""
-        _validate_name(name)  # is this check redundant?
-        self._name = name
+        name_repr = repr(self.name) if self.name is not None else ""
+        return f"NamedNode({name_repr})"
 
     def _copy_node(
         self: AnyNamedNode,

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -24,9 +24,27 @@ class TestTreeCreation:
         assert dt.children == {}
         assert_identical(dt.to_dataset(), xr.Dataset())
 
-    def test_unnamed(self):
+    def test_name(self):
         dt = DataTree()
         assert dt.name is None
+
+        dt = DataTree(name="foo")
+        assert dt.name == "foo"
+
+        dt.name = "bar"
+        assert dt.name == "bar"
+
+        dt = DataTree(children={"foo": DataTree()})
+        assert dt["/foo"].name == "foo"
+        with pytest.raises(
+            ValueError, match="cannot set the name of a node with a parent"
+        ):
+            dt["/foo"].name = "bar"
+
+        detached = dt["/foo"].copy()
+        assert detached.name == "foo"
+        detached.name = "bar"
+        assert detached.name == "bar"
 
     def test_bad_names(self):
         with pytest.raises(TypeError):

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -37,7 +37,7 @@ class TestTreeCreation:
         dt = DataTree(children={"foo": DataTree()})
         assert dt["/foo"].name == "foo"
         with pytest.raises(
-            ValueError, match="cannot set the name of a node with a parent"
+            ValueError, match="cannot set the name of a node which already has a parent"
         ):
             dt["/foo"].name = "bar"
 


### PR DESCRIPTION
This ensures that the tree cannot be in an inconsistent state.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #9447
- [x] Tests added
