### PR TITLE
Fix bug when encoding an empty `numpy.datetime64` array

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -31,6 +31,9 @@ Bug fixes
 
 - Fix the ``align_chunks`` parameter on the :py:meth:`~xarray.Dataset.to_zarr` method, it was not being
   passed to the underlying :py:meth:`~xarray.backends.api` method (:issue:`10501`, :pull:`10516`).
+- Fix error when encoding an empty :py:class:`numpy.datetime64` array
+  (:issue:`10722`, :pull:`10723`). By `Spencer Clark
+  <https://github.com/spencerkclark>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -1065,9 +1065,12 @@ def _eagerly_encode_cf_datetime(
             # parse with cftime instead
             raise OutOfBoundsDatetime
         assert np.issubdtype(dates.dtype, "datetime64")
-        if calendar in ["standard", "gregorian"] and np.nanmin(dates).astype(
-            "=M8[us]"
-        ).astype(datetime) < datetime(1582, 10, 15):
+        if (
+            calendar in ["standard", "gregorian"]
+            and dates.size > 0
+            and np.nanmin(dates).astype("=M8[us]").astype(datetime)
+            < datetime(1582, 10, 15)
+        ):
             raise_gregorian_proleptic_gregorian_mismatch_error = True
 
         time_unit, ref_date = _unpack_time_unit_and_ref_date(units)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This PR fixes the bug identified in #10722 related to encoding an empty `numpy.datetime64` array.  

Note we are still not able to encode an empty array of `cftime.datetime` objects, but there is a bit of ambiguity since there is no way to infer the calendar type in that circumstance, so I will punt on fixing that for now.

- [x] Closes #10722
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
