### PR TITLE
docs: clarify DataArray coords list description

### DIFF
--- a/doc/user-guide/data-structures.rst
+++ b/doc/user-guide/data-structures.rst
@@ -55,9 +55,10 @@ The :py:class:`~xarray.DataArray` constructor takes:
 - ``data``: a multi-dimensional array of values (e.g., a numpy ndarray,
   a :ref:`numpy-like array <userguide.duckarrays>`, :py:class:`~pandas.Series`,
   :py:class:`~pandas.DataFrame` or ``pandas.Panel``)
-- ``coords``: a list or dictionary of coordinates. If a list, it should be a
-  list of tuples where the first element is the dimension name and the second
-  element is the corresponding coordinate array_like object.
+- ``coords``: a list or dictionary of coordinates. If a list, entries are
+  matched with dimensions by position, as in the example below. Coordinate
+  names and more complex coordinate definitions can be provided by passing a
+  dictionary instead.
 - ``dims``: a list of dimension names. If omitted and ``coords`` is a list of
   tuples, dimension names are taken from ``coords``.
 - ``attrs``: a dictionary of attributes to add to the instance


### PR DESCRIPTION
### Description

Closes #10118.

Clarifies the `DataArray` user-guide description of `coords` when a list is passed. The old text said a list "should be a list of tuples", but the example immediately below uses `coords=[times, locs]` with `dims=["time", "space"]`. The updated text matches that positional form and points readers to dictionaries for named or more complex coordinate definitions.

### Checklist

- [x] Closes #10118
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### Verification

- Ran a Python check for the documented `xr.DataArray(data, coords=[times, locs], dims=["time", "space"])` example and verified the dimensions/coordinates.
- Checked that the stale "list of tuples" wording was removed from `doc/user-guide/data-structures.rst`.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Hermes Agent / OpenAI Codex
