### PR TITLE
allow using `__array_function__` as a fallback for missing Array API functions

### DIFF
--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -875,10 +875,10 @@ def as_indexable(array):
         return PandasIndexingAdapter(array)
     if is_duck_dask_array(array):
         return DaskIndexingAdapter(array)
-    if hasattr(array, "__array_function__"):
-        return NdArrayLikeIndexingAdapter(array)
     if hasattr(array, "__array_namespace__"):
         return ArrayApiIndexingAdapter(array)
+    if hasattr(array, "__array_function__"):
+        return NdArrayLikeIndexingAdapter(array)
 
     raise TypeError(f"Invalid array type: {type(array)}")
 

--- a/xarray/core/nanops.py
+++ b/xarray/core/nanops.py
@@ -162,7 +162,7 @@ def nanstd(a, axis=None, dtype=None, out=None, ddof=0):
 
 def nanprod(a, axis=None, dtype=None, out=None, min_count=None):
     mask = isnull(a)
-    result = nputils.nanprod(a, axis=axis, dtype=dtype, out=out)
+    result = nputils.nanprod(a, axis=axis, dtype=dtype)
     if min_count is not None:
         return _maybe_null_out(result, axis, mask, min_count)
     else:

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -912,6 +912,12 @@ class ArrayWithNamespaceAndArrayFunction:
         pass
 
 
+def as_dask_array(arr, chunks):
+    import dask.array as da
+
+    return da.from_array(arr, chunks=chunks)
+
+
 @pytest.mark.parametrize(
     ["array", "expected_type"],
     (
@@ -925,6 +931,12 @@ class ArrayWithNamespaceAndArrayFunction:
         ),
         pytest.param(
             pd.Index([1, 2]), indexing.PandasIndexingAdapter, id="pandas.Index"
+        ),
+        pytest.param(
+            as_dask_array(np.array([1, 2]), chunks=(1,)),
+            indexing.DaskIndexingAdapter,
+            id="dask.array",
+            marks=requires_dask,
         ),
         pytest.param(
             ArrayWithNamespace(), indexing.ArrayApiIndexingAdapter, id="array_api"

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -904,6 +904,14 @@ class ArrayWithArrayFunction:
         pass
 
 
+class ArrayWithNamespaceAndArrayFunction:
+    def __array_namespace__(self, version=None):
+        pass
+
+    def __array_function__(self, func, types, args, kwargs):
+        pass
+
+
 @pytest.mark.parametrize(
     ["array", "expected_type"],
     (
@@ -925,6 +933,11 @@ class ArrayWithArrayFunction:
             ArrayWithArrayFunction(),
             indexing.NdArrayLikeIndexingAdapter,
             id="array_like",
+        ),
+        pytest.param(
+            ArrayWithNamespaceAndArrayFunction(),
+            indexing.ArrayApiIndexingAdapter,
+            id="array_api_with_fallback",
         ),
     ),
 )

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -913,7 +913,10 @@ class ArrayWithNamespaceAndArrayFunction:
 
 
 def as_dask_array(arr, chunks):
-    import dask.array as da
+    try:
+        import dask.array as da
+    except ImportError:
+        return None
 
     return da.from_array(arr, chunks=chunks)
 

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -894,6 +894,46 @@ def test_posify_mask_subindexer(indices, expected) -> None:
     np.testing.assert_array_equal(expected, actual)
 
 
+class ArrayWithNamespace:
+    def __array_namespace__(self, version=None):
+        pass
+
+
+class ArrayWithArrayFunction:
+    def __array_function__(self, func, types, args, kwargs):
+        pass
+
+
+@pytest.mark.parametrize(
+    ["array", "expected_type"],
+    (
+        pytest.param(
+            indexing.CopyOnWriteArray(np.array([1, 2])),
+            indexing.CopyOnWriteArray,
+            id="ExplicitlyIndexed",
+        ),
+        pytest.param(
+            np.array([1, 2]), indexing.NumpyIndexingAdapter, id="numpy.ndarray"
+        ),
+        pytest.param(
+            pd.Index([1, 2]), indexing.PandasIndexingAdapter, id="pandas.Index"
+        ),
+        pytest.param(
+            ArrayWithNamespace(), indexing.ArrayApiIndexingAdapter, id="array_api"
+        ),
+        pytest.param(
+            ArrayWithArrayFunction(),
+            indexing.NdArrayLikeIndexingAdapter,
+            id="array_like",
+        ),
+    ),
+)
+def test_as_indexable(array, expected_type):
+    actual = indexing.as_indexable(array)
+
+    assert isinstance(actual, expected_type)
+
+
 def test_indexing_1d_object_array() -> None:
     items = (np.arange(3), np.arange(6))
     arr = DataArray(np.array(items, dtype=object))


### PR DESCRIPTION
As discussed in https://github.com/pydata/xarray/issues/8834#issuecomment-2124914727, this swaps the order of special casing for types implementing both `__array_function__` and `__array_namespace__`, such that the Array API is preferred over `__array_function__`.

I've also disabled passing the `out` kwarg to `nanprod`, as that was the only occurrence where we actually do that, all other `nan*` functions silently ignore that kwarg.

- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

cc @tomwhite