### PR TITLE
Fixed color.shape != grid.shape in streamplot when nx != ny

### DIFF
--- a/xarray/plot/dataset_plot.py
+++ b/xarray/plot/dataset_plot.py
@@ -630,6 +630,8 @@ def streamplot(
     cmap_params = kwargs.pop("cmap_params")
 
     if hue:
+        if xdim is not None and ydim is not None:
+            ds[hue] = ds[hue].transpose(ydim, xdim)
         kwargs["color"] = ds[hue].values
 
         # TODO: Fix this by always returning a norm with vmin, vmax in cmap_params

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2698,9 +2698,9 @@ class TestDatasetStreamplotPlots(PlotTestCase):
     def setUp(self) -> None:
         das = [
             DataArray(
-                np.random.randn(3, 3, 2, 2),
+                np.random.randn(3, 4, 2, 2),
                 dims=["x", "y", "row", "col"],
-                coords=[range(k) for k in [3, 3, 2, 2]],
+                coords=[range(k) for k in [3, 4, 2, 2]],
             )
             for _ in [1, 2]
         ]


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

In https://github.com/pydata/xarray/blob/f1a2c08f21a8237c082913fcad2d77469448cf4c/xarray/plot/dataset_plot.py#L622-L633

`x`, `y`, `u`, `v` are all transposed, if the dataset only gives a 1D array for both `x` and `y`, which is a pretty nice addition to mpl's behavior. However, the color was left out. If one has a spatial grid of shape `(nx, ny)` and uses `hue`,  and `nx` is different from `ny`, then `matplotlib.streamplot` will raises a value error caused by `color.shape != grid.shape`.

This PR simply adds the same condition to transpose `hue` if  `x`, `y`, `u`, `v` are transposed.

I could not find a unittest corresponding to `streamplot`. But here is a minimal working example that does not work under current code but works after the simple change.

```python
import numpy as np
import xarray

nx = 64
ny = 128
nt = 5

t = np.linspace(0, 1, nt, dtype=np.float64)
x = np.linspace(0, np.pi, nx, dtype=np.float64)
y = np.linspace(0, np.pi, ny, dtype=np.float64)

coords = {
    "t": t,
    "x": x,
    "y": y,
}

T, X, Y = np.meshgrid(t, x, y, indexing="ij")
u = np.sin(X) * np.cos(T*Y)
v = -np.cos(T*X) * np.sin(Y)

u_dataset = xarray.DataArray(
    u, dims=["t", "x", "y"], coords=coords
).to_dataset(name="u")
v_dataset = xarray.DataArray(
    v, dims=["t", "x", "y"], coords=coords
).to_dataset(name="v")

velocity_mag = np.sqrt(u**2 + v**2)
vmag_dataset = xarray.DataArray(
    velocity_mag, dims=["t", "x", "y"], coords=coords
).to_dataset(name="magnitude")

data = xarray.merge([u_dataset, v_dataset, vmag_dataset])

_ = data.plot.streamplot(
    x="x",
    y="y",
    u="u",
    v="v",
    hue="magnitude",
    col="t",
)
```
