### PR TITLE
Fix MultiIndex sel with tuple-valued levels (GH#11341)

### DIFF
--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -610,7 +610,7 @@ def _asarray_tuplesafe(values):
 
 def _is_nested_tuple(possible_tuple):
     return isinstance(possible_tuple, tuple) and any(
-        isinstance(value, tuple | list | slice) for value in possible_tuple
+        isinstance(value, list | slice) for value in possible_tuple
     )
 
 

--- a/xarray/tests/test_indexes.py
+++ b/xarray/tests/test_indexes.py
@@ -509,6 +509,28 @@ class TestPandasMultiIndex:
         with pytest.raises(IndexError):
             index.sel({"x": (slice(None), 1, "no_level")})
 
+    def test_sel_nested_tuple_key(self) -> None:
+        """Test that tuple-valued MultiIndex levels can be selected with a single key.
+
+        Regression test for GH#11341: when a MultiIndex level contains tuples,
+        selecting with a nested tuple key ((1, 1), 2) should collapse the dimension
+        just like selecting with a non-nested tuple key (1, 2).
+        """
+        # Create a MultiIndex where the first level contains tuples
+        nested_level_0 = pd.Index(
+            [(1, 1), (1, 1), (2, 2), (3, 3)], name="a", tupleize_cols=False
+        )
+        nested_level_1 = pd.Index([1, 2, 10, 20], name="b")
+        nested_mi = pd.MultiIndex.from_arrays([nested_level_0, nested_level_1])
+
+        index = PandasMultiIndex(nested_mi, "index")
+
+        # Select with a nested tuple key - should return scalar indexer
+        actual = index.sel({"index": ((1, 1), 2)})
+        # pandas.get_loc returns an integer for exact match
+        expected_dim_indexers = {"index": 1}
+        assert actual.dim_indexers == expected_dim_indexers
+
     def test_join(self):
         midx = pd.MultiIndex.from_product([["a", "aa"], [1, 2]], names=("one", "two"))
         level_coords_dtype = {"one": "=U2", "two": "i"}


### PR DESCRIPTION
## Problem

When a MultiIndex level contains tuple-valued entries (e.g., `(1,1)`), selecting with a nested tuple key like `((1,1), 2)` incorrectly preserves the dimension instead of collapsing it to a scalar result.

### Example from Issue #11341

```python
import xarray as xr
import numpy as np
import pandas as pd

# Create MultiIndex where first level contains tuples
nested_level_0 = pd.Index([(1, 1), (1, 1), (2, 2), (3, 3)], name="a")
nested_level_1 = pd.Index([1, 2, 10, 20], name="b")
nested_mi = pd.MultiIndex.from_arrays([nested_level_0, nested_level_1])

nested = xr.DataArray(
    np.arange(4),
    dims=("index",),
    coords={"index": nested_mi},
)

# This should collapse the dimension (shape=()) but returns shape=(1,)
result = nested.sel(index=((1, 1), 2))
```

## Root Cause

The `_is_nested_tuple()` function was checking for `tuple` in addition to `list` and `slice`:

```python
def _is_nested_tuple(possible_tuple):
    return isinstance(possible_tuple, tuple) and any(
        isinstance(value, tuple | list | slice) for value in possible_tuple
    )
```

This caused tuple-valued keys like `((1,1), 2)` to be incorrectly identified as nested selection tuples (containing multiple selection values), when they are actually single keys with a tuple-valued first level.

## Fix

Remove `tuple` from the isinstance check so only `list` and `slice` are treated as indicators of nested selections:

```python
def _is_nested_tuple(possible_tuple):
    return isinstance(possible_tuple, tuple) and any(
        isinstance(value, list | slice) for value in possible_tuple
    )
```

This correctly distinguishes:
- `(1, 2)` → single key (scalar values) → use `get_loc()`
- `((1,1), 2)` → single key (tuple value in first level) → use `get_loc()`
- `([1,2], 3)` → nested selection (list) → use `get_locs()`
- `(slice(1,2), 3)` → nested selection (slice) → use `get_locs()`

## Tests

Added regression test `test_sel_nested_tuple_key` that verifies:
1. MultiIndex with tuple-valued levels can be selected with nested tuple keys
2. The dimension is correctly collapsed (scalar result, not length-1)

Closes #11341