### PR TITLE
slicing a slice with an array without expanding the slice

### DIFF
--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -300,10 +300,9 @@ def slice_slice(old_slice: slice, applied_slice: slice, size: int) -> slice:
 
 
 def slice_slice_by_array(old_slice, array, size):
-    # _expand_slice(old_indexer, size)[applied_indexer]
     normalized = normalize_slice(old_slice, size)
-
     new_indexer = array * normalized.step + normalized.start
+
     if np.any(new_indexer >= normalized.stop):
         raise IndexError("indices out of bounds")  # TODO: more helpful error message
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -339,6 +339,9 @@ def _index_indexer_1d(
     if is_full_slice(applied_indexer):
         # shortcut for the usual case
         return old_indexer
+    if is_full_slice(old_indexer):
+        # shortcut for full slices
+        return applied_indexer
 
     indexer: OuterIndexerType
     if isinstance(old_indexer, slice):
@@ -346,8 +349,6 @@ def _index_indexer_1d(
             indexer = slice_slice(old_indexer, applied_indexer, size)
         elif isinstance(applied_indexer, integer_types):
             indexer = range(*old_indexer.indices(size))[applied_indexer]
-        elif is_full_slice(old_indexer):
-            indexer = applied_indexer
         else:
             indexer = slice_slice_by_array(old_indexer, applied_indexer, size)
     elif isinstance(old_indexer, np.ndarray):

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -308,6 +308,8 @@ def _index_indexer_1d(old_indexer, applied_indexer, size: int):
             indexer = slice_slice(old_indexer, applied_indexer, size)
         elif isinstance(applied_indexer, integer_types):
             indexer = range(*old_indexer.indices(size))[applied_indexer]  # type: ignore[assignment]
+        elif is_full_slice(old_indexer):
+            indexer = applied_indexer
         else:
             indexer = _expand_slice(old_indexer, size)[applied_indexer]
     else:

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -299,6 +299,17 @@ def slice_slice(old_slice: slice, applied_slice: slice, size: int) -> slice:
     return slice(start, stop, step)
 
 
+def slice_slice_by_array(old_slice, array, size):
+    # _expand_slice(old_indexer, size)[applied_indexer]
+    normalized = normalize_slice(old_slice, size)
+
+    new_indexer = array * normalized.step + normalized.start
+    if np.any(new_indexer >= normalized.stop):
+        raise IndexError("indices out of bounds")  # TODO: more helpful error message
+
+    return new_indexer
+
+
 def _index_indexer_1d(old_indexer, applied_indexer, size: int):
     if is_full_slice(applied_indexer):
         # shortcut for the usual case
@@ -311,7 +322,7 @@ def _index_indexer_1d(old_indexer, applied_indexer, size: int):
         elif is_full_slice(old_indexer):
             indexer = applied_indexer
         else:
-            indexer = _expand_slice(old_indexer, size)[applied_indexer]
+            indexer = slice_slice_by_array(old_indexer, applied_indexer, size)
     else:
         indexer = old_indexer[applied_indexer]
     return indexer

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -309,7 +309,7 @@ def slice_slice_by_array(
 
     new_indexer = array * normalized.step + normalized.start
 
-    if np.any(new_indexer >= normalized.stop):
+    if np.any(new_indexer >= size):
         raise IndexError("indices out of bounds")  # TODO: more helpful error message
 
     return new_indexer

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -42,8 +42,8 @@ if TYPE_CHECKING:
     from xarray.namedarray._typing import _Shape, duckarray
     from xarray.namedarray.parallelcompat import ChunkManagerEntrypoint
 
-    BasicIndexerType = int | np.integer | slice
-    OuterIndexerType = BasicIndexerType | np.ndarray[Any, np.dtype[np.integer]]
+BasicIndexerType = int | np.integer | slice
+OuterIndexerType = BasicIndexerType | np.ndarray[Any, np.dtype[np.integer]]
 
 
 @dataclass

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -299,8 +299,14 @@ def slice_slice(old_slice: slice, applied_slice: slice, size: int) -> slice:
     return slice(start, stop, step)
 
 
-def slice_slice_by_array(old_slice, array, size):
+def slice_slice_by_array(
+    old_slice: slice,
+    array: np.ndarray[Any, np.dtype[np.generic]],
+    size: int,
+) -> np.ndarray[Any, np.dtype[np.generic]]:
+    # to get a concrete slice, limited to the size of the array
     normalized = normalize_slice(old_slice, size)
+
     new_indexer = array * normalized.step + normalized.start
 
     if np.any(new_indexer >= normalized.stop):

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -304,6 +304,19 @@ def slice_slice_by_array(
     array: np.ndarray[Any, np.dtype[np.generic]],
     size: int,
 ) -> np.ndarray[Any, np.dtype[np.generic]]:
+    """Given a slice and the size of the dimension to which it will be applied,
+    index it with an array to return a new array equivalent to applying
+    the slices sequentially
+
+    Examples
+    --------
+    >>> slice_slice_by_array(slice(2, 10), np.array([1, 3, 5]), 12)
+    array([3, 5, 7])
+    >>> slice_slice_by_array(slice(1, None, 2), np.array([1, 3, 7, 8]), 20)
+    array([ 3,  7, 15, 17])
+    >>> slice_slice_by_array(slice(None, None, -1), np.array([2, 4, 7]), 20)
+    array([17, 15, 12])
+    """
     # to get a concrete slice, limited to the size of the array
     normalized = normalize_slice(old_slice, size)
 

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -304,9 +304,9 @@ def slice_slice(old_slice: slice, applied_slice: slice, size: int) -> slice:
 
 def slice_slice_by_array(
     old_slice: slice,
-    array: np.ndarray[Any, np.dtype[np.generic]],
+    array: np.ndarray[Any, np.dtype[np.integer]],
     size: int,
-) -> np.ndarray[Any, np.dtype[np.generic]]:
+) -> np.ndarray[Any, np.dtype[np.integer]]:
     """Given a slice and the size of the dimension to which it will be applied,
     index it with an array to return a new array equivalent to applying
     the slices sequentially

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -42,6 +42,9 @@ if TYPE_CHECKING:
     from xarray.namedarray._typing import _Shape, duckarray
     from xarray.namedarray.parallelcompat import ChunkManagerEntrypoint
 
+    BasicIndexerType = int | np.integer | slice
+    OuterIndexerType = BasicIndexerType | np.ndarray[Any, np.dtype[np.integer]]
+
 
 @dataclass
 class IndexSelResult:
@@ -328,7 +331,11 @@ def slice_slice_by_array(
     return new_indexer
 
 
-def _index_indexer_1d(old_indexer, applied_indexer, size: int):
+def _index_indexer_1d(
+    old_indexer: OuterIndexerType,
+    applied_indexer: OuterIndexerType,
+    size: int,
+) -> OuterIndexerType:
     if is_full_slice(applied_indexer):
         # shortcut for the usual case
         return old_indexer
@@ -419,7 +426,7 @@ class BasicIndexer(ExplicitIndexer):
 
     __slots__ = ()
 
-    def __init__(self, key: tuple[int | np.integer | slice, ...]):
+    def __init__(self, key: tuple[BasicIndexerType, ...]):
         if not isinstance(key, tuple):
             raise TypeError(f"key must be a tuple: {key!r}")
 
@@ -451,9 +458,7 @@ class OuterIndexer(ExplicitIndexer):
 
     def __init__(
         self,
-        key: tuple[
-            int | np.integer | slice | np.ndarray[Any, np.dtype[np.generic]], ...
-        ],
+        key: tuple[BasicIndexerType | np.ndarray[Any, np.dtype[np.generic]], ...],
     ):
         if not isinstance(key, tuple):
             raise TypeError(f"key must be a tuple: {key!r}")

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -26,6 +26,7 @@ from xarray.core.utils import (
     get_valid_numpy_dtype,
     is_duck_array,
     is_duck_dask_array,
+    is_full_slice,
     is_scalar,
     is_valid_numpy_dtype,
     to_0d_array,
@@ -299,7 +300,7 @@ def slice_slice(old_slice: slice, applied_slice: slice, size: int) -> slice:
 
 
 def _index_indexer_1d(old_indexer, applied_indexer, size: int):
-    if isinstance(applied_indexer, slice) and applied_indexer == slice(None):
+    if is_full_slice(applied_indexer):
         # shortcut for the usual case
         return old_indexer
     if isinstance(old_indexer, slice):

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -316,7 +316,7 @@ class TestLazyArray:
     )
     def test_slice_slice_by_array(self, old_slice, array, size, expected):
         actual = indexing.slice_slice_by_array(old_slice, array, size)
-
+    expected = np.arange(size)[old_slice][array]
         assert_array_equal(actual, expected)
 
     def test_lazily_indexed_array(self) -> None:

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -305,6 +305,20 @@ class TestLazyArray:
                     actual = x[new_slice]
                     assert_array_equal(expected, actual)
 
+    @pytest.mark.parametrize(
+        ["old_slice", "array", "size", "expected"],
+        (
+            (slice(None, 8), np.arange(2, 6), 10, np.arange(2, 6)),
+            (slice(2, None), np.arange(2, 6), 10, np.arange(4, 8)),
+            (slice(1, 10, 2), np.arange(1, 4), 15, np.arange(3, 8, 2)),
+            (slice(10, None, -1), np.array([2, 5, 7]), 12, np.array([8, 5, 3])),
+        ),
+    )
+    def test_slice_slice_by_array(self, old_slice, array, size, expected):
+        actual = indexing.slice_slice_by_array(old_slice, array, size)
+
+        assert_array_equal(actual, expected)
+
     def test_lazily_indexed_array(self) -> None:
         original = np.random.rand(10, 20, 30)
         x = indexing.NumpyIndexingAdapter(original)

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -312,6 +312,8 @@ class TestLazyArray:
             (slice(2, None), np.arange(2, 6), 10),
             (slice(1, 10, 2), np.arange(1, 4), 15),
             (slice(10, None, -1), np.array([2, 5, 7]), 12),
+            (slice(2, None, 2), np.array([3, -2, 5, -1]), 13),
+            (slice(8, None), np.array([1, -2, 2, -1, -7]), 20),
         ),
     )
     def test_slice_slice_by_array(self, old_slice, array, size):

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -306,17 +306,17 @@ class TestLazyArray:
                     assert_array_equal(expected, actual)
 
     @pytest.mark.parametrize(
-        ["old_slice", "array", "size", "expected"],
+        ["old_slice", "array", "size"],
         (
-            (slice(None, 8), np.arange(2, 6), 10, np.arange(2, 6)),
-            (slice(2, None), np.arange(2, 6), 10, np.arange(4, 8)),
-            (slice(1, 10, 2), np.arange(1, 4), 15, np.arange(3, 8, 2)),
-            (slice(10, None, -1), np.array([2, 5, 7]), 12, np.array([8, 5, 3])),
+            (slice(None, 8), np.arange(2, 6), 10),
+            (slice(2, None), np.arange(2, 6), 10),
+            (slice(1, 10, 2), np.arange(1, 4), 15),
+            (slice(10, None, -1), np.array([2, 5, 7]), 12),
         ),
     )
-    def test_slice_slice_by_array(self, old_slice, array, size, expected):
+    def test_slice_slice_by_array(self, old_slice, array, size):
         actual = indexing.slice_slice_by_array(old_slice, array, size)
-    expected = np.arange(size)[old_slice][array]
+        expected = np.arange(size)[old_slice][array]
         assert_array_equal(actual, expected)
 
     def test_lazily_indexed_array(self) -> None:


### PR DESCRIPTION
The lazy indexing machinery currently uses `_index_indexer_1d` to keep indexing lazy (for orthogonal indexing only), which tries very hard to combine multiple sequential indexers into a single indexer.

However, it currently uses `_expand_slice` when indexing a `slice` with an array, which has the potential to run out of memory for very large dimension sizes of the indexed array.

Instead of materializing, we can just combine the slice (`s`) with the array (`idx`) by:

``` python
new_idx = idx * s.step + s.start
```

Interestingly, this works regardless of whether `step` is negative or positive, but we do have to raise an `IndexError` if there's any value `>= size`.

- [x] Tests added