### PR TITLE
fix: defer pd.to_datetime() in test parametrize to avoid nightly segfault

### DIFF
--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -538,20 +538,21 @@ def test_infer_datetime_units(freq, units) -> None:
 
 
 @pytest.mark.parametrize(
-    ["dates", "expected"],
+    ["date_strings", "expected"],
     [
         (
-            pd.to_datetime(["1900-01-01", "1900-01-02", "NaT"], unit="ns"),
+            ["1900-01-01", "1900-01-02", "NaT"],
             "days since 1900-01-01 00:00:00",
         ),
         (
-            pd.to_datetime(["NaT", "1900-01-01"], unit="ns"),
+            ["NaT", "1900-01-01"],
             "days since 1900-01-01 00:00:00",
         ),
-        (pd.to_datetime(["NaT"], unit="ns"), "days since 1970-01-01 00:00:00"),
+        (["NaT"], "days since 1970-01-01 00:00:00"),
     ],
 )
-def test_infer_datetime_units_with_NaT(dates, expected) -> None:
+def test_infer_datetime_units_with_NaT(date_strings, expected) -> None:
+    dates = pd.to_datetime(date_strings, unit="ns")
     assert expected == infer_datetime_units(dates)
 
 


### PR DESCRIPTION
Fixes #11402

## Problem
Nightly upstream-dev CI is failing with a segfault in pandas when `pd.to_datetime()` is called at module level (inside `@pytest.mark.parametrize` decorator arguments). The segfault occurs during test collection, crashing all xdist workers.

The root cause is `pd.to_datetime()` being called with `unit="ns"` at import time in `test_coding_times.py`, which triggers a pandas bug in the nightly build.

## Fix
Move the `pd.to_datetime()` calls from the module-level `@pytest.mark.parametrize` into the test function body. Instead of passing pre-constructed datetime arrays as parameters, pass raw string lists and construct the datetime objects inside the test.

This is a minimal, surgical fix that:
- Avoids the pandas segfault by deferring datetime construction to test runtime
- Preserves the exact same test logic and assertions
- All 307 tests pass, 854 skipped, 1 xfailed
