### PR TITLE
DOC: Update docstring for Index.from_variables()

### DIFF
--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -85,8 +85,8 @@ class Index:
             to index.
         options : dict-like
             Keyword arguments passed to this constructor. Propagated from
-            the ``**options`` argument of :py:meth:`~xarray.DataArray.set_xindex`
-            or :py:meth:`~xarray.Dataset.set_xindex`.
+            the ``**options`` argument of :py:meth:`xarray.DataArray.set_xindex`
+            or :py:meth:`xarray.Dataset.set_xindex`.
 
         Returns
         -------


### PR DESCRIPTION
There was no mention of the `options` keyword

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes None


Docstring of `Dataset.set_xindex` for reference:

https://github.com/pydata/xarray/blob/bf8da57f3fcc11d925c1a1cd77973a7ddd515f4e/xarray/core/dataset.py#L4983-L5003
