### PR TITLE
Create locks thread-safe

### DIFF
--- a/xarray/backends/locks.py
+++ b/xarray/backends/locks.py
@@ -49,7 +49,7 @@ class SerializableLock(Lock):
     lock: threading.Lock
 
     def __init__(self, token: Hashable | None = None):
-        with threading.Lock() :
+        with threading.Lock():
             self.token = token or str(uuid.uuid4())
             if self.token in SerializableLock._locks:
                 self.lock = SerializableLock._locks[self.token]


### PR DESCRIPTION
This fixes a race conditions that caused the [xbout](https://github.com/boutproject/xbout) test to fail with python3.14.

I thought it would be #9779 

 - but I also had issues after switching to h5netcdf - I just tested and 3 out 4 runs failed with a segfault.
 - The MRE from #9779 still fails

With this patch 0 out of 3 runs failed with a segfault.

With the remove of GIL in python 3.14 this may affect more users going forward.

https://github.com/intake/intake-esm/issues/697 sounds similar to the issue I am having, but I am not sure.