### PR TITLE
open an issue even with a missing log file

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -94,6 +94,11 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.
           persist-credentials: false
+      - name: Determine log path
+        id: determine-log-path
+        run: |
+          echo "log-file=output-${{ matrix.pixi-env }}-log.jsonl" >> $GITHUB_OUTPUT;
+          cat $GITHUB_OUTPUT
       - name: Restore cached pixi lockfile
         uses: Parcels-code/pixi-lock/restore@38495788b79a5ff26009aecc15daa9a8310b8832 # v0.1.0
         with:
@@ -110,11 +115,6 @@ jobs:
       - name: Import xarray
         run: |
           pixi run -e ${{matrix.pixi-env}} -- python -c 'import xarray'
-      - name: Determine log path
-        id: determine-log-path
-        run: |
-          echo "log-file=output-${{ matrix.pixi-env }}-log.jsonl" >> $GITHUB_OUTPUT;
-          cat $GITHUB_OUTPUT
       - name: Run Tests
         if: success()
         id: status

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -86,6 +86,9 @@ jobs:
       matrix:
         pixi-env: ["test-nightly"]
 
+    env:
+      ENV: ${{ matrix.pixi-env }}
+
     outputs:
       log-file: ${{ steps.determine-log-path.outputs.log-file }}
 
@@ -97,7 +100,7 @@ jobs:
       - name: Determine log path
         id: determine-log-path
         run: |
-          echo "log-file=output-${{ matrix.pixi-env }}-log.jsonl" >> $GITHUB_OUTPUT;
+          echo "log-file=output-${ENV}-log.jsonl" >> $GITHUB_OUTPUT;
           cat $GITHUB_OUTPUT
       - name: Restore cached pixi lockfile
         uses: Parcels-code/pixi-lock/restore@38495788b79a5ff26009aecc15daa9a8310b8832 # v0.1.0
@@ -111,17 +114,17 @@ jobs:
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       - name: Version info
         run: |
-          pixi run -e ${{matrix.pixi-env}} -- python xarray/util/print_versions.py
+          pixi run -e $ENV -- python xarray/util/print_versions.py
       - name: Import xarray
         run: |
-          pixi run -e ${{matrix.pixi-env}} -- python -c 'import xarray'
+          pixi run -e $ENV -- python -c 'import xarray'
       - name: Run Tests
         if: success()
         id: status
         env:
           LOG_PATH: ${{ steps.determine-log-path.outputs.log-file }}
         run: |
-          pixi run -e ${{matrix.pixi-env}} -- python -m pytest --timeout=60 -rf -nauto \
+          pixi run -e $ENV -- python -m pytest --timeout=60 -rf -nauto \
             --report-log "$LOG_PATH"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
@@ -167,6 +170,9 @@ jobs:
       matrix:
         pixi-env: ["mypy-upstream"]
 
+    env:
+      ENV: ${{ matrix.pixi-env }}
+
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -187,13 +193,13 @@ jobs:
       - name: set environment variables
         run: |
           echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-          echo "PYTHON_VERSION=$(pixi run -e ${{matrix.pixi-env}} -- python --version | cut -d' ' -f2 | cut -d. -f1,2)" >> $GITHUB_ENV
+          echo "PYTHON_VERSION=$(pixi run -e $ENV -- python --version | cut -d' ' -f2 | cut -d. -f1,2)" >> $GITHUB_ENV
       - name: Version info
         run: |
-          pixi run -e ${{matrix.pixi-env}} -- python xarray/util/print_versions.py
+          pixi run -e $ENV -- python xarray/util/print_versions.py
       - name: Run mypy
         run: |
-          pixi run -e ${{matrix.pixi-env}} -- python -m mypy --install-types --non-interactive --cobertura-xml-report mypy_report
+          pixi run -e $ENV -- python -m mypy --install-types --non-interactive --cobertura-xml-report mypy_report
       - name: Upload mypy coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -148,7 +148,7 @@ jobs:
           name: log file
           path: logs/
       - name: Generate and publish the report
-        uses: scientific-python/issue-from-pytest-log-action@8e905db353437cda1d6a773de245343fbfc940dd # v1.5.0
+        uses: scientific-python/issue-from-pytest-log-action@87351a8f864e969567cda22a25a2f214cbe2340f # v1.6.0
         with:
           log-path: logs/${{ needs.upstream-dev.outputs.log-file }}
 

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -128,7 +128,6 @@ jobs:
         with:
           name: log file
           path: ${{ steps.determine-log-path.outputs.log-file }}
-          if-no-files-found: error
 
   create-issue:
     needs: upstream-dev

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -41,6 +41,7 @@ jobs:
           keyword: "[test-upstream]"
 
   cache-pixi-lock:
+    name: cache pixi.lock
     runs-on: ubuntu-latest
     needs: detect-ci-trigger
     if: |
@@ -133,6 +134,7 @@ jobs:
           path: ${{ steps.determine-log-path.outputs.log-file }}
 
   create-issue:
+    name: report failing upstream-dev runs
     needs: upstream-dev
     runs-on: ubuntu-slim
     if: |
@@ -142,7 +144,7 @@ jobs:
       && github.repository_owner == 'pydata'
 
     permissions:
-      issues: write
+      issues: write # open or edit an issue for failed CI runs
 
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -124,7 +124,7 @@ jobs:
           pixi run -e ${{matrix.pixi-env}} -- python -m pytest --timeout=60 -rf -nauto \
             --report-log "$LOG_PATH"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: failure() && steps.status.outcome == 'failure'
+        if: failure()
         with:
           name: log file
           path: ${{ steps.determine-log-path.outputs.log-file }}


### PR DESCRIPTION
Allow the nightly CI to make use of the newly added support for a missing log file. This means that if any previous step (e.g. the import) failed we still get an issue.
