### PR TITLE
undo the pin on the pixi version

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -52,8 +52,6 @@ jobs:
           persist-credentials: false
       - uses: Parcels-code/pixi-lock/create-and-cache@38495788b79a5ff26009aecc15daa9a8310b8832 # v0.1.0
         id: pixi-lock
-        with:
-          pixi-version: v0.67.1
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pixi-lock

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,6 @@ jobs:
 
     outputs:
       cache-key: ${{ steps.pixi-lock.outputs.cache-key }}
-      pixi-version: ${{ steps.pixi-lock.outputs.pixi-version }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -54,8 +53,6 @@ jobs:
           persist-credentials: false
       - uses: Parcels-code/pixi-lock/create-and-cache@38495788b79a5ff26009aecc15daa9a8310b8832 # v0.1.0
         id: pixi-lock
-        with:
-          pixi-version: v0.67.1
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pixi-lock

--- a/.github/workflows/hypothesis.yaml
+++ b/.github/workflows/hypothesis.yaml
@@ -59,8 +59,6 @@ jobs:
           persist-credentials: false
       - uses: Parcels-code/pixi-lock/create-and-cache@38495788b79a5ff26009aecc15daa9a8310b8832 # v0.1.0
         id: pixi-lock
-        with:
-          pixi-version: v0.67.1
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pixi-lock

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -66,8 +66,6 @@ jobs:
           persist-credentials: false
       - uses: Parcels-code/pixi-lock/create-and-cache@38495788b79a5ff26009aecc15daa9a8310b8832 # v0.1.0
         id: pixi-lock
-        with:
-          pixi-version: v0.67.1
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pixi-lock

--- a/pixi.toml
+++ b/pixi.toml
@@ -2,7 +2,7 @@
 preview = ["pixi-build"]
 channels = ["conda-forge", "nodefaults"]
 platforms = ["win-64", "linux-64", "osx-arm64"]
-requires-pixi = ">=0.63.2,!=0.68.0"
+requires-pixi = ">=0.63.2"
 
 [package]
 name = "xarray"

--- a/pixi.toml
+++ b/pixi.toml
@@ -2,7 +2,7 @@
 preview = ["pixi-build"]
 channels = ["conda-forge", "nodefaults"]
 platforms = ["win-64", "linux-64", "osx-arm64"]
-requires-pixi = ">=0.63.2"
+requires-pixi = ">=0.63.2,!=0.68.0"
 
 [package]
 name = "xarray"


### PR DESCRIPTION
- [x] follow-up to #11331
- [x] closes #11330

As mentioned in #11330, this reverts the changes from #11331, now that the new version of pixi is out. I've kept the exclusion of the broken version, though.