### PR TITLE
Use the same function to floatize coords in polyfit and polyval

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -37,6 +37,8 @@ Bug fixes
 
 - Fix inadvertent deep-copying of child data in DataTree.
   By `Stephan Hoyer <https://github.com/shoyer>`_.
+- Fix regression in the interoperability of :py:meth:`DataArray.polyfit` and :py:meth:`xr.polyval` for date-time coordinates. (:pull:`9691`).
+  By `Pascal Bourgault <https://github.com/aulemahal>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -60,7 +60,7 @@ from xarray.core.common import (
     _contains_datetime_like_objects,
     get_chunksizes,
 )
-from xarray.core.computation import unify_chunks
+from xarray.core.computation import _ensure_numeric, unify_chunks
 from xarray.core.coordinates import (
     Coordinates,
     DatasetCoordinates,
@@ -87,7 +87,6 @@ from xarray.core.merge import (
     merge_coordinates_without_align,
     merge_core,
 )
-from xarray.core.missing import _floatize_x
 from xarray.core.options import OPTIONS, _get_keep_attrs
 from xarray.core.types import (
     Bins,
@@ -9066,15 +9065,7 @@ class Dataset(
         variables = {}
         skipna_da = skipna
 
-        x: Any = self.coords[dim].variable
-        x = _floatize_x((x,), (x,))[0][0]
-
-        try:
-            x = x.values.astype(np.float64)
-        except TypeError as e:
-            raise TypeError(
-                f"Dim {dim!r} must be castable to float64, got {type(x).__name__}."
-            ) from e
+        x: Any = _ensure_numeric(self.coords[dim]).astype(np.float64)
 
         xname = f"{self[dim].name}_"
         order = int(deg) + 1

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -9072,7 +9072,7 @@ class Dataset(
         lhs = np.vander(x, order)
 
         if rcond is None:
-            rcond = x.shape[0] * np.finfo(x.dtype).eps
+            rcond = x.shape[0] * np.finfo(x.dtype).eps  # type: ignore[assignment]
 
         # Weights:
         if w is not None:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -9065,7 +9065,7 @@ class Dataset(
         variables = {}
         skipna_da = skipna
 
-        x: Any = _ensure_numeric(self.coords[dim]).astype(np.float64)
+        x = np.asarray(_ensure_numeric(self.coords[dim]).astype(np.float64))
 
         xname = f"{self[dim].name}_"
         order = int(deg) + 1

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6728,12 +6728,12 @@ class TestDataset:
         out = da.polyfit("x", 3, full=False)
         da_fitval = xr.polyval(da.x, out.polyfit_coefficients)
         # polyval introduces very small errors (1e-16 here)
-        np.testing.assert_allclose(da_fitval, da)
+        xr.testing.assert_allclose(da_fitval, da)
 
         da = da.assign_coords(x=xr.date_range("2001-01-01", periods=9, freq="YS"))
         out = da.polyfit("x", 3, full=False)
         da_fitval = xr.polyval(da.x, out.polyfit_coefficients)
-        np.testing.assert_allclose(da_fitval, da, rtol=1e-3)
+        xr.testing.assert_allclose(da_fitval, da, rtol=1e-3)
 
     @requires_cftime
     def test_polyfit_polyval_cftime(self) -> None:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6720,6 +6720,32 @@ class TestDataset:
             ds.var1.polyfit("dim2", 10, full=True)
             assert len(ws) == 1
 
+    def test_polyfit_polyval(self) -> None:
+        da = xr.DataArray([1.0, 2.0, 3.0], dims=["x"], coords=dict(x=[0, 1, 2]))
+
+        out = da.polyfit("x", 3, full=False)
+        da_fitval = xr.polyval(da.x, out.polyfit_coefficients)
+        # polyval introduces very small errors (1e-16 here)
+        np.testing.assert_allclose(da_fitval, da)
+
+        da = da.assign_coords(x=xr.date_range("2001-01-01", periods=3, freq="YS"))
+        out = da.polyfit("x", 3, full=False)
+        da_fitval = xr.polyval(da.x, out.polyfit_coefficients)
+        np.testing.assert_allclose(da_fitval, da)
+
+    @pytest.mark.skipif(not has_cftime, reason="Test requires cftime.")
+    def test_polyfit_polyval_cftime(self) -> None:
+        da = xr.DataArray(
+            [1.0, 2.0, 3.0],
+            dims=["x"],
+            coords=dict(
+                x=xr.date_range("2001-01-01", periods=3, freq="YS", calendar="noleap")
+            ),
+        )
+        out = da.polyfit("x", 3, full=False)
+        da_fitval = xr.polyval(da.x, out.polyfit_coefficients)
+        np.testing.assert_allclose(da_fitval, da)
+
     @staticmethod
     def _test_data_var_interior(
         original_data_var, padded_data_var, padded_dim_name, expected_pad_values

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6721,25 +6721,27 @@ class TestDataset:
             assert len(ws) == 1
 
     def test_polyfit_polyval(self) -> None:
-        da = xr.DataArray([1.0, 2.0, 3.0], dims=["x"], coords=dict(x=[0, 1, 2]))
+        da = xr.DataArray(
+            np.arange(1, 10).astype(np.float64), dims=["x"], coords=dict(x=np.arange(9))
+        )
 
         out = da.polyfit("x", 3, full=False)
         da_fitval = xr.polyval(da.x, out.polyfit_coefficients)
         # polyval introduces very small errors (1e-16 here)
         np.testing.assert_allclose(da_fitval, da)
 
-        da = da.assign_coords(x=xr.date_range("2001-01-01", periods=3, freq="YS"))
+        da = da.assign_coords(x=xr.date_range("2001-01-01", periods=9, freq="YS"))
         out = da.polyfit("x", 3, full=False)
         da_fitval = xr.polyval(da.x, out.polyfit_coefficients)
-        np.testing.assert_allclose(da_fitval, da)
+        np.testing.assert_allclose(da_fitval, da, rtol=1e-3)
 
     @pytest.mark.skipif(not has_cftime, reason="Test requires cftime.")
     def test_polyfit_polyval_cftime(self) -> None:
         da = xr.DataArray(
-            [1.0, 2.0, 3.0],
+            np.arange(1, 10).astype(np.float64),
             dims=["x"],
             coords=dict(
-                x=xr.date_range("2001-01-01", periods=3, freq="YS", calendar="noleap")
+                x=xr.date_range("2001-01-01", periods=9, freq="YS", calendar="noleap")
             ),
         )
         out = da.polyfit("x", 3, full=False)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6735,7 +6735,7 @@ class TestDataset:
         da_fitval = xr.polyval(da.x, out.polyfit_coefficients)
         np.testing.assert_allclose(da_fitval, da, rtol=1e-3)
 
-    @pytest.mark.skipif(not has_cftime, reason="Test requires cftime.")
+    @requires_cftime
     def test_polyfit_polyval_cftime(self) -> None:
         da = xr.DataArray(
             np.arange(1, 10).astype(np.float64),
@@ -7258,7 +7258,7 @@ def test_differentiate_datetime(dask) -> None:
     assert np.allclose(actual, 1.0)
 
 
-@pytest.mark.skipif(not has_cftime, reason="Test requires cftime.")
+@requires_cftime
 @pytest.mark.parametrize("dask", [True, False])
 def test_differentiate_cftime(dask) -> None:
     rs = np.random.RandomState(42)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #9690
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

The coordinate on which the fit is computed in `da.polyfit` is transformed into a `float` using the same function as in `xr.polyval`. This ensures a symmetry between the two operations. Fixes a bug where `da.polyfit` would transform datetime coordinate to nanoseconds, but starting at 0 on the first element, while in `polyval` the transformation puts the 0 on 1970-01-01.

This solution seemed the most easiest to me, but I can see how importing a private function from a sub-module to another might not be the best.  Maybe, `_ensure_numeric` could be moved elsewhere ? `duck_array_ops.py` ?