### PR TITLE
Apply assorted ruff/flake8-pytest-style rules (PT)

### DIFF
--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -400,14 +400,14 @@ def calendar(request):
     return request.param
 
 
-@pytest.fixture()
+@pytest.fixture
 def cftime_date_type(calendar):
     if calendar == "standard":
         calendar = "proleptic_gregorian"
     return _all_cftime_date_types()[calendar]
 
 
-@pytest.fixture()
+@pytest.fixture
 def times(calendar):
     import cftime
 
@@ -419,7 +419,7 @@ def times(calendar):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def data(times):
     data = np.random.rand(10, 10, _NT)
     lons = np.linspace(0, 11, 10)
@@ -429,7 +429,7 @@ def data(times):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def times_3d(times):
     lons = np.linspace(0, 11, 10)
     lats = np.linspace(0, 20, 10)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -805,7 +805,7 @@ def calendar(request):
     return request.param
 
 
-@pytest.fixture()
+@pytest.fixture
 def times(calendar):
     import cftime
 
@@ -817,7 +817,7 @@ def times(calendar):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def data(times):
     data = np.random.rand(2, 2, 4)
     lons = np.linspace(0, 11, 2)
@@ -827,7 +827,7 @@ def data(times):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def times_3d(times):
     lons = np.linspace(0, 11, 2)
     lats = np.linspace(0, 20, 2)

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -255,14 +255,10 @@ class TestVariable(DaskTestCase):
 
     def test_missing_methods(self):
         v = self.lazy_var
-        try:
+        with pytest.raises(NotImplementedError, match="dask"):
             v.argsort()
-        except NotImplementedError as err:
-            assert "dask" in str(err)
-        try:
+        with pytest.raises(NotImplementedError, match="dask"):
             v[0].item()
-        except NotImplementedError as err:
-            assert "dask" in str(err)
 
     def test_univariate_ufunc(self):
         u = self.eager_var

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -2325,7 +2325,7 @@ class Closer:
         self.closed = True
 
 
-@pytest.fixture()
+@pytest.fixture
 def tree_and_closers():
     tree = DataTree.from_dict({"/child/grandchild": None})
     closers = {

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -220,7 +220,7 @@ def test_dask_distributed_read_netcdf_integration_test(
 # fixture vendored from dask
 # heads-up, this is using quite private zarr API
 # https://github.com/dask/dask/blob/e04734b4d8959ba259801f2e2a490cb4ee8d891f/dask/tests/test_distributed.py#L338-L358
-@pytest.fixture(scope="function")
+@pytest.fixture
 def zarr(client):
     zarr_lib = pytest.importorskip("zarr")
     # Zarr-Python 3 lazily allocates a dedicated thread/IO loop

--- a/xarray/tests/test_formatting_html.py
+++ b/xarray/tests/test_formatting_html.py
@@ -231,7 +231,7 @@ class Test_summarize_datatree_children:
         """
         return childfree_tree_factory()
 
-    @pytest.fixture(scope="function")
+    @pytest.fixture
     def mock_datatree_node_repr(self, monkeypatch):
         """
         Apply mocking for datatree_node_repr.
@@ -245,7 +245,7 @@ class Test_summarize_datatree_children:
 
         monkeypatch.setattr(fh, "datatree_node_repr", mock)
 
-    @pytest.fixture(scope="function")
+    @pytest.fixture
     def mock_wrap_datatree_repr(self, monkeypatch):
         """
         Apply mocking for _wrap_datatree_repr.

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -66,7 +66,7 @@ def figure_context(*args, **kwargs):
         plt.close("all")
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def test_all_figures_closed():
     """meta-test to ensure all figures are closed at the end of a test
 


### PR DESCRIPTION
Other `PT` rules either result in too many changes ([`PT006`](https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/), [`PT007`](https://docs.astral.sh/ruff/rules/pytest-parametrize-values-wrong-type/)) or seem less interesting to me in the short term ([`PT011`](https://docs.astral.sh/ruff/rules/pytest-parametrize-values-wrong-type/), [`PT012`](https://docs.astral.sh/ruff/rules/pytest-raises-with-multiple-statements/), [`PT018`](https://docs.astral.sh/ruff/rules/pytest-composite-assertion/), [`PT022`](https://docs.astral.sh/ruff/rules/pytest-useless-yield-fixture/)).

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
