### PR TITLE
Add assert to CombinedLock

### DIFF
--- a/xarray/backends/locks.py
+++ b/xarray/backends/locks.py
@@ -218,6 +218,7 @@ class CombinedLock(Lock):
         self.locks = tuple(set(locks))  # remove duplicates
 
     def acquire(self, blocking=True):
+        assert blocking, "Without blocking you will never know which locks you have to unlock!"
         return all(acquire(lock, blocking=blocking) for lock in self.locks)
 
     def release(self):


### PR DESCRIPTION
If you have a non-blocking acquire, you have to release all the locks that you did acquire, but you must not release any of the locks that have been locked by another thread.

As it is not stored which locks where acquired, the release is not possible. It is thus not save to use this function without locking.
