### PR TITLE
Fix doc typo for caption "Interoperability"

### DIFF
--- a/doc/user-guide/index.rst
+++ b/doc/user-guide/index.rst
@@ -43,7 +43,7 @@ examples that describe many common tasks that you can accomplish with Xarray.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Interoperatbility
+   :caption: Interoperability
 
    pandas
    duckarrays


### PR DESCRIPTION
I was browsing the docs and found a typo.