### PR TITLE
Fix: handle num=1 in RangeIndex.linspace to match numpy behavior

### DIFF
--- a/xarray/indexes/range_index.py
+++ b/xarray/indexes/range_index.py
@@ -347,7 +347,9 @@ class RangeIndex(CoordinateTransformIndex):
         if coord_name is None:
             coord_name = dim
 
-        if endpoint:
+        if num == 1:
+            stop = start
+        elif endpoint:
             stop += (stop - start) / (num - 1)
 
         transform = RangeCoordinateTransform(


### PR DESCRIPTION
## Description

`RangeIndex.linspace` raises `ZeroDivisionError` when called with `num=1` because it divides by `(num - 1)` when `endpoint=True`. `numpy.linspace` handles this case by returning a single-element array at the `start` value.

This fix adds an early return when `num == 1`, setting `stop = start` to produce a single-element RangeIndex, matching numpy's behavior.

## Changes

- `xarray/indexes/range_index.py`: Added `num == 1` guard in `linspace` method

## Testing

```python
>>> RangeIndex.linspace(0, 1, num=1, dim="x")
# Before: ZeroDivisionError
# After: RangeIndex with start=0, stop=0, size=1
```

Fixes #11397

---

Payment: PayPal n6085530@gmail.com