### PR TITLE
Discard useless `!s` conversion in f-string

### DIFF
--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -1008,7 +1008,7 @@ def parse_ordered_dims(
 def _check_dims(dim: Set[Hashable], all_dims: Set[Hashable]) -> None:
     wrong_dims = (dim - all_dims) - {...}
     if wrong_dims:
-        wrong_dims_str = ", ".join(f"'{d!s}'" for d in wrong_dims)
+        wrong_dims_str = ", ".join(f"'{d}'" for d in wrong_dims)
         raise ValueError(
             f"Dimension(s) {wrong_dims_str} do not exist. Expected one or more of {all_dims}"
         )


### PR DESCRIPTION
From [PEP 3101](https://peps.python.org/pep-3101/):
> #### [Explicit Conversion Flag](https://peps.python.org/pep-3101/#explicit-conversion-flag)
> 
> The explicit conversion flag is used to transform the format field value before it is formatted. This can be used to override the type-specific formatting behavior, and format the value as if it were a more generic type.

In the absence of an explicit conversion flag, the value is simply formatted. The default formatting converts to a `str`:
> #### [Controlling Formatting on a Per-Type Basis](https://peps.python.org/pep-3101/#controlling-formatting-on-a-per-type-basis)
> [...]
> The `object.__format__` method is the simplest: It simply converts the object to a string, and then calls format again:
> ```python
> class object:
>     def __format__(self, format_spec):
>         return format(str(self), format_spec)
> ```

I don't think `!s` was added for a reason here, the default `str` conversion in the `__format__` can be used instead.