### PR TITLE
Remove unvetted DataTree methods

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -705,16 +705,16 @@ Pathlib-like Interface
    DataTree.parents
    DataTree.relative_to
 
-Missing:
+.. Missing:
 
-..
+.. ..
 
-   ``DataTree.glob``
-   ``DataTree.joinpath``
-   ``DataTree.with_name``
-   ``DataTree.walk``
-   ``DataTree.rename``
-   ``DataTree.replace``
+..    ``DataTree.glob``
+..    ``DataTree.joinpath``
+..    ``DataTree.with_name``
+..    ``DataTree.walk``
+..    ``DataTree.rename``
+..    ``DataTree.replace``
 
 DataTree Contents
 -----------------
@@ -962,10 +962,10 @@ DataTree methods
    DataTree.to_netcdf
    DataTree.to_zarr
 
-..
+.. ..
 
-   Missing:
-   ``open_mfdatatree``
+..    Missing:
+..    ``open_mfdatatree``
 
 Coordinates objects
 ===================
@@ -1477,10 +1477,10 @@ Advanced API
    backends.list_engines
    backends.refresh_engines
 
-..
+.. ..
 
-   Missing:
-   ``DataTree.set_close``
+..    Missing:
+..    ``DataTree.set_close``
 
 Default, pandas-backed indexes built-in Xarray:
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -725,17 +725,18 @@ Manipulate the contents of all nodes in a ``DataTree`` simultaneously.
    :toctree: generated/
 
    DataTree.copy
-   DataTree.assign_coords
-   DataTree.merge
-   DataTree.rename
-   DataTree.rename_vars
-   DataTree.rename_dims
-   DataTree.swap_dims
-   DataTree.expand_dims
-   DataTree.drop_vars
-   DataTree.drop_dims
-   DataTree.set_coords
-   DataTree.reset_coords
+
+   .. DataTree.assign_coords
+   .. DataTree.merge
+   .. DataTree.rename
+   .. DataTree.rename_vars
+   .. DataTree.rename_dims
+   .. DataTree.swap_dims
+   .. DataTree.expand_dims
+   .. DataTree.drop_vars
+   .. DataTree.drop_dims
+   .. DataTree.set_coords
+   .. DataTree.reset_coords
 
 DataTree Node Contents
 ----------------------
@@ -760,129 +761,129 @@ Compare one ``DataTree`` object to another.
     DataTree.equals
     DataTree.identical
 
-Indexing
---------
+.. Indexing
+.. --------
 
-Index into all nodes in the subtree simultaneously.
+.. Index into all nodes in the subtree simultaneously.
 
-.. autosummary::
-   :toctree: generated/
+.. .. autosummary::
+..    :toctree: generated/
 
-   DataTree.isel
-   DataTree.sel
-   DataTree.drop_sel
-   DataTree.drop_isel
-   DataTree.head
-   DataTree.tail
-   DataTree.thin
-   DataTree.squeeze
-   DataTree.interp
-   DataTree.interp_like
-   DataTree.reindex
-   DataTree.reindex_like
-   DataTree.set_index
-   DataTree.reset_index
-   DataTree.reorder_levels
-   DataTree.query
+..    DataTree.isel
+..    DataTree.sel
+..    DataTree.drop_sel
+..    DataTree.drop_isel
+..    DataTree.head
+..    DataTree.tail
+..    DataTree.thin
+..    DataTree.squeeze
+..    DataTree.interp
+..    DataTree.interp_like
+..    DataTree.reindex
+..    DataTree.reindex_like
+..    DataTree.set_index
+..    DataTree.reset_index
+..    DataTree.reorder_levels
+..    DataTree.query
 
-..
+.. ..
 
-   Missing:
-   ``DataTree.loc``
+..    Missing:
+..    ``DataTree.loc``
 
 
-Missing Value Handling
-----------------------
+.. Missing Value Handling
+.. ----------------------
 
-.. autosummary::
-   :toctree: generated/
+.. .. autosummary::
+..    :toctree: generated/
 
-   DataTree.isnull
-   DataTree.notnull
-   DataTree.combine_first
-   DataTree.dropna
-   DataTree.fillna
-   DataTree.ffill
-   DataTree.bfill
-   DataTree.interpolate_na
-   DataTree.where
-   DataTree.isin
+..    DataTree.isnull
+..    DataTree.notnull
+..    DataTree.combine_first
+..    DataTree.dropna
+..    DataTree.fillna
+..    DataTree.ffill
+..    DataTree.bfill
+..    DataTree.interpolate_na
+..    DataTree.where
+..    DataTree.isin
 
-Computation
------------
+.. Computation
+.. -----------
 
-Apply a computation to the data in all nodes in the subtree simultaneously.
+.. Apply a computation to the data in all nodes in the subtree simultaneously.
 
-.. autosummary::
-   :toctree: generated/
+.. .. autosummary::
+..    :toctree: generated/
 
-   DataTree.map
-   DataTree.reduce
-   DataTree.diff
-   DataTree.quantile
-   DataTree.differentiate
-   DataTree.integrate
-   DataTree.map_blocks
-   DataTree.polyfit
-   DataTree.curvefit
+..    DataTree.map
+..    DataTree.reduce
+..    DataTree.diff
+..    DataTree.quantile
+..    DataTree.differentiate
+..    DataTree.integrate
+..    DataTree.map_blocks
+..    DataTree.polyfit
+..    DataTree.curvefit
 
-Aggregation
------------
+.. Aggregation
+.. -----------
 
-Aggregate data in all nodes in the subtree simultaneously.
+.. Aggregate data in all nodes in the subtree simultaneously.
 
-.. autosummary::
-   :toctree: generated/
+.. .. autosummary::
+..    :toctree: generated/
 
-   DataTree.all
-   DataTree.any
-   DataTree.argmax
-   DataTree.argmin
-   DataTree.idxmax
-   DataTree.idxmin
-   DataTree.max
-   DataTree.min
-   DataTree.mean
-   DataTree.median
-   DataTree.prod
-   DataTree.sum
-   DataTree.std
-   DataTree.var
-   DataTree.cumsum
-   DataTree.cumprod
+..    DataTree.all
+..    DataTree.any
+..    DataTree.argmax
+..    DataTree.argmin
+..    DataTree.idxmax
+..    DataTree.idxmin
+..    DataTree.max
+..    DataTree.min
+..    DataTree.mean
+..    DataTree.median
+..    DataTree.prod
+..    DataTree.sum
+..    DataTree.std
+..    DataTree.var
+..    DataTree.cumsum
+..    DataTree.cumprod
 
-ndarray methods
----------------
+.. ndarray methods
+.. ---------------
 
-Methods copied from :py:class:`numpy.ndarray` objects, here applying to the data in all nodes in the subtree.
+.. Methods copied from :py:class:`numpy.ndarray` objects, here applying to the data in all nodes in the subtree.
 
-.. autosummary::
-   :toctree: generated/
+.. .. autosummary::
+..    :toctree: generated/
 
-   DataTree.argsort
-   DataTree.astype
-   DataTree.clip
-   DataTree.conj
-   DataTree.conjugate
-   DataTree.round
-   DataTree.rank
+..    DataTree.argsort
+..    DataTree.astype
+..    DataTree.clip
+..    DataTree.conj
+..    DataTree.conjugate
+..    DataTree.round
+..    DataTree.rank
 
-Reshaping and reorganising
---------------------------
+.. Reshaping and reorganising
+.. --------------------------
 
-Reshape or reorganise the data in all nodes in the subtree.
+.. Reshape or reorganise the data in all nodes in the subtree.
 
-.. autosummary::
-   :toctree: generated/
+.. .. autosummary::
+..    :toctree: generated/
 
-   DataTree.transpose
-   DataTree.stack
-   DataTree.unstack
-   DataTree.shift
-   DataTree.roll
-   DataTree.pad
-   DataTree.sortby
-   DataTree.broadcast_like
+..    DataTree.transpose
+..    DataTree.stack
+..    DataTree.unstack
+..    DataTree.shift
+..    DataTree.roll
+..    DataTree.pad
+..    DataTree.sortby
+..    DataTree.broadcast_like
 
 IO / Conversion
 ===============

--- a/doc/getting-started-guide/quick-overview.rst
+++ b/doc/getting-started-guide/quick-overview.rst
@@ -314,19 +314,23 @@ And you can get a copy of just the node local values of :py:class:`~xarray.Datas
     ds_node_local = dt["simulation/coarse"].to_dataset(inherited=False)
     ds_node_local
 
-Operations map over subtrees, so we can take a mean over the ``x`` dimension of both the ``fine`` and ``coarse`` groups just by:
+We intend to eventually implement most :py:class:`~xarray.Dataset` methods
+(indexing, aggregation, arithmetic, etc) on :py:class:`~xarray.DataTree`
+objects, but many methods have not been implemented yet.
 
-.. ipython:: python
+.. Operations map over subtrees, so we can take a mean over the ``x`` dimension of both the ``fine`` and ``coarse`` groups just by:
 
-    avg = dt["simulation"].mean(dim="x")
-    avg
+.. .. ipython:: python
 
-Here the ``"x"`` dimension used is always the one local to that subgroup.
+..     avg = dt["simulation"].mean(dim="x")
+..     avg
+
+.. Here the ``"x"`` dimension used is always the one local to that subgroup.
 
 
-You can do almost everything you can do with :py:class:`~xarray.Dataset` objects with :py:class:`~xarray.DataTree` objects
-(including indexing and arithmetic), as operations will be mapped over every subgroup in the tree.
-This allows you to work with multiple groups of non-alignable variables at once.
+.. You can do almost everything you can do with :py:class:`~xarray.Dataset` objects with :py:class:`~xarray.DataTree` objects
+.. (including indexing and arithmetic), as operations will be mapped over every subgroup in the tree.
+.. This allows you to work with multiple groups of non-alignable variables at once.
 
 .. note::
 

--- a/doc/getting-started-guide/quick-overview.rst
+++ b/doc/getting-started-guide/quick-overview.rst
@@ -314,9 +314,11 @@ And you can get a copy of just the node local values of :py:class:`~xarray.Datas
     ds_node_local = dt["simulation/coarse"].to_dataset(inherited=False)
     ds_node_local
 
-We intend to eventually implement most :py:class:`~xarray.Dataset` methods
-(indexing, aggregation, arithmetic, etc) on :py:class:`~xarray.DataTree`
-objects, but many methods have not been implemented yet.
+.. note::
+
+    We intend to eventually implement most :py:class:`~xarray.Dataset` methods
+    (indexing, aggregation, arithmetic, etc) on :py:class:`~xarray.DataTree`
+    objects, but many methods have not been implemented yet.
 
 .. Operations map over subtrees, so we can take a mean over the ``x`` dimension of both the ``fine`` and ``coarse`` groups just by:
 
@@ -332,9 +334,9 @@ objects, but many methods have not been implemented yet.
 .. (including indexing and arithmetic), as operations will be mapped over every subgroup in the tree.
 .. This allows you to work with multiple groups of non-alignable variables at once.
 
-.. note::
+.. tip::
 
-    If all of your variables are mutually alignable (i.e. they live on the same
+    If all of your variables are mutually alignable (i.e., they live on the same
     grid, such that every common dimension name maps to the same length), then
     you probably don't need :py:class:`xarray.DataTree`, and should consider
     just sticking with :py:class:`xarray.Dataset`.

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1468,7 +1468,7 @@ class DataTree(
 
     @property
     def groups(self):
-        """Return all netCDF4 groups in the tree, given as a tuple of path-like strings."""
+        """Return all groups in the tree, given as a tuple of path-like strings."""
         return tuple(node.path for node in self.subtree)
 
     def to_netcdf(

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -668,10 +668,11 @@ class TestCoords:
             actual.coords["x"] = ("x", [-1])
         assert_identical(actual, dt)  # should not be modified
 
-        actual = dt.copy()
-        del actual.coords["b"]
-        expected = dt.reset_coords("b", drop=True)
-        assert_identical(expected, actual)
+        # TODO: re-enable after implementing reset_coords()
+        # actual = dt.copy()
+        # del actual.coords["b"]
+        # expected = dt.reset_coords("b", drop=True)
+        # assert_identical(expected, actual)
 
         with pytest.raises(KeyError):
             del dt.coords["not_found"]
@@ -679,14 +680,15 @@ class TestCoords:
         with pytest.raises(KeyError):
             del dt.coords["foo"]
 
-        actual = dt.copy(deep=True)
-        actual.coords.update({"c": 11})
-        expected = dt.assign_coords({"c": 11})
-        assert_identical(expected, actual)
+        # TODO: re-enable after implementing assign_coords()
+        # actual = dt.copy(deep=True)
+        # actual.coords.update({"c": 11})
+        # expected = dt.assign_coords({"c": 11})
+        # assert_identical(expected, actual)
 
-        # regression test for GH3746
-        del actual.coords["x"]
-        assert "x" not in actual.xindexes
+        # # regression test for GH3746
+        # del actual.coords["x"]
+        # assert "x" not in actual.xindexes
 
         # test that constructors can also handle the `DataTreeCoordinates` object
         ds2 = Dataset(coords=dt.coords)
@@ -968,6 +970,7 @@ class TestAccess:
         var_keys = list(dt.variables.keys())
         assert all(var_key in key_completions for var_key in var_keys)
 
+    @pytest.mark.xfail(reason="sel not implemented yet")
     def test_operation_with_attrs_but_no_data(self):
         # tests bug from xarray-datatree GH262
         xs = xr.Dataset({"testvar": xr.DataArray(np.ones((2, 3)))})
@@ -1557,6 +1560,7 @@ class TestSubset:
 
 
 class TestDSMethodInheritance:
+    @pytest.mark.xfail(reason="isel not implemented yet")
     def test_dataset_method(self):
         ds = xr.Dataset({"a": ("x", [1, 2, 3])})
         dt = DataTree.from_dict(
@@ -1576,6 +1580,7 @@ class TestDSMethodInheritance:
         result = dt.isel(x=1)
         assert_equal(result, expected)
 
+    @pytest.mark.xfail(reason="reduce methods not implemented yet")
     def test_reduce_method(self):
         ds = xr.Dataset({"a": ("x", [False, True, False])})
         dt = DataTree.from_dict({"/": ds, "/results": ds})
@@ -1585,6 +1590,7 @@ class TestDSMethodInheritance:
         result = dt.any()
         assert_equal(result, expected)
 
+    @pytest.mark.xfail(reason="reduce methods not implemented yet")
     def test_nan_reduce_method(self):
         ds = xr.Dataset({"a": ("x", [1, 2, 3])})
         dt = DataTree.from_dict({"/": ds, "/results": ds})
@@ -1594,6 +1600,7 @@ class TestDSMethodInheritance:
         result = dt.mean()
         assert_equal(result, expected)
 
+    @pytest.mark.xfail(reason="cum methods not implemented yet")
     def test_cum_method(self):
         ds = xr.Dataset({"a": ("x", [1, 2, 3])})
         dt = DataTree.from_dict({"/": ds, "/results": ds})
@@ -1610,6 +1617,7 @@ class TestDSMethodInheritance:
 
 
 class TestOps:
+    @pytest.mark.xfail(reason="arithmetic not implemented yet")
     def test_binary_op_on_int(self):
         ds1 = xr.Dataset({"a": [5], "b": [3]})
         ds2 = xr.Dataset({"x": [0.1, 0.2], "y": [10, 20]})
@@ -1621,6 +1629,7 @@ class TestOps:
         result: DataTree = dt * 5  # type: ignore[assignment,operator]
         assert_equal(result, expected)
 
+    @pytest.mark.xfail(reason="arithmetic not implemented yet")
     def test_binary_op_on_dataset(self):
         ds1 = xr.Dataset({"a": [5], "b": [3]})
         ds2 = xr.Dataset({"x": [0.1, 0.2], "y": [10, 20]})
@@ -1643,6 +1652,7 @@ class TestOps:
         result = dt * other_ds
         assert_equal(result, expected)
 
+    @pytest.mark.xfail(reason="arithmetic not implemented yet")
     def test_binary_op_on_datatree(self):
         ds1 = xr.Dataset({"a": [5], "b": [3]})
         ds2 = xr.Dataset({"x": [0.1, 0.2], "y": [10, 20]})
@@ -1655,6 +1665,7 @@ class TestOps:
         result = dt * dt  # type: ignore[operator]
         assert_equal(result, expected)
 
+    @pytest.mark.xfail(reason="arithmetic not implemented yet")
     def test_arithmetic_inherited_coords(self):
         tree = DataTree(xr.Dataset(coords={"x": [1, 2, 3]}))
         tree["/foo"] = DataTree(xr.Dataset({"bar": ("x", [4, 5, 6])}))
@@ -1669,6 +1680,8 @@ class TestOps:
 
 
 class TestUFuncs:
+
+    @pytest.mark.xfail(reason="__array_ufunc__ not implemented yet")
     def test_tree(self, create_test_datatree):
         dt = create_test_datatree()
         expected = create_test_datatree(modify=lambda ds: np.sin(ds))


### PR DESCRIPTION
This PR deletes the many Dataset methods that were copied onto DataTree without unit tests, along with a few that are not implemented properly yet, e.g.,

1. Arithmetic methods were removed, because `DataTree + Dataset` should probably raise an error.
2. Indexing and aggregation methods were removed, because these should allow for dimensions that are missing only on some nodes.
3. The untested `map_over_subtree_inplace` and `render` methods were removed.
3. A few other methods (e.g., `merge` and `plot`) that were only implemented by raising `NotImplementedError`` are entirely removed instead.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #9582
- [x] Tests added
