### PR TITLE
Extend ``rolling_exp`` to support ``pd.Timedelta`` objects with window ``halflife``

### DIFF
--- a/doc/user-guide/computation.rst
+++ b/doc/user-guide/computation.rst
@@ -324,6 +324,22 @@ The ``rolling_exp`` method takes a ``window_type`` kwarg, which can be ``'alpha'
 ``'com'`` (for ``center-of-mass``), ``'span'``, and ``'halflife'``. The default is
 ``span``.
 
+For datetime axes, ``rolling_exp`` can work with timedelta windows when using ``window_type='halflife'``.
+This enables handling irregular time series by computing weights based on the actual time differences
+between points, similar to pandas' ``ewm`` with ``times`` parameter:
+
+.. code:: python
+
+    # Create a DataArray with datetime index
+    times = pd.date_range("2020-01-01", periods=5, freq="1D")
+    da = xr.DataArray([1, 2, 3, 4, 5], dims="time", coords={"time": times})
+
+    # Apply exponential moving average with 1-day halflife
+    da.rolling_exp(time=pd.Timedelta(days=1), window_type="halflife").mean()
+
+Note that when using timedeltas with ``window_type='halflife'``, only the ``mean()`` operation is currently
+supported, and it must be applied to a datetime coordinate.
+
 Finally, the rolling object has a ``construct`` method which returns a
 view of the original ``DataArray`` with the windowed dimension in
 the last position.

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,6 +27,10 @@ New Features
 - Improved compatibility with OPeNDAP DAP4 data model for backend engine ``pydap``. This
   includes ``datatree`` support, and removing slashes from dimension names. By
   `Miguel Jimenez-Urias <https://github.com/Mikejmnez>`_.
+- Extended ``rolling_exp`` to support ``pd.Timedelta`` objects for the window size when using
+  ``window_type="halflife"`` along datetime dimensions, similar to pandas' ``ewm``. This allows
+  expressions like ``da.rolling_exp(time=pd.Timedelta("1D"), window_type="halflife").mean()``.
+  By `Andrea Biasioli <https://github.com/abiasiol>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

# Description
Extended `rolling_exp` to support `pd.Timedelta` objects for the window size when using `window_type="halflife"` along datetime dimensions, similar to pandas' `ewm`. This allows expressions like `da.rolling_exp(time=pd.Timedelta(days=1), window_type="halflife").mean()`.

# Implementation
- Matches pandas implementation, allowing the operation only when:
  - window is a `pd.Timedelta` object
  - window_type is `"halflife"`
  - dimension is a datetime index
  - operation is `mean`
- Take advantage of numbagg's implementation of `nanmean` which allows `alpha` to be an array
- Ported over `_calculate_deltas` function rather than relying on pandas' private implementation

# Behavior Note
One difference from pandas' behavior: when dealing with nan values and a very short timedelta, this implementation returns nan while pandas appears to carry forward the previous value. This behavior seems more appropriate to me (user can fill it later, if they need to).

Example demonstrating the difference:
```python
times = pd.date_range("2000-01-01", freq="1D", periods=21)
da = DataArray(
    np.random.random((21, 4)),
    dims=("time", "x"),
    coords=dict(time=times),
)
da = da.where(da > 0.2)
da.to_pandas().ewm(halflife=pd.Timedelta(minutes=1), times=da.time.values).mean()
da.rolling_exp(time=pd.Timedelta(minutes=1), window_type="halflife").mean().to_pandas()
```

