### PR TITLE
Enable mypy type checking for xarray.tests.test_combine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,6 @@ check_untyped_defs = false
 module = [
   "xarray.tests.test_coarsen",
   "xarray.tests.test_coding_times",
-  "xarray.tests.test_combine",
   "xarray.tests.test_computation",
   "xarray.tests.test_concat",
   "xarray.tests.test_coordinates",

--- a/xarray/structure/combine.py
+++ b/xarray/structure/combine.py
@@ -405,7 +405,7 @@ DATASET_HYPERCUBE = Union[Dataset, Iterable["DATASET_HYPERCUBE"]]
 
 def combine_nested(
     datasets: DATASET_HYPERCUBE,
-    concat_dim: str | DataArray | Sequence[str | DataArray | pd.Index | None],
+    concat_dim: str | DataArray | Sequence[str | DataArray | pd.Index | None] | None,
     compat: str | CombineKwargDefault = _COMPAT_DEFAULT,
     data_vars: str | CombineKwargDefault = _DATA_VARS_DEFAULT,
     coords: str | CombineKwargDefault = _COORDS_DEFAULT,

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -28,7 +28,7 @@ from xarray.tests import assert_equal, assert_identical, requires_cftime
 from xarray.tests.test_dataset import create_test_data
 
 
-def assert_combined_tile_ids_equal(dict1, dict2):
+def assert_combined_tile_ids_equal(dict1: dict, dict2: dict) -> None:
     assert len(dict1) == len(dict2)
     for k in dict1.keys():
         assert k in dict2.keys()
@@ -41,7 +41,9 @@ class TestTileIDsFromNestedList:
         input = [ds(0), ds(1)]
 
         expected = {(0,): ds(0), (1,): ds(1)}
-        actual = _infer_concat_order_from_positions(input)
+        actual: dict[tuple[int, ...], Dataset] = _infer_concat_order_from_positions(
+            input
+        )
         assert_combined_tile_ids_equal(expected, actual)
 
     def test_2d(self):
@@ -56,7 +58,9 @@ class TestTileIDsFromNestedList:
             (2, 0): ds(4),
             (2, 1): ds(5),
         }
-        actual = _infer_concat_order_from_positions(input)
+        actual: dict[tuple[int, ...], Dataset] = _infer_concat_order_from_positions(
+            input
+        )
         assert_combined_tile_ids_equal(expected, actual)
 
     def test_3d(self):
@@ -80,7 +84,9 @@ class TestTileIDsFromNestedList:
             (1, 2, 0): ds(10),
             (1, 2, 1): ds(11),
         }
-        actual = _infer_concat_order_from_positions(input)
+        actual: dict[tuple[int, ...], Dataset] = _infer_concat_order_from_positions(
+            input
+        )
         assert_combined_tile_ids_equal(expected, actual)
 
     def test_single_dataset(self):
@@ -88,7 +94,9 @@ class TestTileIDsFromNestedList:
         input = [ds]
 
         expected = {(0,): ds}
-        actual = _infer_concat_order_from_positions(input)
+        actual: dict[tuple[int, ...], Dataset] = _infer_concat_order_from_positions(
+            input
+        )
         assert_combined_tile_ids_equal(expected, actual)
 
     def test_redundant_nesting(self):
@@ -96,24 +104,30 @@ class TestTileIDsFromNestedList:
         input = [[ds(0)], [ds(1)]]
 
         expected = {(0, 0): ds(0), (1, 0): ds(1)}
-        actual = _infer_concat_order_from_positions(input)
+        actual: dict[tuple[int, ...], Dataset] = _infer_concat_order_from_positions(
+            input
+        )
         assert_combined_tile_ids_equal(expected, actual)
 
     def test_ignore_empty_list(self):
         ds = create_test_data(0)
-        input = [ds, []]
+        input: list = [ds, []]
         expected = {(0,): ds}
-        actual = _infer_concat_order_from_positions(input)
+        actual: dict[tuple[int, ...], Dataset] = _infer_concat_order_from_positions(
+            input
+        )
         assert_combined_tile_ids_equal(expected, actual)
 
     def test_uneven_depth_input(self):
         # Auto_combine won't work on ragged input
         # but this is just to increase test coverage
         ds = create_test_data
-        input = [ds(0), [ds(1), ds(2)]]
+        input: list = [ds(0), [ds(1), ds(2)]]
 
         expected = {(0,): ds(0), (1, 0): ds(1), (1, 1): ds(2)}
-        actual = _infer_concat_order_from_positions(input)
+        actual: dict[tuple[int, ...], Dataset] = _infer_concat_order_from_positions(
+            input
+        )
         assert_combined_tile_ids_equal(expected, actual)
 
     def test_uneven_length_input(self):
@@ -123,7 +137,9 @@ class TestTileIDsFromNestedList:
         input = [[ds(0)], [ds(1), ds(2)]]
 
         expected = {(0, 0): ds(0), (1, 0): ds(1), (1, 1): ds(2)}
-        actual = _infer_concat_order_from_positions(input)
+        actual: dict[tuple[int, ...], Dataset] = _infer_concat_order_from_positions(
+            input
+        )
         assert_combined_tile_ids_equal(expected, actual)
 
     def test_infer_from_datasets(self):
@@ -131,7 +147,9 @@ class TestTileIDsFromNestedList:
         input = [ds(0), ds(1)]
 
         expected = {(0,): ds(0), (1,): ds(1)}
-        actual = _infer_concat_order_from_positions(input)
+        actual: dict[tuple[int, ...], Dataset] = _infer_concat_order_from_positions(
+            input
+        )
         assert_combined_tile_ids_equal(expected, actual)
 
 
@@ -581,8 +599,8 @@ class TestNestedCombine:
         expected_dict["override"] = expected.copy(deep=True)
         expected_dict["override"].attrs = {"a": 1}
         f = lambda attrs, context: attrs[0]
-        expected_dict[f] = expected.copy(deep=True)
-        expected_dict[f].attrs = f([{"a": 1}], None)
+        expected_dict[f] = expected.copy(deep=True)  # type: ignore[index]
+        expected_dict[f].attrs = f([{"a": 1}], None)  # type: ignore[index]
 
         datasets = [[ds(0), ds(1), ds(2)], [ds(3), ds(4), ds(5)]]
 
@@ -606,7 +624,7 @@ class TestNestedCombine:
                 datasets,
                 concat_dim=["dim1", "dim2"],
                 data_vars="all",
-                combine_attrs=combine_attrs,
+                combine_attrs=combine_attrs,  # type: ignore[arg-type]
             )
             assert_identical(result, expected)
 
@@ -632,11 +650,11 @@ class TestNestedCombine:
         ):
             combine_nested(datasets, concat_dim=["dim1", "dim2"])
 
-        datasets = [[ds(0), ds(1)], [[ds(3), ds(4)]]]
+        datasets2: list = [[ds(0), ds(1)], [[ds(3), ds(4)]]]
         with pytest.raises(
             ValueError, match=r"sub-lists do not have consistent depths"
         ):
-            combine_nested(datasets, concat_dim=["dim1", "dim2"])
+            combine_nested(datasets2, concat_dim=["dim1", "dim2"])
 
         datasets = [[ds(0), ds(1)], [ds(3), ds(4)]]
         with pytest.raises(ValueError, match=r"concat_dims has length"):
@@ -1019,7 +1037,7 @@ class TestCombineDatasetsbyCoords:
         objs = [data.isel(dim2=slice(4, 9)), data.isel(dim2=slice(4))]
         actual = combine_by_coords(objs, data_vars="all")
         expected = data
-        assert expected.broadcast_equals(actual)
+        assert expected.broadcast_equals(actual)  # type: ignore[arg-type]
 
         with set_options(use_new_combine_kwarg_defaults=True):
             actual = combine_by_coords(objs)
@@ -1067,7 +1085,7 @@ class TestCombineDatasetsbyCoords:
         # https://github.com/pydata/xarray/issues/508
         datasets = [Dataset({"x": 0}, {"y": 0}), Dataset({"x": 1}, {"y": 1, "z": 1})]
         with pytest.raises(ValueError):
-            combine_by_coords(datasets, "y")
+            combine_by_coords(datasets, "y")  # type: ignore[arg-type]
 
     def test_combine_by_coords_no_concat(self):
         objs = [Dataset({"x": 0}), Dataset({"y": 1})]


### PR DESCRIPTION
## Summary
- Removes `xarray.tests.test_combine` from the mypy exclusion list
- Enables `check_untyped_defs` for this test file

## Changes
1. **pyproject.toml**: Remove test_combine from mypy exclusions
2. **xarray/structure/combine.py**: Fix type signature to accept `None` for `concat_dim` (matching runtime behavior)
3. **xarray/tests/test_combine.py**: Add minimal type annotations where mypy cannot infer types

## Notes
- No behavioral changes - all existing code works exactly as before
- The `combine_nested` function already accepted `concat_dim=None` at runtime (converting it to `[None]` internally), so we just updated the type signature to reflect this
- All 118 tests pass (with 1 expected xfail)
- Mypy now successfully type-checks this file

🤖 Generated with [Claude Code](https://claude.ai/code)