### PR TITLE
Namespace-aware `xarray.ufuncs`

### DIFF
--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -1,6 +1,6 @@
 from importlib.metadata import version as _version
 
-from xarray import groupers, testing, tutorial
+from xarray import groupers, testing, tutorial, ufuncs
 from xarray.backends.api import (
     load_dataarray,
     load_dataset,
@@ -69,6 +69,7 @@ __all__ = (
     "groupers",
     "testing",
     "tutorial",
+    "ufuncs",
     # Top-level functions
     "align",
     "apply_ufunc",

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pytest
 
 import xarray as xr
+import xarray.ufuncs as xu
 from xarray import DataArray, Dataset, Variable
 from xarray.core import duck_array_ops
 from xarray.core.duck_array_ops import lazy_array_equiv
@@ -273,6 +274,17 @@ class TestVariable(DaskTestCase):
         v = self.lazy_var
         self.assertLazyAndAllClose(np.maximum(u, 0), np.maximum(v, 0))
         self.assertLazyAndAllClose(np.maximum(u, 0), np.maximum(0, v))
+
+    def test_univariate_xufunc(self):
+        u = self.eager_var
+        v = self.lazy_var
+        self.assertLazyAndAllClose(np.sin(u), xu.sin(v))
+
+    def test_bivariate_xufunc(self):
+        u = self.eager_var
+        v = self.lazy_var
+        self.assertLazyAndAllClose(np.maximum(u, 0), xu.maximum(v, 0))
+        self.assertLazyAndAllClose(np.maximum(u, 0), xu.maximum(0, v))
 
     def test_compute(self):
         u = self.eager_var

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 import xarray as xr
+import xarray.ufuncs as xu
 from xarray import DataArray, Variable
 from xarray.namedarray.pycompat import array_type
 from xarray.tests import assert_equal, assert_identical, requires_dask
@@ -293,6 +294,13 @@ class TestSparseVariable:
     def test_bivariate_ufunc(self):
         assert_sparse_equal(np.maximum(self.data, 0), np.maximum(self.var, 0).data)
         assert_sparse_equal(np.maximum(self.data, 0), np.maximum(0, self.var).data)
+
+    def test_univariate_xufunc(self):
+        assert_sparse_equal(xu.sin(self.var).data, np.sin(self.data))
+
+    def test_bivariate_xufunc(self):
+        assert_sparse_equal(xu.multiply(self.var, 0).data, np.multiply(self.data, 0))
+        assert_sparse_equal(xu.multiply(0, self.var).data, np.multiply(0, self.data))
 
     def test_repr(self):
         expected = dedent(

--- a/xarray/ufuncs.py
+++ b/xarray/ufuncs.py
@@ -1,0 +1,125 @@
+"""xarray specific universal functions."""
+
+import textwrap
+import warnings
+
+import numpy as np
+
+import xarray as xr
+from xarray.core.groupby import GroupBy
+from xarray.namedarray.pycompat import array_type
+
+
+def _walk_array_namespaces(obj, namespaces):
+    if isinstance(obj, xr.DataTree):
+        for node in obj.subtree:
+            _walk_array_namespaces(node.dataset, namespaces)
+    elif isinstance(obj, xr.Dataset):
+        for name in obj.data_vars:
+            _walk_array_namespaces(obj[name], namespaces)
+    elif isinstance(obj, GroupBy):
+        _walk_array_namespaces(next(iter(obj))[1], namespaces)
+    elif isinstance(obj, xr.DataArray | xr.Variable):
+        _walk_array_namespaces(obj.data, namespaces)
+    elif isinstance(obj, array_type("dask")):
+        _walk_array_namespaces(obj._meta, namespaces)
+    else:
+        namespace = getattr(obj, "__array_namespace__", None)
+        if namespace is not None:
+            namespaces.add(namespace())
+
+    return namespaces
+
+
+class _UFuncDispatcher:
+    """Wrapper for dispatching ufuncs."""
+
+    def __init__(self, name):
+        self._name = name
+
+    def __call__(self, *args, **kwargs):
+        xps = set()
+        for arg in args:
+            _walk_array_namespaces(arg, xps)
+
+        xps.discard(np)
+        if len(xps) > 1:
+            names = [module.__name__ for module in xps]
+            raise ValueError(
+                f"Mixed array types {names} are not supported by xarray.ufuncs"
+            )
+
+        xp = next(iter(xps)) if len(xps) else np
+        func = getattr(xp, self._name, None)
+
+        if func is None:
+            warnings.warn(
+                f"Function {self._name} not found in {xp.__name__}, falling back to numpy",
+                stacklevel=2,
+            )
+            func = getattr(np, self._name)
+
+        return xr.apply_ufunc(func, *args, dask="parallelized", **kwargs)
+
+
+def _skip_signature(doc, name):
+    if not isinstance(doc, str):
+        return doc
+
+    if doc.startswith(name):
+        signature_end = doc.find("\n\n")
+        doc = doc[signature_end + 2 :]
+
+    return doc
+
+
+def _remove_unused_reference_labels(doc):
+    if not isinstance(doc, str):
+        return doc
+
+    max_references = 5
+    for num in range(max_references):
+        label = f".. [{num}]"
+        reference = f"[{num}]_"
+        index = f"{num}.    "
+
+        if label not in doc or reference in doc:
+            continue
+
+        doc = doc.replace(label, index)
+
+    return doc
+
+
+def _dedent(doc):
+    if not isinstance(doc, str):
+        return doc
+
+    return textwrap.dedent(doc)
+
+
+def _create_op(name):
+    func = _UFuncDispatcher(name)
+    func.__name__ = name
+    doc = getattr(np, name).__doc__
+
+    doc = _remove_unused_reference_labels(_skip_signature(_dedent(doc), name))
+
+    func.__doc__ = (
+        f"xarray specific variant of numpy.{name}. Handles "
+        "xarray objects by dispatching to the appropriate "
+        "function for the underlying array type.\n\n"
+        f"Documentation from numpy:\n\n{doc}"
+    )
+    return func
+
+
+# Auto generate from the public numpy ufuncs
+np_ufuncs = {name for name in dir(np) if isinstance(getattr(np, name), np.ufunc)}
+excluded_ufuncs = {"divmod", "frexp", "isnat", "matmul", "modf", "vecdot"}
+additional_ufuncs = {"isreal"}  # "angle", "iscomplex"
+__all__ = sorted(np_ufuncs - excluded_ufuncs | additional_ufuncs)
+
+
+for name in __all__:
+    globals()[name] = _create_op(name)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #7848 (partially)
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

Re-implement the old `xarray.ufuncs` module to allow generic ufunc handling for array types that don't implement `__array_ufunc__`:

```python
import jax.numpy as jnp
import numpy as np
import xarray as xr
import xarray.ufuncs as xu

x = xr.DataArray(jnp.asarray([1, 2, 3]))
print(type(xu.sin(x).data))
print(type(np.sin(x).data))

# <class 'jaxlib.xla_extension.ArrayImpl'>
# <class 'numpy.ndarray'>
```
