### PR TITLE
Relax nanosecond datetime restriction in CF time decoding

### DIFF
--- a/doc/internals/time-coding.rst
+++ b/doc/internals/time-coding.rst
@@ -326,7 +326,7 @@ CF time decoding
 
 Decoding of ``values`` with a time unit specification like ``"seconds since 1992-10-8 15:15:42.5 -6:00"`` into datetimes using the CF conventions is a multistage process.
 
-1. If we have a non-standard calendar (e.g. ``"noleap"``) decoding is done with the ``cftime`` package, which is not covered in this section. For the``"standard"``/``"gregorian"`` calendar as well as the ``"proleptic_gregorian"`` calendar the above outlined pandas functionality is used.
+1. If we have a non-standard calendar (e.g. ``"noleap"``) decoding is done with the ``cftime`` package, which is not covered in this section. For the ``"standard"``/``"gregorian"`` calendar as well as the ``"proleptic_gregorian"`` calendar the above outlined pandas functionality is used.
 
 2. The ``"standard"``/``"gregorian"`` calendar and the ``"proleptic_gregorian"`` are equivalent for any dates and reference times >= ``"1582-10-15"``. First the reference time is checked and any timezone information stripped off. In a second step, the minimum and maximum ``values`` are checked if they can be represented in the current reference time resolution. At the same time integer overflow would be caught. For the ``"standard"``/``"gregorian"`` calendar the dates are checked to be >= ``"1582-10-15"``. If anything fails, the decoding is attempted with ``cftime``.
 

--- a/doc/internals/time-coding.rst
+++ b/doc/internals/time-coding.rst
@@ -264,9 +264,6 @@ DatetimeIndex
 :py:class:`pandas.DatetimeIndex` is used to wrap ``np.datetime64`` values or other datetime-likes when encoding. The resolution of the DatetimeIndex depends on the input, but can be only one of ``'s'``, ``'ms'``, ``'us'``, ``'ns'``. Lower resolution input is automatically converted to ``'s'``, higher resolution input is cut to ``'ns'``.
 :py:class:`pandas.DatetimeIndex` will raise :py:class:`pandas.OutOfBoundsDatetime` if the input can't be represented in the given resolution.
 
-.. note::
-    For xarray we assume that all :py:class:`numpy.datetime64` provided to :py:class:`pandas.DatetimeIndex` are up to the specs. This is especially true, when those values have been decoded upfront. If the data is provided by users, they should handle any issues before.
-
 .. ipython:: python
 
     try:

--- a/doc/internals/time-coding.rst
+++ b/doc/internals/time-coding.rst
@@ -334,7 +334,7 @@ Decoding of ``values`` with time unit specification like ``seconds since 1992-10
 
 3. As the unit (here ``seconds``) and the resolution of the reference time ``1992-10-8 15:15:42.5 -6:00`` (here ``milliseconds``) might be different, this has to be aligned to the higher resolution (retrieve new unit). User may also specify their wanted target resolution by setting kwarg ``time_unit`` to one of ``'s'``, ``'ms'``, ``'us'``, ``'ns'`` (default ``'ns'``). This will be included into the alignment process. This is done by multiplying the ``values`` by the ratio of nanoseconds per time unit and nanoseconds per reference time unit. To not break consistency for ``NaT`` a mask is kept and re-introduced after the multiplication.
 
-4. Times encoded as floating point values are checked for fractional parts and the resolution is enhanced in an iterative process until a fitting resolution (or nansosecond) is found. A ``SerializationWarning`` is issued to make the user aware of the possibly problematic encoding.
+4. Times encoded as floating point values are checked for fractional parts and the resolution is enhanced in an iterative process until a fitting resolution (or ``'ns'``) is found. A ``SerializationWarning`` is issued to make the user aware of the possibly problematic encoding.
 
 5. Finally, the ``values`` (``int64``) are cast to ``datetime64[unit]`` (using the above retrieved unit) and added to the reference time :py:class:`pandas.Timestamp`.
 
@@ -439,6 +439,4 @@ For encoding the process is more or less a reversal of the above, but we have to
 Default Time Unit
 ~~~~~~~~~~~~~~~~~
 
-The default time unit of xarray is ``'s'``. It aligns well with the lower resolution of pandas. For normal operation that has no consequences on the output as all decoded datetimes are already at least in second resolution. Setting the default time unit to ``'ns'`` (the former default) the datetimes will be converted to ``'ns'``-resolution, if possible. Same holds true for ``'us'`` and ``'ms'``.
-
-If the datetimes are decoded to ``'us'`` resolution, this resolution will be kept, even if the default resolution is set to ``'s'`` or ``'ms'``.
+The current default time unit of xarray is ``'ns'``. Setting keyword argument ``time_unit`` unit to ``'s'`` (the lowest resolution pandas allows) datetimes will be converted to at least ``'s'``-resolution, if possible. Same holds true for ``'ms'`` and ``'us'``.

--- a/doc/internals/time-coding.rst
+++ b/doc/internals/time-coding.rst
@@ -26,15 +26,15 @@ to_datetime
 
 The function :py:func:`pandas.to_datetime` is used within xarray for inferring units and for testing purposes.
 
-In normal operation :py:func:`pandas.to_datetime` returns :py:class:`pandas.Timestamp` (scalar input) or :py:class:`pandas.DatetimeIndex` (array-like input) which are datetime64 with inherited resolution (from the source). If no resolution can be inherited ``'ns'`` is assumed. That has the implication, that the maximum usable timerange for those cases is +-292 years centered around the epoch. To accommodate for that, we are carefully checking the units/resolution in the encoding and decoding step.
+In normal operation :py:func:`pandas.to_datetime` returns a :py:class:`pandas.Timestamp` (for scalar input) or :py:class:`pandas.DatetimeIndex` (for array-like input) which are related to ``np.datetime64`` values with a resolution inherited from the input. If no resolution can be inherited ``'ns'`` is assumed. That has the implication that the maximum usable time range for those cases is approximately +/- 292 years centered around the Unix epoch (1970-01-01). To accommodate that, we carefully check the units/resolution in the encoding and decoding step.
 
-When args are numeric (no strings) "unit" can be anything from ``'Y'``, ``'W'``, ``'D'``, ``'h'``, ``'m'``, ``'s'``, ``'ms'``, ``'us'`` or ``'ns'``.
+When the arguments are numeric (not strings or ``np.datetime64`` values) ``"unit"`` can be anything from ``'Y'``, ``'W'``, ``'D'``, ``'h'``, ``'m'``, ``'s'``, ``'ms'``, ``'us'`` or ``'ns'``, though the returned resolution will be ``"ns"``.
 
 .. ipython:: python
 
     f"Maximum datetime range: ({pd.to_datetime(int64_min, unit="ns")}, {pd.to_datetime(int64_max, unit="ns")})"
 
-For input values which can't be represented in nanosecond resolution :py:class:`pandas.OutOfBoundsDatetime` exception is raised:
+For input values which can't be represented in nanosecond resolution an :py:class:`pandas.OutOfBoundsDatetime` exception is raised:
 
 .. ipython:: python
 
@@ -49,10 +49,10 @@ For input values which can't be represented in nanosecond resolution :py:class:`
     except Exception as err:
         print(err)
 
-Numpy datetime64 can be extracted with :py:meth:`pandas.Datetime.to_numpy` and :py:meth:`pandas.DatetimeIndex.to_numpy`. The returned resolution depends on the internal representation. This representation can be changed using :py:meth:`pandas.Datetime.as_unit`
+``np.datetime64`` values can be extracted with :py:meth:`pandas.Timestamp.to_numpy` and :py:meth:`pandas.DatetimeIndex.to_numpy`. The returned resolution depends on the internal representation. This representation can be changed using :py:meth:`pandas.Timestamp.as_unit`
 and :py:meth:`pandas.DatetimeIndex.as_unit` respectively.
 
-``as_unit`` takes one of ``'s'``, ``'ms'``, ``'us'``, ``'ns'`` as argument. That means we are able to represent datetimes with second, millisecond, microsecond or nanosecond resolution.
+``as_unit`` takes one of ``'s'``, ``'ms'``, ``'us'``, ``'ns'`` as an argument. That means we are able to represent datetimes with second, millisecond, microsecond or nanosecond resolution.
 
 .. ipython:: python
 
@@ -122,13 +122,13 @@ to_timedelta
 
 The function :py:func:`pandas.to_timedelta` is used within xarray for inferring units and for testing purposes.
 
-In normal operation :py:func:`pandas.to_timedelta` returns :py:class:`pandas.Timedelta` (scalar input) or :py:class:`pandas.TimedeltaIndex` (array-like input) which are timedelta64 with ``ns`` resolution internally. That has the implication, that the usable timedelta covers only roughly 585 years. To accommodate for that, we are working around that limitation in the encoding and decoding step.
+In normal operation :py:func:`pandas.to_timedelta` returns a :py:class:`pandas.Timedelta` (for scalar input) or :py:class:`pandas.TimedeltaIndex` (for array-like input) which are ``np.timedelta64`` values with ``ns`` resolution internally. That has the implication, that the usable timedelta covers only roughly 585 years. To accommodate for that, we are working around that limitation in the encoding and decoding step.
 
 .. ipython:: python
 
     f"Maximum timedelta range: ({pd.to_timedelta(int64_min, unit="ns")}, {pd.to_timedelta(int64_max, unit="ns")})"
 
-For input values which can't be represented in nanosecond resolution :py:class:`pandas.OutOfBoundsTimedelta` exception is raised:
+For input values which can't be represented in nanosecond resolution an :py:class:`pandas.OutOfBoundsTimedelta` exception is raised:
 
 .. ipython:: python
 
@@ -141,12 +141,12 @@ For input values which can't be represented in nanosecond resolution :py:class:`
     except Exception as err:
         print("Second:", err)
 
-When args are numeric (no strings) "unit" can be anything from ``'W'``, ``'D'``, ``'h'``, ``'m'``, ``'s'``, ``'ms'``, ``'us'`` or ``'ns'``.
+When arguments are numeric (not strings or ``np.timedelta64`` values) "unit" can be anything from ``'W'``, ``'D'``, ``'h'``, ``'m'``, ``'s'``, ``'ms'``, ``'us'`` or ``'ns'``, though the returned resolution will be ``"ns"``.
 
-Numpy timedelta64 can be extracted with :py:meth:`pandas.Timedelta.to_numpy` and :py:meth:`pandas.TimedeltaIndex.to_numpy`. The returned resolution depends on the internal representation. This representation can be changed using :py:meth:`pandas.Timedelta.as_unit`
+``np.timedelta64`` values can be extracted with :py:meth:`pandas.Timedelta.to_numpy` and :py:meth:`pandas.TimedeltaIndex.to_numpy`. The returned resolution depends on the internal representation. This representation can be changed using :py:meth:`pandas.Timedelta.as_unit`
 and :py:meth:`pandas.TimedeltaIndex.as_unit` respectively.
 
-``as_unit`` takes one of ``'s'``, ``'ms'``, ``'us'``, ``'ns'`` as argument. That means we are able to represent timedeltas with second, millisecond, microsecond or nanosecond resolution.
+``as_unit`` takes one of ``'s'``, ``'ms'``, ``'us'``, ``'ns'`` as an argument. That means we are able to represent timedeltas with second, millisecond, microsecond or nanosecond resolution.
 
 .. ipython:: python
 
@@ -197,13 +197,13 @@ and :py:meth:`pandas.TimedeltaIndex.as_unit` respectively.
 Timestamp
 ~~~~~~~~~
 
-:py:class:`pandas.Timestamp` is used within xarray to wrap strings of CF reference times and datetime.datetime.
+:py:class:`pandas.Timestamp` is used within xarray to wrap strings of CF encoding reference times and datetime.datetime.
 
-When args are numeric (no strings) "unit" can be anything from ``'Y'``, ``'W'``, ``'D'``, ``'h'``, ``'m'``, ``'s'``, ``'ms'``, ``'us'`` or ``'ns'``.
+When arguments are numeric (not strings) "unit" can be anything from ``'Y'``, ``'W'``, ``'D'``, ``'h'``, ``'m'``, ``'s'``, ``'ms'``, ``'us'`` or ``'ns'``, though the returned resolution will be ``"ns"``.
 
 In normal operation :py:class:`pandas.Timestamp` holds the timestamp in the provided resolution, but only one of ``'s'``, ``'ms'``, ``'us'``, ``'ns'``. Lower resolution input is automatically converted to ``'s'``, higher resolution input is cutted to ``'ns'``.
 
-Same conversion rules apply here as for :py:func:`pandas.to_timedelta` (see above).
+The same conversion rules apply here as for :py:func:`pandas.to_timedelta` (see above).
 Depending on the internal resolution Timestamps can be represented in the range:
 
 .. ipython:: python
@@ -213,7 +213,7 @@ Depending on the internal resolution Timestamps can be represented in the range:
             f"unit: {unit!r} time range ({pd.Timestamp(int64_min, unit=unit)}, {pd.Timestamp(int64_max, unit=unit)})"
         )
 
-Since relaxing the resolution this enhances the range to several hundreds of thousands of centuries with microsecond representation. ``NaT`` will be at ``np.iinfo("int64").min`` for all of the different representations.
+Since relaxing the resolution, this enhances the range to several hundreds of thousands of centuries with microsecond representation. ``NaT`` will be at ``np.iinfo("int64").min`` for all of the different representations.
 
 .. warning::
     When initialized with a datetime string this is only defined from ``-9999-01-01`` to ``9999-12-31``.
@@ -260,7 +260,7 @@ Since relaxing the resolution this enhances the range to several hundreds of tho
 DatetimeIndex
 ~~~~~~~~~~~~~
 
-:py:class:`pandas.DatetimeIndex` is used to wrap numpy datetime64 or other datetime-likes, when encoding. The resolution of the DatetimeIndex depends on the input, but can be only one of ``'s'``, ``'ms'``, ``'us'``, ``'ns'``. Lower resolution input is automatically converted to ``'s'``, higher resolution input is cutted to ``'ns'``.
+:py:class:`pandas.DatetimeIndex` is used to wrap ``np.datetime64`` values or other datetime-likes when encoding. The resolution of the DatetimeIndex depends on the input, but can be only one of ``'s'``, ``'ms'``, ``'us'``, ``'ns'``. Lower resolution input is automatically converted to ``'s'``, higher resolution input is cut to ``'ns'``.
 :py:class:`pandas.DatetimeIndex` will raise :py:class:`pandas.OutOfBoundsDatetime` if the input can't be represented in the given resolution.
 
 .. note::
@@ -326,17 +326,17 @@ Xarray tries to adhere to the latest version of the `CF Conventions`_. Relevant 
 CF time decoding
 ~~~~~~~~~~~~~~~~
 
-Decoding of ``values`` with time unit specification like ``seconds since 1992-10-8 15:15:42.5 -6:00`` into datetimes (using CF convention) is a multistage process.
+Decoding of ``values`` with a time unit specification like ``"seconds since 1992-10-8 15:15:42.5 -6:00"`` into datetimes using the CF conventions is a multistage process.
 
-1. If we have a non-standard calendar (eg. ``noleap``) the decoding is done with ``cftime`` package (which is not covered in this section). For ``standard``/``gregorian`` calendar as well as ``proleptic_gregorian`` the above outlined pandas functionality is used.
+1. If we have a non-standard calendar (e.g. ``"noleap"``) decoding is done with the ``cftime`` package, which is not covered in this section. For the``"standard"``/``"gregorian"`` calendar as well as the ``"proleptic_gregorian"`` calendar the above outlined pandas functionality is used.
 
-2. ``standard``/``gregorian`` calendar and ``proleptic_gregorian`` are equivalent for any dates and reference times >= ``1582-10-15``. First the reference time is checked and any timezone information stripped off and in a second step, the minimum and maximum ``values`` are checked if they can be represented in the current reference time resolution. At the same time integer overflow would be caught. For ``standard``/``gregorian`` calendar the dates are checked to be >= ``1582-10-15``. If anything fails, the decoding is done with ``cftime``).
+2. The ``"standard"``/``"gregorian"`` calendar and the ``"proleptic_gregorian"`` are equivalent for any dates and reference times >= ``"1582-10-15"``. First the reference time is checked and any timezone information stripped off. In a second step, the minimum and maximum ``values`` are checked if they can be represented in the current reference time resolution. At the same time integer overflow would be caught. For the ``"standard"``/``"gregorian"`` calendar the dates are checked to be >= ``"1582-10-15"``. If anything fails, the decoding is attempted with ``cftime``.
 
-3. As the unit (here ``seconds``) and the resolution of the reference time ``1992-10-8 15:15:42.5 -6:00`` (here ``milliseconds``) might be different, this has to be aligned to the higher resolution (retrieve new unit). User may also specify their wanted target resolution by setting kwarg ``time_unit`` to one of ``'s'``, ``'ms'``, ``'us'``, ``'ns'`` (default ``'ns'``). This will be included into the alignment process. This is done by multiplying the ``values`` by the ratio of nanoseconds per time unit and nanoseconds per reference time unit. To not break consistency for ``NaT`` a mask is kept and re-introduced after the multiplication.
+3. As the unit (here ``"seconds"``) and the resolution of the reference time ``"1992-10-8 15:15:42.5 -6:00"`` (here ``"milliseconds"``) might be different, the decoding resolution is aligned to the higher resolution of the two. Users may also specify their wanted target resolution by setting the ``time_unit`` keyword argument to one of ``'s'``, ``'ms'``, ``'us'``, ``'ns'`` (default ``'ns'``). This will be included in the alignment process. This is done by multiplying the ``values`` by the ratio of nanoseconds per time unit and nanoseconds per reference time unit. To retain consistency for ``NaT`` values a mask is kept and re-introduced after the multiplication.
 
 4. Times encoded as floating point values are checked for fractional parts and the resolution is enhanced in an iterative process until a fitting resolution (or ``'ns'``) is found. A ``SerializationWarning`` is issued to make the user aware of the possibly problematic encoding.
 
-5. Finally, the ``values`` (``int64``) are cast to ``datetime64[unit]`` (using the above retrieved unit) and added to the reference time :py:class:`pandas.Timestamp`.
+5. Finally, the ``values`` (at this point converted to ``int64`` values) are cast to ``datetime64[unit]`` (using the above retrieved unit) and added to the reference time :py:class:`pandas.Timestamp`.
 
 .. ipython:: python
 
@@ -383,8 +383,8 @@ For encoding the process is more or less a reversal of the above, but we have to
 
 1. Infer ``data_units`` from the given ``dates``.
 2. Infer ``units`` (either cleanup given ``units`` or use ``data_units``
-3. Infer calendar name from given ``dates``.
-4. If non standard calendar or object dates (CFTime) encode with ``cftime``
+3. Infer the calendar name from the given ``dates``.
+4. If dates are :py:class:`cftime.datetime` objects then encode with ``cftime.date2num``
 5. Retrieve ``time_units`` and ``ref_date`` from ``units``
 6. Check ``ref_date`` >= ``1582-10-15``, otherwise -> ``cftime``
 7. Wrap ``dates`` with pd.DatetimeIndex
@@ -439,4 +439,4 @@ For encoding the process is more or less a reversal of the above, but we have to
 Default Time Unit
 ~~~~~~~~~~~~~~~~~
 
-The current default time unit of xarray is ``'ns'``. Setting keyword argument ``time_unit`` unit to ``'s'`` (the lowest resolution pandas allows) datetimes will be converted to at least ``'s'``-resolution, if possible. Same holds true for ``'ms'`` and ``'us'``.
+The current default time unit of xarray is ``'ns'``. When setting keyword argument ``time_unit`` unit to ``'s'`` (the lowest resolution pandas allows) datetimes will be converted to at least ``'s'``-resolution, if possible. The same holds true for ``'ms'`` and ``'us'``.

--- a/doc/internals/time-coding.rst
+++ b/doc/internals/time-coding.rst
@@ -151,17 +151,17 @@ and :py:meth:`pandas.TimedeltaIndex.as_unit` respectively.
 
 .. ipython:: python
 
-    delta = pd.to_timedelta(1, unit="D")
-    print("Timedelta:", delta)
-    print("Timedelta as_unit('s'):", delta.as_unit("s"))
-    print("Timedelta to_numpy():", delta.as_unit("s").to_numpy())
+    delta = pd.to_timedelta(np.timedelta64(1, "D"))
+    print("Timedelta:", delta, np.asarray([delta.to_numpy()]).dtype)
+    print("Timedelta as_unit('ms'):", delta.as_unit("ms"))
+    print("Timedelta to_numpy():", delta.as_unit("ms").to_numpy())
     delta = pd.to_timedelta([0, 1, 2], unit="D")
     print("TimedeltaIndex:", delta)
-    print("TimedeltaIndex as_unit('s'):", delta.as_unit("s"))
-    print("TimedeltaIndex to_numpy():", delta.as_unit("s").to_numpy())
+    print("TimedeltaIndex as_unit('ms'):", delta.as_unit("ms"))
+    print("TimedeltaIndex to_numpy():", delta.as_unit("ms").to_numpy())
 
 .. note::
-    For the functionality in xarray the output resolution is converted from ``'ns'`` to the lowest needed resolution.
+    For the functionality in xarray the resolution is converted from ``'ns'`` to the lowest needed resolution when decoding.
 
 .. warning::
     Care has to be taken, as some configurations of input data will raise. The following shows, that we are safe to use :py:func:`pandas.to_timedelta` when providing :py:class:`numpy.timedelta64` as scalar or numpy array as input.

--- a/doc/internals/time-coding.rst
+++ b/doc/internals/time-coding.rst
@@ -26,7 +26,7 @@ to_datetime
 
 The function :py:func:`pandas.to_datetime` is used within xarray for inferring units and for testing purposes.
 
-In normal operation :py:func:`pandas.to_datetime` returns a :py:class:`pandas.Timestamp` (for scalar input) or :py:class:`pandas.DatetimeIndex` (for array-like input) which are related to ``np.datetime64`` values with a resolution inherited from the input. If no resolution can be inherited ``'ns'`` is assumed. That has the implication that the maximum usable time range for those cases is approximately +/- 292 years centered around the Unix epoch (1970-01-01). To accommodate that, we carefully check the units/resolution in the encoding and decoding step.
+In normal operation :py:func:`pandas.to_datetime` returns a :py:class:`pandas.Timestamp` (for scalar input) or :py:class:`pandas.DatetimeIndex` (for array-like input) which are related to ``np.datetime64`` values with a resolution inherited from the input (can be one of ``'s'``, ``'ms'``, ``'us'``, ``'ns'``). If no resolution can be inherited ``'ns'`` is assumed. That has the implication that the maximum usable time range for those cases is approximately +/- 292 years centered around the Unix epoch (1970-01-01). To accommodate that, we carefully check the units/resolution in the encoding and decoding step.
 
 When the arguments are numeric (not strings or ``np.datetime64`` values) ``"unit"`` can be anything from ``'Y'``, ``'W'``, ``'D'``, ``'h'``, ``'m'``, ``'s'``, ``'ms'``, ``'us'`` or ``'ns'``, though the returned resolution will be ``"ns"``.
 
@@ -52,18 +52,19 @@ For input values which can't be represented in nanosecond resolution an :py:clas
 ``np.datetime64`` values can be extracted with :py:meth:`pandas.Timestamp.to_numpy` and :py:meth:`pandas.DatetimeIndex.to_numpy`. The returned resolution depends on the internal representation. This representation can be changed using :py:meth:`pandas.Timestamp.as_unit`
 and :py:meth:`pandas.DatetimeIndex.as_unit` respectively.
 
+
 ``as_unit`` takes one of ``'s'``, ``'ms'``, ``'us'``, ``'ns'`` as an argument. That means we are able to represent datetimes with second, millisecond, microsecond or nanosecond resolution.
 
 .. ipython:: python
 
     time = pd.to_datetime(np.datetime64(0, "D"))
     print("Datetime:", time, np.asarray([time.to_numpy()]).dtype)
-    print("Datetime as_unit('s'):", time.as_unit("s"))
-    print("Datetime to_numpy():", time.as_unit("s").to_numpy())
+    print("Datetime as_unit('ms'):", time.as_unit("ms"))
+    print("Datetime to_numpy():", time.as_unit("ms").to_numpy())
     time = pd.to_datetime(np.array([-1000, 1, 2], dtype="datetime64[Y]"))
     print("DatetimeIndex:", time)
-    print("DatetimeIndex as_unit('s'):", time.as_unit("s"))
-    print("DatetimeIndex to_numpy():", time.as_unit("s").to_numpy())
+    print("DatetimeIndex as_unit('us'):", time.as_unit("us"))
+    print("DatetimeIndex to_numpy():", time.as_unit("us").to_numpy())
 
 .. warning::
     Input data with resolution higher than ``'ns'`` (eg. ``'ps'``, ``'fs'``, ``'as'``) is truncated (not rounded) at the ``'ns'``-level. This is currently broken for the ``'ps'`` input, where it is interpreted as ``'ns'``.

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -540,8 +540,8 @@ The ``units`` and ``calendar`` attributes control how xarray serializes ``dateti
 ``timedelta64`` arrays to datasets on disk as numeric values. The ``units`` encoding
 should be a string like ``'days since 1900-01-01'`` for ``datetime64`` data or a string
 like ``'days'`` for ``timedelta64`` data. ``calendar`` should be one of the calendar types
-supported by netCDF4-python: 'standard', 'gregorian', 'proleptic_gregorian' 'noleap',
-'365_day', '360_day', 'julian', 'all_leap', '366_day'.
+supported by netCDF4-python: ``'standard'``, ``'gregorian'``, ``'proleptic_gregorian'``, ``'noleap'``,
+``'365_day'``, ``'360_day'``, ``'julian'``, ``'all_leap'``, ``'366_day'``.
 
 By default, xarray uses the ``'proleptic_gregorian'`` calendar and units of the smallest time
 difference between values, with a reference time of the first time value.

--- a/doc/user-guide/time-series.rst
+++ b/doc/user-guide/time-series.rst
@@ -42,8 +42,7 @@ using :py:func:`pandas.to_datetime` and :py:func:`pandas.date_range`:
     For :py:func:`pandas.date_range` the ``unit``-kwarg has to be specified
     and for :py:func:`pandas.to_datetime` the selection of the resolution
     isn't possible at all. For that :py:class:`pd.DatetimeIndex` can be used
-    directly. There is more in-depth information in section
-    :ref:`<internals.time-coding>`.
+    directly.
 
 Alternatively, you can supply arrays of Python ``datetime`` objects. These get
 converted automatically when used as arguments in xarray objects (with us-resolution):

--- a/doc/user-guide/time-series.rst
+++ b/doc/user-guide/time-series.rst
@@ -83,7 +83,7 @@ You can manual decode arrays in this form by passing a dataset to
     coder = xr.coders.CFDatetimeCoder(time_unit="s")
     xr.decode_cf(ds, decode_times=coder)
 
-From xarray TODO: version the resolution of the dates can be tuned between "s", "ms", "us" and "ns". One limitation of using ``datetime64[ns]`` is that it limits the native representation of dates to those that fall between the years 1678 and 2262, which gets increased significantly with lower resolutions. When a netCDF file contains dates outside of these bounds (or dates < 1582-10-15), dates will be returned as arrays of :py:class:`cftime.datetime` objects and a :py:class:`~xarray.CFTimeIndex` will be used for indexing.
+From xarray TODO: version the resolution of the dates can be tuned between "s", "ms", "us" and "ns". One limitation of using ``datetime64[ns]`` is that it limits the native representation of dates to those that fall between the years 1678 and 2262, which gets increased significantly with lower resolutions. When a netCDF file contains dates outside of these bounds (or dates < 1582-10-15) and no ``proleptic_gregorian`` calendar is used, dates will be returned as arrays of :py:class:`cftime.datetime` objects and a :py:class:`~xarray.CFTimeIndex` will be used for indexing.
 :py:class:`~xarray.CFTimeIndex` enables a subset of the indexing functionality of a :py:class:`pandas.DatetimeIndex`.
 See :ref:`CFTimeIndex` for more information.
 

--- a/doc/user-guide/time-series.rst
+++ b/doc/user-guide/time-series.rst
@@ -22,7 +22,7 @@ Creating datetime64 data
 ------------------------
 
 Xarray uses the numpy dtypes ``datetime64[unit]`` and ``timedelta64[unit]``
-(where unit is one of "s", "ms", "us" and "ns") to represent datetime
+(where unit is one of ``"s"``, ``"ms"``, ``"us"`` and ``"ns"``) to represent datetime
 data, which offer vectorized operations with numpy and smooth integration with pandas.
 
 To convert to or create regular arrays of ``datetime64`` data, we recommend
@@ -42,7 +42,8 @@ using :py:func:`pandas.to_datetime` and :py:func:`pandas.date_range`:
     For :py:func:`pandas.date_range` the ``unit``-kwarg has to be specified
     and for :py:func:`pandas.to_datetime` the selection of the resolution
     isn't possible at all. For that :py:class:`pd.DatetimeIndex` can be used
-    directly.
+    directly. There is more in-depth information in section
+    :ref:`internals.timecoding`.
 
 Alternatively, you can supply arrays of Python ``datetime`` objects. These get
 converted automatically when used as arguments in xarray objects (with us-resolution):
@@ -62,12 +63,13 @@ attribute like ``'days since 2000-01-01'``).
 .. note::
 
    When decoding/encoding datetimes for non-standard calendars or for dates
-   before [1582-10-15](https://en.wikipedia.org/wiki/Gregorian_calendar), xarray uses the `cftime`_ library by default.
+   before `1582-10-15`_, xarray uses the `cftime`_ library by default.
    It was previously packaged with the ``netcdf4-python`` package under the
    name ``netcdftime`` but is now distributed separately. ``cftime`` is an
    :ref:`optional dependency<installing>` of xarray.
 
 .. _cftime: https://unidata.github.io/cftime
+.. _1582-10-15: https://en.wikipedia.org/wiki/Gregorian_calendar
 
 
 You can manual decode arrays in this form by passing a dataset to
@@ -83,7 +85,7 @@ You can manual decode arrays in this form by passing a dataset to
     coder = xr.coders.CFDatetimeCoder(time_unit="s")
     xr.decode_cf(ds, decode_times=coder)
 
-From xarray 2025.01.1 the resolution of the dates can be one of "s", "ms", "us" or "ns". One limitation of using ``datetime64[ns]`` is that it limits the native representation of dates to those that fall between the years 1678 and 2262, which gets increased significantly with lower resolutions. When a store contains dates outside of these bounds (or dates < 1582-10-15 with a Gregorian, also known as standard, calendar), dates will be returned as arrays of :py:class:`cftime.datetime` objects and a :py:class:`~xarray.CFTimeIndex` will be used for indexing.
+From xarray 2025.01.2 the resolution of the dates can be one of ``"s"``, ``"ms"``, ``"us"`` or ``"ns"``. One limitation of using ``datetime64[ns]`` is that it limits the native representation of dates to those that fall between the years 1678 and 2262, which gets increased significantly with lower resolutions. When a store contains dates outside of these bounds (or dates < `1582-10-15`_ with a Gregorian, also known as standard, calendar), dates will be returned as arrays of :py:class:`cftime.datetime` objects and a :py:class:`~xarray.CFTimeIndex` will be used for indexing.
 :py:class:`~xarray.CFTimeIndex` enables most of the indexing functionality of a :py:class:`pandas.DatetimeIndex`.
 See :ref:`CFTimeIndex` for more information.
 

--- a/doc/user-guide/time-series.rst
+++ b/doc/user-guide/time-series.rst
@@ -42,7 +42,8 @@ using :py:func:`pandas.to_datetime` and :py:func:`pandas.date_range`:
     For :py:func:`pandas.date_range` the ``unit``-kwarg has to be specified
     and for :py:func:`pandas.to_datetime` the selection of the resolution
     isn't possible at all. For that :py:class:`pd.DatetimeIndex` can be used
-    directly.
+    directly. There is more in-depth information in section
+    :ref:`<internals.timecoding>`.
 
 Alternatively, you can supply arrays of Python ``datetime`` objects. These get
 converted automatically when used as arguments in xarray objects (with us-resolution):

--- a/doc/user-guide/time-series.rst
+++ b/doc/user-guide/time-series.rst
@@ -83,8 +83,8 @@ You can manual decode arrays in this form by passing a dataset to
     coder = xr.coders.CFDatetimeCoder(time_unit="s")
     xr.decode_cf(ds, decode_times=coder)
 
-From xarray TODO: version the resolution of the dates can be tuned between "s", "ms", "us" and "ns". One limitation of using ``datetime64[ns]`` is that it limits the native representation of dates to those that fall between the years 1678 and 2262, which gets increased significantly with lower resolutions. When a netCDF file contains dates outside of these bounds (or dates < 1582-10-15) and no ``proleptic_gregorian`` calendar is used, dates will be returned as arrays of :py:class:`cftime.datetime` objects and a :py:class:`~xarray.CFTimeIndex` will be used for indexing.
-:py:class:`~xarray.CFTimeIndex` enables a subset of the indexing functionality of a :py:class:`pandas.DatetimeIndex`.
+From xarray 2025.01.1 the resolution of the dates can be tuned between "s", "ms", "us" and "ns". One limitation of using ``datetime64[ns]`` is that it limits the native representation of dates to those that fall between the years 1678 and 2262, which gets increased significantly with lower resolutions. When a store contains dates outside of these bounds (or dates < 1582-10-15 with a Gregorian, also known as standard, calendar), dates will be returned as arrays of :py:class:`cftime.datetime` objects and a :py:class:`~xarray.CFTimeIndex` will be used for indexing.
+:py:class:`~xarray.CFTimeIndex` enables most of the indexing functionality of a :py:class:`pandas.DatetimeIndex`.
 See :ref:`CFTimeIndex` for more information.
 
 Datetime indexing

--- a/doc/user-guide/time-series.rst
+++ b/doc/user-guide/time-series.rst
@@ -37,6 +37,14 @@ using :py:func:`pandas.to_datetime` and :py:func:`pandas.date_range`:
     pd.date_range("2000-01-01", periods=365)
     pd.date_range("2000-01-01", periods=365, unit="s")
 
+It is also possible to use corresponding :py:func:`xarray.date_range`:
+
+.. ipython:: python
+
+    xr.date_range("2000-01-01", periods=365)
+    xr.date_range("2000-01-01", periods=365, unit="s")
+
+
 .. note::
     Care has to be taken to create the output with the wanted resolution.
     For :py:func:`pandas.date_range` the ``unit``-kwarg has to be specified

--- a/doc/user-guide/time-series.rst
+++ b/doc/user-guide/time-series.rst
@@ -43,7 +43,7 @@ using :py:func:`pandas.to_datetime` and :py:func:`pandas.date_range`:
     and for :py:func:`pandas.to_datetime` the selection of the resolution
     isn't possible at all. For that :py:class:`pd.DatetimeIndex` can be used
     directly. There is more in-depth information in section
-    :ref:`<internals.timecoding>`.
+    :ref:`<internals.time-coding>`.
 
 Alternatively, you can supply arrays of Python ``datetime`` objects. These get
 converted automatically when used as arguments in xarray objects (with us-resolution):

--- a/doc/user-guide/time-series.rst
+++ b/doc/user-guide/time-series.rst
@@ -83,7 +83,7 @@ You can manual decode arrays in this form by passing a dataset to
     coder = xr.coders.CFDatetimeCoder(time_unit="s")
     xr.decode_cf(ds, decode_times=coder)
 
-From xarray 2025.01.1 the resolution of the dates can be tuned between "s", "ms", "us" and "ns". One limitation of using ``datetime64[ns]`` is that it limits the native representation of dates to those that fall between the years 1678 and 2262, which gets increased significantly with lower resolutions. When a store contains dates outside of these bounds (or dates < 1582-10-15 with a Gregorian, also known as standard, calendar), dates will be returned as arrays of :py:class:`cftime.datetime` objects and a :py:class:`~xarray.CFTimeIndex` will be used for indexing.
+From xarray 2025.01.1 the resolution of the dates can be one of "s", "ms", "us" or "ns". One limitation of using ``datetime64[ns]`` is that it limits the native representation of dates to those that fall between the years 1678 and 2262, which gets increased significantly with lower resolutions. When a store contains dates outside of these bounds (or dates < 1582-10-15 with a Gregorian, also known as standard, calendar), dates will be returned as arrays of :py:class:`cftime.datetime` objects and a :py:class:`~xarray.CFTimeIndex` will be used for indexing.
 :py:class:`~xarray.CFTimeIndex` enables most of the indexing functionality of a :py:class:`pandas.DatetimeIndex`.
 See :ref:`CFTimeIndex` for more information.
 

--- a/doc/user-guide/weather-climate.rst
+++ b/doc/user-guide/weather-climate.rst
@@ -81,7 +81,7 @@ using a standard calendar, but outside the `precision range`_ and dates [prior t
    represented with the ``np.datetime64[unit]`` data type (where unit can be one of ["s", "ms", "us", "ns"]), enabling the use of a :py:class:`pandas.DatetimeIndex` or arrays with dtype ``np.datetime64[unit]`` and their full set of associated features.
 
    As of pandas version 2.0.0, pandas supports non-nanosecond precision datetime
-   values. From xarray version 2025.01.1 on, non-nanosecond precision datetime values are also supported in xarray (this can be parameterized via :py:class:`coders.CFDatetimeCoder` and ``decode_times` kwarg).
+   values. From xarray version 2025.01.1 on, non-nanosecond precision datetime values are also supported in xarray (this can be parameterized via :py:class:`~xarray.coders.CFDatetimeCoder` and ``decode_times`` kwarg).
 
 For example, you can create a DataArray indexed by a time
 coordinate with dates from a no-leap calendar and a

--- a/doc/user-guide/weather-climate.rst
+++ b/doc/user-guide/weather-climate.rst
@@ -81,7 +81,7 @@ using a standard calendar, but outside the `precision range`_ and dates [prior t
    represented with the ``np.datetime64[unit]`` data type (where unit can be one of ["s", "ms", "us", "ns"]), enabling the use of a :py:class:`pandas.DatetimeIndex` or arrays with dtype ``np.datetime64[unit]`` and their full set of associated features.
 
    As of pandas version 2.0.0, pandas supports non-nanosecond precision datetime
-   values. From xarray version 2025.01.1 relaxed non-nanosecond precision datetime values can be parameterized via :py:class:`coders.CFDatetimeCoder` and ``decode_times` kwarg.
+   values. From xarray version 2025.01.1 on, non-nanosecond precision datetime values are also supported in xarray (this can be parameterized via :py:class:`coders.CFDatetimeCoder` and ``decode_times` kwarg).
 
 For example, you can create a DataArray indexed by a time
 coordinate with dates from a no-leap calendar and a

--- a/doc/user-guide/weather-climate.rst
+++ b/doc/user-guide/weather-climate.rst
@@ -75,7 +75,7 @@ using a standard calendar, but outside the `precision range`_ and dates [prior t
 
    - The dates are from a non-standard calendar
    - Any dates are outside the nanosecond-precision range (prior xarray version 2025.01.1)
-   - Any dates are outside the time span limited by the resolution (from xarray version v2025.01.1)
+   - Any dates are outside the time span limited by the resolution (from xarray version 2025.01.1)
 
    Otherwise pandas-compatible dates from a standard calendar will be
    represented with the ``np.datetime64[unit]`` data type (where unit can be one of ["s", "ms", "us", "ns"]), enabling the use of a :py:class:`pandas.DatetimeIndex` or arrays with dtype ``np.datetime64[unit]`` and their full set of associated features.

--- a/doc/user-guide/weather-climate.rst
+++ b/doc/user-guide/weather-climate.rst
@@ -57,14 +57,14 @@ CF-compliant coordinate variables
 
 .. _CFTimeIndex:
 
-Non-standard calendars and dates outside the nanosecond-precision range
------------------------------------------------------------------------
+Non-standard calendars and dates outside the precision range
+------------------------------------------------------------
 
 Through the standalone ``cftime`` library and a custom subclass of
 :py:class:`pandas.Index`, xarray supports a subset of the indexing
 functionality enabled through the standard :py:class:`pandas.DatetimeIndex` for
 dates from non-standard calendars commonly used in climate science or dates
-using a standard calendar, but outside the `precision range`_ and dates [prior to 1582-10-15](https://en.wikipedia.org/wiki/Gregorian_calendar).
+using a standard calendar, but outside the `precision range`_ and dates prior to `1582-10-15`_.
 
 .. note::
 
@@ -74,14 +74,14 @@ using a standard calendar, but outside the `precision range`_ and dates [prior t
    any of the following are true:
 
    - The dates are from a non-standard calendar
-   - Any dates are outside the nanosecond-precision range (prior xarray version 2025.01.1)
-   - Any dates are outside the time span limited by the resolution (from xarray version 2025.01.1)
+   - Any dates are outside the nanosecond-precision range (prior xarray version 2025.01.2)
+   - Any dates are outside the time span limited by the resolution (from xarray version 2025.01.2)
 
    Otherwise pandas-compatible dates from a standard calendar will be
-   represented with the ``np.datetime64[unit]`` data type (where unit can be one of ["s", "ms", "us", "ns"]), enabling the use of a :py:class:`pandas.DatetimeIndex` or arrays with dtype ``np.datetime64[unit]`` and their full set of associated features.
+   represented with the ``np.datetime64[unit]`` data type (where unit can be one of ``"s"``, ``"ms"``, ``"us"``, ``"ns"``), enabling the use of a :py:class:`pandas.DatetimeIndex` or arrays with dtype ``np.datetime64[unit]`` and their full set of associated features.
 
    As of pandas version 2.0.0, pandas supports non-nanosecond precision datetime
-   values. From xarray version 2025.01.1 on, non-nanosecond precision datetime values are also supported in xarray (this can be parameterized via :py:class:`~xarray.coders.CFDatetimeCoder` and ``decode_times`` kwarg).
+   values. From xarray version 2025.01.2 on, non-nanosecond precision datetime values are also supported in xarray (this can be parameterized via :py:class:`~xarray.coders.CFDatetimeCoder` and ``decode_times`` kwarg). See also :ref:`internals.timecoding`.
 
 For example, you can create a DataArray indexed by a time
 coordinate with dates from a no-leap calendar and a
@@ -132,7 +132,9 @@ Conversion between non-standard calendar and to/from pandas DatetimeIndexes is
 facilitated with the :py:meth:`xarray.Dataset.convert_calendar` method (also available as
 :py:meth:`xarray.DataArray.convert_calendar`). Here, like elsewhere in xarray, the ``use_cftime``
 argument controls which datetime backend is used in the output. The default (``None``) is to
-use ``pandas`` when possible, i.e. when the calendar is ``standard``/``gregorian`` and dates [starting with 1582-10-15]((https://en.wikipedia.org/wiki/Gregorian_calendar)). There is no such restriction when converting to a ``proleptic_gregorian`` calendar.
+use ``pandas`` when possible, i.e. when the calendar is ``standard``/``gregorian`` and dates starting with `1582-10-15`_. There is no such restriction when converting to a ``proleptic_gregorian`` calendar.
+
+.. _1582-10-15: https://en.wikipedia.org/wiki/Gregorian_calendar
 
 .. ipython:: python
 

--- a/doc/user-guide/weather-climate.rst
+++ b/doc/user-guide/weather-climate.rst
@@ -132,7 +132,7 @@ Conversion between non-standard calendar and to/from pandas DatetimeIndexes is
 facilitated with the :py:meth:`xarray.Dataset.convert_calendar` method (also available as
 :py:meth:`xarray.DataArray.convert_calendar`). Here, like elsewhere in xarray, the ``use_cftime``
 argument controls which datetime backend is used in the output. The default (``None``) is to
-use ``pandas`` when possible, i.e. when the calendar is ``standard``/``gregorian`` and dates [starting with 1582-10-15]((https://en.wikipedia.org/wiki/Gregorian_calendar)). There is no such restriction when converting to ``proleptic_gregorian`` calendar.
+use ``pandas`` when possible, i.e. when the calendar is ``standard``/``gregorian`` and dates [starting with 1582-10-15]((https://en.wikipedia.org/wiki/Gregorian_calendar)). There is no such restriction when converting to a ``proleptic_gregorian`` calendar.
 
 .. ipython:: python
 

--- a/doc/user-guide/weather-climate.rst
+++ b/doc/user-guide/weather-climate.rst
@@ -74,14 +74,14 @@ using a standard calendar, but outside the `precision range`_ and dates [prior t
    any of the following are true:
 
    - The dates are from a non-standard calendar
-   - Any dates are outside the nanosecond-precision range (prior xarray version 2024.11)
-   - Any dates are outside the time span limited by the resolution (from xarray version v2024.11)
+   - Any dates are outside the nanosecond-precision range (prior xarray version 2025.01.1)
+   - Any dates are outside the time span limited by the resolution (from xarray version v2025.01.1)
 
    Otherwise pandas-compatible dates from a standard calendar will be
-   represented with the ``np.datetime64[unit]`` data type (where unit can be one of ["s", "ms", "us", "ns"], enabling the use of a :py:class:`pandas.DatetimeIndex` or arrays with dtype ``np.datetime64[unit]`` and their full set of associated features.
+   represented with the ``np.datetime64[unit]`` data type (where unit can be one of ["s", "ms", "us", "ns"]), enabling the use of a :py:class:`pandas.DatetimeIndex` or arrays with dtype ``np.datetime64[unit]`` and their full set of associated features.
 
    As of pandas version 2.0.0, pandas supports non-nanosecond precision datetime
-   values. From xarray version 2024.11 the relaxed non-nanosecond precision datetime values will be used.
+   values. From xarray version 2025.01.1 relaxed non-nanosecond precision datetime values can be parameterized via :py:class:`coders.CFDatetimeCoder` and ``decode_times` kwarg.
 
 For example, you can create a DataArray indexed by a time
 coordinate with dates from a no-leap calendar and a

--- a/doc/user-guide/weather-climate.rst
+++ b/doc/user-guide/weather-climate.rst
@@ -132,7 +132,7 @@ Conversion between non-standard calendar and to/from pandas DatetimeIndexes is
 facilitated with the :py:meth:`xarray.Dataset.convert_calendar` method (also available as
 :py:meth:`xarray.DataArray.convert_calendar`). Here, like elsewhere in xarray, the ``use_cftime``
 argument controls which datetime backend is used in the output. The default (``None``) is to
-use ``pandas`` when possible, i.e. when the calendar is standard and dates [starting with 1582-10-15]((https://en.wikipedia.org/wiki/Gregorian_calendar)).
+use ``pandas`` when possible, i.e. when the calendar is ``standard``/``gregorian`` and dates [starting with 1582-10-15]((https://en.wikipedia.org/wiki/Gregorian_calendar)). There is no such restriction when converting to ``proleptic_gregorian`` calendar.
 
 .. ipython:: python
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -74,7 +74,7 @@ New Features
   latency. (:issue:`9853`, :pull:`9861`). By `Davis Bennett <https://github.com/d-v-b>`_.
 - Add ``unit`` - keyword argument to :py:func:`date_range` and ``microsecond`` parsing to
   iso8601-parser (:pull:`9885`).
-  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 
 Breaking changes
@@ -88,10 +88,6 @@ Breaking changes
 
 Deprecations
 ~~~~~~~~~~~~
-- Time decoding related kwarg ``use_cftime`` is deprecated. Use keyword argument
-  ``decode_times=CFDatetimeCoder(use_cftime=True)`` in the respective functions
-  instead (:pull:`9618`).
-  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - Finalize deprecation of ``closed`` parameters of :py:func:`cftime_range` and
   :py:func:`date_range` (:pull:`9882`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,6 +25,8 @@ New Features
 - Split out :py:class:`coders.CFDatetimeCoder` as public API in ``xr.coders``, make ``decode_times`` keyword argument
   consume :py:class:`coders.CFDatetimeCoder` (:pull:`9901`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Relax nanosecond datetime restriction in CF time decoding (:issue:`7493`, :pull:`9618`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
@@ -72,10 +74,7 @@ New Features
   latency. (:issue:`9853`, :pull:`9861`). By `Davis Bennett <https://github.com/d-v-b>`_.
 - Add ``unit`` - keyword argument to :py:func:`date_range` and ``microsecond`` parsing to
   iso8601-parser (:pull:`9885`).
-  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
-- Relax nanosecond datetime restriction in CF time decoding (:issue:`7493`, :pull:`9618`).
-  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
-
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_
 
 
 Breaking changes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -51,7 +51,7 @@ eventually be deprecated.
 New Features
 ~~~~~~~~~~~~
 - Relax nanosecond datetime restriction in CF time decoding (:issue:`7493`, :pull:`9618`).
-  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_ and `Spencer Clark <https://github.com/spencerkclark>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -19,6 +19,35 @@ What's New
 v2025.01.2 (unreleased)
 -----------------------
 
+This release brings non-nanosecond datetime resolution to xarray. In the
+last couple of releases xarray has been prepared for that change. The code had
+to be changed and adapted in numerous places, affecting especially the test suite.
+The documentation has been updated accordingly and a new internal chapter
+on :ref:`internals.timecoding` has been added.
+
+To make the transition as smooth as possible this is designed to be fully backwards
+compatible, keeping the current default of ``'ns'`` resolution on decoding.
+To opt-in decoding into other resolutions (``'us'``, ``'ms'`` or ``'s'``) the
+new :py:class:`coders.CFDatetimeCoder` is used as parameter to ``decode_times``
+kwarg (see also :ref:`internals.default_timeunit`):
+
+.. code-block:: python
+
+    coder = xr.coders.CFDatetimeCoder(time_unit="s")
+    ds = xr.open_dataset(filename, decode_times=coder)
+
+There might slight changes when encoding/decoding times as some warning and
+error messages have been removed or rewritten. Xarray will now also allow
+non-nanosecond datetimes (with ``'us'``, ``'ms'`` or ``'s'`` resolution) when
+creating DataArray's from scratch, picking the lowest possible resolution:
+
+.. ipython:: python
+
+    xr.DataArray(data=[np.datetime64("2000-01-01", "D")], dims=("time",))
+
+In a future release the current default of ``'ns'`` resolution on decoding will
+eventually be deprecated.
+
 New Features
 ~~~~~~~~~~~~
 - Relax nanosecond datetime restriction in CF time decoding (:issue:`7493`, :pull:`9618`).
@@ -38,7 +67,8 @@ Bug fixes
 
 Documentation
 ~~~~~~~~~~~~~
-
+- A chapter on :ref:`internals.timecoding` is added to the internal section (:pull:`9618`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/coding/cftimeindex.py
+++ b/xarray/coding/cftimeindex.py
@@ -588,7 +588,7 @@ class CFTimeIndex(pd.Index):
             return pd.DatetimeIndex([])
 
         # transform to us-resolution is needed for DatetimeIndex
-        nptimes = cftime_to_nptime(self).astype("=M8[us]")
+        nptimes = cftime_to_nptime(self, time_unit="us")
         calendar = infer_calendar_name(self)
         if calendar not in _STANDARD_CALENDARS and not unsafe:
             warnings.warn(

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -577,7 +577,8 @@ def to_timedelta_unboxed(value, **kwargs):
     unique_timedeltas = np.unique(result[pd.notnull(result)])
     unit = _netcdf_to_numpy_timeunit(_infer_time_units_from_diff(unique_timedeltas))
     if unit not in {"s", "ms", "us", "ns"}:
-        unit = "s"
+        # default to ns, when not specified
+        unit = "ns"
     result = result.astype(f"timedelta64[{unit}]")
     assert np.issubdtype(result.dtype, "timedelta64")
     return result
@@ -598,7 +599,8 @@ def decode_cf_timedelta(num_timedeltas, units: str) -> np.ndarray:
     unit = _netcdf_to_numpy_timeunit(units)
     as_unit = unit
     if unit not in {"s", "ms", "us", "ns"}:
-        as_unit = "s"
+        # default to ns, when not specified
+        as_unit = "ns"
     result = (
         pd.to_timedelta(ravel(num_timedeltas), unit=unit).as_unit(as_unit).to_numpy()
     )

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -720,7 +720,9 @@ def cftime_to_nptime(
         try:
             # We expect either "us" resolution or "s" resolution depending on
             # whether 'microseconds' are defined for the input or not.
-            dt = np.datetime64(t.isoformat()).astype(f"=M8[{time_unit}]")
+            dt = (
+                pd.Timestamp(np.datetime64(t.isoformat())).as_unit(time_unit).to_numpy()
+            )
         except ValueError as e:
             if raise_on_invalid:
                 raise ValueError(

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -395,7 +395,7 @@ def _check_higher_resolution(
 ) -> tuple[np.ndarray, PDDatetimeUnitOptions]:
     """Iterate until fitting resolution found."""
     res: list[PDDatetimeUnitOptions] = ["s", "ms", "us", "ns"]
-    new_units = res[res.index(cast(PDDatetimeUnitOptions, time_unit)) :]
+    new_units = res[res.index(time_unit) :]
     for new_time_unit in new_units:
         if not ((np.unique(flat_num_dates % 1) > 0).any() and new_time_unit != "ns"):
             break
@@ -582,7 +582,7 @@ def _numbers_to_timedelta(
     # estimate fitting resolution for floating point values
     # this iterates until all floats are fractionless or time_unit == "ns"
     if flat_num.dtype.kind == "f" and time_unit != "ns":
-        flat_num_dates, new_time_unit = _check_higher_resolution(flat_num, time_unit)
+        flat_num_dates, new_time_unit = _check_higher_resolution(flat_num, time_unit)  # type: ignore[arg-type]
         if time_unit != new_time_unit:
             msg = (
                 f"Can't decode floating point {datatype} to {time_unit!r} without "

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -543,22 +543,22 @@ def decode_cf_datetime(
 
             if dates_min < border:
                 if _is_standard_calendar(calendar):
-                    warnings.warn(
+                    emit_user_level_warning(
                         "Unable to decode time axis into full "
                         "numpy.datetime64 objects, continuing using "
-                        "cftime.datetime objects instead, reason: dates out "
-                        "of range",
+                        "cftime.datetime objects instead, reason: dates prior "
+                        "reform date (1582-10-15). To silence this warning specify "
+                        "'use_cftime=True'.",
                         SerializationWarning,
-                        stacklevel=3,
                     )
             elif time_unit == "ns" and (dates_min < lower or dates_max > upper):
-                warnings.warn(
+                emit_user_level_warning(
                     "Unable to decode time axis into full "
-                    "numpy.datetime64 objects, continuing using "
+                    "numpy.datetime64[ns] objects, continuing using "
                     "cftime.datetime objects instead, reason: dates out "
-                    "of range",
+                    "of range. To silence this warning use a coarser resolution "
+                    "'time_unit' or specify 'use_cftime=True'.",
                     SerializationWarning,
-                    stacklevel=3,
                 )
             else:
                 if _is_standard_calendar(calendar):
@@ -1114,7 +1114,6 @@ def _eagerly_encode_cf_timedelta(
     time_deltas = pd.TimedeltaIndex(ravel(timedeltas))
     # get resolution of TimedeltaIndex and align time_delta
     deltas_unit = time_deltas.unit
-    # todo: check, if this works in any case
     time_delta = time_delta.astype(f"=m8[{deltas_unit}]")
 
     # retrieve needed units to faithfully encode to int64

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -541,8 +541,7 @@ def decode_cf_datetime(
             lower = cftype(1677, 9, 21, 0, 12, 43, 145224)
             upper = cftype(2262, 4, 11, 23, 47, 16, 854775)
 
-            # todo: check if test for minimum date is enough
-            if dates_min < border or dates_max < border:
+            if dates_min < border:
                 if _is_standard_calendar(calendar):
                     warnings.warn(
                         "Unable to decode time axis into full "

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -1241,6 +1241,25 @@ def _lazily_encode_cf_timedelta(
 
 
 class CFDatetimeCoder(VariableCoder):
+    """Coder for CF Datetime coding.
+
+    Parameters
+    ----------
+    use_cftime : bool, optional
+        Only relevant if encoded dates come from a standard calendar
+        (e.g. "gregorian", "proleptic_gregorian", "standard", or not
+        specified).  If None (default), attempt to decode times to
+        ``np.datetime64`` objects; if this is not possible, decode times to
+        ``cftime.datetime`` objects. If True, always decode times to
+        ``cftime.datetime`` objects, regardless of whether or not they can be
+        represented using ``np.datetime64`` objects.  If False, always
+        decode times to ``np.datetime64`` objects; if this is not possible
+        raise an error.
+        May not be supported by all the backends.
+    time_unit : PDDatetimeUnitOptions
+          Target resolution when decoding dates. Defaults to "ns".
+    """
+
     def __init__(
         self,
         use_cftime: bool | None = None,

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -291,18 +291,6 @@ def _unpack_time_unit_and_ref_date(
     return time_unit, ref_date
 
 
-def _unpack_time_unit_and_ref_date(
-    units: str,
-) -> tuple[NPDatetimeUnitOptions, pd.Timestamp]:
-    # same us _unpack_netcdf_time_units but finalizes time_unit and ref_date
-    # for processing in encode_cf_datetime
-    time_unit, _ref_date = _unpack_netcdf_time_units(units)
-    time_unit = _netcdf_to_numpy_timeunit(time_unit)
-    ref_date = pd.Timestamp(_ref_date)
-    ref_date = _maybe_strip_tz_from_timestamp(ref_date)
-    return time_unit, ref_date
-
-
 def _decode_cf_datetime_dtype(
     data,
     units: str,

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -365,6 +365,21 @@ def _check_date_for_units_since_refdate(
         return pd.Timestamp("NaT")
 
 
+def _check_timedelta_range(value, data_unit, time_unit):
+    if value > np.iinfo("int64").max or value < np.iinfo("int64").min:
+        OutOfBoundsTimedelta(f"Value {value} can't be represented as Timedelta.")
+    delta = value * np.timedelta64(1, data_unit)
+    if not np.isnan(delta):
+        # this will raise on dtype overflow for integer dtypes
+        if value.dtype.kind in "u" and not np.int64(delta) == value:
+            raise OutOfBoundsTimedelta(
+                "DType overflow in Datetime/Timedelta calculation."
+            )
+        # this will raise on overflow if delta cannot be represented with the
+        # resolutions supported by pandas.
+        pd.to_timedelta(delta)
+
+
 def _align_reference_date_and_unit(
     ref_date: pd.Timestamp, unit: NPDatetimeUnitOptions
 ) -> pd.Timestamp:
@@ -542,19 +557,6 @@ def decode_cf_datetime(
     return reshape(dates, num_dates.shape)
 
 
-def to_timedelta_unboxed(value, **kwargs):
-    # todo: check, if the procedure here is correct
-    result = pd.to_timedelta(value, **kwargs).to_numpy()
-    unique_timedeltas = np.unique(result[pd.notnull(result)])
-    unit = _netcdf_to_numpy_timeunit(_infer_time_units_from_diff(unique_timedeltas))
-    if unit not in {"s", "ms", "us", "ns"}:
-        # default to "ns", when not specified
-        unit = "ns"
-    result = result.astype(f"timedelta64[{unit}]")
-    assert np.issubdtype(result.dtype, "timedelta64")
-    return result
-
-
 def to_datetime_unboxed(value, **kwargs):
     result = pd.to_datetime(value, **kwargs).to_numpy()
     assert np.issubdtype(result.dtype, "datetime64")
@@ -604,22 +606,36 @@ def _numbers_to_timedelta(
     return flat_num.astype(f"timedelta64[{time_unit}]")
 
 
-def decode_cf_timedelta(num_timedeltas, units: str) -> np.ndarray:
-    # todo: check, if this works as intended
+def decode_cf_timedelta(
+    num_timedeltas, units: str, time_unit: str = "ns"
+) -> np.ndarray:
     """Given an array of numeric timedeltas in netCDF format, convert it into a
     numpy timedelta64 ["s", "ms", "us", "ns"] array.
     """
     num_timedeltas = np.asarray(num_timedeltas)
     unit = _netcdf_to_numpy_timeunit(units)
 
-    timedeltas = _numbers_to_timedelta(num_timedeltas, unit, "s", "timedelta")
+    _check_timedelta_range(num_timedeltas.min(), unit, time_unit)
+    _check_timedelta_range(num_timedeltas.max(), unit, time_unit)
 
-    as_unit = unit
-    if unit not in {"s", "ms", "us", "ns"}:
-        # default to "ns", when not specified
-        as_unit = "ns"
-    result = pd.to_timedelta(ravel(timedeltas)).as_unit(as_unit).to_numpy()
-    return reshape(result, timedeltas.shape)
+    timedeltas = _numbers_to_timedelta(num_timedeltas, unit, "s", "timedelta")
+    timedeltas = pd.to_timedelta(ravel(timedeltas))
+
+    if np.isnat(timedeltas).all():
+        empirical_unit = time_unit
+    else:
+        empirical_unit = timedeltas.unit
+
+    if np.timedelta64(1, time_unit) > np.timedelta64(1, empirical_unit):
+        time_unit = empirical_unit
+
+    if time_unit not in {"s", "ms", "us", "ns"}:
+        raise ValueError(
+            f"time_unit must be one of 's', 'ms', 'us', or 'ns'. Got: {time_unit}"
+        )
+
+    result = timedeltas.as_unit(time_unit).to_numpy()
+    return reshape(result, num_timedeltas.shape)
 
 
 def _unit_timedelta_cftime(units: str) -> timedelta:
@@ -700,7 +716,7 @@ def infer_timedelta_units(deltas) -> str:
     {'days', 'hours', 'minutes' 'seconds'} (the first one that can evenly
     divide all unique time deltas in `deltas`)
     """
-    deltas = to_timedelta_unboxed(ravel(np.asarray(deltas)))
+    deltas = ravel(deltas)
     unique_timedeltas = np.unique(deltas[pd.notnull(deltas)])
     return _infer_time_units_from_diff(unique_timedeltas)
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -385,7 +385,7 @@ def _check_date_is_after_shift(date: pd.Timestamp, calendar: str) -> None:
         if date < type(date)(1582, 10, 15):
             raise OutOfBoundsDatetime(
                 f"Dates before 1582-10-15 cannot be decoded "
-                f"with pandas using {calendar!r} calendar."
+                f"with pandas using {calendar!r} calendar: {date}"
             )
 
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -548,7 +548,7 @@ def to_timedelta_unboxed(value, **kwargs):
     unique_timedeltas = np.unique(result[pd.notnull(result)])
     unit = _netcdf_to_numpy_timeunit(_infer_time_units_from_diff(unique_timedeltas))
     if unit not in {"s", "ms", "us", "ns"}:
-        # default to ns, when not specified
+        # default to "ns", when not specified
         unit = "ns"
     result = result.astype(f"timedelta64[{unit}]")
     assert np.issubdtype(result.dtype, "timedelta64")
@@ -616,7 +616,7 @@ def decode_cf_timedelta(num_timedeltas, units: str) -> np.ndarray:
 
     as_unit = unit
     if unit not in {"s", "ms", "us", "ns"}:
-        # default to ns, when not specified
+        # default to "ns", when not specified
         as_unit = "ns"
     result = pd.to_timedelta(ravel(timedeltas)).as_unit(as_unit).to_numpy()
     return reshape(result, timedeltas.shape)

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -365,12 +365,14 @@ def _check_date_for_units_since_refdate(
         return pd.Timestamp("NaT")
 
 
-def _align_reference_date_and_unit(ref_date: pd.Timestamp, unit: str) -> pd.Timestamp:
+def _align_reference_date_and_unit(
+    ref_date: pd.Timestamp, unit: NPDatetimeUnitOptions
+) -> pd.Timestamp:
     # align to the highest needed resolution of ref_date or unit
     if np.timedelta64(1, ref_date.unit) > np.timedelta64(1, unit):
         # this will raise accordingly
         # if data can't be represented in the higher resolution
-        return timestamp_as_unit(ref_date, unit)
+        return timestamp_as_unit(ref_date, cast(PDDatetimeUnitOptions, unit))
     return ref_date
 
 

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -46,7 +46,7 @@ class VariableCoder:
         raise NotImplementedError()
 
     def decode(self, variable: Variable, name: T_Name = None) -> Variable:
-        """Convert an decoded variable to a encoded variable"""
+        """Convert a decoded variable to an encoded variable"""
         raise NotImplementedError()
 
 

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -155,11 +155,6 @@ def decode_cf_variable(
         represented using ``np.datetime64[ns]`` objects.  If False, always
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error.
-        Usage of use_cftime as kwarg is deprecated, please initialize it with
-        CFDatetimeCoder and ``decode_times``.
-
-        .. deprecated:: 2025.01.0
-           Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
         .. deprecated:: 2025.01.1
            Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -622,7 +622,7 @@ class DataWithCoords(AttrAccessMixin):
             lon             (x, y) float64 32B 260.2 260.7 260.2 260.8
             lat             (x, y) float64 32B 42.25 42.21 42.63 42.59
           * time            (time) datetime64[ns] 32B 2014-09-06 ... 2014-09-09
-            reference_time  datetime64[s] 8B 2014-09-05
+            reference_time  datetime64[ns] 8B 2014-09-05
         Dimensions without coordinates: x, y
         Data variables:
             temperature     (x, y, time) float64 128B 20.0 20.8 21.6 ... 30.4 31.2 32.0
@@ -636,7 +636,7 @@ class DataWithCoords(AttrAccessMixin):
             lon             (x, y) float64 32B -99.83 -99.32 -99.79 -99.23
             lat             (x, y) float64 32B 42.25 42.21 42.63 42.59
           * time            (time) datetime64[ns] 32B 2014-09-06 ... 2014-09-09
-            reference_time  datetime64[s] 8B 2014-09-05
+            reference_time  datetime64[ns] 8B 2014-09-05
         Dimensions without coordinates: x, y
         Data variables:
             temperature     (x, y, time) float64 128B 20.0 20.8 21.6 ... 30.4 31.2 32.0

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -394,7 +394,7 @@ class DataArray(
         lon             (x, y) float64 32B -99.83 -99.32 -99.79 -99.23
         lat             (x, y) float64 32B 42.25 42.21 42.63 42.59
       * time            (time) datetime64[ns] 24B 2014-09-06 2014-09-07 2014-09-08
-        reference_time  datetime64[s] 8B 2014-09-05
+        reference_time  datetime64[ns] 8B 2014-09-05
     Dimensions without coordinates: x, y
     Attributes:
         description:  Ambient temperature.
@@ -409,7 +409,7 @@ class DataArray(
         lon             float64 8B -99.32
         lat             float64 8B 42.21
         time            datetime64[ns] 8B 2014-09-08
-        reference_time  datetime64[s] 8B 2014-09-05
+        reference_time  datetime64[ns] 8B 2014-09-05
     Attributes:
         description:  Ambient temperature.
         units:        degC

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -673,7 +673,7 @@ class Dataset(
         lat             (loc) float64 16B 42.25 42.21
       * instrument      (instrument) <U8 96B 'manufac1' 'manufac2' 'manufac3'
       * time            (time) datetime64[ns] 32B 2014-09-06 ... 2014-09-09
-        reference_time  datetime64[s] 8B 2014-09-05
+        reference_time  datetime64[ns] 8B 2014-09-05
     Dimensions without coordinates: loc
     Data variables:
         temperature     (loc, instrument, time) float64 192B 29.11 18.2 ... 9.063
@@ -692,7 +692,7 @@ class Dataset(
         lat             float64 8B 42.21
         instrument      <U8 32B 'manufac3'
         time            datetime64[ns] 8B 2014-09-06
-        reference_time  datetime64[s] 8B 2014-09-05
+        reference_time  datetime64[ns] 8B 2014-09-05
     Data variables:
         temperature     float64 8B -5.424
         precipitation   float64 8B 9.884
@@ -8893,7 +8893,7 @@ class Dataset(
             lon             (x, y) float64 32B -99.83 -99.32 -99.79 -99.23
             lat             (x, y) float64 32B 42.25 42.21 42.63 42.59
           * time            (time) datetime64[ns] 24B 2014-09-06 2014-09-07 2014-09-08
-            reference_time  datetime64[s] 8B 2014-09-05
+            reference_time  datetime64[ns] 8B 2014-09-05
         Dimensions without coordinates: x, y
         Data variables:
             precipitation   (x, y, time) float64 96B 5.68 9.256 0.7104 ... 4.615 7.805
@@ -8908,7 +8908,7 @@ class Dataset(
             lon             (x, y) float64 32B -99.83 -99.32 -99.79 -99.23
             lat             (x, y) float64 32B 42.25 42.21 42.63 42.59
           * time            (time) datetime64[ns] 24B 2014-09-06 2014-09-07 2014-09-08
-            reference_time  datetime64[s] 8B 2014-09-05
+            reference_time  datetime64[ns] 8B 2014-09-05
         Dimensions without coordinates: x, y
         Data variables:
             temperature     (x, y, time) float64 96B 29.11 18.2 22.83 ... 16.15 26.63

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1754,7 +1754,10 @@ class PandasIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
             # (for now)
             item = np.datetime64("NaT", "ns")
         elif isinstance(item, timedelta):
-            item = np.timedelta64(getattr(item, "value", item), "ns")
+            # from xarray 2025.01.1 xarray allows non-nanosecond resolution
+            # so we just convert to_numpy if possible
+            if hasattr(item, "to_numpy"):
+                item = item.to_numpy()
         elif isinstance(item, pd.Timestamp):
             # Work around for GH: pydata/xarray#1932 and numpy/numpy#10668
             # numpy fails to convert pd.Timestamp to np.datetime64[ns]

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1753,11 +1753,10 @@ class PandasIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
             # pd.Timestamp rather np.than datetime64 but this is easier
             # (for now)
             item = np.datetime64("NaT", "ns")
+        elif isinstance(item, pd.Timedelta):
+            item = item.to_numpy()
         elif isinstance(item, timedelta):
-            # from xarray 2025.01.1 xarray allows non-nanosecond resolution
-            # so we just convert to_numpy if possible
-            if hasattr(item, "to_numpy"):
-                item = item.to_numpy()
+            item = np.timedelta64(item)
         elif isinstance(item, pd.Timestamp):
             # Work around for GH: pydata/xarray#1932 and numpy/numpy#10668
             # numpy fails to convert pd.Timestamp to np.datetime64[ns]

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -258,8 +258,6 @@ class set_options:
     warn_for_unclosed_files : bool, default: False
         Whether or not to issue a warning when unclosed files are
         deallocated. This is mostly useful for debugging.
-    time_resolution : {"s", "ms", "us", "ns"}, default: "s"
-        Time resolution used for CF encoding/decoding.
 
     Examples
     --------

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -78,14 +78,6 @@ if TYPE_CHECKING:
     from xarray.namedarray.parallelcompat import ChunkManagerEntrypoint
 
 
-NON_DEFAULTPRECISION_WARNING = (
-    "Converting non-default precision {case} values to default precision. "
-    "This warning is caused by passing non-default np.datetime64 or "
-    "np.timedelta64 values to the DataArray or Variable constructor; it can be "
-    "silenced by converting the values to default precision {res!r} ahead of time."
-)
-
-
 class MissingDimensionsError(ValueError):
     """Error class used when we can't safely guess a dimension name."""
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -6,7 +6,6 @@ import math
 import numbers
 import warnings
 from collections.abc import Callable, Hashable, Mapping, Sequence
-from datetime import datetime
 from functools import partial
 from types import EllipsisType
 from typing import TYPE_CHECKING, Any, NoReturn, cast
@@ -214,18 +213,6 @@ def _possibly_convert_objects(values):
     * pd.Timedelta
     """
     as_series = pd.Series(values.ravel(), copy=False)
-    # When receiving objects which pd.Series can't resolve by its own
-    # we try astype-conversion to "ns"-resolution for datetimes and pd.Timestamp.
-    if (
-        values.dtype.kind == "O"
-        and as_series.dtype.kind == "O"
-        and as_series.size > 0
-        and (
-            isinstance(as_series[0], datetime | pd.Timestamp)
-            or pd.api.types.is_datetime64_dtype(as_series[0])
-        )
-    ):
-        as_series = as_series.astype("=M8[ns]")
     result = np.asarray(as_series).reshape(values.shape)
     if not result.flags.writeable:
         # GH8843, pandas copy-on-write mode creates read-only arrays by default

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -219,6 +219,7 @@ def _possibly_convert_objects(values):
     if (
         values.dtype.kind == "O"
         and as_series.dtype.kind == "O"
+        and as_series.size > 0
         and isinstance(as_series[0], datetime | pd.Timestamp)
     ):
         as_series = as_series.astype("=M8[us]")

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -215,14 +215,17 @@ def _possibly_convert_objects(values):
     """
     as_series = pd.Series(values.ravel(), copy=False)
     # When receiving objects which pd.Series can't resolve by its own
-    # we try astype-conversion to "us"-resolution for datetimes and pd.Timestamp.
+    # we try astype-conversion to "ns"-resolution for datetimes and pd.Timestamp.
     if (
         values.dtype.kind == "O"
         and as_series.dtype.kind == "O"
         and as_series.size > 0
-        and isinstance(as_series[0], datetime | pd.Timestamp)
+        and (
+            isinstance(as_series[0], datetime | pd.Timestamp)
+            or pd.api.types.is_datetime64_dtype(as_series[0])
+        )
     ):
-        as_series = as_series.astype("=M8[us]")
+        as_series = as_series.astype("=M8[ns]")
     result = np.asarray(as_series).reshape(values.shape)
     if not result.flags.writeable:
         # GH8843, pandas copy-on-write mode creates read-only arrays by default

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5831,7 +5831,7 @@ def test_open_fsspec() -> None:
     ds0 = ds.copy()
     # pd.to_timedelta returns ns-precision, but the example data is in second precision
     # so we need to fix this
-    ds0["time"] = ds.time + pd.to_timedelta("1 day").as_unit("s")
+    ds0["time"] = ds.time + np.timedelta64(1, "D")
     mm = m.get_mapper("out2.zarr")
     ds0.to_zarr(mm)  # old interface
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5707,7 +5707,8 @@ def test_use_cftime_false_standard_calendar_in_range(calendar) -> None:
     with create_tmp_file() as tmp_file:
         original.to_netcdf(tmp_file)
         with warnings.catch_warnings(record=True) as record:
-            with open_dataset(tmp_file, use_cftime=False) as ds:
+            coder = xr.coders.CFDatetimeCoder(use_cftime=False)
+            with open_dataset(tmp_file, decode_times=coder) as ds:
                 assert_identical(expected_x, ds.x)
                 assert_identical(expected_time, ds.time)
             _assert_no_dates_out_of_range_warning(record)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -616,7 +616,7 @@ class DatasetIOBase:
                     # proleptic gregorian will be decoded into numpy datetime64
                     # fixing to expectations
                     if actual.t.dtype.kind == "M":
-                        dtype = f"datetime64[{np.datetime_data(actual.t)[0]}]"
+                        dtype = actual.t.dtype
                         expected_decoded_t = expected_decoded_t.astype(dtype)
                         expected_decoded_t0 = expected_decoded_t0.astype(dtype)
                     abs_diff = abs(actual.t.values - expected_decoded_t)

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -1266,7 +1266,7 @@ def test_multiindex():
 @pytest.mark.parametrize("freq", ["3663s", "33min", "2h"])
 @pytest.mark.parametrize("method", ["floor", "ceil", "round"])
 def test_rounding_methods_against_datetimeindex(freq, method):
-    # todo: check, if setting to "us" is enough
+    # for now unit="us" seems good enough
     expected = pd.date_range("2000-01-02T01:03:51", periods=10, freq="1777s", unit="us")
     expected = getattr(expected, method)(freq)
     result = xr.cftime_range("2000-01-02T01:03:51", periods=10, freq="1777s")

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -1238,7 +1238,11 @@ def test_to_datetimeindex(calendar, unsafe):
 @pytest.mark.parametrize("calendar", _ALL_CALENDARS)
 def test_to_datetimeindex_out_of_range(calendar):
     index = xr.cftime_range("0001", periods=5, calendar=calendar)
-    # todo: needs discussion, do we need this test?
+    # todo: suggestion from code review:
+    #  - still warn when converting from a non-standard calendar
+    #  to a proleptic Gregorian calendar
+    #  - also warn when converting from a Gregorian calendar
+    #  to a proleptic Gregorian calendar when dates fall before the reform
     if calendar in _NON_STANDARD_CALENDARS:
         with pytest.warns(RuntimeWarning, match="non-standard"):
             index.to_datetimeindex()

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -1330,7 +1330,7 @@ def test_contains_cftime_lazy() -> None:
 
 
 @pytest.mark.parametrize(
-    "timestr, timeunit, dtype, fill_value, use_encoding",
+    "timestr, format, dtype, fill_value, use_encoding",
     [
         ("1677-09-21T00:12:43.145224193", "ns", np.int64, 20, True),
         ("1970-09-21T00:12:44.145224808", "ns", np.float64, 1e30, True),
@@ -1349,15 +1349,15 @@ def test_contains_cftime_lazy() -> None:
 )
 def test_roundtrip_datetime64_nanosecond_precision(
     timestr: str,
-    timeunit: Literal["ns", "us"],
+    format: Literal["ns", "us"],
     dtype: np.typing.DTypeLike,
     fill_value: int | float | None,
     use_encoding: bool,
     time_unit: PDDatetimeUnitOptions,
 ) -> None:
     # test for GH7817
-    time = np.datetime64(timestr, timeunit)
-    times = [np.datetime64("1970-01-01T00:00:00", timeunit), np.datetime64("NaT"), time]
+    time = np.datetime64(timestr, format)
+    times = [np.datetime64("1970-01-01T00:00:00", format), np.datetime64("NaT"), time]
 
     if use_encoding:
         encoding = dict(dtype=dtype, _FillValue=fill_value)
@@ -1365,12 +1365,12 @@ def test_roundtrip_datetime64_nanosecond_precision(
         encoding = {}
 
     var = Variable(["time"], times, encoding=encoding)
-    assert var.dtype == np.dtype(f"=M8[{timeunit}]")
+    assert var.dtype == np.dtype(f"=M8[{format}]")
 
     encoded_var = conventions.encode_cf_variable(var)
     assert (
         encoded_var.attrs["units"]
-        == f"{_numpy_to_netcdf_timeunit(timeunit)} since 1970-01-01 00:00:00"
+        == f"{_numpy_to_netcdf_timeunit(format)} since 1970-01-01 00:00:00"
     )
     assert encoded_var.attrs["calendar"] == "proleptic_gregorian"
     assert encoded_var.data.dtype == dtype
@@ -1379,14 +1379,14 @@ def test_roundtrip_datetime64_nanosecond_precision(
     )
 
     result_unit = (
-        timeunit
-        if np.timedelta64(1, timeunit) <= np.timedelta64(1, time_unit)
+        format
+        if np.timedelta64(1, format) <= np.timedelta64(1, time_unit)
         else time_unit
     )
     assert decoded_var.dtype == np.dtype(f"=M8[{result_unit}]")
     assert (
         decoded_var.encoding["units"]
-        == f"{_numpy_to_netcdf_timeunit(timeunit)} since 1970-01-01 00:00:00"
+        == f"{_numpy_to_netcdf_timeunit(format)} since 1970-01-01 00:00:00"
     )
     assert decoded_var.encoding["dtype"] == dtype
     assert decoded_var.encoding["calendar"] == "proleptic_gregorian"

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -172,12 +172,18 @@ def test_decode_cf_datetime_overflow(time_unit: PDDatetimeUnitOptions) -> None:
     # date after 2262 and before 1678
     days = (-117710, 95795)
     expected = (datetime(1677, 9, 20), datetime(2262, 4, 12))
-
     for i, day in enumerate(days):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", "Unable to decode time axis")
-            result = decode_cf_datetime(day, units, time_unit=time_unit)
+            result = decode_cf_datetime(
+                day, units, calendar="standard", time_unit=time_unit
+            )
         assert result == expected[i]
+        # additional check to see if type/dtypes are correct
+        if time_unit == "ns":
+            assert isinstance(result.item(), datetime)
+        else:
+            assert result.dtype == np.dtype(f"=M8[{time_unit}]")
 
 
 def test_decode_cf_datetime_non_standard_units() -> None:

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -681,7 +681,7 @@ def test_decode_cf_timedelta_time_unit(time_unit, encoding_unit) -> None:
     assert result.dtype == expected.dtype
 
 
-def test_decode_cf_timedelta_time_unit_out_of_bounds(time_unit):
+def test_decode_cf_timedelta_time_unit_out_of_bounds(time_unit) -> None:
     # Define a scale factor that will guarantee overflow with the given
     # time_unit.
     scale_factor = np.timedelta64(1, time_unit) // np.timedelta64(1, "ns")
@@ -690,7 +690,7 @@ def test_decode_cf_timedelta_time_unit_out_of_bounds(time_unit):
         decode_cf_timedelta(encoded, "days", time_unit)
 
 
-def test_cf_timedelta_roundtrip_large_value(time_unit):
+def test_cf_timedelta_roundtrip_large_value(time_unit) -> None:
     value = np.timedelta64(np.iinfo(np.int64).max, time_unit)
     encoded, units = encode_cf_timedelta(value)
     decoded = decode_cf_timedelta(encoded, units, time_unit=time_unit)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -626,9 +626,8 @@ def test_infer_cftime_datetime_units(calendar, date_args, expected) -> None:
     ],
 )
 def test_cf_timedelta(timedeltas, units, numbers) -> None:
-    # todo: check, if this test is OK
     if timedeltas == "NaT":
-        timedeltas = np.timedelta64("NaT", "s")
+        timedeltas = np.timedelta64("NaT", "ns")
     else:
         timedeltas = to_timedelta_unboxed(timedeltas)
     numbers = np.array(numbers)
@@ -644,7 +643,7 @@ def test_cf_timedelta(timedeltas, units, numbers) -> None:
         assert_array_equal(expected, actual)
         assert expected.dtype == actual.dtype
 
-    expected = np.timedelta64("NaT", "s")
+    expected = np.timedelta64("NaT", "ns")
     actual = decode_cf_timedelta(np.array(np.nan), "days")
     assert_array_equal(expected, actual)
     assert expected.dtype == actual.dtype

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -223,7 +223,9 @@ def test_decode_standard_calendar_inside_timestamp_range(
     time = cftime.date2num(times.to_pydatetime(), units, calendar=calendar)
     expected = times.values
     # for cftime we get "us" resolution
-    # ns resolution is handled by cftime, too (OutOfBounds)
+    # ns resolution is handled by cftime due to the reference date
+    # being out of bounds, but the times themselves are
+    # representable with nanosecond resolution.
     actual = decode_cf_datetime(time, units, calendar=calendar, time_unit=time_unit)
     assert actual.dtype == np.dtype(f"=M8[{time_unit}]")
     abs_diff = abs(actual - expected)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -138,7 +138,7 @@ def test_cf_datetime(
         actual = decode_cf_datetime(num_dates, units, calendar, time_unit=time_unit)
 
     if actual.dtype.kind != "O":
-        expected = cftime_to_nptime(expected)
+        expected = cftime_to_nptime(expected, time_unit=time_unit)
 
     abs_diff = np.asarray(abs(actual - expected)).ravel()
     abs_diff = pd.to_timedelta(abs_diff.tolist()).to_numpy()
@@ -281,7 +281,7 @@ def test_decode_dates_outside_timestamp_range(
         time, units, calendar=calendar, only_use_cftime_datetimes=True
     )
     if calendar == "proleptic_gregorian" and time_unit != "ns":
-        expected = cftime_to_nptime(expected)
+        expected = cftime_to_nptime(expected, time_unit=time_unit)
     expected_date_type = type(expected[0])
 
     with warnings.catch_warnings():
@@ -441,8 +441,8 @@ def test_decode_multidim_time_outside_timestamp_range(
     expected2 = cftime.num2date(time2, units, calendar, only_use_cftime_datetimes=True)
 
     if calendar == "proleptic_gregorian" and time_unit != "ns":
-        expected1 = cftime_to_nptime(expected1)
-        expected2 = cftime_to_nptime(expected2)
+        expected1 = cftime_to_nptime(expected1, time_unit=time_unit)
+        expected2 = cftime_to_nptime(expected2, time_unit=time_unit)
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", "Unable to decode time axis")

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -2344,6 +2344,20 @@ def test_where_attrs() -> None:
             id="datetime",
         ),
         pytest.param(
+            # Force a non-ns unit for the coordinate, make sure we convert to `ns`
+            # for backwards compatibility at the moment. This can be relaxed in the future.
+            xr.DataArray(
+                pd.date_range("1970-01-01", freq="s", periods=3, unit="s"), dims="x"
+            ),
+            xr.DataArray([0, 1], dims="degree", coords={"degree": [0, 1]}),
+            xr.DataArray(
+                [0, 1e9, 2e9],
+                dims="x",
+                coords={"x": pd.date_range("1970-01-01", freq="s", periods=3)},
+            ),
+            id="datetime-non-ns",
+        ),
+        pytest.param(
             xr.DataArray(
                 np.array([1000, 2000, 3000], dtype="timedelta64[ns]"), dims="x"
             ),
@@ -2456,6 +2470,14 @@ def test_polyval_degree_dim_checks() -> None:
         pytest.param(
             xr.DataArray(pd.date_range("1970-01-01", freq="ns", periods=3), dims="x"),
             id="datetime",
+        ),
+        # Force a non-ns unit for the coordinate, make sure we convert to `ns` in both polyfit & polval
+        # for backwards compatibility at the moment. This can be relaxed in the future.
+        pytest.param(
+            xr.DataArray(
+                pd.date_range("1970-01-01", freq="s", unit="s", periods=3), dims="x"
+            ),
+            id="datetime-non-ns",
         ),
         pytest.param(
             xr.DataArray(np.array([0, 1, 2], dtype="timedelta64[ns]"), dims="x"),

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -317,7 +317,6 @@ def test_concat_multiple_datasets_with_multiple_missing_variables() -> None:
     assert_identical(actual, expected)
 
 
-@pytest.mark.filterwarnings("ignore:Converting non-default")
 def test_concat_type_of_missing_fill() -> None:
     datasets = create_typed_datasets(2, seed=123)
     expected1 = concat(datasets, dim="day", fill_value=dtypes.NA)

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -511,13 +511,16 @@ class TestDecodeCF:
 
     @pytest.mark.parametrize("time_unit", ["s", "ms", "us", "ns"])
     def test_decode_cf_time_kwargs(self, time_unit) -> None:
+        # todo: if we set timedelta attrs "units": "days"
+        #  this errors on the last decode_cf wrt to the lazy_elemwise_func
+        #  trying to convert twice
         ds = Dataset.from_dict(
             {
                 "coords": {
                     "timedelta": {
                         "data": np.array([1, 2, 3], dtype="int64"),
                         "dims": "timedelta",
-                        "attrs": {"units": "days"},
+                        "attrs": {"units": "seconds"},
                     },
                     "time": {
                         "data": np.array([1, 2, 3], dtype="int64"),

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -214,7 +214,6 @@ class TestEncodeCFVariable:
         vars, attrs = conventions.encode_dataset_coordinates(ds)
         assert attrs["coordinates"] == "bar baz"
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_emit_coordinates_attribute_in_attrs(self) -> None:
         orig = Dataset(
             {"a": 1, "b": 1},
@@ -232,7 +231,6 @@ class TestEncodeCFVariable:
         assert enc["b"].attrs.get("coordinates") == "t"
         assert "coordinates" not in enc["b"].encoding
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_emit_coordinates_attribute_in_encoding(self) -> None:
         orig = Dataset(
             {"a": 1, "b": 1},

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3661,7 +3661,6 @@ class TestDataArray:
         actual_no_data = da.to_dict(data=False, encoding=encoding)
         assert expected_no_data == actual_no_data
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_to_and_from_dict_with_time_dim(self) -> None:
         x = np.random.randn(10, 3)
         t = pd.date_range("20130101", periods=10)
@@ -3670,7 +3669,6 @@ class TestDataArray:
         roundtripped = DataArray.from_dict(da.to_dict())
         assert_identical(da, roundtripped)
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_to_and_from_dict_with_nan_nat(self) -> None:
         y = np.random.randn(10, 3)
         y[2] = np.nan

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -7208,7 +7208,6 @@ def test_differentiate(dask, edge_order) -> None:
         da.differentiate("x2d")
 
 
-@pytest.mark.filterwarnings("ignore:Converting non-default")
 @pytest.mark.parametrize("dask", [True, False])
 def test_differentiate_datetime(dask) -> None:
     rs = np.random.default_rng(42)
@@ -7403,7 +7402,6 @@ def test_cumulative_integrate(dask) -> None:
         da.cumulative_integrate("x2d")
 
 
-@pytest.mark.filterwarnings("ignore:Converting non-default")
 @pytest.mark.parametrize("dask", [True, False])
 @pytest.mark.parametrize("which_datetime", ["np", "cftime"])
 def test_trapezoid_datetime(dask, which_datetime) -> None:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -500,7 +500,6 @@ class TestDataset:
         actual = Dataset({"x": [5, 6, 7, 8, 9]})
         assert_identical(expected, actual)
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_constructor_0d(self) -> None:
         expected = Dataset({"x": ([], 1)})
         for arg in [1, np.array(1), expected["x"]]:
@@ -6071,7 +6070,6 @@ class TestDataset:
         expected = ds + other.reindex_like(ds)
         assert_identical(expected, actual)
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_dataset_math_errors(self) -> None:
         ds = self.make_example_math_dataset()
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3551,7 +3551,7 @@ class TestDataset:
     def test_expand_dims_non_nanosecond_conversion(self) -> None:
         # Regression test for https://github.com/pydata/xarray/issues/7493#issuecomment-1953091000
         # todo: test still needed?
-        ds = Dataset().expand_dims({"time": [np.datetime64("2018-01-01", "s")]})
+        ds = Dataset().expand_dims({"time": [np.datetime64("2018-01-01", "m")]})
         assert ds.time.dtype == np.dtype("datetime64[s]")
 
     def test_set_index(self) -> None:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -105,7 +105,6 @@ def create_append_test_data(seed=None) -> tuple[Dataset, Dataset, Dataset]:
     lon = [0, 1, 2]
     nt1 = 3
     nt2 = 2
-    # todo: check, if all changes below are correct
     time1 = pd.date_range("2000-01-01", periods=nt1).as_unit("ns")
     time2 = pd.date_range("2000-02-01", periods=nt2).as_unit("ns")
     string_var = np.array(["a", "bc", "def"], dtype=object)

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -636,7 +636,6 @@ def test_groupby_repr_datetime(obj) -> None:
 
 
 @pytest.mark.filterwarnings("ignore:No index created for dimension id:UserWarning")
-@pytest.mark.filterwarnings("ignore:Converting non-default")
 @pytest.mark.filterwarnings("ignore:invalid value encountered in divide:RuntimeWarning")
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize(

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -2198,7 +2198,6 @@ class TestDataArrayResample:
             assert_allclose(expected, actual, rtol=1e-16)
 
     @requires_scipy
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_upsample_interpolate_bug_2197(self) -> None:
         dates = pd.date_range("2007-02-01", "2007-03-01", freq="D", unit="s")
         da = xr.DataArray(np.arange(len(dates)), [("time", dates)])

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -718,7 +718,6 @@ def test_interp_like() -> None:
         pytest.param("2000-01-01T12:00", 0.5, marks=pytest.mark.xfail),
     ],
 )
-@pytest.mark.filterwarnings("ignore:Converting non-default")
 def test_datetime(x_new, expected) -> None:
     da = xr.DataArray(
         np.arange(24),

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2962,7 +2962,6 @@ class TestDatetimePlot(PlotTestCase):
         # mpl.dates.AutoDateLocator passes and no other subclasses:
         assert type(ax.xaxis.get_major_locator()) is mpl.dates.AutoDateLocator
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_datetime_plot2d(self) -> None:
         # Test that matplotlib-native datetime works:
         da = DataArray(

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -216,9 +216,8 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
     def test_index_0d_timedelta64(self):
         td = timedelta(hours=1)
         # todo: discussion needed
-        td64 = np.timedelta64(td, "ns")
-        x = self.cls(["x"], [td64])
-        self._assertIndexedLikeNDArray(x, td64, np.dtype("timedelta64[ns]"))
+        x = self.cls(["x"], [np.timedelta64(td)])
+        self._assertIndexedLikeNDArray(x, np.timedelta64(td), np.dtype("timedelta64[us]"))
 
         x = self.cls(["x"], pd.to_timedelta([td]))
         self._assertIndexedLikeNDArray(x, np.timedelta64(td), "timedelta64[ns]")
@@ -1128,7 +1127,7 @@ class TestVariable(VariableSubclassobjects):
         # todo: check, if this test is OK
         v = Variable([], pd.Timestamp("2000-01-01"))
         assert v.dtype == np.dtype("datetime64[ns]")
-        assert v.values == np.datetime64("2000-01-01", "s")
+        assert v.values == np.datetime64("2000-01-01", "ns")
 
     @pytest.mark.filterwarnings("ignore:Converting non-default")
     @pytest.mark.parametrize(
@@ -2677,7 +2676,7 @@ class TestAsCompatibleData(Generic[T_DuckArray]):
         assert np.dtype("datetime64[ns]") == actual.dtype
         assert expected is source_ndarray(np.asarray(actual))
 
-        expected = np.datetime64("2000-01-01", "us")
+        expected = np.datetime64("2000-01-01", "ns")
         actual = as_compatible_data(datetime(2000, 1, 1))
         assert np.asarray(expected) == actual
         assert np.ndarray is type(actual)
@@ -3016,7 +3015,7 @@ class TestNumpyCoercion:
     ],
     ids=lambda x: f"{x}",
 )
-def test_datetime_conversion_warning(values, unit) -> None:
+def test_datetime_conversion(values, unit) -> None:
     # todo: needs discussion
     # todo: check, if this test is OK
     dims = ["time"] if isinstance(values, np.ndarray | pd.Index | pd.Series) else []
@@ -3087,7 +3086,7 @@ def test_pandas_two_only_datetime_conversion_warnings(
     ],
     ids=lambda x: f"{x}",
 )
-def test_timedelta_conversion_warning(values, unit) -> None:
+def test_timedelta_conversion(values, unit) -> None:
     dims = ["time"] if isinstance(values, np.ndarray | pd.Index) else []
     var = Variable(dims, values)
     assert var.dtype == np.dtype(f"timedelta64[{unit}]")

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1086,8 +1086,8 @@ class TestVariable(VariableSubclassobjects):
         "values, unit",
         [
             (np.datetime64("2000-01-01"), "s"),
-            (pd.Timestamp("2000-01-01T00"), "s"),
-            (datetime(2000, 1, 1), "us"),
+            (pd.Timestamp("2000-01-01T00"), "ns"),
+            (datetime(2000, 1, 1), "ns"),
         ],
     )
     def test_datetime64_conversion_scalar(self, values, unit):
@@ -1102,8 +1102,8 @@ class TestVariable(VariableSubclassobjects):
         "values, unit",
         [
             (np.timedelta64(1, "D"), "s"),
-            (pd.Timedelta("1 day"), "us"),
-            (timedelta(days=1), "us"),
+            (pd.Timedelta("1 day"), "ns"),
+            (timedelta(days=1), "ns"),
         ],
     )
     def test_timedelta64_conversion_scalar(self, values, unit):
@@ -1126,12 +1126,12 @@ class TestVariable(VariableSubclassobjects):
     def test_0d_datetime(self):
         # todo: check, if this test is OK
         v = Variable([], pd.Timestamp("2000-01-01"))
-        assert v.dtype == np.dtype("datetime64[s]")
+        assert v.dtype == np.dtype("datetime64[ns]")
         assert v.values == np.datetime64("2000-01-01", "s")
 
     @pytest.mark.filterwarnings("ignore:Converting non-default")
     @pytest.mark.parametrize(
-        "values, unit", [(pd.to_timedelta("1s"), "us"), (np.timedelta64(1, "s"), "s")]
+        "values, unit", [(pd.to_timedelta("1s"), "ns"), (np.timedelta64(1, "s"), "s")]
     )
     def test_0d_timedelta(self, values, unit):
         # todo: check, if this test is OK
@@ -2679,7 +2679,7 @@ class TestAsCompatibleData(Generic[T_DuckArray]):
         actual = as_compatible_data(datetime(2000, 1, 1))
         assert np.asarray(expected) == actual
         assert np.ndarray is type(actual)
-        assert np.dtype("datetime64[us]") == actual.dtype
+        assert np.dtype("datetime64[ns]") == actual.dtype
 
     def test_tz_datetime(self) -> None:
         # todo: check, if this test is OK
@@ -3002,7 +3002,7 @@ class TestNumpyCoercion:
         (np.array([np.datetime64("2000-01-01", "ns")]), "ns"),
         (np.array([np.datetime64("2000-01-01", "s")]), "s"),
         (pd.date_range("2000", periods=1), "ns"),
-        (datetime(2000, 1, 1), "us"),
+        (datetime(2000, 1, 1), "ns"),
         (np.array([datetime(2000, 1, 1)]), "ns"),
         (pd.date_range("2000", periods=1, tz=pytz.timezone("America/New_York")), "ns"),
         (
@@ -3079,7 +3079,7 @@ def test_pandas_two_only_datetime_conversion_warnings(
         (np.array([np.timedelta64(10, "ns")]), "ns"),
         (np.array([np.timedelta64(10, "s")]), "s"),
         (pd.timedelta_range("1", periods=1), "ns"),
-        (timedelta(days=1), "us"),
+        (timedelta(days=1), "ns"),
         (np.array([timedelta(days=1)]), "ns"),
         (pd.timedelta_range("1", periods=1).astype("timedelta64[s]"), "s"),
     ],

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -200,7 +200,6 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
         x = self.cls(["x"], [value])
         self._assertIndexedLikeNDArray(x, value, dtype)
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_index_0d_datetime(self):
         d = datetime(2000, 1, 1)
         x = self.cls(["x"], [d])
@@ -212,7 +211,6 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
         x = self.cls(["x"], pd.DatetimeIndex([d]))
         self._assertIndexedLikeNDArray(x, np.datetime64(d), "datetime64[ns]")
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_index_0d_timedelta64(self):
         td = timedelta(hours=1)
         # todo: discussion needed
@@ -255,7 +253,6 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
         assert_array_equal(x[0].data, listarray.squeeze())
         assert_array_equal(x.squeeze().data, listarray.squeeze())
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_index_and_concat_datetime(self):
         # regression test for #125
         date_range = pd.date_range("2011-09-01", periods=10)
@@ -278,7 +275,6 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
 
     dt64_data = pd.date_range("2000-01-01", periods=3)
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     @pytest.mark.parametrize(
         "values, unit",
         [
@@ -297,7 +293,6 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
 
     td64_data = pd.timedelta_range(start=0, periods=3)
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     @pytest.mark.parametrize(
         "values, unit",
         [
@@ -319,13 +314,11 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
         actual = self.cls("x", data)
         assert actual.dtype == data.dtype
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_datetime64_valid_range(self):
         # todo: test still needed?
         data = np.datetime64("1250-01-01", "us")
         self.cls(["t"], [data])
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_timedelta64_valid_range(self):
         # todo: test still needed?
         data = np.timedelta64("200000", "D")
@@ -1082,7 +1075,6 @@ class TestVariable(VariableSubclassobjects):
         v = IndexVariable("x", np.arange(5))
         assert 2 == v.searchsorted(2)
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     @pytest.mark.parametrize(
         "values, unit",
         [
@@ -1098,7 +1090,6 @@ class TestVariable(VariableSubclassobjects):
         assert np.issubdtype(v.values, "datetime64")
         assert v.values.dtype == np.dtype(f"datetime64[{unit}]")
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     @pytest.mark.parametrize(
         "values, unit",
         [
@@ -1131,7 +1122,6 @@ class TestVariable(VariableSubclassobjects):
         assert v.dtype == np.dtype("datetime64[ns]")
         assert v.values == np.datetime64("2000-01-01", "ns")
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     @pytest.mark.parametrize(
         "values, unit", [(pd.to_timedelta("1s"), "ns"), (np.timedelta64(1, "s"), "s")]
     )
@@ -1579,7 +1569,6 @@ class TestVariable(VariableSubclassobjects):
             v.transpose(..., "not_a_dim", missing_dims="warn")
             assert_identical(expected_ell, actual)
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_transpose_0d(self):
         for value in [
             3.5,
@@ -2656,7 +2645,6 @@ class TestAsCompatibleData(Generic[T_DuckArray]):
         assert_array_equal(expected, actual)
         assert actual.dtype == expected.dtype
 
-    @pytest.mark.filterwarnings("ignore:Converting non-default")
     def test_datetime(self):
         # todo: check, if this test is OK
         expected = np.datetime64("2000-01-01")

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -217,7 +217,9 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
         td = timedelta(hours=1)
         # todo: discussion needed
         x = self.cls(["x"], [np.timedelta64(td)])
-        self._assertIndexedLikeNDArray(x, np.timedelta64(td), np.dtype("timedelta64[us]"))
+        self._assertIndexedLikeNDArray(
+            x, np.timedelta64(td), np.dtype("timedelta64[us]")
+        )
 
         x = self.cls(["x"], pd.to_timedelta([td]))
         self._assertIndexedLikeNDArray(x, np.timedelta64(td), "timedelta64[ns]")

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -3063,6 +3063,7 @@ def test_pandas_two_only_datetime_conversion_warnings(
     ids=lambda x: f"{x}",
 )
 def test_timedelta_conversion(values, unit) -> None:
+    # todo: check for redundancy
     dims = ["time"] if isinstance(values, np.ndarray | pd.Index) else []
     var = Variable(dims, values)
     assert var.dtype == np.dtype(f"timedelta64[{unit}]")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #7493
- [x] Closes #2587
- [x] Tests added/changed
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in api.rst

This is another attempt to resolve #7493. This goes a step further than #9580.

The idea of this PR is to automatically infer the needed resolutions for decoding/~encoding~ and only keep the constraints pandas imposes ("s" - lowest resolution, "ns" - highest resolution). There is still the idea of a `default resolution`, but this should only take precedence if it doesn't clash with the automatic inference. This can be discussed, though. Update: I've implemented `time-unit`-kwarg ~a first try to have default resolution~ on decode, which will override the current inferred resolution only to higher resolution (eg. `'s'` -> `'ns'`). To work towards #4490 the time decoding options (`decode_time` and `use_cftime` are bundled within `CFDatetimeCoder` which is distributed via `decode_times` kwarg. `use_cftime`-kwarg is deprecated.

For sanity checking, and also for my own good, I've created [a documentation page on time-coding in the internal dev section](https://xray--9618.org.readthedocs.build/en/9618/internals/time-coding.html). Any suggestions (especially grammar) or ideas for enhancements are much appreciated.

There still might be room for consolidation of functions/methods (mostly in coding/times.py), but I have to leave it alone for some days. I went down that rabbit hole and need to relax, too :grimacing:.

Looking forward to get your insights here, @spencerkclark, @ChrisBarker-NOAA, @pydata/xarray.

Todo:

- [x] floating point handling
- [x] update decoding tests to iterate over `time_units` (where appropriate)
- [x] `CFDatetimeCoder` as input for `decode_times` kwarg
- [ ] ... 

  