### PR TITLE
fix: handle None module in module_available()

### DIFF
--- a/xarray/namedarray/utils.py
+++ b/xarray/namedarray/utils.py
@@ -37,15 +37,15 @@ T = TypeVar("T")
 
 
 @lru_cache
-def module_available(module: str, minversion: str | None = None) -> bool:
+def module_available(module: str | None, minversion: str | None = None) -> bool:
     """Checks whether a module is installed without importing it.
 
     Use this for a lightweight check and lazy imports.
 
     Parameters
     ----------
-    module : str
-        Name of the module.
+    module : str or None
+        Name of the module. If None, returns False.
     minversion : str, optional
         Minimum version of the module
 
@@ -54,6 +54,8 @@ def module_available(module: str, minversion: str | None = None) -> bool:
     available : bool
         Whether the module is installed.
     """
+    if module is None:
+        return False
     if importlib.util.find_spec(module) is None:
         return False
 


### PR DESCRIPTION
When `module_available()` is called with `None` (e.g., through a third-party plugin import chain), `importlib.util.find_spec(None)` raises TypeError. Add an explicit None guard that returns False instead. Also updates type hint.