### PR TITLE
Remove `BooleanCoder` from `zarr` writes

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -63,6 +63,12 @@ Bug Fixes
 - :py:func:`polyval` now propagates ``NaN`` for ``NaT`` entries in ``timedelta64``
   coordinates instead of returning a large sentinel value (:issue:`11462`).
   By `Dipak Chaudhari <https://github.com/dchaudhari7177>`_.
+- The zarr backend now writes boolean arrays with native ``bool`` dtype instead
+  of converting them to ``int8``. Zarr supports ``bool`` natively, so the
+  ``BooleanCoder`` (which was designed for NetCDF compatibility) is now skipped
+  for zarr writes. Existing zarr stores written with the old ``int8`` encoding
+  are still read correctly. (:issue:`2937`, :pull:`11318`)
+  By `Evan Lyall <https://github.com/elyall>`_.
 
 
 Documentation
@@ -140,12 +146,6 @@ Bug Fixes
 - :py:meth:`~xarray.indexes.RangeIndex.linspace` now handles ``num=1`` like
   :py:func:`numpy.linspace` (:issue:`11397`, :pull:`11401`).
   By `S Anand <https://github.com/sanand0>`_.
-- The zarr backend now writes boolean arrays with native ``bool`` dtype instead
-  of converting them to ``int8``. Zarr supports ``bool`` natively, so the
-  ``BooleanCoder`` (which was designed for NetCDF compatibility) is now skipped
-  for zarr writes. Existing zarr stores written with the old ``int8`` encoding
-  are still read correctly. (:issue:`2937`, :pull:`11318`)
-  By `Evan Lyall <https://github.com/elyall>`_.
 - Fix a major performance regression in :py:meth:`Coordinates.to_index` (and
   consequently :py:meth:`Dataset.to_dataframe`) caused by converting the cached
   code ndarrays into Python lists (:issue:`11305`).

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -140,6 +140,12 @@ Bug Fixes
 - :py:meth:`~xarray.indexes.RangeIndex.linspace` now handles ``num=1`` like
   :py:func:`numpy.linspace` (:issue:`11397`, :pull:`11401`).
   By `S Anand <https://github.com/sanand0>`_.
+- The zarr backend now writes boolean arrays with native ``bool`` dtype instead
+  of converting them to ``int8``. Zarr supports ``bool`` natively, so the
+  ``BooleanCoder`` (which was designed for NetCDF compatibility) is now skipped
+  for zarr writes. Existing zarr stores written with the old ``int8`` encoding
+  are still read correctly. (:issue:`2937`, :pull:`11318`)
+  By `Evan Lyall <https://github.com/elyall>`_.
 - Fix a major performance regression in :py:meth:`Coordinates.to_index` (and
   consequently :py:meth:`Dataset.to_dataframe`) caused by converting the cached
   code ndarrays into Python lists (:issue:`11305`).

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -531,7 +531,12 @@ def encode_zarr_variable(var, needs_copy=True, name=None):
         A variable which has been encoded as described above.
     """
 
-    var = conventions.encode_cf_variable(var, name=name)
+    coders = [
+        c
+        for c in conventions._default_encode_cf_coders()
+        if not isinstance(c, coding.variables.BooleanCoder)
+    ]
+    var = conventions.encode_cf_variable(var, name=name, coders=coders)
     var = ensure_dtype_not_object(var, name=name)
 
     # zarr allows unicode, but not variable-length strings, so it's both

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -24,6 +24,7 @@ from xarray.backends.common import (
     ensure_dtype_not_object,
 )
 from xarray.backends.store import StoreBackendEntrypoint
+from xarray.conventions import ZARR_CODERS
 from xarray.core import indexing
 from xarray.core.treenode import NodePath
 from xarray.core.types import ZarrWriteModes
@@ -530,13 +531,7 @@ def encode_zarr_variable(var, needs_copy=True, name=None):
     out : Variable
         A variable which has been encoded as described above.
     """
-
-    coders = [
-        c
-        for c in conventions._default_encode_cf_coders()
-        if not isinstance(c, coding.variables.BooleanCoder)
-    ]
-    var = conventions.encode_cf_variable(var, name=name, coders=coders)
+    var = conventions.encode_cf_variable(var, name=name, coders=ZARR_CODERS)
     var = ensure_dtype_not_object(var, name=name)
 
     # zarr allows unicode, but not variable-length strings, so it's both

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -46,9 +46,7 @@ ZARR_CODERS = (
     variables.NonStringCoder(),
     variables.DefaultFillvalueCoder(),
 )
-DEFAULT_CODERS = ZARR_CODERS + (
-    variables.BooleanCoder(),
-)
+DEFAULT_CODERS = ZARR_CODERS + (variables.BooleanCoder(),)
 
 if TYPE_CHECKING:
     from xarray.backends.common import AbstractDataStore

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -65,8 +65,22 @@ def ensure_not_multiindex(var: Variable, name: T_Name = None) -> None:
             )
 
 
+def _default_encode_cf_coders():
+    """Return the default list of coders used by encode_cf_variable."""
+    return [
+        CFDatetimeCoder(),
+        CFTimedeltaCoder(),
+        variables.CFScaleOffsetCoder(),
+        variables.CFMaskCoder(),
+        variables.NativeEnumCoder(),
+        variables.NonStringCoder(),
+        variables.DefaultFillvalueCoder(),
+        variables.BooleanCoder(),
+    ]
+
+
 def encode_cf_variable(
-    var: Variable, needs_copy: bool = True, name: T_Name = None
+    var: Variable, needs_copy: bool = True, name: T_Name = None, coders=None
 ) -> Variable:
     """
     Converts a Variable into a Variable which follows some
@@ -81,6 +95,8 @@ def encode_cf_variable(
     ----------
     var : Variable
         A variable holding un-encoded data.
+    coders : list of VariableCoder, optional
+        List of coders to apply. If None, uses the default CF coder chain.
 
     Returns
     -------
@@ -89,16 +105,10 @@ def encode_cf_variable(
     """
     ensure_not_multiindex(var, name=name)
 
-    for coder in [
-        CFDatetimeCoder(),
-        CFTimedeltaCoder(),
-        variables.CFScaleOffsetCoder(),
-        variables.CFMaskCoder(),
-        variables.NativeEnumCoder(),
-        variables.NonStringCoder(),
-        variables.DefaultFillvalueCoder(),
-        variables.BooleanCoder(),
-    ]:
+    if coders is None:
+        coders = _default_encode_cf_coders()
+
+    for coder in coders:
         var = coder.encode(var, name=name)
 
     for attr_name in CF_RELATED_DATA:

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -37,7 +37,18 @@ CF_RELATED_DATA_NEEDS_PARSING = (
     "cell_measures",
     "formula_terms",
 )
-
+ZARR_CODERS = (
+    CFDatetimeCoder(),
+    CFTimedeltaCoder(),
+    variables.CFScaleOffsetCoder(),
+    variables.CFMaskCoder(),
+    variables.NativeEnumCoder(),
+    variables.NonStringCoder(),
+    variables.DefaultFillvalueCoder(),
+)
+DEFAULT_CODERS = ZARR_CODERS + (
+    variables.BooleanCoder(),
+)
 
 if TYPE_CHECKING:
     from xarray.backends.common import AbstractDataStore
@@ -63,20 +74,6 @@ def ensure_not_multiindex(var: Variable, name: T_Name = None) -> None:
                 "to convert MultiIndex levels into coordinate variables instead "
                 "or use https://cf-xarray.readthedocs.io/en/latest/coding.html."
             )
-
-
-def _default_encode_cf_coders():
-    """Return the default list of coders used by encode_cf_variable."""
-    return [
-        CFDatetimeCoder(),
-        CFTimedeltaCoder(),
-        variables.CFScaleOffsetCoder(),
-        variables.CFMaskCoder(),
-        variables.NativeEnumCoder(),
-        variables.NonStringCoder(),
-        variables.DefaultFillvalueCoder(),
-        variables.BooleanCoder(),
-    ]
 
 
 def encode_cf_variable(
@@ -106,7 +103,7 @@ def encode_cf_variable(
     ensure_not_multiindex(var, name=name)
 
     if coders is None:
-        coders = _default_encode_cf_coders()
+        coders = DEFAULT_CODERS
 
     for coder in coders:
         var = coder.encode(var, name=name)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2715,10 +2715,15 @@ class ZarrBase(CFEncodedBase):
         with self.create_zarr_target() as store_target:
             zg = zarr.open_group(store_target, mode="w")
             data_int8 = original["x"].values.astype("i1")
-            create_kwargs = {"fill_value": -1}
+            create_kwargs = {
+                "shape": data_int8.shape,
+                "dtype": data_int8.dtype,
+                "fill_value": -1,
+            }
             if has_zarr_v3 and zg.metadata.zarr_format == 3:
                 create_kwargs["dimension_names"] = ("t", "x")
-            arr = zg.create_array("x", data=data_int8, **create_kwargs)
+            arr = zg.create_array("x", **create_kwargs)
+            arr[:] = data_int8
             arr.attrs["dtype"] = "bool"
             arr.attrs["units"] = "-"
             if not (has_zarr_v3 and zg.metadata.zarr_format == 3):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2717,7 +2717,7 @@ class ZarrBase(CFEncodedBase):
         with self.create_zarr_target() as store_target:
             zg = zarr.open_group(store_target, mode="w")
             data_int8 = original["x"].values.astype("i1")
-            is_v3_format = has_zarr_v3 and zg.metadata.zarr_format == 3
+            is_v3_format = zg.metadata.zarr_format == 3
             if is_v3_format:
                 arr = zg.create_array(
                     "x",

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2697,8 +2697,10 @@ class ZarrBase(CFEncodedBase):
             self.save(original, store_target, consolidated=False)
             # Verify on-disk zarr array uses native bool dtype (not int8)
             zg = zarr.open_group(store_target, mode="r")
-            assert zg["x"].dtype == np.dtype("bool")
-            assert "dtype" not in zg["x"].attrs
+            zarr_arr = zg["x"]
+            assert isinstance(zarr_arr, zarr.Array)
+            assert zarr_arr.dtype == np.dtype("bool")
+            assert "dtype" not in zarr_arr.attrs
             with self.open(
                 store_target, backend_kwargs={"consolidated": False}
             ) as actual:
@@ -2715,18 +2717,26 @@ class ZarrBase(CFEncodedBase):
         with self.create_zarr_target() as store_target:
             zg = zarr.open_group(store_target, mode="w")
             data_int8 = original["x"].values.astype("i1")
-            create_kwargs = {
-                "shape": data_int8.shape,
-                "dtype": data_int8.dtype,
-                "fill_value": -1,
-            }
-            if has_zarr_v3 and zg.metadata.zarr_format == 3:
-                create_kwargs["dimension_names"] = ("t", "x")
-            arr = zg.create_array("x", **create_kwargs)
+            is_v3_format = has_zarr_v3 and zg.metadata.zarr_format == 3
+            if is_v3_format:
+                arr = zg.create_array(
+                    "x",
+                    shape=data_int8.shape,
+                    dtype=data_int8.dtype,
+                    fill_value=-1,
+                    dimension_names=("t", "x"),
+                )
+            else:
+                arr = zg.create_array(
+                    "x",
+                    shape=data_int8.shape,
+                    dtype=data_int8.dtype,
+                    fill_value=-1,
+                )
             arr[:] = data_int8
             arr.attrs["dtype"] = "bool"
             arr.attrs["units"] = "-"
-            if not (has_zarr_v3 and zg.metadata.zarr_format == 3):
+            if not is_v3_format:
                 arr.attrs["_ARRAY_DIMENSIONS"] = ["t", "x"]
             with self.open(
                 store_target, backend_kwargs={"consolidated": False}

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2690,6 +2690,45 @@ class ZarrBase(CFEncodedBase):
     async def test_load_async(self) -> None:
         await super().test_load_async()
 
+    def test_roundtrip_boolean_dtype(self) -> None:
+        original = create_boolean_data()
+        assert original["x"].dtype == "bool"
+        with self.create_zarr_target() as store_target:
+            self.save(original, store_target, consolidated=False)
+            # Verify on-disk zarr array uses native bool dtype (not int8)
+            zg = zarr.open_group(store_target, mode="r")
+            assert zg["x"].dtype == np.dtype("bool")
+            assert "dtype" not in zg["x"].attrs
+            with self.open(
+                store_target, backend_kwargs={"consolidated": False}
+            ) as actual:
+                assert_identical(original, actual)
+                assert actual["x"].dtype == "bool"
+                # Verify second roundtrip also preserves bool
+                with self.roundtrip(actual) as actual2:
+                    assert_identical(original, actual2)
+                    assert actual2["x"].dtype == "bool"
+
+    def test_roundtrip_boolean_dtype_legacy_int8(self) -> None:
+        """Verify backward compat: old-style int8 + attrs['dtype']='bool' decodes to bool."""
+        original = create_boolean_data()
+        with self.create_zarr_target() as store_target:
+            zg = zarr.open_group(store_target, mode="w")
+            data_int8 = original["x"].values.astype("i1")
+            create_kwargs = {"fill_value": -1}
+            if has_zarr_v3 and zg.metadata.zarr_format == 3:
+                create_kwargs["dimension_names"] = ("t", "x")
+            arr = zg.create_array("x", data=data_int8, **create_kwargs)
+            arr.attrs["dtype"] = "bool"
+            arr.attrs["units"] = "-"
+            if not (has_zarr_v3 and zg.metadata.zarr_format == 3):
+                arr.attrs["_ARRAY_DIMENSIONS"] = ["t", "x"]
+            with self.open(
+                store_target, backend_kwargs={"consolidated": False}
+            ) as actual:
+                assert actual["x"].dtype == "bool"
+                np.testing.assert_array_equal(actual["x"].values, original["x"].values)
+
     def test_roundtrip_bytes_with_fill_value(self):
         pytest.xfail("Broken by Zarr 3.0.7")
 

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -43,6 +43,31 @@ class TestBoolTypeArray:
         assert_array_equal(bx.transpose((1, 0)), x.transpose((1, 0)))
 
 
+class TestEncodeCfVariableCoders:
+    def test_empty_coders_is_identity(self) -> None:
+        var = Variable(["x"], np.array([True, False, True]), {"units": "test"})
+        result = conventions.encode_cf_variable(var, coders=[])
+        assert result.dtype == bool
+        assert_array_equal(result.values, var.values)
+
+    def test_custom_coders_excludes_boolean_coder(self) -> None:
+        var = Variable(["x"], np.array([True, False, True]))
+        coders = [
+            c
+            for c in conventions._default_encode_cf_coders()
+            if not isinstance(c, coding.variables.BooleanCoder)
+        ]
+        result = conventions.encode_cf_variable(var, coders=coders)
+        assert result.dtype == bool
+        assert "dtype" not in result.attrs
+
+    def test_default_coders_encodes_bool_to_int8(self) -> None:
+        var = Variable(["x"], np.array([True, False, True]))
+        result = conventions.encode_cf_variable(var)
+        assert result.dtype == np.int8
+        assert result.attrs.get("dtype") == "bool"
+
+
 class TestNativeEndiannessArray:
     def test(self) -> None:
         x = np.arange(5, dtype=">i8")

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -52,12 +52,7 @@ class TestEncodeCfVariableCoders:
 
     def test_custom_coders_excludes_boolean_coder(self) -> None:
         var = Variable(["x"], np.array([True, False, True]))
-        coders = [
-            c
-            for c in conventions._default_encode_cf_coders()
-            if not isinstance(c, coding.variables.BooleanCoder)
-        ]
-        result = conventions.encode_cf_variable(var, coders=coders)
+        result = conventions.encode_cf_variable(var, coders=conventions.ZARR_CODERS)
         assert result.dtype == bool
         assert "dtype" not in result.attrs
 


### PR DESCRIPTION
### Description
The zarr backend currently converts boolean arrays to `int8` before writing, using the `BooleanCoder` from the CF encoding pipeline. This was inherited from NetCDF compatibility (which can't store booleans natively), but zarr v2 and v3 both support `bool` dtype directly. The conversion results in:
- On-disk arrays stored as `int8` with a `dtype: "bool"` attribute, which non-xarray zarr readers don't understand
- Unnecessary dtype mismatch when reading zarr stores outside xarray

This PR skips `BooleanCoder` during zarr writes by:
1. Adding an optional `coders` parameter to `conventions.encode_cf_variable()` so backends can customize the encoding chain
2. Having `encode_zarr_variable()` pass a filtered coder list that excludes `BooleanCoder`

The decode path is unchanged -- `BooleanCoder.decode` is attribute-driven (`attrs.get('dtype') == 'bool'`), so existing zarr stores written with the old `int8` encoding still decode to `bool` correctly.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2937 
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
  - Tools: Claude Opus 4.6
  - Prompt: "Please plan out the cleanest approach to skipping `BooleanCoder` for boolean arrays when writing to or reading from zarr files. Automatically skip BooleanCoder for all zarr writes (v2 and v3). Please provide a "Description" for the pull request and document changes in `whats-new.rst`."