### PR TITLE
Fix mypy errors with numpy 2.3 type stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,9 @@ accel = [
   "scipy>=1.13",
   "bottleneck",
   "numbagg>=0.8",
-  "numba>=0.59",
+  "numba>=0.62",  # numba 0.62 added support for numpy 2.3
   "flox>=0.9",
   "opt_einsum",
-  "numpy<2.3",    # numba has not updated yet: https://github.com/numba/numba/issues/10105
 ]
 complete = ["xarray[accel,etc,io,parallel,viz]"]
 io = [

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -694,8 +694,8 @@ class LazilyIndexedArray(ExplicitlyIndexedNDArrayMixin):
         """
         if isinstance(array, type(self)) and key is None:
             # unwrap
-            key = array.key
-            array = array.array
+            key = array.key  # type: ignore[has-type, unused-ignore]
+            array = array.array  # type: ignore[has-type, unused-ignore]
 
         if key is None:
             key = BasicIndexer((slice(None),) * array.ndim)

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -694,8 +694,8 @@ class LazilyIndexedArray(ExplicitlyIndexedNDArrayMixin):
         """
         if isinstance(array, type(self)) and key is None:
             # unwrap
-            key = array.key  # type: ignore[has-type]
-            array = array.array  # type: ignore[has-type]
+            key = array.key
+            array = array.array
 
         if key is None:
             key = BasicIndexer((slice(None),) * array.ndim)
@@ -1251,8 +1251,8 @@ def _decompose_vectorized_indexer(
     if indexing_support is IndexingSupport.VECTORIZED:
         return indexer, BasicIndexer(())
 
-    backend_indexer_elems = []
-    np_indexer_elems = []
+    backend_indexer_elems: list[slice | np.ndarray[Any, np.dtype[np.generic]]] = []
+    np_indexer_elems: list[slice | np.ndarray[Any, np.dtype[np.generic]]] = []
     # convert negative indices
     indexer_elems = [
         np.where(k < 0, k + s, k) if isinstance(k, np.ndarray) else k

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3871,7 +3871,7 @@ class TestDataArray:
         v = range(N)
         da = DataArray(v)
         ma = da.to_masked_array()
-        assert len(ma.mask) == N
+        assert isinstance(ma.mask, np.ndarray) and len(ma.mask) == N
 
     def test_to_dataset_whole(self) -> None:
         unnamed = DataArray([1, 2], dims="x")

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -374,7 +374,7 @@ class TestNamedArray(NamedArraySubclassobjects):
 
         masked_a: np.ma.MaskedArray[Any, np.dtype[np.int64]]
         masked_a = np.ma.asarray([2.1, 4], dtype=np.dtype(np.int64))  # type: ignore[no-untyped-call]
-        check_duck_array_typevar(masked_a)
+        check_duck_array_typevar(masked_a)  # type: ignore[arg-type]  # MaskedArray not in duckarray union
 
         custom_a: CustomArrayIndexable[Any, np.dtype[np.int64]]
         custom_a = CustomArrayIndexable(numpy_a)

--- a/xarray/tests/test_parallelcompat.py
+++ b/xarray/tests/test_parallelcompat.py
@@ -90,7 +90,7 @@ class DummyChunkManager(ChunkManagerEntrypoint):
     def rechunk(self, data: DummyChunkedArray, chunks, **kwargs) -> DummyChunkedArray:
         return data.rechunk(chunks, **kwargs)
 
-    def compute(self, *data: DummyChunkedArray, **kwargs) -> tuple[np.ndarray, ...]:
+    def compute(self, *data: DummyChunkedArray, **kwargs) -> tuple[np.ndarray, ...]:  # type: ignore[override]
         from dask.array import compute
 
         return compute(*data, **kwargs)


### PR DESCRIPTION
## Summary

Fixes the mypy test failures reported in #10791. The issue was caused by numpy 2.3's stricter type stubs revealing legitimate type issues in our codebase.

## The Problem

CI environments use numpy 2.3.3 (via conda-forge) while local development was constrained to numpy<2.3 due to an outdated numba compatibility constraint. NumPy 2.3 has stricter type annotations that caught several type issues:

1. In `xarray/core/indexing.py`: Lists were being used to hold mixed types (slices and ndarrays) without proper type annotations
2. In test files: Various type compatibility issues with MaskedArray, method overrides, and union types

## Changes

1. **Updated dependency constraints**:
   - Removed `numpy<2.3` constraint 
   - Updated `numba>=0.62` (numba 0.62+ supports numpy 2.3)

2. **Fixed type annotations**:
   - Added proper type hints for `backend_indexer_elems` and `np_indexer_elems` in `indexing.py`
   - These lists hold `slice | np.ndarray` types for use with `OuterIndexer` and `VectorizedIndexer`

3. **Added targeted type ignores**:
   - `test_namedarray.py`: MaskedArray not in duckarray union
   - `test_parallelcompat.py`: Covariant return type in compute method override
   - Fixed assertion in `test_dataarray.py` to handle union type for mask attribute

## Testing

- ✅ All mypy checks pass
- ✅ All affected tests pass
- ✅ Pre-commit hooks pass

Closes #10791

🤖 Generated with [Claude Code](https://claude.ai/code)