### PR TITLE
Fix NamedArray html repr crashing

### DIFF
--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -303,7 +303,7 @@ def inline_variable_array_repr(var, max_width):
     """Build a one-line summary of a variable's data."""
     if hasattr(var._data, "_repr_inline_"):
         return var._data._repr_inline_(max_width)
-    if var._in_memory:
+    if getattr(var, "_in_memory", False):
         return format_array_flat(var, max_width)
     dask_array_type = array_type("dask")
     if isinstance(var._data, dask_array_type):

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -591,3 +591,14 @@ class TestNamedArray(NamedArraySubclassobjects):
     def test_warn_on_repeated_dimension_names(self) -> None:
         with pytest.warns(UserWarning, match="Duplicate dimension names"):
             NamedArray(("x", "x"), np.arange(4).reshape(2, 2))
+
+
+def test_repr() -> None:
+    x = NamedArray(("x",), np.array([1, 2, 3]))
+
+    # Reprs should not crash:
+    r = x.__repr__()
+    x._repr_html_()
+
+    # Basic comparison:
+    assert r == "<xarray.NamedArray (x: 3)> Size: 24B\narray([1, 2, 3])"

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -594,7 +594,8 @@ class TestNamedArray(NamedArraySubclassobjects):
 
 
 def test_repr() -> None:
-    x = NamedArray(("x",), np.array([1, 2, 3]))
+    x: NamedArray[Any, np.dtype[np.int64]]
+    x = NamedArray(("x",), np.array([1, 2, 3], dtype=np.int64))
 
     # Reprs should not crash:
     r = x.__repr__()

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -594,12 +594,12 @@ class TestNamedArray(NamedArraySubclassobjects):
 
 
 def test_repr() -> None:
-    x: NamedArray[Any, np.dtype[np.int64]]
-    x = NamedArray(("x",), np.array([1, 2, 3], dtype=np.int64))
+    x: NamedArray[Any, np.dtype[np.uint64]]
+    x = NamedArray(("x",), np.array([0], dtype=np.uint64))
 
     # Reprs should not crash:
     r = x.__repr__()
     x._repr_html_()
 
     # Basic comparison:
-    assert r == "<xarray.NamedArray (x: 3)> Size: 24B\narray([1, 2, 3])"
+    assert r == "<xarray.NamedArray (x: 1)> Size: 8B\narray([0], dtype=uint64)"


### PR DESCRIPTION
This crashes on main:

```python
import numpy as np
from xarray.namedarray.core import NamedArray

x = NamedArray(("x",), np.array([1, 2, 3]))
x._repr_html_()
#   File ~\Documents\GitHub\xarray\xarray\core\formatting.py:306 in inline_variable_array_repr
#     if var._in_memory:

# AttributeError: 'NamedArray' object has no attribute '_in_memory'
```