### PR TITLE
Fix missing coordinate attributes after apply_ufunc operations

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -57,7 +57,8 @@ Bug fixes
   Haacker <https://github.com/j-haacker>`_.
 - Fix ``isel`` for multi-coordinate Xarray indexes (:issue:`10063`, :pull:`10066`).
   By `Benoit Bovy <https://github.com/benbovy>`_.
-
+- Always merge coordinates with "no_conflicts" to fix missing attributes after apply_ufunc
+  operations (:issue:`9317`). By `Jasper de Jong <https://github.com/JdeJong96>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -306,7 +306,7 @@ def apply_dataarray_vfunc(
         first_obj = _first_of_type(args, DataArray)
         name = first_obj.name
     result_coords, result_indexes = build_output_coords_and_indexes(
-        args, signature, exclude_dims, combine_attrs="no_conflicts"
+        args, signature, exclude_dims, combine_attrs="drop_conflicts"
     )
 
     data_vars = [getattr(a, "variable", a) for a in args]
@@ -522,7 +522,7 @@ def apply_dataset_vfunc(
         )
 
     list_of_coords, list_of_indexes = build_output_coords_and_indexes(
-        args, signature, exclude_dims, combine_attrs="no_conflicts"
+        args, signature, exclude_dims, combine_attrs="drop_conflicts"
     )
     args = tuple(getattr(arg, "data_vars", arg) for arg in args)
 

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -306,7 +306,7 @@ def apply_dataarray_vfunc(
         first_obj = _first_of_type(args, DataArray)
         name = first_obj.name
     result_coords, result_indexes = build_output_coords_and_indexes(
-        args, signature, exclude_dims, combine_attrs=keep_attrs
+        args, signature, exclude_dims, combine_attrs="no_conflicts"
     )
 
     data_vars = [getattr(a, "variable", a) for a in args]
@@ -522,7 +522,7 @@ def apply_dataset_vfunc(
         )
 
     list_of_coords, list_of_indexes = build_output_coords_and_indexes(
-        args, signature, exclude_dims, combine_attrs=keep_attrs
+        args, signature, exclude_dims, combine_attrs="no_conflicts"
     )
     args = tuple(getattr(arg, "data_vars", arg) for arg in args)
 

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -306,7 +306,7 @@ def apply_dataarray_vfunc(
         first_obj = _first_of_type(args, DataArray)
         name = first_obj.name
     result_coords, result_indexes = build_output_coords_and_indexes(
-        args, signature, exclude_dims, combine_attrs="drop_conflicts"
+        args, signature, exclude_dims, combine_attrs="no_conflicts"
     )
 
     data_vars = [getattr(a, "variable", a) for a in args]
@@ -522,7 +522,7 @@ def apply_dataset_vfunc(
         )
 
     list_of_coords, list_of_indexes = build_output_coords_and_indexes(
-        args, signature, exclude_dims, combine_attrs="drop_conflicts"
+        args, signature, exclude_dims, combine_attrs="no_conflicts"
     )
     args = tuple(getattr(arg, "data_vars", arg) for arg in args)
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -691,6 +691,12 @@ def test_broadcast_compat_data_2d() -> None:
     )
 
 
+def test_keep_coordattrs() -> None:
+    a = xr.DataArray([0, 1], [("x", [0, 1], {"a": "b"})])
+    actual = apply_ufunc(operator.abs, a)
+    assert actual.x.attrs == a.x.attrs
+
+
 def test_keep_attrs() -> None:
     def add(a, b, keep_attrs):
         if keep_attrs:


### PR DESCRIPTION
Fix missing coordinates after apply_ufunc operations.

- [ ] Closes #9317
- [ ] Tests added `test_keep_coordattrs`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Dear code owners,

I have put some effort in trying to prevent missing coordinate attributes. The benefit of this is best seen in missingcoords.pdf. I do run into some issues with testing however. As far as I can tell, the failed tests (see pytest_output.txt) are caused mainly by a few tests in tests/computation.py that only pass if some data can be merged depending on the keep_attrs value. This is a bit confusing to me as I expected the keep_attrs argument to only be relevant for the data itself, not the coordinates. For example, when you call DataArray.mean(dim, keep_attrs=False), the coordinate attributes are still present on the result even though its data does not have attributes. To me, as a user of your package, this behaviour is really great and I would expect coordinates to keep their attributes during various operations, including the apply_ufunc ops. I have intentionally set the compat value to "no_conflicts" in my fix, because I could not come up with a use case where one would merge dataarrays together with different coordinate attributes. Differing coordinate attributes may imply the coordinates have a different physical meaning, so I would expect a merge error. This would mean that the failed tests in the attachment would need to be reconsidered, however. 

Do you think this is the right direction to go? I would like to hear your vision on this. Maybe I'm just overlooking something important here. I am happy to help out in resolving this issue.

Kind regards,
Jasper

[missingcoords.pdf](https://github.com/user-attachments/files/19015393/missingcoords.pdf)
[pytest_output.txt](https://github.com/user-attachments/files/19015435/pytest_output.txt)
