### PR TITLE
Apply ruff preview rule RUF046

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,10 +276,9 @@ ignore = [
   "RUF001",  # string contains ambiguous unicode character
   "RUF002",  # docstring contains ambiguous acute accent unicode character
   "RUF003",  # comment contains ambiguous no-break space unicode character
-  "RUF005",  # consider upacking operator instead of concatenation
+  "RUF005",  # consider unpacking operator instead of concatenation
   "RUF012",  # mutable class attributes
 ]
-
 
 [tool.ruff.lint.per-file-ignores]
 # don't enforce absolute imports

--- a/xarray/core/resample_cftime.py
+++ b/xarray/core/resample_cftime.py
@@ -475,7 +475,7 @@ def exact_cftime_datetime_difference(a: CFTimeDatetime, b: CFTimeDatetime):
     datetime.timedelta
     """
     seconds = b.replace(microsecond=0) - a.replace(microsecond=0)
-    seconds = int(round(seconds.total_seconds()))
+    seconds = round(seconds.total_seconds())
     microseconds = b.microsecond - a.microsecond
     return datetime.timedelta(seconds=seconds, microseconds=microseconds)
 


### PR DESCRIPTION
RUF046 Value being cast to `int` is already an integer