### PR TITLE
Revert "Add osx-64 to the pixi config."

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,7 +1,7 @@
 [workspace]
 preview = ["pixi-build"]
 channels = ["conda-forge", "nodefaults"]
-platforms = ["win-64", "linux-64", "osx-arm64", "osx-64"]
+platforms = ["win-64", "linux-64", "osx-arm64"]
 requires-pixi = ">=0.63.2"
 
 [package]


### PR DESCRIPTION
This reverts commit faeae19e5fa922400db80c20dee806393dd9b992.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] xref https://github.com/pydata/xarray/issues/11175#issuecomment-3958439991 and  #11137