### PR TITLE
assert_equal: ensure check_dim_order=False works for DataTree

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,6 +34,8 @@ Bug fixes
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - Fix the error message of :py:func:`testing.assert_equal` when two different :py:class:`DataTree` objects
   are passed (:pull:`10440`). By `Mathias Hauser <https://github.com/mathause>`_.
+- Fix :py:func:`testing.assert_equal` with ``check_dim_order=False`` for :py:class:`DataTree` objects
+  (:pull:`10442`). By `Mathias Hauser <https://github.com/mathause>`_.
 
 
 Documentation

--- a/xarray/tests/test_assertions.py
+++ b/xarray/tests/test_assertions.py
@@ -88,6 +88,19 @@ def test_assert_allclose_equal_transpose(func) -> None:
     getattr(xr.testing, func)(ds1, ds2, check_dim_order=False)
 
 
+def test_assert_equal_transpose_datatree():
+    """Ensure `check_dim_order=False` works for transposed DataTree"""
+    ds = xr.Dataset(data_vars={"data": (("x", "y"), [[1, 2]])})
+
+    a = xr.DataTree.from_dict({"node": ds})
+    b = xr.DataTree.from_dict({"node": ds.transpose("y", "x")})
+
+    with pytest.raises(AssertionError):
+        xr.testing.assert_equal(a, b)
+
+    xr.testing.assert_equal(a, b, check_dim_order=False)
+
+
 @pytest.mark.filterwarnings("error")
 @pytest.mark.parametrize(
     "duckarray",

--- a/xarray/tests/test_assertions.py
+++ b/xarray/tests/test_assertions.py
@@ -88,7 +88,7 @@ def test_assert_allclose_equal_transpose(func) -> None:
     getattr(xr.testing, func)(ds1, ds2, check_dim_order=False)
 
 
-def test_assert_equal_transpose_datatree():
+def test_assert_equal_transpose_datatree() -> None:
     """Ensure `check_dim_order=False` works for transposed DataTree"""
     ds = xr.Dataset(data_vars={"data": (("x", "y"), [[1, 2]])})
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

`assert_equal(..., check_dim_order=False)` did not do anything when two `DataTree` objects are passed.

Requires #10440 for the tests to pass, so a draft for now.