### PR TITLE
fix Dataset.sum crash with scalar string variable (GH11417)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -695,7 +695,8 @@ Bug fixes
   By `Stephan Hoyer <https://github.com/shoyer>`_.
 - Fix :py:meth:`Dataset.sum` and other reductions raising a ``TypeError`` when a
   scalar (0-d) non-numeric variable is present; such variables are now left
-  untouched when reducing over a dimension they do not have (:issue:`11417`).
+  untouched when reducing over a dimension they do not have
+  (:issue:`11417`, :pull:`11442`).
   By `Selim <https://github.com/CodingSelim>`_.
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -693,6 +693,10 @@ Bug fixes
 - Fix error raised when writing scalar variables to Zarr with ``region={}``
   (:pull:`10796`).
   By `Stephan Hoyer <https://github.com/shoyer>`_.
+- Fix :py:meth:`Dataset.sum` and other reductions raising a ``TypeError`` when a
+  scalar (0-d) non-numeric variable is present; such variables are now left
+  untouched when reducing over a dimension they do not have (:issue:`11417`).
+  By `Selim <https://github.com/CodingSelim>`_.
 
 
 .. _whats-new.2025.09.1:

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -6966,7 +6966,7 @@ class Dataset(
                 # keep single-element dims as list, to support Hashables
                 reduce_maybe_single = (
                     None
-                    if len(reduce_dims) == var.ndim and var.ndim != 1
+                    if reduce_dims and len(reduce_dims) == var.ndim and var.ndim != 1
                     else reduce_dims
                 )
                 variables[name] = var.reduce(

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6314,6 +6314,16 @@ class TestDataset:
         actual = ds.min()
         assert_identical(expected, actual)
 
+    def test_reduce_string_scalar_along_missing_dim(self) -> None:
+        # regression test for GH11417: reducing over a dim that a scalar
+        # (0-d) string variable doesn't have should leave it untouched
+        # instead of trying to sum the string.
+        ds = Dataset({"a": ("index", [1, 2, 3]), "d": ((), "hello")})
+        expected = Dataset({"a": 6, "d": ((), "hello")})
+        assert_identical(ds.sum("index"), expected)
+        # also with no dim given, the string scalar just passes through
+        assert_identical(ds.sum(), expected)
+
     def test_reduce_dtypes(self) -> None:
         # regression test for GH342
         expected = Dataset({"x": 1})


### PR DESCRIPTION
### Description

`Dataset.sum('index')` (and other reductions) raises a `TypeError` when the dataset has a scalar non-numeric variable that doesn't have the reduced dim:

```python
xr.Dataset({'a': (['index'], [1, 2, 3]), 'd': ([], 'hello')}).sum('index')
# TypeError: the resolved dtypes are not compatible with add.reduce
```

the scalar `d` has no `index` dim so it should just pass through unchanged. in `Dataset.reduce` a 0-d variable that shares none of the reduce dims ends up with `reduce_maybe_single=None` (reduce over everything) instead of `[]` (reduce over nothing), because the "reduce over all dims" shortcut also triggers when `reduce_dims` is empty. numeric scalars survived by accident (summing a scalar gives it back), strings hit `add.reduce` and blew up. fix is to only take the reduce-all path when `reduce_dims` is actually non-empty.

### Checklist

- [x] Closes #11417
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Claude (Claude Code). This was an existing open issue (#11417), not something I found myself. I used Claude Code to investigate and root-cause it and to write the fix. I directed the work and reviewed and tested it locally (the new regression test fails before the change and passes after, and the existing reduction tests still pass), and I take responsibility for the change.
