### PR TITLE
Add IntervalIndex

### DIFF
--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -612,9 +612,6 @@ def get_indexer_nd(index: pd.Index, labels, method=None, tolerance=None) -> np.n
     return indexer
 
 
-T_PandasIndex = TypeVar("T_PandasIndex", bound="PandasIndex")
-
-
 class PandasIndex(Index):
     """Wrap a pandas.Index as an xarray compatible index."""
 
@@ -912,9 +909,7 @@ class PandasIndex(Index):
         new_dim = dims_dict.get(self.dim, self.dim)
         return self._replace(index, dim=new_dim)
 
-    def _copy(
-        self: T_PandasIndex, deep: bool = True, memo: dict[int, Any] | None = None
-    ) -> T_PandasIndex:
+    def _copy(self, deep: bool = True, memo: dict[int, Any] | None = None) -> Self:
         if deep:
             # pandas is not using the memo
             index = self.index.copy(deep=True)

--- a/xarray/indexes/__init__.py
+++ b/xarray/indexes/__init__.py
@@ -8,6 +8,7 @@ from xarray.core.indexes import (
     PandasIndex,
     PandasMultiIndex,
 )
+from xarray.indexes.interval_index import IntervalIndex
 from xarray.indexes.range_index import RangeIndex
 
-__all__ = ["Index", "PandasIndex", "PandasMultiIndex", "RangeIndex"]
+__all__ = ["Index", "IntervalIndex", "PandasIndex", "PandasMultiIndex", "RangeIndex"]

--- a/xarray/indexes/interval_index.py
+++ b/xarray/indexes/interval_index.py
@@ -1,0 +1,112 @@
+from collections.abc import Hashable
+
+import numpy as np
+import pandas as pd
+
+from xarray import Variable
+from xarray.core.indexes import Index, PandasIndex
+
+
+class IntervalIndex(Index):
+    def __init__(self, index: PandasIndex, bounds_name: Hashable, bounds_dim: str):
+        assert isinstance(index.index, pd.IntervalIndex)
+        self._index = index
+        self._bounds_name = bounds_name
+        self._bounds_dim = bounds_dim
+
+    @classmethod
+    def from_variables(cls, variables, options):
+        assert len(variables) == 2
+
+        for k, v in variables.items():
+            if v.ndim == 2:
+                bounds_name, bounds = k, v
+            elif v.ndim == 1:
+                dim, _ = k, v
+
+        bounds = bounds.transpose(..., dim)
+        left, right = bounds.data.tolist()
+        index = PandasIndex(pd.IntervalIndex.from_arrays(left, right), dim)
+        bounds_dim = (set(bounds.dims) - set(dim)).pop()
+
+        return cls(index, bounds_name, bounds_dim)
+
+    @classmethod
+    def concat(cls, indexes, dim, positions=None):
+        new_index = PandasIndex.concat(
+            [idx._index for idx in indexes], dim, positions=positions
+        )
+
+        if indexes:
+            bounds_name = indexes[0]._bounds_name
+            bounds_dim = indexes[0]._bounds_dim
+            if any(
+                idx._bounds_name != bounds_name or idx._bounds_dim != bounds_dim
+                for idx in indexes
+            ):
+                raise ValueError(
+                    f"Cannot concatenate along dimension {dim!r} indexes with different "
+                    "boundary coordinate or dimension names"
+                )
+        else:
+            bounds_name = new_index.index.name + "_bounds"
+            bounds_dim = "bnd"
+
+        return cls(new_index, bounds_name, bounds_dim)
+
+    def create_variables(self, variables=None):
+        empty_var = Variable((), 0)
+        bounds_attrs = variables.get(self._bounds_name, empty_var).attrs
+        mid_attrs = variables.get(self._index.dim, empty_var).attrs
+
+        bounds_var = Variable(
+            dims=(self._bounds_dim, self._index.dim),
+            data=np.stack([self._index.index.left, self._index.index.right], axis=0),
+            attrs=bounds_attrs,
+        )
+        mid_var = Variable(
+            dims=(self._index.dim,),
+            data=self._index.index.mid,
+            attrs=mid_attrs,
+        )
+
+        return {self._index.dim: mid_var, self._bounds_name: bounds_var}
+
+    def should_add_coord_to_array(self, name, var, dims):
+        # add both the mid and boundary coordinates if the index dimension
+        # is present in the array dimensions
+        if self._index.dim in dims:
+            return True
+        else:
+            return False
+
+    def equals(self, other):
+        if not isinstance(other, IntervalIndex):
+            return False
+        return self._index.equals(other._index, exclude_dims=frozenset())
+
+    def sel(self, labels, **kwargs):
+        return self._index.sel(labels, **kwargs)
+
+    def isel(self, indexers):
+        new_index = self._index.isel(indexers)
+        if new_index is not None:
+            return type(self)(new_index, self._bounds_name, self._bounds_dim)
+        else:
+            return None
+
+    def roll(self, shifts):
+        new_index = self._index.roll(shifts)
+        return type(self)(new_index, self._bounds_name, self._bounds_dim)
+
+    def rename(self, name_dict, dims_dict):
+        new_index = self._index.rename(name_dict, dims_dict)
+
+        bounds_name = name_dict.get(self._bounds_name, self._bounds_name)
+        bounds_dim = dims_dict.get(self._bounds_dim, self._bounds_dim)
+
+        return type(self)(new_index, bounds_name, bounds_dim)
+
+    def __repr__(self):
+        string = f"{self._index!r}"
+        return string

--- a/xarray/indexes/interval_index.py
+++ b/xarray/indexes/interval_index.py
@@ -8,6 +8,22 @@ from xarray.core.indexes import Index, PandasIndex
 
 
 class IntervalIndex(Index):
+    """Xarray index of 1-dimensional intervals.
+
+    This index is built on top of :py:class:`~xarray.indexes.PandasIndex` and
+    wraps a :py:class:`pandas.IntervalIndex`. It is associated with two
+    coordinate variables:
+
+    - a 1-dimensional coordinate where each label represents an interval that is
+      materialized by its midpoint (i.e., the average of its left and right
+      boundaries)
+
+    - a 2-dimensional coordinate that represents the left and right boundaries
+      of each interval. One of the two dimensions is shared with the
+      aforementioned coordinate and the other one has length 2.
+
+    """
+
     def __init__(self, index: PandasIndex, bounds_name: Hashable, bounds_dim: str):
         assert isinstance(index.index, pd.IntervalIndex)
         self._index = index


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #8005
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

The `IntervalIndex` added here works with two coordinates, one for the midpoints (1D) and the other one for the left-right boundaries (2D), similarly to the CF conventions. Both coordinates are propagated in DataArrays thanks to #10137.

A few TODOs / thoughts:

- Besides `.set_xindex(["x", "x_bounds"], IntervalIndex)` we could also support the single coordinate case `.set_xindex("x", IntervalIndex)` where the "x" original variable is either:
  - already wrapping a `pd.IntervalIndex` -> simply reuse the latter
  - any other arbitrary 1D coordinate -> infer bounds similarly to [cf_xarray's add_bounds](https://cf-xarray.readthedocs.io/en/latest/generated/xarray.Dataset.cf.add_bounds.html#xarray.Dataset.cf.add_bounds)

- A quicker way to wrap a `pd.IntervalIndex` would be useful to have too, e.g.,

```python
>>> xidx = IntervalIndex.from_index(pd.IntervalIndex(...), dim="x", bounds_dim="bnd")
>>> ds = xr.Dataset(coords=xr.Coordinates.from_xindex(xidx))
>>> ds
<xarray.Dataset>
Dimensions:      (x: 10, bnd: 2)
Coordinates:
  * x            (x) float64
  * x_bnd        (x, bnd) float64 
Data variables:
  *empty*
```  

- Conversely, perhaps it would be nice to have some convenient API that converts an IntervalIndex and its two coordinates into a basic PandasIndex and its unique coordinate? I.e., something equivalent to `.drop_indexes(["x", "x_bounds"]).drop_vars("x_bounds").set_xindex("x")`, assuming that the "x" coordinate data still wraps the `pd.IntervalIndex` after dropping the Xarray IntervalIndex.

- [ ] (TODO): wrap IntervalIndex coordinate data with `PandasIndexingAdapter` so we avoid duplicating data (also for the bounds coordinate via a dedicated adapter subclass).

- [ ] (TODO): implement `IntervalIndex.join()` and `IntervalIndex.reindex_like()`

- I tested `xr.concat()` with IntervalIndex and it is working but requires #10293

- By default for `pd.IntervalIndex` the intervals are closed on the right-side. From my understanding of CF conventions ([section 7.1.1](https://cfconventions.org/cf-conventions/cf-conventions.html#bounds-one-d)) it seems that the intervals should be closed on either the left of the right side, although none of these two is clearly stated. Should we stick with pandas' defaults then?

- I've not seen either in the CF conventions any specific statement on where exactly the cell coordinate labels should be located within each interval. Is it common to have locations different than midpoints? If it is the case, we could introduce an index build option to keep the original cell coordinate labels instead of relying on `pd.IntervalIndex.mid`.