### PR TITLE
allow zlib to be an alias for gzip for h5netcdf backend

### DIFF
--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -324,6 +324,13 @@ class H5NetCDFStore(WritableCFDataStore):
                 raise ValueError("'zlib' and 'compression' encodings mismatch")
             encoding.setdefault("compression", "gzip")
 
+        # "zlib" is allowed as an alias for "gzip" since in
+        # libnetcdf4 allows "zlib" to be set "gzip" compression
+        # making it difficult to write code that enables common
+        # compression options for both
+        if encoding.get("compression") == "zlib":
+            encoding["compression"] = "gzip"
+
         if (
             check_encoding
             and "complevel" in encoding

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4024,6 +4024,12 @@ class TestH5NetCDFData(NetCDF4Base):
                 {"compression": "gzip", "compression_opts": 9},
                 {"zlib": True, "complevel": 9},
             ),
+            # For compatibility with libnetcdf4 we allow users to specify
+            # zlib for gzip
+            (
+                {"compression": "zlib", "compression_opts": 9},
+                {"zlib": True, "complevel": 9},
+            ),
             # What can't be expressed in NetCDF4-Python style is
             # round-tripped unaltered
             (


### PR DESCRIPTION
I'm not too sure where to put this, but it seemed like you already had a compatibility shims for this kind of stuff:

xref: https://github.com/h5netcdf/h5netcdf/pull/252

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
