### PR TITLE
Release notes for v2026.07.0

### DIFF
--- a/ci/release_contributors.py
+++ b/ci/release_contributors.py
@@ -18,6 +18,7 @@ ignored = [
             "no-reply@anthropic.com",
         ],
     },
+    {"name": "OpenAI"},
 ]
 
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -26,12 +26,12 @@ Vincent Gao, Wali Reheman, Wei Ji and eeshsaxena
 
 New Features
 ~~~~~~~~~~~~
-- Added support for Dask's query-optimizing expression arrays. Xarray now
-  implements the ``__dask_exprs__`` protocol so that Dask can identify and
-  optimize xarray :py:class:`Variable` objects without materializing their
-  graphs, together with a chunk manager and
-  :py:meth:`~xarray.Dataset.map_blocks` support for these arrays
-  (:pull:`11382`, :pull:`11398`, :pull:`11423`).
+- Added support for Dask's query-optimizing expression arrays (`dask-array
+  <https://github.com/mrocklin/dask-array>`_). Xarray now implements the
+  ``__dask_exprs__`` protocol so that Dask can identify and optimize xarray
+  :py:class:`Variable` objects without materializing their graphs, together
+  with a chunk manager and :py:meth:`~xarray.Dataset.map_blocks` support for
+  these arrays (:pull:`11382`, :pull:`11398`, :pull:`11423`).
   By `Matthew Rocklin <https://github.com/mrocklin>`_.
 - Following pandas, xarray's
   :py:class:`~xarray.core.accessor_dt.DatetimeAccessor` now supports

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -26,8 +26,8 @@ Vincent Gao, Wali Reheman, Wei Ji and eeshsaxena
 
 New Features
 ~~~~~~~~~~~~
-- Added support for Dask's query-optimizing expression arrays (`dask-array
-  <https://github.com/mrocklin/dask-array>`_). Xarray now implements the
+- Added support for Dask's `query-optimizing expression arrays
+  <https://github.com/mrocklin/dask-array>`_. Xarray now implements the
   ``__dask_exprs__`` protocol so that Dask can identify and optimize xarray
   :py:class:`Variable` objects without materializing their graphs, together
   with a chunk manager and :py:meth:`~xarray.Dataset.map_blocks` support for

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -6,13 +6,33 @@
 What's New
 ==========
 
-.. _whats-new.2026.05.0:
+.. _whats-new.2026.07.0:
 
-v2026.05.0 (unreleased)
------------------------
+v2026.07.0 (Jul 9, 2026)
+------------------------
+
+This release adds support for Dask's query-optimizing expression arrays, along
+with new ``day_of_week`` and ``day_of_year`` datetime accessor attributes. It
+also includes a number of bug fixes, notably for a performance regression in
+:py:meth:`Coordinates.to_index`, Zarr ``fill_value`` round-tripping, and
+excessive memory use in ``drop_encoding``.
+
+Thanks to the 25 contributors to this release:
+Davis Bennett, Deepak Cherian, Ian Hunt-Isaak, Illviljan, Jonathan Dung, Julia
+Signell, Justus Magin, Kai Mühlbauer, MJSHANG, Mark Harfouche, Mathias Hauser,
+Matt Van Horn, Matthew Rocklin, Max Jones, Maximilian Roos, Nick Hodgskin,
+S Anand, Spencer Clark, Sreekant Baheti, Timothy Hodson, Tom Nicholas,
+Vincent Gao, Wali Reheman, Wei Ji and eeshsaxena
 
 New Features
 ~~~~~~~~~~~~
+- Added support for Dask's query-optimizing expression arrays. Xarray now
+  implements the ``__dask_exprs__`` protocol so that Dask can identify and
+  optimize xarray :py:class:`Variable` objects without materializing their
+  graphs, together with a chunk manager and
+  :py:meth:`~xarray.Dataset.map_blocks` support for these arrays
+  (:pull:`11382`, :pull:`11398`, :pull:`11423`).
+  By `Matthew Rocklin <https://github.com/mrocklin>`_.
 - Following pandas, xarray's
   :py:class:`~xarray.core.accessor_dt.DatetimeAccessor` now supports
   :py:attr:`~xarray.core.accessor_dt.DatetimeAccessor.day_of_week` and
@@ -35,6 +55,21 @@ Deprecations
 Bug Fixes
 ~~~~~~~~~
 
+- :py:meth:`Dataset.drop_encoding` and :py:meth:`DataArray.drop_encoding` no
+  longer copy the underlying data, avoiding excessive memory use on large
+  datasets (:issue:`11390`, :pull:`11394`).
+  By `Wali Reheman <https://github.com/wali-reheman>`_.
+- Fix :py:func:`open_dataset` raising ``OSError`` when opening data from GDAL
+  virtual filesystems (e.g. ``/vsicurl/``, ``/vsis3/``) or other URI-like paths
+  that do not support ``stat`` (:pull:`11392`).
+  By `Vincent Gao <https://github.com/gaoflow>`_.
+- Fix :py:func:`testing.assert_equal` with ``check_dim_order=False`` for
+  :py:class:`Dataset` objects containing variables with different dimension
+  orders (:issue:`10704`, :pull:`10718`).
+  By `Maximilian Roos <https://github.com/max-sixty>`_.
+- :py:meth:`~xarray.indexes.RangeIndex.linspace` now handles ``num=1`` like
+  :py:func:`numpy.linspace` (:issue:`11397`, :pull:`11401`).
+  By `S Anand <https://github.com/sanand0>`_.
 - Fix a major performance regression in :py:meth:`Coordinates.to_index` (and
   consequently :py:meth:`Dataset.to_dataframe`) caused by converting the cached
   code ndarrays into Python lists (:issue:`11305`).


### PR DESCRIPTION
Release notes and summary for **v2026.07.0**.

## Changes
- Relabel the `unreleased` whats-new section as `v2026.07.0` (CALVER — release month), with a release summary and the 25-contributor list.
- Add whats-new entries for user-facing changes that were missing: Dask expression-array query optimization (#11382, #11398, #11423), `drop_encoding` memory fix (#11394), `open_dataset` OSError on GDAL virtual filesystems (#11392), `assert_equal(check_dim_order=False)` fix (#10718), and `RangeIndex.linspace(num=1)` (#11401).
- Filter the `OpenAI` co-author trailer (from Codex commits) out of `ci/release_contributors.py`, mirroring the existing `Claude` filter.

The release headline / summary in particular could use a sanity check from the team on what's most important to highlight.

Applying the `Release` label to trigger the test build.

[This is Claude Code on behalf of Stephan Hoyer]