### PR TITLE
`pre-commit` hook maintenance: `typos`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
     hooks:
       - id: validate-pyproject
         additional_dependencies: ["validate-pyproject-schema-store[all]"]
-  - repo: https://github.com/crate-ci/typos
-    rev: v1
+  - repo: https://github.com/adhtruong/mirrors-typos
+    rev: v1.34.0
     hooks:
       - id: typos

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,5 +76,3 @@ repos:
     rev: v1
     hooks:
       - id: typos
-        # https://github.com/crate-ci/typos/issues/347
-        pass_filenames: false


### PR DESCRIPTION
- make `pre-commit` pass the filenames to `typos` again (the bug that made us not do so has been resolved)
- switch to a mirror repo of `typos`, which allows autoupdating the version (important for persistent `pre-commit` cache dirs, e.g. local installations)