### PR TITLE
Avoid copying vectorized indexes

### DIFF
--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -39,16 +39,23 @@ outer_assignment_values = {
     "2d-1scalar": xr.DataArray(randn(100, frac_nan=0.1), dims=["x"]),
 }
 
+n_index = 400000
 vectorized_indexes = {
-    "1-1d": {"x": xr.DataArray(randint(0, nx, 400), dims="a")},
+    "1-1d": {"x": xr.DataArray(randint(0, nx, n_index), dims="a")},
     "2-1d": {
-        "x": xr.DataArray(randint(0, nx, 400), dims="a"),
-        "y": xr.DataArray(randint(0, ny, 400), dims="a"),
+        "x": xr.DataArray(randint(0, nx, n_index), dims="a"),
+        "y": xr.DataArray(randint(0, ny, n_index), dims="a"),
     },
     "3-2d": {
-        "x": xr.DataArray(randint(0, nx, 400).reshape(4, 100), dims=["a", "b"]),
-        "y": xr.DataArray(randint(0, ny, 400).reshape(4, 100), dims=["a", "b"]),
-        "t": xr.DataArray(randint(0, nt, 400).reshape(4, 100), dims=["a", "b"]),
+        "x": xr.DataArray(
+            randint(0, nx, n_index).reshape(n_index // 100, 100), dims=["a", "b"]
+        ),
+        "y": xr.DataArray(
+            randint(0, ny, n_index).reshape(n_index // 100, 100), dims=["a", "b"]
+        ),
+        "t": xr.DataArray(
+            randint(0, nt, n_index).reshape(n_index // 100, 100), dims=["a", "b"]
+        ),
     },
 }
 

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -28,20 +28,11 @@ basic_assignment_values = {
 }
 
 
-def make_outer_indexes(n_index):
-    return {
-        "1d": {"x": randint(0, nx, n_index)},
-        "2d": {"x": randint(0, nx, n_index), "y": randint(0, ny, n_index)},
-        "2d-1scalar": {
-            "x": randint(0, nx, n_index),
-            "y": 1,
-            "t": randint(0, nt, n_index),
-        },
-    }
-
-
-outer_indexes = make_outer_indexes(400)
-big_outer_indexes = make_outer_indexes(400_000)
+outer_indexes = {
+    "1d": {"x": randint(0, nx, 400)},
+    "2d": {"x": randint(0, nx, 500), "y": randint(0, ny, 400)},
+    "2d-1scalar": {"x": randint(0, nx, 100), "y": 1, "t": randint(0, nt, 400)},
+}
 
 outer_assignment_values = {
     "1d": xr.DataArray(randn((400, ny), frac_nan=0.1), dims=["x", "y"]),
@@ -130,12 +121,12 @@ class IndexingOnly(Base):
     def time_indexing_basic(self, key):
         self.ds.isel(**basic_indexes[key])
 
-    @parameterized(["key"], [list(big_outer_indexes.keys())])
+    @parameterized(["key"], [list(outer_indexes.keys())])
     def time_indexing_outer(self, key):
-        self.ds.isel(**big_outer_indexes[key])
+        self.ds.isel(**outer_indexes[key])
 
     @parameterized(["key"], [list(big_vectorized_indexes.keys())])
-    def time_indexing_vectorized(self, key):
+    def time_indexing_big_vectorized(self, key):
         self.ds.isel(**big_vectorized_indexes[key])
 
 

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -27,11 +27,21 @@ basic_assignment_values = {
     ),
 }
 
-outer_indexes = {
-    "1d": {"x": randint(0, nx, 400)},
-    "2d": {"x": randint(0, nx, 500), "y": randint(0, ny, 400)},
-    "2d-1scalar": {"x": randint(0, nx, 100), "y": 1, "t": randint(0, nt, 400)},
-}
+
+def make_outer_indexes(n_index):
+    return {
+        "1d": {"x": randint(0, nx, n_index)},
+        "2d": {"x": randint(0, nx, n_index), "y": randint(0, ny, n_index)},
+        "2d-1scalar": {
+            "x": randint(0, nx, n_index),
+            "y": 1,
+            "t": randint(0, nt, n_index),
+        },
+    }
+
+
+outer_indexes = make_outer_indexes(400)
+big_outer_indexes = make_outer_indexes(400_000)
 
 outer_assignment_values = {
     "1d": xr.DataArray(randn((400, ny), frac_nan=0.1), dims=["x", "y"]),
@@ -39,31 +49,38 @@ outer_assignment_values = {
     "2d-1scalar": xr.DataArray(randn(100, frac_nan=0.1), dims=["x"]),
 }
 
-n_index = 400000
-vectorized_indexes = {
-    "1-1d": {"x": xr.DataArray(randint(0, nx, n_index), dims="a")},
-    "2-1d": {
-        "x": xr.DataArray(randint(0, nx, n_index), dims="a"),
-        "y": xr.DataArray(randint(0, ny, n_index), dims="a"),
-    },
-    "3-2d": {
-        "x": xr.DataArray(
-            randint(0, nx, n_index).reshape(n_index // 100, 100), dims=["a", "b"]
-        ),
-        "y": xr.DataArray(
-            randint(0, ny, n_index).reshape(n_index // 100, 100), dims=["a", "b"]
-        ),
-        "t": xr.DataArray(
-            randint(0, nt, n_index).reshape(n_index // 100, 100), dims=["a", "b"]
-        ),
-    },
-}
+
+def make_vectorized_indexes(n_index):
+    return {
+        "1-1d": {"x": xr.DataArray(randint(0, nx, n_index), dims="a")},
+        "2-1d": {
+            "x": xr.DataArray(randint(0, nx, n_index), dims="a"),
+            "y": xr.DataArray(randint(0, ny, n_index), dims="a"),
+        },
+        "3-2d": {
+            "x": xr.DataArray(
+                randint(0, nx, n_index).reshape(n_index // 100, 100), dims=["a", "b"]
+            ),
+            "y": xr.DataArray(
+                randint(0, ny, n_index).reshape(n_index // 100, 100), dims=["a", "b"]
+            ),
+            "t": xr.DataArray(
+                randint(0, nt, n_index).reshape(n_index // 100, 100), dims=["a", "b"]
+            ),
+        },
+    }
+
+
+vectorized_indexes = make_vectorized_indexes(400)
+big_vectorized_indexes = make_vectorized_indexes(400_000)
 
 vectorized_assignment_values = {
     "1-1d": xr.DataArray(randn((400, ny)), dims=["a", "y"], coords={"a": randn(400)}),
     "2-1d": xr.DataArray(randn(400), dims=["a"], coords={"a": randn(400)}),
     "3-2d": xr.DataArray(
-        randn((4, 100)), dims=["a", "b"], coords={"a": randn(4), "b": randn(100)}
+        randn((400 // 100, 100)),
+        dims=["a", "b"],
+        coords={"a": randn(400 // 100), "b": randn(100)},
     ),
 }
 
@@ -106,6 +123,20 @@ class Indexing(Base):
     def time_indexing_basic_ds_large(self, key):
         # https://github.com/pydata/xarray/pull/9003
         self.ds_large.isel(**basic_indexes[key]).load()
+
+
+class IndexingOnly(Base):
+    @parameterized(["key"], [list(basic_indexes.keys())])
+    def time_indexing_basic(self, key):
+        self.ds.isel(**basic_indexes[key])
+
+    @parameterized(["key"], [list(big_outer_indexes.keys())])
+    def time_indexing_outer(self, key):
+        self.ds.isel(**big_outer_indexes[key])
+
+    @parameterized(["key"], [list(big_vectorized_indexes.keys())])
+    def time_indexing_vectorized(self, key):
+        self.ds.isel(**big_vectorized_indexes[key])
 
 
 class Assignment(Base):

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -27,7 +27,6 @@ basic_assignment_values = {
     ),
 }
 
-
 outer_indexes = {
     "1d": {"x": randint(0, nx, 400)},
     "2d": {"x": randint(0, nx, 500), "y": randint(0, ny, 400)},
@@ -69,9 +68,7 @@ vectorized_assignment_values = {
     "1-1d": xr.DataArray(randn((400, ny)), dims=["a", "y"], coords={"a": randn(400)}),
     "2-1d": xr.DataArray(randn(400), dims=["a"], coords={"a": randn(400)}),
     "3-2d": xr.DataArray(
-        randn((400 // 100, 100)),
-        dims=["a", "b"],
-        coords={"a": randn(400 // 100), "b": randn(100)},
+        randn((4, 100)), dims=["a", "b"], coords={"a": randn(4), "b": randn(100)}
     ),
 }
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -47,6 +47,14 @@ Bug fixes
   By `Deepak Cherian <https://github.com/dcherian>`_.
 
 
+Performance
+~~~~~~~~~~~
+- Lazily indexed arrays now use less memory to store keys by avoiding copies
+  in :py:class:`~xarray.indexing.VectorizedIndexer` and :py:class:`~xarray.indexing.OuterIndexer`
+  (:issue:`10316`).
+  By `Jesse Rusak <https://github.com/jder>`_.
+
+
 Documentation
 ~~~~~~~~~~~~~
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -488,7 +488,7 @@ class VectorizedIndexer(ExplicitIndexer):
                         "invalid indexer key: ndarray arguments "
                         f"have different numbers of dimensions: {ndims}"
                     )
-                k = k.astype(np.int64)  # type: ignore[union-attr]
+                k = k.astype(np.int64, copy=False)  # type: ignore[union-attr]
             else:
                 raise TypeError(
                     f"unexpected indexer type for {type(self).__name__}: {k!r}"

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -444,7 +444,7 @@ class OuterIndexer(ExplicitIndexer):
                         f"invalid indexer array for {type(self).__name__}; must be scalar "
                         f"or have 1 dimension: {k!r}"
                     )
-                k = k.astype(np.int64)  # type: ignore[union-attr]
+                k = duck_array_ops.astype(k, np.int64, copy=False)
             else:
                 raise TypeError(
                     f"unexpected indexer type for {type(self).__name__}: {k!r}"
@@ -488,7 +488,7 @@ class VectorizedIndexer(ExplicitIndexer):
                         "invalid indexer key: ndarray arguments "
                         f"have different numbers of dimensions: {ndims}"
                     )
-                k = k.astype(np.int64, copy=False)  # type: ignore[union-attr]
+                k = duck_array_ops.astype(k, np.int64, copy=False)
             else:
                 raise TypeError(
                     f"unexpected indexer type for {type(self).__name__}: {k!r}"


### PR DESCRIPTION
While investigating #10311, I noticed that the large memory usage described there was exacerbated by duplicating the passed indexes in `VectorizedIndexer.__init__`. While this could be a defensive copy to avoid someone else mutating the passed ndarrays, looking at the [PR it was introduced](https://github.com/pydata/xarray/pull/5873/files#diff-44298663560e4e667c3235f546e7e4a92866f69619a0503a9171148e934d5cc9R386) I would guess this was an unintentional regression as part of supporting duck arrays, since `asarray` defaults to *not* copying the data and `astype` defaults to copying the data, but cc @dcherian in case that's not true.

Also included in this PR is increasing the size of the benchmark to show the improvement more clearly. (On my machine, it's a ~20% time savings.) Happy to break this out or remove it if you'd prefer to leave the benchmarks as is.

- [x] Tests added
