### PR TITLE
[docs] Remove duplicated example in ".where"

### DIFF
--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -1203,14 +1203,6 @@ class DataWithCoords(AttrAccessMixin):
                [-20, -21, -22, -23, -24]])
         Dimensions without coordinates: x, y
 
-        >>> a.where(a.x + a.y < 4, drop=True)
-        <xarray.DataArray (x: 4, y: 4)> Size: 128B
-        array([[ 0.,  1.,  2.,  3.],
-               [ 5.,  6.,  7., nan],
-               [10., 11., nan, nan],
-               [15., nan, nan, nan]])
-        Dimensions without coordinates: x, y
-
         See Also
         --------
         numpy.where : corresponding numpy function


### PR DESCRIPTION
This is only a small improvement of the docs, which removes the duplicated example for the `drop` Argument.
<img width="639" height="534" alt="Skärmavbild 2025-10-29 kl  09 45 53" src="https://github.com/user-attachments/assets/10c6d179-9a48-46a5-9bc3-782450e2fa19" />
