### PR TITLE
Fix RTD builds by restricting test-nightly platforms

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -143,6 +143,12 @@ sparse = "0.15.*"
 toolz = "0.12.*"
 zarr = "2.18.*"
 
+# TODO: Remove `platforms` restriction once pandas nightly has win-64 wheels again.
+# Without this, `pixi lock` fails because it can't solve the nightly feature for win-64,
+# which breaks RTD builds (RTD has no lock file cache, unlike GitHub Actions CI).
+[feature.nightly]
+platforms = ["linux-64", "osx-arm64"]
+
 [feature.nightly.dependencies]
 python = "*"
 


### PR DESCRIPTION
this should solve the Pixi issue that's preventing all CIs from passing. I don't know much about it, but I'll merge to keep things moving if that's reasonable; can easily revert

---

## Summary

- Restrict `test-nightly` environment to `linux-64` and `osx-arm64` platforms (excluding `win-64`)
- Add explanatory comment noting this is temporary until pandas nightly provides win-64 wheels

## Problem

RTD builds have been failing across all PRs because:

1. The `test-nightly` environment uses pandas nightly wheels from `pypi.anaconda.org/scientific-python-nightly-wheels`
2. Pandas nightly (`3.0.0rc0`) doesn't currently provide win-64 wheels
3. When `pixi lock` runs, it must solve ALL environments for ALL platforms defined in `pixi.toml`
4. RTD has no lock file cache (unlike GitHub Actions CI), so it must run `pixi lock` fresh every build
5. The unsolvable `test-nightly` × `win-64` combination causes lock file generation to fail

GitHub Actions CI "hides" this issue by caching `pixi.lock` - once generated successfully, subsequent runs skip `pixi lock` entirely.

## Test plan

- [ ] RTD build passes on this PR
- [ ] CI passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)