### PR TITLE
Branches of the `if` statement have similar implementation

### DIFF
--- a/asv_bench/benchmarks/dataset_io.py
+++ b/asv_bench/benchmarks/dataset_io.py
@@ -678,13 +678,7 @@ class IOReadCustomEngine:
                 lock: xr.backends.locks.SerializableLock | None = None,
                 autoclose: bool = False,
             ):
-                if lock is None:
-                    if mode == "r":
-                        locker = xr.backends.locks.SerializableLock()
-                    else:
-                        locker = xr.backends.locks.SerializableLock()
-                else:
-                    locker = lock
+                locker = lock or xr.backends.locks.SerializableLock()
 
                 manager = xr.backends.CachingFileManager(
                     xr.backends.DummyFileManager,

--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence
 from enum import Enum
 from types import EllipsisType, ModuleType
@@ -20,10 +19,7 @@ from typing import (
 import numpy as np
 
 try:
-    if sys.version_info >= (3, 11):
-        from typing import TypeAlias
-    else:
-        from typing import TypeAlias
+    from typing import TypeAlias
 except ImportError:
     if TYPE_CHECKING:
         raise


### PR DESCRIPTION
Issue introduced by 16b53ac / #8937.

It looks like the `sys.version_info >= (3, 11)` test is incorrect, as [`typing.TypeAlias`](https://docs.python.org/3/library/typing.html#typing.TypeAlias)  was added in version 3.10, not 3.11:
> _Added in version 3.10._

Note that [`TypeAlias`](https://docs.python.org/3/library/typing.html#typing.TypeAlias) itself will be deprecated:
> _Deprecated since version 3.12:_ [`TypeAlias`](https://docs.python.org/3/library/typing.html#typing.TypeAlias) is deprecated in favor of the [`type`](https://docs.python.org/3/reference/simple_stmts.html#type) statement, which creates instances of [`TypeAliasType`](https://docs.python.org/3/library/typing.html#typing.TypeAliasType) and which natively supports forward references. Note that while [`TypeAlias`](https://docs.python.org/3/library/typing.html#typing.TypeAlias) and [`TypeAliasType`](https://docs.python.org/3/library/typing.html#typing.TypeAliasType) serve similar purposes and have similar names, they are distinct and the latter is not the type of the former. Removal of [`TypeAlias`](https://docs.python.org/3/library/typing.html#typing.TypeAlias) is not currently planned, but users are encouraged to migrate to [`type`](https://docs.python.org/3/reference/simple_stmts.html#type) statements.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
