### PR TITLE
Fix mypy failures on main

### DIFF
--- a/xarray/computation/fit.py
+++ b/xarray/computation/fit.py
@@ -103,7 +103,7 @@ def polyfit(
     dim: Hashable,
     deg: int,
     skipna: bool | None = None,
-    rcond: float | None = None,
+    rcond: np.floating[Any] | float | None = None,
     w: Hashable | Any = None,
     full: bool = False,
     cov: bool | Literal["unscaled"] = False,
@@ -278,6 +278,7 @@ def polyfit(
                 dims=other_dims,
             )
 
+        fac: Variable | int
         if cov:
             Vbase = np.linalg.inv(np.dot(lhs.T, lhs))
             Vbase /= np.outer(scale, scale)

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -67,7 +67,16 @@ from collections.abc import (
 from enum import Enum
 from pathlib import Path
 from types import EllipsisType, ModuleType
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeGuard, TypeVar, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    Literal,
+    TypeGuard,
+    TypeVar,
+    cast,
+    overload,
+)
 
 import numpy as np
 import pandas as pd
@@ -751,7 +760,7 @@ def decode_numpy_dict_values(attrs: Mapping[K, V]) -> dict[K, V]:
     attrs = dict(attrs)
     for k, v in attrs.items():
         if isinstance(v, np.ndarray):
-            attrs[k] = v.tolist()
+            attrs[k] = cast(V, v.tolist())
         elif isinstance(v, np.generic):
             attrs[k] = v.item()
     return attrs

--- a/xarray/plot/dataarray_plot.py
+++ b/xarray/plot/dataarray_plot.py
@@ -697,8 +697,8 @@ def hist(
 
     ax = get_axis(figsize, size, aspect, ax)
 
-    no_nan = np.ravel(darray.to_numpy())
-    no_nan = no_nan[pd.notnull(no_nan)]
+    no_nan_arr = np.ravel(darray.to_numpy())
+    no_nan = no_nan_arr[pd.notnull(no_nan_arr)]
 
     n, bins, patches = cast(
         tuple[np.ndarray, np.ndarray, Union["BarContainer", "Polygon"]],

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -13,7 +13,7 @@ from collections.abc import (
 )
 from datetime import date, datetime
 from inspect import getfullargspec
-from typing import TYPE_CHECKING, Any, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 import numpy as np
 import pandas as pd
@@ -1744,8 +1744,8 @@ def _add_legend(
             # Only save unique values:
             u, ind = np.unique(lbl, return_index=True)
             ind = np.argsort(ind)
-            lbl = u[ind].tolist()
-            hdl = np.array(hdl)[ind].tolist()
+            lbl = cast(list, u[ind].tolist())
+            hdl = cast(list, np.array(hdl)[ind].tolist())
 
             # Add a subtitle:
             hdl, lbl = _legend_add_subtitle(hdl, lbl, label_from_attrs(huesizeplt.data))

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -724,7 +724,7 @@ class TestDataArray:
 
     def test_setitem(self) -> None:
         # basic indexing should work as numpy's indexing
-        tuples = [
+        tuples: list[tuple[int | list[int] | slice, int | list[int] | slice]] = [
             (0, 0),
             (0, slice(None, None)),
             (slice(None, None), slice(None, None)),
@@ -3608,8 +3608,8 @@ class TestDataArray:
         return_data = array.to_numpy()
         coords_data = np.array(["a", "b"])
         if data == "list" or data is True:
-            return_data = return_data.tolist()
-            coords_data = coords_data.tolist()
+            return_data = return_data.tolist()  # type:ignore[assignment]
+            coords_data = coords_data.tolist()  # type:ignore[assignment]
 
         expected: dict[str, Any] = {
             "name": "foo",

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -1025,11 +1025,11 @@ class TestDatasetView:
         ds = xr.Dataset({"data": data}, attrs={"ds": "attrs"})
         dt = DataTree(ds)
 
-        def func(ds):
+        def func_keep(ds):
             # x.mean() removes the attrs of the data_vars
             return ds.map(lambda x: x.mean(), keep_attrs=True)
 
-        result = xr.map_over_datasets(func, dt)
+        result = xr.map_over_datasets(func_keep, dt)
         expected = dt.mean(keep_attrs=True)
         xr.testing.assert_identical(result, expected)
 

--- a/xarray/tests/test_pandas_to_xarray.py
+++ b/xarray/tests/test_pandas_to_xarray.py
@@ -51,7 +51,7 @@ from pandas import (
     timedelta_range,
 )
 
-indices_dict = {
+indices_dict: dict[str, Index] = {
     "object": Index([f"pandas_{i}" for i in range(10)], dtype=object),
     "string": Index([f"pandas_{i}" for i in range(10)], dtype="str"),
     "datetime": date_range("2020-01-01", periods=10),
@@ -78,7 +78,7 @@ indices_dict = {
         np.arange(10, dtype="complex128") + 1.0j * np.arange(10, dtype="complex128")
     ),
     "categorical": CategoricalIndex(list("abcd") * 2),
-    "interval": IntervalIndex.from_breaks(np.linspace(0, 100, num=11)),
+    "interval": IntervalIndex.from_breaks(np.linspace(0, 100, num=11, dtype="int")),
     "empty": Index([]),
     # "tuples": MultiIndex.from_tuples(zip(["foo", "bar", "baz"], [1, 2, 3])),
     # "mi-with-dt64tz-level": _create_mi_with_dt64tz_level(),


### PR DESCRIPTION
Closes #10231

Some of these look like they might have come from upstream changes. The only one that is maybe concerning is that `np.array.tolist()` is not guaranteed to return a list - for instance if the array is 0D. 

