### PR TITLE
Fix: Correct axis labelling with units for FacetGrid plots

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -47,7 +47,8 @@ Bug fixes
   By `Mathias Hauser <https://github.com/mathause>`_.
 - Fix grouped and resampled ``first``, ``last`` with datetimes (:issue:`10169`, :pull:`10173`)
   By `Deepak Cherian <https://github.com/dcherian>`_.
-
+- FacetGrid plots now include units in their axis labels when available (:issue:`10184`, :pull:`10185`)
+  By `Andre Wendlinger <https://github.com/andrewendlinger>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -353,6 +353,8 @@ class FacetGrid(Generic[T_DataArrayOrSet]):
             if k not in {"cmap", "colors", "cbar_kwargs", "levels"}
         }
         func_kwargs.update(cmap_params)
+        # to avoid redundant calling, colorbar and labelling is instead handled
+        # by `_finalize_grid` at the end
         func_kwargs["add_colorbar"] = False
         if func.__name__ != "surface":
             func_kwargs["add_labels"] = False
@@ -375,7 +377,10 @@ class FacetGrid(Generic[T_DataArrayOrSet]):
                 )
                 self._mappables.append(mappable)
 
-        self._finalize_grid(x, y)
+        xlabel = label_from_attrs(self.data[x])
+        ylabel = label_from_attrs(self.data[y])
+
+        self._finalize_grid(xlabel, ylabel)
 
         if kwargs.get("add_colorbar", True):
             self.add_colorbar(**cbar_kwargs)

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2429,6 +2429,25 @@ class TestFacetGrid(PlotTestCase):
             col="z", subplot_kws=dict(projection="polar"), sharex=False, sharey=False
         )
 
+    @pytest.mark.slow
+    def test_units_appear_somewhere(self) -> None:
+
+        # assign coordinates to all dims so we can test for units
+        darray = self.darray.assign_coords({"x": np.arange(self.darray.x.size), "y": np.arange(self.darray.y.size)})
+
+        darray.x.attrs["units"] = "x_unit"
+        darray.y.attrs["units"] = "y_unit"
+
+        g = xplt.FacetGrid(darray, col="z")
+
+        g.map_dataarray(xplt.contourf, "x", "y")
+
+        alltxt = text_in_fig()
+
+        # unit should appear as e.g. 'x [x_unit]'
+        for unit_name in ["x_unit", "y_unit"]:
+            assert unit_name in "".join(alltxt)
+
 
 @pytest.mark.filterwarnings("ignore:tight_layout cannot")
 class TestFacetGrid4d(PlotTestCase):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #10184 
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
