### PR TITLE
fix(typing): correct chunks parameter type annotation in open_zarr (#11221)

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1414,7 +1414,7 @@ def open_zarr(
     store,
     group=None,
     synchronizer=None,
-    chunks=_default,
+    chunks: int | dict[str, int] | Literal["auto"] | None | type[_default] = _default,
     decode_cf=True,
     mask_and_scale=True,
     decode_times=True,


### PR DESCRIPTION
Fixes #11221

## Problem
The `chunks` parameter in `open_zarr()` lacks proper type annotation. When mypy/pyright analyze code using `open_zarr(chunks='auto')` or similar valid inputs, they fail with:

```
error: Argument of type "Literal['auto']" cannot be assigned to parameter "chunks" of type "Default" in function "open_zarr"
```

This happens because without an explicit type annotation, type checkers infer the type from the default value (`_default` sentinel), which is overly restrictive.

## Solution
Add explicit type annotation to the `chunks` parameter that accepts all documented valid types:
- `int`: Single chunk size for all dimensions
- `dict[str, int]`: Chunk sizes per dimension
- `Literal['auto']`: Use dask auto chunking
- `None`: Skip dask
- `type[_default]`: Use library defaults

## Changes
- Single-line change to add type annotation in `open_zarr` function signature
- No runtime behavior changes, purely for type checking

## Testing
- Minimal, focused change
- Directly addresses the type checking issue reported
- Aligns with documented function behavior