### PR TITLE
Use zarr-python default open mode when opening arrays

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -639,7 +639,7 @@ class ZarrStore(AbstractWritableDataStore):
     def open_group(
         cls,
         store,
-        mode: ZarrWriteModes = "r",
+        mode: ZarrWriteModes | None = None,
         synchronizer=None,
         group=None,
         consolidated=False,
@@ -1561,7 +1561,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
         use_cftime=None,
         decode_timedelta=None,
         group=None,
-        mode="r",
+        mode=None,
         synchronizer=None,
         consolidated=None,
         chunk_store=None,
@@ -1746,6 +1746,9 @@ def _get_open_params(
         synchronizer=synchronizer,
         path=group,
     )
+    if mode is None:
+        # Let zarr-python use its default open mode
+        open_kwargs.pop("mode")
     open_kwargs["storage_options"] = storage_options
 
     zarr_format = _handle_zarr_version_or_format(


### PR DESCRIPTION
This is an experimental PR, aimed a fixing errors in the upstream CI (e.g., see https://github.com/pydata/xarray/actions/runs/15646254224/job/44084198866) caused by (the unreleased) https://github.com/zarr-developers/zarr-python/pull/3068.

Instead of defaulting to opening an array with mode='r', if not specified this defers choice of the mode to the default in zarr-python. In zarr-python 3 the default is mode='a', which avoids issues around requesting a read-only array from a writeable store.