### PR TITLE
[do not merge] test new dtypes in zarr-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ io = [
   "h5netcdf",
   "scipy",
   'pydap; python_version<"3.10"',
-  "zarr",
+  "zarr @ git+https://github.com/d-v-b/zarr-python.git@feat/fixed-length-strings",
   "fsspec",
   "cftime",
   "pooch",


### PR DESCRIPTION
This PR tests compatibility between xarray and a [branch of zarr-python](https://github.com/zarr-developers/zarr-python/pull/2874) that supports more numpy data types. Do not merge this PR.  