### PR TITLE
split out CFDatetimeCoder, deprecate use_cftime as kwarg

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1096,6 +1096,17 @@ DataTree methods
 ..    Missing:
 ..    ``open_mfdatatree``
 
+Encoding/Decoding
+=================
+
+Coder objects
+-------------
+
+.. autosummary::
+   :toctree: generated/
+
+   coders.CFDatetimeCoder
+
 Coordinates objects
 ===================
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -23,8 +23,8 @@ v2025.01.1 (unreleased)
 New Features
 ~~~~~~~~~~~~
 - Split out :py:class:`coders.CFDatetimeCoder` as public API in ``xr.coders``, make ``decode_times`` keyword argument
-  consume :py:class:`coders.CFDatetimeCoder`.
-
+  consume :py:class:`coders.CFDatetimeCoder` (:pull:`9901`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
@@ -32,7 +32,9 @@ Breaking changes
 
 Deprecations
 ~~~~~~~~~~~~
-
+- Time decoding related kwarg ``use_cftime`` is deprecated. Use keyword argument
+  ``decode_times=CFDatetimeCoder(use_cftime=True)`` in :py:func:`~xarray.open_dataset`, :py:func:`~xarray.open_dataarray`, :py:func:`~xarray.open_datatree`, :py:func:`~xarray.open_groups`, :py:func:`~xarray.open_zarr` and :py:func:`~xarray.decode_cf` instead (:pull:`9901`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Bug fixes
 ~~~~~~~~~
@@ -86,9 +88,6 @@ Deprecations
 ~~~~~~~~~~~~
 - Finalize deprecation of ``closed`` parameters of :py:func:`cftime_range` and
   :py:func:`date_range` (:pull:`9882`).
-  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
-- Time decoding related kwarg ``use_cftime`` is deprecated. Use keyword argument
-  ``decode_times=CFDatetimeCoder(use_cftime=True)`` in :py:func:`~xarray.open_dataset`, :py:func:`~xarray.open_dataarray`, :py:func:`~xarray.open_datatree`, :py:func:`~xarray.open_groups`, :py:func:`~xarray.open_zarr` and :py:func:`~xarray.decode_cf` instead.
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Performance

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,6 +22,8 @@ v2025.01.1 (unreleased)
 
 New Features
 ~~~~~~~~~~~~
+- Split out :py:class:`coders.CFDatetimeCoder` as public API in ``xr.coders``, make ``decode_times`` keyword argument
+  consume :py:class:`coders.CFDatetimeCoder`.
 
 
 Breaking changes
@@ -69,8 +71,6 @@ New Features
 - Add ``unit`` - keyword argument to :py:func:`date_range` and ``microsecond`` parsing to
   iso8601-parser (:pull:`9885`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
-- Split out :py:class:`coders.CFDatetimeCoder` as public API in ``xr.coders``, make ``decode_times`` keyword argument
-  consume :py:class:`coders.CFDatetimeCoder`.
 
 
 Breaking changes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,6 +27,9 @@ New Features
 - Add ``unit`` - keyword argument to :py:func:`date_range` and ``microsecond`` parsing to
   iso8601-parser (:pull:`9885`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Split out ``CFDatetimeCoder`` in ``xr.coders``, make ``decode_times`` keyword argument
+  consume ``CFDatetimeCoder``.
+
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
@@ -45,6 +48,7 @@ Deprecations
 - Time decoding related kwarg ``use_cftime`` is deprecated. Use keyword argument
   ``decode_times=CFDatetimeCoder(use_cftime=True)`` in the respective functions
   instead.
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -42,6 +42,9 @@ Deprecations
 - Finalize deprecation of ``closed`` parameters of :py:func:`cftime_range` and
   :py:func:`date_range` (:pull:`9882`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Time decoding related kwarg ``use_cftime`` is deprecated. Use keyword argument
+  ``decode_times=CFDatetimeCoder(use_cftime=True)`` in the respective functions
+  instead.
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,7 +27,7 @@ New Features
 - Add ``unit`` - keyword argument to :py:func:`date_range` and ``microsecond`` parsing to
   iso8601-parser (:pull:`9885`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
-- Split out ``CFDatetimeCoder`` in ``xr.coders``, make ``decode_times`` keyword argument
+- Split out ``CFDatetimeCoder`` as public API in ``xr.coders``, make ``decode_times`` keyword argument
   consume ``CFDatetimeCoder``.
 
 
@@ -46,8 +46,7 @@ Deprecations
   :py:func:`date_range` (:pull:`9882`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - Time decoding related kwarg ``use_cftime`` is deprecated. Use keyword argument
-  ``decode_times=CFDatetimeCoder(use_cftime=True)`` in the respective functions
-  instead.
+  ``decode_times=CFDatetimeCoder(use_cftime=True)`` in :py:func:`~xarray.open_dataset`, :py:func:`~xarray.open_dataarray`, :py:func:`~xarray.open_datatree`, :py:func:`~xarray.open_groups`, :py:func:`~xarray.open_zarr` and :py:func:`~xarray.decode_cf` instead.
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Bug fixes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,8 +35,8 @@ New Features
 - Add ``unit`` - keyword argument to :py:func:`date_range` and ``microsecond`` parsing to
   iso8601-parser (:pull:`9885`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
-- Split out ``CFDatetimeCoder`` as public API in ``xr.coders``, make ``decode_times`` keyword argument
-  consume ``CFDatetimeCoder``.
+- Split out :py:class:`coders.CFDatetimeCoder` as public API in ``xr.coders``, make ``decode_times`` keyword argument
+  consume :py:class:`coders.CFDatetimeCoder`.
 
 
 Breaking changes

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -1,6 +1,6 @@
 from importlib.metadata import version as _version
 
-from xarray import groupers, testing, tutorial, ufuncs
+from xarray import coders, groupers, testing, tutorial, ufuncs
 from xarray.backends.api import (
     load_dataarray,
     load_dataset,
@@ -66,6 +66,7 @@ except Exception:
 # `mypy --strict` running in projects that import xarray.
 __all__ = (  # noqa: RUF022
     # Sub-packages
+    "coders",
     "groupers",
     "testing",
     "tutorial",

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1010,7 +1010,7 @@ def open_datatree(
         This keyword may not be supported by all the backends.
 
         .. deprecated:: 2024.12.0
-           Please initialize it with ``CFDatetimeCoder`` and ``decode_times`` kwarg.
+           Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     concat_characters : bool or dict-like, optional
         If True, concatenate along the last dimension of character arrays to

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -575,7 +575,7 @@ def open_dataset(
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
 
-        .. deprecated:: 2024.12.0
+        .. deprecated:: 2025.01.0
            Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     concat_characters : bool or dict-like, optional
@@ -796,7 +796,7 @@ def open_dataarray(
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error. This keyword may not be supported by all the backends.
 
-        .. deprecated:: 2024.12.0
+        .. deprecated:: 2025.01.0
            Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     concat_characters : bool, optional
@@ -1009,7 +1009,7 @@ def open_datatree(
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
 
-        .. deprecated:: 2024.12.0
+        .. deprecated:: 2025.01.0
            Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     concat_characters : bool or dict-like, optional
@@ -1235,7 +1235,7 @@ def open_groups(
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
 
-        .. deprecated:: 2024.12.0
+        .. deprecated:: 2025.01.0
            Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     concat_characters : bool or dict-like, optional

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -549,7 +549,7 @@ def open_dataset(
         This keyword may not be supported by all the backends.
     decode_times : bool, CFDatetimeCoder or dict-like, optional
         If True, decode times encoded in the standard NetCDF datetime format
-        into datetime objects. Otherwise, use CFDatetimeCoder or leave them encoded as numbers.
+        into datetime objects. Otherwise, use ``CFDatetimeCoder`` or leave them encoded as numbers.
         Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
@@ -573,8 +573,8 @@ def open_dataset(
         raise an error. Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
-        Usage of 'use_cftime' as kwarg is deprecated. Please initialize it
-        with CFDatetimeCoder and 'decode_times' kwarg.
+        .. deprecated:: 2024.12.0
+           Please initialize it with ``CFDatetimeCoder`` and ``decode_times`` kwarg.
     concat_characters : bool or dict-like, optional
         If True, concatenate along the last dimension of character arrays to
         form string arrays. Dimensions will only be concatenated over (and

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -549,7 +549,8 @@ def open_dataset(
         This keyword may not be supported by all the backends.
     decode_times : bool, CFDatetimeCoder or dict-like, optional
         If True, decode times encoded in the standard NetCDF datetime format
-        into datetime objects. Otherwise, use ``CFDatetimeCoder`` or leave them encoded as numbers.
+        into datetime objects. Otherwise, use ``CFDatetimeCoder`` or leave them
+        encoded as numbers.
         Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
@@ -573,8 +574,10 @@ def open_dataset(
         raise an error. Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
+
         .. deprecated:: 2024.12.0
            Please initialize it with ``CFDatetimeCoder`` and ``decode_times`` kwarg.
+
     concat_characters : bool or dict-like, optional
         If True, concatenate along the last dimension of character arrays to
         form string arrays. Dimensions will only be concatenated over (and
@@ -792,8 +795,10 @@ def open_dataarray(
         represented using ``np.datetime64[ns]`` objects.  If False, always
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error. This keyword may not be supported by all the backends.
-        Usage of 'use_cftime' as kwarg is deprecated. Please initialize it
-        with CFDatetimeCoder and 'decode_times' kwarg.
+
+        .. deprecated:: 2024.12.0
+           Please initialize it with ``CFDatetimeCoder`` and ``decode_times`` kwarg.
+
     concat_characters : bool, optional
         If True, concatenate along the last dimension of character arrays to
         form string arrays. Dimensions will only be concatenated over (and
@@ -1003,8 +1008,10 @@ def open_datatree(
         raise an error. Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
-        Usage of 'use_cftime' as kwarg is deprecated. Please initialize it
-        with CFDatetimeCoder and 'decode_times' kwarg.
+
+        .. deprecated:: 2024.12.0
+           Please initialize it with ``CFDatetimeCoder`` and ``decode_times`` kwarg.
+
     concat_characters : bool or dict-like, optional
         If True, concatenate along the last dimension of character arrays to
         form string arrays. Dimensions will only be concatenated over (and
@@ -1227,8 +1234,10 @@ def open_groups(
         raise an error. Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
-        Usage of 'use_cftime' as kwarg is deprecated. Please initialize it
-        with CFDatetimeCoder and 'decode_times' kwarg.
+
+        .. deprecated:: 2024.12.0
+           Please initialize it with ``CFDatetimeCoder`` and ``decode_times`` kwarg.
+
     concat_characters : bool or dict-like, optional
         If True, concatenate along the last dimension of character arrays to
         form string arrays. Dimensions will only be concatenated over (and

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -575,7 +575,7 @@ def open_dataset(
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
 
-        .. deprecated:: 2025.01.0
+        .. deprecated:: 2025.01.1
            Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     concat_characters : bool or dict-like, optional
@@ -796,7 +796,7 @@ def open_dataarray(
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error. This keyword may not be supported by all the backends.
 
-        .. deprecated:: 2025.01.0
+        .. deprecated:: 2025.01.1
            Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     concat_characters : bool, optional
@@ -1009,7 +1009,7 @@ def open_datatree(
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
 
-        .. deprecated:: 2025.01.0
+        .. deprecated:: 2025.01.1
            Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     concat_characters : bool or dict-like, optional
@@ -1235,7 +1235,7 @@ def open_groups(
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
 
-        .. deprecated:: 2025.01.0
+        .. deprecated:: 2025.01.1
            Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     concat_characters : bool or dict-like, optional

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -33,6 +33,7 @@ from xarray.backends.common import (
     _normalize_path,
 )
 from xarray.backends.locks import _get_scheduler
+from xarray.coders import CFDatetimeCoder
 from xarray.core import indexing
 from xarray.core.combine import (
     _infer_concat_order_from_positions,
@@ -481,7 +482,10 @@ def open_dataset(
     cache: bool | None = None,
     decode_cf: bool | None = None,
     mask_and_scale: bool | Mapping[str, bool] | None = None,
-    decode_times: bool | Mapping[str, bool] | None = None,
+    decode_times: bool
+    | CFDatetimeCoder
+    | Mapping[str, bool | CFDatetimeCoder]
+    | None = None,
     decode_timedelta: bool | Mapping[str, bool] | None = None,
     use_cftime: bool | Mapping[str, bool] | None = None,
     concat_characters: bool | Mapping[str, bool] | None = None,
@@ -543,9 +547,9 @@ def open_dataset(
         be replaced by NA. Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
-    decode_times : bool or dict-like, optional
+    decode_times : bool, CFDatetimeCoder or dict-like, optional
         If True, decode times encoded in the standard NetCDF datetime format
-        into datetime objects. Otherwise, leave them encoded as numbers.
+        into datetime objects. Otherwise, use CFDatetimeCoder or leave them encoded as numbers.
         Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
@@ -569,6 +573,8 @@ def open_dataset(
         raise an error. Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
+        Usage of 'use_cftime' as kwarg is deprecated. Please initialize it
+        with CFDatetimeCoder and 'decode_times' kwarg.
     concat_characters : bool or dict-like, optional
         If True, concatenate along the last dimension of character arrays to
         form string arrays. Dimensions will only be concatenated over (and
@@ -698,7 +704,10 @@ def open_dataarray(
     cache: bool | None = None,
     decode_cf: bool | None = None,
     mask_and_scale: bool | None = None,
-    decode_times: bool | None = None,
+    decode_times: bool
+    | CFDatetimeCoder
+    | Mapping[str, bool | CFDatetimeCoder]
+    | None = None,
     decode_timedelta: bool | None = None,
     use_cftime: bool | None = None,
     concat_characters: bool | None = None,
@@ -761,9 +770,11 @@ def open_dataarray(
         `missing_value` attribute contains multiple values a warning will be
         issued and all array values matching one of the multiple values will
         be replaced by NA. This keyword may not be supported by all the backends.
-    decode_times : bool, optional
+    decode_times : bool, CFDatetimeCoder or dict-like, optional
         If True, decode times encoded in the standard NetCDF datetime format
-        into datetime objects. Otherwise, leave them encoded as numbers.
+        into datetime objects. Otherwise, use CFDatetimeCoder or leave them encoded as numbers.
+        Pass a mapping, e.g. ``{"my_variable": False}``,
+        to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
     decode_timedelta : bool, optional
         If True, decode variables and coordinates with time units in
@@ -781,6 +792,8 @@ def open_dataarray(
         represented using ``np.datetime64[ns]`` objects.  If False, always
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error. This keyword may not be supported by all the backends.
+        Usage of 'use_cftime' as kwarg is deprecated. Please initialize it
+        with CFDatetimeCoder and 'decode_times' kwarg.
     concat_characters : bool, optional
         If True, concatenate along the last dimension of character arrays to
         form string arrays. Dimensions will only be concatenated over (and
@@ -903,7 +916,10 @@ def open_datatree(
     cache: bool | None = None,
     decode_cf: bool | None = None,
     mask_and_scale: bool | Mapping[str, bool] | None = None,
-    decode_times: bool | Mapping[str, bool] | None = None,
+    decode_times: bool
+    | CFDatetimeCoder
+    | Mapping[str, bool | CFDatetimeCoder]
+    | None = None,
     decode_timedelta: bool | Mapping[str, bool] | None = None,
     use_cftime: bool | Mapping[str, bool] | None = None,
     concat_characters: bool | Mapping[str, bool] | None = None,
@@ -961,9 +977,9 @@ def open_datatree(
         be replaced by NA. Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
-    decode_times : bool or dict-like, optional
+    decode_times : bool, CFDatetimeCoder or dict-like, optional
         If True, decode times encoded in the standard NetCDF datetime format
-        into datetime objects. Otherwise, leave them encoded as numbers.
+        into datetime objects. Otherwise, use CFDatetimeCoder or leave them encoded as numbers.
         Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
@@ -987,6 +1003,8 @@ def open_datatree(
         raise an error. Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
+        Usage of 'use_cftime' as kwarg is deprecated. Please initialize it
+        with CFDatetimeCoder and 'decode_times' kwarg.
     concat_characters : bool or dict-like, optional
         If True, concatenate along the last dimension of character arrays to
         form string arrays. Dimensions will only be concatenated over (and
@@ -1118,7 +1136,10 @@ def open_groups(
     cache: bool | None = None,
     decode_cf: bool | None = None,
     mask_and_scale: bool | Mapping[str, bool] | None = None,
-    decode_times: bool | Mapping[str, bool] | None = None,
+    decode_times: bool
+    | CFDatetimeCoder
+    | Mapping[str, bool | CFDatetimeCoder]
+    | None = None,
     decode_timedelta: bool | Mapping[str, bool] | None = None,
     use_cftime: bool | Mapping[str, bool] | None = None,
     concat_characters: bool | Mapping[str, bool] | None = None,
@@ -1180,9 +1201,9 @@ def open_groups(
         be replaced by NA. Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
-    decode_times : bool or dict-like, optional
+    decode_times : bool, CFDatetimeCoder or dict-like, optional
         If True, decode times encoded in the standard NetCDF datetime format
-        into datetime objects. Otherwise, leave them encoded as numbers.
+        into datetime objects. Otherwise, use CFDatetimeCoder or leave them encoded as numbers.
         Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
@@ -1206,6 +1227,8 @@ def open_groups(
         raise an error. Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
+        Usage of 'use_cftime' as kwarg is deprecated. Please initialize it
+        with CFDatetimeCoder and 'decode_times' kwarg.
     concat_characters : bool or dict-like, optional
         If True, concatenate along the last dimension of character arrays to
         form string arrays. Dimensions will only be concatenated over (and

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -549,7 +549,7 @@ def open_dataset(
         This keyword may not be supported by all the backends.
     decode_times : bool, CFDatetimeCoder or dict-like, optional
         If True, decode times encoded in the standard NetCDF datetime format
-        into datetime objects. Otherwise, use ``CFDatetimeCoder`` or leave them
+        into datetime objects. Otherwise, use :py:class:`coders.CFDatetimeCoder` or leave them
         encoded as numbers.
         Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
@@ -576,7 +576,7 @@ def open_dataset(
         This keyword may not be supported by all the backends.
 
         .. deprecated:: 2024.12.0
-           Please initialize it with ``CFDatetimeCoder`` and ``decode_times`` kwarg.
+           Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     concat_characters : bool or dict-like, optional
         If True, concatenate along the last dimension of character arrays to
@@ -775,7 +775,7 @@ def open_dataarray(
         be replaced by NA. This keyword may not be supported by all the backends.
     decode_times : bool, CFDatetimeCoder or dict-like, optional
         If True, decode times encoded in the standard NetCDF datetime format
-        into datetime objects. Otherwise, use CFDatetimeCoder or leave them encoded as numbers.
+        into datetime objects. Otherwise, use :py:class:`coders.CFDatetimeCoder` or leave them encoded as numbers.
         Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
@@ -797,7 +797,7 @@ def open_dataarray(
         raise an error. This keyword may not be supported by all the backends.
 
         .. deprecated:: 2024.12.0
-           Please initialize it with ``CFDatetimeCoder`` and ``decode_times`` kwarg.
+           Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     concat_characters : bool, optional
         If True, concatenate along the last dimension of character arrays to
@@ -984,7 +984,7 @@ def open_datatree(
         This keyword may not be supported by all the backends.
     decode_times : bool, CFDatetimeCoder or dict-like, optional
         If True, decode times encoded in the standard NetCDF datetime format
-        into datetime objects. Otherwise, use CFDatetimeCoder or leave them encoded as numbers.
+        into datetime objects. Otherwise, use :py:class:`coders.CFDatetimeCoder` or leave them encoded as numbers.
         Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
@@ -1210,7 +1210,7 @@ def open_groups(
         This keyword may not be supported by all the backends.
     decode_times : bool, CFDatetimeCoder or dict-like, optional
         If True, decode times encoded in the standard NetCDF datetime format
-        into datetime objects. Otherwise, use CFDatetimeCoder or leave them encoded as numbers.
+        into datetime objects. Otherwise, use :py:class:`coders.CFDatetimeCoder` or leave them encoded as numbers.
         Pass a mapping, e.g. ``{"my_variable": False}``,
         to toggle this feature per-variable individually.
         This keyword may not be supported by all the backends.
@@ -1236,7 +1236,7 @@ def open_groups(
         This keyword may not be supported by all the backends.
 
         .. deprecated:: 2024.12.0
-           Please initialize it with ``CFDatetimeCoder`` and ``decode_times`` kwarg.
+           Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     concat_characters : bool or dict-like, optional
         If True, concatenate along the last dimension of character arrays to

--- a/xarray/coders.py
+++ b/xarray/coders.py
@@ -1,0 +1,10 @@
+"""
+This module provides coder objects that encapsulate the
+"encoding/decoding" process.
+"""
+
+from xarray.coding.times import CFDatetimeCoder
+
+__all__ = [
+    "CFDatetimeCoder",
+]

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -36,7 +36,11 @@ try:
 except ImportError:
     cftime = None
 
-from xarray.core.types import CFCalendar, NPDatetimeUnitOptions, T_DuckArray
+from xarray.core.types import (
+    CFCalendar,
+    NPDatetimeUnitOptions,
+    T_DuckArray,
+)
 
 T_Name = Union[Hashable, None]
 
@@ -204,7 +208,10 @@ def _unpack_time_units_and_ref_date(units: str) -> tuple[str, pd.Timestamp]:
 
 
 def _decode_cf_datetime_dtype(
-    data, units: str, calendar: str | None, use_cftime: bool | None
+    data,
+    units: str,
+    calendar: str | None,
+    use_cftime: bool | None,
 ) -> np.dtype:
     # Verify that at least the first and last date can be decoded
     # successfully. Otherwise, tracebacks end up swallowed by
@@ -311,7 +318,10 @@ def _decode_datetime_with_pandas(
 
 
 def decode_cf_datetime(
-    num_dates, units: str, calendar: str | None = None, use_cftime: bool | None = None
+    num_dates,
+    units: str,
+    calendar: str | None = None,
+    use_cftime: bool | None = None,
 ) -> np.ndarray:
     """Given an array of numeric dates in netCDF format, convert it into a
     numpy array of date time objects.
@@ -974,7 +984,10 @@ def _lazily_encode_cf_timedelta(
 
 
 class CFDatetimeCoder(VariableCoder):
-    def __init__(self, use_cftime: bool | None = None) -> None:
+    def __init__(
+        self,
+        use_cftime: bool | None = None,
+    ) -> None:
         self.use_cftime = use_cftime
 
     def encode(self, variable: Variable, name: T_Name = None) -> Variable:

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -197,13 +197,11 @@ def decode_cf_variable(
         # remove checks after end of deprecation cycle
         if not isinstance(decode_times, CFDatetimeCoder):
             if use_cftime is not None:
-
                 emit_user_level_warning(
                     "Usage of 'use_cftime' as kwarg is deprecated. "
                     "Please initialize it with CFDatetimeCoder and "
                     "'decode_times' kwarg.",
                     DeprecationWarning,
-                    stacklevel=2,
                 )
             decode_times = CFDatetimeCoder(use_cftime=use_cftime)
         else:

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -201,9 +201,9 @@ def decode_cf_variable(
                 emit_user_level_warning(
                     "Usage of 'use_cftime' as a kwarg is deprecated. "
                     "Please pass a CFDatetimeCoder instance initialized "
-                    "with use_cftime to the decode_times kwarg instead.\n",
-                    "Example usage:\n",
-                    "    time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)\n",
+                    "with use_cftime to the decode_times kwarg instead.\n"
+                    "Example usage:\n"
+                    "    time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)\n"
                     "    ds = xr.open_dataset(decode_times=time_coder)\n",
                     DeprecationWarning,
                 )

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -197,7 +197,6 @@ def decode_cf_variable(
         # remove checks after end of deprecation cycle
         if not isinstance(decode_times, CFDatetimeCoder):
             if use_cftime is not None:
-                from warnings import warn
 
                 emit_user_level_warning(
                     "Usage of 'use_cftime' as kwarg is deprecated. "

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -157,7 +157,7 @@ def decode_cf_variable(
         raise an error.
 
         .. deprecated:: 2024.12.0
-           Please initialize it with ``CFDatetimeCoder`` and ``decode_times`` kwarg.
+           Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     Returns
     -------
@@ -201,17 +201,20 @@ def decode_cf_variable(
                 emit_user_level_warning(
                     "Usage of 'use_cftime' as kwarg is deprecated. "
                     "Please initialize it with CFDatetimeCoder and "
-                    "'decode_times' kwarg.",
+                    "'decode_times' kwarg.\n",
+                    "Example usage:\n",
+                    "    time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)\n",
+                    "    ds = xr.open_dataset(decode_times=time_coder)\n",
                     DeprecationWarning,
                 )
             decode_times = CFDatetimeCoder(use_cftime=use_cftime)
         else:
             if use_cftime is not None:
                 raise TypeError(
-                    "Usage of 'use_cftime' as kwarg is not allowed, "
-                    "if 'decode_times' is initialized with "
-                    "CFDatetimeCoder. Please add 'use_cftime' "
-                    "when initializing CFDatetimeCoder."
+                    "Usage of 'use_cftime' as a kwarg is not allowed "
+                    "if a CFDatetimeCoder instance is passed to "
+                    "decode_times. Please set use_cftime "
+                    "when initializing CFDatetimeCoder instead."
                 )
         var = decode_times.decode(var, name=name)
 
@@ -508,7 +511,7 @@ def decode_cf(
         raise an error.
 
         .. deprecated:: 2024.12.0
-           Please initialize it with ``CFDatetimeCoder`` and ``decode_times`` kwarg.
+           Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     decode_timedelta : bool, optional
         If True, decode variables and coordinates with time units in

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -199,7 +199,7 @@ def decode_cf_variable(
             if use_cftime is not None:
                 from warnings import warn
 
-                warn(
+                emit_user_level_warning(
                     "Usage of 'use_cftime' as kwarg is deprecated. "
                     "Please initialize it with CFDatetimeCoder and "
                     "'decode_times' kwarg.",

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -156,7 +156,7 @@ def decode_cf_variable(
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error.
 
-        .. deprecated:: 2025.01.0
+        .. deprecated:: 2025.01.1
            Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     Returns
@@ -510,7 +510,7 @@ def decode_cf(
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error.
 
-        .. deprecated:: 2025.01.0
+        .. deprecated:: 2025.01.1
            Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     decode_timedelta : bool, optional

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -156,7 +156,7 @@ def decode_cf_variable(
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error.
 
-        .. deprecated:: 2024.12.0
+        .. deprecated:: 2025.01.0
            Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     Returns
@@ -510,7 +510,7 @@ def decode_cf(
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error.
 
-        .. deprecated:: 2024.12.0
+        .. deprecated:: 2025.01.0
            Please pass a :py:class:`coders.CFDatetimeCoder` instance initialized with ``use_cftime`` to the ``decode_times`` kwarg instead.
 
     decode_timedelta : bool, optional

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -155,8 +155,9 @@ def decode_cf_variable(
         represented using ``np.datetime64[ns]`` objects.  If False, always
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error.
-        Usage of use_cftime as kwarg is deprecated, please initialize it with
-        CFDatetimeCoder and ``decode_times``.
+
+        .. deprecated:: 2024.12.0
+           Please initialize it with ``CFDatetimeCoder`` and ``decode_times`` kwarg.
 
     Returns
     -------

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -310,9 +310,10 @@ def _update_bounds_encoding(variables: T_Variables) -> None:
 
 
 T = TypeVar("T")
+U = TypeVar("U")
 
 
-def _item_or_default(obj: Mapping[Any, T] | T, key: Hashable, default: T) -> T:
+def _item_or_default(obj: Mapping[Any, T | U] | T, key: Hashable, default: T) -> T | U:
     """
     Return item by key if obj is mapping and key is present, else return default value.
     """
@@ -461,7 +462,7 @@ def decode_cf(
     obj: T_DatasetOrAbstractstore,
     concat_characters: bool = True,
     mask_and_scale: bool = True,
-    decode_times: bool | CFDatetimeCoder = True,
+    decode_times: bool | CFDatetimeCoder | Mapping[str, bool | CFDatetimeCoder] = True,
     decode_coords: bool | Literal["coordinates", "all"] = True,
     drop_variables: T_DropVariables = None,
     use_cftime: bool | None = None,
@@ -480,7 +481,7 @@ def decode_cf(
     mask_and_scale : bool, optional
         Lazily scale (using scale_factor and add_offset) and mask
         (using _FillValue).
-    decode_times : bool or CFDatetimeCoder, optional
+    decode_times : bool | CFDatetimeCoder | Mapping[str, bool | CFDatetimeCoder], optional
         Decode cf times (e.g., integers since "hours since 2000-01-01") to
         np.datetime64.
     decode_coords : bool or {"coordinates", "all"}, optional
@@ -505,8 +506,10 @@ def decode_cf(
         represented using ``np.datetime64[ns]`` objects.  If False, always
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
         raise an error.
-        Usage of use_cftime as kwarg is deprecated, please initialize it with
-        CFDatetimeCoder and ``decode_times``.
+
+        .. deprecated:: 2024.12.0
+           Please initialize it with ``CFDatetimeCoder`` and ``decode_times`` kwarg.
+
     decode_timedelta : bool, optional
         If True, decode variables and coordinates with time units in
         {"days", "hours", "minutes", "seconds", "milliseconds", "microseconds"}
@@ -560,7 +563,7 @@ def cf_decoder(
     attributes: T_Attrs,
     concat_characters: bool = True,
     mask_and_scale: bool = True,
-    decode_times: bool | CFDatetimeCoder = True,
+    decode_times: bool | CFDatetimeCoder | Mapping[str, bool | CFDatetimeCoder] = True,
 ) -> tuple[T_Variables, T_Attrs]:
     """
     Decode a set of CF encoded variables and attributes.
@@ -577,7 +580,7 @@ def cf_decoder(
     mask_and_scale : bool
         Lazily scale (using scale_factor and add_offset) and mask
         (using _FillValue).
-    decode_times : bool | CFDatetimeCoder
+    decode_times : bool | CFDatetimeCoder | Mapping[str, bool | CFDatetimeCoder]
         Decode cf times ("hours since 2000-01-01") to np.datetime64.
 
     Returns

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -200,8 +200,8 @@ def decode_cf_variable(
             if use_cftime is not None:
                 emit_user_level_warning(
                     "Usage of 'use_cftime' as a kwarg is deprecated. "
-                    "Please pass a CFDatetimeCoder instance initialized "
-                    "with use_cftime to the decode_times kwarg instead.\n"
+                    "Please pass a 'CFDatetimeCoder' instance initialized "
+                    "with 'use_cftime' to the 'decode_times' kwarg instead.\n"
                     "Example usage:\n"
                     "    time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)\n"
                     "    ds = xr.open_dataset(decode_times=time_coder)\n",
@@ -212,9 +212,12 @@ def decode_cf_variable(
             if use_cftime is not None:
                 raise TypeError(
                     "Usage of 'use_cftime' as a kwarg is not allowed "
-                    "if a CFDatetimeCoder instance is passed to "
-                    "decode_times. Please set use_cftime "
-                    "when initializing CFDatetimeCoder instead."
+                    "if a 'CFDatetimeCoder' instance is passed to "
+                    "'decode_times'. Please set 'use_cftime' "
+                    "when initializing 'CFDatetimeCoder' instead.\n"
+                    "Example usage:\n"
+                    "    time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)\n"
+                    "    ds = xr.open_dataset(decode_times=time_coder)\n",
                 )
         var = decode_times.decode(var, name=name)
 

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -199,9 +199,9 @@ def decode_cf_variable(
         if not isinstance(decode_times, CFDatetimeCoder):
             if use_cftime is not None:
                 emit_user_level_warning(
-                    "Usage of 'use_cftime' as kwarg is deprecated. "
-                    "Please initialize it with CFDatetimeCoder and "
-                    "'decode_times' kwarg.\n",
+                    "Usage of 'use_cftime' as a kwarg is deprecated. "
+                    "Please pass a CFDatetimeCoder instance initialized "
+                    "with use_cftime to the decode_times kwarg instead.\n",
                     "Example usage:\n",
                     "    time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)\n",
                     "    ds = xr.open_dataset(decode_times=time_coder)\n",

--- a/xarray/convert.py
+++ b/xarray/convert.py
@@ -4,7 +4,8 @@ from collections import Counter
 
 import numpy as np
 
-from xarray.coding.times import CFDatetimeCoder, CFTimedeltaCoder
+from xarray.coders import CFDatetimeCoder
+from xarray.coding.times import CFTimedeltaCoder
 from xarray.conventions import decode_cf
 from xarray.core import duck_array_ops
 from xarray.core.dataarray import DataArray

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -48,6 +48,7 @@ from xarray.backends.netCDF4_ import (
 )
 from xarray.backends.pydap_ import PydapDataStore
 from xarray.backends.scipy_ import ScipyBackendEntrypoint
+from xarray.coders import CFDatetimeCoder
 from xarray.coding.cftime_offsets import cftime_range
 from xarray.coding.strings import check_vlen_dtype, create_vlen_dtype
 from xarray.coding.variables import SerializationWarning
@@ -3206,7 +3207,10 @@ class ZarrBase(CFEncodedBase):
             ds.to_zarr(store_target, **self.version_kwargs)
             ds_a = xr.open_zarr(store_target, **self.version_kwargs)
             assert_identical(ds, ds_a)
-            ds_b = xr.open_zarr(store_target, use_cftime=True, **self.version_kwargs)
+            decoder = CFDatetimeCoder(use_cftime=True)
+            ds_b = xr.open_zarr(
+                store_target, decode_times=decoder, **self.version_kwargs
+            )
             assert xr.coding.times.contains_cftime_datetimes(ds_b.time.variable)
 
     def test_write_read_select_write(self) -> None:
@@ -5622,7 +5626,8 @@ def test_use_cftime_true(calendar, units_year) -> None:
     with create_tmp_file() as tmp_file:
         original.to_netcdf(tmp_file)
         with warnings.catch_warnings(record=True) as record:
-            with open_dataset(tmp_file, use_cftime=True) as ds:
+            decoder = CFDatetimeCoder(use_cftime=True)
+            with open_dataset(tmp_file, decode_times=decoder) as ds:
                 assert_identical(expected_x, ds.x)
                 assert_identical(expected_time, ds.time)
             _assert_no_dates_out_of_range_warning(record)
@@ -5674,7 +5679,8 @@ def test_use_cftime_false_standard_calendar_out_of_range(calendar, units_year) -
     with create_tmp_file() as tmp_file:
         original.to_netcdf(tmp_file)
         with pytest.raises((OutOfBoundsDatetime, ValueError)):
-            open_dataset(tmp_file, use_cftime=False)
+            decoder = CFDatetimeCoder(use_cftime=False)
+            open_dataset(tmp_file, decode_times=decoder)
 
 
 @requires_scipy_or_netCDF4
@@ -5692,7 +5698,8 @@ def test_use_cftime_false_nonstandard_calendar(calendar, units_year) -> None:
     with create_tmp_file() as tmp_file:
         original.to_netcdf(tmp_file)
         with pytest.raises((OutOfBoundsDatetime, ValueError)):
-            open_dataset(tmp_file, use_cftime=False)
+            decoder = CFDatetimeCoder(use_cftime=False)
+            open_dataset(tmp_file, decode_times=decoder)
 
 
 @pytest.mark.parametrize("engine", ["netcdf4", "scipy"])

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -446,7 +446,9 @@ class TestDecodeCF:
             assert "(time) object" in repr(ds)
 
         attrs = {"units": "days since 1900-01-01"}
-        ds = decode_cf(Dataset({"time": ("time", [0, 1], attrs)}))
+        ds = decode_cf(
+            Dataset({"time": ("time", [0, 1], attrs)}),
+        )
         assert "(time) datetime64[ns]" in repr(ds)
 
     @requires_cftime

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -30,7 +30,7 @@ from xarray import (
     broadcast,
     set_options,
 )
-from xarray.coding.times import CFDatetimeCoder
+from xarray.coders import CFDatetimeCoder
 from xarray.core import dtypes
 from xarray.core.common import full_like
 from xarray.core.coordinates import Coordinates


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`


This makes something like this possible:

```python
import xarray as xr
from xarray.coders import CFDatetimeCoder
# available with this PR
ds = xr.open_mfdataset(..., decode_times=CFDatetimeCoder(use_cftime=True))
# available with #9618
ds = xr.open_mfdataset(..., decode_times=CFDatetimeCoder(time_unit="s"))
```