### PR TITLE
allow triggering the upstream-dev CI if the check is skipped

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cache-pixi-lock
     if: |
-      always() && needs.cache-pixi-lock.conclusion == 'success'
+      always() && needs.cache-pixi-lock.result == 'success'
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
#11096 inadvertently skipped CI if the `detect-ci-trigger` job was skipped. By replacing the default `success()` (`true` only if all previous steps reported `'success'`, everything else, including `'skipped'`, will evaluate to `false`) with `always()` and comparing against the result of the `cache-pixi-lock` step, we can get CI to run on `workflow_dispatch` and `schedule` events again.

This has caused me to believe we don't have any current issues with upstream, when we actually do have breaking tests, see #11183.

cc @doronbehar