### PR TITLE
fix: preserve falsy but valid multi-index level names

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,6 +30,12 @@ Bug Fixes
   differ from the dtype returned by the matching numpy-backed bottleneck path,
   notably ``object`` instead of ``float64`` for boolean inputs.
   By `Matthew Rocklin <https://github.com/mrocklin>`_.
+- Fixed a :py:class:`KeyError` when building a multi-index (e.g. via
+  :py:meth:`Dataset.stack` or :py:meth:`Dataset.set_index`) from levels whose
+  name is falsy but valid, such as an empty string ``""``. Such names were
+  incorrectly replaced by the default ``{dim}_level_{i}`` name instead of being
+  preserved.
+  By `Kropiunig <https://github.com/Kropiunig>`_.
 
 
 Documentation

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -1038,7 +1038,7 @@ class PandasMultiIndex(PandasIndex):
         # default index level names
         names = []
         for i, idx in enumerate(self.index.levels):
-            name = idx.name or f"{dim}_level_{i}"
+            name = idx.name if idx.name is not None else f"{dim}_level_{i}"
             if name == dim:
                 raise ValueError(
                     f"conflicting multi-index level name {name!r} with dimension {dim!r}"

--- a/xarray/tests/test_indexes.py
+++ b/xarray/tests/test_indexes.py
@@ -354,6 +354,12 @@ class TestPandasMultiIndex:
         index = PandasMultiIndex(pd_idx, "x")
         assert list(index.index.names) == ["x_level_0", "x_level_1"]
 
+        # a falsy but valid level name (e.g. "") must be preserved rather than
+        # replaced by the default ``{dim}_level_{i}`` name
+        pd_idx = pd.MultiIndex.from_arrays([foo_data, bar_data], names=("", "bar"))
+        index = PandasMultiIndex(pd_idx, "x")
+        assert list(index.index.names) == ["", "bar"]
+
     def test_from_variables(self) -> None:
         v_level1 = xr.Variable(
             "x", [1, 2, 3], attrs={"unit": "m"}, encoding={"dtype": np.int32}


### PR DESCRIPTION
## What happened

Building a `pandas.MultiIndex`-backed index whose level name is *falsy but valid* — most naturally an empty string `""` — raises `KeyError` through public APIs:

```python
import numpy as np, xarray as xr

ds = xr.Dataset(
    {"v": (("x", "y"), np.arange(6).reshape(3, 2))},
    coords={"": ("x", [10, 20, 30]), "b": ("y", [1, 2])},
)
ds.stack(z=["", "b"])        # KeyError: 'z_level_0'
# ds.set_index(...) with a "" level name fails the same way
```

An empty string is a perfectly valid coordinate name (`ds.sel({"": 20})` works, `"" in ds.coords` is `True`), so this is a crash on legitimate input rather than rejection of a disallowed one.

## Cause

`PandasMultiIndex.__init__` fills in default names for *unnamed* levels:

```python
name = idx.name or f"{dim}_level_{i}"
```

pandas represents an unnamed level as `None`, but `or` also discards legitimate falsy names (`""`, `0`, `False`), swapping them for the synthetic `{dim}_level_{i}`. Meanwhile `level_coords_dtype` is still keyed by the original name, so the two fall out of sync and `create_variables` raises `KeyError` on the lookup `self.level_coords_dtype[name]`.

## Fix

Use an explicit `is not None` check so only truly unnamed (`None`) levels get the default name:

```python
name = idx.name if idx.name is not None else f"{dim}_level_{i}"
```

## Tests

Added a regression assertion to `TestPandasMultiIndex::test_constructor` covering a `""` level name (fails before, passes after). The existing default-name case (`None` levels → `x_level_0`, `x_level_1`) is unchanged and still asserted.
