### PR TITLE
Fix test_doc_example on big-endian systems

### DIFF
--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -1240,8 +1240,12 @@ class TestRepr:
     )
     def test_doc_example(self) -> None:
         # regression test for https://github.com/pydata/xarray/issues/9499
-        time = xr.DataArray(data=["2022-01", "2023-01"], dims="time")
-        stations = xr.DataArray(data=list("abcdef"), dims="station")
+        time = xr.DataArray(
+            data=np.array(["2022-01", "2023-01"], dtype="<U7"), dims="time"
+        )
+        stations = xr.DataArray(
+            data=np.array(list("abcdef"), dtype="<U1"), dims="station"
+        )
         lon = [-100, -80, -60]
         lat = [10, 20, 30]
         # Set up fake data


### PR DESCRIPTION
... by using a fixed-endian input.

- [n/a] Closes #xxxx
- [x] Tests added
- [n/a] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [n/a] New functions/methods are listed in `api.rst`