### PR TITLE
support `chunks` in `open_groups` and `open_datatree`

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -456,7 +456,8 @@ def _datatree_from_backend_datatree(
                     **extra_tokens,
                 )
                 for path, [node] in group_subtrees(backend_tree)
-            }
+            },
+            name=backend_tree.name,
         )
 
         for path, [node] in group_subtrees(backend_tree):

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -260,6 +260,7 @@ def _protect_dataset_variables_inplace(dataset: Dataset, cache: bool) -> None:
     for name, variable in dataset.variables.items():
         if name not in dataset._indexes:
             # no need to protect IndexVariable objects
+            data: indexing.ExplicitlyIndexedNDarrayMixin
             data = indexing.CopyOnWriteArray(variable._data)
             if cache:
                 data = indexing.MemoryCachedArray(data)

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -926,13 +926,142 @@ def open_datatree(
     ----------
     filename_or_obj : str, Path, file-like, or DataStore
         Strings and Path objects are interpreted as a path to a netCDF file or Zarr store.
-    engine : str, optional
-        Xarray backend engine to use. Valid options include `{"netcdf4", "h5netcdf", "zarr"}`.
-    **kwargs : dict
-        Additional keyword arguments passed to :py:func:`~xarray.open_dataset` for each group.
+    engine : {"netcdf4", "h5netcdf", "zarr", None}, \
+             installed backend or xarray.backends.BackendEntrypoint, optional
+        Engine to use when reading files. If not provided, the default engine
+        is chosen based on available dependencies, with a preference for
+        "netcdf4". A custom backend class (a subclass of ``BackendEntrypoint``)
+        can also be used.
+    chunks : int, dict, 'auto' or None, default: None
+        If provided, used to load the data into dask arrays.
+
+        - ``chunks="auto"`` will use dask ``auto`` chunking taking into account the
+          engine preferred chunks.
+        - ``chunks=None`` skips using dask, which is generally faster for
+          small arrays.
+        - ``chunks=-1`` loads the data with dask using a single chunk for all arrays.
+        - ``chunks={}`` loads the data with dask using the engine's preferred chunk
+          size, generally identical to the format's chunk size. If not available, a
+          single chunk for all arrays.
+
+        See dask chunking for more details.
+    cache : bool, optional
+        If True, cache data loaded from the underlying datastore in memory as
+        NumPy arrays when accessed to avoid reading from the underlying data-
+        store multiple times. Defaults to True unless you specify the `chunks`
+        argument to use dask, in which case it defaults to False. Does not
+        change the behavior of coordinates corresponding to dimensions, which
+        always load their data from disk into a ``pandas.Index``.
+    decode_cf : bool, optional
+        Whether to decode these variables, assuming they were saved according
+        to CF conventions.
+    mask_and_scale : bool or dict-like, optional
+        If True, replace array values equal to `_FillValue` with NA and scale
+        values according to the formula `original_values * scale_factor +
+        add_offset`, where `_FillValue`, `scale_factor` and `add_offset` are
+        taken from variable attributes (if they exist).  If the `_FillValue` or
+        `missing_value` attribute contains multiple values a warning will be
+        issued and all array values matching one of the multiple values will
+        be replaced by NA. Pass a mapping, e.g. ``{"my_variable": False}``,
+        to toggle this feature per-variable individually.
+        This keyword may not be supported by all the backends.
+    decode_times : bool or dict-like, optional
+        If True, decode times encoded in the standard NetCDF datetime format
+        into datetime objects. Otherwise, leave them encoded as numbers.
+        Pass a mapping, e.g. ``{"my_variable": False}``,
+        to toggle this feature per-variable individually.
+        This keyword may not be supported by all the backends.
+    decode_timedelta : bool or dict-like, optional
+        If True, decode variables and coordinates with time units in
+        {"days", "hours", "minutes", "seconds", "milliseconds", "microseconds"}
+        into timedelta objects. If False, leave them encoded as numbers.
+        If None (default), assume the same value of decode_time.
+        Pass a mapping, e.g. ``{"my_variable": False}``,
+        to toggle this feature per-variable individually.
+        This keyword may not be supported by all the backends.
+    use_cftime: bool or dict-like, optional
+        Only relevant if encoded dates come from a standard calendar
+        (e.g. "gregorian", "proleptic_gregorian", "standard", or not
+        specified).  If None (default), attempt to decode times to
+        ``np.datetime64[ns]`` objects; if this is not possible, decode times to
+        ``cftime.datetime`` objects. If True, always decode times to
+        ``cftime.datetime`` objects, regardless of whether or not they can be
+        represented using ``np.datetime64[ns]`` objects.  If False, always
+        decode times to ``np.datetime64[ns]`` objects; if this is not possible
+        raise an error. Pass a mapping, e.g. ``{"my_variable": False}``,
+        to toggle this feature per-variable individually.
+        This keyword may not be supported by all the backends.
+    concat_characters : bool or dict-like, optional
+        If True, concatenate along the last dimension of character arrays to
+        form string arrays. Dimensions will only be concatenated over (and
+        removed) if they have no corresponding variable and if they are only
+        used as the last dimension of character arrays.
+        Pass a mapping, e.g. ``{"my_variable": False}``,
+        to toggle this feature per-variable individually.
+        This keyword may not be supported by all the backends.
+    decode_coords : bool or {"coordinates", "all"}, optional
+        Controls which variables are set as coordinate variables:
+
+        - "coordinates" or True: Set variables referred to in the
+          ``'coordinates'`` attribute of the datasets or individual variables
+          as coordinate variables.
+        - "all": Set variables referred to in  ``'grid_mapping'``, ``'bounds'`` and
+          other attributes as coordinate variables.
+
+        Only existing variables can be set as coordinates. Missing variables
+        will be silently ignored.
+    drop_variables: str or iterable of str, optional
+        A variable or list of variables to exclude from being parsed from the
+        dataset. This may be useful to drop variables with problems or
+        inconsistent values.
+    inline_array: bool, default: False
+        How to include the array in the dask task graph.
+        By default(``inline_array=False``) the array is included in a task by
+        itself, and each chunk refers to that task by its key. With
+        ``inline_array=True``, Dask will instead inline the array directly
+        in the values of the task graph. See :py:func:`dask.array.from_array`.
+    chunked_array_type: str, optional
+        Which chunked array type to coerce this datasets' arrays to.
+        Defaults to 'dask' if installed, else whatever is registered via the `ChunkManagerEnetryPoint` system.
+        Experimental API that should not be relied upon.
+    from_array_kwargs: dict
+        Additional keyword arguments passed on to the `ChunkManagerEntrypoint.from_array` method used to create
+        chunked arrays, via whichever chunk manager is specified through the `chunked_array_type` kwarg.
+        For example if :py:func:`dask.array.Array` objects are used for chunking, additional kwargs will be passed
+        to :py:func:`dask.array.from_array`. Experimental API that should not be relied upon.
+    backend_kwargs: dict
+        Additional keyword arguments passed on to the engine open function,
+        equivalent to `**kwargs`.
+    **kwargs: dict
+        Additional keyword arguments passed on to the engine open function.
+        For example:
+
+        - 'group': path to the group in the given file to open as the root group as
+          a str.
+        - 'lock': resource lock to use when reading data from disk. Only
+          relevant when using dask or another form of parallelism. By default,
+          appropriate locks are chosen to safely read and write files with the
+          currently active dask scheduler. Supported by "netcdf4", "h5netcdf",
+          "scipy".
+
+        See engine open function for kwargs accepted by each specific engine.
+
     Returns
     -------
-    xarray.DataTree
+    tree : DataTree
+        The newly created datatree.
+
+    Notes
+    -----
+    ``open_datatree`` opens the file with read-only access. When you modify
+    values of a DataTree, even one linked to files on disk, only the in-memory
+    copy you are manipulating in xarray is modified: the original file on disk
+    is never touched.
+
+    See Also
+    --------
+    xarray.open_groups
+    xarray.open_dataset
     """
     if cache is None:
         cache = chunks is None

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -265,6 +265,17 @@ def _protect_dataset_variables_inplace(dataset, cache):
             variable.data = data
 
 
+def _protect_datatree_variables_inplace(tree, cache):
+    for node in tree.subtree:
+        for name, variable in node.variables.items():
+            if name not in node._indexes:
+                # no need to protect IndexVariable objects
+                data = indexing.CopyOnWriteArray(variable._data)
+                if cache:
+                    data = indexing.MemoryCachedArray(data)
+                variable.data = data
+
+
 def _finalize_store(write, store):
     """Finalize this store by explicitly syncing and closing"""
     del write  # ensure writing is done first
@@ -432,7 +443,7 @@ def _datatree_from_backend_datatree(
             f"chunks must be an int, dict, 'auto', or None. Instead found {chunks}."
         )
 
-    # _protect_datatree_variables_inplace(backend_tree, cache)
+    _protect_datatree_variables_inplace(backend_tree, cache)
     if chunks is None:
         tree = backend_tree
     else:

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -268,13 +268,7 @@ def _protect_dataset_variables_inplace(dataset, cache):
 
 def _protect_datatree_variables_inplace(tree, cache):
     for node in tree.subtree:
-        for name, variable in node.variables.items():
-            if name not in node._indexes:
-                # no need to protect IndexVariable objects
-                data = indexing.CopyOnWriteArray(variable._data)
-                if cache:
-                    data = indexing.MemoryCachedArray(data)
-                variable.data = data
+        _protect_dataset_variables_inplace(node, cache)
 
 
 def _finalize_store(write, store):

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -266,7 +266,7 @@ def _protect_dataset_variables_inplace(dataset, cache):
             variable.data = data
 
 
-def _protect_datatree_variables_inplace(tree, cache):
+def _protect_datatree_variables_inplace(tree: DataTree, cache: bool) -> None:
     for node in tree.subtree:
         _protect_dataset_variables_inplace(node, cache)
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -464,7 +464,8 @@ def _datatree_from_backend_datatree(
             }
         )
 
-    # ds.set_close(backend_ds._close)
+        for path, [node] in group_subtrees(backend_tree):
+            tree[path].set_close(node._close)
 
     # Ensure source filename always stored in dataset object
     if "source" not in tree.encoding:

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -256,7 +256,7 @@ def _get_mtime(filename_or_obj):
     return mtime
 
 
-def _protect_dataset_variables_inplace(dataset, cache):
+def _protect_dataset_variables_inplace(dataset: Dataset, cache: bool) -> None:
     for name, variable in dataset.variables.items():
         if name not in dataset._indexes:
             # no need to protect IndexVariable objects

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1136,6 +1136,7 @@ def open_groups(
 ) -> dict[str, Dataset]:
     """
     Open and decode a file or file-like object, creating a dictionary containing one xarray Dataset for each group in the file.
+
     Useful for an HDF file ("netcdf4" or "h5netcdf") containing many groups that are not alignable with their parents
     and cannot be opened directly with ``open_datatree``. It is encouraged to use this function to inspect your data,
     then make the necessary changes to make the structure coercible to a `DataTree` object before calling `DataTree.from_dict()` and proceeding with your analysis.
@@ -1144,19 +1145,147 @@ def open_groups(
     ----------
     filename_or_obj : str, Path, file-like, or DataStore
         Strings and Path objects are interpreted as a path to a netCDF file.
-    engine : str, optional
-        Xarray backend engine to use. Valid options include `{"netcdf4", "h5netcdf"}`.
-    **kwargs : dict
-        Additional keyword arguments passed to :py:func:`~xarray.open_dataset` for each group.
+    Parameters
+    ----------
+    filename_or_obj : str, Path, file-like, or DataStore
+        Strings and Path objects are interpreted as a path to a netCDF file or Zarr store.
+    engine : {"netcdf4", "h5netcdf", "zarr", None}, \
+             installed backend or xarray.backends.BackendEntrypoint, optional
+        Engine to use when reading files. If not provided, the default engine
+        is chosen based on available dependencies, with a preference for
+        "netcdf4". A custom backend class (a subclass of ``BackendEntrypoint``)
+        can also be used.
+    chunks : int, dict, 'auto' or None, default: None
+        If provided, used to load the data into dask arrays.
+
+        - ``chunks="auto"`` will use dask ``auto`` chunking taking into account the
+          engine preferred chunks.
+        - ``chunks=None`` skips using dask, which is generally faster for
+          small arrays.
+        - ``chunks=-1`` loads the data with dask using a single chunk for all arrays.
+        - ``chunks={}`` loads the data with dask using the engine's preferred chunk
+          size, generally identical to the format's chunk size. If not available, a
+          single chunk for all arrays.
+
+        See dask chunking for more details.
+    cache : bool, optional
+        If True, cache data loaded from the underlying datastore in memory as
+        NumPy arrays when accessed to avoid reading from the underlying data-
+        store multiple times. Defaults to True unless you specify the `chunks`
+        argument to use dask, in which case it defaults to False. Does not
+        change the behavior of coordinates corresponding to dimensions, which
+        always load their data from disk into a ``pandas.Index``.
+    decode_cf : bool, optional
+        Whether to decode these variables, assuming they were saved according
+        to CF conventions.
+    mask_and_scale : bool or dict-like, optional
+        If True, replace array values equal to `_FillValue` with NA and scale
+        values according to the formula `original_values * scale_factor +
+        add_offset`, where `_FillValue`, `scale_factor` and `add_offset` are
+        taken from variable attributes (if they exist).  If the `_FillValue` or
+        `missing_value` attribute contains multiple values a warning will be
+        issued and all array values matching one of the multiple values will
+        be replaced by NA. Pass a mapping, e.g. ``{"my_variable": False}``,
+        to toggle this feature per-variable individually.
+        This keyword may not be supported by all the backends.
+    decode_times : bool or dict-like, optional
+        If True, decode times encoded in the standard NetCDF datetime format
+        into datetime objects. Otherwise, leave them encoded as numbers.
+        Pass a mapping, e.g. ``{"my_variable": False}``,
+        to toggle this feature per-variable individually.
+        This keyword may not be supported by all the backends.
+    decode_timedelta : bool or dict-like, optional
+        If True, decode variables and coordinates with time units in
+        {"days", "hours", "minutes", "seconds", "milliseconds", "microseconds"}
+        into timedelta objects. If False, leave them encoded as numbers.
+        If None (default), assume the same value of decode_time.
+        Pass a mapping, e.g. ``{"my_variable": False}``,
+        to toggle this feature per-variable individually.
+        This keyword may not be supported by all the backends.
+    use_cftime: bool or dict-like, optional
+        Only relevant if encoded dates come from a standard calendar
+        (e.g. "gregorian", "proleptic_gregorian", "standard", or not
+        specified).  If None (default), attempt to decode times to
+        ``np.datetime64[ns]`` objects; if this is not possible, decode times to
+        ``cftime.datetime`` objects. If True, always decode times to
+        ``cftime.datetime`` objects, regardless of whether or not they can be
+        represented using ``np.datetime64[ns]`` objects.  If False, always
+        decode times to ``np.datetime64[ns]`` objects; if this is not possible
+        raise an error. Pass a mapping, e.g. ``{"my_variable": False}``,
+        to toggle this feature per-variable individually.
+        This keyword may not be supported by all the backends.
+    concat_characters : bool or dict-like, optional
+        If True, concatenate along the last dimension of character arrays to
+        form string arrays. Dimensions will only be concatenated over (and
+        removed) if they have no corresponding variable and if they are only
+        used as the last dimension of character arrays.
+        Pass a mapping, e.g. ``{"my_variable": False}``,
+        to toggle this feature per-variable individually.
+        This keyword may not be supported by all the backends.
+    decode_coords : bool or {"coordinates", "all"}, optional
+        Controls which variables are set as coordinate variables:
+
+        - "coordinates" or True: Set variables referred to in the
+          ``'coordinates'`` attribute of the datasets or individual variables
+          as coordinate variables.
+        - "all": Set variables referred to in  ``'grid_mapping'``, ``'bounds'`` and
+          other attributes as coordinate variables.
+
+        Only existing variables can be set as coordinates. Missing variables
+        will be silently ignored.
+    drop_variables: str or iterable of str, optional
+        A variable or list of variables to exclude from being parsed from the
+        dataset. This may be useful to drop variables with problems or
+        inconsistent values.
+    inline_array: bool, default: False
+        How to include the array in the dask task graph.
+        By default(``inline_array=False``) the array is included in a task by
+        itself, and each chunk refers to that task by its key. With
+        ``inline_array=True``, Dask will instead inline the array directly
+        in the values of the task graph. See :py:func:`dask.array.from_array`.
+    chunked_array_type: str, optional
+        Which chunked array type to coerce this datasets' arrays to.
+        Defaults to 'dask' if installed, else whatever is registered via the `ChunkManagerEnetryPoint` system.
+        Experimental API that should not be relied upon.
+    from_array_kwargs: dict
+        Additional keyword arguments passed on to the `ChunkManagerEntrypoint.from_array` method used to create
+        chunked arrays, via whichever chunk manager is specified through the `chunked_array_type` kwarg.
+        For example if :py:func:`dask.array.Array` objects are used for chunking, additional kwargs will be passed
+        to :py:func:`dask.array.from_array`. Experimental API that should not be relied upon.
+    backend_kwargs: dict
+        Additional keyword arguments passed on to the engine open function,
+        equivalent to `**kwargs`.
+    **kwargs: dict
+        Additional keyword arguments passed on to the engine open function.
+        For example:
+
+        - 'group': path to the group in the given file to open as the root group as
+          a str.
+        - 'lock': resource lock to use when reading data from disk. Only
+          relevant when using dask or another form of parallelism. By default,
+          appropriate locks are chosen to safely read and write files with the
+          currently active dask scheduler. Supported by "netcdf4", "h5netcdf",
+          "scipy".
+
+        See engine open function for kwargs accepted by each specific engine.
 
     Returns
     -------
-    dict[str, xarray.Dataset]
+    groups : dict of str to xarray.Dataset
+        The groups as Dataset objects
+
+    Notes
+    -----
+    ``open_groups`` opens the file with read-only access. When you modify
+    values of a Dataset, even one linked to files on disk, only the in-memory
+    copy you are manipulating in xarray is modified: the original file on disk
+    is never touched.
 
     See Also
     --------
-    open_datatree()
-    DataTree.from_dict()
+    xarray.open_datatree
+    xarray.open_dataset
+    xarray.DataTree.from_dict
     """
     if cache is None:
         cache = chunks is None

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -260,7 +260,7 @@ def _protect_dataset_variables_inplace(dataset: Dataset, cache: bool) -> None:
     for name, variable in dataset.variables.items():
         if name not in dataset._indexes:
             # no need to protect IndexVariable objects
-            data: indexing.ExplicitlyIndexedNDarrayMixin
+            data: indexing.ExplicitlyIndexedNDArrayMixin
             data = indexing.CopyOnWriteArray(variable._data)
             if cache:
                 data = indexing.MemoryCachedArray(data)

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -28,7 +28,7 @@ except ImportError:
 have_zarr_v3 = xr.backends.zarr._zarr_v3()
 
 
-def diff_chunks(comparison, tree1, tree2):
+def diff_chunks(comparison: dict[tuple[str, str], bool]], tree1: DataTree, tree2: DataTree) -> str:
     mismatching_variables = [loc for loc, equals in comparison.items() if not equals]
 
     variable_messages = [
@@ -43,7 +43,7 @@ def diff_chunks(comparison, tree1, tree2):
     return "\n".join(["Differing chunk sizes:"] + variable_messages)
 
 
-def assert_chunks_equal(actual, expected, enforce_dask=False):
+def assert_chunks_equal(actual: DataTree, expected: DataTree, enforce_dask: bool = False) -> None:
     __tracebackhide__ = True
 
     from xarray.namedarray.pycompat import array_type

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Hashable
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
@@ -29,7 +30,7 @@ have_zarr_v3 = xr.backends.zarr._zarr_v3()
 
 
 def diff_chunks(
-    comparison: dict[tuple[str, str], bool], tree1: DataTree, tree2: DataTree
+    comparison: dict[tuple[str, Hashable], bool], tree1: DataTree, tree2: DataTree
 ) -> str:
     mismatching_variables = [loc for loc, equals in comparison.items() if not equals]
 

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -28,7 +28,9 @@ except ImportError:
 have_zarr_v3 = xr.backends.zarr._zarr_v3()
 
 
-def diff_chunks(comparison: dict[tuple[str, str], bool]], tree1: DataTree, tree2: DataTree) -> str:
+def diff_chunks(
+    comparison: dict[tuple[str, str], bool], tree1: DataTree, tree2: DataTree
+) -> str:
     mismatching_variables = [loc for loc, equals in comparison.items() if not equals]
 
     variable_messages = [
@@ -43,7 +45,9 @@ def diff_chunks(comparison: dict[tuple[str, str], bool]], tree1: DataTree, tree2
     return "\n".join(["Differing chunk sizes:"] + variable_messages)
 
 
-def assert_chunks_equal(actual: DataTree, expected: DataTree, enforce_dask: bool = False) -> None:
+def assert_chunks_equal(
+    actual: DataTree, expected: DataTree, enforce_dask: bool = False
+) -> None:
     __tracebackhide__ = True
 
     from xarray.namedarray.pycompat import array_type

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -252,6 +252,7 @@ class TestNetCDF4DatatreeIO(DatatreeIOBase):
         for ds in unaligned_dict_of_datasets.values():
             ds.close()
 
+    @requires_dask
     def test_open_groups_chunks(self, tmpdir) -> None:
         """Test `open_groups` with chunks on a netcdf4 file."""
 

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -212,20 +212,23 @@ class TestNetCDF4DatatreeIO(DatatreeIOBase):
     def test_open_datatree_chunks(self, tmpdir, simple_datatree) -> None:
         filepath = tmpdir / "test.nc"
 
+        chunks = {"x": 2, "y": 1}
+
         root_data = xr.Dataset({"a": ("y", [6, 7, 8]), "set0": ("x", [9, 10])})
         set1_data = xr.Dataset({"a": ("y", [-1, 0, 1]), "b": ("x", [-10, 6])})
         set2_data = xr.Dataset({"a": ("y", [1, 2, 3]), "b": ("x", [0.1, 0.2])})
         original_tree = DataTree.from_dict(
             {
-                "/": root_data.chunk({"x": 2, "y": 1}),
-                "/group1": set1_data.chunk({"x": 1, "y": 2}),
-                "/group2": set2_data.chunk({"x": 2, "y": 3}),
+                "/": root_data.chunk(chunks),
+                "/group1": set1_data.chunk(chunks),
+                "/group2": set2_data.chunk(chunks),
             }
         )
         original_tree.to_netcdf(filepath, engine="netcdf4")
 
-        with open_datatree(filepath, engine="netcdf4", chunks={}) as tree:
+        with open_datatree(filepath, engine="netcdf4", chunks=chunks) as tree:
             xr.testing.assert_identical(tree, original_tree)
+
             assert_chunks_equal(tree, original_tree, enforce_dask=True)
 
     def test_open_groups(self, unaligned_datatree_nc) -> None:
@@ -410,19 +413,21 @@ class TestZarrDatatreeIO:
     def test_open_datatree_chunks(self, tmpdir, simple_datatree) -> None:
         filepath = tmpdir / "test.zarr"
 
+        chunks = {"x": 2, "y": 1}
+
         root_data = xr.Dataset({"a": ("y", [6, 7, 8]), "set0": ("x", [9, 10])})
         set1_data = xr.Dataset({"a": ("y", [-1, 0, 1]), "b": ("x", [-10, 6])})
         set2_data = xr.Dataset({"a": ("y", [1, 2, 3]), "b": ("x", [0.1, 0.2])})
         original_tree = DataTree.from_dict(
             {
-                "/": root_data.chunk({"x": 2, "y": 1}),
-                "/group1": set1_data.chunk({"x": 1, "y": 2}),
-                "/group2": set2_data.chunk({"x": 2, "y": 3}),
+                "/": root_data.chunk(chunks),
+                "/group1": set1_data.chunk(chunks),
+                "/group2": set2_data.chunk(chunks),
             }
         )
         original_tree.to_zarr(filepath)
 
-        with open_datatree(filepath, engine="zarr", chunks={}) as tree:
+        with open_datatree(filepath, engine="zarr", chunks=chunks) as tree:
             xr.testing.assert_identical(original_tree, tree)
             assert_chunks_equal(tree, original_tree, enforce_dask=True)
 

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -497,6 +497,7 @@ class TestZarrDatatreeIO:
         for ds in unaligned_dict_of_datasets.values():
             ds.close()
 
+    @requires_dask
     def test_open_groups_chunks(self, tmpdir) -> None:
         """Test `open_groups` with chunks on a zarr store."""
 

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -468,7 +468,7 @@ class TestZarrDatatreeIO:
         original_tree.to_zarr(filepath)
 
         with open_datatree(filepath, engine="zarr", chunks=chunks) as tree:
-            xr.testing.assert_identical(original_tree, tree)
+            xr.testing.assert_identical(tree, original_tree)
             assert_chunks_equal(tree, original_tree, enforce_dask=True)
 
     def test_open_groups(self, unaligned_datatree_zarr) -> None:


### PR DESCRIPTION
In trying to support `chunks` the way we do for `open_dataset` I had to add a lot of parameters to the top-level `open_datatree` and `open_groups` functions.

I'm also still looking for the equivalent of `_protect_dataset_variables_inplace`, and finally `_dataset_from_backend_dataset` has been the place to call `set_close`, while #9651 pushed this to the backends for datatree.

No tests yet, and I also want to improve the docstrings before merging.

(the chunked array methods – `chunk`, `load`, `compute`, and `persist` – should be a separate PR)

- [x] complete docstrings
- [x] Tests added

cc @TomNicholas, @shoyer