### PR TITLE
Use micromamba 1.5.10 where conda is needed

### DIFF
--- a/.github/workflows/benchmarks-last-release.yml
+++ b/.github/workflows/benchmarks-last-release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up conda environment
         uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '2.0.2-2'
+          micromamba-version: '1.5.10-0'
           environment-file: ${{env.CONDA_ENV_FILE}}
           environment-name: xarray-tests
           cache-environment: true

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -36,7 +36,7 @@ jobs:
           create-args: >-
             asv
             python-build
-            mamba <=1.5.10
+            mamba<=1.5.10
 
 
       - name: Run benchmarks

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up conda environment
         uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '2.0.2-2'
+          micromamba-version: '1.5.10-0'
           environment-file: ${{env.CONDA_ENV_FILE}}
           environment-name: xarray-tests
           cache-environment: true

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -36,7 +36,7 @@ jobs:
           create-args: >-
             asv
             python-build
-            mamba
+            mamba <=1.5.10
 
 
       - name: Run benchmarks

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -318,7 +318,7 @@ jobs:
         with:
           # run with micromamba 1.5.10 together with conda
           # conda.api is not API compatible with libmambapy
-          micromamba-version: 1.5.10
+          micromamba-version: "1.5.10-0"
           environment-name: xarray-tests
           create-args: >-
             python=3.12

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -304,8 +304,6 @@ jobs:
     name: Minimum Version Policy
     runs-on: "ubuntu-latest"
     needs: detect-ci-trigger
-    # disabled until `conda` is compatible with the new `libmambapy`
-    if: false && needs.detect-ci-trigger.outputs.triggered == 'false'
     defaults:
       run:
         shell: bash -l {0}
@@ -318,13 +316,15 @@ jobs:
       - name: Setup micromamba
         uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: ${{env.MICROMAMBA_VERSION}}
+          # run with micromamba 1.5.10 together with conda
+          # conda.api is not API compatible with libmambapy
+          micromamba-version: 1.5.10
           environment-name: xarray-tests
           create-args: >-
             python=3.12
             pyyaml
             python-dateutil
-            libmambapy
+            conda
 
       - name: All-deps minimum versions policy
         run: |

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -14,7 +14,6 @@ concurrency:
 
 env:
   FORCE_COLOR: 3
-  MICROMAMBA_VERSION: "2.0.2-2"
 
 jobs:
   detect-ci-trigger:
@@ -58,7 +57,6 @@ jobs:
       - name: Setup micromamba
         uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: ${{env.MICROMAMBA_VERSION}}
           environment-file: ${{env.CONDA_ENV_FILE}}
           environment-name: xarray-tests
           create-args: >-
@@ -104,7 +102,6 @@ jobs:
       - name: Setup micromamba
         uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: ${{env.MICROMAMBA_VERSION}}
           environment-file: ${{env.CONDA_ENV_FILE}}
           environment-name: xarray-tests
           create-args: >-
@@ -156,7 +153,6 @@ jobs:
       - name: Setup micromamba
         uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: ${{env.MICROMAMBA_VERSION}}
           environment-file: ${{env.CONDA_ENV_FILE}}
           environment-name: xarray-tests
           create-args: >-
@@ -213,7 +209,6 @@ jobs:
       - name: Setup micromamba
         uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: ${{env.MICROMAMBA_VERSION}}
           environment-file: ${{env.CONDA_ENV_FILE}}
           environment-name: xarray-tests
           create-args: >-
@@ -270,7 +265,6 @@ jobs:
       - name: Setup micromamba
         uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: ${{env.MICROMAMBA_VERSION}}
           environment-file: ${{env.CONDA_ENV_FILE}}
           environment-name: xarray-tests
           create-args: >-
@@ -304,6 +298,7 @@ jobs:
     name: Minimum Version Policy
     runs-on: "ubuntu-latest"
     needs: detect-ci-trigger
+    if: needs.detect-ci-trigger.outputs.triggered == 'false'
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,6 @@ concurrency:
 
 env:
   FORCE_COLOR: 3
-  micromamba_version: 2
 
 jobs:
   detect-ci-trigger:
@@ -111,7 +110,6 @@ jobs:
       - name: Setup micromamba
         uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '2.0.2-2'
           environment-file: ${{ env.CONDA_ENV_FILE }}
           environment-name: xarray-tests
           cache-environment: true

--- a/.github/workflows/hypothesis.yaml
+++ b/.github/workflows/hypothesis.yaml
@@ -63,7 +63,6 @@ jobs:
       - name: Setup micromamba
         uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: "2.0.2-2"
           environment-file: ci/requirements/environment.yml
           environment-name: xarray-tests
           create-args: >-

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -17,7 +17,6 @@ concurrency:
 
 env:
   FORCE_COLOR: 3
-  MICROMAMBA_VERSION: "2.0.2-2"
 
 jobs:
   detect-ci-trigger:
@@ -64,7 +63,6 @@ jobs:
       - name: Set up conda environment
         uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: ${{env.MICROMAMBA_VERSION}}
           environment-file: ci/requirements/environment.yml
           environment-name: xarray-tests
           create-args: >-
@@ -121,7 +119,6 @@ jobs:
       - name: Set up conda environment
         uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: ${{env.MICROMAMBA_VERSION}}
           environment-file: ci/requirements/environment.yml
           environment-name: xarray-tests
           create-args: >-

--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -11,7 +11,7 @@ import sys
 from collections.abc import Iterator
 from datetime import datetime
 
-import libmambapy  # type: ignore[import]
+import conda.api  # type: ignore[import]
 import yaml
 from dateutil.relativedelta import relativedelta
 
@@ -93,7 +93,7 @@ def query_conda(pkg: str) -> dict[tuple[int, int], datetime]:
 
         return (major, minor), time
 
-    raw_data = libmambapy.SubdirData.query_all(pkg, channels=CHANNELS)
+    raw_data = conda.api.SubdirData.query_all(pkg, channels=CHANNELS)
     data = sorted(metadata(entry) for entry in raw_data if entry.timestamp != 0)
 
     release_dates = {


### PR DESCRIPTION
## Updated behaviour

Since micromamba 2.0 installing conda seems to be broken in CI. In #9732 conda was removed from the install where not absolutely needed and the micromamba version was pinned to 2.0.2-0 due to broken 2.0.3-0.

The broken version was yanked and this PR reverts to the default micromamba version (now 2.0.2-0). In CI runs where conda is absolutely needed the micromamba-version is set to 1.5.10-0 (last version of v1-release line).

- When https://github.com/airspeed-velocity/asv/pull/1439 is resolved, we can remove the pin in the benchmark CI runs. 
- By resolving https://github.com/pydata/xarray/pull/9737#issuecomment-2463397879 the pin in the min-deps-check CI run will be removed.

## Former ramblings:

conda.api and libmambapy are not API compatible

In https://github.com/pydata/xarray/blob/main/ci/min_deps_check.py we use `conda.api` to gather package versions from `["conda-forge", "defaults"]` channel (shouldn't we remove defaults, because of the legal stuff?).

The replacement for micromamba v2 is `libmambapy` which unfortunately isn't API compatible. It should have all the capabilities to do the same, but I wasn`t successful ( :man_shrugging: ) in gathering the correct incantations from the docs:

- https://mamba.readthedocs.io/en/latest/usage/specs.html
- https://mamba.readthedocs.io/en/latest/usage/solver.html

If figured out the correct way, this can eventually be replaced.

Tested micromamba/libmamba 2.0.2-0 also for:

- :white_check_mark: upstream
- :x: benchmark, asv doesn't work, need to step back here, too
- :white_check_mark: hypothesis
- :x: pyright, currently disabled 
