### PR TITLE
Fix bug with `ci/release_contributors.py` script

### DIFF
--- a/ci/release_contributors.py
+++ b/ci/release_contributors.py
@@ -10,7 +10,7 @@ co_author_re = re.compile(r"Co-authored-by: (?P<name>[^<]+?) <(?P<email>.+)>")
 def main():
     repo = git.Repo(".")
 
-    most_recent_release = last(repo.tags)
+    most_recent_release = last(list(repo.tags))
 
     # extract information from commits
     contributors = {}


### PR DESCRIPTION
I tried to run the [`ci/release_contributors.py`](https://github.com/pydata/xarray/blob/main/ci/release_contributors.py) script using uv, but got a weird error

```
tom@Toms-MacBook-Air xarray % uv run python ci/release_contributors.py
<class 'list'>
Traceback (most recent call last):
  File "/Users/tom/Documents/Work/Code/xarray/ci/release_contributors.py", line 51, in <module>
    main()
    ~~~~^^
  File "/Users/tom/Documents/Work/Code/xarray/ci/release_contributors.py", line 15, in main
    most_recent_release = last(repo.tags)
  File "/Users/tom/Documents/Work/Code/xarray/.venv/lib/python3.13/site-packages/toolz/itertoolz.py", line 407, in last
    return tail(1, seq)[0]
           ~~~~^^^^^^^^
  File "/Users/tom/Documents/Work/Code/xarray/.venv/lib/python3.13/site-packages/toolz/itertoolz.py", line 342, in tail
    return seq[-n:]
           ~~~^^^^^
  File "/Users/tom/Documents/Work/Code/xarray/.venv/lib/python3.13/site-packages/git/util.py", line 1208, in __getitem__
    raise ValueError("Index should be an int or str")
ValueError: Index should be an int or str
```

It seems to be a bug in the way `toolz.last` handles the type returned by repo.tags, because that type is iterable but not actually a list. I don't know which exact versions of dependencies this happens with, but I can fix it by just explicitly casting to a list, so this PR does that.

FYI @keewis 