### PR TITLE
include accessors in `__dir__

### DIFF
--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -351,7 +351,7 @@ class AttrAccessMixin:
             for item in source
             if isinstance(item, str)
         }
-        return sorted(set(dir(type(self))) | extra_attrs)
+        return sorted(set(dir(type(self))) | self._accessors | extra_attrs)
 
     def _ipython_key_completions_(self) -> list[str]:
         """Provide method for the key-autocompletions in IPython.

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -421,6 +421,7 @@ class DataArray(
     _indexes: dict[Hashable, Index]
     _name: Hashable | None
     _variable: Variable
+    _accessors: set[str] = set()
 
     __slots__ = (
         "__weakref__",

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -709,6 +709,7 @@ class Dataset(
     _close: Callable[[], None] | None
     _indexes: dict[Hashable, Index]
     _variables: dict[Hashable, Variable]
+    _accessors: set[str] = set()
 
     __slots__ = (
         "__weakref__",

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -224,7 +224,6 @@ class DatasetView(Dataset):
         "_indexes",
         "_variables",
     )
-    _accessors: str[str] = set()
 
     def __init__(
         self,
@@ -456,6 +455,7 @@ class DataTree(
     _attrs: dict[Hashable, Any] | None
     _encoding: dict[Hashable, Any] | None
     _close: Callable[[], None] | None
+    _accessors: str[str] = set()
 
     __slots__ = (
         "_attrs",

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -224,6 +224,7 @@ class DatasetView(Dataset):
         "_indexes",
         "_variables",
     )
+    _accessors: str[str] = set()
 
     def __init__(
         self,

--- a/xarray/core/extensions.py
+++ b/xarray/core/extensions.py
@@ -57,6 +57,7 @@ def _register_accessor(name, cls):
                 stacklevel=2,
             )
         setattr(cls, name, _CachedAccessor(name, accessor))
+        cls._accessors.add(name)
         return accessor
 
     return decorator


### PR DESCRIPTION
We were not including accessors in `__dir__` so far, which would mean that dynamic code completion was not suggesting any accessors.

This can't make use of `_cache`, which is related but an instance variable, and will only be populated on the first access of each accessor (by `_CachedAccessor`).

- [x] xref #zarr-developers/VirtualiZarr#389
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`