### PR TITLE
Use add_note() to annotate exceptions when encoding fails

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -14,7 +14,8 @@ New Features
 ~~~~~~~~~~~~
 - Expose :py:class:`~xarray.indexes.RangeIndex`, and :py:class:`~xarray.indexes.CoordinateTransformIndex` as public api
   under the ``xarray.indexes`` namespace. By `Deepak Cherian <https://github.com/dcherian>`_.
-
+- Better error messages when encoding data to be written to disk fails (:pull:`10464`).
+  By `Stephan Hoyer <https://github.com/shoyer>`_
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -389,9 +389,23 @@ class AbstractWritableDataStore(AbstractDataStore):
         attributes : dict-like
 
         """
-        variables = {k: self.encode_variable(v, name=k) for k, v in variables.items()}
-        attributes = {k: self.encode_attribute(v) for k, v in attributes.items()}
-        return variables, attributes
+        encoded_variables = {}
+        for k, v in variables.items():
+            try:
+                encoded_variables[k] = self.encode_variable(v)
+            except Exception as e:
+                e.add_note(f"Raised while encoding variable {k!r} with value {v!r}")
+                raise
+
+        encoded_attributes = {}
+        for k, v in attributes.items():
+            try:
+                encoded_attributes[k] = self.encode_attribute(v)
+            except Exception as e:
+                e.add_note(f"Raised while encoding attribute {k!r} with value {v!r}")
+                raise
+
+        return encoded_variables, encoded_attributes
 
     def encode_variable(self, v, name=None):
         """encode one variable"""
@@ -641,9 +655,7 @@ class WritableCFDataStore(AbstractWritableDataStore):
         variables = {
             k: ensure_dtype_not_object(v, name=k) for k, v in variables.items()
         }
-        variables = {k: self.encode_variable(v, name=k) for k, v in variables.items()}
-        attributes = {k: self.encode_attribute(v) for k, v in attributes.items()}
-        return variables, attributes
+        return super().encode(variables, attributes)
 
 
 class BackendEntrypoint:

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -792,7 +792,13 @@ def cf_encoder(variables: T_Variables, attributes: T_Attrs):
     # add encoding for time bounds variables if present.
     _update_bounds_encoding(variables)
 
-    new_vars = {k: encode_cf_variable(v, name=k) for k, v in variables.items()}
+    new_vars = {}
+    for k, v in variables.items():
+        try:
+            new_vars[k] = encode_cf_variable(v, name=k)
+        except Exception as e:
+            e.add_note(f"Raised while encoding variable {k!r} with value {v!r}")
+            raise
 
     # Remove attrs from bounds variables (issue #2921)
     for var in new_vars.values():


### PR DESCRIPTION
We now always add variable names and contents when encoding fails, in contrast to the current practice where variable names and values are only sometimes specified, based on the `name` passed into `VariableCoder.encode()`. This provides better debugging experience for users.

In the future, we might remove `name` from `VariableCoder.encode()` because this makes it redundant.

For example, attempting to save a int64 fail in netCDF3 file now shows something like the following:

    ValueError: could not safely cast array from int64 to int32...
    Raised while encoding variable 'invalid' with value <xarray.Variable (invalid: 1)> Size: 8B
    array([9223372036854775807])

Note that `Exception.add_note()` is a Python 3.11+ feature, so this PR will need to wait until #10438 is submitted.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
