### PR TITLE
ruff: default rule set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,8 +249,6 @@ extend-exclude = ["doc", "_typed_ops.pyi"]
 
 [tool.ruff.lint]
 extend-select = [
-  "F",    # Pyflakes
-  "E",    # pycodestyle errors
   "W",    # pycodestyle warnings
   "I",    # isort
   "UP",   # pyupgrade
@@ -267,7 +265,6 @@ extend-safe-fixes = [
 ]
 ignore = [
   "E402",    # module level import not at top of file
-  "E501",    # line too long - let the formatter worry about that
   "E731",    # do not assign a lambda expression, use a def
   "UP007",   # use X | Y for type annotations
   "C40",     # unnecessary generator, comprehension, or literal


### PR DESCRIPTION
By default, Ruff enables Flake8's `F` rules, along with a subset of the `E` rules (`E4`, `E7`, `E9`), omitting any stylistic rules that overlap with the use of a formatter ( `E1`, `E2`, `E3`, `E5`).

The  [`extend-select`](https://docs.astral.sh/ruff/settings/#lint_extend-select) setting implicitly enables the default rule set, no need to explicitly enable `F` and `E` rules.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
