### PR TITLE
Fix incorrect parameter name in cumulative() docstrings

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -7296,7 +7296,7 @@ class DataArray(
 
         Parameters
         ----------
-        dims : iterable of hashable
+        dim : iterable of hashable
             The name(s) of the dimensions to create the cumulative window along
         min_periods : int, default: 1
             Minimum number of observations in window required to have a value

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -10459,7 +10459,7 @@ class Dataset(
 
         Parameters
         ----------
-        dims : iterable of hashable
+        dim : iterable of hashable
             The name(s) of the dimensions to create the cumulative window along
         min_periods : int, default: 1
             Minimum number of observations in window required to have a value


### PR DESCRIPTION
### Description

The docstrings for `DataArray.cumulative` and `Dataset.cumulative` document the parameter as `dims`, but the actual signature parameter is `dim`. As a result, calling `obj.cumulative(dims=...)` raises a `TypeError` even though the docs show
`dims`. This corrects `dims` → `dim` in both Parameters sections to match the signature. Documentation-only change; no behavior change.

### Checklist

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes documented in `whats-new.rst`
- [ ] New functions/methods listed in `api.rst`

(Docstring-only correction — no tests, whats-new, or api.rst entry needed.)

### AI Disclosure

- [x] This PR contains AI-generated content.
- [x] I have tested any AI-generated content in my PR.
- [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude (Claude Code) was used to help identify the docstring/signature mismatch. I reviewed the change against the `cumulative` signatures in both `dataarray.py` and `dataset.py`, confirmed `dim` is the correct parameter name, and take full responsibility for the change.