### PR TITLE
Support for DataTree.to_netcdf to write to a file-like object or bytes

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -13,6 +13,8 @@ v2025.07.2 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- :py:meth:`DataTree.to_netcdf` can now write to a file-like object, or return bytes if called without a filepath. (:issue:`10570`)
+  By `Matthew Willson <https://github.com/mjwillson>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -497,7 +497,7 @@ def _datatree_from_backend_datatree(
 
 
 def open_dataset(
-    filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+    filename_or_obj: str | os.PathLike[Any] | ReadBuffer | bytes | AbstractDataStore,
     *,
     engine: T_Engine = None,
     chunks: T_Chunks = None,
@@ -527,12 +527,12 @@ def open_dataset(
 
     Parameters
     ----------
-    filename_or_obj : str, Path, file-like or DataStore
+    filename_or_obj : str, Path, file-like, bytes or DataStore
         Strings and Path objects are interpreted as a path to a netCDF file
         or an OpenDAP URL and opened with python-netCDF4, unless the filename
         ends with .gz, in which case the file is gunzipped and opened with
         scipy.io.netcdf (only netCDF3 supported). Byte-strings or file-like
-        objects are opened by scipy.io.netcdf (netCDF3) or h5py (netCDF4/HDF).
+        objects are opened by scipy.io.netcdf (netCDF3) or h5netcdf (netCDF4).
     engine : {"netcdf4", "scipy", "pydap", "h5netcdf", "zarr", None}\
         , installed backend \
         or subclass of xarray.backends.BackendEntrypoint, optional
@@ -686,6 +686,9 @@ def open_dataset(
     open_mfdataset
     """
 
+    if isinstance(filename_or_obj, bytes):
+        filename_or_obj = BytesIO(filename_or_obj)
+
     if cache is None:
         cache = chunks is None
 
@@ -737,7 +740,7 @@ def open_dataset(
 
 
 def open_dataarray(
-    filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+    filename_or_obj: str | os.PathLike[Any] | ReadBuffer | bytes | AbstractDataStore,
     *,
     engine: T_Engine = None,
     chunks: T_Chunks = None,
@@ -768,12 +771,12 @@ def open_dataarray(
 
     Parameters
     ----------
-    filename_or_obj : str, Path, file-like or DataStore
+    filename_or_obj : str, Path, file-like, bytes or DataStore
         Strings and Path objects are interpreted as a path to a netCDF file
         or an OpenDAP URL and opened with python-netCDF4, unless the filename
         ends with .gz, in which case the file is gunzipped and opened with
         scipy.io.netcdf (only netCDF3 supported). Byte-strings or file-like
-        objects are opened by scipy.io.netcdf (netCDF3) or h5py (netCDF4/HDF).
+        objects are opened by scipy.io.netcdf (netCDF3) or h5netcdf (netCDF4).
     engine : {"netcdf4", "scipy", "pydap", "h5netcdf", "zarr", None}\
         , installed backend \
         or subclass of xarray.backends.BackendEntrypoint, optional
@@ -964,7 +967,7 @@ def open_dataarray(
 
 
 def open_datatree(
-    filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+    filename_or_obj: str | os.PathLike[Any] | ReadBuffer | bytes | AbstractDataStore,
     *,
     engine: T_Engine = None,
     chunks: T_Chunks = None,
@@ -995,8 +998,9 @@ def open_datatree(
 
     Parameters
     ----------
-    filename_or_obj : str, Path, file-like, or DataStore
-        Strings and Path objects are interpreted as a path to a netCDF file or Zarr store.
+    filename_or_obj : str, Path, file-like, bytes or DataStore
+        Strings and Path objects are interpreted as a path to a netCDF file or
+        Zarr store. Bytes are interpreted as file contents.
     engine : {"netcdf4", "h5netcdf", "zarr", None}, \
              installed backend or xarray.backends.BackendEntrypoint, optional
         Engine to use when reading files. If not provided, the default engine
@@ -1149,6 +1153,9 @@ def open_datatree(
     xarray.open_groups
     xarray.open_dataset
     """
+    if isinstance(filename_or_obj, bytes):
+        filename_or_obj = BytesIO(filename_or_obj)
+
     if cache is None:
         cache = chunks is None
 
@@ -1237,8 +1244,9 @@ def open_groups(
 
     Parameters
     ----------
-    filename_or_obj : str, Path, file-like, or DataStore
-        Strings and Path objects are interpreted as a path to a netCDF file or Zarr store.
+    filename_or_obj : str, Path, file-like, butes, or DataStore
+        Strings and Path objects are interpreted as a path to a netCDF file or
+        Zarr store. Bytes are interpreted as file contents.
     engine : {"netcdf4", "h5netcdf", "zarr", None}, \
              installed backend or xarray.backends.BackendEntrypoint, optional
         Engine to use when reading files. If not provided, the default engine
@@ -1390,6 +1398,9 @@ def open_groups(
     xarray.open_dataset
     xarray.DataTree.from_dict
     """
+    if isinstance(filename_or_obj, bytes):
+        filename_or_obj = BytesIO(filename_or_obj)
+
     if cache is None:
         cache = chunks is None
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -10,7 +10,7 @@ from collections.abc import (
     Sequence,
 )
 from functools import partial
-from io import BytesIO, IOBase
+from io import IOBase
 from itertools import starmap
 from numbers import Number
 from typing import (
@@ -693,9 +693,6 @@ def open_dataset(
     open_mfdataset
     """
 
-    if isinstance(filename_or_obj, bytes | memoryview):
-        filename_or_obj = BytesIO(filename_or_obj)
-
     if cache is None:
         cache = chunks is None
 
@@ -1172,9 +1169,6 @@ def open_datatree(
     xarray.open_groups
     xarray.open_dataset
     """
-    if isinstance(filename_or_obj, bytes | memoryview):
-        filename_or_obj = BytesIO(filename_or_obj)
-
     if cache is None:
         cache = chunks is None
 
@@ -1423,9 +1417,6 @@ def open_groups(
     xarray.open_dataset
     xarray.DataTree.from_dict
     """
-    if isinstance(filename_or_obj, bytes | memoryview):
-        filename_or_obj = BytesIO(filename_or_obj)
-
     if cache is None:
         cache = chunks is None
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -10,7 +10,7 @@ from collections.abc import (
     Sequence,
 )
 from functools import partial
-from io import BytesIO
+from io import BytesIO, IOBase
 from itertools import starmap
 from numbers import Number
 from typing import (
@@ -1811,7 +1811,7 @@ def to_netcdf(
 @overload
 def to_netcdf(
     dataset: Dataset,
-    path_or_file: str | os.PathLike,
+    path_or_file: str | os.PathLike | IOBase,
     mode: NetcdfWriteModes = "w",
     format: T_NetcdfTypes | None = None,
     group: str | None = None,
@@ -1867,7 +1867,7 @@ def to_netcdf(
 @overload
 def to_netcdf(
     dataset: Dataset,
-    path_or_file: str | os.PathLike | None,
+    path_or_file: str | os.PathLike | IOBase | None,
     mode: NetcdfWriteModes = "w",
     format: T_NetcdfTypes | None = None,
     group: str | None = None,
@@ -1883,7 +1883,7 @@ def to_netcdf(
 
 def to_netcdf(
     dataset: Dataset,
-    path_or_file: str | os.PathLike | None = None,
+    path_or_file: str | os.PathLike | IOBase | None = None,
     mode: NetcdfWriteModes = "w",
     format: T_NetcdfTypes | None = None,
     group: str | None = None,

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1959,13 +1959,6 @@ def to_netcdf(
 
     if path_or_file is None:
         target = BytesIO()
-        # We can't get the BytesIO's value *before* closing the store, since
-        # the h5netcdf backend won't finish writing until its close is called.
-        # However if we try to get the BytesIO's value *after* closing the store,
-        # the scipy backend will close the BytesIO, preventing its value from
-        # being read. The solution is to prevent the BytesIO from being closed:
-        close_bytesio = target.close
-        target.close = lambda: None  # type: ignore[method-assign]
     else:
         target = path_or_file  # type: ignore[assignment]
 
@@ -2013,8 +2006,9 @@ def to_netcdf(
             store.close()
 
     if path_or_file is None:
+        assert isinstance(target, BytesIO)  # created in this function
         value = target.getvalue()
-        close_bytesio()
+        target.close()
         return value
 
     if not compute:

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -1926,14 +1926,13 @@ def to_netcdf(
         if engine is None:
             engine = _get_default_engine(path_or_file)
         path_or_file = _normalize_path(path_or_file)
-    else:  # file-like object
-        if engine not in ("scipy", "h5netcdf"):
-            emit_user_level_warning(
-                f"Requested {engine=} is not compatible with writing to a file-like object. "
-                "This will raise an error in the future, for now defaulting to engine='scipy'.",
-                FutureWarning,
-            )
-            engine = "scipy"
+    elif engine not in ("scipy", "h5netcdf"):
+        emit_user_level_warning(
+            f"Requested {engine=} is not compatible with writing to a file-like object. "
+            "This will raise an error in the future, for now defaulting to engine='scipy'.",
+            FutureWarning,
+        )
+        engine = "scipy"
 
     # validate Dataset keys, DataArray names, and attr keys/values
     _validate_dataset_names(dataset)

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -32,6 +32,7 @@ from xarray.backends.common import (
     AbstractDataStore,
     ArrayWriter,
     BytesIOProxy,
+    T_PathFileOrDataStore,
     _find_absolute_paths,
     _normalize_path,
 )
@@ -504,12 +505,7 @@ def _datatree_from_backend_datatree(
 
 
 def open_dataset(
-    filename_or_obj: str
-    | os.PathLike[Any]
-    | ReadBuffer
-    | bytes
-    | memoryview
-    | AbstractDataStore,
+    filename_or_obj: T_PathFileOrDataStore,
     *,
     engine: T_Engine = None,
     chunks: T_Chunks = None,
@@ -750,12 +746,7 @@ def open_dataset(
 
 
 def open_dataarray(
-    filename_or_obj: str
-    | os.PathLike[Any]
-    | ReadBuffer
-    | bytes
-    | memoryview
-    | AbstractDataStore,
+    filename_or_obj: T_PathFileOrDataStore,
     *,
     engine: T_Engine = None,
     chunks: T_Chunks = None,
@@ -983,12 +974,7 @@ def open_dataarray(
 
 
 def open_datatree(
-    filename_or_obj: str
-    | os.PathLike[Any]
-    | ReadBuffer
-    | bytes
-    | memoryview
-    | AbstractDataStore,
+    filename_or_obj: T_PathFileOrDataStore,
     *,
     engine: T_Engine = None,
     chunks: T_Chunks = None,
@@ -1228,12 +1214,7 @@ def open_datatree(
 
 
 def open_groups(
-    filename_or_obj: str
-    | os.PathLike[Any]
-    | ReadBuffer
-    | bytes
-    | memoryview
-    | AbstractDataStore,
+    filename_or_obj: T_PathFileOrDataStore,
     *,
     engine: T_Engine = None,
     chunks: T_Chunks = None,

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -351,6 +351,11 @@ class AbstractDataStore:
         self.close()
 
 
+T_PathFileOrDataStore = (
+    str | os.PathLike[Any] | ReadBuffer | bytes | memoryview | AbstractDataStore
+)
+
+
 class ArrayWriter:
     __slots__ = ("lock", "regions", "sources", "targets")
 

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -732,7 +732,12 @@ class BackendEntrypoint:
 
     def open_dataset(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
         *,
         drop_variables: str | Iterable[str] | None = None,
     ) -> Dataset:
@@ -744,7 +749,12 @@ class BackendEntrypoint:
 
     def guess_can_open(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
     ) -> bool:
         """
         Backend open_dataset method used by Xarray in :py:func:`~xarray.open_dataset`.
@@ -754,7 +764,12 @@ class BackendEntrypoint:
 
     def open_datatree(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
         *,
         drop_variables: str | Iterable[str] | None = None,
     ) -> DataTree:
@@ -766,7 +781,12 @@ class BackendEntrypoint:
 
     def open_groups_as_dict(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
         *,
         drop_variables: str | Iterable[str] | None = None,
     ) -> dict[str, Dataset]:

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -202,10 +202,10 @@ BytesOrMemory = TypeVar("BytesOrMemory", bytes, memoryview)
 
 @dataclass
 class BytesIOProxy(Generic[BytesOrMemory]):
-    """Proxy object for a write that either bytes or a memoryview."""
+    """Proxy object for a write that returns either bytes or a memoryview."""
 
     # TODO: remove this in favor of BytesIO when Dataset.to_netcdf() stops
-    # return bytes from the scipy engine
+    # returning bytes from the scipy engine
     getvalue: Callable[[], BytesOrMemory] | None = None
 
     def getvalue_or_getbuffer(self) -> BytesOrMemory:

--- a/xarray/backends/file_manager.py
+++ b/xarray/backends/file_manager.py
@@ -339,8 +339,11 @@ class _HashedSequence(list):
 class DummyFileManager(FileManager):
     """FileManager that simply wraps an open file in the FileManager interface."""
 
-    def __init__(self, value):
+    def __init__(self, value, *, close=None):
+        if close is None:
+            close = value.close
         self._value = value
+        self._close = close
 
     def acquire(self, needs_lock=True):
         del needs_lock  # ignored
@@ -353,4 +356,4 @@ class DummyFileManager(FileManager):
 
     def close(self, needs_lock=True):
         del needs_lock  # ignored
-        self._value.close()
+        self._close()

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -159,11 +159,9 @@ class H5NetCDFStore(WritableCFDataStore):
             )
 
         if isinstance(filename, bytes):
-            raise ValueError(
-                "can't open netCDF4/HDF5 as bytes "
-                "try passing a path or file-like object"
-            )
-        elif isinstance(filename, io.IOBase):
+            filename = io.BytesIO(filename)
+
+        if isinstance(filename, io.IOBase) and mode == "r":
             magic_number = read_magic_number_from_file(filename)
             if not magic_number.startswith(b"\211HDF\r\n\032\n"):
                 raise ValueError(

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -12,6 +12,7 @@ from xarray.backends.common import (
     BACKEND_ENTRYPOINTS,
     BackendEntrypoint,
     BytesIOProxy,
+    T_PathFileOrDataStore,
     WritableCFDataStore,
     _normalize_path,
     _open_remote_file,
@@ -407,17 +408,12 @@ def _emit_phony_dims_warning():
 
 
 def _normalize_filename_or_obj(
-    filename_or_obj: str
-    | os.PathLike[Any]
-    | ReadBuffer
-    | bytes
-    | memoryview
-    | AbstractDataStore,
+    filename_or_obj: T_PathFileOrDataStore,
 ) -> str | ReadBuffer | AbstractDataStore:
     if isinstance(filename_or_obj, bytes | memoryview):
         return io.BytesIO(filename_or_obj)
     else:
-        return _normalize_path(filename_or_obj)  # type: ignore[return-value]
+        return _normalize_path(filename_or_obj)
 
 
 class H5netcdfBackendEntrypoint(BackendEntrypoint):
@@ -447,15 +443,7 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
     )
     url = "https://docs.xarray.dev/en/stable/generated/xarray.backends.H5netcdfBackendEntrypoint.html"
 
-    def guess_can_open(
-        self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
-    ) -> bool:
+    def guess_can_open(self, filename_or_obj: T_PathFileOrDataStore) -> bool:
         filename_or_obj = _normalize_filename_or_obj(filename_or_obj)
         magic_number = try_read_magic_number_from_file_or_path(filename_or_obj)
         if magic_number is not None:
@@ -469,12 +457,7 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
 
     def open_dataset(
         self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
+        filename_or_obj: T_PathFileOrDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,
@@ -534,12 +517,7 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
 
     def open_datatree(
         self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
+        filename_or_obj: T_PathFileOrDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,
@@ -582,12 +560,7 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
 
     def open_groups_as_dict(
         self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
+        filename_or_obj: T_PathFileOrDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -208,7 +208,6 @@ class H5NetCDFStore(WritableCFDataStore):
             if isinstance(filename, str)
             else h5netcdf.File(filename, mode=mode, **kwargs)
         )
-        print(f"{manager=}")
         return cls(manager, group=group, mode=mode, lock=lock, autoclose=autoclose)
 
     def _acquire(self, needs_lock=True):

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -13,6 +13,7 @@ from xarray.backends.common import (
     BACKEND_ENTRYPOINTS,
     BackendArray,
     BackendEntrypoint,
+    T_PathFileOrDataStore,
     WritableCFDataStore,
     _normalize_path,
     datatree_from_dict_with_io_cleanup,
@@ -49,10 +50,8 @@ if TYPE_CHECKING:
     from h5netcdf.core import EnumType as h5EnumType
     from netCDF4 import EnumType as ncEnumType
 
-    from xarray.backends.common import AbstractDataStore
     from xarray.core.dataset import Dataset
     from xarray.core.datatree import DataTree
-    from xarray.core.types import ReadBuffer
 
 # This lookup table maps from dtype.byteorder to a readable endian
 # string used by netCDF4.
@@ -629,15 +628,7 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
     )
     url = "https://docs.xarray.dev/en/stable/generated/xarray.backends.NetCDF4BackendEntrypoint.html"
 
-    def guess_can_open(
-        self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
-    ) -> bool:
+    def guess_can_open(self, filename_or_obj: T_PathFileOrDataStore) -> bool:
         if isinstance(filename_or_obj, str) and is_remote_uri(filename_or_obj):
             return True
         magic_number = try_read_magic_number_from_path(filename_or_obj)
@@ -653,12 +644,7 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
 
     def open_dataset(
         self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
+        filename_or_obj: T_PathFileOrDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,
@@ -707,12 +693,7 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
 
     def open_datatree(
         self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
+        filename_or_obj: T_PathFileOrDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,
@@ -754,12 +735,7 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
 
     def open_groups_as_dict(
         self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
+        filename_or_obj: T_PathFileOrDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -631,7 +631,12 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
 
     def guess_can_open(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
     ) -> bool:
         if isinstance(filename_or_obj, str) and is_remote_uri(filename_or_obj):
             return True
@@ -648,7 +653,12 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
 
     def open_dataset(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,
@@ -697,7 +707,12 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
 
     def open_datatree(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,
@@ -739,7 +754,12 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
 
     def open_groups_as_dict(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -138,7 +138,12 @@ def refresh_engines() -> None:
 
 
 def guess_engine(
-    store_spec: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+    store_spec: str
+    | os.PathLike[Any]
+    | ReadBuffer
+    | bytes
+    | memoryview
+    | AbstractDataStore,
 ) -> str | type[BackendEntrypoint]:
     engines = list_engines()
 

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -209,13 +209,23 @@ class PydapBackendEntrypoint(BackendEntrypoint):
 
     def guess_can_open(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
     ) -> bool:
         return isinstance(filename_or_obj, str) and is_remote_uri(filename_or_obj)
 
     def open_dataset(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,
@@ -258,7 +268,12 @@ class PydapBackendEntrypoint(BackendEntrypoint):
 
     def open_datatree(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,
@@ -295,7 +310,12 @@ class PydapBackendEntrypoint(BackendEntrypoint):
 
     def open_groups_as_dict(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -10,6 +10,7 @@ from xarray.backends.common import (
     AbstractDataStore,
     BackendArray,
     BackendEntrypoint,
+    T_PathFileOrDataStore,
     _normalize_path,
     datatree_from_dict_with_io_cleanup,
     robust_getitem,
@@ -207,25 +208,14 @@ class PydapBackendEntrypoint(BackendEntrypoint):
     description = "Open remote datasets via OPeNDAP using pydap in Xarray"
     url = "https://docs.xarray.dev/en/stable/generated/xarray.backends.PydapBackendEntrypoint.html"
 
-    def guess_can_open(
-        self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
-    ) -> bool:
+    def guess_can_open(self, filename_or_obj: T_PathFileOrDataStore) -> bool:
         return isinstance(filename_or_obj, str) and is_remote_uri(filename_or_obj)
 
     def open_dataset(
         self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
+        filename_or_obj: (
+            str | os.PathLike[Any] | ReadBuffer | bytes | memoryview | AbstractDataStore
+        ),
         *,
         mask_and_scale=True,
         decode_times=True,
@@ -268,12 +258,7 @@ class PydapBackendEntrypoint(BackendEntrypoint):
 
     def open_datatree(
         self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
+        filename_or_obj: T_PathFileOrDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,
@@ -310,12 +295,7 @@ class PydapBackendEntrypoint(BackendEntrypoint):
 
     def open_groups_as_dict(
         self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
+        filename_or_obj: T_PathFileOrDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -13,6 +13,7 @@ from xarray.backends.common import (
     BackendArray,
     BackendEntrypoint,
     BytesIOProxy,
+    T_PathFileOrDataStore,
     WritableCFDataStore,
     _normalize_path,
 )
@@ -337,12 +338,7 @@ class ScipyBackendEntrypoint(BackendEntrypoint):
 
     def guess_can_open(
         self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
+        filename_or_obj: T_PathFileOrDataStore,
     ) -> bool:
         filename_or_obj = _normalize_filename_or_obj(filename_or_obj)
         magic_number = try_read_magic_number_from_file_or_path(filename_or_obj)
@@ -360,12 +356,7 @@ class ScipyBackendEntrypoint(BackendEntrypoint):
 
     def open_dataset(
         self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
+        filename_or_obj: T_PathFileOrDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -1,46 +1,32 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from xarray import conventions
 from xarray.backends.common import (
     BACKEND_ENTRYPOINTS,
     AbstractDataStore,
     BackendEntrypoint,
+    T_PathFileOrDataStore,
 )
 from xarray.core.coordinates import Coordinates
 from xarray.core.dataset import Dataset
 
 if TYPE_CHECKING:
-    import os
-
-    from xarray.core.types import ReadBuffer
+    pass
 
 
 class StoreBackendEntrypoint(BackendEntrypoint):
     description = "Open AbstractDataStore instances in Xarray"
     url = "https://docs.xarray.dev/en/stable/generated/xarray.backends.StoreBackendEntrypoint.html"
 
-    def guess_can_open(
-        self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
-    ) -> bool:
+    def guess_can_open(self, filename_or_obj: T_PathFileOrDataStore) -> bool:
         return isinstance(filename_or_obj, AbstractDataStore)
 
     def open_dataset(
         self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
+        filename_or_obj: T_PathFileOrDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -24,13 +24,23 @@ class StoreBackendEntrypoint(BackendEntrypoint):
 
     def guess_can_open(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
     ) -> bool:
         return isinstance(filename_or_obj, AbstractDataStore)
 
     def open_dataset(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -17,6 +17,7 @@ from xarray.backends.common import (
     AbstractWritableDataStore,
     BackendArray,
     BackendEntrypoint,
+    T_PathFileOrDataStore,
     _encode_variable_name,
     _normalize_path,
     datatree_from_dict_with_io_cleanup,
@@ -39,10 +40,9 @@ from xarray.namedarray.pycompat import integer_types
 from xarray.namedarray.utils import module_available
 
 if TYPE_CHECKING:
-    from xarray.backends.common import AbstractDataStore
     from xarray.core.dataset import Dataset
     from xarray.core.datatree import DataTree
-    from xarray.core.types import ReadBuffer, ZarrArray, ZarrGroup
+    from xarray.core.types import ZarrArray, ZarrGroup
 
 
 def _get_mappers(*, storage_options, store, chunk_store):
@@ -1548,15 +1548,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
     description = "Open zarr files (.zarr) using zarr in Xarray"
     url = "https://docs.xarray.dev/en/stable/generated/xarray.backends.ZarrBackendEntrypoint.html"
 
-    def guess_can_open(
-        self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
-    ) -> bool:
+    def guess_can_open(self, filename_or_obj: T_PathFileOrDataStore) -> bool:
         if isinstance(filename_or_obj, str | os.PathLike):
             _, ext = os.path.splitext(filename_or_obj)
             return ext == ".zarr"
@@ -1565,12 +1557,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
 
     def open_dataset(
         self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
+        filename_or_obj: T_PathFileOrDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,
@@ -1625,12 +1612,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
 
     def open_datatree(
         self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
+        filename_or_obj: T_PathFileOrDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,
@@ -1672,12 +1654,7 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
 
     def open_groups_as_dict(
         self,
-        filename_or_obj: str
-        | os.PathLike[Any]
-        | ReadBuffer
-        | bytes
-        | memoryview
-        | AbstractDataStore,
+        filename_or_obj: T_PathFileOrDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1550,7 +1550,12 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
 
     def guess_can_open(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
     ) -> bool:
         if isinstance(filename_or_obj, str | os.PathLike):
             _, ext = os.path.splitext(filename_or_obj)
@@ -1560,7 +1565,12 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
 
     def open_dataset(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,
@@ -1615,7 +1625,12 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
 
     def open_datatree(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,
@@ -1657,7 +1672,12 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
 
     def open_groups_as_dict(
         self,
-        filename_or_obj: str | os.PathLike[Any] | ReadBuffer | AbstractDataStore,
+        filename_or_obj: str
+        | os.PathLike[Any]
+        | ReadBuffer
+        | bytes
+        | memoryview
+        | AbstractDataStore,
         *,
         mask_and_scale=True,
         decode_times=True,

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4015,7 +4015,7 @@ class DataArray(
         compute: bool = True,
         invalid_netcdf: bool = False,
         auto_complex: bool | None = None,
-    ) -> bytes: ...
+    ) -> bytes | memoryview: ...
 
     # compute=False returns dask.Delayed
     @overload
@@ -4079,7 +4079,7 @@ class DataArray(
         compute: bool = True,
         invalid_netcdf: bool = False,
         auto_complex: bool | None = None,
-    ) -> bytes | Delayed | None:
+    ) -> bytes | memoryview | Delayed | None:
         """Write DataArray contents to a netCDF file.
 
         Parameters
@@ -4149,8 +4149,7 @@ class DataArray(
 
         Returns
         -------
-        store: bytes or Delayed or None
-            * ``bytes`` if path is None
+            * ``bytes`` or ``memoryview`` if path is None
             * ``dask.delayed.Delayed`` if compute is False
             * None otherwise
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import datetime
+import io
 import math
 import sys
 import warnings
@@ -1901,7 +1902,7 @@ class Dataset(
     @overload
     def to_netcdf(
         self,
-        path: str | PathLike,
+        path: str | PathLike | io.IOBase,
         mode: NetcdfWriteModes = "w",
         format: T_NetcdfTypes | None = None,
         group: str | None = None,
@@ -1932,7 +1933,7 @@ class Dataset(
 
     def to_netcdf(
         self,
-        path: str | PathLike | None = None,
+        path: str | PathLike | io.IOBase | None = None,
         mode: NetcdfWriteModes = "w",
         format: T_NetcdfTypes | None = None,
         group: str | None = None,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1879,7 +1879,7 @@ class Dataset(
         compute: bool = True,
         invalid_netcdf: bool = False,
         auto_complex: bool | None = None,
-    ) -> bytes: ...
+    ) -> bytes | memoryview: ...
 
     # compute=False returns dask.Delayed
     @overload
@@ -1943,7 +1943,7 @@ class Dataset(
         compute: bool = True,
         invalid_netcdf: bool = False,
         auto_complex: bool | None = None,
-    ) -> bytes | Delayed | None:
+    ) -> bytes | memoryview | Delayed | None:
         """Write dataset contents to a netCDF file.
 
         Parameters
@@ -2015,9 +2015,9 @@ class Dataset(
 
         Returns
         -------
-            * ``bytes`` if path is None
+            * ``bytes`` or ``memoryview`` if path is None
             * ``dask.delayed.Delayed`` if compute is False
-            * None otherwise
+            * ``None`` otherwise
 
         See Also
         --------

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import functools
 import io
 import itertools
-from os import PathLike
 import textwrap
 from collections import ChainMap
 from collections.abc import (
@@ -14,6 +13,7 @@ from collections.abc import (
     Mapping,
 )
 from html import escape
+from os import PathLike
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1680,7 +1680,7 @@ class DataTree(
     @overload
     def to_netcdf(
         self,
-        filepath: str | PathLike,
+        filepath: str | PathLike | io.IOBase,
         mode: NetcdfWriteModes = "w",
         encoding=None,
         unlimited_dims=None,

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1661,7 +1661,7 @@ class DataTree(
     def __eq__(self, other: DtCompatible) -> Self:  # type: ignore[override]
         return super().__eq__(other)
 
-    # filepath=None writes to bytes
+    # filepath=None writes to a memoryview
     @overload
     def to_netcdf(
         self,
@@ -1675,7 +1675,7 @@ class DataTree(
         write_inherited_coords: bool = False,
         compute: bool = True,
         **kwargs,
-    ) -> bytes: ...
+    ) -> memoryview: ...
 
     @overload
     def to_netcdf(
@@ -1704,7 +1704,7 @@ class DataTree(
         write_inherited_coords: bool = False,
         compute: bool = True,
         **kwargs,
-    ) -> None | bytes:
+    ) -> None | memoryview:
         """
         Write datatree contents to a netCDF file.
 
@@ -1713,7 +1713,7 @@ class DataTree(
         filepath : str or PathLike or file-like object or None
             Path to which to save this datatree, or a file-like object to write
             it to (which must support read and write and be seekable) or None
-            to return in-memory bytes.
+            to return in-memory bytes as a memoryview.
         mode : {"w", "a"}, default: "w"
             Write ('w') or append ('a') mode. If mode='w', any existing file at
             this location will be overwritten. If mode='a', existing variables
@@ -1754,7 +1754,8 @@ class DataTree(
 
         Returns
         -------
-            A bytes object with the byte content of the netCDF file, if filepath was None.
+            * ``memoryview`` if path is None
+            * ``None`` otherwise
 
         Note
         ----

--- a/xarray/core/datatree_io.py
+++ b/xarray/core/datatree_io.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
 import io
+from collections.abc import Mapping
 from os import PathLike
-from typing import TYPE_CHECKING, Any, Literal, get_args, overload
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
 from xarray.core.datatree import DataTree
 from xarray.core.types import NetcdfWriteModes, ZarrWriteModes
@@ -13,6 +13,7 @@ T_DataTreeNetcdfTypes = Literal["NETCDF4"]
 
 if TYPE_CHECKING:
     from xarray.core.types import ZarrStoreLike
+
 
 def _datatree_to_netcdf(
     dt: DataTree,
@@ -37,7 +38,9 @@ def _datatree_to_netcdf(
         raise ValueError("DataTree.to_netcdf only supports the NETCDF4 format")
 
     if engine not in [None, *get_args(T_DataTreeNetcdfEngine)]:
-        raise ValueError("DataTree.to_netcdf only supports the netcdf4 and h5netcdf engines")
+        raise ValueError(
+            "DataTree.to_netcdf only supports the netcdf4 and h5netcdf engines"
+        )
 
     if engine is None:
         engine = "h5netcdf"

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -680,15 +680,12 @@ def is_remote_uri(path: str) -> bool:
 
 def read_magic_number_from_file(filename_or_obj, count=8) -> bytes:
     # check byte header to determine file type
-    if isinstance(filename_or_obj, bytes):
-        magic_number = filename_or_obj[:count]
-    elif isinstance(filename_or_obj, io.IOBase):
-        if filename_or_obj.tell() != 0:
-            filename_or_obj.seek(0)
-        magic_number = filename_or_obj.read(count)
-        filename_or_obj.seek(0)
-    else:
+    if not isinstance(filename_or_obj, io.IOBase):
         raise TypeError(f"cannot read the magic number from {type(filename_or_obj)}")
+    if filename_or_obj.tell() != 0:
+        filename_or_obj.seek(0)
+    magic_number = filename_or_obj.read(count)
+    filename_or_obj.seek(0)
     return magic_number
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4543,9 +4543,6 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
     engine: T_NetcdfEngine = "h5netcdf"
 
     def test_open_badbytes(self) -> None:
-        with pytest.raises(ValueError, match=r"HDF5 as bytes"):
-            with open_dataset(b"\211HDF\r\n\032\n", engine="h5netcdf"):  # type: ignore[arg-type]
-                pass
         with pytest.raises(
             ValueError, match=r"match in any of xarray's currently installed IO"
         ):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4602,6 +4602,15 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
 
 
 @requires_h5netcdf
+class TestH5NetCDFInMemoryData:
+    def test_roundtrip_via_bytes(self) -> None:
+        original = create_test_data()
+        netcdf_bytes = original.to_netcdf(engine="h5netcdf")
+        roundtrip = open_dataset(netcdf_bytes, engine="h5netcdf")  # type: ignore[arg-type]
+        assert_identical(roundtrip, original)
+
+
+@requires_h5netcdf
 @requires_dask
 @pytest.mark.filterwarnings("ignore:deallocating CachingFileManager")
 class TestH5NetCDFViaDaskData(TestH5NetCDFData):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4062,6 +4062,16 @@ class TestScipyInMemoryData(CFEncodedBase, NetCDF3Only):
         ):
             Dataset({"foo": 42}).to_netcdf(engine="scipy")
 
+    def test_roundtrip_via_bytes(self) -> None:
+        original = create_test_data()
+        with pytest.warns(
+            FutureWarning,
+            match=re.escape("return value of to_netcdf() without a target"),
+        ):
+            netcdf_bytes = original.to_netcdf(engine="scipy")
+        roundtrip = open_dataset(netcdf_bytes, engine="scipy")
+        assert_identical(roundtrip, original)
+
     def test_bytes_pickle(self) -> None:
         data = Dataset({"foo": ("x", [1, 2, 3])})
         with pytest.warns(

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4562,10 +4562,10 @@ class TestH5NetCDFFileObject(TestH5NetCDFData):
         with pytest.raises(
             ValueError, match=r"match in any of xarray's currently installed IO"
         ):
-            with open_dataset(b"garbage"):  # type: ignore[arg-type]
+            with open_dataset(b"garbage"):
                 pass
         with pytest.raises(ValueError, match=r"can only read bytes"):
-            with open_dataset(b"garbage", engine="netcdf4"):  # type: ignore[arg-type]
+            with open_dataset(b"garbage", engine="netcdf4"):
                 pass
         with pytest.raises(
             ValueError, match=r"not the signature of a valid netCDF4 file"
@@ -4633,7 +4633,13 @@ class TestH5NetCDFInMemoryData:
     def test_roundtrip_via_bytes(self) -> None:
         original = create_test_data()
         netcdf_bytes = original.to_netcdf(engine="h5netcdf")
-        roundtrip = open_dataset(netcdf_bytes, engine="h5netcdf")  # type: ignore[arg-type]
+        roundtrip = open_dataset(netcdf_bytes, engine="h5netcdf")
+        assert_identical(roundtrip, original)
+
+    def test_roundtrip_group_via_bytes(self) -> None:
+        original = create_test_data()
+        netcdf_bytes = original.to_netcdf(group="sub", engine="h5netcdf")
+        roundtrip = open_dataset(netcdf_bytes, group="sub", engine="h5netcdf")
         assert_identical(roundtrip, original)
 
 

--- a/xarray/tests/test_backends_common.py
+++ b/xarray/tests/test_backends_common.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import re
 
 import numpy as np
@@ -53,10 +54,11 @@ def test_infer_dtype_error_on_mixed_types(data):
 def test_encoding_failure_note():
     # Create an arbitrary value that cannot be encoded in netCDF3
     ds = xr.Dataset({"invalid": np.array([2**63 - 1], dtype=np.int64)})
+    f = io.BytesIO()
     with pytest.raises(
         ValueError,
         match=re.escape(
             "Raised while encoding variable 'invalid' with value <xarray.Variable"
         ),
     ):
-        ds.to_netcdf()
+        ds.to_netcdf(f, engine="scipy")

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -539,6 +539,28 @@ class TestH5NetCDFDatatreeIO(DatatreeIOBase):
                     "phony_dim_3": 25,
                 }
 
+    def test_roundtrip_via_bytes(self, simple_datatree):
+        original_dt = simple_datatree
+        roundtrip_dt = open_datatree(original_dt.to_netcdf())
+        assert_equal(original_dt, roundtrip_dt)
+
+    def test_roundtrip_via_bytes_engine_specified(self, simple_datatree):
+        original_dt = simple_datatree
+        roundtrip_dt = open_datatree(original_dt.to_netcdf(engine=self.engine))
+        assert_equal(original_dt, roundtrip_dt)
+
+    def test_roundtrip_using_filelike_object(self, tmpdir, simple_datatree):
+        original_dt = simple_datatree
+        filepath = tmpdir + '/test.nc'
+        # h5py requires both read and write access when writing, it will
+        # work with file-like objects provided they support both, and are
+        # seekable.
+        with open(filepath, 'wb+') as file:
+            original_dt.to_netcdf(file, engine=self.engine)
+        with open(filepath, 'rb') as file:
+            roundtrip_dt = open_datatree(file, engine=self.engine)
+            assert_equal(original_dt, roundtrip_dt)
+
 
 @requires_zarr
 @parametrize_zarr_format

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -551,13 +551,13 @@ class TestH5NetCDFDatatreeIO(DatatreeIOBase):
 
     def test_roundtrip_using_filelike_object(self, tmpdir, simple_datatree):
         original_dt = simple_datatree
-        filepath = tmpdir + '/test.nc'
+        filepath = tmpdir + "/test.nc"
         # h5py requires both read and write access when writing, it will
         # work with file-like objects provided they support both, and are
         # seekable.
-        with open(filepath, 'wb+') as file:
+        with open(filepath, "wb+") as file:
             original_dt.to_netcdf(file, engine=self.engine)
-        with open(filepath, 'rb') as file:
+        with open(filepath, "rb") as file:
             roundtrip_dt = open_datatree(file, engine=self.engine)
             assert_equal(original_dt, roundtrip_dt)
 

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -558,8 +558,8 @@ class TestH5NetCDFDatatreeIO(DatatreeIOBase):
         with open(filepath, "wb+") as file:
             original_dt.to_netcdf(file, engine=self.engine)
         with open(filepath, "rb") as file:
-            roundtrip_dt = open_datatree(file, engine=self.engine)
-            assert_equal(original_dt, roundtrip_dt)
+            with open_datatree(file, engine=self.engine) as roundtrip_dt:
+                assert_equal(original_dt, roundtrip_dt)
 
 
 @requires_zarr


### PR DESCRIPTION
And some other related improvements to reading and writing of NetCDF files to/from bytes or file-like objects.

* Allows use of h5netcdf engine when writing to file-like objects (such as `BytesIO`), stop forcing use of scipy backend in this case (which is incompatible with groups and `DataTree`). Makes h5netcdf the default engine for `DataTree.to_netcdf` rather than leaving the choice of default up to `Dataset.to_netcdf`.
* Allows use of h5netcdf engine to read from a bytes object.
* Allows `DataTree.to_netcdf` to return bytes when filepath argument is omitted (similar to `Dataset.to_netcdf`).

- [x] Closes #10570
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`