### PR TITLE
Update to_dataframe doc to match current behavior

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -7371,7 +7371,7 @@ class Dataset(
             dataframe.
 
             If provided, must include all dimensions of this dataset. By
-            default, dimensions are sorted alphabetically.
+            default, dimensions are in the same order as in `Dataset.sizes`.
 
         Returns
         -------


### PR DESCRIPTION
Closes #9653.

This behavior was introduced in #4333 but was then changed in #4753. See discussion in #9653 for more details.