### PR TITLE
fix(zarr): use inplace array.resize for zarr 2 and 3

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -996,10 +996,7 @@ class ZarrStore(AbstractWritableDataStore):
 
                     new_shape = list(zarr_array.shape)
                     new_shape[append_axis] += v.shape[append_axis]
-                    if _zarr_v3():
-                        zarr_array = zarr_array.resize(new_shape)
-                    else:
-                        zarr_array.resize(new_shape)
+                    zarr_array.resize(new_shape)
 
                 zarr_shape = zarr_array.shape
 


### PR DESCRIPTION
This fixes an error in upstream dev (seen in https://github.com/pydata/xarray/issues/9277 and https://github.com/pydata/xarray/pull/9669)

xref: https://github.com/zarr-developers/zarr-python/pull/2413

