### PR TITLE
Remove mention of xarray-mongodb

### DIFF
--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -1451,11 +1451,3 @@ For CSV files, one might also consider `xarray_extras`_.
 .. _xarray_extras: https://xarray-extras.readthedocs.io/en/latest/api/csv.html
 
 .. _IO tools: https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html
-
-
-Third party libraries
----------------------
-
-More formats are supported by extension libraries:
-
-- `xarray-mongodb <https://xarray-mongodb.readthedocs.io/en/latest/>`_: Store xarray objects on MongoDB


### PR DESCRIPTION
The xarray_mongodb project hasn't had a release in over a year, and may not be maintained at all. The link to it was added to our docs in 2020 (https://github.com/pydata/xarray/issues/683), but I don't think it warrants a mention in our docs here anymore.