### PR TITLE
Apply ruff rule RUF007

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,7 +249,6 @@ ignore = [
   "RUF002",
   "RUF003",
   "RUF005",
-  "RUF007",
   "RUF012",
 ]
 extend-select = [

--- a/xarray/groupers.py
+++ b/xarray/groupers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import datetime
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from itertools import pairwise
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
@@ -496,8 +497,7 @@ class TimeResampler(Resampler):
         full_index, first_items, codes_ = self._get_index_and_items()
         sbins = first_items.values.astype(np.int64)
         group_indices: GroupIndices = tuple(
-            [slice(i, j) for i, j in zip(sbins[:-1], sbins[1:], strict=True)]
-            + [slice(sbins[-1], None)]
+            [slice(i, j) for i, j in pairwise(sbins)] + [slice(sbins[-1], None)]
         )
 
         unique_coord = Variable(

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import operator
 import warnings
+from itertools import pairwise
 from unittest import mock
 
 import numpy as np
@@ -1732,7 +1733,7 @@ class TestDataArrayGroupBy:
         bincoord = np.array(
             [
                 pd.Interval(left, right, closed="right")
-                for left, right in zip(bins[:-1], bins[1:], strict=True)
+                for left, right in pairwise(bins)
             ],
             dtype=object,
         )


### PR DESCRIPTION
RUF007 Prefer `itertools.pairwise()` over `zip()` when iterating over successive pairs