### PR TITLE
add pydap-server dependencies to environment.yml

### DIFF
--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -36,6 +36,14 @@ dependencies:
   - pre-commit
   - pyarrow # pandas raises a deprecation warning without this, breaking doctests
   - pydap
+  # start pydap server dependencies, can be removed if pydap-server is available
+  - gunicorn
+  - PasteDeploy
+  - docopt-ng
+  - Webob
+  - Jinja2
+  - beautifulsoup4
+  # end pydap server dependencies
   - pytest
   - pytest-cov
   - pytest-env


### PR DESCRIPTION
This adds the pydap server dependencies needed to operate the pydap-tests in flaky CI.

See #9708 