### PR TITLE
ENH: render DataTree children as a forest

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -14,6 +14,10 @@ v2026.07.1 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- :py:attr:`DataTree.children` now has a rich HTML representation that displays
+  child nodes as a collapsible forest instead of an inline mapping
+  (:issue:`11453`). By `Deepak Ganesh <https://github.com/deepakganesh78>`_.
+
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -46,6 +46,9 @@ from xarray.core.formatting import (
     dims_and_coords_repr,
 )
 from xarray.core.formatting_html import (
+    datatree_children_repr,
+)
+from xarray.core.formatting_html import (
     datatree_repr as datatree_repr_html,
 )
 from xarray.core.indexes import Index, Indexes
@@ -459,6 +462,18 @@ class _DatasetArgs:
     coords: dict[str, CoercibleValue] = field(default_factory=dict)
 
 
+class _DataTreeChildren(Frozen[str, "DataTree"]):
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return f"Frozen({self.mapping!r})"
+
+    def _repr_html_(self) -> str:
+        if XR_OPTS["display_style"] == "text":
+            return f"<pre>{escape(repr(self))}</pre>"
+        return datatree_children_repr(self)
+
+
 class DataTree(
     NamedNode,
     DataTreeAggregations,
@@ -559,6 +574,9 @@ class DataTree(
         self._encoding = dataset._encoding
         self._attrs = dataset._attrs
         self._close = dataset._close
+
+    def _children_view(self) -> Mapping[str, DataTree]:
+        return _DataTreeChildren(self._children)
 
     def _pre_attach(self: DataTree, parent: DataTree, name: str) -> None:
         super()._pre_attach(parent, name)

--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -659,3 +659,17 @@ def datatree_repr(node: DataTree) -> str:
         header_components.append(f"<div class='xr-obj-name'>{name}</div>")
     sections = datatree_sections(node, displays)
     return _obj_repr(node, header_components, sections)
+
+
+def datatree_children_repr(children: Mapping[str, DataTree]) -> str:
+    displays = {}
+    for child in children.values():
+        child_displays = _build_datatree_displays(child)
+        child_displays[child.path].collapsed = True
+        displays.update(child_displays)
+
+    header_components = [
+        "<div class='xr-obj-type'>xarray.DataTree children</div>",
+    ]
+    sections = [children_section(children, displays)] if children else []
+    return _obj_repr(children, header_components, sections)

--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import uuid
-from collections import OrderedDict
-from collections.abc import Mapping
+from collections import OrderedDict, deque
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from functools import lru_cache, partial
 from html import escape
@@ -478,12 +478,14 @@ class _DataTreeDisplay:
     disabled: bool
 
 
-def _build_datatree_displays(tree: DataTree) -> dict[str, _DataTreeDisplay]:
+def _build_datatree_displays_from_nodes(
+    nodes: Iterable[DataTree], *, has_root: bool
+) -> dict[str, _DataTreeDisplay]:
     displayed_line_count = 0
     html_line_count = 0
     displays: dict[str, _DataTreeDisplay] = {}
     item_count_cache: dict[int, int] = {}
-    root = True
+    root = has_root
     collapsed = False
     disabled = False
 
@@ -497,7 +499,7 @@ def _build_datatree_displays(tree: DataTree) -> dict[str, _DataTreeDisplay]:
         span_grid=True,
     )
 
-    for node in tree.subtree:  # breadth-first
+    for node in nodes:
         parent = node.parent
         if parent is not None:
             parent_display = displays.get(parent.path)
@@ -537,6 +539,26 @@ def _build_datatree_displays(tree: DataTree) -> dict[str, _DataTreeDisplay]:
                     displays[child.path].collapsed = True
 
     return displays
+
+
+def _build_datatree_displays(tree: DataTree) -> dict[str, _DataTreeDisplay]:
+    return _build_datatree_displays_from_nodes(tree.subtree, has_root=True)
+
+
+def _children_subtree(children: Mapping[str, DataTree]) -> Iterator[DataTree]:
+    queue = deque(children.values())
+    while queue:
+        node = queue.popleft()
+        yield node
+        queue.extend(node.children.values())
+
+
+def _build_datatree_children_displays(
+    children: Mapping[str, DataTree],
+) -> dict[str, _DataTreeDisplay]:
+    return _build_datatree_displays_from_nodes(
+        _children_subtree(children), has_root=False
+    )
 
 
 def _ellipsis_element() -> str:
@@ -662,11 +684,9 @@ def datatree_repr(node: DataTree) -> str:
 
 
 def datatree_children_repr(children: Mapping[str, DataTree]) -> str:
-    displays = {}
+    displays = _build_datatree_children_displays(children)
     for child in children.values():
-        child_displays = _build_datatree_displays(child)
-        child_displays[child.path].collapsed = True
-        displays.update(child_displays)
+        displays[child.path].collapsed = True
 
     header_components = [
         "<div class='xr-obj-type'>xarray.DataTree children</div>",

--- a/xarray/core/treenode.py
+++ b/xarray/core/treenode.py
@@ -160,10 +160,13 @@ class TreeNode:
         """Detach this node from its parent."""
         self._set_parent(new_parent=None)
 
+    def _children_view(self) -> Mapping[str, Self]:
+        return Frozen(self._children)
+
     @property
     def children(self) -> Mapping[str, Self]:
         """Child nodes of this node, stored under a mapping via their names."""
-        return Frozen(self._children)
+        return self._children_view()
 
     @children.setter
     def children(self, children: Mapping[str, Self]) -> None:

--- a/xarray/tests/test_formatting_html.py
+++ b/xarray/tests/test_formatting_html.py
@@ -477,6 +477,20 @@ class TestDataTreeChildren:
         assert "/reanalysis/model" in html_only
         assert "type='checkbox' checked" in html_only
 
+    def test_repr_html_respects_global_element_limit(self) -> None:
+        tree = xr.DataTree.from_dict(
+            {
+                "observed": xr.Dataset({"temperature": 1}),
+                "reanalysis": xr.Dataset({"temperature": 2}),
+            }
+        )
+
+        with xr.set_options(display_max_html_elements=1):
+            html = tree.children._repr_html_()  # type: ignore[attr-defined]
+        html_only = drop_fallback_text_repr(html)
+
+        assert html_only.count("Too many items to display") == 2
+
     def test_text_repr_unchanged(self) -> None:
         tree = xr.DataTree.from_dict({"child": None})
 

--- a/xarray/tests/test_formatting_html.py
+++ b/xarray/tests/test_formatting_html.py
@@ -448,3 +448,39 @@ class TestDataTreeInheritance:
         html = dt._repr_html_()
         assert html.count("<style>") == 1
         assert html.count("<pre class='xr-text-repr-fallback'>") == 1
+
+
+class TestDataTreeChildren:
+    def test_empty_repr_html(self) -> None:
+        html = xr.DataTree().children._repr_html_()  # type: ignore[attr-defined]
+        html_only = drop_fallback_text_repr(html)
+
+        assert "xarray.DataTree children" in html_only
+        assert "<div class='xr-children'>" not in html_only
+
+    def test_repr_html(self) -> None:
+        tree = xr.DataTree.from_dict(
+            {
+                "observed": xr.Dataset({"temperature": 1}),
+                "reanalysis/model": xr.Dataset({"temperature": 2}),
+            }
+        )
+
+        html = tree.children._repr_html_()  # type: ignore[attr-defined]
+        html_only = drop_fallback_text_repr(html)
+
+        assert html.count("<style>") == 1
+        assert html.count("<pre class='xr-text-repr-fallback'>") == 1
+        assert "xarray.DataTree children" in html_only
+        assert "/observed" in html_only
+        assert "/reanalysis" in html_only
+        assert "/reanalysis/model" in html_only
+        assert "type='checkbox' checked" in html_only
+
+    def test_text_repr_unchanged(self) -> None:
+        tree = xr.DataTree.from_dict({"child": None})
+
+        assert repr(tree.children).startswith("Frozen({")
+        with xr.set_options(display_style="text"):
+            html = tree.children._repr_html_()  # type: ignore[attr-defined]
+        assert html.startswith("<pre>Frozen({")


### PR DESCRIPTION
### Description

Closes #11453.

`DataTree.children` now returns a dedicated immutable view with a rich HTML representation. The representation reuses the existing DataTree renderer to show direct children as collapsed roots in a forest, while preserving the existing `Frozen(...)` text representation and mapping behavior.

The forest is built in one breadth-first pass, so all direct children and descendants share `display_max_html_elements` and `display_max_items` budgets. This matches normal `DataTree` truncation instead of granting every direct child a fresh root exemption. Nested descendants, direct-child truncation, empty child mappings, and text display mode are covered.

### Checklist

- [x] Closes #11453
- [x] Tests added
- [x] User visible changes are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst` (not applicable; no public API added)

### Validation

- `uv run pytest xarray/tests/test_formatting_html.py xarray/tests/test_treenode.py xarray/tests/test_datatree.py -q` — 220 passed, 1 skipped, 5 xfailed
- `uv run pre-commit run --files xarray/core/formatting_html.py xarray/tests/test_formatting_html.py` — passed
- `git diff --check` — passed

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: GitHub Copilot CLI. The implementation and tests were reviewed against the existing DataTree formatting, truncation, and mapping behavior, then validated with the commands above.

[Opened by GitHub Copilot CLI on behalf of Deepak Ganesh.]