### PR TITLE
fix bugreport.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugreport.yml
+++ b/.github/ISSUE_TEMPLATE/bugreport.yml
@@ -33,7 +33,8 @@ body:
     id: reproduce
     attributes:
       label: Steps to reproduce
-      description: Consider listing additional or specific dependencies in [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#example)
+      description:
+        Consider listing additional or specific dependencies in [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#example)
         so that calling `uv run issue.py` shows the issue when copied into `issue.py`. (not strictly required)
       value: |
         ```python

--- a/.github/ISSUE_TEMPLATE/bugreport.yml
+++ b/.github/ISSUE_TEMPLATE/bugreport.yml
@@ -29,17 +29,11 @@ body:
         Minimal, self-contained copy-pastable example that demonstrates the issue.         This will be automatically formatted into code, so no need for markdown backticks.
       render: Python
 
-  - type: checkboxes
-    id: mvce-checkboxes
+  - type: textarea
+    id: reproduce
     attributes:
-      label: MVCE confirmation
-      description: |
-        Please confirm that the bug report is in an excellent state, so we can understand & fix it quickly & efficiently. For more details, check out:
-
-        - [Minimal Complete Verifiable Examples](https://stackoverflow.com/help/mcve)
-        - [Craft Minimal Bug Reports](https://matthewrocklin.com/minimal-bug-reports)
-
-        Consider listing additional or specific dependencies in [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#example)
+      label: Steps to reproduce
+      description: Consider listing additional or specific dependencies in [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#example)
         so that calling `uv run issue.py` shows the issue when copied into `issue.py`. (not strictly required)
       value: |
         ```python
@@ -56,6 +50,19 @@ body:
         xr.show_versions()
         # your reproducer code ...
         ```
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: mvce-checkboxes
+    attributes:
+      label: MVCE confirmation
+      description: |
+        Please confirm that the bug report is in an excellent state, so we can understand & fix it quickly & efficiently. For more details, check out:
+
+        - [Minimal Complete Verifiable Examples](https://stackoverflow.com/help/mcve)
+        - [Craft Minimal Bug Reports](https://matthewrocklin.com/minimal-bug-reports)
+
       options:
         - label: Minimal example — the example is as focused as reasonably possible to demonstrate the underlying issue in xarray.
         - label: Complete example — the example is self-contained, including all data and the text of any traceback.


### PR DESCRIPTION
Currently, bugreport is not offered as issue template, as it contains an error.
This PR fixes the Github template `bugreport.yml` (was messed by PR #10707) and allows creation of bugreport issues again.
