### PR TITLE
fix: guard against None version in module_available

### DIFF
--- a/xarray/namedarray/utils.py
+++ b/xarray/namedarray/utils.py
@@ -60,6 +60,9 @@ def module_available(module: str, minversion: str | None = None) -> bool:
     if minversion is not None:
         version = importlib.metadata.version(module)
 
+        if version is None:
+            return False
+
         return Version(version) >= Version(minversion)
 
     return True

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -18,7 +18,7 @@ from xarray.namedarray._typing import (
     _ShapeType_co,
 )
 from xarray.namedarray.core import NamedArray, from_array
-from xarray.namedarray.utils import fake_target_chunksize
+from xarray.namedarray.utils import fake_target_chunksize, module_available
 from xarray.tests import requires_cftime
 
 if TYPE_CHECKING:
@@ -666,3 +666,26 @@ def test_fake_target_chunksize_cftime() -> None:
 
     assert faked_chunksize == 73
     assert dtype == np.float64
+
+
+def test_module_available_version_none() -> None:
+    """module_available should return False gracefully when metadata.version returns None."""
+    import importlib.metadata as _metadata
+
+    original_version = _metadata.version
+
+    def mock_version(name: str) -> str | None:
+        if name == "pip":
+            return None
+        return original_version(name)
+
+    _metadata.version = mock_version
+    try:
+        assert module_available("pip", minversion="1.0.0") is False
+    finally:
+        _metadata.version = original_version
+
+
+def test_module_available_valid() -> None:
+    """module_available should return True for an installed module with version check."""
+    assert module_available("pip", minversion="0.0.1") is True

--- a/xarray/tests/test_namedarray.py
+++ b/xarray/tests/test_namedarray.py
@@ -675,17 +675,17 @@ def test_module_available_version_none() -> None:
     original_version = _metadata.version
 
     def mock_version(name: str) -> str | None:
-        if name == "pip":
+        if name == "packaging":
             return None
         return original_version(name)
 
     _metadata.version = mock_version
     try:
-        assert module_available("pip", minversion="1.0.0") is False
+        assert module_available("packaging", minversion="1.0.0") is False
     finally:
         _metadata.version = original_version
 
 
 def test_module_available_valid() -> None:
     """module_available should return True for an installed module with version check."""
-    assert module_available("pip", minversion="0.0.1") is True
+    assert module_available("packaging", minversion="0.0.1") is True


### PR DESCRIPTION
## Summary

`importlib.metadata.version()` can return `None` in some environments (e.g. QGIS with custom import hooks, PEP 660 editable installs). When this happens, `Version(None)` crashes with `TypeError: expected string or bytes-like object, got NoneType`.

## Problem

Issue #11344 reports a crash in the rain-to-flood toolkit when importing xarray. The traceback shows:

```
File "...xarray/namedarray/utils.py", line 63, in module_available
    return Version(version) >= Version(minversion)
           ^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got NoneType
```

The `module` parameter is always a valid string (`"numpy"`), but `importlib.metadata.version("numpy")` returns `None` in the reporter's QGIS environment.

## Fix

Add a `None` guard on the result of `importlib.metadata.version()` before passing it to `Version()`. When version is `None`, return `False` (the module is technically available but version metadata can't be determined).

## Test Plan

- `test_module_available_version_none` — mocks `importlib.metadata.version` to return `None` for a known module and verifies `module_available` returns `False` without crashing.
- `test_module_available_valid` — verifies normal version checks still pass.

Closes #11344