### PR TITLE
Implement default time resolution for CF time encoding/decoding

### DIFF
--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -163,7 +163,7 @@ def _get_keep_attrs(default: bool) -> bool:
     return _get_boolean_with_default("keep_attrs", default)
 
 
-def _get_datetime_resolution() -> str:
+def _get_datetime_resolution() -> Literal["s", "ms", "us", "ns"]:
     return OPTIONS["time_resolution"]
 
 

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -86,10 +86,12 @@ OPTIONS: T_Options = {
     "use_flox": True,
     "use_numbagg": True,
     "use_opt_einsum": True,
+    "time_resolution": "ns",
 }
 
 _JOIN_OPTIONS = frozenset(["inner", "outer", "left", "right", "exact"])
 _DISPLAY_OPTIONS = frozenset(["text", "html"])
+_TIME_RESOLUTION_OPTIONS = frozenset(["s", "ms", "us", "ns"])
 
 
 def _positive_integer(value: Any) -> bool:
@@ -117,6 +119,7 @@ _VALIDATORS = {
     "use_opt_einsum": lambda value: isinstance(value, bool),
     "use_flox": lambda value: isinstance(value, bool),
     "warn_for_unclosed_files": lambda value: isinstance(value, bool),
+    "time_resolution": _TIME_RESOLUTION_OPTIONS.__contains__,
 }
 
 
@@ -156,6 +159,10 @@ def _get_boolean_with_default(option: Options, default: bool) -> bool:
 
 def _get_keep_attrs(default: bool) -> bool:
     return _get_boolean_with_default("keep_attrs", default)
+
+
+def _get_datetime_resolution() -> str:
+    return OPTIONS["time_resolution"]
 
 
 class set_options:
@@ -258,6 +265,8 @@ class set_options:
     warn_for_unclosed_files : bool, default: False
         Whether or not to issue a warning when unclosed files are
         deallocated. This is mostly useful for debugging.
+    time_resolution : {"s", "ms", "us", "ns"}, default: "ns"
+        Time resolution used for CF encoding/decoding.
 
     Examples
     --------

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
         "use_numbagg",
         "use_opt_einsum",
         "use_flox",
+        "time_resolution",
     ]
 
     class T_Options(TypedDict):
@@ -59,6 +60,7 @@ if TYPE_CHECKING:
         use_flox: bool
         use_numbagg: bool
         use_opt_einsum: bool
+        time_resolution: Literal["s", "ms", "us", "ns"]
 
 
 OPTIONS: T_Options = {

--- a/xarray/core/pdcompat.py
+++ b/xarray/core/pdcompat.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Literal
 
+import numpy as np
 import pandas as pd
 
 from xarray.core.options import _get_datetime_resolution
@@ -84,6 +85,7 @@ def default_precision_timestamp(*args, **kwargs) -> pd.Timestamp:
     dt = pd.Timestamp(*args, **kwargs)
     units = ["s", "ms", "us", "ns"]
     default = _get_datetime_resolution()
-    if units.index(default) > units.index(dt.unit):
+    unit = dt.unit if hasattr(dt, "unit") else np.datetime_data(dt.asm8)[0]
+    if units.index(default) > units.index(unit):
         dt = dt.as_unit(default)
     return dt

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -1496,7 +1496,7 @@ def test_date_range_like_same_calendar():
     assert src is out
 
 
-@pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+@pytest.mark.filterwarnings("ignore:Converting non-default")
 def test_date_range_like_errors():
     src = date_range("1899-02-03", periods=20, freq="D", use_cftime=False)
     src = src[np.arange(20) != 10]  # Remove 1 day so the frequency is not inferable.

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -319,7 +319,7 @@ def test_concat_multiple_datasets_with_multiple_missing_variables() -> None:
     assert_identical(actual, expected)
 
 
-@pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+@pytest.mark.filterwarnings("ignore:Converting non-default")
 def test_concat_type_of_missing_fill() -> None:
     datasets = create_typed_datasets(2, seed=123)
     expected1 = concat(datasets, dim="day", fill_value=dtypes.NA)

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -213,7 +213,7 @@ class TestEncodeCFVariable:
         vars, attrs = conventions.encode_dataset_coordinates(ds)
         assert attrs["coordinates"] == "bar baz"
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_emit_coordinates_attribute_in_attrs(self) -> None:
         orig = Dataset(
             {"a": 1, "b": 1},
@@ -231,7 +231,7 @@ class TestEncodeCFVariable:
         assert enc["b"].attrs.get("coordinates") == "t"
         assert "coordinates" not in enc["b"].encoding
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_emit_coordinates_attribute_in_encoding(self) -> None:
         orig = Dataset(
             {"a": 1, "b": 1},

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3657,7 +3657,7 @@ class TestDataArray:
         actual_no_data = da.to_dict(data=False, encoding=encoding)
         assert expected_no_data == actual_no_data
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_to_and_from_dict_with_time_dim(self) -> None:
         x = np.random.randn(10, 3)
         t = pd.date_range("20130101", periods=10)
@@ -3666,7 +3666,7 @@ class TestDataArray:
         roundtripped = DataArray.from_dict(da.to_dict())
         assert_identical(da, roundtripped)
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_to_and_from_dict_with_nan_nat(self) -> None:
         y = np.random.randn(10, 3)
         y[2] = np.nan

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3549,7 +3549,7 @@ class TestDataset:
 
     def test_expand_dims_non_nanosecond_conversion(self) -> None:
         # Regression test for https://github.com/pydata/xarray/issues/7493#issuecomment-1953091000
-        with pytest.warns(UserWarning, match="non-nanosecond precision"):
+        with pytest.warns(UserWarning, match="non-default precision"):
             ds = Dataset().expand_dims({"time": [np.datetime64("2018-01-01", "s")]})
         assert ds.time.dtype == np.dtype("datetime64[ns]")
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -122,7 +122,7 @@ def create_append_test_data(seed=None) -> tuple[Dataset, Dataset, Dataset]:
     bool_var_to_append = np.array([False, True], dtype=bool)
 
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "Converting non-nanosecond")
+        warnings.filterwarnings("ignore", "Converting non-default")
         ds = xr.Dataset(
             data_vars={
                 "da": xr.DataArray(
@@ -499,7 +499,7 @@ class TestDataset:
         actual = Dataset({"x": [5, 6, 7, 8, 9]})
         assert_identical(expected, actual)
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_constructor_0d(self) -> None:
         expected = Dataset({"x": ([], 1)})
         for arg in [1, np.array(1), expected["x"]]:
@@ -6070,7 +6070,7 @@ class TestDataset:
         expected = ds + other.reindex_like(ds)
         assert_identical(expected, actual)
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_dataset_math_errors(self) -> None:
         ds = self.make_example_math_dataset()
 
@@ -7164,7 +7164,7 @@ def test_differentiate(dask, edge_order) -> None:
         da.differentiate("x2d")
 
 
-@pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+@pytest.mark.filterwarnings("ignore:Converting non-default")
 @pytest.mark.parametrize("dask", [True, False])
 def test_differentiate_datetime(dask) -> None:
     rs = np.random.RandomState(42)
@@ -7359,7 +7359,7 @@ def test_cumulative_integrate(dask) -> None:
         da.cumulative_integrate("x2d")
 
 
-@pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+@pytest.mark.filterwarnings("ignore:Converting non-default")
 @pytest.mark.parametrize("dask", [True, False])
 @pytest.mark.parametrize("which_datetime", ["np", "cftime"])
 def test_trapezoid_datetime(dask, which_datetime) -> None:

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -607,7 +607,7 @@ def test_groupby_repr_datetime(obj) -> None:
     assert actual == expected
 
 
-@pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+@pytest.mark.filterwarnings("ignore:Converting non-default")
 @pytest.mark.filterwarnings("ignore:invalid value encountered in divide:RuntimeWarning")
 @pytest.mark.filterwarnings("ignore:No index created for dimension id:UserWarning")
 def test_groupby_drops_nans() -> None:
@@ -2124,7 +2124,7 @@ class TestDataArrayResample:
             assert_allclose(expected, actual, rtol=1e-16)
 
     @requires_scipy
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_upsample_interpolate_bug_2197(self) -> None:
         dates = pd.date_range("2007-02-01", "2007-03-01", freq="D")
         da = xr.DataArray(np.arange(len(dates)), [("time", dates)])

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -641,7 +641,7 @@ def test_interp_like() -> None:
         pytest.param("2000-01-01T12:00", 0.5, marks=pytest.mark.xfail),
     ],
 )
-@pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+@pytest.mark.filterwarnings("ignore:Converting non-default")
 def test_datetime(x_new, expected) -> None:
     da = xr.DataArray(
         np.arange(24),

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2963,7 +2963,7 @@ class TestDatetimePlot(PlotTestCase):
         # mpl.dates.AutoDateLocator passes and no other subclasses:
         assert type(ax.xaxis.get_major_locator()) is mpl.dates.AutoDateLocator
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_datetime_plot2d(self) -> None:
         # Test that matplotlib-native datetime works:
         da = DataArray(

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -200,7 +200,7 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
         x = self.cls(["x"], [value])
         self._assertIndexedLikeNDArray(x, value, dtype)
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_index_0d_datetime(self):
         d = datetime(2000, 1, 1)
         x = self.cls(["x"], [d])
@@ -212,7 +212,7 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
         x = self.cls(["x"], pd.DatetimeIndex([d]))
         self._assertIndexedLikeNDArray(x, np.datetime64(d), "datetime64[ns]")
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_index_0d_timedelta64(self):
         td = timedelta(hours=1)
 
@@ -253,7 +253,7 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
         assert_array_equal(x[0].data, listarray.squeeze())
         assert_array_equal(x.squeeze().data, listarray.squeeze())
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_index_and_concat_datetime(self):
         # regression test for #125
         date_range = pd.date_range("2011-09-01", periods=10)
@@ -274,7 +274,7 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
         expected = np.datetime64("2000-01-01", "ns")
         assert x[0].values == expected
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_datetime64_conversion(self):
         times = pd.date_range("2000-01-01", periods=3)
         for values, preserve_source in [
@@ -290,7 +290,7 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
             same_source = source_ndarray(v.values) is source_ndarray(values)
             assert preserve_source == same_source
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_timedelta64_conversion(self):
         times = pd.timedelta_range(start=0, periods=3)
         for values, preserve_source in [
@@ -311,14 +311,14 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
         actual = self.cls("x", data)
         assert actual.dtype == data.dtype
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_datetime64_valid_range(self):
         data = np.datetime64("1250-01-01", "us")
         pderror = pd.errors.OutOfBoundsDatetime
         with pytest.raises(pderror, match=r"Out of bounds nanosecond"):
             self.cls(["t"], [data])
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_timedelta64_valid_range(self):
         data = np.timedelta64("200000", "D")
         pderror = pd.errors.OutOfBoundsTimedelta
@@ -1076,7 +1076,7 @@ class TestVariable(VariableSubclassobjects):
         v = IndexVariable("x", np.arange(5))
         assert 2 == v.searchsorted(2)
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_datetime64_conversion_scalar(self):
         expected = np.datetime64("2000-01-01", "ns")
         for values in [
@@ -1089,7 +1089,7 @@ class TestVariable(VariableSubclassobjects):
             assert v.values == expected
             assert v.values.dtype == np.dtype("datetime64[ns]")
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_timedelta64_conversion_scalar(self):
         expected = np.timedelta64(24 * 60 * 60 * 10**9, "ns")
         for values in [
@@ -1116,7 +1116,7 @@ class TestVariable(VariableSubclassobjects):
         assert v.dtype == np.dtype("datetime64[ns]")
         assert v.values == np.datetime64("2000-01-01", "ns")
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_0d_timedelta(self):
         for td in [pd.to_timedelta("1s"), np.timedelta64(1, "s")]:
             v = Variable([], td)
@@ -1561,7 +1561,7 @@ class TestVariable(VariableSubclassobjects):
             v.transpose(..., "not_a_dim", missing_dims="warn")
             assert_identical(expected_ell, actual)
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_transpose_0d(self):
         for value in [
             3.5,
@@ -2623,7 +2623,7 @@ class TestAsCompatibleData(Generic[T_DuckArray]):
         assert_array_equal(expected, actual)
         assert actual.dtype == expected.dtype
 
-    @pytest.mark.filterwarnings("ignore:Converting non-nanosecond")
+    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_datetime(self):
         expected = np.datetime64("2000-01-01")
         actual = as_compatible_data(expected)
@@ -2965,7 +2965,7 @@ class TestNumpyCoercion:
 def test_datetime_conversion_warning(values, warns) -> None:
     dims = ["time"] if isinstance(values, np.ndarray | pd.Index | pd.Series) else []
     if warns:
-        with pytest.warns(UserWarning, match="non-nanosecond precision datetime"):
+        with pytest.warns(UserWarning, match="non-default precision datetime"):
             var = Variable(dims, values)
     else:
         with warnings.catch_warnings():
@@ -3011,7 +3011,7 @@ tz_ny = pytz.timezone("America/New_York")
 def test_pandas_two_only_datetime_conversion_warnings(
     data: pd.DatetimeIndex | pd.Series, dtype: str | pd.DatetimeTZDtype
 ) -> None:
-    with pytest.warns(UserWarning, match="non-nanosecond precision datetime"):
+    with pytest.warns(UserWarning, match="non-default precision datetime"):
         var = Variable(["time"], data.astype(dtype))  # type: ignore[arg-type]
 
     if var.dtype.kind == "M":
@@ -3040,7 +3040,7 @@ def test_pandas_two_only_datetime_conversion_warnings(
 def test_timedelta_conversion_warning(values, warns) -> None:
     dims = ["time"] if isinstance(values, np.ndarray | pd.Index) else []
     if warns:
-        with pytest.warns(UserWarning, match="non-nanosecond precision timedelta"):
+        with pytest.warns(UserWarning, match="non-default precision timedelta"):
             var = Variable(dims, values)
     else:
         with warnings.catch_warnings():
@@ -3054,7 +3054,7 @@ def test_pandas_two_only_timedelta_conversion_warning() -> None:
     # Note this test relies on a pandas feature that is only present in pandas
     # 2.0.0 and above, and so for now cannot be parametrized.
     data = pd.timedelta_range("1", periods=1).astype("timedelta64[s]")
-    with pytest.warns(UserWarning, match="non-nanosecond precision timedelta"):
+    with pytest.warns(UserWarning, match="non-default precision timedelta"):
         var = Variable(["time"], data)
 
     assert var.dtype == np.dtype("timedelta64[ns]")
@@ -3070,6 +3070,6 @@ def test_pandas_two_only_timedelta_conversion_warning() -> None:
 )
 def test_pandas_indexing_adapter_non_nanosecond_conversion(index, dtype) -> None:
     data = PandasIndexingAdapter(index.astype(f"{dtype}[s]"))
-    with pytest.warns(UserWarning, match="non-nanosecond precision"):
+    with pytest.warns(UserWarning, match="non-default precision"):
         var = Variable(["time"], data)
     assert var.dtype == np.dtype(f"{dtype}[ns]")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

This is a first attempt to get behind #7493 and #9154.

- added `time_resolution` option to `OPTIONS` to be set with `xr.set_options(time_resolution="us")` (defaulting to `ns`)
- refactored `nanosecond_precision_timestamp` to `default_precision_timestamp`, this now returns lowest needed resolution or default resolution (if that is higher)
- refactored `decode_datetime_with_pandas` to accomodate for non-naosecond treatment,
as pd.to_timedelta returns nanosecond-resolution in any case the processing had to be adapted in case of non-nanosecond timedeltas
- adapted some warnings

Besides enabling the changed warnings no tests have been changed so far, everything should work as expected with the default resolution of `ns`. 

This already works for encoding/decoding with different default resolutions (but, note the datetime64 issue for "0001-01-01T00:00:00.000000000"):

```python
for tu in ["s", "ms", "us", "ns"]:
    print("-----------------------------------------------------------------------------------")
    times = [
        np.datetime64("0001-01-01T00:00:00.000000000", tu), 
        np.datetime64("1677-09-21T00:12:43.145224193", tu), 
        np.datetime64("1970-01-01T00:00:00", tu), 
        np.datetime64("NaT")
    ]
    encoding = dict(dtype="int64", _FillValue=20)
    with xr.set_options(time_resolution=tu):
        var = xr.Variable(["time"], times, encoding=encoding)
        assert var.dtype == np.dtype(f"=M8[{tu}]")
        print(var)
        encoded_var = xr.conventions.encode_cf_variable(var)
        print(encoded_var)
        decoded_var = xr.conventions.decode_cf_variable("foo", encoded_var)
        assert decoded_var.dtype == np.dtype(f"=M8[{tu}]")
        print(decoded_var.load())
        print(var.encoding, decoded_var.encoding)
```

<details>
<summary>Output</summary>

```python
-----------------------------------------------------------------------------------
<xarray.Variable (time: 4)> Size: 32B
array(['0001-01-01T00:00:00', '1677-09-21T00:12:43',
       '1970-01-01T00:00:00',                 'NaT'],
      dtype='datetime64[s]')
<xarray.Variable (time: 4)> Size: 32B
array([          0, 52912224763, 62135596800,          20])
Attributes:
    units:       seconds since 0001-01-01 00:00:00
    calendar:    proleptic_gregorian
    _FillValue:  20
<xarray.Variable (time: 4)> Size: 32B
array(['0001-01-01T00:00:00', '1677-09-21T00:12:43',
       '1970-01-01T00:00:00',                 'NaT'],
      dtype='datetime64[s]')
{'dtype': 'int64', '_FillValue': 20} {'_FillValue': np.int64(20), 'units': 'seconds since 0001-01-01 00:00:00', 'calendar': 'proleptic_gregorian', 'dtype': dtype('int64')}
-----------------------------------------------------------------------------------
<xarray.Variable (time: 4)> Size: 32B
array(['0001-01-01T00:00:00.000', '1677-09-21T00:12:43.145',
       '1970-01-01T00:00:00.000',                     'NaT'],
      dtype='datetime64[ms]')
<xarray.Variable (time: 4)> Size: 32B
array([             0, 52912224763145, 62135596800000,             20])
Attributes:
    units:       milliseconds since 0001-01-01 00:00:00
    calendar:    proleptic_gregorian
    _FillValue:  20
<xarray.Variable (time: 4)> Size: 32B
array(['0001-01-01T00:00:00.000', '1677-09-21T00:12:43.145',
       '1970-01-01T00:00:00.000',                     'NaT'],
      dtype='datetime64[ms]')
{'dtype': 'int64', '_FillValue': 20} {'_FillValue': np.int64(20), 'units': 'milliseconds since 0001-01-01 00:00:00', 'calendar': 'proleptic_gregorian', 'dtype': dtype('int64')}
-----------------------------------------------------------------------------------
<xarray.Variable (time: 4)> Size: 32B
array(['0001-01-01T00:00:00.000000', '1677-09-21T00:12:43.145224',
       '1970-01-01T00:00:00.000000',                        'NaT'],
      dtype='datetime64[us]')
<xarray.Variable (time: 4)> Size: 32B
array([                0, 52912224763145224, 62135596800000000,
                      20])
Attributes:
    units:       microseconds since 0001-01-01 00:00:00
    calendar:    proleptic_gregorian
    _FillValue:  20
<xarray.Variable (time: 4)> Size: 32B
array(['0001-01-01T00:00:00.000000', '1677-09-21T00:12:43.145224',
       '1970-01-01T00:00:00.000000',                        'NaT'],
      dtype='datetime64[us]')
{'dtype': 'int64', '_FillValue': 20} {'_FillValue': np.int64(20), 'units': 'microseconds since 0001-01-01 00:00:00', 'calendar': 'proleptic_gregorian', 'dtype': dtype('int64')}
-----------------------------------------------------------------------------------
<xarray.Variable (time: 4)> Size: 32B
array(['1754-08-30T22:43:41.128654848', '1677-09-21T00:12:43.145224193',
       '1970-01-01T00:00:00.000000000',                           'NaT'],
      dtype='datetime64[ns]')
<xarray.Variable (time: 4)> Size: 32B
array([                   0, -2428007457983430655,  6795364578871345152,
                         20])
Attributes:
    units:       nanoseconds since 1754-08-30 22:43:41.128654848
    calendar:    proleptic_gregorian
    _FillValue:  20
<xarray.Variable (time: 4)> Size: 32B
array(['1754-08-30T22:43:41.128654848', '1677-09-21T00:12:43.145224193',
       '1970-01-01T00:00:00.000000000',                           'NaT'],
      dtype='datetime64[ns]')
{'dtype': 'int64', '_FillValue': 20} {'_FillValue': np.int64(20), 'units': 'nanoseconds since 1754-08-30 22:43:41.128654848', 'calendar': 'proleptic_gregorian', 'dtype': dtype('int64')}
```
</details>

Enabling the proposed changes would allow us to (at least) get feedback which of their workflows already work if they use another default resolution and which not. It would also help us in investigation solutions to fully resolve #7493. I've already tried to come up with a fully automagic version, but that didn't work out (yet) more or less because the current tests are not easy to transform to different default resolution.

Anyway, it would be great to get any feedback here. Pinging some folks who might have interest,  @spencerkclark, @ChrisBarker-NOAA, @rabernat, @khider, please include other interested parties, too.
