### PR TITLE
bump `scientific-python/upload-nightly-action`

### DIFF
--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -38,7 +38,7 @@ jobs:
           fi
 
       - name: Upload wheel
-        uses: scientific-python/upload-nightly-action@ccf29c805b5d0c1dc31fa97fcdb962be074cade3 # 0.6.0
+        uses: scientific-python/upload-nightly-action@82396a2ed4269ba06c6b2988bb4fd568ef3c3d6b # 0.6.1
         with:
           anaconda_nightly_upload_token: ${{ secrets.ANACONDA_NIGHTLY }}
           artifacts_path: dist

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Our nightly wheels are currently failing because #9556 upgraded to a version of the action that later has been declared broken.