### PR TITLE
FIX: gracfully handle missing seaborn dependency

### DIFF
--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -143,14 +143,11 @@ def _color_palette(cmap, n_colors):
             pal = cmap(colors_i)
         except ValueError:
             # ValueError happens when mpl doesn't like a colormap, try seaborn
-            if TYPE_CHECKING:
-                import seaborn as sns
-            else:
-                sns = attempt_import("seaborn")
-
             try:
-                pal = sns.color_palette(cmap, n_colors=n_colors)
-            except ValueError:
+                from seaborn import color_palette
+
+                pal = color_palette(cmap, n_colors=n_colors)
+            except (ValueError, ImportError):
                 # or maybe we just got a single color as a string
                 cmap = ListedColormap([cmap] * n_colors)
                 pal = cmap(colors_i)
@@ -192,7 +189,10 @@ def _determine_cmap_params(
     cmap_params : dict
         Use depends on the type of the plotting function
     """
-    import matplotlib as mpl
+    if TYPE_CHECKING:
+        import matplotlib as mpl
+    else:
+        mpl = attempt_import("matplotlib")
 
     if isinstance(levels, Iterable):
         levels = sorted(levels)


### PR DESCRIPTION
xref: https://github.com/pydata/xarray/pull/9561#discussion_r1861273284

Fixes  a regression I introduced in #9561

MWE:

On current `main`, this code will fail if `seaborn` is not installed _even if matplotlib is installed_:

```bash
conda create -n xr-test python=3.10 xarray pooch scipy matplotlib
```

```python
import xarray as xr
air = xr.tutorial.open_dataset("air_temperature")
air.air.isel(time=0).plot.contourf(colors="k")
```

As mentioned in https://github.com/pydata/xarray/pull/9561#discussion_r1861273284 , it seems that this wasn't caught by a CI because there isnt' a CI that has matplotlib but _not_ seaborn installed.


EDIT: AFAICT - The behavior before #9561 was that if you pass a single color to the `colors` parameter like in the MWE, xarray will try to use Seaborn for this but fallback to matplotlib if necessary (e.g. if Seaborn is not installed). 



