### PR TITLE
Skip a few tests that require flox is flox is not installed

### DIFF
--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -2768,6 +2768,7 @@ def test_multiple_groupers_string(as_dataset) -> None:
         obj.groupby("labels1", foo=UniqueGrouper())
 
 
+@requires_flox
 @pytest.mark.parametrize("use_flox", [True, False])
 def test_multiple_groupers(use_flox) -> None:
     da = DataArray(
@@ -2978,6 +2979,7 @@ def test_groupby_transpose():
 
 
 @requires_dask
+@requires_flox
 @pytest.mark.parametrize(
     "grouper, expect_index",
     [


### PR DESCRIPTION
These failures turned up in my local tests.

I guess we don't currently have a CI environment that installs Dask but not Flox.

cc @dcherian
