### PR TITLE
use numpy dtype exposed by zarr array instead of metadata.data_type

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -877,9 +877,8 @@ class ZarrStore(AbstractWritableDataStore):
             if zarr_array.fill_value is not None:
                 attributes["_FillValue"] = zarr_array.fill_value
         elif "_FillValue" in attributes:
-            original_zarr_dtype = zarr_array.metadata.data_type
             attributes["_FillValue"] = FillValueCoder.decode(
-                attributes["_FillValue"], original_zarr_dtype.value
+                attributes["_FillValue"], zarr_array.dtype
             )
 
         return Variable(dimensions, data, attributes, encoding)


### PR DESCRIPTION
in `main` the zarr backend uses the `zarr_array.metadata.data_type` attribute to get the dtype of the zarr array. If the goal is to ultimately get a numpy data type, it's simpler and safer to retrieve the data type from from the `dtype` attribute of the zarr array. This PR makes that change. 

This addresses on of the incompatibilities noted in https://github.com/pydata/xarray/issues/10329
