### PR TITLE
Add missing xarray.core.missing import

### DIFF
--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -20,6 +20,7 @@ except ImportError:
     from numpy import RankWarning  # type: ignore[no-redef,attr-defined,unused-ignore]
 
 import xarray as xr
+import xarray.core.missing
 from xarray import (
     DataArray,
     Dataset,


### PR DESCRIPTION
xarray.core.missing is only imported inside DataArray.interp(), which means that it is not necessarily defined in this test, unless `interp()` happened to be called first.