### PR TITLE
Preserve coordinates after non-leading-dimension groupby reductions

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -120,6 +120,10 @@ Bug Fixes
   By `Emmanuel Ferdman <https://github.com/emmanuel-ferdman>`_.
 - :func:`combine_by_coords` no longer returns an empty dataset when a generator is passed as ``data_objects`` (:issue:`10114`, :pull:`11265`).
   By `Amartya Anand <https://github.com/SurfyPenguin>`_.
+- Preserve non-grouped coordinates in fallback ``groupby`` reductions when grouping
+  by a non-leading dimension reorders the underlying variable dimensions
+  (:issue:`11188`).
+  By `Sarthak <https://github.com/Sarthak160>`_.
 - Fix h5netcdf backend module detection and ros3 tests (:issue:`11243`, :pull:`11274`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -529,7 +529,7 @@ class DataArray(
             indexes = self._indexes
         elif set(self.dims) == set(variable.dims):
             # Shape has changed (e.g. from reduce(..., keepdims=True)
-            new_sizes = dict(zip(self.dims, variable.shape, strict=True))
+            new_sizes = dict(variable.sizes)
             coords = {
                 k: v
                 for k, v in self._coords.items()

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -555,6 +555,18 @@ class TestDataArray:
         assert_identical(actual.coords, coords, check_default_indexes=False)
         assert "x_bnds" not in actual.dims
 
+    def test_replace_maybe_drop_dims_keeps_reordered_coords(self) -> None:
+        array = DataArray(
+            np.empty((0, 2)),
+            dims=("x", "y"),
+            coords={"x": [], "y": [1, 1]},
+        )
+
+        actual = array._replace_maybe_drop_dims(Variable(("y", "x"), np.empty((1, 0))))
+
+        assert "x" in actual.coords
+        assert actual.sizes == {"y": 1, "x": 0}
+
     def test_equals_and_identical(self) -> None:
         orig = DataArray(np.arange(5.0), {"a": 42}, dims="x")
 

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -3202,6 +3202,20 @@ def test_groupby_transpose() -> None:
     assert_identical(first, second.transpose(*first.dims))
 
 
+def test_groupby_non_leading_dim_preserves_coords() -> None:
+    data = xr.DataArray(
+        np.empty((0, 2)),
+        dims=["x", "y"],
+        coords={"x": [], "y": [1, 1]},
+    )
+
+    with xr.set_options(use_flox=False):
+        actual = data.groupby("y").sum()
+
+    assert "x" in actual.coords
+    assert actual.sizes == {"x": 0, "y": 1}
+
+
 @requires_dask
 @pytest.mark.parametrize(
     "grouper, expect_index",


### PR DESCRIPTION
### Description

Fallback `groupby` reductions can reorder variable dimensions before `DataArray._replace_maybe_drop_dims` filters coordinates. That path still zipped shapes against the original dimension order, which dropped unrelated coordinates when the reordered dimensions had different lengths.

This switches that branch to use `variable.sizes` and adds regression coverage for both the helper and the user-visible `groupby` behavior.

### Checklist

- [x] Closes #11188
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst` *(N/A - no new public API)*

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Codex