### PR TITLE
enforced return types of groupby sequence arguments

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -66,6 +66,8 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Ensured tuple return types of ``groupby`` calls with sequences, regardless of ``len==1``.
+  By `Nick Papior <https://github.com/zerothi>`_.
 - :py:meth:`~xarray.Dataset.to_stacked_array` now uses dimensions in order of appearance.
   This fixes the issue where using :py:meth:`~xarray.Dataset.transpose` before :py:meth:`~xarray.Dataset.to_stacked_array`
   had no effect. (Mentioned in :issue:`9921`)

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -3308,6 +3308,33 @@ def test_groupby_dask_eager_load_warnings() -> None:
     ds.groupby_bins("x", bins=[1, 2, 3], eagerly_compute_group=False)
 
 
+def test_groupby_return_group_dataset_type(dataset):
+    # Checks GH10246
+    def group_val(groupers):
+        ret = next(iter(groupers))[0]
+        return ret
+
+    assert isinstance(group_val(dataset.groupby("baz")), str)
+    assert isinstance(group_val(dataset.groupby(["baz"])), tuple)
+    assert isinstance(group_val(dataset.groupby(["baz"]))[0], str)
+
+
+def test_groupby_return_group_dataarray_type(array):
+    # Checks GH10246
+    def group_val(groupers):
+        ret = next(iter(groupers))[0]
+        return ret
+
+    assert isinstance(group_val(array.groupby("x")), str)
+    assert isinstance(group_val(array.groupby(["x"])), tuple)
+    assert isinstance(group_val(array.groupby(["x"]))[0], str)
+
+
+def test_groupby_return_group_type_raise(dataset):
+    with pytest.raises(TypeError, match="xarray variable or dimension"):
+        dataset.groupby_bins(["y"], [0, 1])
+
+
 # TODO: Possible property tests to add to this module
 # 1. lambda x: x
 # 2. grouped-reduce on unique coords is identical to array


### PR DESCRIPTION
By distinguishing between scalar vs. sequence arguments we can now correctly return a scalar/tuple of the corresponding group values that is grouped over.

This makes autonomous usage of `groupby` more predictable.

E.g.

   ().groupby("x")[0] is a scalar

whereas

   ().groupby(["x"])[0] is a tuple of length 1

This meant some slight restructuring in the
core.groupby code, but it should be relatively simple.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #10246 
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`
