### PR TITLE
Improve html repr in dark mode (Jupyterlab + Xarray docs)

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -44,3 +44,11 @@ html[data-theme="dark"] .sd-card img[src*=".svg"] {
 .bd-content .sd-card .sd-card-body {
   background-color: unset !important;
 }
+
+/* workaround Pydata Sphinx theme using light colors for widget cell outputs in dark-mode */
+/* works for many widgets but not for Xarray html reprs */
+/* https://github.com/pydata/pydata-sphinx-theme/issues/2189 */
+html[data-theme="dark"] div.cell_output .text_html:has(div.xr-wrap) {
+  background-color: var(--pst-color-on-background) !important;
+  color: var(--pst-color-text-base) !important;
+}

--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -3,28 +3,76 @@
  */
 
 :root {
-  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
-  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
-  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
-  --xr-border-color: var(--jp-border-color2, #e0e0e0);
-  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
-  --xr-background-color: var(--jp-layout-color0, white);
-  --xr-background-color-row-even: var(--jp-layout-color1, white);
-  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
+  --xr-font-color0: var(
+    --jp-content-font-color0,
+    var(--pst-color-text-base rgba(0, 0, 0, 1))
+  );
+  --xr-font-color2: var(
+    --jp-content-font-color2,
+    var(--pst-color-text-base, rgba(0, 0, 0, 0.54))
+  );
+  --xr-font-color3: var(
+    --jp-content-font-color3,
+    var(--pst-color-text-base, rgba(0, 0, 0, 0.38))
+  );
+  --xr-border-color: var(
+    --jp-border-color2,
+    hsl(from var(--pst-color-on-background, white) h s calc(l - 10))
+  );
+  --xr-disabled-color: var(
+    --jp-layout-color3,
+    hsl(from var(--pst-color-on-background, white) h s calc(l - 40))
+  );
+  --xr-background-color: var(
+    --jp-layout-color0,
+    var(--pst-color-on-background, white)
+  );
+  --xr-background-color-row-even: var(
+    --jp-layout-color1,
+    hsl(from var(--pst-color-on-background, white) h s calc(l - 10))
+  );
+  --xr-background-color-row-odd: var(
+    --jp-layout-color2,
+    hsl(from var(--pst-color-on-background, white) h s calc(l - 30))
+  );
 }
 
 html[theme="dark"],
 html[data-theme="dark"],
 body[data-theme="dark"],
 body.vscode-dark {
-  --xr-font-color0: rgba(255, 255, 255, 1);
-  --xr-font-color2: rgba(255, 255, 255, 0.54);
-  --xr-font-color3: rgba(255, 255, 255, 0.38);
-  --xr-border-color: #1f1f1f;
-  --xr-disabled-color: #515151;
-  --xr-background-color: #111111;
-  --xr-background-color-row-even: #111111;
-  --xr-background-color-row-odd: #313131;
+  --xr-font-color0: var(
+    --jp-content-font-color0,
+    var(--pst-color-text-base, rgba(255, 255, 255, 1))
+  );
+  --xr-font-color2: var(
+    --jp-content-font-color2,
+    var(--pst-color-text-base, rgba(255, 255, 255, 0.54))
+  );
+  --xr-font-color3: var(
+    --jp-content-font-color3,
+    var(--pst-color-text-base, rgba(255, 255, 255, 0.38))
+  );
+  --xr-border-color: var(
+    --jp-border-color2,
+    hsl(from var(--pst-color-on-background, #111111) h s calc(l + 10))
+  );
+  --xr-disabled-color: var(
+    --jp-layout-color3,
+    hsl(from var(--pst-color-on-background, #111111) h s calc(l + 40))
+  );
+  --xr-background-color: var(
+    --jp-layout-color0,
+    var(--pst-color-on-background, #111111)
+  );
+  --xr-background-color-row-even: var(
+    --jp-layout-color1,
+    hsl(from var(--pst-color-on-background, #111111) h s calc(l + 10))
+  );
+  --xr-background-color-row-odd: var(
+    --jp-layout-color2,
+    hsl(from var(--pst-color-on-background, #111111) h s calc(l + 30))
+  );
 }
 
 .xr-wrap {

--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -29,11 +29,11 @@
   );
   --xr-background-color-row-even: var(
     --jp-layout-color1,
-    hsl(from var(--pst-color-on-background, white) h s calc(l - 10))
+    hsl(from var(--pst-color-on-background, white) h s calc(l - 5))
   );
   --xr-background-color-row-odd: var(
     --jp-layout-color2,
-    hsl(from var(--pst-color-on-background, white) h s calc(l - 30))
+    hsl(from var(--pst-color-on-background, white) h s calc(l - 15))
   );
 }
 
@@ -67,11 +67,11 @@ body.vscode-dark {
   );
   --xr-background-color-row-even: var(
     --jp-layout-color1,
-    hsl(from var(--pst-color-on-background, #111111) h s calc(l + 10))
+    hsl(from var(--pst-color-on-background, #111111) h s calc(l + 5))
   );
   --xr-background-color-row-odd: var(
     --jp-layout-color2,
-    hsl(from var(--pst-color-on-background, #111111) h s calc(l + 30))
+    hsl(from var(--pst-color-on-background, #111111) h s calc(l + 15))
   );
 }
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #8097

## Jupyterlab (custom dark theme)

<br>

Main branch:

<img width="781" alt="Screenshot 2025-05-26 at 09 03 35" src="https://github.com/user-attachments/assets/cfa69968-b7ac-4abc-b2e3-c83f473623e3" />

<br><br>

This PR:

<img width="781" alt="Screenshot 2025-05-26 at 08 58 13" src="https://github.com/user-attachments/assets/bdaab8d7-07e5-4d1e-82b1-8f29d2ce7a5b" />

## Xarray documentation (dark mode)

<br>

Main branch:

<img width="840" alt="Screenshot 2025-05-26 at 12 07 19" src="https://github.com/user-attachments/assets/f611403a-452b-40fe-a80e-c20dda34c71e" />

<br><br>

This PR:

<img width="834" alt="Screenshot 2025-05-26 at 11 55 44" src="https://github.com/user-attachments/assets/e2ab1378-4cb1-4e96-92bf-f97fe7d5dc76" />
