### PR TITLE
fix: handle non-iterable hashables as dim names

### DIFF
--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -1707,8 +1707,8 @@ class Indexes(collections.abc.Mapping, Generic[T_PandasOrXarrayIndex]):
             )
 
         self._index_type = index_type
-        self._indexes = dict(**indexes)
-        self._variables = dict(**variables)
+        self._indexes = dict(indexes)
+        self._variables = dict(variables)
 
         self._dims: Mapping[Hashable, int] | None = None
         self.__coord_name_id: dict[Any, int] | None = None

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -47,6 +47,7 @@ from xarray.core.utils import (
     is_duck_dask_array,
     maybe_coerce_to_str,
 )
+from xarray.namedarray._typing import _DimsLike
 from xarray.namedarray.core import NamedArray, _raise_if_any_duplicate_dimensions
 from xarray.namedarray.parallelcompat import get_chunked_array_type
 from xarray.namedarray.pycompat import (
@@ -369,7 +370,7 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
 
     def __init__(
         self,
-        dims,
+        dims: _DimsLike,
         data: T_DuckArray | ArrayLike,
         attrs=None,
         encoding=None,
@@ -378,10 +379,14 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
         """
         Parameters
         ----------
-        dims : str or sequence of str
-            Name(s) of the the data dimension(s). Must be either a string (only
-            for 1D data) or a sequence of strings with length equal to the
+        dims : Hashable or sequence of Hashable
+            Name(s) of the the data dimension(s). Must be either a Hashable
+            (only for 1D data) or a sequence of Hashables with length equal to the
             number of dimensions.
+
+            Note: Tuples are treated as sequences, so ('a', 'b') means two
+            dimensions named 'a' and 'b'. To use a tuple as a single dimension
+            name, wrap it in a list: [('a', 'b')].
         data : array_like
             Data array which supports numpy-like data access.
         attrs : dict_like or None, optional

--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -81,7 +81,7 @@ T_Chunks: TypeAlias = T_ChunkDim | Mapping[Any, T_ChunkDim]
 _Dim = Hashable
 _Dims = tuple[_Dim, ...]
 
-_DimsLike = Union[str, Iterable[_Dim]]
+_DimsLike = Union[_Dim, Iterable[_Dim]]
 
 # https://data-apis.org/array-api/latest/API_specification/indexing.html
 # TODO: np.array_api was bugged and didn't allow (None,), but should!

--- a/xarray/tests/test_hashable.py
+++ b/xarray/tests/test_hashable.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from enum import Enum
 from typing import TYPE_CHECKING, Union
 
@@ -10,7 +11,7 @@ from xarray import DataArray, Dataset, Variable
 if TYPE_CHECKING:
     from xarray.core.types import TypeAlias
 
-    DimT: TypeAlias = Union[int, tuple, "DEnum", "CustomHashable"]
+    DimT: TypeAlias = Union[int, tuple, "DEnum", "CustomHashable", uuid.UUID]
 
 
 class DEnum(Enum):
@@ -32,15 +33,38 @@ parametrize_dim = pytest.mark.parametrize(
         pytest.param(("a", "b"), id="tuple"),
         pytest.param(DEnum.dim, id="enum"),
         pytest.param(CustomHashable(3), id="HashableObject"),
+        pytest.param(uuid.UUID("12345678-1234-5678-1234-567812345678"), id="uuid"),
+    ],
+)
+
+parametrize_wrapped = pytest.mark.parametrize(
+    "wrapped",
+    [
+        pytest.param(True, id="wrapped"),
+        pytest.param(False, id="bare"),
     ],
 )
 
 
 @parametrize_dim
-def test_hashable_dims(dim: DimT) -> None:
-    v = Variable([dim], [1, 2, 3])
-    da = DataArray([1, 2, 3], dims=[dim])
-    Dataset({"a": ([dim], [1, 2, 3])})
+@parametrize_wrapped
+def test_hashable_dims(dim: DimT, wrapped: bool) -> None:
+    # Pass dims either wrapped in a list or bare
+    dims_arg = [dim] if wrapped else dim
+
+    # Bare tuple case should error with helpful message for 1D data
+    if not wrapped and isinstance(dim, tuple):
+        with pytest.raises(ValueError, match="This is ambiguous"):
+            Variable(dims_arg, [1, 2, 3])
+        with pytest.raises(ValueError, match="This is ambiguous"):
+            DataArray([1, 2, 3], dims=dims_arg)
+        with pytest.raises(ValueError):
+            Dataset({"a": (dims_arg, [1, 2, 3])})
+        return  # Don't run the other tests for this case
+
+    v = Variable(dims_arg, [1, 2, 3])
+    da = DataArray([1, 2, 3], dims=dims_arg)
+    Dataset({"a": (dims_arg, [1, 2, 3])})
 
     # alternative constructors
     DataArray(v)


### PR DESCRIPTION
Fixes: https://github.com/pydata/xarray/issues/10634

- Core dimension parsing fixes in namedarray/core.py
- Type definition updates in _typing.py
- Index handling fixes in core/indexes.py
- DataArray dimension parsing in core/dataarray.py
- Variable docstring updates in core/variable.py

This exposed that `('a', 'b')` is ambiguous as it is both hashable and a sequence of hashable, so I added an error message in a case where it is ambiguous.

There's some error duplication logic, but that is matching the existing duplication of logic.
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #10634
- [x] Tests added
- [NA?] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [NA] New functions/methods are listed in `api.rst`
