### PR TITLE
docs: Document Index._repr_inline_ in custom-index how-to

### DIFF
--- a/doc/internals/how-to-create-custom-index.rst
+++ b/doc/internals/how-to-create-custom-index.rst
@@ -128,6 +128,33 @@ e.g., a kd-tree object may not be easily indexed. If ``Index.isel()`` is not
 implemented, the index in just dropped in the DataArray or Dataset resulting
 from the selection.
 
+Custom representation
+---------------------
+
+When a :py:class:`Dataset` or :py:class:`DataArray` is displayed, Xarray shows
+a one-line summary of each index. By default — i.e. via :py:meth:`Index._repr_inline_`
+on the :py:class:`Index` base class — that summary is just the class name. Override
+:py:meth:`Index._repr_inline_` to show whatever short, single-line description is
+useful for your index. The method receives a ``max_width`` argument (the number of
+characters the formatter has reserved for the inline ``repr``); the returned string
+should respect it.
+
+Two examples ship with Xarray itself:
+
+- :py:class:`~xarray.indexes.RangeIndex` returns
+  ``RangeIndex (start=0, stop=10, step=0.1)``.
+- :py:class:`~xarray.indexes.NDPointIndex` returns
+  ``NDPointIndex (KDTree)``.
+
+For the ``RasterIndex`` defined above, a useful inline ``repr`` is the list of
+dimensions the index is bound to:
+
+.. code-block:: python
+
+    def _repr_inline_(self, max_width: int) -> str:
+        dims = [idx.dim for idx in self._xy_indexes.values()]
+        return f"{type(self).__name__} (dims={dims})"
+
 Alignment
 ---------
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,6 +34,10 @@ Bug Fixes
 Documentation
 ~~~~~~~~~~~~~
 
+- Document :py:meth:`Index._repr_inline_` in the custom-index how-to guide
+  (:issue:`11036`).
+  By `Mike Yevdokimov <https://github.com/xronocode>`_.
+
 
 Internal Changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

Adds a "Custom representation" subsection to `doc/internals/how-to-create-custom-index.rst` documenting [`Index._repr_inline_`](https://github.com/pydata/xarray/blob/main/xarray/core/indexes.py#L487) — the override hook used to customise the one-line summary Xarray prints for each index.

The new section:

1. Explains what `_repr_inline_` does and what `max_width` means.
2. Names the two built-in implementations a reader can crib from — [`RangeIndex._repr_inline_`](https://github.com/pydata/xarray/blob/main/xarray/indexes/range_index.py#L465) and [`NDPointIndex._repr_inline_`](https://github.com/pydata/xarray/blob/main/xarray/indexes/nd_point_index.py#L396) — and shows what each currently returns.
3. Hooks `_repr_inline_` into the existing `RasterIndex` example via a `code-block:: python` snippet.

A `whats-new.rst` entry under `v2026.05.0 (unreleased)` → Documentation is included.

## About the prior attempt — credit + why a fresh PR

This builds on the now-abandoned #11046 by @sshekhar563. That PR (last updated 2026-02-03, no response to @jsignell's docs-build-failure ping on 2026-01-30) attempted the same documentation goal but used `jupyter-execute` for a self-contained example whose body called `DataArray.set_index(x=MyIndex(np.arange(10)))`. That isn't a valid xarray API — for a custom `Index` subclass the right call is `da.set_xindex(["x"], MyIndex)`, which is what the existing `RasterIndex` example a few lines above already uses. The result was a `jupyter-execute` block that failed at doc build time, which is what blocked #11046.

This PR sidesteps that by using a `code-block:: python` snippet (the section is documenting a method-body fragment, which can't stand alone as `jupyter-execute`) and by wiring the example into `RasterIndex` rather than introducing a brand-new toy class. Net diff is +31 lines vs. #11046's +51.

## Closes

- gh-11036

## AI usage disclosure

I drafted this with Claude Code per `CLAUDE.md`'s contribution conventions — context: locating the source of `_repr_inline_`, identifying the API mismatch in the prior attempt, and matching the existing `RasterIndex` example's style. I read every line of the diff, verified the cross-refs (`RangeIndex` and `NDPointIndex` are exported from `xarray.indexes.__init__`), and stand behind the patch.

[This is Claude Code on behalf of Mike Yevdokimov]