### PR TITLE
DataArray: propagate index coordinates with non-array dimensions

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,6 +34,9 @@ New Features
   By `Benoit Bovy <https://github.com/benbovy>`_.
 - Support reading to `GPU memory with Zarr <https://zarr.readthedocs.io/en/stable/user-guide/gpu.html>`_ (:pull:`10078`).
   By `Deepak Cherian <https://github.com/dcherian>`_.
+- Allow assigning index coordinates with non-array dimension(s) in a :py:class:`DataArray`, enabling
+  support for CF boundaries coordinate (e.g., ``time(time)`` and ``time_bnds(time, nbnd)``) in a DataArray (:pull:`10116`).
+  By `Benoit Bovy <https://github.com/benbovy>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -134,7 +134,7 @@ def _check_coords_dims(
     shape: tuple[int, ...], coords: Coordinates, dims: tuple[Hashable, ...]
 ):
     sizes = dict(zip(dims, shape, strict=True))
-    extra_index_dims = set()
+    extra_index_dims: set[str] = set()
 
     for k, v in coords.items():
         if any(d not in dims for d in v.dims):

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -131,25 +131,25 @@ if TYPE_CHECKING:
 
 
 def _check_coords_dims(
-    shape: tuple[int, ...], coords: Coordinates, dims: tuple[Hashable, ...]
+    shape: tuple[int, ...], coords: Coordinates, dim: tuple[Hashable, ...]
 ):
-    sizes = dict(zip(dims, shape, strict=True))
+    sizes = dict(zip(dim, shape, strict=True))
     extra_index_dims: set[str] = set()
 
     for k, v in coords.items():
-        if any(d not in dims for d in v.dims):
+        if any(d not in dim for d in v.dims):
             # allow any coordinate associated with an index that shares at least
             # one of dataarray's dimensions
             indexes = coords.xindexes
             if k in indexes:
                 index_dims = indexes.get_all_dims(k)
-                if any(d in dims for d in index_dims):
-                    extra_index_dims.update(d for d in v.dims if d not in dims)
+                if any(d in dim for d in index_dims):
+                    extra_index_dims.update(d for d in v.dims if d not in dim)
                     continue
             raise ValueError(
                 f"coordinate {k} has dimensions {v.dims}, but these "
                 "are not a subset of the DataArray "
-                f"dimensions {dims}"
+                f"dimensions {dim}"
             )
 
         for d, s in v.sizes.items():

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1210,18 +1210,18 @@ class Dataset(
         needed_dims = set(variable.dims)
 
         coords: dict[Hashable, Variable] = {}
-        indexes = self.xindexes
+        temp_indexes = self.xindexes
         # preserve ordering
         for k in self._variables:
             if k in self._coord_names:
                 if (
                     k not in coords
-                    and k in indexes
-                    and set(indexes.get_all_dims(k)) & needed_dims
+                    and k in temp_indexes
+                    and set(temp_indexes.get_all_dims(k)) & needed_dims
                 ):
                     # add all coordinates of each index that shares at least one dimension
                     # with the dimensions of the extracted variable
-                    coords.update(indexes.get_all_coords(k))
+                    coords.update(temp_indexes.get_all_coords(k))
                 elif set(self._variables[k].dims) <= needed_dims:
                     coords[k] = self._variables[k]
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1210,10 +1210,20 @@ class Dataset(
         needed_dims = set(variable.dims)
 
         coords: dict[Hashable, Variable] = {}
+        indexes = self.xindexes
         # preserve ordering
         for k in self._variables:
-            if k in self._coord_names and set(self._variables[k].dims) <= needed_dims:
-                coords[k] = self._variables[k]
+            if k in self._coord_names:
+                if (
+                    k not in coords
+                    and k in indexes
+                    and set(indexes.get_all_dims(k)) & needed_dims
+                ):
+                    # add all coordinates of each index that shares at least one dimension
+                    # with the dimensions of the extracted variable
+                    coords.update(indexes.get_all_coords(k))
+                elif set(self._variables[k].dims) <= needed_dims:
+                    coords[k] = self._variables[k]
 
         indexes = filter_indexes_from_coords(self._indexes, set(coords))
 

--- a/xarray/core/dataset_variables.py
+++ b/xarray/core/dataset_variables.py
@@ -40,7 +40,7 @@ class DataVariables(Mapping[Any, "DataArray"]):
         raise KeyError(key)
 
     def __repr__(self) -> str:
-        return formatting.data_vars_repr(self)
+        return formatting.data_vars_repr(self.variables)
 
     @property
     def variables(self) -> Mapping[Hashable, Variable]:

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -429,7 +429,7 @@ def coords_repr(coords: AbstractCoordinates, col_width=None, max_rows=None):
     if col_width is None:
         col_width = _calculate_col_width(coords)
     return _mapping_repr(
-        coords,
+        coords.variables,
         title="Coordinates",
         summarizer=summarize_variable,
         expand_option_name="display_expand_coords",
@@ -743,7 +743,9 @@ def dataset_repr(ds):
     if unindexed_dims_str:
         summary.append(unindexed_dims_str)
 
-    summary.append(data_vars_repr(ds.data_vars, col_width=col_width, max_rows=max_rows))
+    summary.append(
+        data_vars_repr(ds.data_vars.variables, col_width=col_width, max_rows=max_rows)
+    )
 
     display_default_indexes = _get_boolean_with_default(
         "display_default_indexes", False

--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -113,10 +113,11 @@ def summarize_variable(name, var, is_index=False, dtype=None) -> str:
     )
 
 
-def summarize_coords(variables) -> str:
+def summarize_coords(coords) -> str:
     li_items = []
-    for k, v in variables.items():
-        li_content = summarize_variable(k, v, is_index=k in variables.xindexes)
+    indexes = coords.xindexes
+    for k, v in coords.variables.items():
+        li_content = summarize_variable(k, v, is_index=k in indexes)
         li_items.append(f"<li class='xr-var-item'>{li_content}</li>")
 
     vars_li = "".join(li_items)
@@ -339,7 +340,7 @@ def dataset_repr(ds) -> str:
     sections = [
         dim_section(ds),
         coord_section(ds.coords),
-        datavar_section(ds.data_vars),
+        datavar_section(ds.data_vars.variables),
         index_section(_get_indexes_dict(ds.xindexes)),
         attr_section(ds.attrs),
     ]
@@ -415,7 +416,7 @@ def datatree_node_repr(group_title: str, node: DataTree, show_inherited=False) -
         sections.append(inherited_coord_section(inherited_coords))
 
     sections += [
-        datavar_section(ds.data_vars),
+        datavar_section(ds.data_vars.variables),
         attr_section(ds.attrs),
     ]
 

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -1568,6 +1568,7 @@ class Indexes(collections.abc.Mapping, Generic[T_PandasOrXarrayIndex]):
     """
 
     _index_type: type[Index] | type[pd.Index]
+    _index_dims: dict[Hashable, Mapping[Hashable, int]]
     _indexes: dict[Any, T_PandasOrXarrayIndex]
     _variables: dict[Any, Variable]
 
@@ -1576,6 +1577,7 @@ class Indexes(collections.abc.Mapping, Generic[T_PandasOrXarrayIndex]):
         "__id_coord_names",
         "__id_index",
         "_dims",
+        "_index_dims",
         "_index_type",
         "_indexes",
         "_variables",
@@ -1619,6 +1621,7 @@ class Indexes(collections.abc.Mapping, Generic[T_PandasOrXarrayIndex]):
             )
 
         self._index_type = index_type
+        self._index_dims = {}
         self._indexes = dict(**indexes)
         self._variables = dict(**variables)
 
@@ -1737,7 +1740,13 @@ class Indexes(collections.abc.Mapping, Generic[T_PandasOrXarrayIndex]):
         """
         from xarray.core.variable import calculate_dimensions
 
-        return calculate_dimensions(self.get_all_coords(key, errors=errors))
+        if key in self._index_dims:
+            return self._index_dims[key]
+        else:
+            dims = calculate_dimensions(self.get_all_coords(key, errors=errors))
+            if dims:
+                self._index_dims[key] = dims
+            return dims
 
     def group_by_index(
         self,

--- a/xarray/testing/assertions.py
+++ b/xarray/testing/assertions.py
@@ -330,10 +330,13 @@ def _assert_indexes_invariants_checks(
         k: type(v) for k, v in indexes.items()
     }
 
-    index_vars = {
-        k for k, v in possible_coord_variables.items() if isinstance(v, IndexVariable)
-    }
-    assert indexes.keys() <= index_vars, (set(indexes), index_vars)
+    if check_default:
+        index_vars = {
+            k
+            for k, v in possible_coord_variables.items()
+            if isinstance(v, IndexVariable)
+        }
+        assert indexes.keys() <= index_vars, (set(indexes), index_vars)
 
     # check pandas index wrappers vs. coordinate data adapters
     for k, index in indexes.items():
@@ -399,9 +402,14 @@ def _assert_dataarray_invariants(da: DataArray, check_default_indexes: bool):
         da.dims,
         {k: v.dims for k, v in da._coords.items()},
     )
-    assert all(
-        isinstance(v, IndexVariable) for (k, v) in da._coords.items() if v.dims == (k,)
-    ), {k: type(v) for k, v in da._coords.items()}
+
+    if check_default_indexes:
+        assert all(
+            isinstance(v, IndexVariable)
+            for (k, v) in da._coords.items()
+            if v.dims == (k,)
+        ), {k: type(v) for k, v in da._coords.items()}
+
     for k, v in da._coords.items():
         _assert_variable_invariants(v, k)
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -529,6 +529,30 @@ class TestDataArray:
         # test coordinate variables copied
         assert da.coords["x"] is not coords.variables["x"]
 
+    def test_constructor_extra_dim_index_coord(self) -> None:
+        class AnyIndex(Index):
+            # This test only requires that the coordinates to assign have an
+            # index, whatever its type.
+            pass
+
+        idx = AnyIndex()
+        coords = Coordinates(
+            coords={
+                "x": ("x", [1, 2]),
+                "x_bounds": (("x", "x_bnds"), [(0.5, 1.5), (1.5, 2.5)]),
+            },
+            indexes={"x": idx, "x_bounds": idx},
+        )
+
+        actual = DataArray([1.0, 2.0], coords=coords, dims="x")
+
+        # cannot use `assert_identical()` test utility function here yet
+        # (indexes invariant check is still based on IndexVariable, which
+        # doesn't work with AnyIndex coordinate variables here)
+        assert actual.coords.to_dataset().equals(coords.to_dataset())
+        assert list(actual.coords.xindexes) == list(coords.xindexes)
+        assert "x_bnds" not in actual.dims
+
     def test_equals_and_identical(self) -> None:
         orig = DataArray(np.arange(5.0), {"a": 42}, dims="x")
 
@@ -1633,6 +1657,31 @@ class TestDataArray:
         actual = da.assign_coords(coords)
         assert_identical(actual.coords, coords, check_default_indexes=False)
         assert "y" not in actual.xindexes
+
+    def test_assign_coords_extra_dim_index_coord(self) -> None:
+        class AnyIndex(Index):
+            # This test only requires that the coordinates to assign have an
+            # index, whatever its type.
+            pass
+
+        idx = AnyIndex()
+        coords = Coordinates(
+            coords={
+                "x": ("x", [1, 2]),
+                "x_bounds": (("x", "x_bnds"), [(0.5, 1.5), (1.5, 2.5)]),
+            },
+            indexes={"x": idx, "x_bounds": idx},
+        )
+
+        da = DataArray([1.0, 2.0], dims="x")
+        actual = da.assign_coords(coords)
+
+        # cannot use `assert_identical()` test utility function here yet
+        # (indexes invariant check is still based on IndexVariable, which
+        # doesn't work with AnyIndex coordinate variables here)
+        assert actual.coords.to_dataset().equals(coords.to_dataset())
+        assert list(actual.coords.xindexes) == list(coords.xindexes)
+        assert "x_bnds" not in actual.dims
 
     def test_coords_alignment(self) -> None:
         lhs = DataArray([1, 2, 3], [("x", [0, 1, 2])])

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -546,11 +546,7 @@ class TestDataArray:
 
         actual = DataArray([1.0, 2.0], coords=coords, dims="x")
 
-        # cannot use `assert_identical()` test utility function here yet
-        # (indexes invariant check is still based on IndexVariable, which
-        # doesn't work with AnyIndex coordinate variables here)
-        assert actual.coords.to_dataset().equals(coords.to_dataset())
-        assert list(actual.coords.xindexes) == list(coords.xindexes)
+        assert_identical(actual.coords, coords, check_default_indexes=False)
         assert "x_bnds" not in actual.dims
 
     def test_equals_and_identical(self) -> None:
@@ -1676,11 +1672,7 @@ class TestDataArray:
         da = DataArray([1.0, 2.0], dims="x")
         actual = da.assign_coords(coords)
 
-        # cannot use `assert_identical()` test utility function here yet
-        # (indexes invariant check is still based on IndexVariable, which
-        # doesn't work with AnyIndex coordinate variables here)
-        assert actual.coords.to_dataset().equals(coords.to_dataset())
-        assert list(actual.coords.xindexes) == list(coords.xindexes)
+        assert_identical(actual.coords, coords, check_default_indexes=False)
         assert "x_bnds" not in actual.dims
 
     def test_coords_alignment(self) -> None:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4224,11 +4224,7 @@ class TestDataset:
         ds = Dataset({"foo": (("x"), [1.0, 2.0])}, coords=coords)
         actual = ds["foo"]
 
-        # cannot use `assert_identical()` test utility function here yet
-        # (indexes invariant check is still based on IndexVariable, which
-        # doesn't work with AnyIndex coordinate variables here)
-        assert actual.coords.to_dataset().equals(coords.to_dataset())
-        assert list(actual.coords.xindexes) == list(coords.xindexes)
+        assert_identical(actual.coords, coords, check_default_indexes=False)
         assert "x_bnds" not in actual.dims
 
     def test_virtual_variables_default_coords(self) -> None:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] support DataArray constructor
- [x] support DataArray constructed from Dataset (variable access)
- [x] support update or `assign_coords`
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`

This PR allows including coordinates in a DataArray that do not need to have dimensions strictly matching (a subset of) the array dimensions. It still requires such coordinates to be associated with an index that shares at least one dimension with the array dimensions.

This is particularly useful for CF cell boundaries coordinates, see #1475.

Here is an example [notebook](https://notebooksharing.space/view/91d4cf942b6466a02d1931047022294147475dd7500345fbb2545a068dd3490b#displayOptions=) showing this PR in action with an Xarray IntervalIndex that works with CF 2-dimensional bounds coordinates (#8005).