### PR TITLE
fix: handle num=1 in RangeIndex.linspace to match numpy behavior

### DIFF
--- a/xarray/indexes/range_index.py
+++ b/xarray/indexes/range_index.py
@@ -339,7 +339,7 @@ class RangeIndex(CoordinateTransformIndex):
         if coord_name is None:
             coord_name = dim
 
-        if endpoint:
+        if endpoint and num > 1:
             stop += (stop - start) / (num - 1)
 
         transform = RangeCoordinateTransform(

--- a/xarray/tests/test_range_index.py
+++ b/xarray/tests/test_range_index.py
@@ -81,6 +81,20 @@ def test_range_index_linspace() -> None:
     assert index.stop == 1.1
     assert index.step == 0.1
 
+    # https://github.com/pydata/xarray/issues/11397
+    # num=1 should match numpy behavior (single point at start value)
+    index = RangeIndex.linspace(0.0, 1.0, num=1, endpoint=True, dim="x")
+    actual = xr.Coordinates.from_xindex(index)
+    expected = xr.Coordinates({"x": np.linspace(0.0, 1.0, num=1, endpoint=True)})
+    assert_allclose(actual, expected, check_default_indexes=False)
+    assert index.start == 0.0
+
+    index = RangeIndex.linspace(0.0, 1.0, num=1, endpoint=False, dim="x")
+    actual = xr.Coordinates.from_xindex(index)
+    expected = xr.Coordinates({"x": np.linspace(0.0, 1.0, num=1, endpoint=False)})
+    assert_allclose(actual, expected, check_default_indexes=False)
+    assert index.start == 0.0
+
 
 def test_range_index_dtype() -> None:
     index = RangeIndex.arange(0.0, 1.0, 0.1, dim="x", dtype=np.float32)


### PR DESCRIPTION
Closes #11397

```python
>>> from xarray.indexes import RangeIndex
>>> RangeIndex.linspace(0.0, 1.0, num=1, dim="x")
```

Previously raised `ZeroDivisionError: division by zero` because the
endpoint adjustment divided by `(num - 1)`. When `num=1`, there is only
one point in the interval so no adjustment is needed.

This fix copies numpy's behavior: `linspace(0, 1, num=1)` returns
`[0.]` regardless of `endpoint=True/False`.

Co-authored-by: Claude <noreply@anthropic.com>