### PR TITLE
Fix transpose of BoolTypeArray, NativeEndiannessArray

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -28,6 +28,9 @@ Bug fixes
 - Fix Pydap Datatree backend testing. Testing now compares elements of (unordered) two sets (before, lists) (:pull:`10525`).
   By `Miguel Jimenez-Urias <https://github.com/Mikejmnez>`_.
 
+- Fix transpose of boolean arrays read from disk. (:issue:`10536`)
+  By `Deepak Cherian <https://github.com/dcherian>`_.
+
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -70,6 +70,9 @@ class NativeEndiannessArray(indexing.ExplicitlyIndexedNDArrayMixin):
     def get_duck_array(self):
         return duck_array_ops.astype(self.array.get_duck_array(), dtype=self.dtype)
 
+    def transpose(self, order):
+        return type(self)(self.array.transpose(order))
+
 
 class BoolTypeArray(indexing.ExplicitlyIndexedNDArrayMixin):
     """Decode arrays on the fly from integer to boolean datatype
@@ -110,6 +113,9 @@ class BoolTypeArray(indexing.ExplicitlyIndexedNDArrayMixin):
 
     def get_duck_array(self):
         return duck_array_ops.astype(self.array.get_duck_array(), dtype=self.dtype)
+
+    def transpose(self, order):
+        return type(self)(self.array.transpose(order))
 
 
 def _apply_mask(

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -308,7 +308,15 @@ def create_encoded_unsigned_false_masked_scaled_data(dtype: np.dtype) -> Dataset
 
 def create_boolean_data() -> Dataset:
     attributes = {"units": "-"}
-    return Dataset({"x": ("t", [True, False, False, True], attributes)})
+    return Dataset(
+        {
+            "x": (
+                ("t", "x"),
+                [[False, True, False, True], [True, False, False, True]],
+                attributes,
+            )
+        }
+    )
 
 
 class TestCommon:
@@ -726,6 +734,9 @@ class DatasetIOBase:
             with self.roundtrip(actual) as actual2:
                 assert_identical(original, actual2)
                 assert actual2["x"].dtype == "bool"
+            with self.roundtrip(actual) as actual3:
+                # GH10536
+                assert_identical(original.transpose(), actual3.transpose())
 
     def test_orthogonal_indexing(self) -> None:
         in_memory = create_test_data()

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -53,8 +53,8 @@ class TestNativeEndiannessArray:
 
         y = np.arange(6, dtype=">i8").reshape((2, 3))
         b = coding.variables.NativeEndiannessArray(y)
-        expected = np.arange(6, dtype="int64").reshape((2, 3))
-        assert_array_equal(b.transpose((1, 0)), expected.transpose((1, 0)))
+        expected2 = np.arange(6, dtype="int64").reshape((2, 3))
+        assert_array_equal(b.transpose((1, 0)), expected2.transpose((1, 0)))
 
 
 def test_decode_cf_with_conflicting_fill_missing_value() -> None:

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -51,10 +51,10 @@ class TestNativeEndiannessArray:
         assert a.dtype == expected[:].dtype
         assert_array_equal(a, expected)
 
-        x = np.arange(6, dtype=">i8").reshape((2, 3))
-        a = coding.variables.NativeEndiannessArray(x)
+        y = np.arange(6, dtype=">i8").reshape((2, 3))
+        b = coding.variables.NativeEndiannessArray(y)
         expected = np.arange(6, dtype="int64").reshape((2, 3))
-        assert_array_equal(a.transpose((1, 0)), expected.transpose((1, 0)))
+        assert_array_equal(b.transpose((1, 0)), expected.transpose((1, 0)))
 
 
 def test_decode_cf_with_conflicting_fill_missing_value() -> None:

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -37,6 +37,10 @@ class TestBoolTypeArray:
         assert bx.dtype == bool
         assert_array_equal(bx, np.array([True, False, True, True, False], dtype=bool))
 
+        x = np.array([[1, 0, 1], [0, 1, 0]], dtype="i1")
+        bx = coding.variables.BoolTypeArray(x)
+        assert_array_equal(bx.transpose((1, 0)), x.transpose((1, 0)))
+
 
 class TestNativeEndiannessArray:
     def test(self) -> None:
@@ -46,6 +50,11 @@ class TestNativeEndiannessArray:
         assert a.dtype == expected.dtype
         assert a.dtype == expected[:].dtype
         assert_array_equal(a, expected)
+
+        x = np.arange(6, dtype=">i8").reshape((2, 3))
+        a = coding.variables.NativeEndiannessArray(x)
+        expected = np.arange(6, dtype="int64").reshape((2, 3))
+        assert_array_equal(a.transpose((1, 0)), expected.transpose((1, 0)))
 
 
 def test_decode_cf_with_conflicting_fill_missing_value() -> None:


### PR DESCRIPTION
Closes #10536
- [x] Closes #xxxx
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
