### PR TITLE
Add nodask constraint for test-py314-no-dask environment

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -218,6 +218,7 @@ test = { cmd = "pytest", description = "Run the test suite with pytest." }
 kerchunk = "*"
 ipykernel = "*"
 ipywidgets = "*"                   # silence nbsphinx warning
+iris = "*"
 ipython = "*"
 jupyter_client = "*"
 jupyter_sphinx = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -93,6 +93,9 @@ pooch = "*"
 # calendar
 cftime = "*"
 
+# other
+iris = "*"
+
 [feature.extras.pypi-dependencies]
 # array
 jax = "*" # no way to get cpu-only jaxlib from conda if gpu is present

--- a/pixi.toml
+++ b/pixi.toml
@@ -376,6 +376,9 @@ numpydoc = "*"
 [feature.numpydoc-lint.tasks]
 numpydoc-lint = { cmd = "python ci/numpydoc-public-api.py" }
 
+[feature.nodask.constraints]
+dask-core = "<0.0a0"
+
 [environments]
 # Testing
 # test-just-xarray = { features = ["test"] } # https://github.com/pydata/xarray/pull/10888/files#r2511336147
@@ -390,6 +393,7 @@ test-py313-no-numba = { features = [
 ] }
 test-py313-no-dask = { features = [
   "py312",
+  "nodask",
   "test",
   "backends",
   "accel",

--- a/pixi.toml
+++ b/pixi.toml
@@ -93,9 +93,6 @@ pooch = "*"
 # calendar
 cftime = "*"
 
-# other
-iris = "*"
-
 [feature.extras.pypi-dependencies]
 # array
 jax = "*" # no way to get cpu-only jaxlib from conda if gpu is present

--- a/pixi.toml
+++ b/pixi.toml
@@ -63,6 +63,7 @@ numbagg = "*"
 [feature.dask.dependencies]
 dask = "*"
 distributed = "*"
+iris = "*"        # depends on dask
 
 [feature.accel.dependencies]
 flox = "*"
@@ -92,9 +93,6 @@ pooch = "*"
 
 # calendar
 cftime = "*"
-
-# other
-iris = "*"
 
 [feature.extras.pypi-dependencies]
 # array

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -6917,6 +6917,7 @@ def test_source_encoding_always_present_with_pathlib() -> None:
 
 @requires_h5netcdf
 @requires_fsspec
+@requires_dask  # TODO remove after https://github.com/pydata/xarray/issues/9038
 def test_source_encoding_always_present_with_fsspec() -> None:
     import fsspec
 
@@ -8122,6 +8123,7 @@ class TestZarrRegionAuto:
 
 @requires_h5netcdf
 @requires_fsspec
+@requires_dask  # TODO remove after https://github.com/pydata/xarray/issues/9038
 def test_h5netcdf_storage_options() -> None:
     with create_tmp_files(2, allow_cleanup_failure=ON_WINDOWS) as (f1, f2):
         ds1 = create_test_data()


### PR DESCRIPTION
### Description

Explicitly exclude dask-core from being installed. Discovered that some [dask-dependent tests were being ran in the no-dask environment](https://github.com/pydata/xarray/actions/runs/27460478309/job/81173208206?pr=11383) in PR #11383.

Reference: https://pixi.prefix.dev/latest/reference/pixi_manifest/#constraints

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Patches #10976
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

![](https://notbyai.fyi/img/written-by-human-not-by-ai-black.svg)