### PR TITLE
Handle new data model in pydap v3.5.5+

### DIFF
--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -131,7 +131,10 @@ class PydapDataStore(AbstractDataStore):
 
     def open_store_variable(self, var):
         data = indexing.LazilyIndexedArray(PydapArrayWrapper(var))
-        return Variable(var.dimensions, data, _fix_attributes(var.attributes))
+        return Variable(
+            var.dimensions if hasattr(var, "dimensions") else var.dims,
+            data, _fix_attributes(var.attributes)
+        )
 
     def get_variables(self):
         return FrozenDict(

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -133,7 +133,8 @@ class PydapDataStore(AbstractDataStore):
         data = indexing.LazilyIndexedArray(PydapArrayWrapper(var))
         return Variable(
             var.dimensions if hasattr(var, "dimensions") else var.dims,
-            data, _fix_attributes(var.attributes)
+            data,
+            _fix_attributes(var.attributes),
         )
 
     def get_variables(self):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

The latest version of `pydap` (v3.5.5) slightly adjust their data model and is incompatible with the current backend handler here.

This proposes a backwards-compatible fix for the `dims|dimensions` field.

Changes were introduced in: https://github.com/pydap/pydap/pull/481