### PR TITLE
apply_ufunc: don't modify attrs on input variables

### DIFF
--- a/xarray/structure/merge.py
+++ b/xarray/structure/merge.py
@@ -283,7 +283,9 @@ def merge_collected(
                                 "conflicting attribute values on combined "
                                 f"variable {name!r}:\nfirst value: {variable.attrs!r}\nsecond value: {other_variable.attrs!r}"
                             )
-                merged_vars[name] = variable
+                # Make a shallow copy to so that assigning merged_vars[name].attrs 
+                # does not affect the original input variable.
+                merged_vars[name] = variable.copy(False)
                 merged_vars[name].attrs = merge_attrs(
                     [var.attrs for var, _ in indexed_elements],
                     combine_attrs=combine_attrs,

--- a/xarray/structure/merge.py
+++ b/xarray/structure/merge.py
@@ -283,7 +283,7 @@ def merge_collected(
                                 "conflicting attribute values on combined "
                                 f"variable {name!r}:\nfirst value: {variable.attrs!r}\nsecond value: {other_variable.attrs!r}"
                             )
-                # Make a shallow copy to so that assigning merged_vars[name].attrs 
+                # Make a shallow copy to so that assigning merged_vars[name].attrs
                 # does not affect the original input variable.
                 merged_vars[name] = variable.copy(False)
                 merged_vars[name].attrs = merge_attrs(

--- a/xarray/structure/merge.py
+++ b/xarray/structure/merge.py
@@ -288,7 +288,7 @@ def merge_collected(
                     combine_attrs=combine_attrs,
                 )
                 if variable.attrs or attrs:
-                    # Make a shallow copy to so that assigning merged_vars[name].attrs 
+                    # Make a shallow copy to so that assigning merged_vars[name].attrs
                     # does not affect the original input variable.
                     merged_vars[name] = variable.copy(False)
                     merged_vars[name].attrs = attrs

--- a/xarray/structure/merge.py
+++ b/xarray/structure/merge.py
@@ -290,7 +290,7 @@ def merge_collected(
                 if variable.attrs or attrs:
                     # Make a shallow copy to so that assigning merged_vars[name].attrs
                     # does not affect the original input variable.
-                    merged_vars[name] = variable.copy(False)
+                    merged_vars[name] = variable.copy(deep=False)
                     merged_vars[name].attrs = attrs
                 else:
                     merged_vars[name] = variable

--- a/xarray/structure/merge.py
+++ b/xarray/structure/merge.py
@@ -283,13 +283,17 @@ def merge_collected(
                                 "conflicting attribute values on combined "
                                 f"variable {name!r}:\nfirst value: {variable.attrs!r}\nsecond value: {other_variable.attrs!r}"
                             )
-                # Make a shallow copy to so that assigning merged_vars[name].attrs
-                # does not affect the original input variable.
-                merged_vars[name] = variable.copy(False)
-                merged_vars[name].attrs = merge_attrs(
+                attrs = merge_attrs(
                     [var.attrs for var, _ in indexed_elements],
                     combine_attrs=combine_attrs,
                 )
+                if variable.attrs or attrs:
+                    # Make a shallow copy to so that assigning merged_vars[name].attrs 
+                    # does not affect the original input variable.
+                    merged_vars[name] = variable.copy(False)
+                    merged_vars[name].attrs = attrs
+                else:
+                    merged_vars[name] = variable
                 merged_indexes[name] = index
             else:
                 variables = [variable for variable, _ in elements_list]

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -2227,7 +2227,7 @@ def test_where_attrs() -> None:
     actual = xr.where(cond, x, y, keep_attrs=False)
     expected = xr.DataArray([1, 0], coords={"a": [0, 1]})
     assert_identical(expected, actual)
-    assert_identical(expected.coords['a'], actual.coords['a'])
+    assert_identical(expected.coords["a"], actual.coords["a"])
     # Check also that input coordinate attributes weren't modified by reference
     assert x["a"].attrs == {"attr": "x_coord"}
     assert y["a"].attrs == {"attr": "y_coord"}

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -2206,6 +2206,7 @@ def test_where() -> None:
 def test_where_attrs() -> None:
     cond = xr.DataArray([True, False], coords={"a": [0, 1]}, attrs={"attr": "cond_da"})
     cond["a"].attrs = {"attr": "cond_coord"}
+    input_cond = cond.copy()
     x = xr.DataArray([1, 1], coords={"a": [0, 1]}, attrs={"attr": "x_da"})
     x["a"].attrs = {"attr": "x_coord"}
     y = xr.DataArray([0, 0], coords={"a": [0, 1]}, attrs={"attr": "y_da"})
@@ -2216,6 +2217,22 @@ def test_where_attrs() -> None:
     expected = xr.DataArray([1, 0], coords={"a": [0, 1]}, attrs={"attr": "x_da"})
     expected["a"].attrs = {"attr": "x_coord"}
     assert_identical(expected, actual)
+    # Check also that input coordinate attributes weren't modified by reference
+    assert x["a"].attrs == {"attr": "x_coord"}
+    assert y["a"].attrs == {"attr": "y_coord"}
+    assert cond["a"].attrs == {"attr": "cond_coord"}
+    assert_identical(cond, input_cond)
+
+    # 3 DataArrays, drop attrs
+    actual = xr.where(cond, x, y, keep_attrs=False)
+    expected = xr.DataArray([1, 0], coords={"a": [0, 1]})
+    assert_identical(expected, actual)
+    assert_identical(expected.coords['a'], actual.coords['a'])
+    # Check also that input coordinate attributes weren't modified by reference
+    assert x["a"].attrs == {"attr": "x_coord"}
+    assert y["a"].attrs == {"attr": "y_coord"}
+    assert cond["a"].attrs == {"attr": "cond_coord"}
+    assert_identical(cond, input_cond)
 
     # x as a scalar, takes no attrs
     actual = xr.where(cond, 0, y, keep_attrs=True)

--- a/xarray/tests/test_ufuncs.py
+++ b/xarray/tests/test_ufuncs.py
@@ -62,6 +62,19 @@ def test_binary_out():
         assert_identical(actual_exponent, arg)
 
 
+def test_binary_coord_attrs():
+    t = xr.Variable("t", np.arange(2, 4), attrs={"units": "s"})
+    x = xr.DataArray(t.values**2, coords={"t": t}, attrs={"units": "s^2"})
+    y = xr.DataArray(t.values**3, coords={"t": t}, attrs={"units": "s^3"})
+    z1 = xr.apply_ufunc(np.add, x, y, keep_attrs=True)
+    assert z1.coords["t"].attrs == {"units": "s"}
+    z2 = xr.apply_ufunc(np.add, x, y, keep_attrs=False)
+    assert z2.coords["t"].attrs == {}
+    # Check also that input array's coordinate attributes weren't affected
+    assert t.attrs == {"units": "s"}
+    assert x.coords["t"].attrs == {"units": "s"}
+
+
 def test_groupby():
     ds = xr.Dataset({"a": ("x", [0, 0, 0])}, {"c": ("x", [0, 0, 1])})
     ds_grouped = ds.groupby("c")


### PR DESCRIPTION
Fixing #8047 (and at least the #8480 duplicate) by copying coordinate-variables before overwriting their .attrs in `structure.merge.merge_collected()`.

In a call to `apply_ufunc()`, the output coordinates and their attributes are produced in `merge_collected()` based on the combine_attrs argument (which is "override" or "drop" depending on the keep_attrs argument). However, a side effect of the line `merged_vars[name].attrs = merge_attrs(`... was that also the .attrs of the coordinate on the _input_ arrays would be changed to the output arrays', i.e. dropped or changed to those of the first input array.

The proposed solution of creating a shallow copy of the input coordinate before assigning attributes works, according to the new tests I added in in test_ufuncs.py and test_computation.py, with a slight performance penalty (3% on an unpublished test I did, didn't install enough things to run the asv performance test suite locally).

Although the last `else`-clause of `merge_collected()` has similar code assigning `merged_vars[name].attrs`, my tests pass without doing a copy there. Feel free to propose test cases that will exercise that code (indexed_elements being empty?) and still cause a bug like #8047 or #8480.

I also extended the tests in test_merge.py to ensure that input attributes aren't affected by `merge`. These tests passed from the beginning, so they are not strictly related to the bug, but meant as precautions to catch hypothetical regressions.

- Closes #8047 
- Tests added