### PR TITLE
opendap / dap4 support for pydap backend

### DIFF
--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -42,7 +42,7 @@ dependencies:
   - pandas=2.1
   - pint=0.22
   - pip
-  - pydap=3.5
+  - pydap=3.5.5
   - pytest
   - pytest-cov
   - pytest-env

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -42,7 +42,7 @@ dependencies:
   - pandas=2.1
   - pint=0.22
   - pip
-  - pydap=3.5.5
+  - pydap=3.5.0
   - pytest
   - pytest-cov
   - pytest-env

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -42,7 +42,7 @@ dependencies:
   - pandas=2.1
   - pint=0.22
   - pip
-  - pydap=3.4
+  - pydap=3.5
   - pytest
   - pytest-cov
   - pytest-env

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -1246,10 +1246,10 @@ over the network until we look at particular values:
 .. image:: ../_static/opendap-prism-tmax.png
 
 Some servers require authentication before we can access the data. `Pydap` uses
-a `Requests`__ session object (which the user can pre-define), and this 
-session object can recover authentication credentials from a locally stored 
-`.netrc` file. For example, to connect to server that require NASA's 
-URS authentication, with the username/password credentials stored on a locally 
+a `Requests`__ session object (which the user can pre-define), and this
+session object can recover authentication credentials from a locally stored
+`.netrc` file. For example, to connect to server that require NASA's
+URS authentication, with the username/password credentials stored on a locally
 accessible `.netrc`, access to OPeNDAP data should be as simple as this::
 
     import xarray as xr
@@ -1261,19 +1261,19 @@ accessible `.netrc`, access to OPeNDAP data should be as simple as this::
 
     ds = xr.open_dataset(ds_url, session=my_session, engine="pydap")
 
-Moreover, a bearer token header can be included in a `Requests`__ session 
+Moreover, a bearer token header can be included in a `Requests`__ session
 object, allowing for token-based authentication which  OPeNDAP servers can use
-to avoid some redirects. 
+to avoid some redirects.
 
 
 Lastly, OPeNDAP servers may provide endpoint URLs for different OPeNDAP protocols,
-DAP2 and DAP4. To specify which protocol between the two options to use, you can 
-replace the scheme of the url with the name of the protocol. For example:: 
+DAP2 and DAP4. To specify which protocol between the two options to use, you can
+replace the scheme of the url with the name of the protocol. For example::
 
-    # dap2 url 
+    # dap2 url
     ds_url = 'dap2://gpm1.gesdisc.eosdis.nasa.gov/opendap/hyrax/example.nc'
 
-    # dap4 url 
+    # dap4 url
     ds_url = 'dap4://gpm1.gesdisc.eosdis.nasa.gov/opendap/hyrax/example.nc'
 
 __ https://docs.python-requests.org

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -1245,12 +1245,12 @@ over the network until we look at particular values:
 
 .. image:: ../_static/opendap-prism-tmax.png
 
-Some servers require authentication before we can access the data. `Pydap` uses
+Some servers require authentication before we can access the data. Pydap uses
 a `Requests`__ session object (which the user can pre-define), and this
-session object can recover authentication credentials from a locally stored
-`.netrc` file. For example, to connect to server that require NASA's
+session object can recover `authentication`__` credentials from a locally stored
+``.netrc`` file. For example, to connect to a server that requires NASA's
 URS authentication, with the username/password credentials stored on a locally
-accessible `.netrc`, access to OPeNDAP data should be as simple as this::
+accessible ``.netrc``, access to OPeNDAP data should be as simple as this::
 
     import xarray as xr
     import requests
@@ -1276,9 +1276,13 @@ replace the scheme of the url with the name of the protocol. For example::
     # dap4 url
     ds_url = 'dap4://gpm1.gesdisc.eosdis.nasa.gov/opendap/hyrax/example.nc'
 
+While most OPeNDAP servers implement DAP2, not all servers implement DAP4. It
+is recommended to check if the URL you are using `supports DAP4`__ by checking the
+URL on a browser.
+
 __ https://docs.python-requests.org
 __ https://pydap.github.io/pydap/en/notebooks/Authentication.html
-__ https://pydap.github.io/pydap/en/Q3.html
+__ https://pydap.github.io/pydap/en/faqs/dap2_or_dap4_url.html
 
 .. _io.pickle:
 

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -1252,14 +1252,14 @@ session object can recover authentication credentials from a locally stored
 URS authentication, with the username/password credentials stored on a locally 
 accessible `.netrc`, access to OPeNDAP data should be as simple as this::
 
-  import xarray as xr
-  import requests
+    import xarray as xr
+    import requests
 
-  my_session = requests.Session()
+    my_session = requests.Session()
 
-  ds_url = 'https://gpm1.gesdisc.eosdis.nasa.gov/opendap/hyrax/example.nc'
+    ds_url = 'https://gpm1.gesdisc.eosdis.nasa.gov/opendap/hyrax/example.nc'
 
-  ds = xr.open_dataset(ds_url, session=my_session, engine="pydap")
+    ds = xr.open_dataset(ds_url, session=my_session, engine="pydap")
 
 Moreover, a bearer token header can be included in a `Requests`__ session 
 object, allowing for token-based authentication which  OPeNDAP servers can use

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -1245,37 +1245,40 @@ over the network until we look at particular values:
 
 .. image:: ../_static/opendap-prism-tmax.png
 
-Some servers require authentication before we can access the data. For this
-purpose we can explicitly create a :py:class:`backends.PydapDataStore`
-and pass in a `Requests`__ session object. For example for
-HTTP Basic authentication::
-
-    import xarray as xr
-    import requests
-
-    session = requests.Session()
-    session.auth = ('username', 'password')
-
-    store = xr.backends.PydapDataStore.open('http://example.com/data',
-                                            session=session)
-    ds = xr.open_dataset(store)
-
-`Pydap's cas module`__ has functions that generate custom sessions for
-servers that use CAS single sign-on. For example, to connect to servers
-that require NASA's URS authentication::
+Some servers require authentication before we can access the data. `Pydap` uses
+a `Requests`__ session object (which the user can pre-define), and this 
+session object can recover authentication credentials from a locally stored 
+`.netrc` file. For example, to connect to server that require NASA's 
+URS authentication, with the username/password credentials stored on a locally 
+accessible `.netrc`, access to OPeNDAP data should be as simple as this::
 
   import xarray as xr
-  from pydata.cas.urs import setup_session
+  import requests
+
+  my_session = requests.Session()
 
   ds_url = 'https://gpm1.gesdisc.eosdis.nasa.gov/opendap/hyrax/example.nc'
 
-  session = setup_session('username', 'password', check_url=ds_url)
-  store = xr.backends.PydapDataStore.open(ds_url, session=session)
+  ds = xr.open_dataset(ds_url, session=my_session, engine="pydap")
 
-  ds = xr.open_dataset(store)
+Moreover, a bearer token header can be included in a `Requests`__ session 
+object, allowing for token-based authentication which  OPeNDAP servers can use
+to avoid some redirects. 
+
+
+Lastly, OPeNDAP servers may provide endpoint URLs for different OPeNDAP protocols,
+DAP2 and DAP4. To specify which protocol between the two options to use, you can 
+replace the scheme of the url with the name of the protocol. For example:: 
+
+    # dap2 url 
+    ds_url = 'dap2://gpm1.gesdisc.eosdis.nasa.gov/opendap/hyrax/example.nc'
+
+    # dap4 url 
+    ds_url = 'dap4://gpm1.gesdisc.eosdis.nasa.gov/opendap/hyrax/example.nc'
 
 __ https://docs.python-requests.org
-__ https://www.pydap.org/en/latest/client.html#authentication
+__ https://pydap.github.io/pydap/en/notebooks/Authentication.html
+__ https://pydap.github.io/pydap/en/Q3.html
 
 .. _io.pickle:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -24,10 +24,20 @@ New Features
 
 - Added `scipy-stubs <https://github.com/scipy/scipy-stubs>`_ to the ``xarray[types]`` dependencies.
   By `Joren Hammudoglu <https://github.com/jorenham>`_.
+- Improved compatibility with OPeNDAP DAP4 data model for backend engine ``pydap``. This
+  includes ``datatree`` support, and removing slashes from dimension names. By
+  `Miguel Jimenez-Urias <https://github.com/Mikejmnez>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- The minimum versions of some dependencies were changed
+
+  ===================== =========  =======
+   Package                    Old      New
+  ===================== =========  =======
+    pydap                    3.4     3.5.0
+  ===================== =========  =======
 
 Deprecations
 ~~~~~~~~~~~~
@@ -47,6 +57,8 @@ Documentation
 
 - Fix references to core classes in docs (:issue:`10195`, :pull:`10207`).
   By `Mattia Almansi <https://github.com/malmans2>`_.
+- Fix references to point to updated pydap documentation (:pull:`10182`).
+  By `Miguel Jimenez-Urias <https://github.com/Mikejmnez>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -167,10 +167,9 @@ class PydapDataStore(AbstractDataStore):
             "libdap",
             "invocation",
             "dimensions",
-            "path",
         )
         attrs = self.ds.attributes
-        list(map(attrs.pop, opendap_attrs, [None] * 7))
+        list(map(attrs.pop, opendap_attrs, [None] * 6))
         return Frozen(attrs)
 
     def get_dimensions(self):

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -4,7 +4,6 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from requests.utils import urlparse
 
 from xarray.backends.common import (
     BACKEND_ENTRYPOINTS,
@@ -139,7 +138,6 @@ class PydapDataStore(AbstractDataStore):
         elif hasattr(url, "ds"):
             # pydap dataset
             dataset = url.ds
-            groups = dataset.groups()
         args = {"dataset": dataset}
         if group:
             # only then, change the default

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -160,9 +160,17 @@ class PydapDataStore(AbstractDataStore):
 
     def get_attrs(self):
         """Remove any opendap specific attributes"""
-        opendap_attrs = ("configuration", "build_dmrpp", "bes", "libdap", "invocation")
+        opendap_attrs = (
+            "configuration",
+            "build_dmrpp",
+            "bes",
+            "libdap",
+            "invocation",
+            "dimensions",
+            "path",
+        )
         attrs = self.ds.attributes
-        list(map(attrs.pop, opendap_attrs, [None] * 5))
+        list(map(attrs.pop, opendap_attrs, [None] * 7))
         return Frozen(attrs)
 
     def get_dimensions(self):

--- a/xarray/core/datatree_io.py
+++ b/xarray/core/datatree_io.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal, get_args
 from xarray.core.datatree import DataTree
 from xarray.core.types import NetcdfWriteModes, ZarrWriteModes
 
-T_DataTreeNetcdfEngine = Literal["netcdf4", "h5netcdf"]
+T_DataTreeNetcdfEngine = Literal["netcdf4", "h5netcdf", "pydap"]
 T_DataTreeNetcdfTypes = Literal["NETCDF4"]
 
 if TYPE_CHECKING:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5355,10 +5355,10 @@ class TestPydapOnline(TestPydap):
             # workaround to restore string which is converted to byte
             expected["bears"] = expected["bears"].astype(str)
             yield actual, expected
-        
+
     def output_grid_deprecation_warning_dap2dataset(self):
         with pytest.warns(DeprecationWarning, match="`output_grid` is deprecated"):
-            with self.create_dap2_datasets(outout_grid=True) as (actual, expected):
+            with self.create_dap2_datasets(output_grid=True) as (actual, expected):
                 assert_equal(actual, expected)
 
     def create_dap4_dataset(self, **kwargs):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5282,9 +5282,7 @@ class TestPydap:
             ds[key] = BaseType(key, var.values, dims=var.dims, **var.attrs)
         # check all dims are stored in ds
         for d in original.coords:
-            ds[d] = BaseType(
-                d, original[d].values, dims=(d,), **original[d].attrs
-            )
+            ds[d] = BaseType(d, original[d].values, dims=(d,), **original[d].attrs)
         return ds
 
     @contextlib.contextmanager

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5375,12 +5375,20 @@ class TestPydapOnline(TestPydap):
     def test_session(self) -> None:
         from pydap.net import create_session
 
-        session = create_session()  # black requests.Session object
+        session = create_session()  # blank requests.Session object
         with mock.patch("pydap.client.open_url") as mock_func:
             xr.backends.PydapDataStore.open("http://test.url", session=session)
         mock_func.assert_called_with(
             url="http://test.url",
+            application=None,
             session=session,
+            timeout=120,
+            verify=True,
+            user_charset=None,
+            use_cache=False,
+            session_kwargs={},
+            cache_kwargs={},
+            get_kwargs={},
         )
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5279,11 +5279,11 @@ class TestPydap:
 
         ds = DatasetType("bears", **original.attrs)
         for key, var in original.data_vars.items():
-            ds[key] = BaseType(key, var.values, dimensions=var.dims, **var.attrs)
+            ds[key] = BaseType(key, var.values, dims=var.dims, **var.attrs)
         # check all dims are stored in ds
         for d in original.coords:
             ds[d] = BaseType(
-                d, original[d].values, dimensions=(d,), **original[d].attrs
+                d, original[d].values, dims=(d,), **original[d].attrs
             )
         return ds
 
@@ -5365,12 +5365,6 @@ class TestPydapOnline(TestPydap):
             # workaround to restore string which is converted to byte
             expected["bears"] = expected["bears"].astype(str)
             yield actual, expected
-
-    def test_protocol(self):
-        url2 = "dap2://test.opendap.org/opendap/data/nc/bears.nc"
-        url4 = "dap4://test.opendap.org/opendap/data/nc/bears.nc"
-        assert PydapDataStore.open(url2).dap2
-        assert not PydapDataStore.open(url4).dap2
 
     def test_session(self) -> None:
         from pydap.net import create_session

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5355,6 +5355,11 @@ class TestPydapOnline(TestPydap):
             # workaround to restore string which is converted to byte
             expected["bears"] = expected["bears"].astype(str)
             yield actual, expected
+        
+    def output_grid_deprecation_warning_dap2dataset(self):
+        with pytest.warns(DeprecationWarning, match="`output_grid` is deprecated"):
+            with self.create_dap2_datasets(outout_grid=True) as (actual, expected):
+                assert_equal(actual, expected)
 
     def create_dap4_dataset(self, **kwargs):
         url = "dap4://test.opendap.org/opendap/data/nc/bears.nc"
@@ -5377,10 +5382,6 @@ class TestPydapOnline(TestPydap):
             timeout=120,
             verify=True,
             user_charset=None,
-            use_cache=False,
-            session_kwargs={},
-            cache_kwargs={},
-            get_kwargs={},
         )
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5409,7 +5409,8 @@ class TestPydap:
 class TestPydapOnline(TestPydap):
     @contextlib.contextmanager
     def create_dap2_datasets(self, **kwargs):
-        url = "dap2://test.opendap.org/opendap/data/nc/bears.nc"
+        # in pydap 3.5.0, urls defaults to dap2.
+        url = "http://test.opendap.org/opendap/data/nc/bears.nc"
         actual = open_dataset(url, engine="pydap", **kwargs)
         with open_example_dataset("bears.nc") as expected:
             # workaround to restore string which is converted to byte
@@ -5430,15 +5431,16 @@ class TestPydapOnline(TestPydap):
             yield actual, expected
 
     def test_session(self) -> None:
-        from pydap.net import create_session
+        from requests import Session
 
-        session = create_session()  # blank requests.Session object
+        session = Session()  # blank requests.Session object
         with mock.patch("pydap.client.open_url") as mock_func:
             xr.backends.PydapDataStore.open("http://test.url", session=session)
         mock_func.assert_called_with(
             url="http://test.url",
             application=None,
             session=session,
+            output_grid=False,
             timeout=120,
             verify=True,
             user_charset=None,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -13,7 +13,6 @@ import sys
 import tempfile
 import uuid
 import warnings
-from collections import ChainMap
 from collections.abc import Generator, Iterator, Mapping
 from contextlib import ExitStack
 from io import BytesIO
@@ -2628,10 +2627,12 @@ class ZarrBase(CFEncodedBase):
                 for var in expected.variables.keys():
                     assert self.DIMENSION_KEY not in expected[var].attrs
 
+            if has_zarr_v3:
+                # temporary workaround for https://github.com/zarr-developers/zarr-python/issues/2338
+                zarr_group.store._is_open = True
+
             # put it back and try removing from a variable
-            attrs = dict(zarr_group["var2"].attrs)
-            del attrs[self.DIMENSION_KEY]
-            zarr_group["var2"].attrs.put(attrs)
+            del zarr_group["var2"].attrs[self.DIMENSION_KEY]
 
             with pytest.raises(KeyError):
                 with xr.decode_cf(store):
@@ -3342,67 +3343,6 @@ class ZarrBase(CFEncodedBase):
 
             observed_keys_2 = sorted(zstore_mut.array_keys())
             assert observed_keys_2 == sorted(array_keys + [new_key])
-
-    @requires_dask
-    @pytest.mark.parametrize("dtype", [int, float])
-    def test_zarr_fill_value_setting(self, dtype):
-        # When zarr_format=2, _FillValue sets fill_value
-        # When zarr_format=3, fill_value is set independently
-        # We test this by writing a dask array with compute=False,
-        # on read we should receive chunks filled with `fill_value`
-        fv = -1
-        ds = xr.Dataset(
-            {"foo": ("x", dask.array.from_array(np.array([0, 0, 0], dtype=dtype)))}
-        )
-        expected = xr.Dataset({"foo": ("x", [fv] * 3)})
-
-        zarr_format_2 = (
-            has_zarr_v3 and zarr.config.get("default_zarr_format") == 2
-        ) or not has_zarr_v3
-        if zarr_format_2:
-            attr = "_FillValue"
-            expected.foo.attrs[attr] = fv
-        else:
-            attr = "fill_value"
-            if dtype is float:
-                # for floats, Xarray inserts a default `np.nan`
-                expected.foo.attrs["_FillValue"] = np.nan
-
-        # turn off all decoding so we see what Zarr returns to us.
-        # Since chunks, are not written, we should receive on `fill_value`
-        open_kwargs = {
-            "mask_and_scale": False,
-            "consolidated": False,
-            "use_zarr_fill_value_as_mask": False,
-        }
-        save_kwargs = dict(compute=False, consolidated=False)
-        with self.roundtrip(
-            ds,
-            save_kwargs=ChainMap(save_kwargs, dict(encoding={"foo": {attr: fv}})),
-            open_kwargs=open_kwargs,
-        ) as actual:
-            assert_identical(actual, expected)
-
-        ds.foo.encoding[attr] = fv
-        with self.roundtrip(
-            ds, save_kwargs=save_kwargs, open_kwargs=open_kwargs
-        ) as actual:
-            assert_identical(actual, expected)
-
-        if zarr_format_2:
-            ds = ds.drop_encoding()
-            with pytest.raises(ValueError, match="_FillValue"):
-                with self.roundtrip(
-                    ds,
-                    save_kwargs=ChainMap(
-                        save_kwargs, dict(encoding={"foo": {"fill_value": fv}})
-                    ),
-                    open_kwargs=open_kwargs,
-                ):
-                    pass
-            # TODO: this doesn't fail because of the
-            # ``raise_on_invalid=vn in check_encoding_set`` line in zarr.py
-            # ds.foo.encoding["fill_value"] = fv
 
 
 @requires_zarr
@@ -5335,15 +5275,11 @@ class TestDask(DatasetIOBase):
 @pytest.mark.filterwarnings("ignore:The binary mode of fromstring is deprecated")
 class TestPydap:
     def convert_to_pydap_dataset(self, original):
-        from pydap.model import BaseType, DatasetType, GridType
+        from pydap.model import BaseType, DatasetType
 
         ds = DatasetType("bears", **original.attrs)
         for key, var in original.data_vars.items():
-            v = GridType(key)
-            v[key] = BaseType(key, var.values, dimensions=var.dims, **var.attrs)
-            for d in var.dims:
-                v[d] = BaseType(d, var[d].values)
-            ds[key] = v
+            ds[key] = BaseType(key, var.values, dimensions=var.dims, **var.attrs)
         # check all dims are stored in ds
         for d in original.coords:
             ds[d] = BaseType(
@@ -5372,9 +5308,7 @@ class TestPydap:
             # we don't check attributes exactly with assertDatasetIdentical()
             # because the test DAP server seems to insert some extra
             # attributes not found in the netCDF file.
-            # 2025/03/18 : The DAP server now modifies the keys too
-            # assert actual.attrs.keys() == expected.attrs.keys()
-            assert len(actual.attrs.keys()) == len(expected.attrs.keys())
+            assert actual.attrs.keys() == expected.attrs.keys()
 
         with self.create_datasets() as (actual, expected):
             assert_equal(actual[{"l": 2}], expected[{"l": 2}])
@@ -5416,26 +5350,37 @@ class TestPydap:
 @requires_pydap
 class TestPydapOnline(TestPydap):
     @contextlib.contextmanager
-    def create_datasets(self, **kwargs):
-        url = "http://test.opendap.org/opendap/data/nc/bears.nc"
+    def create_dap2_datasets(self, **kwargs):
+        url = "dap2://test.opendap.org/opendap/data/nc/bears.nc"
         actual = open_dataset(url, engine="pydap", **kwargs)
         with open_example_dataset("bears.nc") as expected:
             # workaround to restore string which is converted to byte
             expected["bears"] = expected["bears"].astype(str)
             yield actual, expected
 
-    def test_session(self) -> None:
-        from pydap.cas.urs import setup_session
+    def create_dap4_dataset(self, **kwargs):
+        url = "dap4://test.opendap.org/opendap/data/nc/bears.nc"
+        actual = open_dataset(url, engine="pydap", **kwargs)
+        with open_example_dataset("bears.nc") as expected:
+            # workaround to restore string which is converted to byte
+            expected["bears"] = expected["bears"].astype(str)
+            yield actual, expected
 
-        session = setup_session("XarrayTestUser", "Xarray2017")
+    def test_protocol(self):
+        url2 = "dap2://test.opendap.org/opendap/data/nc/bears.nc"
+        url4 = "dap4://test.opendap.org/opendap/data/nc/bears.nc"
+        assert PydapDataStore.open(url2).dap2
+        assert not PydapDataStore.open(url4).dap2
+
+    def test_session(self) -> None:
+        from pydap.net import create_session
+
+        session = create_session()  # black requests.Session object
         with mock.patch("pydap.client.open_url") as mock_func:
             xr.backends.PydapDataStore.open("http://test.url", session=session)
         mock_func.assert_called_with(
             url="http://test.url",
-            application=None,
             session=session,
-            output_grid=True,
-            timeout=120,
         )
 
 
@@ -5933,23 +5878,23 @@ def test_encode_zarr_attr_value() -> None:
 @requires_zarr
 def test_extract_zarr_variable_encoding() -> None:
     var = xr.Variable("x", [1, 2])
-    actual = backends.zarr.extract_zarr_variable_encoding(var, zarr_format=3)
+    actual = backends.zarr.extract_zarr_variable_encoding(var)
     assert "chunks" in actual
     assert actual["chunks"] == ("auto" if has_zarr_v3 else None)
 
     var = xr.Variable("x", [1, 2], encoding={"chunks": (1,)})
-    actual = backends.zarr.extract_zarr_variable_encoding(var, zarr_format=3)
+    actual = backends.zarr.extract_zarr_variable_encoding(var)
     assert actual["chunks"] == (1,)
 
     # does not raise on invalid
     var = xr.Variable("x", [1, 2], encoding={"foo": (1,)})
-    actual = backends.zarr.extract_zarr_variable_encoding(var, zarr_format=3)
+    actual = backends.zarr.extract_zarr_variable_encoding(var)
 
     # raises on invalid
     var = xr.Variable("x", [1, 2], encoding={"foo": (1,)})
     with pytest.raises(ValueError, match=r"unexpected encoding parameters"):
         actual = backends.zarr.extract_zarr_variable_encoding(
-            var, raise_on_invalid=True, zarr_format=3
+            var, raise_on_invalid=True
         )
 
 

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -428,8 +428,8 @@ class TestPyDAPDatatreeIO:
     unaligned_datatree_url = (
         "dap4://test.opendap.org/opendap/dap4/unaligned_simple_datatree.nc.h5"
     )
-    aligned_datatree_url = (
-        "dap4://test.opendap.org/opendap/dap4/unaligned_simple_datatree.nc.h5"
+    all_aligned_child_nodes_url = (
+        "dap4://test.opendap.org/opendap/dap4/all_aligned_child_nodes.nc.h5"
     )
     simplegroup_datatree_url = "dap4://test.opendap.org/opendap/dap4/SimpleGroup.nc4.h5"
 
@@ -493,7 +493,6 @@ class TestPyDAPDatatreeIO:
             │       Temperature  (time, Z, Y, X) float32 ...
             |       Salinity     (time, Z, Y, X) float32 ...
         """
-        print(url)
         tree = open_datatree(url, engine="pydap")
         assert list(tree.dims) == ["time", "Z", "nv"]
         assert tree["/SimpleGroup"].coords["time"].dims == ("time",)
@@ -504,6 +503,12 @@ class TestPyDAPDatatreeIO:
             assert set(tree["/SimpleGroup"].dims) == set(
                 list(expected.dims) + ["Z", "nv"]
             )
+
+    def test_open_groups_to_dict(self, url=all_aligned_child_nodes_url) -> None:
+        aligned_dict_of_datasets = open_groups(url, engine="pydap")
+        aligned_dt = DataTree.from_dict(aligned_dict_of_datasets)
+        with open_datatree(url, engine="pydap") as opened_tree:
+            assert opened_tree.identical(aligned_dt)
 
 
 @requires_h5netcdf

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -14,10 +14,12 @@ from xarray.core.datatree import DataTree
 from xarray.testing import assert_equal, assert_identical
 from xarray.tests import (
     has_zarr_v3,
+    network,
     parametrize_zarr_format,
     requires_dask,
     requires_h5netcdf,
     requires_netCDF4,
+    requires_pydap,
     requires_zarr,
 )
 
@@ -416,6 +418,92 @@ class TestNetCDF4DatatreeIO(DatatreeIOBase):
         with open_datatree(filepath, group=group, engine=self.engine) as subgroup_tree:
             assert subgroup_tree.root.parent is None
             assert_equal(subgroup_tree, expected_subtree)
+
+
+@network
+@requires_pydap
+class TestPyDAPDatatreeIO:
+    # engine: T_DataTreeNetcdfEngine | None = "pydap"
+    # you can check these by adding a .dmr to urls, and replacing dap4 with http
+    unaligned_datatree_url = (
+        "dap4://test.opendap.org/opendap/dap4/unaligned_simple_datatree.nc.h5"
+    )
+    aligned_datatree_url = (
+        "dap4://test.opendap.org/opendap/dap4/unaligned_simple_datatree.nc.h5"
+    )
+    simplegroup_datatree_url = "dap4://test.opendap.org/opendap/dap4/SimpleGroup.nc4.h5"
+
+    def test_open_datatree(self, url=unaligned_datatree_url) -> None:
+        """Test if `open_datatree` fails to open a netCDF4 with an unaligned group hierarchy."""
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                re.escape(
+                    "group '/Group1/subgroup1' is not aligned with its parents:\nGroup:\n"
+                )
+                + ".*"
+            ),
+        ):
+            open_datatree(url, engine="pydap")
+
+    def test_open_groups(self, url=unaligned_datatree_url) -> None:
+        """Test `open_groups` with a netCDF4/HDF5 file with an unaligned group hierarchy."""
+        unaligned_dict_of_datasets = open_groups(url, engine="pydap")
+
+        # Check that group names are keys in the dictionary of `xr.Datasets`
+        assert "/" in unaligned_dict_of_datasets.keys()
+        assert "/Group1" in unaligned_dict_of_datasets.keys()
+        assert "/Group1/subgroup1" in unaligned_dict_of_datasets.keys()
+        # Check that group name returns the correct datasets
+        with xr.open_dataset(url, engine="pydap", group="/") as expected:
+            assert_identical(unaligned_dict_of_datasets["/"], expected)
+        with xr.open_dataset(url, group="Group1", engine="pydap") as expected:
+            assert_identical(unaligned_dict_of_datasets["/Group1"], expected)
+        with xr.open_dataset(
+            url,
+            group="/Group1/subgroup1",
+            engine="pydap",
+        ) as expected:
+            assert_identical(unaligned_dict_of_datasets["/Group1/subgroup1"], expected)
+
+    def test_inherited_coords(self, url=simplegroup_datatree_url) -> None:
+        """Test that `open_datatree` inherits coordinates from root tree.
+
+        This particular h5 file is a test file that inherits the time coordinate from the root
+        dataset to the child dataset.
+
+        Group: /
+        │   Dimensions:        (time: 1, Z: 1000, nv: 2)
+        │   Coordinates:
+        |       time: (time)    float32 0.5
+        |       Z:    (Z)       float32 -0.0 -1.0 -2.0 ...
+        │   Data variables:
+        │       Pressure  (Z)   float32 ...
+        |       time_bnds (time, nv) float32 ...
+        └── Group: /SimpleGroup
+            │   Dimensions:      (time: 1, Z: 1000, nv: 2, Y: 40, X: 40)
+            │   Coordinates:
+            |      Y:   (Y)     int16 1 2 3 4 ...
+            |      X:   (X)     int16 1 2 3 4 ...
+            |   Inherited coordinates:
+            |      time: (time)    float32 0.5
+            |      Z:    (Z)       float32 -0.0 -1.0 -2.0 ...
+            │   Data variables:
+            │       Temperature  (time, Z, Y, X) float32 ...
+            |       Salinity     (time, Z, Y, X) float32 ...
+        """
+        print(url)
+        tree = open_datatree(url, engine="pydap")
+        assert list(tree.dims) == ["time", "Z", "nv"]
+        assert tree["/SimpleGroup"].coords["time"].dims == ("time",)
+        assert tree["/SimpleGroup"].coords["Z"].dims == ("Z",)
+        assert tree["/SimpleGroup"].coords["Y"].dims == ("Y",)
+        assert tree["/SimpleGroup"].coords["X"].dims == ("X",)
+        with xr.open_dataset(url, engine="pydap", group="/SimpleGroup") as expected:
+            assert set(tree["/SimpleGroup"].dims) == set(
+                list(expected.dims) + ["Z", "nv"]
+            )
 
 
 @requires_h5netcdf

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -423,7 +423,9 @@ class TestNetCDF4DatatreeIO(DatatreeIOBase):
 @network
 @requires_pydap
 class TestPyDAPDatatreeIO:
-    # engine: T_DataTreeNetcdfEngine | None = "pydap"
+    """Test PyDAP backend for DataTree."""
+
+    engine: T_DataTreeNetcdfEngine | None = "pydap"
     # you can check these by adding a .dmr to urls, and replacing dap4 with http
     unaligned_datatree_url = (
         "dap4://test.opendap.org/opendap/dap4/unaligned_simple_datatree.nc.h5"
@@ -445,25 +447,25 @@ class TestPyDAPDatatreeIO:
                 + ".*"
             ),
         ):
-            open_datatree(url, engine="pydap")
+            open_datatree(url, engine=self.engine)
 
     def test_open_groups(self, url=unaligned_datatree_url) -> None:
         """Test `open_groups` with a netCDF4/HDF5 file with an unaligned group hierarchy."""
-        unaligned_dict_of_datasets = open_groups(url, engine="pydap")
+        unaligned_dict_of_datasets = open_groups(url, engine=self.engine)
 
         # Check that group names are keys in the dictionary of `xr.Datasets`
         assert "/" in unaligned_dict_of_datasets.keys()
         assert "/Group1" in unaligned_dict_of_datasets.keys()
         assert "/Group1/subgroup1" in unaligned_dict_of_datasets.keys()
         # Check that group name returns the correct datasets
-        with xr.open_dataset(url, engine="pydap", group="/") as expected:
+        with xr.open_dataset(url, engine=self.engine, group="/") as expected:
             assert_identical(unaligned_dict_of_datasets["/"], expected)
-        with xr.open_dataset(url, group="Group1", engine="pydap") as expected:
+        with xr.open_dataset(url, group="Group1", engine=self.engine) as expected:
             assert_identical(unaligned_dict_of_datasets["/Group1"], expected)
         with xr.open_dataset(
             url,
             group="/Group1/subgroup1",
-            engine="pydap",
+            engine=self.engine,
         ) as expected:
             assert_identical(unaligned_dict_of_datasets["/Group1/subgroup1"], expected)
 
@@ -493,21 +495,21 @@ class TestPyDAPDatatreeIO:
             │       Temperature  (time, Z, Y, X) float32 ...
             |       Salinity     (time, Z, Y, X) float32 ...
         """
-        tree = open_datatree(url, engine="pydap")
+        tree = open_datatree(url, engine=self.engine)
         assert list(tree.dims) == ["time", "Z", "nv"]
         assert tree["/SimpleGroup"].coords["time"].dims == ("time",)
         assert tree["/SimpleGroup"].coords["Z"].dims == ("Z",)
         assert tree["/SimpleGroup"].coords["Y"].dims == ("Y",)
         assert tree["/SimpleGroup"].coords["X"].dims == ("X",)
-        with xr.open_dataset(url, engine="pydap", group="/SimpleGroup") as expected:
+        with xr.open_dataset(url, engine=self.engine, group="/SimpleGroup") as expected:
             assert set(tree["/SimpleGroup"].dims) == set(
                 list(expected.dims) + ["Z", "nv"]
             )
 
     def test_open_groups_to_dict(self, url=all_aligned_child_nodes_url) -> None:
-        aligned_dict_of_datasets = open_groups(url, engine="pydap")
+        aligned_dict_of_datasets = open_groups(url, engine=self.engine)
         aligned_dt = DataTree.from_dict(aligned_dict_of_datasets)
-        with open_datatree(url, engine="pydap") as opened_tree:
+        with open_datatree(url, engine=self.engine) as opened_tree:
             assert opened_tree.identical(aligned_dt)
 
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

There have been some (revitalizing) upgrades over the last year to [pydap](https://pydap.github.io/pydap/en/intro.html) (with some more to come), including authentication, pydap data model (dap2 vs dap4). This ~Draft~ PR aims to

- [x] DOC: Update info on how to authenticate (handled by requests, which recovers credentials )
- [x] DOC: updates links to new (regularly updated) pydap documentation.
- [x] DOC: How to define opendap protocol via URLs.
- [x] DOC: Some info on [caching sessions](https://pydap.github.io/pydap/en/PydapAsClient.html#use-cached-session) to avoid repeatedly downloading same metadata/data from server.  At least point to pydap documentation. (Performance upgrade)
- [x] Removes slashes in variable names (part of dap4 protocol, which allows for hierarchical variables in dataset)
- [x] Support for `DataTree`.
- [x] Improves testing of backend. 
- [x] removes (largely unused) `output_grid` option. It is now set to `False` as default in `pydap`.
- [x] Add deprecation warning of `output_grid` as an input parameter. It will always be `False` as default (and there is no need for it to be `True`, as it only adds unnecessary logic).

This PR enables, for example (check [test opendap dap4 url](http://test.opendap.org/opendap/dap4/SimpleGroup.nc4.h5.dmr.html))

```python
URL = "dap4://test.opendap.org/opendap/dap4/SimpleGroup.nc4.h5"
ds = xr.open_datatree(URL, engine='pydap')
```

![Screenshot 2025-04-14 at 2 23 17 PM](https://github.com/user-attachments/assets/6af1a6de-0234-4d67-b5e2-9481125e4b80)




