### PR TITLE
DOC: Clarify error message in open_dataarray

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -810,11 +810,15 @@ def open_dataarray(
     )
 
     if len(dataset.data_vars) != 1:
-        raise ValueError(
-            "Given file dataset contains more than one data "
-            "variable. Please read with xarray.open_dataset and "
-            "then select the variable you want."
-        )
+        if len(dataset.data_vars) == 0:
+            msg = "Given file dataset contains no data variables."
+        else:
+            msg = (
+                "Given file dataset contains more than one data "
+                "variable. Please read with xarray.open_dataset and "
+                "then select the variable you want."
+            )
+        raise ValueError(msg)
     else:
         (data_array,) = dataset.data_vars.values()
 


### PR DESCRIPTION
If the file is empty (or contains no variables matching any filtering done by the backend), use a different error message indicating that, rather than suggesting that the file has too many variables for this function.

I feel like the new message could be longer, but there's not really a way to fix "no data" in python, unless the writing process decided to add everything to the global `coordinates` attribute or something.
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
