### PR TITLE
fix roundtripping zero-size timedelta arrays

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -44,11 +44,11 @@ Bug fixes
   By `Deepak Cherian <https://github.com/dcherian>`_.
 - Allow accessing arbitrary attributes on Pandas ExtensionArrays.
   By `Deepak Cherian <https://github.com/dcherian>`_.
-- Fix coding empty (zero-size) timedelta64 arrays, ``units`` taking precedence when encoding, 
+- Fix coding empty (zero-size) timedelta64 arrays, ``units`` taking precedence when encoding,
   fallback to default values when decoding (:issue:`10310`, :pull:`10313`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
-- Use dtype from intermediate sum instead of source dtype or "int" for casting of count when 
-  calculating mean in rolling for correct operations (preserve float dtypes, 
+- Use dtype from intermediate sum instead of source dtype or "int" for casting of count when
+  calculating mean in rolling for correct operations (preserve float dtypes,
   correct mean of bool arrays) (:issue:`10340`, :pull:`10341`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,9 +38,10 @@ Bug fixes
 ~~~~~~~~~
 - Fix :py:class:`~xarray.groupers.BinGrouper` when ``labels`` is not specified (:issue:`10284`).
   By `Deepak Cherian <https://github.com/dcherian>`_.
-
 - Allow accessing arbitrary attributes on Pandas ExtensionArrays.
   By `Deepak Cherian <https://github.com/dcherian>`_.
+- Fix coding empty (zero-size) timedelta64 arrays, ``units`` taking precedence when encoding, fallback to default values when decoding.
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 
 Documentation

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -659,9 +659,12 @@ def decode_cf_timedelta(
     num_timedeltas = to_numpy(num_timedeltas)
     unit = _netcdf_to_numpy_timeunit(units)
 
+    # special case empty arrays
+    is_empty_array = num_timedeltas.size == 0
+
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", "All-NaN slice encountered", RuntimeWarning)
-        if num_timedeltas.size > 0:
+        if not is_empty_array:
             _check_timedelta_range(np.nanmin(num_timedeltas), unit, time_unit)
             _check_timedelta_range(np.nanmax(num_timedeltas), unit, time_unit)
 
@@ -670,14 +673,13 @@ def decode_cf_timedelta(
     )
     pd_timedeltas = pd.to_timedelta(ravel(timedeltas))
 
-    if timedeltas.size > 0 and np.isnat(timedeltas).all():
+    if not is_empty_array and np.isnat(timedeltas).all():
         empirical_unit = time_unit
     else:
         empirical_unit = pd_timedeltas.unit
 
-    if (
-        np.timedelta64(1, time_unit) > np.timedelta64(1, empirical_unit)
-        or timedeltas.size == 0
+    if is_empty_array or np.timedelta64(1, time_unit) > np.timedelta64(
+        1, empirical_unit
     ):
         time_unit = empirical_unit
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #10310
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
