### PR TITLE
DOC: Remove RTD htmlzip output format

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,6 +24,3 @@ build:
     build:
       html:
         - pixi run doc BUILDDIR=$READTHEDOCS_OUTPUT
-
-formats:
-  - htmlzip


### PR DESCRIPTION
The feature doesn't play nice with pixi in RTD builds - fixes https://github.com/pydata/xarray/issues/10974

<!-- Feel free to remove check-list items aren't relevant to your change -->

