### PR TITLE
Use flox for grouped first, last

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -54,6 +54,8 @@ New Features
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_ and `Spencer Clark <https://github.com/spencerkclark>`_.
 - Improve the error message raised when no key is matching the available variables in a dataset.  (:pull:`9943`)
   By `Jimmy Westling <https://github.com/illviljan>`_.
+- :py:meth:`DatasetGroupBy.first` and :py:meth:`DatasetGroupBy.last` can now use ``flox`` if available. (:issue:`9647`)
+  By `Deepak Cherian <https://github.com/dcherian>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -1357,7 +1357,12 @@ class GroupBy(Generic[T_Xarray]):
         """
         return ops.where_method(self, cond, other)
 
-    def _first_or_last(self, op: str, skipna: bool | None, keep_attrs: bool | None):
+    def _first_or_last(
+        self,
+        op: Literal["first" | "last"],
+        skipna: bool | None,
+        keep_attrs: bool | None,
+    ):
         if all(
             isinstance(maybe_slice, slice)
             and (maybe_slice.stop == maybe_slice.start + 1)
@@ -1369,13 +1374,12 @@ class GroupBy(Generic[T_Xarray]):
         if keep_attrs is None:
             keep_attrs = _get_keep_attrs(default=True)
         if (
-            skipna
-            and module_available("flox", minversion="0.9.16")
+            module_available("flox", minversion="0.9.16")
             and OPTIONS["use_flox"]
             and contains_only_chunked_or_numpy(self._obj)
         ):
             result, *_ = self._flox_reduce(
-                dim=None, func=f"nan{op}" if skipna else op, keep_attrs=keep_attrs
+                dim=None, func=op, skipna=skipna, keep_attrs=keep_attrs
             )
         else:
             result = self.reduce(

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -20,7 +20,6 @@ from xarray.core._aggregations import (
 from xarray.core.alignment import align, broadcast
 from xarray.core.arithmetic import DataArrayGroupbyArithmetic, DatasetGroupbyArithmetic
 from xarray.core.common import ImplementsArrayReduce, ImplementsDatasetReduce
-from xarray.core.computation import apply_ufunc
 from xarray.core.concat import concat
 from xarray.core.coordinates import Coordinates, _coordinates_from_variable
 from xarray.core.duck_array_ops import where
@@ -1359,8 +1358,6 @@ class GroupBy(Generic[T_Xarray]):
         return ops.where_method(self, cond, other)
 
     def _first_or_last(self, op: str, skipna: bool | None, keep_attrs: bool | None):
-        from xarray.core.dataarray import DataArray
-
         if all(
             isinstance(maybe_slice, slice)
             and (maybe_slice.stop == maybe_slice.start + 1)
@@ -1371,86 +1368,22 @@ class GroupBy(Generic[T_Xarray]):
             return self._obj
         if keep_attrs is None:
             keep_attrs = _get_keep_attrs(default=True)
-
-        def _groupby_first_last_wrapper(
-            values,
-            by,
-            *,
-            op: Literal["first", "last"],
-            skipna: bool | None,
-            group_indices,
+        if (
+            skipna
+            and module_available("flox", minversion="0.9.16")
+            and OPTIONS["use_flox"]
+            and contains_only_chunked_or_numpy(self._obj)
         ):
-            no_nans = dtypes.isdtype(
-                values.dtype, "signed integer"
-            ) or dtypes.is_string(values.dtype)
-            if (skipna or skipna is None) and not no_nans:
-                skipna = True
-            else:
-                skipna = False
-
-            if TYPE_CHECKING:
-                assert isinstance(skipna, bool)
-
-            if skipna is False or (skipna and no_nans):
-                # this is an optimization: when skipna=False, we can simply index
-                # the whole object after picking the first/last member of each group
-                # in self.encoded.group_indices
-                if op == "first":
-                    indices = [
-                        (idx.start if isinstance(idx, slice) else idx[0])
-                        for idx in group_indices
-                        if idx
-                    ]
-                else:
-                    indices = [
-                        (idx.stop - 1 if isinstance(idx, slice) else idx[-1])
-                        for idx in self.encoded.group_indices
-                        if idx
-                    ]
-                return self._obj.isel({self._group_dim: indices})
-
-            elif (
-                skipna
-                and module_available("flox", minversion="0.9.14")
-                and OPTIONS["use_flox"]
-                and contains_only_chunked_or_numpy(self._obj)
-            ):
-                import flox
-
-                result, *_ = flox.groupby_reduce(
-                    values, self.group1d.data, axis=-1, func=f"nan{op}"
-                )
-                return result
-
-            else:
-                return self.reduce(
-                    getattr(duck_array_ops, op),
-                    dim=[self._group_dim],
-                    skipna=skipna,
-                    keep_attrs=keep_attrs,
-                )
-
-        result = apply_ufunc(
-            _groupby_first_last_wrapper,
-            self._obj,
-            self.group1d,
-            input_core_dims=[[self._group_dim], [self._group_dim]],
-            output_core_dims=[[self.group1d.name]],
-            dask="allowed",
-            output_sizes={self.group1d.name: len(self)},
-            exclude_dims={self._group_dim},
-            keep_attrs=keep_attrs,
-            kwargs={
-                "op": op,
-                "skipna": skipna,
-                "group_indices": self.encoded.group_indices,
-            },
-        )
-        result = result.assign_coords(self.encoded.coords)
-        result = self._maybe_unstack(result)
-        result = self._maybe_restore_empty_groups(result)
-        if isinstance(result, DataArray):
-            result = self._restore_dim_order(result)
+            result, *_ = self._flox_reduce(
+                dim=None, func=f"nan{op}" if skipna else op, keep_attrs=keep_attrs
+            )
+        else:
+            result = self.reduce(
+                getattr(duck_array_ops, op),
+                dim=[self._group_dim],
+                skipna=skipna,
+                keep_attrs=keep_attrs,
+            )
         return result
 
     def first(self, skipna: bool | None = None, keep_attrs: bool | None = None):

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -109,7 +109,6 @@ class Resample(GroupBy[T_Xarray]):
         from xarray.core.dataset import Dataset
 
         result = super()._first_or_last(op=op, skipna=skipna, keep_attrs=keep_attrs)
-        result = result.rename({RESAMPLE_DIM: self._group_dim})
         if isinstance(result, Dataset):
             # Can't do this in the base class because group_dim is RESAMPLE_DIM
             # which is not present in the original object

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable, Hashable, Iterable, Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from xarray.core._aggregations import (
     DataArrayResampleAggregations,
@@ -104,7 +104,7 @@ class Resample(GroupBy[T_Xarray]):
         return self._shuffle_obj(chunks).drop_vars(RESAMPLE_DIM)
 
     def _first_or_last(
-        self, op: str, skipna: bool | None, keep_attrs: bool | None
+        self, op: Literal["first", "last"], skipna: bool | None, keep_attrs: bool | None
     ) -> T_Xarray:
         from xarray.core.dataset import Dataset
 

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -1618,6 +1618,8 @@ class TestDataArrayGroupBy:
         expected = array  # should be a no-op
         assert_identical(expected, actual)
 
+        # TODO: groupby_bins too
+
     def make_groupby_multidim_example_array(self) -> DataArray:
         return DataArray(
             [[[0, 1], [2, 3]], [[5, 10], [15, 20]]],


### PR DESCRIPTION
- [x] Closes #9647
- [ ] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

cc @max-sixty . Alas I struggled with using a plain indexing operation when possible (see the first commit). We have the indices in `.encoded.group_indices` 