### PR TITLE
Display nested attribute dictionaries collapsibly in notebook output

### DIFF
--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -62,10 +62,24 @@ def format_dims(dim_sizes, dims_with_index) -> str:
 
 
 def summarize_attrs(attrs) -> str:
-    attrs_dl = "".join(
-        f"<dt><span>{escape(str(k))} :</span></dt><dd>{escape(str(v))}</dd>"
-        for k, v in attrs.items()
-    )
+    attrs_dl = ""
+    for k, v in attrs.items():
+        if isinstance(v, dict):
+            attr_id = "attrs-" + str(uuid.uuid4())
+
+            attrs_dl += "<div class='xr-attr-item'>"
+            attrs_dl += f"<input id='{attr_id}' class='xr-attr-in' type='checkbox'>"
+            attrs_dl += (
+                f"<label class='xr-attr-nested' for='{attr_id}'>{escape(str(k))} : "
+            )
+            attrs_dl += f"<span>({len(v)})</span></label>"
+            attrs_dl += "<span class='xr-attr-nested-inner'>"
+            attrs_dl += summarize_attrs(v)
+            attrs_dl += "</span></div>"
+        else:
+            attrs_dl += (
+                f"<dt><span>{escape(str(k))} :</span></dt><dd>{escape(str(v))}</dd>"
+            )
 
     return f"<dl class='xr-attrs'>{attrs_dl}</dl>"
 

--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -407,6 +407,53 @@ dl.xr-attrs {
   word-break: break-all;
 }
 
+.xr-attr-item {
+  grid-column: 1/-1;
+}
+
+.xr-attr-item input {
+  display: none;
+}
+
+.xr-attr-item label.xr-attr-nested {
+  border: 0 !important;
+}
+
+.xr-attr label > span {
+  display: inline-block;
+  padding-left: 0.5em;
+}
+
+.xr-attr-item input + label.xr-attr-nested {
+  color: var(--xr-font-color0);
+}
+
+.xr-attr-in + label::before {
+  display: inline-block;
+  content: "►";
+  font-size: 11px;
+  width: 15px;
+  margin-left: -15px;
+  text-align: center;
+}
+
+.xr-attr-in:checked + label:before {
+  content: "▼";
+}
+
+.xr-attr-in:checked + label > span {
+  display: none;
+}
+
+.xr-attr-nested-inner {
+  display: none;
+  padding-left: 1em;
+}
+
+.xr-attr-in:checked ~ .xr-attr-nested-inner {
+  display: block;
+}
+
 .xr-icon-database,
 .xr-icon-file-text2,
 .xr-no-icon {


### PR DESCRIPTION
This change allows nested dictionaries within Dataset attributes to be displayed as collapsible sections in notebook output (`_repr_html_`).

I'm working on a project that produces xarray Datasets with large nested attribute dictionaries. I couldn't find any way of overriding the `_repr_html_` output without subclassing Dataset. We've temporarily [implemented an accessor](https://github.com/thomasteisberg/xopr/blob/main/src/xopr/xarray_repr_fix/xopr_accessor.py) as a work-around, but I'm hoping this change in display format is generally useful enough to make it into xarray.

I'd appreciate any feedback on this display format and if xarray would be interested in incorporating something like this.

### Minimal example

```
import xarray as xr

ds = xr.Dataset(
    {},
    attrs={
        "test": "This is a test dataset",
        "nested_dict": {
            "key1": "value1",
            "key2": "value2",
            "nested": {
                "subkey1": "subvalue1",
                "subkey2": "subvalue2",
            },
        },
        "nested_dict_2": {
            "key3": "value3",
            "key4": "value4",
        },
        "regular_key": "regular_value",
    }
)

ds
```

**Before:**

<img width="722" height="349" alt="Screenshot from 2025-08-20 16-58-32" src="https://github.com/user-attachments/assets/8f52af28-5444-4e8b-bc98-bf0abf6ac083" />

**After:**

<img width="722" height="395" alt="Screenshot from 2025-08-20 16-46-46" src="https://github.com/user-attachments/assets/104c7b0a-6196-40e7-99f9-4eb7df46f767" />

There's an example of how we're using this (currently through an accessor) here: https://www.thomasteisberg.com/xopr/demo-notebook/



<!-- Feel free to remove check-list items aren't relevant to your change -->

<!--
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
-->