### PR TITLE
Fix broken Zarr test

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2628,12 +2628,10 @@ class ZarrBase(CFEncodedBase):
                 for var in expected.variables.keys():
                     assert self.DIMENSION_KEY not in expected[var].attrs
 
-            if has_zarr_v3:
-                # temporary workaround for https://github.com/zarr-developers/zarr-python/issues/2338
-                zarr_group.store._is_open = True
-
             # put it back and try removing from a variable
-            del zarr_group["var2"].attrs[self.DIMENSION_KEY]
+            attrs = dict(zarr_group["var2"].attrs)
+            del attrs[self.DIMENSION_KEY]
+            zarr_group["var2"].attrs.put(attrs)
 
             with pytest.raises(KeyError):
                 with xr.decode_cf(store):


### PR DESCRIPTION
Zarr's implementation of `attrs.__delitem__` is broken.

https://github.com/zarr-developers/zarr-python/issues/2903

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
