### PR TITLE
Fix: collapse dimension for single nested tuple MultiIndex key

### DIFF
--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
 
 import numpy as np
 import pandas as pd
+from pandas.errors import InvalidIndexError
 
 from xarray.core import formatting, nputils, utils
 from xarray.core.coordinate_transform import CoordinateTransform
@@ -1367,7 +1368,14 @@ class PandasMultiIndex(PandasIndex):
 
             elif isinstance(label, tuple):
                 if _is_nested_tuple(label):
-                    indexer = self.index.get_locs(label)
+                    # When the tuple contains sub-tuples/lists/slices, it could be:
+                    # 1. A single key with tuple-valued levels (e.g., ((1, 1), 2))
+                    # 2. A multi-value selection (e.g., (1, slice(1, 2)))
+                    # Try get_loc first for case 1, fall back to get_locs for case 2
+                    try:
+                        indexer = self.index.get_loc(label)
+                    except (InvalidIndexError, KeyError):
+                        indexer = self.index.get_locs(label)
                 elif len(label) == self.index.nlevels:
                     indexer = self.index.get_loc(label)
                 else:

--- a/xarray/tests/test_indexes.py
+++ b/xarray/tests/test_indexes.py
@@ -559,6 +559,22 @@ class TestPandasMultiIndex:
         assert actual.dim == expected.dim
         assert actual.level_coords_dtype == expected.level_coords_dtype
 
+    def test_sel_nested_tuple_key_collapses_dimension(self) -> None:
+        # Regression test for GH#11341
+        # When indexing with a single nested tuple key (where one level has
+        # tuple-valued entries), the dimension should collapse like scalar selection
+        nested_level_0 = pd.Index(
+            [(1, 1), (1, 1), (2, 2), (3, 3)], name="a", tupleize_cols=False
+        )
+        nested_level_1 = pd.Index([1, 2, 10, 20], name="b")
+        nested_mi = pd.MultiIndex.from_arrays([nested_level_0, nested_level_1])
+        index = PandasMultiIndex(nested_mi, "index")
+
+        # A single nested tuple key should produce a scalar indexer (int),
+        # not an array, collapsing the dimension
+        actual = index.sel({"index": ((1, 1), 2)})
+        assert isinstance(actual.dim_indexers["index"], (int, np.integer))
+
 
 class TestIndexes:
     @pytest.fixture


### PR DESCRIPTION
## Problem

When indexing a DataArray with a single nested tuple MultiIndex key (where one level has tuple-valued entries), the result is located correctly but the MultiIndex dimension is incorrectly preserved in the output.

```python
nested_level_0 = pd.Index([(1, 1), (1, 1), (2, 2), (3, 3)], name="a", tupleize_cols=False)
nested_level_1 = pd.Index([1, 2, 10, 20], name="b")
nested_mi = pd.MultiIndex.from_arrays([nested_level_0, nested_level_1])

nested = xr.DataArray(np.arange(4), dims=("index",), ...)
result = nested.sel(index=((1, 1), 2))

# Before: result.dims == ('index',), result.shape == (1,)  # WRONG
# After:  result.dims == (), result.shape == ()             # CORRECT
```

## Root Cause

In `PandasMultiIndex.sel()`, the `_is_nested_tuple()` helper detected that `((1, 1), 2)` contains a sub-tuple `(1, 1)` and routed it to `get_locs()`, which returns an array. But this tuple is actually a **single key** for the MultiIndex (level `a` = `(1, 1)`, level `b` = `2`), and `get_loc()` correctly returns a scalar integer for it.

## Fix

Try `get_loc()` first when a nested tuple is detected. If it succeeds (returns a scalar), use that result. If it raises `InvalidIndexError` or `KeyError` (e.g., for slice-in-tuple multi-value selections like `(1, slice(1, 2))`), fall back to `get_locs()`.

## Tests

Added a regression test `test_sel_nested_tuple_key_collapses_dimension` that verifies the dimension collapses for single nested tuple keys.

Closes #11341