### PR TITLE
pin mypy to 1.11.2

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -122,7 +122,7 @@ jobs:
           python xarray/util/print_versions.py
       - name: Install mypy
         run: |
-          python -m pip install "mypy" --force-reinstall
+          python -m pip install "mypy==1.11.2" --force-reinstall
 
       - name: Run mypy
         run: |
@@ -176,7 +176,7 @@ jobs:
           python xarray/util/print_versions.py
       - name: Install mypy
         run: |
-          python -m pip install "mypy" --force-reinstall
+          python -m pip install "mypy==1.11.2" --force-reinstall
 
       - name: Run mypy
         run: |


### PR DESCRIPTION

Mypy 1.12 broke our typing tests today. Pinning to 1.11.2 until we've figured out a fix.