### PR TITLE
install `pyarrow` from its official repo

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -35,15 +35,7 @@ python -m pip install \
     numpy \
     scipy \
     matplotlib \
-    pandas
-# for some reason pandas depends on pyarrow already.
-# Remove once a `pyarrow` version compiled with `numpy>=2.0` is on `conda-forge`
-python -m pip install \
-    -i https://pypi.fury.io/arrow-nightlies/ \
-    --prefer-binary \
-    --no-deps \
-    --pre \
-    --upgrade \
+    pandas \
     pyarrow
 # manually install `pint`, `donfig`, and `crc32c` to pull in new dependencies
 python -m pip install --upgrade pint donfig crc32c


### PR DESCRIPTION
The `pyarrow` nightly wheels (which we needed for upstream `pandas` when that moved to depending on `pyarrow`) have moved to a different place, so this updates our upstream-dev script.

Alternatively, we could just not install `pyarrow` separately, as we don't use it directly and the version pulled in from conda-forge by pandas should be recent enough.