### PR TITLE
cast `numpy` scalars to arrays in `NamedArray.from_array`

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -106,6 +106,8 @@ Bug fixes
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - Fix weighted ``polyfit`` for arrays with more than two dimensions (:issue:`9972`, :pull:`9974`).
   By `Mattia Almansi <https://github.com/malmans2>`_.
+- Cast ``numpy`` scalars to arrays in :py:meth:`NamedArray.from_arrays` (:issue:`10005`, :pull:`10008`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/namedarray/core.py
+++ b/xarray/namedarray/core.py
@@ -205,7 +205,7 @@ def from_array(
 
         return NamedArray(dims, data, attrs)
 
-    if isinstance(data, _arrayfunction_or_api):
+    if isinstance(data, _arrayfunction_or_api) and not isinstance(data, np.generic):
         return NamedArray(dims, data, attrs)
 
     if isinstance(data, tuple):

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -591,6 +591,12 @@ class TestNamedArray(NamedArraySubclassobjects):
         with pytest.warns(UserWarning, match="Duplicate dimension names"):
             NamedArray(("x", "x"), np.arange(4).reshape(2, 2))
 
+    def test_aggregation(self) -> None:
+        x = NamedArray(("x", "y"), np.arange(4).reshape(2, 2))
+
+        result = x.sum()
+        assert isinstance(result.data, np.ndarray)
+
 
 def test_repr() -> None:
     x: NamedArray[Any, np.dtype[np.uint64]]

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -592,6 +592,7 @@ class TestNamedArray(NamedArraySubclassobjects):
             NamedArray(("x", "x"), np.arange(4).reshape(2, 2))
 
     def test_aggregation(self) -> None:
+        x: NamedArray[Any, np.dtype[np.int64]]
         x = NamedArray(("x", "y"), np.arange(4).reshape(2, 2))
 
         result = x.sum()


### PR DESCRIPTION
- [x] Closes #10005, follow-up to #9403
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

cc @kmuehlbauer