### PR TITLE
topk and argtopk

### DIFF
--- a/xarray/core/dask_array_ops.py
+++ b/xarray/core/dask_array_ops.py
@@ -134,3 +134,15 @@ def push(array, n, axis, method="blelloch"):
         pushed_array = da.where(valid_positions, pushed_array, np.nan)
 
     return pushed_array
+
+
+def topk(a, k, axis):
+    import dask.array as da
+
+    return da.topk(a, k=k, axis=axis)
+
+
+def argtopk(a, k, axis):
+    import dask.array as da
+
+    return da.argtopk(a, k=k, axis=axis)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -6288,6 +6288,37 @@ class DataArray(
         else:
             return self._replace_maybe_drop_dims(result)
 
+    def argtopk(
+        self,
+        k: int,
+        dim: Dims = None,
+        *,
+        keep_attrs: bool | None = None,
+        skipna: bool | None = None,
+    ) -> Self | dict[Hashable, Self]:
+        """
+        TODO docstring
+        """
+        result = self.variable.argtopk(k, dim, keep_attrs, skipna)
+        if isinstance(result, dict):
+            return {k: self._replace_maybe_drop_dims(v) for k, v in result.items()}
+        else:
+            return self._replace_maybe_drop_dims(result)
+
+    def topk(
+        self,
+        k: int,
+        dim: Dims = None,
+        *,
+        keep_attrs: bool | None = None,
+        skipna: bool | None = None,
+    ) -> Self:
+        """
+        TODO docstring
+        """
+        result = self.variable.topk(k, dim, keep_attrs, skipna)
+        return self._replace_maybe_drop_dims(result)
+
     def query(
         self,
         queries: Mapping[Any, Any] | None = None,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -9727,6 +9727,26 @@ class Dataset(
                 "Dataset.argmin() with a sequence or ... for dim"
             )
 
+    def argtopk(self, k: int, dim: Hashable | None = None, **kwargs) -> Self:
+        """
+        TODO docstring
+        """
+        from xarray.core.missing import _apply_over_vars_with_dim
+
+        func = duck_array_ops.argtopk
+        new = _apply_over_vars_with_dim(func, self, dim=dim, k=k)
+        return new
+
+    def topk(self, k: int, dim: Hashable | None = None, **kwargs) -> Self:
+        """
+        TODO docstring
+        """
+        from xarray.core.missing import _apply_over_vars_with_dim
+
+        func = duck_array_ops.topk
+        new = _apply_over_vars_with_dim(func, self, dim=dim, k=k)
+        return new
+
     def eval(
         self,
         statement: str,

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -27,7 +27,12 @@ from pandas.api.types import is_extension_array_dtype
 from xarray.core import dask_array_compat, dask_array_ops, dtypes, nputils
 from xarray.core.array_api_compat import get_array_namespace
 from xarray.core.options import OPTIONS
-from xarray.core.utils import is_duck_array, is_duck_dask_array, module_available
+from xarray.core.utils import (
+    is_duck_array,
+    is_duck_dask_array,
+    module_available,
+    to_0d_object_array,
+)
 from xarray.namedarray.parallelcompat import get_chunked_array_type
 from xarray.namedarray.pycompat import array_type, is_chunked_array
 
@@ -875,3 +880,78 @@ def chunked_nanfirst(darray, axis):
 
 def chunked_nanlast(darray, axis):
     return _chunked_first_or_last(darray, axis, op=nputils.nanlast)
+
+
+def argtopk(values, k, axis=None, skipna=None):
+    if is_chunked_array(values):
+        func = dask_array_ops.argtopk
+    else:
+        func = nputils.argtopk
+
+    # Borrowed from nanops
+    xp = get_array_namespace(values)
+    if skipna or (
+        skipna is None
+        and (
+            dtypes.isdtype(
+                values.dtype, ("complex floating", "real floating"), xp=xp
+            )
+            or dtypes.is_object(values.dtype)
+        )
+    ):
+        valid_count = count(values, axis=axis)
+
+        if k < 0:
+            fill_value = dtypes.get_pos_infinity(values.dtype)
+        else:
+            fill_value = dtypes.get_neg_infinity(values.dtype)
+
+        filled_values = fillna(values, fill_value)
+    else:
+        return func(values, k=k, axis=axis)
+
+    data = func(filled_values, k=k, axis=axis)
+
+    # TODO This will evaluate dask arrays and might be costly.
+    if array_any(valid_count == 0):
+        raise ValueError("All-NaN slice encountered")
+    return data
+
+
+def topk(values, k, axis=None, skipna=None):
+    if is_chunked_array(values):
+        func = dask_array_ops.topk
+    else:
+        func = nputils.topk
+
+    # Borrowed from nanops
+    xp = get_array_namespace(values)
+    if skipna or (
+        skipna is None
+        and (
+            dtypes.isdtype(
+                values.dtype, ("complex floating", "real floating"), xp=xp
+            )
+            or dtypes.is_object(values.dtype)
+        )
+    ):
+        valid_count = count(values, axis=axis)
+
+        if k < 0:
+            fill_value = dtypes.get_pos_infinity(values.dtype)
+        else:
+            fill_value = dtypes.get_neg_infinity(values.dtype)
+
+        filled_values = fillna(values, fill_value)
+    else:
+        return func(values, k=k, axis=axis)
+
+    data = func(filled_values, k=k, axis=axis)
+
+    if not hasattr(data, "dtype"):  # scalar case
+        data = fill_value if valid_count == 0 else data
+        # we've computed a single min, max value of type object.
+        # don't let np.array turn a tuple back into an array
+        return to_0d_object_array(data)
+
+    return where_method(data, valid_count != 0)

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -302,6 +302,56 @@ def least_squares(lhs, rhs, rcond=None, skipna=False):
     return coeffs, residuals
 
 
+def topk(values, k: int, axis: int):
+    """Extract the k largest elements from a on the given axis.
+    If k is negative, extract the -k smallest elements instead.
+    The returned elements are sorted.
+    """
+    if axis < 0:
+        axis = values.ndim + axis
+
+    if abs(k) >= values.shape[axis]:
+        b = np.sort(values, axis=axis)
+    else:
+        a = np.partition(values, -k, axis=axis)
+        k_slice = slice(-k, None) if k > 0 else slice(-k)
+        b = a[tuple(k_slice if i == axis else slice(None) for i in range(values.ndim))]
+        b.sort(axis=axis)
+    if k < 0:
+        return b
+    return b[
+        tuple(
+            slice(None, None, -1) if i == axis else slice(None) for i in range(values.ndim)
+        )
+    ]
+
+
+def argtopk(values, k: int, axis: int):
+    """Extract the indices of the k largest elements from a on the given axis.
+    If k is negative, extract the indices of the -k smallest elements instead.
+    The returned elements are argsorted.
+    """
+    if axis < 0:
+        axis = values.ndim + axis
+
+    if abs(k) >= values.shape[axis]:
+        idx3 = np.argsort(values, axis=axis)
+    else:
+        idx = np.argpartition(values, -k, axis=axis)
+        k_slice = slice(-k, None) if k > 0 else slice(-k)
+        idx = idx[tuple(k_slice if i == axis else slice(None) for i in range(values.ndim))]
+        a = np.take_along_axis(values, idx, axis)
+        idx2 = np.argsort(a, axis=axis)
+        idx3 = np.take_along_axis(idx, idx2, axis)
+    if k < 0:
+        return idx3
+    return idx3[
+        tuple(
+            slice(None, None, -1) if i == axis else slice(None) for i in range(idx.ndim)
+        )
+    ]
+
+
 nanmin = _create_method("nanmin")
 nanmax = _create_method("nanmax")
 nanmean = _create_method("nanmean")

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2511,6 +2511,137 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
         """
         return self._unravel_argminmax("argmax", dim, axis, keep_attrs, skipna)
 
+    def _topk_stack(
+        self,
+        topk_funcname: str,
+        dim: Dims,
+    ) -> Variable:
+        # Get a name for the new dimension that does not conflict with any existing
+        # dimension
+        newdimname = f"_unravel_{topk_funcname}_dim_0"
+        count = 1
+        while newdimname in self.dims:
+            newdimname = f"_unravel_{topk_funcname}_dim_{count}"
+            count += 1
+        return self.stack({newdimname: dim})
+
+    def _topk_helper(
+        self,
+        topk_funcname: str,
+        k: int,
+        dim: str,
+        dtype: Any,
+        keep_attrs: bool | None = None,
+        skipna: bool | None = None,
+    ) -> Variable:
+        from xarray.core.computation import apply_ufunc
+
+        topk_func = getattr(duck_array_ops, topk_funcname)
+        # apply_ufunc moves the dimension to the back.
+        kwargs = {"k": k, "axis": -1, "skipna": skipna}
+
+        result = apply_ufunc(
+            topk_func,
+            self,
+            input_core_dims=[[dim]],
+            exclude_dims={dim},
+            output_core_dims=[[topk_funcname]],
+            output_dtypes=[dtype],
+            dask_gufunc_kwargs=dict(output_sizes={topk_funcname: k}),
+            dask="allowed",
+            kwargs=kwargs,
+        )
+
+        keep_attrs_ = (
+            _get_keep_attrs(default=False) if keep_attrs is None else keep_attrs
+        )
+
+        if keep_attrs_:
+            result.attrs = self._attrs
+        return result
+
+    def topk(
+        self,
+        k: int,
+        dim: Dims = None,
+        keep_attrs: bool | None = None,
+        skipna: bool | None = None,
+    ) -> Variable | dict[Hashable, Variable]:
+        """
+        TODO docstring
+        """
+        # topk accepts only an integer axis like argmin or argmax,
+        # not tuples, so we need to stack multiple dimensions.
+        if dim is ... or dim is None:
+            # Return dimension for 1D data.
+            if self.ndim == 1:
+                dim = self.dims[0]
+            else:
+                dim = self.dims
+
+        if isinstance(dim, str):
+            stacked = self
+        else:
+            stacked = self._topk_stack("topk", dim)
+            dim = stacked.dims[-1]
+
+        result = stacked._topk_helper("topk", k=k, dim=dim, dtype=self.dtype, keep_attrs=keep_attrs, skipna=skipna)
+        return result
+
+    def argtopk(
+        self,
+        k: int,
+        dim: Dims = None,
+        keep_attrs: bool | None = None,
+        skipna: bool | None = None,
+    ) -> Variable | dict[Hashable, Variable]:
+        """
+        TODO docstring
+        """
+        # argtopk accepts only an integer axis like argmin or argmax,
+        # not tuples, so we need to stack multiple dimensions.
+        if dim is ... or dim is None:
+            # Return dimension for 1D data.
+            if self.ndim == 1:
+                dim = self.dims[0]
+            else:
+                dim = self.dims
+
+        if isinstance(dim, str):
+            return self._topk_helper("argtopk", k=k, dim=dim, dtype=np.intp, keep_attrs=keep_attrs, skipna=skipna)
+
+        stacked = self._topk_stack("topk", dim)
+        newdimname = stacked.dims[-1]
+
+        result_flat_indices = stacked._topk_helper(
+            "argtopk",
+            k=k,
+            dim=newdimname,
+            dtype=np.intp,
+            keep_attrs=keep_attrs,
+            skipna=skipna
+        )
+
+        reduce_shape = tuple(self.sizes[d] for d in dim)
+
+        result_unravelled_indices = duck_array_ops.unravel_index(
+            result_flat_indices.data, reduce_shape
+        )
+
+        result_dims = [d for d in stacked.dims if d != newdimname] + ["argtopk"]
+        result = {
+            d: Variable(dims=result_dims, data=i)
+            for d, i in zip(dim, result_unravelled_indices, strict=True)
+        }
+
+        if keep_attrs is None:
+            keep_attrs = _get_keep_attrs(default=False)
+        if keep_attrs:
+            for v in result.values():
+                v.attrs = self.attrs
+
+        return result
+
     def _as_sparse(self, sparse_format=_default, fill_value=_default) -> Variable:
         """
         Use sparse-array as backend.


### PR DESCRIPTION
- [ ] Closes #10075
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

I've made a start with implementations of `topk` and `argtopk`.
This'll work uncontroversially for DataArrays, although I'm getting mostly stuck on what `skipna=True` should entail.

There's a number of choices to make, however, which are probably best illustrated along this PR.

* Numpy does not provide a topk implementation, [dask does](https://docs.dask.org/en/latest/generated/dask.array.topk.html#dask-array-topk), as @dcherian helpfully pointed out. I've borrowed some parts of the dask implementation and put it in `nputils.py`. The question that arises here for me: I guess this would work with `cupy` too, but I don't quite oversee what's the best way to integrate it? Because dask provides `topk` of its own, it appears a bit exceptional.
* Another question: [bottleneck also provides `partition` and `argpartition`](https://bottleneck.readthedocs.io/en/latest/reference.html#bottleneck.partition). This version works differs from `numpy.partition` in its handling of NaNs, however. Using numpy's partition has the benefit that it's consistent with dask.
* In terms of API: `topk` feels mostly similar to [quantile](https://docs.xarray.dev/en/stable/generated/[xarray.DataArray.quantile](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.quantile.html#xarray-dataarray-quantile).html#xarray-dataarray-quantile), since it shortens, but doesn't reduce the dimension entirely. [argmin](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.argmin.html#xarray.DataArray.argmin) also supports an `axis` argument next to `dim` (though exclusive) -- is the axis argument desirable?
* The code in `variable.py` borrows somewhat from `quantile`, since the result has an axis with dim `k` size instead of `len(q)`. Unlike  `quantile`, dask's `topk` and `argtopk` do not support tuple arguments for the axis (although `topk` [accepts it and produces an unexpected result](https://github.com/dask/dask/issues/11798)), so part of the stacking and unraveling functionality of `_unravel_argminmax` is required. I've currently duplicated the relevant lines to keep changes clearly visible.
* `quantile` returns a result with a new dimension and coordinate called `quantile`, I've mimicked this and `topk` and `argtopk` return a result with a new `topk` or `argtopk` dimension respectively. I was thinking no labels are required for `topk`, but since both positive k values (for largest) and negative k values (for smallest) are possible, it's probably smart to return labels `range(0, k)` and `range(-k, 0, 1)`?
* There's also [idxmin](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.idxmin.html) for the coordinate labels, and I suppose `idxtopk` would make sense too?
* `skipna=True` is giving me some headaches. A (naive) implementation as in this PR is assymetric. Numpy partition (and thus the dask version too) sorts NaNs towards the end of the array, such that k > 0 will return NaNs, but k < 0 will not. For the testing, I figured `da.topk(k=-1, skipna=False)` should equal `da.min(skipna=False)` and `da.topk(k=1, skipna=False), should equal `da.max()`, but this isn't the case. k=-1 will return a value since numpy partition moves the NaN to the end; k=1 will not:
