### PR TITLE
Fix `DatetimeAccessor.strftime` errors due to upstream changes

### DIFF
--- a/xarray/core/accessor_dt.py
+++ b/xarray/core/accessor_dt.py
@@ -206,7 +206,7 @@ def _strftime_through_cftimeindex(values, date_format: str):
     values_as_cftimeindex = CFTimeIndex(duck_array_ops.ravel(values))
 
     field_values = values_as_cftimeindex.strftime(date_format)
-    return field_values.values.reshape(values.shape)
+    return field_values.to_numpy().reshape(values.shape)
 
 
 def _strftime_through_series(values, date_format: str):
@@ -215,7 +215,7 @@ def _strftime_through_series(values, date_format: str):
     """
     values_as_series = pd.Series(duck_array_ops.ravel(values), copy=False)
     strs = values_as_series.dt.strftime(date_format)
-    return strs.values.reshape(values.shape)
+    return strs.to_numpy().reshape(values.shape)
 
 
 def _strftime(values, date_format):


### PR DESCRIPTION
This PR addresses the following upstream build errors (#10548) by explicitly converting the intermediate `strftime` results to NumPy arrays before reshaping.

```
FAILED test_accessor_dt.py::TestDatetimeAccessor::test_strftime - NotImplementedError: <class 'pandas.core.arrays.string_arrow.ArrowStringArrayNumpySemantics'> does not support reshape as backed by a 1D pyarrow.ChunkedArray.
FAILED test_accessor_dt.py::TestDatetimeAccessor::test_dask_accessor_method[strftime-%Y-%m-%d %H:%M:%S] - NotImplementedError: <class 'pandas.core.arrays.string_arrow.ArrowStringArrayNumpySemantics'> does not support reshape as backed by a 1D pyarrow.ChunkedArray.
FAILED test_accessor_dt.py::test_cftime_strftime_access[360_day] - NotImplementedError: <class 'pandas.core.arrays.string_arrow.ArrowStringArrayNumpySemantics'> does not support reshape as backed by a 1D pyarrow.ChunkedArray.
FAILED test_accessor_dt.py::test_cftime_strftime_access[365_day] - NotImplementedError: <class 'pandas.core.arrays.string_arrow.ArrowStringArrayNumpySemantics'> does not support reshape as backed by a 1D pyarrow.ChunkedArray.
FAILED test_accessor_dt.py::test_cftime_strftime_access[366_day] - NotImplementedError: <class 'pandas.core.arrays.string_arrow.ArrowStringArrayNumpySemantics'> does not support reshape as backed by a 1D pyarrow.ChunkedArray.
FAILED test_accessor_dt.py::test_cftime_strftime_access[all_leap] - NotImplementedError: <class 'pandas.core.arrays.string_arrow.ArrowStringArrayNumpySemantics'> does not support reshape as backed by a 1D pyarrow.ChunkedArray.
FAILED test_accessor_dt.py::test_cftime_strftime_access[gregorian] - NotImplementedError: <class 'pandas.core.arrays.string_arrow.ArrowStringArrayNumpySemantics'> does not support reshape as backed by a 1D pyarrow.ChunkedArray.
FAILED test_accessor_dt.py::test_cftime_strftime_access[julian] - NotImplementedError: <class 'pandas.core.arrays.string_arrow.ArrowStringArrayNumpySemantics'> does not support reshape as backed by a 1D pyarrow.ChunkedArray.
FAILED test_accessor_dt.py::test_cftime_strftime_access[noleap] - NotImplementedError: <class 'pandas.core.arrays.string_arrow.ArrowStringArrayNumpySemantics'> does not support reshape as backed by a 1D pyarrow.ChunkedArray.
FAILED test_accessor_dt.py::test_cftime_strftime_access[proleptic_gregorian] - NotImplementedError: <class 'pandas.core.arrays.string_arrow.ArrowStringArrayNumpySemantics'> does not support reshape as backed by a 1D pyarrow.ChunkedArray.
FAILED test_accessor_dt.py::test_cftime_strftime_access[standard] - NotImplementedError: <class 'pandas.core.arrays.string_arrow.ArrowStringArrayNumpySemantics'> does not support reshape as backed by a 1D pyarrow.ChunkedArray.
```