### PR TITLE
Release v2025.12.1

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -8,8 +8,12 @@ What's New
 
 .. _whats-new.v2025.12.1:
 
-v2025.12.1 (unreleased)
------------------------
+v2025.12.1 (Dec 31, 2025)
+-------------------------
+This release harmonizes ``chunks`` behavior between ``open_zarr`` and ``open_dataset``, improves xindex handling, and contains several bug fixes.
+
+Thanks to the 13 contributors to this release:
+Christine P. Chai, Davis Bennett, Deepak Cherian, Dhruva Kumar Kaushal, Florian Knappers, Ian Hunt-Isaak, Jacob Tomlinson, Julia Signell, Justus Magin, Sam Levang, Simon Høxbro Hansen and Spencer Clark
 
 New Features
 ~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

- Add release date (Dec 31, 2025) and summary to what's-new.rst
- Add contributors list (13 contributors)

This release harmonizes `chunks` behavior between `open_zarr` and `open_dataset`, improves xindex handling, and contains several bug fixes.

## Checklist

After merging this PR:
1. Issue the release on GitHub by creating a new release at https://github.com/pydata/xarray/releases
2. Tag: `v2025.12.1`
3. This will trigger the PyPI upload via GitHub Actions

[This is Claude Code on behalf of Maximilian Roos]

🤖 Generated with [Claude Code](https://claude.com/claude-code)