### PR TITLE
DOC: Correct typos like a/an usage

### DIFF
--- a/design_notes/flexible_indexes_notes.md
+++ b/design_notes/flexible_indexes_notes.md
@@ -350,7 +350,7 @@ Indexes:
 
 To keep the `repr` compact, we could:
 
-- consolidate entries that map to the same index object, and have an short inline repr for `XarrayIndex` object
+- consolidate entries that map to the same index object, and have a short inline repr for `XarrayIndex` object
 - collapse the index section by default in the HTML `repr`
 - maybe omit all trivial indexes for 1D coordinates that match the dimension name
 

--- a/doc/user-guide/data-structures.rst
+++ b/doc/user-guide/data-structures.rst
@@ -360,7 +360,7 @@ in the dictionary:
 Where a pandas object is supplied as a value, the names of its indexes are used as dimension
 names, and its data is aligned to any existing dimensions.
 
-You can also create an dataset from:
+You can also create a dataset from:
 
 - A :py:class:`pandas.DataFrame` or ``pandas.Panel`` along its columns and items
   respectively, by passing it into the :py:class:`~xarray.Dataset` directly
@@ -559,7 +559,7 @@ nested dict-like containers of both :py:class:`xarray.DataArray`\s and :py:class
 A single datatree object is known as a "node", and its position relative to
 other nodes is defined by two more key properties:
 
-- ``children``: An dictionary mapping from names to other :py:class:`~xarray.DataTree`
+- ``children``: A dictionary mapping from names to other :py:class:`~xarray.DataTree`
   objects, known as its "child nodes".
 - ``parent``: The single :py:class:`~xarray.DataTree` object whose children this datatree is a
   member of, known as its "parent node".

--- a/doc/user-guide/hierarchical-data.rst
+++ b/doc/user-guide/hierarchical-data.rst
@@ -485,7 +485,7 @@ Operations and Methods on Trees
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To show how applying operations across a whole tree at once can be useful,
-let's first create a example scientific dataset.
+let's first create an example scientific dataset.
 
 .. jupyter-execute::
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -650,7 +650,7 @@ def open_dataarray(
     backend_kwargs: dict[str, Any] | None = None,
     **kwargs,
 ) -> DataArray:
-    """Open an DataArray from a file or file-like object containing a single
+    """Open a DataArray from a file or file-like object containing a single
     data variable.
 
     This is designed to read netCDF files with only one data variable. If

--- a/xarray/convert.py
+++ b/xarray/convert.py
@@ -155,7 +155,7 @@ def _name(iris_obj, default="unknown"):
 
 
 def from_iris(cube):
-    """Convert a Iris cube into an DataArray"""
+    """Convert a Iris cube into a DataArray"""
     import iris.exceptions
 
     name = _name(cube)

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -977,7 +977,7 @@ class MemoryCachedArray(ExplicitlyIndexedNDArrayMixin):
 
 def as_indexable(array):
     """
-    This function always returns a ExplicitlyIndexed subclass,
+    This function always returns an ExplicitlyIndexed subclass,
     so that the vectorized indexing is always possible with the returned
     object.
     """
@@ -1315,7 +1315,7 @@ def _decompose_outer_indexer(
     arrays that only support basic or outer indexing.
 
     As an example, let us consider to index a few elements from a backend array
-    with a orthogonal indexer ([0, 3, 1], [2, 3, 2]).
+    with an orthogonal indexer ([0, 3, 1], [2, 3, 2]).
     Even if the backend array only supports basic indexing, it is more
     efficient to load a subslice of the array than loading the entire array,
 

--- a/xarray/core/treenode.py
+++ b/xarray/core/treenode.py
@@ -49,7 +49,7 @@ class TreeNode:
 
     This class stores no data, it has only parents and children attributes, and various methods.
 
-    Stores child nodes in an dict, ensuring that equality checks between trees
+    Stores child nodes in a dict, ensuring that equality checks between trees
     and order of child nodes is preserved (since python 3.7).
 
     Nodes themselves are intrinsically unnamed (do not possess a ._name attribute), but if the node has a parent you can

--- a/xarray/core/utils.py
+++ b/xarray/core/utils.py
@@ -900,7 +900,7 @@ class HiddenKeyDict(MutableMapping[K, V]):
 
 
 def get_temp_dimname(dims: Container[Hashable], new_dim: Hashable) -> Hashable:
-    """Get an new dimension name based on new_dim, that is not used in dims.
+    """Get a new dimension name based on new_dim, that is not used in dims.
     If the same name exists, we add an underscore(s) in the head.
 
     Example1:


### PR DESCRIPTION
Correct typos like a/an usage