### PR TITLE
Add `.rolling_exp` onto `.rolling`'s 'See also'

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -10621,7 +10621,7 @@ class Dataset(
         --------
         Dataset.cumulative
         DataArray.rolling
-        core.rolling.DatasetRolling
+        DataArray.rolling_exp
         """
         from xarray.core.rolling import DatasetRolling
 
@@ -10651,9 +10651,9 @@ class Dataset(
 
         See Also
         --------
-        Dataset.rolling
         DataArray.cumulative
-        core.rolling.DatasetRolling
+        Dataset.rolling
+        Dataset.rolling_exp
         """
         from xarray.core.rolling import DatasetRolling
 


### PR DESCRIPTION
Also remove the internal object, which is referenced from `Returns:` already
