### PR TITLE
FIX: prevent unnecessary type casts in rolling mean

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -45,6 +45,7 @@ Bug fixes
 
 - Allow accessing arbitrary attributes on Pandas ExtensionArrays.
   By `Deepak Cherian <https://github.com/dcherian>`_.
+- Use dtype from intermediate sum instead of source dtype or "int" for casting of count when calculating mean in rolling for correct operations (preserve float dtypes, correct mean of bool arrays) (:issue:`10340`, :pull:`10341`).
 
 
 Documentation

--- a/xarray/computation/rolling.py
+++ b/xarray/computation/rolling.py
@@ -195,14 +195,13 @@ class Rolling(Generic[T_Xarray]):
         return method
 
     def _mean(self, keep_attrs, **kwargs):
-        result = self.sum(keep_attrs=False, **kwargs) / duck_array_ops.astype(
-            self.count(keep_attrs=False), dtype=int, copy=False
+        result = self.sum(keep_attrs=False, **kwargs)
+        result /= duck_array_ops.astype(
+            self.count(keep_attrs=False), dtype=result.dtype, copy=False
         )
         if keep_attrs:
             result.attrs = self.obj.attrs
 
-        if self.obj.dtype.kind not in "bi":
-            result = result.astype(self.obj.dtype, copy=False)
         return result
 
     _mean.__doc__ = _ROLLING_REDUCE_DOCSTRING_TEMPLATE.format(name="mean")

--- a/xarray/computation/rolling.py
+++ b/xarray/computation/rolling.py
@@ -196,6 +196,8 @@ class Rolling(Generic[T_Xarray]):
 
     def _mean(self, keep_attrs, **kwargs):
         result = self.sum(keep_attrs=False, **kwargs)
+        # use dtype of result for casting of count
+        # this allows for GH #7062 and GH #8864, fixes GH #10340
         result /= duck_array_ops.astype(
             self.count(keep_attrs=False), dtype=result.dtype, copy=False
         )


### PR DESCRIPTION
Use dtype from intermediate sum for casting of count instead of current "int" when calculating mean in rolling operations to prevent unnecessary casting to/from int

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #10340
- [ ] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
