### PR TITLE
Adjust pip extra dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 accel = ["scipy", "bottleneck", "numbagg", "flox", "opt_einsum"]
-complete = ["xarray[accel,io,parallel,viz,dev]"]
+complete = ["xarray[accel,etc,io,parallel,viz]"]
 dev = [
   "hypothesis",
   "mypy",
@@ -43,6 +43,7 @@ dev = [
   "xarray[complete]",
 ]
 io = ["netCDF4", "h5netcdf", "scipy", 'pydap; python_version<"3.10"', "zarr<3", "fsspec", "cftime", "pooch"]
+etc = ["sparse"]
 parallel = ["dask[complete]"]
 viz = ["matplotlib", "seaborn", "nc-time-axis"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,14 @@ dev = [
   "pytest-xdist",
   "pytest-timeout",
   "ruff",
+  "sphinx",
+  "sphinx_autosummary_accessors",
   "xarray[complete]",
 ]
 io = ["netCDF4", "h5netcdf", "scipy", 'pydap; python_version<"3.10"', "zarr<3", "fsspec", "cftime", "pooch"]
 etc = ["sparse"]
 parallel = ["dask[complete]"]
-viz = ["matplotlib", "seaborn", "nc-time-axis"]
+viz = ["cartopy", "matplotlib", "nc-time-axis", "seaborn"]
 
 [project.urls]
 Documentation = "https://docs.xarray.dev"


### PR DESCRIPTION
- Add `sparse` to an `etc` category (or put in `io`?)
- In `complete`, don't include `dev` -- `dev` contains `complete` + dev tools (or could adjust `dev` so it's dev-only). And `complete` is everything a user might want. (Fine to adjust but currently they're recursive, which doesn't make sense
