### PR TITLE
Warn when explicit dims rename tuple-style DataArray coords

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -181,6 +181,9 @@ Bug Fixes
   By `Emmanuel Ferdman <https://github.com/emmanuel-ferdman>`_.
 - :func:`combine_by_coords` no longer returns an empty dataset when a generator is passed as ``data_objects`` (:issue:`10114`, :pull:`11265`).
   By `Amartya Anand <https://github.com/SurfyPenguin>`_.
+- Warn when tuple-style ``DataArray`` coordinates are renamed by explicitly
+  provided dimension names (:issue:`11234`).
+  By `Asish Kumar <https://github.com/officialasishkumar>`_.
 - Fix h5netcdf backend module detection and ros3 tests (:issue:`11243`, :pull:`11274`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -177,7 +177,7 @@ def _infer_coords_and_dims(
         if any(
             isinstance(coord, tuple)
             and len(coord) >= 2
-            and isinstance(coord[0], str)
+            and hashable(coord[0])
             and coord[0] != dim
             for dim, coord in zip(dims_tuple, coords, strict=True)
         ):
@@ -185,7 +185,7 @@ def _infer_coords_and_dims(
                 "Coordinate names in tuple-style coords are ignored when `dims` "
                 "are provided. Use a mapping for `coords` if you need named "
                 "coordinates.",
-                FutureWarning,
+                UserWarning,
             )
 
     new_coords: Mapping[Hashable, Any]

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -173,6 +173,21 @@ def _infer_coords_and_dims(
         if not hashable(d):
             raise TypeError(f"Dimension {d} is not hashable")
 
+    if coords is not None and not utils.is_dict_like(coords):
+        if any(
+            isinstance(coord, tuple)
+            and len(coord) >= 2
+            and isinstance(coord[0], str)
+            and coord[0] != dim
+            for dim, coord in zip(dims_tuple, coords, strict=True)
+        ):
+            utils.emit_user_level_warning(
+                "Coordinate names in tuple-style coords are ignored when `dims` "
+                "are provided. Use a mapping for `coords` if you need named "
+                "coordinates.",
+                FutureWarning,
+            )
+
     new_coords: Mapping[Hashable, Any]
 
     if isinstance(coords, Coordinates):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -417,11 +417,10 @@ class TestDataArray:
         ):
             actual = DataArray(data, coords=coords, dims=["x", "y"])
 
-        expected = DataArray(
-            data,
+        expected = Dataset(
+            {None: (["x", "y"], data)},
             coords={"x": [0, 1], "y": [-1, -2, -3]},
-            dims=["x", "y"],
-        )
+        )[None]
         assert_identical(expected, actual)
 
     def test_constructor_tuple_coords_no_warning_when_names_match_dims(self) -> None:
@@ -434,11 +433,10 @@ class TestDataArray:
                 dims=["x", "y"],
             )
 
-        expected = DataArray(
-            data,
+        expected = Dataset(
+            {None: (["x", "y"], data)},
             coords={"x": [0, 1], "y": [-1, -2, -3]},
-            dims=["x", "y"],
-        )
+        )[None]
         assert_identical(expected, actual)
 
     def test_constructor_invalid(self) -> None:

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -407,6 +407,40 @@ class TestDataArray:
         expected = DataArray([1, 2, 3], coords=[("x", [0, 1, 2])])
         assert_identical(expected, actual)
 
+    def test_constructor_tuple_coords_warn_when_dims_override_names(self) -> None:
+        data = np.random.random((2, 3))
+        coords = [("a", [0, 1]), ("b", [-1, -2, -3])]
+
+        with pytest.warns(
+            FutureWarning,
+            match="Coordinate names in tuple-style coords are ignored",
+        ):
+            actual = DataArray(data, coords=coords, dims=["x", "y"])
+
+        expected = DataArray(
+            data,
+            coords={"x": [0, 1], "y": [-1, -2, -3]},
+            dims=["x", "y"],
+        )
+        assert_identical(expected, actual)
+
+    def test_constructor_tuple_coords_no_warning_when_names_match_dims(self) -> None:
+        data = np.random.random((2, 3))
+
+        with assert_no_warnings():
+            actual = DataArray(
+                data,
+                coords=[("x", [0, 1]), ("y", [-1, -2, -3])],
+                dims=["x", "y"],
+            )
+
+        expected = DataArray(
+            data,
+            coords={"x": [0, 1], "y": [-1, -2, -3]},
+            dims=["x", "y"],
+        )
+        assert_identical(expected, actual)
+
     def test_constructor_invalid(self) -> None:
         data = np.random.randn(3, 2)
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -412,7 +412,7 @@ class TestDataArray:
         coords = [("a", [0, 1]), ("b", [-1, -2, -3])]
 
         with pytest.warns(
-            FutureWarning,
+            UserWarning,
             match="Coordinate names in tuple-style coords are ignored",
         ):
             actual = DataArray(data, coords=coords, dims=["x", "y"])


### PR DESCRIPTION
### Description
Warn when tuple-style coordinates are passed to `DataArray(...)` together with explicit `dims=` and their tuple names are silently ignored. This adds a user-facing warning for that case, targeted constructor tests, and a whats-new entry.

### Checklist

- [x] Closes #11234
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst` *(N/A - no new public API)*

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Codex

### Test plan

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -o addopts= /tmp/xarray-wt-11234/xarray/tests/test_dataarray.py -k constructor_tuple_coords -q`
