### PR TITLE
Fix idxmax on DataArray with IntervalIndex coordinates

### DIFF
--- a/xarray/computation/computation.py
+++ b/xarray/computation/computation.py
@@ -1000,18 +1000,28 @@ def _calc_idxminmax(
     # This will run argmin or argmax.
     index = func(array, dim=dim, axis=None, keep_attrs=keep_attrs, skipna=skipna)
 
-    # Handle chunked arrays (e.g. dask).
-    coord = array[dim]._variable.to_base_variable()
-    if is_chunked_array(array.data):
-        chunkmanager = get_chunked_array_type(array.data)
-        coord_array = chunkmanager.from_array(
-            array[dim].data, chunks=((array.sizes[dim],),)
+    coord_data = array[dim].data
+    if utils.is_allowed_extension_array(coord_data):
+        # Preserve extension-array-backed coordinates by reconstructing the
+        # selected labels directly instead of routing through Variable indexing.
+        data = duck_array_ops.reshape(
+            coord_data[duck_array_ops.ravel(index.data)], index.shape
         )
-        coord = coord.copy(data=coord_array)
+        res = index.copy(data=data)
+        res.name = dim
     else:
-        coord = coord.copy(data=to_like_array(array[dim].data, array.data))
+        # Handle chunked arrays (e.g. dask).
+        coord = array[dim]._variable.to_base_variable()
+        if is_chunked_array(array.data):
+            chunkmanager = get_chunked_array_type(array.data)
+            coord_array = chunkmanager.from_array(
+                coord_data, chunks=((array.sizes[dim],),)
+            )
+            coord = coord.copy(data=coord_array)
+        else:
+            coord = coord.copy(data=to_like_array(coord_data, array.data))
 
-    res = index._replace(coord[(index.variable,)]).rename(dim)
+        res = index._replace(coord[(index.variable,)]).rename(dim)
 
     if skipna or (skipna is None and array.dtype.kind in na_dtypes):
         # Put the NaN values back in after removing them

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -5623,6 +5623,15 @@ class TestReduce1D(TestReduce):
             assert_identical(result2[key], expected2[key])
 
 
+def test_idxmax_intervalindex_coord() -> None:
+    idx = pd.IntervalIndex.from_breaks([0, 1, 2, 3])
+    da = xr.DataArray([False, True, True], dims=["z"], coords={"z": idx})
+
+    expected = xr.DataArray(idx[1], name="z")
+
+    assert_identical(da.idxmax(), expected)
+
+
 @pytest.mark.parametrize(
     ["x", "minindex", "maxindex", "nanindex"],
     [


### PR DESCRIPTION
### Description

Fixes a regression in `DataArray.idxmax()` for `pandas.IntervalIndex` coordinates.

On current `main`, a simple `IntervalIndex`-backed `DataArray.idxmax()` call raises `TypeError: len() of unsized object` while older xarray releases (verified for 2024.11) returned the selected interval label correctly. The failure comes from `_calc_idxminmax()` rebuilding the coordinate result through the generic variable indexing path, which breaks for extension-array-backed interval coordinates.

This PR adds a minimal regression test and applies a narrow fix in `_calc_idxminmax()`: for extension-array-backed coordinates, it reconstructs the selected labels directly instead of routing through the broken replacement path. This restores the expected `idxmax()` behavior and also fixes the same underlying issue for `idxmin()`.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #11300
- [x] Tests added

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    <!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
    Tools: Codex
