### PR TITLE
DOC: Remove reference to `absolufy-imports` from contributing guide

### DIFF
--- a/doc/contribute/contributing.rst
+++ b/doc/contribute/contributing.rst
@@ -549,8 +549,7 @@ Code Formatting
 
 xarray uses several tools to ensure a consistent code format throughout the project:
 
-- `ruff <https://github.com/astral-sh/ruff>`_ for formatting, code quality checks and standardized order in imports
-- `absolufy-imports <https://github.com/MarcoGorelli/absolufy-imports>`_ for absolute instead of relative imports from different files,
+- `ruff <https://github.com/astral-sh/ruff>`_ for formatting, code quality checks and standardized order in imports, and
 - `mypy <https://mypy-lang.org/>`_ for static type checking on `type hints
   <https://docs.python.org/3/library/typing.html>`_.
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes None

#8680 removed absolufy from the codebase, this PR brings the contributing guide up to date.
