### PR TITLE
New chunking approach that never splits encoded chunks

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -18,6 +18,9 @@ New Features
   guarantees that chunks in xarray match on-disk chunks or multiples of them.
   No chunk splitting allowed. (:pull:`11060`).
   By `Julia Signell <https://github.com/jsignell>`_
+- Added ``inherit='all_coords'`` option to :py:meth:`DataTree.to_dataset` to inherit
+  all parent coordinates, not just indexed ones (:issue:`10812`, :pull:`11230`).
+  By `Alfonso Ladino <https://github.com/aladinor>`_.
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -14,13 +14,10 @@ v2026.05.0 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
-- Adds a new option ``chunks="preserve"`` when opening a dataset. This option
-  guarantees that chunks in xarray match on-disk chunks or multiples of them.
-  No chunk splitting allowed. (:pull:`11060`).
+- Change behavior of ``chunks="auto"`` to guarantee that chunks in xarray
+  match on-disk chunks or multiples of them. No automatic chunk splitting allowed.
+  (:pull:`11060`).
   By `Julia Signell <https://github.com/jsignell>`_
-- Added ``inherit='all_coords'`` option to :py:meth:`DataTree.to_dataset` to inherit
-  all parent coordinates, not just indexed ones (:issue:`10812`, :pull:`11230`).
-  By `Alfonso Ladino <https://github.com/aladinor>`_.
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -14,6 +14,10 @@ v2026.05.0 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- Adds a new option ``chunks="preserve"`` when opening a dataset. This option
+  guarantees that chunks in xarray match on-disk chunks or multiples of them.
+  No chunk splitting allowed. (:pull:`11060`).
+  By `Julia Signell <https://github.com/jsignell>`_
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~

--- a/properties/test_parallelcompat.py
+++ b/properties/test_parallelcompat.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("hypothesis")
+# isort: split
+
+from hypothesis import given
+
+import xarray.testing.strategies as xrst
+from xarray.namedarray.parallelcompat import ChunkManagerEntrypoint
+
+
+class TestPreserveChunks:
+    @given(xrst.shape_and_chunks())
+    def test_preserve_all_chunks(
+        self, shape_and_chunks: tuple[tuple[int, ...], tuple[int, ...]]
+    ) -> None:
+        shape, previous_chunks = shape_and_chunks
+        typesize = 8
+        target = 1024 * 1024
+
+        actual = ChunkManagerEntrypoint.preserve_chunks(
+            chunks=("preserve",) * len(shape),
+            shape=shape,
+            target=target,
+            typesize=typesize,
+            previous_chunks=previous_chunks,
+        )
+        for i, chunk in enumerate(actual):
+            if chunk != shape[i]:
+                assert chunk >= previous_chunks[i]
+                assert chunk % previous_chunks[i] == 0
+                assert chunk <= shape[i]
+
+        if actual != shape:
+            assert np.prod(actual) * typesize >= 0.5 * target
+
+    @pytest.mark.parametrize("first_chunk", [-1, (), 1])
+    @given(xrst.shape_and_chunks(min_dims=2))
+    def test_preserve_some_chunks(
+        self,
+        first_chunk: int | tuple[int, ...],
+        shape_and_chunks: tuple[tuple[int, ...], tuple[int, ...]],
+    ) -> None:
+        shape, previous_chunks = shape_and_chunks
+        typesize = 4
+        target = 2 * 1024 * 1024
+
+        actual = ChunkManagerEntrypoint.preserve_chunks(
+            chunks=(first_chunk, *["preserve" for _ in range(len(shape) - 1)]),
+            shape=shape,
+            target=target,
+            typesize=typesize,
+            previous_chunks=previous_chunks,
+        )
+        for i, chunk in enumerate(actual):
+            if i == 0:
+                if first_chunk == 1:
+                    assert chunk == 1
+                elif first_chunk == -1:
+                    assert chunk == shape[i]
+                elif first_chunk == ():
+                    assert chunk == previous_chunks[i]
+            elif chunk != shape[i]:
+                assert chunk >= previous_chunks[i]
+                assert chunk % previous_chunks[i] == 0
+                assert chunk <= shape[i]
+
+        # if we have more than one chunk, make sure the chunks are big enough
+        if actual[1:] != shape[1:]:
+            assert np.prod(actual) * typesize >= 0.5 * target

--- a/properties/test_parallelcompat.py
+++ b/properties/test_parallelcompat.py
@@ -20,7 +20,7 @@ class TestPreserveChunks:
         target = 1024 * 1024
 
         actual = ChunkManagerEntrypoint.preserve_chunks(
-            chunks=("preserve",) * len(shape),
+            chunks=("auto",) * len(shape),
             shape=shape,
             target=target,
             typesize=typesize,
@@ -47,7 +47,7 @@ class TestPreserveChunks:
         target = 2 * 1024 * 1024
 
         actual = ChunkManagerEntrypoint.preserve_chunks(
-            chunks=(first_chunk, *["preserve" for _ in range(len(shape) - 1)]),
+            chunks=(first_chunk, *["auto" for _ in range(len(shape) - 1)]),
             shape=shape,
             target=target,
             typesize=typesize,

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -292,9 +292,9 @@ def _dataset_from_backend_dataset(
     create_default_indexes,
     **extra_tokens,
 ):
-    if not isinstance(chunks, int | dict) and chunks not in {None, "auto"}:
+    if not isinstance(chunks, int | dict) and chunks not in {None, "auto", "preserve"}:
         raise ValueError(
-            f"chunks must be an int, dict, 'auto', or None. Instead found {chunks}."
+            f"chunks must be an int, dict, 'auto', 'preserve', or None. Instead found {chunks}."
         )
 
     _protect_dataset_variables_inplace(backend_ds, cache)

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -259,11 +259,11 @@ def _chunk_ds(
             name,
             var,
             var_chunks,
+            chunkmanager,
             overwrite_encoded_chunks=overwrite_encoded_chunks,
             name_prefix=name_prefix,
             token=token,
             inline_array=inline_array,
-            chunked_array_type=chunkmanager,
             from_array_kwargs=from_array_kwargs.copy(),
             just_use_token=True,
         )
@@ -292,9 +292,9 @@ def _dataset_from_backend_dataset(
     create_default_indexes,
     **extra_tokens,
 ):
-    if not isinstance(chunks, int | dict) and chunks not in {None, "auto", "preserve"}:
+    if not isinstance(chunks, int | dict) and chunks not in {None, "auto"}:
         raise ValueError(
-            f"chunks must be an int, dict, 'auto', 'preserve', or None. Instead found {chunks}."
+            f"chunks must be an int, dict, 'auto', or None. Instead found {chunks}."
         )
 
     _protect_dataset_variables_inplace(backend_ds, cache)
@@ -430,14 +430,14 @@ def open_dataset(
         "netcdf4" over "h5netcdf" over "scipy" (customizable via
         ``netcdf_engine_order`` in ``xarray.set_options()``). A custom backend
         class (a subclass of ``BackendEntrypoint``) can also be used.
-    chunks : int, dict, 'auto', 'preserve' or None, default: None
+    chunks : int, dict, 'auto', 'dask-auto' or None, default: None
         If provided, used to load the data into dask arrays.
 
-        - ``chunks="auto"`` will use dask ``auto`` chunking taking into account the
-          engine preferred chunks.
-        - ``chunks="preserve"`` will use a chunking scheme that never splits encoded
-          chunks. If encoded chunks are small then "preserve" takes multiples of them
+        - ``chunks="auto"`` will use a chunking scheme that never splits encoded
+          chunks. If encoded chunks are small then "auto" takes multiples of them
           over the largest dimension.
+        - ``chunks="dask-auto"`` will use dask ``auto`` chunking taking into account the
+          engine preferred chunks.
         - ``chunks=None`` skips using dask. This uses xarray's internally private
           :ref:`lazy indexing classes <internal design.lazy indexing>`,
           but data is eagerly loaded into memory as numpy arrays when accessed.
@@ -677,14 +677,14 @@ def open_dataarray(
         "netcdf4" over "h5netcdf" over "scipy" (customizable via
         ``netcdf_engine_order`` in ``xarray.set_options()``). A custom backend
         class (a subclass of ``BackendEntrypoint``) can also be used.
-    chunks : int, dict, 'auto', 'preserve', or None, default: None
+    chunks : int, dict, 'auto', 'dask-auto', or None, default: None
         If provided, used to load the data into dask arrays.
 
-        - ``chunks='auto'`` will use dask ``auto`` chunking taking into account the
-          engine preferred chunks.
-        - ``chunks="preserve"`` will use a chunking scheme that never splits encoded
-          chunks. If encoded chunks are small then "preserve" takes multiples of them
+        - ``chunks="auto"`` will use a chunking scheme that never splits encoded
+          chunks. If encoded chunks are small then "auto" takes multiples of them
           over the largest dimension.
+        - ``chunks='dask-auto'`` will use dask ``auto`` chunking taking into account the
+          engine preferred chunks.
         - ``chunks=None`` skips using dask. This uses xarray's internally private
           :ref:`lazy indexing classes <internal design.lazy indexing>`,
           but data is eagerly loaded into memory as numpy arrays when accessed.
@@ -906,13 +906,13 @@ def open_datatree(
         "h5netcdf" over "netcdf4" (customizable via ``netcdf_engine_order`` in
         ``xarray.set_options()``). A custom backend class (a subclass of
         ``BackendEntrypoint``) can also be used.
-    chunks : int, dict, 'auto', preserve, or None, default: None
+    chunks : int, dict, 'auto', 'dask-auto', or None, default: None
         If provided, used to load the data into dask arrays.
 
-        - ``chunks="auto"`` will use dask ``auto`` chunking taking into account the
+        - ``chunks="dask-auto"`` will use dask ``auto`` chunking taking into account the
           engine preferred chunks.
-        - ``chunks="preserve"`` will use a chunking scheme that never splits encoded
-          chunks. If encoded chunks are small then "preserve" takes multiples of them
+        - ``chunks="auto"`` will use a chunking scheme that never splits encoded
+          chunks. If encoded chunks are small then "auto" takes multiples of them
           over the largest dimension.
         - ``chunks=None`` skips using dask. This uses xarray's internally private
           :ref:`lazy indexing classes <internal design.lazy indexing>`,
@@ -1155,14 +1155,14 @@ def open_groups(
         ``xarray.set_options()``). A custom backend class (a subclass of
         ``BackendEntrypoint``) can also be used.
         can also be used.
-    chunks : int, dict, 'auto', 'preserve', or None, default: None
+    chunks : int, dict, 'auto', 'dask-auto', or None, default: None
         If provided, used to load the data into dask arrays.
 
-        - ``chunks="auto"`` will use dask ``auto`` chunking taking into account the
-          engine preferred chunks.
-        - ``chunks="preserve"`` will use a chunking scheme that never splits encoded
-          chunks. If encoded chunks are small then "preserve" takes multiples of them
+        - ``chunks="auto"`` will use a chunking scheme that never splits encoded
+          chunks. If encoded chunks are small then "auto" takes multiples of them
           over the largest dimension.
+        - ``chunks="dask-auto"`` will use dask ``auto`` chunking taking into account the
+          engine preferred chunks.
         - ``chunks=None`` skips using dask. This uses xarray's internally private
           :ref:`lazy indexing classes <internal design.lazy indexing>`,
           but data is eagerly loaded into memory as numpy arrays when accessed.
@@ -1430,7 +1430,7 @@ def open_mfdataset(
         concatenation along more than one dimension is desired, then ``paths`` must be a
         nested list-of-lists (see ``combine_nested`` for details). (A string glob will
         be expanded to a 1-dimensional list.)
-    chunks : int, dict, 'auto', 'preserve', or None, optional
+    chunks : int, dict, 'auto', 'dask-auto', or None, optional
         Dictionary with keys given by dimension names and values given by chunk sizes.
         In general, these should divide the dimensions of each dataset. If int, chunk
         each dimension by ``chunks``. By default, chunks will be chosen to match the

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -294,7 +294,7 @@ def _dataset_from_backend_dataset(
 ):
     if not isinstance(chunks, int | dict) and chunks not in {None, "auto"}:
         raise ValueError(
-            f"chunks must be an int, dict, 'auto', or None. Instead found {chunks}."
+            f"chunks must be an int, dict, 'auto' or None. Instead found {chunks}."
         )
 
     _protect_dataset_variables_inplace(backend_ds, cache)
@@ -344,7 +344,7 @@ def _datatree_from_backend_datatree(
 ):
     if not isinstance(chunks, int | dict) and chunks not in {None, "auto"}:
         raise ValueError(
-            f"chunks must be an int, dict, 'auto', or None. Instead found {chunks}."
+            f"chunks must be an int, dict, 'auto' or None. Instead found {chunks}."
         )
 
     _protect_datatree_variables_inplace(backend_tree, cache)
@@ -430,7 +430,7 @@ def open_dataset(
         "netcdf4" over "h5netcdf" over "scipy" (customizable via
         ``netcdf_engine_order`` in ``xarray.set_options()``). A custom backend
         class (a subclass of ``BackendEntrypoint``) can also be used.
-    chunks : int, dict, 'auto', or None, default: None
+    chunks : int, dict, 'auto' or None, default: None
         If provided, used to load the data into dask arrays.
 
         - ``chunks="auto"`` will use a chunking scheme that never splits encoded
@@ -675,7 +675,7 @@ def open_dataarray(
         "netcdf4" over "h5netcdf" over "scipy" (customizable via
         ``netcdf_engine_order`` in ``xarray.set_options()``). A custom backend
         class (a subclass of ``BackendEntrypoint``) can also be used.
-    chunks : int, dict, 'auto', or None, default: None
+    chunks : int, dict, 'auto' or None, default: None
         If provided, used to load the data into dask arrays.
 
         - ``chunks="auto"`` will use a chunking scheme that never splits encoded
@@ -902,7 +902,7 @@ def open_datatree(
         "h5netcdf" over "netcdf4" (customizable via ``netcdf_engine_order`` in
         ``xarray.set_options()``). A custom backend class (a subclass of
         ``BackendEntrypoint``) can also be used.
-    chunks : int, dict, 'auto', or None, default: None
+    chunks : int, dict, 'auto' or None, default: None
         If provided, used to load the data into dask arrays.
 
         - ``chunks="auto"`` will use a chunking scheme that never splits encoded
@@ -1149,7 +1149,7 @@ def open_groups(
         ``xarray.set_options()``). A custom backend class (a subclass of
         ``BackendEntrypoint``) can also be used.
         can also be used.
-    chunks : int, dict, 'auto', or None, default: None
+    chunks : int, dict, 'auto' or None, default: None
         If provided, used to load the data into dask arrays.
 
         - ``chunks="auto"`` will use a chunking scheme that never splits encoded
@@ -1422,7 +1422,7 @@ def open_mfdataset(
         concatenation along more than one dimension is desired, then ``paths`` must be a
         nested list-of-lists (see ``combine_nested`` for details). (A string glob will
         be expanded to a 1-dimensional list.)
-    chunks : int, dict, 'auto', or None, optional
+    chunks : int, dict, 'auto' or None, optional
         Dictionary with keys given by dimension names and values given by chunk sizes.
         In general, these should divide the dimensions of each dataset. If int, chunk
         each dimension by ``chunks``. By default, chunks will be chosen to match the

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -430,14 +430,12 @@ def open_dataset(
         "netcdf4" over "h5netcdf" over "scipy" (customizable via
         ``netcdf_engine_order`` in ``xarray.set_options()``). A custom backend
         class (a subclass of ``BackendEntrypoint``) can also be used.
-    chunks : int, dict, 'auto', 'dask-auto' or None, default: None
+    chunks : int, dict, 'auto', or None, default: None
         If provided, used to load the data into dask arrays.
 
         - ``chunks="auto"`` will use a chunking scheme that never splits encoded
           chunks. If encoded chunks are small then "auto" takes multiples of them
           over the largest dimension.
-        - ``chunks="dask-auto"`` will use dask ``auto`` chunking taking into account the
-          engine preferred chunks.
         - ``chunks=None`` skips using dask. This uses xarray's internally private
           :ref:`lazy indexing classes <internal design.lazy indexing>`,
           but data is eagerly loaded into memory as numpy arrays when accessed.
@@ -677,14 +675,12 @@ def open_dataarray(
         "netcdf4" over "h5netcdf" over "scipy" (customizable via
         ``netcdf_engine_order`` in ``xarray.set_options()``). A custom backend
         class (a subclass of ``BackendEntrypoint``) can also be used.
-    chunks : int, dict, 'auto', 'dask-auto', or None, default: None
+    chunks : int, dict, 'auto', or None, default: None
         If provided, used to load the data into dask arrays.
 
         - ``chunks="auto"`` will use a chunking scheme that never splits encoded
           chunks. If encoded chunks are small then "auto" takes multiples of them
           over the largest dimension.
-        - ``chunks='dask-auto'`` will use dask ``auto`` chunking taking into account the
-          engine preferred chunks.
         - ``chunks=None`` skips using dask. This uses xarray's internally private
           :ref:`lazy indexing classes <internal design.lazy indexing>`,
           but data is eagerly loaded into memory as numpy arrays when accessed.
@@ -906,11 +902,9 @@ def open_datatree(
         "h5netcdf" over "netcdf4" (customizable via ``netcdf_engine_order`` in
         ``xarray.set_options()``). A custom backend class (a subclass of
         ``BackendEntrypoint``) can also be used.
-    chunks : int, dict, 'auto', 'dask-auto', or None, default: None
+    chunks : int, dict, 'auto', or None, default: None
         If provided, used to load the data into dask arrays.
 
-        - ``chunks="dask-auto"`` will use dask ``auto`` chunking taking into account the
-          engine preferred chunks.
         - ``chunks="auto"`` will use a chunking scheme that never splits encoded
           chunks. If encoded chunks are small then "auto" takes multiples of them
           over the largest dimension.
@@ -1155,14 +1149,12 @@ def open_groups(
         ``xarray.set_options()``). A custom backend class (a subclass of
         ``BackendEntrypoint``) can also be used.
         can also be used.
-    chunks : int, dict, 'auto', 'dask-auto', or None, default: None
+    chunks : int, dict, 'auto', or None, default: None
         If provided, used to load the data into dask arrays.
 
         - ``chunks="auto"`` will use a chunking scheme that never splits encoded
           chunks. If encoded chunks are small then "auto" takes multiples of them
           over the largest dimension.
-        - ``chunks="dask-auto"`` will use dask ``auto`` chunking taking into account the
-          engine preferred chunks.
         - ``chunks=None`` skips using dask. This uses xarray's internally private
           :ref:`lazy indexing classes <internal design.lazy indexing>`,
           but data is eagerly loaded into memory as numpy arrays when accessed.
@@ -1430,7 +1422,7 @@ def open_mfdataset(
         concatenation along more than one dimension is desired, then ``paths`` must be a
         nested list-of-lists (see ``combine_nested`` for details). (A string glob will
         be expanded to a 1-dimensional list.)
-    chunks : int, dict, 'auto', 'dask-auto', or None, optional
+    chunks : int, dict, 'auto', or None, optional
         Dictionary with keys given by dimension names and values given by chunk sizes.
         In general, these should divide the dimensions of each dataset. If int, chunk
         each dimension by ``chunks``. By default, chunks will be chosen to match the

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -430,11 +430,14 @@ def open_dataset(
         "netcdf4" over "h5netcdf" over "scipy" (customizable via
         ``netcdf_engine_order`` in ``xarray.set_options()``). A custom backend
         class (a subclass of ``BackendEntrypoint``) can also be used.
-    chunks : int, dict, 'auto' or None, default: None
+    chunks : int, dict, 'auto', 'preserve' or None, default: None
         If provided, used to load the data into dask arrays.
 
         - ``chunks="auto"`` will use dask ``auto`` chunking taking into account the
           engine preferred chunks.
+        - ``chunks="preserve"`` will use a chunking scheme that never splits encoded
+          chunks. If encoded chunks are small then "preserve" takes multiples of them
+          over the largest dimension.
         - ``chunks=None`` skips using dask. This uses xarray's internally private
           :ref:`lazy indexing classes <internal design.lazy indexing>`,
           but data is eagerly loaded into memory as numpy arrays when accessed.
@@ -674,11 +677,14 @@ def open_dataarray(
         "netcdf4" over "h5netcdf" over "scipy" (customizable via
         ``netcdf_engine_order`` in ``xarray.set_options()``). A custom backend
         class (a subclass of ``BackendEntrypoint``) can also be used.
-    chunks : int, dict, 'auto' or None, default: None
+    chunks : int, dict, 'auto', 'preserve', or None, default: None
         If provided, used to load the data into dask arrays.
 
         - ``chunks='auto'`` will use dask ``auto`` chunking taking into account the
           engine preferred chunks.
+        - ``chunks="preserve"`` will use a chunking scheme that never splits encoded
+          chunks. If encoded chunks are small then "preserve" takes multiples of them
+          over the largest dimension.
         - ``chunks=None`` skips using dask. This uses xarray's internally private
           :ref:`lazy indexing classes <internal design.lazy indexing>`,
           but data is eagerly loaded into memory as numpy arrays when accessed.
@@ -900,11 +906,14 @@ def open_datatree(
         "h5netcdf" over "netcdf4" (customizable via ``netcdf_engine_order`` in
         ``xarray.set_options()``). A custom backend class (a subclass of
         ``BackendEntrypoint``) can also be used.
-    chunks : int, dict, 'auto' or None, default: None
+    chunks : int, dict, 'auto', preserve, or None, default: None
         If provided, used to load the data into dask arrays.
 
         - ``chunks="auto"`` will use dask ``auto`` chunking taking into account the
           engine preferred chunks.
+        - ``chunks="preserve"`` will use a chunking scheme that never splits encoded
+          chunks. If encoded chunks are small then "preserve" takes multiples of them
+          over the largest dimension.
         - ``chunks=None`` skips using dask. This uses xarray's internally private
           :ref:`lazy indexing classes <internal design.lazy indexing>`,
           but data is eagerly loaded into memory as numpy arrays when accessed.
@@ -1146,11 +1155,14 @@ def open_groups(
         ``xarray.set_options()``). A custom backend class (a subclass of
         ``BackendEntrypoint``) can also be used.
         can also be used.
-    chunks : int, dict, 'auto' or None, default: None
+    chunks : int, dict, 'auto', 'preserve', or None, default: None
         If provided, used to load the data into dask arrays.
 
         - ``chunks="auto"`` will use dask ``auto`` chunking taking into account the
           engine preferred chunks.
+        - ``chunks="preserve"`` will use a chunking scheme that never splits encoded
+          chunks. If encoded chunks are small then "preserve" takes multiples of them
+          over the largest dimension.
         - ``chunks=None`` skips using dask. This uses xarray's internally private
           :ref:`lazy indexing classes <internal design.lazy indexing>`,
           but data is eagerly loaded into memory as numpy arrays when accessed.
@@ -1418,7 +1430,7 @@ def open_mfdataset(
         concatenation along more than one dimension is desired, then ``paths`` must be a
         nested list-of-lists (see ``combine_nested`` for details). (A string glob will
         be expanded to a 1-dimensional list.)
-    chunks : int, dict, 'auto' or None, optional
+    chunks : int, dict, 'auto', 'preserve', or None, optional
         Dictionary with keys given by dimension names and values given by chunk sizes.
         In general, these should divide the dimensions of each dataset. If int, chunk
         each dimension by ``chunks``. By default, chunks will be chosen to match the

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1499,12 +1499,15 @@ def open_zarr(
         Array synchronizer provided to zarr
     group : str, optional
         Group path. (a.k.a. `path` in zarr terminology.)
-    chunks : int, dict, "auto" or None, optional
+    chunks : int, dict, "auto", "preserve", or None, optional
         Used to load the data into dask arrays. Default behavior is to use
         ``chunks={}`` if dask is available, otherwise ``chunks=None``.
 
         - ``chunks='auto'`` will use dask ``auto`` chunking taking into account the
           engine preferred chunks.
+        - ``chunks="preserve"`` will use a chunking scheme that never splits encoded
+          chunks. If encoded chunks are small then "preserve" takes multiples of them
+          over the largest dimension.
         - ``chunks=None`` skips using dask. This uses xarray's internally private
           :ref:`lazy indexing classes <internal design.lazy indexing>`,
           but data is eagerly loaded into memory as numpy arrays when accessed.

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1499,15 +1499,15 @@ def open_zarr(
         Array synchronizer provided to zarr
     group : str, optional
         Group path. (a.k.a. `path` in zarr terminology.)
-    chunks : int, dict, "auto", "preserve", or None, optional
+    chunks : int, dict, "auto", "dask-auto", or None, optional
         Used to load the data into dask arrays. Default behavior is to use
         ``chunks={}`` if dask is available, otherwise ``chunks=None``.
 
-        - ``chunks='auto'`` will use dask ``auto`` chunking taking into account the
-          engine preferred chunks.
-        - ``chunks="preserve"`` will use a chunking scheme that never splits encoded
-          chunks. If encoded chunks are small then "preserve" takes multiples of them
+        - ``chunks="auto"`` will use a chunking scheme that never splits encoded
+          chunks. If encoded chunks are small then "auto" takes multiples of them
           over the largest dimension.
+        - ``chunks='dask-auto'`` will use dask ``auto`` chunking taking into account the
+          engine preferred chunks.
         - ``chunks=None`` skips using dask. This uses xarray's internally private
           :ref:`lazy indexing classes <internal design.lazy indexing>`,
           but data is eagerly loaded into memory as numpy arrays when accessed.

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1499,15 +1499,13 @@ def open_zarr(
         Array synchronizer provided to zarr
     group : str, optional
         Group path. (a.k.a. `path` in zarr terminology.)
-    chunks : int, dict, "auto", "dask-auto", or None, optional
+    chunks : int, dict, "auto", or None, optional
         Used to load the data into dask arrays. Default behavior is to use
         ``chunks={}`` if dask is available, otherwise ``chunks=None``.
 
         - ``chunks="auto"`` will use a chunking scheme that never splits encoded
           chunks. If encoded chunks are small then "auto" takes multiples of them
           over the largest dimension.
-        - ``chunks='dask-auto'`` will use dask ``auto`` chunking taking into account the
-          engine preferred chunks.
         - ``chunks=None`` skips using dask. This uses xarray's internally private
           :ref:`lazy indexing classes <internal design.lazy indexing>`,
           but data is eagerly loaded into memory as numpy arrays when accessed.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2639,11 +2639,11 @@ class Dataset(
                 k,
                 v,
                 chunks_mapping_ints,
+                chunkmanager,
                 token,
                 lock,
                 name_prefix,
                 inline_array=inline_array,
-                chunked_array_type=chunkmanager,
                 from_array_kwargs=from_array_kwargs.copy(),
             )
             for k, v in self.variables.items()

--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -74,7 +74,7 @@ _Chunks = tuple[_Shape, ...]
 _NormalizedChunks = tuple[tuple[int, ...], ...]
 # FYI in some cases we don't allow `None`, which this doesn't take account of.
 # # FYI the `str` is for a size string, e.g. "16MB", supported by dask.
-T_ChunkDim: TypeAlias = str | int | Literal["auto"] | tuple[int, ...] | None  # noqa: PYI051
+T_ChunkDim: TypeAlias = str | int | Literal["auto", "preserve"] | tuple[int, ...] | None  # noqa: PYI051
 # We allow the tuple form of this (though arguably we could transition to named dims only)
 T_Chunks: TypeAlias = T_ChunkDim | Mapping[Any, T_ChunkDim]
 

--- a/xarray/namedarray/_typing.py
+++ b/xarray/namedarray/_typing.py
@@ -74,7 +74,7 @@ _Chunks = tuple[_Shape, ...]
 _NormalizedChunks = tuple[tuple[int, ...], ...]
 # FYI in some cases we don't allow `None`, which this doesn't take account of.
 # # FYI the `str` is for a size string, e.g. "16MB", supported by dask.
-T_ChunkDim: TypeAlias = str | int | Literal["auto", "preserve"] | tuple[int, ...] | None  # noqa: PYI051
+T_ChunkDim: TypeAlias = str | int | Literal["auto"] | tuple[int, ...] | None  # noqa: PYI051
 # We allow the tuple form of this (though arguably we could transition to named dims only)
 T_Chunks: TypeAlias = T_ChunkDim | Mapping[Any, T_ChunkDim]
 

--- a/xarray/namedarray/daskmanager.py
+++ b/xarray/namedarray/daskmanager.py
@@ -43,75 +43,6 @@ class DaskManager(ChunkManagerEntrypoint["DaskArray"]):
     def chunks(self, data: Any) -> _NormalizedChunks:
         return data.chunks  # type: ignore[no-any-return]
 
-    def preserve_chunks(
-        self,
-        chunks: T_Chunks,
-        shape: tuple[int, ...],
-        target: int,
-        typesize: int,
-        previous_chunks: tuple[int],
-    ) -> tuple[int]:
-        """Determine meta chunks
-
-        This takes in a chunks value that contains ``"preserve"`` values in certain
-        dimensions and replaces those values with concrete dimension sizes that try
-        to get chunks to be of a certain size in bytes, provided by the ``limit=``
-        keyword. Any dimensions marked as ``"preserve"`` will potentially be multiplied
-        to get close to the byte target, while never splitting ``previous_chunks``.
-
-        Parameters
-        ----------
-        chunks: tuple[int | str | tuple, ...]
-            A tuple of either dimensions or tuples of explicit chunk dimensions
-            Some entries should be "preserve". Any explicit dimensions must match or
-            be multiple of ``previous_chunks``
-        shape: tuple[int]
-            The shape of the array
-        target: int
-            The target size of the chunk in bytes.
-        typesize: int
-            The size, in bytes, of each element of the chunk.
-        previous_chunks: tuple[int]
-            Size of chunks being preserved. Expressed as a tuple of ints which matches
-            the way chunks are encoded in Zarr.
-        """
-        shape = np.array(shape)
-        previous_chunks = np.array(previous_chunks)
-
-        # "preserve" stays as "preserve"
-        # empty tuple means match previous chunks
-        # -1 means whole dim is in one chunk
-        desired_chunks = np.array(
-            [
-                c or previous_chunks[i] if c != -1 else shape[i]
-                for i, c in enumerate(chunks)
-            ]
-        )
-
-        preserve_chunks = desired_chunks == "preserve"
-        chunks = np.where(preserve_chunks, previous_chunks, desired_chunks).astype(int)
-
-        while True:
-            # Repeatedly loop over the ``previous_chunks``, multiplying them by 2.
-            # Stop when:
-            # 1a. we are larger than the target chunk size OR
-            # 1b. we are within 50% of the target chunk size OR
-            # 2. the chunk covers the entire array
-
-            num_chunks = shape / chunks * preserve_chunks
-            idx = np.argmax(num_chunks)
-            chunk_bytes = np.prod(chunks) * typesize
-
-            if chunk_bytes > target or abs(chunk_bytes - target) / target < 0.5:
-                break
-
-            if (num_chunks <= 1).all():
-                break
-
-            chunks[idx] = min(chunks[idx] * 2, shape[idx])
-
-        return tuple(int(x) for x in chunks)
-
     def normalize_chunks(
         self,
         chunks: T_Chunks | _NormalizedChunks,
@@ -130,7 +61,7 @@ class DaskManager(ChunkManagerEntrypoint["DaskArray"]):
             chunks = self.preserve_chunks(
                 chunks,
                 shape=shape,
-                target=96 * 1024 * 1024,
+                target=self.get_auto_chunk_size(),
                 typesize=dtype.itemsize,
                 previous_chunks=previous_chunks,
             )

--- a/xarray/namedarray/daskmanager.py
+++ b/xarray/namedarray/daskmanager.py
@@ -55,18 +55,6 @@ class DaskManager(ChunkManagerEntrypoint["DaskArray"]):
         """Called by open_dataset"""
         from dask.array.core import normalize_chunks
 
-        if any(c == "preserve" for c in chunks) and any(c == "auto" for c in chunks):
-            raise ValueError('chunks cannot use a combination of "auto" and "preserve"')
-
-        if shape and previous_chunks and any(c == "preserve" for c in chunks):
-            chunks = self.preserve_chunks(
-                chunks,
-                shape=shape,
-                target=self.get_auto_chunk_size(),
-                typesize=getattr(dtype, "itemsize", 8),
-                previous_chunks=previous_chunks,
-            )
-
         return normalize_chunks(
             chunks,
             shape=shape,

--- a/xarray/namedarray/daskmanager.py
+++ b/xarray/namedarray/daskmanager.py
@@ -43,7 +43,7 @@ class DaskManager(ChunkManagerEntrypoint["DaskArray"]):
     def chunks(self, data: Any) -> _NormalizedChunks:
         return data.chunks  # type: ignore[no-any-return]
 
-    def meta_chunks(chunks, shape, target, typesize, encoded_chunks):
+    def meta_chunks(self, chunks, shape, target, typesize, encoded_chunks):
         """Determine meta chunks
 
         This takes in a chunks value that contains ``"auto"`` values in certain

--- a/xarray/namedarray/parallelcompat.py
+++ b/xarray/namedarray/parallelcompat.py
@@ -823,7 +823,7 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
         ...     typesize=8,
         ...     previous_chunks=(128, 128, 1),
         ... )
-        (512, 256, 1)
+        (128, 1024, 1)
 
         >>> ChunkManagerEntrypoint.preserve_chunks(
         ...     chunks=("preserve", "preserve", 1),
@@ -861,6 +861,7 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
                 if isinstance(previous_chunk, tuple):
                     # For uniform chunks just take the first item
                     if previous_chunk[1:-1] == previous_chunk[:-2]:
+                        new_chunks[i] = previous_chunk[0]
                         previous_chunk = previous_chunk[0]
                     # For non-uniform chunks, leave them alone
                     else:
@@ -880,14 +881,13 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
             return chunks
 
         while True:
-            # Repeatedly look for the dim with the most chunks and multiply it by 2.
+            # Repeatedly look for the last dim with more than one chunk and multiply it by 2.
             # Stop when:
             # 1a. we are larger than the target chunk size OR
             # 1b. we are within 50% of the target chunk size OR
             # 2. the chunk covers the entire array
 
             num_chunks = np.array(shape) / max_chunks * auto_dims
-            idx = np.argmax(num_chunks)
             chunk_bytes = np.prod(max_chunks) * typesize
 
             if chunk_bytes > target or abs(chunk_bytes - target) / target < 0.5:
@@ -895,6 +895,8 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
 
             if (num_chunks <= 1).all():
                 break
+
+            idx = int(np.nonzero(num_chunks > 1)[0][-1])
 
             new_chunks[idx] = min(new_chunks[idx] * 2, shape[idx])
             max_chunks[idx] = new_chunks[idx]

--- a/xarray/namedarray/parallelcompat.py
+++ b/xarray/namedarray/parallelcompat.py
@@ -797,13 +797,13 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
         """Quickly determine optimal chunks close to target size but never splitting
         previous_chunks.
 
-        This takes in a chunks argument potentially containing ``"preserve"`` for all
-        dimensions (if scalar) or several dimensions (if tuple). This function
-        replaces ``"preserver"`` with concrete dimension sizes that try
-        to get chunks to be close to certain size in bytes, provided by the ``target=``
+        This takes in a chunks argument potentially containing ``"preserve"`` for several
+        dimensions. This function replaces ``"preserve"`` with concrete dimension sizes that
+        try to get chunks to be close to certain size in bytes, provided by the ``target=``
         keyword. Any dimensions marked as ``"preserve"`` will potentially be multiplied
         by some factor to get close to the byte target, while never splitting
-        ``previous_chunks``.
+        ``previous_chunks``. If chunks are non-uniform along a particular dimension
+        then that dimension will always use exactly ``previous_chunks``.
 
         Examples
         --------
@@ -825,44 +825,59 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
         ... )
         (512, 256, 1)
 
+        >>> ChunkManagerEntrypoint.preserve_chunks(
+        ...     chunks=("preserve", "preserve", 1),
+        ...     shape=(1280, 1280, 20),
+        ...     target=1 * 1024 * 1024,
+        ...     typesize=8,
+        ...     previous_chunks=((128,) * 10, (128, 256, 256, 512), (1,) * 20),
+        ... )
+        (256, (128, 256, 256, 512), 1)
+
         Parameters
         ----------
-        chunks: tuple[int | str | tuple, ...]
+        chunks: tuple[int | str | tuple[int], ...]
             A tuple of either dimensions or tuples of explicit chunk dimensions
-            Some entries should be "preserve". Any explicit dimensions must match or
-            be multiple of ``previous_chunks``
+            Some entries should be "preserve".
         shape: tuple[int]
             The shape of the array
         target: int
             The target size of the chunk in bytes.
         typesize: int
             The size, in bytes, of each element of the chunk.
-        previous_chunks: tuple[int]
-            Size of chunks being preserved. Expressed as a tuple of ints which matches
-            the way chunks are encoded in Zarr.
+        previous_chunks: tuple[int | tuple[int], ...]
+            Size of chunks being preserved. Expressed as a tuple of ints or tuple
+            of tuple of ints.
         """
-        # pop the first item off in case it's a tuple of tuples
-        preferred_chunks = np.array(
-            [c if isinstance(c, int) else c[0] for c in previous_chunks]
-        )
+        new_chunks = [*previous_chunks]
+        auto_dims = [c == "preserve" for c in chunks]
+        max_chunks = np.array(shape)
+        for i, previous_chunk in enumerate(previous_chunks):
+            chunk = chunks[i]
+            if chunk == -1:
+                # -1 means whole dim is in one chunk
+                new_chunks[i] = shape[i]
+            else:
+                if isinstance(previous_chunk, tuple):
+                    # For uniform chunks just take the first item
+                    if previous_chunk[1:-1] == previous_chunk[:-2]:
+                        previous_chunk = previous_chunk[0]
+                    # For non-uniform chunks, leave them alone
+                    else:
+                        auto_dims[i] = False
+                        max_chunks[i] = max(previous_chunk)
 
-        # "preserve" stays as "preserve"
-        # None or empty tuple means match preferred_chunks
-        # -1 means whole dim is in one chunk
-        desired_chunks = np.array(
-            [
-                c or preferred_chunks[i] if c != -1 else shape[i]
-                for i, c in enumerate(chunks)
-            ]
-        )
-        preserve_chunks = desired_chunks == "preserve"
+                if isinstance(previous_chunk, int):
+                    # preserve, None or () means we want to track previous chunk
+                    if chunk == "preserve" or not chunk:
+                        max_chunks[i] = previous_chunk
+                    # otherwise use the explicitly provided chunk
+                    else:
+                        new_chunks[i] = chunk
+                        max_chunks[i] = chunk if isinstance(chunk, int) else max(chunk)
 
-        if not preserve_chunks.any():
+        if not any(auto_dims):
             return chunks
-
-        new_chunks = np.where(preserve_chunks, preferred_chunks, desired_chunks).astype(
-            int
-        )
 
         while True:
             # Repeatedly look for the dim with the most chunks and multiply it by 2.
@@ -871,9 +886,9 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
             # 1b. we are within 50% of the target chunk size OR
             # 2. the chunk covers the entire array
 
-            num_chunks = np.array(shape) / new_chunks * preserve_chunks
+            num_chunks = np.array(shape) / max_chunks * auto_dims
             idx = np.argmax(num_chunks)
-            chunk_bytes = np.prod(new_chunks) * typesize
+            chunk_bytes = np.prod(max_chunks) * typesize
 
             if chunk_bytes > target or abs(chunk_bytes - target) / target < 0.5:
                 break
@@ -882,5 +897,6 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
                 break
 
             new_chunks[idx] = min(new_chunks[idx] * 2, shape[idx])
+            max_chunks[idx] = new_chunks[idx]
 
-        return tuple(int(x) for x in new_chunks)
+        return tuple(new_chunks)

--- a/xarray/namedarray/parallelcompat.py
+++ b/xarray/namedarray/parallelcompat.py
@@ -784,3 +784,72 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
         raise NotImplementedError(
             "For 'auto' rechunking of cftime arrays, get_auto_chunk_size must be implemented by the chunk manager"
         )
+
+    @staticmethod
+    def preserve_chunks(
+        chunks: T_Chunks,
+        shape: tuple[int, ...],
+        target: int,
+        typesize: int,
+        previous_chunks: tuple[int],
+    ) -> tuple[int]:
+        """Determine meta chunks
+
+        This takes in a chunks value that contains ``"preserve"`` values in certain
+        dimensions and replaces those values with concrete dimension sizes that try
+        to get chunks to be of a certain size in bytes, provided by the ``limit=``
+        keyword. Any dimensions marked as ``"preserve"`` will potentially be multiplied
+        to get close to the byte target, while never splitting ``previous_chunks``.
+
+        Parameters
+        ----------
+        chunks: tuple[int | str | tuple, ...]
+            A tuple of either dimensions or tuples of explicit chunk dimensions
+            Some entries should be "preserve". Any explicit dimensions must match or
+            be multiple of ``previous_chunks``
+        shape: tuple[int]
+            The shape of the array
+        target: int
+            The target size of the chunk in bytes.
+        typesize: int
+            The size, in bytes, of each element of the chunk.
+        previous_chunks: tuple[int]
+            Size of chunks being preserved. Expressed as a tuple of ints which matches
+            the way chunks are encoded in Zarr.
+        """
+        shape = np.array(shape)
+        previous_chunks = np.array(previous_chunks)
+
+        # "preserve" stays as "preserve"
+        # empty tuple means match previous chunks
+        # -1 means whole dim is in one chunk
+        desired_chunks = np.array(
+            [
+                c or previous_chunks[i] if c != -1 else shape[i]
+                for i, c in enumerate(chunks)
+            ]
+        )
+
+        preserve_chunks = desired_chunks == "preserve"
+        chunks = np.where(preserve_chunks, previous_chunks, desired_chunks).astype(int)
+
+        while True:
+            # Repeatedly loop over the ``previous_chunks``, multiplying them by 2.
+            # Stop when:
+            # 1a. we are larger than the target chunk size OR
+            # 1b. we are within 50% of the target chunk size OR
+            # 2. the chunk covers the entire array
+
+            num_chunks = shape / chunks * preserve_chunks
+            idx = np.argmax(num_chunks)
+            chunk_bytes = np.prod(chunks) * typesize
+
+            if chunk_bytes > target or abs(chunk_bytes - target) / target < 0.5:
+                break
+
+            if (num_chunks <= 1).all():
+                break
+
+            chunks[idx] = min(chunks[idx] * 2, shape[idx])
+
+        return tuple(int(x) for x in chunks)

--- a/xarray/namedarray/parallelcompat.py
+++ b/xarray/namedarray/parallelcompat.py
@@ -850,7 +850,7 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
             of tuple of ints.
         """
         new_chunks = [*previous_chunks]
-        auto_dims = [c == "preserve" for c in chunks]
+        auto_dims = [c == "auto" for c in chunks]
         max_chunks = np.array(shape)
         for i, previous_chunk in enumerate(previous_chunks):
             chunk = chunks[i]
@@ -869,8 +869,8 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
                         max_chunks[i] = max(previous_chunk)
 
                 if isinstance(previous_chunk, int):
-                    # preserve, None or () means we want to track previous chunk
-                    if chunk == "preserve" or not chunk:
+                    # auto, None or () means we want to track previous chunk
+                    if chunk == "auto" or not chunk:
                         max_chunks[i] = previous_chunk
                     # otherwise use the explicitly provided chunk
                     else:

--- a/xarray/namedarray/parallelcompat.py
+++ b/xarray/namedarray/parallelcompat.py
@@ -794,13 +794,36 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
         typesize: int,
         previous_chunks: tuple[int, ...] | _NormalizedChunks,
     ) -> tuple[T_ChunkDim, ...]:
-        """Determine meta chunks
+        """Quickly determine optimal chunks close to target size but never splitting
+        previous_chunks.
 
-        This takes in a chunks value that contains ``"preserve"`` values in certain
-        dimensions and replaces those values with concrete dimension sizes that try
-        to get chunks to be of a certain size in bytes, provided by the ``limit=``
+        This takes in a chunks argument potentially containing ``"preserve"`` for all
+        dimensions (if scalar) or several dimensions (if tuple). This function
+        replaces ``"preserver"`` with concrete dimension sizes that try
+        to get chunks to be close to certain size in bytes, provided by the ``target=``
         keyword. Any dimensions marked as ``"preserve"`` will potentially be multiplied
-        to get close to the byte target, while never splitting ``previous_chunks``.
+        by some factor to get close to the byte target, while never splitting
+        ``previous_chunks``.
+
+        Examples
+        --------
+        >>> ChunkManagerEntrypoint.preserve_chunks(
+        ...     chunks=("preserve", "preserve", "preserve"),
+        ...     shape=(1280, 1280, 20),
+        ...     target=500 * 1024,
+        ...     typesize=8,
+        ...     previous_chunks=(128, 128, 1),
+        ... )
+        (128, 128, 2)
+
+        >>> ChunkManagerEntrypoint.preserve_chunks(
+        ...     chunks=("preserve", "preserve", 1),
+        ...     shape=(1280, 1280, 20),
+        ...     target=1 * 1024 * 1024,
+        ...     typesize=8,
+        ...     previous_chunks=(128, 128, 1),
+        ... )
+        (512, 256, 1)
 
         Parameters
         ----------
@@ -824,7 +847,7 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
         )
 
         # "preserve" stays as "preserve"
-        # None or empty tuple means match previous chunks
+        # None or empty tuple means match preferred_chunks
         # -1 means whole dim is in one chunk
         desired_chunks = np.array(
             [
@@ -842,7 +865,7 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
         )
 
         while True:
-            # Repeatedly loop over the ``previous_chunks``, multiplying them by 2.
+            # Repeatedly look for the dim with the most chunks and multiply it by 2.
             # Stop when:
             # 1a. we are larger than the target chunk size OR
             # 1b. we are within 50% of the target chunk size OR

--- a/xarray/namedarray/parallelcompat.py
+++ b/xarray/namedarray/parallelcompat.py
@@ -797,10 +797,10 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
         """Quickly determine optimal chunks close to target size but never splitting
         previous_chunks.
 
-        This takes in a chunks argument potentially containing ``"preserve"`` for several
-        dimensions. This function replaces ``"preserve"`` with concrete dimension sizes that
+        This takes in a chunks argument potentially containing ``"auto"`` for several
+        dimensions. This function replaces ``"auto"`` with concrete dimension sizes that
         try to get chunks to be close to certain size in bytes, provided by the ``target=``
-        keyword. Any dimensions marked as ``"preserve"`` will potentially be multiplied
+        keyword. Any dimensions marked as ``"auto"`` will potentially be multiplied
         by some factor to get close to the byte target, while never splitting
         ``previous_chunks``. If chunks are non-uniform along a particular dimension
         then that dimension will always use exactly ``previous_chunks``.
@@ -808,7 +808,7 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
         Examples
         --------
         >>> ChunkManagerEntrypoint.preserve_chunks(
-        ...     chunks=("preserve", "preserve", "preserve"),
+        ...     chunks=("auto", "auto", "auto"),
         ...     shape=(1280, 1280, 20),
         ...     target=500 * 1024,
         ...     typesize=8,
@@ -817,7 +817,7 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
         (128, 128, 2)
 
         >>> ChunkManagerEntrypoint.preserve_chunks(
-        ...     chunks=("preserve", "preserve", 1),
+        ...     chunks=("auto", "auto", 1),
         ...     shape=(1280, 1280, 20),
         ...     target=1 * 1024 * 1024,
         ...     typesize=8,
@@ -826,7 +826,7 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
         (128, 1024, 1)
 
         >>> ChunkManagerEntrypoint.preserve_chunks(
-        ...     chunks=("preserve", "preserve", 1),
+        ...     chunks=("auto", "auto", 1),
         ...     shape=(1280, 1280, 20),
         ...     target=1 * 1024 * 1024,
         ...     typesize=8,
@@ -838,7 +838,7 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
         ----------
         chunks: tuple[int | str | tuple[int], ...]
             A tuple of either dimensions or tuples of explicit chunk dimensions
-            Some entries should be "preserve".
+            Some entries should be "auto".
         shape: tuple[int]
             The shape of the array
         target: int

--- a/xarray/namedarray/parallelcompat.py
+++ b/xarray/namedarray/parallelcompat.py
@@ -20,6 +20,7 @@ from xarray.namedarray.pycompat import is_chunked_array
 
 if TYPE_CHECKING:
     from xarray.namedarray._typing import (
+        T_ChunkDim,
         T_Chunks,
         _Chunks,
         _DType,
@@ -787,12 +788,12 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
 
     @staticmethod
     def preserve_chunks(
-        chunks: T_Chunks,
+        chunks: tuple[T_ChunkDim, ...],
         shape: tuple[int, ...],
         target: int,
         typesize: int,
-        previous_chunks: tuple[int],
-    ) -> tuple[int]:
+        previous_chunks: tuple[int, ...] | _NormalizedChunks,
+    ) -> tuple[T_ChunkDim, ...]:
         """Determine meta chunks
 
         This takes in a chunks value that contains ``"preserve"`` values in certain
@@ -817,21 +818,28 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
             Size of chunks being preserved. Expressed as a tuple of ints which matches
             the way chunks are encoded in Zarr.
         """
-        shape = np.array(shape)
-        previous_chunks = np.array(previous_chunks)
+        # pop the first item off in case it's a tuple of tuples
+        preferred_chunks = np.array(
+            [c if isinstance(c, int) else c[0] for c in previous_chunks]
+        )
 
         # "preserve" stays as "preserve"
-        # empty tuple means match previous chunks
+        # None or empty tuple means match previous chunks
         # -1 means whole dim is in one chunk
         desired_chunks = np.array(
             [
-                c or previous_chunks[i] if c != -1 else shape[i]
+                c or preferred_chunks[i] if c != -1 else shape[i]
                 for i, c in enumerate(chunks)
             ]
         )
-
         preserve_chunks = desired_chunks == "preserve"
-        chunks = np.where(preserve_chunks, previous_chunks, desired_chunks).astype(int)
+
+        if not preserve_chunks.any():
+            return chunks
+
+        new_chunks = np.where(preserve_chunks, preferred_chunks, desired_chunks).astype(
+            int
+        )
 
         while True:
             # Repeatedly loop over the ``previous_chunks``, multiplying them by 2.
@@ -840,9 +848,9 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
             # 1b. we are within 50% of the target chunk size OR
             # 2. the chunk covers the entire array
 
-            num_chunks = shape / chunks * preserve_chunks
+            num_chunks = np.array(shape) / new_chunks * preserve_chunks
             idx = np.argmax(num_chunks)
-            chunk_bytes = np.prod(chunks) * typesize
+            chunk_bytes = np.prod(new_chunks) * typesize
 
             if chunk_bytes > target or abs(chunk_bytes - target) / target < 0.5:
                 break
@@ -850,6 +858,6 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
             if (num_chunks <= 1).all():
                 break
 
-            chunks[idx] = min(chunks[idx] * 2, shape[idx])
+            new_chunks[idx] = min(new_chunks[idx] * 2, shape[idx])
 
-        return tuple(int(x) for x in chunks)
+        return tuple(int(x) for x in new_chunks)

--- a/xarray/namedarray/utils.py
+++ b/xarray/namedarray/utils.py
@@ -236,6 +236,20 @@ def _get_chunk(  # type: ignore[no-untyped-def]
         limit = None
         dtype = data.dtype
 
+    if any(c == "preserve" for c in chunk_shape) and any(
+        c == "auto" for c in chunk_shape
+    ):
+        raise ValueError('chunks cannot use a combination of "auto" and "preserve"')
+
+    if shape and preferred_chunk_shape and any(c == "preserve" for c in chunk_shape):
+        chunk_shape = chunkmanager.preserve_chunks(
+            chunk_shape,
+            shape=shape,
+            target=chunkmanager.get_auto_chunk_size(),
+            typesize=getattr(dtype, "itemsize", 8),
+            previous_chunks=preferred_chunk_shape,
+        )
+
     chunk_shape = chunkmanager.normalize_chunks(
         chunk_shape,
         shape=shape,

--- a/xarray/namedarray/utils.py
+++ b/xarray/namedarray/utils.py
@@ -222,7 +222,7 @@ def _get_chunk(  # type: ignore[no-untyped-def]
     preferred_chunk_shape = tuple(
         itertools.starmap(preferred_chunks.get, zip(dims, shape, strict=True))
     )
-    if isinstance(chunks, Number) or (chunks == "auto"):
+    if isinstance(chunks, (Number, str)):
         chunks = dict.fromkeys(dims, chunks)
     chunk_shape = tuple(
         chunks.get(dim, None) or preferred_chunk_sizes

--- a/xarray/namedarray/utils.py
+++ b/xarray/namedarray/utils.py
@@ -236,12 +236,7 @@ def _get_chunk(  # type: ignore[no-untyped-def]
         limit = None
         dtype = data.dtype
 
-    if any(c == "preserve" for c in chunk_shape) and any(
-        c == "auto" for c in chunk_shape
-    ):
-        raise ValueError('chunks cannot use a combination of "auto" and "preserve"')
-
-    if shape and preferred_chunk_shape and any(c == "preserve" for c in chunk_shape):
+    if shape and preferred_chunk_shape and any(c == "auto" for c in chunk_shape):
         chunk_shape = chunkmanager.preserve_chunks(
             chunk_shape,
             shape=shape,

--- a/xarray/structure/chunks.py
+++ b/xarray/structure/chunks.py
@@ -14,7 +14,6 @@ from xarray.core.variable import Variable
 from xarray.namedarray.parallelcompat import (
     ChunkManagerEntrypoint,
     get_chunked_array_type,
-    guess_chunkmanager,
 )
 
 if TYPE_CHECKING:
@@ -65,12 +64,12 @@ def _maybe_chunk(
     name: Hashable,
     var: Variable,
     chunks: Mapping[Any, T_ChunkDim] | None,
+    chunkmanager: ChunkManagerEntrypoint,
     token=None,
     lock=None,
     name_prefix: str = "xarray-",
     overwrite_encoded_chunks: bool = False,
     inline_array: bool = False,
-    chunked_array_type: str | ChunkManagerEntrypoint | None = None,
     from_array_kwargs=None,
     just_use_token=False,
 ) -> Variable:
@@ -80,10 +79,24 @@ def _maybe_chunk(
         chunks = {dim: chunks[dim] for dim in var.dims if dim in chunks}
 
     if var.ndim:
-        chunked_array_type = guess_chunkmanager(
-            chunked_array_type
-        )  # coerce string to ChunkManagerEntrypoint type
-        if isinstance(chunked_array_type, DaskManager):
+        if (
+            var.shape
+            and var.chunks
+            and chunks
+            and any(c == "auto" for c in chunks.values())
+        ):
+            chunk_shape = chunkmanager.preserve_chunks(
+                tuple(chunks.get(dim, ()) for dim in var.dims),
+                shape=var.shape,
+                target=chunkmanager.get_auto_chunk_size(),
+                typesize=getattr(var.dtype, "itemsize", 8),
+                previous_chunks=var.chunks,
+            )
+            chunks = {
+                dim: chunk_shape[i] for i, dim in enumerate(var.dims) if dim in chunks
+            }
+
+        if isinstance(chunkmanager, DaskManager):
             if not just_use_token:
                 from dask.base import tokenize
 
@@ -104,7 +117,7 @@ def _maybe_chunk(
 
         var = var.chunk(
             chunks,
-            chunked_array_type=chunked_array_type,
+            chunked_array_type=chunkmanager,
             from_array_kwargs=from_array_kwargs,
         )
 

--- a/xarray/testing/strategies.py
+++ b/xarray/testing/strategies.py
@@ -266,15 +266,10 @@ def shape_and_chunks(
             *[st.integers(min_value=min_size, max_value=max_size) for _ in range(ndim)]
         )
     )
-
     # Generate chunks tuple with each element <= corresponding shape element
-    chunks_elements = []
-    for size in shape:
-        # Each chunk is an integer between 1 and the size of that dimension
-        chunk_element = draw(st.integers(min_value=1, max_value=size))
-        chunks_elements.append(chunk_element)
-
-    chunks = tuple(chunks_elements)
+    chunks = draw(
+        st.tuples(*[st.integers(min_value=1, max_value=size) for size in shape])
+    )
     return shape, chunks
 
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -7439,7 +7439,7 @@ def test_chunking_consistency(chunks, tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "chunks,expected",
     [
-        ("preserve", (320, 320)),
+        ("preserve", (160, 500)),
         (-1, (500, 500)),
         ({}, (10, 10)),
         ({"x": "preserve"}, (500, 10)),

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -7405,7 +7405,6 @@ def test_open_dataset_chunking_zarr(chunks, tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "chunks", ["auto", -1, {}, {"x": "auto"}, {"x": -1}, {"x": "auto", "y": -1}]
 )
-@pytest.mark.filterwarnings("ignore:The specified chunks separate")
 def test_chunking_consistency(chunks, tmp_path: Path) -> None:
     encoded_chunks: dict[str, Any] = {}
     dask_arr = da.from_array(
@@ -7439,12 +7438,12 @@ def test_chunking_consistency(chunks, tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "chunks,expected",
     [
-        ("preserve", (160, 500)),
+        ("auto", (160, 500)),
         (-1, (500, 500)),
         ({}, (10, 10)),
-        ({"x": "preserve"}, (500, 10)),
+        ({"x": "auto"}, (500, 10)),
         ({"x": -1}, (500, 10)),
-        ({"x": "preserve", "y": -1}, (160, 500)),
+        ({"x": "auto", "y": -1}, (160, 500)),
     ],
 )
 def test_open_dataset_chunking_zarr_with_preserve(

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -7434,6 +7434,44 @@ def test_chunking_consistency(chunks, tmp_path: Path) -> None:
             xr.testing.assert_chunks_equal(actual, expected)
 
 
+@requires_zarr
+@requires_dask
+@pytest.mark.parametrize(
+    "chunks,expected",
+    [
+        ("preserve", (320, 320)),
+        (-1, (500, 500)),
+        ({}, (10, 10)),
+        ({"x": "preserve"}, (500, 10)),
+        ({"x": -1}, (500, 10)),
+        ({"x": "preserve", "y": -1}, (160, 500)),
+    ],
+)
+def test_open_dataset_chunking_zarr_with_preserve(
+    chunks, expected, tmp_path: Path
+) -> None:
+    encoded_chunks = 10
+    dask_arr = da.from_array(
+        np.ones((500, 500), dtype="float64"), chunks=encoded_chunks
+    )
+    ds = xr.Dataset(
+        {
+            "test": xr.DataArray(
+                dask_arr,
+                dims=("x", "y"),
+            )
+        }
+    )
+    ds["test"].encoding["chunks"] = encoded_chunks
+    ds.to_zarr(tmp_path / "test.zarr")
+
+    with dask.config.set({"array.chunk-size": "1MiB"}):
+        with open_dataset(
+            tmp_path / "test.zarr", engine="zarr", chunks=chunks
+        ) as actual:
+            assert (actual.chunks["x"][0], actual.chunks["y"][0]) == expected
+
+
 def _check_guess_can_open_and_open(entrypoint, obj, engine, expected):
     assert entrypoint.guess_can_open(obj)
     with open_dataset(obj, engine=engine) as actual:


### PR DESCRIPTION
- [x] Towards #8902
  - it doesn't really close it, but it is a better alternative than `chunks={}` or `chunks="auto"`. Since #11010 got in xarra could eventually change the default on `open_zarr` to map it to `"preserve"` rather than to `{}` if dask is available.
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`

## Proposal
A new `chunks` option that is only allowed to use encoded chunks or multiples of them. No chunk splitting allowed. 

## Demo

Current behavior when `chunks="auto"`
```python
ds = xr.open_zarr("gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3", chunks="auto")
```
<img width="1059" height="561" alt="image" src="https://github.com/user-attachments/assets/61ae56d1-2c83-47d5-89a6-6d0fa8e97242" />

This PR introduces a new option: `chunks="preserve"`

```python
ds = xr.open_zarr("gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3", chunks="preserve")
```

<img width="1059" height="417" alt="image" src="https://github.com/user-attachments/assets/21114249-b0a9-4f8a-a369-322150eba13e" />

## Context

I originally set out to update the `auto_chunks` function in dask, but it felt like my goals were actually quite different. The goal of the dask `auto_chunks` function is to guarantee that the chunksize will be under a configurable limit while preserving the aspect ratio of `previous_chunks` (`previous_chunks` == `encoding`). This PR instead guarantees that encoded chunks are never split but it will multiply them by some factor to try to get the chunksize close to a targetsize. It doesn't try to preserve the aspect ratio of the chunks. Instead it goes after the dim where there is the greatest number of chunks and it tries to take those in bigger bites.

Also:
- I'm not quite sure how the interface should work and I am definitely not attached to the word `"preserve"`.
- I originally put this in the DaskManager, but moved it to the base ChunkManagerEntrypoint class once I realized there was nothing dasky about it. I'm not sure if there is really supposed to be logic in methods on that class though.
