### PR TITLE
DOC fix parameter name in CoordinateTransform.reverse docstring

### DIFF
--- a/xarray/core/coordinate_transform.py
+++ b/xarray/core/coordinate_transform.py
@@ -56,7 +56,7 @@ class CoordinateTransform:
 
         Parameters
         ----------
-        labels : dict
+        coord_labels : dict
             World coordinate labels.
 
         Returns


### PR DESCRIPTION
The `reverse` method of `CoordinateTransform` documents parameter `labels` but the actual signature uses `coord_labels`:

```python
def reverse(self, coord_labels: dict[Hashable, Any]) -> dict[str, Any]:
    """
    labels : dict   # <-- wrong: should be coord_labels
    """
```

One-line docstring fix.