### PR TITLE
implement `dask` methods on `DataTree`

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1343,8 +1343,10 @@ class DataArray(
     @property
     def chunksizes(self) -> Mapping[Any, tuple[int, ...]]:
         """
-        Mapping from dimension names to block lengths for this dataarray's data, or None if
-        the underlying data is not a dask array.
+        Mapping from dimension names to block lengths for this dataset's data.
+
+        If this dataset does not contain chunked arrays, the mapping will be empty.
+
         Cannot be modified directly, but can be modified by calling .chunk().
 
         Differs from DataArray.chunks because it returns a mapping of dimensions to chunk shapes

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1343,9 +1343,9 @@ class DataArray(
     @property
     def chunksizes(self) -> Mapping[Any, tuple[int, ...]]:
         """
-        Mapping from dimension names to block lengths for this dataset's data.
+        Mapping from dimension names to block lengths for this dataarray's data.
 
-        If this dataset does not contain chunked arrays, the mapping will be empty.
+        If this dataarray does not contain chunked arrays, the mapping will be empty.
 
         Cannot be modified directly, but can be modified by calling .chunk().
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2658,8 +2658,10 @@ class Dataset(
     @property
     def chunks(self) -> Mapping[Hashable, tuple[int, ...]]:
         """
-        Mapping from dimension names to block lengths for this dataset's data, or None if
-        the underlying data is not a dask array.
+        Mapping from dimension names to block lengths for this dataset's data.
+
+        If this dataset does not contain chunked arrays, the mapping will be empty.
+
         Cannot be modified directly, but can be modified by calling .chunk().
 
         Same as Dataset.chunksizes, but maintained for backwards compatibility.
@@ -2675,8 +2677,10 @@ class Dataset(
     @property
     def chunksizes(self) -> Mapping[Hashable, tuple[int, ...]]:
         """
-        Mapping from dimension names to block lengths for this dataset's data, or None if
-        the underlying data is not a dask array.
+        Mapping from dimension names to block lengths for this dataset's data.
+
+        If this dataset does not contain chunked arrays, the mapping will be empty.
+
         Cannot be modified directly, but can be modified by calling .chunk().
 
         Same as Dataset.chunks.

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -18,7 +18,7 @@ from xarray.core import utils
 from xarray.core._aggregations import DataTreeAggregations
 from xarray.core._typed_ops import DataTreeOpsMixin
 from xarray.core.alignment import align
-from xarray.core.common import TreeAttrAccessMixin
+from xarray.core.common import TreeAttrAccessMixin, get_chunksizes
 from xarray.core.coordinates import Coordinates, DataTreeCoordinates
 from xarray.core.dataarray import DataArray
 from xarray.core.dataset import Dataset, DataVariables
@@ -1979,3 +1979,21 @@ class DataTree(
         """
         new = self.copy(deep=False)
         return new.load(**kwargs)
+
+    @property
+    def chunksizes(self) -> Mapping[Hashable, tuple[int, ...]]:
+        """
+        Mapping from group paths to a mapping of dimension names to block lengths for this dataset's data, or None if
+        the underlying data is not a dask array.
+
+        Cannot be modified directly, but can be modified by calling .chunk().
+
+        See Also
+        --------
+        DataTree.chunk
+        Dataset.chunksizes
+        """
+        return {
+            f"/{path}" if path != "." else "/": get_chunksizes(node.variables.values())
+            for path, node in self.subtree_with_keys
+        }

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1985,7 +1985,7 @@ class DataTree(
         return new.load(**kwargs)
 
     @property
-    def chunksizes(self) -> Mapping[Hashable, tuple[int, ...]]:
+    def chunksizes(self) -> Mapping[str, Mapping[Hashable, tuple[int, ...]]]:
         """
         Mapping from group paths to a mapping of dimension names to block lengths for this dataset's data, or None if
         the underlying data is not a dask array.

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1998,8 +1998,7 @@ class DataTree(
         Dataset.chunksizes
         """
         return {
-            f"/{path}" if path != "." else "/": get_chunksizes(node.variables.values())
-            for path, node in self.subtree_with_keys
+            node.path: get_chunksizes(node.variables.values()) for node in self.subtree
         }
 
     def chunk(

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -70,8 +70,11 @@ if TYPE_CHECKING:
         ErrorOptions,
         ErrorOptionsWithWarn,
         NetcdfWriteModes,
+        T_ChunkDimFreq,
+        T_ChunksFreq,
         ZarrWriteModes,
     )
+    from xarray.namedarray.parallelcompat import ChunkManagerEntrypoint
 
 # """
 # DEVELOPERS' NOTE
@@ -1997,3 +2000,82 @@ class DataTree(
             f"/{path}" if path != "." else "/": get_chunksizes(node.variables.values())
             for path, node in self.subtree_with_keys
         }
+
+    def chunk(
+        self,
+        chunks: T_ChunksFreq = {},  # noqa: B006  # {} even though it's technically unsafe, is being used intentionally here (#4667)
+        name_prefix: str = "xarray-",
+        token: str | None = None,
+        lock: bool = False,
+        inline_array: bool = False,
+        chunked_array_type: str | ChunkManagerEntrypoint | None = None,
+        from_array_kwargs=None,
+        **chunks_kwargs: T_ChunkDimFreq,
+    ) -> Self:
+        """Coerce all arrays in all groups in this tree into dask arrays with the given
+        chunks.
+
+        Non-dask arrays in this tree will be converted to dask arrays. Dask
+        arrays will be rechunked to the given chunk sizes.
+
+        If neither chunks is not provided for one or more dimensions, chunk
+        sizes along that dimension will not be updated; non-dask arrays will be
+        converted into dask arrays with a single block.
+
+        Along datetime-like dimensions, a :py:class:`groupers.TimeResampler` object is also accepted.
+
+        Parameters
+        ----------
+        chunks : int, tuple of int, "auto" or mapping of hashable to int or a TimeResampler, optional
+            Chunk sizes along each dimension, e.g., ``5``, ``"auto"``, or
+            ``{"x": 5, "y": 5}`` or ``{"x": 5, "time": TimeResampler(freq="YE")}``.
+        name_prefix : str, default: "xarray-"
+            Prefix for the name of any new dask arrays.
+        token : str, optional
+            Token uniquely identifying this dataset.
+        lock : bool, default: False
+            Passed on to :py:func:`dask.array.from_array`, if the array is not
+            already as dask array.
+        inline_array: bool, default: False
+            Passed on to :py:func:`dask.array.from_array`, if the array is not
+            already as dask array.
+        chunked_array_type: str, optional
+            Which chunked array type to coerce this datasets' arrays to.
+            Defaults to 'dask' if installed, else whatever is registered via the `ChunkManagerEntryPoint` system.
+            Experimental API that should not be relied upon.
+        from_array_kwargs: dict, optional
+            Additional keyword arguments passed on to the `ChunkManagerEntrypoint.from_array` method used to create
+            chunked arrays, via whichever chunk manager is specified through the `chunked_array_type` kwarg.
+            For example, with dask as the default chunked array type, this method would pass additional kwargs
+            to :py:func:`dask.array.from_array`. Experimental API that should not be relied upon.
+        **chunks_kwargs : {dim: chunks, ...}, optional
+            The keyword arguments form of ``chunks``.
+            One of chunks or chunks_kwargs must be provided
+
+        Returns
+        -------
+        chunked : xarray.DataTree
+
+        See Also
+        --------
+        Dataset.chunk
+        Dataset.chunksizes
+        xarray.unify_chunks
+        dask.array.from_array
+        """
+        return DataTree.from_dict(
+            {
+                path: node.dataset.chunk(
+                    chunks,
+                    name_prefix=name_prefix,
+                    token=token,
+                    lock=lock,
+                    inline_array=inline_array,
+                    chunked_array_type=chunked_array_type,
+                    from_array_kwargs=from_array_kwargs,
+                    **chunks_kwargs,
+                )
+                for path, node in self.subtree_with_keys
+            },
+            name=self.name,
+        )

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -2070,6 +2070,14 @@ class DataTree(
             )
         combined_chunks = either_dict_or_kwargs(chunks, chunks_kwargs, "chunk")
 
+        all_dims = self._get_all_dims()
+
+        bad_dims = combined_chunks.keys() - all_dims
+        if bad_dims:
+            raise ValueError(
+                f"chunks keys {tuple(bad_dims)} not found in data dimensions {tuple(all_dims)}"
+            )
+
         rechunked_groups = {
             path: node.dataset.chunk(
                 {

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -2075,7 +2075,7 @@ class DataTree(
                 {
                     dim: size
                     for dim, size in combined_chunks.items()
-                    if dim in node.dataset.dims
+                    if dim in node._node_dims
                 },
                 name_prefix=name_prefix,
                 token=token,

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -864,9 +864,9 @@ class DataTree(
     ) -> Self:
         """Copy just one node of a tree."""
         new_node = super()._copy_node(inherit=inherit, deep=deep, memo=memo)
-        data = self._to_dataset_view(rebuild_dims=False, inherit=inherit)
-        if deep:
-            data = data._copy(deep=True, memo=memo)
+        data = self._to_dataset_view(rebuild_dims=False, inherit=inherit)._copy(
+            deep=deep, memo=memo
+        )
         new_node._set_node_data(data)
         return new_node
 

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1919,6 +1919,7 @@ class DataTree(
 
         See Also
         --------
+        Dataset.load
         dask.compute
         """
         # access .data to coerce everything to numpy or dask arrays

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1959,8 +1959,8 @@ class DataTree(
 
     def compute(self, **kwargs) -> Self:
         """Manually trigger loading and/or computation of this datatree's data
-        from disk or a remote source into memory and return a new dataset.
-        Unlike load, the original dataset is left unaltered.
+        from disk or a remote source into memory and return a new datatree.
+        Unlike load, the original datatree is left unaltered.
 
         Normally, it should not be necessary to call this method in user code,
         because all xarray functions should either work on deferred data or
@@ -1987,7 +1987,7 @@ class DataTree(
     @property
     def chunksizes(self) -> Mapping[str, Mapping[Hashable, tuple[int, ...]]]:
         """
-        Mapping from group paths to a mapping of dimension names to block lengths for this dataset's data, or None if
+        Mapping from group paths to a mapping of dimension names to block lengths for this datatree's data, or None if
         the underlying data is not a dask array.
 
         Cannot be modified directly, but can be modified by calling .chunk().
@@ -2032,7 +2032,7 @@ class DataTree(
         name_prefix : str, default: "xarray-"
             Prefix for the name of any new dask arrays.
         token : str, optional
-            Token uniquely identifying this dataset.
+            Token uniquely identifying this datatree.
         lock : bool, default: False
             Passed on to :py:func:`dask.array.from_array`, if the array is not
             already as dask array.
@@ -2040,7 +2040,7 @@ class DataTree(
             Passed on to :py:func:`dask.array.from_array`, if the array is not
             already as dask array.
         chunked_array_type: str, optional
-            Which chunked array type to coerce this datasets' arrays to.
+            Which chunked array type to coerce this datatree's arrays to.
             Defaults to 'dask' if installed, else whatever is registered via the `ChunkManagerEntryPoint` system.
             Experimental API that should not be relied upon.
         from_array_kwargs: dict, optional

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1936,7 +1936,7 @@ class DataTree(
             for path, node in lazy_data.items()
             for var_name, array in node.items()
         }
-        if lazy_data:
+        if flat_lazy_data:
             chunkmanager = get_chunked_array_type(*flat_lazy_data.values())
 
             # evaluate all the chunked arrays simultaneously

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -2087,4 +2087,4 @@ class DataTree(
             for path, node in self.subtree_with_keys
         }
 
-        return DataTree.from_dict(rechunked_groups, name=self.name)
+        return self.from_dict(rechunked_groups, name=self.name)

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1987,8 +1987,9 @@ class DataTree(
     @property
     def chunksizes(self) -> Mapping[str, Mapping[Hashable, tuple[int, ...]]]:
         """
-        Mapping from group paths to a mapping of dimension names to block lengths for this datatree's data, or None if
-        the underlying data is not a dask array.
+        Mapping from group paths to a mapping of chunksizes.
+
+        If there's no chunked data in a group, the corresponding mapping of chunksizes will be empty.
 
         Cannot be modified directly, but can be modified by calling .chunk().
 

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1998,9 +1998,12 @@ class DataTree(
         DataTree.chunk
         Dataset.chunksizes
         """
-        return {
-            node.path: get_chunksizes(node.variables.values()) for node in self.subtree
-        }
+        return Frozen(
+            {
+                node.path: get_chunksizes(node.variables.values())
+                for node in self.subtree
+            }
+        )
 
     def chunk(
         self,

--- a/xarray/namedarray/core.py
+++ b/xarray/namedarray/core.py
@@ -725,8 +725,10 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
         self,
     ) -> Mapping[_Dim, _Shape]:
         """
-        Mapping from dimension names to block lengths for this namedArray's data, or None if
-        the underlying data is not a dask array.
+        Mapping from dimension names to block lengths for this NamedArray's data.
+
+        If this NamedArray does not contain chunked arrays, the mapping will be empty.
+
         Cannot be modified directly, but can be modified by calling .chunk().
 
         Differs from NamedArray.chunks because it returns a mapping of dimensions to chunk shapes

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -2240,7 +2240,10 @@ class TestDask:
                 "/group1/subgroup1": ds4.chunk({"x": 5}),
             }
         )
+        expected_chunksizes = {
+            f"/{path}" if path != "." else "/": {} for path, _ in tree.subtree_with_keys
+        }
         actual = tree.load()
 
         assert_identical(actual, expected)
-        # assert_chunks_equal(actual, expected, enforce_dask=False)
+        assert tree.chunksizes == expected_chunksizes

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -2274,3 +2274,26 @@ class TestDask:
 
         assert actual.chunksizes == expected_chunksizes, "mismatching chunksizes"
         assert tree.chunksizes == original_chunksizes, "original tree was modified"
+
+    def test_chunk(self):
+        ds1 = xr.Dataset({"a": ("x", np.arange(10))})
+        ds2 = xr.Dataset({"b": ("y", np.arange(5))})
+        ds3 = xr.Dataset({"c": ("z", np.arange(4))})
+        ds4 = xr.Dataset({"d": ("x", np.arange(-5, 5))})
+
+        expected = xr.DataTree.from_dict(
+            {
+                "/": ds1.chunk({"x": 5}),
+                "/group1": ds2.chunk({"y": 3}),
+                "/group2": ds3.chunk({"z": 2}),
+                "/group1/subgroup1": ds4.chunk({"x": 5}),
+            }
+        )
+
+        tree = xr.DataTree.from_dict(
+            {"/": ds1, "/group1": ds2, "/group2": ds3, "/group1/subgroup1": ds4}
+        )
+        actual = tree.chunk({"x": 5, "y": 3, "z": 2})
+
+        assert_identical(actual, expected)
+        assert actual.chunksizes == expected.chunksizes

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -1,6 +1,7 @@
 import re
 import sys
 import typing
+from collections.abc import Mapping
 from copy import copy, deepcopy
 from textwrap import dedent
 
@@ -2239,6 +2240,7 @@ class TestDask:
                 "/group1/subgroup1": ds4.chunk({"x": 5}),
             }
         )
+        expected_chunksizes: Mapping[str, Mapping]
         expected_chunksizes = {node.path: {} for node in tree.subtree}
         actual = tree.load()
 
@@ -2263,6 +2265,7 @@ class TestDask:
             }
         )
         original_chunksizes = tree.chunksizes
+        expected_chunksizes: Mapping[str, Mapping]
         expected_chunksizes = {node.path: {} for node in tree.subtree}
         actual = tree.compute()
 

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -2296,3 +2296,12 @@ class TestDask:
 
         assert_identical(actual, expected)
         assert actual.chunksizes == expected.chunksizes
+
+        with pytest.raises(TypeError, match="invalid type"):
+            tree.chunk(None)
+
+        with pytest.raises(TypeError, match="invalid type"):
+            tree.chunk((1, 2))
+
+        with pytest.raises(ValueError, match="not found in data dimensions"):
+            tree.chunk({"u": 2})

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -863,7 +863,6 @@ class TestTreeFromDict:
         actual = DataTree.from_dict(tree.children["a"].to_dict(relative=True))
         assert_identical(expected, actual)
 
-    @pytest.mark.xfail
     def test_roundtrip_unnamed_root(self, simple_datatree) -> None:
         # See GH81
 

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -2204,6 +2204,25 @@ class TestClose:
 
 @requires_dask
 class TestDask:
+    def test_chunksizes(self):
+        ds1 = xr.Dataset({"a": ("x", np.arange(10))})
+        ds2 = xr.Dataset({"b": ("y", np.arange(5))})
+        ds3 = xr.Dataset({"c": ("z", np.arange(4))})
+        ds4 = xr.Dataset({"d": ("x", np.arange(-5, 5))})
+
+        groups = {
+            "/": ds1.chunk({"x": 5}),
+            "/group1": ds2.chunk({"y": 3}),
+            "/group2": ds3.chunk({"z": 2}),
+            "/group1/subgroup1": ds4.chunk({"x": 5}),
+        }
+
+        tree = xr.DataTree.from_dict(groups)
+
+        expected_chunksizes = {path: node.chunksizes for path, node in groups.items()}
+
+        assert tree.chunksizes == expected_chunksizes
+
     def test_load(self):
         ds1 = xr.Dataset({"a": ("x", np.arange(10))})
         ds2 = xr.Dataset({"b": ("y", np.arange(5))})

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -2229,9 +2229,9 @@ class TestDask:
         ds3 = xr.Dataset({"c": ("z", np.arange(4))})
         ds4 = xr.Dataset({"d": ("x", np.arange(-5, 5))})
 
-        expected = xr.DataTree.from_dict(
-            {"/": ds1, "/group1": ds2, "/group2": ds3, "/group1/subgroup1": ds4}
-        )
+        groups = {"/": ds1, "/group1": ds2, "/group2": ds3, "/group1/subgroup1": ds4}
+
+        expected = xr.DataTree.from_dict(groups)
         tree = xr.DataTree.from_dict(
             {
                 "/": ds1.chunk({"x": 5}),
@@ -2246,6 +2246,12 @@ class TestDask:
 
         assert_identical(actual, expected)
         assert tree.chunksizes == expected_chunksizes
+        assert actual.chunksizes == expected_chunksizes
+
+        tree = xr.DataTree.from_dict(groups)
+        actual = tree.load()
+        assert_identical(actual, expected)
+        assert actual.chunksizes == expected_chunksizes
 
     def test_compute(self):
         ds1 = xr.Dataset({"a": ("x", np.arange(10))})

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -2239,9 +2239,7 @@ class TestDask:
                 "/group1/subgroup1": ds4.chunk({"x": 5}),
             }
         )
-        expected_chunksizes = {
-            f"/{path}" if path != "." else "/": {} for path, _ in tree.subtree_with_keys
-        }
+        expected_chunksizes = {node.path: {} for node in tree.subtree}
         actual = tree.load()
 
         assert_identical(actual, expected)
@@ -2265,9 +2263,7 @@ class TestDask:
             }
         )
         original_chunksizes = tree.chunksizes
-        expected_chunksizes = {
-            f"/{path}" if path != "." else "/": {} for path, _ in tree.subtree_with_keys
-        }
+        expected_chunksizes = {node.path: {} for node in tree.subtree}
         actual = tree.compute()
 
         assert_identical(actual, expected)


### PR DESCRIPTION
For now this only contains `compute` and `load`, but in implementing those I've found a bug in `copy`: we don't actually (shallow) copy the variables, which means that my implementation of `compute` would modify the original tree.

- [x] follow-up to #9660
- [x] Tests added