### PR TITLE
docs: remove unused imports in quick overview guide

### DIFF
--- a/doc/getting-started-guide/quick-overview.rst
+++ b/doc/getting-started-guide/quick-overview.rst
@@ -255,9 +255,6 @@ Let's first make some example xarray datasets:
 
 .. jupyter-execute::
 
-    import numpy as np
-    import xarray as xr
-
     data = xr.DataArray(np.random.randn(2, 3), dims=("x", "y"), coords={"x": [10, 20]})
     ds = xr.Dataset({"foo": data, "bar": ("x", [1, 2]), "baz": np.pi})
     ds


### PR DESCRIPTION
### Description

Removed unnecessary import statements for `numpy` and `xarray` from the DataTree section. The imports used throughout the guide are at the top of the file, like for all the other sections.