### PR TITLE
Harmonize encoding from h5netcdf with netcdf4

### DIFF
--- a/ci/policy.yaml
+++ b/ci/policy.yaml
@@ -30,3 +30,7 @@ policy:
   # these packages don't fail the CI, but will be printed in the report
   ignored_violations:
     - array-api-strict
+    # h5netcdf 1.8.0 introduced compatibility features with netcdf4 that we
+    # rely on, so we intentionally require a newer minimum than the policy
+    # https://github.com/pydata/xarray/issues/10657#issuecomment-3711095986
+    - h5netcdf

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -14,6 +14,13 @@ v2026.07.1 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- The ``h5netcdf`` backend now reports compression and filter settings in the
+  variable ``encoding`` consistently with the ``netCDF4`` backend (using
+  ``h5netcdf``'s ``Variable.filters()``). This means data compressed with codecs
+  such as ``zstd`` or ``blosc`` keeps its compression when re-saved, instead of
+  silently being written uncompressed (:issue:`10657`, :pull:`11067`).
+  By `Mark Harfouche <https://github.com/hmaarrfk>`_.
+
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
@@ -30,6 +37,10 @@ Breaking Changes
   - ``chunk_store``: Not supported in zarr-python 3.x.
 
   By `Joe Hamman <https://github.com/jhamman>`_ (:pull:`11232`).
+- The minimum supported version of ``h5netcdf`` is now 1.8.0, which introduced
+  the compatibility features with ``netCDF4`` that the harmonized encoding relies
+  on (:issue:`10657`, :pull:`11067`).
+  By `Mark Harfouche <https://github.com/hmaarrfk>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/pixi.toml
+++ b/pixi.toml
@@ -116,7 +116,9 @@ cftime = "1.6.*"
 dask-core = "2025.2.*"
 distributed = "2025.2.*"
 flox = "0.10.*"
-h5netcdf = "1.5.*"
+# h5netcdf 1.8.0 introduced a few compatibility features with netcdf4
+# https://github.com/pydata/xarray/issues/10657#issuecomment-3711095986
+h5netcdf = "1.8.*"
 # h5py and hdf5 tend to cause conflicts
 # for e.g. hdf5 1.12 conflicts with h5py=3.1
 # prioritize bumping other packages instead

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,9 @@ accel = [
 complete = ["xarray[accel,etc,io,parallel,viz]"]
 io = [
   "netCDF4>=1.6.0",
-  "h5netcdf[h5py]>=1.5.0",
+  # h5netcdf 1.8.0 introduced a few compatibility features with netcdf4
+  # https://github.com/pydata/xarray/issues/10657#issuecomment-3711095986
+  "h5netcdf[h5py]>=1.8.0",
   "pydap",
   "scipy>=1.15",
   "zarr>=3.0",

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -282,16 +282,38 @@ class H5NetCDFStore(WritableCFDataStore):
         data = indexing.LazilyIndexedArray(H5NetCDFArrayWrapper(name, self))
         attrs = _read_attributes(var)
 
-        # netCDF4 specific encoding
-        encoding = {
-            "chunksizes": var.chunks,
-            "fletcher32": var.fletcher32,
-            "shuffle": var.shuffle,
-        }
+        h5py = var._root._h5py
+
+        encoding = {}
+        if (datatype := var.datatype) and isinstance(datatype, h5netcdf.core.EnumType):
+            encoding["dtype"] = np.dtype(
+                data.dtype,
+                metadata={
+                    "enum": datatype.enum_dict,
+                    "enum_name": datatype.name,
+                },
+            )
+        else:
+            vlen_dtype = h5py.check_dtype(vlen=var.dtype)
+            if vlen_dtype is str:
+                encoding["dtype"] = str
+            else:
+                # xarray doesn't support writing arbitrary vlen dtypes yet, so
+                # they fall back to the variable's dtype here.
+                encoding["dtype"] = var.dtype
+
         if var.chunks:
+            encoding["contiguous"] = False
+            encoding["chunksizes"] = var.chunks
             encoding["preferred_chunks"] = dict(
                 zip(var.dimensions, var.chunks, strict=True)
             )
+        else:
+            encoding["contiguous"] = True
+            encoding["chunksizes"] = None
+
+        encoding.update(var.filters())
+
         # Convert h5py-style compression options to NetCDF4-Python
         # style, if possible
         if var.compression == "gzip":
@@ -304,28 +326,6 @@ class H5NetCDFStore(WritableCFDataStore):
         # save source so __repr__ can detect if it's local or not
         encoding["source"] = self._filename
         encoding["original_shape"] = data.shape
-
-        h5py = var._root._h5py
-        vlen_dtype = h5py.check_dtype(vlen=var.dtype)
-        if vlen_dtype is str:
-            encoding["dtype"] = str
-        elif vlen_dtype is not None:  # pragma: no cover
-            # xarray doesn't support writing arbitrary vlen dtypes yet.
-            pass
-        # just check if datatype is available and create dtype
-        # this check can be removed if h5netcdf >= 1.4.0 for any environment
-        elif (datatype := getattr(var, "datatype", None)) and isinstance(
-            datatype, h5netcdf.core.EnumType
-        ):
-            encoding["dtype"] = np.dtype(
-                data.dtype,
-                metadata={
-                    "enum": datatype.enum_dict,
-                    "enum_name": datatype.name,
-                },
-            )
-        else:
-            encoding["dtype"] = var.dtype
 
         return Variable(dimensions, data, attrs, encoding)
 

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -268,6 +268,10 @@ def _extract_nc4_variable_encoding(
     safe_to_drop = {"source", "original_shape"}
     valid_encodings = {
         "zlib",
+        "szip",
+        "bzip2",
+        "blosc",
+        "zstd",
         "complevel",
         "fletcher32",
         "contiguous",
@@ -313,6 +317,27 @@ def _extract_nc4_variable_encoding(
     for k in safe_to_drop:
         if k in encoding:
             del encoding[k]
+
+    # Translate the boolean netCDF4-Python style compression flags (as produced
+    # by h5netcdf's ``variable.filters()``) into a single h5py-style
+    # ``compression`` string. At most one of these is ever true for a given
+    # variable; if several were set we keep the last one.
+    compression = None
+    if encoding.pop("zlib", False):
+        compression = "zlib"
+    if encoding.pop("szip", False):
+        compression = "szip"
+    if encoding.pop("bzip2", False):
+        compression = "bzip2"
+    if encoding.pop("blosc", False):
+        compression = "blosc"
+    if encoding.pop("zstd", False):
+        compression = "zstd"
+
+    # If both styles are used together, the explicit h5py-style ``compression``
+    # takes precedence over the translated netCDF4-Python style flag.
+    if compression is not None and encoding.get("compression") is None:
+        encoding["compression"] = compression
 
     if raise_on_invalid:
         invalid = [k for k in encoding if k not in valid_encodings]

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -247,10 +247,6 @@ has_netCDF4_1_6_2_or_above, requires_netCDF4_1_6_2_or_above = _importorskip(
     "netCDF4", "1.6.2"
 )
 
-has_h5netcdf_1_7_0_or_above, requires_h5netcdf_1_7_0_or_above = _importorskip(
-    "h5netcdf", "1.7.0.dev"
-)
-
 has_netCDF4_1_7_0_or_above, requires_netCDF4_1_7_0_or_above = _importorskip(
     "netCDF4", "1.7.0"
 )

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -90,7 +90,6 @@ from xarray.tests import (
     requires_dask,
     requires_fsspec,
     requires_h5netcdf,
-    requires_h5netcdf_1_7_0_or_above,
     requires_h5netcdf_or_netCDF4,
     requires_h5netcdf_ros3,
     requires_iris,
@@ -4673,7 +4672,6 @@ class TestNetCDF4ClassicViaNetCDF4Data(NetCDF3Only, CFEncodedBase):
             assert ds._h5file.attrs["foo"].dtype == np.dtype("S3")
 
 
-@requires_h5netcdf_1_7_0_or_above
 class TestNetCDF4ClassicViaH5NetCDFData(TestNetCDF4ClassicViaNetCDF4Data):
     engine: T_NetcdfEngine = "h5netcdf"
     file_format: T_NetcdfTypes = "NETCDF4_CLASSIC"
@@ -4925,17 +4923,6 @@ class TestH5NetCDFData(NetCDF4Base):
             with open_dataset(tmp_file, engine="h5netcdf") as actual:
                 assert actual.x.encoding["zlib"] is True
                 assert actual.x.encoding["complevel"] == 6
-
-        # Incompatible encodings cause a crash
-        with create_tmp_file() as tmp_file:
-            with pytest.raises(
-                ValueError, match=r"'zlib' and 'compression' encodings mismatch"
-            ):
-                data.to_netcdf(
-                    tmp_file,
-                    engine="h5netcdf",
-                    encoding={"x": {"compression": "lzf", "zlib": True}},
-                )
 
         with create_tmp_file() as tmp_file:
             with pytest.raises(


### PR DESCRIPTION
We were trying to figure why certain compression features were not included in our h5netcdf backend.

This PR to h5netcdf should provide the filters variable, but I understand that it is too bleeding edge for you all to pin to https://github.com/h5netcdf/h5netcdf/pull/307

xref: https://github.com/pydata/xarray/issues/10657

Ultimately, I don't think you can change the backend without ensuring it is "drop in replacement" at least in what concerns metadata.
Critically, if you compress certain data with zstd, and you try to resave it, it would be saved as 'raw' ruining any gains you had from the compression.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`


I used AI (Claude) to help me fix the linter problems.