### PR TITLE
Improve handling of dtype and NaT when encoding/decoding masked and packaged datetimes and timedeltas

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -71,7 +71,7 @@ Bug fixes
   By `Benoit Bovy <https://github.com/benbovy>`_.
 - Fix dask tokenization when opening each node in :py:func:`xarray.open_datatree`
   (:issue:`10098`, :pull:`10100`). By `Sam Levang <https://github.com/slevang>`_.
-- Improve handling of dtype and NaT when encoding/decoding masked and packaged 
+- Improve handling of dtype and NaT when encoding/decoding masked and packaged
   datetimes and timedeltas (:issue:`8957`, :pull:`10050`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -57,6 +57,8 @@ Bug fixes
   Haacker <https://github.com/j-haacker>`_.
 - Fix ``isel`` for multi-coordinate Xarray indexes (:issue:`10063`, :pull:`10066`).
   By `Benoit Bovy <https://github.com/benbovy>`_.
+- Improve handling of dtype and NaT when encoding/decoding masked and packaged datetimes and timedeltas (:issue:`8957`, :pull:`10050`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 
 Documentation

--- a/xarray/coding/common.py
+++ b/xarray/coding/common.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Hashable, MutableMapping
+from typing import TYPE_CHECKING, Any, Union
+
+import numpy as np
+
+from xarray.core import indexing
+from xarray.core.variable import Variable
+from xarray.namedarray.parallelcompat import get_chunked_array_type
+from xarray.namedarray.pycompat import is_chunked_array
+
+if TYPE_CHECKING:
+    T_VarTuple = tuple[tuple[Hashable, ...], Any, dict, dict]
+    T_Name = Union[Hashable, None]
+
+
+class SerializationWarning(RuntimeWarning):
+    """Warnings about encoding/decoding issues in serialization."""
+
+
+class VariableCoder:
+    """Base class for encoding and decoding transformations on variables.
+
+    We use coders for transforming variables between xarray's data model and
+    a format suitable for serialization. For example, coders apply CF
+    conventions for how data should be represented in netCDF files.
+
+    Subclasses should implement encode() and decode(), which should satisfy
+    the identity ``coder.decode(coder.encode(variable)) == variable``. If any
+    options are necessary, they should be implemented as arguments to the
+    __init__ method.
+
+    The optional name argument to encode() and decode() exists solely for the
+    sake of better error messages, and should correspond to the name of
+    variables in the underlying store.
+    """
+
+    def encode(self, variable: Variable, name: T_Name = None) -> Variable:
+        """Convert an encoded variable to a decoded variable"""
+        raise NotImplementedError()
+
+    def decode(self, variable: Variable, name: T_Name = None) -> Variable:
+        """Convert a decoded variable to an encoded variable"""
+        raise NotImplementedError()
+
+
+class _ElementwiseFunctionArray(indexing.ExplicitlyIndexedNDArrayMixin):
+    """Lazily computed array holding values of elemwise-function.
+
+    Do not construct this object directly: call lazy_elemwise_func instead.
+
+    Values are computed upon indexing or coercion to a NumPy array.
+    """
+
+    def __init__(self, array, func: Callable, dtype: np.typing.DTypeLike):
+        assert not is_chunked_array(array)
+        self.array = indexing.as_indexable(array)
+        self.func = func
+        self._dtype = dtype
+
+    @property
+    def dtype(self) -> np.dtype:
+        return np.dtype(self._dtype)
+
+    def _oindex_get(self, key):
+        return type(self)(self.array.oindex[key], self.func, self.dtype)
+
+    def _vindex_get(self, key):
+        return type(self)(self.array.vindex[key], self.func, self.dtype)
+
+    def __getitem__(self, key):
+        return type(self)(self.array[key], self.func, self.dtype)
+
+    def get_duck_array(self):
+        return self.func(self.array.get_duck_array())
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self.array!r}, func={self.func!r}, dtype={self.dtype!r})"
+
+
+def lazy_elemwise_func(array, func: Callable, dtype: np.typing.DTypeLike):
+    """Lazily apply an element-wise function to an array.
+    Parameters
+    ----------
+    array : any valid value of Variable._data
+    func : callable
+        Function to apply to indexed slices of an array. For use with dask,
+        this should be a pickle-able object.
+    dtype : coercible to np.dtype
+        Dtype for the result of this function.
+
+    Returns
+    -------
+    Either a dask.array.Array or _ElementwiseFunctionArray.
+    """
+    if is_chunked_array(array):
+        chunkmanager = get_chunked_array_type(array)
+
+        return chunkmanager.map_blocks(func, array, dtype=dtype)  # type: ignore[arg-type]
+    else:
+        return _ElementwiseFunctionArray(array, func, dtype)
+
+
+def safe_setitem(dest, key: Hashable, value, name: T_Name = None):
+    if key in dest:
+        var_str = f" on variable {name!r}" if name else ""
+        raise ValueError(
+            f"failed to prevent overwriting existing key {key} in attrs{var_str}. "
+            "This is probably an encoding field used by xarray to describe "
+            "how a variable is serialized. To proceed, remove this key from "
+            "the variable's attributes manually."
+        )
+    dest[key] = value
+
+
+def pop_to(
+    source: MutableMapping, dest: MutableMapping, key: Hashable, name: T_Name = None
+) -> Any:
+    """
+    A convenience function which pops a key k from source to dest.
+    None values are not passed on.  If k already exists in dest an
+    error is raised.
+    """
+    value = source.pop(key, None)
+    if value is not None:
+        safe_setitem(dest, key, value, name=name)
+    return value
+
+
+def unpack_for_encoding(var: Variable) -> T_VarTuple:
+    return var.dims, var.data, var.attrs.copy(), var.encoding.copy()
+
+
+def unpack_for_decoding(var: Variable) -> T_VarTuple:
+    return var.dims, var._data, var.attrs.copy(), var.encoding.copy()

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 from pandas.errors import OutOfBoundsDatetime, OutOfBoundsTimedelta
 
-from xarray.coding.variables import (
+from xarray.coding.common import (
     SerializationWarning,
     VariableCoder,
     lazy_elemwise_func,

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -1315,9 +1315,11 @@ class CFDatetimeCoder(VariableCoder):
 
             units = encoding.pop("units", None)
             calendar = encoding.pop("calendar", None)
-            dtype = encoding.get("dtype", None)
+            dtype = encoding.pop("dtype", None)
             (data, units, calendar) = encode_cf_datetime(data, units, calendar, dtype)
-
+            # if no dtype is provided, preserve data.dtype in encoding
+            if dtype is None:
+                safe_setitem(encoding, "dtype", data.dtype, name=name)
             safe_setitem(attrs, "units", units, name=name)
             safe_setitem(attrs, "calendar", calendar, name=name)
 
@@ -1369,8 +1371,16 @@ class CFTimedeltaCoder(VariableCoder):
         if np.issubdtype(variable.data.dtype, np.timedelta64):
             dims, data, attrs, encoding = unpack_for_encoding(variable)
 
+            # in the case of packed data we need to encode into
+            # float first, the correct dtype will be established
+            # via CFScaleOffsetCoder/CFMaskCoder
+            dtype = None
+            if "add_offset" in encoding or "scale_factor" in encoding:
+                encoding.pop("dtype")
+                dtype = data.dtype if data.dtype.kind == "f" else "float64"
+
             data, units = encode_cf_timedelta(
-                data, encoding.pop("units", None), encoding.get("dtype", None)
+                data, encoding.pop("units", None), encoding.get("dtype", dtype)
             )
             safe_setitem(attrs, "units", units, name=name)
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -1320,13 +1320,15 @@ class CFDatetimeCoder(VariableCoder):
             # in the case of packed data we need to encode into
             # float first, the correct dtype will be established
             # via CFScaleOffsetCoder/CFMaskCoder
+            set_dtype_encoding = None
             if "add_offset" in encoding or "scale_factor" in encoding:
+                set_dtype_encoding = dtype
                 dtype = data.dtype if data.dtype.kind == "f" else "float64"
             (data, units, calendar) = encode_cf_datetime(data, units, calendar, dtype)
 
-            # if no dtype is provided, preserve data.dtype in encoding
-            if dtype is None:
-                safe_setitem(encoding, "dtype", data.dtype, name=name)
+            # retain dtype for packed data
+            if set_dtype_encoding is not None:
+                safe_setitem(encoding, "dtype", set_dtype_encoding, name=name)
             safe_setitem(attrs, "units", units, name=name)
             safe_setitem(attrs, "calendar", calendar, name=name)
 
@@ -1383,14 +1385,16 @@ class CFTimedeltaCoder(VariableCoder):
             # in the case of packed data we need to encode into
             # float first, the correct dtype will be established
             # via CFScaleOffsetCoder/CFMaskCoder
+            set_dtype_encoding = None
             if "add_offset" in encoding or "scale_factor" in encoding:
+                set_dtype_encoding = dtype
                 dtype = data.dtype if data.dtype.kind == "f" else "float64"
 
             data, units = encode_cf_timedelta(data, encoding.pop("units", None), dtype)
 
-            # if no dtype is provided, preserve data.dtype in encoding
-            if dtype is None:
-                safe_setitem(encoding, "dtype", data.dtype, name=name)
+            # retain dtype for packed data
+            if set_dtype_encoding is not None:
+                safe_setitem(encoding, "dtype", set_dtype_encoding, name=name)
 
             safe_setitem(attrs, "units", units, name=name)
 

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING, Any, Union
 
 import numpy as np
 import pandas as pd
-
 from build.lib.xarray.coding.times import CFDatetimeCoder, CFTimedeltaCoder
+
 from xarray.core import dtypes, duck_array_ops, indexing
 from xarray.core.variable import Variable
 from xarray.namedarray.parallelcompat import get_chunked_array_type

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -502,10 +502,8 @@ class CFMaskCoder(VariableCoder):
                     (is_time_like == "datetime" and self.decode_times)
                     or (is_time_like == "timedelta" and self.decode_timedelta)
                 ) and data.dtype.kind in "iu":
-                    dtype, decoded_fill_value = (
-                        np.int64,
-                        np.iinfo(np.int64).min,
-                    )  # np.dtype(f"{is_time_like}64[s]")
+                    dtype = np.int64
+                    decoded_fill_value = np.iinfo(np.int64).min
                 else:
                     dtype, decoded_fill_value = dtypes.maybe_promote(data.dtype)
 
@@ -624,16 +622,16 @@ class CFScaleOffsetCoder(VariableCoder):
                 scale_factor = np.asarray(scale_factor).item()
             if np.ndim(add_offset) > 0:
                 add_offset = np.asarray(add_offset).item()
-            # if we have a _FillValue/masked_value we already have the wanted
+            # if we have a _FillValue/masked_value in encoding we already have the wanted
             # floating point dtype here (via CFMaskCoder), so no check is necessary
             # only check in other cases and for time-like
             dtype = data.dtype
             is_time_like = _is_time_like(attrs.get("units"))
-            if (is_time_like == "datetime" and self.decode_times) or (
-                is_time_like == "timedelta" and self.decode_timedelta
+            if (
+                ("_FillValue" not in encoding and "missing_value" not in encoding)
+                or (is_time_like == "datetime" and self.decode_times)
+                or (is_time_like == "timedelta" and self.decode_timedelta)
             ):
-                dtype = _choose_float_dtype(dtype, encoding)
-            if "_FillValue" not in encoding and "missing_value" not in encoding:
                 dtype = _choose_float_dtype(dtype, encoding)
 
             transform = partial(

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING, Any, Union
 
 import numpy as np
 import pandas as pd
-from xarray.coding.times import CFDatetimeCoder, CFTimedeltaCoder
 
+from xarray.coding.times import CFDatetimeCoder, CFTimedeltaCoder
 from xarray.core import dtypes, duck_array_ops, indexing
 from xarray.core.variable import Variable
 from xarray.namedarray.parallelcompat import get_chunked_array_type

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Union
 import numpy as np
 import pandas as pd
 
+from build.lib.xarray.coding.times import CFDatetimeCoder, CFTimedeltaCoder
 from xarray.core import dtypes, duck_array_ops, indexing
 from xarray.core.variable import Variable
 from xarray.namedarray.parallelcompat import get_chunked_array_type
@@ -371,8 +372,8 @@ class CFMaskCoder(VariableCoder):
 
     def __init__(
         self,
-        decode_times: bool = False,
-        decode_timedelta: bool = False,
+        decode_times: bool | CFDatetimeCoder = False,
+        decode_timedelta: bool | CFTimedeltaCoder = False,
     ) -> None:
         self.decode_times = decode_times
         self.decode_timedelta = decode_timedelta
@@ -584,8 +585,8 @@ class CFScaleOffsetCoder(VariableCoder):
 
     def __init__(
         self,
-        decode_times: bool = False,
-        decode_timedelta: bool = False,
+        decode_times: bool | CFDatetimeCoder = False,
+        decode_timedelta: bool | CFTimedeltaCoder = False,
     ) -> None:
         self.decode_times = decode_times
         self.decode_timedelta = decode_timedelta

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, Union
 import numpy as np
 import pandas as pd
 
-from xarray.coding.times import CFDatetimeCoder, CFTimedeltaCoder
 from xarray.core import dtypes, duck_array_ops, indexing
 from xarray.core.variable import Variable
 from xarray.namedarray.parallelcompat import get_chunked_array_type
@@ -372,8 +371,8 @@ class CFMaskCoder(VariableCoder):
 
     def __init__(
         self,
-        decode_times: bool | CFDatetimeCoder = False,
-        decode_timedelta: bool | CFTimedeltaCoder = False,
+        decode_times: bool = False,
+        decode_timedelta: bool = False,
     ) -> None:
         self.decode_times = decode_times
         self.decode_timedelta = decode_timedelta
@@ -585,8 +584,8 @@ class CFScaleOffsetCoder(VariableCoder):
 
     def __init__(
         self,
-        decode_times: bool | CFDatetimeCoder = False,
-        decode_timedelta: bool | CFTimedeltaCoder = False,
+        decode_times: bool = False,
+        decode_timedelta: bool = False,
     ) -> None:
         self.decode_times = decode_times
         self.decode_timedelta = decode_timedelta

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -234,7 +234,7 @@ def _apply_mask(
 
 def _is_time_like(units):
     # test for time-like
-    # return "datetime" for datetetime-like
+    # return "datetime" for datetime-like
     # return "timedelta" for timedelta-like
     if units is None:
         return False

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -416,6 +416,7 @@ class CFMaskCoder(VariableCoder):
         if mv_exists:
             # try to use _FillValue, if it exists to align both values
             # or use missing_value and ensure it's cast to same dtype as data's
+            # but not for packed data
             encoding["missing_value"] = attrs.get(
                 "_FillValue",
                 (
@@ -437,7 +438,11 @@ class CFMaskCoder(VariableCoder):
                         data != np.iinfo(np.int64).min, data, fill_value
                     )
                 else:
+                    # if we have float data (data was packed prior masking)
+                    # we just fillna
                     data = duck_array_ops.fillna(data, fill_value)
+                    # but if the fill_value is of integer type
+                    # we need to round and cast
                     if np.array(fill_value).dtype.kind in "iu":
                         data = duck_array_ops.astype(
                             duck_array_ops.around(data), type(fill_value)

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Union
 
 import numpy as np
 import pandas as pd
-from build.lib.xarray.coding.times import CFDatetimeCoder, CFTimedeltaCoder
+from xarray.coding.times import CFDatetimeCoder, CFTimedeltaCoder
 
 from xarray.core import dtypes, duck_array_ops, indexing
 from xarray.core.variable import Variable

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -194,8 +194,12 @@ def decode_cf_variable(
 
     if mask_and_scale:
         for coder in [
-            variables.CFMaskCoder(),
-            variables.CFScaleOffsetCoder(),
+            variables.CFMaskCoder(
+                decode_times=decode_times, decode_timedelta=decode_timedelta
+            ),
+            variables.CFScaleOffsetCoder(
+                decode_times=decode_times, decode_timedelta=decode_timedelta
+            ),
         ]:
             var = coder.decode(var, name=name)
 

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -193,12 +193,14 @@ def decode_cf_variable(
         var = variables.Numpy2StringDTypeCoder().decode(var)
 
     if mask_and_scale:
+        dec_times = True if decode_times else False
+        dec_timedelta = True if decode_timedelta else False
         for coder in [
             variables.CFMaskCoder(
-                decode_times=decode_times, decode_timedelta=decode_timedelta
+                decode_times=dec_times, decode_timedelta=dec_timedelta
             ),
             variables.CFScaleOffsetCoder(
-                decode_times=decode_times, decode_timedelta=decode_timedelta
+                decode_times=dec_times, decode_timedelta=dec_timedelta
             ),
         ]:
             var = coder.decode(var, name=name)

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -193,14 +193,12 @@ def decode_cf_variable(
         var = variables.Numpy2StringDTypeCoder().decode(var)
 
     if mask_and_scale:
-        dec_times = True if decode_times else False
-        dec_timedelta = True if decode_timedelta else False
         for coder in [
             variables.CFMaskCoder(
-                decode_times=dec_times, decode_timedelta=dec_timedelta
+                decode_times=decode_times, decode_timedelta=decode_timedelta
             ),
             variables.CFScaleOffsetCoder(
-                decode_times=dec_times, decode_timedelta=dec_timedelta
+                decode_times=decode_times, decode_timedelta=decode_timedelta
             ),
         ]:
             var = coder.decode(var, name=name)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -1949,7 +1949,7 @@ def test_decode_timedelta_mask_and_scale(
     assert_identical(encoded, result)
     assert encoded.dtype == result.dtype
 
-    
+
 def test_decode_floating_point_timedelta_no_serialization_warning() -> None:
     attrs = {"units": "seconds"}
     encoded = Variable(["time"], [0, 0.1, 0.2], attrs=attrs)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -525,6 +525,24 @@ def test_decoded_cf_datetime_array_2d(time_unit: PDDatetimeUnitOptions) -> None:
     assert_array_equal(np.asarray(result), expected)
 
 
+@pytest.mark.parametrize("decode_times", [True, False])
+@pytest.mark.parametrize("mask_and_scale", [True, False])
+def test_decode_datetime_mask_and_scale(
+    decode_times: bool, mask_and_scale: bool
+) -> None:
+    attrs = {
+        "units": "nanoseconds since 1970-01-01",
+        "_FillValue": np.int16(-1),
+        "add_offset": 100000.0,
+    }
+    encoded = Variable(["time"], np.array([0, -1, 1], "int16"), attrs=attrs)
+    decoded = conventions.decode_cf_variable(
+        "foo", encoded, mask_and_scale=mask_and_scale, decode_times=decode_times
+    )
+    result = conventions.encode_cf_variable(decoded, name="foo")
+    assert_equal(encoded, result)
+
+
 FREQUENCIES_TO_ENCODING_UNITS = {
     "ns": "nanoseconds",
     "us": "microseconds",
@@ -1914,7 +1932,7 @@ def test_lazy_decode_timedelta_error() -> None:
 def test_decode_timedelta_mask_and_scale(
     decode_timedelta: bool, mask_and_scale: bool
 ) -> None:
-    attrs = {"units": "days", "_FillValue": np.int16(-1), "add_offset": 100.0}
+    attrs = {"units": "nanoseconds", "_FillValue": np.int16(-1), "add_offset": 100000.0}
     encoded = Variable(["time"], np.array([0, -1, 1], "int16"), attrs=attrs)
     decoded = conventions.decode_cf_variable(
         "foo", encoded, mask_and_scale=mask_and_scale, decode_timedelta=decode_timedelta

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -638,7 +638,9 @@ def test_cf_timedelta_2d() -> None:
 
 
 @pytest.mark.parametrize("encoding_unit", FREQUENCIES_TO_ENCODING_UNITS.values())
-def test_decode_cf_timedelta_time_unit(time_unit, encoding_unit) -> None:
+def test_decode_cf_timedelta_time_unit(
+    time_unit: PDDatetimeUnitOptions, encoding_unit
+) -> None:
     encoded = 1
     encoding_unit_as_numpy = _netcdf_to_numpy_timeunit(encoding_unit)
     if np.timedelta64(1, time_unit) > np.timedelta64(1, encoding_unit_as_numpy):
@@ -652,7 +654,9 @@ def test_decode_cf_timedelta_time_unit(time_unit, encoding_unit) -> None:
     assert result.dtype == expected.dtype
 
 
-def test_decode_cf_timedelta_time_unit_out_of_bounds(time_unit) -> None:
+def test_decode_cf_timedelta_time_unit_out_of_bounds(
+    time_unit: PDDatetimeUnitOptions,
+) -> None:
     # Define a scale factor that will guarantee overflow with the given
     # time_unit.
     scale_factor = np.timedelta64(1, time_unit) // np.timedelta64(1, "ns")
@@ -661,7 +665,7 @@ def test_decode_cf_timedelta_time_unit_out_of_bounds(time_unit) -> None:
         decode_cf_timedelta(encoded, "days", time_unit)
 
 
-def test_cf_timedelta_roundtrip_large_value(time_unit) -> None:
+def test_cf_timedelta_roundtrip_large_value(time_unit: PDDatetimeUnitOptions) -> None:
     value = np.timedelta64(np.iinfo(np.int64).max, time_unit)
     encoded, units = encode_cf_timedelta(value)
     decoded = decode_cf_timedelta(encoded, units, time_unit=time_unit)
@@ -983,7 +987,7 @@ def test_use_cftime_default_standard_calendar_out_of_range(
 @pytest.mark.parametrize("calendar", _NON_STANDARD_CALENDARS)
 @pytest.mark.parametrize("units_year", [1500, 2000, 2500])
 def test_use_cftime_default_non_standard_calendar(
-    calendar, units_year, time_unit
+    calendar, units_year, time_unit: PDDatetimeUnitOptions
 ) -> None:
     from cftime import num2date
 
@@ -1620,7 +1624,9 @@ _ENCODE_DATETIME64_VIA_DASK_TESTS = {
     _ENCODE_DATETIME64_VIA_DASK_TESTS.values(),
     ids=_ENCODE_DATETIME64_VIA_DASK_TESTS.keys(),
 )
-def test_encode_cf_datetime_datetime64_via_dask(freq, units, dtype, time_unit) -> None:
+def test_encode_cf_datetime_datetime64_via_dask(
+    freq, units, dtype, time_unit: PDDatetimeUnitOptions
+) -> None:
     import dask.array
 
     times_pd = pd.date_range(start="1700", freq=freq, periods=3, unit=time_unit)
@@ -1905,7 +1911,9 @@ def test_lazy_decode_timedelta_error() -> None:
 
 @pytest.mark.parametrize("decode_timedelta", [True, False])
 @pytest.mark.parametrize("mask_and_scale", [True, False])
-def test_decode_timedelta_mask_and_scale(decode_timedelta, mask_and_scale) -> None:
+def test_decode_timedelta_mask_and_scale(
+    decode_timedelta: bool, mask_and_scale: bool
+) -> None:
     attrs = {"units": "days", "_FillValue": np.int16(-1), "add_offset": 100.0}
     encoded = Variable(["time"], np.array([0, -1, 1], "int16"), attrs=attrs)
     decoded = conventions.decode_cf_variable(

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -532,6 +532,7 @@ def test_decode_datetime_mask_and_scale(
 ) -> None:
     attrs = {
         "units": "nanoseconds since 1970-01-01",
+        "calendar": "proleptic_gregorian",
         "_FillValue": np.int16(-1),
         "add_offset": 100000.0,
     }
@@ -540,7 +541,8 @@ def test_decode_datetime_mask_and_scale(
         "foo", encoded, mask_and_scale=mask_and_scale, decode_times=decode_times
     )
     result = conventions.encode_cf_variable(decoded, name="foo")
-    assert_equal(encoded, result)
+    assert_identical(encoded, result)
+    assert encoded.dtype == result.dtype
 
 
 FREQUENCIES_TO_ENCODING_UNITS = {
@@ -1938,4 +1940,5 @@ def test_decode_timedelta_mask_and_scale(
         "foo", encoded, mask_and_scale=mask_and_scale, decode_timedelta=decode_timedelta
     )
     result = conventions.encode_cf_variable(decoded, name="foo")
-    assert_equal(encoded, result)
+    assert_identical(encoded, result)
+    assert encoded.dtype == result.dtype

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -511,16 +511,13 @@ class TestDecodeCF:
 
     @pytest.mark.parametrize("time_unit", ["s", "ms", "us", "ns"])
     def test_decode_cf_time_kwargs(self, time_unit) -> None:
-        # todo: if we set timedelta attrs "units": "days"
-        #  this errors on the last decode_cf wrt to the lazy_elemwise_func
-        #  trying to convert twice
         ds = Dataset.from_dict(
             {
                 "coords": {
                     "timedelta": {
                         "data": np.array([1, 2, 3], dtype="int64"),
                         "dims": "timedelta",
-                        "attrs": {"units": "seconds"},
+                        "attrs": {"units": "days"},
                     },
                     "time": {
                         "data": np.array([1, 2, 3], dtype="int64"),


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #8957
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Expecially for datetime/timedelta decoding we are still running into issue when partly decoding or issues when trying to roundtrip partially decoded data. Another issue is with keeping track of state for packed data / masked data. This PR solves this by adding state to CFMaskCoder/CFScaleOffsetCoder.