### PR TITLE
test: update write_empty test for zarr 3.1.2

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4301,9 +4301,10 @@ class TestZarrWriteEmpty(TestZarrDirectoryStore):
                 # that was performed by the roundtrip_dir
                 if (write_empty is False) or (write_empty is None and has_zarr_v3):
                     expected.append("1.1.0")
-                elif not has_zarr_v3:
-                    # TODO: remove zarr3 if once zarr issue is fixed
-                    # https://github.com/zarr-developers/zarr-python/issues/2931
+                elif not has_zarr_v3 or has_zarr_v3_async_oindex:
+                    # this was broken from zarr 3.0.0 until 3.1.2
+                    # async oindex released in 3.1.2 along with a fix
+                    # for write_empty_chunks in append
                     expected.extend(
                         [
                             "1.1.0",


### PR DESCRIPTION
The issue in the comment https://github.com/zarr-developers/zarr-python/issues/2931 was fixed by https://github.com/zarr-developers/zarr-python/pull/3378

As noted in the comment the async_oindex check is a proxy for 3.1.2 which is the release that fix will be released in.

- [NA] Closes #xxxx
- [NA] Tests added
- [NA] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [NA] New functions/methods are listed in `api.rst`
