### PR TITLE
Support compute=False from DataTree.to_netcdf

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,6 +15,9 @@ New Features
 
 - :py:meth:`DataTree.to_netcdf` can now write to a file-like object, or return bytes if called without a filepath. (:issue:`10570`)
   By `Matthew Willson <https://github.com/mjwillson>`_.
+- ``compute=False`` is now supported by :py:meth:`DataTree.to_netcdf` and
+  :py:meth:`DataTree.to_zarr`.
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -30,13 +30,14 @@ from xarray import backends, conventions
 from xarray.backends import plugins
 from xarray.backends.common import (
     AbstractDataStore,
+    AbstractWritableDataStore,
     ArrayWriter,
     BytesIOProxy,
     T_PathFileOrDataStore,
     _find_absolute_paths,
     _normalize_path,
 )
-from xarray.backends.locks import _get_scheduler
+from xarray.backends.locks import get_dask_scheduler
 from xarray.coders import CFDatetimeCoder, CFTimedeltaCoder
 from xarray.core import dtypes, indexing
 from xarray.core.coordinates import Coordinates
@@ -283,10 +284,16 @@ def _protect_datatree_variables_inplace(tree: DataTree, cache: bool) -> None:
         _protect_dataset_variables_inplace(node, cache)
 
 
-def _finalize_store(write, store):
+def _finalize_store(writes, store):
     """Finalize this store by explicitly syncing and closing"""
-    del write  # ensure writing is done first
+    del writes  # ensure writing is done first
     store.close()
+
+
+def delayed_close_after_writes(writes, store):
+    import dask
+
+    return dask.delayed(_finalize_store)(writes, store)
 
 
 def _multi_file_closer(closers):
@@ -1769,6 +1776,39 @@ WRITEABLE_STORES: dict[T_NetcdfEngine, Callable] = {
 }
 
 
+def get_writable_netcdf_store(
+    target,
+    engine: T_NetcdfEngine,
+    *,
+    format: T_NetcdfTypes | None,
+    mode: NetcdfWriteModes,
+    autoclose: bool,
+    invalid_netcdf: bool,
+    auto_complex: bool | None,
+) -> AbstractWritableDataStore:
+    """Create a store for writing to a netCDF file."""
+    try:
+        store_open = WRITEABLE_STORES[engine]
+    except KeyError as err:
+        raise ValueError(f"unrecognized engine for to_netcdf: {engine!r}") from err
+
+    if format is not None:
+        format = format.upper()  # type: ignore[assignment]
+
+    kwargs = dict(autoclose=True) if autoclose else {}
+    if invalid_netcdf:
+        if engine == "h5netcdf":
+            kwargs["invalid_netcdf"] = invalid_netcdf
+        else:
+            raise ValueError(
+                f"unrecognized option 'invalid_netcdf' for engine {engine}"
+            )
+    if auto_complex is not None:
+        kwargs["auto_complex"] = auto_complex
+
+    return store_open(target, mode=mode, format=format, **kwargs)
+
+
 # multifile=True returns writer and datastore
 @overload
 def to_netcdf(
@@ -1952,16 +1992,8 @@ def to_netcdf(
     _validate_dataset_names(dataset)
     _validate_attrs(dataset, engine, invalid_netcdf)
 
-    try:
-        store_open = WRITEABLE_STORES[engine]
-    except KeyError as err:
-        raise ValueError(f"unrecognized engine for to_netcdf: {engine!r}") from err
-
-    if format is not None:
-        format = format.upper()  # type: ignore[assignment]
-
     # handle scheduler specific logic
-    scheduler = _get_scheduler()
+    scheduler = get_dask_scheduler()
     have_chunks = any(v.chunks is not None for v in dataset.variables.values())
 
     autoclose = have_chunks and scheduler in ["distributed", "multiprocessing"]
@@ -1976,26 +2008,17 @@ def to_netcdf(
     else:
         target = path_or_file  # type: ignore[assignment]
 
-    kwargs = dict(autoclose=True) if autoclose else {}
-    if invalid_netcdf:
-        if engine == "h5netcdf":
-            kwargs["invalid_netcdf"] = invalid_netcdf
-        else:
-            raise ValueError(
-                f"unrecognized option 'invalid_netcdf' for engine {engine}"
-            )
-    if auto_complex is not None:
-        kwargs["auto_complex"] = auto_complex
-
-    store = store_open(target, mode, format, group, **kwargs)
-
-    if unlimited_dims is None:
-        unlimited_dims = dataset.encoding.get("unlimited_dims", None)
-    if unlimited_dims is not None:
-        if isinstance(unlimited_dims, str) or not isinstance(unlimited_dims, Iterable):
-            unlimited_dims = [unlimited_dims]
-        else:
-            unlimited_dims = list(unlimited_dims)
+    store = get_writable_netcdf_store(
+        target,
+        engine,
+        mode=mode,
+        format=format,
+        autoclose=autoclose,
+        invalid_netcdf=invalid_netcdf,
+        auto_complex=auto_complex,
+    )
+    if group is not None:
+        store = store.get_child_store(group)
 
     writer = ArrayWriter()
 
@@ -2016,17 +2039,18 @@ def to_netcdf(
         writes = writer.sync(compute=compute)
 
     finally:
-        if not multifile and compute:  # type: ignore[redundant-expr]
-            store.close()
+        if not multifile:
+            if compute:
+                store.close()
+            else:
+                store.sync()
 
     if path_or_file is None:
         assert isinstance(target, BytesIOProxy)  # created in this function
         return target.getvalue_or_getbuffer()
 
     if not compute:
-        import dask
-
-        return dask.delayed(_finalize_store)(writes, store)
+        return delayed_close_after_writes(writes, store)
 
     return None
 
@@ -2040,6 +2064,15 @@ def dump_to_store(
 
     if encoding is None:
         encoding = {}
+
+    if unlimited_dims is None:
+        unlimited_dims = dataset.encoding.get("unlimited_dims", None)
+
+    if unlimited_dims is not None:
+        if isinstance(unlimited_dims, str) or not isinstance(unlimited_dims, Iterable):
+            unlimited_dims = [unlimited_dims]
+        else:
+            unlimited_dims = list(unlimited_dims)
 
     variables, attrs = conventions.encode_dataset_coordinates(dataset)
 
@@ -2182,18 +2215,69 @@ def save_mfdataset(
     try:
         writes = [w.sync(compute=compute) for w in writers]
     finally:
-        if compute:
-            for store in stores:
+        for store in stores:
+            if compute:
                 store.close()
+            else:
+                store.sync()
 
     if not compute:
         import dask
 
         return dask.delayed(
-            list(
-                starmap(dask.delayed(_finalize_store), zip(writes, stores, strict=True))
-            )
+            list(starmap(delayed_close_after_writes, zip(writes, stores, strict=True)))
         )
+
+
+def get_writable_zarr_store(
+    store: ZarrStoreLike | None = None,
+    *,
+    chunk_store: MutableMapping | str | os.PathLike | None = None,
+    mode: ZarrWriteModes | None = None,
+    synchronizer=None,
+    group: str | None = None,
+    consolidated: bool | None = None,
+    append_dim: Hashable | None = None,
+    region: Mapping[str, slice | Literal["auto"]] | Literal["auto"] | None = None,
+    safe_chunks: bool = True,
+    align_chunks: bool = False,
+    storage_options: dict[str, str] | None = None,
+    zarr_version: int | None = None,
+    zarr_format: int | None = None,
+    write_empty_chunks: bool | None = None,
+) -> backends.ZarrStore:
+    """Create a store for writing to Zarr."""
+    from xarray.backends.zarr import _choose_default_mode, _get_mappers
+
+    kwargs, mapper, chunk_mapper = _get_mappers(
+        storage_options=storage_options, store=store, chunk_store=chunk_store
+    )
+    mode = _choose_default_mode(mode=mode, append_dim=append_dim, region=region)
+
+    if mode == "r+":
+        already_consolidated = consolidated
+        consolidate_on_close = False
+    else:
+        already_consolidated = False
+        consolidate_on_close = consolidated or consolidated is None
+
+    return backends.ZarrStore.open_group(
+        store=mapper,
+        mode=mode,
+        synchronizer=synchronizer,
+        group=group,
+        consolidated=already_consolidated,
+        consolidate_on_close=consolidate_on_close,
+        chunk_store=chunk_mapper,
+        append_dim=append_dim,
+        write_region=region,
+        safe_chunks=safe_chunks,
+        align_chunks=align_chunks,
+        zarr_version=zarr_version,
+        zarr_format=zarr_format,
+        write_empty=write_empty_chunks,
+        **kwargs,
+    )
 
 
 # compute=True returns ZarrStore
@@ -2270,7 +2354,6 @@ def to_zarr(
 
     See `Dataset.to_zarr` for full API docs.
     """
-    from xarray.backends.zarr import _choose_default_mode, _get_mappers
 
     # validate Dataset keys, DataArray names
     _validate_dataset_names(dataset)
@@ -2285,53 +2368,39 @@ def to_zarr(
     if encoding is None:
         encoding = {}
 
-    kwargs, mapper, chunk_mapper = _get_mappers(
-        storage_options=storage_options, store=store, chunk_store=chunk_store
-    )
-    mode = _choose_default_mode(mode=mode, append_dim=append_dim, region=region)
-
-    if mode == "r+":
-        already_consolidated = consolidated
-        consolidate_on_close = False
-    else:
-        already_consolidated = False
-        consolidate_on_close = consolidated or consolidated is None
-
-    zstore = backends.ZarrStore.open_group(
-        store=mapper,
+    zstore = get_writable_zarr_store(
+        store,
+        chunk_store=chunk_store,
         mode=mode,
         synchronizer=synchronizer,
         group=group,
-        consolidated=already_consolidated,
-        consolidate_on_close=consolidate_on_close,
-        chunk_store=chunk_mapper,
+        consolidated=consolidated,
         append_dim=append_dim,
-        write_region=region,
+        region=region,
         safe_chunks=safe_chunks,
         align_chunks=align_chunks,
+        storage_options=storage_options,
         zarr_version=zarr_version,
         zarr_format=zarr_format,
-        write_empty=write_empty_chunks,
-        **kwargs,
+        write_empty_chunks=write_empty_chunks,
     )
 
-    dataset = zstore._validate_and_autodetect_region(
-        dataset,
-    )
+    dataset = zstore._validate_and_autodetect_region(dataset)
     zstore._validate_encoding(encoding)
 
     writer = ArrayWriter()
+
     # TODO: figure out how to properly handle unlimited_dims
-    dump_to_store(dataset, zstore, writer, encoding=encoding)
-    writes = writer.sync(
-        compute=compute, chunkmanager_store_kwargs=chunkmanager_store_kwargs
-    )
+    try:
+        dump_to_store(dataset, zstore, writer, encoding=encoding)
+        writes = writer.sync(
+            compute=compute, chunkmanager_store_kwargs=chunkmanager_store_kwargs
+        )
+    finally:
+        if compute:
+            zstore.close()
 
-    if compute:
-        _finalize_store(writes, zstore)
-    else:
-        import dask
-
-        return dask.delayed(_finalize_store)(writes, zstore)
+    if not compute:
+        return delayed_close_after_writes(writes, zstore)
 
     return zstore

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -12,6 +12,7 @@ from typing import (
     Any,
     ClassVar,
     Generic,
+    Self,
     TypeVar,
     Union,
     overload,
@@ -305,6 +306,10 @@ class BackendArray(NdimSizeLenMixin, indexing.ExplicitlyIndexed):
 class AbstractDataStore:
     __slots__ = ()
 
+    def get_child_store(self, group: str) -> Self:  # pragma: no cover
+        """Get a store corresponding to the indicated child group."""
+        raise NotImplementedError()
+
     def get_dimensions(self):  # pragma: no cover
         raise NotImplementedError()
 
@@ -580,6 +585,10 @@ class AbstractWritableDataStore(AbstractDataStore):
             elif dim not in existing_dims:
                 is_unlimited = dim in unlimited_dims
                 self.set_dimension(dim, length, is_unlimited)
+
+    def sync(self):
+        """Write all buffered data to disk."""
+        raise NotImplementedError()
 
 
 def _infer_dtype(array, name=None):

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -4,7 +4,7 @@ import functools
 import io
 import os
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
 import numpy as np
 
@@ -148,6 +148,17 @@ class H5NetCDFStore(WritableCFDataStore):
         self.is_remote = is_remote_uri(self._filename)
         self.lock = ensure_lock(lock)
         self.autoclose = autoclose
+
+    def get_child_store(self, group: str) -> Self:
+        if self._group is not None:
+            group = os.path.join(self._group, group)
+        return type(self)(
+            self._manager,
+            group=group,
+            mode=self._mode,
+            lock=self.lock,
+            autoclose=self.autoclose,
+        )
 
     @classmethod
     def open(

--- a/xarray/backends/locks.py
+++ b/xarray/backends/locks.py
@@ -134,7 +134,7 @@ def _get_lock_maker(scheduler=None):
         raise KeyError(scheduler)
 
 
-def _get_scheduler(get=None, collection=None) -> str | None:
+def get_dask_scheduler(get=None, collection=None) -> str | None:
     """Determine the dask scheduler that is being used.
 
     None is returned if no dask scheduler is active.
@@ -184,7 +184,7 @@ def get_write_lock(key):
     -------
     Lock object that can be used like a threading.Lock object.
     """
-    scheduler = _get_scheduler()
+    scheduler = get_dask_scheduler()
     lock_maker = _get_lock_maker(scheduler)
     return lock_maker(key)
 

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -5,7 +5,7 @@ import operator
 import os
 from collections.abc import Iterable
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
 import numpy as np
 
@@ -399,6 +399,17 @@ class NetCDF4DataStore(WritableCFDataStore):
         self.is_remote = is_remote_uri(self._filename)
         self.lock = ensure_lock(lock)
         self.autoclose = autoclose
+
+    def get_child_store(self, group: str) -> Self:
+        if self._group is not None:
+            group = os.path.join(self._group, group)
+        return type(self)(
+            self._manager,
+            group=group,
+            mode=self._mode,
+            lock=self.lock,
+            autoclose=self.autoclose,
+        )
 
     @classmethod
     def open(

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -5,7 +5,7 @@ import json
 import os
 import struct
 from collections.abc import Hashable, Iterable, Mapping
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, Self, cast
 
 import numpy as np
 import pandas as pd
@@ -735,6 +735,22 @@ class ZarrStore(AbstractWritableDataStore):
             # on demand.
             self._members = self._fetch_members()
 
+    def get_child_store(self, group: str) -> Self:
+        zarr_group = self.zarr_group.require_group(group)
+        return type(self)(
+            zarr_group=zarr_group,
+            mode=self._mode,
+            consolidate_on_close=self._consolidate_on_close,
+            append_dim=self._append_dim,
+            write_region=self._write_region,
+            safe_chunks=self._safe_chunks,
+            write_empty=self._write_empty,
+            close_store_on_close=self._close_store_on_close,
+            use_zarr_fill_value_as_mask=self._use_zarr_fill_value_as_mask,
+            align_chunks=self._align_chunks,
+            cache_members=self._cache_members,
+        )
+
     @property
     def members(self) -> dict[str, ZarrArray | ZarrGroup]:
         """
@@ -996,9 +1012,6 @@ class ZarrStore(AbstractWritableDataStore):
                 kwargs["zarr_format"] = self.zarr_group.metadata.zarr_format
             zarr.consolidate_metadata(self.zarr_group.store, **kwargs)
 
-    def sync(self):
-        pass
-
     def _open_existing_array(self, *, name) -> ZarrArray:
         import zarr
         from zarr import Array as ZarrArray
@@ -1215,6 +1228,9 @@ class ZarrStore(AbstractWritableDataStore):
                 )
 
             writer.add(v.data, zarr_array, region)
+
+    def sync(self) -> None:
+        pass
 
     def close(self) -> None:
         if self._close_store_on_close:

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -18,6 +18,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Concatenate,
+    Literal,
     NoReturn,
     ParamSpec,
     TypeVar,
@@ -75,7 +76,9 @@ except ImportError:
 if TYPE_CHECKING:
     import numpy as np
     import pandas as pd
+    from dask.delayed import Delayed
 
+    from xarray.backends import ZarrStore
     from xarray.core.datatree_io import T_DataTreeNetcdfEngine, T_DataTreeNetcdfTypes
     from xarray.core.types import (
         Dims,
@@ -1677,6 +1680,7 @@ class DataTree(
         **kwargs,
     ) -> memoryview: ...
 
+    # compute=False returns dask.Delayed
     @overload
     def to_netcdf(
         self,
@@ -1688,7 +1692,24 @@ class DataTree(
         engine: T_DataTreeNetcdfEngine | None = None,
         group: str | None = None,
         write_inherited_coords: bool = False,
-        compute: bool = True,
+        *,
+        compute: Literal[False],
+        **kwargs,
+    ) -> Delayed: ...
+
+    # default return None
+    @overload
+    def to_netcdf(
+        self,
+        filepath: str | PathLike | io.IOBase,
+        mode: NetcdfWriteModes = "w",
+        encoding=None,
+        unlimited_dims=None,
+        format: T_DataTreeNetcdfTypes | None = None,
+        engine: T_DataTreeNetcdfEngine | None = None,
+        group: str | None = None,
+        write_inherited_coords: bool = False,
+        compute: Literal[True] = True,
         **kwargs,
     ) -> None: ...
 
@@ -1704,7 +1725,7 @@ class DataTree(
         write_inherited_coords: bool = False,
         compute: bool = True,
         **kwargs,
-    ) -> None | memoryview:
+    ) -> None | memoryview | Delayed:
         """
         Write datatree contents to a netCDF file.
 
@@ -1748,13 +1769,13 @@ class DataTree(
         compute : bool, default: True
             If true compute immediately, otherwise return a
             ``dask.delayed.Delayed`` object that can be computed later.
-            Currently, ``compute=False`` is not supported.
         kwargs :
             Additional keyword arguments to be passed to ``xarray.Dataset.to_netcdf``
 
         Returns
         -------
             * ``memoryview`` if path is None
+            * ``dask.delayed.Delayed`` if compute is False
             * ``None`` otherwise
 
         Note
@@ -1778,6 +1799,35 @@ class DataTree(
             **kwargs,
         )
 
+    # compute=False returns dask.Delayed
+    @overload
+    def to_zarr(
+        self,
+        store,
+        mode: ZarrWriteModes = "w-",
+        encoding=None,
+        consolidated: bool = True,
+        group: str | None = None,
+        write_inherited_coords: bool = False,
+        *,
+        compute: Literal[False],
+        **kwargs,
+    ) -> Delayed: ...
+
+    # default returns ZarrStore
+    @overload
+    def to_zarr(
+        self,
+        store,
+        mode: ZarrWriteModes = "w-",
+        encoding=None,
+        consolidated: bool = True,
+        group: str | None = None,
+        write_inherited_coords: bool = False,
+        compute: Literal[True] = True,
+        **kwargs,
+    ) -> ZarrStore: ...
+
     def to_zarr(
         self,
         store,
@@ -1788,7 +1838,7 @@ class DataTree(
         write_inherited_coords: bool = False,
         compute: bool = True,
         **kwargs,
-    ):
+    ) -> ZarrStore | Delayed:
         """
         Write datatree contents to a Zarr store.
 
@@ -1819,8 +1869,7 @@ class DataTree(
         compute : bool, default: True
             If true compute immediately, otherwise return a
             ``dask.delayed.Delayed`` object that can be computed later. Metadata
-            is always updated eagerly. Currently, ``compute=False`` is not
-            supported.
+            is always updated eagerly.
         kwargs :
             Additional keyword arguments to be passed to ``xarray.Dataset.to_zarr``
 
@@ -1831,7 +1880,7 @@ class DataTree(
         """
         from xarray.core.datatree_io import _datatree_to_zarr
 
-        _datatree_to_zarr(
+        return _datatree_to_zarr(
             self,
             store,
             mode=mode,

--- a/xarray/core/datatree_io.py
+++ b/xarray/core/datatree_io.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
 import io
-from collections.abc import Mapping
+from collections.abc import Hashable, Mapping, MutableMapping
 from os import PathLike
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
+from xarray.backends.api import (
+    delayed_close_after_writes,
+    dump_to_store,
+    get_writable_netcdf_store,
+    get_writable_zarr_store,
+)
+from xarray.backends.common import ArrayWriter
+from xarray.backends.locks import get_dask_scheduler
 from xarray.core.datatree import DataTree
 from xarray.core.types import NetcdfWriteModes, ZarrWriteModes
 
@@ -12,6 +20,9 @@ T_DataTreeNetcdfEngine = Literal["netcdf4", "h5netcdf", "pydap"]
 T_DataTreeNetcdfTypes = Literal["NETCDF4"]
 
 if TYPE_CHECKING:
+    from dask.delayed import Delayed
+
+    from xarray.backends import ZarrStore
     from xarray.core.types import ZarrStoreLike
 
 
@@ -26,7 +37,8 @@ def _datatree_to_netcdf(
     group: str | None = None,
     write_inherited_coords: bool = False,
     compute: bool = True,
-    **kwargs,
+    invalid_netcdf: bool = False,
+    auto_complex: bool | None = None,
 ) -> None | memoryview:
     """Implementation of `DataTree.to_netcdf`."""
 
@@ -45,9 +57,6 @@ def _datatree_to_netcdf(
         raise NotImplementedError(
             "specifying a root group for the tree has not been implemented"
         )
-
-    if not compute:
-        raise NotImplementedError("compute=False has not been implemented yet")
 
     if encoding is None:
         encoding = {}
@@ -70,26 +79,61 @@ def _datatree_to_netcdf(
     if unlimited_dims is None:
         unlimited_dims = {}
 
-    for node in dt.subtree:
-        at_root = node is dt
-        ds = node.to_dataset(inherit=write_inherited_coords or at_root)
-        group_path = None if at_root else "/" + node.relative_to(dt)
-        ds.to_netcdf(
-            target,
-            group=group_path,
-            mode=mode,
-            encoding=encoding.get(node.path),
-            unlimited_dims=unlimited_dims.get(node.path),
-            engine=engine,
-            format=format,
-            compute=compute,
-            **kwargs,
-        )
-        mode = "a"
+    scheduler = get_dask_scheduler()
+    have_chunks = any(
+        v.chunks is not None for node in dt.subtree for v in node.variables.values()
+    )
+    autoclose = have_chunks and scheduler in ["distributed", "multiprocessing"]
+
+    root_store = get_writable_netcdf_store(
+        target,
+        engine,  # type: ignore[arg-type]
+        mode=mode,
+        format=format,
+        autoclose=autoclose,
+        invalid_netcdf=invalid_netcdf,
+        auto_complex=auto_complex,
+    )
+    if group is not None:
+        root_store = root_store.get_child(group)
+
+    writer = ArrayWriter()
+
+    try:
+        # TODO: allow this work (setting up the file for writing array data)
+        # to be parallelized with dask
+
+        for node in dt.subtree:
+            at_root = node is dt
+            dataset = node.to_dataset(inherit=write_inherited_coords or at_root)
+            node_store = (
+                root_store if at_root else root_store.get_child_store(node.path)
+            )
+            dump_to_store(
+                dataset,
+                node_store,
+                writer,
+                encoding=encoding.get(node.path),
+                unlimited_dims=unlimited_dims.get(node.path),
+            )
+
+        if autoclose:
+            root_store.close()
+
+        writes = writer.sync(compute=compute)
+
+    finally:
+        if compute:
+            root_store.close()
+        else:
+            root_store.sync()
 
     if filepath is None:
         assert isinstance(target, io.BytesIO)
         return target.getbuffer()
+
+    if not compute:
+        return delayed_close_after_writes(writes, root_store)
 
     return None
 
@@ -99,22 +143,31 @@ def _datatree_to_zarr(
     store: ZarrStoreLike,
     mode: ZarrWriteModes = "w-",
     encoding: Mapping[str, Any] | None = None,
-    consolidated: bool = True,
+    synchronizer=None,
     group: str | None = None,
     write_inherited_coords: bool = False,
+    *,
+    chunk_store: MutableMapping | str | PathLike | None = None,
     compute: bool = True,
-    **kwargs,
-):
+    consolidated: bool | None = None,
+    append_dim: Hashable | None = None,
+    region: Mapping[str, slice | Literal["auto"]] | Literal["auto"] | None = None,
+    safe_chunks: bool = True,
+    align_chunks: bool = False,
+    storage_options: dict[str, str] | None = None,
+    zarr_version: int | None = None,
+    zarr_format: int | None = None,
+    write_empty_chunks: bool | None = None,
+    chunkmanager_store_kwargs: dict[str, Any] | None = None,
+) -> ZarrStore | Delayed:
     """Implementation of `DataTree.to_zarr`."""
-
-    from zarr import consolidate_metadata
 
     if group is not None:
         raise NotImplementedError(
             "specifying a root group for the tree has not been implemented"
         )
 
-    if "append_dim" in kwargs:
+    if append_dim is not None:
         raise NotImplementedError(
             "specifying ``append_dim`` with ``DataTree.to_zarr`` has not been implemented"
         )
@@ -130,21 +183,51 @@ def _datatree_to_zarr(
             f"unexpected encoding group name(s) provided: {set(encoding) - set(dt.groups)}"
         )
 
-    for node in dt.subtree:
-        at_root = node is dt
-        ds = node.to_dataset(inherit=write_inherited_coords or at_root)
-        group_path = None if at_root else "/" + node.relative_to(dt)
-        ds.to_zarr(
-            store,
-            group=group_path,
-            mode=mode,
-            encoding=encoding.get(node.path),
-            consolidated=False,
-            compute=compute,
-            **kwargs,
-        )
-        if "w" in mode:
-            mode = "a"
+    root_store = get_writable_zarr_store(
+        store,
+        chunk_store=chunk_store,
+        mode=mode,
+        synchronizer=synchronizer,
+        group=group,
+        consolidated=consolidated,
+        append_dim=append_dim,
+        region=region,
+        safe_chunks=safe_chunks,
+        align_chunks=align_chunks,
+        storage_options=storage_options,
+        zarr_version=zarr_version,
+        zarr_format=zarr_format,
+        write_empty_chunks=write_empty_chunks,
+    )
 
-    if consolidated:
-        consolidate_metadata(store)
+    writer = ArrayWriter()
+
+    # TODO: figure out how to properly handle unlimited_dims
+    try:
+        for node in dt.subtree:
+            at_root = node is dt
+            dataset = node.to_dataset(inherit=write_inherited_coords or at_root)
+            node_store = (
+                root_store if at_root else root_store.get_child_store(node.path)
+            )
+
+            dataset = node_store._validate_and_autodetect_region(dataset)
+            node_store._validate_encoding(encoding)
+
+            dump_to_store(
+                dataset,
+                node_store,
+                writer,
+                encoding=encoding.get(node.path),
+            )
+        writes = writer.sync(
+            compute=compute, chunkmanager_store_kwargs=chunkmanager_store_kwargs
+        )
+    finally:
+        if compute:
+            root_store.close()
+
+    if not compute:
+        return delayed_close_after_writes(writes, root_store)
+
+    return root_store


### PR DESCRIPTION
Split out of https://github.com/pydata/xarray/pull/10624

This PR combines adds support for `compute=False` from `DataTree.to_netcdf` and `to_zarr`. To do so, I refactored the internals of these methods to use Xarray's lower level data store interface directly.

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
