### PR TITLE
align_chunks not working for datasets

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2302,6 +2302,7 @@ class Dataset(
             append_dim=append_dim,
             region=region,
             safe_chunks=safe_chunks,
+            align_chunks=align_chunks,
             zarr_version=zarr_version,
             zarr_format=zarr_format,
             write_empty_chunks=write_empty_chunks,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -6868,6 +6868,21 @@ class TestZarrRegionAuto:
             chunk = chunk.chunk()
             self.save(store, chunk.chunk(), region=region)
 
+    @requires_dask
+    def test_dataset_to_zarr_align_chunks_true(self, tmp_store) -> None:
+        skip_if_zarr_format_3(tmp_store)
+        dataset = DataArray(
+            np.arange(4), dims=["a"], coords={"a": np.arange(4)}
+        ).chunk(a=(2, 1, 1)).to_dataset(name="foo")
+
+        dataset.to_zarr(
+            tmp_store,
+            align_chunks=True,
+            encoding={"foo": {"chunks": (3,)}},
+        )
+        with open_dataset(tmp_store, engine="zarr") as loaded_ds:
+            assert_identical(dataset, loaded_ds)
+
 
 @requires_h5netcdf
 @requires_fsspec


### PR DESCRIPTION
I forgot to send the align_chunks to the to_zarr method on the datasets, which makes the feature useless for this kind of data structure. I added an specific test to cover this issue
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x ] Closes #10501
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
