### PR TITLE
Fix Upstream CI NaT issues

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,6 +33,9 @@ Bug Fixes
   a ``zarr_format=3`` store with ``use_zarr_fill_value_as_mask=False``, so it is no
   longer silently lost on round-trip (:issue:`10269`).
   By `Davis Bennett <https://github.com/d-v-b>`_.
+- Fix :py:func:`decode_cf` failing on integer-encoded time arrays that contain
+  NaT when running against numpy 2.5+.
+  By `Ian Hunt-Isaak <https://github.com/ianhi>`_.
 
 
 Documentation

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -386,45 +386,45 @@ def _decode_datetime_with_cftime(
         return np.array([], dtype=object)
 
 
+def _decode_to_timedelta(value, unit: NPDatetimeUnitOptions) -> np.timedelta64:
+    """Decode a single CF-encoded scalar to ``np.timedelta64``.
+
+    Returns NaT for encoded NaT inputs. Raises ``OutOfBoundsTimedelta`` if the
+    value is not representable.
+    """
+    # Integer arrays encode NaT as int64.min (numpy/pandas's NaT bit pattern);
+    # float arrays encode it as NaN. Detect both before the multiplication
+    # below. In numpy >= 2.5 (numpy/numpy#31378) int64.min * timedelta64
+    # raises OverflowError instead of silently producing NaT.
+    if (value.dtype.kind == "i" and int(value) == np.iinfo("int64").min) or (
+        value.dtype.kind == "f" and np.isnan(value)
+    ):
+        return np.timedelta64("NaT", unit)
+    if value > np.iinfo("int64").max or value < np.iinfo("int64").min:
+        raise OutOfBoundsTimedelta(
+            f"Value {value} can't be represented as Datetime/Timedelta."
+        )
+    delta = value * np.timedelta64(1, unit)
+    # uint overflow during the multiplication above
+    if value.dtype.kind == "u" and not np.int64(delta) == value:
+        raise OutOfBoundsTimedelta("DType overflow in Datetime/Timedelta calculation.")
+    return delta
+
+
 def _check_date_for_units_since_refdate(
     date, unit: NPDatetimeUnitOptions, ref_date: pd.Timestamp
 ) -> pd.Timestamp:
-    # check for out-of-bounds floats and raise
-    if date > np.iinfo("int64").max or date < np.iinfo("int64").min:
-        raise OutOfBoundsTimedelta(
-            f"Value {date} can't be represented as Datetime/Timedelta."
-        )
-    delta = date * np.timedelta64(1, unit)
-    if not np.isnan(delta):
-        # this will raise on dtype overflow for integer dtypes
-        if date.dtype.kind == "u" and not np.int64(delta) == date:
-            raise OutOfBoundsTimedelta(
-                "DType overflow in Datetime/Timedelta calculation."
-            )
-        # this will raise on overflow if ref_date + delta
-        # can't be represented in the current ref_date resolution
-        return timestamp_as_unit(ref_date + delta, ref_date.unit)
-    else:
-        # if date is exactly NaT (np.iinfo("int64").min) return NaT
-        # to make follow-up checks work
+    delta = _decode_to_timedelta(date, unit)
+    if np.isnat(delta):
         return pd.Timestamp("NaT")
+    # this will raise on overflow if ref_date + delta can't be represented in
+    # the current ref_date resolution
+    return timestamp_as_unit(ref_date + delta, ref_date.unit)
 
 
 def _check_timedelta_range(value, data_unit, time_unit):
-    if value > np.iinfo("int64").max or value < np.iinfo("int64").min:
-        OutOfBoundsTimedelta(f"Value {value} can't be represented as Timedelta.")
-    # on windows multiplying nan leads to RuntimeWarning
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore", "invalid value encountered in multiply", RuntimeWarning
-        )
-        delta = value * np.timedelta64(1, data_unit)
-    if not np.isnan(delta):
-        # this will raise on dtype overflow for integer dtypes
-        if value.dtype.kind == "u" and not np.int64(delta) == value:
-            raise OutOfBoundsTimedelta(
-                "DType overflow in Datetime/Timedelta calculation."
-            )
+    delta = _decode_to_timedelta(value, data_unit)
+    if not np.isnat(delta):
         # this will raise on overflow if delta cannot be represented with the
         # resolutions supported by pandas.
         pd.to_timedelta(delta)

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -353,10 +353,10 @@ class TestArrayNotNullEquiv:
         "val1, val2, val3, null",
         [
             (
-                np.datetime64("2000"),
-                np.datetime64("2001"),
-                np.datetime64("2002"),
-                np.datetime64("NaT"),
+                np.datetime64("2000", "ns"),
+                np.datetime64("2001", "ns"),
+                np.datetime64("2002", "ns"),
+                np.datetime64("NaT", "ns"),
             ),
             (1.0, 2.0, 3.0, np.nan),
             ("foo", "bar", "baz", None),


### PR DESCRIPTION
### Description

Two separate things: 

- Generic typing of datetimes causing collection errors -> upstream failing bug report action failed
- multiplying a timedelta by the integer min value (the NaT sentinel) started raising an overflow instead of becoming a NaT with https://github.com/numpy/numpy/pull/31378 so catch that explicitly to return NaT

I ended up consolidating the two methods in code/times by a bit to avoid writing the same fix twice. They had almost exactly the same code path.



cc @dcherian 

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [NA] Closes #xxxx
- [NA] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [NA] New functions/methods are listed in `api.rst`

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    <!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
    Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}
