### PR TITLE
Replace black and blackdoc with ruff-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,20 +15,15 @@ repos:
     # Ruff version.
     rev: 'v0.6.9'
     hooks:
+      - id: ruff-format
       - id: ruff
         args: ["--fix", "--show-fixes"]
-  # https://github.com/python/black#version-control-integration
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0
-    hooks:
-      - id: black-jupyter
   - repo: https://github.com/keewis/blackdoc
     rev: v0.3.9
     hooks:
       - id: blackdoc
         exclude: "generate_aggregations.py"
         additional_dependencies: ["black==24.8.0"]
-      - id: blackdoc-autoupdate-black
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.11.2
     hooks:

--- a/CORE_TEAM_GUIDE.md
+++ b/CORE_TEAM_GUIDE.md
@@ -271,8 +271,7 @@ resources such as:
    [NumPy documentation guide](https://numpy.org/devdocs/dev/howto-docs.html#documentation-style)
    for docstring conventions.
 - [`pre-commit`](https://pre-commit.com) hooks for autoformatting.
-- [`black`](https://github.com/psf/black) autoformatting.
-- [`flake8`](https://github.com/PyCQA/flake8) linting.
+- [`ruff`](https://github.com/astral-sh/ruff) autoformatting and linting.
 - [python-xarray](https://stackoverflow.com/questions/tagged/python-xarray) on Stack Overflow.
 - [@xarray_dev](https://twitter.com/xarray_dev) on Twitter.
 - [xarray-dev](https://discord.gg/bsSGdwBn) discord community (normally only used for remote synchronous chat during sprints).

--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -17,7 +17,6 @@ from dateutil.relativedelta import relativedelta
 
 CHANNELS = ["conda-forge", "defaults"]
 IGNORE_DEPS = {
-    "black",
     "coveralls",
     "flake8",
     "hypothesis",

--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -3,6 +3,7 @@
 publication date. Compare it against requirements/min-all-deps.yml to verify the
 policy on obsolete dependencies is being followed. Print a pretty report :)
 """
+
 from __future__ import annotations
 
 import itertools

--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - black
   - aiobotocore
   - array-api-strict
   - boto3

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -549,11 +549,7 @@ Code Formatting
 
 xarray uses several tools to ensure a consistent code format throughout the project:
 
-- `Black <https://black.readthedocs.io/en/stable/>`_ for standardized
-  code formatting,
-- `blackdoc <https://blackdoc.readthedocs.io/en/stable/>`_ for
-  standardized code formatting in documentation,
-- `ruff <https://github.com/charliermarsh/ruff/>`_ for code quality checks and standardized order in imports
+- `ruff <https://github.com/astral-sh/ruff>`_ for formatting, code quality checks and standardized order in imports
 - `absolufy-imports <https://github.com/MarcoGorelli/absolufy-imports>`_ for absolute instead of relative imports from different files,
 - `mypy <http://mypy-lang.org/>`_ for static type checking on `type hints
   <https://docs.python.org/3/library/typing.html>`_.
@@ -1069,7 +1065,7 @@ PR checklist
   - Test the code using `Pytest <http://doc.pytest.org/en/latest/>`_. Running all tests (type ``pytest`` in the root directory) takes a while, so feel free to only run the tests you think are needed based on your PR (example: ``pytest xarray/tests/test_dataarray.py``). CI will catch any failing tests.
   - By default, the upstream dev CI is disabled on pull request and push events. You can override this behavior per commit by adding a ``[test-upstream]`` tag to the first line of the commit message. For documentation-only commits, you can skip the CI per commit by adding a ``[skip-ci]`` tag to the first line of the commit message.
 
-- **Properly format your code** and verify that it passes the formatting guidelines set by `Black <https://black.readthedocs.io/en/stable/>`_ and `Flake8 <http://flake8.pycqa.org/en/latest/>`_. See `"Code formatting" <https://docs.xarray.dev/en/stablcontributing.html#code-formatting>`_. You can use `pre-commit <https://pre-commit.com/>`_ to run these automatically on each commit.
+- **Properly format your code** and verify that it passes the formatting guidelines set by `ruff <https://github.com/astral-sh/ruff>`_. See `"Code formatting" <https://docs.xarray.dev/en/stablcontributing.html#code-formatting>`_. You can use `pre-commit <https://pre-commit.com/>`_ to run these automatically on each commit.
 
   - Run ``pre-commit run --all-files`` in the root directory. This may modify some files. Confirm and commit any formatting changes.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,7 +233,7 @@ extend-exclude = [
 
 [tool.ruff.lint]
 # E402: module level import not at top of file
-# E501: line too long - let black worry about that
+# E501: line too long - let the formatter worry about that
 # E731: do not assign a lambda expression, use a def
 extend-safe-fixes = [
   "TID252", # absolute imports

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -206,13 +206,10 @@ class AbstractDataStore:
         For example::
 
             class SuffixAppendingDataStore(AbstractDataStore):
-
                 def load(self):
                     variables, attributes = AbstractDataStore.load(self)
-                    variables = {'%s_suffix' % k: v
-                                 for k, v in variables.items()}
-                    attributes = {'%s_suffix' % k: v
-                                  for k, v in attributes.items()}
+                    variables = {"%s_suffix" % k: v for k, v in variables.items()}
+                    attributes = {"%s_suffix" % k: v for k, v in attributes.items()}
                     return variables, attributes
 
         This function will be called anytime variables or attributes

--- a/xarray/backends/file_manager.py
+++ b/xarray/backends/file_manager.py
@@ -65,7 +65,7 @@ class CachingFileManager(FileManager):
 
     Example usage::
 
-        manager = FileManager(open, 'example.txt', mode='w')
+        manager = FileManager(open, "example.txt", mode="w")
         f = manager.acquire()
         f.write(...)
         manager.close()  # ensures file is closed

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -474,7 +474,6 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         driver_kwds=None,
         **kwargs,
     ) -> DataTree:
-
         from xarray.core.datatree import DataTree
 
         groups_dict = self.open_groups_as_dict(
@@ -520,7 +519,6 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         driver_kwds=None,
         **kwargs,
     ) -> dict[str, Dataset]:
-
         from xarray.backends.common import _iter_nc_groups
         from xarray.core.treenode import NodePath
         from xarray.core.utils import close_on_error

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -710,7 +710,6 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
         autoclose=False,
         **kwargs,
     ) -> DataTree:
-
         from xarray.core.datatree import DataTree
 
         groups_dict = self.open_groups_as_dict(

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -80,7 +80,7 @@ def backends_dict_from_pkg(
 
 
 def set_missing_parameters(
-    backend_entrypoints: dict[str, type[BackendEntrypoint]]
+    backend_entrypoints: dict[str, type[BackendEntrypoint]],
 ) -> None:
     for _, backend in backend_entrypoints.items():
         if backend.open_dataset_parameters is None:
@@ -89,7 +89,7 @@ def set_missing_parameters(
 
 
 def sort_backends(
-    backend_entrypoints: dict[str, type[BackendEntrypoint]]
+    backend_entrypoints: dict[str, type[BackendEntrypoint]],
 ) -> dict[str, type[BackendEntrypoint]]:
     ordered_backends_entrypoints = {}
     for be_name in STANDARD_BACKENDS_ORDER:

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -496,7 +496,6 @@ class ZarrStore(AbstractWritableDataStore):
         zarr_version=None,
         write_empty: bool | None = None,
     ):
-
         zarr_group, consolidate_on_close, close_store_on_close = _get_open_params(
             store=store,
             mode=mode,
@@ -542,7 +541,6 @@ class ZarrStore(AbstractWritableDataStore):
         zarr_version=None,
         write_empty: bool | None = None,
     ):
-
         zarr_group, consolidate_on_close, close_store_on_close = _get_open_params(
             store=store,
             mode=mode,
@@ -1338,7 +1336,6 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
         zarr_version=None,
         **kwargs,
     ) -> dict[str, Dataset]:
-
         from xarray.core.treenode import NodePath
 
         filename_or_obj = _normalize_path(filename_or_obj)
@@ -1385,7 +1382,6 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
 
 
 def _iter_zarr_groups(root: ZarrGroup, parent: str = "/") -> Iterable[str]:
-
     parent_nodepath = NodePath(parent)
     yield str(parent_nodepath)
     for path, group in root.groups():

--- a/xarray/convert.py
+++ b/xarray/convert.py
@@ -1,5 +1,4 @@
-"""Functions for converting to and from xarray objects
-"""
+"""Functions for converting to and from xarray objects"""
 
 from collections import Counter
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1582,7 +1582,7 @@ class DataArray(
           Do not try to assign values when using any of the indexing methods
           ``isel`` or ``sel``::
 
-            da = xr.DataArray([0, 1, 2, 3], dims=['x'])
+            da = xr.DataArray([0, 1, 2, 3], dims=["x"])
             # DO NOT do this
             da.isel(x=[0, 1, 2])[1] = -1
 

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -801,7 +801,6 @@ class DataTree(
         data: Dataset | Default = _default,
         children: dict[str, DataTree] | Default = _default,
     ) -> None:
-
         ds = self.to_dataset(inherit=False) if data is _default else data
 
         if children is _default:

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -1,5 +1,4 @@
-"""String formatting routines for __repr__.
-"""
+"""String formatting routines for __repr__."""
 
 from __future__ import annotations
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -465,8 +465,9 @@ class ComposedGrouper:
         # NaNs; as well as values outside the bins are coded by -1
         # Restore these after the raveling
         mask = functools.reduce(
-            np.logical_or, [(code == -1) for code in broadcasted_codes]
-        )  # type: ignore[arg-type]
+            np.logical_or,  # type: ignore[arg-type]
+            [(code == -1) for code in broadcasted_codes],
+        )
         _flatcodes[mask] = -1
 
         midx = pd.MultiIndex.from_product(

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -235,7 +235,9 @@ class _DummyGroup(Generic[T_Xarray]):
 T_Group = Union["T_DataArray", _DummyGroup]
 
 
-def _ensure_1d(group: T_Group, obj: T_DataWithCoords) -> tuple[
+def _ensure_1d(
+    group: T_Group, obj: T_DataWithCoords
+) -> tuple[
     T_Group,
     T_DataWithCoords,
     Hashable | None,
@@ -462,7 +464,9 @@ class ComposedGrouper:
         )
         # NaNs; as well as values outside the bins are coded by -1
         # Restore these after the raveling
-        mask = functools.reduce(np.logical_or, [(code == -1) for code in broadcasted_codes])  # type: ignore[arg-type]
+        mask = functools.reduce(
+            np.logical_or, [(code == -1) for code in broadcasted_codes]
+        )  # type: ignore[arg-type]
         _flatcodes[mask] = -1
 
         midx = pd.MultiIndex.from_product(
@@ -1288,7 +1292,6 @@ class DataArrayGroupByBase(GroupBy["DataArray"], DataArrayGroupbyArithmetic):
         return self._obj._replace_maybe_drop_dims(reordered)
 
     def _restore_dim_order(self, stacked: DataArray) -> DataArray:
-
         def lookup_order(dimension):
             for grouper in self.groupers:
                 if dimension == grouper.name and grouper.group.ndim == 1:

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -1768,7 +1768,7 @@ def indexes_equal(
 
 
 def indexes_all_equal(
-    elements: Sequence[tuple[Index, dict[Hashable, Variable]]]
+    elements: Sequence[tuple[Index, dict[Hashable, Variable]]],
 ) -> bool:
     """Check if indexes are all equal.
 

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -372,7 +372,8 @@ def map_blocks(
 
             # ChainMap wants MutableMapping, but xindexes is Mapping
             merged_indexes = collections.ChainMap(
-                expected["indexes"], merged_coordinates.xindexes  # type: ignore[arg-type]
+                expected["indexes"],
+                merged_coordinates.xindexes,  # type: ignore[arg-type]
             )
             expected_index = merged_indexes.get(name, None)
             if expected_index is not None and not index.equals(expected_index):

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -188,9 +188,9 @@ class Resample(GroupBy[T_Xarray]):
 
 
 # https://github.com/python/mypy/issues/9031
-class DataArrayResample(
+class DataArrayResample(  # type: ignore[misc]
     Resample["DataArray"], DataArrayGroupByBase, DataArrayResampleAggregations
-):  # type: ignore[misc]
+):
     """DataArrayGroupBy object specialized to time resampling operations over a
     specified dimension
     """
@@ -331,9 +331,9 @@ class DataArrayResample(
 
 
 # https://github.com/python/mypy/issues/9031
-class DatasetResample(
+class DatasetResample(  # type: ignore[misc]
     Resample["Dataset"], DatasetGroupByBase, DatasetResampleAggregations
-):  # type: ignore[misc]
+):
     """DatasetGroupBy object specialized to resampling a specified dimension"""
 
     def map(

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -188,7 +188,9 @@ class Resample(GroupBy[T_Xarray]):
 
 
 # https://github.com/python/mypy/issues/9031
-class DataArrayResample(Resample["DataArray"], DataArrayGroupByBase, DataArrayResampleAggregations):  # type: ignore[misc]
+class DataArrayResample(
+    Resample["DataArray"], DataArrayGroupByBase, DataArrayResampleAggregations
+):  # type: ignore[misc]
     """DataArrayGroupBy object specialized to time resampling operations over a
     specified dimension
     """
@@ -329,7 +331,9 @@ class DataArrayResample(Resample["DataArray"], DataArrayGroupByBase, DataArrayRe
 
 
 # https://github.com/python/mypy/issues/9031
-class DatasetResample(Resample["Dataset"], DatasetGroupByBase, DatasetResampleAggregations):  # type: ignore[misc]
+class DatasetResample(
+    Resample["Dataset"], DatasetGroupByBase, DatasetResampleAggregations
+):  # type: ignore[misc]
     """DatasetGroupBy object specialized to resampling a specified dimension"""
 
     def map(

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -839,7 +839,6 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
         dims, indexer, new_order = self._broadcast_indexes(key)
 
         if self.size:
-
             if is_duck_dask_array(self._data):
                 # dask's indexing is faster this way; also vindex does not
                 # support negative indices yet:

--- a/xarray/namedarray/_array_api.py
+++ b/xarray/namedarray/_array_api.py
@@ -79,7 +79,8 @@ def astype(
 
 
 def imag(
-    x: NamedArray[_ShapeType, np.dtype[_SupportsImag[_ScalarType]]], /  # type: ignore[type-var]
+    x: NamedArray[_ShapeType, np.dtype[_SupportsImag[_ScalarType]]],
+    /,  # type: ignore[type-var]
 ) -> NamedArray[_ShapeType, np.dtype[_ScalarType]]:
     """
     Returns the imaginary component of a complex number for each element x_i of the
@@ -111,7 +112,8 @@ def imag(
 
 
 def real(
-    x: NamedArray[_ShapeType, np.dtype[_SupportsReal[_ScalarType]]], /  # type: ignore[type-var]
+    x: NamedArray[_ShapeType, np.dtype[_SupportsReal[_ScalarType]]],
+    /,  # type: ignore[type-var]
 ) -> NamedArray[_ShapeType, np.dtype[_ScalarType]]:
     """
     Returns the real component of a complex number for each element x_i of the

--- a/xarray/namedarray/_array_api.py
+++ b/xarray/namedarray/_array_api.py
@@ -79,8 +79,8 @@ def astype(
 
 
 def imag(
-    x: NamedArray[_ShapeType, np.dtype[_SupportsImag[_ScalarType]]],
-    /,  # type: ignore[type-var]
+    x: NamedArray[_ShapeType, np.dtype[_SupportsImag[_ScalarType]]],  # type: ignore[type-var]
+    /,
 ) -> NamedArray[_ShapeType, np.dtype[_ScalarType]]:
     """
     Returns the imaginary component of a complex number for each element x_i of the
@@ -112,8 +112,8 @@ def imag(
 
 
 def real(
-    x: NamedArray[_ShapeType, np.dtype[_SupportsReal[_ScalarType]]],
-    /,  # type: ignore[type-var]
+    x: NamedArray[_ShapeType, np.dtype[_SupportsReal[_ScalarType]]],  # type: ignore[type-var]
+    /,
 ) -> NamedArray[_ShapeType, np.dtype[_ScalarType]]:
     """
     Returns the real component of a complex number for each element x_i of the

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -986,7 +986,7 @@ def legend_elements(
     This is useful for obtaining a legend for a `~.Axes.scatter` plot;
     e.g.::
 
-        scatter = plt.scatter([1, 2, 3],  [4, 5, 6],  c=[7, 2, 3])
+        scatter = plt.scatter([1, 2, 3], [4, 5, 6], c=[7, 2, 3])
         plt.legend(*scatter.legend_elements())
 
     creates three legend elements, one for each color with the numerical

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -1673,7 +1673,6 @@ def test_new_to_legacy_freq_anchored(year_alias, n):
     ),
 )
 def test_legacy_to_new_freq_pd_freq_passthrough(freq, expected):
-
     result = _legacy_to_new_freq(freq)
     assert result == expected
 
@@ -1699,7 +1698,6 @@ def test_legacy_to_new_freq_pd_freq_passthrough(freq, expected):
     ),
 )
 def test_new_to_legacy_freq_pd_freq_passthrough(freq, expected):
-
     result = _new_to_legacy_freq(freq)
     assert result == expected
 
@@ -1786,7 +1784,6 @@ def test_date_range_no_freq(start, end, periods):
 )
 @pytest.mark.parametrize("has_year_zero", [False, True])
 def test_offset_addition_preserves_has_year_zero(offset, has_year_zero):
-
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="this date/calendar/year zero")
         datetime = cftime.DatetimeGregorian(-1, 12, 31, has_year_zero=has_year_zero)

--- a/xarray/tests/test_coordinates.py
+++ b/xarray/tests/test_coordinates.py
@@ -65,8 +65,9 @@ class TestCoordinates:
 
         with pytest.raises(TypeError, match=".* is not an `xarray.indexes.Index`"):
             Coordinates(
-                coords={"x": ("x", [1, 2, 3])}, indexes={"x": "not_an_xarray_index"}
-            )  # type: ignore[dict-item]
+                coords={"x": ("x", [1, 2, 3])},
+                indexes={"x": "not_an_xarray_index"},  # type: ignore[dict-item]
+            )
 
     def test_init_dim_sizes_conflict(self) -> None:
         with pytest.raises(ValueError):

--- a/xarray/tests/test_coordinates.py
+++ b/xarray/tests/test_coordinates.py
@@ -64,7 +64,9 @@ class TestCoordinates:
             Coordinates(indexes={"x": idx})
 
         with pytest.raises(TypeError, match=".* is not an `xarray.indexes.Index`"):
-            Coordinates(coords={"x": ("x", [1, 2, 3])}, indexes={"x": "not_an_xarray_index"})  # type: ignore[dict-item]
+            Coordinates(
+                coords={"x": ("x", [1, 2, 3])}, indexes={"x": "not_an_xarray_index"}
+            )  # type: ignore[dict-item]
 
     def test_init_dim_sizes_conflict(self) -> None:
         with pytest.raises(ValueError):

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -297,9 +297,7 @@ class TestDataset:
                 var2     (dim1, dim2) float64 576B 1.162 -1.097 -2.123 ... 1.267 0.3328
                 var3     (dim3, dim1) float64 640B 0.5565 -0.2121 0.4563 ... -0.2452 -0.3616
             Attributes:
-                foo:      bar""".format(
-                data["dim3"].dtype
-            )
+                foo:      bar""".format(data["dim3"].dtype)
         )
         actual = "\n".join(x.rstrip() for x in repr(data).split("\n"))
         print(actual)

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -1031,7 +1031,6 @@ class TestAccess:
 
 
 class TestRepr:
-
     def test_repr_four_nodes(self) -> None:
         dt = DataTree.from_dict(
             {
@@ -1581,7 +1580,6 @@ class TestPipe:
 
 
 class TestEqualsAndIdentical:
-
     def test_minimal_variations(self):
         tree = DataTree.from_dict(
             {
@@ -1729,7 +1727,6 @@ class TestSubset:
 
 
 class TestIndexing:
-
     def test_isel_siblings(self) -> None:
         tree = DataTree.from_dict(
             {
@@ -1835,7 +1832,6 @@ class TestIndexing:
 
 
 class TestAggregations:
-
     def test_reduce_method(self) -> None:
         ds = xr.Dataset({"a": ("x", [False, True, False])})
         dt = DataTree.from_dict({"/": ds, "/results": ds})
@@ -2061,7 +2057,6 @@ class TestOps:
 
 
 class TestUFuncs:
-
     @pytest.mark.xfail(reason="__array_ufunc__ not implemented yet")
     def test_tree(self, create_test_datatree):
         dt = create_test_datatree()
@@ -2074,7 +2069,6 @@ class TestDocInsertion:
     """Tests map_over_datasets docstring injection."""
 
     def test_standard_doc(self):
-
         dataset_doc = dedent(
             """\
             Manually trigger loading and/or computation of this dataset's data

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -1,4 +1,4 @@
-""" isort:skip_file """
+"""isort:skip_file"""
 
 from __future__ import annotations
 

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -1034,7 +1034,6 @@ Coordinates:
 
 
 def test_array_repr_dtypes():
-
     # These dtypes are expected to be represented similarly
     # on Ubuntu, macOS and Windows environments of the CI.
     # Unsigned integer could be used as easy replacements

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -350,7 +350,6 @@ class TestLazyArray:
             ([0, 3, 5], arr[:2]),
         ]
         for i, j in indexers:
-
             expected_b = v[i][j]
             actual = v_lazy[i][j]
             assert expected_b.shape == actual.shape
@@ -416,7 +415,6 @@ class TestLazyArray:
         check_indexing(v_eager, v_lazy, indexers)
 
     def test_lazily_indexed_array_vindex_setitem(self) -> None:
-
         lazy = indexing.LazilyIndexedArray(np.random.rand(10, 20, 30))
 
         # vectorized indexing

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -180,7 +180,6 @@ def test_interpolate_vectorize(use_dask: bool, method: InterpOptions) -> None:
                 da[dim], obj.data, axis=obj.get_axis_num(dim), **scipy_kwargs
             )(new_x).reshape(shape)
         else:
-
             return scipy.interpolate.interp1d(
                 da[dim],
                 obj.data,

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -57,7 +57,6 @@ class CustomArray(
     def __array__(
         self, dtype: np.typing.DTypeLike = None, /, *, copy: bool | None = None
     ) -> np.ndarray[Any, np.dtype[np.generic]]:
-
         if Version(np.__version__) >= Version("2.0.0"):
             return np.asarray(self.array, dtype=dtype, copy=copy)
         else:

--- a/xarray/tests/test_treenode.py
+++ b/xarray/tests/test_treenode.py
@@ -304,7 +304,6 @@ def create_test_tree() -> tuple[NamedNode, NamedNode]:
 
 
 class TestZipSubtrees:
-
     def test_one_tree(self) -> None:
         root, _ = create_test_tree()
         expected = [
@@ -351,7 +350,6 @@ class TestZipSubtrees:
 
 
 class TestAncestry:
-
     def test_parents(self) -> None:
         _, leaf_f = create_test_tree()
         expected = ["e", "b", "a"]


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Since ruff is already used for linting I figured we could also use it for formatting.
This allows to remove `black` as well as `blackdoc` which feels relatively slow on my machine.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
