### PR TITLE
zarr deprecation: enums becoming string literals

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -157,7 +157,7 @@ pyarrow = { version = "*", index = "https://pypi.anaconda.org/scientific-python-
 dask = { git = "https://github.com/dask/dask" }
 distributed = { git = "https://github.com/dask/distributed" }
 zarr = { git = "https://github.com/zarr-developers/zarr-python" }
-numcodecs = { git = "https://github.com/zarr-developers/numcodecs" }
+# numcodecs = { git = "https://github.com/zarr-developers/numcodecs" }
 cftime = { git = "https://github.com/Unidata/cftime" }
 # packaging = { git = "https://github.com/pypa/packaging"} #? Pixi warns if this is enabled
 pint = { git = "https://github.com/hgrecco/pint" }
@@ -181,7 +181,7 @@ pyarrow = "*"
 dask = "*"
 distributed = "*"
 zarr = "*"
-numcodecs = "*"
+# numcodecs = "*"
 cftime = "*"
 packaging = "*"
 pint = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -157,7 +157,7 @@ pyarrow = { version = "*", index = "https://pypi.anaconda.org/scientific-python-
 dask = { git = "https://github.com/dask/dask" }
 distributed = { git = "https://github.com/dask/distributed" }
 zarr = { git = "https://github.com/zarr-developers/zarr-python" }
-# numcodecs = { git = "https://github.com/zarr-developers/numcodecs" }
+# numcodecs = { git = "https://github.com/zarr-developers/numcodecs" }  #? commented to workaround for #11437
 cftime = { git = "https://github.com/Unidata/cftime" }
 # packaging = { git = "https://github.com/pypa/packaging"} #? Pixi warns if this is enabled
 pint = { git = "https://github.com/hgrecco/pint" }
@@ -181,7 +181,7 @@ pyarrow = "*"
 dask = "*"
 distributed = "*"
 zarr = "*"
-# numcodecs = "*"
+numcodecs = "*"
 cftime = "*"
 packaging = "*"
 pint = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -157,7 +157,7 @@ pyarrow = { version = "*", index = "https://pypi.anaconda.org/scientific-python-
 dask = { git = "https://github.com/dask/dask" }
 distributed = { git = "https://github.com/dask/distributed" }
 zarr = { git = "https://github.com/zarr-developers/zarr-python" }
-# numcodecs = { git = "https://github.com/zarr-developers/numcodecs" }  #? commented to workaround for #11437
+# numcodecs = { git = "https://github.com/zarr-developers/numcodecs" }  #? compilation fails currently, see #11437
 cftime = { git = "https://github.com/Unidata/cftime" }
 # packaging = { git = "https://github.com/pypa/packaging"} #? Pixi warns if this is enabled
 pint = { git = "https://github.com/hgrecco/pint" }

--- a/xarray/tests/test_backends_datatree.py
+++ b/xarray/tests/test_backends_datatree.py
@@ -716,7 +716,11 @@ class TestZarrDatatreeIO:
                 # zarr v3 BloscCodec auto-tunes typesize and shuffle on write,
                 # so we only check the attributes we explicitly set
                 rt_codec = roundtrip_dt["/set2/a"].encoding[compressor_key][0]
-                assert rt_codec.cname.value == "zstd"
+                # DEPR: backwards compatibility with zarr <= 3.2.1
+                # This will become a string in the future.
+                # Once we can drop zarr <= 3.2.1, the assertion can become
+                #   assert rt_codec.cname == "zstd"
+                assert getattr(rt_codec.cname, "value", rt_codec.cname) == "zstd"
                 assert rt_codec.clevel == 3
             else:
                 assert (


### PR DESCRIPTION
- [x] closes #11402

In the PRs associated with zarr-developers/zarr-python#3457 (zarr-developers/zarr-python#3963, zarr-developers/zarr-python#3968), `zarr-python` has changed the codec names for `BloscCodec` from enums to string literals.

This also works around #11437 by temporarily removing the nightly `numcodecs` from the nightly envs.