### PR TITLE
Add token to codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,6 +160,8 @@ jobs:
 
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v5.0.7
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./coverage.xml
           flags: unittests


### PR DESCRIPTION
Without this, we can't upload on `main`, I think. I added a token into our Actions Secrets.

ref https://github.com/pydata/xarray/issues/9860
