### PR TITLE
Fix `open_datatree` when `decode_cf=False`

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1119,7 +1119,7 @@ def open_datatree(
 
     decoders = _resolve_decoders_kwargs(
         decode_cf,
-        open_backend_dataset_parameters=(),
+        open_backend_dataset_parameters=backend.open_dataset_parameters,
         mask_and_scale=mask_and_scale,
         decode_times=decode_times,
         decode_timedelta=decode_timedelta,

--- a/xarray/tests/conftest.py
+++ b/xarray/tests/conftest.py
@@ -164,27 +164,27 @@ def create_test_datatree():
     Create a test datatree with this structure:
 
     <xarray.DataTree>
-    |-- set1
-    |   |-- <xarray.Dataset>
-    |   |   Dimensions:  ()
-    |   |   Data variables:
-    |   |       a        int64 0
-    |   |       b        int64 1
-    |   |-- set1
-    |   |-- set2
-    |-- set2
-    |   |-- <xarray.Dataset>
-    |   |   Dimensions:  (x: 2)
-    |   |   Data variables:
-    |   |       a        (x) int64 2, 3
-    |   |       b        (x) int64 0.1, 0.2
-    |   |-- set1
-    |-- set3
-    |-- <xarray.Dataset>
-    |   Dimensions:  (x: 2, y: 3)
-    |   Data variables:
-    |       a        (y) int64 6, 7, 8
-    |       set0     (x) int64 9, 10
+    Group: /
+    │   Dimensions:  (y: 3, x: 2)
+    │   Dimensions without coordinates: y, x
+    │   Data variables:
+    │       a        (y) int64 24B 6 7 8
+    │       set0     (x) int64 16B 9 10
+    ├── Group: /set1
+    │   │   Dimensions:  ()
+    │   │   Data variables:
+    │   │       a        int64 8B 0
+    │   │       b        int64 8B 1
+    │   ├── Group: /set1/set1
+    │   └── Group: /set1/set2
+    ├── Group: /set2
+    │   │   Dimensions:  (x: 2)
+    │   │   Dimensions without coordinates: x
+    │   │   Data variables:
+    │   │       a        (x) int64 16B 2 3
+    │   │       b        (x) float64 16B 0.1 0.2
+    │   └── Group: /set2/set1
+    └── Group: /set3
 
     The structure has deliberately repeated names of tags, variables, and
     dimensions in order to better check for bugs caused by name conflicts.

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -164,6 +164,24 @@ class DatatreeIOBase:
             assert roundtrip_dt._close is not None
             assert_equal(original_dt, roundtrip_dt)
 
+    def test_decode_cf(self, tmpdir):
+        filepath = tmpdir / "test-cf-convention.nc"
+        original_dt = xr.DataTree(
+            xr.Dataset(
+                {
+                    "test": xr.DataArray(
+                        data=np.array([0, 1, 2], dtype=np.uint16),
+                        attrs={"_FillValue": 99},
+                    ),
+                }
+            )
+        )
+        original_dt.to_netcdf(filepath, engine=self.engine)
+        with open_datatree(
+            filepath, engine=self.engine, decode_cf=False
+        ) as roundtrip_dt:
+            assert original_dt["test"].dtype == roundtrip_dt["test"].dtype
+
     def test_to_netcdf_inherited_coords(self, tmpdir):
         filepath = tmpdir / "test.nc"
         original_dt = DataTree.from_dict(


### PR DESCRIPTION
Harmonizes behavior with dataset for the same situation. When the dataarray has an attribute that triggers cf_convention decoding, passing `decode_cf=False` had not effect.

I also updated the text rendering of the `simple_datatree` test fixture to the current rendering which looks nicer and also correctly indentifies the type of each array.

As a side note (for follow up) it seems that `assert_equal` as is used in the other tests does not check for dtype.

attn @TomNicholas 

- [x] Closes #10037 
- [x] Tests added
- [NA?] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [NA ] New functions/methods are listed in `api.rst`
