### PR TITLE
Exceptions are overlapping

### DIFF
--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -1292,7 +1292,7 @@ def attempt_import(module: str) -> ModuleType:
     reason = package_purpose.get(package_name, "")
     try:
         return importlib.import_module(module)
-    except (ImportError, ModuleNotFoundError) as e:
+    except ImportError as e:
         raise ImportError(
             f"The {install_name} package is required {reason}"
             " but could not be imported."


### PR DESCRIPTION
`ModuleNotFoundError` is a subclass of `ImportError`:
[Exception hierarchy](https://docs.python.org/3/library/exceptions.html#exception-hierarchy)

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
