### PR TITLE
Fix html repr indexes section

### DIFF
--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -155,7 +155,9 @@ def summarize_index(coord_names, index) -> str:
     return (
         f"<div class='xr-index-name'><div>{name}</div></div>"
         f"<div class='xr-index-preview'>{preview}</div>"
-        f"<div></div>"
+        # need empty input + label here to conform to the fixed CSS grid layout
+        f"<input type='checkbox' disabled/>"
+        f"<label></label>"
         f"<input id='{index_id}' class='xr-index-data-in' type='checkbox'/>"
         f"<label for='{index_id}' title='Show/Hide index repr'>{data_icon}</label>"
         f"<div class='xr-index-data'>{details}</div>"

--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -75,6 +75,7 @@ body.vscode-dark {
 .xr-section-item input {
   display: inline-block;
   opacity: 0;
+  height: 0;
 }
 
 .xr-section-item input + label {


### PR DESCRIPTION
The changes introduced in #9412 caused display issues in the "Indexes" section (+ lots of vertical space between the main repr sections). This PR should fix that (in a kind of hacky way).

@srijan55 hopefully this doesn't break accessibility.

Main branch:
 
<img width="760" alt="Screenshot 2024-11-12 at 13 46 16" src="https://github.com/user-attachments/assets/587c5542-c55a-4b8b-a000-0f2a3b8516ae">

This PR:

<img width="710" alt="Screenshot 2024-11-12 at 13 40 43" src="https://github.com/user-attachments/assets/f375f95a-88c4-4bca-b8fe-194ff42c256f">
