### PR TITLE
`map_over_datasets`: fix error message for wrong result type

### DIFF
--- a/xarray/core/datatree_mapping.py
+++ b/xarray/core/datatree_mapping.py
@@ -160,8 +160,8 @@ def _check_single_set_return_values(path_to_node: str, obj: Any) -> int | None:
         isinstance(r, Dataset | None) for r in obj
     ):
         raise TypeError(
-            f"the result of calling func on the node at position is not a Dataset or None "
-            f"or a tuple of such types: {obj!r}"
+            f"the result of calling func on the node at position '{path_to_node}' is"
+            f" not a Dataset or None or a tuple of such types: {obj!r}"
         )
 
     return len(obj)

--- a/xarray/core/datatree_mapping.py
+++ b/xarray/core/datatree_mapping.py
@@ -161,7 +161,7 @@ def _check_single_set_return_values(path_to_node: str, obj: Any) -> int | None:
     ):
         raise TypeError(
             f"the result of calling func on the node at position '{path_to_node}' is"
-            f" not a Dataset or None or a tuple of such types: {obj!r}"
+            f" not a Dataset or None or a tuple of such types:\n{obj!r}"
         )
 
     return len(obj)

--- a/xarray/tests/test_datatree_mapping.py
+++ b/xarray/tests/test_datatree_mapping.py
@@ -72,7 +72,7 @@ class TestMapOverSubTree:
         with pytest.raises(
             TypeError,
             match=re.escape(
-                "the result of calling func on the node at position is not a "
+                "the result of calling func on the node at position '.' is not a "
                 "Dataset or None or a tuple of such types"
             ),
         ):
@@ -84,7 +84,7 @@ class TestMapOverSubTree:
         with pytest.raises(
             TypeError,
             match=re.escape(
-                "the result of calling func on the node at position is not a "
+                "the result of calling func on the node at position '.' is not a "
                 "Dataset or None or a tuple of such types"
             ),
         ):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

The error message did not indicate the name of the node which is fixed here.

It shows `'.'` for the root node while the repr uses `/` which is maybe confusing. This comes from using `NodePath()` - maybe this should be changed to `NodePath("/")`?

https://github.com/pydata/xarray/blob/c25215299c02cd36781cf3aa38e8583d1fe14849/xarray/core/treenode.py#L432
