### PR TITLE
Pydap flaky tests

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,6 +25,9 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Fix Pydap Datatree backend testing. Testing now compares elements of (unordered) two sets (before, lists).
+  By `Miguel Jimenez-Urias <https://github.com/Mikejmnez>`_.
+
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -25,7 +25,7 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
-- Fix Pydap Datatree backend testing. Testing now compares elements of (unordered) two sets (before, lists).
+- Fix Pydap Datatree backend testing. Testing now compares elements of (unordered) two sets (before, lists) (:pull:`10525`).
   By `Miguel Jimenez-Urias <https://github.com/Mikejmnez>`_.
 
 

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -495,7 +495,7 @@ class TestPyDAPDatatreeIO:
             |       Salinity     (time, Z, Y, X) float32 ...
         """
         tree = open_datatree(url, engine=self.engine)
-        assert list(tree.dims) == ["time", "Z", "nv"]
+        assert set(tree.dims) == set(["time", "Z", "nv"])
         assert tree["/SimpleGroup"].coords["time"].dims == ("time",)
         assert tree["/SimpleGroup"].coords["Z"].dims == ("Z",)
         assert tree["/SimpleGroup"].coords["Y"].dims == ("Y",)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] ~Tests added~  Fixes testing for pydap's Datatree. The failing tests is related to the comparison of two lists. Elements of these match but their order differ. Test is amended to now compare two sets. Their order does not matter.
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

