### PR TITLE
Alignment of n-dimensional indexes with partially excluded dims

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -24,7 +24,11 @@ v2025.05.0 (unreleased)
 
 New Features
 ~~~~~~~~~~~~
-
+- Allow an Xarray index that uses multiple dimensions checking equality with another
+  index for only a subset of those dimensions (i.e., ignoring the dimensions
+  that are excluded from alignment).
+  (:issue:`10243`, :pull:`10293`)
+  By `Benoit Bovy <https://github.com/benbovy>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/coordinate_transform.py
+++ b/xarray/core/coordinate_transform.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from collections.abc import Hashable, Iterable, Mapping
-from typing import Any
+from typing import Any, overload
 
 import numpy as np
 
@@ -64,8 +66,30 @@ class CoordinateTransform:
         """
         raise NotImplementedError
 
-    def equals(self, other: "CoordinateTransform") -> bool:
-        """Check equality with another CoordinateTransform of the same kind."""
+    @overload
+    def equals(self, other: CoordinateTransform) -> bool: ...
+
+    @overload
+    def equals(
+        self, other: CoordinateTransform, *, exclude: frozenset[Hashable] | None = None
+    ) -> bool: ...
+
+    def equals(self, other: CoordinateTransform, **kwargs) -> bool:
+        """Check equality with another CoordinateTransform of the same kind.
+
+        Parameters
+        ----------
+        other : CoordinateTransform
+            The other Index object to compare with this object.
+        exclude : frozenset of hashable, optional
+            Dimensions excluded from checking. It is None by default, (i.e.,
+            when this method is not called in the context of alignment). For a
+            n-dimensional transform this option allows a CoordinateTransform to
+            optionally ignore any dimension in ``exclude`` when comparing
+            ``self`` with ``other``. For a 1-dimensional transform this kwarg
+            can be safely ignored, as this method is not called when all of the
+            transform's dimensions are also excluded from alignment.
+        """
         raise NotImplementedError
 
     def generate_coords(

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -367,14 +367,13 @@ class Index:
         other : Index
             The other Index object to compare with this object.
         exclude_dims : frozenset of hashable, optional
-            All the dimensions that are excluded from alignment, or None by default
+            Dimensions excluded from checking. It is None by default,
             (i.e., when this method is not called in the context of alignment).
-            For a n-dimensional index it allows ignoring any relevant dimension found
-            in ``exclude_dims`` when comparing this index with the other index.
-            For a 1-dimensional index it can be always safely ignored as this
-            method is not called when all of the index's dimensions are also excluded
-            from alignment
-            (note: the index's dimensions correspond to the union of the dimensions
+            For a n-dimensional index this option allows an Index to optionally, 
+            ignore any dimension in ``exclude_dims`` when comparing 
+            ``self`` with ``other``. For a 1-dimensional index this kwarg can be safely ignored ,
+            as this method is not called when all of the index's dimensions are also excluded
+            from alignment (note: the index's dimensions correspond to the union of the dimensions
             of all coordinate variables associated with this index).
 
         Returns

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -369,8 +369,8 @@ class Index:
         exclude_dims : frozenset of hashable, optional
             Dimensions excluded from checking. It is None by default,
             (i.e., when this method is not called in the context of alignment).
-            For a n-dimensional index this option allows an Index to optionally, 
-            ignore any dimension in ``exclude_dims`` when comparing 
+            For a n-dimensional index this option allows an Index to optionally,
+            ignore any dimension in ``exclude_dims`` when comparing
             ``self`` with ``other``. For a 1-dimensional index this kwarg can be safely ignored ,
             as this method is not called when all of the index's dimensions are also excluded
             from alignment (note: the index's dimensions correspond to the union of the dimensions

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -354,7 +354,7 @@ class Index:
 
     @overload
     def equals(
-        self, other: Index, *, exclude_dims: frozenset[Hashable] | None = None
+        self, other: Index, *, exclude: frozenset[Hashable] | None = None
     ) -> bool: ...
 
     def equals(self, other: Index, **kwargs) -> bool:
@@ -366,20 +366,22 @@ class Index:
         ----------
         other : Index
             The other Index object to compare with this object.
-        exclude_dims : frozenset of hashable, optional
-            Dimensions excluded from checking. It is None by default,
-            (i.e., when this method is not called in the context of alignment).
-            For a n-dimensional index this option allows an Index to optionally,
-            ignore any dimension in ``exclude_dims`` when comparing
-            ``self`` with ``other``. For a 1-dimensional index this kwarg can be safely ignored ,
-            as this method is not called when all of the index's dimensions are also excluded
-            from alignment (note: the index's dimensions correspond to the union of the dimensions
-            of all coordinate variables associated with this index).
+        exclude : frozenset of hashable, optional
+            Dimensions excluded from checking. It is None by default, (i.e.,
+            when this method is not called in the context of alignment). For a
+            n-dimensional index this option allows an Index to optionally ignore
+            any dimension in ``exclude`` when comparing ``self`` with ``other``.
+            For a 1-dimensional index this kwarg can be safely ignored, as this
+            method is not called when all of the index's dimensions are also
+            excluded from alignment (note: the index's dimensions correspond to
+            the union of the dimensions of all coordinate variables associated
+            with this index).
 
         Returns
         -------
         is_equal : bool
             ``True`` if the indexes are equal, ``False`` otherwise.
+
         """
         raise NotImplementedError()
 
@@ -881,7 +883,7 @@ class PandasIndex(Index):
 
         return IndexSelResult({self.dim: indexer})
 
-    def equals(self, other: Index, *, exclude_dims: frozenset[Hashable] | None = None):
+    def equals(self, other: Index, *, exclude: frozenset[Hashable] | None = None):
         if not isinstance(other, PandasIndex):
             return False
         return self.index.equals(other.index) and self.dim == other.dim
@@ -1561,7 +1563,7 @@ class CoordinateTransformIndex(Index):
         return IndexSelResult(results)
 
     def equals(
-        self, other: Index, *, exclude_dims: frozenset[Hashable] | None = None
+        self, other: Index, *, exclude: frozenset[Hashable] | None = None
     ) -> bool:
         if not isinstance(other, CoordinateTransformIndex):
             return False
@@ -1957,18 +1959,18 @@ def _wrap_index_equals(
         emit_user_level_warning(
             f"the signature ``{index_cls_name}.equals(self, other)`` is deprecated. "
             f"Please update it to "
-            f"``{index_cls_name}.equals(self, other, *, exclude_dims=None)`` "
+            f"``{index_cls_name}.equals(self, other, *, exclude=None)`` "
             "or kindly ask the maintainers of ``{index_cls_name}`` to do it. "
             "See documentation of xarray.Index.equals() for more info.",
             FutureWarning,
         )
-        exclude_dims_kwarg = False
+        exclude_kwarg = False
     else:
-        exclude_dims_kwarg = True
+        exclude_kwarg = True
 
-    def equals_wrapper(other: Index, exclude_dims: frozenset[Hashable]) -> bool:
-        if exclude_dims_kwarg:
-            return index.equals(other, exclude_dims=exclude_dims)
+    def equals_wrapper(other: Index, exclude: frozenset[Hashable]) -> bool:
+        if exclude_kwarg:
+            return index.equals(other, exclude=exclude)
         else:
             return index.equals(other)
 

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -1567,7 +1567,7 @@ class CoordinateTransformIndex(Index):
     ) -> bool:
         if not isinstance(other, CoordinateTransformIndex):
             return False
-        return self.transform.equals(other.transform)
+        return self.transform.equals(other.transform, exclude=exclude)
 
     def rename(
         self,

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -1958,7 +1958,7 @@ def _wrap_index_equals(
             f"the signature ``{index_cls_name}.equals(self, other)`` is deprecated. "
             f"Please update it to "
             f"``{index_cls_name}.equals(self, other, *, exclude_dims=None)`` "
-            "or kindly ask the maintainers doing it. "
+            "or kindly ask the maintainers of ``{index_cls_name}`` to do it. "
             "See documentation of xarray.Index.equals() for more info.",
             FutureWarning,
         )

--- a/xarray/indexes/range_index.py
+++ b/xarray/indexes/range_index.py
@@ -65,7 +65,9 @@ class RangeCoordinateTransform(CoordinateTransform):
         positions = (labels - self.start) / self.step
         return {self.dim: positions}
 
-    def equals(self, other: CoordinateTransform) -> bool:
+    def equals(
+        self, other: CoordinateTransform, exclude: frozenset[Hashable] | None = None
+    ) -> bool:
         if not isinstance(other, RangeCoordinateTransform):
             return False
 

--- a/xarray/tests/test_coordinate_transform.py
+++ b/xarray/tests/test_coordinate_transform.py
@@ -32,7 +32,9 @@ class SimpleCoordinateTransform(CoordinateTransform):
     def reverse(self, coord_labels: dict[Hashable, Any]) -> dict[str, Any]:
         return {dim: coord_labels[dim] / self.scale for dim in self.xy_dims}
 
-    def equals(self, other: "CoordinateTransform") -> bool:
+    def equals(
+        self, other: CoordinateTransform, exclude: frozenset[Hashable] | None = None
+    ) -> bool:
         if not isinstance(other, SimpleCoordinateTransform):
             return False
         return self.scale == other.scale

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2675,9 +2675,10 @@ class TestDataset:
             .set_xindex(["x", "y"], XYIndex)
         )
 
-        actual = xr.align(ds1, ds2, join="exact", exclude="y")
-        assert_identical(actual[0], ds1, check_default_indexes=False)
-        assert_identical(actual[1], ds2, check_default_indexes=False)
+        for join in ("outer", "exact"):
+            actual = xr.align(ds1, ds2, join=join, exclude="y")
+            assert_identical(actual[0], ds1, check_default_indexes=False)
+            assert_identical(actual[1], ds2, check_default_indexes=False)
 
         with pytest.raises(
             AlignmentError, match="cannot align objects.*index.*not equal"

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2627,7 +2627,7 @@ class TestDataset:
                 var = next(iter(variables.values()))
                 return cls(int(var.values))
 
-            def equals(self, other, *, exclude_dims=None):
+            def equals(self, other, *, exclude=None):
                 return isinstance(other, ScalarIndex) and other.value == self.value
 
         ds1 = Dataset(coords={"x": 0}).set_xindex("x", ScalarIndex)
@@ -2659,9 +2659,9 @@ class TestDataset:
                     ),
                 )
 
-            def equals(self, other, exclude_dims=None):
-                x_eq = True if self.x.dim in exclude_dims else self.x.equals(other.x)
-                y_eq = True if self.y.dim in exclude_dims else self.y.equals(other.y)
+            def equals(self, other, exclude=None):
+                x_eq = True if self.x.dim in exclude else self.x.equals(other.x)
+                y_eq = True if self.y.dim in exclude else self.y.equals(other.y)
                 return x_eq and y_eq
 
         ds1 = (
@@ -2691,7 +2691,7 @@ class TestDataset:
         # TODO: remove this test once the deprecation cycle is completed
         class DeprecatedEqualsSignatureIndex(PandasIndex):
             def equals(self, other: Index) -> bool:  # type: ignore[override]
-                return super().equals(other, exclude_dims=None)
+                return super().equals(other, exclude=None)
 
         ds = (
             Dataset(coords={"x": [1, 2]})

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2615,6 +2615,93 @@ class TestDataset:
         assert ds.x.attrs == {"units": "m"}
         assert ds_noattr.x.attrs == {}
 
+    def test_align_scalar_index(self) -> None:
+        # ensure that indexes associated with scalar coordinates are not ignored
+        # during alignment
+        class ScalarIndex(Index):
+            def __init__(self, value: int):
+                self.value = value
+
+            @classmethod
+            def from_variables(cls, variables, *, options):
+                var = next(iter(variables.values()))
+                return cls(int(var.values))
+
+            def equals(self, other, *, exclude_dims=None):
+                return isinstance(other, ScalarIndex) and other.value == self.value
+
+        ds1 = Dataset(coords={"x": 0}).set_xindex("x", ScalarIndex)
+        ds2 = Dataset(coords={"x": 0}).set_xindex("x", ScalarIndex)
+
+        actual = xr.align(ds1, ds2, join="exact")
+        assert_identical(actual[0], ds1, check_default_indexes=False)
+        assert_identical(actual[1], ds2, check_default_indexes=False)
+
+        ds3 = Dataset(coords={"x": 1}).set_xindex("x", ScalarIndex)
+
+        with pytest.raises(AlignmentError, match="cannot align objects"):
+            xr.align(ds1, ds3, join="exact")
+
+    def test_align_multi_dim_index_exclude_dims(self) -> None:
+        class XYIndex(Index):
+            def __init__(self, x: PandasIndex, y: PandasIndex):
+                self.x: PandasIndex = x
+                self.y: PandasIndex = y
+
+            @classmethod
+            def from_variables(cls, variables, *, options):
+                return cls(
+                    x=PandasIndex.from_variables(
+                        {"x": variables["x"]}, options=options
+                    ),
+                    y=PandasIndex.from_variables(
+                        {"y": variables["y"]}, options=options
+                    ),
+                )
+
+            def equals(self, other, exclude_dims=None):
+                x_eq = True if self.x.dim in exclude_dims else self.x.equals(other.x)
+                y_eq = True if self.y.dim in exclude_dims else self.y.equals(other.y)
+                return x_eq and y_eq
+
+        ds1 = (
+            Dataset(coords={"x": [1, 2], "y": [3, 4]})
+            .drop_indexes(["x", "y"])
+            .set_xindex(["x", "y"], XYIndex)
+        )
+        ds2 = (
+            Dataset(coords={"x": [1, 2], "y": [5, 6]})
+            .drop_indexes(["x", "y"])
+            .set_xindex(["x", "y"], XYIndex)
+        )
+
+        actual = xr.align(ds1, ds2, join="exact", exclude="y")
+        assert_identical(actual[0], ds1, check_default_indexes=False)
+        assert_identical(actual[1], ds2, check_default_indexes=False)
+
+        with pytest.raises(
+            AlignmentError, match="cannot align objects.*index.*not equal"
+        ):
+            xr.align(ds1, ds2, join="exact")
+
+        with pytest.raises(AlignmentError, match="cannot exclude dimension"):
+            xr.align(ds1, ds2, join="outer", exclude="y")
+
+    def test_align_index_equals_future_warning(self) -> None:
+        # TODO: remove this test once the deprecation cycle is completed
+        class DeprecatedEqualsSignatureIndex(PandasIndex):
+            def equals(self, other: Index) -> bool:  # type: ignore[override]
+                return super().equals(other, exclude_dims=None)
+
+        ds = (
+            Dataset(coords={"x": [1, 2]})
+            .drop_indexes("x")
+            .set_xindex("x", DeprecatedEqualsSignatureIndex)
+        )
+
+        with pytest.warns(FutureWarning, match="signature.*deprecated"):
+            xr.align(ds, ds.copy(), join="exact")
+
     def test_broadcast(self) -> None:
         ds = Dataset(
             {"foo": 0, "bar": ("x", [1]), "baz": ("y", [2, 3])}, {"c": ("x", [4])}

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2685,7 +2685,7 @@ class TestDataset:
             xr.align(ds1, ds2, join="exact")
 
         with pytest.raises(AlignmentError, match="cannot exclude dimension"):
-            xr.align(ds1, ds2, join="outer", exclude="y")
+            xr.align(ds1, ds2, join="override", exclude="y")
 
     def test_align_index_equals_future_warning(self) -> None:
         # TODO: remove this test once the deprecation cycle is completed


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #10243
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Support checking exact alignment of indexes that use multiple dimensions in the cases where some of those dimensions are included in alignment while others are excluded.

Add the `exclude_dims` keyword argument to `Index.equals()` (still support old signature with `FutureWarning`).

Also fixed a bug: indexes associated with scalar coordinates were ignored during alignment.

TODO:

- [x] add `exclude_dims` kwarg to `CoordinateTransform.equals()` as well
- [x] copy or assign the index of each original object in the new aligned objects instead of assigning the aligned index (when copying this may have an impact on performance).
