### PR TITLE
End of deprecation cycle: default to using new combine kwargs

### DIFF
--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -477,6 +477,12 @@ class TestNestedCombine:
         ds1 = Dataset({"a": ("x", [1, 2]), "x": [0, 1]})
         ds2 = Dataset({"a": ("x", [2, 3]), "x": [1, 2]})
         expected = Dataset({"a": ("x", [1, 2, 3]), "x": [0, 1, 2]})
+        with pytest.warns(
+            FutureWarning,
+            match="will change from compat='no_conflicts' to compat='override'",
+        ):
+            actual = combine_nested([ds1, ds2], join="outer", concat_dim=None)
+        assert_identical(expected, actual)
         actual = combine_nested(
             [ds1, ds2], join="outer", compat="no_conflicts", concat_dim=None
         )
@@ -491,6 +497,11 @@ class TestNestedCombine:
         tmp2 = Dataset({"x": np.nan})
         actual = combine_nested([tmp1, tmp2], compat="no_conflicts", concat_dim=None)
         assert_identical(tmp1, actual)
+        with pytest.warns(
+            FutureWarning,
+            match="will change from compat='no_conflicts' to compat='override'",
+        ):
+            combine_nested([tmp1, tmp2], concat_dim=None)
         actual = combine_nested([tmp1, tmp2], compat="no_conflicts", concat_dim=[None])
         assert_identical(tmp1, actual)
 
@@ -1044,7 +1055,8 @@ class TestCombineDatasetsbyCoords:
         expected = data
         assert expected.broadcast_equals(actual)  # type: ignore[arg-type]
 
-        actual = combine_by_coords(objs)
+        with set_options(use_new_combine_kwarg_defaults=True):
+            actual = combine_by_coords(objs)
         assert_identical(actual, expected)
 
     def test_combine_leaving_bystander_dimensions(self):
@@ -1252,11 +1264,11 @@ class TestNewDefaults:
         expected = Dataset({"a": ("x", [1, 2, 3]), "x": [0, 1, 2]})
         with set_options(use_new_combine_kwarg_defaults=False):
             with pytest.warns(
-                FutureWarning, match="changed from join='outer' to join='exact'"
+                FutureWarning, match="will change from join='outer' to join='exact'"
             ):
                 with pytest.warns(
                     FutureWarning,
-                    match="changed from compat='no_conflicts' to compat='override'",
+                    match="will change from compat='no_conflicts' to compat='override'",
                 ):
                     old = combine_nested([ds1, ds2], concat_dim=None)
         with set_options(use_new_combine_kwarg_defaults=True):
@@ -1271,7 +1283,7 @@ class TestNewDefaults:
         with set_options(use_new_combine_kwarg_defaults=False):
             with pytest.warns(
                 FutureWarning,
-                match="changed from compat='no_conflicts' to compat='override'",
+                match="will change from compat='no_conflicts' to compat='override'",
             ):
                 old = combine_nested([ds1, ds2], concat_dim=None)
         with set_options(use_new_combine_kwarg_defaults=True):
@@ -1283,7 +1295,7 @@ class TestNewDefaults:
         with set_options(use_new_combine_kwarg_defaults=False):
             with pytest.warns(
                 FutureWarning,
-                match="changed from compat='no_conflicts' to compat='override'",
+                match="will change from compat='no_conflicts' to compat='override'",
             ):
                 old = combine_nested([ds2, ds1], concat_dim=None)
         with set_options(use_new_combine_kwarg_defaults=True):
@@ -1319,7 +1331,7 @@ class TestNewDefaults:
         )
         with set_options(use_new_combine_kwarg_defaults=False):
             with pytest.warns(
-                FutureWarning, match="changed from join='outer' to join='exact'"
+                FutureWarning, match="will change from join='outer' to join='exact'"
             ):
                 old = combine_nested(datasets, concat_dim="t")
         with set_options(use_new_combine_kwarg_defaults=True):
@@ -1336,7 +1348,7 @@ class TestNewDefaults:
 
         with set_options(use_new_combine_kwarg_defaults=False):
             with pytest.warns(
-                FutureWarning, match="changed from join='outer' to join='exact'"
+                FutureWarning, match="will change from join='outer' to join='exact'"
             ):
                 old = combine_by_coords(objs)
         with set_options(use_new_combine_kwarg_defaults=True):

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -649,10 +649,15 @@ class TestConcatDataset:
         ds1 = Dataset({"foo": 1.5}, {"y": 1})
         ds2 = Dataset({"foo": 2.5}, {"y": 1})
 
-        with pytest.raises(
-            ValueError, match="data_vars='minimal' and coords='minimal'"
-        ):
-            concat([ds1, ds2], dim="new_dim", data_vars="minimal")
+        with set_options(use_new_combine_kwarg_defaults=False):
+            with pytest.raises(merge.MergeError, match="conflicting values"):
+                concat([ds1, ds2], dim="new_dim", data_vars="minimal")
+
+        with set_options(use_new_combine_kwarg_defaults=True):
+            with pytest.raises(
+                ValueError, match="data_vars='minimal' and coords='minimal'"
+            ):
+                concat([ds1, ds2], dim="new_dim", data_vars="minimal")
 
     def test_concat_size0(self) -> None:
         data = create_test_data()
@@ -974,8 +979,12 @@ class TestConcatDataset:
             Dataset({"y": ("t", [1])}, {"x": 1, "t": [0]}),
             Dataset({"y": ("t", [2])}, {"x": 2, "t": [0]}),
         ]
-        with pytest.raises(ValueError):
-            concat(objs, "t", compat="equals")
+        with set_options(use_new_combine_kwarg_defaults=False):
+            with pytest.raises(ValueError):
+                concat(objs, "t", coords="minimal")
+        with set_options(use_new_combine_kwarg_defaults=True):
+            with pytest.raises(ValueError):
+                concat(objs, "t", compat="equals")
 
     def test_concat_dim_is_variable(self) -> None:
         objs = [Dataset({"x": 0}), Dataset({"x": 1})]
@@ -1493,7 +1502,7 @@ class TestNewDefaults:
         with set_options(use_new_combine_kwarg_defaults=False):
             with pytest.warns(
                 FutureWarning,
-                match="changed from compat='equals' to compat='override'",
+                match="will change from compat='equals' to compat='override'",
             ):
                 actual = concat(
                     [ds1, ds2], dim="y", coords="different", data_vars="different"
@@ -1540,7 +1549,7 @@ class TestNewDefaults:
             expectation: AbstractContextManager = (
                 pytest.warns(
                     FutureWarning,
-                    match="changed from compat='equals' to compat='override'",
+                    match="will change from compat='equals' to compat='override'",
                 )
                 if coords == "different"
                 else nullcontext()
@@ -1565,7 +1574,7 @@ class TestNewDefaults:
         with set_options(use_new_combine_kwarg_defaults=False):
             with pytest.warns(
                 FutureWarning,
-                match="changed from coords='different' to coords='minimal'",
+                match="will change from coords='different' to coords='minimal'",
             ):
                 old = concat(objs, "x")
                 assert_identical(old, expected)
@@ -1653,10 +1662,22 @@ class TestConcatDataTree:
         dt1 = DataTree.from_dict(data={"/a": ("x", [1]), "/b": 3}, coords={"/x": [0]})
         dt2 = DataTree.from_dict(data={"/a": ("x", [2]), "/b": 3}, coords={"/x": [1]})
         expected = DataTree.from_dict(
-            data={"/a": ("x", [1, 2]), "/b": 3}, coords={"/x": [0, 1]}
+            data={"/a": ("x", [1, 2]), "/b": ("x", [3, 3])}, coords={"/x": [0, 1]}
         )
-        actual = concat([dt1, dt2], dim="x")
+        with pytest.warns(
+            FutureWarning, match="will change from data_vars='all' to data_vars=None"
+        ):
+            actual = concat([dt1, dt2], dim="x")
+
         assert actual.identical(expected)
+
+        with set_options(use_new_combine_kwarg_defaults=True):
+            expected = DataTree.from_dict(
+                data={"/a": ("x", [1, 2]), "/b": 3}, coords={"/x": [0, 1]}
+            )
+            actual = concat([dt1, dt2], dim="x")
+
+            assert actual.identical(expected)
 
     def test_concat_datatree_isomorphic_error(self):
         dt1 = DataTree.from_dict(data={"/data": ("x", [1]), "/a": None})

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -471,11 +471,12 @@ class TestDataArrayAndDataset(DaskTestCase):
         assert isinstance(out["d"].data, dask.array.Array)
         assert isinstance(out["c"].data, dask.array.Array)
 
-        out = xr.concat([ds1, ds2, ds3], dim="n", data_vars=[], coords=[])
-        # no extra kernel calls
-        assert kernel_call_count == 6
-        assert isinstance(out["d"].data, dask.array.Array)
-        assert isinstance(out["c"].data, dask.array.Array)
+        with xr.set_options(use_new_combine_kwarg_defaults=True):
+            out = xr.concat([ds1, ds2, ds3], dim="n", data_vars=[], coords=[])
+            # no extra kernel calls
+            assert kernel_call_count == 6
+            assert isinstance(out["d"].data, dask.array.Array)
+            assert isinstance(out["c"].data, dask.array.Array)
 
         out = xr.concat(
             [ds1, ds2, ds3], dim="n", data_vars=[], coords=[], compat="equals"

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1458,13 +1458,17 @@ class TestDataArray:
         expected = data.isel(xy=[0, 1]).unstack("xy").squeeze("y")
         assert_equal(actual, expected)
 
-    def test_concat_with_default_coords(self) -> None:
+    def test_concat_with_default_coords_warns(self) -> None:
         da = DataArray([0, 1], dims=["x"], coords={"x": [0, 1], "y": "a"})
         db = DataArray([2, 3], dims=["x"], coords={"x": [0, 1], "y": "b"})
 
-        # default compat="override" will pick the first one
-        new = xr.concat([da, db], dim="x")
-        assert new.y.size == 1
+        with pytest.warns(FutureWarning):
+            original = xr.concat([da, db], dim="x")
+            assert original.y.size == 4
+        with set_options(use_new_combine_kwarg_defaults=True):
+            # default compat="override" will pick the first one
+            new = xr.concat([da, db], dim="x")
+            assert new.y.size == 1
 
     def test_virtual_default_coords(self) -> None:
         array = DataArray(np.zeros((5,)), dims="x")

--- a/xarray/tests/test_units.py
+++ b/xarray/tests/test_units.py
@@ -745,6 +745,9 @@ def test_broadcast_dataset(dtype):
         "coords",
     ),
 )
+@pytest.mark.filterwarnings(
+    "ignore:.*the default value for coords will change:FutureWarning"
+)
 def test_combine_by_coords(variant, unit, error, dtype):
     original_unit = unit_registry.m
 
@@ -5586,6 +5589,9 @@ class TestDataset:
             ),
             "coords",
         ),
+    )
+    @pytest.mark.filterwarnings(
+        "ignore:.*the default value for compat will change:FutureWarning"
     )
     def test_merge(self, variant, unit, error, dtype):
         left_variants = {


### PR DESCRIPTION
It's been almost 6 months and I haven't seen any reports of issues. All the original PR (#10062) did was raise `FutureWarnings` though, so this could still have an impact on people who ignored those.

- [x] Closes #8778
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] ~New functions/methods are listed in `api.rst`~
