### PR TITLE
Remove `test_dask_layers_and_dependencies`

### DIFF
--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1042,6 +1042,12 @@ def test_basic_compute():
             ds.foo.variable.compute()
 
 
+def test_dataset_as_delayed():
+    ds = Dataset({"foo": ("x", range(5)), "bar": ("x", range(5))}).chunk()
+
+    assert dask.delayed(ds).compute() == ds.compute()
+
+
 def make_da():
     da = xr.DataArray(
         np.ones((10, 20)),

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1042,18 +1042,6 @@ def test_basic_compute():
             ds.foo.variable.compute()
 
 
-def test_dask_layers_and_dependencies():
-    ds = Dataset({"foo": ("x", range(5)), "bar": ("x", range(5))}).chunk()
-
-    x = dask.delayed(ds)
-    assert set(x.__dask_graph__().dependencies).issuperset(
-        ds.__dask_graph__().dependencies
-    )
-    assert set(x.foo.__dask_graph__().dependencies).issuperset(
-        ds.__dask_graph__().dependencies
-    )
-
-
 def make_da():
     da = xr.DataArray(
         np.ones((10, 20)),


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes https://github.com/dask/dask/issues/11895
- [x] Partial https://github.com/pydata/xarray/issues/10189

This test is intended to break after https://github.com/dask/dask/pull/11881

## What is this test testing?

This test was implemented as part of https://github.com/pydata/xarray/pull/2603 at a time when HighLevelGraphs were just introduced. The test itself ensures pretty much that if a collection is passed to a Delayed objects, the underlying dask graph is a superset of the graph of the original collection. In different terms, the delayed is only adding additional tasks but is keeping the original graph as is.

## Why is this now different?

One of the changes in https://github.com/dask/dask/pull/11881 is that it now respects optimization of the collection when passed to the delayed function. In earlier dask versions, the collection would've been passed (and be computed) unoptimized, i.e. no culling, no fusion, no slicing, just the raw graph. That is not only inconsistent but it also created many (performance) problems in the past that should now be gone.

Instead of the test on dask internals, I replaced this test with a simple version that checks that we can indeed pass a `Dataset` object to a delayed object and get the expected result.

