### PR TITLE
refactor: remove dead zarr<3 (has_zarr_v3) guards in tests

### DIFF
--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -131,10 +131,10 @@ else:
 has_bottleneck, requires_bottleneck = _importorskip("bottleneck")
 has_rasterio, requires_rasterio = _importorskip("rasterio")
 has_zarr, requires_zarr = _importorskip("zarr")
-has_zarr_v3, requires_zarr_v3 = _importorskip("zarr", "3.0.0")
+requires_zarr_v3 = requires_zarr
 has_zarr_v3_dtypes, requires_zarr_v3_dtypes = _importorskip("zarr", "3.1.0")
 has_zarr_v3_async_oindex, requires_zarr_v3_async_oindex = _importorskip("zarr", "3.1.2")
-if has_zarr_v3:
+if has_zarr:
     import zarr
 
     # manual update by checking attrs for now
@@ -197,14 +197,7 @@ parametrize_zarr_format = pytest.mark.parametrize(
     "zarr_format",
     [
         pytest.param(2, id="zarr_format=2"),
-        pytest.param(
-            3,
-            marks=pytest.mark.skipif(
-                not has_zarr_v3,
-                reason="zarr-python v2 cannot understand the zarr v3 format",
-            ),
-            id="zarr_format=3",
-        ),
+        pytest.param(3, id="zarr_format=3"),
     ],
 )
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -79,7 +79,6 @@ from xarray.tests import (
     has_numpy_2,
     has_scipy,
     has_zarr,
-    has_zarr_v3,
     has_zarr_v3_async_oindex,
     has_zarr_v3_dtypes,
     mock,
@@ -128,22 +127,10 @@ with contextlib.suppress(ImportError):
 if has_zarr:
     import zarr
     import zarr.codecs
+    from zarr.storage import MemoryStore as KVStore
+    from zarr.storage import WrapperStore
 
-    if has_zarr_v3:
-        from zarr.storage import MemoryStore as KVStore
-        from zarr.storage import WrapperStore
-
-        ZARR_FORMATS = [2, 3]
-    else:
-        ZARR_FORMATS = [2]
-        try:
-            from zarr import (  # type: ignore[attr-defined,no-redef,unused-ignore]
-                KVStoreV3 as KVStore,
-            )
-        except ImportError:
-            KVStore = None  # type: ignore[assignment,misc,unused-ignore]
-
-        WrapperStore = object  # type: ignore[assignment,misc,unused-ignore]
+    ZARR_FORMATS = [2, 3]
 else:
     KVStore = None  # type: ignore[assignment,misc,unused-ignore]
     WrapperStore = object  # type: ignore[assignment,misc,unused-ignore]
@@ -158,20 +145,17 @@ if TYPE_CHECKING:
 
 @pytest.fixture(scope="module", params=ZARR_FORMATS)
 def default_zarr_format(request) -> Generator[None, None]:
-    if has_zarr_v3:
-        with zarr.config.set(default_zarr_format=request.param):
-            yield
-    else:
+    with zarr.config.set(default_zarr_format=request.param):
         yield
 
 
 def skip_if_zarr_format_3(reason: str):
-    if has_zarr_v3 and zarr.config["default_zarr_format"] == 3:
+    if zarr.config["default_zarr_format"] == 3:
         pytest.skip(reason=f"Unsupported with zarr_format=3: {reason}")
 
 
 def skip_if_zarr_format_2(reason: str):
-    if not has_zarr_v3 or (zarr.config["default_zarr_format"] == 2):
+    if zarr.config["default_zarr_format"] == 2:
         pytest.skip(reason=f"Unsupported with zarr_format=2: {reason}")
 
 
@@ -2702,10 +2686,6 @@ class ZarrBase(CFEncodedBase):
                 yield ds
 
     @pytest.mark.asyncio
-    @pytest.mark.skipif(
-        not has_zarr_v3,
-        reason="zarr-python <3 did not support async loading",
-    )
     async def test_load_async(self) -> None:
         await super().test_load_async()
 
@@ -2747,7 +2727,7 @@ class ZarrBase(CFEncodedBase):
         with pytest.raises(FileNotFoundError, match=f"({'|'.join(patterns)})"):
             xr.open_zarr(f"{uuid.uuid4()}")
 
-    @pytest.mark.skipif(has_zarr_v3, reason="chunk_store not implemented in zarr v3")
+    @pytest.mark.skip(reason="chunk_store not implemented in zarr v3")
     def test_with_chunkstore(self) -> None:
         expected = create_test_data()
         with (
@@ -2905,7 +2885,7 @@ class ZarrBase(CFEncodedBase):
     def test_shard_encoding(self) -> None:
         # These datasets have no dask chunks. All chunking/sharding specified in
         # encoding
-        if has_zarr_v3 and zarr.config.config["default_zarr_format"] == 3:
+        if zarr.config.config["default_zarr_format"] == 3:
             data = create_test_data()
             chunks = (1, 1)
             shards = (5, 5)
@@ -2924,7 +2904,7 @@ class ZarrBase(CFEncodedBase):
     def test_shard_encoding_with_dask(self) -> None:
         # Test that dask chunks must align with shard boundaries.
         # See https://github.com/pydata/xarray/issues/10831
-        if not (has_zarr_v3 and zarr.config.config["default_zarr_format"] == 3):
+        if zarr.config.config["default_zarr_format"] != 3:
             pytest.skip("sharding requires zarr v3 format")
 
         ds = xr.DataArray(np.arange(12), dims="x", name="var1").to_dataset()
@@ -3140,7 +3120,7 @@ class ZarrBase(CFEncodedBase):
     def test_compressor_encoding(self) -> None:
         # specify a custom compressor
         original = create_test_data()
-        if has_zarr_v3 and zarr.config.config["default_zarr_format"] == 3:
+        if zarr.config.config["default_zarr_format"] == 3:
             encoding_key = "compressors"
             # all parameters need to be explicitly specified in order for the comparison to pass below
             encoding = {
@@ -3158,9 +3138,9 @@ class ZarrBase(CFEncodedBase):
         else:
             from numcodecs.blosc import Blosc
 
-            encoding_key = "compressors" if has_zarr_v3 else "compressor"
+            encoding_key = "compressors"
             comp = Blosc(cname="zstd", clevel=3, shuffle=2)
-            encoding = {encoding_key: (comp,) if has_zarr_v3 else comp}
+            encoding = {encoding_key: (comp,)}
 
         save_kwargs = dict(encoding={"var1": encoding})
 
@@ -3275,7 +3255,7 @@ class ZarrBase(CFEncodedBase):
 
     @pytest.mark.parametrize("dtype", ["U", "S"])
     def test_append_string_length_mismatch_raises(self, dtype) -> None:
-        if has_zarr_v3 and not has_zarr_v3_dtypes:
+        if not has_zarr_v3_dtypes:
             skip_if_zarr_format_3("This actually works fine with Zarr format 3")
 
         ds, ds_to_append = create_append_string_length_mismatch_test_data(dtype)
@@ -3310,12 +3290,12 @@ class ZarrBase(CFEncodedBase):
             import numcodecs
 
             encoding_value: Any
-            if has_zarr_v3 and zarr.config.config["default_zarr_format"] == 3:
+            if zarr.config.config["default_zarr_format"] == 3:
                 compressor = zarr.codecs.BloscCodec()
             else:
                 compressor = numcodecs.Blosc()
-            encoding_key = "compressors" if has_zarr_v3 else "compressor"
-            encoding_value = (compressor,) if has_zarr_v3 else compressor
+            encoding_key = "compressors"
+            encoding_value = (compressor,)
 
             encoding = {"da": {encoding_key: encoding_value}}
             ds.to_zarr(store_target, mode="w", encoding=encoding, **self.version_kwargs)
@@ -3821,9 +3801,7 @@ class ZarrBase(CFEncodedBase):
         )
         expected = xr.Dataset({"foo": ("x", [fv] * 3)})
 
-        zarr_format_2 = (
-            has_zarr_v3 and zarr.config.get("default_zarr_format") == 2
-        ) or not has_zarr_v3
+        zarr_format_2 = zarr.config.get("default_zarr_format") == 2
         if zarr_format_2:
             attr = "_FillValue"
             expected.foo.attrs[attr] = fv
@@ -3874,7 +3852,7 @@ class ZarrBase(CFEncodedBase):
         # variable encoding on read, so that it is not lost on round-trip.
         # `fill_value` is an independent encoding key only for zarr_format 3;
         # for zarr_format 2 the fill_value is set via `_FillValue`.
-        if not has_zarr_v3 or zarr.config.get("default_zarr_format") != 3:
+        if zarr.config.get("default_zarr_format") != 3:
             pytest.skip("fill_value is only an encoding key for zarr_format 3")
 
         ds = xr.Dataset({"foo": ("x", [1, 2, 3])})
@@ -3892,38 +3870,20 @@ class ZarrBase(CFEncodedBase):
 
 
 @requires_zarr
-@pytest.mark.skipif(
-    KVStore is None, reason="zarr-python 2.x or ZARR_V3_EXPERIMENTAL_API is unset."
-)
 class TestInstrumentedZarrStore:
-    if has_zarr_v3:
-        methods = [
-            "get",
-            "set",
-            "list_dir",
-            "list_prefix",
-        ]
-    else:
-        methods = [
-            "__iter__",
-            "__contains__",
-            "__setitem__",
-            "__getitem__",
-            "listdir",
-            "list_prefix",
-        ]
+    methods = [
+        "get",
+        "set",
+        "list_dir",
+        "list_prefix",
+    ]
 
     @contextlib.contextmanager
     def create_zarr_target(self):
         if Version(zarr.__version__) < Version("2.18.0"):
             pytest.skip("Instrumented tests only work on latest Zarr.")
 
-        if has_zarr_v3:
-            kwargs = {"read_only": False}
-        else:
-            kwargs = {}  # type: ignore[arg-type,unused-ignore]
-
-        store = KVStore({}, **kwargs)  # type: ignore[arg-type,unused-ignore]
+        store = KVStore({}, read_only=False)  # type: ignore[arg-type,unused-ignore]
         yield store
 
     def make_patches(self, store):
@@ -3958,23 +3918,13 @@ class TestInstrumentedZarrStore:
         modified = Dataset({"foo": ("x", [2])}, coords={"x": [1]})
 
         with self.create_zarr_target() as store:
-            if has_zarr_v3:
-                # TODO: verify these
-                expected = {
-                    "set": 5,
-                    "get": 4,
-                    "list_dir": 2,
-                    "list_prefix": 1,
-                }
-            else:
-                expected = {
-                    "iter": 1,
-                    "contains": 18,
-                    "setitem": 10,
-                    "getitem": 13,
-                    "listdir": 0,
-                    "list_prefix": 3,
-                }
+            # TODO: verify these
+            expected = {
+                "set": 5,
+                "get": 4,
+                "list_dir": 2,
+                "list_prefix": 1,
+            }
 
             patches = self.make_patches(store)
             with patch.multiple(KVStore, **patches):
@@ -3984,22 +3934,12 @@ class TestInstrumentedZarrStore:
             patches = self.make_patches(store)
             # v2024.03.0: {'iter': 6, 'contains': 2, 'setitem': 5, 'getitem': 10, 'listdir': 6, 'list_prefix': 0}
             # 6057128b: {'iter': 5, 'contains': 2, 'setitem': 5, 'getitem': 10, "listdir": 5, "list_prefix": 0}
-            if has_zarr_v3:
-                expected = {
-                    "set": 4,
-                    "get": 9,  # TODO: fixme upstream (should be 8)
-                    "list_dir": 2,  # TODO: fixme upstream (should be 2)
-                    "list_prefix": 0,
-                }
-            else:
-                expected = {
-                    "iter": 1,
-                    "contains": 11,
-                    "setitem": 6,
-                    "getitem": 15,
-                    "listdir": 0,
-                    "list_prefix": 1,
-                }
+            expected = {
+                "set": 4,
+                "get": 9,  # TODO: fixme upstream (should be 8)
+                "list_dir": 2,  # TODO: fixme upstream (should be 2)
+                "list_prefix": 0,
+            }
 
             with patch.multiple(KVStore, **patches):
                 modified.to_zarr(store, mode="a", append_dim="x")
@@ -4007,22 +3947,12 @@ class TestInstrumentedZarrStore:
 
             patches = self.make_patches(store)
 
-            if has_zarr_v3:
-                expected = {
-                    "set": 4,
-                    "get": 9,  # TODO: fixme upstream (should be 8)
-                    "list_dir": 2,  # TODO: fixme upstream (should be 2)
-                    "list_prefix": 0,
-                }
-            else:
-                expected = {
-                    "iter": 1,
-                    "contains": 11,
-                    "setitem": 6,
-                    "getitem": 15,
-                    "listdir": 0,
-                    "list_prefix": 1,
-                }
+            expected = {
+                "set": 4,
+                "get": 9,  # TODO: fixme upstream (should be 8)
+                "list_dir": 2,  # TODO: fixme upstream (should be 2)
+                "list_prefix": 0,
+            }
 
             with patch.multiple(KVStore, **patches):
                 modified.to_zarr(store, mode="a-", append_dim="x")
@@ -4037,22 +3967,12 @@ class TestInstrumentedZarrStore:
     def test_region_write(self) -> None:
         ds = Dataset({"foo": ("x", [1, 2, 3])}, coords={"x": [1, 2, 3]}).chunk()
         with self.create_zarr_target() as store:
-            if has_zarr_v3:
-                expected = {
-                    "set": 5,
-                    "get": 2,
-                    "list_dir": 2,
-                    "list_prefix": 4,
-                }
-            else:
-                expected = {
-                    "iter": 1,
-                    "contains": 16,
-                    "setitem": 9,
-                    "getitem": 13,
-                    "listdir": 0,
-                    "list_prefix": 5,
-                }
+            expected = {
+                "set": 5,
+                "get": 2,
+                "list_dir": 2,
+                "list_prefix": 4,
+            }
 
             patches = self.make_patches(store)
             with patch.multiple(KVStore, **patches):
@@ -4061,22 +3981,12 @@ class TestInstrumentedZarrStore:
 
             # v2024.03.0: {'iter': 5, 'contains': 2, 'setitem': 1, 'getitem': 6, 'listdir': 5, 'list_prefix': 0}
             # 6057128b: {'iter': 4, 'contains': 2, 'setitem': 1, 'getitem': 5, 'listdir': 4, 'list_prefix': 0}
-            if has_zarr_v3:
-                expected = {
-                    "set": 1,
-                    "get": 3,
-                    "list_dir": 0,
-                    "list_prefix": 0,
-                }
-            else:
-                expected = {
-                    "iter": 1,
-                    "contains": 6,
-                    "setitem": 1,
-                    "getitem": 7,
-                    "listdir": 0,
-                    "list_prefix": 0,
-                }
+            expected = {
+                "set": 1,
+                "get": 3,
+                "list_dir": 0,
+                "list_prefix": 0,
+            }
 
             patches = self.make_patches(store)
             with patch.multiple(KVStore, **patches):
@@ -4085,44 +3995,24 @@ class TestInstrumentedZarrStore:
 
             # v2024.03.0: {'iter': 6, 'contains': 4, 'setitem': 1, 'getitem': 11, 'listdir': 6, 'list_prefix': 0}
             # 6057128b: {'iter': 4, 'contains': 2, 'setitem': 1, 'getitem': 7, 'listdir': 4, 'list_prefix': 0}
-            if has_zarr_v3:
-                expected = {
-                    "set": 1,
-                    "get": 4,
-                    "list_dir": 0,
-                    "list_prefix": 0,
-                }
-            else:
-                expected = {
-                    "iter": 1,
-                    "contains": 6,
-                    "setitem": 1,
-                    "getitem": 8,
-                    "listdir": 0,
-                    "list_prefix": 0,
-                }
+            expected = {
+                "set": 1,
+                "get": 4,
+                "list_dir": 0,
+                "list_prefix": 0,
+            }
 
             patches = self.make_patches(store)
             with patch.multiple(KVStore, **patches):
                 ds.to_zarr(store, region="auto")
             self.check_requests(expected, patches)
 
-            if has_zarr_v3:
-                expected = {
-                    "set": 0,
-                    "get": 5,
-                    "list_dir": 0,
-                    "list_prefix": 0,
-                }
-            else:
-                expected = {
-                    "iter": 1,
-                    "contains": 6,
-                    "setitem": 0,
-                    "getitem": 8,
-                    "listdir": 0,
-                    "list_prefix": 0,
-                }
+            expected = {
+                "set": 0,
+                "get": 5,
+                "list_dir": 0,
+                "list_prefix": 0,
+            }
 
             patches = self.make_patches(store)
             with patch.multiple(KVStore, **patches):
@@ -4135,10 +4025,7 @@ class TestInstrumentedZarrStore:
 class TestZarrDictStore(ZarrBase):
     @contextlib.contextmanager
     def create_zarr_target(self):
-        if has_zarr_v3:
-            yield zarr.storage.MemoryStore({}, read_only=False)
-        else:
-            yield {}
+        yield zarr.storage.MemoryStore({}, read_only=False)
 
     def test_chunk_key_encoding_v2(self) -> None:
         encoding = {"name": "v2", "configuration": {"separator": "/"}}
@@ -4158,14 +4045,6 @@ class TestZarrDictStore(ZarrBase):
         # Write to store with custom encoding
         with self.create_zarr_target() as store:
             original.to_zarr(store, encoding=encoding)
-
-            # Verify the chunk keys in store use the slash separator
-            if not has_zarr_v3:
-                chunk_keys = [k for k in store.keys() if k.startswith("var1/")]
-                assert len(chunk_keys) > 0
-                for key in chunk_keys:
-                    assert "/" in key
-                    assert "." not in key.split("/")[1:]  # No dots in chunk coordinates
 
             # Read back and verify data
             with xr.open_zarr(store) as actual:
@@ -4347,9 +4226,8 @@ class TestZarrDictStore(ZarrBase):
             pytest.param(
                 {"dim2": 2},
                 "basic async indexing",
-                marks=pytest.mark.skipif(
-                    has_zarr_v3,
-                    reason="current version of zarr has basic async indexing",
+                marks=pytest.mark.skip(
+                    reason="current version of zarr has basic async indexing"
                 ),
             ),  # tests basic indexing
             pytest.param(
@@ -4512,10 +4390,6 @@ class TestZarrWriteEmpty(TestZarrDirectoryStore):
                 assert (
                     "_FillValue" not in on_disk.variables["ints"].encoding
                 )  # use default
-                if not has_zarr_v3:
-                    # zarr-python v2 interprets fill_value=None inconsistently
-                    del on_disk["ints"]
-                    del expected["ints"]
                 assert_identical(expected, on_disk)
 
     @pytest.mark.parametrize("consolidated", [True, False, None])
@@ -4545,8 +4419,8 @@ class TestZarrWriteEmpty(TestZarrDirectoryStore):
 
         # The zarr format is set by the `default_zarr_format`
         # pytest fixture that acts on a superclass
-        zarr_format_3 = has_zarr_v3 and zarr.config.config["default_zarr_format"] == 3
-        if (write_empty is False) or (write_empty is None and has_zarr_v3):
+        zarr_format_3 = zarr.config.config["default_zarr_format"] == 3
+        if (write_empty is False) or (write_empty is None):
             expected = ["0.1.0"]
         else:
             expected = [
@@ -4597,9 +4471,9 @@ class TestZarrWriteEmpty(TestZarrDirectoryStore):
                 assert_identical(a_ds, expected_ds.compute())
                 # add the new files we expect to be created by the append
                 # that was performed by the roundtrip_dir
-                if (write_empty is False) or (write_empty is None and has_zarr_v3):
+                if (write_empty is False) or (write_empty is None):
                     expected.append("1.1.0")
-                elif not has_zarr_v3 or has_zarr_v3_async_oindex:
+                elif has_zarr_v3_async_oindex:
                     # this was broken from zarr 3.0.0 until 3.1.2
                     # async oindex released in 3.1.2 along with a fix
                     # for write_empty_chunks in append
@@ -4634,16 +4508,10 @@ class TestZarrWriteEmpty(TestZarrDirectoryStore):
         # rather than a mocked method.
 
         Group: Any
-        if has_zarr_v3:
-            Group = zarr.AsyncGroup
-            patched = patch.object(
-                Group, "getitem", side_effect=Group.getitem, autospec=True
-            )
-        else:
-            Group = zarr.Group
-            patched = patch.object(
-                Group, "__getitem__", side_effect=Group.__getitem__, autospec=True
-            )
+        Group = zarr.AsyncGroup
+        patched = patch.object(
+            Group, "getitem", side_effect=Group.getitem, autospec=True
+        )
 
         with self.create_zarr_target() as store, patched as mock:
             ds.to_zarr(store, mode="w")
@@ -4661,7 +4529,7 @@ class TestZarrWriteEmpty(TestZarrDirectoryStore):
 
 @requires_zarr
 @requires_fsspec
-@pytest.mark.skipif(has_zarr_v3, reason="Difficult to test.")
+@pytest.mark.skip(reason="Difficult to test.")
 def test_zarr_storage_options() -> None:
     pytest.importorskip("aiobotocore")
     ds = create_test_data()
@@ -4675,10 +4543,7 @@ def test_zarr_storage_options() -> None:
 def test_zarr_version_deprecated() -> None:
     ds = create_test_data()
     store: Any
-    if has_zarr_v3:
-        store = KVStore()
-    else:
-        store = {}
+    store = KVStore()
 
     with pytest.warns(FutureWarning, match="zarr_version"):
         ds.to_zarr(store=store, zarr_version=2)
@@ -6938,7 +6803,7 @@ class TestDataArrayToNetCDF:
 @requires_zarr
 class TestDataArrayToZarr:
     def skip_if_zarr_python_3_and_zip_store(self, store) -> None:
-        if has_zarr_v3 and isinstance(store, zarr.storage.ZipStore):
+        if isinstance(store, zarr.storage.ZipStore):
             pytest.skip(
                 reason="zarr-python 3.x doesn't support reopening ZipStore with a new mode."
             )
@@ -7302,7 +7167,7 @@ def test_extract_zarr_variable_encoding() -> None:
     var = xr.Variable("x", [1, 2])
     actual = backends.zarr.extract_zarr_variable_encoding(var, zarr_format=3)
     assert "chunks" in actual
-    assert actual["chunks"] == ("auto" if has_zarr_v3 else None)
+    assert actual["chunks"] == "auto"
 
     var = xr.Variable("x", [1, 2], encoding={"chunks": (1,)})
     actual = backends.zarr.extract_zarr_variable_encoding(var, zarr_format=3)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -145,17 +145,20 @@ if TYPE_CHECKING:
 
 @pytest.fixture(scope="module", params=ZARR_FORMATS)
 def default_zarr_format(request) -> Generator[None, None]:
-    with zarr.config.set(default_zarr_format=request.param):
+    if has_zarr:
+        with zarr.config.set(default_zarr_format=request.param):
+            yield
+    else:
         yield
 
 
 def skip_if_zarr_format_3(reason: str):
-    if zarr.config["default_zarr_format"] == 3:
+    if has_zarr and zarr.config["default_zarr_format"] == 3:
         pytest.skip(reason=f"Unsupported with zarr_format=3: {reason}")
 
 
 def skip_if_zarr_format_2(reason: str):
-    if zarr.config["default_zarr_format"] == 2:
+    if has_zarr and zarr.config["default_zarr_format"] == 2:
         pytest.skip(reason=f"Unsupported with zarr_format=2: {reason}")
 
 

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -15,7 +15,6 @@ import xarray as xr
 from xarray import DataTree, load_datatree, open_datatree, open_groups
 from xarray.testing import assert_equal, assert_identical
 from xarray.tests import (
-    has_zarr_v3,
     network,
     parametrize_zarr_format,
     requires_dask,
@@ -702,7 +701,7 @@ class TestZarrDatatreeIO:
             from numcodecs.blosc import Blosc
 
             codec = Blosc(cname="zstd", clevel=3, shuffle=2)
-            comp = {"compressors": (codec,)} if has_zarr_v3 else {"compressor": codec}
+            comp = {"compressors": (codec,)}
         elif zarr_format == 3:
             import zarr
 
@@ -714,7 +713,7 @@ class TestZarrDatatreeIO:
         original_dt.to_zarr(filepath, encoding=enc, zarr_format=zarr_format)
 
         with open_datatree(filepath, engine="zarr") as roundtrip_dt:
-            compressor_key = "compressors" if has_zarr_v3 else "compressor"
+            compressor_key = "compressors"
             if zarr_format == 3:
                 # zarr v3 BloscCodec auto-tunes typesize and shuffle on write,
                 # so we only check the attributes we explicitly set
@@ -765,15 +764,8 @@ class TestZarrDatatreeIO:
     ) -> None:
         simple_datatree.to_zarr(str(tmpdir), zarr_format=zarr_format)
 
-        import zarr
-
-        # expected exception type changed in zarr-python v2->v3, see https://github.com/zarr-developers/zarr-python/issues/2821
-        expected_exception_type = (
-            FileExistsError if has_zarr_v3 else zarr.errors.ContainsGroupError
-        )
-
         # with default settings, to_zarr should not overwrite an existing dir
-        with pytest.raises(expected_exception_type):
+        with pytest.raises(FileExistsError):
             simple_datatree.to_zarr(str(tmpdir))
 
     @requires_dask
@@ -833,8 +825,7 @@ class TestZarrDatatreeIO:
                     assert not chunk_file.exists()
 
         DEFAULT_ZARR_FILL_VALUE = 0
-        # The default value of write_empty_chunks changed from True->False in zarr-python v2->v3
-        WRITE_EMPTY_CHUNKS_DEFAULT = not has_zarr_v3
+        WRITE_EMPTY_CHUNKS_DEFAULT = False
 
         for node in original_dt.subtree:
             # inherited variables aren't meant to be written to zarr


### PR DESCRIPTION
## Summary

Removes the now-dead zarr v2 test guards built on `has_zarr_v3`, which can no longer be false now that xarray requires `zarr>=3.0.0`.

## Why

xarray's lower bound for `zarr` is now `3.0.0`, so the `has_zarr_v3` flag is always true whenever zarr is installed. The `skipif(not has_zarr_v3, ...)` decorators and `if has_zarr_v3:` branches built on it are dead code that can never take the false path. Issue #11346 asks to clear out these stale 2.x guards so the test suite stops carrying conditionals that no longer mean anything.

### Description

Now that xarray's lower bound for `zarr` is `3.0.0`, the `has_zarr_v3` flag in `xarray/tests/__init__.py` is always true whenever zarr is installed, so the `skipif(not has_zarr_v3, ...)` decorators and `if has_zarr_v3:` branches built on it never take the false path. This removes those stale 2.x guards in `test_backends.py` and `test_backends_datatree.py` and collapses the conditional in `xarray/tests/__init__.py`, keeping the formerly-guarded bodies. The still-meaningful version gates `has_zarr_v3_dtypes` (3.1.0) and `has_zarr_v3_async_oindex` (3.1.2) are left untouched, per issue #11346.

### Checklist

- [x] Closes #11346
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Claude
