### PR TITLE
MAINT: remove pandas 2.2 compat (incl. infer_freq)

### DIFF
--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -51,7 +51,6 @@ from typing import TYPE_CHECKING, ClassVar, Literal, TypeVar, get_args
 
 import numpy as np
 import pandas as pd
-from packaging.version import Version
 
 from xarray.coding.cftimeindex import CFTimeIndex
 from xarray.coding.times import (
@@ -782,7 +781,7 @@ def to_offset(
     if isinstance(freq, timedelta | pd.Timedelta):
         return delta_to_tick(freq)
     if isinstance(freq, pd.DateOffset):
-        freq = _legacy_to_new_freq(freq.freqstr)
+        freq = freq.freqstr
 
     match = re.match(_PATTERN, freq)
     if match is None:
@@ -1430,8 +1429,7 @@ def date_range(
                 start=start,
                 end=end,
                 periods=periods,
-                # TODO remove translation once requiring pandas >= 2.2
-                freq=_new_to_legacy_freq(freq),
+                freq=freq,
                 tz=tz,
                 normalize=normalize,
                 name=name,
@@ -1458,96 +1456,6 @@ def date_range(
         inclusive=inclusive,
         calendar=calendar,
     )
-
-
-def _new_to_legacy_freq(freq):
-    # xarray will now always return "ME" and "QE" for MonthEnd and QuarterEnd
-    # frequencies, but older versions of pandas do not support these as
-    # frequency strings.  Until xarray's minimum pandas version is 2.2 or above,
-    # we add logic to continue using the deprecated "M" and "Q" frequency
-    # strings in these circumstances.
-
-    # NOTE: other conversions ("h" -> "H", ..., "ns" -> "N") not required
-
-    # TODO: remove once requiring pandas >= 2.2
-    if not freq or Version(pd.__version__) >= Version("2.2"):
-        return freq
-
-    try:
-        freq_as_offset = to_offset(freq)
-    except ValueError:
-        # freq may be valid in pandas but not in xarray
-        return freq
-
-    if isinstance(freq_as_offset, MonthEnd) and "ME" in freq:
-        freq = freq.replace("ME", "M")
-    elif isinstance(freq_as_offset, QuarterEnd) and "QE" in freq:
-        freq = freq.replace("QE", "Q")
-    elif isinstance(freq_as_offset, YearBegin) and "YS" in freq:
-        freq = freq.replace("YS", "AS")
-    elif isinstance(freq_as_offset, YearEnd):
-        # testing for "Y" is required as this was valid in xarray 2023.11 - 2024.01
-        if "Y-" in freq:
-            # Check for and replace "Y-" instead of just "Y" to prevent
-            # corrupting anchored offsets that contain "Y" in the month
-            # abbreviation, e.g. "Y-MAY" -> "A-MAY".
-            freq = freq.replace("Y-", "A-")
-        elif "YE-" in freq:
-            freq = freq.replace("YE-", "A-")
-        elif "A-" not in freq and freq.endswith("Y"):
-            freq = freq.replace("Y", "A")
-        elif freq.endswith("YE"):
-            freq = freq.replace("YE", "A")
-
-    return freq
-
-
-def _legacy_to_new_freq(freq: T_FreqStr) -> T_FreqStr:
-    # to avoid internal deprecation warnings when freq is determined using pandas < 2.2
-
-    # TODO: remove once requiring pandas >= 2.2
-
-    if not freq or Version(pd.__version__) >= Version("2.2"):
-        return freq
-
-    try:
-        freq_as_offset = to_offset(freq, warn=False)
-    except ValueError:
-        # freq may be valid in pandas but not in xarray
-        return freq
-
-    if isinstance(freq_as_offset, MonthEnd) and "ME" not in freq:
-        freq = freq.replace("M", "ME")
-    elif isinstance(freq_as_offset, QuarterEnd) and "QE" not in freq:
-        freq = freq.replace("Q", "QE")
-    elif isinstance(freq_as_offset, YearBegin) and "YS" not in freq:
-        freq = freq.replace("AS", "YS")
-    elif isinstance(freq_as_offset, YearEnd):
-        if "A-" in freq:
-            # Check for and replace "A-" instead of just "A" to prevent
-            # corrupting anchored offsets that contain "Y" in the month
-            # abbreviation, e.g. "A-MAY" -> "YE-MAY".
-            freq = freq.replace("A-", "YE-")
-        elif "Y-" in freq:
-            freq = freq.replace("Y-", "YE-")
-        elif freq.endswith("A"):
-            # the "A-MAY" case is already handled above
-            freq = freq.replace("A", "YE")
-        elif "YE" not in freq and freq.endswith("Y"):
-            # the "Y-MAY" case is already handled above
-            freq = freq.replace("Y", "YE")
-    elif isinstance(freq_as_offset, Hour):
-        freq = freq.replace("H", "h")
-    elif isinstance(freq_as_offset, Minute):
-        freq = freq.replace("T", "min")
-    elif isinstance(freq_as_offset, Second):
-        freq = freq.replace("S", "s")
-    elif isinstance(freq_as_offset, Millisecond):
-        freq = freq.replace("L", "ms")
-    elif isinstance(freq_as_offset, Microsecond):
-        freq = freq.replace("U", "us")
-
-    return freq
 
 
 def date_range_like(source, calendar, use_cftime=None):
@@ -1592,9 +1500,6 @@ def date_range_like(source, calendar, use_cftime=None):
         raise ValueError(
             "`date_range_like` was unable to generate a range as the source frequency was not inferable."
         )
-
-    # TODO remove once requiring pandas >= 2.2
-    freq = _legacy_to_new_freq(freq)
 
     use_cftime = _should_cftime_be_used(source, calendar, use_cftime)
 

--- a/xarray/coding/frequencies.py
+++ b/xarray/coding/frequencies.py
@@ -45,7 +45,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from xarray.coding.cftime_offsets import _MONTH_ABBREVIATIONS, _legacy_to_new_freq
+from xarray.coding.cftime_offsets import _MONTH_ABBREVIATIONS
 from xarray.coding.cftimeindex import CFTimeIndex
 from xarray.core.common import _contains_datetime_like_objects
 from xarray.core.dtypes import _is_numpy_subdtype
@@ -101,7 +101,7 @@ def infer_freq(index):
         inferer = _CFTimeFrequencyInferer(index)
         return inferer.get_freq()
 
-    return _legacy_to_new_freq(pd.infer_freq(index))
+    return pd.infer_freq(index)
 
 
 class _CFTimeFrequencyInferer:  # (pd.tseries.frequencies._FrequencyInferer):

--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -21,7 +21,7 @@ from xarray.coding.common import (
     unpack_for_decoding,
     unpack_for_encoding,
 )
-from xarray.compat.pdcompat import default_precision_timestamp, timestamp_as_unit
+from xarray.compat.pdcompat import default_precision_timestamp
 from xarray.core import indexing
 from xarray.core.common import contains_cftime_datetimes, is_np_datetime_like
 from xarray.core.duck_array_ops import array_all, asarray, ravel, reshape
@@ -419,7 +419,7 @@ def _check_date_for_units_since_refdate(
         return pd.Timestamp("NaT")
     # this will raise on overflow if ref_date + delta can't be represented in
     # the current ref_date resolution
-    return timestamp_as_unit(ref_date + delta, ref_date.unit)
+    return (ref_date + delta).as_unit(ref_date.unit)
 
 
 def _check_timedelta_range(value, data_unit, time_unit):
@@ -437,7 +437,7 @@ def _align_reference_date_and_unit(
     if np.timedelta64(1, ref_date.unit) > np.timedelta64(1, unit):
         # this will raise accordingly
         # if data can't be represented in the higher resolution
-        return timestamp_as_unit(ref_date, cast(PDDatetimeUnitOptions, unit))
+        return ref_date.as_unit(cast(PDDatetimeUnitOptions, unit))
     return ref_date
 
 

--- a/xarray/compat/pdcompat.py
+++ b/xarray/compat/pdcompat.py
@@ -39,8 +39,6 @@ from typing import Literal
 
 import pandas as pd
 
-from xarray.core.types import PDDatetimeUnitOptions
-
 
 def count_not_none(*args) -> int:
     """Compute the number of non-None arguments.
@@ -73,20 +71,6 @@ no_default = (
 NoDefault = Literal[_NoDefault.no_default]  # For typing following pandas
 
 
-def timestamp_as_unit(date: pd.Timestamp, unit: PDDatetimeUnitOptions) -> pd.Timestamp:
-    """Convert the underlying int64 representation to the given unit.
-
-    Compatibility function for pandas issue where "as_unit" is not defined
-    for pandas.Timestamp in pandas versions < 2.2. Can be removed minimum
-    pandas version is >= 2.2.
-    """
-    if hasattr(date, "as_unit"):
-        date = date.as_unit(unit)
-    elif hasattr(date, "_as_unit"):
-        date = date._as_unit(unit)
-    return date
-
-
 def default_precision_timestamp(*args, **kwargs) -> pd.Timestamp:
     """Return a Timestamp object with the default precision.
 
@@ -94,5 +78,5 @@ def default_precision_timestamp(*args, **kwargs) -> pd.Timestamp:
     """
     dt = pd.Timestamp(*args, **kwargs)
     if dt.unit != "ns":
-        dt = timestamp_as_unit(dt, "ns")
+        dt = dt.as_unit("ns")
     return dt

--- a/xarray/groupers.py
+++ b/xarray/groupers.py
@@ -22,7 +22,7 @@ import numpy as np
 import pandas as pd
 from numpy.typing import ArrayLike
 
-from xarray.coding.cftime_offsets import BaseCFTimeOffset, _new_to_legacy_freq
+from xarray.coding.cftime_offsets import BaseCFTimeOffset
 from xarray.coding.cftimeindex import CFTimeIndex
 from xarray.compat.toolzcompat import sliding_window
 from xarray.computation.apply_ufunc import apply_ufunc
@@ -542,7 +542,7 @@ class TimeResampler(Resampler):
 
             self.index_grouper = pd.Grouper(
                 # TODO remove once requiring pandas >= 2.2
-                freq=_new_to_legacy_freq(self.freq),
+                freq=self.freq,
                 closed=self.closed,
                 label=self.label,
                 origin=self.origin,

--- a/xarray/groupers.py
+++ b/xarray/groupers.py
@@ -540,9 +540,8 @@ class TimeResampler(Resampler):
                     "when resampling a 'CFTimeIndex'"
                 )
 
-            self.index_grouper = pd.Grouper(
-                # TODO remove once requiring pandas >= 2.2
-                freq=self.freq,
+            self.index_grouper = pd.Grouper(  # type:ignore[misc]
+                freq=self.freq,  # type:ignore[arg-type]
                 closed=self.closed,
                 label=self.label,
                 origin=self.origin,

--- a/xarray/tests/__init__.py
+++ b/xarray/tests/__init__.py
@@ -189,7 +189,6 @@ has_pint, requires_pint = _importorskip("pint")
 has_numexpr, requires_numexpr = _importorskip("numexpr")
 has_flox, requires_flox = _importorskip("flox")
 has_netcdf, requires_netcdf = _importorskip("netcdf")
-has_pandas_ge_2_2, requires_pandas_ge_2_2 = _importorskip("pandas", "2.2")
 has_pandas_3, requires_pandas_3 = _importorskip("pandas", "3.0.0")
 
 

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -25,8 +25,6 @@ from xarray.coding.cftime_offsets import (
     Tick,
     YearBegin,
     YearEnd,
-    _legacy_to_new_freq,
-    _new_to_legacy_freq,
     cftime_range,
     date_range,
     date_range_like,
@@ -40,7 +38,6 @@ from xarray.tests import (
     _CFTIME_CALENDARS,
     assert_no_warnings,
     has_cftime,
-    has_pandas_ge_2_2,
     requires_cftime,
     requires_pandas_3,
 )
@@ -1381,8 +1378,6 @@ def test_calendar_year_length(
 @pytest.mark.parametrize("freq", ["YE", "ME", "D"])
 def test_dayofweek_after_cftime(freq: str) -> None:
     result = date_range("2000-02-01", periods=3, freq=freq, use_cftime=True).day_of_week
-    # TODO: remove once requiring pandas 2.2+
-    freq = _new_to_legacy_freq(freq)
     expected = pd.date_range("2000-02-01", periods=3, freq=freq).day_of_week
     np.testing.assert_array_equal(result, expected)
 
@@ -1390,8 +1385,6 @@ def test_dayofweek_after_cftime(freq: str) -> None:
 @pytest.mark.parametrize("freq", ["YE", "ME", "D"])
 def test_dayofyear_after_cftime(freq: str) -> None:
     result = date_range("2000-02-01", periods=3, freq=freq, use_cftime=True).day_of_year
-    # TODO: remove once requiring pandas 2.2+
-    freq = _new_to_legacy_freq(freq)
     expected = pd.date_range("2000-02-01", periods=3, freq=freq).day_of_year
     np.testing.assert_array_equal(result, expected)
 
@@ -1571,114 +1564,6 @@ def test_to_offset_deprecation_warning(freq):
     # Test for deprecations outlined in GitHub issue #8394
     with pytest.warns(FutureWarning, match="is deprecated"):
         to_offset(freq)
-
-
-@pytest.mark.skipif(has_pandas_ge_2_2, reason="only relevant for pandas lt 2.2")
-@pytest.mark.parametrize(
-    "freq, expected",
-    (
-        ["Y", "YE"],
-        ["A", "YE"],
-        ["Q", "QE"],
-        ["M", "ME"],
-        ["AS", "YS"],
-        ["YE", "YE"],
-        ["QE", "QE"],
-        ["ME", "ME"],
-        ["YS", "YS"],
-    ),
-)
-@pytest.mark.parametrize("n", ("", "2"))
-def test_legacy_to_new_freq(freq, expected, n):
-    freq = f"{n}{freq}"
-    result = _legacy_to_new_freq(freq)
-
-    expected = f"{n}{expected}"
-
-    assert result == expected
-
-
-@pytest.mark.skipif(has_pandas_ge_2_2, reason="only relevant for pandas lt 2.2")
-@pytest.mark.parametrize("year_alias", ("YE", "Y", "A"))
-@pytest.mark.parametrize("n", ("", "2"))
-def test_legacy_to_new_freq_anchored(year_alias, n):
-    for month in _MONTH_ABBREVIATIONS.values():
-        freq = f"{n}{year_alias}-{month}"
-        result = _legacy_to_new_freq(freq)
-
-        expected = f"{n}YE-{month}"
-
-        assert result == expected
-
-
-@pytest.mark.skipif(has_pandas_ge_2_2, reason="only relevant for pandas lt 2.2")
-@pytest.mark.filterwarnings("ignore:'[AY]' is deprecated")
-@pytest.mark.parametrize(
-    "freq, expected",
-    (["A", "A"], ["YE", "A"], ["Y", "A"], ["QE", "Q"], ["ME", "M"], ["YS", "AS"]),
-)
-@pytest.mark.parametrize("n", ("", "2"))
-def test_new_to_legacy_freq(freq, expected, n):
-    freq = f"{n}{freq}"
-    result = _new_to_legacy_freq(freq)
-
-    expected = f"{n}{expected}"
-
-    assert result == expected
-
-
-@pytest.mark.skipif(has_pandas_ge_2_2, reason="only relevant for pandas lt 2.2")
-@pytest.mark.filterwarnings("ignore:'[AY]-.{3}' is deprecated")
-@pytest.mark.parametrize("year_alias", ("A", "Y", "YE"))
-@pytest.mark.parametrize("n", ("", "2"))
-def test_new_to_legacy_freq_anchored(year_alias, n):
-    for month in _MONTH_ABBREVIATIONS.values():
-        freq = f"{n}{year_alias}-{month}"
-        result = _new_to_legacy_freq(freq)
-
-        expected = f"{n}A-{month}"
-
-        assert result == expected
-
-
-@pytest.mark.skipif(has_pandas_ge_2_2, reason="only for pandas lt 2.2")
-@pytest.mark.parametrize(
-    "freq, expected",
-    (
-        # pandas-only freq strings are passed through
-        ("BH", "BH"),
-        ("CBH", "CBH"),
-        ("N", "N"),
-    ),
-)
-def test_legacy_to_new_freq_pd_freq_passthrough(freq, expected):
-    result = _legacy_to_new_freq(freq)
-    assert result == expected
-
-
-@pytest.mark.filterwarnings("ignore:'.' is deprecated ")
-@pytest.mark.skipif(has_pandas_ge_2_2, reason="only for pandas lt 2.2")
-@pytest.mark.parametrize(
-    "freq, expected",
-    (
-        # these are each valid in pandas lt 2.2
-        ("T", "T"),
-        ("min", "min"),
-        ("S", "S"),
-        ("s", "s"),
-        ("L", "L"),
-        ("ms", "ms"),
-        ("U", "U"),
-        ("us", "us"),
-        # pandas-only freq strings are passed through
-        ("bh", "bh"),
-        ("cbh", "cbh"),
-        ("ns", "ns"),
-    ),
-)
-def test_new_to_legacy_freq_pd_freq_passthrough(freq, expected):
-    result = _new_to_legacy_freq(freq)
-    assert result == expected
 
 
 @pytest.mark.filterwarnings("ignore:Converting a CFTimeIndex with:")

--- a/xarray/tests/test_cftimeindex_resample.py
+++ b/xarray/tests/test_cftimeindex_resample.py
@@ -11,7 +11,6 @@ import xarray as xr
 from xarray.coding.cftime_offsets import (
     CFTIME_TICKS,
     Day,
-    _new_to_legacy_freq,
     to_offset,
 )
 from xarray.coding.cftimeindex import CFTimeIndex
@@ -141,9 +140,7 @@ def test_resample_with_tick_resample_freq(freqs, closed, label, offset) -> None:
     start = "2000-01-01T12:07:01"
     origin = "start"
 
-    datetime_index = pd.date_range(
-        start=start, periods=5, freq=_new_to_legacy_freq(initial_freq), unit="ns"
-    )
+    datetime_index = pd.date_range(start=start, periods=5, freq=initial_freq, unit="ns")
     cftime_index = xr.date_range(
         start=start, periods=5, freq=initial_freq, use_cftime=True
     )
@@ -178,9 +175,7 @@ def test_resample_with_non_tick_resample_freq(freqs, closed, label) -> None:
     offset = None
     origin = "start_day"
 
-    datetime_index = pd.date_range(
-        start=start, periods=5, freq=_new_to_legacy_freq(initial_freq), unit="ns"
-    )
+    datetime_index = pd.date_range(start=start, periods=5, freq=initial_freq, unit="ns")
     cftime_index = xr.date_range(
         start=start, periods=5, freq=initial_freq, use_cftime=True
     )

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -45,14 +45,12 @@ from xarray.tests import (
     has_dask_array_expr,
     has_dask_ge_2024_08_1,
     has_flox,
-    has_pandas_ge_2_2,
     raise_if_dask_computes,
     requires_cftime,
     requires_dask,
     requires_dask_ge_2024_08_1,
     requires_flox,
     requires_flox_0_9_12,
-    requires_pandas_ge_2_2,
     requires_scipy,
 )
 
@@ -155,15 +153,10 @@ def test_multi_index_groupby_sum() -> None:
         )
         assert_equal(expected, ds)
 
-    if not has_pandas_ge_2_2:
-        # the next line triggers a mysterious multiindex error on pandas 2.0
-        return
-
     actual = ds.stack(space=["x", "y"]).groupby("space").sum(...).unstack("space")
     assert_equal(expected, actual)
 
 
-@requires_pandas_ge_2_2
 def test_multi_index_propagation() -> None:
     # regression test for GH9648
     times = pd.date_range("2023-01-01", periods=4)


### PR DESCRIPTION
### Description

### Checklist

Now that we require pandas >= 2.2 we can remove quite some compat code.

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
    <!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
    Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}
