### PR TITLE
Less vertical whitespace in HTML reprs

### DIFF
--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -121,6 +121,8 @@ body.vscode-dark {
   padding-left: 0 !important;
   display: grid;
   grid-template-columns: 150px auto auto 1fr 0 20px 0 20px;
+  margin-block-start: 0;
+  margin-block-end: 0;
 }
 
 .xr-section-item {
@@ -131,6 +133,7 @@ body.vscode-dark {
   display: inline-block;
   opacity: 0;
   height: 0;
+  margin: 0;
 }
 
 .xr-section-item input + label {
@@ -189,7 +192,6 @@ body.vscode-dark {
 .xr-section-summary,
 .xr-section-inline-details {
   padding-top: 4px;
-  padding-bottom: 4px;
 }
 
 .xr-section-inline-details {
@@ -199,6 +201,7 @@ body.vscode-dark {
 .xr-section-details {
   display: none;
   grid-column: 1 / -1;
+  margin-top: 4px;
   margin-bottom: 5px;
 }
 

--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -1,6 +1,4 @@
-/* CSS stylesheet for displaying xarray objects in jupyterlab.
- *
- */
+/* CSS stylesheet for displaying xarray objects in notebooks */
 
 :root {
   --xr-font-color0: var(
@@ -79,6 +77,7 @@ body.vscode-dark {
   display: block !important;
   min-width: 300px;
   max-width: 700px;
+  line-height: 1.6;
 }
 
 .xr-text-repr-fallback {


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

## Dataset

### Updated:

<img width="719" height="196" alt="image" src="https://github.com/user-attachments/assets/e169753d-926b-4a16-8a94-8947b12db3ad" />

### Before:

<img width="717" height="231" alt="image" src="https://github.com/user-attachments/assets/a85bdc9a-9ae9-46f7-ab86-d4eb57a2f633" />


## DataTree

### Updated: 
<img width="720" height="643" alt="image" src="https://github.com/user-attachments/assets/ec706c4c-7328-4174-b66f-9315f9e8c068" />

### Before:
<img width="712" height="751" alt="image" src="https://github.com/user-attachments/assets/d3babaea-64fb-423b-a159-595fd5cace0d" />
