### PR TITLE
pin array-api-strict<=2.1

### DIFF
--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -4,7 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - aiobotocore
-  - array-api-strict<=2.1.1
+  - array-api-strict<=2.1
   - boto3
   - bottleneck
   - cartopy

--- a/ci/requirements/all-but-dask.yml
+++ b/ci/requirements/all-but-dask.yml
@@ -4,7 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - aiobotocore
-  - array-api-strict
+  - array-api-strict<=2.1.1
   - boto3
   - bottleneck
   - cartopy

--- a/ci/requirements/all-but-numba.yml
+++ b/ci/requirements/all-but-numba.yml
@@ -6,7 +6,7 @@ dependencies:
   # Pin a "very new numpy" (updated Sept 24, 2024)
   - numpy>=2.1.1
   - aiobotocore
-  - array-api-strict
+  - array-api-strict<=2.1
   - boto3
   - bottleneck
   - cartopy

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -2,7 +2,7 @@ name: xarray-tests
 channels:
   - conda-forge
 dependencies:
-  - array-api-strict
+  - array-api-strict<=2.1.1
   - boto3
   - bottleneck
   - cartopy

--- a/ci/requirements/environment-windows.yml
+++ b/ci/requirements/environment-windows.yml
@@ -2,7 +2,7 @@ name: xarray-tests
 channels:
   - conda-forge
 dependencies:
-  - array-api-strict<=2.1.1
+  - array-api-strict<=2.1
   - boto3
   - bottleneck
   - cartopy

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -4,7 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - aiobotocore
-  - array-api-strict<=2.1.1
+  - array-api-strict<=2.1
   - boto3
   - bottleneck
   - cartopy

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -4,7 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - aiobotocore
-  - array-api-strict
+  - array-api-strict<=2.1.1
   - boto3
   - bottleneck
   - cartopy


### PR DESCRIPTION
Pinning array-api-strict<=2.1 for now until issues with new version (2.1.2) are sorted out.