### PR TITLE
Fix combine_by_coords monotonicity check for non-concat dims

### DIFF
--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -501,7 +501,8 @@ def combine_by_coords(datasets, compat='no_conflicts', data_vars='all',
                                    fill_value=fill_value)
 
         # Check the overall coordinates are monotonically increasing
-        for dim in concatenated.dims:
+        # Only check dimensions that were used for concatenation
+        for dim in concat_dims:
             if dim in concatenated:
                 indexes = concatenated.indexes.get(dim)
                 if not (indexes.is_monotonic_increasing

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -618,6 +618,30 @@ class TestCombineAuto:
                                       " along dimension x"):
             combine_by_coords([ds1, ds0])
 
+    def test_combine_by_coords_non_monotonic_non_concat_dim(self):
+        # Test that non-monotonic coordinates are allowed on dimensions
+        # that don't vary between datasets (i.e., not concatenation dims)
+        # Regression test for GH issue
+        yCoord = ['a', 'c', 'b']  # non-monotonic
+
+        ds1 = Dataset(
+            data_vars={'data': (['x', 'y'], np.random.rand(3, 3))},
+            coords={'x': [1, 2, 3], 'y': yCoord}
+        )
+
+        ds2 = Dataset(
+            data_vars={'data': (['x', 'y'], np.random.rand(4, 3))},
+            coords={'x': [4, 5, 6, 7], 'y': yCoord}
+        )
+
+        # Should not raise an error - y is not a concatenation dimension
+        actual = combine_by_coords([ds1, ds2])
+
+        # Verify the result has the expected shape and coordinates
+        assert actual.dims == {'x': 7, 'y': 3}
+        assert list(actual.coords['x'].values) == [1, 2, 3, 4, 5, 6, 7]
+        assert list(actual.coords['y'].values) == yCoord
+
 
 @pytest.mark.filterwarnings("ignore:In xarray version 0.13 `auto_combine` "
                             "will be deprecated")


### PR DESCRIPTION
Only require monotonic coordinates along concatenation dimensions. Previously, identical non-monotonic coordinates on non-concat dims erroneously raised a ValueError. Includes regression test.

Closes # (refer to issue number if applicable)

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
