### PR TITLE
adding draft for fixing behaviour for group parameter

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -580,7 +580,7 @@ class ZarrStore(AbstractWritableDataStore):
             use_zarr_fill_value_as_mask=use_zarr_fill_value_as_mask,
             zarr_format=zarr_format,
         )
-        group_paths = [node for node in _iter_zarr_groups(zarr_group, parent=group)]
+        group_paths = list(set([node for node in _iter_zarr_groups(zarr_group, parent=group)]))
         return {
             group: cls(
                 zarr_group.get(group),
@@ -1531,8 +1531,12 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
                     decode_timedelta=decode_timedelta,
                 )
             group_name = str(NodePath(path_group))
-            groups_dict[group_name] = group_ds
-
+            # groups_dict[group_name] = group_ds
+            if group:
+                group_name = str(NodePath(NodePath(group).stem) / NodePath(group_name).stem)
+                groups_dict[group_name] = group_ds
+            else:
+                groups_dict[group_name] = group_ds
         return groups_dict
 
 


### PR DESCRIPTION
Hi all. 

This might be more complex than pruning the path in the open_group_as_dict function. It is kind of complex because when we use `_iter_zarr_groups, ` it yields the root group. I am still working o it

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
