### PR TITLE
Disallow standard calendar `np.datetime64` encoding prior to reform

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,7 +33,6 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-
 Deprecations
 ~~~~~~~~~~~~
 
@@ -51,6 +50,14 @@ Bug fixes
   calculating mean in rolling for correct operations (preserve float dtypes,
   correct mean of bool arrays) (:issue:`10340`, :pull:`10341`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Raise an error when attempting to encode :py:class:`numpy.datetime64` values
+  prior to the Gregorian calendar reform date of 1582-10-15 with a
+  ``"standard"`` or ``"gregorian"`` calendar. Previously we would warn and
+  encode these as :py:class:`cftime.DatetimeGregorian` objects, but it is not
+  clear that this is the user's intent, since this implicitly converts the
+  calendar of the datetimes from ``"proleptic_gregorian"`` to ``"gregorian"``
+  and prevents round-tripping them as :py:class:`numpy.datetime64` values
+  (:pull:`10352`). By `Spencer Clark <https://github.com/spencerkclark>`_.
 
 Documentation
 ~~~~~~~~~~~~~


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

In #9618 we allowed encoding `np.datetime64` values prior to 1582-10-15 using a `"standard"` or `"gregorian"` calendar through cftime. While technically possible, this implicitly introduces a calendar change, and means the values can no longer be round tripped as `np.datetime64`—xarray will choose `cftime.DatetimeGregorian` instances when decoding instead. I am not sure how often this will come up and the behavior may not be the user's intent.

This PR switches to raising a `ValueError` in this circumstance, and recommends encoding with a `"proleptic_gregorian"` calendar instead (the calendar that xarray automatically chooses for `np.datetime64` values if provided no user input).

cc: @kmuehlbauer (this one possible way to address the issue in #8342)

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
