### PR TITLE
Draft: Extend `idxmin` and `idxmax` to accept multiple dimensions

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -5991,9 +5991,9 @@ class DataArray(
         """
         # Check if dim is multi-dimensional (either ellipsis or a sequence, not a string or tuple)
         # This is the same check pattern used in argmin to ensure consistent behavior
-        if (dim is ... or (isinstance(dim, Iterable) and not isinstance(dim, str))) and not isinstance(
-            dim, tuple
-        ):
+        if (
+            dim is ... or (isinstance(dim, Iterable) and not isinstance(dim, str))
+        ) and not isinstance(dim, tuple):
             # For multiple dimensions, process each dimension separately
             # This matches the behavior pattern of argmin when given multiple dimensions,
             # but returns coordinate labels instead of indices
@@ -6118,9 +6118,9 @@ class DataArray(
         """
         # Check if dim is multi-dimensional (either ellipsis or a sequence, not a string or tuple)
         # This is the same check pattern used in argmax to ensure consistent behavior
-        if (dim is ... or (isinstance(dim, Iterable) and not isinstance(dim, str))) and not isinstance(
-            dim, tuple
-        ):
+        if (
+            dim is ... or (isinstance(dim, Iterable) and not isinstance(dim, str))
+        ) and not isinstance(dim, tuple):
             # For multiple dimensions, process each dimension separately
             # This matches the behavior pattern of argmax when given multiple dimensions,
             # but returns coordinate labels instead of indices

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -5989,8 +5989,10 @@ class DataArray(
          'y': <xarray.DataArray 'y' ()> Size: 8B
         array(0)}
         """
-        # Check if dim is multi-dimensional (either ellipsis or a sequence, not a string or tuple)
-        # This is the same check pattern used in argmin to ensure consistent behavior
+        # Check if dim is multi-dimensional
+        # TODO: resolve how we're checking for singular dims; we seem to have a few
+        # different ways through the codebase. This is reflected in requiring some mypy
+        # ignores for some corner cases.
         if (
             dim is ... or (isinstance(dim, Iterable) and not isinstance(dim, str))
         ) and not isinstance(dim, tuple):
@@ -6000,12 +6002,12 @@ class DataArray(
             result = {}
             for k in dim if dim is not ... else self.dims:
                 result[k] = self.idxmin(
-                    dim=k,
+                    dim=k,  # type: ignore[arg-type] # k is Hashable from self.dims
                     skipna=skipna,
                     fill_value=fill_value,
                     keep_attrs=keep_attrs,
                 )
-            return result
+            return result  # type: ignore[return-value]
         else:
             # Use the existing implementation for single dimension
             # This wraps argmin through the _calc_idxminmax helper function
@@ -6116,27 +6118,20 @@ class DataArray(
          'y': <xarray.DataArray 'y' ()> Size: 8B
         array(-1)}
         """
-        # Check if dim is multi-dimensional (either ellipsis or a sequence, not a string or tuple)
-        # This is the same check pattern used in argmax to ensure consistent behavior
+        # Copy/paste from idxmin; comments are there
         if (
             dim is ... or (isinstance(dim, Iterable) and not isinstance(dim, str))
         ) and not isinstance(dim, tuple):
-            # For multiple dimensions, process each dimension separately
-            # This matches the behavior pattern of argmax when given multiple dimensions,
-            # but returns coordinate labels instead of indices
             result = {}
             for k in dim if dim is not ... else self.dims:
                 result[k] = self.idxmax(
-                    dim=k,
+                    dim=k,  # type: ignore[arg-type] # k is Hashable from self.dims
                     skipna=skipna,
                     fill_value=fill_value,
                     keep_attrs=keep_attrs,
                 )
-            return result
+            return result  # type: ignore[return-value]
         else:
-            # Use the existing implementation for single dimension
-            # This wraps argmax through the _calc_idxminmax helper function
-            # which converts indices to coordinate values
             return computation._calc_idxminmax(
                 array=self,
                 func=lambda x, *args, **kwargs: x.argmax(*args, **kwargs),

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -5575,6 +5575,22 @@ class TestReduce2D(TestReduce):
             ar0 = ar0_raw.chunk({})
         else:
             ar0 = ar0_raw
+            
+        # Test multi-dimensional idxmin
+        if not np.isnan(minindex).any():
+            # Get the indices for the minimum values along both dimensions
+            idx_y = ar0.argmin(dim="x")
+            idx_x = ar0.argmin(dim="y")
+            
+            # Get the coordinate labels for these minimum values using idxmin
+            idxmin_result = ar0.idxmin(dim=["x", "y"])
+            
+            # Verify we have the expected keys in the result dictionary
+            assert set(idxmin_result.keys()) == {"x", "y"}
+            
+            # Verify the values match what we'd expect from individually applying idxmin
+            assert_identical(idxmin_result["x"], ar0.idxmin(dim="x"))
+            assert_identical(idxmin_result["y"], ar0.idxmin(dim="y"))
 
         assert_identical(ar0, ar0)
 
@@ -5716,6 +5732,22 @@ class TestReduce2D(TestReduce):
             ar0 = ar0_raw.chunk({})
         else:
             ar0 = ar0_raw
+            
+        # Test multi-dimensional idxmax
+        if not np.isnan(maxindex).any():
+            # Get the indices for the maximum values along both dimensions
+            idx_y = ar0.argmax(dim="x")
+            idx_x = ar0.argmax(dim="y")
+            
+            # Get the coordinate labels for these maximum values using idxmax
+            idxmax_result = ar0.idxmax(dim=["x", "y"])
+            
+            # Verify we have the expected keys in the result dictionary
+            assert set(idxmax_result.keys()) == {"x", "y"}
+            
+            # Verify the values match what we'd expect from individually applying idxmax
+            assert_identical(idxmax_result["x"], ar0.idxmax(dim="x"))
+            assert_identical(idxmax_result["y"], ar0.idxmax(dim="y"))
 
         # No dimension specified
         with pytest.raises(ValueError):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -5575,19 +5575,19 @@ class TestReduce2D(TestReduce):
             ar0 = ar0_raw.chunk({})
         else:
             ar0 = ar0_raw
-            
+
         # Test multi-dimensional idxmin
         if not np.isnan(minindex).any():
             # Get the indices for the minimum values along both dimensions
             idx_y = ar0.argmin(dim="x")
             idx_x = ar0.argmin(dim="y")
-            
+
             # Get the coordinate labels for these minimum values using idxmin
             idxmin_result = ar0.idxmin(dim=["x", "y"])
-            
+
             # Verify we have the expected keys in the result dictionary
             assert set(idxmin_result.keys()) == {"x", "y"}
-            
+
             # Verify the values match what we'd expect from individually applying idxmin
             assert_identical(idxmin_result["x"], ar0.idxmin(dim="x"))
             assert_identical(idxmin_result["y"], ar0.idxmin(dim="y"))
@@ -5732,19 +5732,19 @@ class TestReduce2D(TestReduce):
             ar0 = ar0_raw.chunk({})
         else:
             ar0 = ar0_raw
-            
+
         # Test multi-dimensional idxmax
         if not np.isnan(maxindex).any():
             # Get the indices for the maximum values along both dimensions
             idx_y = ar0.argmax(dim="x")
             idx_x = ar0.argmax(dim="y")
-            
+
             # Get the coordinate labels for these maximum values using idxmax
             idxmax_result = ar0.idxmax(dim=["x", "y"])
-            
+
             # Verify we have the expected keys in the result dictionary
             assert set(idxmax_result.keys()) == {"x", "y"}
-            
+
             # Verify the values match what we'd expect from individually applying idxmax
             assert_identical(idxmax_result["x"], ar0.idxmax(dim="x"))
             assert_identical(idxmax_result["y"], ar0.idxmax(dim="y"))


### PR DESCRIPTION
fhis was almost totally done by Claude Code (though our files are super-inefficient, such that it used 17M tokens! which still only costs $8.44 but I guess it could be a couple of orders of magnitude less than that)

my main contribution was trying to find a better way to express the:
```
if (dim is ... or (isinstance(dim, Iterable) and not isinstance(dim, str))) and not isinstance(
    dim, tuple
):
```

we seem to have a lot of functions which touch on this: `infix_dims`, `parse_ordered_dims` (which only seems to be called in our tests?!), `parse_dims_as_tuple`, `parse_dims_as_set`. Let me know if there's a recommended way
