### PR TITLE
Fix idxminmax for interval coordinates

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -29,6 +29,9 @@ Bug Fixes
 - Fix a major performance regression in :py:meth:`Coordinates.to_index` (and
   consequently :py:meth:`Dataset.to_dataframe`) caused by converting the cached
   code ndarrays into Python lists (:issue:`11305`).
+- Fix :py:meth:`DataArray.idxmax` and :py:meth:`DataArray.idxmin` for interval
+  coordinates by preserving pandas extension index adapters during label lookup
+  (:issue:`11300`).
 
 
 Documentation

--- a/xarray/compat/array_api_compat.py
+++ b/xarray/compat/array_api_compat.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from xarray.core.utils import is_allowed_extension_array
 from xarray.namedarray.pycompat import array_type
 
 
@@ -78,5 +79,7 @@ def to_like_array(array, like):
     xp = get_array_namespace(like)
     if xp is not np:
         return xp.asarray(array)
+    if is_allowed_extension_array(array):
+        return np.asarray(array)
     # avoid casting things like pint quantities to numpy arrays
     return array

--- a/xarray/computation/computation.py
+++ b/xarray/computation/computation.py
@@ -24,7 +24,6 @@ from xarray.core.duck_array_ops import datetime_to_numeric
 from xarray.core.options import OPTIONS, _get_keep_attrs
 from xarray.core.types import Dims, T_DataArray
 from xarray.core.utils import (
-    is_allowed_extension_array,
     is_scalar,
     parse_dims_as_set,
 )
@@ -1009,11 +1008,6 @@ def _calc_idxminmax(
             array[dim].data, chunks=((array.sizes[dim],),)
         )
         coord = coord.copy(data=coord_array)
-    elif is_allowed_extension_array(array[dim].data):
-        # Keep pandas-backed extension coordinates on their original indexing
-        # adapter so scalar lookups return a 0d array rather than a malformed
-        # ExtensionArray scalar wrapper.
-        pass
     else:
         coord = coord.copy(data=to_like_array(array[dim].data, array.data))
 

--- a/xarray/computation/computation.py
+++ b/xarray/computation/computation.py
@@ -24,6 +24,7 @@ from xarray.core.duck_array_ops import datetime_to_numeric
 from xarray.core.options import OPTIONS, _get_keep_attrs
 from xarray.core.types import Dims, T_DataArray
 from xarray.core.utils import (
+    is_allowed_extension_array,
     is_scalar,
     parse_dims_as_set,
 )
@@ -1008,6 +1009,11 @@ def _calc_idxminmax(
             array[dim].data, chunks=((array.sizes[dim],),)
         )
         coord = coord.copy(data=coord_array)
+    elif is_allowed_extension_array(array[dim].data):
+        # Keep pandas-backed extension coordinates on their original indexing
+        # adapter so scalar lookups return a 0d array rather than a malformed
+        # ExtensionArray scalar wrapper.
+        pass
     else:
         coord = coord.copy(data=to_like_array(array[dim].data, array.data))
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -5530,6 +5530,30 @@ class TestReduce1D(TestReduce):
         result7 = ar0.idxmax(fill_value=-1j)
         assert_identical(result7, expected7)
 
+    @pytest.mark.parametrize(
+        ("func_name", "values"),
+        [
+            pytest.param("idxmax", [False, True, True], id="idxmax"),
+            pytest.param("idxmin", [True, False, True], id="idxmin"),
+        ],
+    )
+    def test_idxminmax_interval_coords(
+        self,
+        x: np.ndarray,
+        minindex: int | float,
+        maxindex: int | float,
+        nanindex: int | None,
+        func_name: Literal["idxmax", "idxmin"],
+        values: list[bool],
+    ) -> None:
+        interval_index = pd.IntervalIndex.from_breaks([0, 1, 2, 3])
+        array = xr.DataArray(values, dims=["z"], coords={"z": interval_index})
+
+        result = getattr(array, func_name)()
+
+        expected = xr.DataArray(pd.Interval(1, 2, closed="right"), name="z")
+        assert_identical(result, expected)
+
     @pytest.mark.filterwarnings(
         "ignore:Behaviour of argmin/argmax with neither dim nor :FutureWarning"
     )


### PR DESCRIPTION
### Description

Fix `DataArray.idxmax()` and `DataArray.idxmin()` when the reduced dimension uses interval coordinates. `_calc_idxminmax()` was replacing the coordinate's original pandas index adapter with a raw extension array before the final label lookup, which causes scalar interval selections to fail with `TypeError: len() of unsized object`.

This keeps pandas extension-backed coordinates on their original adapter for the final lookup, adds a regression test for both `idxmax` and `idxmin`, and documents the bug fix in `doc/whats-new.rst`.

### Checklist

- [x] Closes #11300
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Codex
