### PR TITLE
Document Dataset.load_async and DataArray.load_async

### DIFF
--- a/doc/api/io.rst
+++ b/doc/api/io.rst
@@ -30,6 +30,7 @@ Dataset methods
    Dataset.filter_by_attrs
    Dataset.info
    Dataset.load
+   Dataset.load_async
    Dataset.persist
    Dataset.unify_chunks
 
@@ -62,6 +63,7 @@ DataArray methods
    DataArray.compute
    DataArray.persist
    DataArray.load
+   DataArray.load_async
    DataArray.unify_chunks
 
 DataTree methods


### PR DESCRIPTION
## Summary

- Adds `Dataset.load_async` and `DataArray.load_async` to the autosummary blocks in `doc/api/io.rst` so Sphinx generates dedicated reference pages for them.
- Without these entries, only `Variable.load_async` had a generated page (it's listed in `doc/api-hidden.rst`), so the `:py:meth:\`Dataset.load_async\`` / `:py:meth:\`DataArray.load_async\`` cross-references in `whats-new.rst` rendered as plain text.

Reported by @kylebarron in https://github.com/pydata/xarray/pull/10327#issuecomment-4306366292.

`DataTree.load_async` is not added here because it doesn't exist yet (it was left unchecked in #10327's API checklist).

## Test plan

- [ ] Build the docs locally and confirm `xarray.Dataset.load_async` and `xarray.DataArray.load_async` pages are generated and the whats-new cross-references resolve.

[This is Claude Code on behalf of Tom Nicholas]