### PR TITLE
Fix dask rolling bottleneck dtype metadata

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -26,6 +26,11 @@ Deprecations
 Bug Fixes
 ~~~~~~~~~
 
+- Fixed dask-backed bottleneck rolling reductions declaring a dtype that could
+  differ from the dtype returned by the matching numpy-backed bottleneck path,
+  notably ``object`` instead of ``float64`` for boolean inputs.
+  By `Matthew Rocklin <https://github.com/mrocklin>`_.
+
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xarray/compat/dask_array_ops.py
+++ b/xarray/compat/dask_array_ops.py
@@ -2,14 +2,25 @@ from __future__ import annotations
 
 import math
 
+import numpy as np
+
 from xarray.compat.dask_array_compat import reshape_blockwise
 from xarray.core import dtypes, nputils
 from xarray.namedarray.parallelcompat import get_chunked_array_type
 
 
-def dask_rolling_wrapper(moving_func, a, window, min_count=None, axis=-1):
+def dask_rolling_wrapper(
+    moving_func, a, window, min_count=None, axis=-1, input_dtype=None
+):
     """Wrapper to apply bottleneck moving window funcs on dask arrays"""
-    dtype, _ = dtypes.maybe_promote(a.dtype)
+    if input_dtype is None:
+        input_dtype = a.dtype
+    if input_dtype.kind in "biufc":
+        dtype = moving_func(
+            np.empty((1,), dtype=input_dtype), window=1, min_count=1, axis=0
+        ).dtype
+    else:
+        dtype, _ = dtypes.maybe_promote(a.dtype)
     return a.data.map_overlap(
         moving_func,
         depth={axis: (window - 1, 0)},

--- a/xarray/compat/dask_array_ops.py
+++ b/xarray/compat/dask_array_ops.py
@@ -16,6 +16,7 @@ def dask_rolling_wrapper(
     if input_dtype is None:
         input_dtype = a.dtype
     if input_dtype.kind in "biufc":
+        // auto-detect bottleneck/numbagg type promotion
         dtype = moving_func(
             np.empty((1,), dtype=input_dtype), window=1, min_count=1, axis=0
         ).dtype

--- a/xarray/compat/dask_array_ops.py
+++ b/xarray/compat/dask_array_ops.py
@@ -16,7 +16,6 @@ def dask_rolling_wrapper(
     if input_dtype is None:
         input_dtype = a.dtype
     if input_dtype.kind in "biufc":
-        // auto-detect bottleneck/numbagg type promotion
         dtype = moving_func(
             np.empty((1,), dtype=input_dtype), window=1, min_count=1, axis=0
         ).dtype

--- a/xarray/computation/rolling.py
+++ b/xarray/computation/rolling.py
@@ -670,8 +670,14 @@ class DataArrayRolling(Rolling["DataArray"]):
             padded = padded.pad({self.dim[0]: (0, -shift)}, mode="constant")
 
         if is_duck_dask_array(padded.data):
+            input_dtype = self.obj.dtype if self.obj.dtype.kind == "b" else padded.dtype
             values = dask_array_ops.dask_rolling_wrapper(
-                func, padded, axis=axis, window=self.window[0], min_count=min_count
+                func,
+                padded,
+                axis=axis,
+                window=self.window[0],
+                min_count=min_count,
+                input_dtype=input_dtype,
             )
         else:
             values = func(

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -14,6 +14,7 @@ from xarray.tests import (
     assert_identical,
     dask_array_api,
     has_dask,
+    requires_bottleneck,
     requires_dask,
     requires_dask_ge_2024_11_0,
     requires_numbagg,
@@ -433,6 +434,43 @@ class TestDataArrayRolling:
         unchunked_result = data.rolling(x=3, min_periods=1).mean()
         chunked_result = data.chunk({"x": 1}).rolling(x=3, min_periods=1).mean()
         assert chunked_result.dtype == unchunked_result.dtype
+
+    @requires_bottleneck
+    @requires_dask_ge_2024_11_0
+    @pytest.mark.parametrize(
+        "name",
+        ("sum", "mean", "std", "var", "min", "max", "median", "argmin", "argmax"),
+    )
+    @pytest.mark.parametrize("center", [False, True])
+    @pytest.mark.parametrize("dtype", [bool, np.int8, np.int64])
+    def test_rolling_bottleneck_dask_dtype_matches_numpy(
+        self, name, center, dtype
+    ) -> None:
+        if center and dtype is bool and name in ("std", "median"):
+            pytest.skip("centered bool bottleneck path fails for numpy-backed arrays")
+
+        raw = np.arange(100 * 4).reshape(100, 4)
+        data = raw % 3 == 0 if dtype is bool else raw.astype(dtype)
+        unchunked = DataArray(data, dims=("t", "a")).rolling(
+            t=72, min_periods=72, center=center
+        )
+        chunked = (
+            DataArray(data, dims=("t", "a"))
+            .chunk({"t": 40})
+            .rolling(t=72, min_periods=72, center=center)
+        )
+
+        with set_options(use_numbagg=False):
+            expected = getattr(unchunked, name)()
+            actual = getattr(chunked, name)()
+        actual_block = actual.data.blocks[0, 0].compute()
+        computed = actual.compute()
+
+        assert actual.dtype == expected.dtype
+        assert actual.data._meta.dtype == expected.dtype
+        assert actual_block.dtype == expected.dtype
+        assert computed.dtype == expected.dtype
+        assert_allclose(computed, expected)
 
     def test_rolling_mean_bool(self) -> None:
         bool_raster = DataArray(


### PR DESCRIPTION
## Summary

- Fix dask-backed bottleneck rolling reductions declaring metadata dtypes that
  differ from the matching numpy-backed bottleneck result.
- In particular, boolean rolling reductions now declare `float64` metadata
  instead of `object`, matching the actual bottleneck result dtype.
- Preserve centered rolling behavior by using the original bool dtype through
  object padding, while continuing to infer centered integer metadata from the
  padded dtype.
- Add bool and integer coverage comparing numpy-backed and dask-backed rolling
  values, result dtype, dask `_meta`, computed block dtype, and full computed
  dtype.

## Background

The same rolling reduction can currently report different dtypes depending on
the backend:

```python
import xarray as xr, numpy as np, dask.array as dda

n = (
    xr.DataArray(np.ones((100, 4)), dims=("t", "a")) > 0
).rolling(t=72, min_periods=72).sum()

d = (
    xr.DataArray(dda.ones((100, 4), chunks=(100, 4)), dims=("t", "a")) > 0
).rolling(t=72, min_periods=72).sum()

print(n.dtype, d.dtype)
print(d.data._meta.dtype, d.compute().dtype)
```

On xarray 2025.12 and current main, the numpy-backed result is `float64`, while
the dask-backed result declares `object` metadata. With legacy dask, this is
partly masked because computed blocks are still `float64` under the declared
`object` meta. Stricter dask backends can faithfully materialize the declared
`object` dtype, surfacing the inconsistency.

## Diagnosis

`xarray/compat/dask_array_ops.py::dask_rolling_wrapper` previously declared the
dask `map_overlap` dtype using:

```python
dtype = dtypes.maybe_promote(a.dtype)[0]
```

For bool input, `maybe_promote(bool)` returns `object`. That promotion is
appropriate for generic missing-value operations such as padding, filling, and
`where`, but it is too broad for bottleneck moving-window reductions.

Bottleneck accepts bool arrays directly and returns `float64`, which already
has room for the `NaN` values introduced by `min_periods`. The dask wrapper was
therefore declaring metadata from generic NA-promotion rules instead of from the
actual moving function result type.

The centered path has one extra wrinkle: xarray pads before calling the dask
rolling wrapper. For centered bool rolling, padding turns the intermediate dask
array into `object`, so dtype inference needs to use the original bool dtype.
For centered integer rolling, the padded dtype is already the behavior that
matches the numpy-backed path, so that should be preserved.

## Implementation

The dask bottleneck wrapper now derives metadata for numeric and boolean inputs
from the moving function's actual NumPy result dtype. Non-numeric inputs keep
the previous `maybe_promote` fallback.

`_bottleneck_reduce` now passes an explicit `input_dtype` into the dask wrapper:
bool inputs use the original rolling object dtype, while other inputs use the
padded dtype. This fixes centered bool rolling without changing centered
integer behavior.

This change intentionally does not modify `dtypes.maybe_promote`. The
`maybe_promote(bool) -> object` rule may be worth revisiting separately, but
that function is shared by broader NA-handling paths and should not be changed
as part of this targeted bottleneck metadata fix.

## Tests

- Added rolling coverage for bool, `int8`, and `int64` inputs.
- Covered bottleneck reductions across centered and non-centered rolling.
- Asserted numpy-backed and dask-backed results agree on values and dtype.
- Asserted dask `_meta`, a computed block, and the full computed result all
  agree on dtype.
- Skipped only centered bool `std` and `median`, where the numpy-backed
  bottleneck path itself currently errors.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

### AI Disclosure


- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

    Tools: Codex
