### PR TITLE
Reject scalar coordinates as plot axes

### DIFF
--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -428,6 +428,13 @@ def _infer_xy_labels(
         ):
             raise ValueError("x and y cannot be levels of the same MultiIndex")
 
+    for name, label in (("x", x), ("y", y)):
+        if darray[label].ndim == 0:
+            raise ValueError(
+                f"{name} must be a dimension or a non-scalar coordinate. "
+                f"Received {label!r} instead."
+            )
+
     return x, y
 
 

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2267,6 +2267,13 @@ class TestFacetGrid(PlotTestCase):
         self.darray = DataArray(d, dims=["y", "x", "z"], coords={"z": ["a", "b", "c"]})
         self.g = xplt.FacetGrid(self.darray, col="z")
 
+    def test_map_dataarray_rejects_scalar_axis(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="x must be a dimension or a non-scalar coordinate",
+        ):
+            self.g.map_dataarray(xplt.pcolormesh, "z", "y")
+
     @pytest.mark.slow
     def test_no_args(self) -> None:
         self.g.map_dataarray(xplt.contourf, "x", "y")


### PR DESCRIPTION
### Description

Closes #7333.

Facet coordinates remain attached as zero-dimensional coordinates after `FacetGrid` selects each panel. `_infer_xy_labels` accepted those coordinates as plotting axes, causing the 2D plotting code to index a nonexistent first dimension and raise `IndexError`.

This change rejects zero-dimensional x/y coordinates during label inference and raises a clear `ValueError` instead. It also adds a regression test covering a faceting coordinate passed as an axis.

### Tests

- `uv run pytest xarray/tests/test_plot.py`
- `pre-commit run --files xarray/plot/utils.py xarray/tests/test_plot.py`

### Checklist

- [x] Closes #7333
- [x] Tests added
- [ ] User visible changes are documented in `whats-new.rst`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Codex