### PR TITLE
Adapt to coming `pd.infer_freq` behavior change

### DIFF
--- a/xarray/coding/frequencies.py
+++ b/xarray/coding/frequencies.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+from packaging.version import Version
 
 from xarray.coding.cftime_offsets import _MONTH_ABBREVIATIONS
 from xarray.coding.cftimeindex import CFTimeIndex
@@ -101,7 +102,11 @@ def infer_freq(index):
         inferer = _CFTimeFrequencyInferer(index)
         return inferer.get_freq()
 
-    return pd.infer_freq(index)
+    if Version(pd.__version__) >= Version("3.1.0.dev0"):
+        with pd.option_context({"future.infer_freq_returns_offset": False}):
+            return pd.infer_freq(index)
+    else:
+        return pd.infer_freq(index)
 
 
 class _CFTimeFrequencyInferer:  # (pd.tseries.frequencies._FrequencyInferer):


### PR DESCRIPTION
### Description

This PR addresses the coming `pd.infer_freq` behavior change by forcing the current behavior for now.  Maybe in the future we can consider returning offset objects in our version of `infer_freq`, but that would need to wait until #5687 were addressed.

Addresses one part of #11402.