### PR TITLE
Update docs to reflect open_mfdataset default chunk behaviour

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1494,10 +1494,10 @@ def open_mfdataset(
     chunks : int, dict, 'auto' or None, optional
         Dictionary with keys given by dimension names and values given by chunk sizes.
         In general, these should divide the dimensions of each dataset. If int, chunk
-        each dimension by ``chunks``. By default, chunks will be chosen to load entire
-        input files into memory at once. This has a major impact on performance: please
-        see the full documentation for more details [2]_. This argument is evaluated
-        on a per-file basis, so chunk sizes that span multiple files will be ignored.
+        each dimension by ``chunks``. By default, chunks will be chosen to match the 
+        chunks on disk. This may impact performance: please see the full documentation 
+        for more details [2]_. This argument is evaluated on a per-file basis, so chunk 
+        sizes that span multiple files will be ignored.
     concat_dim : str, DataArray, Index or a Sequence of these or None, optional
         Dimensions to concatenate files along.  You only need to provide this argument
         if ``combine='nested'``, and if any of the dimensions along which you want to


### PR DESCRIPTION
Looking at #5704 and #9038 (and various other issues that reference these), it seems like there's no easy solution and the current `open_mfdataset` chunk default is going to stay for a while. i.e. `chunks=None` as a kwarg to `open_mfdataset` is overwritten with `chunks={}` before calling `open_dataset`, so the default chunks are disk chunks not single-file chunks.https://github.com/pydata/xarray/blob/5ce69b2b993874bda88dd1670b125b964779eeb5/xarray/backends/api.py#L1677

In which case, we should probably update the docs to reflect this current behaviour.
