### PR TITLE
fix: don't expect string arrays to roundtrip in `pandas`

### DIFF
--- a/properties/test_pandas_roundtrip.py
+++ b/properties/test_pandas_roundtrip.py
@@ -163,7 +163,9 @@ def test_roundtrip_1d_pandas_extension_array(extension_array, is_index) -> None:
     df_arr_to_test = df.index if is_index else df["arr"]
     assert (df_arr_to_test == roundtripped).all()
     # `NumpyExtensionArray` types are not roundtripped, including `StringArray` which subtypes.
-    if isinstance(extension_array, pd.arrays.NumpyExtensionArray):  # type: ignore[attr-defined]
+    if isinstance(
+        extension_array, pd.arrays.NumpyExtensionArray | pd.arrays.ArrowStringArray
+    ):  # type: ignore[attr-defined]
         assert isinstance(arr.data, np.ndarray)
     else:
         assert (


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

We probably should have always been checking for this type in the test @dcherian 

- [x] Closes #10890
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
