### PR TITLE
Call `super().__init__()` in `st.SearchStrategy` subclasses

### DIFF
--- a/xarray/testing/strategies.py
+++ b/xarray/testing/strategies.py
@@ -479,6 +479,7 @@ def unique_subset_of(
 
 class CFTimeStrategy(st.SearchStrategy):
     def __init__(self, min_value, max_value):
+        super().__init__()
         self.min_value = min_value
         self.max_value = max_value
 
@@ -495,6 +496,7 @@ class CFTimeStrategyISO8601(st.SearchStrategy):
     def __init__(self):
         from xarray.tests.test_coding_times import _all_cftime_date_types
 
+        super().__init__()
         self.date_types = _all_cftime_date_types()
         self.calendars = list(self.date_types)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

In the next version of `hypothesis` subclasses of `hypothesis.strategies.SearchStrategy` will be required to call `super().__init__()` in their `__init__` method (https://github.com/HypothesisWorks/hypothesis/pull/4473).  This PR addresses this in the two subclasses in our codebase: `CFTimeStrategy` and `CFTimeStrategyISO8601`.  

Apparently this kind of subclassing is not actually part of the public API ([link](https://github.com/HypothesisWorks/hypothesis/pull/4473/files#diff-9abc0311b216f25f0b71cfff6b7043b22071d09a58cb949f6bc5022ddeaa8e7f)), so maybe we should adjust the approach here long term, but this at least gets the tests passing for now.

- [x] Closes #10541