### PR TITLE
Suggest the correct name when no key matches in the dataset

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -50,10 +50,10 @@ eventually be deprecated.
 
 New Features
 ~~~~~~~~~~~~
-- Improve the error message raised when no key is matching the available variables in a dataset.  (:pull:`9943`)
-  By `Jimmy Westling <https://github.com/illviljan>`_.
 - Relax nanosecond datetime restriction in CF time decoding (:issue:`7493`, :pull:`9618`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_ and `Spencer Clark <https://github.com/spencerkclark>`_.
+- Improve the error message raised when no key is matching the available variables in a dataset.  (:pull:`9943`)
+  By `Jimmy Westling <https://github.com/illviljan>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,7 +21,8 @@ v2025.01.2 (unreleased)
 
 New Features
 ~~~~~~~~~~~~
-
+- Improve the error message raised when no key is matching the available variables in a dataset.  (:pull:`9943`)
+  By `Jimmy Westling <https://github.com/illviljan>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1611,6 +1611,11 @@ class Dataset(
                 return self._construct_dataarray(key)
             except KeyError as e:
                 message = f"No variable named {key!r}. Variables on the dataset include {shorten_list_repr(list(self.variables.keys()), max_items=10)}"
+
+                best_guess = utils.did_you_mean(key, self.variables.keys())
+                if best_guess:
+                    message += f" {best_guess}"
+
                 # If someone attempts `ds['foo' , 'bar']` instead of `ds[['foo', 'bar']]`
                 if isinstance(key, tuple):
                     message += f"\nHint: use a list to select multiple variables, for example `ds[{list(key)}]`"

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1616,7 +1616,7 @@ class Dataset(
                 if best_guess:
                     message += f" {best_guess}"
                 else:
-                    message += f"  Variables on the dataset include {shorten_list_repr(list(self.variables.keys()), max_items=10)}"
+                    message += f" Variables on the dataset include {shorten_list_repr(list(self.variables.keys()), max_items=10)}"
 
                 # If someone attempts `ds['foo' , 'bar']` instead of `ds[['foo', 'bar']]`
                 if isinstance(key, tuple):

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1610,11 +1610,13 @@ class Dataset(
             try:
                 return self._construct_dataarray(key)
             except KeyError as e:
-                message = f"No variable named {key!r}. Variables on the dataset include {shorten_list_repr(list(self.variables.keys()), max_items=10)}"
+                message = f"No variable named {key!r}."
 
                 best_guess = utils.did_you_mean(key, self.variables.keys())
                 if best_guess:
                     message += f" {best_guess}"
+                else:
+                    message += f"  Variables on the dataset include {shorten_list_repr(list(self.variables.keys()), max_items=10)}"
 
                 # If someone attempts `ds['foo' , 'bar']` instead of `ds[['foo', 'bar']]`
                 if isinstance(key, tuple):

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -141,6 +141,7 @@ def did_you_mean(
     --------
     https://en.wikipedia.org/wiki/String_metric
     """
+    # Convert all values to string, get_close_matches doesn't handle all hashables:
     possibilites_str: dict[str, Hashable] = {str(k): k for k in possibilities}
 
     msg = ""

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -114,6 +114,31 @@ def alias(obj: Callable[..., T], old_name: str) -> Callable[..., T]:
     return wrapper
 
 
+def did_you_mean(word: Hashable, possibilities: Iterable[Hashable]) -> str:
+    """
+    Get a suggested word.
+
+    Examples
+    --------
+    >>> did_you_mean("bluch", ("blech", "gray_r", 1, None, (2, 56)))
+    "Did you mean one of ('blech',)?"
+    >>> did_you_mean(1, ("blech", "gray_r", 1, None, (2, 56)))
+    'Did you mean one of (1,)?'
+    """
+    import difflib
+
+    possibilites_str: dict[str, Hashable] = {str(k): k for k in possibilities}
+
+    msg = ""
+    if len(
+        best_str := difflib.get_close_matches(str(word), list(possibilites_str.keys()))
+    ):
+        best = tuple(possibilites_str[k] for k in best_str)
+        msg = f"Did you mean one of {best}?"
+
+    return msg
+
+
 def get_valid_numpy_dtype(array: np.ndarray | pd.Index) -> np.dtype:
     """Return a numpy compatible dtype from either
     a numpy array or a pandas.Index.

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -37,6 +37,7 @@
 from __future__ import annotations
 
 import contextlib
+import difflib
 import functools
 import importlib
 import inspect
@@ -114,24 +115,39 @@ def alias(obj: Callable[..., T], old_name: str) -> Callable[..., T]:
     return wrapper
 
 
-def did_you_mean(word: Hashable, possibilities: Iterable[Hashable]) -> str:
+def did_you_mean(
+    word: Hashable, possibilities: Iterable[Hashable], *, n: int = 10
+) -> str:
     """
-    Get a suggested word.
+    Suggest a few correct words based on a list of possibilites
+
+    Parameters
+    ----------
+    word : Hashable
+        Word to compare to a list of possibilites.
+    possibilities : Iterable of Hashable
+        The iterable of Hashable that contains the correct values.
+    n : int, default: 10
+        Maximum number of suggestions to show.
 
     Examples
     --------
     >>> did_you_mean("bluch", ("blech", "gray_r", 1, None, (2, 56)))
     "Did you mean one of ('blech',)?"
-    >>> did_you_mean(1, ("blech", "gray_r", 1, None, (2, 56)))
-    'Did you mean one of (1,)?'
-    """
-    import difflib
+    >>> did_you_mean("none", ("blech", "gray_r", 1, None, (2, 56)))
+    'Did you mean one of (None,)?'
 
+    See also
+    --------
+    https://en.wikipedia.org/wiki/String_metric
+    """
     possibilites_str: dict[str, Hashable] = {str(k): k for k in possibilities}
 
     msg = ""
     if len(
-        best_str := difflib.get_close_matches(str(word), list(possibilites_str.keys()))
+        best_str := difflib.get_close_matches(
+            str(word), list(possibilites_str.keys()), n=n
+        )
     ):
         best = tuple(possibilites_str[k] for k in best_str)
         msg = f"Did you mean one of {best}?"


### PR DESCRIPTION
I found the error when I make a typo on the dataset keys not so helpful. The truncated list of variables hides all the ones that I wanted to see. Instead, add a fuzzy matching function that does the typical "Did you mean X". 

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

```python
possibilities = ("blech", "gray_r", 1, None, (2, 56))
# possibilities = tuple(f"long_name_{i}" for i in range(0, 1000))
t = np.arange(80)
var = xr.Variable(dims=("time",), data=np.arange(t.size))
data_vars = {v: ("time", var) for v in possibilities}
ds = xr.Dataset(data_vars, coords={"T": t})
ds["bluch"]
# KeyError: "No variable named 'bluch'. Did you mean one of ('blech',)?"
```

```python
# Performance is pretty much linear with number of variables:
%timeit xr.core.utils.did_you_mean("long_name9o5", tuple(f"long_name_{i}" for i in range(0, 1000)))
35.1 ms ± 1.95 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit xr.core.utils.did_you_mean("long_name9o5", tuple(f"long_name_{i}" for i in range(0, 100)))
3.29 ms ± 104 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

%timeit xr.core.utils.did_you_mean("long_name9o5", tuple(f"long_name_{i}" for i in range(0, 10)))
320 μs ± 10.3 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

# Number of suggestions has no significant effect:
%timeit xr.core.utils.did_you_mean("long_name9o5", tuple(f"long_name_{i}" for i in range(0, 1000)), n=10)
34.6 ms ± 1.01 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Further reading:
https://github.com/python/cpython/pull/16850
https://github.com/matplotlib/matplotlib/pull/28115
https://en.wikipedia.org/wiki/Levenshtein_distance