### PR TITLE
Fix type annotations for `get_axis_num` (GH 9822)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,7 +36,8 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
-
+- Fix type annotations for ``get_axis_num``. (:issue:`9822`).
+  By `Bruce Merry <https://github.com/bmerry>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,7 +36,7 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
-- Fix type annotations for ``get_axis_num``. (:issue:`9822`).
+- Fix type annotations for ``get_axis_num``. (:issue:`9822`, :pull:`9827`).
   By `Bruce Merry <https://github.com/bmerry>`_.
 - Fix unintended load on datasets when calling :py:meth:`DataArray.plot.scatter` (:pull:`9818`).
   By `Jimmy Westling <https://github.com/illviljan>`_.

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -214,6 +214,9 @@ class AbstractArray:
         return self._iter()
 
     @overload
+    def get_axis_num(self, dim: str) -> int: ...
+
+    @overload
     def get_axis_num(self, dim: Iterable[Hashable]) -> tuple[int, ...]: ...
 
     @overload

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -214,7 +214,7 @@ class AbstractArray:
         return self._iter()
 
     @overload
-    def get_axis_num(self, dim: str) -> int: ...
+    def get_axis_num(self, dim: str) -> int: ...  # type: ignore [overload-overlap]
 
     @overload
     def get_axis_num(self, dim: Iterable[Hashable]) -> tuple[int, ...]: ...

--- a/xarray/namedarray/core.py
+++ b/xarray/namedarray/core.py
@@ -670,6 +670,9 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
         return type(self)(self._dims, data, attrs=self._attrs)
 
     @overload
+    def get_axis_num(self, dim: str) -> int: ...
+
+    @overload
     def get_axis_num(self, dim: Iterable[Hashable]) -> tuple[int, ...]: ...
 
     @overload

--- a/xarray/namedarray/core.py
+++ b/xarray/namedarray/core.py
@@ -670,7 +670,7 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
         return type(self)(self._dims, data, attrs=self._attrs)
 
     @overload
-    def get_axis_num(self, dim: str) -> int: ...
+    def get_axis_num(self, dim: str) -> int: ...  # type: ignore [overload-overlap]
 
     @overload
     def get_axis_num(self, dim: Iterable[Hashable]) -> tuple[int, ...]: ...


### PR DESCRIPTION
Explicitly annotate that a single `str` argument leads to an `int` return, overriding the match against Iterable.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #9822
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

I haven't added tests since I didn't spot any existing tests of type annotations, but let me know if I missed them.