### PR TITLE
Raise `ValueError` for unmatching chunks length in `DataArray.chunk()`

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1444,6 +1444,11 @@ class DataArray(
                 "It will raise an error in the future. Instead use a dict with dimension names as keys.",
                 category=DeprecationWarning,
             )
+            if len(chunks) != len(self.dims):
+                raise ValueError(
+                    f"chunks must have the same number of elements as dimensions. "
+                    f"Expected {len(self.dims)} elements, got {len(chunks)}."
+                )
             chunk_mapping = dict(zip(self.dims, chunks, strict=True))
         else:
             chunk_mapping = either_dict_or_kwargs(chunks, chunks_kwargs, "chunk")

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -897,6 +897,9 @@ class TestDataArray:
             assert blocked.chunks == ((3,), (3, 1))
             assert blocked.data.name != first_dask_name
 
+            with pytest.raises(ValueError):
+                blocked.chunk(chunks=(3, 3, 3))
+
         # name doesn't change when rechunking by same amount
         # this fails if ReprObject doesn't have __dask_tokenize__ defined
         assert unblocked.chunk(2).data.name == unblocked.chunk(2).data.name


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

https://github.com/pydata/xarray/pull/9450 introduced strict handling of `zip()`.
In `DataArray.chunk()`, this leads to a breaking change when passing a tuple/list as `chunks` where the length doesn't match `self.dims`. Previously these were just discarded.

https://github.com/pydata/xarray/blob/2c8f2e81e2ac8c49cbdad86367c571cfef9cdba7/xarray/core/dataarray.py#L1452

Since passing a tuple/list as `chunks` is deprecated anyway, this PR simply adds a `ValueError` to make the problem clear to the user instead of this ambiguous strict zip error.

Current error:
``` bash
Traceback (most recent call last):
  File "/Users/../.venv/lib/python3.12/site-packages/xarray/util/deprecation_helpers.py", line 118, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/../.venv/lib/python3.12/site-packages/xarray/core/dataarray.py", line 1447, in chunk
    chunk_mapping = dict(zip(self.dims, chunks, strict=True))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: zip() argument 2 is longer than argument 1
```
