### PR TITLE
Fix inconsistent hue color mapping in plot.line

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -38,6 +38,10 @@ Deprecations
 Bug Fixes
 ~~~~~~~~~
 
+- :py:meth:`DataArray.plot.line` now draws lines sharing a hue value with the
+  same color and deduplicates their legend entries, consistent with
+  :py:meth:`DataArray.plot.scatter` (:issue:`10998`, :pull:`11164`).
+  By `Harikrishna KP <https://github.com/Mr-Neutr0n>`_.
 - Fix async zarr tests using ``wraps`` with ``autospec=True`` on async methods,
   which caused ``AsyncMock`` objects to leak through instead of real array data
   (:pull:`11232`).

--- a/xarray/plot/dataarray_plot.py
+++ b/xarray/plot/dataarray_plot.py
@@ -517,43 +517,29 @@ def line(
 
     _ensure_plottable(xplt_val, yplt_val)
 
-    # When plotting 2D data with hue, group lines by hue value so that
-    # lines sharing the same hue are drawn with the same color. Without
-    # this, ax.plot draws each column as a separate line with a new color
-    # from the cycle, causing duplicate hue values to get different colors.
-    # The 2D array can be xplt_val or yplt_val depending on orientation.
-    _has_2d_data = xplt_val.ndim == 2 or yplt_val.ndim == 2
-    if hueplt is not None and _has_2d_data:
-        import matplotlib as mpl
+    primitive = ax.plot(xplt_val, yplt_val, *args, **kwargs)
 
+    # ax.plot draws each column of a 2D array with the next color from the
+    # axes' property cycle, so duplicate hue values get distinct colors.
+    # Recolor so lines sharing a hue value share a color: the k-th hue value
+    # (in order of first appearance) takes the k-th color the axes assigned,
+    # which leaves palettes unchanged whenever the hue values are already
+    # unique and inherits whatever property cycle the axes carries. Skipped
+    # when the caller pinned a color, since every line already shares it.
+    if (
+        hueplt is not None
+        and len(primitive) == hueplt.size
+        and "color" not in kwargs
+        and "c" not in kwargs
+    ):
         hue_values = hueplt.to_numpy()
-        # Unique values in order of first appearance
         unique_hues = list(dict.fromkeys(hue_values))
-
-        # Only assign per-hue colors if the caller didn't set one explicitly
-        user_set_color = "color" in kwargs or "c" in kwargs
-        if not user_set_color:
-            prop_cycle = mpl.rcParams["axes.prop_cycle"]
-            cycle_colors = [p["color"] for p in prop_cycle]
-
-        primitive = []
-        legend_handles = []
-        for idx, hue_val in enumerate(unique_hues):
-            plot_kwargs = dict(kwargs)
-            if not user_set_color:
-                plot_kwargs["color"] = cycle_colors[idx % len(cycle_colors)]
-            # Find all columns belonging to this hue group
-            col_indices = [i for i, h in enumerate(hue_values) if h == hue_val]
-            for col_idx in col_indices:
-                x_vals = xplt_val[:, col_idx] if xplt_val.ndim == 2 else xplt_val
-                y_vals = yplt_val[:, col_idx] if yplt_val.ndim == 2 else yplt_val
-                lines = ax.plot(x_vals, y_vals, *args, **plot_kwargs)
-                primitive.extend(lines)
-                # Keep only the first line per group for the legend
-                if col_idx == col_indices[0]:
-                    legend_handles.extend(lines)
-    else:
-        primitive = ax.plot(xplt_val, yplt_val, *args, **kwargs)
+        color_by_hue: dict[Hashable, Any] = {
+            hue_value: primitive[k].get_color()
+            for k, hue_value in enumerate(unique_hues)
+        }
+        for line2d, hue_value in zip(primitive, hue_values, strict=True):
+            line2d.set_color(color_by_hue[hue_value])
 
     if _labels:
         if xlabel is not None:
@@ -566,11 +552,14 @@ def line(
 
     if darray.ndim == 2 and add_legend:
         assert hueplt is not None
-        hue_values = hueplt.to_numpy()
-        unique_hues = list(dict.fromkeys(hue_values))
+        # One legend entry per hue value, keyed to the first line drawn with
+        # it, so duplicate hue values don't produce duplicate entries.
+        first_line_by_hue: dict[Hashable, Any] = {}
+        for line2d, hue_value in zip(primitive, hueplt.to_numpy(), strict=False):
+            first_line_by_hue.setdefault(hue_value, line2d)
         ax.legend(
-            handles=legend_handles,
-            labels=[str(h) for h in unique_hues],
+            handles=list(first_line_by_hue.values()),
+            labels=list(first_line_by_hue.keys()),
             title=hue_label,
         )
 

--- a/xarray/plot/dataarray_plot.py
+++ b/xarray/plot/dataarray_plot.py
@@ -545,12 +545,8 @@ def line(
             # Find all columns belonging to this hue group
             col_indices = [i for i, h in enumerate(hue_values) if h == hue_val]
             for col_idx in col_indices:
-                x_vals = (
-                    xplt_val[:, col_idx] if xplt_val.ndim == 2 else xplt_val
-                )
-                y_vals = (
-                    yplt_val[:, col_idx] if yplt_val.ndim == 2 else yplt_val
-                )
+                x_vals = xplt_val[:, col_idx] if xplt_val.ndim == 2 else xplt_val
+                y_vals = yplt_val[:, col_idx] if yplt_val.ndim == 2 else yplt_val
                 lines = ax.plot(x_vals, y_vals, *args, **plot_kwargs)
                 primitive.extend(lines)
                 # Keep only the first line per group for the legend

--- a/xarray/plot/dataarray_plot.py
+++ b/xarray/plot/dataarray_plot.py
@@ -517,7 +517,47 @@ def line(
 
     _ensure_plottable(xplt_val, yplt_val)
 
-    primitive = ax.plot(xplt_val, yplt_val, *args, **kwargs)
+    # When plotting 2D data with hue, group lines by hue value so that
+    # lines sharing the same hue are drawn with the same color. Without
+    # this, ax.plot draws each column as a separate line with a new color
+    # from the cycle, causing duplicate hue values to get different colors.
+    # The 2D array can be xplt_val or yplt_val depending on orientation.
+    _has_2d_data = xplt_val.ndim == 2 or yplt_val.ndim == 2
+    if hueplt is not None and _has_2d_data:
+        import matplotlib as mpl
+
+        hue_values = hueplt.to_numpy()
+        # Unique values in order of first appearance
+        unique_hues = list(dict.fromkeys(hue_values))
+
+        # Only assign per-hue colors if the caller didn't set one explicitly
+        user_set_color = "color" in kwargs or "c" in kwargs
+        if not user_set_color:
+            prop_cycle = mpl.rcParams["axes.prop_cycle"]
+            cycle_colors = [p["color"] for p in prop_cycle]
+
+        primitive = []
+        legend_handles = []
+        for idx, hue_val in enumerate(unique_hues):
+            plot_kwargs = dict(kwargs)
+            if not user_set_color:
+                plot_kwargs["color"] = cycle_colors[idx % len(cycle_colors)]
+            # Find all columns belonging to this hue group
+            col_indices = [i for i, h in enumerate(hue_values) if h == hue_val]
+            for col_idx in col_indices:
+                x_vals = (
+                    xplt_val[:, col_idx] if xplt_val.ndim == 2 else xplt_val
+                )
+                y_vals = (
+                    yplt_val[:, col_idx] if yplt_val.ndim == 2 else yplt_val
+                )
+                lines = ax.plot(x_vals, y_vals, *args, **plot_kwargs)
+                primitive.extend(lines)
+                # Keep only the first line per group for the legend
+                if col_idx == col_indices[0]:
+                    legend_handles.extend(lines)
+    else:
+        primitive = ax.plot(xplt_val, yplt_val, *args, **kwargs)
 
     if _labels:
         if xlabel is not None:
@@ -530,7 +570,13 @@ def line(
 
     if darray.ndim == 2 and add_legend:
         assert hueplt is not None
-        ax.legend(handles=primitive, labels=list(hueplt.to_numpy()), title=hue_label)
+        hue_values = hueplt.to_numpy()
+        unique_hues = list(dict.fromkeys(hue_values))
+        ax.legend(
+            handles=legend_handles,
+            labels=[str(h) for h in unique_hues],
+            title=hue_label,
+        )
 
     if isinstance(xplt.dtype, np.dtype) and np.issubdtype(xplt.dtype, np.datetime64):  # type: ignore[redundant-expr]
         _set_concise_date(ax, axis="x")

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -355,6 +355,45 @@ class TestPlot(PlotTestCase):
         assert legend is not None
         assert legend.get_title().get_text() == "dim_1"
 
+    def test_2d_line_duplicate_hue_shares_color(self) -> None:
+        # GH10998: lines sharing a hue value must share a color, and the
+        # legend must carry one entry per hue value, matching scatter.
+        da = xr.DataArray(
+            np.arange(12).reshape(4, 3),
+            dims=("category", "x"),
+            coords={"category": ["a", "a", "b", "b"], "x": [0, 1, 2]},
+        )
+        lines = da.plot.line(hue="category", x="x")
+        colors = [line.get_color() for line in lines]
+        assert colors[0] == colors[1]
+        assert colors[2] == colors[3]
+        assert colors[0] != colors[2]
+
+        legend = plt.gca().get_legend()
+        assert legend is not None
+        assert [t.get_text() for t in legend.get_texts()] == ["a", "b"]
+
+    def test_2d_line_unique_hue_palette_unchanged(self) -> None:
+        # With unique hue values the recoloring must be a no-op: each line
+        # keeps the color the axes' property cycle assigned it.
+        da = xr.DataArray(
+            np.arange(9).reshape(3, 3),
+            dims=("category", "x"),
+            coords={"category": ["a", "b", "c"], "x": [0, 1, 2]},
+        )
+        prop_cycle = mpl.rcParams["axes.prop_cycle"].by_key()["color"]
+        lines = da.plot.line(hue="category", x="x")
+        assert [line.get_color() for line in lines] == prop_cycle[:3]
+
+    def test_2d_line_duplicate_hue_respects_user_color(self) -> None:
+        da = xr.DataArray(
+            np.arange(12).reshape(4, 3),
+            dims=("category", "x"),
+            coords={"category": ["a", "a", "b", "b"], "x": [0, 1, 2]},
+        )
+        lines = da.plot.line(hue="category", x="x", color="green")
+        assert all(line.get_color() == "green" for line in lines)
+
     def test_2d_coords_line_plot(self) -> None:
         lon, lat = np.meshgrid(np.linspace(-20, 20, 5), np.linspace(0, 30, 4))
         lon += lat / 10


### PR DESCRIPTION
## Summary

Fixes #10998

When `plot.line` receives a hue coordinate with duplicate values (e.g., `["a", "a", "b", "b"]`), lines sharing the same hue value now get the same color — matching the behavior of `plot.scatter`.

**Before:** `ax.plot` was called with the full 2D array, so matplotlib assigned each column a new color from the property cycle regardless of hue grouping. With `categories = ["a", "a", "b", "b", "c", "c"]`, all 6 lines got different colors even though there are only 3 unique hue values.

**After:** Lines are grouped by unique hue value and plotted per-group with a consistent color. The legend is also deduplicated to show one entry per unique hue value.

## Changes

- `xarray/plot/dataarray_plot.py` — In the `line()` function, instead of passing the full 2D array to `ax.plot`, iterate over unique hue values and plot each group with a color from the property cycle. Handles both `x=` and `y=` orientations (where either `xplt_val` or `yplt_val` may be 2D). Respects user-specified `color`/`c` kwargs.

## Test plan

- All 519 existing tests in `test_plot.py` pass (including `test_line_plot_along_1d_coord`, `test_2d_line`, and all line-related tests)
- Verified with the exact reproduction script from the issue: lines with hue `"a"` share one color, `"b"` another, `"c"` another, and the legend shows 3 deduplicated entries