### PR TITLE
Support zarr `write_empty_chunks` for zarr-python 3 and up

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1075,13 +1075,18 @@ class ZarrStore(AbstractWritableDataStore):
             #     - Existing variables already have their attrs included in the consolidated metadata file.
             #     - The size of dimensions can not be expanded, that would require a call using `append_dim`
             #        which is mutually exclusive with `region`
+            if _zarr_v3():
+                empty = dict(config={"write_empty_chunks": self._write_empty})
+            else:
+                empty = dict(write_empty_chunks=self._write_empty)
+
             zarr_array = zarr.open(
                 store=(
                     self.zarr_group.store if _zarr_v3() else self.zarr_group.chunk_store
                 ),
                 # TODO: see if zarr should normalize these strings.
                 path="/".join([self.zarr_group.name.rstrip("/"), name]).lstrip("/"),
-                write_empty_chunks=self._write_empty,
+                **empty,
             )
         else:
             zarr_array = self.zarr_group[name]

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1075,6 +1075,7 @@ class ZarrStore(AbstractWritableDataStore):
             #     - Existing variables already have their attrs included in the consolidated metadata file.
             #     - The size of dimensions can not be expanded, that would require a call using `append_dim`
             #        which is mutually exclusive with `region`
+            empty: dict[str, bool] | dict[str, dict[str, bool]]
             if _zarr_v3():
                 empty = dict(config={"write_empty_chunks": self._write_empty})
             else:

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1106,6 +1106,14 @@ class ZarrStore(AbstractWritableDataStore):
             else:
                 encoding["write_empty_chunks"] = self._write_empty
 
+        if _zarr_v3():
+            # zarr v3 deprecated origin and write_empty_chunks
+            # instead preferring to pass them via the config argument
+            encoding["config"] = {}
+            for c in ("write_empty_chunks", "order"):
+                if c in encoding:
+                    encoding["config"][c] = encoding.pop(c)
+
         zarr_array = self.zarr_group.create(
             name,
             shape=shape,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3735,21 +3735,16 @@ class TestZarrWriteEmpty(TestZarrDirectoryStore):
                 "0.1.1",
             ]
 
-        data = np.array([np.nan, np.nan, 1.0, np.nan]).reshape((1, 2, 2))
         if zarr_format_3:
             data = np.array([0.0, 0, 1.0, 0]).reshape((1, 2, 2))
             # transform to the path style of zarr 3
             # e.g. 0/0/1
             expected = [e.replace(".", "/") for e in expected]
+        else:
+            # use nan for default fill_value behaviour
+            data = np.array([np.nan, np.nan, 1.0, np.nan]).reshape((1, 2, 2))
 
-        ds = xr.Dataset(
-            data_vars={
-                "test": (
-                    ("Z", "Y", "X"),
-                    data,
-                )
-            }
-        )
+        ds = xr.Dataset(data_vars={"test": (("Z", "Y", "X"), data)})
 
         if has_dask:
             ds["test"] = ds["test"].chunk(1)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3640,7 +3640,7 @@ class TestZarrWriteEmpty(TestZarrDirectoryStore):
         consolidated: bool | None,
         write_empty: bool | None,
     ) -> None:
-        def assert_expected_files(expected: set[str], store: str) -> None:
+        def assert_expected_files(expected: list[str], store: str) -> None:
             """Convenience for comparing with actual files written"""
             ls = []
             test_root = os.path.join(store, "test")
@@ -3662,7 +3662,7 @@ class TestZarrWriteEmpty(TestZarrDirectoryStore):
 
         # The zarr format is set by the `default_zarr_format`
         # pytest fixture that acts on a superclass
-        zarr_format_3 = zarr.config.config["default_zarr_format"] == 3
+        zarr_format_3 = has_zarr_v3 and zarr.config.config["default_zarr_format"] == 3
         if (write_empty is False) or (write_empty is None and has_zarr_v3):
             expected = ["0.1.0"]
         else:


### PR DESCRIPTION
Prevent passing `write_empty_chunks` from raising an error. Prior to this PR `Dataset.to_zarr(...,write_empty_chunks=)` would raise:

```python
TypeError: Group.create_array() got an unexpected keyword argument 'write_empty_chunks'
```

This seems like the shortest path to prevent this bug without changing the xarray api at all, in the future it might be good to better align the xarray api with the zarr api. I also added `order` to this fix for create array as it underwent a similar deprecation.

@sotosoul I independently encountered this issue and set out to fix it, I hadn't seen the fix in your fork. Can you try this out and see if it fixes it for you.


**Test Changes**

The test that would have caught this issue was not enabled for zarr v3. I enabled it but had to make some modifications to have it work for both format 2 and 3. I did a few things

1. changed the file listing to work for both format 2 and format 3
2. test the expected files after the first write and again after the append
    - This helped me understand what was happening in the test and is a bit more throrough
3. temporarily don't test some files when the zarr-python library is version 3 due a zarr bug: https://github.com/zarr-developers/zarr-python/issues/2931




- [x] Closes https://github.com/pydata/xarray/issues/10056
- [x] Tests added
- [NA?] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [NA] New functions/methods are listed in `api.rst`
