### PR TITLE
bump the build metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ dask = "xarray.namedarray.daskmanager:DaskManager"
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=77", "setuptools-scm>=7"]
+requires = ["setuptools>=77", "setuptools-scm>=8"]
 
 [tool.setuptools.packages.find]
 include = ["xarray*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ dask = "xarray.namedarray.daskmanager:DaskManager"
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=77", "setuptools-scm>=8"]
+requires = ["setuptools>=77.0.3", "setuptools-scm>=8"]
 
 [tool.setuptools.packages.find]
 include = ["xarray*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ dask = "xarray.namedarray.daskmanager:DaskManager"
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=42", "setuptools-scm>=7"]
+requires = ["setuptools>=77", "setuptools-scm>=7"]
 
 [tool.setuptools.packages.find]
 include = ["xarray*"]


### PR DESCRIPTION
- [x] Closes #10588

This bumps the build deps to `setuptools>=77.0.3` and ``setuptools-scm>=8`. The bump in `setuptools` became necessary because we use a SPDX identifier for the license metadata, which is only supported for that version, and `setuptools-scm=8` has been out for almost 2 years.