### PR TITLE
MAINT(pixi): Update listed xarray version, and update docs cfgrib definition

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -238,9 +238,7 @@ sphinxcontrib-srclinks = "*"
 sphinx-remove-toctrees = "*"
 sphinxext-opengraph = "*"
 sphinxext-rediraffe = "*"
-
-[feature.doc.pypi-dependencies]
-cfgrib = "*" # pypi dep because of https://github.com/prefix-dev/pixi/issues/3032#issuecomment-3302638043
+cfgrib = "*"
 
 [feature.doc.tasks]
 doc = { cmd = "make html", cwd = "doc" }


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

We also needed to update from `version = 'dynamic'` version to fix this (see https://github.com/pydata/xarray/pull/11130#issuecomment-3849274518 , and https://github.com/prefix-dev/pixi/issues/3032#issuecomment-3856604829 for the cfgrib discussion)

ping @jsignell (overlap with your pandas PR)
