### PR TITLE
Add version requirement to matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ io = [
 ]
 etc = ["sparse>=0.15"]
 parallel = ["dask[complete]"]
-viz = ["cartopy>=0.23", "matplotlib", "nc-time-axis", "seaborn"]
+viz = ["cartopy>=0.23", "matplotlib>=3.8", "nc-time-axis", "seaborn"]
 types = [
   "pandas-stubs",
   "scipy-stubs",


### PR DESCRIPTION
Just adding the current minimum version required. Not sure why this wasn't defined before? 

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

Seen in #10836
