### PR TITLE
MAINT: Add make to Pixi::doc feature

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -241,6 +241,7 @@ sphinxext-opengraph = "*"
 sphinxext-rediraffe = "*"
 cfgrib = "*"
 myst-parser = "*"
+make = "*"
 
 [feature.doc.tasks]
 doc = { cmd = "make html", cwd = "doc", description = "Build the HTML documentation." }


### PR DESCRIPTION
### Description

Its not available on Windows by default.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes None

### AI Disclosure

None