### PR TITLE
QOL: detect both `.zarr` and `.zarr/` as using the zarr engine

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -23,6 +23,8 @@ New Features
 - ``compute=False`` is now supported by :py:meth:`DataTree.to_netcdf` and
   :py:meth:`DataTree.to_zarr`.
   By `Stephan Hoyer <https://github.com/shoyer>`_.
+- ``open_dataset`` will now correctly infer a path ending in ``.zarr/`` as zarr
+  By `Ian Hunt-Isaak <https://github.com/ianhi>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1618,8 +1618,10 @@ class ZarrBackendEntrypoint(BackendEntrypoint):
 
     def guess_can_open(self, filename_or_obj: T_PathFileOrDataStore) -> bool:
         if isinstance(filename_or_obj, str | os.PathLike):
-            _, ext = os.path.splitext(filename_or_obj)
-            return ext == ".zarr"
+            # allow a trailing slash to account for an autocomplete
+            # adding it.
+            _, ext = os.path.splitext(str(filename_or_obj).rstrip("/"))
+            return ext in [".zarr"]
 
         return False
 


### PR DESCRIPTION

When in a notebook and tabbing to fill out a file path I almost always run into a zarr file getting a trailing slash and then get an error about adding an explicit `engine="zarr"`. This comes pretty much every time I am using a local zarr file.

<img width="921" height="571" alt="image" src="https://github.com/user-attachments/assets/6d3cedfa-1b96-4d89-8f8e-85bfaa1dd9d8" />

This PR fixes this by also accepting a `.zarr/`. I also add the previously missing zarr entrypoint tests

 
- [NA] Closes #xxxx
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [NA] New functions/methods are listed in `api.rst`
