### PR TITLE
More permissive Index typing

### DIFF
--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -209,7 +209,7 @@ class Index:
 
     def isel(
         self, indexers: Mapping[Any, int | slice | np.ndarray | Variable]
-    ) -> Self | None:
+    ) -> Index | None:
         """Maybe returns a new index from the current index itself indexed by
         positional indexers.
 
@@ -1424,7 +1424,7 @@ class CoordinateTransformIndex(Index):
 
     def isel(
         self, indexers: Mapping[Any, int | slice | np.ndarray | Variable]
-    ) -> Self | None:
+    ) -> Index | None:
         # TODO: support returning a new index (e.g., possible to re-calculate the
         # the transform or calculate another transform on a reduced dimension space)
         return None

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -304,7 +304,7 @@ class Index:
         """
         raise NotImplementedError(f"{self!r} doesn't support re-indexing labels")
 
-    def equals(self, other: Self) -> bool:
+    def equals(self, other: Index) -> bool:
         """Compare this index with another index of the same type.
 
         Implementation is optional but required in order to support alignment.
@@ -1486,7 +1486,9 @@ class CoordinateTransformIndex(Index):
 
         return IndexSelResult(results)
 
-    def equals(self, other: Self) -> bool:
+    def equals(self, other: Index) -> bool:
+        if not isinstance(other, CoordinateTransformIndex):
+            return False
         return self.transform.equals(other.transform)
 
     def rename(


### PR DESCRIPTION
- `Index.isel`: more permissive return type (any Xarray Index)

This allows an index to return a new index of another type, e.g., a
1-dimensional CoordinateTransformIndex to return a PandasIndex when a
new transform cannot be computed (selection at arbitrary locations).

- `Index.equals`: more permissive `other` type (any Xarray Index)

Xarray alignment logic is such that Xarray indexes are always compared
with other indexes of the same type. However, this is not necessarily
the case for "meta" indexes (i.e., indexes encapsulating one or more
index objects that may have another type) that are dispatching `equals`
to their wrapped indexes.

More context and concrete examples in https://github.com/corteva/rioxarray/pull/846#discussion_r1965142497 and https://github.com/corteva/rioxarray/pull/846#discussion_r1964042312.