### PR TITLE
Remove test skip

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3647,10 +3647,6 @@ class TestInstrumentedZarrStore:
                 )
 
     @requires_dask
-    @pytest.mark.skipif(
-        sys.version_info < (3, 11),
-        reason="zarr too old",
-    )
     def test_region_write(self) -> None:
         ds = Dataset({"foo": ("x", [1, 2, 3])}, coords={"x": [1, 2, 3]}).chunk()
         with self.create_zarr_target() as store:


### PR DESCRIPTION
Python 3.10 was dropped in #10438

<!-- Feel free to remove check-list items aren't relevant to your change -->

