### PR TITLE
Adapt `test_dataset_math_errors` for coming NumPy behavior change

### DIFF
--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6753,10 +6753,11 @@ class TestDataset:
             ds += ds[["bar"]]
 
         # verify we can rollback in-place operations if something goes wrong
-        # nb. inplace datetime64 math actually will work with an integer array
-        # but not floats thanks to numpy's inconsistent handling
-        other = DataArray(np.datetime64("2000-01-01"), coords={"c": 2})
+        # (datetime64 math works with timedelta64 values stored in "bar", but
+        # not floats stored in "foo").
+        other = DataArray(np.datetime64("2000-01-01", "ns"), coords={"c": 2})
         actual = ds.copy(deep=True)
+        actual["bar"] = actual.bar.astype("timedelta64[ns]")
         with pytest.raises(TypeError):
             actual += other
         assert_identical(actual, ds)


### PR DESCRIPTION
### Description

This PR adapts `test_dataset_math_errors` for coming updates in NumPy.  We can no longer rely on arithmetic between `datetime64` values and plain integers working without a warning or error.  

My understanding of this test is that we want adding a `datetime64` value to `"bar"` to succeed so that we can check that the failure in adding a `datetime64` value to `"foo"` prevents updating any variable in the Dataset.  Therefore we explicitly cast `"bar"` to an array of `"timedelta64[ns]"` values so that this continues to be the case moving forward.  

Even though it is not strictly necessary, we also provide units in the `datetime64` constructor when creating `other`.

Addresses one part of #11402.