### PR TITLE
Switch to using the NumFOCUS Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,46 +1,23 @@
-# Contributor Covenant Code of Conduct
+# NUMFOCUS CODE OF CONDUCT
 
-## Our Pledge
+You can find the full Code of Conduct on the NumFOCUS website: https://numfocus.org/code-of-conduct
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+## THE SHORT VERSION
 
-## Our Standards
+NumFOCUS is dedicated to providing a harassment-free community for everyone, regardless of gender, sexual orientation, gender identity and expression, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of community members in any form.
 
-Examples of behavior that contributes to creating a positive environment include:
+Be kind to others. Do not insult or put down others. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for NumFOCUS.
 
-- Using welcoming and inclusive language
-- Being respectful of differing viewpoints and experiences
-- Gracefully accepting constructive criticism
-- Focusing on what is best for the community
-- Showing empathy towards other community members
+All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate.
 
-Examples of unacceptable behavior by participants include:
+Thank you for helping make this a welcoming, friendly community for all.
 
-- The use of sexualized language or imagery and unwelcome sexual attention or advances
-- Trolling, insulting/derogatory comments, and personal or political attacks
-- Public or private harassment
-- Publishing others' private information, such as a physical or electronic address, without explicit permission
-- Other conduct which could reasonably be considered inappropriate in a professional setting
+## HOW TO REPORT
 
-## Our Responsibilities
+If you feel that the Code of Conduct has been violated, feel free to submit a report, by using the form: [NumFOCUS Code of Conduct Reporting Form](https://numfocus.typeform.com/to/ynjGdT?typeform-source=numfocus.org)
 
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+## WHO WILL RECEIVE YOUR REPORT
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+Your report will be received and handled by NumFOCUS Code of Conduct Working Group; trained, and experienced contributors with diverse backgrounds. The group is making decisions independently from the project, PyData, NumFOCUS or any other organization.
 
-## Scope
-
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
-
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at xarray-core-team@googlegroups.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [https://contributor-covenant.org/version/1/4][version]
-
-[homepage]: https://contributor-covenant.org
-[version]: https://contributor-covenant.org/version/1/4/
+You can learn more about the current group members, as well as the reporting procedure here: https://numfocus.org/code-of-conduct


### PR DESCRIPTION
When Xarray joined NumFOCUS in 2018, we adopted the "Contributor Covenant" Code of Conduct because that was recommended by NumFOCUS, and having a Code of Conduct was a requirement for NumFOCUS affiliation. Our code of conduct suggests contacting the core project team to report any issues,  but in practice we have never had a code of conduct report.

Recently, NumFOCUS introduced a standard [NumFOCUS code of conduct](https://numfocus.org/code-of-conduct), which it has encourraged all NumFOCUS projects to adopt. In practice, the main difference is that the NumFOCUS Code of Conduct Working Group would handle all reports, rather than Xarray's project core team. We have the option to either have the Working Group recommendations (with final decisions by Xarray project leadership) or to let the Working Group make binding decisions themselves.

**I recommend that Xarray adopt the NumFOCUS Code of Conduct, with the NumFOCUS Code of Conduct Working Group making final decisions**:
1. The Code of Conduct Working Group is better prepared to handle Code of Conduct reports than Xarray's project leadership, because they handle code of conduct reports regularly.
2. If any Code of Conduct violations did arise, they could likely involve some core project team members, which makes our current structure of reporting violating to the core team problematic. In addition, our core team is fairly large (20+ members with various levels of activity), which preserving anonymity hard to guarantee.
3. Xarray does not have an established formal governance structure, which could make making final decisions ourselves in any contentious situations challenging.

CC @pydata/xarray for visibility.

Consider indicating your support or any concerns via emoticon responses to this post (e.g. 👍 )