### PR TITLE
Allow wrapping astropy.units.Quantity

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -320,10 +320,17 @@ def as_compatible_data(
         else:
             data = np.asarray(data)
 
+    _is_array_like = isinstance(data, np.ndarray | np.generic)
+    _is_nep18 = hasattr(data, "__array_function__")
+    _has_array_api = hasattr(data, "__array_namespace__")
+    _has_unit = hasattr(data, "_unit")
+
+    # Allow `astropy.units.Quantity`
+    if _is_array_like and (_is_nep18 or _has_array_api) and _has_unit:
+        return cast("T_DuckArray", data)
+
     # immediately return array-like types except `numpy.ndarray` subclasses and `numpy` scalars
-    if not isinstance(data, np.ndarray | np.generic) and (
-        hasattr(data, "__array_function__") or hasattr(data, "__array_namespace__")
-    ):
+    if not _is_array_like and (_is_nep18 or _has_array_api):
         return cast("T_DuckArray", data)
 
     # validate whether the data is valid data types. Also, explicitly cast `numpy`


### PR DESCRIPTION
Ticks off first item in #9704 and also [astropy #14454 ](https://github.com/astropy/astropy/issues/14454).

The conditions added catch ``astropy.units.Quantity`` type while banning ``numpy.matrix`` and ``numpy.ma.masked_array``, as suggested in [#525 ](https://github.com/pydata/xarray/issues/525#issuecomment-2453218607), i.e.,
```
>>> _is_array_like = lambda data: isinstance(data, np.ndarray | np.generic)
>>> _is_nep18 = lambda data: hasattr(data, "__array_function__")
>>> _has_array_api = lambda data: hasattr(data, "__array_namespace__")
>>> _has_unit = lambda data: hasattr(data, "_unit")
>>> catch_astropy = (
...    lambda data: _is_array_like(data)
...    and (_is_nep18(data) or _has_array_api(data))
...    and _has_unit(data)
... )

>>> catch_non_numpy_array = lambda data: not _is_array_like(data) and (
...    _is_nep18(data) or _has_array_api(data)
... )

>>> narray = np.arange(100)
>>> matrix = np.matrix(np.identity(3))
>>> marray = np.ma.masked_array(narray)
>>> uarray = u.Quantity(narray)
>>> parray = pint.Quantity(narray)
>>> darray = da.array(narray)

>>> catch_astropy(narray)  # False
>>> catch_astropy(matrix)  # False
>>> catch_astropy(marray)  # False
>>> catch_astropy(uarray)  # True
>>> catch_astropy(parray)  # False
>>> catch_astropy(darray)  # False

>>> catch_non_numpy_array(narray)  # False
>>> catch_non_numpy_array(matrix)  # False
>>> catch_non_numpy_array(marray)  # False
>>> catch_non_numpy_array(uarray)  # False
>>> catch_non_numpy_array(parray)  # True
>>> catch_non_numpy_array(darray)  # True
```
@keewis The above can be put into tests. I'm just not sure where. [xarray/tests/test_units.py](https://github.com/pydata/xarray/blob/5fd50c501f4ff03067b5a87429033597e7efa02e/xarray/tests/test_units.py) seems busy with ``pint``-related stuff.