### PR TITLE
Speed up Dataset.load for in-memory datasets with many variables

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -42,6 +42,12 @@ Documentation
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Speed up :py:meth:`Dataset.load` and other ``.load()`` paths on datasets
+  with many variables by short-circuiting ``is_chunked_array`` for
+  ``numpy.ndarray`` inputs and removing a duplicate ``is_duck_array``
+  call inside the function. Roughly 1.5× faster ``isel().load()`` on a
+  400-scalar-var dataset (0.52 ms → 0.34 ms); no effect on chunked paths.
+
 
 .. _whats-new.2026.04.0:
 

--- a/xarray/namedarray/pycompat.py
+++ b/xarray/namedarray/pycompat.py
@@ -8,7 +8,11 @@ import numpy as np
 from packaging.version import Version
 
 from xarray.core.utils import is_scalar
-from xarray.namedarray.utils import is_dask_collection, is_duck_array, is_duck_dask_array
+from xarray.namedarray.utils import (
+    is_dask_collection,
+    is_duck_array,
+    is_duck_dask_array,
+)
 
 integer_types = (int, np.integer)
 

--- a/xarray/namedarray/pycompat.py
+++ b/xarray/namedarray/pycompat.py
@@ -8,7 +8,7 @@ import numpy as np
 from packaging.version import Version
 
 from xarray.core.utils import is_scalar
-from xarray.namedarray.utils import is_duck_array, is_duck_dask_array
+from xarray.namedarray.utils import is_dask_collection, is_duck_array, is_duck_dask_array
 
 integer_types = (int, np.integer)
 
@@ -89,7 +89,16 @@ def mod_version(mod: ModType) -> Version:
 
 
 def is_chunked_array(x: duckarray[Any, Any]) -> bool:
-    return is_duck_dask_array(x) or (is_duck_array(x) and hasattr(x, "chunks"))
+    # Fast path: numpy arrays are the dominant case in non-dask datasets and
+    # never expose a `chunks` attribute, so we can skip all the duck-array
+    # protocol work. Avoiding this dispatch matters for ``Dataset.load()`` on
+    # datasets with many variables — each variable was previously paying for
+    # two ``is_duck_array`` calls plus a dask-collection check.
+    if isinstance(x, np.ndarray):
+        return False
+    if not is_duck_array(x):
+        return False
+    return is_dask_collection(x) or hasattr(x, "chunks")
 
 
 def is_0d_dask_array(x: duckarray[Any, Any]) -> bool:


### PR DESCRIPTION
## Summary

`Dataset.load()` and `DataArray.load()` walk all variables and call `is_chunked_array(...)` on each — first inside the dict comprehension in `Dataset.load`, then again per variable via `Variable.load() -> to_duck_array()`. `is_chunked_array` itself ran `is_duck_array` twice (once directly, once via `is_duck_dask_array`).

For the dominant case — a `numpy.ndarray` — none of this work is needed. This PR:

1. Adds a `np.ndarray` fast-path that returns `False` immediately.
2. Consolidates to a single `is_duck_array(x)` check feeding both the dask-collection branch (now via `is_dask_collection` directly) and the `hasattr(x, "chunks")` fallback.

Behavior is unchanged on non-numpy inputs: any duck-array with a dask graph or a `chunks` attribute is still reported as chunked.

## Benchmark numbers

`asv_bench/benchmarks/indexing.py::Indexing.time_indexing_basic_ds_large` (an `isel(...).load()` on a 400-scalar-var dataset), best of 5×50 iterations, GC off:

|         | per call |
|---------|---------:|
| `main`  | 0.524 ms |
| this PR | 0.335 ms |
| speedup | **~1.56×** |

Scaling check on synthetic `isel().load()` workloads, varying variable count and per-variable size:

- Speedup scales with **variable count** — 1.20× at 50 vars → 1.29× at 2000 vars — as expected for a per-variable saving.
- Speedup is **flat across per-var size** (~1.24× from size=0 to size=10,000), confirming the saving is pure dispatch overhead, not work-per-element.

Profiler attribution previously showed ~25% of `load()` wall time inside the `is_chunked_array` dispatch chain; that portion is now near-free.

## Test plan

- [x] `pytest xarray/tests/test_variable.py` — 544 passed, 69 skipped, 8 xfailed, 3 xpassed
- [x] Chunked paths preserved — any duck-array with a `chunks` attribute or a dask graph is still reported as chunked; the duck-array shortcut now performs the same check as the prior `is_duck_dask_array or (is_duck_array and hasattr chunks)` chain
- [x] `doc/whats-new.rst` entry under *Internal Changes*

---

[This is Claude Code on behalf of Felix Bumann]