### PR TITLE
raise error on slice-based selection of multi-index levels

### DIFF
--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -1308,6 +1308,16 @@ class PandasMultiIndex(PandasIndex):
 
             has_slice = any(isinstance(v, slice) for v in label_values.values())
 
+            if has_slice:
+                slice_levels = [
+                    k for k, v in label_values.items() if isinstance(v, slice)
+                ]
+                raise ValueError(
+                    f"slice-based selection on multi-index level(s) {slice_levels} "
+                    f"is not supported. Use scalar values for multi-index level "
+                    f"selection instead, e.g., ``.sel({slice_levels[0]}=value)``."
+                )
+
             if len(label_values) == self.index.nlevels and not has_slice:
                 indexer = self.index.get_loc(
                     tuple(label_values[k] for k in self.index.names)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2246,6 +2246,12 @@ class TestDataset:
 
         assert_identical(mdata.sel(x={"one": "a", "two": 1}), mdata.sel(one="a", two=1))
 
+        # GH10534: slicing on multi-index levels should raise
+        with pytest.raises(ValueError, match="slice-based selection on multi-index"):
+            mdata.sel(one=slice("a", "b"))
+        with pytest.raises(ValueError, match="slice-based selection on multi-index"):
+            mdata.sel(two=slice(1, 2))
+
     def test_broadcast_like(self) -> None:
         original1 = DataArray(
             np.random.randn(5), [("x", range(5))], name="a"


### PR DESCRIPTION
Fixes #10534.

`.sel(level=slice(...))` on a multi-index level was silently returning wrong results — the slice got passed straight to pandas `get_loc_level`, which interpreted it as a range query on just that one level. Depending on the data, this either returns garbage results or an unhelpful KeyError.

Now it raises a `ValueError` with a message pointing the user to use scalar values instead. Added a test covering both cases.