### PR TITLE
Fix DataArray coordinate mismatch after shape-changing array wrap

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4882,7 +4882,7 @@ class DataArray(
 
     def __array_wrap__(self, obj, context=None, return_scalar=False) -> Self:
         new_var = self.variable.__array_wrap__(obj, context, return_scalar)
-        return self._replace(new_var)
+        return self._replace_maybe_drop_dims(new_var)
 
     def __matmul__(self, obj: T_Xarray) -> T_Xarray:
         return self.dot(obj)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2432,6 +2432,19 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
         return self._new(data=self.data.real)
 
     def __array_wrap__(self, obj, context=None, return_scalar=False):
+        if obj.shape != self.shape:
+            # Shape changed during the numpy operation.
+            # Check if only the last two dims are transposed (e.g. np.linalg.pinv).
+            if (
+                obj.ndim == self.ndim
+                and obj.ndim >= 2
+                and obj.shape[:-2] == self.shape[:-2]
+                and obj.shape[-2:] == self.shape[-2:][::-1]
+            ):
+                new_dims = self.dims[:-2] + (self.dims[-1], self.dims[-2])
+                return Variable(new_dims, obj)
+            # Fallback: use generic dim names since we can't reliably map dims.
+            return Variable(tuple(f"dim_{i}" for i in range(obj.ndim)), obj)
         return Variable(self.dims, obj)
 
     def _unary_op(self, f, *args, **kwargs):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2478,6 +2478,34 @@ class TestDataArray:
         bar = Variable(["x", "y"], np.zeros((10, 20)))
         assert_equal(self.dv, np.maximum(self.dv, bar))
 
+    def test_array_wrap_drops_mismatched_coords(self) -> None:
+        array = DataArray(
+            np.arange(12).reshape(3, 4),
+            dims=("foo", "bar"),
+            coords={
+                "foo": ["x", "y", "z"],
+                "bar": ["a", "b", "c", "d"],
+                "aux": (("foo", "bar"), np.ones((3, 4))),
+                "scalar": 1,
+            },
+        )
+
+        actual = np.linalg.pinv(array)
+        # pinv transposes the last two dims, so dims are swapped from
+        # (foo: 3, bar: 4) to (bar: 4, foo: 3). All coords whose dims
+        # still exist in the result are preserved.
+        expected = DataArray(
+            np.linalg.pinv(array.data),
+            dims=("bar", "foo"),
+            coords={
+                "foo": ["x", "y", "z"],
+                "bar": ["a", "b", "c", "d"],
+                "aux": (("foo", "bar"), np.ones((3, 4))),
+                "scalar": 1,
+            },
+        )
+        assert_identical(expected, actual)
+
     def test_astype_attrs(self) -> None:
         # Split into two loops for mypy - Variable, DataArray, and Dataset
         # don't share a common base class, so mypy infers type object for v,


### PR DESCRIPTION
## Summary
- Route `DataArray.__array_wrap__` through `_replace_maybe_drop_dims` to properly handle coordinates when shape changes
- In `Variable.__array_wrap__`, detect when the last two dims are transposed (e.g. `np.linalg.pinv`) and swap dim names accordingly
- Fall back to generic dim names for other shape changes where dims can't be reliably mapped
- Add a regression test for `np.linalg.pinv` on a rectangular DataArray

Fixes #11396

## How it works

When `np.linalg.pinv` is called on a DataArray of shape `(3, 4)` with dims `(foo, bar)`:
1. `Variable.__array_wrap__` detects the shape changed from `(3, 4)` to `(4, 3)` — the last two dims are transposed
2. It returns a new Variable with swapped dims: `(bar, foo)` 
3. `DataArray.__array_wrap__` calls `_replace_maybe_drop_dims`, which sees that sizes match after the dim swap and preserves all coordinates

This approach correctly maps dimensions rather than just dropping mismatched coordinates, so coords like `foo: ['x', 'y', 'z']` stay on the `foo` dimension (which is still size 3).

## Tests
```
python3 -m pytest -o addopts='' xarray/tests/test_dataarray.py::TestDataArray::test_array_wrap_drops_mismatched_coords
python3 -m pytest -o addopts='' xarray/tests/test_dataarray.py::TestDataArray::test_array_interface xarray/tests/test_dataarray.py::TestDataArray::test_reduce_keepdims xarray/tests/test_dataarray.py::TestDataArray::test_math_with_coords
python3 -m pytest -o addopts='' xarray/tests/test_computation.py::test_apply_dask_new_output_sizes_not_supplied_same_dim_names
python3 -m pytest -o addopts='' xarray/tests/test_variable.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)