### PR TITLE
Expose top-level xarray.indexes in __init__

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1576,6 +1576,7 @@ Custom Indexes
 
    CFTimeIndex
    indexes.RangeIndex
+   indexes.CoordinateTransformIndex
 
 Creating custom indexes
 -----------------------
@@ -1587,6 +1588,13 @@ Creating custom indexes
    date_range_like
    indexes.RangeIndex.arange
    indexes.RangeIndex.linspace
+
+Building custom indexes
+-----------------------
+.. autosummary::
+   :toctree: generated/
+
+   indexes.CoordinateTransform
 
 Tutorial
 ========

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -12,6 +12,8 @@ v2025.07.0 (unreleased)
 
 New Features
 ~~~~~~~~~~~~
+- Expose :py:class:`~xarray.indexes.RangeIndex`, and :py:class:`~xarray.indexes.CoordinateTransformIndex` as public api
+  under the ``xarray.indexes`` namespace. By `Deepak Cherian <https://github.com/dcherian>`_.
 
 
 Breaking changes

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -1,6 +1,6 @@
 from importlib.metadata import version as _version
 
-from xarray import coders, groupers, testing, tutorial, ufuncs
+from xarray import coders, groupers, indexes, testing, tutorial, ufuncs
 from xarray.backends.api import (
     load_dataarray,
     load_dataset,
@@ -70,6 +70,7 @@ __all__ = (  # noqa: RUF022
     # Sub-packages
     "coders",
     "groupers",
+    "indexes",
     "testing",
     "tutorial",
     "ufuncs",

--- a/xarray/indexes/__init__.py
+++ b/xarray/indexes/__init__.py
@@ -3,11 +3,20 @@ DataArray objects.
 
 """
 
+from xarray.core.coordinate_transform import CoordinateTransform
 from xarray.core.indexes import (
+    CoordinateTransformIndex,
     Index,
     PandasIndex,
     PandasMultiIndex,
 )
 from xarray.indexes.range_index import RangeIndex
 
-__all__ = ["Index", "PandasIndex", "PandasMultiIndex", "RangeIndex"]
+__all__ = [
+    "CoordinateTransform",
+    "CoordinateTransformIndex",
+    "Index",
+    "PandasIndex",
+    "PandasMultiIndex",
+    "RangeIndex",
+]


### PR DESCRIPTION
Also expose CoordinateTransformIndex

Closes #10424
