### PR TITLE
Fix type annotation for DataVariables to use Hashable instead of Any

### DIFF
--- a/xarray/core/dataset_variables.py
+++ b/xarray/core/dataset_variables.py
@@ -1,6 +1,5 @@
 import typing
 from collections.abc import Hashable, Iterator, Mapping
-from typing import Any
 
 import numpy as np
 
@@ -13,7 +12,7 @@ if typing.TYPE_CHECKING:
     from xarray.core.dataset import Dataset
 
 
-class DataVariables(Mapping[Any, "DataArray"]):
+class DataVariables(Mapping[Hashable, "DataArray"]):
     __slots__ = ("_dataset",)
 
     def __init__(self, dataset: "Dataset"):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #10906

Currently. using [Any] also disables type checking, making it harder to catch type-related errors. Updated the type annotation in [dataset_variables.py] to use instead of [Any], making it consistent with hashables.
