### PR TITLE
Disable bottleneck by default

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -32,6 +32,7 @@ Bug Fixes
   By `Matthew Rocklin <https://github.com/mrocklin>`_.
 - Disable using bottleneck by default, as certain operations are less numerically
   stable than the equivalent numpy functions.
+  By `Thomas Kluyver <https://github.com/takluyver>`_.
 
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -17,7 +17,9 @@ New Features
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
-
+- Disable using bottleneck by default, as certain operations are less numerically
+  stable than the equivalent numpy functions.
+  By `Thomas Kluyver <https://github.com/takluyver>`_.
 
 Deprecations
 ~~~~~~~~~~~~
@@ -30,9 +32,6 @@ Bug Fixes
   differ from the dtype returned by the matching numpy-backed bottleneck path,
   notably ``object`` instead of ``float64`` for boolean inputs.
   By `Matthew Rocklin <https://github.com/mrocklin>`_.
-- Disable using bottleneck by default, as certain operations are less numerically
-  stable than the equivalent numpy functions.
-  By `Thomas Kluyver <https://github.com/takluyver>`_.
 
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,6 +30,8 @@ Bug Fixes
   differ from the dtype returned by the matching numpy-backed bottleneck path,
   notably ``object`` instead of ``float64`` for boolean inputs.
   By `Matthew Rocklin <https://github.com/mrocklin>`_.
+- Disable using bottleneck by default, as certain operations are less numerically
+  stable than the equivalent numpy functions.
 
 
 Documentation

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -100,6 +100,7 @@ from xarray.core.utils import (
     is_duck_dask_array,
     is_scalar,
     maybe_wrap_array,
+    module_available,
     parse_dims_as_set,
 )
 from xarray.core.variable import (
@@ -8447,11 +8448,8 @@ class Dataset(
         ranked : Dataset
             Variables that do not depend on `dim` are dropped.
         """
-        if not OPTIONS["use_bottleneck"]:
-            raise RuntimeError(
-                "rank requires bottleneck to be enabled."
-                " Call `xr.set_options(use_bottleneck=True)` to enable it."
-            )
+        if not module_available("bottleneck"):
+            raise ImportError("rank requires bottleneck to be installed.")
 
         if dim not in self.dims:
             raise ValueError(

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -103,7 +103,7 @@ OPTIONS: T_Options = {
     "keep_attrs": "default",
     "netcdf_engine_order": ("netcdf4", "h5netcdf", "scipy"),
     "warn_for_unclosed_files": False,
-    "use_bottleneck": True,
+    "use_bottleneck": False,
     "use_flox": True,
     "use_new_combine_kwarg_defaults": False,
     "use_numbagg": True,

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2093,11 +2093,8 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
         Dataset.rank, DataArray.rank
         """
         # This could / should arguably be implemented at the DataArray & Dataset level
-        if not OPTIONS["use_bottleneck"]:
-            raise RuntimeError(
-                "rank requires bottleneck to be enabled."
-                " Call `xr.set_options(use_bottleneck=True)` to enable it."
-            )
+        if not module_available("bottleneck"):
+            raise ImportError("rank requires bottleneck to be installed.")
 
         import bottleneck as bn
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6518,12 +6518,6 @@ class TestDataset:
         ):
             x.rank("invalid_dim")
 
-    def test_rank_use_bottleneck(self) -> None:
-        ds = Dataset({"a": ("x", [0, np.nan, 2]), "b": ("y", [4, 6, 3, 4])})
-        with xr.set_options(use_bottleneck=False):
-            with pytest.raises(RuntimeError):
-                ds.rank("x")
-
     def test_count(self) -> None:
         ds = Dataset({"x": ("a", [np.nan, 1]), "y": 0, "z": np.nan})
         expected = Dataset({"x": 1, "y": 1, "z": 0})

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -460,7 +460,7 @@ class TestDataArrayRolling:
             .rolling(t=72, min_periods=72, center=center)
         )
 
-        with set_options(use_numbagg=False):
+        with set_options(use_numbagg=False, use_bottleneck=True):
             expected = getattr(unchunked, name)()
             actual = getattr(chunked, name)()
         actual_block = actual.data.blocks[0, 0].compute()

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -2018,12 +2018,6 @@ class TestVariable(VariableSubclassobjects):
         ):
             v.rank("x")
 
-    def test_rank_use_bottleneck(self):
-        v = Variable(["x"], [3.0, 1.0, np.nan, 2.0, 4.0])
-        with set_options(use_bottleneck=False):
-            with pytest.raises(RuntimeError):
-                v.rank("x")
-
     @requires_bottleneck
     def test_rank(self):
         import bottleneck as bn


### PR DESCRIPTION
### Description

Certain algorithms in bottleneck are less numerically stable than their numpy equivalents, causing e.g. `arr.mean()` to give surprisingly inaccurate answers if bottleneck is installed. I was just bitten by this, and it's not obvious what the source of the issue is. Everyone commenting on #7344 seems to agree that the more accurate option should be the default, even if it's slower. 

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #7344
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`