### PR TITLE
Enable `DataTree.to_zarr(compute=False)`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -52,6 +52,8 @@ New Features
 ~~~~~~~~~~~~
 - Relax nanosecond datetime restriction in CF time decoding (:issue:`7493`, :pull:`9618`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_ and `Spencer Clark <https://github.com/spencerkclark>`_.
+- Enable the ``compute=False`` option in :py:meth:`DataTree.to_zarr`. (:pull:`9958`).
+  By `Sam Levang <https://github.com/slevang>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/datatree_io.py
+++ b/xarray/core/datatree_io.py
@@ -84,7 +84,7 @@ def _datatree_to_zarr(
     consolidated: bool = True,
     group: str | None = None,
     write_inherited_coords: bool = False,
-    compute: Literal[True] = True,
+    compute: bool = True,
     **kwargs,
 ):
     """This function creates an appropriate datastore for writing a datatree
@@ -99,9 +99,6 @@ def _datatree_to_zarr(
         raise NotImplementedError(
             "specifying a root group for the tree has not been implemented"
         )
-
-    if not compute:
-        raise NotImplementedError("compute=False has not been implemented yet")
 
     if encoding is None:
         encoding = {}
@@ -124,6 +121,7 @@ def _datatree_to_zarr(
             mode=mode,
             encoding=encoding.get(node.path),
             consolidated=False,
+            compute=compute,
             **kwargs,
         )
         if "w" in mode:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

As far as I can tell there is no reason this needs to be disabled, since we just call `ds.to_zarr` repeatedly in the current implementation.