### PR TITLE
Fix mypy failure: drop dead zarr<3 branch in invalid-store test

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -7772,10 +7772,7 @@ def test_zarr_create_default_indexes(tmp_path, create_default_indexes) -> None:
 @pytest.mark.usefixtures("default_zarr_format")
 def test_raises_key_error_on_invalid_zarr_store(tmp_path):
     root = zarr.open_group(tmp_path / "tmp.zarr")
-    if Version(zarr.__version__) < Version("3.0.0"):
-        root.create_dataset("bar", shape=(3, 5), dtype=np.float32)
-    else:
-        root.create_array("bar", shape=(3, 5), dtype=np.float32)
+    root.create_array("bar", shape=(3, 5), dtype=np.float32)
     with pytest.raises(KeyError, match=r"xarray to determine variable dimensions"):
         xr.open_zarr(tmp_path / "tmp.zarr", consolidated=False)
 


### PR DESCRIPTION
Seems like min value for zarr is 3.0 at runtime
https://github.com/pydata/xarray/blob/f70bc9c9fece368c57ef1c1ea0d3b7154be2ad7e/pyproject.toml#L43

<details><summary>Claude's draft</summary>

`test_raises_key_error_on_invalid_zarr_store` branched on `zarr.__version__ < 3.0.0` and called `Group.create_dataset`, which no longer exists in zarr 3. Since xarray's minimum supported zarr is now 3.0, that branch is dead code and mypy fails with:

    "Group" has no attribute "create_dataset"  [attr-defined]

Drop the version guard and always use `Group.create_array`.

Co-authored-by: Claude <noreply@anthropic.com>

Resume this Claude session:
```
claude --resume 9faa34e9-aaf5-4e94-a2b7-b03f468175f8
```
</details>

### Description

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Claude
