### PR TITLE
Add map_blocks and some testing support for array query expressions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,8 +6,8 @@ import pytest
 
 
 def _use_dask_array(config: pytest.Config) -> bool:
-    env_value = os.environ.get("XR_USE_DASK_ARRAY", "")
-    return config.getoption("--use-dask-array") or env_value.lower() in {
+    env_value = os.environ.get("XR_USE_DASK_ARRAY_WITH_EXPR", "")
+    return config.getoption("--use-dask-array-with-expr") or env_value.lower() in {
         "1",
         "true",
         "yes",
@@ -20,14 +20,18 @@ def _register_dask_array() -> None:
         import dask_array.xarray
     except ImportError as err:
         raise pytest.UsageError(
-            "--use-dask-array requires dask-array to be importable"
+            "--use-dask-array-with-expr requires dask-array to be importable"
         ) from err
 
     dask_array.xarray.register()
     if not dask_array.xarray.isactive():
         raise pytest.UsageError(
-            "--use-dask-array registered dask-array, but it is not the active dask chunk manager"
+            "--use-dask-array-with-expr registered dask-array, but it is not the active dask chunk manager"
         )
+
+    from xarray.tests import refresh_dask_chunkmanager_helpers
+
+    refresh_dask_chunkmanager_helpers()
 
 
 def pytest_addoption(parser: pytest.Parser):
@@ -40,7 +44,7 @@ def pytest_addoption(parser: pytest.Parser):
     )
     parser.addoption("--run-mypy", action="store_true", help="runs mypy tests")
     parser.addoption(
-        "--use-dask-array",
+        "--use-dask-array-with-expr",
         action="store_true",
         help="register dask-array as xarray's dask chunk manager",
     )

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,33 @@
 """Configuration for pytest."""
 
+import os
+
 import pytest
+
+
+def _use_dask_array(config: pytest.Config) -> bool:
+    env_value = os.environ.get("XR_USE_DASK_ARRAY", "")
+    return config.getoption("--use-dask-array") or env_value.lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _register_dask_array() -> None:
+    try:
+        import dask_array.xarray
+    except ImportError as err:
+        raise pytest.UsageError(
+            "--use-dask-array requires dask-array to be importable"
+        ) from err
+
+    dask_array.xarray.register()
+    if not dask_array.xarray.isactive():
+        raise pytest.UsageError(
+            "--use-dask-array registered dask-array, but it is not the active dask chunk manager"
+        )
 
 
 def pytest_addoption(parser: pytest.Parser):
@@ -12,9 +39,31 @@ def pytest_addoption(parser: pytest.Parser):
         help="runs tests requiring a network connection",
     )
     parser.addoption("--run-mypy", action="store_true", help="runs mypy tests")
+    parser.addoption(
+        "--use-dask-array",
+        action="store_true",
+        help="register dask-array as xarray's dask chunk manager",
+    )
+
+
+def pytest_configure(config: pytest.Config):
+    config.addinivalue_line(
+        "markers",
+        "skip_with_dask_array: skip when dask-array is registered as xarray's dask chunk manager",
+    )
+    config.addinivalue_line(
+        "markers",
+        "xfail_with_dask_array: xfail when dask-array is registered as xarray's dask chunk manager",
+    )
+    if not _use_dask_array(config):
+        return
+
+    _register_dask_array()
 
 
 def pytest_runtest_setup(item):
+    if _use_dask_array(item.config):
+        _register_dask_array()
     # based on https://stackoverflow.com/questions/47559524
     if "flaky" in item.keywords and not item.config.getoption("--run-flaky"):
         pytest.skip("set --run-flaky option to run flaky tests")
@@ -39,6 +88,18 @@ def pytest_collection_modifyitems(items):
             # marking approach, meaning that each test case must contain "mypy" in the
             # name.
             item.add_marker(pytest.mark.mypy)
+        if _use_dask_array(item.config) and "skip_with_dask_array" in item.keywords:
+            item.add_marker(
+                pytest.mark.skip(reason="skipped with dask-array chunk manager")
+            )
+        if _use_dask_array(item.config) and "xfail_with_dask_array" in item.keywords:
+            mark = item.get_closest_marker("xfail_with_dask_array")
+            kwargs = dict(mark.kwargs) if mark is not None else {}
+            kwargs.setdefault(
+                "reason", "expected failure with dask-array chunk manager"
+            )
+            kwargs.setdefault("strict", True)
+            item.add_marker(pytest.mark.xfail(**kwargs))
 
 
 @pytest.fixture(autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -29,10 +29,6 @@ def _register_dask_array() -> None:
             "--use-dask-array-with-expr registered dask-array, but it is not the active dask chunk manager"
         )
 
-    from xarray.tests import refresh_dask_chunkmanager_helpers
-
-    refresh_dask_chunkmanager_helpers()
-
 
 def pytest_addoption(parser: pytest.Parser):
     """Add command-line flags for pytest."""

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -34,7 +34,7 @@ from xarray.core.treenode import group_subtrees
 from xarray.core.types import ReadBuffer
 from xarray.core.utils import emit_user_level_warning, is_remote_uri
 from xarray.namedarray.daskmanager import DaskManager
-from xarray.namedarray.parallelcompat import guess_chunkmanager
+from xarray.namedarray.parallelcompat import guess_chunkmanager, list_chunkmanagers
 from xarray.namedarray.utils import _get_chunk
 from xarray.structure.chunks import _maybe_chunk
 from xarray.structure.combine import (
@@ -232,7 +232,11 @@ def _chunk_ds(
     chunkmanager = guess_chunkmanager(chunked_array_type)
 
     # TODO refactor to move this dask-specific logic inside the DaskManager class
-    if isinstance(chunkmanager, DaskManager):
+    registered_as_dask = any(
+        name == "dask" and manager is chunkmanager
+        for name, manager in list_chunkmanagers().items()
+    )
+    if isinstance(chunkmanager, DaskManager) or registered_as_dask:
         from dask.base import tokenize
 
         mtime = _get_mtime(filename_or_obj)

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -232,11 +232,11 @@ def _chunk_ds(
     chunkmanager = guess_chunkmanager(chunked_array_type)
 
     # TODO refactor to move this dask-specific logic inside the DaskManager class
-    registered_as_dask = any(
+    is_dask_chunkmanager = isinstance(chunkmanager, DaskManager) or any(
         name == "dask" and manager is chunkmanager
         for name, manager in list_chunkmanagers().items()
     )
-    if isinstance(chunkmanager, DaskManager) or registered_as_dask:
+    if is_dask_chunkmanager:
         from dask.base import tokenize
 
         mtime = _get_mtime(filename_or_obj)

--- a/xarray/compat/dask_array_compat.py
+++ b/xarray/compat/dask_array_compat.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from xarray.namedarray.parallelcompat import get_chunked_array_type
+from xarray.namedarray.pycompat import is_chunked_array
 from xarray.namedarray.utils import module_available
 
 
@@ -12,6 +13,8 @@ def reshape_blockwise(
     try:
         array_api = get_chunked_array_type(x).array_api
     except TypeError:
+        if is_chunked_array(x):
+            raise
         array_api = None
 
     if array_api is not None and hasattr(array_api, "reshape_blockwise"):
@@ -29,6 +32,23 @@ def sliding_window_view(
 ):
     # Backcompat for handling `automatic_rechunk`, delete when dask>=2024.11.0
     # Note that subok, writeable are unsupported by dask, so we ignore those in kwargs
+    try:
+        array_api = get_chunked_array_type(x).array_api
+    except TypeError:
+        if is_chunked_array(x):
+            raise
+        array_api = None
+
+    if array_api is not None:
+        array_sliding_window_view = getattr(array_api, "sliding_window_view", None)
+        if array_sliding_window_view is not None:
+            return array_sliding_window_view(
+                x,
+                window_shape=window_shape,
+                axis=axis,
+                automatic_rechunk=automatic_rechunk,
+            )
+
     from dask.array.lib.stride_tricks import sliding_window_view
 
     if module_available("dask", "2024.11.0"):

--- a/xarray/core/accessor_dt.py
+++ b/xarray/core/accessor_dt.py
@@ -17,6 +17,7 @@ from xarray.core.common import (
 )
 from xarray.core.types import T_DataArray
 from xarray.core.variable import IndexVariable, Variable
+from xarray.namedarray.parallelcompat import get_chunked_array_type
 from xarray.namedarray.utils import is_duck_dask_array
 
 if TYPE_CHECKING:
@@ -129,15 +130,14 @@ def _get_date_field(values, name, dtype):
         access_method = _access_through_cftimeindex
 
     if is_duck_dask_array(values):
-        from dask.array import map_blocks
-
+        chunkmanager = get_chunked_array_type(values)
         new_axis = chunks = None
         # isocalendar adds an axis
         if name == "isocalendar":
             chunks = (3,) + values.chunksize
             new_axis = 0
 
-        return map_blocks(
+        return chunkmanager.map_blocks(
             access_method, values, name, dtype=dtype, new_axis=new_axis, chunks=chunks
         )
     else:
@@ -187,10 +187,9 @@ def _round_field(values, name, freq):
 
     """
     if is_duck_dask_array(values):
-        from dask.array import map_blocks
-
+        chunkmanager = get_chunked_array_type(values)
         dtype = np.datetime64 if is_np_datetime_like(values.dtype) else np.dtype("O")
-        return map_blocks(
+        return chunkmanager.map_blocks(
             _round_through_series_or_index, values, name, freq=freq, dtype=dtype
         )
     else:
@@ -224,9 +223,8 @@ def _strftime(values, date_format):
     else:
         access_method = _strftime_through_cftimeindex
     if is_duck_dask_array(values):
-        from dask.array import map_blocks
-
-        return map_blocks(access_method, values, date_format)
+        chunkmanager = get_chunked_array_type(values)
+        return chunkmanager.map_blocks(access_method, values, date_format)
     else:
         return access_method(values, date_format)
 

--- a/xarray/core/accessor_dt.py
+++ b/xarray/core/accessor_dt.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Generic
+from typing import TYPE_CHECKING, Generic, cast
 
 import numpy as np
 import pandas as pd
@@ -134,7 +134,7 @@ def _get_date_field(values, name, dtype):
         new_axis = chunks = None
         # isocalendar adds an axis
         if name == "isocalendar":
-            chunks = (3,) + values.chunksize
+            chunks = cast(tuple[int, ...], (3,) + values.chunksize)
             new_axis = 0
 
         return chunkmanager.map_blocks(
@@ -188,7 +188,11 @@ def _round_field(values, name, freq):
     """
     if is_duck_dask_array(values):
         chunkmanager = get_chunked_array_type(values)
-        dtype = np.datetime64 if is_np_datetime_like(values.dtype) else np.dtype("O")
+        dtype = (
+            np.dtype(values.dtype)
+            if is_np_datetime_like(values.dtype)
+            else np.dtype("O")
+        )
         return chunkmanager.map_blocks(
             _round_through_series_or_index, values, name, freq=freq, dtype=dtype
         )

--- a/xarray/core/dask_array_expr.py
+++ b/xarray/core/dask_array_expr.py
@@ -1,0 +1,300 @@
+"""Optional xarray integration for ``dask_array`` expression-backed arrays.
+
+xarray stays expression-free. ``dask_array`` owns the lazy array expression
+objects, while xarray owns Dataset/DataArray semantics such as coordinates,
+indexes, attrs, template validation, and rebuilding final xarray objects.
+
+Most xarray operations only need the normal chunk-manager methods. The special
+case here is ``xarray.map_blocks``: it can return multiple output variables from
+one user function call per input block. The helper below converts xarray's block
+metadata into a private ``dask_array`` multi-output map expression. Each output
+variable is still a normal ``dask_array.Array`` child expression, so Dask can
+group the children with the composite-collection protocol and ``dask_array`` can
+optimize, cull, persist, and compute those arrays.
+
+If a Dataset mixes ``dask_array.Array`` with legacy ``dask.array.Array`` objects,
+this path raises before constructing a graph. The generic Dataset expression
+protocol instead returns ``None`` for mixed datasets so Dask can use xarray's
+existing HighLevelGraph fallback.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Callable, Hashable, Mapping, Sequence
+from importlib import import_module
+from typing import Any
+
+from xarray.core.coordinates import Coordinates
+from xarray.core.dataarray import DataArray
+from xarray.core.dataset import Dataset
+from xarray.core.utils import is_dask_collection
+
+
+def is_dask_array_expr_array(data: Any) -> bool:
+    try:
+        dask_array = import_module("dask_array")
+    except ImportError:
+        return False
+
+    array_type = getattr(dask_array, "Array", None)
+    return array_type is not None and isinstance(data, array_type)
+
+
+def collect_dask_array_expr_chunked_data(
+    xarray_objs: Sequence[Dataset],
+) -> tuple[bool, list[Any]]:
+    chunked_data = [
+        variable.data
+        for arg in xarray_objs
+        for variable in arg.variables.values()
+        if is_dask_collection(variable.data)
+    ]
+    has_dask_array_expr = any(is_dask_array_expr_array(data) for data in chunked_data)
+    has_other_chunked = any(not is_dask_array_expr_array(data) for data in chunked_data)
+
+    if has_dask_array_expr and has_other_chunked:
+        raise TypeError(
+            "xarray.map_blocks cannot mix dask_array.Array with legacy or other "
+            "Dask-backed arrays. Convert inputs to one array backend first."
+        )
+
+    return has_dask_array_expr, chunked_data
+
+
+def _execute_map_blocks_multi_output(block_spec: Mapping[str, Any], *blocks: Any):
+    args = []
+    for arg_spec in block_spec["args"]:
+        if arg_spec[0] == "literal":
+            args.append(arg_spec[1])
+            continue
+
+        _, data_vars, coords, attrs = arg_spec
+
+        def build_variables(variable_specs):
+            variables = []
+            for name, dims, data, var_attrs in variable_specs:
+                if data[0] == "block":
+                    data = blocks[data[1]]
+                else:
+                    data = data[1]
+                variables.append((name, (dims, data, var_attrs)))
+            return dict(variables)
+
+        args.append(Dataset(build_variables(data_vars), build_variables(coords), attrs))
+
+    result = block_spec["wrapper"](
+        block_spec["func"],
+        args,
+        block_spec["kwargs"],
+        block_spec["arg_is_array"],
+        block_spec["expected"],
+        block_spec["expected_indexes"],
+    )
+    return {
+        output_index: result[variable_name]
+        for output_index, variable_name in enumerate(block_spec["output_variables"])
+    }
+
+
+def map_blocks_with_dask_array_expr(
+    *,
+    func: Callable[..., Any],
+    npargs: Sequence[Any],
+    kwargs: Mapping[str, Any],
+    is_xarray: Sequence[bool],
+    is_array: Sequence[bool],
+    input_chunks: Mapping[Hashable, tuple[int, ...]],
+    output_chunks: Mapping[Hashable, tuple[int, ...]],
+    coordinates: Coordinates,
+    template: Dataset,
+    result_is_array: bool,
+    template_name: Hashable | None,
+    token: str,
+    ichunk: Mapping[Hashable, range],
+    input_chunk_bounds: Mapping[Hashable, Any],
+    output_chunk_bounds: Mapping[Hashable, Any],
+    computed_variables: Sequence[Hashable],
+    new_indexes: set[Hashable],
+    modified_indexes: set[Hashable],
+    chunked_data: Sequence[Any],
+    wrapper: Callable[..., Any],
+    get_chunk_slicer: Callable[[Hashable, Mapping[Any, Any], Mapping[Any, Any]], slice],
+    dataset_to_dataarray: Callable[[Dataset], DataArray],
+) -> DataArray | Dataset:
+    missing_chunked_dims = {
+        dim
+        for dim, chunks in input_chunks.items()
+        if len(chunks) > 1 and dim not in output_chunks
+    }
+    if missing_chunked_dims:
+        raise NotImplementedError(
+            "dask_array-backed xarray.map_blocks does not yet support "
+            "dropping multi-chunk dimensions. Rechunk these dimensions to "
+            f"one chunk first: {sorted(missing_chunked_dims, key=repr)!r}."
+        )
+
+    from xarray.namedarray.parallelcompat import get_chunked_array_type
+
+    chunkmanager = get_chunked_array_type(*chunked_data)
+    map_blocks_multi_output = getattr(chunkmanager, "map_blocks_multi_output", None)
+    if map_blocks_multi_output is None:
+        raise NotImplementedError(
+            "The dask_array chunk manager does not support map_blocks_multi_output."
+        )
+
+    input_exprs: list[Any] = []
+    input_indices: list[Any] = []
+    arg_templates: list[Any] = []
+    for isxr, arg in zip(is_xarray, npargs, strict=True):
+        if not isxr:
+            if is_dask_collection(arg):
+                raise TypeError(
+                    "dask_array-backed xarray.map_blocks only supports Dask "
+                    "collections inside xarray arguments."
+                )
+            arg_templates.append(("literal", arg))
+            continue
+
+        variable_templates: list[Any] = []
+        for name, variable in arg.variables.items():
+            is_coord = name in arg._coord_names
+            if is_dask_collection(variable.data):
+                data: Any = variable.data
+                input_exprs.append(data.expr)
+                input_indices.append(variable.dims)
+                variable_templates.append(
+                    (
+                        "chunked",
+                        name,
+                        variable.dims,
+                        variable.attrs,
+                        len(input_exprs) - 1,
+                        is_coord,
+                        None,
+                    )
+                )
+            else:
+                variable_templates.append(
+                    (
+                        "static",
+                        name,
+                        variable.dims,
+                        variable.attrs,
+                        None,
+                        is_coord,
+                        variable,
+                    )
+                )
+        arg_templates.append(("xarray", arg.attrs, variable_templates))
+
+    def build_block_specs() -> dict[tuple[Any, ...], dict[str, Any]]:
+        specs: dict[tuple[Any, ...], dict[str, Any]] = {}
+        for chunk_tuple in itertools.product(*ichunk.values()):
+            chunk_index = dict(zip(ichunk.keys(), chunk_tuple, strict=True))
+            arg_specs: list[Any] = []
+            for arg_template in arg_templates:
+                if arg_template[0] == "literal":
+                    arg_specs.append(arg_template)
+                    continue
+
+                _, dataset_attrs, variable_templates = arg_template
+                data_vars: list[Any] = []
+                coords: list[Any] = []
+                for (
+                    kind,
+                    name,
+                    dims,
+                    variable_attrs,
+                    input_position,
+                    is_coord,
+                    variable,
+                ) in variable_templates:
+                    if kind == "chunked":
+                        data = ("block", input_position)
+                    else:
+                        assert variable is not None
+                        subsetter = {
+                            dim: get_chunk_slicer(dim, chunk_index, input_chunk_bounds)
+                            for dim in variable.dims
+                        }
+                        data = ("static", variable.isel(subsetter)._data)
+
+                    target = coords if is_coord else data_vars
+                    target.append((name, dims, data, variable_attrs))
+
+                arg_specs.append(("xarray", data_vars, coords, dataset_attrs))
+
+            indexes = {
+                dim: coordinates.xindexes[dim][
+                    get_chunk_slicer(dim, chunk_index, output_chunk_bounds)
+                ]
+                for dim in (new_indexes | modified_indexes)
+            }
+            expected = {
+                "shapes": {
+                    k: output_chunks[k][v]
+                    for k, v in chunk_index.items()
+                    if k in output_chunks
+                },
+                "data_vars": set(template.data_vars.keys()),
+                "coords": set(template.coords.keys()),
+            }
+            specs[chunk_tuple] = {
+                "wrapper": wrapper,
+                "func": func,
+                "args": arg_specs,
+                "kwargs": kwargs,
+                "arg_is_array": is_array,
+                "expected": expected,
+                "expected_indexes": indexes,
+                "output_variables": tuple(computed_variables),
+            }
+        return specs
+
+    outputs = []
+    for output_index, name in enumerate(computed_variables):
+        variable = template.variables[name]
+        var_chunks = []
+        for dim in variable.dims:
+            if dim in output_chunks:
+                var_chunks.append(output_chunks[dim])
+            elif dim in template.dims:
+                var_chunks.append((template.sizes[dim],))
+
+        outputs.append(
+            {
+                "key": output_index,
+                "indices": variable.dims,
+                "chunks": tuple(var_chunks),
+                "dtype": variable.dtype,
+                "name": f"{name}-{token}",
+            }
+        )
+
+    mapped_arrays = map_blocks_multi_output(
+        _execute_map_blocks_multi_output,
+        input_exprs,
+        input_indices,
+        tuple(input_chunks),
+        build_block_specs(),
+        outputs,
+        token=token,
+    )
+
+    result = Dataset(coords=coordinates, attrs=template.attrs)
+    for index in result._indexes:
+        result[index].attrs = template[index].attrs
+        result[index].encoding = template[index].encoding
+
+    for name, data in zip(computed_variables, mapped_arrays, strict=True):
+        result[name] = (template[name].dims, data, template[name].attrs)
+        result[name].encoding = template[name].encoding
+
+    result = result.set_coords(template._coord_names)
+
+    if result_is_array:
+        da = dataset_to_dataarray(result)
+        da.name = template_name
+        return da
+    return result

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -7568,9 +7568,9 @@ class Dataset(
         dask.dataframe.DataFrame
         """
 
-        import dask.array as da
         import dask.dataframe as dd
 
+        chunkmanager = guess_chunkmanager("dask")
         ordered_dims = self._normalize_dim_order(dim_order=dim_order)
 
         columns = list(ordered_dims)
@@ -7587,7 +7587,7 @@ class Dataset(
             except KeyError:
                 # dimension without a matching coordinate
                 size = self.sizes[name]
-                data = da.arange(size, chunks=size, dtype=np.int64)
+                data = chunkmanager.array_api.arange(size, chunks=size, dtype=np.int64)
                 var = Variable((name,), data)
 
             # IndexVariable objects have a dummy .chunk() method

--- a/xarray/core/duck_array_ops.py
+++ b/xarray/core/duck_array_ops.py
@@ -92,11 +92,20 @@ def _dask_or_eager_func(
 
     def f(*args, **kwargs):
         if dask_available and any(is_duck_dask_array(a) for a in args):
-            mod = (
-                import_module(dask_module)
-                if isinstance(dask_module, str)
-                else dask_module
-            )
+            chunkmanager = get_chunked_array_type(*args)
+            mod = chunkmanager.array_api
+            if not hasattr(mod, name):
+                from xarray.namedarray.daskmanager import DaskManager
+
+                if not isinstance(chunkmanager, DaskManager):
+                    raise NotImplementedError(
+                        f"{name!r} is not available on the active dask chunk manager"
+                    )
+                mod = (
+                    import_module(dask_module)
+                    if isinstance(dask_module, str)
+                    else dask_module
+                )
             wrapped = getattr(mod, name)
             for kwarg in numpy_only_kwargs:
                 kwargs.pop(kwarg, None)

--- a/xarray/core/parallel.py
+++ b/xarray/core/parallel.py
@@ -441,8 +441,16 @@ def map_blocks(
         for arg in aligned
     )
 
+    from xarray.core.dask_array_expr import collect_dask_array_expr_chunked_data
+
+    has_dask_array_expr, chunked_data = collect_dask_array_expr_chunked_data(
+        xarray_objs
+    )
+
     # rechunk any numpy variables appropriately
     xarray_objs = tuple(arg.chunk(arg.chunksizes) for arg in xarray_objs)
+    if has_dask_array_expr:
+        _, chunked_data = collect_dask_array_expr_chunked_data(xarray_objs)
 
     merged_coordinates = merge(
         [arg.coords for arg in aligned],
@@ -522,6 +530,7 @@ def map_blocks(
         template = template._to_temp_dataset()
     elif isinstance(template, Dataset):
         result_is_array = False
+        template_name = None
     else:
         raise TypeError(
             f"func output must be DataArray or Dataset; got {type(template)}"
@@ -547,7 +556,42 @@ def map_blocks(
         dim: np.cumsum((0,) + chunks_v) for dim, chunks_v in output_chunks.items()
     }
 
-    computed_variables = set(template.variables) - set(coordinates.indexes)
+    computed_variables = [
+        name for name in template.variables if name not in coordinates.indexes
+    ]
+
+    if has_dask_array_expr:
+        from xarray.core.dask_array_expr import map_blocks_with_dask_array_expr
+
+        dask_array_token = (
+            f"{dask.utils.funcname(func)}-"
+            f"{dask.base.tokenize(func, npargs[0], args, kwargs)}"
+        )
+        return map_blocks_with_dask_array_expr(
+            func=func,
+            npargs=npargs,
+            kwargs=kwargs,
+            is_xarray=is_xarray,
+            is_array=is_array,
+            input_chunks=input_chunks,
+            output_chunks=output_chunks,
+            coordinates=coordinates,
+            template=template,
+            result_is_array=result_is_array,
+            template_name=template_name,
+            token=dask_array_token,
+            ichunk=ichunk,
+            input_chunk_bounds=input_chunk_bounds,
+            output_chunk_bounds=output_chunk_bounds,
+            computed_variables=computed_variables,
+            new_indexes=new_indexes,
+            modified_indexes=modified_indexes,
+            chunked_data=chunked_data,
+            wrapper=_wrapper,
+            get_chunk_slicer=_get_chunk_slicer,
+            dataset_to_dataarray=dataset_to_dataarray,
+        )  # type: ignore[return-value]
+
     # iterate over all possible chunk combinations
     for chunk_tuple in itertools.product(*ichunk.values()):
         # mapping from dimension name to chunk index

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -807,6 +807,14 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
 
         if slice_positions:
             new_order = [i for i in range(len(out_dims)) if i not in slice_positions]
+            if is_duck_dask_array(self._data):
+                try:
+                    chunkmanager = get_chunked_array_type(self._data)
+                except TypeError:
+                    pass
+                else:
+                    if chunkmanager.vectorized_indexing_returns_numpy_order:
+                        new_order = None
         else:
             new_order = None
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -807,14 +807,6 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
 
         if slice_positions:
             new_order = [i for i in range(len(out_dims)) if i not in slice_positions]
-            if is_duck_dask_array(self._data):
-                try:
-                    chunkmanager = get_chunked_array_type(self._data)
-                except TypeError:
-                    pass
-                else:
-                    if chunkmanager.vectorized_indexing_returns_numpy_order:
-                        new_order = None
         else:
             new_order = None
 

--- a/xarray/namedarray/parallelcompat.py
+++ b/xarray/namedarray/parallelcompat.py
@@ -211,6 +211,7 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
 
     array_cls: type[T_ChunkedArray]
     available: bool = True
+    vectorized_indexing_returns_numpy_order: bool = False
 
     @abstractmethod
     def __init__(self) -> None:

--- a/xarray/namedarray/parallelcompat.py
+++ b/xarray/namedarray/parallelcompat.py
@@ -211,7 +211,6 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
 
     array_cls: type[T_ChunkedArray]
     available: bool = True
-    vectorized_indexing_returns_numpy_order: bool = False
 
     @abstractmethod
     def __init__(self) -> None:

--- a/xarray/structure/chunks.py
+++ b/xarray/structure/chunks.py
@@ -15,6 +15,7 @@ from xarray.namedarray.parallelcompat import (
     ChunkManagerEntrypoint,
     get_chunked_array_type,
     guess_chunkmanager,
+    list_chunkmanagers,
 )
 
 if TYPE_CHECKING:
@@ -83,7 +84,11 @@ def _maybe_chunk(
         chunked_array_type = guess_chunkmanager(
             chunked_array_type
         )  # coerce string to ChunkManagerEntrypoint type
-        if isinstance(chunked_array_type, DaskManager):
+        registered_as_dask = any(
+            name == "dask" and manager is chunked_array_type
+            for name, manager in list_chunkmanagers().items()
+        )
+        if isinstance(chunked_array_type, DaskManager) or registered_as_dask:
             if not just_use_token:
                 from dask.base import tokenize
 

--- a/xarray/structure/chunks.py
+++ b/xarray/structure/chunks.py
@@ -84,11 +84,11 @@ def _maybe_chunk(
         chunked_array_type = guess_chunkmanager(
             chunked_array_type
         )  # coerce string to ChunkManagerEntrypoint type
-        registered_as_dask = any(
+        is_dask_chunkmanager = isinstance(chunked_array_type, DaskManager) or any(
             name == "dask" and manager is chunked_array_type
             for name, manager in list_chunkmanagers().items()
         )
-        if isinstance(chunked_array_type, DaskManager) or registered_as_dask:
+        if is_dask_chunkmanager:
             if not just_use_token:
                 from dask.base import tokenize
 

--- a/xarray/tests/CLAUDE.md
+++ b/xarray/tests/CLAUDE.md
@@ -10,6 +10,10 @@ xarray has many optional dependencies that may not be available in all testing e
 
 All available decorators are defined in `xarray/tests/__init__.py` (look for `requires_*` decorators).
 
+Use the dask helpers from `xarray.tests` instead of importing `dask.array`
+directly. In dask-array expression test mode those helpers point at the
+registered chunk manager, so tests can run against either implementation.
+
 ### DO NOT use conditional imports or skipif
 
 ❌ **WRONG - Do not do this:**

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -115,13 +115,10 @@ with warnings.catch_warnings():
         category=UserWarning,
     )
 
-    has_h5netcdf, requires_h5netcdf = _importorskip("h5netcdf")
+has_h5netcdf, requires_h5netcdf = _importorskip("h5netcdf")
 has_cftime, requires_cftime = _importorskip("cftime")
 has_dask, requires_dask = _importorskip("dask")
-has_dask_array = importlib.util.find_spec("dask_array") is not None
-requires_dask_array = pytest.mark.skipif(
-    not has_dask_array, reason="requires dask_array"
-)
+has_dask_array, requires_dask_array = _importorskip("dask_array")
 has_dask_ge_2024_08_1, requires_dask_ge_2024_08_1 = _importorskip(
     "dask", minversion="2024.08.1"
 )
@@ -139,25 +136,15 @@ else:
         )
         has_dask_expr, requires_dask_expr = _importorskip("dask_expr")
 
-dask_array_api = None
-dask_array_type = ()
-has_dask_array_expr = False
-
-
-def refresh_dask_chunkmanager_helpers() -> None:
-    global dask_array_api, dask_array_type, has_dask_array_expr
-
+if has_dask:
+    dask_chunkmanager = get_dask_chunkmanager()
+    dask_array_api = dask_chunkmanager.array_api
+    dask_array_type = dask_chunkmanager.array_cls
+    has_dask_array_expr = dask_array_type.__module__.startswith("dask_array")
+else:
     dask_array_api = None
     dask_array_type = ()
     has_dask_array_expr = False
-    if has_dask:
-        dask_chunkmanager = get_dask_chunkmanager()
-        dask_array_api = dask_chunkmanager.array_api
-        dask_array_type = dask_chunkmanager.array_cls
-        has_dask_array_expr = dask_array_type.__module__.startswith("dask_array")
-
-
-refresh_dask_chunkmanager_helpers()
 
 has_bottleneck, requires_bottleneck = _importorskip("bottleneck")
 has_rasterio, requires_rasterio = _importorskip("rasterio")

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -140,21 +140,21 @@ else:
         has_dask_expr, requires_dask_expr = _importorskip("dask_expr")
 
 dask_array_api = None
-dask_array_type = dask_array_cls = ()
+dask_array_type = ()
 has_dask_array_expr = False
 
 
 def refresh_dask_chunkmanager_helpers() -> None:
-    global dask_array_api, dask_array_type, dask_array_cls, has_dask_array_expr
+    global dask_array_api, dask_array_type, has_dask_array_expr
 
     dask_array_api = None
-    dask_array_type = dask_array_cls = ()
+    dask_array_type = ()
     has_dask_array_expr = False
     if has_dask:
         dask_chunkmanager = get_dask_chunkmanager()
         dask_array_api = dask_chunkmanager.array_api
-        dask_array_type = dask_array_cls = dask_chunkmanager.array_cls
-        has_dask_array_expr = dask_array_cls.__module__.startswith("dask_array")
+        dask_array_type = dask_chunkmanager.array_cls
+        has_dask_array_expr = dask_array_type.__module__.startswith("dask_array")
 
 
 refresh_dask_chunkmanager_helpers()

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -90,6 +90,12 @@ def _importorskip(
     return has, func
 
 
+def get_dask_chunkmanager():
+    from xarray.namedarray.parallelcompat import guess_chunkmanager
+
+    return guess_chunkmanager("dask")
+
+
 has_matplotlib, requires_matplotlib = _importorskip("matplotlib")
 has_scipy, requires_scipy = _importorskip("scipy")
 has_scipy_ge_1_13, requires_scipy_ge_1_13 = _importorskip("scipy", "1.13")

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -118,6 +118,10 @@ with warnings.catch_warnings():
     has_h5netcdf, requires_h5netcdf = _importorskip("h5netcdf")
 has_cftime, requires_cftime = _importorskip("cftime")
 has_dask, requires_dask = _importorskip("dask")
+has_dask_array = importlib.util.find_spec("dask_array") is not None
+requires_dask_array = pytest.mark.skipif(
+    not has_dask_array, reason="requires dask_array"
+)
 has_dask_ge_2024_08_1, requires_dask_ge_2024_08_1 = _importorskip(
     "dask", minversion="2024.08.1"
 )
@@ -134,6 +138,27 @@ else:
             category=FutureWarning,
         )
         has_dask_expr, requires_dask_expr = _importorskip("dask_expr")
+
+dask_array_api = None
+dask_array_type = dask_array_cls = ()
+has_dask_array_expr = False
+
+
+def refresh_dask_chunkmanager_helpers() -> None:
+    global dask_array_api, dask_array_type, dask_array_cls, has_dask_array_expr
+
+    dask_array_api = None
+    dask_array_type = dask_array_cls = ()
+    has_dask_array_expr = False
+    if has_dask:
+        dask_chunkmanager = get_dask_chunkmanager()
+        dask_array_api = dask_chunkmanager.array_api
+        dask_array_type = dask_array_cls = dask_chunkmanager.array_cls
+        has_dask_array_expr = dask_array_cls.__module__.startswith("dask_array")
+
+
+refresh_dask_chunkmanager_helpers()
+
 has_bottleneck, requires_bottleneck = _importorskip("bottleneck")
 has_rasterio, requires_rasterio = _importorskip("rasterio")
 has_zarr, requires_zarr = _importorskip("zarr")

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -13,6 +13,7 @@ from xarray.tests import (
     assert_chunks_equal,
     assert_equal,
     assert_identical,
+    get_dask_chunkmanager,
     raise_if_dask_computes,
     requires_cftime,
     requires_dask,
@@ -198,19 +199,13 @@ class TestDatetimeAccessor:
         ],
     )
     def test_dask_field_access(self, field) -> None:
-        import dask.array as da
-
         expected = getattr(self.times_data.dt, field)
-
-        dask_times_arr = da.from_array(self.times_arr, chunks=(5, 5, 50))
-        dask_times_2d = xr.DataArray(
-            dask_times_arr, coords=self.data.coords, dims=self.data.dims, name="data"
-        )
+        dask_times_2d = self.times_data.chunk({"lon": 5, "lat": 5, "time": 50})
 
         with raise_if_dask_computes():
             actual = getattr(dask_times_2d.dt, field)
 
-        assert isinstance(actual.data, da.Array)
+        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
         assert_chunks_equal(actual, dask_times_2d)
         assert_equal(actual.compute(), expected.compute())
 
@@ -224,19 +219,13 @@ class TestDatetimeAccessor:
         ],
     )
     def test_isocalendar_dask(self, field) -> None:
-        import dask.array as da
-
         expected = getattr(self.times_data.dt.isocalendar(), field)
-
-        dask_times_arr = da.from_array(self.times_arr, chunks=(5, 5, 50))
-        dask_times_2d = xr.DataArray(
-            dask_times_arr, coords=self.data.coords, dims=self.data.dims, name="data"
-        )
+        dask_times_2d = self.times_data.chunk({"lon": 5, "lat": 5, "time": 50})
 
         with raise_if_dask_computes():
             actual = dask_times_2d.dt.isocalendar()[field]
 
-        assert isinstance(actual.data, da.Array)
+        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
         assert_chunks_equal(actual, dask_times_2d)
         assert_equal(actual.compute(), expected.compute())
 
@@ -251,18 +240,13 @@ class TestDatetimeAccessor:
         ],
     )
     def test_dask_accessor_method(self, method, parameters) -> None:
-        import dask.array as da
-
         expected = getattr(self.times_data.dt, method)(parameters)
-        dask_times_arr = da.from_array(self.times_arr, chunks=(5, 5, 50))
-        dask_times_2d = xr.DataArray(
-            dask_times_arr, coords=self.data.coords, dims=self.data.dims, name="data"
-        )
+        dask_times_2d = self.times_data.chunk({"lon": 5, "lat": 5, "time": 50})
 
         with raise_if_dask_computes():
             actual = getattr(dask_times_2d.dt, method)(parameters)
 
-        assert isinstance(actual.data, da.Array)
+        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
         assert_chunks_equal(actual, dask_times_2d)
         assert_equal(actual.compute(), expected.compute())
 
@@ -359,19 +343,13 @@ class TestTimedeltaAccessor:
         "field", ["days", "seconds", "microseconds", "nanoseconds"]
     )
     def test_dask_field_access(self, field) -> None:
-        import dask.array as da
-
         expected = getattr(self.times_data.dt, field)
-
-        dask_times_arr = da.from_array(self.times_arr, chunks=(5, 5, 50))
-        dask_times_2d = xr.DataArray(
-            dask_times_arr, coords=self.data.coords, dims=self.data.dims, name="data"
-        )
+        dask_times_2d = self.times_data.chunk({"lon": 5, "lat": 5, "time": 50})
 
         with raise_if_dask_computes():
             actual = getattr(dask_times_2d.dt, field)
 
-        assert isinstance(actual.data, da.Array)
+        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
         assert_chunks_equal(actual, dask_times_2d)
         assert_equal(actual, expected)
 
@@ -380,18 +358,13 @@ class TestTimedeltaAccessor:
         "method, parameters", [("floor", "D"), ("ceil", "D"), ("round", "D")]
     )
     def test_dask_accessor_method(self, method, parameters) -> None:
-        import dask.array as da
-
         expected = getattr(self.times_data.dt, method)(parameters)
-        dask_times_arr = da.from_array(self.times_arr, chunks=(5, 5, 50))
-        dask_times_2d = xr.DataArray(
-            dask_times_arr, coords=self.data.coords, dims=self.data.dims, name="data"
-        )
+        dask_times_2d = self.times_data.chunk({"lon": 5, "lat": 5, "time": 50})
 
         with raise_if_dask_computes():
             actual = getattr(dask_times_2d.dt, method)(parameters)
 
-        assert isinstance(actual.data, da.Array)
+        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
         assert_chunks_equal(actual, dask_times_2d)
         assert_equal(actual.compute(), expected.compute())
 
@@ -472,11 +445,9 @@ def test_calendar_datetime64_2d() -> None:
 
 @requires_dask
 def test_calendar_datetime64_3d_dask() -> None:
-    import dask.array as da
-
     data = xr.DataArray(
-        da.zeros((4, 5, 6), dtype="datetime64[ns]"), dims=("x", "y", "z")
-    )
+        np.zeros((4, 5, 6), dtype="datetime64[ns]"), dims=("x", "y", "z")
+    ).chunk({"x": 2})
     with raise_if_dask_computes():
         assert data.dt.calendar == "proleptic_gregorian"
 
@@ -540,8 +511,6 @@ def test_cftime_strftime_access(data) -> None:
     "field", ["year", "month", "day", "hour", "day_of_year", "day_of_week"]
 )
 def test_dask_field_access_1d(data, field) -> None:
-    import dask.array as da
-
     expected = xr.DataArray(
         getattr(xr.coding.cftimeindex.CFTimeIndex(data.time.values), field),
         name=field,
@@ -549,7 +518,7 @@ def test_dask_field_access_1d(data, field) -> None:
     )
     times = xr.DataArray(data.time.values, dims=["time"]).chunk({"time": 50})
     result = getattr(times.dt, field)
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, get_dask_chunkmanager().array_cls)
     assert result.chunks == times.chunks
     assert_equal(result.compute(), expected)
 
@@ -560,8 +529,6 @@ def test_dask_field_access_1d(data, field) -> None:
     "field", ["year", "month", "day", "hour", "day_of_year", "day_of_week"]
 )
 def test_dask_field_access(times_3d, data, field) -> None:
-    import dask.array as da
-
     expected = xr.DataArray(
         getattr(
             xr.coding.cftimeindex.CFTimeIndex(times_3d.values.ravel()), field
@@ -572,7 +539,7 @@ def test_dask_field_access(times_3d, data, field) -> None:
     )
     times_3d = times_3d.chunk({"lon": 5, "lat": 5, "time": 50})
     result = getattr(times_3d.dt, field)
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, get_dask_chunkmanager().array_cls)
     assert result.chunks == times_3d.chunks
     assert_equal(result.compute(), expected)
 
@@ -618,8 +585,6 @@ def cftime_rounding_dataarray(cftime_date_type):
 def test_cftime_floor_accessor(
     cftime_rounding_dataarray, cftime_date_type, use_dask
 ) -> None:
-    import dask.array as da
-
     freq = "D"
     expected = xr.DataArray(
         [
@@ -637,7 +602,7 @@ def test_cftime_floor_accessor(
         with raise_if_dask_computes(max_computes=1):
             result = cftime_rounding_dataarray.chunk(chunks).dt.floor(freq)
         expected = expected.chunk(chunks)
-        assert isinstance(result.data, da.Array)
+        assert isinstance(result.data, get_dask_chunkmanager().array_cls)
         assert result.chunks == expected.chunks
     else:
         result = cftime_rounding_dataarray.dt.floor(freq)
@@ -651,8 +616,6 @@ def test_cftime_floor_accessor(
 def test_cftime_ceil_accessor(
     cftime_rounding_dataarray, cftime_date_type, use_dask
 ) -> None:
-    import dask.array as da
-
     freq = "D"
     expected = xr.DataArray(
         [
@@ -670,7 +633,7 @@ def test_cftime_ceil_accessor(
         with raise_if_dask_computes(max_computes=1):
             result = cftime_rounding_dataarray.chunk(chunks).dt.ceil(freq)
         expected = expected.chunk(chunks)
-        assert isinstance(result.data, da.Array)
+        assert isinstance(result.data, get_dask_chunkmanager().array_cls)
         assert result.chunks == expected.chunks
     else:
         result = cftime_rounding_dataarray.dt.ceil(freq)
@@ -684,8 +647,6 @@ def test_cftime_ceil_accessor(
 def test_cftime_round_accessor(
     cftime_rounding_dataarray, cftime_date_type, use_dask
 ) -> None:
-    import dask.array as da
-
     freq = "D"
     expected = xr.DataArray(
         [
@@ -703,7 +664,7 @@ def test_cftime_round_accessor(
         with raise_if_dask_computes(max_computes=1):
             result = cftime_rounding_dataarray.chunk(chunks).dt.round(freq)
         expected = expected.chunk(chunks)
-        assert isinstance(result.data, da.Array)
+        assert isinstance(result.data, get_dask_chunkmanager().array_cls)
         assert result.chunks == expected.chunks
     else:
         result = cftime_rounding_dataarray.dt.round(freq)

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -13,7 +13,7 @@ from xarray.tests import (
     assert_chunks_equal,
     assert_equal,
     assert_identical,
-    get_dask_chunkmanager,
+    dask_array_type,
     raise_if_dask_computes,
     requires_cftime,
     requires_dask,
@@ -205,7 +205,7 @@ class TestDatetimeAccessor:
         with raise_if_dask_computes():
             actual = getattr(dask_times_2d.dt, field)
 
-        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(actual.data, dask_array_type)
         assert_chunks_equal(actual, dask_times_2d)
         assert_equal(actual.compute(), expected.compute())
 
@@ -225,7 +225,7 @@ class TestDatetimeAccessor:
         with raise_if_dask_computes():
             actual = dask_times_2d.dt.isocalendar()[field]
 
-        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(actual.data, dask_array_type)
         assert_chunks_equal(actual, dask_times_2d)
         assert_equal(actual.compute(), expected.compute())
 
@@ -246,7 +246,7 @@ class TestDatetimeAccessor:
         with raise_if_dask_computes():
             actual = getattr(dask_times_2d.dt, method)(parameters)
 
-        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(actual.data, dask_array_type)
         assert_chunks_equal(actual, dask_times_2d)
         assert_equal(actual.compute(), expected.compute())
 
@@ -349,7 +349,7 @@ class TestTimedeltaAccessor:
         with raise_if_dask_computes():
             actual = getattr(dask_times_2d.dt, field)
 
-        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(actual.data, dask_array_type)
         assert_chunks_equal(actual, dask_times_2d)
         assert_equal(actual, expected)
 
@@ -364,7 +364,7 @@ class TestTimedeltaAccessor:
         with raise_if_dask_computes():
             actual = getattr(dask_times_2d.dt, method)(parameters)
 
-        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(actual.data, dask_array_type)
         assert_chunks_equal(actual, dask_times_2d)
         assert_equal(actual.compute(), expected.compute())
 
@@ -518,7 +518,7 @@ def test_dask_field_access_1d(data, field) -> None:
     )
     times = xr.DataArray(data.time.values, dims=["time"]).chunk({"time": 50})
     result = getattr(times.dt, field)
-    assert isinstance(result.data, get_dask_chunkmanager().array_cls)
+    assert isinstance(result.data, dask_array_type)
     assert result.chunks == times.chunks
     assert_equal(result.compute(), expected)
 
@@ -539,7 +539,7 @@ def test_dask_field_access(times_3d, data, field) -> None:
     )
     times_3d = times_3d.chunk({"lon": 5, "lat": 5, "time": 50})
     result = getattr(times_3d.dt, field)
-    assert isinstance(result.data, get_dask_chunkmanager().array_cls)
+    assert isinstance(result.data, dask_array_type)
     assert result.chunks == times_3d.chunks
     assert_equal(result.compute(), expected)
 
@@ -602,7 +602,7 @@ def test_cftime_floor_accessor(
         with raise_if_dask_computes(max_computes=1):
             result = cftime_rounding_dataarray.chunk(chunks).dt.floor(freq)
         expected = expected.chunk(chunks)
-        assert isinstance(result.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(result.data, dask_array_type)
         assert result.chunks == expected.chunks
     else:
         result = cftime_rounding_dataarray.dt.floor(freq)
@@ -633,7 +633,7 @@ def test_cftime_ceil_accessor(
         with raise_if_dask_computes(max_computes=1):
             result = cftime_rounding_dataarray.chunk(chunks).dt.ceil(freq)
         expected = expected.chunk(chunks)
-        assert isinstance(result.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(result.data, dask_array_type)
         assert result.chunks == expected.chunks
     else:
         result = cftime_rounding_dataarray.dt.ceil(freq)
@@ -664,7 +664,7 @@ def test_cftime_round_accessor(
         with raise_if_dask_computes(max_computes=1):
             result = cftime_rounding_dataarray.chunk(chunks).dt.round(freq)
         expected = expected.chunk(chunks)
-        assert isinstance(result.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(result.data, dask_array_type)
         assert result.chunks == expected.chunks
     else:
         result = cftime_rounding_dataarray.dt.round(freq)

--- a/xarray/tests/test_accessor_str.py
+++ b/xarray/tests/test_accessor_str.py
@@ -57,10 +57,7 @@ def dtype(request):
 
 @requires_dask
 def test_dask() -> None:
-    import dask.array as da
-
-    arr = da.from_array(["a", "b", "c"], chunks=-1)
-    xarr = xr.DataArray(arr)
+    xarr = xr.DataArray(["a", "b", "c"]).chunk()
 
     result = xarr.str.len().compute()
     expected = xr.DataArray([1, 1, 1])

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1016,7 +1016,9 @@ class DatasetIOBase:
                     find_and_validate_array(obj.array)
                 elif isinstance(obj.array, np.ndarray):
                     assert isinstance(obj, indexing.NumpyIndexingAdapter)
-                elif isinstance(obj.array, get_dask_chunkmanager().array_cls):
+                elif has_dask and isinstance(
+                    obj.array, get_dask_chunkmanager().array_cls
+                ):
                     assert isinstance(obj, indexing.DaskIndexingAdapter)
                 elif isinstance(obj.array, pd.Index):
                     assert isinstance(obj, indexing.PandasIndexingAdapter)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -66,7 +66,6 @@ from xarray.core.indexes import PandasIndex
 from xarray.core.options import set_options
 from xarray.core.types import PDDatetimeUnitOptions
 from xarray.core.utils import module_available
-from xarray.namedarray.pycompat import array_type
 from xarray.structure.alignment import AlignmentError
 from xarray.tests import (
     assert_allclose,
@@ -74,6 +73,7 @@ from xarray.tests import (
     assert_equal,
     assert_identical,
     assert_no_warnings,
+    get_dask_chunkmanager,
     has_dask,
     has_netCDF4,
     has_numpy_2,
@@ -119,7 +119,7 @@ with contextlib.suppress(ImportError):
 
 with contextlib.suppress(ImportError):
     import dask
-    import dask.array as da
+
 
 with contextlib.suppress(ImportError):
     import fsspec
@@ -225,9 +225,6 @@ def _check_compression_codec_available(codec: str | None) -> bool:
     except Exception:
         # Any other error, assume codec is not available
         return False
-
-
-dask_array_type = array_type("dask")
 
 
 def open_example_dataset(name, *args, **kwargs) -> Dataset:
@@ -1010,6 +1007,7 @@ class DatasetIOBase:
             assert_identical(expected, actual)
 
     def validate_array_type(self, ds):
+
         # Make sure that only NumpyIndexingAdapter stores a bare np.ndarray.
         def find_and_validate_array(obj):
             # recursively called function. obj: array or array wrapper.
@@ -1018,7 +1016,7 @@ class DatasetIOBase:
                     find_and_validate_array(obj.array)
                 elif isinstance(obj.array, np.ndarray):
                     assert isinstance(obj, indexing.NumpyIndexingAdapter)
-                elif isinstance(obj.array, dask_array_type):
+                elif isinstance(obj.array, get_dask_chunkmanager().array_cls):
                     assert isinstance(obj, indexing.DaskIndexingAdapter)
                 elif isinstance(obj.array, pd.Index):
                     assert isinstance(obj, indexing.PandasIndexingAdapter)
@@ -2248,16 +2246,19 @@ class NetCDF4Base(NetCDFBase):
                 assert len(loaded_ds.xindexes) == 0
 
     @requires_dask
+    @pytest.mark.skip_with_dask_array
     def test_encoding_masked_arrays(self, tmp_path) -> None:
         store_path = tmp_path / "tmp.nc"
 
         with raise_if_dask_computes():
+            da = get_dask_chunkmanager().array_api
             ds = xr.DataArray(
-                dask.array.from_array(
+                da.from_array(
                     np.ma.masked_array(
                         np.array([[np.nan, np.nan], [np.nan, 2]]),
                         np.array([[True, True], [True, False]]),
-                    )
+                    ),
+                    chunks=(2, 2),
                 ).astype("float32"),
                 dims=("x", "y"),
             ).to_dataset(name="mydata")
@@ -2595,6 +2596,7 @@ class TestNetCDF4ViaDaskData(TestNetCDF4Data):
     def test_write_inconsistent_chunks(self) -> None:
         # Construct two variables with the same dimensions, but different
         # chunk sizes.
+        da = get_dask_chunkmanager().array_api
         x = da.zeros((100, 100), dtype="f4", chunks=(50, 100))
         x = DataArray(data=x, dims=("lat", "lon"), name="x")
         x.encoding["chunksizes"] = (50, 100)
@@ -3799,8 +3801,14 @@ class ZarrBase(CFEncodedBase):
         # We test this by writing a dask array with compute=False,
         # on read we should receive chunks filled with `fill_value`
         fv = -1
+        da = get_dask_chunkmanager().array_api
         ds = xr.Dataset(
-            {"foo": ("x", dask.array.from_array(np.array([0, 0, 0], dtype=dtype)))}
+            {
+                "foo": (
+                    "x",
+                    da.from_array(np.array([0, 0, 0], dtype=dtype), chunks=(3,)),
+                )
+            }
         )
         expected = xr.Dataset({"foo": ("x", [fv] * 3)})
 
@@ -5218,6 +5226,7 @@ class TestH5NetCDFViaDaskData(TestH5NetCDFData):
     def test_write_inconsistent_chunks(self) -> None:
         # Construct two variables with the same dimensions, but different
         # chunk sizes.
+        da = get_dask_chunkmanager().array_api
         x = da.zeros((100, 100), dtype="f4", chunks=(50, 100))
         x = DataArray(data=x, dims=("lat", "lon"), name="x")
         x.encoding["chunksizes"] = (50, 100)
@@ -5439,7 +5448,7 @@ def test_open_mfdataset_manyfiles(
             chunks=chunks if (not chunks and readengine != "zarr") else "auto",
         ) as actual:
             # check that using open_mfdataset returns dask arrays for variables
-            assert isinstance(actual["foo"].data, dask_array_type)
+            assert isinstance(actual["foo"].data, get_dask_chunkmanager().array_cls)
 
             assert_identical(original, actual)
 
@@ -5868,7 +5877,9 @@ class TestDask(DatasetIOBase):
                 with open_mfdataset(
                     [tmp1, tmp2], concat_dim="x", combine="nested"
                 ) as actual:
-                    assert isinstance(actual.foo.variable.data, da.Array)
+                    assert isinstance(
+                        actual.foo.variable.data, get_dask_chunkmanager().array_cls
+                    )
                     assert actual.foo.variable.data.chunks == ((5, 5),)
                     assert_identical(original, actual)
                 with open_mfdataset(
@@ -5904,7 +5915,10 @@ class TestDask(DatasetIOBase):
                             combine="nested",
                             concat_dim=["y", "x"],
                         ) as actual:
-                            assert isinstance(actual.foo.variable.data, da.Array)
+                            assert isinstance(
+                                actual.foo.variable.data,
+                                get_dask_chunkmanager().array_cls,
+                            )
                             assert actual.foo.variable.data.chunks == ((5, 5), (4, 4))
                             assert_identical(original, actual)
                         with open_mfdataset(
@@ -6264,7 +6278,9 @@ class TestDask(DatasetIOBase):
         with create_tmp_file() as tmp:
             original.to_netcdf(tmp)
             with open_dataset(tmp, chunks={"x": 5}) as actual:
-                assert isinstance(actual.foo.variable.data, da.Array)
+                assert isinstance(
+                    actual.foo.variable.data, get_dask_chunkmanager().array_cls
+                )
                 assert actual.foo.variable.data.chunks == ((5, 5),)
                 assert_identical(original, actual)
             with open_dataset(tmp, chunks=5) as actual:
@@ -6336,7 +6352,9 @@ class TestDask(DatasetIOBase):
             {"time": [cftime.Datetime360Day(2005, 12, 1, 12, 0, 0, 0)]},
         )
         with self.roundtrip(original, open_kwargs={"chunks": "auto"}) as actual:
-            assert isinstance(actual.time_bnds.variable.data, da.Array)
+            assert isinstance(
+                actual.time_bnds.variable.data, get_dask_chunkmanager().array_cls
+            )
             assert _contains_cftime_datetimes(actual.time)
             assert_identical(original, actual)
 
@@ -6427,6 +6445,7 @@ class TestDask(DatasetIOBase):
         ON_WINDOWS,
         reason="counting number of tasks in graph fails on windows for some reason",
     )
+    @pytest.mark.skip_with_dask_array
     def test_inline_array(self) -> None:
         with create_tmp_file() as tmp:
             original = Dataset({"foo": ("x", np.random.randn(10))})
@@ -7267,7 +7286,7 @@ def test_load_single_value_h5netcdf(tmp_path: Path) -> None:
 )
 def test_open_dataset_chunking_zarr(chunks, tmp_path: Path) -> None:
     encoded_chunks = 100
-    dask_arr = da.from_array(
+    dask_arr = get_dask_chunkmanager().array_api.from_array(
         np.ones((500, 500), dtype="float64"), chunks=encoded_chunks
     )
     ds = xr.Dataset(
@@ -7297,7 +7316,7 @@ def test_open_dataset_chunking_zarr(chunks, tmp_path: Path) -> None:
 @pytest.mark.filterwarnings("ignore:The specified chunks separate")
 def test_chunking_consistency(chunks, tmp_path: Path) -> None:
     encoded_chunks: dict[str, Any] = {}
-    dask_arr = da.from_array(
+    dask_arr = get_dask_chunkmanager().array_api.from_array(
         np.ones((500, 500), dtype="float64"), chunks=encoded_chunks
     )
     ds = xr.Dataset(

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -73,7 +73,8 @@ from xarray.tests import (
     assert_equal,
     assert_identical,
     assert_no_warnings,
-    get_dask_chunkmanager,
+    dask_array_api,
+    dask_array_type,
     has_dask,
     has_netCDF4,
     has_numpy_2,
@@ -1016,9 +1017,7 @@ class DatasetIOBase:
                     find_and_validate_array(obj.array)
                 elif isinstance(obj.array, np.ndarray):
                     assert isinstance(obj, indexing.NumpyIndexingAdapter)
-                elif has_dask and isinstance(
-                    obj.array, get_dask_chunkmanager().array_cls
-                ):
+                elif has_dask and isinstance(obj.array, dask_array_type):
                     assert isinstance(obj, indexing.DaskIndexingAdapter)
                 elif isinstance(obj.array, pd.Index):
                     assert isinstance(obj, indexing.PandasIndexingAdapter)
@@ -2253,7 +2252,7 @@ class NetCDF4Base(NetCDFBase):
         store_path = tmp_path / "tmp.nc"
 
         with raise_if_dask_computes():
-            da = get_dask_chunkmanager().array_api
+            da = dask_array_api
             ds = xr.DataArray(
                 da.from_array(
                     np.ma.masked_array(
@@ -2598,7 +2597,7 @@ class TestNetCDF4ViaDaskData(TestNetCDF4Data):
     def test_write_inconsistent_chunks(self) -> None:
         # Construct two variables with the same dimensions, but different
         # chunk sizes.
-        da = get_dask_chunkmanager().array_api
+        da = dask_array_api
         x = da.zeros((100, 100), dtype="f4", chunks=(50, 100))
         x = DataArray(data=x, dims=("lat", "lon"), name="x")
         x.encoding["chunksizes"] = (50, 100)
@@ -3803,7 +3802,7 @@ class ZarrBase(CFEncodedBase):
         # We test this by writing a dask array with compute=False,
         # on read we should receive chunks filled with `fill_value`
         fv = -1
-        da = get_dask_chunkmanager().array_api
+        da = dask_array_api
         ds = xr.Dataset(
             {
                 "foo": (
@@ -5228,7 +5227,7 @@ class TestH5NetCDFViaDaskData(TestH5NetCDFData):
     def test_write_inconsistent_chunks(self) -> None:
         # Construct two variables with the same dimensions, but different
         # chunk sizes.
-        da = get_dask_chunkmanager().array_api
+        da = dask_array_api
         x = da.zeros((100, 100), dtype="f4", chunks=(50, 100))
         x = DataArray(data=x, dims=("lat", "lon"), name="x")
         x.encoding["chunksizes"] = (50, 100)
@@ -5450,7 +5449,7 @@ def test_open_mfdataset_manyfiles(
             chunks=chunks if (not chunks and readengine != "zarr") else "auto",
         ) as actual:
             # check that using open_mfdataset returns dask arrays for variables
-            assert isinstance(actual["foo"].data, get_dask_chunkmanager().array_cls)
+            assert isinstance(actual["foo"].data, dask_array_type)
 
             assert_identical(original, actual)
 
@@ -5879,9 +5878,7 @@ class TestDask(DatasetIOBase):
                 with open_mfdataset(
                     [tmp1, tmp2], concat_dim="x", combine="nested"
                 ) as actual:
-                    assert isinstance(
-                        actual.foo.variable.data, get_dask_chunkmanager().array_cls
-                    )
+                    assert isinstance(actual.foo.variable.data, dask_array_type)
                     assert actual.foo.variable.data.chunks == ((5, 5),)
                     assert_identical(original, actual)
                 with open_mfdataset(
@@ -5919,7 +5916,7 @@ class TestDask(DatasetIOBase):
                         ) as actual:
                             assert isinstance(
                                 actual.foo.variable.data,
-                                get_dask_chunkmanager().array_cls,
+                                dask_array_type,
                             )
                             assert actual.foo.variable.data.chunks == ((5, 5), (4, 4))
                             assert_identical(original, actual)
@@ -6280,9 +6277,7 @@ class TestDask(DatasetIOBase):
         with create_tmp_file() as tmp:
             original.to_netcdf(tmp)
             with open_dataset(tmp, chunks={"x": 5}) as actual:
-                assert isinstance(
-                    actual.foo.variable.data, get_dask_chunkmanager().array_cls
-                )
+                assert isinstance(actual.foo.variable.data, dask_array_type)
                 assert actual.foo.variable.data.chunks == ((5, 5),)
                 assert_identical(original, actual)
             with open_dataset(tmp, chunks=5) as actual:
@@ -6354,9 +6349,7 @@ class TestDask(DatasetIOBase):
             {"time": [cftime.Datetime360Day(2005, 12, 1, 12, 0, 0, 0)]},
         )
         with self.roundtrip(original, open_kwargs={"chunks": "auto"}) as actual:
-            assert isinstance(
-                actual.time_bnds.variable.data, get_dask_chunkmanager().array_cls
-            )
+            assert isinstance(actual.time_bnds.variable.data, dask_array_type)
             assert _contains_cftime_datetimes(actual.time)
             assert_identical(original, actual)
 
@@ -7288,7 +7281,7 @@ def test_load_single_value_h5netcdf(tmp_path: Path) -> None:
 )
 def test_open_dataset_chunking_zarr(chunks, tmp_path: Path) -> None:
     encoded_chunks = 100
-    dask_arr = get_dask_chunkmanager().array_api.from_array(
+    dask_arr = dask_array_api.from_array(
         np.ones((500, 500), dtype="float64"), chunks=encoded_chunks
     )
     ds = xr.Dataset(
@@ -7318,7 +7311,7 @@ def test_open_dataset_chunking_zarr(chunks, tmp_path: Path) -> None:
 @pytest.mark.filterwarnings("ignore:The specified chunks separate")
 def test_chunking_consistency(chunks, tmp_path: Path) -> None:
     encoded_chunks: dict[str, Any] = {}
-    dask_arr = get_dask_chunkmanager().array_api.from_array(
+    dask_arr = dask_array_api.from_array(
         np.ones((500, 500), dtype="float64"), chunks=encoded_chunks
     )
     ds = xr.Dataset(

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -15,6 +15,7 @@ import xarray as xr
 from xarray import DataTree, load_datatree, open_datatree, open_groups
 from xarray.testing import assert_equal, assert_identical
 from xarray.tests import (
+    dask_array_type,
     get_dask_chunkmanager,
     network,
     parametrize_zarr_format,
@@ -76,9 +77,7 @@ def assert_chunks_equal(
         (path, name): (
             (
                 not enforce_dask
-                or isinstance(
-                    node1.variables[name].data, get_dask_chunkmanager().array_cls
-                )
+                or isinstance(node1.variables[name].data, dask_array_type)
             )
             and node1.variables[name].chunksizes == node2.variables[name].chunksizes
         )
@@ -835,7 +834,7 @@ class TestZarrDatatreeIO:
                     # don't expect dask.Arrays to be written to disk, as compute=False
                     # also don't expect numpy arrays containing only zarr's fill_value to be written to disk
                     chunks_expected=(
-                        not isinstance(var.data, get_dask_chunkmanager().array_cls)
+                        not isinstance(var.data, dask_array_type)
                         and (
                             var.data != DEFAULT_ZARR_FILL_VALUE
                             or WRITE_EMPTY_CHUNKS_DEFAULT

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -15,6 +15,7 @@ import xarray as xr
 from xarray import DataTree, load_datatree, open_datatree, open_groups
 from xarray.testing import assert_equal, assert_identical
 from xarray.tests import (
+    get_dask_chunkmanager,
     network,
     parametrize_zarr_format,
     requires_dask,
@@ -71,15 +72,13 @@ def assert_chunks_equal(
 ) -> None:
     __tracebackhide__ = True
 
-    from xarray.namedarray.pycompat import array_type
-
-    dask_array_type = array_type("dask")
-
     comparison = {
         (path, name): (
             (
                 not enforce_dask
-                or isinstance(node1.variables[name].data, dask_array_type)
+                or isinstance(
+                    node1.variables[name].data, get_dask_chunkmanager().array_cls
+                )
             )
             and node1.variables[name].chunksizes == node2.variables[name].chunksizes
         )
@@ -772,8 +771,6 @@ class TestZarrDatatreeIO:
     def test_to_zarr_compute_false(
         self, tmp_path: Path, simple_datatree: DataTree, zarr_format: Literal[2, 3]
     ) -> None:
-        import dask.array as da
-
         storepath = tmp_path / "test.zarr"
         original_dt = simple_datatree.chunk()
         result = original_dt.to_zarr(
@@ -838,7 +835,7 @@ class TestZarrDatatreeIO:
                     # don't expect dask.Arrays to be written to disk, as compute=False
                     # also don't expect numpy arrays containing only zarr's fill_value to be written to disk
                     chunks_expected=(
-                        not isinstance(var.data, da.Array)
+                        not isinstance(var.data, get_dask_chunkmanager().array_cls)
                         and (
                             var.data != DEFAULT_ZARR_FILL_VALUE
                             or WRITE_EMPTY_CHUNKS_DEFAULT
@@ -868,8 +865,6 @@ class TestZarrDatatreeIO:
 
     @requires_dask
     def test_to_zarr_no_redundant_computation(self, tmpdir, zarr_format) -> None:
-        import dask.array as da
-
         eval_count = 0
 
         def expensive_func(x):
@@ -877,8 +872,11 @@ class TestZarrDatatreeIO:
             eval_count += 1
             return x + 1
 
-        base = da.random.random((), chunks=())
-        derived1 = da.map_blocks(expensive_func, base, meta=np.array((), np.float64))
+        chunkmanager = get_dask_chunkmanager()
+        base = chunkmanager.array_api.random.random((), chunks=())
+        derived1 = chunkmanager.map_blocks(
+            expensive_func, base, meta=np.array((), np.float64)
+        )
         derived2 = derived1 + 1  # depends on derived1
         tree = DataTree.from_dict(
             {

--- a/xarray/tests/test_coding.py
+++ b/xarray/tests/test_coding.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from contextlib import suppress
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -9,10 +7,13 @@ import pytest
 import xarray as xr
 from xarray.coding import variables
 from xarray.conventions import decode_cf_variable, encode_cf_variable
-from xarray.tests import assert_allclose, assert_equal, assert_identical, requires_dask
-
-with suppress(ImportError):
-    import dask.array as da
+from xarray.tests import (
+    assert_allclose,
+    assert_equal,
+    assert_identical,
+    get_dask_chunkmanager,
+    requires_dask,
+)
 
 
 def test_CFMaskCoder_decode() -> None:
@@ -79,7 +80,7 @@ def test_CFMaskCoder_decode_dask() -> None:
     expected = xr.Variable(("x",), [0, np.nan, 1])
     coder = variables.CFMaskCoder()
     encoded = coder.decode(original)
-    assert isinstance(encoded.data, da.Array)
+    assert isinstance(encoded.data, get_dask_chunkmanager().array_cls)
     assert_identical(expected, encoded)
 
 

--- a/xarray/tests/test_coding.py
+++ b/xarray/tests/test_coding.py
@@ -11,7 +11,7 @@ from xarray.tests import (
     assert_allclose,
     assert_equal,
     assert_identical,
-    get_dask_chunkmanager,
+    dask_array_type,
     requires_dask,
 )
 
@@ -80,7 +80,7 @@ def test_CFMaskCoder_decode_dask() -> None:
     expected = xr.Variable(("x",), [0, np.nan, 1])
     coder = variables.CFMaskCoder()
     encoded = coder.decode(original)
-    assert isinstance(encoded.data, get_dask_chunkmanager().array_cls)
+    assert isinstance(encoded.data, dask_array_type)
     assert_identical(expected, encoded)
 
 

--- a/xarray/tests/test_coding_strings.py
+++ b/xarray/tests/test_coding_strings.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from contextlib import suppress
-
 import numpy as np
 import pytest
 
@@ -12,11 +10,9 @@ from xarray.tests import (
     IndexerMaker,
     assert_array_equal,
     assert_identical,
+    get_dask_chunkmanager,
     requires_dask,
 )
-
-with suppress(ImportError):
-    import dask.array as da
 
 
 def test_vlen_dtype() -> None:
@@ -75,13 +71,13 @@ def test_EncodedStringCoder_decode_dask() -> None:
     raw_data = np.array([b"abc", "ß∂µ∆".encode()])
     raw = Variable(("x",), raw_data, {"_Encoding": "utf-8"}).chunk()
     actual = coder.decode(raw)
-    assert isinstance(actual.data, da.Array)
+    assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
 
     expected = Variable(("x",), np.array(["abc", "ß∂µ∆"], dtype=object))
     assert_identical(actual, expected)
 
     actual_indexed = coder.decode(actual[0])
-    assert isinstance(actual_indexed.data, da.Array)
+    assert isinstance(actual_indexed.data, get_dask_chunkmanager().array_cls)
     assert_identical(actual_indexed, expected[0])
 
 
@@ -275,10 +271,10 @@ def test_char_to_bytes_size_zero() -> None:
 @requires_dask
 def test_char_to_bytes_dask() -> None:
     numpy_array = np.array([[b"a", b"b", b"c"], [b"d", b"e", b"f"]])
-    array = da.from_array(numpy_array, ((2,), (3,)))
+    array = Variable(("x", "y"), numpy_array).chunk({"x": 2, "y": 3}).data
     expected = np.array([b"abc", b"def"])
     actual = strings.char_to_bytes(array)
-    assert isinstance(actual, da.Array)
+    assert isinstance(actual, get_dask_chunkmanager().array_cls)
     assert actual.chunks == ((2,),)
     assert actual.dtype == "S3"
     assert_array_equal(np.array(actual), expected)
@@ -301,10 +297,10 @@ def test_bytes_to_char() -> None:
 @requires_dask
 def test_bytes_to_char_dask() -> None:
     numpy_array = np.array([b"ab", b"cd"])
-    array = da.from_array(numpy_array, ((1, 1),))
+    array = Variable(("x",), numpy_array).chunk({"x": 1}).data
     expected = np.array([[b"a", b"b"], [b"c", b"d"]])
     actual = strings.bytes_to_char(array)
-    assert isinstance(actual, da.Array)
+    assert isinstance(actual, get_dask_chunkmanager().array_cls)
     assert actual.chunks == ((1, 1), ((2,)))
     assert actual.dtype == "S1"
     assert_array_equal(np.array(actual), expected)

--- a/xarray/tests/test_coding_strings.py
+++ b/xarray/tests/test_coding_strings.py
@@ -10,7 +10,7 @@ from xarray.tests import (
     IndexerMaker,
     assert_array_equal,
     assert_identical,
-    get_dask_chunkmanager,
+    dask_array_type,
     requires_dask,
 )
 
@@ -71,13 +71,13 @@ def test_EncodedStringCoder_decode_dask() -> None:
     raw_data = np.array([b"abc", "ß∂µ∆".encode()])
     raw = Variable(("x",), raw_data, {"_Encoding": "utf-8"}).chunk()
     actual = coder.decode(raw)
-    assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+    assert isinstance(actual.data, dask_array_type)
 
     expected = Variable(("x",), np.array(["abc", "ß∂µ∆"], dtype=object))
     assert_identical(actual, expected)
 
     actual_indexed = coder.decode(actual[0])
-    assert isinstance(actual_indexed.data, get_dask_chunkmanager().array_cls)
+    assert isinstance(actual_indexed.data, dask_array_type)
     assert_identical(actual_indexed, expected[0])
 
 
@@ -274,7 +274,7 @@ def test_char_to_bytes_dask() -> None:
     array = Variable(("x", "y"), numpy_array).chunk({"x": 2, "y": 3}).data
     expected = np.array([b"abc", b"def"])
     actual = strings.char_to_bytes(array)
-    assert isinstance(actual, get_dask_chunkmanager().array_cls)
+    assert isinstance(actual, dask_array_type)
     assert actual.chunks == ((2,),)
     assert actual.dtype == "S3"
     assert_array_equal(np.array(actual), expected)
@@ -300,7 +300,7 @@ def test_bytes_to_char_dask() -> None:
     array = Variable(("x",), numpy_array).chunk({"x": 1}).data
     expected = np.array([[b"a", b"b"], [b"c", b"d"]])
     actual = strings.bytes_to_char(array)
-    assert isinstance(actual, get_dask_chunkmanager().array_cls)
+    assert isinstance(actual, dask_array_type)
     assert actual.chunks == ((1, 1), ((2,)))
     assert actual.dtype == "S1"
     assert_array_equal(np.array(actual), expected)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -52,6 +52,7 @@ from xarray.tests import (
     assert_duckarray_allclose,
     assert_duckarray_equal,
     assert_no_warnings,
+    get_dask_chunkmanager,
     has_cftime,
     requires_cftime,
     requires_dask,
@@ -1630,14 +1631,13 @@ _ENCODE_DATETIME64_VIA_DASK_TESTS = {
 def test_encode_cf_datetime_datetime64_via_dask(
     freq, units, dtype, time_unit: PDDatetimeUnitOptions
 ) -> None:
-    import dask.array
-
     times_pd = pd.date_range(start="1700", freq=freq, periods=3, unit=time_unit)
-    times = dask.array.from_array(times_pd, chunks=1)
+    times = Variable(["time"], times_pd).chunk({"time": 1}).data
     encoded_times, encoding_units, encoding_calendar = encode_cf_datetime(
         times, units, None, dtype
     )
 
+    assert isinstance(encoded_times, get_dask_chunkmanager().array_cls)
     assert is_duck_dask_array(encoded_times)
     assert encoded_times.chunks == times.chunks
 
@@ -1684,17 +1684,16 @@ def test_encode_via_dask_cannot_infer_error(
     ("units", "dtype"), [("days since 1700-01-01", np.dtype("int32")), (None, None)]
 )
 def test_encode_cf_datetime_cftime_datetime_via_dask(units, dtype) -> None:
-    import dask.array
-
     calendar = "standard"
     times_idx = date_range(
         start="1700", freq="D", periods=3, calendar=calendar, use_cftime=True
     )
-    times = dask.array.from_array(times_idx, chunks=1)
+    times = Variable(["time"], times_idx).chunk({"time": 1}).data
     encoded_times, encoding_units, encoding_calendar = encode_cf_datetime(
         times, units, None, dtype
     )
 
+    assert isinstance(encoded_times, get_dask_chunkmanager().array_cls)
     assert is_duck_dask_array(encoded_times)
     assert encoded_times.chunks == times.chunks
 
@@ -1766,12 +1765,11 @@ def test_encode_cf_datetime_precision_loss_regression_test(use_dask) -> None:
 def test_encode_cf_timedelta_via_dask(
     units: str | None, dtype: np.dtype | None, time_unit: PDDatetimeUnitOptions
 ) -> None:
-    import dask.array
-
     times_pd = pd.timedelta_range(start="0D", freq="D", periods=3, unit=time_unit)  # type: ignore[call-arg,unused-ignore]
-    times = dask.array.from_array(times_pd, chunks=1)
+    times = Variable(["time"], times_pd).chunk({"time": 1}).data
     encoded_times, encoding_units = encode_cf_timedelta(times, units, dtype)
 
+    assert isinstance(encoded_times, get_dask_chunkmanager().array_cls)
     assert is_duck_dask_array(encoded_times)
     assert encoded_times.chunks == times.chunks
 

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -52,7 +52,7 @@ from xarray.tests import (
     assert_duckarray_allclose,
     assert_duckarray_equal,
     assert_no_warnings,
-    get_dask_chunkmanager,
+    dask_array_type,
     has_cftime,
     requires_cftime,
     requires_dask,
@@ -1637,7 +1637,7 @@ def test_encode_cf_datetime_datetime64_via_dask(
         times, units, None, dtype
     )
 
-    assert isinstance(encoded_times, get_dask_chunkmanager().array_cls)
+    assert isinstance(encoded_times, dask_array_type)
     assert is_duck_dask_array(encoded_times)
     assert encoded_times.chunks == times.chunks
 
@@ -1693,7 +1693,7 @@ def test_encode_cf_datetime_cftime_datetime_via_dask(units, dtype) -> None:
         times, units, None, dtype
     )
 
-    assert isinstance(encoded_times, get_dask_chunkmanager().array_cls)
+    assert isinstance(encoded_times, dask_array_type)
     assert is_duck_dask_array(encoded_times)
     assert encoded_times.chunks == times.chunks
 
@@ -1769,7 +1769,7 @@ def test_encode_cf_timedelta_via_dask(
     times = Variable(["time"], times_pd).chunk({"time": 1}).data
     encoded_times, encoding_units = encode_cf_timedelta(times, units, dtype)
 
-    assert isinstance(encoded_times, get_dask_chunkmanager().array_cls)
+    assert isinstance(encoded_times, dask_array_type)
     assert is_duck_dask_array(encoded_times)
     assert encoded_times.chunks == times.chunks
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -23,7 +23,8 @@ from xarray.computation.apply_ufunc import (
 from xarray.core.utils import result_name
 from xarray.structure.alignment import broadcast
 from xarray.tests import (
-    get_dask_chunkmanager,
+    dask_array_api,
+    dask_array_type,
     has_dask,
     raise_if_dask_computes,
     requires_cftime,
@@ -1170,7 +1171,7 @@ def test_dataset_join() -> None:
 
 @requires_dask
 def test_apply_dask() -> None:
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
     array = da.ones((2,), chunks=2)
     variable = xr.Variable("x", array)
     coords = xr.DataArray(variable).coords.variables
@@ -1197,21 +1198,21 @@ def test_apply_dask() -> None:
     assert array is dask_safe_identity(array)
 
     actual = dask_safe_identity(variable)
-    assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+    assert isinstance(actual.data, dask_array_type)
     assert_identical(variable, actual)
 
     actual = dask_safe_identity(data_array)
-    assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+    assert isinstance(actual.data, dask_array_type)
     assert_identical(data_array, actual)
 
     actual = dask_safe_identity(dataset)
-    assert isinstance(actual["y"].data, get_dask_chunkmanager().array_cls)
+    assert isinstance(actual["y"].data, dask_array_type)
     assert_identical(dataset, actual)
 
 
 @requires_dask
 def test_apply_dask_parallelized_one_arg() -> None:
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
     array = da.ones((2, 2), chunks=(1, 1))
     data_array = xr.DataArray(array, dims=("x", "y"))
 
@@ -1219,7 +1220,7 @@ def test_apply_dask_parallelized_one_arg() -> None:
         return apply_ufunc(identity, x, dask="parallelized", output_dtypes=[x.dtype])
 
     actual = parallel_identity(data_array)
-    assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+    assert isinstance(actual.data, dask_array_type)
     assert actual.data.chunks == array.chunks
     assert_identical(data_array, actual)
 
@@ -1230,7 +1231,7 @@ def test_apply_dask_parallelized_one_arg() -> None:
 
 @requires_dask
 def test_apply_dask_parallelized_two_args() -> None:
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
     array = da.ones((2, 2), chunks=(1, 1), dtype=np.int64)
     data_array = xr.DataArray(array, dims=("x", "y"))
     data_array.name = None
@@ -1242,7 +1243,7 @@ def test_apply_dask_parallelized_two_args() -> None:
 
     def check(x, y):
         actual = parallel_add(x, y)
-        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(actual.data, dask_array_type)
         assert actual.data.chunks == array.chunks
         assert_identical(data_array, actual)
 
@@ -1257,7 +1258,7 @@ def test_apply_dask_parallelized_two_args() -> None:
 
 @requires_dask
 def test_apply_dask_parallelized_errors() -> None:
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
     array = da.ones((2, 2), chunks=(1, 1))
     data_array = xr.DataArray(array, dims=("x", "y"))
 
@@ -1282,7 +1283,7 @@ def test_apply_dask_parallelized_errors() -> None:
 @requires_dask
 @pytest.mark.filterwarnings("ignore:Mean of empty slice")
 def test_apply_dask_multiple_inputs() -> None:
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
 
     def covariance(x, y):
         return (
@@ -1308,7 +1309,7 @@ def test_apply_dask_multiple_inputs() -> None:
         input_core_dims=[["z"], ["z"]],
         dask="allowed",
     )
-    assert isinstance(allowed.data, get_dask_chunkmanager().array_cls)
+    assert isinstance(allowed.data, dask_array_type)
     xr.testing.assert_allclose(expected, allowed.compute())
 
     parallelized = apply_ufunc(
@@ -1319,13 +1320,13 @@ def test_apply_dask_multiple_inputs() -> None:
         dask="parallelized",
         output_dtypes=[float],
     )
-    assert isinstance(parallelized.data, get_dask_chunkmanager().array_cls)
+    assert isinstance(parallelized.data, dask_array_type)
     xr.testing.assert_allclose(expected, parallelized.compute())
 
 
 @requires_dask
 def test_apply_dask_new_output_dimension() -> None:
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
     array = da.ones((2, 2), chunks=(1, 1))
     data_array = xr.DataArray(array, dims=("x", "y"))
 
@@ -1347,7 +1348,7 @@ def test_apply_dask_new_output_dimension() -> None:
     actual = stack_negative(data_array)
     assert actual.dims == ("x", "y", "sign")
     assert actual.shape == (2, 2, 2)
-    assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+    assert isinstance(actual.data, dask_array_type)
     assert_identical(expected, actual)
 
 

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -23,6 +23,7 @@ from xarray.computation.apply_ufunc import (
 from xarray.core.utils import result_name
 from xarray.structure.alignment import broadcast
 from xarray.tests import (
+    get_dask_chunkmanager,
     has_dask,
     raise_if_dask_computes,
     requires_cftime,
@@ -1169,8 +1170,7 @@ def test_dataset_join() -> None:
 
 @requires_dask
 def test_apply_dask() -> None:
-    import dask.array as da
-
+    da = get_dask_chunkmanager().array_api
     array = da.ones((2,), chunks=2)
     variable = xr.Variable("x", array)
     coords = xr.DataArray(variable).coords.variables
@@ -1197,22 +1197,21 @@ def test_apply_dask() -> None:
     assert array is dask_safe_identity(array)
 
     actual = dask_safe_identity(variable)
-    assert isinstance(actual.data, da.Array)
+    assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
     assert_identical(variable, actual)
 
     actual = dask_safe_identity(data_array)
-    assert isinstance(actual.data, da.Array)
+    assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
     assert_identical(data_array, actual)
 
     actual = dask_safe_identity(dataset)
-    assert isinstance(actual["y"].data, da.Array)
+    assert isinstance(actual["y"].data, get_dask_chunkmanager().array_cls)
     assert_identical(dataset, actual)
 
 
 @requires_dask
 def test_apply_dask_parallelized_one_arg() -> None:
-    import dask.array as da
-
+    da = get_dask_chunkmanager().array_api
     array = da.ones((2, 2), chunks=(1, 1))
     data_array = xr.DataArray(array, dims=("x", "y"))
 
@@ -1220,7 +1219,7 @@ def test_apply_dask_parallelized_one_arg() -> None:
         return apply_ufunc(identity, x, dask="parallelized", output_dtypes=[x.dtype])
 
     actual = parallel_identity(data_array)
-    assert isinstance(actual.data, da.Array)
+    assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
     assert actual.data.chunks == array.chunks
     assert_identical(data_array, actual)
 
@@ -1231,8 +1230,7 @@ def test_apply_dask_parallelized_one_arg() -> None:
 
 @requires_dask
 def test_apply_dask_parallelized_two_args() -> None:
-    import dask.array as da
-
+    da = get_dask_chunkmanager().array_api
     array = da.ones((2, 2), chunks=(1, 1), dtype=np.int64)
     data_array = xr.DataArray(array, dims=("x", "y"))
     data_array.name = None
@@ -1244,7 +1242,7 @@ def test_apply_dask_parallelized_two_args() -> None:
 
     def check(x, y):
         actual = parallel_add(x, y)
-        assert isinstance(actual.data, da.Array)
+        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
         assert actual.data.chunks == array.chunks
         assert_identical(data_array, actual)
 
@@ -1259,8 +1257,7 @@ def test_apply_dask_parallelized_two_args() -> None:
 
 @requires_dask
 def test_apply_dask_parallelized_errors() -> None:
-    import dask.array as da
-
+    da = get_dask_chunkmanager().array_api
     array = da.ones((2, 2), chunks=(1, 1))
     data_array = xr.DataArray(array, dims=("x", "y"))
 
@@ -1285,7 +1282,7 @@ def test_apply_dask_parallelized_errors() -> None:
 @requires_dask
 @pytest.mark.filterwarnings("ignore:Mean of empty slice")
 def test_apply_dask_multiple_inputs() -> None:
-    import dask.array as da
+    da = get_dask_chunkmanager().array_api
 
     def covariance(x, y):
         return (
@@ -1311,7 +1308,7 @@ def test_apply_dask_multiple_inputs() -> None:
         input_core_dims=[["z"], ["z"]],
         dask="allowed",
     )
-    assert isinstance(allowed.data, da.Array)
+    assert isinstance(allowed.data, get_dask_chunkmanager().array_cls)
     xr.testing.assert_allclose(expected, allowed.compute())
 
     parallelized = apply_ufunc(
@@ -1322,14 +1319,13 @@ def test_apply_dask_multiple_inputs() -> None:
         dask="parallelized",
         output_dtypes=[float],
     )
-    assert isinstance(parallelized.data, da.Array)
+    assert isinstance(parallelized.data, get_dask_chunkmanager().array_cls)
     xr.testing.assert_allclose(expected, parallelized.compute())
 
 
 @requires_dask
 def test_apply_dask_new_output_dimension() -> None:
-    import dask.array as da
-
+    da = get_dask_chunkmanager().array_api
     array = da.ones((2, 2), chunks=(1, 1))
     data_array = xr.DataArray(array, dims=("x", "y"))
 
@@ -1351,7 +1347,7 @@ def test_apply_dask_new_output_dimension() -> None:
     actual = stack_negative(data_array)
     assert actual.dims == ("x", "y", "sign")
     assert actual.shape == (2, 2, 2)
-    assert isinstance(actual.data, da.Array)
+    assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
     assert_identical(expected, actual)
 
 

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -23,6 +23,7 @@ from xarray.conventions import decode_cf
 from xarray.testing import assert_identical
 from xarray.tests import (
     assert_array_equal,
+    get_dask_chunkmanager,
     requires_cftime,
     requires_dask,
     requires_netCDF4,
@@ -488,8 +489,6 @@ class TestDecodeCF:
 
     @requires_dask
     def test_decode_cf_with_dask(self) -> None:
-        import dask.array as da
-
         original = Dataset(
             {
                 "t": ("t", [0, 1, 2], {"units": "days since 2000-01-01"}),
@@ -501,7 +500,7 @@ class TestDecodeCF:
         ).chunk()
         decoded = conventions.decode_cf(original)
         assert all(
-            isinstance(var.data, da.Array)
+            isinstance(var.data, get_dask_chunkmanager().array_cls)
             for name, var in decoded.variables.items()
             if name not in decoded.xindexes
         )

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -23,7 +23,7 @@ from xarray.conventions import decode_cf
 from xarray.testing import assert_identical
 from xarray.tests import (
     assert_array_equal,
-    get_dask_chunkmanager,
+    dask_array_type,
     requires_cftime,
     requires_dask,
     requires_netCDF4,
@@ -500,7 +500,7 @@ class TestDecodeCF:
         ).chunk()
         decoded = conventions.decode_cf(original)
         assert all(
-            isinstance(var.data, get_dask_chunkmanager().array_cls)
+            isinstance(var.data, dask_array_type)
             for name, var in decoded.variables.items()
             if name not in decoded.xindexes
         )

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -38,11 +38,10 @@ dask = pytest.importorskip("dask")
 pytest.importorskip("dask.array")
 dd = pytest.importorskip("dask.dataframe")
 da = dask_array_api
-USING_DASK_ARRAY = has_dask_array_expr
 
 
 def dask_compute_patch_target():
-    if USING_DASK_ARRAY:
+    if has_dask_array_expr:
         return "dask.compute"
     return "dask.array.compute"
 
@@ -313,7 +312,7 @@ class TestVariable(DaskTestCase):
         (v2,) = dask.persist(v)
         assert v is not v2
         assert len(v2.__dask_graph__()) < len(v.__dask_graph__())  # type: ignore[arg-type]
-        if not USING_DASK_ARRAY:
+        if not has_dask_array_expr:
             assert v2.__dask_keys__() == v.__dask_keys__()
         assert dask.is_dask_collection(v)
         assert dask.is_dask_collection(v2)
@@ -433,13 +432,13 @@ class TestDataArrayAndDataset(DaskTestCase):
         u = self.eager_array
         v = self.lazy_array + 1
 
-        if USING_DASK_ARRAY:
+        if has_dask_array_expr:
             v2 = v.persist()
         else:
             (v2,) = dask.persist(v)
         assert v is not v2
         assert len(v2.__dask_graph__()) < len(v.__dask_graph__())
-        if not USING_DASK_ARRAY:
+        if not has_dask_array_expr:
             assert v2.__dask_keys__() == v.__dask_keys__()
         assert dask.is_dask_collection(v)
         assert dask.is_dask_collection(v2)
@@ -1162,7 +1161,7 @@ def test_unify_chunks(map_ds):
     with pytest.raises(ValueError, match=r"inconsistent chunks"):
         _ = ds_copy.chunks
 
-    expected_y_chunks = (10, 10) if USING_DASK_ARRAY else (5, 5, 5, 5)
+    expected_y_chunks = (10, 10) if has_dask_array_expr else (5, 5, 5, 5)
     expected_chunks = {"x": (4, 4, 2), "y": expected_y_chunks}
     with raise_if_dask_computes():
         actual_chunks = ds_copy.unify_chunks().chunks
@@ -1461,7 +1460,7 @@ def test_map_blocks_da_ds_with_template(obj):
         actual = xr.map_blocks(func, obj, template=template)
     assert_identical(actual, template)
 
-    if not USING_DASK_ARRAY:
+    if not has_dask_array_expr:
         # Check that indexes are written into the graph directly
         dsk = dict(actual.__dask_graph__())
         assert {k for k in dsk if "x-coordinate" in k}

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -24,6 +24,7 @@ from xarray.tests import (
     assert_equal,
     assert_frame_equal,
     assert_identical,
+    get_dask_chunkmanager,
     mock,
     raise_if_dask_computes,
     requires_pint,
@@ -32,8 +33,17 @@ from xarray.tests import (
 from xarray.tests.test_backends import create_tmp_file
 
 dask = pytest.importorskip("dask")
-da = pytest.importorskip("dask.array")
+pytest.importorskip("dask.array")
 dd = pytest.importorskip("dask.dataframe")
+da = get_dask_chunkmanager().array_api
+USING_DASK_ARRAY = get_dask_chunkmanager().array_cls.__module__.startswith("dask_array")
+
+
+def dask_compute_patch_target():
+    if USING_DASK_ARRAY:
+        return "dask.compute"
+    return "dask.array.compute"
+
 
 ON_WINDOWS = sys.platform == "win32"
 
@@ -55,16 +65,16 @@ class DaskTestCase:
                 if k in actual.xindexes:
                     assert isinstance(v.data, np.ndarray)
                 else:
-                    assert isinstance(v.data, da.Array)
+                    assert isinstance(v.data, get_dask_chunkmanager().array_cls)
         elif isinstance(actual, DataArray):
-            assert isinstance(actual.data, da.Array)
+            assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
             for k, v in actual.coords.items():
                 if k in actual.xindexes:
                     assert isinstance(v.data, np.ndarray)
                 else:
-                    assert isinstance(v.data, da.Array)
+                    assert isinstance(v.data, get_dask_chunkmanager().array_cls)
         elif isinstance(actual, Variable):
-            assert isinstance(actual.data, da.Array)
+            assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
         else:
             raise AssertionError()
 
@@ -144,9 +154,9 @@ class TestVariable(DaskTestCase):
     def test_equals(self):
         v = self.lazy_var
         assert v.equals(v)
-        assert isinstance(v.data, da.Array)
+        assert isinstance(v.data, get_dask_chunkmanager().array_cls)
         assert v.identical(v)
-        assert isinstance(v.data, da.Array)
+        assert isinstance(v.data, get_dask_chunkmanager().array_cls)
 
     def test_transpose(self):
         u = self.eager_var
@@ -301,7 +311,8 @@ class TestVariable(DaskTestCase):
         (v2,) = dask.persist(v)
         assert v is not v2
         assert len(v2.__dask_graph__()) < len(v.__dask_graph__())  # type: ignore[arg-type]
-        assert v2.__dask_keys__() == v.__dask_keys__()
+        if not USING_DASK_ARRAY:
+            assert v2.__dask_keys__() == v.__dask_keys__()
         assert dask.is_dask_collection(v)
         assert dask.is_dask_collection(v2)
 
@@ -391,7 +402,7 @@ class TestDataArrayAndDataset(DaskTestCase):
 
     def test_lazy_dataset(self):
         lazy_ds = Dataset({"foo": (("x", "y"), self.data)})
-        assert isinstance(lazy_ds.foo.variable.data, da.Array)
+        assert isinstance(lazy_ds.foo.variable.data, get_dask_chunkmanager().array_cls)
 
     def test_lazy_array(self):
         u = self.eager_array
@@ -420,10 +431,14 @@ class TestDataArrayAndDataset(DaskTestCase):
         u = self.eager_array
         v = self.lazy_array + 1
 
-        (v2,) = dask.persist(v)
+        if USING_DASK_ARRAY:
+            v2 = v.persist()
+        else:
+            (v2,) = dask.persist(v)
         assert v is not v2
         assert len(v2.__dask_graph__()) < len(v.__dask_graph__())
-        assert v2.__dask_keys__() == v.__dask_keys__()
+        if not USING_DASK_ARRAY:
+            assert v2.__dask_keys__() == v.__dask_keys__()
         assert dask.is_dask_collection(v)
         assert dask.is_dask_collection(v2)
 
@@ -462,21 +477,21 @@ class TestDataArrayAndDataset(DaskTestCase):
         out = xr.concat([ds1, ds2, ds3], dim="n", data_vars="all", coords="all")
         # no extra kernel calls
         assert kernel_call_count == 6
-        assert isinstance(out["d"].data, dask.array.Array)
-        assert isinstance(out["c"].data, dask.array.Array)
+        assert isinstance(out["d"].data, get_dask_chunkmanager().array_cls)
+        assert isinstance(out["c"].data, get_dask_chunkmanager().array_cls)
 
         out = xr.concat([ds1, ds2, ds3], dim="n", data_vars=["d"], coords=["c"])
         # no extra kernel calls
         assert kernel_call_count == 6
-        assert isinstance(out["d"].data, dask.array.Array)
-        assert isinstance(out["c"].data, dask.array.Array)
+        assert isinstance(out["d"].data, get_dask_chunkmanager().array_cls)
+        assert isinstance(out["c"].data, get_dask_chunkmanager().array_cls)
 
         with xr.set_options(use_new_combine_kwarg_defaults=True):
             out = xr.concat([ds1, ds2, ds3], dim="n", data_vars=[], coords=[])
             # no extra kernel calls
             assert kernel_call_count == 6
-            assert isinstance(out["d"].data, dask.array.Array)
-            assert isinstance(out["c"].data, dask.array.Array)
+            assert isinstance(out["d"].data, get_dask_chunkmanager().array_cls)
+            assert isinstance(out["c"].data, get_dask_chunkmanager().array_cls)
 
         out = xr.concat(
             [ds1, ds2, ds3], dim="n", data_vars=[], coords=[], compat="equals"
@@ -510,8 +525,8 @@ class TestDataArrayAndDataset(DaskTestCase):
         )
         # the variables of ds1 and ds2 were computed, but those of ds3 didn't
         assert kernel_call_count == 22
-        assert isinstance(out["d"].data, dask.array.Array)
-        assert isinstance(out["c"].data, dask.array.Array)
+        assert isinstance(out["d"].data, get_dask_chunkmanager().array_cls)
+        assert isinstance(out["c"].data, get_dask_chunkmanager().array_cls)
         # the data of ds1 and ds2 was loaded into numpy and then
         # concatenated to the data of ds3. Thus, only ds3 is computed now.
         out.compute()
@@ -535,16 +550,16 @@ class TestDataArrayAndDataset(DaskTestCase):
         )
         assert kernel_call_count == 24
         # variables are not loaded in the output
-        assert isinstance(out["d"].data, dask.array.Array)
-        assert isinstance(out["c"].data, dask.array.Array)
+        assert isinstance(out["d"].data, get_dask_chunkmanager().array_cls)
+        assert isinstance(out["c"].data, get_dask_chunkmanager().array_cls)
 
         out = xr.concat(
             [ds1, ds1, ds1], dim="n", data_vars=[], coords=[], compat="identical"
         )
         assert kernel_call_count == 24
         # variables are not loaded in the output
-        assert isinstance(out["d"].data, dask.array.Array)
-        assert isinstance(out["c"].data, dask.array.Array)
+        assert isinstance(out["d"].data, get_dask_chunkmanager().array_cls)
+        assert isinstance(out["c"].data, get_dask_chunkmanager().array_cls)
 
         out = xr.concat(
             [ds1, ds2.compute(), ds3],
@@ -575,6 +590,9 @@ class TestDataArrayAndDataset(DaskTestCase):
         assert ds3["d"].data is d3
         assert ds3["c"].data is c3
 
+    @pytest.mark.xfail_with_dask_array(
+        reason="flox groupby currently builds legacy dask arrays"
+    )
     def test_groupby(self):
         u = self.eager_array
         v = self.lazy_array
@@ -594,6 +612,9 @@ class TestDataArrayAndDataset(DaskTestCase):
         self.assertLazyAndAllClose(expected, actual)
 
     @pytest.mark.parametrize("func", ["first", "last"])
+    @pytest.mark.xfail_with_dask_array(
+        reason="flox groupby currently builds legacy dask arrays"
+    )
     def test_groupby_first_last(self, func):
         method = operator.methodcaller(func)
         u = self.eager_array
@@ -697,32 +718,25 @@ class TestDataArrayAndDataset(DaskTestCase):
         data = build_dask_array("data")
         nonindex_coord = build_dask_array("coord")
         a = DataArray(data, dims=["x"], coords={"y": ("x", nonindex_coord)})
-        expected = dedent(
-            f"""\
-            <xarray.DataArray 'data' (x: 1)> Size: 8B
-            {data!r}
-            Coordinates:
-                y        (x) int64 8B dask.array<chunksize=(1,), meta=np.ndarray>
-            Dimensions without coordinates: x"""
-        )
-        assert expected == repr(a)
+
+        actual = repr(a)
+        assert "<xarray.DataArray 'data' (x: 1)> Size: 8B" in actual
+        assert actual.count("dask.array<") == 2
+        assert "Coordinates:" in actual
+        assert "Dimensions without coordinates: x" in actual
         assert kernel_call_count == 0  # should not evaluate dask array
 
     def test_dataset_repr(self):
         data = build_dask_array("data")
         nonindex_coord = build_dask_array("coord")
         ds = Dataset(data_vars={"a": ("x", data)}, coords={"y": ("x", nonindex_coord)})
-        expected = dedent(
-            """\
-            <xarray.Dataset> Size: 16B
-            Dimensions:  (x: 1)
-            Coordinates:
-                y        (x) int64 8B dask.array<chunksize=(1,), meta=np.ndarray>
-            Dimensions without coordinates: x
-            Data variables:
-                a        (x) int64 8B dask.array<chunksize=(1,), meta=np.ndarray>"""
-        )
-        assert expected == repr(ds)
+
+        actual = repr(ds)
+        assert "<xarray.Dataset> Size: 16B" in actual
+        assert actual.count("dask.array<") == 2
+        assert "Coordinates:" in actual
+        assert "Dimensions without coordinates: x" in actual
+        assert "Data variables:" in actual
         assert kernel_call_count == 0  # should not evaluate dask array
 
     def test_dataarray_pickle(self):
@@ -816,7 +830,6 @@ class TestDataArrayAndDataset(DaskTestCase):
 
 
 class TestToDaskDataFrame:
-    @pytest.mark.xfail(reason="https://github.com/dask/dask/issues/11584")
     def test_to_dask_dataframe(self):
         # Test conversion of Datasets to dask DataFrames
         x = np.random.randn(10)
@@ -956,7 +969,9 @@ def test_dask_kwargs_variable(method):
     chunked_array = da.from_array(np.arange(3), chunks=(2,))
     x = Variable("y", chunked_array)
     # args should be passed on to dask.compute() (via DaskManager.compute())
-    with mock.patch.object(da, "compute", return_value=(np.arange(3),)) as mock_compute:
+    with mock.patch(
+        dask_compute_patch_target(), return_value=(np.arange(3),)
+    ) as mock_compute:
         getattr(x, method)(foo="bar")
     mock_compute.assert_called_with(chunked_array, foo="bar")
 
@@ -966,7 +981,7 @@ def test_dask_kwargs_dataarray(method):
     data = da.from_array(np.arange(3), chunks=(2,))
     x = DataArray(data)
     if method in ["load", "compute"]:
-        dask_func = "dask.array.compute"
+        dask_func = dask_compute_patch_target()
     else:
         dask_func = "dask.persist"
     # args should be passed on to "dask_func"
@@ -980,7 +995,7 @@ def test_dask_kwargs_dataset(method):
     data = da.from_array(np.arange(3), chunks=(2,))
     x = Dataset({"x": (("y"), data)})
     if method in ["load", "compute"]:
-        dask_func = "dask.array.compute"
+        dask_func = dask_compute_patch_target()
     else:
         dask_func = "dask.persist"
     # args should be passed on to "dask_func"
@@ -1004,13 +1019,22 @@ def kernel(name):
 def build_dask_array(name):
     global kernel_call_count
     kernel_call_count = 0
-    return dask.array.Array(
-        dask={(name, 0): (kernel, name)}, name=name, chunks=((1,),), dtype=np.int64
+    return da.from_delayed(
+        dask.delayed(kernel, name=name)(name),
+        shape=(1,),
+        dtype=np.int64,
+        name=name,
     )
 
 
 @pytest.mark.parametrize(
-    "persist", [lambda x: x.persist(), lambda x: dask.persist(x)[0]]
+    "persist",
+    [
+        lambda x: x.persist(),
+        pytest.param(
+            lambda x: dask.persist(x)[0], marks=pytest.mark.skip_with_dask_array
+        ),
+    ],
 )
 def test_persist_Dataset(persist):
     ds = Dataset({"foo": ("x", range(5)), "bar": ("x", range(5))}).chunk()
@@ -1024,7 +1048,13 @@ def test_persist_Dataset(persist):
 
 
 @pytest.mark.parametrize(
-    "persist", [lambda x: x.persist(), lambda x: dask.persist(x)[0]]
+    "persist",
+    [
+        lambda x: x.persist(),
+        pytest.param(
+            lambda x: dask.persist(x)[0], marks=pytest.mark.skip_with_dask_array
+        ),
+    ],
 )
 def test_persist_DataArray(persist):
     x = da.arange(10, chunks=(5,))
@@ -1130,21 +1160,22 @@ def test_unify_chunks(map_ds):
     with pytest.raises(ValueError, match=r"inconsistent chunks"):
         _ = ds_copy.chunks
 
-    expected_chunks = {"x": (4, 4, 2), "y": (5, 5, 5, 5)}
+    expected_y_chunks = (10, 10) if USING_DASK_ARRAY else (5, 5, 5, 5)
+    expected_chunks = {"x": (4, 4, 2), "y": expected_y_chunks}
     with raise_if_dask_computes():
         actual_chunks = ds_copy.unify_chunks().chunks
     assert actual_chunks == expected_chunks
     assert_identical(map_ds, ds_copy.unify_chunks())
 
     out_a, out_b = xr.unify_chunks(ds_copy.cxy, ds_copy.drop_vars("cxy"))
-    assert out_a.chunks == ((4, 4, 2), (5, 5, 5, 5))
+    assert out_a.chunks == ((4, 4, 2), expected_y_chunks)
     assert out_b.chunks == expected_chunks
 
     # Test unordered dims
     da = ds_copy["cxy"]
     out_a, out_b = xr.unify_chunks(da.chunk({"x": -1}), da.T.chunk({"y": -1}))
-    assert out_a.chunks == ((4, 4, 2), (5, 5, 5, 5))
-    assert out_b.chunks == ((5, 5, 5, 5), (4, 4, 2))
+    assert out_a.chunks == ((4, 4, 2), expected_y_chunks)
+    assert out_b.chunks == (expected_y_chunks, (4, 4, 2))
 
     # Test mismatch
     with pytest.raises(ValueError, match=r"Dimension 'x' size mismatch: 10 != 2"):
@@ -1319,11 +1350,14 @@ def test_map_blocks_dask_args():
 @pytest.mark.parametrize("obj", [make_da(), make_ds()])
 def test_map_blocks_add_attrs(obj):
     def add_attrs(obj):
+        assert obj.attrs["existing"] == "existing"
         obj = obj.copy(deep=True)
         obj.attrs["new"] = "new"
         obj.cxy.attrs["new2"] = "new2"
         return obj
 
+    obj = obj.copy(deep=True)
+    obj.attrs["existing"] = "existing"
     expected = add_attrs(obj)
     with raise_if_dask_computes():
         actual = xr.map_blocks(add_attrs, obj)
@@ -1376,7 +1410,12 @@ def test_map_blocks_to_dataarray(map_ds):
         lambda x: x.expand_dims(k=3),
         lambda x: x.assign_coords(new_coord=("y", x.y.data * 2)),
         lambda x: x.astype(np.int32),
-        lambda x: x.x,
+        pytest.param(
+            lambda x: x.x,
+            marks=pytest.mark.xfail_with_dask_array(
+                reason="dask-array map_blocks cannot yet drop multi-chunk dimensions"
+            ),
+        ),
     ],
 )
 def test_map_blocks_da_transformations(func, map_da):
@@ -1396,7 +1435,12 @@ def test_map_blocks_da_transformations(func, map_da):
         lambda x: x.expand_dims(k=[1, 2, 3]),
         lambda x: x.expand_dims(k=3),
         lambda x: x.rename({"a": "new1", "b": "new2"}),
-        lambda x: x.x,
+        pytest.param(
+            lambda x: x.x,
+            marks=pytest.mark.xfail_with_dask_array(
+                reason="dask-array map_blocks cannot yet drop multi-chunk dimensions"
+            ),
+        ),
     ],
 )
 def test_map_blocks_ds_transformations(func, map_ds):
@@ -1415,12 +1459,13 @@ def test_map_blocks_da_ds_with_template(obj):
         actual = xr.map_blocks(func, obj, template=template)
     assert_identical(actual, template)
 
-    # Check that indexes are written into the graph directly
-    dsk = dict(actual.__dask_graph__())
-    assert {k for k in dsk if "x-coordinate" in k}
-    assert all(
-        isinstance(v, PandasIndex) for k, v in dsk.items() if "x-coordinate" in k
-    )
+    if not USING_DASK_ARRAY:
+        # Check that indexes are written into the graph directly
+        dsk = dict(actual.__dask_graph__())
+        assert {k for k in dsk if "x-coordinate" in k}
+        assert all(
+            isinstance(v, PandasIndex) for k, v in dsk.items() if "x-coordinate" in k
+        )
 
     with raise_if_dask_computes():
         actual = obj.map_blocks(func, template=template)
@@ -1507,6 +1552,7 @@ def test_map_blocks_object_method(obj):
     assert_identical(expected, actual)
 
 
+@pytest.mark.skip_with_dask_array
 def test_map_blocks_hlg_layers():
     # regression test for #3599
     ds = xr.Dataset(
@@ -1782,14 +1828,16 @@ def test_more_transforms_pass_lazy_array_equiv(map_da, map_ds):
         assert_equal(map_da.transpose("y", "x", transpose_coords=False).cxy, map_da.cxy)
 
 
+@pytest.mark.skip_with_dask_array
 def test_optimize():
     # https://github.com/pydata/xarray/issues/3698
-    a = dask.array.ones((10, 4), chunks=(5, 2))
+    a = da.ones((10, 4), chunks=(5, 2))
     arr = xr.DataArray(a).chunk(5)
     (arr2,) = dask.optimize(arr)
     arr2.compute()
 
 
+@pytest.mark.skip_with_dask_array
 def test_graph_manipulation():
     """dask.graph_manipulation passes an optional parameter, "rename", to the rebuilder
     function returned by __dask_postperist__; also, the dsk passed to the rebuilder is
@@ -1824,11 +1872,12 @@ def test_graph_manipulation():
 
 def test_new_index_var_computes_once():
     # regression test for GH1533
-    data = dask.array.from_array(np.array([100, 200]))
+    data = da.from_array(np.array([100, 200]), chunks=(2,))
     with raise_if_dask_computes(max_computes=1):
         Dataset(coords={"z": ("z", data)})
 
 
+@pytest.mark.skip_with_dask_array
 def test_minimize_graph_size():
     # regression test for https://github.com/pydata/xarray/issues/8409
     ds = Dataset(

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -24,7 +24,9 @@ from xarray.tests import (
     assert_equal,
     assert_frame_equal,
     assert_identical,
-    get_dask_chunkmanager,
+    dask_array_api,
+    dask_array_type,
+    has_dask_array_expr,
     mock,
     raise_if_dask_computes,
     requires_pint,
@@ -35,8 +37,8 @@ from xarray.tests.test_backends import create_tmp_file
 dask = pytest.importorskip("dask")
 pytest.importorskip("dask.array")
 dd = pytest.importorskip("dask.dataframe")
-da = get_dask_chunkmanager().array_api
-USING_DASK_ARRAY = get_dask_chunkmanager().array_cls.__module__.startswith("dask_array")
+da = dask_array_api
+USING_DASK_ARRAY = has_dask_array_expr
 
 
 def dask_compute_patch_target():
@@ -65,16 +67,16 @@ class DaskTestCase:
                 if k in actual.xindexes:
                     assert isinstance(v.data, np.ndarray)
                 else:
-                    assert isinstance(v.data, get_dask_chunkmanager().array_cls)
+                    assert isinstance(v.data, dask_array_type)
         elif isinstance(actual, DataArray):
-            assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+            assert isinstance(actual.data, dask_array_type)
             for k, v in actual.coords.items():
                 if k in actual.xindexes:
                     assert isinstance(v.data, np.ndarray)
                 else:
-                    assert isinstance(v.data, get_dask_chunkmanager().array_cls)
+                    assert isinstance(v.data, dask_array_type)
         elif isinstance(actual, Variable):
-            assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+            assert isinstance(actual.data, dask_array_type)
         else:
             raise AssertionError()
 
@@ -154,9 +156,9 @@ class TestVariable(DaskTestCase):
     def test_equals(self):
         v = self.lazy_var
         assert v.equals(v)
-        assert isinstance(v.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(v.data, dask_array_type)
         assert v.identical(v)
-        assert isinstance(v.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(v.data, dask_array_type)
 
     def test_transpose(self):
         u = self.eager_var
@@ -402,7 +404,7 @@ class TestDataArrayAndDataset(DaskTestCase):
 
     def test_lazy_dataset(self):
         lazy_ds = Dataset({"foo": (("x", "y"), self.data)})
-        assert isinstance(lazy_ds.foo.variable.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(lazy_ds.foo.variable.data, dask_array_type)
 
     def test_lazy_array(self):
         u = self.eager_array
@@ -477,21 +479,21 @@ class TestDataArrayAndDataset(DaskTestCase):
         out = xr.concat([ds1, ds2, ds3], dim="n", data_vars="all", coords="all")
         # no extra kernel calls
         assert kernel_call_count == 6
-        assert isinstance(out["d"].data, get_dask_chunkmanager().array_cls)
-        assert isinstance(out["c"].data, get_dask_chunkmanager().array_cls)
+        assert isinstance(out["d"].data, dask_array_type)
+        assert isinstance(out["c"].data, dask_array_type)
 
         out = xr.concat([ds1, ds2, ds3], dim="n", data_vars=["d"], coords=["c"])
         # no extra kernel calls
         assert kernel_call_count == 6
-        assert isinstance(out["d"].data, get_dask_chunkmanager().array_cls)
-        assert isinstance(out["c"].data, get_dask_chunkmanager().array_cls)
+        assert isinstance(out["d"].data, dask_array_type)
+        assert isinstance(out["c"].data, dask_array_type)
 
         with xr.set_options(use_new_combine_kwarg_defaults=True):
             out = xr.concat([ds1, ds2, ds3], dim="n", data_vars=[], coords=[])
             # no extra kernel calls
             assert kernel_call_count == 6
-            assert isinstance(out["d"].data, get_dask_chunkmanager().array_cls)
-            assert isinstance(out["c"].data, get_dask_chunkmanager().array_cls)
+            assert isinstance(out["d"].data, dask_array_type)
+            assert isinstance(out["c"].data, dask_array_type)
 
         out = xr.concat(
             [ds1, ds2, ds3], dim="n", data_vars=[], coords=[], compat="equals"
@@ -525,8 +527,8 @@ class TestDataArrayAndDataset(DaskTestCase):
         )
         # the variables of ds1 and ds2 were computed, but those of ds3 didn't
         assert kernel_call_count == 22
-        assert isinstance(out["d"].data, get_dask_chunkmanager().array_cls)
-        assert isinstance(out["c"].data, get_dask_chunkmanager().array_cls)
+        assert isinstance(out["d"].data, dask_array_type)
+        assert isinstance(out["c"].data, dask_array_type)
         # the data of ds1 and ds2 was loaded into numpy and then
         # concatenated to the data of ds3. Thus, only ds3 is computed now.
         out.compute()
@@ -550,16 +552,16 @@ class TestDataArrayAndDataset(DaskTestCase):
         )
         assert kernel_call_count == 24
         # variables are not loaded in the output
-        assert isinstance(out["d"].data, get_dask_chunkmanager().array_cls)
-        assert isinstance(out["c"].data, get_dask_chunkmanager().array_cls)
+        assert isinstance(out["d"].data, dask_array_type)
+        assert isinstance(out["c"].data, dask_array_type)
 
         out = xr.concat(
             [ds1, ds1, ds1], dim="n", data_vars=[], coords=[], compat="identical"
         )
         assert kernel_call_count == 24
         # variables are not loaded in the output
-        assert isinstance(out["d"].data, get_dask_chunkmanager().array_cls)
-        assert isinstance(out["c"].data, get_dask_chunkmanager().array_cls)
+        assert isinstance(out["d"].data, dask_array_type)
+        assert isinstance(out["c"].data, dask_array_type)
 
         out = xr.concat(
             [ds1, ds2.compute(), ds3],

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -312,7 +312,11 @@ class TestVariable(DaskTestCase):
         (v2,) = dask.persist(v)
         assert v is not v2
         assert len(v2.__dask_graph__()) < len(v.__dask_graph__())  # type: ignore[arg-type]
-        if not has_dask_array_expr:
+        if has_dask_array_expr:
+            assert [key[1:] for key in dask.core.flatten(v2.__dask_keys__())] == [
+                key[1:] for key in dask.core.flatten(v.__dask_keys__())
+            ]
+        else:
             assert v2.__dask_keys__() == v.__dask_keys__()
         assert dask.is_dask_collection(v)
         assert dask.is_dask_collection(v2)
@@ -438,7 +442,11 @@ class TestDataArrayAndDataset(DaskTestCase):
             (v2,) = dask.persist(v)
         assert v is not v2
         assert len(v2.__dask_graph__()) < len(v.__dask_graph__())
-        if not has_dask_array_expr:
+        if has_dask_array_expr:
+            assert [key[1:] for key in dask.core.flatten(v2.__dask_keys__())] == [
+                key[1:] for key in dask.core.flatten(v.__dask_keys__())
+            ]
+        else:
             assert v2.__dask_keys__() == v.__dask_keys__()
         assert dask.is_dask_collection(v)
         assert dask.is_dask_collection(v2)

--- a/xarray/tests/test_dask_expr_protocol.py
+++ b/xarray/tests/test_dask_expr_protocol.py
@@ -240,8 +240,8 @@ def test_map_blocks_reduces_single_chunk_dimension():
 def test_map_blocks_slice_pushdown_equivalent_to_preselection():
     x = dask_array.arange(12, chunks=(3,))
     ds = Dataset({"x": ("t", x)}, coords={"t": np.arange(12)})
-    post_calls = []
-    pre_calls = []
+    post_calls: list[tuple[int, ...]] = []
+    pre_calls: list[tuple[int, ...]] = []
 
     def add_one(calls):
         def func(block):

--- a/xarray/tests/test_dask_expr_protocol.py
+++ b/xarray/tests/test_dask_expr_protocol.py
@@ -113,6 +113,14 @@ def test_open_mfdataset_end_to_end(tmp_path):
             dask.optimize(ds)[0].compute(scheduler="single-threaded"), expected
         )
 
+        mapped = xr.map_blocks(lambda block: block + 1, ds)
+        assert isinstance(mapped["x"].data, dask_array.Array)
+        assert isinstance(dask.base.collections_to_expr(mapped), CompositeExpr)
+        assert_identical(
+            mapped.compute(scheduler="single-threaded"),
+            Dataset({"x": ("t", np.arange(6) + 1)}, coords={"t": np.arange(6)}),
+        )
+
 
 @requires_scipy_or_netCDF4
 def test_open_dataset_rechunk_optimization_crosses_composite_expr(tmp_path):
@@ -124,10 +132,6 @@ def test_open_dataset_rechunk_optimization_crosses_composite_expr(tmp_path):
     with xr.open_dataset(path, chunks={"t": 3}) as ds:
         out = ds.chunk({"t": 4})
         expr = dask.base.collections_to_expr(out)
-        source_expr = ds["x"].data.expr
-        expected_operands = list(source_expr.operands)
-        expected_operands[source_expr._parameters.index("_chunks")] = ((4, 4, 4),)
-        expected_expr = type(source_expr)(*expected_operands).optimize()
 
         assert isinstance(expr, CompositeExpr)
         assert len(expr.exprs) == 1
@@ -135,7 +139,6 @@ def test_open_dataset_rechunk_optimization_crosses_composite_expr(tmp_path):
 
         optimized_expr = expr.optimize()
 
-        assert optimized_expr.exprs[0]._name == expected_expr._name
         assert not list(optimized_expr.exprs[0].find_operations(Rechunk))
 
         optimized = dask.optimize(out)[0]
@@ -145,6 +148,93 @@ def test_open_dataset_rechunk_optimization_crosses_composite_expr(tmp_path):
             optimized.compute(scheduler="single-threaded"),
             Dataset({"x": ("t", np.arange(12))}, coords={"t": np.arange(12)}),
         )
+
+
+def test_map_blocks_dataarray_end_to_end():
+    x = dask_array.arange(6, chunks=(3,))
+    arr = DataArray(x, dims="t", name="x")
+    out = xr.map_blocks(lambda block: block + 1, arr)
+
+    assert isinstance(out.data, dask_array.Array)
+    assert isinstance(dask.base.collections_to_expr(out), CompositeExpr)
+
+    expected = DataArray(np.arange(6) + 1, dims="t", name="x")
+    assert_identical(out.compute(scheduler="single-threaded"), expected)
+    assert_identical(
+        out.persist(scheduler="single-threaded").compute(scheduler="single-threaded"),
+        expected,
+    )
+    assert_identical(
+        dask.optimize(out)[0].compute(scheduler="single-threaded"), expected
+    )
+
+
+def test_map_blocks_dataset_outputs_share_block_calls():
+    calls = []
+    x = dask_array.arange(6, chunks=(3,))
+    ds = Dataset({"x": ("t", x)}, coords={"qc": ("t", x + 10)})
+    template = Dataset(
+        {"a": ("t", x), "b": ("t", x)},
+        coords={"qc": ("t", x + 10)},
+        attrs={"kind": "mapped"},
+    )
+
+    def func(block):
+        calls.append(block.sizes["t"])
+        return Dataset(
+            {"a": block["x"] + 1, "b": block["x"] + 2},
+            coords={"qc": block["qc"]},
+            attrs={"kind": "mapped"},
+        )
+
+    out = xr.map_blocks(func, ds, template=template)
+
+    assert isinstance(dask.base.collections_to_expr(out), CompositeExpr)
+    assert all(isinstance(out[name].data, dask_array.Array) for name in out)
+    assert sorted(calls) == []
+
+    expected = Dataset(
+        {"a": ("t", np.arange(6) + 1), "b": ("t", np.arange(6) + 2)},
+        coords={"qc": ("t", np.arange(6) + 10)},
+        attrs={"kind": "mapped"},
+    )
+    assert_identical(out.compute(scheduler="single-threaded"), expected)
+    assert sorted(calls) == [3, 3]
+
+
+def test_map_blocks_preserves_scalar_coords():
+    x = dask_array.arange(6, chunks=(3,)).reshape((3, 2))
+    arr = DataArray(
+        x,
+        dims=("x", "y"),
+        coords={"label": ("x", ["a", "b", "c"]), "scale": 2},
+        name="z",
+    )
+
+    out = xr.map_blocks(lambda block: block + block.scale, arr)
+
+    assert isinstance(dask.base.collections_to_expr(out), CompositeExpr)
+    assert_identical(
+        out.compute(scheduler="single-threaded"),
+        DataArray(
+            np.arange(6).reshape((3, 2)) + 2,
+            dims=("x", "y"),
+            coords={"label": ("x", ["a", "b", "c"]), "scale": 2},
+        ),
+    )
+
+
+def test_map_blocks_reduces_single_chunk_dimension():
+    x = dask_array.arange(12, chunks=(12,)).reshape((3, 4)).rechunk((3, 2))
+    arr = DataArray(x, dims=("x", "y"), name="z")
+
+    out = xr.map_blocks(lambda block: block.sum("x"), arr)
+
+    assert isinstance(dask.base.collections_to_expr(out), CompositeExpr)
+    assert_identical(
+        out.compute(scheduler="single-threaded"),
+        DataArray(np.arange(12).reshape(3, 4).sum(axis=0), dims="y", name="z"),
+    )
 
 
 def test_mixed_legacy_inputs_do_not_use_composite_path():
@@ -177,6 +267,14 @@ def test_mixed_legacy_inputs_do_not_use_composite_path():
         dask.compute(optimized, scheduler="single-threaded")[0],
         expected,
     )
+
+    with pytest.raises(TypeError, match=r"cannot mix dask_array\.Array"):
+        xr.map_blocks(lambda block: block + 1, ds)
+
+    arr = DataArray(dask_array.arange(6, chunks=(3,)), dims="i")
+    other = DataArray(da.arange(6, chunks=(3,)), dims="i")
+    with pytest.raises(TypeError, match=r"cannot mix dask_array\.Array"):
+        xr.map_blocks(lambda a, b: a + b, arr, args=[other])
 
 
 def test_shared_subexpressions_optimize_without_cross_contamination():
@@ -220,6 +318,9 @@ def test_apply_ufunc_parallelized_uses_composite_expr():
     )
 
 
+@pytest.mark.xfail_with_dask_array(
+    reason="flox groupby currently builds legacy dask arrays"
+)
 def test_groupby_sum_uses_composite_expr():
     x = dask_array.arange(6, chunks=(3,))
     arr = DataArray(

--- a/xarray/tests/test_dask_expr_protocol.py
+++ b/xarray/tests/test_dask_expr_protocol.py
@@ -237,6 +237,32 @@ def test_map_blocks_reduces_single_chunk_dimension():
     )
 
 
+def test_map_blocks_slice_pushdown_equivalent_to_preselection():
+    x = dask_array.arange(12, chunks=(3,))
+    ds = Dataset({"x": ("t", x)}, coords={"t": np.arange(12)})
+    post_calls = []
+    pre_calls = []
+
+    def add_one(calls):
+        def func(block):
+            if block.sizes["t"]:
+                calls.append(tuple(block["t"].values.tolist()))
+            return block + 1
+
+        return func
+
+    post_selected = xr.map_blocks(add_one(post_calls), ds).sel(t=slice(3, 8))
+    pre_selected = xr.map_blocks(add_one(pre_calls), ds.sel(t=slice(3, 8)))
+
+    assert isinstance(dask.base.collections_to_expr(post_selected), CompositeExpr)
+    assert_identical(
+        post_selected.compute(scheduler="single-threaded"),
+        pre_selected.compute(scheduler="single-threaded"),
+    )
+    assert sorted(post_calls) == [(3, 4, 5), (6, 7, 8)]
+    assert sorted(pre_calls) == [(3, 4, 5), (6, 7, 8)]
+
+
 def test_mixed_legacy_inputs_do_not_use_composite_path():
     ds = Dataset(
         {

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -48,7 +48,8 @@ from xarray.tests import (
     assert_equal,
     assert_identical,
     assert_no_warnings,
-    get_dask_chunkmanager,
+    dask_array_api,
+    dask_array_type,
     has_dask,
     has_dask_ge_2025_1_0,
     has_pyarrow,
@@ -983,7 +984,7 @@ class TestDataArray:
 
         # Check that kwargs are passed
         blocked = unblocked.chunk(name_prefix="testname_")
-        assert isinstance(blocked.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(blocked.data, dask_array_type)
         assert "testname_" in blocked.data.name
 
         # test kwargs form of chunks
@@ -4825,7 +4826,7 @@ class TestDataArray:
         dd = DataArray(data=d, dims=["z"], name="d", coords={"d2": ("z", d)})
 
         if backend == "dask":
-            da = get_dask_chunkmanager().array_api
+            da = dask_array_api
             aa = aa.copy(data=da.from_array(a, chunks=3))
             bb = bb.copy(data=da.from_array(b, chunks=3))
             cc = cc.copy(data=da.from_array(c, chunks=7))

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -48,6 +48,7 @@ from xarray.tests import (
     assert_equal,
     assert_identical,
     assert_no_warnings,
+    get_dask_chunkmanager,
     has_dask,
     has_dask_ge_2025_1_0,
     has_pyarrow,
@@ -501,10 +502,13 @@ class TestDataArray:
     @requires_dask
     def test_constructor_dask_coords(self) -> None:
         # regression test for GH1684
-        import dask.array as da
-
-        coord = da.arange(8, chunks=(4,))
-        data = da.random.random((8, 8), chunks=(4, 4)) + 1
+        coord = DataArray(np.arange(8), dims="x").chunk({"x": 4}).data
+        data = (
+            DataArray(np.random.random((8, 8)), dims=["x", "y"])
+            .chunk({"x": 4, "y": 4})
+            .data
+            + 1
+        )
         actual = DataArray(data, coords={"x": coord, "y": coord}, dims=["x", "y"])
 
         ecoord = np.arange(8)
@@ -978,10 +982,8 @@ class TestDataArray:
         assert blocked.load().chunks is None
 
         # Check that kwargs are passed
-        import dask.array as da
-
         blocked = unblocked.chunk(name_prefix="testname_")
-        assert isinstance(blocked.data, da.Array)
+        assert isinstance(blocked.data, get_dask_chunkmanager().array_cls)
         assert "testname_" in blocked.data.name
 
         # test kwargs form of chunks
@@ -4823,8 +4825,7 @@ class TestDataArray:
         dd = DataArray(data=d, dims=["z"], name="d", coords={"d2": ("z", d)})
 
         if backend == "dask":
-            import dask.array as da
-
+            da = get_dask_chunkmanager().array_api
             aa = aa.copy(data=da.from_array(a, chunks=3))
             bb = bb.copy(data=da.from_array(b, chunks=3))
             cc = cc.copy(data=da.from_array(c, chunks=7))

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -22,7 +22,6 @@ try:
 except ImportError:
     from numpy import RankWarning  # type: ignore[no-redef,attr-defined,unused-ignore]
 
-import contextlib
 
 from pandas.errors import UndefinedVariableError
 
@@ -61,6 +60,7 @@ from xarray.tests import (
     assert_no_warnings,
     assert_writeable,
     create_test_data,
+    get_dask_chunkmanager,
     has_cftime,
     has_dask,
     has_pyarrow,
@@ -77,9 +77,6 @@ from xarray.tests import (
     source_ndarray,
 )
 from xarray.tests.indexes import ScalarIndex, XYIndex
-
-with contextlib.suppress(ImportError):
-    import dask.array as da
 
 # from numpy version 2.0 trapz is deprecated and renamed to trapezoid
 # remove once numpy 2.0 is the oldest supported version
@@ -1156,8 +1153,6 @@ class TestDataset:
         ],
     )
     def test_chunk_by_season_resampler(self, use_cftime: bool, calendar: str) -> None:
-        import dask.array
-
         N = 365 + 365  # 2 years - 1 day
         time = xr.date_range(
             "2000-01-01", periods=N, freq="D", use_cftime=use_cftime, calendar=calendar
@@ -1165,8 +1160,18 @@ class TestDataset:
 
         ds = Dataset(
             {
-                "pr": ("time", dask.array.random.random((N), chunks=(20))),
-                "pr2d": (("x", "time"), dask.array.random.random((10, N), chunks=(20))),
+                "pr": (
+                    "time",
+                    DataArray(np.random.random(N), dims="time")
+                    .chunk({"time": 20})
+                    .data,
+                ),
+                "pr2d": (
+                    ("x", "time"),
+                    DataArray(np.random.random((10, N)), dims=("x", "time"))
+                    .chunk({"time": 20})
+                    .data,
+                ),
                 "ones": ("time", np.ones((N,))),
             },
             coords={"time": time},
@@ -1262,7 +1267,7 @@ class TestDataset:
             if k in reblocked.dims:
                 assert isinstance(v.data, np.ndarray)
             else:
-                assert isinstance(v.data, da.Array)
+                assert isinstance(v.data, get_dask_chunkmanager().array_cls)
 
         expected_chunks: dict[Hashable, tuple[int, ...]] = {
             "dim1": (8,),
@@ -1326,8 +1331,6 @@ class TestDataset:
     @pytest.mark.parametrize("freq", ["D", "W", "5ME", "YE"])
     @pytest.mark.parametrize("add_gap", [True, False])
     def test_chunk_by_frequency(self, freq: str, calendar: str, add_gap: bool) -> None:
-        import dask.array
-
         N = 365 * 2
         ΔN = 28  # noqa: PLC2401
         time = xr.date_range(
@@ -1342,8 +1345,18 @@ class TestDataset:
 
         ds = Dataset(
             {
-                "pr": ("time", dask.array.random.random((N), chunks=(20))),
-                "pr2d": (("x", "time"), dask.array.random.random((10, N), chunks=(20))),
+                "pr": (
+                    "time",
+                    DataArray(np.random.random(N), dims="time")
+                    .chunk({"time": 20})
+                    .data,
+                ),
+                "pr2d": (
+                    ("x", "time"),
+                    DataArray(np.random.random((10, N)), dims=("x", "time"))
+                    .chunk({"time": 20})
+                    .data,
+                ),
                 "ones": ("time", np.ones((N,))),
             },
             coords={"time": time},
@@ -7673,6 +7686,7 @@ class TestDataset:
                 },
             )
         elif backend == "dask":
+            da = get_dask_chunkmanager().array_api
             ds = Dataset(
                 {
                     "a": ("x", da.from_array(a, chunks=3)),
@@ -7680,7 +7694,10 @@ class TestDataset:
                     "c": ("y", da.from_array(c, chunks=7)),
                     "d": ("z", da.from_array(d, chunks=12)),
                     "e": (("x", "y"), da.from_array(e, chunks=(3, 7))),
-                    "f": (("x", "y", "z"), da.from_array(f, chunks=(3, 7, 12))),
+                    "f": (
+                        ("x", "y", "z"),
+                        da.from_array(f, chunks=(3, 7, 12)),
+                    ),
                 },
                 coords={
                     "a2": ("x", a),

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -60,7 +60,8 @@ from xarray.tests import (
     assert_no_warnings,
     assert_writeable,
     create_test_data,
-    get_dask_chunkmanager,
+    dask_array_api,
+    dask_array_type,
     has_cftime,
     has_dask,
     has_pyarrow,
@@ -1267,7 +1268,7 @@ class TestDataset:
             if k in reblocked.dims:
                 assert isinstance(v.data, np.ndarray)
             else:
-                assert isinstance(v.data, get_dask_chunkmanager().array_cls)
+                assert isinstance(v.data, dask_array_type)
 
         expected_chunks: dict[Hashable, tuple[int, ...]] = {
             "dim1": (8,),
@@ -7686,7 +7687,7 @@ class TestDataset:
                 },
             )
         elif backend == "dask":
-            da = get_dask_chunkmanager().array_api
+            da = dask_array_api
             ds = Dataset(
                 {
                     "a": ("x", da.from_array(a, chunks=3)),

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -2720,13 +2720,21 @@ class TestDask:
         )
         original_chunksizes = tree.chunksizes
         original_hlg_depths = {
-            node.path: len(node.dataset.__dask_graph__().layers)
+            node.path: (
+                len(graph.layers)
+                if hasattr((graph := node.dataset.__dask_graph__()), "layers")
+                else None
+            )
             for node in tree.subtree
         }
 
         actual = tree.persist()
         actual_hlg_depths = {
-            node.path: len(node.dataset.__dask_graph__().layers)
+            node.path: (
+                len(graph.layers)
+                if hasattr((graph := node.dataset.__dask_graph__()), "layers")
+                else None
+            )
             for node in actual.subtree
         }
 
@@ -2736,12 +2744,14 @@ class TestDask:
         assert tree.chunksizes == original_chunksizes, (
             "original chunksizes were modified"
         )
-        assert all(d == 1 for d in actual_hlg_depths.values()), (
-            "unexpected dask graph depth"
-        )
-        assert all(d == 2 for d in original_hlg_depths.values()), (
-            "original dask graph was modified"
-        )
+        if all(d is not None for d in actual_hlg_depths.values()):
+            assert all(d == 1 for d in actual_hlg_depths.values()), (
+                "unexpected dask graph depth"
+            )
+        if all(d is not None for d in original_hlg_depths.values()):
+            assert all(d == 2 for d in original_hlg_depths.values()), (
+                "original dask graph was modified"
+            )
 
     def test_chunk(self):
         ds1 = xr.Dataset({"a": ("x", np.arange(10))})

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -10,11 +10,9 @@ import pytest
 
 if TYPE_CHECKING:
     import dask
-    import dask.array as da
     import distributed
 else:
     dask = pytest.importorskip("dask")
-    da = pytest.importorskip("dask.array")
     distributed = pytest.importorskip("distributed")
 
 import contextlib
@@ -36,6 +34,7 @@ from xarray.backends.locks import HDF5_LOCK, CombinedLock, SerializableLock
 from xarray.tests import (
     assert_allclose,
     assert_identical,
+    get_dask_chunkmanager,
     has_h5netcdf,
     has_netCDF4,
     has_scipy,
@@ -118,7 +117,7 @@ def test_dask_distributed_netcdf_roundtrip(
             with xr.open_dataset(
                 tmp_netcdf_filename, chunks=chunks, engine=engine
             ) as restored:
-                assert isinstance(restored.var1.data, da.Array)
+                assert isinstance(restored.var1.data, get_dask_chunkmanager().array_cls)
                 computed = restored.compute()
                 assert_allclose(original, computed)
 
@@ -130,7 +129,7 @@ def test_dask_distributed_write_netcdf_with_dimensionless_variables(
 ):
     with cluster() as (s, [_a, _b]):
         with Client(s["address"], loop=loop):
-            original = xr.Dataset({"x": da.zeros(())})
+            original = xr.Dataset({"x": get_dask_chunkmanager().array_api.zeros(())})
             original.to_netcdf(tmp_netcdf_filename)
 
             with xr.open_dataset(tmp_netcdf_filename) as actual:
@@ -224,7 +223,7 @@ def test_dask_distributed_read_netcdf_integration_test(
             with xr.open_dataset(
                 tmp_netcdf_filename, chunks=chunks, engine=engine
             ) as restored:
-                assert isinstance(restored.var1.data, da.Array)
+                assert isinstance(restored.var1.data, get_dask_chunkmanager().array_cls)
                 computed = restored.compute()
                 assert_allclose(original, computed)
 
@@ -279,7 +278,7 @@ def test_dask_distributed_zarr_integration_test(
         with xr.open_dataset(
             filename, chunks="auto", engine="zarr", **read_kwargs
         ) as restored:
-            assert isinstance(restored.var1.data, da.Array)
+            assert isinstance(restored.var1.data, get_dask_chunkmanager().array_cls)
             computed = restored.compute()
             assert_allclose(original, computed)
 

--- a/xarray/tests/test_distributed.py
+++ b/xarray/tests/test_distributed.py
@@ -34,7 +34,8 @@ from xarray.backends.locks import HDF5_LOCK, CombinedLock, SerializableLock
 from xarray.tests import (
     assert_allclose,
     assert_identical,
-    get_dask_chunkmanager,
+    dask_array_api,
+    dask_array_type,
     has_h5netcdf,
     has_netCDF4,
     has_scipy,
@@ -117,7 +118,7 @@ def test_dask_distributed_netcdf_roundtrip(
             with xr.open_dataset(
                 tmp_netcdf_filename, chunks=chunks, engine=engine
             ) as restored:
-                assert isinstance(restored.var1.data, get_dask_chunkmanager().array_cls)
+                assert isinstance(restored.var1.data, dask_array_type)
                 computed = restored.compute()
                 assert_allclose(original, computed)
 
@@ -129,7 +130,7 @@ def test_dask_distributed_write_netcdf_with_dimensionless_variables(
 ):
     with cluster() as (s, [_a, _b]):
         with Client(s["address"], loop=loop):
-            original = xr.Dataset({"x": get_dask_chunkmanager().array_api.zeros(())})
+            original = xr.Dataset({"x": dask_array_api.zeros(())})
             original.to_netcdf(tmp_netcdf_filename)
 
             with xr.open_dataset(tmp_netcdf_filename) as actual:
@@ -223,7 +224,7 @@ def test_dask_distributed_read_netcdf_integration_test(
             with xr.open_dataset(
                 tmp_netcdf_filename, chunks=chunks, engine=engine
             ) as restored:
-                assert isinstance(restored.var1.data, get_dask_chunkmanager().array_cls)
+                assert isinstance(restored.var1.data, dask_array_type)
                 computed = restored.compute()
                 assert_allclose(original, computed)
 
@@ -278,7 +279,7 @@ def test_dask_distributed_zarr_integration_test(
         with xr.open_dataset(
             filename, chunks="auto", engine="zarr", **read_kwargs
         ) as restored:
-            assert isinstance(restored.var1.data, get_dask_chunkmanager().array_cls)
+            assert isinstance(restored.var1.data, dask_array_type)
             computed = restored.compute()
             assert_allclose(original, computed)
 

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -38,8 +38,10 @@ from xarray.testing import assert_allclose, assert_equal, assert_identical
 from xarray.tests import (
     arm_xfail,
     assert_array_equal,
-    get_dask_chunkmanager,
+    dask_array_api,
+    dask_array_type,
     has_dask,
+    has_dask_array_expr,
     has_scipy,
     raise_if_dask_computes,
     requires_bottleneck,
@@ -259,7 +261,7 @@ class TestOps:
 class TestDaskOps(TestOps):
     @pytest.fixture(autouse=True)
     def setUp(self):
-        self.x = get_dask_chunkmanager().array_api.from_array(
+        self.x = dask_array_api.from_array(
             [
                 [
                     [nan, nan, 2.0, nan],
@@ -432,7 +434,7 @@ def series_reduce(da, func, dim, **kwargs):
 
 def assert_dask_array(da, dask):
     if dask and da.ndim > 0:
-        assert isinstance(da.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(da.data, dask_array_type)
 
 
 @arm_xfail
@@ -646,7 +648,7 @@ def test_reduce(dim_num, dtype, dask, func, skipna, aggdim):
             # also check ddof!=0 case
             actual = getattr(da, func)(skipna=skipna, dim=aggdim, ddof=5)
             if dask:
-                assert isinstance(da.data, get_dask_chunkmanager().array_cls)
+                assert isinstance(da.data, dask_array_type)
             expected = series_reduce(da, func, skipna=skipna, dim=aggdim, ddof=5)
             assert_allclose(actual, expected, rtol=rtol)
         else:
@@ -663,7 +665,7 @@ def test_reduce(dim_num, dtype, dask, func, skipna, aggdim):
         da = construct_dataarray(dim_num, dtype, contains_nan=False, dask=dask)
         actual = getattr(da, func)(skipna=skipna)
         if dask:
-            assert isinstance(da.data, get_dask_chunkmanager().array_cls)
+            assert isinstance(da.data, dask_array_type)
         expected = getattr(np, f"nan{func}")(da.values)
         if actual.dtype == object:
             assert actual.values == np.array(expected)
@@ -756,7 +758,7 @@ def test_isnull(array, expected):
 @requires_dask
 def test_isnull_with_dask():
     da = construct_dataarray(2, np.float32, contains_nan=True, dask=True)
-    assert isinstance(da.isnull().data, get_dask_chunkmanager().array_cls)
+    assert isinstance(da.isnull().data, dask_array_type)
     assert_equal(da.isnull().load(), da.load().isnull())
 
 
@@ -765,16 +767,16 @@ def test_isnull_with_dask():
     "func", [duck_array_ops.masked_invalid, duck_array_ops.getmaskarray]
 )
 def test_dask_or_eager_func_does_not_fallback_to_legacy_dask_array(func):
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
     array = da.from_array(np.array([1.0, np.nan]), chunks=2)
 
     try:
         result = func(array)
     except NotImplementedError:
-        if get_dask_chunkmanager().array_cls.__module__.startswith("dask.array"):
+        if not has_dask_array_expr:
             raise
     else:
-        assert isinstance(result, get_dask_chunkmanager().array_cls)
+        assert isinstance(result, dask_array_type)
 
 
 @pytest.mark.skipif(not HAS_STRING_DTYPE, reason="requires StringDType to exist")
@@ -818,7 +820,7 @@ def test_isnull_with_default_StringDType():
 @pytest.mark.parametrize("axis", [0, -1, 1])
 @pytest.mark.parametrize("edge_order", [1, 2])
 def test_dask_gradient(axis, edge_order):
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
 
     array = np.array(np.random.randn(100, 5, 40))
     x = np.exp(np.linspace(0, 1, array.shape[axis]))
@@ -827,7 +829,7 @@ def test_dask_gradient(axis, edge_order):
     expected = gradient(array, x, axis=axis, edge_order=edge_order)
     actual = gradient(darray, x, axis=axis, edge_order=edge_order)
 
-    assert isinstance(actual, get_dask_chunkmanager().array_cls)
+    assert isinstance(actual, dask_array_type)
     assert_array_equal(actual, expected)
 
 
@@ -950,7 +952,7 @@ def test_datetime_to_numeric_datetime64(dask, time_unit: PDDatetimeUnitOptions):
 
     times = pd.date_range("2000", periods=5, freq="7D").as_unit(time_unit).values
     if dask:
-        times = get_dask_chunkmanager().array_api.from_array(times, chunks=-1)
+        times = dask_array_api.from_array(times, chunks=-1)
 
     with raise_if_dask_computes():
         result = duck_array_ops.datetime_to_numeric(times, datetime_unit="h")
@@ -984,7 +986,7 @@ def test_datetime_to_numeric_cftime(dask):
         "2000", periods=5, freq="7D", calendar="standard", use_cftime=True
     ).values
     if dask:
-        times = get_dask_chunkmanager().array_api.from_array(times, chunks=-1)
+        times = dask_array_api.from_array(times, chunks=-1)
     with raise_if_dask_computes():
         result = duck_array_ops.datetime_to_numeric(times, datetime_unit="h", dtype=int)
     expected = 24 * np.arange(0, 35, 7)
@@ -1008,7 +1010,7 @@ def test_datetime_to_numeric_cftime(dask):
 
     with raise_if_dask_computes():
         if dask:
-            time = get_dask_chunkmanager().array_api.asarray(times[1])
+            time = dask_array_api.asarray(times[1])
         else:
             time = np.asarray(times[1])
         result = duck_array_ops.datetime_to_numeric(
@@ -1141,7 +1143,7 @@ def test_least_squares(use_dask, skipna):
 def test_push_dask(method, arr):
     import bottleneck
 
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
 
     arr = np.array(arr)
     chunks = list(range(1, 11)) + [(1, 2, 3, 2, 2, 1, 1)]

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -34,11 +34,11 @@ from xarray.core.duck_array_ops import (
 )
 from xarray.core.extension_array import PandasExtensionArray
 from xarray.core.types import NPDatetimeUnitOptions, PDDatetimeUnitOptions
-from xarray.namedarray.pycompat import array_type
 from xarray.testing import assert_allclose, assert_equal, assert_identical
 from xarray.tests import (
     arm_xfail,
     assert_array_equal,
+    get_dask_chunkmanager,
     has_dask,
     has_scipy,
     raise_if_dask_computes,
@@ -48,8 +48,6 @@ from xarray.tests import (
     requires_dask,
     requires_pyarrow,
 )
-
-dask_array_type = array_type("dask")
 
 
 @pytest.fixture
@@ -261,9 +259,7 @@ class TestOps:
 class TestDaskOps(TestOps):
     @pytest.fixture(autouse=True)
     def setUp(self):
-        import dask.array
-
-        self.x = dask.array.from_array(
+        self.x = get_dask_chunkmanager().array_api.from_array(
             [
                 [
                     [nan, nan, 2.0, nan],
@@ -436,7 +432,7 @@ def series_reduce(da, func, dim, **kwargs):
 
 def assert_dask_array(da, dask):
     if dask and da.ndim > 0:
-        assert isinstance(da.data, dask_array_type)
+        assert isinstance(da.data, get_dask_chunkmanager().array_cls)
 
 
 @arm_xfail
@@ -650,7 +646,7 @@ def test_reduce(dim_num, dtype, dask, func, skipna, aggdim):
             # also check ddof!=0 case
             actual = getattr(da, func)(skipna=skipna, dim=aggdim, ddof=5)
             if dask:
-                assert isinstance(da.data, dask_array_type)
+                assert isinstance(da.data, get_dask_chunkmanager().array_cls)
             expected = series_reduce(da, func, skipna=skipna, dim=aggdim, ddof=5)
             assert_allclose(actual, expected, rtol=rtol)
         else:
@@ -667,7 +663,7 @@ def test_reduce(dim_num, dtype, dask, func, skipna, aggdim):
         da = construct_dataarray(dim_num, dtype, contains_nan=False, dask=dask)
         actual = getattr(da, func)(skipna=skipna)
         if dask:
-            assert isinstance(da.data, dask_array_type)
+            assert isinstance(da.data, get_dask_chunkmanager().array_cls)
         expected = getattr(np, f"nan{func}")(da.values)
         if actual.dtype == object:
             assert actual.values == np.array(expected)
@@ -760,8 +756,25 @@ def test_isnull(array, expected):
 @requires_dask
 def test_isnull_with_dask():
     da = construct_dataarray(2, np.float32, contains_nan=True, dask=True)
-    assert isinstance(da.isnull().data, dask_array_type)
+    assert isinstance(da.isnull().data, get_dask_chunkmanager().array_cls)
     assert_equal(da.isnull().load(), da.load().isnull())
+
+
+@requires_dask
+@pytest.mark.parametrize(
+    "func", [duck_array_ops.masked_invalid, duck_array_ops.getmaskarray]
+)
+def test_dask_or_eager_func_does_not_fallback_to_legacy_dask_array(func):
+    da = get_dask_chunkmanager().array_api
+    array = da.from_array(np.array([1.0, np.nan]), chunks=2)
+
+    try:
+        result = func(array)
+    except NotImplementedError:
+        if get_dask_chunkmanager().array_cls.__module__.startswith("dask.array"):
+            raise
+    else:
+        assert isinstance(result, get_dask_chunkmanager().array_cls)
 
 
 @pytest.mark.skipif(not HAS_STRING_DTYPE, reason="requires StringDType to exist")
@@ -805,7 +818,7 @@ def test_isnull_with_default_StringDType():
 @pytest.mark.parametrize("axis", [0, -1, 1])
 @pytest.mark.parametrize("edge_order", [1, 2])
 def test_dask_gradient(axis, edge_order):
-    import dask.array as da
+    da = get_dask_chunkmanager().array_api
 
     array = np.array(np.random.randn(100, 5, 40))
     x = np.exp(np.linspace(0, 1, array.shape[axis]))
@@ -814,7 +827,7 @@ def test_dask_gradient(axis, edge_order):
     expected = gradient(array, x, axis=axis, edge_order=edge_order)
     actual = gradient(darray, x, axis=axis, edge_order=edge_order)
 
-    assert isinstance(actual, da.Array)
+    assert isinstance(actual, get_dask_chunkmanager().array_cls)
     assert_array_equal(actual, expected)
 
 
@@ -937,9 +950,7 @@ def test_datetime_to_numeric_datetime64(dask, time_unit: PDDatetimeUnitOptions):
 
     times = pd.date_range("2000", periods=5, freq="7D").as_unit(time_unit).values
     if dask:
-        import dask.array
-
-        times = dask.array.from_array(times, chunks=-1)
+        times = get_dask_chunkmanager().array_api.from_array(times, chunks=-1)
 
     with raise_if_dask_computes():
         result = duck_array_ops.datetime_to_numeric(times, datetime_unit="h")
@@ -973,9 +984,7 @@ def test_datetime_to_numeric_cftime(dask):
         "2000", periods=5, freq="7D", calendar="standard", use_cftime=True
     ).values
     if dask:
-        import dask.array
-
-        times = dask.array.from_array(times, chunks=-1)
+        times = get_dask_chunkmanager().array_api.from_array(times, chunks=-1)
     with raise_if_dask_computes():
         result = duck_array_ops.datetime_to_numeric(times, datetime_unit="h", dtype=int)
     expected = 24 * np.arange(0, 35, 7)
@@ -999,7 +1008,7 @@ def test_datetime_to_numeric_cftime(dask):
 
     with raise_if_dask_computes():
         if dask:
-            time = dask.array.asarray(times[1])
+            time = get_dask_chunkmanager().array_api.asarray(times[1])
         else:
             time = np.asarray(times[1])
         result = duck_array_ops.datetime_to_numeric(
@@ -1131,7 +1140,8 @@ def test_least_squares(use_dask, skipna):
 )
 def test_push_dask(method, arr):
     import bottleneck
-    import dask.array as da
+
+    da = get_dask_chunkmanager().array_api
 
     arr = np.array(arr)
     chunks = list(range(1, 11)) + [(1, 2, 3, 2, 2, 1, 1)]

--- a/xarray/tests/test_duck_array_wrapping.py
+++ b/xarray/tests/test_duck_array_wrapping.py
@@ -1,8 +1,11 @@
+import os
+
 import numpy as np
 import pandas as pd
 import pytest
 
 import xarray as xr
+from xarray.tests import get_dask_chunkmanager
 
 # Don't run cupy in CI because it requires a GPU
 NAMESPACE_ARRAYS = {
@@ -110,15 +113,37 @@ except ImportError:
     pass
 
 
+def use_dask_array(config):
+    env_value = os.environ.get("XR_USE_DASK_ARRAY", "")
+    return config.getoption("--use-dask-array") or env_value.lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 class _BaseTest:
     def setup_for_test(self, request, namespace):
         self.namespace = namespace
-        self.xp = pytest.importorskip(namespace)
-        self.Array = getattr(self.xp, NAMESPACE_ARRAYS[namespace]["attrs"]["array"])
-        self.constructor = getattr(
-            self.xp, NAMESPACE_ARRAYS[namespace]["attrs"]["constructor"]
-        )
         xarray_method = request.node.name.split("test_")[1].split("[")[0]
+        if namespace == "dask.array" and use_dask_array(request.config):
+            if xarray_method in {"groupby", "groupby_bins", "resample"}:
+                pytest.xfail("flox groupby currently builds legacy dask arrays")
+            chunkmanager = get_dask_chunkmanager()
+            self.xp = chunkmanager.array_api
+            self.Array = chunkmanager.array_cls
+
+            def constructor(data):
+                return chunkmanager.from_array(data, chunks=data.shape)
+
+            self.constructor = constructor
+        else:
+            self.xp = pytest.importorskip(namespace)
+            self.Array = getattr(self.xp, NAMESPACE_ARRAYS[namespace]["attrs"]["array"])
+            self.constructor = getattr(
+                self.xp, NAMESPACE_ARRAYS[namespace]["attrs"]["constructor"]
+            )
         if xarray_method in NAMESPACE_ARRAYS[namespace]["xfails"]:
             reason = NAMESPACE_ARRAYS[namespace]["xfails"][xarray_method]
             pytest.xfail(f"xfail for {self.namespace}: {reason}")

--- a/xarray/tests/test_duck_array_wrapping.py
+++ b/xarray/tests/test_duck_array_wrapping.py
@@ -114,8 +114,8 @@ except ImportError:
 
 
 def use_dask_array(config):
-    env_value = os.environ.get("XR_USE_DASK_ARRAY", "")
-    return config.getoption("--use-dask-array") or env_value.lower() in {
+    env_value = os.environ.get("XR_USE_DASK_ARRAY_WITH_EXPR", "")
+    return config.getoption("--use-dask-array-with-expr") or env_value.lower() in {
         "1",
         "true",
         "yes",

--- a/xarray/tests/test_duck_array_wrapping.py
+++ b/xarray/tests/test_duck_array_wrapping.py
@@ -1,11 +1,9 @@
-import os
-
 import numpy as np
 import pandas as pd
 import pytest
 
 import xarray as xr
-from xarray.tests import get_dask_chunkmanager
+from xarray.tests import get_dask_chunkmanager, has_dask_array_expr
 
 # Don't run cupy in CI because it requires a GPU
 NAMESPACE_ARRAYS = {
@@ -113,21 +111,11 @@ except ImportError:
     pass
 
 
-def use_dask_array(config):
-    env_value = os.environ.get("XR_USE_DASK_ARRAY_WITH_EXPR", "")
-    return config.getoption("--use-dask-array-with-expr") or env_value.lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
-
-
 class _BaseTest:
     def setup_for_test(self, request, namespace):
         self.namespace = namespace
         xarray_method = request.node.name.split("test_")[1].split("[")[0]
-        if namespace == "dask.array" and use_dask_array(request.config):
+        if namespace == "dask.array" and has_dask_array_expr:
             if xarray_method in {"groupby", "groupby_bins", "resample"}:
                 pytest.xfail("flox groupby currently builds legacy dask arrays")
             chunkmanager = get_dask_chunkmanager()

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -57,7 +57,9 @@ from xarray.tests import (
 
 
 def _using_dask_array_chunkmanager() -> bool:
-    return get_dask_chunkmanager().array_cls.__module__.startswith("dask_array")
+    return has_dask and get_dask_chunkmanager().array_cls.__module__.startswith(
+        "dask_array"
+    )
 
 
 @pytest.fixture

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -39,9 +39,10 @@ from xarray.tests import (
     assert_equal,
     assert_identical,
     create_test_data,
-    get_dask_chunkmanager,
+    dask_array_api,
     has_cftime,
     has_dask,
+    has_dask_array_expr,
     has_dask_ge_2024_08_1,
     has_flox,
     has_pandas_ge_2_2,
@@ -57,9 +58,7 @@ from xarray.tests import (
 
 
 def _using_dask_array_chunkmanager() -> bool:
-    return has_dask and get_dask_chunkmanager().array_cls.__module__.startswith(
-        "dask_array"
-    )
+    return has_dask_array_expr
 
 
 @pytest.fixture
@@ -3240,7 +3239,7 @@ def test_groupby_transpose() -> None:
     ],
 )
 def test_lazy_grouping(grouper, expect_index):
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
 
     data = DataArray(
         dims=("x", "y"),
@@ -3275,7 +3274,7 @@ def test_lazy_grouping(grouper, expect_index):
 
 @requires_dask
 def test_lazy_grouping_errors() -> None:
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
 
     data = DataArray(
         dims=("x",),
@@ -3299,7 +3298,7 @@ def test_lazy_grouping_errors() -> None:
 
 @requires_dask
 def test_lazy_int_bins_error() -> None:
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
 
     with pytest.raises(ValueError, match="Bin edges must be provided"):
         with raise_if_dask_computes():
@@ -3388,7 +3387,7 @@ def test_groupby_multiple_bin_grouper_missing_groups() -> None:
 
 @requires_dask_ge_2024_08_1
 def test_shuffle_simple() -> None:
-    array_api = get_dask_chunkmanager().array_api
+    array_api = dask_array_api
 
     da = xr.DataArray(
         dims="x",
@@ -3412,7 +3411,7 @@ def test_shuffle_simple() -> None:
     ],
 )
 def test_shuffle_by(chunks, expected_chunks):
-    array_api = get_dask_chunkmanager().array_api
+    array_api = dask_array_api
 
     da = xr.DataArray(
         dims="x",

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -39,6 +39,7 @@ from xarray.tests import (
     assert_equal,
     assert_identical,
     create_test_data,
+    get_dask_chunkmanager,
     has_cftime,
     has_dask,
     has_dask_ge_2024_08_1,
@@ -53,6 +54,10 @@ from xarray.tests import (
     requires_pandas_ge_2_2,
     requires_scipy,
 )
+
+
+def _using_dask_array_chunkmanager() -> bool:
+    return get_dask_chunkmanager().array_cls.__module__.startswith("dask_array")
 
 
 @pytest.fixture
@@ -291,6 +296,9 @@ def test_da_groupby_empty() -> None:
 
 
 @requires_dask
+@pytest.mark.xfail_with_dask_array(
+    reason="flox groupby currently builds legacy dask arrays"
+)
 def test_dask_da_groupby_quantile() -> None:
     # Scalar quantile
     expected = xr.DataArray(
@@ -664,6 +672,8 @@ def test_groupby_repr_datetime(obj) -> None:
     ],
 )
 def test_groupby_drops_nans(shuffle: bool, chunk: Literal[False] | dict) -> None:
+    if chunk and _using_dask_array_chunkmanager():
+        pytest.xfail("flox groupby currently builds legacy dask arrays")
     if shuffle and chunk and not has_dask_ge_2024_08_1:
         pytest.skip()
     # GH2383
@@ -2643,6 +2653,9 @@ def test_groupby_scans(
     if use_dask and not has_dask:
         pytest.skip("requires dask")
 
+    if use_dask and use_flox and _using_dask_array_chunkmanager():
+        pytest.xfail("flox groupby scans currently mix legacy dask arrays")
+
     if use_flox:
         if not has_flox:
             pytest.skip("requires flox")
@@ -2987,6 +3000,9 @@ def test_multiple_groupers_string(as_dataset) -> None:
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize("use_flox", [True, False])
 def test_multiple_groupers(use_flox: bool, shuffle: bool) -> None:
+    if use_flox and _using_dask_array_chunkmanager():
+        pytest.xfail("flox multiple-groupers currently mix legacy dask arrays")
+
     da = DataArray(
         np.array([1, 2, 3, 0, 2, np.nan]),
         dims="d",
@@ -3082,6 +3098,10 @@ def test_multiple_groupers(use_flox: bool, shuffle: bool) -> None:
         assert is_chunked_array(gb.encoded.codes.data)
         assert not gb.encoded.group_indices
         if has_flox:
+            if _using_dask_array_chunkmanager():
+                pytest.xfail(
+                    "flox lazy multiple-groupers currently mix legacy dask arrays"
+                )
             with raise_if_dask_computes(max_computes=1):
                 assert_identical(gb.count(), expected)
         else:
@@ -3167,6 +3187,9 @@ def test_groupby_preserve_dtype(reduction):
 @requires_dask
 @requires_flox_0_9_12
 @pytest.mark.parametrize("reduction", ["any", "all", "count"])
+@pytest.mark.xfail_with_dask_array(
+    reason="flox resample currently mixes legacy dask arrays"
+)
 def test_gappy_resample_reductions(reduction):
     # GH8090
     dates = (("1988-12-01", "1990-11-30"), ("2000-12-01", "2001-11-30"))
@@ -3215,11 +3238,11 @@ def test_groupby_transpose() -> None:
     ],
 )
 def test_lazy_grouping(grouper, expect_index):
-    import dask.array
+    da = get_dask_chunkmanager().array_api
 
     data = DataArray(
         dims=("x", "y"),
-        data=dask.array.arange(20, chunks=3).reshape((4, 5)),
+        data=da.arange(20, chunks=3).reshape((4, 5)),
         name="zoo",
     )
     with raise_if_dask_computes():
@@ -3240,6 +3263,8 @@ def test_lazy_grouping(grouper, expect_index):
     assert_identical(eager, expected)
 
     if has_flox:
+        if _using_dask_array_chunkmanager():
+            pytest.xfail("flox lazy grouping currently mixes legacy dask arrays")
         lazy = (
             xr.Dataset({"foo": data}, coords={"zoo": data}).groupby(zoo=grouper).count()
         )
@@ -3248,13 +3273,13 @@ def test_lazy_grouping(grouper, expect_index):
 
 @requires_dask
 def test_lazy_grouping_errors() -> None:
-    import dask.array
+    da = get_dask_chunkmanager().array_api
 
     data = DataArray(
         dims=("x",),
-        data=dask.array.arange(20, chunks=3),
+        data=da.arange(20, chunks=3),
         name="foo",
-        coords={"y": ("x", dask.array.arange(20, chunks=3))},
+        coords={"y": ("x", da.arange(20, chunks=3))},
     )
 
     gb = data.groupby(y=UniqueGrouper(labels=np.arange(5, 10)))
@@ -3272,11 +3297,11 @@ def test_lazy_grouping_errors() -> None:
 
 @requires_dask
 def test_lazy_int_bins_error() -> None:
-    import dask.array
+    da = get_dask_chunkmanager().array_api
 
     with pytest.raises(ValueError, match="Bin edges must be provided"):
         with raise_if_dask_computes():
-            _ = BinGrouper(bins=4).factorize(DataArray(dask.array.arange(3)))
+            _ = BinGrouper(bins=4).factorize(DataArray(da.arange(3)))
 
 
 def test_time_grouping_seasons_specified() -> None:
@@ -3361,11 +3386,11 @@ def test_groupby_multiple_bin_grouper_missing_groups() -> None:
 
 @requires_dask_ge_2024_08_1
 def test_shuffle_simple() -> None:
-    import dask
+    array_api = get_dask_chunkmanager().array_api
 
     da = xr.DataArray(
         dims="x",
-        data=dask.array.from_array([1, 2, 3, 4, 5, 6], chunks=2),
+        data=array_api.from_array([1, 2, 3, 4, 5, 6], chunks=2),
         coords={"label": ("x", ["a", "b", "c", "a", "b", "c"])},
     )
     actual = da.groupby(label=UniqueGrouper()).shuffle_to_chunks()
@@ -3385,11 +3410,11 @@ def test_shuffle_simple() -> None:
     ],
 )
 def test_shuffle_by(chunks, expected_chunks):
-    import dask.array
+    array_api = get_dask_chunkmanager().array_api
 
     da = xr.DataArray(
         dims="x",
-        data=dask.array.arange(10, chunks=chunks),
+        data=array_api.arange(10, chunks=chunks),
         coords={"x": [1, 2, 3, 1, 2, 3, 1, 2, 3, 0]},
         name="a",
     )
@@ -3398,6 +3423,10 @@ def test_shuffle_by(chunks, expected_chunks):
     for obj in [ds, da]:
         actual = obj.groupby(x=UniqueGrouper()).shuffle_to_chunks()
         assert_identical(actual, obj.sortby("x"))
+        if chunks == (1,) and _using_dask_array_chunkmanager():
+            pytest.xfail(
+                "dask-array shuffle_to_chunks does not preserve group chunks yet"
+            )
         assert actual.chunksizes["x"] == expected_chunks
 
 

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -57,10 +57,6 @@ from xarray.tests import (
 )
 
 
-def _using_dask_array_chunkmanager() -> bool:
-    return has_dask_array_expr
-
-
 @pytest.fixture
 def dataset() -> xr.Dataset:
     ds = xr.Dataset(
@@ -673,7 +669,7 @@ def test_groupby_repr_datetime(obj) -> None:
     ],
 )
 def test_groupby_drops_nans(shuffle: bool, chunk: Literal[False] | dict) -> None:
-    if chunk and _using_dask_array_chunkmanager():
+    if chunk and has_dask_array_expr:
         pytest.xfail("flox groupby currently builds legacy dask arrays")
     if shuffle and chunk and not has_dask_ge_2024_08_1:
         pytest.skip()
@@ -2654,7 +2650,7 @@ def test_groupby_scans(
     if use_dask and not has_dask:
         pytest.skip("requires dask")
 
-    if use_dask and use_flox and _using_dask_array_chunkmanager():
+    if use_dask and use_flox and has_dask_array_expr:
         pytest.xfail("flox groupby scans currently mix legacy dask arrays")
 
     if use_flox:
@@ -3001,7 +2997,7 @@ def test_multiple_groupers_string(as_dataset) -> None:
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize("use_flox", [True, False])
 def test_multiple_groupers(use_flox: bool, shuffle: bool) -> None:
-    if use_flox and _using_dask_array_chunkmanager():
+    if use_flox and has_dask_array_expr:
         pytest.xfail("flox multiple-groupers currently mix legacy dask arrays")
 
     da = DataArray(
@@ -3099,7 +3095,7 @@ def test_multiple_groupers(use_flox: bool, shuffle: bool) -> None:
         assert is_chunked_array(gb.encoded.codes.data)
         assert not gb.encoded.group_indices
         if has_flox:
-            if _using_dask_array_chunkmanager():
+            if has_dask_array_expr:
                 pytest.xfail(
                     "flox lazy multiple-groupers currently mix legacy dask arrays"
                 )
@@ -3264,7 +3260,7 @@ def test_lazy_grouping(grouper, expect_index):
     assert_identical(eager, expected)
 
     if has_flox:
-        if _using_dask_array_chunkmanager():
+        if has_dask_array_expr:
             pytest.xfail("flox lazy grouping currently mixes legacy dask arrays")
         lazy = (
             xr.Dataset({"foo": data}, coords={"zoo": data}).groupby(zoo=grouper).count()
@@ -3424,7 +3420,7 @@ def test_shuffle_by(chunks, expected_chunks):
     for obj in [ds, da]:
         actual = obj.groupby(x=UniqueGrouper()).shuffle_to_chunks()
         assert_identical(actual, obj.sortby("x"))
-        if chunks == (1,) and _using_dask_array_chunkmanager():
+        if chunks == (1,) and has_dask_array_expr:
             pytest.xfail(
                 "dask-array shuffle_to_chunks does not preserve group chunks yet"
             )

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -16,6 +16,8 @@ from xarray.tests import (
     ReturnItem,
     assert_array_equal,
     assert_identical,
+    get_dask_chunkmanager,
+    has_dask,
     raise_if_dask_computes,
     requires_dask,
     requires_pandas_3,
@@ -983,8 +985,9 @@ def test_create_mask_basic_indexer() -> None:
     np.testing.assert_array_equal(False, actual)
 
 
+@requires_dask
 def test_create_mask_dask() -> None:
-    da = pytest.importorskip("dask.array")
+    da = get_dask_chunkmanager().array_api
 
     indexer = indexing.OuterIndexer((1, slice(2), np.array([0, -1, 2])))
     expected = np.array(2 * [[False, True, False]])
@@ -1001,7 +1004,7 @@ def test_create_mask_dask() -> None:
     actual = indexing.create_mask(
         indexer_vec, (5, 2), da.empty((3, 2), chunks=((3,), (2,)))
     )
-    assert isinstance(actual, da.Array)
+    assert isinstance(actual, get_dask_chunkmanager().array_cls)
     np.testing.assert_array_equal(expected, actual)
 
     with pytest.raises(ValueError):
@@ -1049,11 +1052,10 @@ class ArrayWithNamespaceAndArrayFunction:
 
 
 def as_dask_array(arr, chunks):
-    try:
-        import dask.array as da
-    except ImportError:
+    if not has_dask:
         return None
 
+    da = get_dask_chunkmanager().array_api
     return da.from_array(arr, chunks=chunks)
 
 
@@ -1113,30 +1115,30 @@ def test_indexing_1d_object_array() -> None:
 
 @requires_dask
 def test_indexing_dask_array() -> None:
-    import dask.array
+    da = get_dask_chunkmanager().array_api
 
-    da = DataArray(
+    data = DataArray(
         np.ones(10 * 3 * 3).reshape((10, 3, 3)),
         dims=("time", "x", "y"),
     ).chunk(dict(time=-1, x=1, y=1))
     with raise_if_dask_computes():
-        actual = da.isel(time=dask.array.from_array([9], chunks=(1,)))
-    expected = da.isel(time=[9])
+        actual = data.isel(time=da.from_array([9], chunks=(1,)))
+    expected = data.isel(time=[9])
     assert_identical(actual, expected)
 
 
 @requires_dask
 def test_indexing_dask_array_scalar() -> None:
     # GH4276
-    import dask.array
+    da = get_dask_chunkmanager().array_api
 
-    a = dask.array.from_array(np.linspace(0.0, 1.0))
-    da = DataArray(a, dims="x")
-    x_selector = da.argmax(dim=...)
+    a = da.from_array(np.linspace(0.0, 1.0))
+    data = DataArray(a, dims="x")
+    x_selector = data.argmax(dim=...)
     assert not isinstance(x_selector, DataArray)
     with raise_if_dask_computes():
-        actual = da.isel(x_selector)
-    expected = da.isel(x=-1)
+        actual = data.isel(x_selector)
+    expected = data.isel(x=-1)
     assert_identical(actual, expected)
 
 
@@ -1174,7 +1176,7 @@ def test_vectorized_indexing_dask_array() -> None:
 @requires_dask
 def test_advanced_indexing_dask_array() -> None:
     # GH4663
-    import dask.array as da
+    da = get_dask_chunkmanager().array_api
 
     ds = Dataset(
         dict(

--- a/xarray/tests/test_indexing.py
+++ b/xarray/tests/test_indexing.py
@@ -16,7 +16,8 @@ from xarray.tests import (
     ReturnItem,
     assert_array_equal,
     assert_identical,
-    get_dask_chunkmanager,
+    dask_array_api,
+    dask_array_type,
     has_dask,
     raise_if_dask_computes,
     requires_dask,
@@ -987,7 +988,7 @@ def test_create_mask_basic_indexer() -> None:
 
 @requires_dask
 def test_create_mask_dask() -> None:
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
 
     indexer = indexing.OuterIndexer((1, slice(2), np.array([0, -1, 2])))
     expected = np.array(2 * [[False, True, False]])
@@ -1004,7 +1005,7 @@ def test_create_mask_dask() -> None:
     actual = indexing.create_mask(
         indexer_vec, (5, 2), da.empty((3, 2), chunks=((3,), (2,)))
     )
-    assert isinstance(actual, get_dask_chunkmanager().array_cls)
+    assert isinstance(actual, dask_array_type)
     np.testing.assert_array_equal(expected, actual)
 
     with pytest.raises(ValueError):
@@ -1055,7 +1056,7 @@ def as_dask_array(arr, chunks):
     if not has_dask:
         return None
 
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
     return da.from_array(arr, chunks=chunks)
 
 
@@ -1115,7 +1116,7 @@ def test_indexing_1d_object_array() -> None:
 
 @requires_dask
 def test_indexing_dask_array() -> None:
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
 
     data = DataArray(
         np.ones(10 * 3 * 3).reshape((10, 3, 3)),
@@ -1130,7 +1131,7 @@ def test_indexing_dask_array() -> None:
 @requires_dask
 def test_indexing_dask_array_scalar() -> None:
     # GH4276
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
 
     a = da.from_array(np.linspace(0.0, 1.0))
     data = DataArray(a, dims="x")
@@ -1176,7 +1177,7 @@ def test_vectorized_indexing_dask_array() -> None:
 @requires_dask
 def test_advanced_indexing_dask_array() -> None:
     # GH4663
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
 
     ds = Dataset(
         dict(

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -20,7 +20,7 @@ from xarray.tests import (
     assert_allclose,
     assert_equal,
     assert_identical,
-    get_dask_chunkmanager,
+    dask_array_api,
     has_dask,
     has_scipy,
     has_scipy_ge_1_13,
@@ -1130,7 +1130,7 @@ def test_interp_non_numeric_nd() -> None:
 @requires_scipy
 def test_interp_vectorized_dask() -> None:
     # Synthetic dataset chunked in the two interpolation dimensions
-    da = get_dask_chunkmanager().array_api
+    da = dask_array_api
 
     nt = 10
     nlat = 20

--- a/xarray/tests/test_interp.py
+++ b/xarray/tests/test_interp.py
@@ -20,6 +20,7 @@ from xarray.tests import (
     assert_allclose,
     assert_equal,
     assert_identical,
+    get_dask_chunkmanager,
     has_dask,
     has_scipy,
     has_scipy_ge_1_13,
@@ -1129,7 +1130,7 @@ def test_interp_non_numeric_nd() -> None:
 @requires_scipy
 def test_interp_vectorized_dask() -> None:
     # Synthetic dataset chunked in the two interpolation dimensions
-    import dask.array as da
+    da = get_dask_chunkmanager().array_api
 
     nt = 10
     nlat = 20

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -22,7 +22,7 @@ from xarray.tests import (
     assert_allclose,
     assert_array_equal,
     assert_equal,
-    get_dask_chunkmanager,
+    dask_array_type,
     raise_if_dask_computes,
     requires_bottleneck,
     requires_cftime,
@@ -388,14 +388,14 @@ def test_interpolate_dask():
     da = da.chunk({"x": 5})
     actual = da.interpolate_na("time")
     expected = da.load().interpolate_na("time")
-    assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+    assert isinstance(actual.data, dask_array_type)
     assert_equal(actual.compute(), expected)
 
     # with limit
     da = da.chunk({"x": 5})
     actual = da.interpolate_na("time", limit=3)
     expected = da.load().interpolate_na("time", limit=3)
-    assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+    assert isinstance(actual.data, dask_array_type)
     assert_equal(actual, expected)
 
 

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -17,12 +17,12 @@ from xarray.core.missing import (
     _get_nan_block_lengths,
     get_clean_interp_index,
 )
-from xarray.namedarray.pycompat import array_type
 from xarray.tests import (
     _CFTIME_CALENDARS,
     assert_allclose,
     assert_array_equal,
     assert_equal,
+    get_dask_chunkmanager,
     raise_if_dask_computes,
     requires_bottleneck,
     requires_cftime,
@@ -31,8 +31,6 @@ from xarray.tests import (
     requires_numbagg_or_bottleneck,
     requires_scipy,
 )
-
-dask_array_type = array_type("dask")
 
 
 @pytest.fixture
@@ -390,14 +388,14 @@ def test_interpolate_dask():
     da = da.chunk({"x": 5})
     actual = da.interpolate_na("time")
     expected = da.load().interpolate_na("time")
-    assert isinstance(actual.data, dask_array_type)
+    assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
     assert_equal(actual.compute(), expected)
 
     # with limit
     da = da.chunk({"x": 5})
     actual = da.interpolate_na("time", limit=3)
     expected = da.load().interpolate_na("time", limit=3)
-    assert isinstance(actual.data, dask_array_type)
+    assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
     assert_equal(actual, expected)
 
 

--- a/xarray/tests/test_parallelcompat.py
+++ b/xarray/tests/test_parallelcompat.py
@@ -175,6 +175,7 @@ class TestGetChunkManager:
             guess_chunkmanager("foo")
 
     @requires_dask
+    @pytest.mark.skip_with_dask_array
     def test_get_dask_if_installed(self) -> None:
         chunkmanager = guess_chunkmanager(None)
         assert isinstance(chunkmanager, DaskManager)
@@ -192,6 +193,7 @@ class TestGetChunkManager:
             guess_chunkmanager("dask")
 
     @requires_dask
+    @pytest.mark.skip_with_dask_array
     def test_choose_dask_over_other_chunkmanagers(
         self, register_dummy_chunkmanager
     ) -> None:
@@ -240,6 +242,7 @@ class TestGetChunkedArrayType:
             get_chunked_array_type(dummy_arr)
 
     @requires_dask
+    @pytest.mark.skip_with_dask_array
     def test_detect_dask_if_installed(self) -> None:
         import dask.array as da
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -31,6 +31,7 @@ from xarray.tests import (
     assert_array_equal,
     assert_equal,
     assert_no_warnings,
+    get_dask_chunkmanager,
     requires_cartopy,
     requires_cftime,
     requires_dask,
@@ -3438,9 +3439,7 @@ def test_dataarray_not_loading_inplace(plotfunc: str) -> None:
     with figure_context():
         getattr(ds.A.plot, plotfunc)(x="x")
 
-    from dask.array import Array
-
-    assert isinstance(ds.A.data, Array)
+    assert isinstance(ds.A.data, get_dask_chunkmanager().array_cls)
 
 
 @requires_matplotlib

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -31,7 +31,7 @@ from xarray.tests import (
     assert_array_equal,
     assert_equal,
     assert_no_warnings,
-    get_dask_chunkmanager,
+    dask_array_type,
     requires_cartopy,
     requires_cftime,
     requires_dask,
@@ -3439,7 +3439,7 @@ def test_dataarray_not_loading_inplace(plotfunc: str) -> None:
     with figure_context():
         getattr(ds.A.plot, plotfunc)(x="x")
 
-    assert isinstance(ds.A.data, get_dask_chunkmanager().array_cls)
+    assert isinstance(ds.A.data, dask_array_type)
 
 
 @requires_matplotlib

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -12,7 +12,7 @@ from xarray.tests import (
     assert_allclose,
     assert_equal,
     assert_identical,
-    get_dask_chunkmanager,
+    dask_array_api,
     has_dask,
     requires_dask,
     requires_dask_ge_2024_11_0,
@@ -617,7 +617,7 @@ class TestDatasetRolling:
 
     @requires_dask_ge_2024_11_0
     def test_rolling_construct_automatic_rechunk(self):
-        da = get_dask_chunkmanager().array_api
+        da = dask_array_api
 
         # Construct dataset with chunk size of (400, 400, 1) or 1.22 MiB
         array = DataArray(

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -12,6 +12,7 @@ from xarray.tests import (
     assert_allclose,
     assert_equal,
     assert_identical,
+    get_dask_chunkmanager,
     has_dask,
     requires_dask,
     requires_dask_ge_2024_11_0,
@@ -616,16 +617,16 @@ class TestDatasetRolling:
 
     @requires_dask_ge_2024_11_0
     def test_rolling_construct_automatic_rechunk(self):
-        import dask
+        da = get_dask_chunkmanager().array_api
 
         # Construct dataset with chunk size of (400, 400, 1) or 1.22 MiB
-        da = DataArray(
+        array = DataArray(
             dims=["latitude", "longitude", "time"],
-            data=dask.array.random.random((400, 400, 400), chunks=(-1, -1, 1)),
+            data=da.random.random((400, 400, 400), chunks=(-1, -1, 1)),
             name="foo",
         )
 
-        for obj in [da, da.to_dataset()]:
+        for obj in [array, array.to_dataset()]:
             # Dataset now has chunks of size (400, 400, 100 100) or 11.92 GiB
             rechunked = obj.rolling(time=100, center=True).construct(
                 "window",

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -13,7 +13,12 @@ import xarray as xr
 import xarray.ufuncs as xu
 from xarray import DataArray, Variable
 from xarray.namedarray.pycompat import array_type
-from xarray.tests import assert_equal, assert_identical, requires_dask
+from xarray.tests import (
+    assert_equal,
+    assert_identical,
+    get_dask_chunkmanager,
+    requires_dask,
+)
 
 filterwarnings = pytest.mark.filterwarnings
 param = pytest.param
@@ -722,17 +727,21 @@ class TestSparseDataArrayAndDataset:
         ds = xr.Dataset(
             data_vars={"a": ("x", sparse.COO.from_numpy(np.ones(4)))}
         ).chunk()
-        if Version(sparse.__version__) >= Version("0.16.0"):
-            meta = "sparse.numba_backend._coo.core.COO"
+        if get_dask_chunkmanager().array_cls.__module__.startswith("dask_array"):
+            array_repr = "dask.array<xarray-a, shape=(4,), dtype=float64, ..."
         else:
-            meta = "sparse.COO"
+            if Version(sparse.__version__) >= Version("0.16.0"):
+                meta = "sparse.numba_backend._coo.core.COO"
+            else:
+                meta = "sparse.COO"
+            array_repr = f"dask.array<chunksize=(4,), meta={meta}>"
         expected = dedent(
             f"""\
             <xarray.Dataset> Size: 32B
             Dimensions:  (x: 4)
             Dimensions without coordinates: x
             Data variables:
-                a        (x) float64 32B dask.array<chunksize=(4,), meta={meta}>"""
+                a        (x) float64 32B {array_repr}"""
         )
         assert expected == repr(ds)
 
@@ -880,6 +889,10 @@ def test_chunk():
     ac = a.chunk(2)
     assert ac.chunks == ((2, 2),)
     assert isinstance(ac.data._meta, sparse.COO)
+    if get_dask_chunkmanager().array_cls.__module__.startswith("dask_array"):
+        pytest.xfail(
+            "dask-array sparse COO equality with eager sparse arrays is not implemented"
+        )
     assert_identical(ac, a)
 
     ds = a.to_dataset(name="a")

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -16,7 +16,7 @@ from xarray.namedarray.pycompat import array_type
 from xarray.tests import (
     assert_equal,
     assert_identical,
-    get_dask_chunkmanager,
+    has_dask_array_expr,
     requires_dask,
 )
 
@@ -727,7 +727,7 @@ class TestSparseDataArrayAndDataset:
         ds = xr.Dataset(
             data_vars={"a": ("x", sparse.COO.from_numpy(np.ones(4)))}
         ).chunk()
-        if get_dask_chunkmanager().array_cls.__module__.startswith("dask_array"):
+        if has_dask_array_expr:
             array_repr = "dask.array<xarray-a, shape=(4,), dtype=float64, ..."
         else:
             if Version(sparse.__version__) >= Version("0.16.0"):
@@ -889,7 +889,7 @@ def test_chunk():
     ac = a.chunk(2)
     assert ac.chunks == ((2, 2),)
     assert isinstance(ac.data._meta, sparse.COO)
-    if get_dask_chunkmanager().array_cls.__module__.startswith("dask_array"):
+    if has_dask_array_expr:
         pytest.xfail(
             "dask-array sparse COO equality with eager sparse arrays is not implemented"
         )

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -30,7 +30,6 @@ from xarray.core.indexing import (
 from xarray.core.types import T_DuckArray
 from xarray.core.utils import NDArrayMixin
 from xarray.core.variable import as_compatible_data, as_variable
-from xarray.namedarray.pycompat import array_type
 from xarray.tests import (
     IndexableArray,
     assert_allclose,
@@ -38,6 +37,7 @@ from xarray.tests import (
     assert_equal,
     assert_identical,
     assert_no_warnings,
+    get_dask_chunkmanager,
     has_dask_ge_2024_11_0,
     has_pandas_3,
     raise_if_dask_computes,
@@ -49,8 +49,6 @@ from xarray.tests import (
     source_ndarray,
 )
 from xarray.tests.test_namedarray import NamedArraySubclassobjects
-
-dask_array_type = array_type("dask")
 
 _PAD_XR_NP_ARGS = [
     [{"x": (2, 1)}, ((2, 1), (0, 0), (0, 0))],
@@ -678,9 +676,7 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
         v = self.cls("x", data)
         print(v)  # should not error
         if v.dtype == np.dtype("O"):
-            import dask.array as da
-
-            assert isinstance(v.data, da.Array)
+            assert isinstance(v.data, get_dask_chunkmanager().array_cls)
         else:
             assert v.dtype == data.dtype
 
@@ -1926,7 +1922,7 @@ class TestVariable(VariableSubclassobjects):
     def test_quantile_dask(self, q, axis, dim):
         v = Variable(["x", "y"], self.d).chunk({"x": 2})
         actual = v.quantile(q, dim=dim)
-        assert isinstance(actual.data, dask_array_type)
+        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
         expected = np.nanpercentile(self.d, np.array(q) * 100, axis=axis)
         np.testing.assert_allclose(actual.values, expected)
 
@@ -1945,7 +1941,7 @@ class TestVariable(VariableSubclassobjects):
         expected = np.nanquantile(self.d, q, axis=1, method=method)
 
         if use_dask:
-            assert isinstance(actual.data, dask_array_type)
+            assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
 
         np.testing.assert_allclose(actual.values, expected)
 
@@ -2105,18 +2101,16 @@ class TestVariable(VariableSubclassobjects):
 
     @requires_dask
     def test_reduce_keepdims_dask(self):
-        import dask.array
-
         v = Variable(["x", "y"], self.d).chunk()
 
         actual = v.mean(keepdims=True)
-        assert isinstance(actual.data, dask.array.Array)
+        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
 
         expected = Variable(v.dims, np.mean(self.d, keepdims=True))
         assert_identical(actual, expected)
 
         actual = v.mean(dim="y", keepdims=True)
-        assert isinstance(actual.data, dask.array.Array)
+        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
 
         expected = Variable(v.dims, np.mean(self.d, axis=1, keepdims=True))
         assert_identical(actual, expected)
@@ -2437,10 +2431,8 @@ class TestVariableWithDask(VariableSubclassobjects):
         assert blocked.load().chunks is None
 
         # Check that kwargs are passed
-        import dask.array as da
-
         blocked = unblocked.chunk(name="testname_")
-        assert isinstance(blocked.data, da.Array)
+        assert isinstance(blocked.data, get_dask_chunkmanager().array_cls)
         assert "testname_" in blocked.data.name
 
         # test kwargs form of chunks
@@ -2473,9 +2465,7 @@ class TestVariableWithDask(VariableSubclassobjects):
         super().test_getitem_1d_fancy()
 
     def test_getitem_with_mask_nd_indexer(self):
-        import dask.array as da
-
-        v = Variable(["x"], da.arange(3, chunks=3))
+        v = Variable(["x"], np.arange(3)).chunk({"x": 3})
         indexer = Variable(("x", "y"), [[0, -1], [-1, 2]])
         assert_identical(
             v._getitem_with_mask(indexer, fill_value=-1),
@@ -2487,12 +2477,11 @@ class TestVariableWithDask(VariableSubclassobjects):
     @pytest.mark.parametrize("center", [True, False])
     def test_dask_rolling(self, dim, window, center):
         import dask
-        import dask.array as da
 
         dask.config.set(scheduler="single-threaded")
 
         x = Variable(("x", "y"), np.array(np.random.randn(100, 40), dtype=float))
-        dx = Variable(("x", "y"), da.from_array(x, chunks=[(6, 30, 30, 20, 14), 8]))
+        dx = x.chunk({"x": (6, 30, 30, 20, 14), "y": 8})
 
         expected = x.rolling_window(
             dim, window, "window", center=center, fill_value=np.nan
@@ -2501,9 +2490,19 @@ class TestVariableWithDask(VariableSubclassobjects):
             actual = dx.rolling_window(
                 dim, window, "window", center=center, fill_value=np.nan
             )
-        assert isinstance(actual.data, da.Array)
+        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
         assert actual.shape == expected.shape
         assert_equal(actual, expected)
+
+    def test_legacy_dask_array_rejected_by_dask_array_manager(self):
+        if get_dask_chunkmanager().array_cls.__module__.startswith("dask.array"):
+            pytest.skip("only meaningful with an alternate dask chunk manager")
+
+        import dask.array as da
+
+        x = Variable("x", da.arange(6, chunks=3))
+        with pytest.raises(TypeError, match="Could not find a Chunk Manager"):
+            x.rolling_window("x", 3, "window")
 
     @pytest.mark.xfail(reason="https://github.com/dask/dask/issues/11585")
     def test_multiindex(self):
@@ -3041,6 +3040,7 @@ class TestBackendIndexing:
     @requires_dask
     @pytest.mark.asyncio
     @pytest.mark.parametrize("load_async", [True, False])
+    @pytest.mark.skip_with_dask_array
     async def test_DaskIndexingAdapter(self, load_async):
         import dask.array as da
 
@@ -3140,6 +3140,7 @@ class TestNumpyCoercion:
 
     @requires_dask
     @requires_pint
+    @pytest.mark.skip_with_dask_array
     def test_from_pint_wrapping_dask(self, Var):
         import dask
         import pint

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -37,7 +37,8 @@ from xarray.tests import (
     assert_equal,
     assert_identical,
     assert_no_warnings,
-    get_dask_chunkmanager,
+    dask_array_type,
+    has_dask_array_expr,
     has_dask_ge_2024_11_0,
     has_pandas_3,
     raise_if_dask_computes,
@@ -676,7 +677,7 @@ class VariableSubclassobjects(NamedArraySubclassobjects, ABC):
         v = self.cls("x", data)
         print(v)  # should not error
         if v.dtype == np.dtype("O"):
-            assert isinstance(v.data, get_dask_chunkmanager().array_cls)
+            assert isinstance(v.data, dask_array_type)
         else:
             assert v.dtype == data.dtype
 
@@ -1922,7 +1923,7 @@ class TestVariable(VariableSubclassobjects):
     def test_quantile_dask(self, q, axis, dim):
         v = Variable(["x", "y"], self.d).chunk({"x": 2})
         actual = v.quantile(q, dim=dim)
-        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(actual.data, dask_array_type)
         expected = np.nanpercentile(self.d, np.array(q) * 100, axis=axis)
         np.testing.assert_allclose(actual.values, expected)
 
@@ -1941,7 +1942,7 @@ class TestVariable(VariableSubclassobjects):
         expected = np.nanquantile(self.d, q, axis=1, method=method)
 
         if use_dask:
-            assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+            assert isinstance(actual.data, dask_array_type)
 
         np.testing.assert_allclose(actual.values, expected)
 
@@ -2104,13 +2105,13 @@ class TestVariable(VariableSubclassobjects):
         v = Variable(["x", "y"], self.d).chunk()
 
         actual = v.mean(keepdims=True)
-        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(actual.data, dask_array_type)
 
         expected = Variable(v.dims, np.mean(self.d, keepdims=True))
         assert_identical(actual, expected)
 
         actual = v.mean(dim="y", keepdims=True)
-        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(actual.data, dask_array_type)
 
         expected = Variable(v.dims, np.mean(self.d, axis=1, keepdims=True))
         assert_identical(actual, expected)
@@ -2432,7 +2433,7 @@ class TestVariableWithDask(VariableSubclassobjects):
 
         # Check that kwargs are passed
         blocked = unblocked.chunk(name="testname_")
-        assert isinstance(blocked.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(blocked.data, dask_array_type)
         assert "testname_" in blocked.data.name
 
         # test kwargs form of chunks
@@ -2490,12 +2491,12 @@ class TestVariableWithDask(VariableSubclassobjects):
             actual = dx.rolling_window(
                 dim, window, "window", center=center, fill_value=np.nan
             )
-        assert isinstance(actual.data, get_dask_chunkmanager().array_cls)
+        assert isinstance(actual.data, dask_array_type)
         assert actual.shape == expected.shape
         assert_equal(actual, expected)
 
     def test_legacy_dask_array_rejected_by_dask_array_manager(self):
-        if get_dask_chunkmanager().array_cls.__module__.startswith("dask.array"):
+        if not has_dask_array_expr:
             pytest.skip("only meaningful with an alternate dask chunk manager")
 
         import dask.array as da


### PR DESCRIPTION
This adds a `--use-dask-array` pytest mode that registers the dask-array chunk manager and runs the existing suite through that backend.  Most of the work here is making tests a bit more dask.array/dask-array agnostic.  I also brought back the xarray map_blocks implementation.

I haven't reviewed this thoroughly yet, and it's not complete (there are still sections of tests that would fail if they weren't marked to xfail under dask-array (flox and masked arrays are good examples), but I wanted to push up something before pushing much further forward on this so that this could get some early feedback.

cc @shoyer @dcherian 

### AI Disclosure

- [x] This PR contains AI-generated content.
- [x] I have tested any AI-generated content in my PR.
- [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude, Codex
