### PR TITLE
use the new syntax of ignoring bots

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,5 @@
 changelog:
   exclude:
     authors:
-      - dependabot
-      - pre-commit-ci
+      - dependabot[bot]
+      - pre-commit-ci[bot]


### PR DESCRIPTION
Not sure when, but the syntax for ignoring automatic releases changed such that we credit bots (dependabot, pre-commit-ci) again in the release notes. This makes sure we get back to ignoring those.