### PR TITLE
Remove deprecated behavior for non-dim positional args

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -14,9 +14,9 @@ What's New
 
     np.random.seed(123456)
 
-.. _whats-new.2024.11.1:
+.. _whats-new.2024.12.0:
 
-v.2024.11.1 (unreleased)
+v.2024.12.0 (unreleased)
 ------------------------
 
 New Features
@@ -28,7 +28,12 @@ New Features
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
-
+- Methods including ``dropna``, ``rank``, ``idxmax``, ``idxmin`` require
+  non-dimension arguments to be passed as keyword arguments. The previous
+  behavior, which allowed ``.idxmax('foo', 'all')`` was too easily confused with
+  ``'all'`` being a dimension. The updated equivalent is ``.idxmax('foo',
+  how='all')``. The previous behavior was deprecated in v2023.10.0.
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1026,7 +1026,6 @@ class DataArray(
         drop: Literal[True],
     ) -> Self: ...
 
-    @_deprecate_positional_args("v2023.10.0")
     def reset_coords(
         self,
         names: Dims = None,
@@ -1364,7 +1363,6 @@ class DataArray(
         all_variables = [self.variable] + [c.variable for c in self.coords.values()]
         return get_chunksizes(all_variables)
 
-    @_deprecate_positional_args("v2023.10.0")
     def chunk(
         self,
         chunks: T_ChunksFreq = {},  # noqa: B006  # {} even though it's technically unsafe, is being used intentionally here (#4667)
@@ -1835,7 +1833,6 @@ class DataArray(
         ds = self._to_temp_dataset().thin(indexers, **indexers_kwargs)
         return self._from_temp_dataset(ds)
 
-    @_deprecate_positional_args("v2023.10.0")
     def broadcast_like(
         self,
         other: T_DataArrayOrSet,
@@ -1948,7 +1945,6 @@ class DataArray(
 
         return da
 
-    @_deprecate_positional_args("v2023.10.0")
     def reindex_like(
         self,
         other: T_DataArrayOrSet,
@@ -2135,7 +2131,6 @@ class DataArray(
             fill_value=fill_value,
         )
 
-    @_deprecate_positional_args("v2023.10.0")
     def reindex(
         self,
         indexers: Mapping[Any, Any] | None = None,
@@ -2960,7 +2955,6 @@ class DataArray(
         )
         return self._from_temp_dataset(ds)
 
-    @_deprecate_positional_args("v2023.10.0")
     def unstack(
         self,
         dim: Dims = None,
@@ -3385,7 +3379,6 @@ class DataArray(
         dataset = dataset.drop_isel(indexers=indexers, **indexers_kwargs)
         return self._from_temp_dataset(dataset)
 
-    @_deprecate_positional_args("v2023.10.0")
     def dropna(
         self,
         dim: Hashable,
@@ -4889,7 +4882,6 @@ class DataArray(
 
         return title
 
-    @_deprecate_positional_args("v2023.10.0")
     def diff(
         self,
         dim: Hashable,
@@ -5198,7 +5190,6 @@ class DataArray(
         ds = self._to_temp_dataset().sortby(variables, ascending=ascending)
         return self._from_temp_dataset(ds)
 
-    @_deprecate_positional_args("v2023.10.0")
     def quantile(
         self,
         q: ArrayLike,
@@ -5318,7 +5309,6 @@ class DataArray(
         )
         return self._from_temp_dataset(ds)
 
-    @_deprecate_positional_args("v2023.10.0")
     def rank(
         self,
         dim: Hashable,
@@ -5897,7 +5887,6 @@ class DataArray(
         )
         return self._from_temp_dataset(ds)
 
-    @_deprecate_positional_args("v2023.10.0")
     def idxmin(
         self,
         dim: Hashable | None = None,
@@ -5995,7 +5984,6 @@ class DataArray(
             keep_attrs=keep_attrs,
         )
 
-    @_deprecate_positional_args("v2023.10.0")
     def idxmax(
         self,
         dim: Hashable = None,
@@ -6093,7 +6081,6 @@ class DataArray(
             keep_attrs=keep_attrs,
         )
 
-    @_deprecate_positional_args("v2023.10.0")
     def argmin(
         self,
         dim: Dims = None,
@@ -6195,7 +6182,6 @@ class DataArray(
         else:
             return self._replace_maybe_drop_dims(result)
 
-    @_deprecate_positional_args("v2023.10.0")
     def argmax(
         self,
         dim: Dims = None,
@@ -6544,7 +6530,6 @@ class DataArray(
             kwargs=kwargs,
         )
 
-    @_deprecate_positional_args("v2023.10.0")
     def drop_duplicates(
         self,
         dim: Hashable | Iterable[Hashable],

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3276,9 +3276,11 @@ class Dataset(
         subset = self[[name for name in self._variables if name not in is_chunked]]
 
         no_slices: list[list[int]] = [
-            list(range(*idx.indices(self.sizes[dim])))
-            if isinstance(idx, slice)
-            else idx
+            (
+                list(range(*idx.indices(self.sizes[dim])))
+                if isinstance(idx, slice)
+                else idx
+            )
             for idx in indices
         ]
         no_slices = [idx for idx in no_slices if idx]
@@ -5102,7 +5104,6 @@ class Dataset(
             variables, coord_names=coord_names, indexes=indexes_
         )
 
-    @_deprecate_positional_args("v2023.10.0")
     def reset_index(
         self,
         dims_or_levels: Hashable | Sequence[Hashable],
@@ -5740,7 +5741,6 @@ class Dataset(
             variables, coord_names=coord_names, indexes=indexes
         )
 
-    @_deprecate_positional_args("v2023.10.0")
     def unstack(
         self,
         dim: Dims = None,
@@ -6502,7 +6502,6 @@ class Dataset(
             ds._variables[name] = var.transpose(*var_dims)
         return ds
 
-    @_deprecate_positional_args("v2023.10.0")
     def dropna(
         self,
         dim: Hashable,
@@ -7976,7 +7975,6 @@ class Dataset(
             if v in self.variables:
                 self.variables[v].attrs = other.variables[v].attrs
 
-    @_deprecate_positional_args("v2023.10.0")
     def diff(
         self,
         dim: Hashable,
@@ -8324,7 +8322,6 @@ class Dataset(
             indices[key] = order if ascending else order[::-1]
         return aligned_self.isel(indices)
 
-    @_deprecate_positional_args("v2023.10.0")
     def quantile(
         self,
         q: ArrayLike,
@@ -8505,7 +8502,6 @@ class Dataset(
         )
         return new.assign_coords(quantile=q)
 
-    @_deprecate_positional_args("v2023.10.0")
     def rank(
         self,
         dim: Hashable,
@@ -9476,7 +9472,6 @@ class Dataset(
         attrs = self._attrs if keep_attrs else None
         return self._replace_with_new_dims(variables, indexes=indexes, attrs=attrs)
 
-    @_deprecate_positional_args("v2023.10.0")
     def idxmin(
         self,
         dim: Hashable | None = None,
@@ -9575,7 +9570,6 @@ class Dataset(
             )
         )
 
-    @_deprecate_positional_args("v2023.10.0")
     def idxmax(
         self,
         dim: Hashable | None = None,
@@ -10258,7 +10252,6 @@ class Dataset(
 
         return result
 
-    @_deprecate_positional_args("v2023.10.0")
     def drop_duplicates(
         self,
         dim: Hashable | Iterable[Hashable],

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -244,9 +244,7 @@ class _DummyGroup(Generic[T_Xarray]):
 T_Group = Union["T_DataArray", _DummyGroup]
 
 
-def _ensure_1d(
-    group: T_Group, obj: T_DataWithCoords
-) -> tuple[
+def _ensure_1d(group: T_Group, obj: T_DataWithCoords) -> tuple[
     T_Group,
     T_DataWithCoords,
     Hashable | None,
@@ -1183,7 +1181,6 @@ class GroupBy(Generic[T_Xarray]):
         """
         return ops.fillna(self, value)
 
-    @_deprecate_positional_args("v2023.10.0")
     def quantile(
         self,
         q: ArrayLike,

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -50,7 +50,6 @@ from xarray.core.utils import (
 )
 from xarray.core.variable import IndexVariable, Variable
 from xarray.namedarray.pycompat import is_chunked_array
-from xarray.util.deprecation_helpers import _deprecate_positional_args
 
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
@@ -244,7 +243,9 @@ class _DummyGroup(Generic[T_Xarray]):
 T_Group = Union["T_DataArray", _DummyGroup]
 
 
-def _ensure_1d(group: T_Group, obj: T_DataWithCoords) -> tuple[
+def _ensure_1d(
+    group: T_Group, obj: T_DataWithCoords
+) -> tuple[
     T_Group,
     T_DataWithCoords,
     Hashable | None,

--- a/xarray/core/weighted.py
+++ b/xarray/core/weighted.py
@@ -454,7 +454,6 @@ class Weighted(Generic[T_Xarray]):
     def _implementation(self, func, dim, **kwargs):
         raise NotImplementedError("Use `Dataset.weighted` or `DataArray.weighted`")
 
-    @_deprecate_positional_args("v2023.10.0")
     def sum_of_weights(
         self,
         dim: Dims = None,
@@ -465,7 +464,6 @@ class Weighted(Generic[T_Xarray]):
             self._sum_of_weights, dim=dim, keep_attrs=keep_attrs
         )
 
-    @_deprecate_positional_args("v2023.10.0")
     def sum_of_squares(
         self,
         dim: Dims = None,
@@ -477,7 +475,6 @@ class Weighted(Generic[T_Xarray]):
             self._sum_of_squares, dim=dim, skipna=skipna, keep_attrs=keep_attrs
         )
 
-    @_deprecate_positional_args("v2023.10.0")
     def sum(
         self,
         dim: Dims = None,
@@ -489,7 +486,6 @@ class Weighted(Generic[T_Xarray]):
             self._weighted_sum, dim=dim, skipna=skipna, keep_attrs=keep_attrs
         )
 
-    @_deprecate_positional_args("v2023.10.0")
     def mean(
         self,
         dim: Dims = None,
@@ -501,7 +497,6 @@ class Weighted(Generic[T_Xarray]):
             self._weighted_mean, dim=dim, skipna=skipna, keep_attrs=keep_attrs
         )
 
-    @_deprecate_positional_args("v2023.10.0")
     def var(
         self,
         dim: Dims = None,
@@ -513,7 +508,6 @@ class Weighted(Generic[T_Xarray]):
             self._weighted_var, dim=dim, skipna=skipna, keep_attrs=keep_attrs
         )
 
-    @_deprecate_positional_args("v2023.10.0")
     def std(
         self,
         dim: Dims = None,

--- a/xarray/core/weighted.py
+++ b/xarray/core/weighted.py
@@ -11,7 +11,6 @@ from xarray.core.alignment import align, broadcast
 from xarray.core.computation import apply_ufunc, dot
 from xarray.core.types import Dims, T_DataArray, T_Xarray
 from xarray.namedarray.utils import is_duck_dask_array
-from xarray.util.deprecation_helpers import _deprecate_positional_args
 
 # Weighted quantile methods are a subset of the numpy supported quantile methods.
 QUANTILE_METHODS = Literal[


### PR DESCRIPTION
I wanted to do https://github.com/pydata/xarray/issues/9805, but realize there is already deprecated behavior on `.quantile`; figured it would make sense to complete that cycle before doing another 