### PR TITLE
Fix performance regression in Coordinates.to_index

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -26,6 +26,10 @@ Deprecations
 Bug Fixes
 ~~~~~~~~~
 
+- Fix a major performance regression in :py:meth:`Coordinates.to_index` (and
+  consequently :py:meth:`Dataset.to_dataframe`) caused by converting the cached
+  code ndarrays into Python lists (:issue:`11305`).
+
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -194,7 +194,7 @@ class AbstractCoordinates(Mapping[Hashable, "T_DataArray"]):
 
         return pd.MultiIndex(
             levels=level_list,  # type: ignore[arg-type,unused-ignore]
-            codes=[list(c) for c in code_list],
+            codes=code_list,  # type: ignore[arg-type,unused-ignore]
             names=names,
         )
 


### PR DESCRIPTION
## Summary

Fixes #11305.

The `codes` passed to `pd.MultiIndex` in `Coordinates.to_index` were being converted from the cache-friendly ndarrays produced by `np.tile`/`np.repeat` into Python `list`s. That conversion was introduced in #10694 to silence a mypy `arg-type` error (pandas-stubs declares `codes: Sequence[Sequence[int]]`). The per-element materialisation dominates runtime for large indexes.

This PR passes `code_list` directly and suppresses the mypy complaint the same way we already do for `levels` on the line above (`# type: ignore[arg-type,unused-ignore]`).

Verified that `pd.MultiIndex` with ndarray `codes` produces a result that is `.identical()` to the list-of-int version (same internal code dtype, same values), so the change is purely a performance fix.

## MVCE (from #11305)

```python
# /// script
# requires-python = ">=3.11"
# dependencies = [
#   "xarray[complete]@git+https://github.com/pydata/xarray.git@refs/pull/11306/head",
# ]
# ///
import time
import numpy as np
import xarray as xr

da = xr.DataArray(np.arange(100 * 2000 * 300).reshape(100, 2000, 300), name="foo")
t = time.perf_counter()
da.to_dataframe()
print(f"to_dataframe: {time.perf_counter() - t:.3f}s")
```

Run with `uv run script.py`. Local results on my machine:

| | `to_dataframe` |
|---|---:|
| `main` (before) | 10.33s |
| this PR (after) |  0.26s |

~40× speed-up, matching the ~10s reporter saw.

## Test plan

Ran locally with `uv run pytest -n auto`:

- [x] `xarray/tests/test_coordinates.py` — 27 passed
- [x] `xarray/tests/test_variable.py`, `test_concat.py`, `test_missing.py` — 827 passed, 69 skipped, 9 xfailed, 3 xpassed
- [x] `xarray/tests/test_dataset.py`, `test_dataarray.py`, `test_groupby.py` — 1458 passed, 91 skipped, 5 xfailed, 2 xpassed
- [x] `pre-commit` clean on touched files, no new mypy errors introduced on `xarray/core/coordinates.py`

I grepped for callers of `Coordinates.to_index` (`xarray/core/{dataset,dataarray,variable,indexes,missing,accessor_dt}.py`, `xarray/plot/facetgrid.py`, `xarray/groupers.py`) — all paths produce a `pd.MultiIndex` whose consumers rely on `.values` / `.get_loc` / iteration, which are unaffected by whether `codes` was built from ndarrays or lists.

---

[This is Claude Code on behalf of Tim Hodson]