### PR TITLE
fix weighted polyfit for arrays with more than 2 dimensions

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -71,6 +71,8 @@ Bug fixes
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - Use zarr-fixture to prevent thread leakage errors (:pull:`9967`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Fix weighted ``polyfit`` for arrays with more than two dimensions (:issue:`9972`, :pull:`9974`).
+  By `Mattia Almansi <https://github.com/malmans2>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -9206,7 +9206,7 @@ class Dataset(
 
             present_dims.update(other_dims)
             if w is not None:
-                rhs = rhs * w[:, np.newaxis]
+                rhs = rhs * w.reshape(-1, *((1,) * len(other_dims)))
 
             with warnings.catch_warnings():
                 if full:  # Copy np.polyfit behavior

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6685,11 +6685,15 @@ class TestDataset:
         assert len(out.data_vars) == 0
 
     def test_polyfit_weighted(self) -> None:
-        # Make sure weighted polyfit does not change the original object (issue #5644)
         ds = create_test_data(seed=1)
+        ds = ds.broadcast_like(ds)  # test more than 2 dimensions (issue #9972)
         ds_copy = ds.copy(deep=True)
 
-        ds.polyfit("dim2", 2, w=np.arange(ds.sizes["dim2"]))
+        result_weighted = ds.polyfit("dim2", 2, w=np.ones(ds.sizes["dim2"]))
+        result_unweighted = ds.polyfit("dim2", 2)
+        xr.testing.assert_identical(result_weighted, result_unweighted)
+
+        # Make sure weighted polyfit does not change the original object (issue #5644)
         xr.testing.assert_identical(ds, ds_copy)
 
     def test_polyfit_coord(self) -> None:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -395,7 +395,7 @@ class TestDataset:
             <xarray.Dataset> Size: 12B
             Dimensions:  (foø: 1)
             Coordinates:
-              * foø      (foø) {byteorder}U3 12B {"ba®"!r}
+              * foø      (foø) {byteorder}U3 12B {'ba®'!r}
             Data variables:
                 *empty*
             Attributes:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -395,7 +395,7 @@ class TestDataset:
             <xarray.Dataset> Size: 12B
             Dimensions:  (foø: 1)
             Coordinates:
-              * foø      (foø) {byteorder}U3 12B {'ba®'!r}
+              * foø      (foø) {byteorder}U3 12B {"ba®"!r}
             Data variables:
                 *empty*
             Attributes:
@@ -6689,9 +6689,9 @@ class TestDataset:
         ds = ds.broadcast_like(ds)  # test more than 2 dimensions (issue #9972)
         ds_copy = ds.copy(deep=True)
 
-        result_weighted = ds.polyfit("dim2", 2, w=np.ones(ds.sizes["dim2"]))
-        result_unweighted = ds.polyfit("dim2", 2)
-        xr.testing.assert_identical(result_weighted, result_unweighted)
+        expected = ds.polyfit("dim2", 2)
+        actual = ds.polyfit("dim2", 2, w=np.ones(ds.sizes["dim2"]))
+        xr.testing.assert_identical(expected, actual)
 
         # Make sure weighted polyfit does not change the original object (issue #5644)
         xr.testing.assert_identical(ds, ds_copy)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #9972 
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

