### PR TITLE
Use to_numpy in ImplicitToExplicitIndexingAdapter.__array__ method

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -42,7 +42,9 @@ Bug Fixes
 - Fix :py:func:`decode_cf` failing on integer-encoded time arrays that contain
   NaT when running against numpy 2.5+.
   By `Ian Hunt-Isaak <https://github.com/ianhi>`_.
-
+- Fix ``TypeError: Implicit conversion to a NumPy array is not allowed`` when trying to
+  use :py:func:`open_mfdataset` with a backend engine reading to CuPy arrays.
+  By `Wei Ji Leong <https://github.com/weiji14>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -35,7 +35,12 @@ from xarray.core.utils import (
     to_0d_array,
 )
 from xarray.namedarray.parallelcompat import get_chunked_array_type
-from xarray.namedarray.pycompat import array_type, integer_types, is_chunked_array
+from xarray.namedarray.pycompat import (
+    array_type,
+    integer_types,
+    is_chunked_array,
+    to_numpy,
+)
 
 if TYPE_CHECKING:
     from xarray.core.extension_array import PandasExtensionArray
@@ -683,9 +688,9 @@ class ImplicitToExplicitIndexingAdapter(NDArrayMixin):
         self, dtype: DTypeLike | None = None, /, *, copy: bool | None = None
     ) -> np.ndarray:
         if Version(np.__version__) >= Version("2.0.0"):
-            return np.asarray(self.get_duck_array(), dtype=dtype, copy=copy)
+            return to_numpy(self.get_duck_array(), dtype=dtype, copy=copy)
         else:
-            return np.asarray(self.get_duck_array(), dtype=dtype)
+            return to_numpy(self.get_duck_array(), dtype=dtype)
 
     def get_duck_array(self):
         return self.array.get_duck_array()

--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -688,9 +688,10 @@ class ImplicitToExplicitIndexingAdapter(NDArrayMixin):
         self, dtype: DTypeLike | None = None, /, *, copy: bool | None = None
     ) -> np.ndarray:
         if Version(np.__version__) >= Version("2.0.0"):
-            return to_numpy(self.get_duck_array(), dtype=dtype, copy=copy)
+            return np.asarray(to_numpy(self.get_duck_array()), dtype=dtype, copy=copy)
+
         else:
-            return to_numpy(self.get_duck_array(), dtype=dtype)
+            return np.asarray(to_numpy(self.get_duck_array()), dtype=dtype)
 
     def get_duck_array(self):
         return self.array.get_duck_array()

--- a/xarray/namedarray/pycompat.py
+++ b/xarray/namedarray/pycompat.py
@@ -97,7 +97,7 @@ def is_0d_dask_array(x: duckarray[Any, Any]) -> bool:
 
 
 def to_numpy(
-    data: duckarray[Any, Any], **kwargs: dict[str, Any]
+    data: duckarray[Any, Any], **kwargs: Any
 ) -> np.ndarray[Any, np.dtype[Any]]:
     from xarray.core.indexing import ExplicitlyIndexed
     from xarray.namedarray.parallelcompat import get_chunked_array_type

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -902,6 +902,14 @@ def test_implicit_indexing_adapter_copy_on_write() -> None:
     assert isinstance(implicit[:], indexing.ImplicitToExplicitIndexingAdapter)
 
 
+def test_implicit_indexing_adapter_duck_array() -> None:
+    array = DuckArrayWrapper(array=np.arange(10))
+    implicit = indexing.ImplicitToExplicitIndexingAdapter(
+        indexing.ArrayApiIndexingAdapter(array), indexing.BasicIndexer
+    )
+    np.testing.assert_array_equal(np.asarray(implicit), np.arange(10))
+
+
 def test_outer_indexer_consistency_with_broadcast_indexes_vectorized() -> None:
     def nonzero(x):
         if isinstance(x, np.ndarray) and x.dtype.kind == "b":


### PR DESCRIPTION
### Description

Fixes ```TypeError: Implicit conversion to a NumPy array is not allowed. Please use `.get()` to construct a NumPy array explicitly``` when using a backend engine that loads data onto CuPy, but indexes should stay as NumPy (following convention at https://github.com/xarray-contrib/cupy-xarray/issues/90)

<details>

<summary>Full traceback</summary>

```python
TypeError: Implicit conversion to a NumPy array is not allowed. Please use `.get()` to construct a NumPy array explicitly.
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[10], line 20, in test_xarray_backend_open_mfdataset()
     13         engine="cog3pio",
     14         concat_dim="band",
     15         combine="nested",
     16     )
---> 17     ds.raster.load()
     18     assert ds.sizes == {"band": 2, "y": 183, "x": 183}
     19     assert ds.x.min() == 700260.0
     20     assert ds.x.max() == 809460.0
File ~/mambaforge/envs/cupy-xarray/lib/python3.14/site-packages/xarray/core/dataarray.py:1173, in DataArray.load(self, **kwargs)
   1143 def load(self, **kwargs) -> Self:
   1144     """Trigger loading data into memory and return this dataarray.
   1145
   1146     Data will be computed and/or loaded from disk or a remote source.
   (...)   1171     Variable.load
   1172     """
-> 1173     ds = self._to_temp_dataset().load(**kwargs)
   1174     new = self._from_temp_dataset(ds)
   1175     self._variable = new._variable
File ~/mambaforge/envs/cupy-xarray/lib/python3.14/site-packages/xarray/core/dataset.py:569, in Dataset.load(self, **kwargs)
    565         if chunked_data:
    566             chunkmanager = get_chunked_array_type(*chunked_data.values())
    567
    568             # evaluate all the chunked arrays simultaneously
--> 569             evaluated_data: tuple[np.ndarray[Any, Any], ...] = chunkmanager.compute(
    570                 *chunked_data.values(), **kwargs
    571             )
    572
File ~/mambaforge/envs/cupy-xarray/lib/python3.14/site-packages/xarray/namedarray/daskmanager.py:85, in DaskManager.compute(self
, *data, **kwargs)
     80 def compute(
     81     self, *data: Any, **kwargs: Any
     82 ) -> tuple[np.ndarray[Any, _DType_co], ...]:
     83     from dask.array import compute
---> 85     return compute(*data, **kwargs)
File ~/mambaforge/envs/cupy-xarray/lib/python3.14/site-packages/dask/base.py:685, in compute(traverse, optimize_graph, scheduler
, get, *args, **kwargs)
    682     expr = expr.optimize()
    683     keys = list(flatten(expr.__dask_keys__()))
--> 685     results = schedule(expr, keys, **kwargs)
    687 return repack(results)
File ~/mambaforge/envs/cupy-xarray/lib/python3.14/site-packages/xarray/core/indexing.py:691, in ImplicitToExplicitIndexingAdapte
r.__array__(self, dtype, copy)
    687 def __array__(
    688     self, dtype: DTypeLike | None = None, /, *, copy: bool | None = None
    689 ) -> np.ndarray:
    690     if Version(np.__version__) >= Version("2.0.0"):
--> 691         return np.asarray(self.get_duck_array(), dtype=dtype, copy=copy)
    692     else:
    693         return np.asarray(self.get_duck_array(), dtype=dtype)
File cupy/_core/core.pyx:1760, in cupy._core.core._ndarray_base.__array__()
-> 1760 'Could not get source, probably due dynamically evaluated source code.'
TypeError: Implicit conversion to a NumPy array is not allowed. Please use `.get()` to construct a NumPy array explicitly.
```


</details>


Somewhat similar to https://github.com/pydata/xarray/pull/10078. Helps with some cupy-xarray work that is making TIFF to GPU possible at https://github.com/xarray-contrib/cupy-xarray/pull/81#issuecomment-4677174255 (though not fully working yet :slightly_smiling_face:).

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

![](https://notbyai.fyi/img/written-by-human-not-by-ai-black.svg)
