### PR TITLE
fix warning from scipy backend guess_can_open on directory

### DIFF
--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -645,7 +645,7 @@ def try_read_magic_number_from_path(pathlike, count=8) -> bytes | None:
         try:
             with open(path, "rb") as f:
                 return read_magic_number_from_file(f, count)
-        except (FileNotFoundError, TypeError):
+        except (FileNotFoundError, IsADirectoryError, TypeError):
             pass
     return None
 


### PR DESCRIPTION
When passing a directory to open_dataset(), the scipy backend fails and a "RuntimeWarning: 'scipy' fails while guessing" is produced.

This affects me since I'm implementing a backend to read data written by the adios2 package, whose data "files" are actually a directory.

This tiny patch treats this case just like file not found, that is, the scipy backend will now return that it cannot open such a "file", but without raising an exception.
