### PR TITLE
doc: add required variable to custom index

### DIFF
--- a/doc/internals/how-to-create-custom-index.rst
+++ b/doc/internals/how-to-create-custom-index.rst
@@ -232,4 +232,4 @@ custom index to a Dataset or DataArray, e.g., using the ``RasterIndex`` above:
     da_raster = da.set_xindex(["x", "y"], RasterIndex)
 
     # RasterIndex now takes care of label-based selection
-    selected = da_raster.sel(x=10, y=slice(20, 50))
+    da_raster.sel(x=10, y=slice(20, 50))


### PR DESCRIPTION
Fixes an error on the custom index page. The code as written currently results in an error

```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
[/var/folders/tc/fkgp35zn7z913f9cmsxcl6pc0000gn/T/ipykernel_30850/1307141732.py](http://localhost:8889/var/folders/tc/fkgp35zn7z913f9cmsxcl6pc0000gn/T/ipykernel_30850/1307141732.py) in ?()
     11 # we first need to explicitly drop it
     12 da = da.drop_indexes(["x", "y"])
     13 
     14 # Build a RasterIndex from the 'x' and 'y' coordinates
---> 15 da_raster = da.set_xindex(["x", "y"], RasterIndex)
     16 
     17 # RasterIndex now takes care of label-based selection
     18 selected = da_raster.sel(x=10, y=slice(20, 50))

[~/.cache/uv/environments-v2/juv-tmp-pqf4njks-db7d9291e4e64b3f/lib/python3.13/site-packages/xarray/core/dataarray.py](http://localhost:8889/lab/workspaces/auto-D/tree/~/.cache/uv/environments-v2/juv-tmp-pqf4njks-db7d9291e4e64b3f/lib/python3.13/site-packages/xarray/core/dataarray.py) in ?(self, coord_names, index_cls, **options)
   2887         obj : DataArray
   2888             Another dataarray, with this dataarray's data and with a new index.
   2889 
   2890         """
-> 2891         ds = self._to_temp_dataset().set_xindex(coord_names, index_cls, **options)
   2892         return self._from_temp_dataset(ds)

[~/.cache/uv/environments-v2/juv-tmp-pqf4njks-db7d9291e4e64b3f/lib/python3.13/site-packages/xarray/core/dataset.py](http://localhost:8889/lab/workspaces/auto-D/tree/~/.cache/uv/environments-v2/juv-tmp-pqf4njks-db7d9291e4e64b3f/lib/python3.13/site-packages/xarray/core/dataset.py) in ?(self, coord_names, index_cls, **options)
   5015             )
   5016 
   5017         coord_vars = {name: self._variables[name] for name in coord_names}
   5018 
-> 5019         index = index_cls.from_variables(coord_vars, options=options)
   5020 
   5021         new_coord_vars = index.create_variables(coord_vars)
   5022 

TypeError: RasterIndex.from_variables() got an unexpected keyword argument 'options'
```
