### PR TITLE
style: add pre-commit CI autofix commit message (PC902)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 ci:
   autoupdate_schedule: monthly
   autoupdate_commit_msg: "Update pre-commit hooks"
+  autofix_commit_msg: "style: pre-commit fixes"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0


### PR DESCRIPTION
Adds `autofix_commit_msg` to the pre-commit CI config as suggested by the repo-review tool.
Fixes part of #8239.