### PR TITLE
Fix sortby raising KeyError when passed a tuple of dimension names

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -162,6 +162,9 @@ Deprecations
 Bug Fixes
 ~~~~~~~~~
 
+- Fix :py:meth:`DataArray.sortby` and :py:meth:`Dataset.sortby` raising ``KeyError``
+  when passing a tuple of dimension names, e.g. ``da.sortby(da.dims)`` (:issue:`4821`).
+  By `Timothy Hodson <https://github.com/thodson-usgs>`_.
 - Fix multi-coordinate indexes being dropped in :py:meth:`DataArray._replace_maybe_drop_dims`
   (e.g. after reducing over an unrelated dimension) and in :py:meth:`Dataset._copy_listed`
   (e.g. when subsetting a Dataset by variable names). Both paths now consult

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -5230,10 +5230,10 @@ class DataArray(
     def sortby(
         self,
         variables: (
-            Hashable
+            str
             | DataArray
-            | Sequence[Hashable | DataArray]
-            | Callable[[Self], Hashable | DataArray | Sequence[Hashable | DataArray]]
+            | Iterable[Hashable | DataArray]
+            | Callable[[Self], str | DataArray | Iterable[Hashable | DataArray]]
         ),
         ascending: bool = True,
     ) -> Self:
@@ -5255,7 +5255,7 @@ class DataArray(
 
         Parameters
         ----------
-        variables : Hashable, DataArray, sequence of Hashable or DataArray, or Callable
+        variables : str, DataArray, iterable of Hashable or DataArray, or Callable
             1D DataArray objects or name(s) of 1D variable(s) in coords whose values are
             used to sort this array. If a callable, the callable is passed this object,
             and the result is used as the value for cond.

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8149,8 +8149,12 @@ class Dataset(
 
         if callable(variables):
             variables = variables(self)
-        if not isinstance(variables, list):
+        if isinstance(variables, (str, DataArray)) or not isinstance(
+            variables, Iterable
+        ):
             variables = [variables]
+        else:
+            variables = list(variables)
         arrays = [v if isinstance(v, DataArray) else self[v] for v in variables]
         aligned_vars = align(self, *arrays, join="left")
         aligned_self = cast("Self", aligned_vars[0])

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8071,10 +8071,10 @@ class Dataset(
     def sortby(
         self,
         variables: (
-            Hashable
+            str
             | DataArray
-            | Sequence[Hashable | DataArray]
-            | Callable[[Self], Hashable | DataArray | list[Hashable | DataArray]]
+            | Iterable[Hashable | DataArray]
+            | Callable[[Self], str | DataArray | Iterable[Hashable | DataArray]]
         ),
         ascending: bool = True,
     ) -> Self:
@@ -8097,7 +8097,7 @@ class Dataset(
 
         Parameters
         ----------
-        variables : Hashable, DataArray, sequence of Hashable or DataArray, or Callable
+        variables : str, DataArray, iterable of Hashable or DataArray, or Callable
             1D DataArray objects or name(s) of 1D variable(s) in coords whose values are
             used to sort this array. If a callable, the callable is passed this object,
             and the result is used as the value for cond.

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4558,6 +4558,11 @@ class TestDataArray:
         actual = da.sortby(["x", "y"])
         assert_equal(actual, expected)
 
+        # test tuple of dimension names (GH4821)
+        expected = sorted2d
+        actual = da.sortby(("x", "y"))
+        assert_equal(actual, expected)
+
     @requires_bottleneck
     def test_rank(self) -> None:
         # floats

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -7323,6 +7323,11 @@ class TestDataset:
         actual = ds.sortby(["x", "y"], ascending=False)
         assert_equal(actual, ds)
 
+        # test tuple of dimension names (GH4821)
+        expected = sorted2d
+        actual = ds.sortby(("x", "y"))
+        assert_equal(actual, expected)
+
     def test_sortby_descending_nans(self) -> None:
         # Regression test for https://github.com/pydata/xarray/issues/7358
         # NaN values should remain at the end when sorting in descending order


### PR DESCRIPTION
## Summary

- Fixes `da.sortby(da.dims)` raising `KeyError` when `da.dims` is a tuple (e.g. `('x', 'y')`)
- Tuples are now treated as iterables of variable names, consistent with the `str | Iterable[Hashable]` convention established in #6142

Closes #4821

### Usage example

```python
>>> import xarray as xr
>>> da = xr.DataArray(
...     [[1, 2], [3, 4], [5, 6]],
...     coords={"x": ["c", "b", "a"], "y": [1, 0]},
... )
>>> da.sortby(da.dims)  # da.dims is the tuple ("x", "y")
<xarray.DataArray (x: 3, y: 2)> Size: 48B
array([[6, 5],
       [4, 3],
       [2, 1]])
Coordinates:
  * x        (x) <U1 12B 'a' 'b' 'c'
  * y        (y) int64 16B 0 1
```

## Test plan

- [x] `da.sortby(da.dims)` works when `da.dims` is a tuple of dimension names
- [x] `ds.sortby(("x", "y"))` sorts by both dimensions
- [x] Existing sortby tests pass (string, list, DataArray, descending, NaN handling)
- [x] whats-new.rst entry added

[This is Claude Code on behalf of Timothy Hodson]