### PR TITLE
Add types-requests to type dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ types = [
   "types-openpyxl",
   "types-python-dateutil",
   "types-pytz",
+  "types-requests",
   "types-setuptools",
 ]
 


### PR DESCRIPTION
## Summary
- Add `types-requests` to the `types` optional dependency group in `pyproject.toml`

This provides type stubs for the `requests` library used in the codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)