### PR TITLE
Add missing DataTree attributes to docs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -626,12 +626,14 @@ Attributes relating to the recursive tree-like structure of a ``DataTree``.
    DataTree.depth
    DataTree.width
    DataTree.subtree
+   DataTree.subtree_with_keys
    DataTree.descendants
    DataTree.siblings
    DataTree.lineage
    DataTree.parents
    DataTree.ancestors
    DataTree.groups
+   DataTree.xindexes
 
 Data Contents
 -------------
@@ -645,6 +647,7 @@ This interface echoes that of ``xarray.Dataset``.
    DataTree.dims
    DataTree.sizes
    DataTree.data_vars
+   DataTree.ds
    DataTree.coords
    DataTree.attrs
    DataTree.encoding


### PR DESCRIPTION
This PR is meant to fix missing links in https://docs.xarray.dev/en/latest/generated/xarray.DataTree.html by adding the attributes to the API documentation.