### PR TITLE
MAINT: Add linkcheck Pixi task

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -269,6 +269,10 @@ html_favicon = "_static/logos/Xarray_Icon_Final.svg"
 html_static_path = ["_static"]
 html_css_files = ["style.css"]
 
+linkcheck_exclude_documents = [
+    r'whats-new.*', # Allow broken links in old release notes
+]
+
 
 # configuration for sphinxext.opengraph
 ogp_site_url = "https://docs.xarray.dev/en/latest/"

--- a/pixi.toml
+++ b/pixi.toml
@@ -243,6 +243,7 @@ cfgrib = "*"
 [feature.doc.tasks]
 doc = { cmd = "make html", cwd = "doc" }
 doc-clean = { cmd = "make clean && make html", cwd = "doc" }
+linkcheck = { cmd = "make linkcheck", cwd = "doc", description = "Check URLs in documentation." }
 
 
 [feature.typing.dependencies]


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes None

There are quite a few broken links (e.g., anchors that are no longer defined on the pages, outright 404s) . This workflow makes it easier to manually check for these links (intentionally not included in CI)

Link checking like this is also a nice smoke test to find parts of the documentation that are out of date and need copy edits (e.g., internal links that still refer to sections that were in old Xarray docs, or parts of the documentation that are old and not in sync with the modern Xarray ecosystem).