### PR TITLE
docs: fix DataArray.pad constant_values default documentation

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -5912,7 +5912,7 @@ class DataArray(
             (stat_length,) or int is a shortcut for before = after = statistic
             length for all axes.
             Default is ``None``, to use the entire axis.
-        constant_values : scalar, tuple or mapping of Hashable to tuple, default: 0
+        constant_values : scalar, tuple or mapping of Hashable to tuple, default: None
             Used in 'constant'.  The values to set the padded values for each
             axis.
             ``{dim_1: (before_1, after_1), ... dim_N: (before_N, after_N)}`` unique
@@ -5921,7 +5921,7 @@ class DataArray(
             dimension.
             ``(constant,)`` or ``constant`` is a shortcut for ``before = after = constant`` for
             all dimensions.
-            Default is 0.
+            Default is ``None``, pads with ``np.nan``.
         end_values : scalar, tuple or mapping of Hashable to tuple, default: 0
             Used in 'linear_ramp'.  The values used for the ending value of the
             linear_ramp and that will form the edge of the padded array.

--- a/xarray/namedarray/utils.py
+++ b/xarray/namedarray/utils.py
@@ -37,15 +37,15 @@ T = TypeVar("T")
 
 
 @lru_cache
-def module_available(module: str, minversion: str | None = None) -> bool:
+def module_available(module: str | None, minversion: str | None = None) -> bool:
     """Checks whether a module is installed without importing it.
 
     Use this for a lightweight check and lazy imports.
 
     Parameters
     ----------
-    module : str
-        Name of the module.
+    module : str or None
+        Name of the module. If None, returns False.
     minversion : str, optional
         Minimum version of the module
 
@@ -54,6 +54,8 @@ def module_available(module: str, minversion: str | None = None) -> bool:
     available : bool
         Whether the module is installed.
     """
+    if module is None:
+        return False
     if importlib.util.find_spec(module) is None:
         return False
 

--- a/xarray/namedarray/utils.py
+++ b/xarray/namedarray/utils.py
@@ -37,15 +37,15 @@ T = TypeVar("T")
 
 
 @lru_cache
-def module_available(module: str | None, minversion: str | None = None) -> bool:
+def module_available(module: str, minversion: str | None = None) -> bool:
     """Checks whether a module is installed without importing it.
 
     Use this for a lightweight check and lazy imports.
 
     Parameters
     ----------
-    module : str or None
-        Name of the module. If None, returns False.
+    module : str
+        Name of the module.
     minversion : str, optional
         Minimum version of the module
 
@@ -54,8 +54,6 @@ def module_available(module: str | None, minversion: str | None = None) -> bool:
     available : bool
         Whether the module is installed.
     """
-    if module is None:
-        return False
     if importlib.util.find_spec(module) is None:
         return False
 


### PR DESCRIPTION
The docstring for `DataArray.pad` claimed `constant_values` defaults to `0`, but the actual default is `None` (pads with `np.nan`). This aligns the documentation with the actual behavior, matching the already-correct `Dataset.pad` docs.

Closes #11373