### PR TITLE
Fix false timedelta decoding `SerializationWarning` and improve warning message

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -53,6 +53,11 @@ Bug fixes
 - Fix DataArray().drop_attrs(deep=False) and add support for attrs to
   DataArray()._replace(). (:issue:`10027`, :pull:`10030`). By `Jan
   Haacker <https://github.com/j-haacker>`_.
+- Prevent false resolution change warnings from being emitted when decoding
+  timedeltas encoded with floating point values, and make it clearer how to
+  silence this warning message in the case that it is rightfully emitted
+  (:issue:`10071`, :pull:`10072`).  By `Spencer Clark
+  <https://github.com/spencerkclark>`_.
 
 
 Documentation

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -5,7 +5,7 @@ import warnings
 from collections.abc import Callable, Hashable
 from datetime import datetime, timedelta
 from functools import partial
-from typing import TYPE_CHECKING, Optional, Union, cast
+from typing import TYPE_CHECKING, Union, cast
 
 import numpy as np
 import pandas as pd

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -5,7 +5,7 @@ import warnings
 from collections.abc import Callable, Hashable
 from datetime import datetime, timedelta
 from functools import partial
-from typing import TYPE_CHECKING, Union, cast
+from typing import TYPE_CHECKING, Optional, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -488,7 +488,7 @@ def _decode_datetime_with_pandas(
         flat_num_dates = flat_num_dates.astype(np.float64)
 
     timedeltas = _numbers_to_timedelta(
-        flat_num_dates, time_unit, ref_date.unit, "datetime"
+        flat_num_dates, time_unit, ref_date.unit, "datetimes"
     )
 
     # add timedeltas to ref_date
@@ -582,6 +582,7 @@ def _numbers_to_timedelta(
     time_unit: NPDatetimeUnitOptions,
     ref_unit: PDDatetimeUnitOptions,
     datatype: str,
+    target_unit: Optional[PDDatetimeUnitOptions] = None,
 ) -> np.ndarray:
     """Transform numbers to np.timedelta64."""
     # keep NaT/nan mask
@@ -605,13 +606,23 @@ def _numbers_to_timedelta(
             flat_num, cast(PDDatetimeUnitOptions, time_unit)
         )
         if time_unit != new_time_unit:
-            msg = (
-                f"Can't decode floating point {datatype} to {time_unit!r} without "
-                f"precision loss, decoding to {new_time_unit!r} instead. "
-                f"To silence this warning use time_unit={new_time_unit!r} in call to "
-                f"decoding function."
-            )
-            emit_user_level_warning(msg, SerializationWarning)
+            if target_unit is None or np.timedelta64(1, target_unit) > np.timedelta64(
+                1, new_time_unit
+            ):
+                if datatype == "datetimes":
+                    kwarg = "decode_times"
+                    coder = "CFDatetimeCoder"
+                else:
+                    kwarg = "decode_timedelta"
+                    coder = "CFTimedeltaCoder"
+                formatted_kwarg = f"{kwarg}={coder}(time_unit={new_time_unit!r})"
+                message = (
+                    f"Can't decode floating point {datatype} to {time_unit!r} "
+                    f"without precision loss; decoding to {new_time_unit!r} "
+                    f"instead. To silence this warning pass {formatted_kwarg} "
+                    f"to your opening function."
+                )
+                emit_user_level_warning(message, SerializationWarning)
             time_unit = new_time_unit
 
     # Cast input ordinals to integers and properly handle NaN/NaT
@@ -640,7 +651,9 @@ def decode_cf_timedelta(
         _check_timedelta_range(np.nanmin(num_timedeltas), unit, time_unit)
         _check_timedelta_range(np.nanmax(num_timedeltas), unit, time_unit)
 
-    timedeltas = _numbers_to_timedelta(num_timedeltas, unit, "s", "timedelta")
+    timedeltas = _numbers_to_timedelta(
+        num_timedeltas, unit, "s", "timedeltas", target_unit=time_unit
+    )
     pd_timedeltas = pd.to_timedelta(ravel(timedeltas))
 
     if np.isnat(timedeltas).all():

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -582,7 +582,7 @@ def _numbers_to_timedelta(
     time_unit: NPDatetimeUnitOptions,
     ref_unit: PDDatetimeUnitOptions,
     datatype: str,
-    target_unit: Optional[PDDatetimeUnitOptions] = None,
+    target_unit: PDDatetimeUnitOptions | None = None,
 ) -> np.ndarray:
     """Transform numbers to np.timedelta64."""
     # keep NaT/nan mask

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -1333,7 +1333,7 @@ def test_coding_float_datetime_warning(
     values = np.array([num], dtype="float32")
     with pytest.warns(
         SerializationWarning,
-        match=f"Can't decode floating point datetime to {time_unit!r}",
+        match=f"Can't decode floating point datetimes to {time_unit!r}",
     ):
         decode_cf_datetime(values, units, calendar, time_unit=time_unit)
 
@@ -1900,4 +1900,12 @@ def test_lazy_decode_timedelta_error() -> None:
         "foo", encoded, decode_timedelta=CFTimedeltaCoder(time_unit="ms")
     )
     with pytest.raises(OutOfBoundsTimedelta, match="overflow"):
+        decoded.load()
+
+
+def test_decode_floating_point_timedelta_no_serialization_warning() -> None:
+    attrs = {"units": "seconds"}
+    encoded = Variable(["time"], [0, 0.1, 0.2], attrs=attrs)
+    decoded = conventions.decode_cf_variable("foo", encoded, decode_timedelta=True)
+    with assert_no_warnings():
         decoded.load()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

As reported in #10071, false warnings for resolution changes can be emitted when decoding timedeltas encoded with floating point values.  In addition, the warning message could be clearer when resolution changes do occur.  This PR fixes both issues.  

The warning message in the event of a resolution change now reads:

```
>>> import xarray as xr
>>> var = xr.Variable(["time"], [0, 0.1], attrs={"units": "seconds"})
>>> xr.conventions.decode_cf_variable("foo", var, decode_timedelta=xr.coders.CFTimedeltaCoder(time_unit="s")).compute()
<stdin>:1: SerializationWarning: Can't decode floating point timedeltas to 's' without precision loss; decoding to 'ms' instead. To silence this warning pass decode_timedelta=CFTimedeltaCoder(time_unit='ms') to your opening function.
<xarray.Variable (time: 2)> Size: 16B
array([  0, 100], dtype='timedelta64[ms]')
```

- [x] Closes #10071
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

cc: @kmuehlbauer 
