### PR TITLE
explicitly cast the dtype of `where`'s condition parameter to `bool`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -344,9 +344,6 @@ filterwarnings = [
   "default:the `pandas.MultiIndex` object:FutureWarning:xarray.tests.test_variable",
   "default:Using a non-tuple sequence for multidimensional indexing is deprecated:FutureWarning",
   "default:Duplicate dimension names present:UserWarning:xarray.namedarray.core",
-  # TODO: numpy.bool was deprecated in older versions of numpy, but is in the Array API
-  # TODO: remove once we can drop numpy<2
-  "ignore:In the future `np.bool` will be defined as the corresponding NumPy scalar:FutureWarning",
   # TODO: this is raised for vlen-utf8, consolidated metadata, U1 dtype
   "ignore:is currently not part .* the Zarr version 3 specification.",
   # TODO: remove once we know how to deal with a changed signature in protocols

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -360,7 +360,7 @@ filterwarnings = [
   "default:Duplicate dimension names present:UserWarning:xarray.namedarray.core",
   # TODO: numpy.bool was deprecated in older versions of numpy, but is in the Array API
   # TODO: remove once we can drop numpy<2
-  "ignore:In the future `np.bool` will be defined as the corresponding NumpPy scalar:FutureWarning",
+  "ignore:In the future `np.bool` will be defined as the corresponding NumPy scalar:FutureWarning",
   # TODO: this is raised for vlen-utf8, consolidated metadata, U1 dtype
   "ignore:is currently not part .* the Zarr version 3 specification.",
   # TODO: remove once we know how to deal with a changed signature in protocols

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -358,6 +358,9 @@ filterwarnings = [
   "default:the `pandas.MultiIndex` object:FutureWarning:xarray.tests.test_variable",
   "default:Using a non-tuple sequence for multidimensional indexing is deprecated:FutureWarning",
   "default:Duplicate dimension names present:UserWarning:xarray.namedarray.core",
+  # TODO: numpy.bool was deprecated in older versions of numpy, but is in the Array API
+  # TODO: remove once we can drop numpy<2
+  "ignore:In the future `np.bool` will be defined as the corresponding NumpPy scalar:FutureWarning",
   # TODO: this is raised for vlen-utf8, consolidated metadata, U1 dtype
   "ignore:is currently not part .* the Zarr version 3 specification.",
   # TODO: remove once we know how to deal with a changed signature in protocols

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -360,7 +360,7 @@ filterwarnings = [
   "default:Duplicate dimension names present:UserWarning:xarray.namedarray.core",
   # TODO: numpy.bool was deprecated in older versions of numpy, but is in the Array API
   # TODO: remove once we can drop numpy<2
-  "ignore:In the future `np.bool` will be defined as the corresponding NumPy scalar:FutureWarning",
+  "ignore:In the future `np.bool` will be defined as the corresponding NumPy scalar:FutureWarning:numpy.*",
   # TODO: this is raised for vlen-utf8, consolidated metadata, U1 dtype
   "ignore:is currently not part .* the Zarr version 3 specification.",
   # TODO: remove once we know how to deal with a changed signature in protocols

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -360,7 +360,7 @@ filterwarnings = [
   "default:Duplicate dimension names present:UserWarning:xarray.namedarray.core",
   # TODO: numpy.bool was deprecated in older versions of numpy, but is in the Array API
   # TODO: remove once we can drop numpy<2
-  "ignore:In the future `np.bool` will be defined as the corresponding NumPy scalar:FutureWarning:numpy.*",
+  "ignore:In the future `np.bool` will be defined as the corresponding NumPy scalar:FutureWarning",
   # TODO: this is raised for vlen-utf8, consolidated metadata, U1 dtype
   "ignore:is currently not part .* the Zarr version 3 specification.",
   # TODO: remove once we know how to deal with a changed signature in protocols

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -377,7 +377,7 @@ def where(condition, x, y):
     """Three argument where() with better dtype promotion rules."""
     xp = get_array_namespace(condition, x, y)
 
-    dtype = xp.bool if hasattr(xp, "bool") else xp.bool_
+    dtype = xp.bool_ if hasattr(xp, "bool_") else xp.bool
     if not is_duck_array(condition):
         condition = asarray(condition, dtype=dtype, xp=xp)
     else:

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -377,10 +377,11 @@ def where(condition, x, y):
     """Three argument where() with better dtype promotion rules."""
     xp = get_array_namespace(condition, x, y)
 
+    dtype = xp.bool if hasattr(xp, "bool") else xp.bool_
     if not is_duck_array(condition):
-        condition = asarray(condition, dtype=xp.bool, xp=xp)
+        condition = asarray(condition, dtype=dtype, xp=xp)
     else:
-        condition = astype(condition, dtype=xp.bool, xp=xp)
+        condition = astype(condition, dtype=dtype, xp=xp)
 
     return xp.where(condition, *as_shared_dtype([x, y], xp=xp))
 

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -373,7 +373,7 @@ def sum_where(data, axis=None, dtype=None, where=None):
 def where(condition, x, y):
     """Three argument where() with better dtype promotion rules."""
     xp = get_array_namespace(condition, x, y)
-    return xp.where(condition, *as_shared_dtype([x, y], xp=xp))
+    return xp.where(xp.astype(condition, xp.bool), *as_shared_dtype([x, y], xp=xp))
 
 
 def where_method(data, cond, other=dtypes.NA):

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -378,9 +378,9 @@ def where(condition, x, y):
     xp = get_array_namespace(condition, x, y)
 
     if not is_duck_array(condition):
-        condition = asarray(condition, dtype=xp.bool, xp=xp)
+        condition = asarray(condition, dtype="bool", xp=xp)
     else:
-        condition = astype(condition, dtype=xp.bool, xp=xp)
+        condition = astype(condition, dtype="bool", xp=xp)
 
     return xp.where(condition, *as_shared_dtype([x, y], xp=xp))
 

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -378,9 +378,9 @@ def where(condition, x, y):
     xp = get_array_namespace(condition, x, y)
 
     if not is_duck_array(condition):
-        condition = asarray(condition, dtype="bool", xp=xp)
+        condition = asarray(condition, dtype=xp.bool, xp=xp)
     else:
-        condition = astype(condition, dtype="bool", xp=xp)
+        condition = astype(condition, dtype=xp.bool, xp=xp)
 
     return xp.where(condition, *as_shared_dtype([x, y], xp=xp))
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -524,7 +524,7 @@ class ComposedGrouper:
         # Restore these after the raveling
         broadcasted_masks = broadcast(*masks)
         mask = functools.reduce(np.logical_or, broadcasted_masks)  # type: ignore[arg-type]
-        _flatcodes = where(mask, -1, _flatcodes)
+        _flatcodes = where(mask.data, -1, _flatcodes)
 
         full_index = pd.MultiIndex.from_product(
             (grouper.full_index.values for grouper in groupers),

--- a/xarray/tests/test_array_api.py
+++ b/xarray/tests/test_array_api.py
@@ -139,7 +139,6 @@ def test_unstack(arrays: tuple[xr.DataArray, xr.DataArray]) -> None:
     assert_equal(actual, expected)
 
 
-@pytest.mark.skip
 def test_where() -> None:
     np_arr = xr.DataArray(np.array([1, 0]), dims="x")
     xp_arr = xr.DataArray(xp.asarray([1, 0]), dims="x")


### PR DESCRIPTION
(this is necessary because `array-api-strict` raises an error otherwise)

- [x] towards #10084