### PR TITLE
Fix BinGrouper when labels is not specified

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,7 +36,8 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
-
+- Fix :py:class:`~xarray.groupers.BinGrouper` when ``labels`` is not specified (:issue:`10284`).
+  By `Deepak Cherian <https://github.com/dcherian>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/groupers.py
+++ b/xarray/groupers.py
@@ -413,7 +413,7 @@ class BinGrouper(Grouper):
         # This seems silly, but it lets us have Pandas handle the complexity
         # of `labels`, `precision`, and `include_lowest`, even when group is a chunked array
         # Pandas ignores labels when IntervalIndex is passed
-        if not isinstance(self.bins, pd.IntervalIndex):
+        if self.labels is None or not isinstance(self.bins, pd.IntervalIndex):
             dummy, _ = self._cut(np.array([0]).astype(group.dtype))
             full_index = dummy.categories
         else:


### PR DESCRIPTION
- [x] Closes #10284
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
