### PR TITLE
Update Cartopy and Iris references

### DIFF
--- a/doc/examples/multidimensional-coords.ipynb
+++ b/doc/examples/multidimensional-coords.ipynb
@@ -126,7 +126,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In order to visualize the data on a conventional latitude-longitude grid, we can take advantage of xarray's ability to apply [cartopy](https://scitools.org.uk/cartopy/docs/latest/) map projections."
+    "In order to visualize the data on a conventional latitude-longitude grid, we can take advantage of xarray's ability to apply [cartopy](https://cartopy.readthedocs.io/stable/) map projections."
    ]
   },
   {

--- a/doc/get-help/faq.rst
+++ b/doc/get-help/faq.rst
@@ -169,7 +169,7 @@ different approaches to handling metadata: Iris strictly interprets
 integration with Cartopy_.
 
 .. _Iris: https://scitools-iris.readthedocs.io/en/stable/
-.. _Cartopy: https://scitools.org.uk/cartopy/docs/latest/
+.. _Cartopy: https://cartopy.readthedocs.io/stable/
 
 We think the design decisions we have made for xarray (namely, basing it on
 pandas) make it a faster and more flexible data analysis tool. That said, Iris

--- a/doc/getting-started-guide/installing.rst
+++ b/doc/getting-started-guide/installing.rst
@@ -57,7 +57,7 @@ For plotting
 ~~~~~~~~~~~~
 
 - `matplotlib <https://matplotlib.org>`__: required for :ref:`plotting`
-- `cartopy <https://scitools.org.uk/cartopy>`__: recommended for :ref:`plot-maps`
+- `cartopy <https://cartopy.readthedocs.io>`__: recommended for :ref:`plot-maps`
 - `seaborn <https://seaborn.pydata.org>`__: for better
   color palettes
 - `nc-time-axis <https://nc-time-axis.readthedocs.io>`__: for plotting

--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -1209,7 +1209,7 @@ Ncdata can also adjust file data within load and save operations, to fix data lo
 problems or provide exact save formatting without needing to modify files on disk.
 See for example : `ncdata usage examples`_
 
-.. _Iris: https://scitools.org.uk/iris
+.. _Iris: https://scitools-iris.readthedocs.io
 .. _Ncdata: https://ncdata.readthedocs.io/en/latest/index.html
 .. _ncdata usage examples: https://github.com/pp-mo/ncdata/tree/v0.1.2?tab=readme-ov-file#correct-a-miscoded-attribute-in-iris-input
 

--- a/doc/user-guide/plotting.rst
+++ b/doc/user-guide/plotting.rst
@@ -45,7 +45,7 @@ For more extensive plotting applications consider the following projects:
   dynamic plots (backed by ``Holoviews`` or ``Geoviews``) by adding a ``hvplot``
   accessor to DataArrays.
 
-- `Cartopy <https://scitools.org.uk/cartopy/docs/latest/>`_: Provides cartographic
+- `Cartopy <https://cartopy.readthedocs.io/stable/>`_: Provides cartographic
   tools.
 
 Imports

--- a/doc/user-guide/weather-climate.rst
+++ b/doc/user-guide/weather-climate.rst
@@ -54,7 +54,7 @@ CF-compliant coordinate variables
 
 .. _`MetPy`: https://unidata.github.io/MetPy/dev/index.html
 .. _`metpy documentation`:	https://unidata.github.io/MetPy/dev/tutorials/xarray_tutorial.html#coordinates
-.. _`Cartopy`: https://scitools.org.uk/cartopy/docs/latest/reference/crs.html
+.. _`Cartopy`: https://cartopy.readthedocs.io/stable/reference/crs.html
 
 .. _CFTimeIndex:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -6675,7 +6675,7 @@ Enhancements
 
 .. _Zarr: http://zarr.readthedocs.io/
 
-.. _Iris: http://scitools.org.uk/iris
+.. _Iris: http://scitools-iris.readthedocs.io
 
 .. _netcdftime: https://unidata.github.io/netcdftime
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

The Cartopy docs have a new home on ReadTheDocs and the Iris docs have been there for a while.

I notice this change will conflict with #10526, so I am happy to wait and rebase when that is done if preferred.
