### PR TITLE
Preserve step in RangeIndex.arange and slicing

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -33,6 +33,12 @@ Bug Fixes
   a ``zarr_format=3`` store with ``use_zarr_fill_value_as_mask=False``, so it is no
   longer silently lost on round-trip (:issue:`10269`).
   By `Davis Bennett <https://github.com/d-v-b>`_.
+- :py:meth:`~xarray.indexes.RangeIndex.arange` now preserves the requested
+  ``step`` instead of silently re-deriving it from ``(stop - start) / size``, so
+  its values match :py:func:`numpy.arange` when ``step`` does not evenly divide
+  the interval. Strided slicing of a :py:class:`~xarray.indexes.RangeIndex` now
+  preserves the step as well (:issue:`11325`).
+  By `mokashang <https://github.com/mokashang>`_.
 
 
 Documentation

--- a/xarray/indexes/range_index.py
+++ b/xarray/indexes/range_index.py
@@ -32,6 +32,7 @@ class RangeCoordinateTransform(CoordinateTransform):
         coord_name: Hashable,
         dim: str,
         dtype: Any = None,
+        step: float | None = None,
     ):
         if dtype is None:
             dtype = np.dtype(np.float64)
@@ -40,7 +41,12 @@ class RangeCoordinateTransform(CoordinateTransform):
 
         self.start = start
         self.stop = stop
-        self._step = None  # Will be calculated by property
+        # When ``step`` is not given it is derived from ``(stop - start) / size``
+        # by the ``step`` property. That derivation is only correct when
+        # ``(stop - start)`` is an exact multiple of the spacing, so callers that
+        # know the exact spacing (e.g. ``arange`` and ``slice``) pass it here to
+        # avoid silently changing it. See GH11325.
+        self._step = step
 
     @property
     def coord_name(self) -> Hashable:
@@ -121,21 +127,23 @@ class RangeCoordinateTransform(CoordinateTransform):
         new_range = range(self.size)[sl]
         new_size = len(new_range)
 
+        # A slice scales the spacing by its own step, e.g. ``[::2]`` doubles it.
+        # Preserve the exact resulting step instead of letting it be re-derived
+        # from ``(stop - start) / size``, which would be wrong whenever the
+        # spacing does not evenly divide the interval. See GH11325.
+        new_step = self.step * new_range.step
         new_start = self.start + new_range.start * self.step
-        new_stop = self.start + new_range.stop * self.step
+        new_stop = new_start + new_size * new_step
 
-        result = type(self)(
+        return type(self)(
             new_start,
             new_stop,
             new_size,
             self.coord_name,
             self.dim,
             dtype=self.dtype,
+            step=new_step,
         )
-        if new_size == 0:
-            # For empty slices, preserve step from parent
-            result._step = self.step
-        return result
 
 
 class RangeIndex(CoordinateTransformIndex):
@@ -278,8 +286,13 @@ class RangeIndex(CoordinateTransformIndex):
 
         size = math.ceil((stop - start) / step)
 
+        # Snap ``stop`` to ``start + size * step`` and keep the exact ``step`` so
+        # that the materialized values match ``numpy.arange`` even when ``step``
+        # does not evenly divide ``stop - start``. See GH11325.
+        stop = start + size * step
+
         transform = RangeCoordinateTransform(
-            start, stop, size, coord_name, dim, dtype=dtype
+            start, stop, size, coord_name, dim, dtype=dtype, step=step
         )
 
         return cls(transform)

--- a/xarray/indexes/range_index.py
+++ b/xarray/indexes/range_index.py
@@ -41,11 +41,6 @@ class RangeCoordinateTransform(CoordinateTransform):
 
         self.start = start
         self.stop = stop
-        # When ``step`` is not given it is derived from ``(stop - start) / size``
-        # by the ``step`` property. That derivation is only correct when
-        # ``(stop - start)`` is an exact multiple of the spacing, so callers that
-        # know the exact spacing (e.g. ``arange`` and ``slice``) pass it here to
-        # avoid silently changing it. See GH11325.
         self._step = step
 
     @property

--- a/xarray/indexes/range_index.py
+++ b/xarray/indexes/range_index.py
@@ -285,7 +285,7 @@ class RangeIndex(CoordinateTransformIndex):
         # that the materialized values match ``numpy.arange`` even when ``step``
         # does not evenly divide ``stop - start``. See GH11325.
         stop = start + size * step
-
+        # Snap `stop` to `start + size * step`
         transform = RangeCoordinateTransform(
             start, stop, size, coord_name, dim, dtype=dtype, step=step
         )

--- a/xarray/tests/test_range_index.py
+++ b/xarray/tests/test_range_index.py
@@ -154,11 +154,6 @@ def test_range_index_isel() -> None:
     ds2 = create_dataset_arange(0.0, 3.0, 0.1)
     actual = ds2.isel(x=slice(4, None, 3))
     expected = create_dataset_arange(0.4, 3.0, 0.3)
-    # The strided slice now preserves the step (0.3), so its values match
-    # ``np.arange``. The index ``equals`` check (isclose-based) is used rather
-    # than ``assert_identical`` because the slice computes its step as ``0.1 * 3``
-    # while ``arange`` uses the literal ``0.3``; these agree up to floating point
-    # round-off (GH11325).
     assert actual.xindexes["x"].equals(expected.xindexes["x"])
     np.testing.assert_allclose(actual["x"].values, np.arange(0.0, 3.0, 0.1)[4::3])
 

--- a/xarray/tests/test_range_index.py
+++ b/xarray/tests/test_range_index.py
@@ -64,6 +64,19 @@ def test_range_index_arange_properties() -> None:
     assert index.step == 0.1
 
 
+def test_range_index_arange_step_not_dividing_interval() -> None:
+    # GH11325: when ``step`` does not evenly divide ``stop - start`` the
+    # requested step must still be honored and the materialized values must
+    # match ``numpy.arange`` (previously the step was silently re-derived from
+    # ``(stop - start) / size``, e.g. 0.25 instead of the requested 0.3).
+    index = RangeIndex.arange(0.0, 1.0, 0.3, dim="x")
+    assert index.step == 0.3
+    assert index.size == 4
+    actual = xr.Coordinates.from_xindex(index)
+    expected = xr.Coordinates({"x": np.arange(0.0, 1.0, 0.3)})
+    assert_equal(actual, expected, check_default_indexes=False)
+
+
 def test_range_index_linspace() -> None:
     index = RangeIndex.linspace(0.0, 1.0, num=10, endpoint=False, dim="x")
     actual = xr.Coordinates.from_xindex(index)
@@ -141,7 +154,13 @@ def test_range_index_isel() -> None:
     ds2 = create_dataset_arange(0.0, 3.0, 0.1)
     actual = ds2.isel(x=slice(4, None, 3))
     expected = create_dataset_arange(0.4, 3.0, 0.3)
-    assert_identical(actual, expected, check_default_indexes=False, check_indexes=True)
+    # The strided slice now preserves the step (0.3), so its values match
+    # ``np.arange``. The index ``equals`` check (isclose-based) is used rather
+    # than ``assert_identical`` because the slice computes its step as ``0.1 * 3``
+    # while ``arange`` uses the literal ``0.3``; these agree up to floating point
+    # round-off (GH11325).
+    assert actual.xindexes["x"].equals(expected.xindexes["x"])
+    np.testing.assert_allclose(actual["x"].values, np.arange(0.0, 3.0, 0.1)[4::3])
 
     # scalar
     actual = ds.isel(x=0)
@@ -372,11 +391,8 @@ def test_range_index_equals_exact() -> None:
     # Create an index directly
     index1 = RangeIndex.arange(0.0, 0.3, 0.1, dim="x")
 
-    # Create the same index by slicing - this accumulates floating point error
-    index_large = RangeIndex.arange(0.0, 1.0, 0.1, dim="x")
-    ds_large = xr.Dataset(coords=xr.Coordinates.from_xindex(index_large))
-    ds_sliced = ds_large.isel(x=slice(3))
-    index2 = ds_sliced.xindexes["x"]
+    # Create an index whose start differs by a tiny floating point amount
+    index2 = RangeIndex.arange(1e-12, 0.3 + 1e-12, 0.1, dim="x")
 
     # Default (exact=False) should be equal due to np.isclose tolerance
     assert index1.equals(index2)


### PR DESCRIPTION
### Description

Fixes #11325.

`RangeIndex` is stored lazily as `(start, stop, size)` and the spacing is re-derived on demand as `(stop - start) / size`. That derivation only equals the requested spacing when `(stop - start)` is an exact multiple of the step, so `RangeIndex.arange` silently dropped the user's `step` whenever it didn't evenly divide the interval:

```python
>>> import numpy as np
>>> from xarray.indexes import RangeIndex
>>> np.arange(0.0, 1.0, 0.3)
array([0. , 0.3, 0.6, 0.9])
>>> idx = RangeIndex.arange(0.0, 1.0, 0.3, dim="x")
>>> idx.step
0.25                                  # requested 0.3
>>> np.asarray(idx.to_pandas_index())
array([0.  , 0.25, 0.5 , 0.75])       # expected [0. , 0.3, 0.6, 0.9]
```

While fixing this I found the **same** root cause affects strided slicing, which was previously masked in the test suite because both the slice result and the `arange` it was compared against shared the identical (wrong) derivation. For `arange(0, 3, 0.1)`, `isel(x=slice(4, None, 3))` returned `[0.4, 0.6889, …]` instead of the actually-selected `[0.4, 0.7, 1.0, …]`.

### Approach

Carry the exact step through `RangeCoordinateTransform` (the reporter's suggested alternative of representing the range in terms of `start`, `stop` and `step` directly):

- `RangeCoordinateTransform.__init__` gains an optional `step`; when omitted, the existing `(stop - start) / size` derivation is kept (correct for `linspace`, which divides the interval evenly by construction).
- `arange` snaps `stop` to `start + size * step` and passes the exact `step`. Snapping `stop` keeps the class invariant `step == (stop - start) / size` intact, so `equals`, `repr` and `slice` stay internally consistent (e.g. `index.equals(index[:])` remains true).
- `slice` scales the parent step by the slice's own step (`[::2]` doubles it, etc.) and propagates it explicitly. This also subsumes the previous empty-slice special case.

Both `arange` and strided slicing now match `numpy.arange` across the cases I checked (positive/negative steps, evenly- and unevenly-dividing steps, forward/reverse and strided slices, slice-of-slice, empty slices).

### Testing

- Added `test_range_index_arange_step_not_dividing_interval` (the `0.3` regression case).
- Updated the GH10441 strided-slice assertion in `test_range_index_isel`: the slice now genuinely matches `numpy.arange`, so it is checked via the index's `equals` (isclose-based) plus `np.testing.assert_allclose` against the numpy ground truth. Bit-exact `assert_identical` is no longer appropriate here because the slice computes its step as `0.1 * 3` while `arange` uses the literal `0.3`; these are equal only up to floating-point round-off. This matches the rationale already documented on `RangeIndex.equals`, which uses `np.isclose` for exactly this reason.
- Updated `test_range_index_equals_exact` to use a deliberately perturbed start, since the fix makes a sliced index bit-identical to the equivalent `arange` (the scenario the test previously relied on to introduce float error).
- Full `xarray/tests/test_range_index.py` suite passes (27 passed); module doctests pass; `ruff check`/`ruff format` clean.

### Checklist

- [x] Closes #11325
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst` (n/a — only an internal, keyword-only argument on the non-public `RangeCoordinateTransform`)