### PR TITLE
Fix concat failure with pandas StringDtype indexes (#11317)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -64,6 +64,11 @@ Bug Fixes
   ``"dayofweek"``, and ``"week"``, respectively; now they return objects named
   ``"days_in_month"``, ``"weekday"``, and ``"weekofyear"`` (:pull:`11270`). By
   `Spencer Clark <https://github.com/spencerkclark>`_.
+- Fix :py:func:`concat` failing with ``TypeError: Cannot interpret
+  '<StringDtype...>' as a data type`` when a ``pandas.Index`` with a
+  ``StringDtype`` is used as the new concat dimension and another input has a
+  numpy string-dtype coord (:issue:`11317`).
+
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/structure/concat.py
+++ b/xarray/structure/concat.py
@@ -363,6 +363,13 @@ def _calc_concat_dim_index(
         else:
             (dim,) = dim_or_data.dims
         coord_dtype = getattr(dim_or_data, "dtype", None)
+        # pandas may produce a StringDtype-backed Index, which xarray does
+        # not treat as an allowed extension array dtype for coords. Let
+        # PandasIndex compute a valid numpy coord_dtype in that case so a
+        # subsequent concat against a numpy-string-dtype coord does not fail
+        # in ``np.result_type``. See GH#11317.
+        if isinstance(coord_dtype, pd.StringDtype):
+            coord_dtype = None
         index = PandasIndex(dim_or_data, dim, coord_dtype=coord_dtype)
 
     return dim, index

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -1491,6 +1491,19 @@ def test_concat_index_not_same_dim() -> None:
         concat([ds1, ds2], dim="x")
 
 
+def test_concat_pandas_index_string_dtype() -> None:
+    # Regression test for GH#11317. When pandas yields a StringDtype-backed
+    # Index (e.g. with ``future.infer_string`` enabled), passing it as the
+    # new concat dim must not break a subsequent concat against a coord with
+    # a numpy string dtype.
+    with pd.option_context("future.infer_string", True):
+        da = DataArray([0], dims=["dim_a"], coords={"dim_a": ["a"]})
+        db = DataArray([0], dims=["dim_b"], coords={"dim_b": ["b"]})
+        db2 = concat([db], pd.Index(["b"], name="dim_a"))
+        result = concat([da, db2], dim="dim_a")
+    assert list(result["dim_a"].values) == ["a", "b"]
+
+
 class TestNewDefaults:
     def test_concat_second_empty_with_scalar_data_var_only_on_first(self) -> None:
         ds1 = Dataset(data_vars={"a": ("y", [0.1]), "b": 0.1}, coords={"x": 0.1})


### PR DESCRIPTION
### Description

Fixes #11317. When ``pandas`` returns a ``StringDtype``-backed ``Index`` (e.g. with ``future.infer_string`` enabled or pandas 3.x defaults), passing it as the new concat dim caused ``_calc_concat_dim_index`` to store the ``StringDtype`` as the resulting ``PandasIndex.coord_dtype``. A subsequent concat against another input with a numpy ``<U*`` coord then failed in ``np.result_type`` with ``TypeError: Cannot interpret '<StringDtype...>' as a data type``. ``PandasIndex.__init__`` already coerces non-allowed extension dtypes via ``get_valid_numpy_dtype`` when ``coord_dtype`` is ``None``; this PR reuses that path for ``StringDtype`` so the resulting coord ends up as ``object`` and concat succeeds. Regression test added.

### Checklist

- [x] Closes #11317
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Claude. I directed the agent to localize the failure to ``_calc_concat_dim_index`` in ``xarray/structure/concat.py``, evaluated alternative fix sites (``PandasIndex.concat`` vs the dim-index helper), reviewed and tested the resulting patch, and confirmed the regression test fails on ``main`` and passes here.