### PR TITLE
Complete deprecation cycle for Dataset.update return value

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -20,7 +20,7 @@ Breaking changes
 - :py:meth:`Dataset.update` now returns ``None``, instead of the updated dataset. This
   completes the deprecation cycle started in version 0.17. The method still updates the
   dataset in-place. (:issue:`10167`)
-  By `Maximilian Roos <https://github.com/max-sixty>`_ and `Claude <https://github.com/anthropics>`_.
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -17,6 +17,10 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- :py:meth:`Dataset.update` now returns ``None``, instead of the updated dataset. This
+  completes the deprecation cycle started in version 0.17. The method still updates the
+  dataset in-place. (:issue:`10167`)
+  By `Maximilian Roos <https://github.com/max-sixty>`_ and `Claude <https://github.com/anthropics>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -5592,7 +5592,7 @@ class Dataset(
                 result = result._unstack_once(d, stacked_indexes[d], fill_value, sparse)
         return result
 
-    def update(self, other: CoercibleMapping) -> Self:
+    def update(self, other: CoercibleMapping) -> None:
         """Update this dataset's variables with those from another dataset.
 
         Just like :py:meth:`dict.update` this is a in-place operation.
@@ -5609,14 +5609,6 @@ class Dataset(
             - mapping {var name: (dimension name, array-like)}
             - mapping {var name: (tuple of dimension names, array-like)}
 
-        Returns
-        -------
-        updated : Dataset
-            Updated dataset. Note that since the update is in-place this is the input
-            dataset.
-
-            It is deprecated since version 0.17 and scheduled to be removed in 0.21.
-
         Raises
         ------
         ValueError
@@ -5629,7 +5621,7 @@ class Dataset(
         Dataset.merge
         """
         merge_result = dataset_update_method(self, other)
-        return self._replace(inplace=True, **merge_result._asdict())
+        self._replace(inplace=True, **merge_result._asdict())
 
     def merge(
         self,


### PR DESCRIPTION
## Summary
- Completes the deprecation cycle for `Dataset.update()` return value that was started in v0.17
- The method now returns `None` instead of `self`, aligning with Python's standard `dict.update()` behavior

## Changes
- Modified `Dataset.update()` to return `None` instead of `self`
- Updated docstring to remove return value documentation
- Added breaking change entry to changelog

Closes #10167

## Test plan
- [x] All existing tests pass without modification (they weren't using the return value)
- [x] Verified the method still updates the dataset in-place
- [x] Pre-commit checks pass
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.ai/code)