### PR TITLE
DOC: Correct grammatical errors such as 'a xarray' -> 'an xarray'

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -25,7 +25,7 @@ help:
 	@echo "  singlehtml to make a single large HTML file"
 	@echo "  pickle     to make pickle files"
 	@echo "  json       to make JSON files"
-	@echo "  htmlhelp   to make HTML files and a HTML help project"
+	@echo "  htmlhelp   to make HTML files and an HTML help project"
 	@echo "  qthelp     to make HTML files and a qthelp project"
 	@echo "  applehelp  to make an Apple Help Book"
 	@echo "  devhelp    to make HTML files and a Devhelp project"

--- a/doc/user-guide/testing.rst
+++ b/doc/user-guide/testing.rst
@@ -178,7 +178,7 @@ numpy array (so-called "duck array wrapping", see :ref:`wrapping numpy-like arra
 Imagine we want to write a strategy which generates arbitrary ``Variable`` objects, each of which wraps a
 :py:class:`sparse.COO` array instead of a ``numpy.ndarray``. How could we do that? There are two ways:
 
-1. Create a xarray object with numpy data and use the hypothesis' ``.map()`` method to convert the underlying array to a
+1. Create an xarray object with numpy data and use the hypothesis' ``.map()`` method to convert the underlying array to a
 different type:
 
 .. jupyter-execute::

--- a/xarray/backends/file_manager.py
+++ b/xarray/backends/file_manager.py
@@ -242,7 +242,7 @@ class CachingFileManager(FileManager[T_File]):
                 file.close()
 
     def __del__(self) -> None:
-        # If we're the only CachingFileManger referencing a unclosed file,
+        # If we're the only CachingFileManger referencing an unclosed file,
         # remove it from the cache upon garbage collection.
         #
         # We keep track of our own reference count because we don't want to

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4208,7 +4208,7 @@ class DataArray(
         Notes
         -----
         Only xarray.Dataset objects can be written to netCDF files, so
-        the xarray.DataArray is converted to a xarray.Dataset object
+        the xarray.DataArray is converted to an xarray.Dataset object
         containing a single variable. If the DataArray has no name, or if the
         name is the same as a coordinate name, then it is given the name
         ``"__xarray_dataarray_variable__"``.

--- a/xarray/plot/facetgrid.py
+++ b/xarray/plot/facetgrid.py
@@ -63,7 +63,7 @@ class FacetGrid(Generic[T_DataArrayOrSet]):
     """
     Initialize the Matplotlib figure and FacetGrid object.
 
-    The :class:`FacetGrid` is an object that links a xarray DataArray to
+    The :class:`FacetGrid` is an object that links an xarray DataArray to
     a Matplotlib figure with a particular structure.
 
     In particular, :class:`FacetGrid` is used to draw plots with multiple

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -573,7 +573,7 @@ def _interval_to_double_bound_points(
     xarray: Iterable[pd.Interval], yarray: Iterable
 ) -> tuple[np.ndarray, np.ndarray]:
     """
-    Helper function to deal with a xarray consisting of pd.Intervals. Each
+    Helper function to deal with an xarray consisting of pd.Intervals. Each
     interval is replaced with both boundaries. I.e. the length of xarray
     doubles. yarray is modified so it matches the new shape of xarray.
     """

--- a/xarray/tests/test_cftimeindex_resample.py
+++ b/xarray/tests/test_cftimeindex_resample.py
@@ -115,7 +115,7 @@ def compare_against_pandas(
             origin=origin_cftime,
             offset=offset,
         ).mean()
-    # TODO (benbovy - flexible indexes): update when CFTimeIndex is a xarray Index subclass
+    # TODO (benbovy - flexible indexes): update when CFTimeIndex is an xarray Index subclass
     result_cftimeindex["time"] = (
         result_cftimeindex.xindexes["time"]
         .to_pandas_index()
@@ -237,7 +237,7 @@ def test_calendars(calendar: str) -> None:
     )
     da_cftime = da(xr_index).resample(time=freq, closed=closed, label=label).mean()
     da_datetime = da(pd_index).resample(time=freq, closed=closed, label=label).mean()
-    # TODO (benbovy - flexible indexes): update when CFTimeIndex is a xarray Index subclass
+    # TODO (benbovy - flexible indexes): update when CFTimeIndex is an xarray Index subclass
     new_pd_index = da_cftime.xindexes["time"].to_pandas_index()
     assert isinstance(new_pd_index, CFTimeIndex)  # shouldn't that be a pd.Index?
     da_cftime["time"] = new_pd_index.to_datetimeindex(time_unit="ns")


### PR DESCRIPTION
Correct grammatical errors such as 'a xarray' -> 'an xarray'