### PR TITLE
Enforce ruff/flake8-implicit-str-concat rules (ISC)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,6 +254,7 @@ extend-select = [
   "UP",   # pyupgrade
   "B",    # flake8-bugbear
   "C4",   # flake8-comprehensions
+  "ISC",  # flake8-implicit-str-concat
   "PIE",  # flake8-pie
   "TID",  # flake8-tidy-imports (absolute imports)
   "PGH",  # pygrep-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,16 +249,16 @@ extend-exclude = ["doc", "_typed_ops.pyi"]
 
 [tool.ruff.lint]
 extend-select = [
-  "W",    # pycodestyle warnings
-  "I",    # isort
-  "UP",   # pyupgrade
   "B",    # flake8-bugbear
   "C4",   # flake8-comprehensions
   "ISC",  # flake8-implicit-str-concat
   "PIE",  # flake8-pie
   "TID",  # flake8-tidy-imports (absolute imports)
-  "PGH",  # pygrep-hooks
+  "I",    # isort
   "PERF", # Perflint
+  "W",    # pycodestyle warnings
+  "PGH",  # pygrep-hooks
+  "UP",   # pyupgrade
   "FURB", # refurb
   "RUF",
 ]
@@ -266,12 +266,12 @@ extend-safe-fixes = [
   "TID252", # absolute imports
 ]
 ignore = [
-  "E402",    # module level import not at top of file
-  "E731",    # do not assign a lambda expression, use a def
-  "UP007",   # use X | Y for type annotations
   "C40",     # unnecessary generator, comprehension, or literal
   "PIE790",  # unnecessary pass statement
   "PERF203", # try-except within a loop incurs performance overhead
+  "E402",    # module level import not at top of file
+  "E731",    # do not assign a lambda expression, use a def
+  "UP007",   # use X | Y for type annotations
   "FURB105", # unnecessary empty string passed to `print`
   "RUF001",  # string contains ambiguous unicode character
   "RUF002",  # docstring contains ambiguous acute accent unicode character


### PR DESCRIPTION
Rules already applied in #9722.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
