### PR TITLE
Support DataArray objects in DataTree.from_dict

### DIFF
--- a/xarray/core/treenode.py
+++ b/xarray/core/treenode.py
@@ -42,6 +42,10 @@ class NodePath(PurePosixPath):
             )
         # TODO should we also forbid suffixes to avoid node names with dots in them?
 
+    def absolute(self) -> Self:
+        """Convert into an absolute path."""
+        return type(self)("/", *self.parts)
+
 
 class TreeNode:
     """


### PR DESCRIPTION
This PR extends the `DataTree.from_dict` constructor to support `DataArray` objects and anything that can be coerced into a `DataArray` via the `Dataset` constructor. It also adds a `coords` argument for explicitly specifying coordinates.

Fixes #9539, #9486

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
