### PR TITLE
Feat/11451 accessor repr

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -14,6 +14,10 @@ v2026.07.1 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- Dataset, DataArray, and DataTree text and HTML reprs can include an Accessors
+  section for accessors registered via ``register_*_accessor`` that define a
+  custom ``__repr__``.
+
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/extensions.py
+++ b/xarray/core/extensions.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import inspect
 import warnings
+from typing import Any
 
 from xarray.core.dataarray import DataArray
 from xarray.core.dataset import Dataset
@@ -47,6 +49,9 @@ class _CachedAccessor:
         return accessor_obj
 
 
+_ACCESSORS: dict[type, dict[str, type]] = {}
+
+
 def _register_accessor(name, cls):
     def decorator(accessor):
         if hasattr(cls, name):
@@ -57,9 +62,42 @@ def _register_accessor(name, cls):
                 stacklevel=2,
             )
         setattr(cls, name, _CachedAccessor(name, accessor))
+        _ACCESSORS.setdefault(cls, {})[name] = accessor
         return accessor
 
     return decorator
+
+
+def get_registered_accessors(cls: type) -> dict[str, type]:
+    """Merge accessor registries along the class MRO."""
+    merged: dict[str, type] = {}
+    for base in reversed(cls.mro()):
+        merged.update(_ACCESSORS.get(base, {}))
+    return merged
+
+
+def get_accessors_for_repr(obj: Any) -> dict[str, object]:
+    """Return ``{name: instance}`` for accessors that should appear in the repr.
+
+    Only accessors registered via ``register_*_accessor`` that still exist as
+    ``_CachedAccessor`` descriptors, define a custom ``__repr__``, and
+    construct without error are included.
+    """
+    result: dict[str, object] = {}
+    obj_type = type(obj)
+    for name, accessor_cls in get_registered_accessors(obj_type).items():
+        # MUST use getattr_static: normal getattr on the class invokes
+        # _CachedAccessor.__get__(None, cls) and returns the accessor class.
+        desc = inspect.getattr_static(obj_type, name, None)
+        if not isinstance(desc, _CachedAccessor):
+            continue
+        if accessor_cls.__repr__ is object.__repr__:
+            continue
+        try:
+            result[name] = getattr(obj, name)
+        except Exception:
+            continue
+    return result
 
 
 def register_dataarray_accessor(name):
@@ -70,6 +108,11 @@ def register_dataarray_accessor(name):
     name : str
         Name under which the accessor should be registered. A warning is issued
         if this name conflicts with a preexisting attribute.
+
+    Notes
+    -----
+    Accessors that define a custom ``__repr__`` may appear under an Accessors
+    section in the DataArray text and HTML repr.
 
     See Also
     --------
@@ -86,6 +129,11 @@ def register_dataset_accessor(name):
     name : str
         Name under which the accessor should be registered. A warning is issued
         if this name conflicts with a preexisting attribute.
+
+    Notes
+    -----
+    Accessors that define a custom ``__repr__`` may appear under an Accessors
+    section in the Dataset text and HTML repr.
 
     Examples
     --------
@@ -132,6 +180,11 @@ def register_datatree_accessor(name):
     name : str
         Name under which the accessor should be registered. A warning is issued
         if this name conflicts with a preexisting attribute.
+
+    Notes
+    -----
+    Accessors that define a custom ``__repr__`` may appear under an Accessors
+    section in the DataTree text and HTML repr.
 
     See Also
     --------

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -443,6 +443,31 @@ attrs_repr = functools.partial(
 )
 
 
+def summarize_accessor(key, value, col_width=None):
+    """Summary line for a registered accessor in ``__repr__``."""
+    k_str = f"    {key}:"
+    if col_width is not None:
+        k_str = pretty_print(k_str, col_width)
+    v_str = repr(value).replace("\t", "\\t").replace("\n", "\\n")
+    return maybe_truncate(f"{k_str} {v_str}", OPTIONS["display_width"])
+
+
+def accessors_repr(obj, max_rows=None):
+    """Return an Accessors section for ``obj``, or ``None`` if empty."""
+    from xarray.core.extensions import get_accessors_for_repr
+
+    accessors = get_accessors_for_repr(obj)
+    if not accessors:
+        return None
+    return _mapping_repr(
+        accessors,
+        title="Accessors",
+        summarizer=summarize_accessor,
+        expand_option_name="display_expand_accessors",
+        max_rows=max_rows,
+    )
+
+
 def _coord_sort_key(coord, dims):
     """Sort key for coordinate ordering.
 
@@ -767,6 +792,9 @@ def array_repr(arr):
         if xindexes:
             summary.append(indexes_repr(xindexes, max_rows=max_rows))
 
+    if accessors_section := accessors_repr(arr, max_rows=max_rows):
+        summary.append(accessors_section)
+
     if arr.attrs:
         summary.append(attrs_repr(arr.attrs, max_rows=max_rows))
 
@@ -804,6 +832,9 @@ def dataset_repr(ds):
     )
     if xindexes:
         summary.append(indexes_repr(xindexes, max_rows=max_rows))
+
+    if accessors_section := accessors_repr(ds, max_rows=max_rows):
+        summary.append(accessors_section)
 
     if ds.attrs:
         summary.append(attrs_repr(ds.attrs, max_rows=max_rows))
@@ -1238,6 +1269,9 @@ def _datatree_node_repr(node: DataTree, root: bool) -> str:
     )
     if xindexes:
         summary.append(indexes_repr(xindexes, max_rows=max_rows))
+
+    if accessors_section := accessors_repr(node, max_rows=max_rows):
+        summary.append(accessors_section)
 
     if node.attrs:
         summary.append(attrs_repr(node.attrs, max_rows=max_rows))

--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -293,6 +293,32 @@ attr_section = partial(
 )
 
 
+def summarize_accessors(accessors) -> str:
+    accessors_dl = "".join(
+        f"<dt><span>{escape(str(k))} :</span></dt><dd>{escape(repr(v))}</dd>"
+        for k, v in accessors.items()
+    )
+    return f"<dl class='xr-attrs'>{accessors_dl}</dl>"
+
+
+accessor_section = partial(
+    _mapping_section,
+    name="Accessors",
+    details_func=summarize_accessors,
+    max_items_collapse=5,
+    expand_option_name="display_expand_accessors",
+)
+
+
+def _accessors_section(obj) -> str | None:
+    from xarray.core.extensions import get_accessors_for_repr
+
+    accessors = get_accessors_for_repr(obj)
+    if not accessors:
+        return None
+    return accessor_section(accessors)
+
+
 def _get_indexes_dict(indexes):
     return {
         tuple(index_vars.keys()): idx for idx, index_vars in indexes.group_by_index()
@@ -358,6 +384,9 @@ def array_repr(arr) -> str:
             indexes = _get_indexes_dict(arr.xindexes)
             sections.append(index_section(indexes))
 
+    if accessors_html := _accessors_section(arr):
+        sections.append(accessors_html)
+
     if arr.attrs:
         sections.append(attr_section(arr.attrs))
 
@@ -386,6 +415,9 @@ def dataset_repr(ds) -> str:
     )
     if xindexes:
         sections.append(index_section(xindexes))
+
+    if accessors_html := _accessors_section(ds):
+        sections.append(accessors_html)
 
     if ds.attrs:
         sections.append(attr_section(ds.attrs))
@@ -435,6 +467,11 @@ def _datatree_node_sections(node: DataTree, root: bool) -> tuple[list[str], int]
         sections.append(datavar_section(ds.data_vars))
     if xindexes:
         sections.append(index_section(xindexes))
+    from xarray.core.extensions import get_accessors_for_repr
+
+    accessors = get_accessors_for_repr(node)
+    if accessors:
+        sections.append(accessor_section(accessors))
     if ds.attrs:
         sections.append(attr_section(ds.attrs))
 
@@ -448,6 +485,8 @@ def _datatree_node_sections(node: DataTree, root: bool) -> tuple[list[str], int]
         + len(ds.data_vars)
         + int(bool(xindexes))
         + len(xindexes)
+        + int(bool(accessors))
+        + len(accessors)
         + int(bool(ds.attrs))
         + len(ds.attrs)
     )

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
         "display_expand_data",
         "display_expand_groups",
         "display_expand_indexes",
+        "display_expand_accessors",
         "display_default_indexes",
         "enable_cftimeindex",
         "file_cache_maxsize",
@@ -63,6 +64,7 @@ if TYPE_CHECKING:
         display_expand_data: Literal["default"] | bool
         display_expand_groups: Literal["default"] | bool
         display_expand_indexes: Literal["default"] | bool
+        display_expand_accessors: Literal["default"] | bool
         display_default_indexes: Literal["default"] | bool
         enable_cftimeindex: bool
         file_cache_maxsize: int
@@ -97,6 +99,7 @@ OPTIONS: T_Options = {
     "display_expand_data": "default",
     "display_expand_groups": "default",
     "display_expand_indexes": "default",
+    "display_expand_accessors": "default",
     "display_default_indexes": False,
     "enable_cftimeindex": True,
     "file_cache_maxsize": 128,
@@ -137,6 +140,7 @@ _VALIDATORS = {
     "display_expand_data_vars": lambda choice: choice in [True, False, "default"],
     "display_expand_data": lambda choice: choice in [True, False, "default"],
     "display_expand_indexes": lambda choice: choice in [True, False, "default"],
+    "display_expand_accessors": lambda choice: choice in [True, False, "default"],
     "display_default_indexes": lambda choice: choice in [True, False, "default"],
     "enable_cftimeindex": lambda value: isinstance(value, bool),
     "file_cache_maxsize": _positive_integer,
@@ -286,6 +290,13 @@ class set_options:
         * ``True`` : to always expand indexes
         * ``False`` : to always collapse indexes
         * ``default`` : to expand unless over a pre-defined limit (always collapse for html style)
+    display_expand_accessors : {"default", True, False}
+        Whether to expand the accessors section for display of
+        ``DataArray``, ``Dataset``, or ``DataTree`` objects. Can be
+
+        * ``True`` : to always expand accessors
+        * ``False`` : to always collapse accessors
+        * ``default`` : to expand unless over a pre-defined limit
     display_max_children : int, default: 12
         Maximum number of children to display for each node in a DataTree.
     display_max_html_elements : int, default: 300

--- a/xarray/tests/test_extensions.py
+++ b/xarray/tests/test_extensions.py
@@ -93,3 +93,38 @@ class TestAccessor:
 
         with pytest.raises(RuntimeError, match=r"error initializing"):
             _ = xr.Dataset().stupid_accessor
+
+    def test_registry_and_repr_accessors(self) -> None:
+        from xarray.core.extensions import get_accessors_for_repr, get_registered_accessors
+
+        @xr.register_dataset_accessor("repr_demo_ds")
+        class ReprDemo:
+            def __init__(self, obj):
+                self._obj = obj
+
+            def __repr__(self) -> str:
+                return "ReprDemo()"
+
+        try:
+            assert "repr_demo_ds" in get_registered_accessors(xr.Dataset)
+            ds = xr.Dataset()
+            accessors = get_accessors_for_repr(ds)
+            assert "repr_demo_ds" in accessors
+            assert repr(accessors["repr_demo_ds"]) == "ReprDemo()"
+        finally:
+            del xr.Dataset.repr_demo_ds  # type: ignore[attr-defined]
+
+        assert "repr_demo_ds" not in get_accessors_for_repr(xr.Dataset())
+
+    def test_repr_skips_default_object_repr(self) -> None:
+        from xarray.core.extensions import get_accessors_for_repr
+
+        @xr.register_dataset_accessor("no_custom_repr_demo")
+        class NoCustomRepr:
+            def __init__(self, obj):
+                self._obj = obj
+
+        try:
+            assert get_accessors_for_repr(xr.Dataset()) == {}
+        finally:
+            del xr.Dataset.no_custom_repr_demo  # type: ignore[attr-defined]

--- a/xarray/tests/test_extensions.py
+++ b/xarray/tests/test_extensions.py
@@ -95,7 +95,10 @@ class TestAccessor:
             _ = xr.Dataset().stupid_accessor
 
     def test_registry_and_repr_accessors(self) -> None:
-        from xarray.core.extensions import get_accessors_for_repr, get_registered_accessors
+        from xarray.core.extensions import (
+            get_accessors_for_repr,
+            get_registered_accessors,
+        )
 
         @xr.register_dataset_accessor("repr_demo_ds")
         class ReprDemo:

--- a/xarray/tests/test_formatting.py
+++ b/xarray/tests/test_formatting.py
@@ -1246,3 +1246,75 @@ Coordinates:
   * bar      (x) int64 32B 1 2 1 2
     """.strip()
     assert actual == expected
+
+
+def test_dataset_repr_includes_custom_accessor() -> None:
+    @xr.register_dataset_accessor("repr_demo_fmt")
+    class ReprDemo:
+        def __init__(self, obj):
+            self._obj = obj
+
+        def __repr__(self) -> str:
+            return "ReprDemo(ok)"
+
+    try:
+        ds = xr.Dataset({"x": 1})
+        text = formatting.dataset_repr(ds)
+        assert "Accessors:" in text
+        assert "repr_demo_fmt:" in text
+        assert "ReprDemo(ok)" in text
+        # Accessors appear before Attributes when both present
+        ds.attrs["a"] = 1
+        text = formatting.dataset_repr(ds)
+        assert text.index("Accessors:") < text.index("Attributes:")
+    finally:
+        del xr.Dataset.repr_demo_fmt  # type: ignore[attr-defined]
+
+
+def test_dataset_repr_skips_accessor_without_custom_repr() -> None:
+    @xr.register_dataset_accessor("no_repr_demo_fmt")
+    class NoCustomRepr:
+        def __init__(self, obj):
+            self._obj = obj
+
+    try:
+        text = formatting.dataset_repr(xr.Dataset())
+        assert "Accessors:" not in text
+        assert "no_repr_demo_fmt" not in text
+    finally:
+        del xr.Dataset.no_repr_demo_fmt  # type: ignore[attr-defined]
+
+
+def test_dataset_repr_omits_broken_accessor() -> None:
+    @xr.register_dataset_accessor("broken_repr_demo_fmt")
+    class BrokenAccessor:
+        def __init__(self, obj):
+            raise AttributeError("broken")
+
+        def __repr__(self) -> str:
+            return "Broken()"
+
+    try:
+        text = formatting.dataset_repr(xr.Dataset())
+        assert "Accessors:" not in text
+        assert "broken_repr_demo_fmt" not in text
+    finally:
+        del xr.Dataset.broken_repr_demo_fmt  # type: ignore[attr-defined]
+
+
+def test_dataarray_repr_includes_custom_accessor() -> None:
+    @xr.register_dataarray_accessor("repr_demo_da")
+    class ReprDemoDA:
+        def __init__(self, obj):
+            self._obj = obj
+
+        def __repr__(self) -> str:
+            return "ReprDemoDA()"
+
+    try:
+        text = formatting.array_repr(xr.DataArray(0))
+        assert "Accessors:" in text
+        assert "repr_demo_da:" in text
+        assert "ReprDemoDA()" in text
+    finally:
+        del xr.DataArray.repr_demo_da  # type: ignore[attr-defined]

--- a/xarray/tests/test_formatting_html.py
+++ b/xarray/tests/test_formatting_html.py
@@ -42,6 +42,7 @@ assert_consistent_text_and_html_dataarray = partial(
     section_headers=[
         "Coordinates",
         "Indexes",
+        "Accessors",
         "Attributes",
     ],
 )
@@ -54,6 +55,7 @@ assert_consistent_text_and_html_dataset = partial(
         "Coordinates",
         "Data variables",
         "Indexes",
+        "Accessors",
         "Attributes",
     ],
 )
@@ -67,6 +69,7 @@ assert_consistent_text_and_html_datatree = partial(
         "Inherited coordinates",
         "Data variables",
         "Indexes",
+        "Accessors",
         "Attributes",
     ],
 )
@@ -448,3 +451,22 @@ class TestDataTreeInheritance:
         html = dt._repr_html_()
         assert html.count("<style>") == 1
         assert html.count("<pre class='xr-text-repr-fallback'>") == 1
+
+
+def test_html_repr_includes_custom_accessor() -> None:
+    @xr.register_dataset_accessor("repr_demo_html")
+    class ReprDemoHtml:
+        def __init__(self, obj):
+            self._obj = obj
+
+        def __repr__(self) -> str:
+            return "ReprDemoHtml(<tag>)"
+
+    try:
+        html = xarray_html_only_repr(xr.Dataset({"x": 1}))
+        assert "Accessors" in html
+        assert "repr_demo_html" in html
+        # escaped angle brackets from __repr__
+        assert "ReprDemoHtml(&lt;tag&gt;)" in html
+    finally:
+        del xr.Dataset.repr_demo_html  # type: ignore[attr-defined]


### PR DESCRIPTION
### Description

Closes #11451.

Dataset, DataArray, and DataTree text and HTML reprs can now show an **Accessors** section for accessors registered with `register_*_accessor` when the accessor class defines a custom `__repr__`.

Approach:
- Track registrations in a module-level registry (`_ACCESSORS`) when `register_*_accessor` runs.
- For repr, resolve accessors along the class MRO, keep only those still installed as `_CachedAccessor` descriptors, skip classes that still use `object.__repr__`, and skip accessors that fail to initialize so `repr()` never raises.
- Place the section after Indexes and before Attributes.
- Add `display_expand_accessors` for the HTML section (same pattern as other `display_expand_*` options).

Built-ins like `.dt` / `.str` / `.plot` are unchanged: they are not registered via `register_*_accessor`, so they do not appear.

Example:

```python
@xr.register_dataset_accessor("geo")
class GeoAccessor:
    def __init__(self, ds):
        self._ds = ds

    def __repr__(self):
        return "GeoAccessor(...)"

print(ds)  # includes Accessors: geo: GeoAccessor(...)

