### PR TITLE
Fix drop_encoding to avoid copying data (GH#11390)

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -983,7 +983,10 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
         if dims is _default:
             dims = copy.copy(self._dims)
         if data is _default:
-            data = copy.copy(self._data)
+            # Only copy data when it is actually being changed.
+            # Many callers (e.g. drop_encoding) only change encoding/attrs,
+            # and a full data copy is expensive for large arrays.
+            data = self._data
         if attrs is _default:
             attrs = copy.copy(self._attrs)
         if encoding is _default:

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -490,6 +490,11 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
         assert v3.encoding == encoding3
         assert v4.encoding == {}
 
+        # drop_encoding should not copy data — fix for GH#11390
+        v = self.cls(["x"], np.arange(1000000))
+        v_dropped = v.drop_encoding()
+        assert v_dropped._data is v._data
+
     def test_concat(self):
         x = np.arange(5)
         y = np.arange(5, 10)


### PR DESCRIPTION
- closes #11390
 
drop_encoding() was triggering a full copy of the underlying data array via _replace, which causes OOM on large datasets. Changed _replace to skip the data copy when only encoding/attrs/dims are being updated — this makes drop_encoding() a true shallow operation as the docs suggest.