### PR TITLE
Group Backend Keyword Arguments

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -31,6 +31,7 @@ from xarray.backends.common import (
     ArrayWriter,
     _find_absolute_paths,
     _normalize_path,
+    _reset_dataclass_to_false,
 )
 from xarray.backends.locks import _get_scheduler
 from xarray.coders import CFDatetimeCoder, CFTimedeltaCoder
@@ -382,18 +383,21 @@ def _dataset_from_backend_dataset(
     backend_ds,
     filename_or_obj,
     engine,
-    chunks,
-    cache,
-    overwrite_encoded_chunks,
-    inline_array,
-    chunked_array_type,
-    from_array_kwargs,
+    coder_opts,
+    backend_opts,
     **extra_tokens,
 ):
+    backend_kwargs = asdict(backend_opts)
+    chunks = backend_kwargs.get("chunks")
+    cache = backend_kwargs.get("cache")
     if not isinstance(chunks, int | dict) and chunks not in {None, "auto"}:
         raise ValueError(
             f"chunks must be an int, dict, 'auto', or None. Instead found {chunks}."
         )
+
+    coders_kwargs = asdict(coder_opts)
+    extra_tokens.update(**coders_kwargs)
+    extra_tokens.update(**backend_kwargs)
 
     _protect_dataset_variables_inplace(backend_ds, cache)
     if chunks is None:
@@ -403,11 +407,6 @@ def _dataset_from_backend_dataset(
             backend_ds,
             filename_or_obj,
             engine,
-            chunks,
-            overwrite_encoded_chunks,
-            inline_array,
-            chunked_array_type,
-            from_array_kwargs,
             **extra_tokens,
         )
 
@@ -476,6 +475,23 @@ def _datatree_from_backend_datatree(
     return tree
 
 
+from dataclasses import asdict
+
+Buffer = Union[bytes, bytearray, memoryview]
+
+
+from xarray.backends.common import BackendOptions, CoderOptions, XarrayBackendOptions
+
+# @dataclass(frozen=True)
+# class XarrayBackendOptions:
+#     chunks: Optional[T_Chunks] = None
+#     cache: Optional[bool] = None
+#     inline_array: Optional[bool] = False
+#     chunked_array_type: Optional[str] = None
+#     from_array_kwargs: Optional[dict[str, Any]] = None
+#     overwrite_encoded_chunks: Optional[bool] = False
+
+
 def open_dataset(
     filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
     *,
@@ -500,6 +516,10 @@ def open_dataset(
     chunked_array_type: str | None = None,
     from_array_kwargs: dict[str, Any] | None = None,
     backend_kwargs: dict[str, Any] | None = None,
+    coder_opts: Union[bool, CoderOptions, None] = None,
+    open_opts: Union[bool, BackendOptions, None] = None,
+    backend_opts: Union[bool, BackendOptions, None] = None,
+    store_opts: Union[bool, BackendOptions, None] = None,
     **kwargs,
 ) -> Dataset:
     """Open and decode a dataset from a file or file-like object.
@@ -672,36 +692,69 @@ def open_dataset(
 
     backend = plugins.get_backend(engine)
 
-    decoders = _resolve_decoders_kwargs(
-        decode_cf,
-        open_backend_dataset_parameters=backend.open_dataset_parameters,
-        mask_and_scale=mask_and_scale,
-        decode_times=decode_times,
-        decode_timedelta=decode_timedelta,
-        concat_characters=concat_characters,
-        use_cftime=use_cftime,
-        decode_coords=decode_coords,
-    )
+    print("XX0:", backend)
+    print("XX1:", type(backend))
+    print("XX2:", type(backend.coder_opts))
+    print("XX3:", coder_opts)
+    print("XX4:", backend.coder_opts)
 
-    overwrite_encoded_chunks = kwargs.pop("overwrite_encoded_chunks", None)
-    backend_ds = backend.open_dataset(
-        filename_or_obj,
-        drop_variables=drop_variables,
-        **decoders,
-        **kwargs,
-    )
+    # initialize CoderOptions with decoders of not given
+    # Deprecation Fallback
+    if coder_opts is False:
+        coder_opts = _reset_dataclass_to_false(backend.coder_opts)
+    elif coder_opts is True:
+        coder_opts = backend.coder_opts
+    elif coder_opts is None:
+        decoders = _resolve_decoders_kwargs(
+            decode_cf,
+            open_backend_dataset_parameters=backend.open_dataset_parameters,
+            mask_and_scale=mask_and_scale,
+            decode_times=decode_times,
+            decode_timedelta=decode_timedelta,
+            concat_characters=concat_characters,
+            use_cftime=use_cftime,
+            decode_coords=decode_coords,
+        )
+        decoders["drop_variables"] = drop_variables
+        coder_opts = CoderOptions(**decoders)
+
+    if backend_opts is None:
+        backend_opts = XarrayBackendOptions(
+            chunks=chunks,
+            cache=cache,
+            inline_array=inline_array,
+            chunked_array_type=chunked_array_type,
+            from_array_kwargs=from_array_kwargs,
+            overwrite_encoded_chunks=kwargs.pop("overwrite_encoded_chunks", None),
+        )
+
+    # Check if store_opts have been ovrridden in the subclass
+    # That indicates new-style behaviour
+    # We can keep backwards compatibility
+    _store_opts = backend.store_opts
+    if type(_store_opts) is BackendOptions:
+        coder_kwargs = asdict(coder_opts)
+
+        backend_ds = backend.open_dataset(
+            filename_or_obj,
+            **coder_kwargs,
+            **kwargs,
+        )
+    else:
+        backend_ds = backend.open_dataset(
+            filename_or_obj,
+            coder_opts=coder_opts,
+            open_opts=open_opts,
+            store_opts=store_opts,
+            **kwargs,
+        )
+
     ds = _dataset_from_backend_dataset(
         backend_ds,
         filename_or_obj,
         engine,
-        chunks,
-        cache,
-        overwrite_encoded_chunks,
-        inline_array,
-        chunked_array_type,
-        from_array_kwargs,
-        drop_variables=drop_variables,
-        **decoders,
+        coder_opts,
+        backend_opts,
         **kwargs,
     )
     return ds

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -672,6 +672,22 @@ class BackendOptions:
     pass
 
 
+from xarray.backends.locks import SerializableLock
+
+
+@dataclass(frozen=True)
+class StoreWriteOptions:
+    group: Optional[str] = None
+    lock: Optional[SerializableLock] = None
+    autoclose: Optional[bool] = False
+
+
+@dataclass(frozen=True)
+class StoreWriteOpenOptions:
+    mode: Optional[str] = "r"
+    format: Optional[str] = "NETCDF4"
+
+
 @dataclass(frozen=True)
 class XarrayBackendOptions:
     chunks: Optional[T_Chunks] = None
@@ -742,9 +758,9 @@ class BackendEntrypoint:
 
     def __init__(
         self,
-        coder_opts: Optional[CoderOptions] = None,
-        open_opts: Optional[CoderOptions] = None,
-        store_opts: Optional[CoderOptions] = None,
+        coder_opts: Optional[BackendOptions] = None,
+        open_opts: Optional[BackendOptions] = None,
+        store_opts: Optional[BackendOptions] = None,
     ):
         self.coder_opts = coder_opts if coder_opts is not None else self.coder_class()
         self.open_opts = open_opts if open_opts is not None else self.open_class()

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -686,7 +686,7 @@ class XarrayBackendOptions:
 class CoderOptions:
     # mask: Optional[bool] = None
     # scale: Optional[bool] = None
-    mask_and_scale: Optional[bool | Mapping[str, bool]] = (None,)
+    mask_and_scale: Optional[bool | Mapping[str, bool]] = None
     decode_times: Optional[
         bool | CFDatetimeCoder | Mapping[str, bool | CFDatetimeCoder]
     ] = None

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -4,7 +4,7 @@ import functools
 import io
 import os
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union
 
 import numpy as np
 
@@ -139,19 +139,27 @@ class H5NetCDFStore(WritableCFDataStore):
         cls,
         filename,
         mode="r",
-        format=None,
-        group=None,
-        lock=None,
-        autoclose=False,
-        invalid_netcdf=None,
-        phony_dims=None,
-        decode_vlen_strings=True,
-        driver=None,
-        driver_kwds=None,
-        storage_options: dict[str, Any] | None = None,
+        # format=None,
+        # group=None,
+        # lock=None,
+        # autoclose=False,
+        # invalid_netcdf=None,
+        # phony_dims=None,
+        # decode_vlen_strings=True,
+        # driver=None,
+        # driver_kwds=None,
+        # storage_options: dict[str, Any] | None = None,
+        open_opts=None,
+        store_opts=None,
+        **kwargs,
     ):
         import h5netcdf
 
+        open_kwargs = asdict(open_opts)
+        store_kwargs = asdict(store_opts)
+
+        driver = open_kwargs["driver"]
+        storage_options = open_kwargs.pop("storage_options", None)
         if isinstance(filename, str) and is_remote_uri(filename) and driver is None:
             mode_ = "rb" if mode == "r" else mode
             filename = _open_remote_file(
@@ -169,28 +177,33 @@ class H5NetCDFStore(WritableCFDataStore):
                 raise ValueError(
                     f"{magic_number!r} is not the signature of a valid netCDF4 file"
                 )
-
+        format = open_kwargs.pop("format")
         if format not in [None, "NETCDF4"]:
             raise ValueError("invalid format for h5netcdf backend")
 
-        kwargs = {
-            "invalid_netcdf": invalid_netcdf,
-            "decode_vlen_strings": decode_vlen_strings,
-            "driver": driver,
-        }
+        kwargs.update(open_kwargs)
+        # kwargs.update(kwargs.pop("driver_kwds", None))
+        #
+        #     = {
+        #     "invalid_netcdf": invalid_netcdf,
+        #     "decode_vlen_strings": decode_vlen_strings,
+        #     "driver": driver,
+        # }
+        driver_kwds = kwargs.pop("driver_kwds")
         if driver_kwds is not None:
             kwargs.update(driver_kwds)
-        if phony_dims is not None:
-            kwargs["phony_dims"] = phony_dims
-
+        print("XX:", kwargs)
+        # if phony_dims is not None:
+        #    kwargs["phony_dims"] = phony_dims
+        lock = store_kwargs.get("lock", None)
         if lock is None:
             if mode == "r":
                 lock = HDF5_LOCK
             else:
                 lock = combine_locks([HDF5_LOCK, get_write_lock(filename)])
-
+            store_kwargs["lock"] = lock
         manager = CachingFileManager(h5netcdf.File, filename, mode=mode, kwargs=kwargs)
-        return cls(manager, group=group, mode=mode, lock=lock, autoclose=autoclose)
+        return cls(manager, mode=mode, **store_kwargs)
 
     def _acquire(self, needs_lock=True):
         with self._manager.acquire_context(needs_lock) as root:
@@ -388,6 +401,35 @@ def _emit_phony_dims_warning():
     )
 
 
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+from xarray.backends.locks import SerializableLock
+
+Buffer = Union[bytes, bytearray, memoryview]
+from xarray.backends.common import BackendOptions
+from xarray.backends.netCDF4_ import NetCDF4CoderOptions as H5netcdfCoderOptions
+
+
+@dataclass(frozen=True)
+class H5netcdfStoreOptions(BackendOptions):
+    group: Optional[str] = None
+    lock: Optional[SerializableLock] = None
+    autoclose: Optional[bool] = False
+
+
+@dataclass(frozen=True)
+class H5netcdfOpenOptions(BackendOptions):
+    format: Optional[str] = "NETCDF4"
+    driver: Optional[str] = None
+    driver_kwds: Optional[dict[str, Any]] = None
+    libver: Optional[Union[str, tuple[str]]] = None
+    invalid_netcdf: Optional[bool] = False
+    phony_dims: Optional[str] = "access"
+    decode_vlen_strings: Optional[bool] = True
+    storage_options: Optional[dict[str, Any]] = None
+
+
 class H5netcdfBackendEntrypoint(BackendEntrypoint):
     """
     Backend for netCDF files based on the h5netcdf package.
@@ -395,7 +437,7 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
     It can open ".nc", ".nc4", ".cdf" files but will only be
     selected as the default if the "netcdf4" engine is not available.
 
-    Additionally it can open valid HDF5 files, see
+    Additionally, it can open valid HDF5 files, see
     https://h5netcdf.org/#invalid-netcdf-files for more info.
     It will not be detected as valid backend for such files, so make
     sure to specify ``engine="h5netcdf"`` in ``open_dataset``.
@@ -409,6 +451,10 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
     backends.NetCDF4BackendEntrypoint
     backends.ScipyBackendEntrypoint
     """
+
+    coder_class = H5netcdfCoderOptions
+    open_class = H5netcdfOpenOptions
+    store_class = H5netcdfStoreOptions
 
     description = (
         "Open netCDF (.nc, .nc4 and .cdf) and most HDF5 files using h5netcdf in Xarray"
@@ -433,59 +479,64 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         self,
         filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
         *,
-        mask_and_scale=True,
-        decode_times=True,
-        concat_characters=True,
-        decode_coords=True,
-        drop_variables: str | Iterable[str] | None = None,
-        use_cftime=None,
-        decode_timedelta=None,
-        format=None,
-        group=None,
-        lock=None,
-        invalid_netcdf=None,
-        phony_dims=None,
-        decode_vlen_strings=True,
-        driver=None,
-        driver_kwds=None,
-        storage_options: dict[str, Any] | None = None,
+        # mask_and_scale=True,
+        # decode_times=True,
+        # concat_characters=True,
+        # decode_coords=True,
+        # drop_variables: str | Iterable[str] | None = None,
+        # use_cftime=None,
+        # decode_timedelta=None,
+        # format=None,
+        # group=None,
+        # lock=None,
+        # invalid_netcdf=None,
+        # phony_dims=None,
+        # decode_vlen_strings=True,
+        # driver=None,
+        # driver_kwds=None,
+        # storage_options: dict[str, Any] | None = None,
+        coder_opts: H5netcdfCoderOptions = None,
+        open_opts: H5netcdfOpenOptions = None,
+        store_opts: H5netcdfStoreOptions = None,
+        **kwargs,
     ) -> Dataset:
+        coder_opts = coder_opts if coder_opts is not None else self.coder_opts
+        open_opts = open_opts if open_opts is not None else self.open_opts
+        store_opts = store_opts if store_opts is not None else self.store_opts
+
         # Keep this message for some versions
         # remove and set phony_dims="access" above
-        emit_phony_dims_warning, phony_dims = _check_phony_dims(phony_dims)
+        # emit_phony_dims_warning, phony_dims = _check_phony_dims(phony_dims)
 
         filename_or_obj = _normalize_path(filename_or_obj)
         store = H5NetCDFStore.open(
             filename_or_obj,
-            format=format,
-            group=group,
-            lock=lock,
-            invalid_netcdf=invalid_netcdf,
-            phony_dims=phony_dims,
-            decode_vlen_strings=decode_vlen_strings,
-            driver=driver,
-            driver_kwds=driver_kwds,
-            storage_options=storage_options,
+            open_opts=open_opts,
+            store_opts=store_opts,
+            # format=format,
+            # group=group,
+            # lock=lock,
+            # invalid_netcdf=invalid_netcdf,
+            # phony_dims=phony_dims,
+            # decode_vlen_strings=decode_vlen_strings,
+            # driver=driver,
+            # driver_kwds=driver_kwds,
+            # storage_options=storage_options,
+            **kwargs,
         )
 
         store_entrypoint = StoreBackendEntrypoint()
 
         ds = store_entrypoint.open_dataset(
             store,
-            mask_and_scale=mask_and_scale,
-            decode_times=decode_times,
-            concat_characters=concat_characters,
-            decode_coords=decode_coords,
-            drop_variables=drop_variables,
-            use_cftime=use_cftime,
-            decode_timedelta=decode_timedelta,
+            coder_opts=coder_opts,
         )
 
         # only warn if phony_dims exist in file
         # remove together with the above check
         # after some versions
-        if store.ds._root._phony_dim_count > 0 and emit_phony_dims_warning:
-            _emit_phony_dims_warning()
+        # if store.ds._root._phony_dim_count > 0 and emit_phony_dims_warning:
+        #    _emit_phony_dims_warning()
 
         return ds
 

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -410,8 +410,8 @@ class NetCDF4DataStore(WritableCFDataStore):
     ):
         import netCDF4
 
-        open_kwargs = asdict(open_opts)
-        store_kwargs = asdict(store_opts)
+        open_kwargs = asdict(open_opts) if open_opts is not None else {}
+        store_kwargs = asdict(store_opts) if store_opts is not None else {}
 
         if isinstance(filename, os.PathLike):
             filename = os.fspath(filename)
@@ -422,7 +422,7 @@ class NetCDF4DataStore(WritableCFDataStore):
                 "with engine='scipy' or 'h5netcdf'"
             )
 
-        format = open_kwargs.pop("format")
+        format = open_kwargs.pop("format", None)
         if format is None:
             format = "NETCDF4"
 
@@ -441,7 +441,8 @@ class NetCDF4DataStore(WritableCFDataStore):
                 lock = combine_locks([base_lock, get_write_lock(filename)])
             store_kwargs["lock"] = lock
         kwargs.update(open_kwargs)
-        print("DD:", kwargs)
+        print("DD0:", kwargs)
+        print("DD1:", store_kwargs)
         manager = CachingFileManager(
             netCDF4.Dataset, filename, mode=mode, kwargs=kwargs
         )
@@ -601,6 +602,18 @@ from xarray.backends.locks import SerializableLock
 
 Buffer = Union[bytes, bytearray, memoryview]
 from xarray.backends.common import BackendOptions
+
+
+@dataclass(frozen=True)
+class StoreWriteOptions:
+    group: Optional[str] = None
+    lock: Optional[SerializableLock] = None
+    autoclose: Optional[bool] = False
+
+
+@dataclass(frozen=True)
+class StoreWriteOpenOptions:
+    format: Optional[str] = "NETCDF4"
 
 
 @dataclass(frozen=True)

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -51,12 +51,12 @@ def detect_parameters(open_dataset: Callable) -> tuple[str, ...]:
     parameters_list = []
     for name, param in parameters.items():
         if param.kind in (
-            inspect.Parameter.VAR_KEYWORD,
+            # inspect.Parameter.VAR_KEYWORD,
             inspect.Parameter.VAR_POSITIONAL,
         ):
             raise TypeError(
-                f"All the parameters in {open_dataset!r} signature should be explicit. "
-                "*args and **kwargs is not supported"
+                f"All arguments in {open_dataset!r} signature should be explicit. "
+                "*args are not supported"
             )
         if name != "self":
             parameters_list.append(name)

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any, Optional
 
 from xarray import conventions
 from xarray.backends.common import (
     BACKEND_ENTRYPOINTS,
     AbstractDataStore,
     BackendEntrypoint,
+    CoderOptions,
 )
 from xarray.core.dataset import Dataset
 
@@ -31,29 +32,20 @@ class StoreBackendEntrypoint(BackendEntrypoint):
         self,
         filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
         *,
-        mask_and_scale=True,
-        decode_times=True,
-        concat_characters=True,
-        decode_coords=True,
-        drop_variables: str | Iterable[str] | None = None,
-        use_cftime=None,
-        decode_timedelta=None,
+        coder_opts: Optional[CoderOptions] = None,
+        **kwargs,
     ) -> Dataset:
         assert isinstance(filename_or_obj, AbstractDataStore)
 
         vars, attrs = filename_or_obj.load()
         encoding = filename_or_obj.get_encoding()
 
+        coder_opts = coder_opts if coder_opts is not None else self.coder_opts
+        coders_kwargs = asdict(coder_opts)
         vars, attrs, coord_names = conventions.decode_cf_variables(
             vars,
             attrs,
-            mask_and_scale=mask_and_scale,
-            decode_times=decode_times,
-            concat_characters=concat_characters,
-            decode_coords=decode_coords,
-            drop_variables=drop_variables,
-            use_cftime=use_cftime,
-            decode_timedelta=decode_timedelta,
+            **coders_kwargs,
         )
 
         ds = Dataset(vars, attrs=attrs)

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     T_Name = Union[Hashable, None]
     T_Variables = Mapping[Any, Variable]
     T_Attrs = MutableMapping[Any, Any]
-    T_DropVariables = Union[str, Iterable[Hashable], None]
+    T_DropVariables = Union[str, Iterable[Hashable], None, False]
     T_DatasetOrAbstractstore = Union[Dataset, AbstractDataStore]
 
 
@@ -382,7 +382,7 @@ def decode_cf_variables(
 
     if isinstance(drop_variables, str):
         drop_variables = [drop_variables]
-    elif drop_variables is None:
+    elif drop_variables is None or drop_variables is False:
         drop_variables = []
     drop_variables = set(drop_variables)
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -368,8 +368,6 @@ class DatasetIOBase:
         if open_kwargs is None:
             open_kwargs = {}
         with create_tmp_file(allow_cleanup_failure=allow_cleanup_failure) as path:
-            print("ZZ0:", save_kwargs)
-            print("ZZ1:", open_kwargs)
             self.save(data, path, **save_kwargs)
             with self.open(path, **open_kwargs) as ds:
                 yield ds
@@ -1556,14 +1554,10 @@ class NetCDF4Base(NetCDFBase):
         data1 = create_test_data()
         data2 = data1 * 2
         with create_tmp_file() as tmp_file:
-            print("----------------------------------------")
             self.save(data1, tmp_file, group="data/1")
-            print("----------------------------------------")
             self.save(data2, tmp_file, group="data/2", mode="a")
-            print("----------------------------------------")
             with self.open(tmp_file, group="data/1") as actual1:
                 assert_identical(data1, actual1)
-            print("----------------------------------------")
             with self.open(tmp_file, group="data/2") as actual2:
                 assert_identical(data2, actual2)
 
@@ -5423,7 +5417,6 @@ class TestPydap:
     @contextlib.contextmanager
     def create_datasets(self, **kwargs):
         with open_example_dataset("bears.nc") as expected:
-            # print("QQ0:", expected["bears"].load())
             pydap_ds = self.convert_to_pydap_dataset(expected)
             actual = open_dataset(PydapDataStore(pydap_ds))
             if Version(np.__version__) < Version("2.3.0"):

--- a/xarray/tests/test_backends_api.py
+++ b/xarray/tests/test_backends_api.py
@@ -69,7 +69,7 @@ def test_multiindex() -> None:
 class PassThroughBackendEntrypoint(xr.backends.BackendEntrypoint):
     """Access an object passed to the `open_dataset` method."""
 
-    def open_dataset(self, dataset, *, drop_variables=None):
+    def open_dataset(self, dataset, *, drop_variables=None, **kwargs):
         """Return the first argument."""
         return dataset
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #10377
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

This is a first attempt and base for discussion.

This PR does the following:

1. split `open_dataset` kwargs into four groups:
   Here I followed @shoyer's suggestion to use dataclasses https://github.com/pydata/xarray/issues/4490.
  - coder_opts: options for CF coders (eg. mask_and_scale, decode_times)
  - open_opts: options for the backend file opener (eg. driver, clobber, diskless, format)
  - backend_opts: options for xarray (eg. chunk, cache, inline_array) 
  - store_opts: options for the backend store (eg. group, lock, autoclose)
2. define these classes in `BackendEntrypoint` and override them in the subclasses.
  for now only for netcdf4/h5netcdf backends
4. implement logic into `open_dataset`
5. implement logic into `to_netcdf`
6. for backwards compatibility reinitialize the above options with the given kwargs as needed

Example usage:

```python
# simple call, use backend default options
ds = xr.open_dataset("test.nc", engine="netcdf4") # simple call
# define once, use many , these should be imported from the backend 
open_opts = NetCDF4OpenOptions(auto_complex=True)
coder_opts = NetCDF4CoderOptions(decode_times=False, mask_and_scale=False)
backend_opts = XarrayBackendOptions(chunk={"time": 10})
store_opts = NetCDF4StoreOptions(group="test")
# engine could also be the `BackenEntryPoint`
ds = xr.open_dataset("test.nc", engine="netcdf4", open_opts=open_opts, coder_opts=coder_opts, backend_opts=backend_opts, store_opts=store_opts) 
```

CONS: 
  - Most users might not need to use these added options at all, but could fallback to current behaviour
  - Users might complain about the additional complexity for setting up the dataclasses
  - tbc.
  
PROS:
  - strict separation of kwargs/options
  - easy forwarding
  - per backend kwargs/options
  - easy adding kwargs/options
  - tbc.     

What this PR still needs to do:

- implement everything above for the other built-in backends (zarr, scipy, pydap, etc.)

I have follow-up ideas:

- implement `save_dataset` in `BackendEntrypoint` to write to the engine's native format, like `to_netcdf` would be for scipy/netcdf4/h5netcdf and `to_zarr` would be for zarr. With that we could do the writing with a unified API, something like:

  ```python
  ds = xr.open_dataset("test.nc", engine="netcdf4")
  # Dataset API
  ds.save_dataset("test.zarr", engine="zarr)
  ds.save_dataset("test2.nc", engine="netcdf4")
  # general API
  xr.save_dataset(ds, "test2.nc", engine="netcdf4")
  ds.save_dataset("test.grib", engine="grib") # my imagination
  ds.save_dataset("test.hdf5", engine="hdf5") # my imagination
  ```

- further disentangle the current built-in backends from xarray so that they could be their own module

I'm sure I have not taken into account all the possible pitfalls/problems which might arise here. I'd appreciate any comments and suggestions. 
 
  