### PR TITLE
Add cross-links for apply_ufunc in top-level API documentation

### DIFF
--- a/doc/api/top-level.rst
+++ b/doc/api/top-level.rst
@@ -11,7 +11,7 @@ Computation
    For worked examples and advanced usage of ``apply_ufunc``, see the
    :doc:`User Guide on Computation </user-guide/computation>`, and the
    `apply_ufunc tutorial <https://tutorial.xarray.dev/advanced/apply_ufunc/apply_ufunc.html>`_.
- 
+
 .. autosummary::
    :toctree: ../generated/
 


### PR DESCRIPTION
This PR adds a short note in the top-level API documentation linking `apply_ufunc` to the User Guide, tutorial site, and Gallery example.

This builds on earlier docstring-level cross-linking (e.g. #8311) and makes it easier for users to find related documentation when starting from the API reference, as discussed in #8008.

Scope is intentionally small and focused.

