### PR TITLE
Prevent pydap (dap4) to change string arrays to unicode type (testing). Fixed upstream

### DIFF
--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -1,4 +1,4 @@
-name: xarray-tests
+name: xarray-tests_min
 channels:
   - conda-forge
   - nodefaults
@@ -42,7 +42,7 @@ dependencies:
   - pandas=2.1
   - pint=0.22
   - pip
-  - pydap=3.5
+  - pydap=3.5.0
   - pytest
   - pytest-cov
   - pytest-env

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -1,4 +1,4 @@
-name: xarray-tests_min
+name: xarray-tests
 channels:
   - conda-forge
   - nodefaults

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,7 +36,7 @@ Bug fixes
   are passed (:pull:`10440`). By `Mathias Hauser <https://github.com/mathause>`_.
 - Fix :py:func:`testing.assert_equal` with ``check_dim_order=False`` for :py:class:`DataTree` objects
   (:pull:`10442`). By `Mathias Hauser <https://github.com/mathause>`_.
-- Fix Pydap backend testing. Now test forces string arrays to dtype "|S" (pydap converts them to unicode type by default). Removes conditional to numpy version. (:issue:`10261`, :pull:`10482`)
+- Fix Pydap backend testing. Now test forces string arrays to dtype "S" (pydap converts them to unicode type by default). Removes conditional to numpy version. (:issue:`10261`, :pull:`10482`)
   By `Miguel Jimenez-Urias <https://github.com/Mikejmnez>`_.
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,6 +36,8 @@ Bug fixes
   are passed (:pull:`10440`). By `Mathias Hauser <https://github.com/mathause>`_.
 - Fix :py:func:`testing.assert_equal` with ``check_dim_order=False`` for :py:class:`DataTree` objects
   (:pull:`10442`). By `Mathias Hauser <https://github.com/mathause>`_.
+- Fix Pydap backend testing. Not test forces string arrays to dtype "|S" (pydap converts them to unicode type by default). Removes conditional to numpy version. (:issue:`10261`,:pull:`10482`)
+  By `Miguel Jimenez-Urias <https://github.com/Mikejmnez>`_.
 
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,7 +36,7 @@ Bug fixes
   are passed (:pull:`10440`). By `Mathias Hauser <https://github.com/mathause>`_.
 - Fix :py:func:`testing.assert_equal` with ``check_dim_order=False`` for :py:class:`DataTree` objects
   (:pull:`10442`). By `Mathias Hauser <https://github.com/mathause>`_.
-- Fix Pydap backend testing. Not test forces string arrays to dtype "|S" (pydap converts them to unicode type by default). Removes conditional to numpy version. (:issue:`10261`,:pull:`10482`)
+- Fix Pydap backend testing. Now test forces string arrays to dtype "|S" (pydap converts them to unicode type by default). Removes conditional to numpy version. (:issue:`10261`, :pull:`10482`)
   By `Miguel Jimenez-Urias <https://github.com/Mikejmnez>`_.
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -5425,7 +5425,9 @@ class TestPydap:
 
         ds = DatasetType("bears", **original.attrs)
         for key, var in original.data_vars.items():
-            ds[key] = BaseType(key, var.values, dims=var.dims, **var.attrs)
+            ds[key] = BaseType(
+                key, var.values, dtype=var.values.dtype.kind, dims=var.dims, **var.attrs
+            )
         # check all dims are stored in ds
         for d in original.coords:
             ds[d] = BaseType(d, original[d].values, dims=(d,), **original[d].attrs)
@@ -5437,9 +5439,9 @@ class TestPydap:
             # print("QQ0:", expected["bears"].load())
             pydap_ds = self.convert_to_pydap_dataset(expected)
             actual = open_dataset(PydapDataStore(pydap_ds))
-            if Version(np.__version__) < Version("2.3.0"):
-                # netcdf converts string to byte not unicode
-                expected["bears"] = expected["bears"].astype(str)
+            # netcdf converts string to byte not unicode
+            # fixed in pydap 3.5.6. https://github.com/pydap/pydap/issues/510
+            actual["bears"].values = actual["bears"].values.astype("S")
             yield actual, expected
 
     def test_cmp_local_file(self) -> None:
@@ -5483,9 +5485,6 @@ class TestPydap:
             with create_tmp_file() as tmp_file:
                 actual.to_netcdf(tmp_file)
                 with open_dataset(tmp_file) as actual2:
-                    if Version(np.__version__) < Version("2.3.0"):
-                        # netcdf converts string to byte not unicode
-                        actual2["bears"] = actual2["bears"].astype(str)
                     assert_equal(actual2, expected)
 
     @requires_dask
@@ -5503,9 +5502,11 @@ class TestPydapOnline(TestPydap):
         # in pydap 3.5.0, urls defaults to dap2.
         url = "http://test.opendap.org/opendap/data/nc/bears.nc"
         actual = open_dataset(url, engine="pydap", **kwargs)
+        # pydap <3.5.6 converts to unicode dtype=|U. Not what
+        # xarray expects. Thus force to bytes dtype. pydap >=3.5.6
+        # does not convert to unicode. https://github.com/pydap/pydap/issues/510
+        actual["bears"].values = actual["bears"].values.astype("S")
         with open_example_dataset("bears.nc") as expected:
-            # workaround to restore string which is converted to byte
-            expected["bears"] = expected["bears"].astype(str)
             yield actual, expected
 
     def output_grid_deprecation_warning_dap2dataset(self):
@@ -5518,7 +5519,8 @@ class TestPydapOnline(TestPydap):
         actual = open_dataset(url, engine="pydap", **kwargs)
         with open_example_dataset("bears.nc") as expected:
             # workaround to restore string which is converted to byte
-            expected["bears"] = expected["bears"].astype(str)
+            # only needed for pydap <3.5.6 https://github.com/pydap/pydap/issues/510
+            expected["bears"].values = expected["bears"].values.astype("S")
             yield actual, expected
 
     def test_session(self) -> None:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Partially addresses issues  #10261 (at least those regarding `pydap` backend). 
- [x] Tests ~added~ now pass on both min-dependencies environment (`pydap 3.5.0 `which has numpy<2) and with python=3.12 (nightly?)
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
