### PR TITLE
fix: handle None module in module_available

### DIFF
--- a/xarray/namedarray/utils.py
+++ b/xarray/namedarray/utils.py
@@ -54,6 +54,9 @@ def module_available(module: str, minversion: str | None = None) -> bool:
     available : bool
         Whether the module is installed.
     """
+    if module is None:
+        return False
+
     if importlib.util.find_spec(module) is None:
         return False
 

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -666,3 +666,17 @@ def test_fake_target_chunksize_cftime() -> None:
 
     assert faked_chunksize == 73
     assert dtype == np.float64
+
+
+def test_module_available() -> None:
+    """Test that module_available handles None input gracefully."""
+    from xarray.namedarray.utils import module_available
+
+    # Existing behavior: valid module names work
+    assert module_available("numpy") is True
+    assert module_available("nonexistent_module_xyz") is False
+    assert module_available("numpy", minversion="1.0.0") is True
+    assert module_available("numpy", minversion="999.0.0") is False
+
+    # Bug fix: None input should return False, not crash
+    assert module_available(None) is False


### PR DESCRIPTION
### Description

Closes #11344.

`module_available(None)` crashes with `AttributeError: 'NoneType' object has no attribute 'startswith'` during version checks (e.g., in the rain-to-flood toolkit).

This adds an early return of `False` when `module is None`, and a regression test covering None input, valid modules, and minversion checks.

### Checklist

- [x] Closes #11344
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Hermes Agent

### Test Plan

- `uv run pytest xarray/tests/test_namedarray.py::test_module_available -v` -> 1 passed
- `uv run pytest xarray/tests/test_namedarray.py -q` -> all existing tests still pass