### PR TITLE
Support taking the mean over `xarray(pint(numpy(uncertainties)))`

### DIFF
--- a/xarray/computation/nanops.py
+++ b/xarray/computation/nanops.py
@@ -107,10 +107,6 @@ def _nanmean_ddof_object(ddof, value, axis=None, dtype=None, **kwargs):
     """In house nanmean. ddof argument will be used in _nanvar method"""
     valid_count = count(value, axis=axis)
     value = fillna(value, 0)
-    # As dtype inference is impossible for object dtype, we assume float
-    # https://github.com/dask/dask/issues/3162
-    if dtype is None and value.dtype.kind == "O":
-        dtype = float
 
     data = np.sum(value, axis=axis, dtype=dtype, **kwargs)
     data = data / (valid_count - ddof)


### PR DESCRIPTION
## Demo

```python

# /// script
# requires-python = ">=3.11"
# dependencies = [
#   "xarray[complete]@git+https://github.com/jsignell/xarray.git@uncertainties",
#   "uncertainties",
#   "pint",
# ]
# ///
#

from uncertainties import ufloat
import numpy as np
import pint
import xarray as xr

# create some uncertainties values
l1 = [ufloat(1, 0.1), ufloat(2, 0.2), ufloat(3, 0.3), ufloat(4, 0.4), ufloat(5, 0.5), ufloat(6, 0.6), ufloat(7, 0.7)]
l2 = [ufloat(10, 1.), ufloat(20, 2.), ufloat(30, 3.), ufloat(40, 4.), ufloat(50, 5.), ufloat(60, 6.), ufloat(70, 7.)]

# assemble a numpy array, we're at numpy(uncertainties)
numpy_array = np.array([l1, l2])

# attach a unit to it, we're at pint(numpy(uncertainties))
ureg = pint.UnitRegistry()
with_unit = numpy_array * ureg.second

# now assemble a DataArray, we're at xarray(pint(numpy(uncertainties)))
data_array = xr.DataArray(with_unit, dims=("a", "b"))

print(data_array.mean(dim="b"))
```

- [x] Closes #10842
- [ ] Tests added -> still need to figure out how to test this without requiring the `uncertainties` library
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
