### PR TITLE
DOC: Correct many grammatical issues

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Run doctests
         run: |
           # Raise an error if there are warnings in the doctests, with `-Werror`.
-          # This is a trial; if it presents an problem, feel free to remove.
+          # This is a trial; if it presents a problem, feel free to remove.
           # See https://github.com/pydata/xarray/issues/7164 for more info.
           #
           # If dependencies emit warnings we can't do anything about, add ignores to

--- a/DATATREE_MIGRATION_GUIDE.md
+++ b/DATATREE_MIGRATION_GUIDE.md
@@ -42,7 +42,7 @@ A number of other API changes have been made, which should only require minor mo
 - Similarly the `ds` kwarg in the `DataTree.__init__` constructor has been replaced by `dataset`, i.e. use `DataTree(dataset=)` instead of `DataTree(ds=...)`.
 - The method `DataTree.to_dataset()` still exists but now has different options for controlling which variables are present on the resulting `Dataset`, e.g. `inherit=True/False`.
 - `DataTree.copy()` also has a new `inherit` keyword argument for controlling whether or not coordinates defined on parents are copied (only relevant when copying a non-root node).
-- The `DataTree.parent` property is now read-only. To assign a ancestral relationships directly you must instead use the `.children` property on the parent node, which remains settable.
+- The `DataTree.parent` property is now read-only. To assign an ancestral relationship directly you must instead use the `.children` property on the parent node, which remains settable.
 - Similarly the `parent` kwarg has been removed from the `DataTree.__init__` constructor.
 - DataTree objects passed to the `children` kwarg in `DataTree.__init__` are now shallow-copied.
 - `DataTree.map_over_subtree` has been renamed to `DataTree.map_over_datasets`, and changed to no longer work like a decorator. Instead you use it to apply the function and arguments directly, more like how `xarray.apply_ufunc` works.

--- a/doc/examples/ROMS_ocean_model.ipynb
+++ b/doc/examples/ROMS_ocean_model.ipynb
@@ -51,7 +51,7 @@
     "    # Pick out some of the variables that will be included as coordinates\n",
     "    ds = ds.set_coords(['Cs_r', 'Cs_w', 'hc', 'h', 'Vtransform'])\n",
     "    \n",
-    "    # Select a a subset of variables. Salt will be visualized, zeta is used to \n",
+    "    # Select a subset of variables. Salt will be visualized, zeta is used to \n",
     "    # calculate the vertical coordinate\n",
     "    variables = ['salt', 'zeta']\n",
     "    ds[variables].isel(ocean_time=slice(47, None, 7*24), \n",

--- a/doc/get-help/faq.rst
+++ b/doc/get-help/faq.rst
@@ -63,7 +63,7 @@ if you were using Panels:
 
 - You need to create a new factory type for each dimensionality.
 - You can't do math between NDPanels with different dimensionality.
-- Each dimension in a NDPanel has a name (e.g., 'labels', 'items',
+- Each dimension in an NDPanel has a name (e.g., 'labels', 'items',
   'major_axis', etc.) but the dimension names refer to order, not their
   meaning. You can't specify an operation as to be applied along the "time"
   axis.

--- a/doc/user-guide/dask.rst
+++ b/doc/user-guide/dask.rst
@@ -210,7 +210,7 @@ It can be helpful to choose chunk sizes based on your downstream analyses and to
 You can chunk or rechunk a dataset by:
 
 - Specifying the ``chunks`` kwarg when reading in your dataset. If you know you'll want to do some spatial subsetting, for example, you could use ``chunks={'latitude': 10, 'longitude': 10}`` to specify small chunks across space. This can avoid loading subsets of data that span multiple chunks, thus reducing the number of file reads. Note that this will only work, though, for chunks that are similar to how the data is chunked on disk. Otherwise, it will be very slow and require a lot of network bandwidth.
-- Many array file formats are chunked on disk. You can specify ``chunks={}`` to have a single dask chunk map to a single on-disk chunk, and ``chunks="auto"`` to have a single dask chunk be a automatically chosen multiple of the on-disk chunks.
+- Many array file formats are chunked on disk. You can specify ``chunks={}`` to have a single dask chunk map to a single on-disk chunk, and ``chunks="auto"`` to have a single dask chunk be an automatically chosen multiple of the on-disk chunks.
 - Using :py:meth:`Dataset.chunk` after you've already read in your dataset. For time domain problems, for example, you can use ``ds.chunk(time=TimeResampler())`` to rechunk according to a specified unit of time. ``ds.chunk(time=TimeResampler("MS"))``, for example, will set the chunks so that a month of data is contained in one chunk.
 
 

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -1483,7 +1483,7 @@ class CFTimedeltaCoder(VariableCoder):
         units attribute, e.g. "seconds". Defaults to True, but in the future
         will default to False.
     decode_via_dtype : bool
-        Whether to decode timedeltas based on the presence of a np.timedelta64
+        Whether to decode timedeltas based on the presence of an np.timedelta64
         dtype attribute, e.g. "timedelta64[s]". Defaults to True.
     """
 

--- a/xarray/computation/apply_ufunc.py
+++ b/xarray/computation/apply_ufunc.py
@@ -713,7 +713,7 @@ def apply_variable_ufunc(
     keep_attrs="override",
     dask_gufunc_kwargs=None,
 ) -> Variable | tuple[Variable, ...]:
-    """Apply a ndarray level function over Variable and/or ndarray objects."""
+    """Apply an ndarray level function over Variable and/or ndarray objects."""
     from xarray.core.formatting import short_array_repr
     from xarray.core.variable import as_compatible_data
 
@@ -869,7 +869,7 @@ def apply_variable_ufunc(
 
 
 def apply_array_ufunc(func, *args, dask="forbidden"):
-    """Apply a ndarray level function over ndarray objects."""
+    """Apply an ndarray level function over ndarray objects."""
     if any(is_chunked_array(arg) for arg in args):
         if dask == "forbidden":
             raise ValueError(

--- a/xarray/computation/rolling.py
+++ b/xarray/computation/rolling.py
@@ -491,7 +491,7 @@ class DataArrayRolling(Rolling["DataArray"]):
         func : callable
             Function which can be called in the form
             `func(x, **kwargs)` to return the result of collapsing an
-            np.ndarray over an the rolling dimension.
+            np.ndarray over the rolling dimension.
         keep_attrs : bool, default: None
             If True, the attributes (``attrs``) will be copied from the original
             object to the new one. If False, the new object will be returned
@@ -860,7 +860,7 @@ class DatasetRolling(Rolling["Dataset"]):
         func : callable
             Function which can be called in the form
             `func(x, **kwargs)` to return the result of collapsing an
-            np.ndarray over an the rolling dimension.
+            np.ndarray over the rolling dimension.
         keep_attrs : bool, default: None
             If True, the attributes (``attrs``) will be copied from the original
             object to the new one. If False, the new object will be returned

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1516,7 +1516,7 @@ class DataArray(
         indexers : dict, optional
             A dict with keys matching dimensions and values given
             by integers, slice objects or arrays.
-            indexer can be a integer, slice, array-like or DataArray.
+            indexer can be an integer, slice, array-like or DataArray.
             If DataArrays are passed as indexers, xarray-style indexing will be
             carried out. See :ref:`indexing` for the details.
             One of indexers or indexers_kwargs must be provided.
@@ -4662,14 +4662,14 @@ class DataArray(
         return result
 
     def to_iris(self) -> iris_Cube:
-        """Convert this array into a iris.cube.Cube"""
+        """Convert this array into an iris.cube.Cube"""
         from xarray.convert import to_iris
 
         return to_iris(self)
 
     @classmethod
     def from_iris(cls, cube: iris_Cube) -> Self:
-        """Convert a iris.cube.Cube into an xarray.DataArray"""
+        """Convert an iris.cube.Cube into an xarray.DataArray"""
         from xarray.convert import from_iris
 
         return from_iris(cube)

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -2252,7 +2252,7 @@ class DataTree(
         indexers : dict, optional
             A dict with keys matching dimensions and values given
             by integers, slice objects or arrays.
-            indexer can be a integer, slice, array-like or DataArray.
+            indexer can be an integer, slice, array-like or DataArray.
             If DataArrays are passed as indexers, xarray-style indexing will be
             carried out. See :ref:`indexing` for the details.
             One of indexers or indexers_kwargs must be provided.

--- a/xarray/core/extension_array.py
+++ b/xarray/core/extension_array.py
@@ -96,7 +96,7 @@ class PandasExtensionArray(NDArrayMixin, Generic[T_ExtensionArray]):
 
     def __post_init__(self):
         if not isinstance(self.array, pd.api.extensions.ExtensionArray):
-            raise TypeError(f"{self.array} is not an pandas ExtensionArray.")
+            raise TypeError(f"{self.array} is not a pandas ExtensionArray.")
         # This does not use the UNSUPPORTED_EXTENSION_ARRAY_TYPES whitelist because
         # we do support extension arrays from datetime, for example, that need
         # duck array support internally via this class.  These can appear from `DatetimeIndex`

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -809,7 +809,7 @@ class PandasIndex(Index):
         indxr = indexers[self.dim]
         if isinstance(indxr, Variable):
             if indxr.dims != (self.dim,):
-                # can't preserve a index if result has new dimensions
+                # can't preserve an index if result has new dimensions
                 return None
             else:
                 indxr = indxr.data

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1651,7 +1651,7 @@ def posify_mask_indexer(indexer: ExplicitIndexer) -> ExplicitIndexer:
 
 
 def is_fancy_indexer(indexer: Any) -> bool:
-    """Return False if indexer is a int, slice, a 1-dimensional list, or a 0 or
+    """Return False if indexer is an int, slice, a 1-dimensional list, or a 0 or
     1-dimensional ndarray; in all other cases return True
     """
     if isinstance(indexer, int | slice) and not isinstance(indexer, bool):

--- a/xarray/core/nputils.py
+++ b/xarray/core/nputils.py
@@ -156,7 +156,7 @@ def _advanced_indexer_subspaces(key):
 
 
 class NumpyVIndexAdapter:
-    """Object that implements indexing like vindex on a np.ndarray.
+    """Object that implements indexing like vindex on an np.ndarray.
 
     This is a pure Python implementation of (some of) the logic in this NumPy
     proposal: https://github.com/numpy/numpy/pull/6256

--- a/xarray/indexes/nd_point_index.py
+++ b/xarray/indexes/nd_point_index.py
@@ -135,7 +135,7 @@ class NDPointIndex(Index, Generic[T_TreeAdapter]):
     Data variables:
         *empty*
 
-    Creation of a NDPointIndex from the "xx" and "yy" coordinate variables:
+    Creation of an NDPointIndex from the "xx" and "yy" coordinate variables:
 
     >>> ds = ds.set_xindex(("xx", "yy"), xr.indexes.NDPointIndex)
     >>> ds

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -509,7 +509,7 @@ def _maybe_gca(**subplot_kws: Any) -> Axes:
 
 
 def _get_units_from_attrs(da: DataArray) -> str:
-    """Extracts and formats the unit/units from a attributes."""
+    """Extracts and formats the unit/units from their attributes."""
     pint_array_type = DuckArrayModule("pint").type
     units = " [{}]"
     if isinstance(da.data, pint_array_type):

--- a/xarray/structure/combine.py
+++ b/xarray/structure/combine.py
@@ -44,7 +44,7 @@ def _infer_tile_ids_from_nested_list(
     entry: NestedSequence[T], current_pos: tuple[int, ...]
 ) -> Iterator[tuple[tuple[int, ...], T]]:
     """
-    Given a list of lists (of lists...) of objects, returns a iterator
+    Given a list of lists (of lists...) of objects, returns an iterator
     which returns a tuple containing the index of each object in the nested
     list structure as the key, and the object. This can then be called by the
     dict constructor to create a dictionary of the objects organised by their

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -246,7 +246,7 @@ def zarr(client):  # noqa: F811
     except AttributeError:
         yield zarr_lib
     finally:
-        # Zarr-Python 3 lazily allocates a IO thread, a thread pool executor, and
+        # Zarr-Python 3 lazily allocates an IO thread, a thread pool executor, and
         # an IO loop. Here we clean up these resources to avoid leaking threads
         # In normal operations, this is done as by an atexit handler when Zarr
         # is shutting down.

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -1064,7 +1064,7 @@ def test_array_repr_dtypes():
     # Unsigned integer could be used as easy replacements
     # for tests where the data-type does not matter,
     # but the repr does, including the size
-    # (size of a int == size of an uint)
+    # (size of an int == size of a uint)
 
     # Signed integer dtypes
 

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -1669,7 +1669,7 @@ class TestDataArrayGroupBy:
 
         if has_flox:
             # GH9803
-            # reduce over one dim of a nD grouper
+            # reduce over one dim of an nD grouper
             array.coords["labels"] = (("ny", "nx"), np.array([["a", "b"], ["b", "a"]]))
             actual = array.groupby("labels").sum("nx")
             expected_np = np.array([[[0, 1], [3, 2]], [[5, 10], [20, 15]]])


### PR DESCRIPTION
Correct grammar issues about a/an usage.

I searched for patterns such as `" a np"` and `" a nd"` in the GitHub codebase, because they are most likely to contain grammatical mistakes. Then I manually reviewed which ones needed to be changed. These patterns are not exhaustive, so a few issues of ("a" vs "an") still remain.