### PR TITLE
Add runtime type checking in CI tests

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -80,6 +80,47 @@ jobs:
           # `xarray/tests/__init__.py`.
           python -m pytest --doctest-modules xarray --ignore xarray/tests -Werror
 
+  beartype:
+    name: beartype
+    runs-on: "ubuntu-latest"
+    needs: detect-ci-trigger
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      CONDA_ENV_FILE: ci/requirements/environment.yml
+      PYTHON_VERSION: "3.12"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for all branches and tags.
+
+      - name: set environment variables
+        run: |
+          echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Setup micromamba
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          micromamba-version: ${{env.MICROMAMBA_VERSION}}
+          environment-file: ${{env.CONDA_ENV_FILE}}
+          environment-name: xarray-tests
+          create-args: >-
+            python=${{env.PYTHON_VERSION}}
+          cache-environment: true
+          cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-${{env.TODAY}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
+      - name: Install xarray
+        run: |
+          python -m pip install --no-deps -e .
+      - name: Version info
+        run: |
+          python xarray/util/print_versions.py
+
+      - name: Run beartype
+        continue-on-error: true
+        run: |
+          python -m pytest --beartype-packages=xarray
+
   mypy:
     name: Mypy
     runs-on: "ubuntu-latest"

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -39,6 +39,7 @@ dependencies:
   - pydap
   - pydap-server
   - pytest
+  - pytest-beartype
   - pytest-cov
   - pytest-env
   - pytest-mypy-plugins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,6 +307,9 @@ addopts = [
   "--mypy-pyproject-toml-file=pyproject.toml",
 ]
 
+[lint.pyupgrade]
+keep-runtime-typing = true
+
 # We want to forbid warnings from within xarray in our tests — instead we should
 # fix our own code, or mark the test itself as expecting a warning. So this:
 # - Converts any warning from xarray into an error

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -192,7 +192,7 @@ class Dataset(
     DataWithCoords,
     DatasetAggregations,
     DatasetArithmetic,
-    Mapping[Hashable, "DataArray"],
+    Mapping[Hashable, "xarray.DataArray"],
 ):
     """A multi-dimensional, in memory, array database.
 


### PR DESCRIPTION
This should prevent `TYPE_CHECKING` misuse.

Fixes #9744.