### PR TITLE
Make sure setuptools is compatible with PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ dask = "xarray.namedarray.daskmanager:DaskManager"
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=42", "setuptools-scm>=7"]
+requires = ["setuptools>=77.0.2", "setuptools-scm>=7"]
 
 [tool.setuptools.packages.find]
 include = ["xarray*"]


### PR DESCRIPTION
~~Instead rely on `project.license` in `pyproject.toml`.~~

Let's see if this fixes this CI error:
```
         /home/runner/work/xarray/xarray/asv_bench/.asv/env/155223cc45b660fb8d622bace3e087eb/lib/python3.11/site-packages/setuptools_scm/_integration/setuptools.py:92: UserWarning: version of None already set
           warnings.warn(f"version of {dist_name} already set")
         configuration error: `project.license` must be valid exactly by one definition (2 matches found):
   
             - keys:
                 'file': {type: string}
               required: ['file']
             - keys:
                 'text': {type: string}
               required: ['text']
   
         DESCRIPTION:
             `Project license <https://peps.python.org/pep-0621/#license>`_.
   
         GIVEN VALUE:
             "Apache-2.0"
   
         OFFENDING RULE: 'oneOf'
   
         DEFINITION:
             {
                 "oneOf": [
                     {
                         "properties": {
                             "file": {
                                 "type": "string",
                                 "$$description": [
                                     "Relative path to the file (UTF-8) which contains the license for the",
                                     "project."
                                 ]
                             }
                         },
                         "required": [
                             "file"
                         ]
                     },
                     {
                         "properties": {
                             "text": {
                                 "type": "string",
                                 "$$description": [
                                     "The license of the project whose meaning is that of the",
                                     "`License field from the core metadata",
                                     "<https://packaging.python.org/specifications/core-metadata/#license>`_."
                                 ]
                             }
                         },
                         "required": [
                             "text"
                         ]
                     }
                 ]
             }
```

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
