### PR TITLE
Set `zarr_format` for `zarr.consolidate_metadata`

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -970,6 +970,7 @@ class ZarrStore(AbstractWritableDataStore):
             if _zarr_v3():
                 # https://github.com/zarr-developers/zarr-python/pull/2113#issuecomment-2386718323
                 kwargs["path"] = self.zarr_group.name.lstrip("/")
+                kwargs["zarr_format"] = self.zarr_group.metadata.zarr_format
             zarr.consolidate_metadata(self.zarr_group.store, **kwargs)
 
     def sync(self):


### PR DESCRIPTION
Avoids a few useless gets with Zarr v3 stores.

Not sure how to test it, or even if a test is needed.

cc @TomAugspurger 