### PR TITLE
Fix: Docs generation create temporary files that are not cleaned up.

### DIFF
--- a/doc/internals/time-coding.rst
+++ b/doc/internals/time-coding.rst
@@ -535,3 +535,20 @@ To opt-out of timedelta decoding (see issue `Undesired decoding to timedelta64 <
 .. note::
     Note that in the future the default value of ``decode_timedelta`` will be
     ``False`` rather than ``None``.
+
+
+
+.. ipython:: python
+    :suppress:
+
+    # Cleanup
+    import os
+
+    for f in [
+        "test-datetimes1.nc",
+        "test-datetimes2.nc",
+        "test-timedeltas1.nc",
+        "test-timedeltas2.nc",
+    ]:
+        if os.path.exists(f):
+            os.remove(f)

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -1356,7 +1356,10 @@ To export just the dataset schema without the data itself, use the
     # However, `ds` (rather than the unpickled dataset) refers to the open file.  Delete
     # `ds` to close the file.
     del ds
-    os.remove("saved_on_disk.nc")
+
+    for f in ["saved_on_disk.nc", "saved_on_disk.h5"]:
+        if os.path.exists(f):
+            os.remove(f)
 
 This can be useful for generating indices of dataset contents to expose to
 search indices or other automated data discovery tools.


### PR DESCRIPTION
When building the documentation, a couple of example files are written to disk but never deleted. 

Currently affected:

- `doc/user-guide/io.rst`
    - In line 608 `saved_on_disk.h5` is written to disk but never removed
       (note: .h5 files are not exlcuded by .gitignore)

-  `doc/internals/time-coding.rst`
    -  `test-datetimes1.nc`
    -   `test-datetimes2.nc`
    -   `test-timedeltas1.nc`
    -   `test-timedeltas2.nc`

This PR adds a simple clean up snippet at the end of each affected file / section to get rid of them:

```rst

.. ipython:: python
    :suppress:

    # Cleanup
    import os

    for f in ["i_am_a_tmp_example.nc", "tmp_file.h5"]:
        if os.path.exists(f):
            os.remove(f)

```