### PR TITLE
Preserve encoding in DataTree.assign

### DIFF
--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1060,6 +1060,7 @@ class DataTree(
             self.to_dataset(inherit=False), new_variables
         )
         data = Dataset._construct_direct(**vars_merge_result._asdict())
+        data.encoding = self.encoding
 
         # TODO are there any subtleties with preserving order of children like this?
         merged_children = {**self.children, **new_children}

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -1679,6 +1679,14 @@ class TestRestructuring:
         result = dt.assign({"foo": xr.DataArray(0), "a": DataTree()})
         assert_equal(result, expected)
 
+    def test_assign_encoding(self) -> None:
+        ds = xr.Dataset({"foo": 0})
+        ds.encoding = {"test": "test"}
+        node = xr.DataTree(ds)
+        assert node.encoding == {"test": "test"}
+        node = node.assign(bar=xr.DataArray(1))
+        assert node.encoding == {"test": "test"}
+
     def test_filter_like(self) -> None:
         flower_tree = DataTree.from_dict(
             {"root": None, "trunk": None, "leaves": None, "flowers": None}


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

I noticed that encoding wasn't preserve during assign operations.

- [x] Tests added
