### PR TITLE
Optimize idxmin, idxmax with dask

### DIFF
--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -2185,7 +2185,7 @@ def _calc_idxminmax(
     # Handle chunked arrays (e.g. dask).
     if is_chunked_array(array.data):
         chunkmanager = get_chunked_array_type(array.data)
-        chunked_coord = chunkmanager.from_array(array[dim].data, chunks=-1)
+        chunked_coord = chunkmanager.from_array(array[dim].data, chunks=(-1,))
 
         if indx.ndim == 0:
             out = chunked_coord[indx.data]

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -2185,7 +2185,7 @@ def _calc_idxminmax(
     # Handle chunked arrays (e.g. dask).
     if is_chunked_array(array.data):
         chunkmanager = get_chunked_array_type(array.data)
-        chunked_coord = chunkmanager.from_array(array[dim].data, chunks=(-1,))
+        chunked_coord = chunkmanager.from_array(array[dim].data, chunks=((-1,),))
 
         if indx.ndim == 0:
             out = chunked_coord[indx.data]

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -2178,6 +2178,9 @@ def _calc_idxminmax(
             array[dim].data, chunks=((array.sizes[dim],),)
         )
         coord = coord.copy(data=coord_array)
+    else:
+        coord = coord.copy(data=to_like_array(array[dim].data, array.data))
+
     res = indx._replace(coord[(indx.variable,)]).rename(dim)
 
     if skipna or (skipna is None and array.dtype.kind in na_dtypes):

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1655,7 +1655,7 @@ class DaskIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
             has_dask = any(is_duck_dask_array(i) for i in indexer.tuple)
             # this only works for "small" 1d coordinate arrays with one chunk
             # it is intended for idxmin, idxmax, and allows indexing with
-            # the output of argmin, argmax
+            # the nD array output of argmin, argmax
             if (
                 not has_dask
                 or len(indexer.tuple) > 1

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1648,9 +1648,15 @@ class DaskIndexingAdapter(ExplicitlyIndexedNDArrayMixin):
         except IndexError as e:
             # TODO: upstream to dask
             has_dask = any(is_duck_dask_array(i) for i in indexer.tuple)
-            if not has_dask or (has_dask and len(indexer.tuple) > 1):
-                raise e
-            if math.prod(self.array.numblocks) > 1 or self.array.ndim > 1:
+            # this only works for "small" 1d coordinate arrays with one chunk
+            # it is intended for idxmin, idxmax, and allows indexing with
+            # the output of argmin, argmax
+            if (
+                not has_dask
+                or len(indexer.tuple) > 1
+                or math.prod(self.array.numblocks) > 1
+                or self.array.ndim > 1
+            ):
                 raise e
             (idxr,) = indexer.tuple
             if idxr.ndim == 0:

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1817,9 +1817,9 @@ def test_minimize_graph_size():
 
 
 def test_idxmin_chunking():
-    # GH
+    # GH9425
     x, y, t = 100, 100, 10
-    rang = np.random.randn(t * x * y)
+    rang = np.arange(t * x * y)
     da = xr.DataArray(
         rang.reshape(t, x, y), coords={"time": range(t), "x": range(x), "y": range(y)}
     )

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1814,3 +1814,16 @@ def test_minimize_graph_size():
         # all the other dimensions.
         # e.g. previously for 'x',  actual == numchunks['y'] * numchunks['z']
         assert actual == numchunks[var], (actual, numchunks[var])
+
+
+def test_idxmin_chunking():
+    # GH
+    x, y, t = 100, 100, 10
+    rang = np.random.randn(t * x * y)
+    da = xr.DataArray(
+        rang.reshape(t, x, y), coords={"time": range(t), "x": range(x), "y": range(y)}
+    )
+    da = da.chunk(dict(time=-1, x=25, y=25))
+    actual = da.idxmin("time")
+    assert actual.chunksizes == {k: da.chunksizes[k] for k in ["x", "y"]}
+    assert_identical(actual, da.compute().idxmin("time"))

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4949,7 +4949,15 @@ class TestReduce1D(TestReduce):
 
         assert_identical(result2, expected2)
 
-    @pytest.mark.parametrize("use_dask", [True, False])
+    @pytest.mark.parametrize(
+        "use_dask",
+        [
+            pytest.param(
+                True, marks=pytest.mark.skipif(not has_dask, reason="no dask")
+            ),
+            False,
+        ],
+    )
     def test_idxmin(
         self,
         x: np.ndarray,
@@ -4958,16 +4966,11 @@ class TestReduce1D(TestReduce):
         nanindex: int | None,
         use_dask: bool,
     ) -> None:
-        if use_dask and not has_dask:
-            pytest.skip("requires dask")
-        if use_dask and x.dtype.kind == "M":
-            pytest.xfail("dask operation 'argmin' breaks when dtype is datetime64 (M)")
         ar0_raw = xr.DataArray(
             x, dims=["x"], coords={"x": np.arange(x.size) * 4}, attrs=self.attrs
         )
-
         if use_dask:
-            ar0 = ar0_raw.chunk({})
+            ar0 = ar0_raw.chunk()
         else:
             ar0 = ar0_raw
 

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -1010,8 +1010,7 @@ def test_vectorized_indexing_dask_array():
         coords={"y": range(4), "x": range(2)},
         dims=("y", "x"),
     )
-    with pytest.raises(ValueError, match="Vectorized indexing with Dask arrays"):
-        darr[indexer.chunk({"y": 2})]
+    darr[indexer.chunk({"y": 2})]
 
 
 @requires_dask


### PR DESCRIPTION
- [x] Closes #9425
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

cc @phofl here we need to index a numpy array with a dask array (commonly a much larger array) in a sane manner.

We now preserve chunksizes for
```
import numpy as np
import xarray as xr

# create some dummy data and chunk
x, y, t = 1000, 1000, 57
rang = np.arange(t*x*y)
da = xr.DataArray(rang.reshape(t, x, y), coords={'time':range(t), 'x': range(x), 'y':range(y)})
da = da.chunk(dict(time=-1, x=256, y=256))
da.idxmin('time')
```

***After***
<img width="559" alt="image" src="https://github.com/user-attachments/assets/809d4282-6f8b-4230-94a0-22ed059a3a5a">

***Before***
<img width="559" alt="image" src="https://github.com/user-attachments/assets/6f39411c-f30c-4a92-83a5-e0687cf70b75">
