### PR TITLE
Use `freq="D"` instead of `freq="d"` in `pd.timedelta_range`

### DIFF
--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -1849,7 +1849,7 @@ _DECODE_TIMEDELTA_TESTS = {
 def test_decode_timedelta(
     decode_times, decode_timedelta, expected_dtype, warns
 ) -> None:
-    timedeltas = pd.timedelta_range(0, freq="d", periods=3)
+    timedeltas = pd.timedelta_range(0, freq="D", periods=3)
     var = Variable(["time"], timedeltas)
     encoded = conventions.encode_cf_variable(var)
     if warns:


### PR DESCRIPTION
`freq="d"` is deprecated, so we make sure to use `freq="D"` to avoid warnings.

- [x] Closes #10003
