### PR TITLE
Fix Dataset.map to handle non-DataArray outputs

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6923,11 +6923,18 @@ class Dataset(
             foo      (dim_0, dim_1) float64 48B 1.764 0.4002 0.9787 2.241 1.868 0.9773
             bar      (x) float64 16B 1.0 2.0
         """
+        from xarray.core.dataarray import DataArray
+
         if keep_attrs is None:
             keep_attrs = _get_keep_attrs(default=False)
         variables = {
             k: maybe_wrap_array(v, func(v, *args, **kwargs))
             for k, v in self.data_vars.items()
+        }
+        # Convert non-DataArray values to DataArrays
+        variables = {
+            k: v if isinstance(v, DataArray) else DataArray(v)
+            for k, v in variables.items()
         }
         coord_vars, indexes = merge_coordinates_without_align(
             [v.coords for v in variables.values()]


### PR DESCRIPTION
Fixes #10835

## Summary

After PR #10602, `Dataset.map` started failing when functions returned non-DataArray values (e.g., scalars), raising `AttributeError: 'int' object has no attribute 'coords'` when trying to access `.coords` on the returned values.

This PR restores backward compatibility by converting non-DataArray outputs to DataArrays before accessing their `.coords` attribute.

## Changes

- Modified `Dataset.map` to check if returned values are DataArrays and convert them if not
- Added comprehensive test coverage for non-DataArray outputs (scalars, numpy arrays, mixed cases)

## Test plan

- [x] Added `test_map_non_dataarray_outputs` covering scalar outputs, numpy arrays, and mixed cases
- [x] All existing `Dataset.map` tests pass
- [x] All tests in `test_dataset.py` pass (495 passed)
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)