### PR TITLE
PandasIndex.create_variables() hot fix.

### DIFF
--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -786,8 +786,16 @@ class PandasIndex(Index):
         attrs: Mapping[Hashable, Any] | None
         encoding: Mapping[Hashable, Any] | None
 
-        if variables is not None and name in variables:
-            var = variables[name]
+        if variables is not None:
+            if name in variables:
+                var = variables[name]
+            else:
+                # temp fix for PandasIndex subclasses that
+                # do not update self.index.name in the
+                # (overridden) PandasIndex.from_variables()
+                assert len(variables) == 1
+                name, var = next(iter(variables.items()))
+                self.index.name = name
             attrs = var.attrs
             encoding = var.encoding
         else:


### PR DESCRIPTION
Hot fix for https://github.com/xarray-contrib/xarray-indexes/pull/25#issuecomment-3053353880

The reason it breaks there is because `PandasIndex.create_variables()` relies on the wrapped pandas index (self.index) `name` property to set the name of the returned coordinate variable. That property is set by default from the `dim` dimension name in `PandasIndex.__init__()`, and is renamed in `PandasIndex.from_variables()` after calling the constructor. PandasIndex subclasses that re-implement `.from_variables()` may miss the last step, which now triggers an error with #10503.
