### PR TITLE
BUG: fix scipy backend pickling after multiple opens

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -29,6 +29,8 @@ Bug Fixes
 - Fix a major performance regression in :py:meth:`Coordinates.to_index` (and
   consequently :py:meth:`Dataset.to_dataframe`) caused by converting the cached
   code ndarrays into Python lists (:issue:`11305`).
+- Fixed pickling of datasets opened from file-like objects with the scipy
+  backend after multiple opens (:issue:`11323`).
 
 
 Documentation

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -143,33 +143,35 @@ def _open_scipy_netcdf(
 ) -> scipy.io.netcdf_file:
     import scipy.io
 
-    # TODO: Remove this after upstreaming these fixes.
-    class flush_only_netcdf_file(scipy.io.netcdf_file):
-        # scipy.io.netcdf_file.close() incorrectly closes file objects that
-        # were passed in as constructor arguments:
-        # https://github.com/scipy/scipy/issues/13905
+    if flush_only:
+        if not hasattr(_PickleWorkaround, "flush_only_netcdf_file"):
+            # TODO: Remove this after upstreaming these fixes.
+            class flush_only_netcdf_file(scipy.io.netcdf_file):
+                # scipy.io.netcdf_file.close() incorrectly closes file objects that
+                # were passed in as constructor arguments:
+                # https://github.com/scipy/scipy/issues/13905
 
-        # Instead of closing such files, only call flush(), which is
-        # equivalent as long as the netcdf_file object is not mmapped.
-        # This suffices to keep BytesIO objects open long enough to read
-        # their contents from to_netcdf(), but underlying files still get
-        # closed when the netcdf_file is garbage collected (via __del__),
-        # and will need to be fixed upstream in scipy.
-        def close(self):
-            if hasattr(self, "fp") and not self.fp.closed:
-                self.flush()
-                self.fp.seek(0)  # allow file to be read again
+                # Instead of closing such files, only call flush(), which is
+                # equivalent as long as the netcdf_file object is not mmapped.
+                # This suffices to keep BytesIO objects open long enough to read
+                # their contents from to_netcdf(), but underlying files still get
+                # closed when the netcdf_file is garbage collected (via __del__),
+                # and will need to be fixed upstream in scipy.
+                def close(self):
+                    if hasattr(self, "fp") and not self.fp.closed:
+                        self.flush()
+                        self.fp.seek(0)  # allow file to be read again
 
-        def __del__(self):
-            # Remove the __del__ method, which in scipy is aliased to close().
-            # These files need to be closed explicitly by xarray.
-            pass
+                def __del__(self):
+                    # Remove the __del__ method, which in scipy is aliased to close().
+                    # These files need to be closed explicitly by xarray.
+                    pass
 
-    _PickleWorkaround.add_cls(flush_only_netcdf_file)
+            _PickleWorkaround.add_cls(flush_only_netcdf_file)
 
-    netcdf_file = (
-        _PickleWorkaround.flush_only_netcdf_file if flush_only else scipy.io.netcdf_file
-    )
+        netcdf_file = _PickleWorkaround.flush_only_netcdf_file
+    else:
+        netcdf_file = scipy.io.netcdf_file
 
     # if the string ends with .gz, then gunzip and open as netcdf file
     if isinstance(filename, str) and filename.endswith(".gz"):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4735,6 +4735,24 @@ class TestScipyFileObject(CFEncodedBase, NetCDF3Only, FileObjectNetCDF):
     def test_pickle_dataarray(self) -> None:
         super().test_pickle_dataarray()
 
+    def test_pickle_open_dataset_from_separate_file_objects(self) -> None:
+        original = Dataset({"foo": ("x", [1, 2, 3])})
+        fobj = BytesIO()
+        original.to_netcdf(fobj, engine="scipy")
+        payload = fobj.getvalue()
+
+        ds1 = ds2 = None
+        try:
+            ds1 = open_dataset(BytesIO(payload), engine="scipy")
+            ds2 = open_dataset(BytesIO(payload), engine="scipy")
+            with pickle.loads(pickle.dumps(ds1)) as unpickled:
+                assert_identical(unpickled, original)
+        finally:
+            if ds1 is not None:
+                ds1.close()
+            if ds2 is not None:
+                ds2.close()
+
     @pytest.mark.parametrize("create_default_indexes", [True, False])
     def test_create_default_indexes(self, tmp_path, create_default_indexes) -> None:
         store_path = tmp_path / "tmp.nc"


### PR DESCRIPTION
Closes #11323.

This fixes a scipy backend pickling regression when multiple datasets are opened
from file-like objects in the same process.

The scipy backend registers a pickle-visible wrapper class for file-like objects.
Re-registering that class on every open can make an earlier dataset refer to a
class object that no longer matches the registered pickle target. This change
registers the wrapper once and reuses it for later file-like opens.

The regression test opens two scipy-backed datasets from the same in-memory
NetCDF payload and verifies that the first dataset can still be pickled and
unpickled.

Validation:
- `python -m pytest xarray/tests/test_backends.py -k "scipy and pickle"`
- `python -m pytest xarray/tests/test_backends.py -k "scipy"`
- `python -m ruff check xarray/backends/scipy_.py xarray/tests/test_backends.py`
- `git diff --check`

AI assistance:
I used ChatGPT/Codex to help inspect the issue and plan a small local patch. I reviewed the final diff and test results myself and understand the submitted changes.
