### PR TITLE
Add whatsnew entry for mypy test suite improvements

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -77,6 +77,10 @@ Documentation
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- All test files now have full mypy type checking enabled (``check_untyped_defs = true``),
+  improving type safety and making the test suite a better reference for type annotations.
+  (:pull:`10768`)
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
 
 .. _whats-new.2025.09.0:
 


### PR DESCRIPTION
## Summary

Adds a whatsnew entry documenting the mypy improvements from #10768.

## Changes

- Added entry to Internal Changes section noting that all test files now have full mypy type checking enabled

This improves type safety and makes the test suite a better reference for type annotations.

🤖 Generated with [Claude Code](https://claude.ai/code)