### PR TITLE
Add empty whats-new section for v2026.07.1

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -6,6 +6,35 @@
 What's New
 ==========
 
+.. _whats-new.2026.07.1:
+
+v2026.07.1 (unreleased)
+-----------------------
+
+New Features
+~~~~~~~~~~~~
+
+
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+
+Deprecations
+~~~~~~~~~~~~
+
+
+Bug Fixes
+~~~~~~~~~
+
+
+Documentation
+~~~~~~~~~~~~~
+
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+
 .. _whats-new.2026.07.0:
 
 v2026.07.0 (Jul 9, 2026)


### PR DESCRIPTION
Adds the empty whats-new section for the next release, following step 11 of `HOW_TO_RELEASE.md`. Done after releasing v2026.07.0 so it doesn't show up in the RTD build.

[This is Claude Code on behalf of Stephan Hoyer]