### PR TITLE
fix: restore performance in Coordinates.to_index()

### DIFF
--- a/xarray/core/coordinates.py
+++ b/xarray/core/coordinates.py
@@ -194,7 +194,7 @@ class AbstractCoordinates(Mapping[Hashable, "T_DataArray"]):
 
         return pd.MultiIndex(
             levels=level_list,  # type: ignore[arg-type,unused-ignore]
-            codes=[list(c) for c in code_list],
+            codes=code_list,
             names=names,
         )
 


### PR DESCRIPTION
## Summary

Fixes #11305 — performance regression in `Coordinates.to_index()` (and downstream `to_dataframe()`).

## Details

Commit a13a255 (mypy type fix) converted `code_list` from ndarray to Python lists via `[list(c) for c in code_list]` before passing to `pd.MultiIndex()`. This introduced a major slowdown because:

1. Converting large numpy arrays to Python lists is O(n) per array
2. Pandas internally converts list codes back to arrays anyway

The fix passes `code_list` (ndarray) directly to `pd.MultiIndex(codes=...)`, which pandas accepts natively. The `level_list += levels` line was already reverted in a later commit, so only the `codes=` conversion needed fixing.

**Change:** 1 line, net -1/+1.