### PR TITLE
Fix merge defaults for Dataset._setitem_ and Dataset.update

### DIFF
--- a/xarray/structure/merge.py
+++ b/xarray/structure/merge.py
@@ -1102,8 +1102,8 @@ def dataset_update_method(dataset: Dataset, other: CoercibleMapping) -> _MergeRe
 
     return merge_core(
         [dataset, other],
-        compat="broadcast_equals",
-        join="outer",
+        compat="override",
+        join="left",
         priority_arg=1,
         indexes=dataset.xindexes,
         combine_attrs="override",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #10585
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

Updates dataset_update_method to use `join="left"` and `compat="override"` instead of the expensive defaults `join="outer"` and `compat="broadcast_equals"`.