### PR TITLE
Change `python_files` in `pyproject.toml` to a list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -362,7 +362,7 @@ markers = [
   "slow_hypothesis: slow hypothesis tests",
 ]
 minversion = "7"
-python_files = "test_*.py"
+python_files = ["test_*.py"]
 testpaths = ["xarray/tests", "properties"]
 
 [tool.aliases]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ dev = [
   "sphinx",
   "sphinx_autosummary_accessors",
   "xarray[complete,types]",
-
 ]
 
 [project.urls]


### PR DESCRIPTION
I was getting a warning from the existing scalar value
