### PR TITLE
docs: correct DataArray.pad constant_values default in docstring

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -5905,7 +5905,7 @@ class DataArray(
             (stat_length,) or int is a shortcut for before = after = statistic
             length for all axes.
             Default is ``None``, to use the entire axis.
-        constant_values : scalar, tuple or mapping of Hashable to tuple, default: 0
+        constant_values : scalar, tuple or mapping of Hashable to tuple, default: None
             Used in 'constant'.  The values to set the padded values for each
             axis.
             ``{dim_1: (before_1, after_1), ... dim_N: (before_N, after_N)}`` unique
@@ -5914,7 +5914,7 @@ class DataArray(
             dimension.
             ``(constant,)`` or ``constant`` is a shortcut for ``before = after = constant`` for
             all dimensions.
-            Default is 0.
+            Default is ``None``, pads with ``np.nan``.
         end_values : scalar, tuple or mapping of Hashable to tuple, default: 0
             Used in 'linear_ramp'.  The values used for the ending value of the
             linear_ramp and that will form the edge of the padded array.


### PR DESCRIPTION
## Summary

Corrects the `DataArray.pad` docstring so the documented `constant_values` default matches the real signature and agrees with `Dataset.pad`.

## Why

The `DataArray.pad` docstring documented `constant_values` as `default: 0`, but the signature actually defaults to `None`, which forwards to `Dataset.pad` and pads with `np.nan`. Issue #11373 reports this as misleading: a user reading the docstring expects zero-padding and gets NaN, and the two methods' docs disagree.

### Description

The `DataArray.pad` docstring in `xarray/core/dataarray.py` documented `constant_values` as `default: 0`, but the actual signature defaults to `None`, which forwards to `Dataset.pad` and pads with `np.nan` (as `Dataset.pad`'s own docstring already states). Issue #11373 reports this mismatch as misleading. This corrects the documented default to `None` and aligns the prose with `Dataset.pad` ("Default is ``None``, pads with ``np.nan``"), so the two methods agree. Docstring only, no behavior change.

### Checklist

- [x] Closes #11373
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Claude (Claude Code). Prompt: correct the `DataArray.pad` `constant_values` docstring default from `0` to `None` to match the signature and `Dataset.pad`.
