### PR TITLE
Update documentation to copy tags when forking, so versioning is reasonable

### DIFF
--- a/doc/contribute/contributing.rst
+++ b/doc/contribute/contributing.rst
@@ -129,6 +129,8 @@ you can work seamlessly between your local repository and GitHub.
     The following instructions assume you want to learn how to interact with github via the git command-line utility,
     but contributors who are new to git may find it easier to use other tools instead such as
     `Github Desktop <https://desktop.github.com/>`_.
+    
+.. _contributing.dev_workflow:
 
 Development workflow
 ====================
@@ -190,7 +192,7 @@ development environment:
 - Install either `Anaconda <https://www.anaconda.com/download/>`_ or `miniconda
   <https://conda.io/miniconda.html>`_
 - Make sure your conda is up to date (``conda update conda``)
-- Make sure that you have :ref:`cloned the repository <contributing.forking>`
+- Make sure that you have :ref:`cloned the repository <contributing.dev_workflow>`
 - ``cd`` to the *xarray* source directory
 
 We'll now kick off a two-step process:

--- a/doc/contribute/contributing.rst
+++ b/doc/contribute/contributing.rst
@@ -262,8 +262,7 @@ from the root of the xarray repository. You can skip the pre-commit checks with
 Update the ``main`` branch
 --------------------------
 
-First make sure you have followed `Setting up xarray for development
-<https://docs.xarray.dev/en/stable/contributing.html#creating-a-development-environment>`_
+First make sure you have :ref:`created a development environment <contributing.dev_env>`.
 
 Before starting a new set of changes, fetch all changes from ``upstream/main``, and start a new
 feature branch from that. From time to time you should fetch the upstream changes from GitHub: ::

--- a/doc/contribute/contributing.rst
+++ b/doc/contribute/contributing.rst
@@ -156,113 +156,11 @@ maintainers to see what you've done, and why you did it, we recommend you to fol
     git fetch --tags upstream
     
    This will ensure that when you create a development environment (below), a reasonable version number is created.
-
-Creating a development environment
-----------------------------------
-
-To test out code changes locally, you'll need to build *xarray* from source, which requires you to
-`create a local development environment <https://docs.xarray.dev/en/stable/contributing.html#contributing-dev-env>`_.
-
-Update the ``main`` branch
---------------------------
-
-First make sure you have followed `Setting up xarray for development
-<https://docs.xarray.dev/en/stable/contributing.html#creating-a-development-environment>`_
-
-Before starting a new set of changes, fetch all changes from ``upstream/main``, and start a new
-feature branch from that. From time to time you should fetch the upstream changes from GitHub: ::
-
-    git fetch --tags upstream
-    git merge upstream/main
-
-This will combine your commits with the latest *xarray* git ``main``.  If this
-leads to merge conflicts, you must resolve these before submitting your pull
-request.  If you have uncommitted changes, you will need to ``git stash`` them
-prior to updating.  This will effectively store your changes, which can be
-reapplied after updating.
-
-If the **xarray** ``main`` branch version has updated since you last fetched changes,
-you may also wish to reinstall xarray so that the pip version reflects the **xarray**
-version::
-    pip install -e .
-
-Create a new feature branch
----------------------------
-
-Create a branch to save your changes, even before you start making changes. You want your
-``main branch`` to contain only production-ready code::
-
-    git checkout -b shiny-new-feature
-
-This changes your working directory to the ``shiny-new-feature`` branch.  Keep any changes in this
-branch specific to one bug or feature so it is clear what the branch brings to *xarray*. You can have
-many "shiny-new-features" and switch in between them using the ``git checkout`` command.
-
-Generally, you will want to keep your feature branches on your public GitHub fork of xarray. To do this,
-you ``git push`` this new branch up to your GitHub repo. Generally (if you followed the instructions in
-these pages, and by default), git will have a link to your fork of the GitHub repo, called ``origin``.
-You push up to your own fork with: ::
-
-    git push origin shiny-new-feature
-
-In git >= 1.7 you can ensure that the link is correctly set by using the ``--set-upstream`` option: ::
-
-    git push --set-upstream origin shiny-new-feature
-
-From now on git will know that ``shiny-new-feature`` is related to the ``shiny-new-feature branch`` in the GitHub repo.
-
-The editing workflow
---------------------
-
-1. Make some changes
-
-2. See which files have changed with ``git status``. You'll see a listing like this one: ::
-
-    # On branch shiny-new-feature
-    # Changed but not updated:
-    #   (use "git add <file>..." to update what will be committed)
-    #   (use "git checkout -- <file>..." to discard changes in working directory)
-    #
-    #  modified:   README
-
-3. Check what the actual changes are with ``git diff``.
-
-4. Build the `documentation run <https://docs.xarray.dev/en/stable/contributing.html#building-the-documentation>`_
-for the documentation changes.
-
-`Run the test suite <https://docs.xarray.dev/en/stable/contributing.html#running-the-test-suite>`_ for code changes.
-
-Commit and push your changes
-----------------------------
-
-1. To commit all modified files into the local copy of your repo, do ``git commit -am 'A commit message'``.
-
-2. To push the changes up to your forked repo on GitHub, do a ``git push``.
-
-Open a pull request
--------------------
-
-When you're ready or need feedback on your code, open a Pull Request (PR) so that the xarray developers can
-give feedback and eventually include your suggested code into the ``main`` branch.
-`Pull requests (PRs) on GitHub <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests>`_
-are the mechanism for contributing to xarray's code and documentation.
-
-Enter a title for the set of changes with some explanation of what you've done.
-Follow the PR template, which looks like this. ::
-
-    [ ]Closes #xxxx
-    [ ]Tests added
-    [ ]User visible changes (including notable bug fixes) are documented in whats-new.rst
-    [ ]New functions/methods are listed in api.rst
-
-Mention anything you'd like particular attention for - such as a complicated change or some code you are not happy with.
-If you don't think your request is ready to be merged, just say so in your pull request message and use
-the "Draft PR" feature of GitHub. This is a good way of getting some preliminary code review.
-
+   
 .. _contributing.dev_env:
 
 Creating a development environment
-==================================
+----------------------------------
 
 To test out code changes locally, you'll need to build *xarray* from source, which
 requires a Python environment. If you're making documentation changes, you can
@@ -359,6 +257,103 @@ from the root of the xarray repository. You can skip the pre-commit checks with
 ``git commit --no-verify``.
 
 .. _contributing.documentation:
+
+
+Update the ``main`` branch
+--------------------------
+
+First make sure you have followed `Setting up xarray for development
+<https://docs.xarray.dev/en/stable/contributing.html#creating-a-development-environment>`_
+
+Before starting a new set of changes, fetch all changes from ``upstream/main``, and start a new
+feature branch from that. From time to time you should fetch the upstream changes from GitHub: ::
+
+    git fetch --tags upstream
+    git merge upstream/main
+
+This will combine your commits with the latest *xarray* git ``main``.  If this
+leads to merge conflicts, you must resolve these before submitting your pull
+request.  If you have uncommitted changes, you will need to ``git stash`` them
+prior to updating.  This will effectively store your changes, which can be
+reapplied after updating.
+
+If the **xarray** ``main`` branch version has updated since you last fetched changes,
+you may also wish to reinstall xarray so that the pip version reflects the **xarray**
+version::
+    pip install -e .
+
+Create a new feature branch
+---------------------------
+
+Create a branch to save your changes, even before you start making changes. You want your
+``main branch`` to contain only production-ready code::
+
+    git checkout -b shiny-new-feature
+
+This changes your working directory to the ``shiny-new-feature`` branch.  Keep any changes in this
+branch specific to one bug or feature so it is clear what the branch brings to *xarray*. You can have
+many "shiny-new-features" and switch in between them using the ``git checkout`` command.
+
+Generally, you will want to keep your feature branches on your public GitHub fork of xarray. To do this,
+you ``git push`` this new branch up to your GitHub repo. Generally (if you followed the instructions in
+these pages, and by default), git will have a link to your fork of the GitHub repo, called ``origin``.
+You push up to your own fork with: ::
+
+    git push origin shiny-new-feature
+
+In git >= 1.7 you can ensure that the link is correctly set by using the ``--set-upstream`` option: ::
+
+    git push --set-upstream origin shiny-new-feature
+
+From now on git will know that ``shiny-new-feature`` is related to the ``shiny-new-feature branch`` in the GitHub repo.
+
+The editing workflow
+--------------------
+
+1. Make some changes
+
+2. See which files have changed with ``git status``. You'll see a listing like this one: ::
+
+    # On branch shiny-new-feature
+    # Changed but not updated:
+    #   (use "git add <file>..." to update what will be committed)
+    #   (use "git checkout -- <file>..." to discard changes in working directory)
+    #
+    #  modified:   README
+
+3. Check what the actual changes are with ``git diff``.
+
+4. Build the `documentation run <https://docs.xarray.dev/en/stable/contributing.html#building-the-documentation>`_
+for the documentation changes.
+
+`Run the test suite <https://docs.xarray.dev/en/stable/contributing.html#running-the-test-suite>`_ for code changes.
+
+Commit and push your changes
+----------------------------
+
+1. To commit all modified files into the local copy of your repo, do ``git commit -am 'A commit message'``.
+
+2. To push the changes up to your forked repo on GitHub, do a ``git push``.
+
+Open a pull request
+-------------------
+
+When you're ready or need feedback on your code, open a Pull Request (PR) so that the xarray developers can
+give feedback and eventually include your suggested code into the ``main`` branch.
+`Pull requests (PRs) on GitHub <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests>`_
+are the mechanism for contributing to xarray's code and documentation.
+
+Enter a title for the set of changes with some explanation of what you've done.
+Follow the PR template, which looks like this. ::
+
+    [ ]Closes #xxxx
+    [ ]Tests added
+    [ ]User visible changes (including notable bug fixes) are documented in whats-new.rst
+    [ ]New functions/methods are listed in api.rst
+
+Mention anything you'd like particular attention for - such as a complicated change or some code you are not happy with.
+If you don't think your request is ready to be merged, just say so in your pull request message and use
+the "Draft PR" feature of GitHub. This is a good way of getting some preliminary code review.
 
 Contributing to the documentation
 =================================

--- a/doc/contribute/contributing.rst
+++ b/doc/contribute/contributing.rst
@@ -157,7 +157,7 @@ maintainers to see what you've done, and why you did it, we recommend you to fol
 
     git fetch --tags upstream
     
-   This will ensure that when you create a development environment (below), a reasonable version number is created.
+   This will ensure that when you create a development environment a reasonable version number is created.
    
 .. _contributing.dev_env:
 

--- a/doc/contribute/contributing.rst
+++ b/doc/contribute/contributing.rst
@@ -256,8 +256,6 @@ This can be done by running: ::
 from the root of the xarray repository. You can skip the pre-commit checks with
 ``git commit --no-verify``.
 
-.. _contributing.documentation:
-
 
 Update the ``main`` branch
 --------------------------
@@ -354,6 +352,8 @@ Follow the PR template, which looks like this. ::
 Mention anything you'd like particular attention for - such as a complicated change or some code you are not happy with.
 If you don't think your request is ready to be merged, just say so in your pull request message and use
 the "Draft PR" feature of GitHub. This is a good way of getting some preliminary code review.
+
+.. _contributing.documentation:
 
 Contributing to the documentation
 =================================

--- a/doc/contribute/contributing.rst
+++ b/doc/contribute/contributing.rst
@@ -276,8 +276,8 @@ request.  If you have uncommitted changes, you will need to ``git stash`` them
 prior to updating.  This will effectively store your changes, which can be
 reapplied after updating.
 
-If the **xarray** ``main`` branch version has updated since you last fetched changes,
-you may also wish to reinstall xarray so that the pip version reflects the **xarray**
+If the *xarray* ``main`` branch version has updated since you last fetched changes,
+you may also wish to reinstall xarray so that the pip version reflects the *xarray*
 version::
     pip install -e .
 
@@ -322,10 +322,10 @@ The editing workflow
 
 3. Check what the actual changes are with ``git diff``.
 
-4. Build the `documentation run <https://docs.xarray.dev/en/stable/contributing.html#building-the-documentation>`_
+4. Build the `documentation <https://docs.xarray.dev/en/stable/contributing.html#building-the-documentation>`_
 for the documentation changes.
 
-`Run the test suite <https://docs.xarray.dev/en/stable/contributing.html#running-the-test-suite>`_ for code changes.
+5. `Run the test suite <https://docs.xarray.dev/en/stable/contributing.html#running-the-test-suite>`_ for code changes.
 
 Commit and push your changes
 ----------------------------

--- a/doc/contribute/contributing.rst
+++ b/doc/contribute/contributing.rst
@@ -151,6 +151,12 @@ maintainers to see what you've done, and why you did it, we recommend you to fol
    This creates the directory ``xarray`` and connects your repository to
    the upstream (main project) *xarray* repository.
 
+4. Copy tags across from the xarray repository::
+
+    git fetch --tags upstream
+    
+   This will ensure that when you create a development environment (below), a reasonable version number is created.
+
 Creating a development environment
 ----------------------------------
 
@@ -316,7 +322,7 @@ built version:
    $ python  # start an interpreter
    >>> import xarray
    >>> xarray.__version__
-   '0.10.0+dev46.g015daca'
+   '2025.7.2.dev14+g5ce69b2b.d20250725'
 
 This will create the new environment, and not touch any of your existing environments,
 nor any existing Python installation.

--- a/doc/contribute/contributing.rst
+++ b/doc/contribute/contributing.rst
@@ -172,7 +172,7 @@ First make sure you have followed `Setting up xarray for development
 Before starting a new set of changes, fetch all changes from ``upstream/main``, and start a new
 feature branch from that. From time to time you should fetch the upstream changes from GitHub: ::
 
-    git fetch upstream
+    git fetch --tags upstream
     git merge upstream/main
 
 This will combine your commits with the latest *xarray* git ``main``.  If this
@@ -180,6 +180,11 @@ leads to merge conflicts, you must resolve these before submitting your pull
 request.  If you have uncommitted changes, you will need to ``git stash`` them
 prior to updating.  This will effectively store your changes, which can be
 reapplied after updating.
+
+If the **xarray** ``main`` branch version has updated since you last fetched changes,
+you may also wish to reinstall xarray so that the pip version reflects the **xarray**
+version::
+    pip install -e .
 
 Create a new feature branch
 ---------------------------


### PR DESCRIPTION
- Closes #10568

The first of the commits is most critical to closing #10568, later commits are just to smooth out the reader's experience. The biggest change is moving "Create a develoment environment" up to when it's first mentioned, otherwise the flow of the docs seems to involve skipping to a later section and then skipping back.

Also tidied up a hyperlink that seemed to unintentionally link to pandas, and another one that used a https webpage instead of an internal cross-reference

@ianhi