### PR TITLE
fix copy-paste error in the release workflow

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@a0af7a228712d6121d37aba47adf55c1332c9c2e # v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         name: Install Python
         with:
           python-version: "3.12"
@@ -61,7 +61,7 @@ jobs:
     needs: build-artifacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@a0af7a228712d6121d37aba47adf55c1332c9c2e # v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         name: Install Python
         with:
           python-version: "3.12"


### PR DESCRIPTION
- [x] follow-up to #11269

thanks for sharing the online warning about the commit hash on zulip, @maxrjones. For reference, that one was a copy-paste error, the commit exists on `prefix/setup-pixi`.