### PR TITLE
Fix labeler for `topic-documentation`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -45,11 +45,10 @@ topic-DataTree:
           - xarray/core/datatree*
 
 topic-documentation:
-  - changed-files:
-      - any-glob-to-any-file:
-          - doc/*
-          - "!doc/whats-new.rst"
-          - doc/**/*
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: "doc/**/*"
+          - all-globs-to-all-files: "!doc/whats-new.rst"
 
 topic-groupby:
   - changed-files:


### PR DESCRIPTION
So, looks like there was a bug in #10201 that made it so it was labeling _every PR_ as `topic-documentation`, even this PR.

I think its because the `any-glob-to-any-file:` is an OR, and technically everything is either in 'doc/**/*' or in '!doc/whats-new.rst'.

Fixed now


<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes None
