### PR TITLE
Fix failing CI on main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,7 +310,6 @@ asyncio_default_fixture_loop_scope = "function"
 addopts = [
   "--strict-config",
   "--strict-markers",
-  "--mypy-no-silence-site-packages",
   "--mypy-pyproject-toml-file=pyproject.toml",
 ]
 


### PR DESCRIPTION
CI is failing on main with errors like:

```
ERROR: usage: __main__.py [options] [file_or_dir] [file_or_dir] [...]
__main__.py: error: unrecognized arguments: --mypy-only-local-stub
  inifile: /home/runner/work/xarray/xarray/pyproject.toml
  rootdir: /home/runner/work/xarray/xarray
```

This PR ~~changes~~ removes "mypy-only-local-stub" ~~to "mypy-no-silence-site-packages"~~ because it feels like what we are seeing is probably https://github.com/typeddjango/pytest-mypy-plugins/blob/4.0.0/CHANGELOG.md?plain=1#L7-L9