### PR TITLE
Opt out of floor division for float dtype time encoding

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -46,7 +46,10 @@ Bug fixes
 - Make illegal path-like variable names when constructing a DataTree from a Dataset
   (:issue:`9339`, :pull:`9378`)
   By `Etienne Schalk <https://github.com/etienneschalk>`_.
-
+- Fix bug when encoding times with missing values as floats in the case when
+  the non-missing times could in theory be encoded with integers
+  (:issue:`9488`, :pull:`9497`). By `Spencer Clark
+  <https://github.com/spencerkclark>`_.
 
 
 Documentation

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -771,7 +771,7 @@ def _eagerly_encode_cf_datetime(
         # needed time delta to encode faithfully to int64
         needed_time_delta = _time_units_to_timedelta64(needed_units)
 
-        floor_division = True
+        floor_division = np.issubdtype(dtype, np.integer) or dtype is None
         if time_delta > needed_time_delta:
             floor_division = False
             if dtype is None:
@@ -892,7 +892,7 @@ def _eagerly_encode_cf_timedelta(
     # needed time delta to encode faithfully to int64
     needed_time_delta = _time_units_to_timedelta64(needed_units)
 
-    floor_division = True
+    floor_division = np.issubdtype(dtype, np.integer) or dtype is None
     if time_delta > needed_time_delta:
         floor_division = False
         if dtype is None:

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -1383,16 +1383,38 @@ def test_roundtrip_timedelta64_nanosecond_precision_warning() -> None:
     assert decoded_var.encoding["dtype"] == np.int64
 
 
-def test_roundtrip_float_times() -> None:
-    # Regression test for GitHub issue #8271
-    fill_value = 20.0
-    times = [
-        np.datetime64("1970-01-01 00:00:00", "ns"),
-        np.datetime64("1970-01-01 06:00:00", "ns"),
-        np.datetime64("NaT", "ns"),
-    ]
+_TEST_ROUNDTRIP_FLOAT_TIMES_TESTS = {
+    "GH-8271": (
+        20.0,
+        np.array(
+            ["1970-01-01 00:00:00", "1970-01-01 06:00:00", "NaT"],
+            dtype="datetime64[ns]",
+        ),
+        "days since 1960-01-01",
+        np.array([3653, 3653.25, 20.0]),
+    ),
+    "GH-9488-datetime64[ns]": (
+        1.0e20,
+        np.array(["2010-01-01 12:00:00", "NaT"], dtype="datetime64[ns]"),
+        "seconds since 2010-01-01",
+        np.array([43200, 1.0e20]),
+    ),
+    "GH-9488-timedelta64[ns]": (
+        1.0e20,
+        np.array([1_000_000_000, "NaT"], dtype="timedelta64[ns]"),
+        "seconds",
+        np.array([1.0, 1.0e20]),
+    ),
+}
 
-    units = "days since 1960-01-01"
+
+@pytest.mark.parametrize(
+    ("fill_value", "times", "units", "encoded_values"),
+    _TEST_ROUNDTRIP_FLOAT_TIMES_TESTS.values(),
+    ids=_TEST_ROUNDTRIP_FLOAT_TIMES_TESTS.keys(),
+)
+def test_roundtrip_float_times(fill_value, times, units, encoded_values) -> None:
+    # Regression test for GitHub issues #8271 and #9488
     var = Variable(
         ["time"],
         times,
@@ -1400,7 +1422,7 @@ def test_roundtrip_float_times() -> None:
     )
 
     encoded_var = conventions.encode_cf_variable(var)
-    np.testing.assert_array_equal(encoded_var, np.array([3653, 3653.25, 20.0]))
+    np.testing.assert_array_equal(encoded_var, encoded_values)
     assert encoded_var.attrs["units"] == units
     assert encoded_var.attrs["_FillValue"] == fill_value
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This PR provides a quick fix for #9488. 

Previously for `datetime64[ns]` and `timedelta64[ns]` values we would always use floor division to encode times if we knew that all non-`"NaT"` values could be represented with integers with the given units, even if we would ultimately cast the values to floats later based on the specified `dtype`.  This causes a problem when encoding `"NaT"` values, because the placeholder integer value is converted to a float [here](https://github.com/pydata/xarray/blob/18e5c87696c2233202bc67066408e6f495d0327d/xarray/coding/times.py#L805-L806), which prevents it from properly being filled with the fill value later in the encoding process.  

This PR changes things such that if we know that we will convert to floats eventually, we will use floating point division from the start, which preserves `"NaT"` values as floating point `np.nan` values.  I update and test the behavior for both `datetime64[ns]` values and `timedelta64[ns]` values.

cc: @kmuehlbauer

- [x] Closes #9488
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
