### PR TITLE
Skip Variable.load dispatch for in-memory numpy data

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -42,6 +42,13 @@ Documentation
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Skip the ``to_duck_array`` dispatch in :py:meth:`Variable.load` and
+  :py:meth:`Variable.load_async` when the underlying data is already a
+  ``numpy.ndarray``. The dispatch was a no-op for that case but added
+  noticeable per-variable overhead to :py:meth:`Dataset.load` /
+  :py:meth:`DataArray.load` on datasets with many in-memory variables
+  (:issue:`11352`).
+
 
 .. _whats-new.2026.04.0:
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1019,6 +1019,12 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
         DataArray.load
         Dataset.load
         """
+        # Fast path: an in-memory numpy array has nothing to load. The full
+        # to_duck_array dispatch otherwise walks is_chunked_array, the
+        # ExplicitlyIndexed isinstance check, and is_duck_array only to return
+        # self._data unchanged.
+        if isinstance(self._data, np.ndarray):
+            return self
         self._data = to_duck_array(self._data, **kwargs)
         return self
 
@@ -1052,6 +1058,8 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
         DataArray.load_async
         Dataset.load_async
         """
+        if isinstance(self._data, np.ndarray):
+            return self
         self._data = await async_to_duck_array(self._data, **kwargs)
         return self
 


### PR DESCRIPTION
## Summary

Addresses #11352.

`Variable.load()` and `Variable.load_async()` always end with `self._data = to_duck_array(self._data, ...)`. For an in-memory `numpy.ndarray`, that dispatch walks `is_chunked_array`, the `ExplicitlyIndexed | ImplicitToExplicitIndexingAdapter` isinstance check, and `is_duck_array` only to return `self._data` unchanged. The whole call is pure overhead — the same no-op that `IndexVariable.load` (`xarray/core/variable.py:2781`) already short-circuits with `return self`.

This PR adds an `isinstance(self._data, np.ndarray)` guard at the top of both `Variable.load` and `Variable.load_async`. Behavior is unchanged on chunked, `ExplicitlyIndexed`, and non-numpy duck-array inputs.

## Benchmark numbers

`isel(...).load()` on synthetic scalar-var datasets, against upstream `main`, best of 5, GC off:

| | per call (main) | per call (this PR) | speedup |
|---|---:|---:|---:|
| 50 scalar vars   | 0.090 ms | 0.063 ms | **1.44×** |
| 200 scalar vars  | 0.283 ms | 0.175 ms | **1.62×** |
| 400 scalar vars  | 0.524 ms | 0.324 ms | **1.62×** |
| 1000 scalar vars | 1.271 ms | 0.760 ms | **1.67×** |
| 2000 scalar vars | 2.484 ms | 1.490 ms | **1.67×** |

Scaling check across per-variable data size (200 vars fixed): flat **~1.56×** speedup from `size=0` to `size=10,000`, confirming the saving is pure dispatch overhead — not work-per-element.

### Note on overlap with #11351

#11351 makes `is_chunked_array(numpy)` near-free. This PR skips the entire `to_duck_array` body for numpy `Variable._data`, which makes the `is_chunked_array` call inside it dead code on that path. The two PRs are still complementary, not redundant:

- `Dataset.load` calls `is_chunked_array(v._data)` in its dict comprehension (`xarray/core/dataset.py:563`) **before** dispatching to `Variable.load` — that call is only sped up by #11351.
- The dispatch inside `Variable.load` itself is what this PR removes.

If both land, the per-variable saving on in-memory datasets compounds.

## Test plan

- [x] `pytest xarray/tests/test_variable.py xarray/tests/test_dataset.py` — 1051 passed, 76 skipped, 9 xfailed, 4 xpassed
- [x] Non-numpy paths preserved: `ExplicitlyIndexed`/`ImplicitToExplicitIndexingAdapter` adapters are not `np.ndarray` instances and still take the `to_duck_array` path; dask arrays likewise hit the existing chunked-compute branch.
- [x] `doc/whats-new.rst` entry under *Internal Changes*

---

[This is Claude Code on behalf of Felix Bumann]