### PR TITLE
Add option for netcdf_engine_order

### DIFF
--- a/doc/user-guide/io.rst
+++ b/doc/user-guide/io.rst
@@ -591,8 +591,8 @@ The library ``h5netcdf`` allows writing some dtypes that aren't
 allowed in netCDF4 (see
 `h5netcdf documentation <https://github.com/h5netcdf/h5netcdf#invalid-netcdf-files>`_).
 This feature is available through :py:meth:`DataArray.to_netcdf` and
-:py:meth:`Dataset.to_netcdf` when used with ``engine="h5netcdf"``
-and currently raises a warning unless ``invalid_netcdf=True`` is set.
+:py:meth:`Dataset.to_netcdf` when used with ``engine="h5netcdf"``, only if
+``invalid_netcdf=True`` is explicitly set.
 
 .. warning::
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -26,9 +26,12 @@ Breaking changes
   dataset in-place. (:issue:`10167`)
   By `Maximilian Roos <https://github.com/max-sixty>`_.
 
-- The default ``engine`` when reading/writing netCDF files in-memory is now
-  netCDF4, consistent with Xarray's default ``engine`` when read/writing netCDF
-  files to disk (:pull:`10624`).
+- The default ``engine`` when reading/writing netCDF files is now h5netcdf
+  or scipy, which are typically faster than the prior default of netCDF4-python.
+  You can control this default behavior explicitly via the new
+  ``netcdf_engine_order`` parameter in :py:func:`~xarray.set_options`, e.g.,
+  ``xr.set_options(netcdf_engine_order=['netcdf4', 'scipy', 'h5netcdf'])`` to
+  restore the prior defaults (:issue:`10657`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
 
 Deprecations

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -9,6 +9,7 @@ from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Any
 
 from xarray.backends.common import BACKEND_ENTRYPOINTS, BackendEntrypoint
+from xarray.core.options import OPTIONS
 from xarray.core.utils import module_available
 
 if TYPE_CHECKING:
@@ -17,8 +18,6 @@ if TYPE_CHECKING:
 
     from xarray.backends.common import AbstractDataStore
     from xarray.core.types import ReadBuffer
-
-NETCDF_BACKENDS_ORDER = ["netcdf4", "h5netcdf", "scipy"]
 
 
 def remove_duplicates(entrypoints: EntryPoints) -> list[EntryPoint]:
@@ -91,8 +90,8 @@ def set_missing_parameters(
 def sort_backends(
     backend_entrypoints: dict[str, type[BackendEntrypoint]],
 ) -> dict[str, type[BackendEntrypoint]]:
-    ordered_backends_entrypoints = {}
-    for be_name in NETCDF_BACKENDS_ORDER:
+    ordered_backends_entrypoints: dict[str, type[BackendEntrypoint]] = {}
+    for be_name in OPTIONS["netcdf_engine_order"]:
         if backend_entrypoints.get(be_name) is not None:
             ordered_backends_entrypoints[be_name] = backend_entrypoints.pop(be_name)
     ordered_backends_entrypoints.update(

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4170,8 +4170,9 @@ class DataArray(
             format='NETCDF4'). The group(s) will be created if necessary.
         engine : {"netcdf4", "scipy", "h5netcdf"}, optional
             Engine to use when writing netCDF files. If not provided, the
-            default engine is chosen based on available dependencies, with a
-            preference for 'netcdf4' if writing to a file on disk.
+            default engine is chosen based on available dependencies, by default
+            preferring "h5netcdf" over "scipy" over "netcdf4" (customizable via
+            ``netcdf_engine_order`` in ``xarray.set_options()``).
         encoding : dict, optional
             Nested dictionary with variable names as keys and dictionaries of
             variable specific encodings as values, e.g.,

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2057,8 +2057,9 @@ class Dataset(
             format='NETCDF4'). The group(s) will be created if necessary.
         engine : {"netcdf4", "scipy", "h5netcdf"}, optional
             Engine to use when writing netCDF files. If not provided, the
-            default engine is chosen based on available dependencies, with a
-            preference for 'netcdf4' if writing to a file on disk.
+            default engine is chosen based on available dependencies, by default
+            preferring "h5netcdf" over "scipy" over "netcdf4" (customizable via
+            ``netcdf_engine_order`` in ``xarray.set_options()``).
         encoding : dict, optional
             Nested dictionary with variable names as keys and dictionaries of
             variable specific encodings as values, e.g.,

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -1849,8 +1849,9 @@ class DataTree(
             * NETCDF4: Data is stored in an HDF5 file, using netCDF4 API features.
         engine : {"netcdf4", "h5netcdf"}, optional
             Engine to use when writing netCDF files. If not provided, the
-            default engine is chosen based on available dependencies, with a
-            preference for "netcdf4" if writing to a file on disk.
+            default engine is chosen based on available dependencies, by default
+            preferring "h5netcdf" over "netcdf4" (customizable via
+            ``netcdf_engine_order`` in ``xarray.set_options()``).
         group : str, optional
             Path to the netCDF4 group in the given file to open as the root group
             of the ``DataTree``. Currently, specifying a group is not supported.

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from xarray.core.utils import FrozenDict
@@ -28,6 +29,7 @@ if TYPE_CHECKING:
         "enable_cftimeindex",
         "file_cache_maxsize",
         "keep_attrs",
+        "netcdf_engine_order",
         "warn_for_unclosed_files",
         "use_bottleneck",
         "use_new_combine_kwarg_defaults",
@@ -57,6 +59,7 @@ if TYPE_CHECKING:
         enable_cftimeindex: bool
         file_cache_maxsize: int
         keep_attrs: Literal["default"] | bool
+        netcdf_engine_order: Sequence[Literal["h5netcdf", "scipy", "netcdf4"]]
         warn_for_unclosed_files: bool
         use_bottleneck: bool
         use_flox: bool
@@ -86,6 +89,7 @@ OPTIONS: T_Options = {
     "enable_cftimeindex": True,
     "file_cache_maxsize": 128,
     "keep_attrs": "default",
+    "netcdf_engine_order": ("h5netcdf", "scipy", "netcdf4"),
     "warn_for_unclosed_files": False,
     "use_bottleneck": True,
     "use_flox": True,
@@ -96,6 +100,7 @@ OPTIONS: T_Options = {
 
 _JOIN_OPTIONS = frozenset(["inner", "outer", "left", "right", "exact"])
 _DISPLAY_OPTIONS = frozenset(["text", "html"])
+_NETCDF_ENGINES = frozenset(["h5netcdf", "scipy", "netcdf4"])
 
 
 def _positive_integer(value: Any) -> bool:
@@ -119,6 +124,7 @@ _VALIDATORS = {
     "enable_cftimeindex": lambda value: isinstance(value, bool),
     "file_cache_maxsize": _positive_integer,
     "keep_attrs": lambda choice: choice in [True, False, "default"],
+    "netcdf_engine_order": lambda engines: set(engines) <= _NETCDF_ENGINES,
     "use_bottleneck": lambda value: isinstance(value, bool),
     "use_new_combine_kwarg_defaults": lambda value: isinstance(value, bool),
     "use_numbagg": lambda value: isinstance(value, bool),
@@ -254,6 +260,11 @@ class set_options:
         * ``False`` : to always discard attrs
         * ``default`` : to use original logic that attrs should only
           be kept in unambiguous circumstances
+    netcdf_engine_order : sequence, default ['h5netcdf', 'scipy', 'netcdf4']
+        Preference order of backend engines to use when reading or writing
+        netCDF files with ``open_dataset()`` and ``to_netcdf()`` if ``engine``
+        is not explicitly specified. May be any permutation or subset of
+        ``['h5netcdf', 'scipy', 'netcdf4']``.
     use_bottleneck : bool, default: True
         Whether to use ``bottleneck`` to accelerate 1D reductions and
         1D rolling reduction operations.
@@ -311,6 +322,8 @@ class set_options:
                     expected = f"Expected one of {_JOIN_OPTIONS!r}"
                 elif k == "display_style":
                     expected = f"Expected one of {_DISPLAY_OPTIONS!r}"
+                elif k == "netcdf_engine_order":
+                    expected = f"Expected a subset of {sorted(_NETCDF_ENGINES)}"
                 else:
                     expected = ""
                 raise ValueError(

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -6775,6 +6775,7 @@ def _assert_no_dates_out_of_range_warning(record):
 
 
 @requires_scipy_or_netCDF4
+@pytest.mark.filterwarnings("ignore:deallocating CachingFileManager")
 @pytest.mark.parametrize("calendar", _STANDARD_CALENDARS)
 def test_use_cftime_standard_calendar_default_in_range(calendar) -> None:
     x = [0, 1]

--- a/xarray/tests/test_options.py
+++ b/xarray/tests/test_options.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 import pytest
 
 import xarray
@@ -67,6 +69,19 @@ def test_nested_options() -> None:
             assert OPTIONS["display_width"] == 2
         assert OPTIONS["display_width"] == 1
     assert OPTIONS["display_width"] == original
+
+
+def test_netcdf_engine_order() -> None:
+    original = OPTIONS["netcdf_engine_order"]
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "option 'netcdf_engine_order' given an invalid value: ['invalid']. "
+            "Expected a subset of ['h5netcdf', 'netcdf4', 'scipy']"
+        ),
+    ):
+        xarray.set_options(netcdf_engine_order=["invalid"])
+    assert OPTIONS["netcdf_engine_order"] == original
 
 
 def test_display_style() -> None:

--- a/xarray/tests/test_plugins.py
+++ b/xarray/tests/test_plugins.py
@@ -8,6 +8,7 @@ from unittest import mock
 import pytest
 
 from xarray.backends import common, plugins
+from xarray.core.options import OPTIONS
 from xarray.tests import (
     has_h5netcdf,
     has_netCDF4,
@@ -171,7 +172,7 @@ def test_build_engines_sorted() -> None:
     backend_entrypoints = list(plugins.build_engines(dummy_pkg_entrypoints))
 
     indices = []
-    for be in plugins.NETCDF_BACKENDS_ORDER:
+    for be in OPTIONS["netcdf_engine_order"]:
         try:
             index = backend_entrypoints.index(be)
             backend_entrypoints.pop(index)


### PR DESCRIPTION
The default `engine` when reading/writing netCDF files is now h5netcdf or scipy, which are typically faster than the prior default of netCDF4-python. You can control this default behavior explicitly via the new `netcdf_engine_order` parameter in `set_options()`, e.g., `xr.set_options(netcdf_engine_order=['netcdf4', 'scipy', 'h5netcdf'])` to restore the prior defaults.

I've also updated the documentation page which misled @lesserwhirls about Xarray supporting invalid netCDF files without `invalid_netcdf=True`.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #10657
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`
