### PR TITLE
Allow for inline_array specification in open_zarr through from_array_kwargs

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1507,6 +1507,8 @@ def open_zarr(
     if from_array_kwargs is None:
         from_array_kwargs = {}
 
+    inline_array = from_array_kwargs.pop("inline_array", False)
+
     if chunks == "auto":
         try:
             guess_chunkmanager(
@@ -1543,6 +1545,7 @@ def open_zarr(
         engine="zarr",
         chunks=chunks,
         drop_variables=drop_variables,
+        inline_array=inline_array,
         chunked_array_type=chunked_array_type,
         from_array_kwargs=from_array_kwargs,
         backend_kwargs=backend_kwargs,


### PR DESCRIPTION
This is probably not the best way to do this, but I figured I would start with the simplest way and go from there.

`inline_array` snakes its way through the codebase all the way to [_maybe_chunk](https://github.com/pydata/xarray/blob/3cbf960aa1005524b81bd8113e1ae4fbec040b2e/xarray/structure/chunks.py#L144) where it gets [resolved](https://github.com/pydata/xarray/blob/3cbf960aa1005524b81bd8113e1ae4fbec040b2e/xarray/core/utils.py#L1184) against from_array_kwargs; if you provide it in `from_array_kwargs` _and_ explicitly to `open_dataset`, you get @dcherian's error message. So with `open_zarr` you can't provide it in `from_array_kwargs` since the default open_dataset value is used (False); this PR just removes it from from_array_kwargs and passes that value to open_dataset.

Pros: 

- Doesn't require changing the signature of anything.

Cons: 

- `open_zarr` is now the one place where you can use `inline_array` in `from_array_kwargs`, which might lead to some confusion down the line.
- Have tied the default value in `open_dataset` to `open_zarr`. 

So alternatively, I could modify `open_zarr` with another `inline_array` arg. 




- [x] Closes #8095 
