### PR TITLE
Add dask expr protocol for variables

### DIFF
--- a/xarray/namedarray/core.py
+++ b/xarray/namedarray/core.py
@@ -601,6 +601,17 @@ class NamedArray(NamedArrayAggregations, Generic[_ShapeType_co, _DType_co]):
             # raise NotImplementedError("Method requires self.data to be a dask array")
             return None
 
+    def __dask_exprs__(self) -> Sequence[Any] | None:
+        try:
+            from dask._expr import Expr
+        except ImportError:
+            return None
+
+        expr = getattr(self._data, "expr", None)
+        if isinstance(expr, Expr):
+            return [expr]
+        return None
+
     def __dask_keys__(self) -> NestedKeys:
         if is_duck_dask_array(self._data):
             return self._data.__dask_keys__()

--- a/xarray/tests/test_dask_expr_protocol.py
+++ b/xarray/tests/test_dask_expr_protocol.py
@@ -36,6 +36,20 @@ def test_dataset_composite_expr_protocol_simple():
     )
 
 
+def test_variable_expr_protocol_avoids_graph_materialization(monkeypatch):
+    x = dask_array.arange(6, chunks=(3,))
+    var = xr.Variable(("i",), x + 1)
+
+    def raise_if_materialized(self):
+        raise AssertionError("__dask_graph__ should not be materialized")
+
+    monkeypatch.setattr(dask_array.Array, "__dask_graph__", raise_if_materialized)
+
+    assert dask.is_dask_collection(var)
+    assert len(var.__dask_exprs__()) == 1
+    assert isinstance(dask.base.collections_to_expr(Dataset({"x": var})), CompositeExpr)
+
+
 def test_dataarray_composite_expr_protocol_includes_chunked_coord():
     x = dask_array.arange(6, chunks=(3,))
     arr = DataArray(x + 1, dims=("i",), coords={"coord": ("i", x + 10)}, name="z")

--- a/xarray/tests/test_dask_expr_protocol.py
+++ b/xarray/tests/test_dask_expr_protocol.py
@@ -46,7 +46,9 @@ def test_variable_expr_protocol_avoids_graph_materialization(monkeypatch):
     monkeypatch.setattr(dask_array.Array, "__dask_graph__", raise_if_materialized)
 
     assert dask.is_dask_collection(var)
-    assert len(var.__dask_exprs__()) == 1
+    exprs = var.__dask_exprs__()
+    assert exprs is not None
+    assert len(exprs) == 1
     assert isinstance(dask.base.collections_to_expr(Dataset({"x": var})), CompositeExpr)
 
 


### PR DESCRIPTION
Expose wrapped Dask expressions from NamedArray so Dask can identify xarray Variables without materializing their graphs. Add a regression that raises if the wrapped dask-array graph is touched.

### AI Disclosure

- [x] This PR contains AI-generated content.
- [x] I have tested any AI-generated content in my PR.
- [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex
