### PR TITLE
Fix interpolation when non-numeric coords are present.

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -45,6 +45,9 @@ Bug fixes
   By `Bruce Merry <https://github.com/bmerry>`_.
 - Fix unintended load on datasets when calling :py:meth:`DataArray.plot.scatter` (:pull:`9818`).
   By `Jimmy Westling <https://github.com/illviljan>`_.
+- Fix interpolation when non-numeric coordinate variables are present (:issue:`8099`, :issue:`9839`).
+  By `Deepak Cherian <https://github.com/dcherian>`_.
+
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4214,10 +4214,11 @@ class Dataset(
                 # interpolated along:
                 variables[name] = var
 
-        if reindex:
-            reindex_indexers = {
+        if reindex and (
+            reindex_indexers := {
                 k: v for k, (_, v) in validated_indexers.items() if v.dims == (k,)
             }
+        ):
             reindexed = alignment.reindex(
                 obj,
                 indexers=reindex_indexers,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -4185,7 +4185,7 @@ class Dataset(
             }
 
         variables: dict[Hashable, Variable] = {}
-        reindex: bool = False
+        reindex_vars: list[Hashable] = []
         for name, var in obj._variables.items():
             if name in indexers:
                 continue
@@ -4207,20 +4207,20 @@ class Dataset(
                 # booleans and objects and retains the dtype but inside
                 # this loop there might be some duplicate code that slows it
                 # down, therefore collect these signals and run it later:
-                reindex = True
+                reindex_vars.append(name)
             elif all(d not in indexers for d in var.dims):
                 # For anything else we can only keep variables if they
                 # are not dependent on any coords that are being
                 # interpolated along:
                 variables[name] = var
 
-        if reindex and (
+        if reindex_vars and (
             reindex_indexers := {
                 k: v for k, (_, v) in validated_indexers.items() if v.dims == (k,)
             }
         ):
             reindexed = alignment.reindex(
-                obj,
+                obj[reindex_vars],
                 indexers=reindex_indexers,
                 method=method_non_numeric,
                 exclude_vars=variables.keys(),

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -1058,7 +1058,28 @@ def test_interp1d_complex_out_of_bounds() -> None:
 
 
 @requires_scipy
-def test_interp_non_numeric() -> None:
+def test_interp_non_numeric_1d() -> None:
+    ds = xr.Dataset(
+        {
+            "numeric": ("time", 1 + np.arange(0, 4, 1)),
+            "non_numeric": ("time", np.array(["a", "b", "c", "d"])),
+        },
+        coords={"time": (np.arange(0, 4, 1))},
+    )
+    actual = ds.interp(time=np.linspace(0, 3, 7))
+
+    expected = xr.Dataset(
+        {
+            "numeric": ("time", 1 + np.linspace(0, 3, 7)),
+            "non_numeric": ("time", np.array(["a", "b", "b", "c", "c", "d", "d"])),
+        },
+        coords={"time": np.linspace(0, 3, 7)},
+    )
+    xr.testing.assert_identical(actual, expected)
+
+
+@requires_scipy
+def test_interp_non_numeric_nd() -> None:
     # regression test for GH8099, GH9839
     ds = xr.Dataset({"x": ("a", np.arange(4))}, coords={"a": (np.arange(4) - 1.5)})
     t = xr.DataArray(


### PR DESCRIPTION
We were calling align with no indexers, which just returned the input object

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #8099
- [x] Closes #9839
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`