### PR TITLE
Fix Blosc import in test for zarr 3.1.13

### DIFF
--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -681,7 +681,7 @@ class TestZarrDatatreeIO:
             from zarr.registry import get_codec_class
 
             Blosc = get_codec_class("numcodecs.blosc")
-            comp = {"compressors": (Blosc(cname="zstd", clevel=3),)}
+            comp = {"compressors": (Blosc(cname="zstd", clevel=3),)}  # type: ignore[call-arg]
 
         enc = {"/set2": dict.fromkeys(original_dt["/set2"].dataset.data_vars, comp)}
         original_dt.to_zarr(filepath, encoding=enc, zarr_format=zarr_format)

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -678,9 +678,10 @@ class TestZarrDatatreeIO:
             comp = {"compressors": (codec,)} if has_zarr_v3 else {"compressor": codec}
         elif zarr_format == 3:
             # specifying codecs in zarr_format=3 requires importing from zarr 3 namespace
-            import numcodecs.zarr3
+            from zarr.registry import get_codec_class
 
-            comp = {"compressors": (numcodecs.zarr3.Blosc(cname="zstd", clevel=3),)}
+            Blosc = get_codec_class("numcodecs.blosc")
+            comp = {"compressors": (Blosc(cname="zstd", clevel=3),)}
 
         enc = {"/set2": dict.fromkeys(original_dt["/set2"].dataset.data_vars, comp)}
         original_dt.to_zarr(filepath, encoding=enc, zarr_format=zarr_format)


### PR DESCRIPTION
Fixes the upstream test failure per advice here: https://github.com/zarr-developers/zarr-python/issues/3462#issuecomment-3299862585

If someone could label this with the "test-upstream" that would be fantastic

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
