### PR TITLE
Add Pyproject pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,3 +63,8 @@ repos:
     rev: ebf0b5e44d67f8beaa1cd13a0d0393ea04c6058d
     hooks:
       - id: validate-cff
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
+        args: ["--option", "array_auto_collapse=false"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,3 +68,8 @@ repos:
     hooks:
       - id: taplo-format
         args: ["--option", "array_auto_collapse=false"]
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.23
+    hooks:
+      - id: validate-pyproject
+        additional_dependencies: ["validate-pyproject-schema-store[all]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -336,7 +336,9 @@ filterwarnings = [
   "default:the `pandas.MultiIndex` object:FutureWarning:xarray.tests.test_variable",
   "default:Using a non-tuple sequence for multidimensional indexing is deprecated:FutureWarning",
   "default:Duplicate dimension names present:UserWarning:xarray.namedarray.core",
-  "default:::xarray.tests.test_strategies",                                                                                                      # TODO: remove once we know how to deal with a changed signature in protocols
+
+  # TODO: remove once we know how to deal with a changed signature in protocols
+  "default:::xarray.tests.test_strategies",
 ]
 
 log_cli_level = "INFO"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 authors = [
-  {name = "xarray Developers", email = "xarray@googlegroups.com"},
+  { name = "xarray Developers", email = "xarray@googlegroups.com" },
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -16,7 +16,7 @@ classifiers = [
 ]
 description = "N-D labeled arrays and datasets in Python"
 dynamic = ["version"]
-license = {text = "Apache-2.0"}
+license = { text = "Apache-2.0" }
 name = "xarray"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -50,7 +50,16 @@ dev = [
   "sphinx_autosummary_accessors",
   "xarray[complete]",
 ]
-io = ["netCDF4", "h5netcdf", "scipy", 'pydap; python_version<"3.10"', "zarr", "fsspec", "cftime", "pooch"]
+io = [
+  "netCDF4",
+  "h5netcdf",
+  "scipy",
+  'pydap; python_version<"3.10"',
+  "zarr",
+  "fsspec",
+  "cftime",
+  "pooch",
+]
 etc = ["sparse"]
 parallel = ["dask[complete]"]
 viz = ["cartopy", "matplotlib", "nc-time-axis", "seaborn"]
@@ -249,7 +258,7 @@ extend-select = [
   "RUF",
 ]
 extend-safe-fixes = [
-  "TID252",  # absolute imports
+  "TID252", # absolute imports
 ]
 ignore = [
   "E402",    # module level import not at top of file
@@ -327,7 +336,7 @@ filterwarnings = [
   "default:the `pandas.MultiIndex` object:FutureWarning:xarray.tests.test_variable",
   "default:Using a non-tuple sequence for multidimensional indexing is deprecated:FutureWarning",
   "default:Duplicate dimension names present:UserWarning:xarray.namedarray.core",
-  "default:::xarray.tests.test_strategies", # TODO: remove once we know how to deal with a changed signature in protocols
+  "default:::xarray.tests.test_strategies",                                                                                                      # TODO: remove once we know how to deal with a changed signature in protocols
 ]
 
 log_cli_level = "INFO"


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes None (see https://github.com/pydata/xarray/pull/9781#discussion_r1845444677)

Changes:
- add taplo (toml formatting) hook
- add `validate-pyproject` hook

Heyo! Looks like Taplo (https://github.com/tamasfe/taplo) would be a good option (same project as VScode extension [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml) with 2.3M downloads) . They don't have an official hook (https://github.com/tamasfe/taplo/issues/535) but there's an unofficial one at https://github.com/ComPWA/taplo-pre-commit. I don't think they'll get an official one soon as they would need to set up a mirror repo (and best to transfer both repos to an org for that).
