### PR TITLE
Use `map_overlap` for rolling reductions with Dask

### DIFF
--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -5,25 +5,15 @@ from xarray.core import dtypes, nputils
 
 def dask_rolling_wrapper(moving_func, a, window, min_count=None, axis=-1):
     """Wrapper to apply bottleneck moving window funcs on dask arrays"""
-    import dask.array as da
-
-    dtype, fill_value = dtypes.maybe_promote(a.dtype)
-    a = a.astype(dtype)
-    # inputs for overlap
-    if axis < 0:
-        axis = a.ndim + axis
-    depth = {d: 0 for d in range(a.ndim)}
-    depth[axis] = (window + 1) // 2
-    boundary = {d: fill_value for d in range(a.ndim)}
-    # Create overlap array.
-    ag = da.overlap.overlap(a, depth=depth, boundary=boundary)
-    # apply rolling func
-    out = da.map_blocks(
-        moving_func, ag, window, min_count=min_count, axis=axis, dtype=a.dtype
+    dtype, _ = dtypes.maybe_promote(a.dtype)
+    return a.data.map_overlap(
+        moving_func,
+        depth={axis: (window - 1, 0)},
+        axis=axis,
+        dtype=dtype,
+        window=window,
+        min_count=min_count,
     )
-    # trim array
-    result = da.overlap.trim_internal(out, depth)
-    return result
 
 
 def least_squares(lhs, rhs, rcond=None, skipna=False):
@@ -92,16 +82,4 @@ def push(array, n, axis):
         x=array,
         axis=axis,
         dtype=array.dtype,
-    )
-
-
-def dask_array_rolling(padded, func, axis, window, min_count=None):
-    dtype = "f8" if not padded.dtype.kind == "f" else padded.dtype
-    return padded.data.map_overlap(
-        func,
-        depth={axis: (window - 1, 0)},
-        axis=axis,
-        dtype=dtype,
-        window=window,
-        min_count=min_count,
     )

--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -93,3 +93,15 @@ def push(array, n, axis):
         axis=axis,
         dtype=array.dtype,
     )
+
+
+def dask_array_rolling(padded, func, axis, window, min_count=None):
+    dtype = "f8" if not padded.dtype.kind == "f" else padded.dtype
+    return padded.data.map_overlap(
+        func,
+        depth={axis: (window - 1, 0)},
+        axis=axis,
+        dtype=dtype,
+        window=window,
+        min_count=min_count,
+    )

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -604,11 +604,11 @@ class DataArrayRolling(Rolling["DataArray"]):
             values = func(
                 padded.data, window=self.window[0], min_count=min_count, axis=axis
             )
-            # index 0 is at the rightmost edge of the window
-            # need to reverse index here
-            # see GH #8541
-            if func in [bottleneck.move_argmin, bottleneck.move_argmax]:
-                values = self.window[0] - 1 - values
+        # index 0 is at the rightmost edge of the window
+        # need to reverse index here
+        # see GH #8541
+        if func in [bottleneck.move_argmin, bottleneck.move_argmax]:
+            values = self.window[0] - 1 - values
 
         if self.center[0]:
             values = values[valid]

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -597,8 +597,8 @@ class DataArrayRolling(Rolling["DataArray"]):
             padded = padded.pad({self.dim[0]: (0, -shift)}, mode="constant")
 
         if is_duck_dask_array(padded.data):
-            values = dask_array_ops.dask_array_rolling(
-                padded, func, axis, self.window[0], min_count
+            values = dask_array_ops.dask_rolling_wrapper(
+                func, padded, axis=axis, window=self.window[0], min_count=min_count
             )
         else:
             values = func(
@@ -677,9 +677,6 @@ class DataArrayRolling(Rolling["DataArray"]):
             )
             and self.ndim == 1
         ):
-            # TODO: re-enable bottleneck with dask after the issues
-            # underlying https://github.com/pydata/xarray/issues/2940 are
-            # fixed.
             return self._bottleneck_reduce(
                 bottleneck_move_func, keep_attrs=keep_attrs, **kwargs
             )

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -107,12 +107,13 @@ class TestDataArrayRolling:
         ):
             da.rolling(foo=2)
 
+    @requires_dask
     @pytest.mark.parametrize(
         "name", ("sum", "mean", "std", "min", "max", "median", "argmin", "argmax")
     )
     @pytest.mark.parametrize("center", (True, False, None))
     @pytest.mark.parametrize("min_periods", (1, None))
-    @pytest.mark.parametrize("backend", ["numpy"], indirect=True)
+    @pytest.mark.parametrize("backend", ["numpy", "dask"], indirect=True)
     def test_rolling_wrapped_bottleneck(
         self, da, name, center, min_periods, compute_backend
     ) -> None:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

This enables Dasks map_overlap for rolling reductions, the [previous issues](https://github.com/pydata/xarray/issues/3165) with memory consumption are now handled in map_overlap as far as I can tell