### PR TITLE
Check requires-mark coverage across CI runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,7 +169,8 @@ jobs:
             --timeout 180 \
             --cov=xarray \
             --cov-report=xml \
-            --junitxml=pytest.xml
+            --junitxml=pytest.xml \
+            --report-log=reportlog.jsonl
 
       - name: Upload test results
         if: always()
@@ -177,6 +178,13 @@ jobs:
         with:
           name: Test results for OS ${{ runner.os }} pixi-env ${{ matrix.pixi-env }} pytest-addopts ${{ matrix.pytest-addopts }}
           path: pytest.xml
+
+      - name: Upload report log
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: report-log-${{ runner.os }}-${{ matrix.pixi-env }}-${{ matrix.pytest-addopts || 'default' }}
+          path: reportlog.jsonl
 
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
@@ -188,6 +196,29 @@ jobs:
           env_vars: RUNNER_OS,PYTHON_VERSION
           name: codecov-umbrella
           fail_ci_if_error: false
+
+  requires-coverage:
+    name: Requires marker coverage
+    runs-on: ubuntu-latest
+    needs: test
+    if: needs.test.result == 'success'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download report logs
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          pattern: report-log-*
+          path: report-logs
+
+      - name: Check requires marker coverage
+        run: |
+          python3 ci/check_requires_coverage.py \
+            report-logs \
+            --allowlist ci/requires_coverage_allowlist.txt
 
   event_file:
     name: "Event File"

--- a/ci/check_requires_coverage.py
+++ b/ci/check_requires_coverage.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+"""Check that requires_* tests are exercised in CI.
+
+The CI test matrix should run tests guarded by ``requires_*`` markers in at
+least one environment whenever possible. This script inspects pytest report-log
+files from the test matrix and fails if a test is only ever skipped for a
+``requires`` reason, unless that skip reason is explicitly allowlisted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable
+
+_SKIP_PREFIX = "Skipped: "
+
+
+def iter_reportlog_paths(paths: Iterable[Path]) -> list[Path]:
+    reportlogs: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            reportlogs.extend(sorted(path.rglob("*.jsonl")))
+        elif path.suffix == ".jsonl":
+            reportlogs.append(path)
+    return reportlogs
+
+
+def load_allowlist(path: Path | None) -> set[str]:
+    if path is None:
+        return set()
+
+    allowlist = set()
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            allowlist.add(stripped)
+    return allowlist
+
+
+def _skip_reason(longrepr: object) -> str | None:
+    if isinstance(longrepr, str):
+        reason = longrepr
+    elif isinstance(longrepr, list) and len(longrepr) >= 3:
+        reason = str(longrepr[2])
+    else:
+        return None
+
+    if reason.startswith(_SKIP_PREFIX):
+        return reason.removeprefix(_SKIP_PREFIX)
+    return reason
+
+
+def collect_reportlog_data(reportlogs: Iterable[Path]) -> dict[str, dict[str, set[str]]]:
+    """Return per-nodeid execution and skip information."""
+    data: dict[str, dict[str, set[str]]] = defaultdict(
+        lambda: {"call_outcomes": set(), "skip_reasons": set()}
+    )
+
+    for reportlog in reportlogs:
+        for line in reportlog.read_text().splitlines():
+            record = json.loads(line)
+            if record.get("$report_type") != "TestReport":
+                continue
+
+            nodeid = record.get("nodeid")
+            if not nodeid:
+                continue
+
+            when = record.get("when")
+            outcome = record.get("outcome")
+            if when == "call":
+                data[nodeid]["call_outcomes"].add(str(outcome))
+            elif when == "setup" and outcome == "skipped":
+                reason = _skip_reason(record.get("longrepr"))
+                if reason is not None:
+                    data[nodeid]["skip_reasons"].add(reason)
+
+    return data
+
+
+def uncovered_requires_tests(
+    reportlogs: Iterable[Path],
+    allowlist: set[str],
+) -> dict[str, set[str]]:
+    """Return tests that only ever skipped for a requires reason."""
+    uncovered: dict[str, set[str]] = {}
+    for nodeid, info in collect_reportlog_data(reportlogs).items():
+        if info["call_outcomes"]:
+            continue
+
+        skip_reasons = info["skip_reasons"]
+        if not skip_reasons:
+            continue
+
+        if all(reason.startswith("requires ") for reason in skip_reasons):
+            missing_reasons = skip_reasons - allowlist
+            if missing_reasons:
+                uncovered[nodeid] = missing_reasons
+
+    return uncovered
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate that requires_* tests are exercised somewhere in CI."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="Report-log files or directories containing report-log files.",
+    )
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=None,
+        help="Optional allowlist of skip reasons that are intentionally uncovered in CI.",
+    )
+    args = parser.parse_args(argv)
+
+    reportlogs = iter_reportlog_paths(args.paths)
+    if not reportlogs:
+        raise SystemExit("No report-log files were found.")
+
+    uncovered = uncovered_requires_tests(
+        reportlogs, allowlist=load_allowlist(args.allowlist)
+    )
+
+    if uncovered:
+        print("The following tests are only ever skipped for a requires reason:")
+        for nodeid, reasons in sorted(uncovered.items()):
+            print(f"- {nodeid}: {', '.join(sorted(reasons))}")
+        return 1
+
+    print(f"Checked {len(reportlogs)} report-log file(s); no uncovered requires tests found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check_requires_coverage.py
+++ b/ci/check_requires_coverage.py
@@ -11,10 +11,9 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 _SKIP_PREFIX = "Skipped: "
 
@@ -54,7 +53,9 @@ def _skip_reason(longrepr: object) -> str | None:
     return reason
 
 
-def collect_reportlog_data(reportlogs: Iterable[Path]) -> dict[str, dict[str, set[str]]]:
+def collect_reportlog_data(
+    reportlogs: Iterable[Path],
+) -> dict[str, dict[str, set[str]]]:
     """Return per-nodeid execution and skip information."""
     data: dict[str, dict[str, set[str]]] = defaultdict(
         lambda: {"call_outcomes": set(), "skip_reasons": set()}
@@ -136,7 +137,9 @@ def main(argv: list[str] | None = None) -> int:
             print(f"- {nodeid}: {', '.join(sorted(reasons))}")
         return 1
 
-    print(f"Checked {len(reportlogs)} report-log file(s); no uncovered requires tests found.")
+    print(
+        f"Checked {len(reportlogs)} report-log file(s); no uncovered requires tests found."
+    )
     return 0
 
 

--- a/ci/requires_coverage_allowlist.txt
+++ b/ci/requires_coverage_allowlist.txt
@@ -1,0 +1,3 @@
+# Dependencies intentionally not exercised in GitHub Actions.
+requires cupy
+requires h5netcdf>=1.3.0 and h5py with ros3 support

--- a/ci/test_check_requires_coverage.py
+++ b/ci/test_check_requires_coverage.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ci.check_requires_coverage import uncovered_requires_tests
+
+
+def _write_reportlog(path: Path, records: list[dict[str, object]]) -> Path:
+    path.write_text("\n".join(json.dumps(record) for record in records) + "\n")
+    return path
+
+
+def test_uncovered_requires_test_is_reported(tmp_path: Path) -> None:
+    reportlog = _write_reportlog(
+        tmp_path / "reportlog.jsonl",
+        [
+            {"$report_type": "TestReport", "nodeid": "test_mod.py::test_gpu", "when": "setup", "outcome": "skipped", "longrepr": ["test_mod.py", 12, "Skipped: requires foo"]},
+            {"$report_type": "TestReport", "nodeid": "test_mod.py::test_gpu", "when": "teardown", "outcome": "passed", "longrepr": None},
+        ],
+    )
+
+    uncovered = uncovered_requires_tests([reportlog], allowlist=set())
+
+    assert uncovered == {"test_mod.py::test_gpu": {"requires foo"}}
+
+
+def test_requires_test_is_covered_if_it_runs_elsewhere(tmp_path: Path) -> None:
+    reportlog_a = _write_reportlog(
+        tmp_path / "a.jsonl",
+        [
+            {"$report_type": "TestReport", "nodeid": "test_mod.py::test_optional", "when": "setup", "outcome": "skipped", "longrepr": ["test_mod.py", 12, "Skipped: requires foo"]},
+        ],
+    )
+    reportlog_b = _write_reportlog(
+        tmp_path / "b.jsonl",
+        [
+            {"$report_type": "TestReport", "nodeid": "test_mod.py::test_optional", "when": "setup", "outcome": "passed", "longrepr": None},
+            {"$report_type": "TestReport", "nodeid": "test_mod.py::test_optional", "when": "call", "outcome": "passed", "longrepr": None},
+            {"$report_type": "TestReport", "nodeid": "test_mod.py::test_optional", "when": "teardown", "outcome": "passed", "longrepr": None},
+        ],
+    )
+
+    assert uncovered_requires_tests([reportlog_a, reportlog_b], allowlist=set()) == {}
+
+
+def test_requires_skip_reason_allowlist_is_respected(tmp_path: Path) -> None:
+    reportlog = _write_reportlog(
+        tmp_path / "reportlog.jsonl",
+        [
+            {"$report_type": "TestReport", "nodeid": "test_mod.py::test_ros3", "when": "setup", "outcome": "skipped", "longrepr": ["test_mod.py", 12, "Skipped: requires h5netcdf>=1.3.0 and h5py with ros3 support"]},
+        ],
+    )
+
+    assert (
+        uncovered_requires_tests(
+            [reportlog],
+            allowlist={"requires h5netcdf>=1.3.0 and h5py with ros3 support"},
+        )
+        == {}
+    )
+
+
+def test_requires_skip_with_non_requires_skip_is_considered_covered(
+    tmp_path: Path,
+) -> None:
+    reportlog = _write_reportlog(
+        tmp_path / "reportlog.jsonl",
+        [
+            {
+                "$report_type": "TestReport",
+                "nodeid": "test_mod.py::test_optional",
+                "when": "setup",
+                "outcome": "skipped",
+                "longrepr": ["test_mod.py", 12, "Skipped: requires foo"],
+            },
+            {
+                "$report_type": "TestReport",
+                "nodeid": "test_mod.py::test_optional",
+                "when": "setup",
+                "outcome": "skipped",
+                "longrepr": ["test_mod.py", 12, "Skipped: some other reason"],
+            },
+        ],
+    )
+
+    assert uncovered_requires_tests([reportlog], allowlist=set()) == {}

--- a/ci/test_check_requires_coverage.py
+++ b/ci/test_check_requires_coverage.py
@@ -15,8 +15,20 @@ def test_uncovered_requires_test_is_reported(tmp_path: Path) -> None:
     reportlog = _write_reportlog(
         tmp_path / "reportlog.jsonl",
         [
-            {"$report_type": "TestReport", "nodeid": "test_mod.py::test_gpu", "when": "setup", "outcome": "skipped", "longrepr": ["test_mod.py", 12, "Skipped: requires foo"]},
-            {"$report_type": "TestReport", "nodeid": "test_mod.py::test_gpu", "when": "teardown", "outcome": "passed", "longrepr": None},
+            {
+                "$report_type": "TestReport",
+                "nodeid": "test_mod.py::test_gpu",
+                "when": "setup",
+                "outcome": "skipped",
+                "longrepr": ["test_mod.py", 12, "Skipped: requires foo"],
+            },
+            {
+                "$report_type": "TestReport",
+                "nodeid": "test_mod.py::test_gpu",
+                "when": "teardown",
+                "outcome": "passed",
+                "longrepr": None,
+            },
         ],
     )
 
@@ -29,15 +41,39 @@ def test_requires_test_is_covered_if_it_runs_elsewhere(tmp_path: Path) -> None:
     reportlog_a = _write_reportlog(
         tmp_path / "a.jsonl",
         [
-            {"$report_type": "TestReport", "nodeid": "test_mod.py::test_optional", "when": "setup", "outcome": "skipped", "longrepr": ["test_mod.py", 12, "Skipped: requires foo"]},
+            {
+                "$report_type": "TestReport",
+                "nodeid": "test_mod.py::test_optional",
+                "when": "setup",
+                "outcome": "skipped",
+                "longrepr": ["test_mod.py", 12, "Skipped: requires foo"],
+            },
         ],
     )
     reportlog_b = _write_reportlog(
         tmp_path / "b.jsonl",
         [
-            {"$report_type": "TestReport", "nodeid": "test_mod.py::test_optional", "when": "setup", "outcome": "passed", "longrepr": None},
-            {"$report_type": "TestReport", "nodeid": "test_mod.py::test_optional", "when": "call", "outcome": "passed", "longrepr": None},
-            {"$report_type": "TestReport", "nodeid": "test_mod.py::test_optional", "when": "teardown", "outcome": "passed", "longrepr": None},
+            {
+                "$report_type": "TestReport",
+                "nodeid": "test_mod.py::test_optional",
+                "when": "setup",
+                "outcome": "passed",
+                "longrepr": None,
+            },
+            {
+                "$report_type": "TestReport",
+                "nodeid": "test_mod.py::test_optional",
+                "when": "call",
+                "outcome": "passed",
+                "longrepr": None,
+            },
+            {
+                "$report_type": "TestReport",
+                "nodeid": "test_mod.py::test_optional",
+                "when": "teardown",
+                "outcome": "passed",
+                "longrepr": None,
+            },
         ],
     )
 
@@ -48,7 +84,17 @@ def test_requires_skip_reason_allowlist_is_respected(tmp_path: Path) -> None:
     reportlog = _write_reportlog(
         tmp_path / "reportlog.jsonl",
         [
-            {"$report_type": "TestReport", "nodeid": "test_mod.py::test_ros3", "when": "setup", "outcome": "skipped", "longrepr": ["test_mod.py", 12, "Skipped: requires h5netcdf>=1.3.0 and h5py with ros3 support"]},
+            {
+                "$report_type": "TestReport",
+                "nodeid": "test_mod.py::test_ros3",
+                "when": "setup",
+                "outcome": "skipped",
+                "longrepr": [
+                    "test_mod.py",
+                    12,
+                    "Skipped: requires h5netcdf>=1.3.0 and h5py with ros3 support",
+                ],
+            },
         ],
     )
 


### PR DESCRIPTION
### Description
Add a CI safeguard that uploads `pytest-reportlog` output from each test-matrix job and checks that tests skipped via `requires_*` markers are exercised somewhere in CI, unless the dependency gate is explicitly allowlisted as unsupported in GitHub Actions.

This also adds focused tests for the coverage checker script.

### Checklist

- [x] Closes #11273
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst` *(N/A - internal CI change)*
- [x] New functions/methods are listed in `api.rst` *(N/A - internal tooling change)*

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Codex

### Test plan

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -o addopts= /tmp/xarray-wt-11273/ci/test_check_requires_coverage.py -q`
