### PR TITLE
Described default centre argument behaviour in rolling functions

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -7081,7 +7081,7 @@ class DataArray(
             (otherwise result is NA). The default, None, is equivalent to
             setting min_periods equal to the size of the window.
         center : bool or Mapping to int, default: False
-            Set the labels at the center of the window. The default, False, 
+            Set the labels at the center of the window. The default, False,
             sets the labels at the right edge of the window.
         **window_kwargs : optional
             The keyword arguments form of ``dim``.

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -7081,7 +7081,8 @@ class DataArray(
             (otherwise result is NA). The default, None, is equivalent to
             setting min_periods equal to the size of the window.
         center : bool or Mapping to int, default: False
-            Set the labels at the center of the window.
+            Set the labels at the center of the window. The default, False, 
+            sets the labels at the right edge of the window.
         **window_kwargs : optional
             The keyword arguments form of ``dim``.
             One of dim or window_kwargs must be provided.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -10728,7 +10728,8 @@ class Dataset(
             (otherwise result is NA). The default, None, is equivalent to
             setting min_periods equal to the size of the window.
         center : bool or Mapping to int, default: False
-            Set the labels at the center of the window.
+            Set the labels at the center of the window. The default, False,
+            sets the labels at the right edge of the window.
         **window_kwargs : optional
             The keyword arguments form of ``dim``.
             One of dim or window_kwargs must be provided.

--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -282,7 +282,8 @@ class DataArrayRolling(Rolling["DataArray"]):
             (otherwise result is NA). The default, None, is equivalent to
             setting min_periods equal to the size of the window.
         center : bool, default: False
-            Set the labels at the center of the window.
+            Set the labels at the center of the window. The default, False,
+            sets the labels at the right edge of the window.
 
         Returns
         -------
@@ -790,7 +791,8 @@ class DatasetRolling(Rolling["Dataset"]):
             (otherwise result is NA). The default, None, is equivalent to
             setting min_periods equal to the size of the window.
         center : bool or mapping of hashable to bool, default: False
-            Set the labels at the center of the window.
+            Set the labels at the center of the window. The default, False,
+            sets the labels at the right edge of the window.
 
         Returns
         -------


### PR DESCRIPTION
- [ ] Closes #9773

Extended the documentation of the centre argument of the following functions:
- xarray.DataArray.rolling
- xarray.Dataset.rolling
- xarray.core.rolling.DataArrayRolling
- xarray.core.rolling.DatasetRolling 


