### PR TITLE
(fix): remove `PandasExtensionArray` from repr

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -392,7 +392,8 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
     @property
     def _in_memory(self):
         return isinstance(
-            self._data, np.ndarray | np.number | PandasIndexingAdapter
+            self._data,
+            np.ndarray | np.number | PandasIndexingAdapter | PandasExtensionArray,
         ) or (
             isinstance(self._data, indexing.MemoryCachedArray)
             and isinstance(self._data.array, indexing.NumpyIndexingAdapter)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -280,7 +280,7 @@ class AccessibleAsDuckArrayDataStore(backends.InMemoryDataStore):
 
 class TestDataset:
     def test_repr(self) -> None:
-        data = create_test_data(seed=123)
+        data = create_test_data(seed=123, use_extension_array=True)
         data.attrs["foo"] = "bar"
         # need to insert str dtype at runtime to handle different endianness
         expected = dedent(
@@ -297,6 +297,7 @@ class TestDataset:
                 var1     (dim1, dim2) float64 576B -0.9891 -0.3678 1.288 ... -0.2116 0.364
                 var2     (dim1, dim2) float64 576B 0.953 1.52 1.704 ... 0.1347 -0.6423
                 var3     (dim3, dim1) float64 640B 0.4107 0.9941 0.1665 ... 0.716 1.555
+                var4     (dim1) category 64B 'b' 'c' 'b' 'a' 'c' 'a' 'c' 'a'
             Attributes:
                 foo:      bar""".format(
                 data["dim3"].dtype,
@@ -1814,7 +1815,7 @@ class TestDataset:
         actual3 = ds.unstack("index")
         assert actual3["var"].shape == (2, 2)
 
-    def test_categorical_reindex(self) -> None:
+    def test_categorical_index_reindex(self) -> None:
         cat = pd.CategoricalIndex(
             ["foo", "bar", "baz"],
             categories=["foo", "bar", "baz", "qux", "quux", "corge"],


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
Just a small fix since I noticed that `repr(ds)` could include `PandasExtensionArray(array=` as it was not being recognized as in memory, and therefore its own `repr` method was used (via inheritance of `NDArrayMixin`)

Much cleaner now!

- [ ] Closes #xxxx
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
