### PR TITLE
(fix): no `fill_value` on reindex

### DIFF
--- a/properties/test_pandas_roundtrip.py
+++ b/properties/test_pandas_roundtrip.py
@@ -134,10 +134,18 @@ def test_roundtrip_pandas_dataframe_datetime(df) -> None:
     xr.testing.assert_identical(dataset, roundtripped.to_xarray())
 
 
-def test_roundtrip_1d_pandas_extension_array() -> None:
-    df = pd.DataFrame({"cat": pd.Categorical(["a", "b", "c"])})
-    arr = xr.Dataset.from_dataframe(df)["cat"]
+@pytest.mark.parametrize(
+    "extension_Array",
+    [
+        pd.Categorical(["a", "b", "c"]),
+        pd.array([1, 2, 3], dtype="int64"),
+        pd.array(["a", "b", "c"], dtype="string"),
+    ],
+)
+def test_roundtrip_1d_pandas_extension_array(extension_Array) -> None:
+    df = pd.DataFrame({"arr": extension_Array})
+    arr = xr.Dataset.from_dataframe(df)["arr"]
     roundtripped = arr.to_pandas()
-    assert (df["cat"] == roundtripped).all()
-    assert df["cat"].dtype == roundtripped.dtype
+    assert (df["arr"] == roundtripped).all()
+    assert df["arr"].dtype == roundtripped.dtype
     xr.testing.assert_identical(arr, roundtripped.to_xarray())

--- a/xarray/core/dtypes.py
+++ b/xarray/core/dtypes.py
@@ -4,6 +4,7 @@ import functools
 from typing import Any
 
 import numpy as np
+import pandas as pd
 from pandas.api.types import is_extension_array_dtype
 
 from xarray.compat import array_api_compat, npcompat
@@ -63,7 +64,9 @@ def maybe_promote(dtype: np.dtype) -> tuple[np.dtype, Any]:
     # N.B. these casting rules should match pandas
     dtype_: np.typing.DTypeLike
     fill_value: Any
-    if HAS_STRING_DTYPE and np.issubdtype(dtype, np.dtypes.StringDType()):
+    if pd.api.types.is_extension_array_dtype(dtype):
+        return dtype, pd.NA
+    elif HAS_STRING_DTYPE and np.issubdtype(dtype, np.dtypes.StringDType()):
         # for now, we always promote string dtypes to object for consistency with existing behavior
         # TODO: refactor this once we have a better way to handle numpy vlen-string dtypes
         dtype_ = object

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -363,6 +363,16 @@ def create_test_data(
                 )
             ),
         )
+        obj["var5"] = (
+            "dim1",
+            pd.array(
+                rs.integers(1, 10, size=dim_sizes[0]).tolist(), dtype=pd.Int64Dtype()
+            ),
+        )
+        obj["var6"] = (
+            "dim1",
+            pd.array(list(string.ascii_lowercase[: dim_sizes[0]]), dtype="string"),
+        )
     if dim_sizes == _DEFAULT_TEST_DIM_SIZES:
         numbers_values = np.array([0, 1, 2, 0, 0, 1, 1, 2, 2, 3], dtype="int64")
     else:

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -154,19 +154,20 @@ def test_concat_missing_var() -> None:
     assert_identical(actual, expected)
 
 
-def test_concat_categorical() -> None:
+def test_concat_extension_array() -> None:
     data1 = create_test_data(use_extension_array=True)
     data2 = create_test_data(use_extension_array=True)
     concatenated = concat([data1, data2], dim="dim1")
-    assert (
-        concatenated["var4"]
-        == type(data2["var4"].variable.data)._concat_same_type(
-            [
-                data1["var4"].variable.data,
-                data2["var4"].variable.data,
-            ]
-        )
-    ).all()
+    for var in ["var4", "var5"]:
+        assert (
+            concatenated[var]
+            == type(data2[var].variable.data)._concat_same_type(
+                [
+                    data1[var].variable.data,
+                    data2[var].variable.data,
+                ]
+            )
+        ).all()
 
 
 def test_concat_missing_multiple_consecutive_var() -> None:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
I also added more extension array types although these "always" passed in so far as the only change to the `xarray` codebase handles pandas extension array dtypes now explicitly with fill values, producing `pd.NA`

- [ ] Closes #10301
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
