### PR TITLE
Fix cumulative argmax/argmin returning window-local indices (GH#11336)

### DIFF
--- a/xarray/computation/rolling.py
+++ b/xarray/computation/rolling.py
@@ -177,7 +177,7 @@ class Rolling(Generic[T_Xarray]):
         def method(self, keep_attrs=None, **kwargs):
             keep_attrs = self._get_keep_attrs(keep_attrs)
 
-            return self._array_reduce(
+            result = self._array_reduce(
                 array_agg_func=array_agg_func,
                 bottleneck_move_func=bottleneck_move_func,
                 numbagg_move_func=numbagg_move_func,
@@ -187,6 +187,11 @@ class Rolling(Generic[T_Xarray]):
                 sliding_window_view_kwargs=dict(automatic_rechunk=automatic_rechunk),
                 **kwargs,
             )
+
+            if name in ("argmax", "argmin"):
+                result = self._adjust_argminmax_result(result)
+
+            return result
 
         method.__name__ = name
         method.__doc__ = _ROLLING_REDUCE_DOCSTRING_TEMPLATE.format(name=name)
@@ -579,6 +584,33 @@ class DataArrayRolling(Rolling["DataArray"]):
         # Find valid windows based on count.
         counts = self._counts(keep_attrs=False)
         return result.where(counts >= self.min_periods)
+
+    def _is_cumulative(self) -> bool:
+        for i, d in enumerate(self.dim):
+            if self.center[i]:
+                return False
+            if self.window[i] != self.obj.sizes[d]:
+                return False
+        return True
+
+    def _adjust_argminmax_result(self, result: DataArray) -> DataArray:
+        if not self._is_cumulative():
+            return result
+
+        for i, d in enumerate(self.dim):
+            window_size = self.window[i]
+            if window_size <= 1:
+                continue
+
+            n = result.sizes[d]
+            position = np.arange(n)
+            # GH#11336: cumulative windows have NaN padding on the left,
+            # so window-local indices need adjustment to become absolute:
+            # absolute = local - (window_size - 1 - position)
+            offset = window_size - 1 - position
+            result = result - offset
+
+        return result
 
     def _counts(self, keep_attrs: bool | None) -> DataArray:
         """Number of non-nan entries in each rolling window."""

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -49,6 +49,31 @@ def test_cumulative_vs_cum(d) -> None:
     assert_identical(result, expected)
 
 
+@pytest.mark.parametrize("func", ["argmax", "argmin"])
+def test_cumulative_argminmax(func) -> None:
+    # Regression test for GH#11336: cumulative argmax/argmin should return
+    # absolute indices, not window-local indices
+    da = DataArray([3, 1, 4, 2, 5], dims=["time"])
+    result = getattr(da.cumulative("time"), func)()
+
+    if func == "argmax":
+        expected = DataArray([0, 0, 2, 2, 4], dims=["time"])
+    else:
+        expected = DataArray([0, 1, 1, 1, 1], dims=["time"])
+
+    assert_identical(result, expected)
+
+
+def test_cumulative_argmax_2d() -> None:
+    da = DataArray(
+        [[1, 3, 2], [4, 1, 5]],
+        dims=("x", "time"),
+    )
+    result = da.cumulative("time").argmax()
+    expected = DataArray([[0, 1, 1], [0, 0, 2]], dims=("x", "time"))
+    assert_identical(result, expected)
+
+
 class TestDataArrayRolling:
     @pytest.mark.parametrize("da", (1, 2), indirect=True)
     @pytest.mark.parametrize("center", [True, False])


### PR DESCRIPTION
## Problem

When calling argmax() or argmin() on a cumulative rolling window, the result returns window-local indices (positions within the NaN-padded window) instead of absolute indices in the original array.

For example, with data [1, 2, 1.5, 3.5, 4]:
- cumulative('time').argmax() returns [4, 4, 3, 4, 4]
- Expected: [0, 1, 1, 3, 4]

## Root Cause

Cumulative rolling constructs a window with NaN padding on the left. argmax/argmin returns the position within this padded window, not the absolute index in the original array.

For example, at position 2:
- Window: [nan, nan, 1.0, 2.0, 1.5]
- argmax returns 3 (position of 2.0 in the window)
- But the absolute index should be 1 (position of 2.0 in the original array)

## Fix

The fix detects cumulative rolling (window size == dimension size, not centered) and adjusts the returned indices by subtracting the NaN padding offset:

absolute = local - (window_size - 1 - position)

## Regression Tests

- test_cumulative_argminmax: Tests both argmax and argmin with 1D data
- test_cumulative_argmax_2d: Tests argmax with 2D data

Closes #11336
