### PR TITLE
Update donation links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 github: numfocus
-custom: http://numfocus.org/donate-to-xarray
+custom: https://numfocus.org/donate-to-xarray

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Xarray is a fiscally sponsored project of
 [NumFOCUS](https://numfocus.org), a nonprofit dedicated to supporting
 the open source scientific computing community. If you like Xarray and
 want to support our mission, please consider making a
-[donation](https://numfocus.salsalabs.org/donate-to-xarray/) to support
+[donation](https://numfocus.org/donate-to-xarray) to support
 our efforts.
 
 ## History


### PR DESCRIPTION
I am a consultant working for NumFOCUS. Please feel free to reach out to me if you have any concerns about the content of this pull request.

  - Update donation link in README to point at current xarray donation page on NumFOCUS' website. NumFOCUS no longer uses Salsa Labs, so the previous link no longer works.
  - Update link in `.github/FUNDING.yml` to use HTTPS.

Based on past updates to this link (#2421, #2829), I think this doesn't count as a user-facing change, so I have not updated the What's New file.