### PR TITLE
Fix: Chunksize when opening sharded zarr

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -462,7 +462,6 @@ def extract_zarr_variable_encoding(
     """
 
     encoding = variable.encoding.copy()
-
     safe_to_drop = {"source", "original_shape", "preferred_chunks"}
     valid_encodings = {
         "chunks",
@@ -859,10 +858,11 @@ class ZarrStore(AbstractWritableDataStore):
             zarr_array, DIMENSION_KEY, try_nczarr
         )
         attributes = dict(attributes)
+        preferred_chunks = zarr_array.shards or zarr_array.chunks
 
         encoding = {
             "chunks": zarr_array.chunks,
-            "preferred_chunks": dict(zip(dimensions, zarr_array.chunks, strict=True)),
+            "preferred_chunks": dict(zip(dimensions, preferred_chunks, strict=True)),
         }
 
         encoding.update(

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -858,7 +858,9 @@ class ZarrStore(AbstractWritableDataStore):
             zarr_array, DIMENSION_KEY, try_nczarr
         )
         attributes = dict(attributes)
-        preferred_chunks = zarr_array.shards or zarr_array.chunks
+        preferred_chunks = (
+            zarr_array.shards if zarr_array.shards is not None else zarr_array.chunks
+        )
 
         encoding = {
             "chunks": zarr_array.chunks,

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -8144,3 +8144,64 @@ def test_get_mtime_non_file_paths() -> None:
 
     # GDAL virtual filesystem paths are not real files
     assert _get_mtime("/vsicurl/https://example.com/file.nc") is None
+
+
+@requires_dask
+@pytest.mark.parametrize(
+    "shape, enc_chunks, enc_shards",
+    [
+        (
+            (10, 10),
+            (2, 2),
+            (4, 4),
+        ),
+        (
+            (100, 10),
+            (2, 2),
+            (4, 4),
+        ),
+        (
+            (100, 10, 1),
+            (2, 2, 1),
+            (4, 4, 1),
+        ),
+    ],
+)
+def test_zarr_shard_roundtrip(shape, enc_chunks, enc_shards, tmp_path):
+
+    dimensions = {f"dim_{i}" for i in range(len(shape))}
+    sizes = dict(zip(dimensions, shape, strict=True))
+
+    data_values = np.arange(np.prod(shape)).reshape(shape)
+    coords = {dim: np.arange(sizes[dim]) for dim in dimensions}
+
+    chunks = dict(zip(dimensions, enc_chunks, strict=True))
+    shards = dict(zip(dimensions, enc_shards, strict=True))
+
+    ds = xr.Dataset(
+        {
+            "data": (dimensions, data_values),
+        },
+        coords=coords,
+    )
+
+    # Make the xarray chunks match the zarr shards
+    ds_sharded = ds.chunk(shards)
+    encoding = {
+        dim: {"chunks": (chunks[dim],), "shards": (shards[dim],)} for dim in dimensions
+    }
+    encoding["data"] = {"chunks": enc_shards, "shards": enc_shards}
+
+    store = tmp_path / "test.zarr"
+    ds_sharded.to_zarr(
+        store,
+        mode="w",
+        encoding=encoding,
+        zarr_format=3,
+        consolidated=False,
+    )
+
+    # reopen dataset and store it back
+    reopend_ds = xr.open_zarr(store, consolidated=False)
+    reopend_ds.to_zarr(store, mode="a")
+    assert reopend_ds.chunks == ds_sharded.chunks


### PR DESCRIPTION
### Description

Use Zarr shards as the preferred chunk size in when opening Zarr datasets. Previously it was necessary to 
know the shard size when opening to avoid error saving back to disk.

I think the term chunk is overloaded. In this case, chunk can refer to both Dask chunks and Zarr chunks, which are not necessarily the same. In the case of a shared Zarr archive, i would argue that the sensible choice of Dask chunks is the shard size. When writing to disk it could create race conditions with multiple Dask chunks in the same shard. This is also what caused the original error


### Checklist

- [x] Closes #11460
- [x] Tests added
