### PR TITLE
Improve HTML reprs

### DIFF
--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -79,7 +79,7 @@ OPTIONS: T_Options = {
     "cmap_divergent": "RdBu_r",
     "cmap_sequential": "viridis",
     "display_max_children": 12,
-    "display_max_html_elements": 500,
+    "display_max_html_elements": 300,
     "display_max_rows": 12,
     "display_max_items": 20,
     "display_values_threshold": 200,
@@ -246,7 +246,7 @@ class set_options:
         * ``default`` : to expand unless over a pre-defined limit (always collapse for html style)
     display_max_children : int, default: 12
         Maximum number of children to display for each node in a DataTree.
-    display_max_html_elements : int, default: 500
+    display_max_html_elements : int, default: 300
         Maximum number of HTML elements to include in DataTree HTML displays.
         Additional items are truncated.
     display_max_rows : int, default: 12

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
         "cmap_divergent",
         "cmap_sequential",
         "display_max_children",
+        "display_max_html_elements",
         "display_max_rows",
         "display_max_items",
         "display_values_threshold",
@@ -46,6 +47,7 @@ if TYPE_CHECKING:
         cmap_divergent: str | Colormap
         cmap_sequential: str | Colormap
         display_max_children: int
+        display_max_html_elements: int
         display_max_rows: int
         display_max_items: int
         display_values_threshold: int
@@ -77,8 +79,9 @@ OPTIONS: T_Options = {
     "cmap_divergent": "RdBu_r",
     "cmap_sequential": "viridis",
     "display_max_children": 12,
+    "display_max_html_elements": 500,
     "display_max_rows": 12,
-    "display_max_items": 30,
+    "display_max_items": 20,
     "display_values_threshold": 200,
     "display_style": "html",
     "display_width": 80,
@@ -114,6 +117,7 @@ _VALIDATORS = {
     "arithmetic_broadcast": lambda value: isinstance(value, bool),
     "arithmetic_join": _JOIN_OPTIONS.__contains__,
     "display_max_children": _positive_integer,
+    "display_max_html_elements": _positive_integer,
     "display_max_rows": _positive_integer,
     "display_max_items": _positive_integer,
     "display_values_threshold": _positive_integer,
@@ -242,10 +246,14 @@ class set_options:
         * ``default`` : to expand unless over a pre-defined limit (always collapse for html style)
     display_max_children : int, default: 12
         Maximum number of children to display for each node in a DataTree.
+    display_max_html_elements : int, default: 500
+        Maximum number of HTML elements to include in DataTree HTML displays.
+        Additional items are truncated.
     display_max_rows : int, default: 12
         Maximum display rows.
-    display_max_items : int, default 30
-        Maximum number of items to display for a DataTree, across all levels.
+    display_max_items : int, default 20
+        Maximum number of items to display for a DataTree before collapsing
+        child nodes, across all levels.
     display_values_threshold : int, default: 200
         Total number of array elements which trigger summarization rather
         than full repr for variable data views (numpy arrays).

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
         "cmap_sequential",
         "display_max_children",
         "display_max_rows",
+        "display_max_items",
         "display_values_threshold",
         "display_style",
         "display_width",
@@ -46,6 +47,7 @@ if TYPE_CHECKING:
         cmap_sequential: str | Colormap
         display_max_children: int
         display_max_rows: int
+        display_max_items: int
         display_values_threshold: int
         display_style: Literal["text", "html"]
         display_width: int
@@ -74,8 +76,9 @@ OPTIONS: T_Options = {
     "chunk_manager": "dask",
     "cmap_divergent": "RdBu_r",
     "cmap_sequential": "viridis",
-    "display_max_children": 6,
+    "display_max_children": 12,
     "display_max_rows": 12,
+    "display_max_items": 30,
     "display_values_threshold": 200,
     "display_style": "html",
     "display_width": 80,
@@ -112,6 +115,7 @@ _VALIDATORS = {
     "arithmetic_join": _JOIN_OPTIONS.__contains__,
     "display_max_children": _positive_integer,
     "display_max_rows": _positive_integer,
+    "display_max_items": _positive_integer,
     "display_values_threshold": _positive_integer,
     "display_style": _DISPLAY_OPTIONS.__contains__,
     "display_width": _positive_integer,
@@ -236,10 +240,12 @@ class set_options:
         * ``True`` : to always expand indexes
         * ``False`` : to always collapse indexes
         * ``default`` : to expand unless over a pre-defined limit (always collapse for html style)
-    display_max_children : int, default: 6
+    display_max_children : int, default: 12
         Maximum number of children to display for each node in a DataTree.
     display_max_rows : int, default: 12
         Maximum display rows.
+    display_max_items : int, default 30
+        Maximum number of items to display for a DataTree, across all levels.
     display_values_threshold : int, default: 200
         Total number of array elements which trigger summarization rather
         than full repr for variable data views (numpy arrays).

--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -136,17 +136,17 @@ body.vscode-dark {
 
 .xr-section-item > input + label {
   color: var(--xr-disabled-color);
-  border: 2px solid transparent !important;
+  /* border: 2px solid transparent !important; */
 }
+
+/* .xr-section-item > input:active + label {
+  border: 2px solid var(--xr-font-color0) !important;
+} */
 
 .xr-section-item > input:enabled + label,
-.xr-group-box-contents > input + label {
+.xr-group-box-contents > input:enabled + label {
   cursor: pointer;
   color: var(--xr-font-color2);
-}
-
-.xr-section-item > input:focus + label {
-  border: 2px solid var(--xr-font-color0) !important;
 }
 
 .xr-section-item > input:enabled + label:hover,
@@ -166,7 +166,8 @@ body.vscode-dark {
   padding-left: 0.5em;
 }
 
-.xr-section-summary-in:disabled + label {
+.xr-section-summary-in:disabled + label,
+.xr-group-box-contents > input:disabled + label {
   color: var(--xr-font-color2);
 }
 
@@ -178,7 +179,8 @@ body.vscode-dark {
   text-align: center;
 }
 
-.xr-section-summary-in:disabled + label:before {
+.xr-section-summary-in:disabled + label:before,
+.xr-group-box-contents > input:disabled + label:before {
   color: var(--xr-disabled-color);
 }
 

--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -121,6 +121,8 @@ body.vscode-dark {
   padding-left: 0 !important;
   display: grid;
   grid-template-columns: 150px auto auto 1fr 0 20px 0 20px;
+  margin-block-start: 0;
+  margin-block-end: 0;
 }
 
 .xr-section-item {
@@ -131,6 +133,7 @@ body.vscode-dark {
   display: inline-block;
   opacity: 0;
   height: 0;
+  margin: 0;
 }
 
 .xr-section-item input + label {
@@ -189,7 +192,6 @@ body.vscode-dark {
 .xr-section-summary,
 .xr-section-inline-details {
   padding-top: 4px;
-  padding-bottom: 4px;
 }
 
 .xr-section-inline-details {
@@ -199,6 +201,7 @@ body.vscode-dark {
 .xr-section-details {
   display: none;
   grid-column: 1 / -1;
+  margin-top: 4px;
   margin-bottom: 5px;
 }
 

--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -1,6 +1,4 @@
-/* CSS stylesheet for displaying xarray objects in jupyterlab.
- *
- */
+/* CSS stylesheet for displaying xarray objects in notebooks */
 
 :root {
   --xr-font-color0: var(
@@ -79,6 +77,7 @@ body.vscode-dark {
   display: block !important;
   min-width: 300px;
   max-width: 700px;
+  line-height: 1.6;
 }
 
 .xr-text-repr-fallback {

--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -78,6 +78,7 @@ body.vscode-dark {
   min-width: 300px;
   max-width: 700px;
   line-height: 1.6;
+  padding-bottom: 4px;
 }
 
 .xr-text-repr-fallback {
@@ -136,12 +137,7 @@ body.vscode-dark {
 
 .xr-section-item > input + label {
   color: var(--xr-disabled-color);
-  /* border: 2px solid transparent !important; */
 }
-
-/* .xr-section-item > input:active + label {
-  border: 2px solid var(--xr-font-color0) !important;
-} */
 
 .xr-section-item > input:enabled + label,
 .xr-group-box-contents > input:enabled + label {
@@ -160,14 +156,25 @@ body.vscode-dark {
   font-weight: 500;
 }
 
-.xr-section-summary > span,
-.xr-group-box-contents > input:checked + label > span {
-  display: inline-block;
-  padding-left: 0.5em;
+.xr-section-summary > em {
+  font-weight: normal;
 }
 
-.xr-section-summary-in:disabled + label,
-.xr-group-box-contents > input:disabled + label {
+.xr-span-grid {
+  grid-column-end: -1;
+}
+
+.xr-section-summary > span {
+  display: inline-block;
+  padding-left: 0.3em;
+}
+
+.xr-group-box-contents > input:checked + label > span {
+  display: inline-block;
+  padding-left: 0.6em;
+}
+
+.xr-section-summary-in:disabled + label {
   color: var(--xr-font-color2);
 }
 
@@ -179,8 +186,7 @@ body.vscode-dark {
   text-align: center;
 }
 
-.xr-section-summary-in:disabled + label:before,
-.xr-group-box-contents > input:disabled + label:before {
+.xr-section-summary-in:disabled + label:before {
   color: var(--xr-disabled-color);
 }
 
@@ -220,13 +226,12 @@ body.vscode-dark {
   display: inline-grid;
   grid-template-columns: 100%;
   grid-column: 1 / -1;
-  width: 100%;
+  padding-top: 4px;
 }
 
 .xr-group-box {
   display: inline-grid;
   grid-template-columns: 0px 30px auto;
-  width: 100%;
 }
 
 .xr-group-box-vline {
@@ -247,7 +252,7 @@ body.vscode-dark {
 
 .xr-group-box-contents {
   grid-column-start: 3;
-  width: 100%;
+  padding-bottom: 4px;
 }
 
 .xr-group-box-contents > label::before {

--- a/xarray/static/css/style.css
+++ b/xarray/static/css/style.css
@@ -88,8 +88,11 @@ body.vscode-dark {
 .xr-header {
   padding-top: 6px;
   padding-bottom: 6px;
-  margin-bottom: 4px;
+}
+
+.xr-header {
   border-bottom: solid 1px var(--xr-border-color);
+  margin-bottom: 4px;
 }
 
 .xr-header > div,
@@ -100,20 +103,15 @@ body.vscode-dark {
 }
 
 .xr-obj-type,
-.xr-obj-name,
-.xr-group-name {
+.xr-obj-name {
   margin-left: 2px;
   margin-right: 10px;
 }
 
-.xr-group-name::before {
-  content: "📁";
-  padding-right: 0.3em;
-}
-
-.xr-group-name,
-.xr-obj-type {
+.xr-obj-type,
+.xr-group-box-contents > label {
   color: var(--xr-font-color2);
+  display: block;
 }
 
 .xr-sections {
@@ -128,28 +126,31 @@ body.vscode-dark {
   display: contents;
 }
 
-.xr-section-item input {
-  display: inline-block;
+.xr-section-item > input,
+.xr-group-box-contents > input {
+  display: block;
   opacity: 0;
   height: 0;
   margin: 0;
 }
 
-.xr-section-item input + label {
+.xr-section-item > input + label {
   color: var(--xr-disabled-color);
   border: 2px solid transparent !important;
 }
 
-.xr-section-item input:enabled + label {
+.xr-section-item > input:enabled + label,
+.xr-group-box-contents > input + label {
   cursor: pointer;
   color: var(--xr-font-color2);
 }
 
-.xr-section-item input:focus + label {
+.xr-section-item > input:focus + label {
   border: 2px solid var(--xr-font-color0) !important;
 }
 
-.xr-section-item input:enabled + label:hover {
+.xr-section-item > input:enabled + label:hover,
+.xr-group-box-contents > input:enabled + label:hover {
   color: var(--xr-font-color0);
 }
 
@@ -159,7 +160,8 @@ body.vscode-dark {
   font-weight: 500;
 }
 
-.xr-section-summary > span {
+.xr-section-summary > span,
+.xr-group-box-contents > input:checked + label > span {
   display: inline-block;
   padding-left: 0.5em;
 }
@@ -189,7 +191,8 @@ body.vscode-dark {
 }
 
 .xr-section-summary,
-.xr-section-inline-details {
+.xr-section-inline-details,
+.xr-group-box-contents > label {
   padding-top: 4px;
 }
 
@@ -198,19 +201,29 @@ body.vscode-dark {
 }
 
 .xr-section-details {
-  display: none;
   grid-column: 1 / -1;
   margin-top: 4px;
   margin-bottom: 5px;
+}
+
+.xr-section-summary-in ~ .xr-section-details {
+  display: none;
 }
 
 .xr-section-summary-in:checked ~ .xr-section-details {
   display: contents;
 }
 
+.xr-children {
+  display: inline-grid;
+  grid-template-columns: 100%;
+  grid-column: 1 / -1;
+  width: 100%;
+}
+
 .xr-group-box {
   display: inline-grid;
-  grid-template-columns: 0px 20px auto;
+  grid-template-columns: 0px 30px auto;
   width: 100%;
 }
 
@@ -225,13 +238,35 @@ body.vscode-dark {
   grid-column-start: 2;
   grid-row-start: 1;
   height: 1em;
-  width: 20px;
+  width: 26px;
   border-bottom: 0.2em solid;
   border-color: var(--xr-border-color);
 }
 
 .xr-group-box-contents {
   grid-column-start: 3;
+  width: 100%;
+}
+
+.xr-group-box-contents > label::before {
+  content: "📂";
+  padding-right: 0.3em;
+}
+
+.xr-group-box-contents > input:checked + label::before {
+  content: "📁";
+}
+
+.xr-group-box-contents > input:checked + label {
+  padding-bottom: 0px;
+}
+
+.xr-group-box-contents > input:checked ~ .xr-sections {
+  display: none;
+}
+
+.xr-group-box-contents > input + label > span {
+  display: none;
 }
 
 .xr-array-wrap {

--- a/xarray/tests/test_formatting_html.py
+++ b/xarray/tests/test_formatting_html.py
@@ -271,48 +271,24 @@ def test_nonstr_variable_repr_html() -> None:
 
 class TestDataTreeTruncatesNodes:
     def test_many_nodes(self) -> None:
-        # construct a datatree with 500 nodes
-        number_of_files = 20
-        number_of_groups = 25
+        number_of_files = 10
+        number_of_groups = 10
         tree_dict = {}
         for f in range(number_of_files):
             for g in range(number_of_groups):
                 tree_dict[f"file_{f}/group_{g}"] = xr.Dataset({"g": f * g})
 
         tree = xr.DataTree.from_dict(tree_dict)
-        with xr.set_options(display_style="html"):
-            result = tree._repr_html_()
 
-        assert "6/20" in result
-        for i in range(number_of_files):
-            if i < 3 or i >= (number_of_files - 3):
-                assert f"file_{i}</div>" in result
-            else:
-                assert f"file_{i}</div>" not in result
+        with xr.set_options(display_max_html_elements=25):
+            result = xarray_html_only_repr(tree)
+        assert result.count("file_0/group_9") == 1
+        assert result.count("file_1/group_0") == 0  # disabled
+        assert result.count("Too many items to display") == 9 + 10
 
-        assert "6/25" in result
-        for i in range(number_of_groups):
-            if i < 3 or i >= (number_of_groups - 3):
-                assert f"group_{i}</div>" in result
-            else:
-                assert f"group_{i}</div>" not in result
-
-        with xr.set_options(display_style="html", display_max_children=3):
-            result = tree._repr_html_()
-
-        assert "3/20" in result
-        for i in range(number_of_files):
-            if i < 2 or i >= (number_of_files - 1):
-                assert f"file_{i}</div>" in result
-            else:
-                assert f"file_{i}</div>" not in result
-
-        assert "3/25" in result
-        for i in range(number_of_groups):
-            if i < 2 or i >= (number_of_groups - 1):
-                assert f"group_{i}</div>" in result
-            else:
-                assert f"group_{i}</div>" not in result
+        with xr.set_options(display_max_html_elements=1000):
+            result = xarray_html_only_repr(tree)
+        assert result.count("Too many items to display") == 0
 
 
 class TestDataTreeInheritance:

--- a/xarray/tests/test_formatting_html.py
+++ b/xarray/tests/test_formatting_html.py
@@ -197,7 +197,7 @@ def test_repr_of_dataset(dataset: xr.Dataset) -> None:
     formatted = xarray_html_only_repr(dataset)
     # coords, attrs, and data_vars are expanded
     assert (
-        formatted.count("class='xr-section-summary-in' type='checkbox'  checked>") == 3
+        formatted.count("class='xr-section-summary-in' type='checkbox' checked />") == 3
     )
     # indexes is omitted
     assert "Indexes" not in formatted
@@ -216,7 +216,7 @@ def test_repr_of_dataset(dataset: xr.Dataset) -> None:
         formatted = xarray_html_only_repr(dataset)
         # coords, attrs, and data_vars are collapsed, indexes is shown & expanded
         assert (
-            formatted.count("class='xr-section-summary-in' type='checkbox'  checked>")
+            formatted.count("class='xr-section-summary-in' type='checkbox' checked />")
             == 1
         )
         assert "Indexes" in formatted


### PR DESCRIPTION
This PR adds a number of improvements and revisions to the Xarray's HTML reprs, especially for DataTree:

1. No line breaks in long headers like "Data variables" and "Inherited Coordinates"
2. Add ~4px of extra padding at the end of HTML reprs, to make pages like [Xarray's docs](https://docs.xarray.dev/en/stable/user-guide/data-structures.html#creating-a-dataset) look a little better
3. Remove 2px shift on headers when actively clicked on. (I think this was intentional, but it seems to result in weird layout glitches because the `:active` selector doesn't always go away when focus is moved elsewhere)
4. Remove the collapsable "Groups" header from DataTree. Instead, each group is separately collapsable, and shows the total number of contained elements.
5. Truncation for too HTML elements is revised. I've added the options `display_max_items` and `display_max_html_elements` for controlling at what point the DataTree HTML repr collapses and truncates nodes, instead of doing this all based on `display_max_children`.

This needs a few more tests and release notes, but is ready for feedback! @jsignell @TomNicholas @benbovy 

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`


Code to generate HTML previews:
<details>

```python
import xarray as xr
import numpy as np

# Set up coordinates
time = xr.DataArray(data=["2022-01", "2023-01"], dims="time")
stations = xr.DataArray(data=list("abcdef"), dims="station")
lon = [-100, -80, -60]
lat = [10, 20, 30]

# Set up fake data
wind_speed = xr.DataArray(np.ones((2, 6)) * 2, dims=("time", "station"))
pressure = xr.DataArray(np.ones((2, 6)) * 3, dims=("time", "station"))
air_temperature = xr.DataArray(np.ones((2, 6)) * 4, dims=("time", "station"))
dewpoint = xr.DataArray(np.ones((2, 6)) * 5, dims=("time", "station"))
infrared = xr.DataArray(np.ones((2, 3, 3)) * 6, dims=("time", "lon", "lat"))
true_color = xr.DataArray(np.ones((2, 3, 3)) * 7, dims=("time", "lon", "lat"))

dt2 = xr.DataTree.from_dict(
    {
        "/": xr.Dataset(
            coords={"time": time},
        ),
        "/weather": xr.Dataset(
            coords={"station": stations},
            data_vars={
                "wind_speed": wind_speed,
                "pressure": pressure,
            },
        ),
        "/weather/temperature": xr.Dataset(
            data_vars={
                "air_temperature": air_temperature,
                "dewpoint": dewpoint,
            },
        ),
        "/satellite": xr.Dataset(
            coords={"lat": lat, "lon": lon},
            data_vars={
                "infrared": infrared,
                "true_color": true_color,
            },
        ),
    },
)
dt2['/other'] = xr.Dataset({f'x{i}': 0 for i in range(500)})

number_of_files = 20
number_of_groups = 50
tree_dict = {}
for f in range(number_of_files):
    for g in range(number_of_groups):
        tree_dict[f"file_{f}/group_{g}"] = xr.Dataset({"g": f * g})
tree_too_many = xr.DataTree.from_dict(tree_dict)


print("<h1>DataTree root</h1>")
print(dt2._repr_html_())

print("<hr />")
print("<h1>Dataset</h1>")

print(dt2.weather.to_dataset()._repr_html_())

print("<hr />")

print("<h1>DataTree inherited</h1>")
print(dt2.weather._repr_html_())

print("<hr />")
print("<h1>DataTree too many nodes</h1>")
print(tree_too_many._repr_html_())
```

</details>

# Revised (this PR)

[Interactive preview](https://jsfiddle.net/kc0ufty3/2/)

<img width="714" height="399" alt="image" src="https://github.com/user-attachments/assets/382b7f0e-22e5-4cdb-848f-64d76fefb986" />

# Baseline

[Interactive preview](https://jsfiddle.net/kc0ufty3/3/)

<img width="715" height="837" alt="image" src="https://github.com/user-attachments/assets/6b7133d2-af1b-44be-ae8c-76400cd94c56" />


