### PR TITLE
DOC: add Pandas(Multi)Index to API reference

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1704,6 +1704,9 @@ Advanced API
 
 Default, pandas-backed indexes built-in Xarray:
 
+.. autosummary::
+   :toctree: generated/
+
    indexes.PandasIndex
    indexes.PandasMultiIndex
 


### PR DESCRIPTION
Added missing directive.

Intersphinx couldn't find the reference.
