### PR TITLE
Restore -1 Zarr chunk sentinel handling

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -120,6 +120,9 @@ Bug Fixes
   By `Emmanuel Ferdman <https://github.com/emmanuel-ferdman>`_.
 - :func:`combine_by_coords` no longer returns an empty dataset when a generator is passed as ``data_objects`` (:issue:`10114`, :pull:`11265`).
   By `Amartya Anand <https://github.com/SurfyPenguin>`_.
+- Restore support for ``-1`` chunk sizes in Zarr encoding, mapping them to the
+  full length of each written dimension (:issue:`11288`).
+  By `Sarthak <https://github.com/Sarthak160>`_.
 - Fix h5netcdf backend module detection and ros3 tests (:issue:`11243`, :pull:`11274`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -333,7 +333,7 @@ class ZarrArrayWrapper(BackendArray):
         )
 
 
-def _determine_zarr_chunks(enc_chunks, var_chunks, ndim, name):
+def _determine_zarr_chunks(enc_chunks, var_chunks, ndim, name, shape):
     """
     Given encoding chunks (possibly None or []) and variable chunks
     (possibly None or []).
@@ -389,6 +389,7 @@ def _determine_zarr_chunks(enc_chunks, var_chunks, ndim, name):
             var_chunks,
             ndim,
             name,
+            shape,
         )
 
     for x in enc_chunks_tuple:
@@ -399,6 +400,13 @@ def _determine_zarr_chunks(enc_chunks, var_chunks, ndim, name):
                 f"Instead found encoding['chunks']={enc_chunks_tuple!r} "
                 f"for variable named {name!r}."
             )
+
+    # Preserve xarray's documented convention that -1 means the full length
+    # of a dimension when encoding chunk sizes for zarr.
+    enc_chunks_tuple = tuple(
+        dim_size if chunk == -1 else chunk
+        for chunk, dim_size in zip(enc_chunks_tuple, shape, strict=True)
+    )
 
     # if there are chunks in encoding and the variable data is a numpy array,
     # we use the specified chunks
@@ -532,6 +540,7 @@ def extract_zarr_variable_encoding(
         var_chunks=variable.chunks,
         ndim=variable.ndim,
         name=name,
+        shape=variable.shape,
     )
     if _zarr_v3() and chunks is None:
         chunks = "auto"

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2908,6 +2908,7 @@ class ZarrBase(CFEncodedBase):
 
         with self.roundtrip(data) as actual:
             assert actual["var2"].encoding["chunks"] == (5, data["var2"].shape[1])
+        assert data["var2"].encoding["chunks"] == (5, -1)
 
     def test_shard_encoding(self) -> None:
         # These datasets have no dask chunks. All chunking/sharding specified in

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2902,6 +2902,13 @@ class ZarrBase(CFEncodedBase):
             with self.roundtrip(data) as actual:
                 pass
 
+    def test_chunk_encoding_full_dimension_sentinel(self) -> None:
+        data = create_test_data()
+        data["var2"].encoding.update({"chunks": (5, -1)})
+
+        with self.roundtrip(data) as actual:
+            assert actual["var2"].encoding["chunks"] == (5, data["var2"].shape[1])
+
     def test_shard_encoding(self) -> None:
         # These datasets have no dask chunks. All chunking/sharding specified in
         # encoding


### PR DESCRIPTION
### Description

`Dataset.to_zarr` and `DataArray.to_zarr` document `-1` as a way to request a full-dimension chunk in the encoding. With zarr v3, passing that sentinel through unchanged now fails because zarr requires non-negative chunk sizes.

This normalizes `-1` to the written dimension length before passing chunk metadata to zarr, preserving the documented behavior and the legacy zarr v2-compatible workflow.

### Checklist

- [x] Closes #11288
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst` *(N/A - no new public API)*

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Codex