### PR TITLE
Add `shards` to `valid_encodings` to enable sharded Zarr writing

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -830,6 +830,7 @@ class ZarrStore(AbstractWritableDataStore):
                 {
                     "compressors": zarr_array.compressors,
                     "filters": zarr_array.filters,
+                    "shards": zarr_array.shards,
                 }
             )
             if self.zarr_group.metadata.zarr_format == 3:

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -448,6 +448,7 @@ def extract_zarr_variable_encoding(
     safe_to_drop = {"source", "original_shape", "preferred_chunks"}
     valid_encodings = {
         "chunks",
+        "shards",
         "compressor",  # TODO: delete when min zarr >=3
         "compressors",
         "filters",

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2507,7 +2507,7 @@ class ZarrBase(CFEncodedBase):
         with pytest.raises(TypeError):
             with self.roundtrip(data) as actual:
                 pass
-    
+
     @requires_dask
     @pytest.mark.skipif(
         ON_WINDOWS,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2504,7 +2504,7 @@ class ZarrBase(CFEncodedBase):
 
             # expect an error with shards not divisible by chunks
             data["var2"].encoding.update({"chunks": (2, 2)})
-            with pytest.raises(TypeError):
+            with pytest.raises(ValueError):
                 with self.roundtrip(data) as actual:
                     pass
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2490,6 +2490,24 @@ class ZarrBase(CFEncodedBase):
             with self.roundtrip(data) as actual:
                 pass
 
+    def test_shard_encoding(self) -> None:
+        # These datasets have no dask chunks. All chunking/sharding specified in
+        # encoding
+        data = create_test_data()
+        chunks = (1, 1)
+        shards = (5, 5)
+        data["var2"].encoding.update({"chunks": chunks})
+        data["var2"].encoding.update({"shards": shards})
+
+        with self.roundtrip(data) as actual:
+            assert shards == actual["var2"].encoding["shards"]
+
+        # expect an error with shards not divisible by chunks
+        data["var2"].encoding.update({"chunks": (2, 2)})
+        with pytest.raises(TypeError):
+            with self.roundtrip(data) as actual:
+                pass
+    
     @requires_dask
     @pytest.mark.skipif(
         ON_WINDOWS,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2493,20 +2493,20 @@ class ZarrBase(CFEncodedBase):
     def test_shard_encoding(self) -> None:
         # These datasets have no dask chunks. All chunking/sharding specified in
         # encoding
-        data = create_test_data()
-        chunks = (1, 1)
-        shards = (5, 5)
-        data["var2"].encoding.update({"chunks": chunks})
-        data["var2"].encoding.update({"shards": shards})
-
-        with self.roundtrip(data) as actual:
-            assert shards == actual["var2"].encoding["shards"]
-
-        # expect an error with shards not divisible by chunks
-        data["var2"].encoding.update({"chunks": (2, 2)})
-        with pytest.raises(TypeError):
+        if has_zarr_v3 and zarr.config.config["default_zarr_format"] == 3:
+            data = create_test_data()
+            chunks = (1, 1)
+            shards = (5, 5)
+            data["var2"].encoding.update({"chunks": chunks})
+            data["var2"].encoding.update({"shards": shards})
             with self.roundtrip(data) as actual:
-                pass
+                assert shards == actual["var2"].encoding["shards"]
+
+            # expect an error with shards not divisible by chunks
+            data["var2"].encoding.update({"chunks": (2, 2)})
+            with pytest.raises(TypeError):
+                with self.roundtrip(data) as actual:
+                    pass
 
     @requires_dask
     @pytest.mark.skipif(


### PR DESCRIPTION
Adds `shards` to the list of `valid_encodings` in the zarr backend, so that sharded Zarr V3s can be written.

- [x] Closes #9947 
