### PR TITLE
Silence warnings from test_tutorial.py

### DIFF
--- a/xarray/tests/test_tutorial.py
+++ b/xarray/tests/test_tutorial.py
@@ -9,19 +9,14 @@ from xarray.tests import network
 class TestLoadDataset:
     def test_download_from_github(self, tmp_path) -> None:
         cache_dir = tmp_path / tutorial._default_cache_dir_name
-        ds = tutorial.open_dataset("tiny", cache_dir=cache_dir).load()
+        ds = tutorial.load_dataset("tiny", cache_dir=cache_dir)
         tiny = DataArray(range(5), name="tiny").to_dataset()
         assert_identical(ds, tiny)
 
-    def test_download_from_github_load_without_cache(
-        self, tmp_path, monkeypatch
-    ) -> None:
+    def test_download_from_github_load_without_cache(self, tmp_path) -> None:
         cache_dir = tmp_path / tutorial._default_cache_dir_name
-
-        ds_nocache = tutorial.open_dataset(
-            "tiny", cache=False, cache_dir=cache_dir
-        ).load()
-        ds_cache = tutorial.open_dataset("tiny", cache_dir=cache_dir).load()
+        ds_nocache = tutorial.load_dataset("tiny", cache=False, cache_dir=cache_dir)
+        ds_cache = tutorial.load_dataset("tiny", cache_dir=cache_dir)
         assert_identical(ds_cache, ds_nocache)
 
 
@@ -29,17 +24,12 @@ class TestLoadDataset:
 class TestLoadDataTree:
     def test_download_from_github(self, tmp_path) -> None:
         cache_dir = tmp_path / tutorial._default_cache_dir_name
-        ds = tutorial.open_datatree("tiny", cache_dir=cache_dir).load()
+        ds = tutorial.load_datatree("tiny", cache_dir=cache_dir)
         tiny = DataTree.from_dict({"/": DataArray(range(5), name="tiny").to_dataset()})
         assert_identical(ds, tiny)
 
-    def test_download_from_github_load_without_cache(
-        self, tmp_path, monkeypatch
-    ) -> None:
+    def test_download_from_github_load_without_cache(self, tmp_path) -> None:
         cache_dir = tmp_path / tutorial._default_cache_dir_name
-
-        ds_nocache = tutorial.open_datatree(
-            "tiny", cache=False, cache_dir=cache_dir
-        ).load()
-        ds_cache = tutorial.open_datatree("tiny", cache_dir=cache_dir).load()
+        ds_nocache = tutorial.load_datatree("tiny", cache=False, cache_dir=cache_dir)
+        ds_cache = tutorial.load_datatree("tiny", cache_dir=cache_dir)
         assert_identical(ds_cache, ds_nocache)


### PR DESCRIPTION
The test suite was showing warning about unclosed files, which are straightforward to avoid by switching from `open_*` to `load_*` functions.