### PR TITLE
Skip dask rolling

### DIFF
--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 import xarray as xr
 
-from . import parameterized, randn
+from . import parameterized, randn, requires_dask, _skip_slow
 
 nx = 3000
 long_nx = 30000
@@ -77,12 +77,15 @@ class Rolling:
             ).sum(dim="window_dim").load()
 
 
-# class RollingDask(Rolling):
-#     def setup(self, *args, **kwargs):
-#         requires_dask()
-#         super().setup(**kwargs)
-#         self.ds = self.ds.chunk({"x": 100, "y": 50, "t": 50})
-#         self.da_long = self.da_long.chunk({"x": 10000})
+class RollingDask(Rolling):
+    def setup(self, *args, **kwargs):
+        requires_dask()
+        # TODO: Lazily skipped in CI as it is very demanding and slow.
+        # Improve times and remove errors.
+        _skip_slow()
+        super().setup(**kwargs)
+        self.ds = self.ds.chunk({"x": 100, "y": 50, "t": 50})
+        self.da_long = self.da_long.chunk({"x": 10000})
 
 
 class RollingMemory:

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 import xarray as xr
 
-from . import parameterized, randn, requires_dask, _skip_slow
+from . import _skip_slow, parameterized, randn, requires_dask
 
 nx = 3000
 long_nx = 30000

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -77,12 +77,12 @@ class Rolling:
             ).sum(dim="window_dim").load()
 
 
-class RollingDask(Rolling):
-    def setup(self, *args, **kwargs):
-        requires_dask()
-        super().setup(**kwargs)
-        self.ds = self.ds.chunk({"x": 100, "y": 50, "t": 50})
-        self.da_long = self.da_long.chunk({"x": 10000})
+# class RollingDask(Rolling):
+#     def setup(self, *args, **kwargs):
+#         requires_dask()
+#         super().setup(**kwargs)
+#         self.ds = self.ds.chunk({"x": 100, "y": 50, "t": 50})
+#         self.da_long = self.da_long.chunk({"x": 10000})
 
 
 class RollingMemory:

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 import xarray as xr
 
-from . import parameterized, randn, requires_dask
+from . import parameterized, randn
 
 nx = 3000
 long_nx = 30000


### PR DESCRIPTION
Skip the rolling tests using dask so the CI becomes usable again. 

- [x] Related to #9890


Test with terrible performance, feel free to fix it and reactivate this test:

```python
import numpy as np
import pandas as pd

import xarray as xr


def randn(shape, frac_nan=None, chunks=None, seed=0):
    rng = np.random.default_rng(seed)
    if chunks is None:
        x = rng.standard_normal(shape)
    else:
        import dask.array as da

        rng = da.random.default_rng(seed)
        x = rng.standard_normal(shape, chunks=chunks)

    if frac_nan is not None:
        inds = rng.choice(range(x.size), int(x.size * frac_nan))
        x.flat[inds] = np.nan

    return x


nx = 3000
long_nx = 30000
ny = 200
nt = 1000
window = 20

randn_xy = randn((nx, ny), frac_nan=0.1)
randn_xt = randn((nx, nt))
randn_t = randn((nt,))
randn_long = randn((long_nx,), frac_nan=0.1)


ds = xr.Dataset(
    {
        "var1": (("x", "y"), randn_xy),
        "var2": (("x", "t"), randn_xt),
        "var3": (("t",), randn_t),
    },
    coords={
        "x": np.arange(nx),
        "y": np.linspace(0, 1, ny),
        "t": pd.date_range("1970-01-01", periods=nt, freq="D"),
        "x_coords": ("x", np.linspace(1.1, 2.1, nx)),
    },
)
window_ = 20
min_periods = 5
use_bottleneck = False
%timeit ds.rolling(x=window_, center=False, min_periods=min_periods).reduce(np.nansum).load()
# 601 ms ± 43.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)


ds = ds.chunk({"x": 100, "y": 50, "t": 50})
%timeit ds.rolling(x=window_, center=False, min_periods=min_periods).reduce(np.nansum).load()
# 1min 9s ± 1.31 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
```