### PR TITLE
Fix convert calendar on non-temporal data in datasets

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -71,6 +71,8 @@ Bug fixes
   had no effect. (Mentioned in :issue:`9921`)
 - Enable ``keep_attrs`` in ``DatasetView.map`` relevant for :py:func:`map_over_datasets`  (:pull:`10219`)
   By `Mathias Hauser <https://github.com/mathause>`_.
+- Variables with no temporal dimension are left untouched by :py:meth:`~xarray.Dataset.convert_calendar`. (:issue:`10266`,  :pull:`10268`)
+  By `Pascal Bourgault <https://github.com/aulemahal>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/coding/calendar_ops.py
+++ b/xarray/coding/calendar_ops.py
@@ -213,7 +213,7 @@ def convert_calendar(
         out[dim] = new_times
 
         # Remove NaN that where put on invalid dates in target calendar
-        out = out.where(out[dim].notnull(), drop=True)
+        out = out.sel(time=out[dim].notnull())
 
         if use_cftime:
             # Reassign times to ensure time index of output is a CFTimeIndex


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #10266
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

When calling `convert_calendar` on dataset with non-temporal variable (no  `time` dimension), the `time` dimension was added. This is because the function was using `where(time.notnull(), drop=True)` to drop the time elements of the source that did not map to a valid time in the target calendar. 

Given that  `time` is always 1D and always loaded (no dask), using `sel(time=time.notnull())` fixes the bug, and, in fact, makes more sense to me. (I don't remember why I didn't use that in my first version of the method...)

I added a minimal test that detects the bug raised in the issue.