### PR TITLE
Add support for NETCDF4_CLASSIC to h5netcdf engine

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -23,6 +23,9 @@ New Features
 - ``compute=False`` is now supported by :py:meth:`DataTree.to_netcdf` and
   :py:meth:`DataTree.to_zarr`.
   By `Stephan Hoyer <https://github.com/shoyer>`_.
+- The ``h5netcdf`` engine can now write ``NETCDF4_CLASSIC`` files
+  (:issue:`10676`, :pull:``).
+  By `David Huard <https://github.com/huard>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -338,7 +338,9 @@ class H5NetCDFStore(WritableCFDataStore):
 
         _ensure_no_forward_slash_in_name(name)
         attrs = variable.attrs.copy()
-        dtype = _get_datatype(variable, self.format, raise_on_invalid_encoding=check_encoding)
+        dtype = _get_datatype(
+            variable, self.format, raise_on_invalid_encoding=check_encoding
+        )
 
         fillvalue = attrs.pop("_FillValue", None)
 

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -321,6 +321,8 @@ class H5NetCDFStore(WritableCFDataStore):
     def set_attribute(self, key, value):
         if self.format != "NETCDF4":
             value = encode_nc3_attr_value(value)
+            if isinstance(value, bytes):
+                value = np.bytes_(value)
         self.ds.attrs[key] = value
 
     def encode_variable(self, variable, name=None):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4575,9 +4575,20 @@ class TestNetCDF4ClassicViaNetCDF4Data(NetCDF3Only, CFEncodedBase):
             ) as store:
                 yield store
 
+    @requires_h5netcdf
+    def test_string_attributes_stored_as_char(self, tmp_path):
+        import h5netcdf
+
+        original = Dataset(attrs={"foo": "bar"})
+        store_path = tmp_path / "tmp.nc"
+        original.to_netcdf(store_path, engine=self.engine, format=self.file_format)
+        with h5netcdf.File(store_path, "r") as ds:
+            # Check that the attribute is stored as a char array
+            assert ds._h5file.attrs["foo"].dtype == np.dtype("S3")
+
 
 @requires_h5netcdf
-class TestNetCDF4ClassicViaH5NetCDFData(NetCDF3Only, CFEncodedBase):
+class TestNetCDF4ClassicViaH5NetCDFData(TestNetCDF4ClassicViaNetCDF4Data):
     engine: T_NetcdfEngine = "h5netcdf"
     file_format: T_NetcdfTypes = "NETCDF4_CLASSIC"
 
@@ -4589,6 +4600,8 @@ class TestNetCDF4ClassicViaH5NetCDFData(NetCDF3Only, CFEncodedBase):
             ) as store:
                 yield store
 
+
+# TODO: add cross-engine tests for NETCDF4_CLASSIC
 
 @requires_scipy_or_netCDF4
 class TestGenericNetCDFData(NetCDF3Only, CFEncodedBase):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4603,6 +4603,7 @@ class TestNetCDF4ClassicViaH5NetCDFData(TestNetCDF4ClassicViaNetCDF4Data):
 
 # TODO: add cross-engine tests for NETCDF4_CLASSIC
 
+
 @requires_scipy_or_netCDF4
 class TestGenericNetCDFData(NetCDF3Only, CFEncodedBase):
     # verify that we can read and write netCDF3 files as long as we have scipy

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4576,6 +4576,20 @@ class TestNetCDF4ClassicViaNetCDF4Data(NetCDF3Only, CFEncodedBase):
                 yield store
 
 
+@requires_h5netcdf
+class TestNetCDF4ClassicViaH5NetCDFData(NetCDF3Only, CFEncodedBase):
+    engine: T_NetcdfEngine = "h5netcdf"
+    file_format: T_NetcdfTypes = "NETCDF4_CLASSIC"
+
+    @contextlib.contextmanager
+    def create_store(self):
+        with create_tmp_file() as tmp_file:
+            with backends.H5NetCDFStore.open(
+                tmp_file, mode="w", format="NETCDF4_CLASSIC"
+            ) as store:
+                yield store
+
+
 @requires_scipy_or_netCDF4
 class TestGenericNetCDFData(NetCDF3Only, CFEncodedBase):
     # verify that we can read and write netCDF3 files as long as we have scipy

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4600,8 +4600,26 @@ class TestNetCDF4ClassicViaH5NetCDFData(TestNetCDF4ClassicViaNetCDF4Data):
             ) as store:
                 yield store
 
+    @requires_netCDF4
+    def test_cdl_representation(self, tmp_path) -> None:
+        import netCDF4
 
-# TODO: add cross-engine tests for NETCDF4_CLASSIC
+        data = create_test_data()
+
+        # Create CDL representation using netCDF4
+        fn = tmp_path / "tmp.nc"
+        data.to_netcdf(fn, engine="netcdf4", format=self.file_format)
+        with netCDF4.Dataset(fn) as ds:
+            expected = ds.tocdl()
+
+        # Write using h5netcdf
+        data.to_netcdf(fn, engine=self.engine, format=self.file_format)
+
+        # Read using netCDF4
+        with netCDF4.Dataset(fn) as ds:
+            actual = ds.tocdl()
+
+        assert expected == actual
 
 
 @requires_scipy_or_netCDF4


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Added logic in the `h5netcdf` engine to write NETCDF4_CLASSIC files, similar to what the `netcdf4` engine does. 

- [x ] Closes #10676 
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

I've created a test that generates a CDL representation of test data written by netCDF4 and h5netcdf and compares them. As you can see below, there are a few differences to fix. It's not clear if those differences can be fixed here or will require changes to `h5netcdf`. Hope someone can shed some light on this. 


```diff
    netcdf tmp {
    dimensions:
    	dim2 = 9 ;
    	dim3 = 10 ;
    	string1 = 1 ;
    	time = 20 ;
    	dim1 = 8 ;
    variables:
    	double dim2(dim2) ;
    		dim2:_FillValue = NaN ;
    		dim2:_Storage = "contiguous" ;
    		dim2:_Endianness = "little" ;
    	char dim3(dim3, string1) ;
    		dim3:_Encoding = "utf-8" ;
    		dim3:_Storage = "contiguous" ;
  - 		dim3:_NoFill = "true" ;
    	int time(time) ;
    		time:units = "days since 2000-01-01 00:00:00" ;
    		time:calendar = "proleptic_gregorian" ;
    		time:_Storage = "contiguous" ;
    		time:_Endianness = "little" ;
  - 		time:_NoFill = "true" ;
    	double var1(dim1, dim2) ;
    		var1:_FillValue = NaN ;
    		var1:foo = "variable" ;
    		var1:_Storage = "contiguous" ;
    		var1:_Endianness = "little" ;
    	double var2(dim1, dim2) ;
    		var2:_FillValue = NaN ;
    		var2:foo = "variable" ;
    		var2:_Storage = "contiguous" ;
    		var2:_Endianness = "little" ;
    	double var3(dim3, dim1) ;
    		var3:_FillValue = NaN ;
    		var3:foo = "variable" ;
    		var3:coordinates = "numbers" ;
    		var3:_Storage = "contiguous" ;
    		var3:_Endianness = "little" ;
    	int numbers(dim3) ;
    		numbers:_Storage = "contiguous" ;
    		numbers:_Endianness = "little" ;
  - 		numbers:_NoFill = "true" ;
    
    // global attributes:
    		:foo = "bar" ;
  - 		:_NCProperties = "version=2,h5netcdf=1.3.0,hdf5=1.14.3,h5py=3.11.0" ;
  ? 		                            --       ^ ^ ^            ------------
  + 		:_NCProperties = "version=2,netcdf=4.9.2,hdf5=1.14.3" ;
  ? 		                                   ^ ^ ^
  - 		:_SuperblockVersion = 0 ;
  ? 		                      ^
  + 		:_SuperblockVersion = 2 ;
  ? 		                      ^
  - 		:_IsNetcdf4 = 1 ;
  ? 		              ^
  + 		:_IsNetcdf4 = 0 ;
  ? 		              ^
  - 		:_Format = "netCDF-4" ;
  + 		:_Format = "netCDF-4 classic model" ;
  ? 		                    ++++++++++++++
    }
```