### PR TITLE
Fix `Index._repr_inline_()` signature

### DIFF
--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -464,7 +464,7 @@ def inherited_coords_repr(node: DataTree, col_width=None, max_rows=None):
     )
 
 
-def inline_index_repr(index: pd.Index, max_width=None):
+def inline_index_repr(index: pd.Index, max_width: int) -> str:
     if hasattr(index, "_repr_inline_"):
         repr_ = index._repr_inline_(max_width=max_width)
     else:

--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -145,7 +145,7 @@ def summarize_index(coord_names, index) -> str:
     name = "<br>".join([escape(str(n)) for n in coord_names])
 
     index_id = f"index-{uuid.uuid4()}"
-    preview = escape(inline_index_repr(index))
+    preview = escape(inline_index_repr(index, max_width=70))
     details = short_index_repr_html(index)
 
     data_icon = _icon("icon-database")

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -479,7 +479,7 @@ class Index:
     def __getitem__(self, indexer: Any) -> Self:
         raise NotImplementedError()
 
-    def _repr_inline_(self, max_width):
+    def _repr_inline_(self, max_width: int) -> str:
         return self.__class__.__name__
 
 

--- a/xarray/tests/test_range_index.py
+++ b/xarray/tests/test_range_index.py
@@ -220,6 +220,6 @@ def test_range_index_repr() -> None:
 
 def test_range_index_repr_inline() -> None:
     index = RangeIndex.arange(0.0, 1.0, 0.1, dim="x")
-    actual = index._repr_inline_(max_width=None)
+    actual = index._repr_inline_(max_width=70)
     expected = "RangeIndex (start=0, stop=1, step=0.1)"
     assert actual == expected


### PR DESCRIPTION
`max_width` is a required argument with type `int`.