### PR TITLE
Fix padding an integer array with non-finite constant_values (NaN)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,6 +35,11 @@ Deprecations
 Bug Fixes
 ~~~~~~~~~
 
+- :py:meth:`DataArray.pad`, :py:meth:`Dataset.pad` and :py:meth:`Variable.pad`
+  no longer raise when padding an integer array with an explicit non-finite
+  ``constant_values`` such as ``np.nan``; the dtype is now promoted so the fill
+  value can be represented, as already happens for the default fill value
+  (:issue:`6431`).
 - Fix a major performance regression in :py:meth:`Coordinates.to_index` (and
   consequently :py:meth:`Dataset.to_dataframe`) caused by converting the cached
   code ndarrays into Python lists (:issue:`11305`).

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1308,7 +1308,7 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
             if (
                 mode == "constant"
                 and constant_values is not None
-                and np.issubdtype(dtype, np.integer)
+                and dtypes.isdtype(dtype, "integral")
             ):
                 # Padding an integer array with a non-finite fill value such as
                 # NaN would raise ("cannot convert float NaN to integer"). Promote

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1305,6 +1305,24 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
             dtype, constant_values = dtypes.maybe_promote(self.dtype)
         else:
             dtype = self.dtype
+            if (
+                mode == "constant"
+                and constant_values is not None
+                and np.issubdtype(dtype, np.integer)
+            ):
+                # Padding an integer array with a non-finite fill value such as
+                # NaN would raise ("cannot convert float NaN to integer"). Promote
+                # the dtype so the fill value can be represented, as is already
+                # done for the default fill value. See GH6431.
+                if isinstance(constant_values, dict):
+                    fill_arrays = [np.asarray(v) for v in constant_values.values()]
+                else:
+                    fill_arrays = [np.asarray(constant_values)]
+                if any(
+                    a.dtype.kind == "f" and not np.isfinite(a).all()
+                    for a in fill_arrays
+                ):
+                    dtype = np.result_type(dtype, *(a.dtype for a in fill_arrays))
 
         # create pad_options_kwargs, numpy requires only relevant kwargs to be nonempty
         if isinstance(stat_length, dict):

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1313,16 +1313,20 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
                 # Padding an integer array with a non-finite fill value such as
                 # NaN would raise ("cannot convert float NaN to integer"). Promote
                 # the dtype so the fill value can be represented, as is already
-                # done for the default fill value. See GH6431.
-                if isinstance(constant_values, dict):
-                    fill_arrays = [np.asarray(v) for v in constant_values.values()]
-                else:
-                    fill_arrays = [np.asarray(constant_values)]
-                if any(
-                    a.dtype.kind == "f" and not np.isfinite(a).all()
-                    for a in fill_arrays
-                ):
-                    dtype = np.result_type(dtype, *(a.dtype for a in fill_arrays))
+                # done for the default fill value. See GH6431. Only plain
+                # floating scalars are inspected here, so unit-aware duck arrays
+                # (e.g. pint quantities) are left untouched.
+                def _has_nonfinite_fill(value):
+                    if isinstance(value, dict):
+                        return any(_has_nonfinite_fill(v) for v in value.values())
+                    if isinstance(value, tuple | list):
+                        return any(_has_nonfinite_fill(v) for v in value)
+                    return isinstance(value, float | np.floating) and not np.isfinite(
+                        value
+                    )
+
+                if _has_nonfinite_fill(constant_values):
+                    dtype = np.result_type(dtype, float)
 
         # create pad_options_kwargs, numpy requires only relevant kwargs to be nonempty
         if isinstance(stat_length, dict):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -4675,8 +4675,15 @@ class TestDataArray:
         expected = xr.DataArray([1, 9, 1], dims="x")
         assert_identical(actual, expected)
 
-        with pytest.raises(ValueError, match="cannot convert float NaN to integer"):
-            ar.pad(x=1, constant_values=np.nan)
+        # padding an integer array with a non-finite fill value promotes the
+        # dtype so the fill value can be represented (GH6431)
+        actual = ar.pad(x=1, constant_values=np.nan)
+        expected = xr.DataArray([np.nan, 9, np.nan], dims="x")
+        assert_identical(actual, expected)
+
+        actual = ar.pad(x=(1, 1), constant_values=(0, np.nan))
+        expected = xr.DataArray([0, 9, np.nan], dims="x")
+        assert_identical(actual, expected)
 
     def test_pad_coords(self) -> None:
         ar = DataArray(


### PR DESCRIPTION
### Description

Fixes padding an integer array with an explicit non-finite `constant_values` (e.g. `np.nan`), which previously raised `ValueError: cannot convert float NaN to integer`:

```python
import numpy as np, xarray as xr
da = xr.DataArray(np.arange(9), dims="x")
da.pad({"x": (0, 1)}, "constant", constant_values=np.nan)   # used to raise
```

`Variable.pad` only promoted the dtype for the default fill sentinel (`dtypes.NA`), not for an explicit `np.nan`. It now promotes the dtype (via `np.result_type`) when an explicit non-finite fill value cannot be represented by an integer dtype, matching the promotion already done for the default fill value. Finite fill values keep numpy's existing casting behaviour (e.g. `constant_values=1.23456` still truncates on an integer array).

### Checklist

- [x] Closes #6431
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Claude Code — prompted to locate and fix issue #6431 with a localized change in `Variable.pad` plus a regression test. I have reviewed and tested the change locally (the `pad` test suites pass).
