### PR TITLE
Allow pydap to use `dims` or `dimensions`

### DIFF
--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -131,7 +131,12 @@ class PydapDataStore(AbstractDataStore):
 
     def open_store_variable(self, var):
         data = indexing.LazilyIndexedArray(PydapArrayWrapper(var))
-        return Variable(var.dimensions, data, _fix_attributes(var.attributes))
+        # dimensions was renamed in https://github.com/pydap/pydap/pull/481
+        try:
+            dims = var.dimensions
+        except AttributeError:
+            dims = var.dims
+        return Variable(dims, data, _fix_attributes(var.attributes))
 
     def get_variables(self):
         return FrozenDict(
@@ -142,7 +147,12 @@ class PydapDataStore(AbstractDataStore):
         return Frozen(_fix_attributes(self.ds.attributes))
 
     def get_dimensions(self):
-        return Frozen(self.ds.dimensions)
+        # dimensions was renamed in https://github.com/pydap/pydap/pull/481
+        try:
+            dims = self.ds.dimensions
+        except AttributeError:
+            dims = self.ds.dims
+        return Frozen(dims)
 
 
 class PydapBackendEntrypoint(BackendEntrypoint):


### PR DESCRIPTION
Quick fix for last failing tests on main. I _think_ what's happening is that `dimensions` got renamed upstream in pydap https://github.com/pydap/pydap/pull/481

- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

