### PR TITLE
support for additional scipy nd interpolants 

### DIFF
--- a/doc/user-guide/interpolation.rst
+++ b/doc/user-guide/interpolation.rst
@@ -132,10 +132,11 @@ It is now possible to safely compute the difference ``other - interpolated``.
 Interpolation methods
 ---------------------
 
-We use :py:class:`scipy.interpolate.interp1d` for 1-dimensional interpolation.
+We use either :py:class:`scipy.interpolate.interp1d` or special interpolants from
+:py:class:`scipy.interpolate` for 1-dimensional interpolation (see :py:meth:`~xarray.Dataset.interp`).
 For multi-dimensional interpolation, an attempt is first made to decompose the
 interpolation in a series of 1-dimensional interpolations, in which case
-:py:class:`scipy.interpolate.interp1d` is used. If a decomposition cannot be
+the relevant 1-dimensional interpolator is used. If a decomposition cannot be
 made (e.g. with advanced interpolation), :py:func:`scipy.interpolate.interpn` is
 used.
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2294,9 +2294,7 @@ class DataArray(
 
         See Also
         --------
-        Dataset.interp
-        Dataset.reindex_like
-        scipy.interpolate
+        :mod:`scipy.interpolate`
 
         :doc:`xarray-tutorial:fundamentals/02.2_manipulating_dimensions`
             Tutorial material on manipulating data resolution using :py:func:`~xarray.DataArray.interp`
@@ -2449,9 +2447,9 @@ class DataArray(
 
         See Also
         --------
-        DataArray.interp
-        DataArray.reindex_like
-        scipy.interpolate
+        :func:`DataArray.interp`
+        :func:`DataArray.reindex_like`
+        :mod:`scipy.interpolate`
 
         Examples
         --------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2265,7 +2265,8 @@ class DataArray(
             New coordinate can be a scalar, array-like or DataArray.
             If DataArrays are passed as new coordinates, their dimensions are
             used for the broadcasting. Missing values are skipped.
-        method : str
+        method : { "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
+            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima" }
             Interpolation method to use (see descriptions above).
         assume_sorted : bool, default: False
             If False, values of x can be in any order and they are sorted
@@ -2420,7 +2421,8 @@ class DataArray(
             Object with an 'indexes' attribute giving a mapping from dimension
             names to an 1d array-like, which provides coordinates upon
             which to index the variables in this dataset. Missing values are skipped.
-        method : str
+        method : { "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
+            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima" }
             Interpolation method to use (see descriptions above).
         assume_sorted : bool, default: False
             If False, values of coordinates that are interpolated over can be

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2235,14 +2235,14 @@ class DataArray(
         method and dimensionality determine which interpolant is used:
 
         1. **Interpolation along one dimension of 1D data (`method='linear'`)**
-            - Uses :py:class:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
+            - Uses :py:func:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
 
         2. **Interpolation along one dimension of N-dimensional data (N ≥ 1)**
             - Methods {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "quintic", "polynomial"}
-                use :py:class:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:class:`numpy.interp`
+                use :py:func:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:func:`numpy.interp`
                 (as in the case of `method='linear'` for 1D data).
             - If `method='polynomial'`, the `order` keyword argument must also be provided. In this case,
-                :py:class:`scipy.interpolate.interp1d` is called with `kind=order`.
+                :py:func:`scipy.interpolate.interp1d` is called with `kind=order`.
 
         3. **Special interpolants for interpolation along one dimension of N-dimensional data (N ≥ 1)**
             - Depending on the `method`, the following interpolants from :py:class:`scipy.interpolate` are used:
@@ -2394,11 +2394,11 @@ class DataArray(
         interpolant is used:
 
         1. **Interpolation along one dimension of 1D data (`method='linear'`)**
-            - Uses :py:class:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
+            - Uses :py:func:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
 
         2. **Interpolation along one dimension of N-dimensional data (N ≥ 1)**
             - Methods {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "quintic", "polynomial"}
-                use :py:class:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:class:`numpy.interp`
+                use :py:func:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:func:`numpy.interp`
                 (as in the case of `method='linear'` for 1D data).
             - If `method='polynomial'`, the `order` keyword argument must also be provided.
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2296,6 +2296,7 @@ class DataArray(
         --------
         Dataset.interp
         Dataset.reindex_like
+        scipy.interpolate
 
         :doc:`xarray-tutorial:fundamentals/02.2_manipulating_dimensions`
             Tutorial material on manipulating data resolution using :py:func:`~xarray.DataArray.interp`
@@ -2450,6 +2451,7 @@ class DataArray(
         --------
         DataArray.interp
         DataArray.reindex_like
+        scipy.interpolate
 
         Examples
         --------

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2242,8 +2242,8 @@ class DataArray(
             New coordinate can be a scalar, array-like or DataArray.
             If DataArrays are passed as new coordinates, their dimensions are
             used for the broadcasting. Missing values are skipped.
-        method : "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
-            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima"
+        method : { "linear", "nearest", "zero", "slinear", "quadratic", "cubic", \
+            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima" }
             Interpolation method to use (see descriptions above).
         assume_sorted : bool, default: False
             If False, values of x can be in any order and they are sorted
@@ -2397,8 +2397,8 @@ class DataArray(
             Object with an 'indexes' attribute giving a mapping from dimension
             names to an 1d array-like, which provides coordinates upon
             which to index the variables in this dataset. Missing values are skipped.
-        method : "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
-            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima"
+        method : { "linear", "nearest", "zero", "slinear", "quadratic", "cubic", \
+            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima" }
             Interpolation method to use (see descriptions above).
         assume_sorted : bool, default: False
             If False, values of coordinates that are interpolated over can be

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2242,8 +2242,8 @@ class DataArray(
             New coordinate can be a scalar, array-like or DataArray.
             If DataArrays are passed as new coordinates, their dimensions are
             used for the broadcasting. Missing values are skipped.
-        method : { "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
-            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima" }
+        method : "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
+            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima"
             Interpolation method to use (see descriptions above).
         assume_sorted : bool, default: False
             If False, values of x can be in any order and they are sorted
@@ -2397,8 +2397,8 @@ class DataArray(
             Object with an 'indexes' attribute giving a mapping from dimension
             names to an 1d array-like, which provides coordinates upon
             which to index the variables in this dataset. Missing values are skipped.
-        method : { "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
-            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima" }
+        method : "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
+            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima"
             Interpolation method to use (see descriptions above).
         assume_sorted : bool, default: False
             If False, values of coordinates that are interpolated over can be
@@ -2423,7 +2423,7 @@ class DataArray(
             the process attempts to decompose the interpolation into independent interpolations
             along one dimension at a time.
         - The specific interpolation method and dimensionality determine which
-        interpolant is used:
+            interpolant is used:
 
             1. **Interpolation along one dimension of 1D data (`method='linear'`)**
                 - Uses :py:func:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -2231,30 +2231,7 @@ class DataArray(
         Interpolate a DataArray onto new coordinates.
 
         Performs univariate or multivariate interpolation of a Dataset onto new coordinates,
-        utilizing either NumPy or SciPy interpolation routines. The specific interpolation
-        method and dimensionality determine which interpolant is used:
-
-        1. **Interpolation along one dimension of 1D data (`method='linear'`)**
-            - Uses :py:func:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
-
-        2. **Interpolation along one dimension of N-dimensional data (N ≥ 1)**
-            - Methods {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "quintic", "polynomial"}
-                use :py:func:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:func:`numpy.interp`
-                (as in the case of `method='linear'` for 1D data).
-            - If `method='polynomial'`, the `order` keyword argument must also be provided. In this case,
-                :py:func:`scipy.interpolate.interp1d` is called with `kind=order`.
-
-        3. **Special interpolants for interpolation along one dimension of N-dimensional data (N ≥ 1)**
-            - Depending on the `method`, the following interpolants from :py:class:`scipy.interpolate` are used:
-                - `"pchip"`: :py:class:`scipy.interpolate.PchipInterpolator`
-                - `"barycentric"`: :py:class:`scipy.interpolate.BarycentricInterpolator`
-                - `"krogh"`: :py:class:`scipy.interpolate.KroghInterpolator`
-                - `"akima"` or `"makima"`: :py:class:`scipy.interpolate.Akima1dInterpolator`
-                    (`makima` is handled by passing `makima` to `method`).
-
-        4. **Interpolation along multiple dimensions of multi-dimensional data**
-            - Uses :py:func:`scipy.interpolate.interpn` for methods {"linear", "nearest", "slinear",
-                "cubic", "quintic", "pchip"}.
+        utilizing either NumPy or SciPy interpolation routines.
 
         Out-of-range values are filled with NaN, unless specified otherwise via `kwargs` to the numpy/scipy interpolant.
 
@@ -2291,6 +2268,29 @@ class DataArray(
         - When interpolating along multiple dimensions with methods `linear` and `nearest`,
             the process attempts to decompose the interpolation into independent interpolations
             along one dimension at a time.
+        - The specific interpolation method and dimensionality determine which
+            interpolant is used:
+
+            1. **Interpolation along one dimension of 1D data (`method='linear'`)**
+                - Uses :py:func:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
+
+            2. **Interpolation along one dimension of N-dimensional data (N ≥ 1)**
+                - Methods {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "quintic", "polynomial"}
+                    use :py:func:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:func:`numpy.interp`
+                    (as in the case of `method='linear'` for 1D data).
+                - If `method='polynomial'`, the `order` keyword argument must also be provided.
+
+            3. **Special interpolants for interpolation along one dimension of N-dimensional data (N ≥ 1)**
+                - Depending on the `method`, the following interpolants from :py:class:`scipy.interpolate` are used:
+                    - `"pchip"`: :py:class:`scipy.interpolate.PchipInterpolator`
+                    - `"barycentric"`: :py:class:`scipy.interpolate.BarycentricInterpolator`
+                    - `"krogh"`: :py:class:`scipy.interpolate.KroghInterpolator`
+                    - `"akima"` or `"makima"`: :py:class:`scipy.interpolate.Akima1dInterpolator`
+                        (`makima` is handled by passing the `makima` flag).
+
+            4. **Interpolation along multiple dimensions of multi-dimensional data**
+                - Uses :py:func:`scipy.interpolate.interpn` for methods {"linear", "nearest", "slinear",
+                    "cubic", "quintic", "pchip"}.
 
         See Also
         --------
@@ -2391,30 +2391,6 @@ class DataArray(
         """Interpolate this object onto the coordinates of another object,
         filling out of range values with NaN.
 
-        The specific interpolation method and dimensionality determine which
-        interpolant is used:
-
-        1. **Interpolation along one dimension of 1D data (`method='linear'`)**
-            - Uses :py:func:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
-
-        2. **Interpolation along one dimension of N-dimensional data (N ≥ 1)**
-            - Methods {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "quintic", "polynomial"}
-                use :py:func:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:func:`numpy.interp`
-                (as in the case of `method='linear'` for 1D data).
-            - If `method='polynomial'`, the `order` keyword argument must also be provided.
-
-        3. **Special interpolants for interpolation along one dimension of N-dimensional data (N ≥ 1)**
-            - Depending on the `method`, the following interpolants from :py:class:`scipy.interpolate` are used:
-                - `"pchip"`: :py:class:`scipy.interpolate.PchipInterpolator`
-                - `"barycentric"`: :py:class:`scipy.interpolate.BarycentricInterpolator`
-                - `"krogh"`: :py:class:`scipy.interpolate.KroghInterpolator`
-                - `"akima"` or `"makima"`: :py:class:`scipy.interpolate.Akima1dInterpolator`
-                    (`makima` is handled by passing the `makima` flag).
-
-        4. **Interpolation along multiple dimensions of multi-dimensional data**
-            - Uses :py:func:`scipy.interpolate.interpn` for methods {"linear", "nearest", "slinear",
-                "cubic", "quintic", "pchip"}.
-
         Parameters
         ----------
         other : Dataset or DataArray
@@ -2446,6 +2422,29 @@ class DataArray(
         - When interpolating along multiple dimensions with methods `linear` and `nearest`,
             the process attempts to decompose the interpolation into independent interpolations
             along one dimension at a time.
+        - The specific interpolation method and dimensionality determine which
+        interpolant is used:
+
+            1. **Interpolation along one dimension of 1D data (`method='linear'`)**
+                - Uses :py:func:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
+
+            2. **Interpolation along one dimension of N-dimensional data (N ≥ 1)**
+                - Methods {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "quintic", "polynomial"}
+                    use :py:func:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:func:`numpy.interp`
+                    (as in the case of `method='linear'` for 1D data).
+                - If `method='polynomial'`, the `order` keyword argument must also be provided.
+
+            3. **Special interpolants for interpolation along one dimension of N-dimensional data (N ≥ 1)**
+                - Depending on the `method`, the following interpolants from :py:class:`scipy.interpolate` are used:
+                    - `"pchip"`: :py:class:`scipy.interpolate.PchipInterpolator`
+                    - `"barycentric"`: :py:class:`scipy.interpolate.BarycentricInterpolator`
+                    - `"krogh"`: :py:class:`scipy.interpolate.KroghInterpolator`
+                    - `"akima"` or `"makima"`: :py:class:`scipy.interpolate.Akima1dInterpolator`
+                        (`makima` is handled by passing the `makima` flag).
+
+            4. **Interpolation along multiple dimensions of multi-dimensional data**
+                - Uses :py:func:`scipy.interpolate.interpn` for methods {"linear", "nearest", "slinear",
+                    "cubic", "quintic", "pchip"}.
 
         See Also
         --------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3923,8 +3923,8 @@ class Dataset(
             New coordinate can be a scalar, array-like or DataArray.
             If DataArrays are passed as new coordinates, their dimensions are
             used for the broadcasting. Missing values are skipped.
-        method : { "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
-            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima" }
+        method : "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
+            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima"
             Interpolation method to use (see descriptions above).
         assume_sorted : bool, default: False
             If False, values of coordinates that are interpolated over can be
@@ -4215,8 +4215,8 @@ class Dataset(
             Object with an 'indexes' attribute giving a mapping from dimension
             names to an 1d array-like, which provides coordinates upon
             which to index the variables in this dataset. Missing values are skipped.
-        method : { "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
-            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima" }
+        method : "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
+            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima"
             Interpolation method to use (see descriptions above).
         assume_sorted : bool, default: False
             If False, values of coordinates that are interpolated over can be

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3916,14 +3916,14 @@ class Dataset(
         method and dimensionality determine which interpolant is used:
 
         1. **Interpolation along one dimension of 1D data (`method='linear'`)**
-            - Uses :py:class:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
+            - Uses :py:func:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
 
         2. **Interpolation along one dimension of N-dimensional data (N ≥ 1)**
             - Methods {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "quintic", "polynomial"}
-                use :py:class:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:class:`numpy.interp`
+                use :py:func:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:func:`numpy.interp`
                 (as in the case of `method='linear'` for 1D data).
             - If `method='polynomial'`, the `order` keyword argument must also be provided. In this case,
-                :py:class:`scipy.interpolate.interp1d` is called with `kind=order`.
+                :py:func:`scipy.interpolate.interp1d` is called with `kind=order`.
 
         3. **Special interpolants for interpolation along one dimension of N-dimensional data (N ≥ 1)**
             - Depending on the `method`, the following interpolants from :py:class:`scipy.interpolate` are used:
@@ -4206,14 +4206,14 @@ class Dataset(
         method and dimensionality determine which interpolant is used:
 
         1. **Interpolation along one dimension of 1D data (`method='linear'`)**
-            - Uses :py:class:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
+            - Uses :py:func:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
 
         2. **Interpolation along one dimension of N-dimensional data (N ≥ 1)**
             - Methods {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "quintic", "polynomial"}
-                use :py:class:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:class:`numpy.interp`
+                use :py:func:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:func:`numpy.interp`
                 (as in the case of `method='linear'` for 1D data).
             - If `method='polynomial'`, the `order` keyword argument must also be provided. In this case,
-                :py:class:`scipy.interpolate.interp1d` is called with `kind=order`.
+                :py:func:`scipy.interpolate.interp1d` is called with `kind=order`.
 
         3. **Special interpolants for interpolation along one dimension of N-dimensional data (N ≥ 1)**
             - Depending on the `method`, the following interpolants from :py:class:`scipy.interpolate` are used:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3946,7 +3946,8 @@ class Dataset(
             New coordinate can be a scalar, array-like or DataArray.
             If DataArrays are passed as new coordinates, their dimensions are
             used for the broadcasting. Missing values are skipped.
-        method : str
+        method : { "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
+            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima" }
             Interpolation method to use (see descriptions above).
         assume_sorted : bool, default: False
             If False, values of coordinates that are interpolated over can be
@@ -4235,7 +4236,8 @@ class Dataset(
             Object with an 'indexes' attribute giving a mapping from dimension
             names to an 1d array-like, which provides coordinates upon
             which to index the variables in this dataset. Missing values are skipped.
-        method : str
+        method : { "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
+            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima" }
             Interpolation method to use (see descriptions above).
         assume_sorted : bool, default: False
             If False, values of coordinates that are interpolated over can be

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3912,30 +3912,7 @@ class Dataset(
         Interpolate a Dataset onto new coordinates.
 
         Performs univariate or multivariate interpolation of a Dataset onto new coordinates,
-        utilizing either NumPy or SciPy interpolation routines. The specific interpolation
-        method and dimensionality determine which interpolant is used:
-
-        1. **Interpolation along one dimension of 1D data (`method='linear'`)**
-            - Uses :py:func:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
-
-        2. **Interpolation along one dimension of N-dimensional data (N ≥ 1)**
-            - Methods {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "quintic", "polynomial"}
-                use :py:func:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:func:`numpy.interp`
-                (as in the case of `method='linear'` for 1D data).
-            - If `method='polynomial'`, the `order` keyword argument must also be provided. In this case,
-                :py:func:`scipy.interpolate.interp1d` is called with `kind=order`.
-
-        3. **Special interpolants for interpolation along one dimension of N-dimensional data (N ≥ 1)**
-            - Depending on the `method`, the following interpolants from :py:class:`scipy.interpolate` are used:
-                - `"pchip"`: :py:class:`scipy.interpolate.PchipInterpolator`
-                - `"barycentric"`: :py:class:`scipy.interpolate.BarycentricInterpolator`
-                - `"krogh"`: :py:class:`scipy.interpolate.KroghInterpolator`
-                - `"akima"` or `"makima"`: :py:class:`scipy.interpolate.Akima1dInterpolator`
-                    (`makima` is handled by passing `makima` to `method`).
-
-        4. **Interpolation along multiple dimensions of multi-dimensional data**
-            - Uses :py:func:`scipy.interpolate.interpn` for methods {"linear", "nearest", "slinear",
-                "cubic", "quintic", "pchip"}.
+        utilizing either NumPy or SciPy interpolation routines.
 
         Out-of-range values are filled with NaN, unless specified otherwise via `kwargs` to the numpy/scipy interpolant.
 
@@ -3976,6 +3953,30 @@ class Dataset(
         - When interpolating along multiple dimensions with methods `linear` and `nearest`,
             the process attempts to decompose the interpolation into independent interpolations
             along one dimension at a time.
+        - The specific interpolation method and dimensionality determine which
+            interpolant is used:
+
+            1. **Interpolation along one dimension of 1D data (`method='linear'`)**
+                - Uses :py:func:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
+
+            2. **Interpolation along one dimension of N-dimensional data (N ≥ 1)**
+                - Methods {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "quintic", "polynomial"}
+                    use :py:func:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:func:`numpy.interp`
+                    (as in the case of `method='linear'` for 1D data).
+                - If `method='polynomial'`, the `order` keyword argument must also be provided.
+
+            3. **Special interpolants for interpolation along one dimension of N-dimensional data (N ≥ 1)**
+                - Depending on the `method`, the following interpolants from :py:class:`scipy.interpolate` are used:
+                    - `"pchip"`: :py:class:`scipy.interpolate.PchipInterpolator`
+                    - `"barycentric"`: :py:class:`scipy.interpolate.BarycentricInterpolator`
+                    - `"krogh"`: :py:class:`scipy.interpolate.KroghInterpolator`
+                    - `"akima"` or `"makima"`: :py:class:`scipy.interpolate.Akima1dInterpolator`
+                        (`makima` is handled by passing the `makima` flag).
+
+            4. **Interpolation along multiple dimensions of multi-dimensional data**
+                - Uses :py:func:`scipy.interpolate.interpn` for methods {"linear", "nearest", "slinear",
+                    "cubic", "quintic", "pchip"}.
+
         --------
         scipy.interpolate.interp1d
         scipy.interpolate.interpn
@@ -4203,30 +4204,7 @@ class Dataset(
         """Interpolate this object onto the coordinates of another object.
 
         Performs univariate or multivariate interpolation of a Dataset onto new coordinates,
-        utilizing either NumPy or SciPy interpolation routines. The specific interpolation
-        method and dimensionality determine which interpolant is used:
-
-        1. **Interpolation along one dimension of 1D data (`method='linear'`)**
-            - Uses :py:func:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
-
-        2. **Interpolation along one dimension of N-dimensional data (N ≥ 1)**
-            - Methods {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "quintic", "polynomial"}
-                use :py:func:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:func:`numpy.interp`
-                (as in the case of `method='linear'` for 1D data).
-            - If `method='polynomial'`, the `order` keyword argument must also be provided. In this case,
-                :py:func:`scipy.interpolate.interp1d` is called with `kind=order`.
-
-        3. **Special interpolants for interpolation along one dimension of N-dimensional data (N ≥ 1)**
-            - Depending on the `method`, the following interpolants from :py:class:`scipy.interpolate` are used:
-                - `"pchip"`: :py:class:`scipy.interpolate.PchipInterpolator`
-                - `"barycentric"`: :py:class:`scipy.interpolate.BarycentricInterpolator`
-                - `"krogh"`: :py:class:`scipy.interpolate.KroghInterpolator`
-                - `"akima"` or `"makima"`: :py:class:`scipy.interpolate.Akima1dInterpolator`
-                    (`makima` is handled by passing `makima` to `method`).
-
-        4. **Interpolation along multiple dimensions of multi-dimensional data**
-            - Uses :py:func:`scipy.interpolate.interpn` for methods {"linear", "nearest", "slinear",
-                "cubic", "quintic", "pchip"}.
+        utilizing either NumPy or SciPy interpolation routines.
 
         Out-of-range values are filled with NaN, unless specified otherwise via `kwargs` to the numpy/scipy interpolant.
 
@@ -4265,6 +4243,29 @@ class Dataset(
         - When interpolating along multiple dimensions with methods `linear` and `nearest`,
             the process attempts to decompose the interpolation into independent interpolations
             along one dimension at a time.
+        - The specific interpolation method and dimensionality determine which
+            interpolant is used:
+
+            1. **Interpolation along one dimension of 1D data (`method='linear'`)**
+                - Uses :py:func:`numpy.interp`, unless `fill_value='extrapolate'` is provided via `kwargs`.
+
+            2. **Interpolation along one dimension of N-dimensional data (N ≥ 1)**
+                - Methods {"linear", "nearest", "zero", "slinear", "quadratic", "cubic", "quintic", "polynomial"}
+                    use :py:func:`scipy.interpolate.interp1d`, unless conditions permit the use of :py:func:`numpy.interp`
+                    (as in the case of `method='linear'` for 1D data).
+                - If `method='polynomial'`, the `order` keyword argument must also be provided.
+
+            3. **Special interpolants for interpolation along one dimension of N-dimensional data (N ≥ 1)**
+                - Depending on the `method`, the following interpolants from :py:class:`scipy.interpolate` are used:
+                    - `"pchip"`: :py:class:`scipy.interpolate.PchipInterpolator`
+                    - `"barycentric"`: :py:class:`scipy.interpolate.BarycentricInterpolator`
+                    - `"krogh"`: :py:class:`scipy.interpolate.KroghInterpolator`
+                    - `"akima"` or `"makima"`: :py:class:`scipy.interpolate.Akima1dInterpolator`
+                        (`makima` is handled by passing the `makima` flag).
+
+            4. **Interpolation along multiple dimensions of multi-dimensional data**
+                - Uses :py:func:`scipy.interpolate.interpn` for methods {"linear", "nearest", "slinear",
+                    "cubic", "quintic", "pchip"}.
 
         See Also
         --------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3979,7 +3979,7 @@ class Dataset(
 
         See Also
         --------
-        scipy.interpolate
+        :mod:`scipy.interpolate`
 
         :doc:`xarray-tutorial:fundamentals/02.2_manipulating_dimensions`
             Tutorial material on manipulating data resolution using :py:func:`~xarray.Dataset.interp`
@@ -4269,9 +4269,9 @@ class Dataset(
 
         See Also
         --------
-        Dataset.interp
-        Dataset.reindex_like
-        scipy.interpolate
+        :func:`Dataset.interp`
+        :func:`Dataset.reindex_like`
+        :mod:`scipy.interpolate`
         """
         if kwargs is None:
             kwargs = {}

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3979,8 +3979,7 @@ class Dataset(
 
         See Also
         --------
-        scipy.interpolate.interp1d
-        scipy.interpolate.interpn
+        scipy.interpolate
 
         :doc:`xarray-tutorial:fundamentals/02.2_manipulating_dimensions`
             Tutorial material on manipulating data resolution using :py:func:`~xarray.Dataset.interp`
@@ -4272,6 +4271,7 @@ class Dataset(
         --------
         Dataset.interp
         Dataset.reindex_like
+        scipy.interpolate
         """
         if kwargs is None:
             kwargs = {}

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3923,8 +3923,8 @@ class Dataset(
             New coordinate can be a scalar, array-like or DataArray.
             If DataArrays are passed as new coordinates, their dimensions are
             used for the broadcasting. Missing values are skipped.
-        method : "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
-            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima"
+        method : { "linear", "nearest", "zero", "slinear", "quadratic", "cubic", \
+            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima" }
             Interpolation method to use (see descriptions above).
         assume_sorted : bool, default: False
             If False, values of coordinates that are interpolated over can be
@@ -4215,8 +4215,8 @@ class Dataset(
             Object with an 'indexes' attribute giving a mapping from dimension
             names to an 1d array-like, which provides coordinates upon
             which to index the variables in this dataset. Missing values are skipped.
-        method : "linear", "nearest", "zero", "slinear", "quadratic", "cubic",
-            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima"
+        method : { "linear", "nearest", "zero", "slinear", "quadratic", "cubic", \
+            "quintic", "polynomial", "pchip", "barycentric", "krogh", "akima", "makima" }
             Interpolation method to use (see descriptions above).
         assume_sorted : bool, default: False
             If False, values of coordinates that are interpolated over can be

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3977,6 +3977,7 @@ class Dataset(
                 - Uses :py:func:`scipy.interpolate.interpn` for methods {"linear", "nearest", "slinear",
                     "cubic", "quintic", "pchip"}.
 
+        See Also
         --------
         scipy.interpolate.interp1d
         scipy.interpolate.interpn

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -20,7 +20,7 @@ from xarray.core.duck_array_ops import (
     timedelta_to_numeric,
 )
 from xarray.core.options import _get_keep_attrs
-from xarray.core.types import Interp1dOptions, InterpOptions
+from xarray.core.types import Interp1dOptions, InterpnOptions, InterpOptions
 from xarray.core.utils import OrderedSet, is_scalar
 from xarray.core.variable import Variable, broadcast_variables
 from xarray.namedarray.parallelcompat import get_chunked_array_type
@@ -153,6 +153,9 @@ class ScipyInterpolator(BaseInterpolator):
             if order is None:
                 raise ValueError("order is required when method=polynomial")
             method = order
+
+        if method == "quintic":
+            method = 5
 
         self.method = method
 
@@ -503,6 +506,7 @@ def _get_interpolator(
             interp_class = _import_interpolant("KroghInterpolator", method)
         elif method == "pchip":
             kwargs.update(axis=-1)
+            kwargs.setdefault("extrapolate", False)
             interp_class = _import_interpolant("PchipInterpolator", method)
         elif method == "spline":
             utils.emit_user_level_warning(
@@ -520,9 +524,6 @@ def _get_interpolator(
         elif method == "makima":
             kwargs.update(method="makima", axis=-1)
             interp_class = _import_interpolant("Akima1DInterpolator", method)
-        elif method == "makima":
-            kwargs.update(method="makima", axis=-1)
-            interp_class = _import_interpolant("Akima1DInterpolator", method)
         else:
             raise ValueError(f"{method} is not a valid scipy interpolator")
     else:
@@ -536,8 +537,7 @@ def _get_interpolator_nd(method, **kwargs):
 
     returns interpolator class and keyword arguments for the class
     """
-    valid_methods = ["linear", "nearest"]
-
+    valid_methods = tuple(get_args(InterpnOptions))
     if method in valid_methods:
         kwargs.update(method=method)
         kwargs.setdefault("bounds_error", False)
@@ -601,7 +601,7 @@ def _floatize_x(x, new_x):
     return x, new_x
 
 
-def interp(var, indexes_coords, method: InterpOptions, **kwargs):
+def interp(var, indexes_coords, method: InterpOptions, reduce: bool = True, **kwargs):
     """Make an interpolation of Variable
 
     Parameters
@@ -615,6 +615,10 @@ def interp(var, indexes_coords, method: InterpOptions, **kwargs):
         One of {'linear', 'nearest', 'zero', 'slinear', 'quadratic',
         'cubic'}. For multidimensional interpolation, only
         {'linear', 'nearest'} can be used.
+    reduce:
+        Decompose the interpolation along independent interpolation dimensions when
+        possible. This will likely improve performance over true multi-dimensional
+        interpolation but will alter the result for certain interpolators.
     **kwargs
         keyword arguments to be passed to scipy.interpolate
 
@@ -631,8 +635,15 @@ def interp(var, indexes_coords, method: InterpOptions, **kwargs):
         return var.copy()
 
     result = var
-    # decompose the interpolation into a succession of independent interpolation
-    for indep_indexes_coords in decompose_interp(indexes_coords):
+
+    if reduce:
+        # decompose the interpolation into a succession of independent interpolation. This may
+        # affect the mathematical behavior of certain nd interpolants.
+        indexes_coords = decompose_interp(indexes_coords)
+    else:
+        indexes_coords = [indexes_coords]
+
+    for indep_indexes_coords in indexes_coords:
         var = result
 
         # target dimensions

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -633,7 +633,7 @@ def interp(var, indexes_coords, method: InterpOptions, **kwargs):
 
     result = var
 
-    if method in ["linear", "nearest"]:
+    if method in ["linear", "nearest", "slinear"]:
         # decompose the interpolation into a succession of independent interpolation.
         indexes_coords = decompose_interp(indexes_coords)
     else:

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -506,6 +506,7 @@ def _get_interpolator(
             interp_class = _import_interpolant("KroghInterpolator", method)
         elif method == "pchip":
             kwargs.update(axis=-1)
+            # pchip default behavior is to extrapolate
             kwargs.setdefault("extrapolate", False)
             interp_class = _import_interpolant("PchipInterpolator", method)
         elif method == "spline":
@@ -601,7 +602,7 @@ def _floatize_x(x, new_x):
     return x, new_x
 
 
-def interp(var, indexes_coords, method: InterpOptions, reduce: bool = True, **kwargs):
+def interp(var, indexes_coords, method: InterpOptions, **kwargs):
     """Make an interpolation of Variable
 
     Parameters
@@ -615,10 +616,6 @@ def interp(var, indexes_coords, method: InterpOptions, reduce: bool = True, **kw
         One of {'linear', 'nearest', 'zero', 'slinear', 'quadratic',
         'cubic'}. For multidimensional interpolation, only
         {'linear', 'nearest'} can be used.
-    reduce:
-        Decompose the interpolation along independent interpolation dimensions when
-        possible. This will likely improve performance over true multi-dimensional
-        interpolation but will alter the result for certain interpolators.
     **kwargs
         keyword arguments to be passed to scipy.interpolate
 
@@ -636,9 +633,8 @@ def interp(var, indexes_coords, method: InterpOptions, reduce: bool = True, **kw
 
     result = var
 
-    if reduce:
-        # decompose the interpolation into a succession of independent interpolation. This may
-        # affect the mathematical behavior of certain nd interpolants.
+    if method in ["linear", "nearest"]:
+        # decompose the interpolation into a succession of independent interpolation.
         indexes_coords = decompose_interp(indexes_coords)
     else:
         indexes_coords = [indexes_coords]

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -229,12 +229,20 @@ CombineAttrsOptions = Union[
 JoinOptions = Literal["outer", "inner", "left", "right", "exact", "override"]
 
 Interp1dOptions = Literal[
-    "linear", "nearest", "zero", "slinear", "quadratic", "cubic", "polynomial"
+    "linear",
+    "nearest",
+    "zero",
+    "slinear",
+    "quadratic",
+    "cubic",
+    "quintic",
+    "polynomial",
 ]
 InterpolantOptions = Literal[
     "barycentric", "krogh", "pchip", "spline", "akima", "makima"
 ]
-InterpOptions = Union[Interp1dOptions, InterpolantOptions]
+InterpnOptions = Literal["linear", "nearest", "slinear", "cubic", "quintic", "pchip"]
+InterpOptions = Union[Interp1dOptions, InterpolantOptions, InterpnOptions]
 
 DatetimeUnitOptions = Literal[
     "Y", "M", "W", "D", "h", "m", "s", "ms", "us", "μs", "ns", "ps", "fs", "as", None

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -355,7 +355,7 @@ def test_interpolate_nd_inseparable(
     grid_grid_points = nd_interp_coords["grid_grid_points"]
     # the presence/absence of z cordinate may affect nd interpolants, even when the
     # coordinate is unchanged
-    actual = da.interp(x=xdestnp, y=ydestnp, z=zdestnp, method=method, reduce=False)
+    actual = da.interp(x=xdestnp, y=ydestnp, z=zdestnp, method=method)
     expected_data = scipy.interpolate.interpn(
         points=(da.x, da.y, da.z),
         values=da.data,
@@ -380,7 +380,7 @@ def test_interpolate_nd_inseparable(
     ydest = nd_interp_coords["ydest"]
     zdest = nd_interp_coords["zdest"]
     grid_oned_points = nd_interp_coords["grid_oned_points"]
-    actual = da.interp(x=xdest, y=ydest, z=zdest, method=method, reduce=False)
+    actual = da.interp(x=xdest, y=ydest, z=zdest, method=method)
     expected_data = scipy.interpolate.interpn(
         points=(da.x, da.y, da.z),
         values=da.data,
@@ -402,7 +402,7 @@ def test_interpolate_nd_inseparable(
     assert_allclose(actual.transpose("y", "z"), expected)
 
     # reversed order
-    actual = da.interp(y=ydest, x=xdest, z=zdest, method=method, reduce=False)
+    actual = da.interp(y=ydest, x=xdest, z=zdest, method=method)
     assert_allclose(actual.transpose("y", "z"), expected)
 
 

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -882,8 +882,8 @@ def test_decompose(method: InterpOptions) -> None:
 @requires_scipy
 @requires_dask
 # omit quintic because not enough points
-# unknown timeout using pchip
-@pytest.mark.parametrize("method", ("cubic", "linear", "slinear"))
+# cubic and pchip omitted because they take too long
+@pytest.mark.parametrize("method", ("linear", "slinear"))
 @pytest.mark.parametrize("chunked", [True, False])
 @pytest.mark.parametrize(
     "data_ndim,interp_ndim,nscalar",

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -72,7 +72,7 @@ def nd_interp_coords():
     # grid -> grid
     coords["xdestnp"] = np.linspace(0.1, 1.0, 11)
     coords["ydestnp"] = np.linspace(0.0, 0.2, 10)
-    coords["zdestnp"] = da.get_index("z")  # type: ignore[assignment]
+    coords["zdestnp"] = da.z.data
     # list of the points defined by the above mesh in C order
     mesh_x, mesh_y, mesh_z = np.meshgrid(
         coords["xdestnp"], coords["ydestnp"], coords["zdestnp"], indexing="ij"

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -359,7 +359,7 @@ def test_interpolate_nd(case: int, method: InterpnOptions, nd_interp_coords) -> 
 
 
 @requires_scipy
-# omit cubic, pchip, quintic becausenot enough points
+# omit cubic, pchip, quintic because not enough points
 @pytest.mark.parametrize("method", ("linear", "nearest", "slinear"))
 def test_interpolate_nd_nd(method: InterpnOptions) -> None:
     """Interpolate nd array with an nd indexer sharing coordinates."""
@@ -881,7 +881,7 @@ def test_decompose(method: InterpOptions) -> None:
 
 @requires_scipy
 @requires_dask
-# omit quintic because not enough points
+# quintic omitted because not enough points
 # cubic and pchip omitted because they take too long
 @pytest.mark.parametrize("method", ("linear", "slinear"))
 @pytest.mark.parametrize("chunked", [True, False])

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -881,9 +881,7 @@ def test_decompose(method: InterpOptions) -> None:
 
 @requires_scipy
 @requires_dask
-# quintic omitted because not enough points
-# cubic and pchip omitted because they take too long
-@pytest.mark.parametrize("method", ("linear", "slinear"))
+@pytest.mark.parametrize("method", ("linear", "nearest", "cubic", "pchip", "quintic"))
 @pytest.mark.parametrize("chunked", [True, False])
 @pytest.mark.parametrize(
     "data_ndim,interp_ndim,nscalar",
@@ -902,10 +900,13 @@ def test_interpolate_chunk_1d(
     It should do a series of 1d interpolation
     """
 
+    if method in ["cubic", "pchip"] and interp_ndim == 3:
+        pytest.skip("Too slow.")
+
     # 3d non chunked data
-    x = np.linspace(0, 1, 5)
+    x = np.linspace(0, 1, 6)
     y = np.linspace(2, 4, 7)
-    z = np.linspace(-0.5, 0.5, 11)
+    z = np.linspace(-0.5, 0.5, 8)
     da = xr.DataArray(
         data=np.sin(x[:, np.newaxis, np.newaxis])
         * np.cos(y[:, np.newaxis])

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -912,7 +912,6 @@ def test_interpolate_chunk_1d(
         * np.exp(z),
         coords=[("x", x), ("y", y), ("z", z)],
     )
-    kwargs = {}
 
     # choose the data dimensions
     for data_dims in permutations(da.dims, data_ndim):
@@ -947,8 +946,8 @@ def test_interpolate_chunk_1d(
                         if chunked:
                             dest[dim] = xr.DataArray(data=dest[dim], dims=[dim])
                             dest[dim] = dest[dim].chunk(2)
-                actual = da.interp(method=method, **dest, kwargs=kwargs)
-                expected = da.compute().interp(method=method, **dest, kwargs=kwargs)
+                actual = da.interp(method=method, **dest)
+                expected = da.compute().interp(method=method, **dest)
 
                 assert_identical(actual, expected)
 

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -9,7 +9,12 @@ import pytest
 
 import xarray as xr
 from xarray.coding.cftimeindex import _parse_array_of_cftime_strings
-from xarray.core.types import InterpnOptions, InterpOptions, Interp1dOptions, InterpolantOptions
+from xarray.core.types import (
+    Interp1dOptions,
+    InterpnOptions,
+    InterpolantOptions,
+    InterpOptions,
+)
 from xarray.tests import (
     assert_allclose,
     assert_equal,
@@ -29,6 +34,7 @@ except ImportError:
     pass
 
 ALL_1D = get_args(Interp1dOptions) + get_args(InterpolantOptions)
+
 
 def get_example_data(case: int) -> xr.DataArray:
     if case == 0:
@@ -282,16 +288,13 @@ def test_interpolate_vectorize(use_dask: bool, method: InterpOptions) -> None:
     )
     assert_allclose(actual, expected.transpose("z", "w", "y", transpose_coords=True))
 
+
 @requires_scipy
-@pytest.mark.parametrize(
-    "method", get_args(InterpnOptions)
-)
+@pytest.mark.parametrize("method", get_args(InterpnOptions))
 @pytest.mark.parametrize(
     "case", [pytest.param(3, id="no_chunk"), pytest.param(4, id="chunked")]
 )
-def test_interpolate_nd(
-    case: int, method: InterpnOptions, nd_interp_coords
-) -> None:
+def test_interpolate_nd(case: int, method: InterpnOptions, nd_interp_coords) -> None:
     if not has_dask and case == 4:
         pytest.skip("dask is not installed in the environment.")
 
@@ -440,7 +443,7 @@ def test_interpolate_scalar(method: InterpOptions, case: int) -> None:
             axis=obj.get_axis_num("x"),
             bounds_error=False,
             fill_value=np.nan,
-            kind=method
+            kind=method,
         )(new_x)
 
     coords = {"x": xdest, "y": da["y"], "x2": func(da["x2"], xdest)}
@@ -857,7 +860,7 @@ def test_3641() -> None:
 
 @requires_scipy
 # cubic, quintic, pchip omitted because not enough points
-@pytest.mark.parametrize("method", ("linear","nearest","slinear"))
+@pytest.mark.parametrize("method", ("linear", "nearest", "slinear"))
 def test_decompose(method: InterpOptions) -> None:
     da = xr.DataArray(
         np.arange(6).reshape(3, 2),
@@ -880,7 +883,7 @@ def test_decompose(method: InterpOptions) -> None:
 @requires_dask
 # omit quintic because not enough points
 # unknown timeout using pchip
-@pytest.mark.parametrize("method", ("cubic","linear","slinear"))
+@pytest.mark.parametrize("method", ("cubic", "linear", "slinear"))
 @pytest.mark.parametrize("chunked", [True, False])
 @pytest.mark.parametrize(
     "data_ndim,interp_ndim,nscalar",
@@ -958,7 +961,7 @@ def test_interpolate_chunk_1d(
 @requires_scipy
 @requires_dask
 # quintic omitted because not enough points
-@pytest.mark.parametrize("method", ("linear","nearest","slinear","cubic","pchip"))
+@pytest.mark.parametrize("method", ("linear", "nearest", "slinear", "cubic", "pchip"))
 @pytest.mark.filterwarnings("ignore:Increasing number of chunks")
 def test_interpolate_chunk_advanced(method: InterpOptions) -> None:
     """Interpolate nd array with an nd indexer sharing coordinates."""

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -921,9 +921,7 @@ def test_decompose(method: InterpOptions) -> None:
 
 @requires_scipy
 @requires_dask
-@pytest.mark.parametrize(
-    "method", ["linear", "nearest", "zero", "slinear", "quadratic", "cubic"]
-)
+@pytest.mark.parametrize("method", ["linear", "nearest"])
 @pytest.mark.parametrize("chunked", [True, False])
 @pytest.mark.parametrize(
     "data_ndim,interp_ndim,nscalar",

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -900,7 +900,7 @@ def test_interpolate_chunk_1d(
     It should do a series of 1d interpolation
     """
 
-    if method in ["cubic", "pchip"] and interp_ndim == 3:
+    if method in ["cubic", "pchip", "quintic"] and interp_ndim == 3:
         pytest.skip("Too slow.")
 
     # 3d non chunked data


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #7704
- [x] Adds support for n dimensional tensor product interpolants `slinear`, `cubic`, `quintic`, and `pchip`. 
- [x] Updates documentation of DataArray/Dataset.interp and DataArray/Dataset.interp_like to reflect updates to scipy interpolants called.
- [x] Adds argument `reduce` to allow disabling of reduction of interpolation along independent dimensions (see #2223).  Prior to this the behavior was always `reduce=True`. However for certain n-dimensional interpolants this will change the mathematical behavior of the interpolation ([I think](https://github.com/pydata/xarray/issues/7704#issuecomment-2389503835)), so I have added an option for users to turn this off. 

_Outstanding uncertainty: dask/chunking behavior? Nothing about this PR touches the chunking of interpolation but I am a bit worried about this. Many interpolants, including those previously supported in one dimension, require nearby/all points from the original coordinate, and also don't parallelize well over the new coordinate. I'm not quite sure how this is currently being handled._