### PR TITLE
Fix RangeIndex.linspace with num=1

### DIFF
--- a/xarray/indexes/range_index.py
+++ b/xarray/indexes/range_index.py
@@ -347,7 +347,7 @@ class RangeIndex(CoordinateTransformIndex):
         if coord_name is None:
             coord_name = dim
 
-        if endpoint:
+        if endpoint and num > 1:
             stop += (stop - start) / (num - 1)
 
         transform = RangeCoordinateTransform(

--- a/xarray/tests/test_range_index.py
+++ b/xarray/tests/test_range_index.py
@@ -95,6 +95,14 @@ def test_range_index_linspace() -> None:
     assert index.step == 0.1
 
 
+@pytest.mark.parametrize("endpoint", [False, True])
+def test_range_index_linspace_num_1(endpoint: bool) -> None:
+    index = RangeIndex.linspace(0.0, 1.0, num=1, endpoint=endpoint, dim="x")
+    actual = xr.Coordinates.from_xindex(index)
+    expected = xr.Coordinates({"x": np.linspace(0.0, 1.0, num=1, endpoint=endpoint)})
+    assert_equal(actual, expected, check_default_indexes=False)
+
+
 def test_range_index_dtype() -> None:
     index = RangeIndex.arange(0.0, 1.0, 0.1, dim="x", dtype=np.float32)
     coords = xr.Coordinates.from_xindex(index)

--- a/xarray/tests/test_range_index.py
+++ b/xarray/tests/test_range_index.py
@@ -94,12 +94,9 @@ def test_range_index_linspace() -> None:
     assert index.stop == 1.1
     assert index.step == 0.1
 
-
-@pytest.mark.parametrize("endpoint", [False, True])
-def test_range_index_linspace_num_1(endpoint: bool) -> None:
-    index = RangeIndex.linspace(0.0, 1.0, num=1, endpoint=endpoint, dim="x")
+    index = RangeIndex.linspace(0.0, 1.0, num=1, dim="x")
     actual = xr.Coordinates.from_xindex(index)
-    expected = xr.Coordinates({"x": np.linspace(0.0, 1.0, num=1, endpoint=endpoint)})
+    expected = xr.Coordinates({"x": np.linspace(0.0, 1.0, num=1)})
     assert_equal(actual, expected, check_default_indexes=False)
 
 


### PR DESCRIPTION
### Description

`RangeIndex.linspace` handles `num=1` like `numpy.linspace`

### Checklist

- [x] Closes #11397
- [x] Tests added
- No user visible changes
- No new functions/methods

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

<details>

<summary>Codex Prompts</summary>

```bash
codex --yolo --model gpt-5.5 --config model_reasoning_effort=medium
```

````markdown
I've cloned https://github.com/pydata/xarray/ here. Fix https://github.com/pydata/xarray/issues/11397 - i.e.
MINIMALLY and ELEGANTLY modify `xarray/indexes/range_index.py` as a small maintainer-friendly change so that

- it doesn't increase the number of code lines and
- works when num = 1, matching the NumPy behaviour, i.e. `np.linspace(0, 1, num=1)` returns `array([0.])`

I believe adding `and num > 1` to the `if` condition in `xarray/indexes/range_index.py` would fix this.

```python
if endpoint and num > 1:
    stop += (stop - start) / (num - 1)
```

Begin by writing a regression test like the below (but write it consistent with the xarray test style) to verify that the bug is fixed:

```python
def test_range_index_linspace_num_1():
    index = RangeIndex.linspace(0.0, 1.0, num=1, dim="x")
    assert_array_equal(index.transform.generate_coords()["x"], np.array([0.0]))

def test_range_index_linspace_num_1_endpoint_false():
    index = RangeIndex.linspace(0.0, 1.0, num=1, endpoint=False, dim="x")
    assert_array_equal(index.transform.generate_coords()["x"], np.array([0.0]))
```

Run and test, make sure the tests fail (before the fix) only because of the bug and pass after the fix.

---

Is it possible to fold the test into an existing test function so that the test code becomes more elegant and maintainable? If so, do that.

---

Is further simplification possible AND desirable?
````

</details>