### PR TITLE
Add release notes for v2025.07.1

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1616,6 +1616,7 @@ These classes are building blocks for more complex Indexes:
    indexes.CoordinateTransform
    indexes.CoordinateTransformIndex
    indexes.NDPointIndex
+   indexes.TreeAdapter
 
 The Index base class for building custom indexes:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -7,7 +7,7 @@ What's New
 
 .. _whats-new.2025.07.1:
 
-v2025.07.1 (July 10, 2025)
+v2025.07.1 (July 09, 2025)
 --------------------------
 
 This release brings a lot of improvements to flexible indexes functionality, including new classes

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,6 +15,8 @@ to ease building of new indexes with custom coordinate transforms (:py:class:`in
 and tree-like index structures (:py:class:`indexes.NDPointIndex`).
 See a new `gallery <https://xarray-indexes.readthedocs.io>`_ showing off the possibilities enabled by flexible indexes.
 
+Thanks to the 7 contributors to this release:
+Benoit Bovy, Deepak Cherian, Dhruva Kumar Kaushal, Dimitri Papadopoulos Orfanos, Illviljan, Justus Magin and Tom Nicholas
 
 New Features
 ~~~~~~~~~~~~
@@ -36,7 +38,7 @@ Bug fixes
 
 Documentation
 ~~~~~~~~~~~~~
-- New `gallery <https://xarray-indexes.readthedocs.io>`_ showing off the possibilities enabled by flexible indexes.
+- `New gallery <https://xarray-indexes.readthedocs.io>`_ showing off the possibilities enabled by flexible indexes.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -13,7 +13,7 @@ v2025.07.1 (July 10, 2025)
 This release brings a lot of improvements to flexible indexes functionality, including new classes
 to ease building of new indexes with custom coordinate transforms (:py:class:`indexes.CoordinateTransformIndex`)
 and tree-like index structures (:py:class:`indexes.NDPointIndex`).
-See a new `gallery <https://xarray-indexes.readthedocs.io>`_ showing off the possibilities enabled by flexible indexes.
+See a `new gallery <https://xarray-indexes.readthedocs.io>`_ showing off the possibilities enabled by flexible indexes.
 
 Thanks to the 7 contributors to this release:
 Benoit Bovy, Deepak Cherian, Dhruva Kumar Kaushal, Dimitri Papadopoulos Orfanos, Illviljan, Justus Magin and Tom Nicholas
@@ -38,7 +38,7 @@ Bug fixes
 
 Documentation
 ~~~~~~~~~~~~~
-- `New gallery <https://xarray-indexes.readthedocs.io>`_ showing off the possibilities enabled by flexible indexes.
+- A `new gallery <https://xarray-indexes.readthedocs.io>`_ showing off the possibilities enabled by flexible indexes.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -7,21 +7,22 @@ What's New
 
 .. _whats-new.2025.07.1:
 
-v2025.07.1 (unreleased)
------------------------
+v2025.07.1 (July 10, 2025)
+--------------------------
+
+This release brings a lot of improvements to flexible indexes functionality, including new classes
+to ease building of new indexes with custom coordinate transforms (:py:class:`indexes.CoordinateTransformIndex`)
+and tree-like index structures (:py:class:`indexes.NDPointIndex`).
+See a new `gallery <https://xarray-indexes.readthedocs.io>`_ showing off the possibilities enabled by flexible indexes.
+
 
 New Features
 ~~~~~~~~~~~~
+- New :py:class:`xarray.indexes.NDPointIndex`, which by default uses :py:class:`scipy.spatial.KDTree` under the hood for
+  the selection of irregular, n-dimensional data (:pull:`10478`).
+  By `Benoit Bovy <https://github.com/benbovy>`_.
 - Allow skipping the creation of default indexes when opening datasets (:pull:`8051`).
   By `Benoit Bovy <https://github.com/benbovy>`_ and `Justus Magin <https://github.com/keewis>`_.
-
-Breaking changes
-~~~~~~~~~~~~~~~~
-
-
-Deprecations
-~~~~~~~~~~~~
-
 
 Bug fixes
 ~~~~~~~~~
@@ -35,7 +36,7 @@ Bug fixes
 
 Documentation
 ~~~~~~~~~~~~~
-
+- New `gallery <https://xarray-indexes.readthedocs.io>`_ showing off the possibilities enabled by flexible indexes.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
@@ -63,9 +64,6 @@ New Features
 
 - Expose :py:class:`~xarray.indexes.RangeIndex`, and :py:class:`~xarray.indexes.CoordinateTransformIndex` as public api
   under the ``xarray.indexes`` namespace. By `Deepak Cherian <https://github.com/dcherian>`_.
-- New :py:class:`xarray.indexes.NDPointIndex`, which by default uses :py:class:`scipy.spatial.KDTree` under the hood for
-  the selection of irregular, n-dimensional data (:pull:`10478`).
-  By `Benoit Bovy <https://github.com/benbovy>`_.
 - Support zarr-python's new ``.supports_consolidated_metadata`` store property (:pull:`10457``).
   by `Tom Nicholas <https://github.com/TomNicholas>`_.
 - Better error messages when encoding data to be written to disk fails (:pull:`10464`).

--- a/xarray/indexes/__init__.py
+++ b/xarray/indexes/__init__.py
@@ -10,7 +10,7 @@ from xarray.core.indexes import (
     PandasIndex,
     PandasMultiIndex,
 )
-from xarray.indexes.nd_point_index import NDPointIndex
+from xarray.indexes.nd_point_index import NDPointIndex, TreeAdapter
 from xarray.indexes.range_index import RangeIndex
 
 __all__ = [
@@ -21,4 +21,5 @@ __all__ = [
     "PandasIndex",
     "PandasMultiIndex",
     "RangeIndex",
+    "TreeAdapter",
 ]


### PR DESCRIPTION
Release in prep for a talk at SciPy 2025 on flexible indexes. See https://xarray-indexes.readthedocs.io/ for more!

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
