### PR TITLE
Add xarray-specific encoding convention for pd.IntervalArray

### DIFF
--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -1358,9 +1358,9 @@ class CFDatetimeCoder(VariableCoder):
         self.time_unit = time_unit
 
     def encode(self, variable: Variable, name: T_Name = None) -> Variable:
-        if np.issubdtype(
-            variable.data.dtype, np.datetime64
-        ) or contains_cftime_datetimes(variable):
+        if np.issubdtype(variable.dtype, np.datetime64) or contains_cftime_datetimes(
+            variable
+        ):
             dims, data, attrs, encoding = unpack_for_encoding(variable)
 
             units = encoding.pop("units", None)
@@ -1477,7 +1477,7 @@ class CFTimedeltaCoder(VariableCoder):
         self._emit_decode_timedelta_future_warning = False
 
     def encode(self, variable: Variable, name: T_Name = None) -> Variable:
-        if np.issubdtype(variable.data.dtype, np.timedelta64):
+        if np.issubdtype(variable.dtype, np.timedelta64):
             dims, data, attrs, encoding = unpack_for_encoding(variable)
             dtype = encoding.get("dtype", None)
             units = encoding.pop("units", None)

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -698,3 +698,53 @@ class NativeEnumCoder(VariableCoder):
 
     def decode(self, variable: Variable, name: T_Name = None) -> Variable:
         raise NotImplementedError()
+
+
+class IntervalCoder(VariableCoder):
+    """
+    Xarray-specific Interval Coder to roundtrip 1D pd.IntervalArray objects.
+    """
+
+    encoded_dtype = "pandas_interval"
+    encoded_bounds_dim = "__xarray_bounds__"
+
+    def encode(self, variable: Variable, name: T_Name = None) -> Variable:
+        if isinstance(dtype := variable.dtype, pd.IntervalDtype):
+            dims, data, attrs, encoding = unpack_for_encoding(variable)
+
+            new_data = np.stack([data.left, data.right], axis=0)
+            dims = (self.encoded_bounds_dim, *dims)
+            safe_setitem(attrs, "closed", dtype.closed, name=name)
+            safe_setitem(attrs, "dtype", self.encoded_dtype, name=name)
+            safe_setitem(attrs, "bounds_dim", self.encoded_bounds_dim, name=name)
+            return Variable(dims, new_data, attrs, encoding, fastpath=True)
+        else:
+            return variable
+
+    def decode(self, variable: Variable, name: T_Name = None) -> Variable:
+        if (
+            variable.attrs.get("dtype", None) == self.encoded_dtype
+            and self.encoded_bounds_dim in variable.dims
+        ):
+            if variable.ndim != 2:
+                raise ValueError(
+                    f"Cannot decode intervals for variable named {name!r} with more than two dimensions."
+                )
+
+            dims, data, attrs, encoding = unpack_for_decoding(variable)
+            pop_to(attrs, encoding, "dtype", name=name)
+            pop_to(attrs, encoding, "bounds_dim", name=name)
+            closed = pop_to(attrs, encoding, "closed", name=name)
+
+            _, new_dims = variable.dims
+            variable = variable.load()
+            new_data = pd.arrays.IntervalArray.from_arrays(
+                variable.isel({self.encoded_bounds_dim: 0}).data,
+                variable.isel({self.encoded_bounds_dim: 1}).data,
+                closed=closed,
+            )
+            return Variable(
+                dims=new_dims, data=new_data, attrs=attrs, encoding=encoding
+            )
+        else:
+            return variable

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -90,6 +90,9 @@ def encode_cf_variable(
     ensure_not_multiindex(var, name=name)
 
     for coder in [
+        # IntervalCoder must be before CFDatetimeCoder,
+        # so we can first encode the interval, then datetimes if necessary
+        variables.IntervalCoder(),
         CFDatetimeCoder(),
         CFTimedeltaCoder(),
         variables.CFScaleOffsetCoder(),
@@ -237,6 +240,8 @@ def decode_cf_variable(
                 "    ds = xr.open_dataset(decode_times=time_coder)\n",
             )
         var = decode_times.decode(var, name=name)
+
+    var = variables.IntervalCoder().decode(var)
 
     if decode_endianness and not var.dtype.isnative:
         var = variables.EndianCoder().decode(var)


### PR DESCRIPTION
Closes #2847

Following the proposal in https://github.com/pydata/xarray/issues/8005#issuecomment-3011641252, this PR adds encoding/decoding machinery for `pd.IntervalArray` objects. I use an ad-hoc convention:
1. The data is stacked to a 2D array with the first dimension named `__xarray_bounds__`. This is not configurable at the moment.
2. we record encoding attributes `"closed"`, and `"dtype"` (this is always `"pandas_interval"`). 

It is possible to create an IntervalArray with Datetime and Timedelta objects so I've stuck the IntervalCoder first in the encoding pipeline, and last in the decoding pipeline. That way it stays independent.

TODO:
- [ ] Add whats-new
- [ ] Add `decode_intervals` kwarg? 
- [ ] Add docs to the "Internals" section.