### PR TITLE
Update `compat` error checking to disallow "minimal" in `concat()`

### DIFF
--- a/xarray/core/concat.py
+++ b/xarray/core/concat.py
@@ -255,7 +255,7 @@ def concat(
     except StopIteration:
         raise ValueError("must supply at least one object to concatenate")
 
-    if compat not in _VALID_COMPAT:
+    if compat not in set(_VALID_COMPAT) - {"minimal"}:
         raise ValueError(
             f"compat={compat!r} invalid: must be 'broadcast_equals', 'equals', 'identical', 'no_conflicts' or 'override'"
         )

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -659,7 +659,7 @@ class TestConcatDataset:
 
         with pytest.raises(ValueError, match=r"compat.* invalid"):
             concat(split_data, "dim1", compat="foobar")
-        
+
         with pytest.raises(ValueError, match=r"compat.* invalid"):
             concat(split_data, "dim1", compat="minimal")
 

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -659,6 +659,9 @@ class TestConcatDataset:
 
         with pytest.raises(ValueError, match=r"compat.* invalid"):
             concat(split_data, "dim1", compat="foobar")
+        
+        with pytest.raises(ValueError, match=r"compat.* invalid"):
+            concat(split_data, "dim1", compat="minimal")
 
         with pytest.raises(ValueError, match=r"unexpected value for"):
             concat([data, data], "new_dim", coords="foobar")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes None (no related issue)
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
  - Not notable

Before:
`AttributeError: 'IndexVariable' object has no attribute 'minimal'`

After:
`ValueError: compat='minimal' invalid: must be 'broadcast_equals', 'equals', 'identical', 'no_conflicts' or "override"`
