### PR TITLE
Array conversion methods

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -117,6 +117,8 @@ Dataset contents
    Dataset.convert_calendar
    Dataset.interp_calendar
    Dataset.get_index
+   Dataset.as_array_type
+   Dataset.is_array_type
 
 Comparisons
 -----------
@@ -315,6 +317,8 @@ DataArray contents
    DataArray.get_index
    DataArray.astype
    DataArray.item
+   DataArray.as_array_type
+   DataArray.is_array_type
 
 Indexing
 --------

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,6 +21,9 @@ v.2024.11.1 (unreleased)
 
 New Features
 ~~~~~~~~~~~~
+- Add convenience methods ``as_array_type`` and ``is_array_type`` for converting wrapped
+  data to other duck array types. (:issue:`7848`, :pull:`9823`).
+  By `Sam Levang <https://github.com/slevang>`_.
 
 
 Breaking changes
@@ -85,10 +88,6 @@ New Features
   By `Sam Levang <https://github.com/slevang>`_.
 - Speed up loading of large zarr stores using dask arrays. (:issue:`8902`)
   By `Deepak Cherian <https://github.com/dcherian>`_.
-- Make more xarray methods fully compatible with duck array types, and introduce new
-  ``as_array_type`` and ``is_array_type`` methods for converting wrapped data to other
-  duck array types. (:issue:`7848`, :pull:`9798`).
-  By `Sam Levang <https://github.com/slevang>`_.
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -85,6 +85,10 @@ New Features
   By `Sam Levang <https://github.com/slevang>`_.
 - Speed up loading of large zarr stores using dask arrays. (:issue:`8902`)
   By `Deepak Cherian <https://github.com/dcherian>`_.
+- Make more xarray methods fully compatible with duck array types, and introduce new
+  ``as_array_type`` and ``is_array_type`` methods for converting wrapped data to other
+  duck array types. (:issue:`7848`, :pull:`9798`).
+  By `Sam Levang <https://github.com/slevang>`_.
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -844,7 +844,7 @@ class DataArray(
         coords = {k: v.as_numpy() for k, v in self._coords.items()}
         return self._replace(self.variable.as_numpy(), coords, indexes=self._indexes)
 
-    def as_array(self, asarray: Callable, **kwargs) -> Self:
+    def as_array_type(self, asarray: Callable, **kwargs) -> Self:
         """
         Coerces wrapped data into a specific array type.
 
@@ -856,7 +856,8 @@ class DataArray(
         ----------
         asarray : Callable
             Function that converts an array-like object to the desired array type.
-            For example, `cupy.asarray`, `jax.numpy.asarray`, or `sparse.COO.from_numpy`.
+            For example, `cupy.asarray`, `jax.numpy.asarray`, `sparse.COO.from_numpy`,
+            or any `from_dlpack` method.
         **kwargs : dict
             Additional keyword arguments passed to the `asarray` function.
 
@@ -864,7 +865,22 @@ class DataArray(
         -------
         DataArray
         """
-        return self._replace(self.variable.as_array(asarray, **kwargs))
+        return self._replace(self.variable.as_array_type(asarray, **kwargs))
+
+    def is_array_type(self, array_type: type) -> bool:
+        """
+        Check if the wrapped data is of a specific array type.
+
+        Parameters
+        ----------
+        array_type : type
+            The array type to check for.
+
+        Returns
+        -------
+        bool
+        """
+        return self.variable.is_array_type(array_type)
 
     @property
     def _in_memory(self) -> bool:

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -846,7 +846,7 @@ class DataArray(
 
     def as_array_type(self, asarray: Callable, **kwargs) -> Self:
         """
-        Coerces wrapped data into a specific array type.
+        Converts wrapped data into a specific array type.
 
         `asarray` should output an object that supports the Array API Standard.
         This method does not convert index coordinates, which can't generally be

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -844,7 +844,7 @@ class DataArray(
         coords = {k: v.as_numpy() for k, v in self._coords.items()}
         return self._replace(self.variable.as_numpy(), coords, indexes=self._indexes)
 
-    def as_array(self, asarray: Callable[[ArrayLike, ...], Any], **kwargs) -> Self:
+    def as_array(self, asarray: Callable, **kwargs) -> Self:
         """
         Coerces wrapped data into a specific array type.
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -848,6 +848,8 @@ class DataArray(
         """
         Converts wrapped data into a specific array type.
 
+        If the data is a chunked array, the conversion is applied to each block.
+
         `asarray` should output an object that supports the Array API Standard.
         This method does not convert index coordinates, which can't generally be
         represented as arbitrary array types.

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -844,6 +844,28 @@ class DataArray(
         coords = {k: v.as_numpy() for k, v in self._coords.items()}
         return self._replace(self.variable.as_numpy(), coords, indexes=self._indexes)
 
+    def as_array(self, asarray: Callable[[ArrayLike, ...], Any], **kwargs) -> Self:
+        """
+        Coerces wrapped data into a specific array type.
+
+        `asarray` should output an object that supports the Array API Standard.
+        This method does not convert index coordinates, which can't generally be
+        represented as arbitrary array types.
+
+        Parameters
+        ----------
+        asarray : Callable
+            Function that converts an array-like object to the desired array type.
+            For example, `cupy.asarray`, `jax.numpy.asarray`, or `sparse.COO.from_numpy`.
+        **kwargs : dict
+            Additional keyword arguments passed to the `asarray` function.
+
+        Returns
+        -------
+        DataArray
+        """
+        return self._replace(self.variable.as_array(asarray, **kwargs))
+
     @property
     def _in_memory(self) -> bool:
         return self.variable._in_memory

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1460,6 +1460,32 @@ class Dataset(
         numpy_variables = {k: v.as_numpy() for k, v in self.variables.items()}
         return self._replace(variables=numpy_variables)
 
+    def as_array(self, asarray: Callable[[ArrayLike, ...], Any], **kwargs) -> Self:
+        """
+        Converts wrapped data into a specific array type.
+
+        `asarray` should output an object that supports the Array API Standard.
+        This method does not convert index coordinates, which can't generally be
+        represented as arbitrary array types.
+
+        Parameters
+        ----------
+        asarray : Callable
+            Function that converts an array-like object to the desired array type.
+            For example, `cupy.asarray`, `jax.numpy.asarray`, or `sparse.COO.from_numpy`.
+        **kwargs : dict
+            Additional keyword arguments passed to the `asarray` function.
+
+        Returns
+        -------
+        Dataset
+        """
+        array_variables = {
+            k: v.as_array(asarray, **kwargs) if k not in self._indexes else v
+            for k, v in self.variables.items()
+        }
+        return self._replace(variables=array_variables)
+
     def _copy_listed(self, names: Iterable[Hashable]) -> Self:
         """Create a new Dataset with the listed variables from this dataset and
         the all relevant coordinates. Skips all validation.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1464,6 +1464,8 @@ class Dataset(
         """
         Converts wrapped data into a specific array type.
 
+        If the data is a chunked array, the conversion is applied to each block.
+
         `asarray` should output an object that supports the Array API Standard.
         This method does not convert index coordinates, which can't generally be
         represented as arbitrary array types.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1460,7 +1460,7 @@ class Dataset(
         numpy_variables = {k: v.as_numpy() for k, v in self.variables.items()}
         return self._replace(variables=numpy_variables)
 
-    def as_array(self, asarray: Callable[[ArrayLike, ...], Any], **kwargs) -> Self:
+    def as_array(self, asarray: Callable, **kwargs) -> Self:
         """
         Converts wrapped data into a specific array type.
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1460,7 +1460,7 @@ class Dataset(
         numpy_variables = {k: v.as_numpy() for k, v in self.variables.items()}
         return self._replace(variables=numpy_variables)
 
-    def as_array(self, asarray: Callable, **kwargs) -> Self:
+    def as_array_type(self, asarray: Callable, **kwargs) -> Self:
         """
         Converts wrapped data into a specific array type.
 
@@ -1472,7 +1472,8 @@ class Dataset(
         ----------
         asarray : Callable
             Function that converts an array-like object to the desired array type.
-            For example, `cupy.asarray`, `jax.numpy.asarray`, or `sparse.COO.from_numpy`.
+            For example, `cupy.asarray`, `jax.numpy.asarray`, `sparse.COO.from_numpy`,
+            or any `from_dlpack` method.
         **kwargs : dict
             Additional keyword arguments passed to the `asarray` function.
 
@@ -1481,10 +1482,29 @@ class Dataset(
         Dataset
         """
         array_variables = {
-            k: v.as_array(asarray, **kwargs) if k not in self._indexes else v
+            k: v.as_array_type(asarray, **kwargs) if k not in self._indexes else v
             for k, v in self.variables.items()
         }
         return self._replace(variables=array_variables)
+
+    def is_array_type(self, array_type: type) -> bool:
+        """
+        Check if all data variables and non-index coordinates are of a specific array type.
+
+        Parameters
+        ----------
+        array_type : type
+            The array type to check for.
+
+        Returns
+        -------
+        bool
+        """
+        return all(
+            v.is_array_type(array_type)
+            for k, v in self.variables.items()
+            if k not in self._indexes
+        )
 
     def _copy_listed(self, names: Iterable[Hashable]) -> Self:
         """Create a new Dataset with the listed variables from this dataset and

--- a/xarray/namedarray/core.py
+++ b/xarray/namedarray/core.py
@@ -860,6 +860,10 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
         """Coerces wrapped data into a numpy array, returning a Variable."""
         return self._replace(data=self.to_numpy())
 
+    def as_array(self, asarray: Callable[[ArrayLike, ...], Any], **kwargs) -> Self:
+        """Coerces wrapped data into a specific array type, returning a Variable."""
+        return self._replace(data=asarray(self._data, **kwargs))
+
     def reduce(
         self,
         func: Callable[..., Any],

--- a/xarray/namedarray/core.py
+++ b/xarray/namedarray/core.py
@@ -860,13 +860,40 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
         """Coerces wrapped data into a numpy array, returning a Variable."""
         return self._replace(data=self.to_numpy())
 
-    def as_array(
+    def as_array_type(
         self,
         asarray: Callable[[duckarray[Any, _DType_co]], duckarray[Any, _DType_co]],
         **kwargs: Any,
     ) -> Self:
-        """Coerces wrapped data into a specific array type, returning a Variable."""
+        """Converts wrapped data into a specific array type.
+
+        Parameters
+        ----------
+        asarray : callable
+            Function that converts the data into a specific array type.
+        **kwargs : dict
+            Additional keyword arguments passed on to `asarray`.
+
+        Returns
+        -------
+        array : NamedArray
+            Array with the same data, but converted into a specific array type
+        """
         return self._replace(data=asarray(self._data, **kwargs))
+
+    def is_array_type(self, array_type: type) -> bool:
+        """Check if the data is an instance of a specific array type.
+
+        Parameters
+        ----------
+        array_type : type
+            Array type to check against.
+
+        Returns
+        -------
+        is_array_type : bool
+        """
+        return isinstance(self._data, array_type)
 
     def reduce(
         self,

--- a/xarray/namedarray/core.py
+++ b/xarray/namedarray/core.py
@@ -860,7 +860,11 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
         """Coerces wrapped data into a numpy array, returning a Variable."""
         return self._replace(data=self.to_numpy())
 
-    def as_array(self, asarray: Callable[[ArrayLike, ...], Any], **kwargs) -> Self:
+    def as_array(
+        self,
+        asarray: Callable[[duckarray[Any, _DType_co]], duckarray[Any, _DType_co]],
+        **kwargs: Any,
+    ) -> Self:
         """Coerces wrapped data into a specific array type, returning a Variable."""
         return self._replace(data=asarray(self._data, **kwargs))
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -7171,14 +7171,25 @@ def test_as_array_type_is_array_type() -> None:
 
     assert da.is_array_type(np.ndarray)
 
-    def as_duck_array(arr):
-        return DuckArrayWrapper(arr)
-
-    result = da.as_array_type(as_duck_array)
+    result = da.as_array_type(lambda x: DuckArrayWrapper(x))
 
     assert isinstance(result.data, DuckArrayWrapper)
     assert isinstance(result.x.data, np.ndarray)
     assert result.is_array_type(DuckArrayWrapper)
+
+
+@requires_dask
+def test_as_array_type_dask() -> None:
+    import dask.array
+
+    da = xr.DataArray([1, 2, 3], dims=["x"], coords={"x": [4, 5, 6]}).chunk()
+
+    result = da.as_array_type(lambda x: DuckArrayWrapper(x))
+
+    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data._meta, DuckArrayWrapper)
+    assert isinstance(result.x.data, np.ndarray)
+    assert result.is_array_type(dask.array.Array)
 
 
 class TestStackEllipsis:

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -7166,16 +7166,19 @@ class TestNumpyCoercion:
         np.testing.assert_equal(da.to_numpy(), arr)
 
 
-def test_as_array() -> None:
+def test_as_array_type_is_array_type() -> None:
     da = xr.DataArray([1, 2, 3], dims=["x"], coords={"x": [4, 5, 6]})
+
+    assert da.is_array_type(np.ndarray)
 
     def as_duck_array(arr):
         return DuckArrayWrapper(arr)
 
-    result = da.as_array(as_duck_array)
+    result = da.as_array_type(as_duck_array)
 
     assert isinstance(result.data, DuckArrayWrapper)
     assert isinstance(result.x.data, np.ndarray)
+    assert result.is_array_type(DuckArrayWrapper)
 
 
 class TestStackEllipsis:

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -39,6 +39,7 @@ from xarray.core.types import QueryEngineOptions, QueryParserOptions
 from xarray.core.utils import is_scalar
 from xarray.testing import _assert_internal_invariants
 from xarray.tests import (
+    DuckArrayWrapper,
     InaccessibleArray,
     ReturnItem,
     assert_allclose,
@@ -7163,6 +7164,18 @@ class TestNumpyCoercion:
         expected = xr.DataArray(arr, dims="x", coords={"lat": ("x", arr * 2)})
         assert_identical(result, expected)
         np.testing.assert_equal(da.to_numpy(), arr)
+
+
+def test_as_array() -> None:
+    da = xr.DataArray([1, 2, 3], dims=["x"], coords={"x": [4, 5, 6]})
+
+    def as_duck_array(arr):
+        return DuckArrayWrapper(arr)
+
+    result = da.as_array(as_duck_array)
+
+    assert isinstance(result.data, DuckArrayWrapper)
+    assert isinstance(result.x.data, np.ndarray)
 
 
 class TestStackEllipsis:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -7639,6 +7639,21 @@ class TestNumpyCoercion:
         assert_identical(result, expected)
 
 
+def test_as_array() -> None:
+    ds = xr.Dataset(
+        {"a": ("x", [1, 2, 3])}, coords={"lat": ("x", [4, 5, 6]), "x": [7, 8, 9]}
+    )
+
+    def as_duck_array(arr):
+        return DuckArrayWrapper(arr)
+
+    result = ds.as_array(as_duck_array)
+
+    assert isinstance(result.a.data, DuckArrayWrapper)
+    assert isinstance(result.lat.data, DuckArrayWrapper)
+    assert isinstance(result.x.data, np.ndarray)
+
+
 def test_string_keys_typing() -> None:
     """Tests that string keys to `variables` are permitted by mypy"""
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -7639,19 +7639,22 @@ class TestNumpyCoercion:
         assert_identical(result, expected)
 
 
-def test_as_array() -> None:
+def test_as_array_type_is_array_type() -> None:
     ds = xr.Dataset(
         {"a": ("x", [1, 2, 3])}, coords={"lat": ("x", [4, 5, 6]), "x": [7, 8, 9]}
     )
+    # lat is a PandasIndex here
+    assert ds.drop_vars("lat").is_array_type(np.ndarray)
 
     def as_duck_array(arr):
         return DuckArrayWrapper(arr)
 
-    result = ds.as_array(as_duck_array)
+    result = ds.as_array_type(as_duck_array)
 
     assert isinstance(result.a.data, DuckArrayWrapper)
     assert isinstance(result.lat.data, DuckArrayWrapper)
     assert isinstance(result.x.data, np.ndarray)
+    assert result.is_array_type(DuckArrayWrapper)
 
 
 def test_string_keys_typing() -> None:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] relates to: #7848
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`

This implements a convenience method to convert data between duck array types, and another to check the current type of your data. Basically identical to cupy-xarray's `as_cupy()`/`is_cupy()` methods, but exposed in a more general way.

The signature I have here takes a callable plus any kwargs, so it's quite flexible:
```python
ds.as_array_type(cp.asarray)
ds.as_array_type(jnp.from_dlpack)
ds.as_array_type(jnp.asarray, device=jax.devices("gpu")[0])
ds.as_array_type(pint.Quantity, units="m/s")
```

Then:
```python
ds.is_array_type(cp.ndarray) # -> True
```

I'm not sure about the naming. There are also other ways we could go about this, e.g. string matching for supported arrays.

Follow up to #9798.