### PR TITLE
allow ignoring contributors by email for the release notes

### DIFF
--- a/ci/release_contributors.py
+++ b/ci/release_contributors.py
@@ -10,7 +10,14 @@ co_author_re = re.compile(r"Co-authored-by: (?P<name>[^<]+?) <(?P<email>.+)>")
 ignored = [
     {"name": "dependabot[bot]"},
     {"name": "pre-commit-ci[bot]"},
-    {"name": "Claude", "email": "noreply@anthropic.com"},
+    {
+        "name": "Claude",
+        "email": [
+            "noreply@anthropic.com",
+            "claude@anthropic.com",
+            "no-reply@anthropic.com",
+        ],
+    },
 ]
 
 


### PR DESCRIPTION
As noted in https://github.com/pydata/xarray/pull/10797#discussion_r2390124183, this removes the AI agent from the generated the list of contributors (I think this is what we decided a while ago, right?).

It also extends the ignore patterns to allow ignoring by email, since "Claude" is a human name.

cc @max-sixty, @shoyer