### PR TITLE
perf: short-circuit duck-array dispatch helpers for numpy

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -42,6 +42,12 @@ Documentation
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Speed up :py:meth:`Dataset.load` and other ``.load()`` paths on datasets
+  with many variables by short-circuiting ``is_chunked_array`` for
+  ``numpy.ndarray`` inputs and removing a duplicate ``is_duck_array``
+  call inside the function. Roughly 1.5× faster ``isel().load()`` on a
+  400-scalar-var dataset (0.52 ms → 0.34 ms); no effect on chunked paths.
+
 
 .. _whats-new.2026.04.0:
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -42,11 +42,15 @@ Documentation
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
-- Speed up :py:meth:`Dataset.load` and other ``.load()`` paths on datasets
-  with many variables by short-circuiting ``is_chunked_array`` for
-  ``numpy.ndarray`` inputs and removing a duplicate ``is_duck_array``
-  call inside the function. Roughly 1.5× faster ``isel().load()`` on a
-  400-scalar-var dataset (0.52 ms → 0.34 ms); no effect on chunked paths.
+- Speed up the duck-array dispatch helpers on ``numpy.ndarray`` inputs:
+  ``is_chunked_array`` no longer duplicates ``is_duck_array``'s built-in
+  ``np.ndarray`` short-circuit, and ``is_dask_collection`` now
+  short-circuits ``np.ndarray`` directly, skipping the dask import and
+  dispatch on numpy-backed data. The knock-on speedup for
+  ``is_duck_dask_array`` (~2× on numpy) benefits many hot paths in
+  ``duck_array_ops``, ``variable``, ``indexing``, ``groupby`` and the
+  ``dt`` / ``str`` accessors. Roughly 1.4× faster ``isel().load()`` on a
+  400-scalar-var dataset; no effect on chunked paths.
 
 
 .. _whats-new.2026.04.0:

--- a/xarray/namedarray/pycompat.py
+++ b/xarray/namedarray/pycompat.py
@@ -8,7 +8,11 @@ import numpy as np
 from packaging.version import Version
 
 from xarray.core.utils import is_scalar
-from xarray.namedarray.utils import is_dask_collection, is_duck_array, is_duck_dask_array
+from xarray.namedarray.utils import (
+    is_dask_collection,
+    is_duck_array,
+    is_duck_dask_array,
+)
 
 integer_types = (int, np.integer)
 

--- a/xarray/namedarray/pycompat.py
+++ b/xarray/namedarray/pycompat.py
@@ -93,16 +93,12 @@ def mod_version(mod: ModType) -> Version:
 
 
 def is_chunked_array(x: duckarray[Any, Any]) -> bool:
-    # Fast path: ndarrays (and ndarray subclasses without a `chunks` attribute,
-    # e.g. MaskedArray) are the dominant non-dask case and skip the duck-array
-    # protocol work entirely. Subclasses that *do* expose `chunks` — test fakes
-    # like DummyChunkedArray, or third-party chunked-array impls — fall through
-    # to the full check below.
-    if isinstance(x, np.ndarray) and not hasattr(x, "chunks"):
-        return False
+    # `is_duck_array` already short-circuits np.ndarray via isinstance, so we
+    # don't repeat that check here. `hasattr("chunks")` runs before
+    # `is_dask_collection` so the dominant numpy case skips the dask dispatch.
     if not is_duck_array(x):
         return False
-    return is_dask_collection(x) or hasattr(x, "chunks")
+    return hasattr(x, "chunks") or is_dask_collection(x)
 
 
 def is_0d_dask_array(x: duckarray[Any, Any]) -> bool:

--- a/xarray/namedarray/pycompat.py
+++ b/xarray/namedarray/pycompat.py
@@ -93,12 +93,12 @@ def mod_version(mod: ModType) -> Version:
 
 
 def is_chunked_array(x: duckarray[Any, Any]) -> bool:
-    # Fast path: numpy arrays are the dominant case in non-dask datasets and
-    # never expose a `chunks` attribute, so we can skip all the duck-array
-    # protocol work. Avoiding this dispatch matters for ``Dataset.load()`` on
-    # datasets with many variables — each variable was previously paying for
-    # two ``is_duck_array`` calls plus a dask-collection check.
-    if isinstance(x, np.ndarray):
+    # Fast path: ndarrays (and ndarray subclasses without a `chunks` attribute,
+    # e.g. MaskedArray) are the dominant non-dask case and skip the duck-array
+    # protocol work entirely. Subclasses that *do* expose `chunks` — test fakes
+    # like DummyChunkedArray, or third-party chunked-array impls — fall through
+    # to the full check below.
+    if isinstance(x, np.ndarray) and not hasattr(x, "chunks"):
         return False
     if not is_duck_array(x):
         return False

--- a/xarray/namedarray/pycompat.py
+++ b/xarray/namedarray/pycompat.py
@@ -8,7 +8,7 @@ import numpy as np
 from packaging.version import Version
 
 from xarray.core.utils import is_scalar
-from xarray.namedarray.utils import is_duck_array, is_duck_dask_array
+from xarray.namedarray.utils import is_dask_collection, is_duck_array, is_duck_dask_array
 
 integer_types = (int, np.integer)
 
@@ -89,7 +89,16 @@ def mod_version(mod: ModType) -> Version:
 
 
 def is_chunked_array(x: duckarray[Any, Any]) -> bool:
-    return is_duck_dask_array(x) or (is_duck_array(x) and hasattr(x, "chunks"))
+    # Fast path: numpy arrays are the dominant case in non-dask datasets and
+    # never expose a `chunks` attribute, so we can skip all the duck-array
+    # protocol work. Avoiding this dispatch matters for ``Dataset.load()`` on
+    # datasets with many variables — each variable was previously paying for
+    # two ``is_duck_array`` calls plus a dask-collection check.
+    if isinstance(x, np.ndarray):
+        return False
+    if not is_duck_array(x):
+        return False
+    return is_dask_collection(x) or hasattr(x, "chunks")
 
 
 def is_0d_dask_array(x: duckarray[Any, Any]) -> bool:

--- a/xarray/namedarray/utils.py
+++ b/xarray/namedarray/utils.py
@@ -66,6 +66,9 @@ def module_available(module: str, minversion: str | None = None) -> bool:
 
 
 def is_dask_collection(x: object) -> TypeGuard[DaskCollection]:
+    # Fast path: numpy never satisfies __dask_graph__; skip the dask dispatch.
+    if isinstance(x, np.ndarray):
+        return False
     if module_available("dask"):
         from dask.base import is_dask_collection
 

--- a/xarray/namedarray/utils.py
+++ b/xarray/namedarray/utils.py
@@ -66,8 +66,11 @@ def module_available(module: str, minversion: str | None = None) -> bool:
 
 
 def is_dask_collection(x: object) -> TypeGuard[DaskCollection]:
-    # Fast path: numpy never satisfies __dask_graph__; skip the dask dispatch.
-    if isinstance(x, np.ndarray):
+    # Fast path: a plain numpy ndarray never satisfies __dask_graph__; skip
+    # the dask dispatch. Exact-type check (not isinstance) so any hypothetical
+    # ndarray subclass that *did* implement __dask_graph__ would still fall
+    # through to the real check.
+    if type(x) is np.ndarray:
         return False
     if module_available("dask"):
         from dask.base import is_dask_collection


### PR DESCRIPTION
### Description

xarray's duck-array dispatch helpers — `is_chunked_array`, `is_dask_collection`, `is_duck_dask_array` — are called per-variable on every operation that has to branch "dask vs. eager", and ~50 sites across the codebase rely on them. For the dominant case of a `numpy.ndarray`, none of those should need to enter the dask machinery, but the existing helpers walked the duck-array protocol and (with dask installed) ended up inside `dask.base.is_dask_collection` anyway.

This PR moves the `np.ndarray` short-circuit one level deeper, into the helpers themselves:

1. **`is_chunked_array` (`xarray/namedarray/pycompat.py`)** — was calling `is_duck_array` twice (once directly, once via `is_duck_dask_array`). Rewritten to one `is_duck_array(x)` check, leaning on its built-in `isinstance(x, np.ndarray)` fast path, with `hasattr(x, "chunks")` checked before `is_dask_collection(x)` so numpy avoids the dask import altogether.
2. **`is_dask_collection` (`xarray/namedarray/utils.py`)** — now does `type(x) is np.ndarray: return False` before falling through to the dask dispatch. Exact-type check (matching #11355's style) — a plain ndarray never satisfies `__dask_graph__`, so this is a no-op semantically, while any hypothetical ndarray subclass that did implement `__dask_graph__` would still fall through to the real check. Removes the cost from every `is_duck_dask_array` call site too.

Behavior is unchanged: any duck-array with a dask graph or a `chunks` attribute is still reported as chunked.

### Where this fires

`is_chunked_array` and `is_duck_dask_array` together are called from ~50 sites across xarray — every place that branches "dask vs. numpy". On numpy-backed data, all of them skip the dispatch chain. Notable categories:

- **Materialization:** `ds.load()`, `da.load()`, `compute()`, `xr.load_dataset/dataarray/datatree`, `persist()`, `.values`, `.to_numpy()`, `.to_dataframe()`, `.to_pandas()`, plotting, repr previews.
- **CF encode/decode** — every variable read or written: `coding/times.py`, `coding/strings.py`, `coding/common.py`.
- **Numerical paths** — `apply_ufunc` (`computation/apply_ufunc.py`), `corr`/`cov`/`polyval`/`polyfit`, `interp`, `interpolate_na`, reductions.
- **Structural ops** — `Dataset.chunk()`, `interp`, vectorized indexer dispatch (`isel`/`sel`), `Variable._shuffle`, `contains_only_chunked_or_numpy`.
- **Groupby internals** — `groupers.py`, `groupby.py`.
- **Accessors** — `accessor_dt.py`, `accessor_str.py`.
- **Backends** — `backends/common.py` (`ArrayWriter.add`).

Not affected: arithmetic on lazy/dask objects (stays lazy); arithmetic on numpy-backed objects (already pure numpy, never reached these helpers).

### Benchmark numbers

**`is_duck_dask_array(numpy)`** — direct microbench, best of 5×500,000:

|         | per call |
|---------|---------:|
| `main`  | 209 ns   |
| this PR | 93 ns    |
| speedup | **2.25×** |

**`Indexing.time_indexing_basic_ds_large`** (added in #9003 for this exact concern), best of 5×50, GC off:

|                       | per call  |
|-----------------------|----------:|
| `main`                | 0.542 ms  |
| this PR               | ~0.40 ms  |
| this PR + #11355      | 0.312 ms  |
| speedup (this PR)     | **~1.36×** |
| speedup (combined)    | **~1.74×** |

The two PRs are independent (parallel branches off `main`, no merge conflicts in either order) but **the wins compound** for numpy-backed `Dataset.load`: #11354 makes the `is_chunked_array` call in `Dataset.load`'s dict comprehension (`xarray/core/dataset.py:563`) near-free, and #11355 then skips the entire `to_duck_array` body for each numpy `_data`.

### Review history

Earlier revisions of this PR added an explicit `isinstance(x, np.ndarray)` guard to `is_chunked_array` directly. Per [@Illviljan's review](https://github.com/pydata/xarray/pull/11354#pullrequestreview-4366865673), that duplicated the isinstance already living inside `is_duck_array`. The current revision drops that duplicate and moves the cheaper numpy short-circuit into `is_dask_collection` instead, where it benefits every `is_duck_dask_array` caller as a bonus.

### Checklist

- [x] Tests covering chunked paths preserved — any duck-array with a `chunks` attribute or a dask graph is still reported as chunked
- [x] `pytest xarray/tests/test_variable.py xarray/tests/test_parallelcompat.py xarray/tests/test_dask.py xarray/tests/test_namedarray.py xarray/namedarray` — 825 passed, 72 skipped, 12 xfailed, 4 xpassed
- [x] `doc/whats-new.rst` entry under *Internal Changes* (updated for the widened scope)

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Claude Code)

---

*[This is Claude Code on behalf of Felix Bumann]*
