### PR TITLE
rewrite of the `Coordinates` section in the data structures guide

### DIFF
--- a/doc/user-guide/data-structures.rst
+++ b/doc/user-guide/data-structures.rst
@@ -821,16 +821,7 @@ But can also be used to customize the behavior of the constructors of these clas
 Coordinate variables
 ~~~~~~~~~~~~~~~~~~~~
 
-Coordinates are ancillary variables stored for ``DataArray`` and ``Dataset``
-objects in the ``coords`` attribute:
-
-.. ipython:: python
-
-    ds.coords
-
-Unlike attributes, xarray *does* interpret and persist coordinates in
-operations that transform xarray objects. There are two types of coordinates
-in xarray:
+Coordinate variables (or simply coordinates) are ancillary variables stored in ``DataArray``, ``Dataset``, and ``DataTree`` objects. Unlike attributes, xarray *does* interpret coordinates in operations that transform xarray objects. There are two types of coordinates in xarray:
 
 - **dimension coordinates** are one dimensional coordinates with a name equal
   to their sole dimension (marked by ``*`` when printing a dataset or data


### PR DESCRIPTION
During the index refactor the `Coordinates` class has become much more important than it was before, changing from a simple proxy class to a full-featured container.

This PR changes the section to focus on the `Coordinates` class, which makes a bit more sense to me because the entire page is supposed to talk about data structures. However, describing the concept of coordinates in a section that looks a bit more advanced (I'd expect an average user to rarely interact with the `Coordinates` object directly) might make it easier to miss?

Either way, I'll keep working on this for a while. 

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] towards #6293
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`