### PR TITLE
Add redirect for contributing guide

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -311,6 +311,7 @@ rediraffe_redirects = {
     "why-xarray.rst": "getting-started-guide/why-xarray.rst",
     "installing.rst": "getting-started-guide/installing.rst",
     "quick-overview.rst": "getting-started-guide/quick-overview.rst",
+    "contributing.rst": "contribute/contributing.rst",
 }
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,


### PR DESCRIPTION
- [ ] Closes #10279

This is a follow on to https://github.com/pydata/xarray/pull/8708 which changed the docs organization with a few new subfolders. I overlooked redirecting existing links. Could merge as is, but I could also spend a bit more time next week how to figure out testing for any other broken links in the docs.