### PR TITLE
Test for preserved dtype during datetime roundtrip

### DIFF
--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -1304,6 +1304,19 @@ def test_decode_float_datetime():
     np.testing.assert_equal(actual, expected)
 
 
+def test_roundtrip_float32_datetime():
+    expected = np.array([1867128, 1867134, 1867140], dtype="float32")
+    units = "hours since 1800-01-01"
+    calendar = "standard"
+
+    arr = decode_cf_datetime(expected, units=units, calendar=calendar, use_cftime=False)
+    actual, _, _ = encode_cf_datetime(
+        arr, units=units, calendar=calendar, dtype=expected.dtype
+    )
+    np.testing.assert_equal(actual, expected)
+    assert actual.dtype == expected.dtype
+
+
 @pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
 def test_decode_float_datetime_with_decimals(
     time_unit: PDDatetimeUnitOptions,


### PR DESCRIPTION
The removal of `_cast_to_dtype_if_safe()` in https://github.com/pydata/xarray/pull/9498/files means that the dtype is not always preserved when roundtripping datetimes (xref https://github.com/zarr-developers/VirtualiZarr/issues/492). This PR adds a test for that property. I'd be glad to add a fix in this PR as well, but first wanted to check if it was intentional to loosen the expectations around this property.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
