### PR TITLE
Rename inherited -> inherit in DataTree.to_dataset

### DIFF
--- a/doc/getting-started-guide/quick-overview.rst
+++ b/doc/getting-started-guide/quick-overview.rst
@@ -307,11 +307,11 @@ We can get a copy of the :py:class:`~xarray.Dataset` including the inherited coo
     ds_inherited = dt["simulation/coarse"].to_dataset()
     ds_inherited
 
-And you can get a copy of just the node local values of :py:class:`~xarray.Dataset` by setting the ``inherited`` keyword to ``False``:
+And you can get a copy of just the node local values of :py:class:`~xarray.Dataset` by setting the ``inherit`` keyword to ``False``:
 
 .. ipython:: python
 
-    ds_node_local = dt["simulation/coarse"].to_dataset(inherited=False)
+    ds_node_local = dt["simulation/coarse"].to_dataset(inherit=False)
     ds_node_local
 
 .. note::

--- a/doc/user-guide/data-structures.rst
+++ b/doc/user-guide/data-structures.rst
@@ -792,13 +792,13 @@ automatically includes coordinates from higher levels (e.g., ``time`` and
     dt2["/weather/temperature"].dataset
 
 Similarly, when you retrieve a Dataset through :py:func:`~xarray.DataTree.to_dataset`  , the inherited coordinates are
-included by default unless you exclude them with the ``inherited`` flag:
+included by default unless you exclude them with the ``inherit`` flag:
 
 .. ipython:: python
 
     dt2["/weather/temperature"].to_dataset()
 
-    dt2["/weather/temperature"].to_dataset(inherited=False)
+    dt2["/weather/temperature"].to_dataset(inherit=False)
 
 
 .. _coordinates:

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -849,14 +849,14 @@ class DataTreeCoordinates(Coordinates):
         from xarray.core.datatree import check_alignment
 
         # create updated node (`.to_dataset` makes a copy so this doesn't modify in-place)
-        node_ds = self._data.to_dataset(inherited=False)
+        node_ds = self._data.to_dataset(inherit=False)
         node_ds.coords._update_coords(coords, indexes)
 
         # check consistency *before* modifying anything in-place
         # TODO can we clean up the signature of check_alignment to make this less awkward?
         if self._data.parent is not None:
             parent_ds = self._data.parent._to_dataset_view(
-                inherited=True, rebuild_dims=False
+                inherit=True, rebuild_dims=False
             )
         else:
             parent_ds = None

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -154,7 +154,7 @@ def check_alignment(
 
         for child_name, child in children.items():
             child_path = str(NodePath(path) / child_name)
-            child_ds = child.to_dataset(inherited=False)
+            child_ds = child.to_dataset(inherit=False)
             check_alignment(child_path, child_ds, base_ds, child.children)
 
 
@@ -503,8 +503,8 @@ class DataTree(
                 f"parent {parent.name} already contains a variable named {name}"
             )
         path = str(NodePath(parent.path) / name)
-        node_ds = self.to_dataset(inherited=False)
-        parent_ds = parent._to_dataset_view(rebuild_dims=False, inherited=True)
+        node_ds = self.to_dataset(inherit=False)
+        parent_ds = parent._to_dataset_view(rebuild_dims=False, inherit=True)
         check_alignment(path, node_ds, parent_ds, self.children)
         _deduplicate_inherited_coordinates(self, parent)
 
@@ -529,14 +529,14 @@ class DataTree(
     def _indexes(self) -> ChainMap[Hashable, Index]:
         return ChainMap(self._node_indexes, *(p._node_indexes for p in self.parents))
 
-    def _to_dataset_view(self, rebuild_dims: bool, inherited: bool) -> DatasetView:
-        coord_vars = self._coord_variables if inherited else self._node_coord_variables
+    def _to_dataset_view(self, rebuild_dims: bool, inherit: bool) -> DatasetView:
+        coord_vars = self._coord_variables if inherit else self._node_coord_variables
         variables = dict(self._data_variables)
         variables |= coord_vars
         if rebuild_dims:
             dims = calculate_dimensions(variables)
-        elif inherited:
-            # Note: rebuild_dims=False with inherited=True can create
+        elif inherit:
+            # Note: rebuild_dims=False with inherit=True can create
             # technically invalid Dataset objects because it still includes
             # dimensions that are only defined on parent data variables
             # (i.e. not present on any parent coordinate variables).
@@ -548,7 +548,7 @@ class DataTree(
             #     ...         "/b": xr.Dataset(),
             #     ...     }
             #     ... )
-            #     >>> ds = tree["b"]._to_dataset_view(rebuild_dims=False, inherited=True)
+            #     >>> ds = tree["b"]._to_dataset_view(rebuild_dims=False, inherit=True)
             #     >>> ds
             #     <xarray.DatasetView> Size: 0B
             #     Dimensions:  (x: 2)
@@ -572,7 +572,7 @@ class DataTree(
             coord_names=set(self._coord_variables),
             dims=dims,
             attrs=self._attrs,
-            indexes=dict(self._indexes if inherited else self._node_indexes),
+            indexes=dict(self._indexes if inherit else self._node_indexes),
             encoding=self._encoding,
             close=None,
         )
@@ -591,7 +591,7 @@ class DataTree(
         --------
         DataTree.to_dataset
         """
-        return self._to_dataset_view(rebuild_dims=True, inherited=True)
+        return self._to_dataset_view(rebuild_dims=True, inherit=True)
 
     @dataset.setter
     def dataset(self, data: Dataset | None = None) -> None:
@@ -602,13 +602,13 @@ class DataTree(
     # xarray-contrib/datatree
     ds = dataset
 
-    def to_dataset(self, inherited: bool = True) -> Dataset:
+    def to_dataset(self, inherit: bool = True) -> Dataset:
         """
         Return the data in this node as a new xarray.Dataset object.
 
         Parameters
         ----------
-        inherited : bool, optional
+        inherit : bool, optional
             If False, only include coordinates and indexes defined at the level
             of this DataTree node, excluding any inherited coordinates and indexes.
 
@@ -616,16 +616,16 @@ class DataTree(
         --------
         DataTree.dataset
         """
-        coord_vars = self._coord_variables if inherited else self._node_coord_variables
+        coord_vars = self._coord_variables if inherit else self._node_coord_variables
         variables = dict(self._data_variables)
         variables |= coord_vars
-        dims = calculate_dimensions(variables) if inherited else dict(self._node_dims)
+        dims = calculate_dimensions(variables) if inherit else dict(self._node_dims)
         return Dataset._construct_direct(
             variables,
             set(coord_vars),
             dims,
             None if self._attrs is None else dict(self._attrs),
-            dict(self._indexes if inherited else self._node_indexes),
+            dict(self._indexes if inherit else self._node_indexes),
             None if self._encoding is None else dict(self._encoding),
             self._close,
         )
@@ -794,7 +794,7 @@ class DataTree(
         children: dict[str, DataTree] | Default = _default,
     ) -> None:
 
-        ds = self.to_dataset(inherited=False) if data is _default else data
+        ds = self.to_dataset(inherit=False) if data is _default else data
 
         if children is _default:
             children = self._children
@@ -804,7 +804,7 @@ class DataTree(
                 raise ValueError(f"node already contains a variable named {child_name}")
 
         parent_ds = (
-            self.parent._to_dataset_view(rebuild_dims=False, inherited=True)
+            self.parent._to_dataset_view(rebuild_dims=False, inherit=True)
             if self.parent is not None
             else None
         )
@@ -823,7 +823,7 @@ class DataTree(
 
         new_node = super()._copy_node()
 
-        data = self._to_dataset_view(rebuild_dims=False, inherited=False)
+        data = self._to_dataset_view(rebuild_dims=False, inherit=False)
         if deep:
             data = data.copy(deep=True)
         new_node._set_node_data(data)
@@ -993,7 +993,7 @@ class DataTree(
                     raise TypeError(f"Type {type(v)} cannot be assigned to a DataTree")
 
         vars_merge_result = dataset_update_method(
-            self.to_dataset(inherited=False), new_variables
+            self.to_dataset(inherit=False), new_variables
         )
         data = Dataset._construct_direct(**vars_merge_result._asdict())
 

--- a/xarray/core/datatree_io.py
+++ b/xarray/core/datatree_io.py
@@ -85,7 +85,7 @@ def _datatree_to_netcdf(
         unlimited_dims = {}
 
     for node in dt.subtree:
-        ds = node.to_dataset(inherited=False)
+        ds = node.to_dataset(inherit=False)
         group_path = node.path
         if ds is None:
             _create_empty_netcdf_group(filepath, group_path, mode, engine)
@@ -151,7 +151,7 @@ def _datatree_to_zarr(
         )
 
     for node in dt.subtree:
-        ds = node.to_dataset(inherited=False)
+        ds = node.to_dataset(inherit=False)
         group_path = node.path
         if ds is None:
             _create_empty_zarr_group(store, group_path, mode)

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -1102,7 +1102,7 @@ def _datatree_node_repr(node: DataTree, show_inherited: bool) -> str:
         summary.append(f"{dims_start}({dims_values})")
 
     if node._node_coord_variables:
-        node_coords = node.to_dataset(inherited=False).coords
+        node_coords = node.to_dataset(inherit=False).coords
         summary.append(coords_repr(node_coords, col_width=col_width, max_rows=max_rows))
 
     if show_inherited and inherited_coords:

--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -386,7 +386,7 @@ children_section = partial(
 def datatree_node_repr(group_title: str, dt: DataTree) -> str:
     header_components = [f"<div class='xr-obj-type'>{escape(group_title)}</div>"]
 
-    ds = dt._to_dataset_view(rebuild_dims=False, inherited=True)
+    ds = dt._to_dataset_view(rebuild_dims=False, inherit=True)
 
     sections = [
         children_section(dt.children),

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -131,7 +131,7 @@ class DatatreeIOBase:
         roundtrip_dt = open_datatree(filepath, engine=self.engine)
         assert_equal(original_dt, roundtrip_dt)
         subtree = cast(DataTree, roundtrip_dt["/sub"])
-        assert "x" not in subtree.to_dataset(inherited=False).coords
+        assert "x" not in subtree.to_dataset(inherit=False).coords
 
     def test_netcdf_encoding(self, tmpdir, simple_datatree):
         filepath = tmpdir / "test.nc"
@@ -320,7 +320,7 @@ class TestZarrDatatreeIO:
         roundtrip_dt = open_datatree(filepath, engine="zarr")
         assert_equal(original_dt, roundtrip_dt)
         subtree = cast(DataTree, roundtrip_dt["/sub"])
-        assert "x" not in subtree.to_dataset(inherited=False).coords
+        assert "x" not in subtree.to_dataset(inherit=False).coords
 
     def test_open_groups_round_trip(self, tmpdir, simple_datatree) -> None:
         """Test `open_groups` opens a zarr store with the `simple_datatree` structure."""

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -1324,7 +1324,7 @@ class TestInheritance:
             }
         )
         dt["b/x"] = dt["x"]
-        child_dataset = dt.children["b"].to_dataset(inherited=False)
+        child_dataset = dt.children["b"].to_dataset(inherit=False)
         expected = xr.Dataset()
         assert_identical(child_dataset, expected)
 

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -222,12 +222,12 @@ class TestToDataset:
         tree = DataTree.from_dict({"/": base, "/sub": sub})
         subtree = typing.cast(DataTree, tree["sub"])
 
-        assert_identical(tree.to_dataset(inherited=False), base)
-        assert_identical(subtree.to_dataset(inherited=False), sub)
+        assert_identical(tree.to_dataset(inherit=False), base)
+        assert_identical(subtree.to_dataset(inherit=False), sub)
 
         sub_and_base = xr.Dataset(coords={"a": [1], "c": [3]})  # no "b"
-        assert_identical(tree.to_dataset(inherited=True), base)
-        assert_identical(subtree.to_dataset(inherited=True), sub_and_base)
+        assert_identical(tree.to_dataset(inherit=True), base)
+        assert_identical(subtree.to_dataset(inherit=True), sub_and_base)
 
 
 class TestVariablesChildrenNameCollisions:
@@ -368,8 +368,8 @@ class TestUpdate:
         # DataTree.identical() currently does not require that non-inherited
         # coordinates are defined identically, so we need to check this
         # explicitly
-        actual_node = actual.children["b"].to_dataset(inherited=False)
-        expected_node = expected.children["b"].to_dataset(inherited=False)
+        actual_node = actual.children["b"].to_dataset(inherit=False)
+        expected_node = expected.children["b"].to_dataset(inherit=False)
         assert_identical(actual_node, expected_node)
 
 
@@ -414,7 +414,7 @@ class TestCopy:
             {"/": xr.Dataset(coords={"x": [0, 1]}), "/c": DataTree()}
         )
         tree2 = tree.copy()
-        node_ds = tree2.children["c"].to_dataset(inherited=False)
+        node_ds = tree2.children["c"].to_dataset(inherit=False)
         assert_identical(node_ds, xr.Dataset())
 
     def test_deepcopy(self, create_test_datatree):
@@ -1267,8 +1267,8 @@ class TestInheritance:
         assert dt.c.sizes == {"x": 2, "y": 3}
         # dataset objects created from nodes should not
         assert dt.b.dataset.sizes == {"y": 1}
-        assert dt.b.to_dataset(inherited=True).sizes == {"y": 1}
-        assert dt.b.to_dataset(inherited=False).sizes == {"y": 1}
+        assert dt.b.to_dataset(inherit=True).sizes == {"y": 1}
+        assert dt.b.to_dataset(inherit=False).sizes == {"y": 1}
 
     def test_inherited_coords_index(self):
         dt = DataTree.from_dict(
@@ -1306,12 +1306,12 @@ class TestInheritance:
                 "/b": xr.Dataset(coords={"x": [1, 2]}),
             }
         )
-        child_dataset = dt.children["b"].to_dataset(inherited=False)
+        child_dataset = dt.children["b"].to_dataset(inherit=False)
         expected = xr.Dataset()
         assert_identical(child_dataset, expected)
 
         dt["/c"] = xr.Dataset({"foo": ("x", [4, 5])}, coords={"x": [1, 2]})
-        child_dataset = dt.children["c"].to_dataset(inherited=False)
+        child_dataset = dt.children["c"].to_dataset(inherit=False)
         expected = xr.Dataset({"foo": ("x", [4, 5])})
         assert_identical(child_dataset, expected)
 
@@ -1741,7 +1741,7 @@ class TestOps:
         tree["/foo"] = DataTree(xr.Dataset({"bar": ("x", [4, 5, 6])}))
         actual: DataTree = 2 * tree  # type: ignore[assignment,operator]
 
-        actual_dataset = actual.children["foo"].to_dataset(inherited=False)
+        actual_dataset = actual.children["foo"].to_dataset(inherit=False)
         assert "x" not in actual_dataset.coords
 
         expected = tree.copy()

--- a/xarray/tests/test_datatree_mapping.py
+++ b/xarray/tests/test_datatree_mapping.py
@@ -314,7 +314,7 @@ class TestMapOverSubTree:
         assert isinstance(actual, xr.DataTree)
         assert_identical(tree, actual)
 
-        actual_child = actual.children["child"].to_dataset(inherited=False)
+        actual_child = actual.children["child"].to_dataset(inherit=False)
         assert_identical(actual_child, child)
 
 


### PR DESCRIPTION
`inherit` is a little shorter than `inherited`, which I think makes for a slightly cleaner API. I believe this is also more consistent with other xarray method arguments, which are typically in the present tense.

Eventually, we can consider adding non-boolean options (e.g., `inherit='indexed_coordinates'` (default) vs `inherit='all_coordinates'`).