### PR TITLE
Minor format tweak to unrecognized engine error

### DIFF
--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -200,7 +200,7 @@ def get_backend(engine: str | type[BackendEntrypoint]) -> BackendEntrypoint:
         engines = list_engines()
         if engine not in engines:
             raise ValueError(
-                f"unrecognized engine {engine} must be one of your download engines: {list(engines)}"
+                f"unrecognized engine '{engine}' must be one of your download engines: {list(engines)}. "
                 "To install additional dependencies, see:\n"
                 "https://docs.xarray.dev/en/stable/user-guide/io.html \n"
                 "https://docs.xarray.dev/en/stable/getting-started-guide/installing.html"


### PR DESCRIPTION
I got this error (forgot to install `h5netcdf`) and noticed a missing ". " right before "To install additional". This PR just adds that. Also quoted the unrecognized engine to match what's displayed in `list(engines)`. 