### PR TITLE
Fix/silence upstream tests

### DIFF
--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -1188,6 +1188,7 @@ def test_to_datetimeindex_feb_29(calendar):
         index.to_datetimeindex()
 
 
+@pytest.mark.xfail(reason="fails on pandas main branch")
 @requires_cftime
 def test_multiindex():
     index = xr.cftime_range("2001-01-01", periods=100, calendar="360_day")

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -1020,9 +1020,10 @@ Data variables:
     assert actual == expected
 
     actual = repr(xds["foo"])
-    expected = """
+    array_repr = repr(xds.foo.data).replace("\n     ", "")
+    expected = f"""
 <xarray.DataArray 'foo' (foo: 1200)> Size: 2kB
-array([   0,    1,    2, ..., 1197, 1198, 1199], dtype=int16)
+{array_repr}
 Coordinates:
   * foo      (foo) int16 2kB 0 1 2 3 4 5 6 ... 1194 1195 1196 1197 1198 1199
 """.strip()


### PR DESCRIPTION
1. Fix numpy formatting test (Closes #9873)
2. xfail cftimeindex test (#9878)

Closes #9810
