### PR TITLE
Fix reindex on Dataset from MultiIndex DataFrame with RuntimeError

### DIFF
--- a/xarray/structure/alignment.py
+++ b/xarray/structure/alignment.py
@@ -120,7 +120,9 @@ def _normalize_indexes(
                 )
             data: T_DuckArray = as_compatible_data(idx)
             pd_idx = safe_cast_to_index(data)
-            pd_idx.name = k
+            if pd_idx.name != k:
+                pd_idx = pd_idx.copy()
+                pd_idx.name = k
             if isinstance(pd_idx, pd.MultiIndex):
                 idx = PandasMultiIndex(pd_idx, k)
             else:

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -7894,3 +7894,17 @@ def test_transpose_error() -> None:
         ),
     ):
         ds.transpose(["y", "x"])  # type: ignore[arg-type]
+
+
+def test_reindex_with_multiindex_level() -> None:
+    # test for https://github.com/pydata/xarray/issues/10347
+    mindex = pd.MultiIndex.from_product(
+        [[100, 200, 300], [1, 2, 3, 4]], names=["x", "y"]
+    )
+    y_idx = PandasIndex(mindex.levels[1], "y")
+
+    ds1 = xr.Dataset(coords={"y": [1, 2, 3]})
+    ds2 = xr.Dataset(coords=xr.Coordinates.from_xindex(y_idx))
+
+    actual = ds1.reindex(y=ds2.y)
+    assert_identical(actual, ds2)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2369,6 +2369,19 @@ class TestDataset:
         assert_identical(expected, actual)
         assert actual.x.dtype == expected.x.dtype
 
+    def test_reindex_with_multiindex_level(self) -> None:
+        # test for https://github.com/pydata/xarray/issues/10347
+        mindex = pd.MultiIndex.from_product(
+            [[100, 200, 300], [1, 2, 3, 4]], names=["x", "y"]
+        )
+        y_idx = PandasIndex(mindex.levels[1], "y")
+
+        ds1 = xr.Dataset(coords={"y": [1, 2, 3]})
+        ds2 = xr.Dataset(coords=xr.Coordinates.from_xindex(y_idx))
+
+        actual = ds1.reindex(y=ds2.y)
+        assert_identical(actual, ds2)
+
     @pytest.mark.parametrize("fill_value", [dtypes.NA, 2, 2.0, {"foo": 2, "bar": 1}])
     def test_align_fill_value(self, fill_value) -> None:
         x = Dataset({"foo": DataArray([1, 2], dims=["x"], coords={"x": [1, 2]})})
@@ -7833,17 +7846,3 @@ def test_transpose_error() -> None:
         ),
     ):
         ds.transpose(["y", "x"])  # type: ignore[arg-type]
-
-
-def test_reindex_with_multiindex_level() -> None:
-    # test for https://github.com/pydata/xarray/issues/10347
-    mindex = pd.MultiIndex.from_product(
-        [[100, 200, 300], [1, 2, 3, 4]], names=["x", "y"]
-    )
-    y_idx = PandasIndex(mindex.levels[1], "y")
-
-    ds1 = xr.Dataset(coords={"y": [1, 2, 3]})
-    ds2 = xr.Dataset(coords=xr.Coordinates.from_xindex(y_idx))
-
-    actual = ds1.reindex(y=ds2.y)
-    assert_identical(actual, ds2)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #10347
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
