### PR TITLE
Use a default fill_value of NaN for floats in Zarr v3

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -31,6 +31,13 @@ Breaking changes
   files to disk (:pull:`10624`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
 
+- Zarr stores written with Xarray now consistently use a default Zarr fill value
+  of ``NaN`` for float variables, for both Zarr v2 and v3 (:issue:`10646``). All
+  other dtypes still use the Zarr default ``fill_value`` of zero. To customize,
+  explicitly set encoding in :py:meth:`~Dataset.to_zarr`, e.g.,
+  ``encoding=dict.fromkey(ds.data_vars, {'fill_value': 0})``.
+  By `Stephan Hoyer <https://github.com/shoyer>`_.
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1178,6 +1178,11 @@ class ZarrStore(AbstractWritableDataStore):
                 fill_value = attrs.pop("_FillValue", None)
             else:
                 fill_value = v.encoding.pop("fill_value", None)
+                if fill_value is None and v.dtype.kind == "f":
+                    # For floating point data, Xarray defaults to a fill_value
+                    # of NaN (unlike Zarr, which uses zero):
+                    # https://github.com/pydata/xarray/issues/10646
+                    fill_value = v.dtype.type(np.nan)
                 if "_FillValue" in attrs:
                     # replace with encoded fill value
                     fv = attrs.pop("_FillValue")


### PR DESCRIPTION
Zarr stores written with Xarray now consistently use a default Zarr fill value of ``NaN`` for float variables, for both Zarr v2 and v3. All other dtypes still use the Zarr default ``fill_value`` of zero. To customize, explicitly set encoding in `Dataset.to_zarr`, e.g., ``encoding=dict.fromkey(ds.data_vars, {'fill_value': 0})``.

Fixes #10646

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #10646
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
