### PR TITLE
Add co-authorship instruction to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,5 @@ uv run dmypy run  # Type checking with mypy
   explicitly instructed
 - Never post "update" messages, progress reports, or explanatory comments on
   GitHub issues/PRs unless specifically instructed
+- When creating commits, always include a co-authorship trailer:
+  `Co-authored-by: Claude <claude@anthropic.com>`


### PR DESCRIPTION
## Summary
- Added instruction to include co-authorship trailer in commits

This ensures proper attribution when Claude assists with code contributions.

[This is Claude Code on behalf of the user]