### PR TITLE
Fix DataTree repr to not repeat inherited coordinates

### DIFF
--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -1102,7 +1102,8 @@ def _datatree_node_repr(node: DataTree, show_inherited: bool) -> str:
         summary.append(f"{dims_start}({dims_values})")
 
     if node._node_coord_variables:
-        summary.append(coords_repr(node.coords, col_width=col_width, max_rows=max_rows))
+        node_coords = node.to_dataset(inherited=False).coords
+        summary.append(coords_repr(node_coords, col_width=col_width, max_rows=max_rows))
 
     if show_inherited and inherited_coords:
         summary.append(

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -1052,7 +1052,7 @@ class TestRepr:
             {
                 "/": Dataset(coords={"x": [1.0]}),
                 "/first_child": None,
-                "/second_child": Dataset({"foo": ("x", [0.0])}),
+                "/second_child": Dataset({"foo": ("x", [0.0])}, coords={"z": 1}),
             }
         )
 
@@ -1067,6 +1067,8 @@ class TestRepr:
             ├── Group: /first_child
             └── Group: /second_child
                     Dimensions:  (x: 1)
+                    Coordinates:
+                        z        int64 8B 1
                     Data variables:
                         foo      (x) float64 8B 0.0
             """
@@ -1091,6 +1093,8 @@ class TestRepr:
             <xarray.DataTree 'second_child'>
             Group: /second_child
                 Dimensions:  (x: 1)
+                Coordinates:
+                    z        int64 8B 1
                 Inherited coordinates:
                   * x        (x) float64 8B 1.0
                 Data variables:
@@ -1134,6 +1138,101 @@ class TestRepr:
                 Dimensions without coordinates: x, y
                 Data variables:
                     bar      (y) float64 8B 2.0
+            """
+        ).strip()
+        assert result == expected
+
+    def test_doc_example(self):
+        # regression test for https://github.com/pydata/xarray/issues/9499
+        time = xr.DataArray(data=["2022-01", "2023-01"], dims="time")
+        stations = xr.DataArray(data=list("abcdef"), dims="station")
+        lon = [-100, -80, -60]
+        lat = [10, 20, 30]
+        # Set up fake data
+        wind_speed = xr.DataArray(np.ones((2, 6)) * 2, dims=("time", "station"))
+        pressure = xr.DataArray(np.ones((2, 6)) * 3, dims=("time", "station"))
+        air_temperature = xr.DataArray(np.ones((2, 6)) * 4, dims=("time", "station"))
+        dewpoint = xr.DataArray(np.ones((2, 6)) * 5, dims=("time", "station"))
+        infrared = xr.DataArray(np.ones((2, 3, 3)) * 6, dims=("time", "lon", "lat"))
+        true_color = xr.DataArray(np.ones((2, 3, 3)) * 7, dims=("time", "lon", "lat"))
+        tree = xr.DataTree.from_dict(
+            {
+                "/": xr.Dataset(
+                    coords={"time": time},
+                ),
+                "/weather": xr.Dataset(
+                    coords={"station": stations},
+                    data_vars={
+                        "wind_speed": wind_speed,
+                        "pressure": pressure,
+                    },
+                ),
+                "/weather/temperature": xr.Dataset(
+                    data_vars={
+                        "air_temperature": air_temperature,
+                        "dewpoint": dewpoint,
+                    },
+                ),
+                "/satellite": xr.Dataset(
+                    coords={"lat": lat, "lon": lon},
+                    data_vars={
+                        "infrared": infrared,
+                        "true_color": true_color,
+                    },
+                ),
+            },
+        )
+
+        result = repr(tree)
+        expected = dedent(
+            """
+            <xarray.DataTree>
+            Group: /
+            │   Dimensions:  (time: 2)
+            │   Coordinates:
+            │     * time     (time) <U7 56B '2022-01' '2023-01'
+            ├── Group: /weather
+            │   │   Dimensions:     (station: 6, time: 2)
+            │   │   Coordinates:
+            │   │     * station     (station) <U1 24B 'a' 'b' 'c' 'd' 'e' 'f'
+            │   │   Data variables:
+            │   │       wind_speed  (time, station) float64 96B 2.0 2.0 2.0 2.0 ... 2.0 2.0 2.0 2.0
+            │   │       pressure    (time, station) float64 96B 3.0 3.0 3.0 3.0 ... 3.0 3.0 3.0 3.0
+            │   └── Group: /weather/temperature
+            │           Dimensions:          (time: 2, station: 6)
+            │           Data variables:
+            │               air_temperature  (time, station) float64 96B 4.0 4.0 4.0 4.0 ... 4.0 4.0 4.0
+            │               dewpoint         (time, station) float64 96B 5.0 5.0 5.0 5.0 ... 5.0 5.0 5.0
+            └── Group: /satellite
+                    Dimensions:     (lat: 3, lon: 3, time: 2)
+                    Coordinates:
+                      * lat         (lat) int64 24B 10 20 30
+                      * lon         (lon) int64 24B -100 -80 -60
+                    Data variables:
+                        infrared    (time, lon, lat) float64 144B 6.0 6.0 6.0 6.0 ... 6.0 6.0 6.0
+                        true_color  (time, lon, lat) float64 144B 7.0 7.0 7.0 7.0 ... 7.0 7.0 7.0
+            """
+        ).strip()
+        assert result == expected
+
+        result = repr(tree["weather"])
+        expected = dedent(
+            """
+            <xarray.DataTree 'weather'>
+            Group: /weather
+            │   Dimensions:     (time: 2, station: 6)
+            │   Coordinates:
+            │     * station     (station) <U1 24B 'a' 'b' 'c' 'd' 'e' 'f'
+            │   Inherited coordinates:
+            │     * time        (time) <U7 56B '2022-01' '2023-01'
+            │   Data variables:
+            │       wind_speed  (time, station) float64 96B 2.0 2.0 2.0 2.0 ... 2.0 2.0 2.0 2.0
+            │       pressure    (time, station) float64 96B 3.0 3.0 3.0 3.0 ... 3.0 3.0 3.0 3.0
+            └── Group: /weather/temperature
+                    Dimensions:          (time: 2, station: 6)
+                    Data variables:
+                        air_temperature  (time, station) float64 96B 4.0 4.0 4.0 4.0 ... 4.0 4.0 4.0
+                        dewpoint         (time, station) float64 96B 5.0 5.0 5.0 5.0 ... 5.0 5.0 5.0
             """
         ).strip()
         assert result == expected

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -1,4 +1,5 @@
 import re
+import sys
 import typing
 from copy import copy, deepcopy
 from textwrap import dedent
@@ -14,6 +15,8 @@ from xarray.core.datatree_ops import _MAPPED_DOCSTRING_ADDENDUM, insert_doc_adde
 from xarray.core.treenode import NotFoundInTreeError
 from xarray.testing import assert_equal, assert_identical
 from xarray.tests import assert_array_equal, create_test_data, source_ndarray
+
+ON_WINDOWS = sys.platform == "win32"
 
 
 class TestTreeCreation:
@@ -1052,7 +1055,7 @@ class TestRepr:
             {
                 "/": Dataset(coords={"x": [1.0]}),
                 "/first_child": None,
-                "/second_child": Dataset({"foo": ("x", [0.0])}, coords={"z": 1}),
+                "/second_child": Dataset({"foo": ("x", [0.0])}, coords={"z": 1.0}),
             }
         )
 
@@ -1068,7 +1071,7 @@ class TestRepr:
             └── Group: /second_child
                     Dimensions:  (x: 1)
                     Coordinates:
-                        z        int64 8B 1
+                        z        float64 8B 1.0
                     Data variables:
                         foo      (x) float64 8B 0.0
             """
@@ -1094,7 +1097,7 @@ class TestRepr:
             Group: /second_child
                 Dimensions:  (x: 1)
                 Coordinates:
-                    z        int64 8B 1
+                    z        float64 8B 1.0
                 Inherited coordinates:
                   * x        (x) float64 8B 1.0
                 Data variables:
@@ -1142,6 +1145,9 @@ class TestRepr:
         ).strip()
         assert result == expected
 
+    @pytest.mark.skipif(
+        ON_WINDOWS, reason="windows (pre NumPy2) uses int32 instead of int64"
+    )
     def test_doc_example(self):
         # regression test for https://github.com/pydata/xarray/issues/9499
         time = xr.DataArray(data=["2022-01", "2023-01"], dims="time")


### PR DESCRIPTION
- [x] Closes #9499
- [x] Tests added
