### PR TITLE
Use integers instead of randint

### DIFF
--- a/asv_bench/benchmarks/__init__.py
+++ b/asv_bench/benchmarks/__init__.py
@@ -48,7 +48,7 @@ def randn(shape, frac_nan=None, chunks=None, seed=0):
 
 def randint(low, high=None, size=None, frac_minus=None, seed=0):
     rng = np.random.default_rng(seed)
-    x = rng.randint(low, high, size)
+    x = rng.integers(low, high, size)
     if frac_minus is not None:
         inds = rng.choice(range(x.size), int(x.size * frac_minus))
         x.flat[inds] = -1


### PR DESCRIPTION
New code should use the [integers](https://numpy.org/doc/2.1/reference/random/generated/numpy.random.Generator.integers.html#numpy.random.Generator.integers) method of a [Generator](https://numpy.org/doc/2.1/reference/random/generator.html#numpy.random.Generator) instance instead of `randint`.

- [x] Seen in #9881

References:
https://numpy.org/doc/2.1/reference/random/generated/numpy.random.Generator.integers.html#numpy.random.Generator.integers
https://numpy.org/doc/2.1/reference/random/generated/numpy.random.randint.html