### PR TITLE
Improve groupby reduce error message for invalid dimensions

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,6 +36,9 @@ Deprecations
 Bug Fixes
 ~~~~~~~~~
 
+- Improve error message when reducing over non-existent dimensions after
+  ``groupby`` (:issue:`10875`).
+  By `Kristian Kollsga <https://github.com/kkollsga>`_.
 - Fix slicing with negative step (:issue:`11000` and :pull:`11044`).
   By `Antonio Valentino <https://github.com/avalentino>`_.
 - Fix ``.plot`` error when using positional args with ``col`` and

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -770,10 +770,10 @@ def test_groupby_reduce_dimension_error(array) -> None:
     grouped = array.groupby("y")
     # assert_identical(array, grouped.mean())
 
-    with pytest.raises(ValueError, match=r"cannot reduce over dimensions"):
+    with pytest.raises(ValueError, match=r"not found in grouped object dimensions"):
         grouped.mean("huh")
 
-    with pytest.raises(ValueError, match=r"cannot reduce over dimensions"):
+    with pytest.raises(ValueError, match=r"not found in grouped object dimensions"):
         grouped.mean(("x", "y", "asd"))
 
     assert_identical(array.mean("x"), grouped.reduce(np.mean, "x"))


### PR DESCRIPTION
- [x] Closes #10875
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

## Summary

- Improved the error message in `_flox_reduce` (flox path) and `check_reduce_dims` (non-flox path) to show which dimensions are invalid and what the available dimensions are
- Removed the misleading "install the `flox` package" suggestion from the non-flox error path
- Both paths now use a consistent message format: `Dimensions ['bad'] not found in grouped object dimensions ('x', 'y')`
- This matches the `"...not found in data dimensions..."` pattern used throughout the rest of xarray

**Before:**
```
ValueError: cannot reduce over dimensions nonexistent.
```

**After:**
```
ValueError: Dimensions ['nonexistent'] not found in grouped object dimensions ('time', 'space').
```