### PR TITLE
add osx-64 to the pixi config.

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,7 +1,7 @@
 [workspace]
 preview = ["pixi-build"]
 channels = ["conda-forge", "nodefaults"]
-platforms = ["win-64", "linux-64", "osx-arm64"]
+platforms = ["win-64", "linux-64", "osx-arm64", "osx-64"]
 
 [package]
 name = "xarray"


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #11136

This adds osx-64 (that's the old Intel mac) to the pixi config, so folks can use the pixi setup on older macs.

It seems to build the environment fine for me.

