### PR TITLE
modification methods on `Coordinates`

### DIFF
--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -561,6 +561,31 @@ class Coordinates(AbstractCoordinates):
             variables=coords, coord_names=coord_names, indexes=indexes
         )
 
+    def __or__(self, other: Self) -> Self:
+        """Merge two sets of coordinates to create a new Coordinates object
+
+        The method implements the logic used for joining coordinates in the
+        result of a binary operation performed on xarray objects:
+
+        - If two index coordinates conflict (are not equal), an exception is
+          raised. You must align your data before passing it to this method.
+        - If an index coordinate and a non-index coordinate conflict, the non-
+          index coordinate is dropped.
+        - If two non-index coordinates conflict, both are dropped.
+
+        Parameters
+        ----------
+        other : dict-like, optional
+            A :py:class:`Coordinates` object or any mapping that can be turned
+            into coordinates.
+
+        Returns
+        -------
+        merged : Coordinates
+            A new Coordinates object with merged coordinates.
+        """
+        return self.merge(other).coords
+
     def __setitem__(self, key: Hashable, value: Any) -> None:
         self.update({key: value})
 

--- a/xarray/tests/test_coordinates.py
+++ b/xarray/tests/test_coordinates.py
@@ -260,3 +260,11 @@ class TestCoordinates:
         actual = coords.rename_vars({"x": "u", "y": "v"})
         assert set(actual.dims) == {"x", "y"}
         assert set(actual.variables) == {"a", "u", "v"}
+
+    def test_operator_merge(self):
+        coords1 = Coordinates({"x": ("x", [0, 1, 2])})
+        coords2 = Coordinates({"y": ("y", [3, 4, 5])})
+        expected = Dataset(coords={"x": [0, 1, 2], "y": [3, 4, 5]})
+
+        actual = coords1 | coords2
+        assert_identical(Dataset(coords=actual), expected)

--- a/xarray/tests/test_coordinates.py
+++ b/xarray/tests/test_coordinates.py
@@ -208,3 +208,19 @@ class TestCoordinates:
         coords = Coordinates(coords={"x": var}, indexes={})
         ds = Dataset(coords=coords)
         assert ds.coords["x"].dims == ("x", "y")
+
+    def test_drop_vars(self):
+        coords = Coordinates(
+            coords={
+                "x": Variable("x", range(3)),
+                "y": Variable("y", list("ab")),
+                "a": Variable(["x", "y"], np.arange(6).reshape(3, 2)),
+            },
+            indexes={},
+        )
+
+        actual = coords.drop_vars("x")
+        assert set(actual.variables) == {"a", "y"}
+
+        actual = coords.drop_vars(["x", "y"])
+        assert set(actual.variables) == {"a"}

--- a/xarray/tests/test_coordinates.py
+++ b/xarray/tests/test_coordinates.py
@@ -224,3 +224,39 @@ class TestCoordinates:
 
         actual = coords.drop_vars(["x", "y"])
         assert set(actual.variables) == {"a"}
+
+    def test_rename_dims(self):
+        coords = Coordinates(
+            coords={
+                "x": Variable("x", range(3)),
+                "y": Variable("y", list("ab")),
+                "a": Variable(["x", "y"], np.arange(6).reshape(3, 2)),
+            },
+            indexes={},
+        )
+
+        actual = coords.rename_dims({"x": "X"})
+        assert set(actual.dims) == {"X", "y"}
+        assert set(actual.variables) == {"a", "x", "y"}
+
+        actual = coords.rename_dims({"x": "u", "y": "v"})
+        assert set(actual.dims) == {"u", "v"}
+        assert set(actual.variables) == {"a", "x", "y"}
+
+    def test_rename_vars(self):
+        coords = Coordinates(
+            coords={
+                "x": Variable("x", range(3)),
+                "y": Variable("y", list("ab")),
+                "a": Variable(["x", "y"], np.arange(6).reshape(3, 2)),
+            },
+            indexes={},
+        )
+
+        actual = coords.rename_vars({"x": "X"})
+        assert set(actual.dims) == {"x", "y"}
+        assert set(actual.variables) == {"a", "X", "y"}
+
+        actual = coords.rename_vars({"x": "u", "y": "v"})
+        assert set(actual.dims) == {"x", "y"}
+        assert set(actual.variables) == {"a", "u", "v"}


### PR DESCRIPTION
For ease of use, this implements a few additional methods on `Coordinates`:
- `rename_dims`
- `rename_vars`
- `drop_vars`
- `coords1 | coords2` as an alias of `coords1.merge(coords2)`

These currently forward to the implementation in `Dataset`, but will be the natural place after refactoring `Coordinates` to not wrap a `Dataset`.

---

- [x] towards #10314
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

cc @benbovy, @scottyhq