### PR TITLE
Don't skip tests when on a `mypy` branch

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -22,7 +22,9 @@ def pytest_runtest_setup(item):
         pytest.skip(
             "set --run-network-tests to run test requiring an internet connection"
         )
-    if "mypy" in item.keywords and not item.config.getoption("--run-mypy"):
+    if any("mypy" in m.name for m in item.own_markers) and not item.config.getoption(
+        "--run-mypy"
+    ):
         pytest.skip("set --run-mypy option to run mypy tests")
 
 


### PR DESCRIPTION
For some reason, my local was skipping tests when on a branch named `mypy`, or at least something was setting a `mypy` keyword on the test items.

This changes the check to whether the test has the `mypy` marker set, which is more precise than just looking at the keywords.
