### PR TITLE
Fix scipy file-object dataset pickling

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -26,6 +26,9 @@ Deprecations
 Bug Fixes
 ~~~~~~~~~
 
+- Restore pickling support for open scipy-engine datasets backed by file-like
+  objects after another scipy file-like dataset is opened (:issue:`11323`).
+  By `Puneet Dixit <https://github.com/puneetdixit200>`_.
 - Fix a major performance regression in :py:meth:`Coordinates.to_index` (and
   consequently :py:meth:`Dataset.to_dataframe`) caused by converting the cached
   code ndarrays into Python lists (:issue:`11305`).

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -8,6 +8,11 @@ from typing import IO, TYPE_CHECKING, Any, Literal, TypeVar, overload
 
 import numpy as np
 
+try:
+    from scipy.io import netcdf_file as netcdf_file_base
+except ImportError:
+    netcdf_file_base = object  # type: ignore[assignment,misc,unused-ignore]  # scipy is optional
+
 from xarray.backends.common import (
     BACKEND_ENTRYPOINTS,
     BackendArray,
@@ -122,16 +127,27 @@ class ScipyArrayWrapper(BackendArray):
                     raise
 
 
-# This is a dirty workaround to allow pickling of the flush_only_netcdf_file class.
-# https://stackoverflow.com/questions/72766345/attributeerror-cant-pickle-local-object-in-multiprocessing
-# TODO: Remove this after upstreaming the fixes to scipy.
-class _PickleWorkaround:
-    flush_only_netcdf_file: type[scipy.io.netcdf_file]
+# TODO: Make the scipy import lazy again after upstreaming these fixes.
+class flush_only_netcdf_file(netcdf_file_base):
+    # scipy.io.netcdf_file.close() incorrectly closes file objects that
+    # were passed in as constructor arguments:
+    # https://github.com/scipy/scipy/issues/13905
 
-    @classmethod
-    def add_cls(cls, new_class: type[Any]) -> None:
-        setattr(cls, new_class.__name__, new_class)
-        new_class.__qualname__ = cls.__qualname__ + "." + new_class.__name__
+    # Instead of closing such files, only call flush(), which is
+    # equivalent as long as the netcdf_file object is not mmapped.
+    # This suffices to keep BytesIO objects open long enough to read
+    # their contents from to_netcdf(), but underlying files still get
+    # closed when the netcdf_file is garbage collected (via __del__),
+    # and will need to be fixed upstream in scipy.
+    def close(self):
+        if hasattr(self, "fp") and not self.fp.closed:
+            self.flush()
+            self.fp.seek(0)  # allow file to be read again
+
+    def __del__(self):
+        # Remove the __del__ method, which in scipy is aliased to close().
+        # These files need to be closed explicitly by xarray.
+        pass
 
 
 def _open_scipy_netcdf(
@@ -143,33 +159,7 @@ def _open_scipy_netcdf(
 ) -> scipy.io.netcdf_file:
     import scipy.io
 
-    # TODO: Remove this after upstreaming these fixes.
-    class flush_only_netcdf_file(scipy.io.netcdf_file):
-        # scipy.io.netcdf_file.close() incorrectly closes file objects that
-        # were passed in as constructor arguments:
-        # https://github.com/scipy/scipy/issues/13905
-
-        # Instead of closing such files, only call flush(), which is
-        # equivalent as long as the netcdf_file object is not mmapped.
-        # This suffices to keep BytesIO objects open long enough to read
-        # their contents from to_netcdf(), but underlying files still get
-        # closed when the netcdf_file is garbage collected (via __del__),
-        # and will need to be fixed upstream in scipy.
-        def close(self):
-            if hasattr(self, "fp") and not self.fp.closed:
-                self.flush()
-                self.fp.seek(0)  # allow file to be read again
-
-        def __del__(self):
-            # Remove the __del__ method, which in scipy is aliased to close().
-            # These files need to be closed explicitly by xarray.
-            pass
-
-    _PickleWorkaround.add_cls(flush_only_netcdf_file)
-
-    netcdf_file = (
-        _PickleWorkaround.flush_only_netcdf_file if flush_only else scipy.io.netcdf_file
-    )
+    netcdf_file = flush_only_netcdf_file if flush_only else scipy.io.netcdf_file
 
     # if the string ends with .gz, then gunzip and open as netcdf file
     if isinstance(filename, str) and filename.endswith(".gz"):

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -8,11 +8,6 @@ from typing import IO, TYPE_CHECKING, Any, Literal, TypeVar, overload
 
 import numpy as np
 
-try:
-    from scipy.io import netcdf_file as netcdf_file_base
-except ImportError:
-    netcdf_file_base = object  # type: ignore[assignment,misc,unused-ignore]  # scipy is optional
-
 from xarray.backends.common import (
     BACKEND_ENTRYPOINTS,
     BackendArray,
@@ -54,6 +49,7 @@ K = TypeVar("K")
 V = TypeVar("V")
 
 HAS_NUMPY_2_0 = module_available("numpy", minversion="2.0.0.dev0")
+_FLUSH_ONLY_NETCDF_FILE: type[scipy.io.netcdf_file] | None = None
 
 
 @overload
@@ -127,27 +123,48 @@ class ScipyArrayWrapper(BackendArray):
                     raise
 
 
-# TODO: Make the scipy import lazy again after upstreaming these fixes.
-class flush_only_netcdf_file(netcdf_file_base):
-    # scipy.io.netcdf_file.close() incorrectly closes file objects that
-    # were passed in as constructor arguments:
-    # https://github.com/scipy/scipy/issues/13905
+def _get_flush_only_netcdf_file() -> type[scipy.io.netcdf_file]:
+    global _FLUSH_ONLY_NETCDF_FILE
 
-    # Instead of closing such files, only call flush(), which is
-    # equivalent as long as the netcdf_file object is not mmapped.
-    # This suffices to keep BytesIO objects open long enough to read
-    # their contents from to_netcdf(), but underlying files still get
-    # closed when the netcdf_file is garbage collected (via __del__),
-    # and will need to be fixed upstream in scipy.
-    def close(self):
-        if hasattr(self, "fp") and not self.fp.closed:
-            self.flush()
-            self.fp.seek(0)  # allow file to be read again
+    if _FLUSH_ONLY_NETCDF_FILE is None:
+        import scipy.io
 
-    def __del__(self):
-        # Remove the __del__ method, which in scipy is aliased to close().
-        # These files need to be closed explicitly by xarray.
-        pass
+        # TODO: Remove this after upstreaming these fixes.
+        class flush_only_netcdf_file(scipy.io.netcdf_file):
+            # scipy.io.netcdf_file.close() incorrectly closes file objects that
+            # were passed in as constructor arguments:
+            # https://github.com/scipy/scipy/issues/13905
+
+            # Instead of closing such files, only call flush(), which is
+            # equivalent as long as the netcdf_file object is not mmapped.
+            # This suffices to keep BytesIO objects open long enough to read
+            # their contents from to_netcdf(), but underlying files still get
+            # closed when the netcdf_file is garbage collected (via __del__),
+            # and will need to be fixed upstream in scipy.
+            def close(self):
+                if hasattr(self, "fp") and not self.fp.closed:
+                    self.flush()
+                    self.fp.seek(0)  # allow file to be read again
+
+            def __del__(self):
+                # Remove the __del__ method, which in scipy is aliased to close().
+                # These files need to be closed explicitly by xarray.
+                pass
+
+        flush_only_netcdf_file.__module__ = __name__
+        flush_only_netcdf_file.__qualname__ = flush_only_netcdf_file.__name__
+        _FLUSH_ONLY_NETCDF_FILE = flush_only_netcdf_file
+        globals()[flush_only_netcdf_file.__name__] = flush_only_netcdf_file
+
+    assert _FLUSH_ONLY_NETCDF_FILE is not None
+    return _FLUSH_ONLY_NETCDF_FILE
+
+
+def __getattr__(name: str) -> Any:
+    if name == "flush_only_netcdf_file":
+        return _get_flush_only_netcdf_file()
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _open_scipy_netcdf(
@@ -159,7 +176,7 @@ def _open_scipy_netcdf(
 ) -> scipy.io.netcdf_file:
     import scipy.io
 
-    netcdf_file = flush_only_netcdf_file if flush_only else scipy.io.netcdf_file
+    netcdf_file = _get_flush_only_netcdf_file() if flush_only else scipy.io.netcdf_file
 
     # if the string ends with .gz, then gunzip and open as netcdf file
     if isinstance(filename, str) and filename.endswith(".gz"):

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4699,6 +4699,18 @@ class TestScipyInMemoryData(CFEncodedBase, NetCDF3Only, InMemoryNetCDF):
         fobj = BytesIO()
         yield backends.ScipyDataStore(fobj, "w")
 
+    def test_pickle_after_second_file_object_open(self) -> None:
+        original = Dataset(
+            {"foo": ("x", np.arange(4, dtype=np.float64))},
+            coords={"x": np.arange(4)},
+        )
+        netcdf_bytes = bytes(original.to_netcdf(engine=self.engine))
+
+        with open_dataset(BytesIO(netcdf_bytes), engine=self.engine) as first:
+            with open_dataset(BytesIO(netcdf_bytes), engine=self.engine):
+                with pickle.loads(pickle.dumps(first)) as unpickled:
+                    assert_identical(original, unpickled)
+
     @contextlib.contextmanager
     def roundtrip(
         self, data, save_kwargs=None, open_kwargs=None, allow_cleanup_failure=False


### PR DESCRIPTION
### Description

Closes #11323.

This keeps the scipy file-object netCDF workaround class stable across opens by defining it at module scope again. That avoids replacing the class object that pickle resolves for an already-open dataset when another scipy file object is opened.

The regression test opens two scipy file-object-backed datasets and pickles the first while the second remains open.

### Checklist

- [x] Closes #11323
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: OpenAI GPT-5
