### PR TITLE
Set `.conjugate` as alias of `.conj`, #10302

### DIFF
--- a/xarray/computation/ops.py
+++ b/xarray/computation/ops.py
@@ -283,7 +283,7 @@ def inplace_to_noninplace_op(f):
 # _typed_ops.py uses the following wrapped functions as a kind of unary operator
 argsort = _method_wrapper("argsort")
 conj = _method_wrapper("conj")
-conjugate = _method_wrapper("conjugate")
+conjugate = _method_wrapper("conj")
 round_ = _func_slash_method_wrapper(duck_array_ops.around, name="round")
 
 

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1822,3 +1822,15 @@ def test_idxmin_chunking():
     actual = da.idxmin("time")
     assert actual.chunksizes == {k: da.chunksizes[k] for k in ["x", "y"]}
     assert_identical(actual, da.compute().idxmin("time"))
+
+
+def test_conjugate():
+    # Test for https://github.com/pydata/xarray/issues/10302
+    z = 1j * da.arange(100)
+
+    data = xr.DataArray(z, coords={"x": np.arange(100)})
+
+    conj_data = data.conjugate()
+    assert dask.is_dask_collection(conj_data)
+
+    assert_equal(conj_data, data.conj())


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes https://github.com/pydata/xarray/issues/10302
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
