### PR TITLE
Support alternative names for the root node in DataTree.from_dict

### DIFF
--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1135,6 +1135,7 @@ class DataTree(
         # Create the root node
         if isinstance(root_data, DataTree):
             obj = root_data.copy()
+            obj.name = name
         elif root_data is None or isinstance(root_data, Dataset):
             obj = cls(name=name, dataset=root_data, children=None)
         else:

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -890,6 +890,7 @@ class TestTreeFromDict:
             "/",
             "/foo",
             "/bar",
+            "/x",
             "/x/y",
         ]
 
@@ -913,6 +914,16 @@ class TestTreeFromDict:
             ValueError, match="multiple entries found corresponding to the root node"
         ):
             DataTree.from_dict({"": ds, "/": ds})
+
+    def test_name(self):
+        tree = DataTree.from_dict({"/": None}, name="foo")
+        assert tree.name == "foo"
+
+        tree = DataTree.from_dict({"/": DataTree()}, name="foo")
+        assert tree.name == "foo"
+
+        tree = DataTree.from_dict({"/": DataTree(name="bar")}, name="foo")
+        assert tree.name == "foo"
 
 
 class TestDatasetView:

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -883,6 +883,37 @@ class TestTreeFromDict:
         with pytest.raises(TypeError):
             DataTree.from_dict(data)  # type: ignore[arg-type]
 
+    def test_relative_paths(self) -> None:
+        tree = DataTree.from_dict({".": None, "foo": None, "./bar": None, "x/y": None})
+        paths = [node.path for node in tree.subtree]
+        assert paths == [
+            "/",
+            "/foo",
+            "/bar",
+            "/x/y",
+        ]
+
+    def test_root_keys(self):
+        ds = Dataset({"x": 1})
+        expected = DataTree(dataset=ds)
+
+        actual = DataTree.from_dict({"": ds})
+        assert_identical(actual, expected)
+
+        actual = DataTree.from_dict({".": ds})
+        assert_identical(actual, expected)
+
+        actual = DataTree.from_dict({"/": ds})
+        assert_identical(actual, expected)
+
+        actual = DataTree.from_dict({"./": ds})
+        assert_identical(actual, expected)
+
+        with pytest.raises(
+            ValueError, match="multiple entries found corresponding to the root node"
+        ):
+            DataTree.from_dict({"": ds, "/": ds})
+
 
 class TestDatasetView:
     def test_view_contents(self) -> None:


### PR DESCRIPTION
`DataTree.from_dict` now supports indicating the root node with "", ".", "/" or "./".

This makes the handling of the root node a bit more consistent with handling of other nested paths. For example, we can use relative paths, which allows for removing special cases for the root from some internal uses of from_dict.

I've also fixed a bug where the `name` argument was sometimes ignored.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests added
