### PR TITLE
DOC: Typo in terminology.rst

### DIFF
--- a/doc/user-guide/terminology.rst
+++ b/doc/user-guide/terminology.rst
@@ -64,7 +64,7 @@ complete examples, please consult the relevant documentation.*
         distinguish :term:`Dimension coordinate` vs. :term:`Non-dimension
         coordinate` and :term:`Indexed coordinate` vs. :term:`Non-indexed
         coordinate`. A coordinate named ``x`` can be retrieved from
-        ``arr.coords[x]``. A ``DataArray`` can have more coordinates than
+        ``arr.coords["x"]``. A ``DataArray`` can have more coordinates than
         dimensions because a single dimension can be labeled by multiple
         coordinate arrays. However, only one coordinate array can be assigned
         as a particular dimension's dimension coordinate array.


### PR DESCRIPTION
The name `x` is a string, not a variable

<!-- Feel free to remove check-list items aren't relevant to your change -->


