### PR TITLE
Address additional upstream deprecation warnings

### DIFF
--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -830,7 +830,7 @@ def cftime_to_nptime(
                     f"standard calendar.  Reason: {e}."
                 ) from e
             else:
-                dt = np.datetime64("NaT")
+                dt = np.datetime64("NaT", time_unit)
         new.append(dt)
     return np.asarray(new).reshape(times.shape)
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -238,7 +238,7 @@ def _possibly_convert_objects(values):
         and values.dtype.kind == "O"
         and Version(pd.__version__) >= Version("3.0.0dev0")
     ):
-        result.dtype = values.dtype
+        result = result.view(values.dtype)
     return result
 
 

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -266,7 +266,7 @@ class TestDatetimeAccessor:
         dates = xr.date_range(
             start="2000/01/01", freq="ME", periods=12, use_cftime=False
         )
-        dates = dates.append(pd.Index([np.datetime64("NaT")]))
+        dates = dates.append(pd.Index([np.datetime64("NaT", "us")]))
         dates = xr.DataArray(dates)
         seasons = xr.DataArray(
             [

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -1391,7 +1391,11 @@ def test_roundtrip_datetime64_nanosecond_precision(
 ) -> None:
     # test for GH7817
     time = np.datetime64(timestr, format)
-    times = [np.datetime64("1970-01-01T00:00:00", format), np.datetime64("NaT"), time]
+    times = [
+        np.datetime64("1970-01-01T00:00:00", format),
+        np.datetime64("NaT", format),
+        time,
+    ]
 
     if use_encoding:
         encoding = dict(dtype=dtype, _FillValue=fill_value)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1335,7 +1335,7 @@ class TestDataset:
         ).to_numpy(copy=True)
         if add_gap:
             # introduce an empty bin
-            time[31 : 31 + ΔN] = np.datetime64("NaT")
+            time[31 : 31 + ΔN] = np.datetime64("NaT", "us")
             time = time[~np.isnat(time)]
         else:
             time = time[:N]

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -723,11 +723,11 @@ def test_argmin_max_error():
     ["array", "expected"],
     [
         (
-            np.array([np.datetime64("2000-01-01"), np.datetime64("NaT")]),
+            np.array([np.datetime64("2000-01-01"), np.datetime64("NaT", "D")]),
             np.array([False, True]),
         ),
         (
-            np.array([np.timedelta64(1, "h"), np.timedelta64("NaT")]),
+            np.array([np.timedelta64(1, "h"), np.timedelta64("NaT", "h")]),
             np.array([False, True]),
         ),
         (

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -726,7 +726,7 @@ def test_groupby_drops_nans(shuffle: bool, chunk: Literal[False] | dict) -> None
         [
             np.datetime64("2001-01-01"),
             np.datetime64("2001-01-01"),
-            np.datetime64("NaT"),
+            np.datetime64("NaT", "D"),
         ],
     )
     expected5 = xr.DataArray(3, [("t", [np.datetime64("2001-01-01")])])
@@ -2018,7 +2018,7 @@ class TestDataArrayResample:
         # missing periods, GH10169
         actual = array.isel(time=[0, 1, 2, 3, 8, 9]).resample(time="1D").last()
         expected = DataArray(
-            np.array([times[3], np.datetime64("NaT"), times[9]]),
+            np.array([times[3], np.datetime64("NaT", "us"), times[9]]),
             dims="time",
             coords={"time": times[::4]},
             name="time",
@@ -3836,7 +3836,7 @@ def test_mean_datetime_edge_cases():
     # Test with NaT values
     dates_with_nat = pd.date_range("2021-01-01", periods=4, freq="D")
     dates_with_nat_array = dates_with_nat.values.copy()
-    dates_with_nat_array[1] = np.datetime64("NaT")
+    dates_with_nat_array[1] = np.datetime64("NaT", "us")
 
     ds = xr.Dataset(
         {


### PR DESCRIPTION
### Description

This PR addresses upstream errors surfaced in this [latest build](https://github.com/pydata/xarray/actions/runs/24281918145/job/70905057343?pr=11270).  Some representative failures can be found below:

<details>
<p>

```
2026-04-11T12:05:56.8329679Z _____________ ERROR collecting xarray/tests/test_duck_array_ops.py _____________
2026-04-11T12:05:56.8330240Z xarray/tests/test_duck_array_ops.py:730: in <module>
2026-04-11T12:05:56.8331067Z     np.array([np.timedelta64(1, "h"), np.timedelta64("NaT")]),
2026-04-11T12:05:56.8331786Z                                       ^^^^^^^^^^^^^^^^^^^^^
2026-04-11T12:05:56.8332599Z E   DeprecationWarning: Using 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. Please use a specific units instead.
2026-04-11T12:05:56.8333444Z ______________ ERROR at setup of test_field_access[360_day-year] _______________
2026-04-11T12:05:56.8334005Z [gw0] linux -- Python 3.13.13 /home/runner/work/xarray/xarray/.pixi/envs/test-nightly/bin/python
2026-04-11T12:05:56.8334362Z
2026-04-11T12:05:56.8334592Z times = array([cftime.Datetime360Day(2000, 1, 1, 0, 0, 0, 0, has_year_zero=True),
2026-04-11T12:05:56.8335350Z        cftime.Datetime360Day(2000, 1, 1, 1, ... 0, has_year_zero=True),
2026-04-11T12:05:56.8335779Z        cftime.Datetime360Day(2000, 1, 5, 3, 0, 0, 0, has_year_zero=True)],
2026-04-11T12:05:56.8336112Z       dtype=object)
2026-04-11T12:05:56.8336230Z
2026-04-11T12:05:56.8336403Z     @pytest.fixture
2026-04-11T12:05:56.8336833Z     def data(times):
2026-04-11T12:05:56.8337346Z         data = np.random.rand(10, 10, _NT)
2026-04-11T12:05:56.8337910Z         lons = np.linspace(0, 11, 10)
2026-04-11T12:05:56.8338491Z         lats = np.linspace(0, 20, 10)
2026-04-11T12:05:56.8338959Z >       return xr.DataArray(
2026-04-11T12:05:56.8340025Z             data, coords=[lons, lats, times], dims=["lon", "lat", "time"], name="data"
2026-04-11T12:05:56.8340972Z         )
2026-04-11T12:05:56.8341103Z
2026-04-11T12:05:56.8341382Z /home/runner/work/xarray/xarray/xarray/tests/test_accessor_dt.py:424:
2026-04-11T12:05:56.8341816Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
2026-04-11T12:05:56.8342337Z /home/runner/work/xarray/xarray/xarray/core/dataarray.py:463: in __init__
2026-04-11T12:05:56.8343168Z     coords, dims = _infer_coords_and_dims(data.shape, coords, dims)
2026-04-11T12:05:56.8343642Z                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-04-11T12:05:56.8344295Z /home/runner/work/xarray/xarray/xarray/core/dataarray.py:189: in _infer_coords_and_dims
2026-04-11T12:05:56.8345185Z     var = as_variable(coord, name=dim, auto_convert=False)
2026-04-11T12:05:56.8345811Z           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-04-11T12:05:56.8346298Z /home/runner/work/xarray/xarray/xarray/core/variable.py:166: in as_variable
2026-04-11T12:05:56.8346818Z     data: T_DuckArray = as_compatible_data(obj)
2026-04-11T12:05:56.8347207Z                         ^^^^^^^^^^^^^^^^^^^^^^^
2026-04-11T12:05:56.8347713Z /home/runner/work/xarray/xarray/xarray/core/variable.py:317: in as_compatible_data
2026-04-11T12:05:56.8348250Z     data = _possibly_convert_objects(data)
2026-04-11T12:05:56.8348616Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-04-11T12:05:56.8348922Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
2026-04-11T12:05:56.8349148Z
2026-04-11T12:05:56.8349357Z values = array([cftime.Datetime360Day(2000, 1, 1, 0, 0, 0, 0, has_year_zero=True),
2026-04-11T12:05:56.8349818Z        cftime.Datetime360Day(2000, 1, 1, 1, ... 0, has_year_zero=True),
2026-04-11T12:05:56.8350231Z        cftime.Datetime360Day(2000, 1, 5, 3, 0, 0, 0, has_year_zero=True)],
2026-04-11T12:05:56.8350563Z       dtype=object)
2026-04-11T12:05:56.8350676Z
2026-04-11T12:05:56.8350999Z     def _possibly_convert_objects(values):
2026-04-11T12:05:56.8351656Z         """Convert object arrays into datetime64 and timedelta64 according
2026-04-11T12:05:56.8352273Z         to the pandas convention.  For backwards compat, as of 3.0.0 pandas,
2026-04-11T12:05:56.8352826Z         object dtype inputs are cast to strings by `pandas.Series`
2026-04-11T12:05:56.8353417Z         but we output them as object dtype with the input metadata preserved as well.
2026-04-11T12:05:56.8353850Z
2026-04-11T12:05:56.8354059Z
2026-04-11T12:05:56.8354305Z         * datetime.datetime
2026-04-11T12:05:56.8354614Z         * datetime.timedelta
2026-04-11T12:05:56.8354917Z         * pd.Timestamp
2026-04-11T12:05:56.8355483Z         * pd.Timedelta
2026-04-11T12:05:56.8355769Z         """
2026-04-11T12:05:56.8356201Z         as_series = pd.Series(values.ravel(), copy=False)
2026-04-11T12:05:56.8356743Z         result = np.asarray(as_series).reshape(values.shape)
2026-04-11T12:05:56.8357250Z         if not result.flags.writeable:
2026-04-11T12:05:56.8357897Z             # GH8843, pandas copy-on-write mode creates read-only arrays by default
2026-04-11T12:05:56.8358409Z             try:
2026-04-11T12:05:56.8358793Z                 result.flags.writeable = True
2026-04-11T12:05:56.8359255Z             except ValueError:
2026-04-11T12:05:56.8359646Z                 result = result.copy()
2026-04-11T12:05:56.8360256Z         # For why we need this behavior: https://github.com/pandas-dev/pandas/issues/61938
2026-04-11T12:05:56.8360893Z         # Object datatype inputs that are strings
2026-04-11T12:05:56.8361504Z         # will be converted to strings by `pandas.Series`, and as of 3.0.0, lose
2026-04-11T12:05:56.8362395Z         # `dtype.metadata`.  If the roundtrip back to numpy in this function yields an
2026-04-11T12:05:56.8363073Z         # object array again, the dtype.metadata will be preserved.
2026-04-11T12:05:56.8363636Z         if (
2026-04-11T12:05:56.8364086Z             result.dtype.kind == "O"
2026-04-11T12:05:56.8364714Z             and values.dtype.kind == "O"
2026-04-11T12:05:56.8365765Z             and Version(pd.__version__) >= Version("3.0.0dev0")
2026-04-11T12:05:56.8366289Z         ):
2026-04-11T12:05:56.8366582Z >           result.dtype = values.dtype
2026-04-11T12:05:56.8366895Z             ^^^^^^^^^^^^
2026-04-11T12:05:56.8367410Z E           DeprecationWarning: Setting the dtype on a NumPy array has been deprecated in NumPy 2.4.
2026-04-11T12:05:56.8368127Z E           Instead of changing the dtype on an array x, create a new array with x.view(new_dtype)
2026-04-11T12:05:56.8368485Z
2026-04-11T12:05:56.8368800Z /home/runner/work/xarray/xarray/xarray/core/variable.py:241: DeprecationWarning
```

</p>
</details>

The switch to non-generic `np.datetime64("NaT")` values is not strictly necessary at this time, but it's not clear whether generic `np.datetime("NaT")` values will be deprecated at some point too, so I figured we might as well switch away from using those as well.  It shouldn't have any impact on behavior.