### PR TITLE
Fix pandas datetime decoding with NumPy >= 2.0 for small integer dtypes

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -49,9 +49,9 @@ Bug fixes
   By `Etienne Schalk <https://github.com/etienneschalk>`_.
 - Work around `upstream pandas issue
   <https://github.com/pandas-dev/pandas/issues/56996>`_ to ensure that we can
-  decode times encoded with ``np.int32`` values in environments with NumPy 2.0
-  or greater without needing to fall back to cftime (:pull:`9518`). By `Spencer
-  Clark <https://github.com/spencerkclark>`_.
+  decode times encoded with small integer dtype values (e.g. ``np.int32``) in
+  environments with NumPy 2.0 or greater without needing to fall back to cftime
+  (:pull:`9518`). By `Spencer Clark <https://github.com/spencerkclark>`_.
 - Fix bug when encoding times with missing values as floats in the case when
   the non-missing times could in theory be encoded with integers
   (:issue:`9488`, :pull:`9497`). By `Spencer Clark

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -47,7 +47,11 @@ Bug fixes
 - Make illegal path-like variable names when constructing a DataTree from a Dataset
   (:issue:`9339`, :pull:`9378`)
   By `Etienne Schalk <https://github.com/etienneschalk>`_.
-
+- Work around `upstream pandas issue
+  <https://github.com/pandas-dev/pandas/issues/56996>`_ to ensure that we can
+  decode times encoded with ``np.int32`` values in environments with NumPy 2.0
+  or greater without needing to fall back to cftime (:pull:`9518`). By `Spencer
+  Clark <https://github.com/spencerkclark>`_.
 
 
 Documentation

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -254,6 +254,15 @@ def _decode_datetime_with_pandas(
             "pandas."
         )
 
+    # Work around pandas.to_timedelta issue with dtypes smaller than int64 and
+    # NumPy 2.0 by casting all int and uint data to int64 and uint64,
+    # respectively. See https://github.com/pandas-dev/pandas/issues/56996 for
+    # more details.
+    if flat_num_dates.dtype.kind == "i":
+        flat_num_dates = flat_num_dates.astype(np.int64)
+    elif flat_num_dates.dtype.kind == "u":
+        flat_num_dates = flat_num_dates.astype(np.uint64)
+
     time_units, ref_date_str = _unpack_netcdf_time_units(units)
     time_units = _netcdf_to_numpy_timeunit(time_units)
     try:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This PR addresses the issue that @langmore brought up in https://github.com/pydata/xarray/pull/9498#pullrequestreview-2307790147.  Thanks again for noting this and suggesting the fix.

I modified an existing test such that it will no longer fall back to cftime, so that it fails without this fix even if cftime is installed.

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
