### PR TITLE
Fix Zarr 'number of requests' test

### DIFF
--- a/xarray/tests/conftest.py
+++ b/xarray/tests/conftest.py
@@ -234,6 +234,6 @@ def simple_datatree(create_test_datatree):
     return create_test_datatree()
 
 
-@pytest.fixture(scope="module", params=["s", "ms", "us", "ns"])
+@pytest.fixture(params=["s", "ms", "us", "ns"])
 def time_unit(request):
     return request.param

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3545,8 +3545,8 @@ class TestInstrumentedZarrStore:
             if has_zarr_v3:
                 # TODO: verify these
                 expected = {
-                    "set": 16,
-                    "get": 8,  # TODO: fixme upstream (should be 4), see https://github.com/zarr-developers/zarr-python/issues/3199
+                    "set": 5,
+                    "get": 4,
                     "list_dir": 2,
                     "list_prefix": 1,
                 }
@@ -3570,8 +3570,8 @@ class TestInstrumentedZarrStore:
             # 6057128b: {'iter': 5, 'contains': 2, 'setitem': 5, 'getitem': 10, "listdir": 5, "list_prefix": 0}
             if has_zarr_v3:
                 expected = {
-                    "set": 11,  # TODO: fixme upstream (should be 4), see https://github.com/zarr-developers/zarr-python/issues/3199
-                    "get": 23,  # TODO: fixme upstream (should be 8), see https://github.com/zarr-developers/zarr-python/issues/3199
+                    "set": 4,
+                    "get": 9,  # TODO: fixme upstream (should be 8)
                     "list_dir": 2,  # TODO: fixme upstream (should be 2)
                     "list_prefix": 0,
                 }
@@ -3593,8 +3593,8 @@ class TestInstrumentedZarrStore:
 
             if has_zarr_v3:
                 expected = {
-                    "set": 11,  # TODO: fixme upstream (should be 4), see https://github.com/zarr-developers/zarr-python/issues/3199
-                    "get": 23,  # TODO: fixme upstream (should be 8), see https://github.com/zarr-developers/zarr-python/issues/3199
+                    "set": 4,
+                    "get": 9,  # TODO: fixme upstream (should be 8)
                     "list_dir": 2,  # TODO: fixme upstream (should be 2)
                     "list_prefix": 0,
                 }
@@ -3627,8 +3627,8 @@ class TestInstrumentedZarrStore:
         with self.create_zarr_target() as store:
             if has_zarr_v3:
                 expected = {
-                    "set": 16,
-                    "get": 8,  # TODO: fixme upstream (should be 2), see https://github.com/zarr-developers/zarr-python/issues/3199
+                    "set": 5,
+                    "get": 2,
                     "list_dir": 2,
                     "list_prefix": 4,
                 }


### PR DESCRIPTION
Fixess the test test failures introduced by https://github.com/pydata/xarray/pull/10469/ 

That PR introduced a new test that used the `time_unit` fixture which is scoped to `module`. This was somehow resulting in leakage of state across tests. Normally this doesn't seem to matter (e.g. other fixtures also use that scope) but it was affecting the get/set counting.

See also: https://docs.pytest.org/en/stable/how-to/fixtures.html#fixture-scopes

This also reverts: https://github.com/pydata/xarray/commit/8d2e563b969da9b540a3d6fb62c769f37ee48f28 to restore the initial values

 @maxrjones your bisecting was very helpful! also @TomNicholas 
- [ ] Closes #xxxx
- [NA] Tests added
- [NA] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [NA] New functions/methods are listed in `api.rst`
