### PR TITLE
expose coordinate padding options in .pad

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -39,6 +39,9 @@ Bug Fixes
   By `Ian Hunt-Isaak <https://github.com/ianhi>`_
 - Coerce masked dask arrays to filled (:issue:`9374` :pull:`11157`).
   By `Julia Signell <https://github.com/jsignell>`_
+- Expose ``coord_pad_mode`` and associated parameters in ``Dataset.pad`` and
+  ``DataArray.pad`` (:issue:`3868` :issue:`6425` :pull:`11213`). By `Ian Cooke
+  <https://github.com/ircwaves>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -5998,6 +5998,23 @@ class DataArray(
           * x        (x) float64 32B nan 0.0 1.0 nan
             z        (x) float64 32B nan 100.0 200.0 nan
           * y        (y) int64 32B 10 20 30 40
+
+        Note that the default behavior of coordinate padding uses NaNs (or NaTs), which
+        requires that integer types be promoted to floats.  Providing values via
+        ``coord_constant_values`` then follows the coercion behavior mentioned above,
+        where array types are preserved:
+
+        >>> da.pad(x=1, constant_values=1.23456789, coord_constant_values=-999.9)
+        <xarray.DataArray (x: 4, y: 4)> Size: 128B
+        array([[ 1,  1,  1,  1],
+               [ 0,  1,  2,  3],
+               [10, 11, 12, 13],
+               [ 1,  1,  1,  1]])
+        Coordinates:
+          * x        (x) int64 32B -999 0 1 -999
+            z        (x) int64 32B -999 100 200 -999
+          * y        (y) int64 32B 10 20 30 40
+
         """
         ds = self._to_temp_dataset().pad(
             pad_width=pad_width,

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -5840,6 +5840,19 @@ class DataArray(
         end_values: int | tuple[int, int] | Mapping[Any, tuple[int, int]] | None = None,
         reflect_type: PadReflectOptions = None,
         keep_attrs: bool | None = None,
+        coord_pad_mode: PadModeOptions | None = None,
+        coord_end_values: int
+        | tuple[int, int]
+        | Mapping[Any, tuple[int, int]]
+        | None = None,
+        coord_constant_values: float
+        | tuple[float, float]
+        | Mapping[Any, tuple[float, float]]
+        | None = None,
+        coord_stat_length: (
+            int | tuple[int, int] | Mapping[Any, tuple[int, int]] | None
+        ) = None,
+        coord_reflect_type: PadReflectOptions = None,
         **pad_width_kwargs: Any,
     ) -> Self:
         """Pad this array along one or more dimensions.
@@ -5921,6 +5934,11 @@ class DataArray(
             If True, the attributes (``attrs``) will be copied from the
             original object to the new one. If False, the new object
             will be returned without attributes.
+        coord_pad_mode : see ``mode``, but this will be used to extend the coordinates
+        coord_end_values : see ``end_values``
+        coord_constant_values : see ``constant_values``
+        coord_stat_length : see ``stat_length``
+        coord_reflect_type : see ``reflect_type``
         **pad_width_kwargs
             The keyword arguments form of ``pad_width``.
             One of ``pad_width`` or ``pad_width_kwargs`` must be provided.
@@ -5989,6 +6007,11 @@ class DataArray(
             end_values=end_values,
             reflect_type=reflect_type,
             keep_attrs=keep_attrs,
+            coord_pad_mode=coord_pad_mode,
+            coord_end_values=coord_end_values,
+            coord_constant_values=coord_constant_values,
+            coord_stat_length=coord_stat_length,
+            coord_reflect_type=coord_reflect_type,
             **pad_width_kwargs,
         )
         return self._from_temp_dataset(ds)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8975,6 +8975,16 @@ class Dataset(
         end_values: int | tuple[int, int] | Mapping[Any, tuple[int, int]] | None = None,
         reflect_type: PadReflectOptions = None,
         keep_attrs: bool | None = None,
+        coord_pad_mode: PadModeOptions | None = None,
+        coord_end_values: int
+        | tuple[int, int]
+        | Mapping[Any, tuple[int, int]]
+        | None = None,
+        coord_constant_values: T_DatasetPadConstantValues | None = None,
+        coord_stat_length: (
+            int | tuple[int, int] | Mapping[Any, tuple[int, int]] | None
+        ) = None,
+        coord_reflect_type: PadReflectOptions = None,
         **pad_width_kwargs: Any,
     ) -> Self:
         """Pad this dataset along one or more dimensions.
@@ -9058,6 +9068,11 @@ class Dataset(
             If True, the attributes (``attrs``) will be copied from the
             original object to the new one. If False, the new object
             will be returned without attributes.
+        coord_pad_mode : see ``mode``, but this will be used to extend the coordinates
+        coord_end_values : see ``end_values``
+        coord_constant_values : see ``constant_values``
+        coord_stat_length : see ``stat_length``
+        coord_reflect_type : see ``reflect_type``
         **pad_width_kwargs
             The keyword arguments form of ``pad_width``.
             One of ``pad_width`` or ``pad_width_kwargs`` must be provided.
@@ -9092,17 +9107,39 @@ class Dataset(
         """
         pad_width = either_dict_or_kwargs(pad_width, pad_width_kwargs, "pad")
 
-        if mode in ("edge", "reflect", "symmetric", "wrap"):
-            coord_pad_mode = mode
+        if not coord_pad_mode:
+            # if not provided, use mode dependent default
+            if mode in ("edge", "reflect", "symmetric", "wrap"):
+                coord_pad_mode = mode
+            else:
+                coord_pad_mode = "constant"
+
+        if coord_pad_mode in ("edge", "reflect", "symmetric", "wrap"):
+            # The ternaries here are for backward compatibility, if we can break that,
+            # then this block would be unnecessary
             coord_pad_options = {
-                "stat_length": stat_length,
-                "constant_values": constant_values,
-                "end_values": end_values,
-                "reflect_type": reflect_type,
+                "stat_length": stat_length
+                if coord_stat_length is None
+                else coord_stat_length,
+                "constant_values": (
+                    constant_values
+                    if coord_constant_values is None
+                    else coord_constant_values
+                ),
+                "end_values": end_values
+                if coord_end_values is None
+                else coord_end_values,
+                "reflect_type": (
+                    reflect_type if coord_reflect_type is None else coord_reflect_type
+                ),
             }
         else:
-            coord_pad_mode = "constant"
-            coord_pad_options = {}
+            coord_pad_options = {
+                "stat_length": coord_stat_length,
+                "constant_values": coord_constant_values,
+                "end_values": coord_end_values,
+                "reflect_type": coord_reflect_type,
+            }
 
         if keep_attrs is None:
             keep_attrs = _get_keep_attrs(default=True)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -9114,32 +9114,24 @@ class Dataset(
             else:
                 coord_pad_mode = "constant"
 
+        coord_pad_options = {
+            "stat_length": coord_stat_length,
+            "constant_values": coord_constant_values,
+            "end_values": coord_end_values,
+            "reflect_type": coord_reflect_type,
+        }
+
         if coord_pad_mode in ("edge", "reflect", "symmetric", "wrap"):
-            # The ternaries here are for backward compatibility, if we can break that,
+            # This block is for backward compatibility, if we can break that,
             # then this block would be unnecessary
-            coord_pad_options = {
-                "stat_length": stat_length
-                if coord_stat_length is None
-                else coord_stat_length,
-                "constant_values": (
-                    constant_values
-                    if coord_constant_values is None
-                    else coord_constant_values
-                ),
-                "end_values": end_values
-                if coord_end_values is None
-                else coord_end_values,
-                "reflect_type": (
-                    reflect_type if coord_reflect_type is None else coord_reflect_type
-                ),
-            }
-        else:
-            coord_pad_options = {
-                "stat_length": coord_stat_length,
-                "constant_values": coord_constant_values,
-                "end_values": coord_end_values,
-                "reflect_type": coord_reflect_type,
-            }
+            if coord_pad_options["stat_length"] is None:
+                coord_pad_options["stat_length"] = stat_length
+            if coord_pad_options["constant_values"] is None:
+                coord_pad_options["constant_values"] = constant_values
+            if coord_pad_options["end_values"] is None:
+                coord_pad_options["end_values"] = end_values
+            if coord_pad_options["reflect_type"] is None:
+                coord_pad_options["reflect_type"] = reflect_type
 
         if keep_attrs is None:
             keep_attrs = _get_keep_attrs(default=True)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -7538,6 +7538,54 @@ class TestDataset:
         )
         xr.testing.assert_identical(actual, expected)
 
+    @pytest.mark.parametrize(
+        ["coord_pad_mode", "coord_pad_kwargs", "coord0", "coord9"],
+        [
+            pytest.param("constant", {}, np.nan, np.nan, id="constant(default)"),
+            pytest.param(
+                "constant", {"coord_constant_values": 5}, 5, 5, id="constant(5)"
+            ),
+            pytest.param("edge", {}, 10, 50, id="edge"),
+            pytest.param(
+                "linear_ramp", {"coord_end_values": (-1, 7)}, -1, 7, id="linear_ramp"
+            ),
+            pytest.param(
+                "maximum", {"coord_stat_length": (3, 4)}, 30, 50, id="maximum"
+            ),
+            pytest.param("mean", {"coord_stat_length": (3, 4)}, 20, 35, id="mean"),
+            pytest.param("median", {"coord_stat_length": (3, 4)}, 20, 35, id="median"),
+            pytest.param(
+                "minimum", {"coord_stat_length": (3, 4)}, 10, 20, id="minimum"
+            ),
+            pytest.param(
+                "reflect", {"coord_reflect_type": "odd"}, -20, 70, id="reflect odd"
+            ),
+            pytest.param(
+                "reflect", {"coord_reflect_type": "even"}, 40, 30, id="reflect even"
+            ),
+            pytest.param("symmetric", {}, 30, 40, id="symmetric"),
+            pytest.param("wrap", {}, 30, 20, id="wrap"),
+        ],
+    )
+    def test_pad_coord_pad_mode(
+        self, coord_pad_mode, coord_pad_kwargs, coord0, coord9
+    ) -> None:
+        ds = xr.Dataset(
+            {"a": ("x", [1, 2, 3, 4, 5])}, coords={"x": [10, 20, 30, 40, 50]}
+        )
+        pad_width = {"x": (3, 2)}  # pad 5 elem array out to 10
+        padded = ds.pad(pad_width, coord_pad_mode=coord_pad_mode, **coord_pad_kwargs)
+
+        assert padded.sizes["x"] == 10
+        if np.isnan(coord0):
+            assert np.isnan(padded["x"].values[0])
+        else:
+            assert padded["x"].values[0] == coord0
+        if np.isnan(coord9):
+            assert np.isnan(padded["x"].values[-1])
+        else:
+            assert padded["x"].values[-1] == coord9
+
     def test_astype_attrs(self) -> None:
         data = create_test_data(seed=123)
         data.attrs["foo"] = "bar"


### PR DESCRIPTION
Digging through the backlog with @jsignell, it seems the [coord padding with NaN issue](https://github.com/pydata/xarray/issues/3868#issue-584461380) comes up every now and again.  I've done enough windowed signal processing to know that changing this method's behavior will probably break things for someone, SO this change doesn't break the default type-promotion-and-fill-NaNs behavior.  So, I thought I'd put up this PR that extends the change that @TomNicholas [suggested](https://github.com/pydata/xarray/issues/6425#issuecomment-1082233028) as a first draft of what that might look like.

### Notes

1. This keeps the behavior of using the non-coord parameter (`end_values`, `constant_values`, etc) values for the coord padding parameters in the case where it is inferred from the data padding `mode` parameter.
2. surfaces `coord_` prefixed versions of the data padding parameters.

### Example runs:
No args `da.pad(x=(5,3))`:

```
---------------- initial array ---------------
<xarray.DataArray (x: 3)> Size: 24B
array([0.5, 1.5, 2.5])
Coordinates:
  * x        (x) int64 24B -1 1 3
---------------- call pad ---------------
<xarray.DataArray (x: 11)> Size: 88B
array([nan, nan, nan, nan, nan, 0.5, 1.5, 2.5, nan, nan, nan])
Coordinates:
  * x        (x) float64 88B nan nan nan nan nan -1.0 1.0 3.0 nan nan nan
```

Or  use the new args  for linear ramped coordinates (`da.pad(x=(5, 3), constant_values=-1, coord_end_values=(-11,9), coord_mode="linear_ramp")`):

```
---------------- initial array ---------------
<xarray.DataArray (x: 3)> Size: 24B
array([0.5, 1.5, 2.5])
Coordinates:
  * x        (x) int64 24B -1 1 3
---------------- call pad w/ linear_ramp on coodrs---------------
<xarray.DataArray (x: 11)> Size: 88B
array([-1. , -1. , -1. , -1. , -1. ,  0.5,  1.5,  2.5, -1. , -1. , -1. ])
Coordinates:
  * x        (x) int64 88B -11 -9 -7 -5 -3 -1 1 3 5 7 9
```

- [x] Closes #3868 #6425
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- ~[ ] New functions/methods are listed in `api.rst`~
