### PR TITLE
Fix incorrect default value for constant_values in DataArray.pad docs

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -5912,7 +5912,7 @@ class DataArray(
             (stat_length,) or int is a shortcut for before = after = statistic
             length for all axes.
             Default is ``None``, to use the entire axis.
-        constant_values : scalar, tuple or mapping of Hashable to tuple, default: 0
+        constant_values : scalar, tuple or mapping of Hashable to tuple, default: None
             Used in 'constant'.  The values to set the padded values for each
             axis.
             ``{dim_1: (before_1, after_1), ... dim_N: (before_N, after_N)}`` unique
@@ -5921,7 +5921,7 @@ class DataArray(
             dimension.
             ``(constant,)`` or ``constant`` is a shortcut for ``before = after = constant`` for
             all dimensions.
-            Default is 0.
+            Default is ``None``, pads with ``np.nan``.
         end_values : scalar, tuple or mapping of Hashable to tuple, default: 0
             Used in 'linear_ramp'.  The values used for the ending value of the
             linear_ramp and that will form the edge of the padded array.


### PR DESCRIPTION
## Summary

Fixes #11373

The docstring for `DataArray.pad` incorrectly stated that `constant_values` defaults to `0`. The actual parameter default is `None`, which results in NaN padding (not zero). This can be verified in `Variable.pad` where `constant_values is None` triggers `dtypes.maybe_promote()` to fill with NaN.

## Changes

Updated the `constant_values` parameter documentation in `DataArray.pad`:
- `default: 0` → `default: None`
- `Default is 0.` → `Default is ``None``, pads with ``np.nan``.`

This now matches the `Dataset.pad` docstring which already correctly documents this behavior.