### PR TITLE
Optimize object conversion

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import datetime
 import itertools
 import math
 import numbers
@@ -208,6 +209,14 @@ def _maybe_wrap_data(data):
     return data
 
 
+_DATETIMELIKE_TYPES = (
+    datetime.datetime,
+    datetime.timedelta,
+    np.datetime64,
+    np.timedelta64,
+)
+
+
 def _possibly_convert_objects(values):
     """Convert object arrays into datetime64 and timedelta64 according
     to the pandas convention.  For backwards compat, as of 3.0.0 pandas,
@@ -220,7 +229,49 @@ def _possibly_convert_objects(values):
     * pd.Timestamp
     * pd.Timedelta
     """
-    as_series = pd.Series(values.ravel(), copy=False)
+    if values.dtype.kind == "O":
+        flat = values.ravel()
+        limit = min(10000, len(flat))
+        has_datetimelike = False
+        has_non_null_non_datetimelike = False
+
+        for i in range(limit):
+            val = flat[i]
+            if isinstance(val, _DATETIMELIKE_TYPES):
+                has_datetimelike = True
+                break
+            is_null = (
+                val is None
+                or val is pd.NaT
+                or (isinstance(val, float) and math.isnan(val))
+                or (isinstance(val, np.floating) and np.isnan(val))
+            )
+            if not is_null:
+                has_non_null_non_datetimelike = True
+                break
+
+        if has_datetimelike:
+            is_datetimelike = True
+        elif has_non_null_non_datetimelike:
+            is_datetimelike = False
+        elif len(flat) > limit:
+            inferred = pd.api.types.infer_dtype(flat, skipna=False)
+            is_datetimelike = inferred in (
+                "datetime",
+                "datetime64",
+                "timedelta",
+                "timedelta64",
+            )
+        else:
+            is_datetimelike = False
+
+        if not is_datetimelike:
+            return values
+
+        as_series = pd.Series(flat, copy=False)
+    else:
+        as_series = pd.Series(values.ravel(), copy=False)
+
     result = np.asarray(as_series).reshape(values.shape)
     if not result.flags.writeable:
         # GH8843, pandas copy-on-write mode creates read-only arrays by default

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -237,7 +237,7 @@ def _possibly_convert_objects(values):
 
         for i in range(limit):
             val = flat[i]
-            if isinstance(val, _DATETIMELIKE_TYPES):
+            if isinstance(val, _DATETIMELIKE_TYPES) or val is pd.NaT:
                 has_datetimelike = True
                 break
             is_null = (

--- a/xarray/tests/test_possibly_convert_objects.py
+++ b/xarray/tests/test_possibly_convert_objects.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import datetime
+
+import numpy as np
+import pandas as pd
+
+from xarray.core.variable import _possibly_convert_objects
+
+
+def test_possibly_convert_objects_datetime():
+    # Array with datetime.datetime
+    data = np.array([datetime.datetime(2020, 1, 1), None], dtype=object)
+    result = _possibly_convert_objects(data)
+    assert result.dtype.kind == "M"
+    assert result[0] == np.datetime64("2020-01-01T00:00:00")
+
+
+def test_possibly_convert_objects_timedelta():
+    # Array with datetime.timedelta
+    data = np.array([datetime.timedelta(days=1), None], dtype=object)
+    result = _possibly_convert_objects(data)
+    assert result.dtype.kind == "m"
+    assert result[0] == np.timedelta64(1, "D")
+
+
+def test_possibly_convert_objects_np_datetime():
+    # Array with np.datetime64
+    data = np.array([np.datetime64("2020-01-01"), None], dtype=object)
+    result = _possibly_convert_objects(data)
+    assert result.dtype.kind == "M"
+
+
+def test_possibly_convert_objects_np_timedelta():
+    # Array with np.timedelta64
+    data = np.array([np.timedelta64(1, "D"), None], dtype=object)
+    result = _possibly_convert_objects(data)
+    assert result.dtype.kind == "m"
+
+
+def test_possibly_convert_objects_strings():
+    # Array with strings (should NOT be converted/modified)
+    data = np.array(["a", "b", "c"], dtype=object)
+    result = _possibly_convert_objects(data)
+    assert result is data  # Should return the exact same array object
+    assert result.dtype == object
+
+
+def test_possibly_convert_objects_mixed_non_datetime():
+    # Array with mixed types, no datetimelike (should NOT be converted/modified)
+    data = np.array([1, "a", 2.5, None], dtype=object)
+    result = _possibly_convert_objects(data)
+    assert result is data
+    assert result.dtype == object
+
+
+def test_possibly_convert_objects_all_nulls_small():
+    # Small array with only non-NaT nulls (should NOT be converted/modified)
+    data = np.array([None, np.nan], dtype=object)
+    result = _possibly_convert_objects(data)
+    assert result is data
+    assert result.dtype == object
+
+    # But if it has pd.NaT, it should be converted to datetime64
+    data_with_nat = np.array([None, np.nan, pd.NaT], dtype=object)
+    result_with_nat = _possibly_convert_objects(data_with_nat)
+    assert result_with_nat.dtype.kind == "M"
+
+
+def test_possibly_convert_objects_all_nulls_large():
+    # Large array (exceeding the 10000 limit) with only nulls (should NOT be converted/modified)
+    data = np.array([None] * 10005, dtype=object)
+    result = _possibly_convert_objects(data)
+    assert result is data
+    assert result.dtype == object
+
+
+def test_possibly_convert_objects_large_with_datetime_at_end():
+    # Large array (exceeding 10000 limit) with nulls first, and a datetime at the end
+    data = np.array([None] * 10000 + [datetime.datetime(2020, 1, 1)], dtype=object)
+    result = _possibly_convert_objects(data)
+    assert result.dtype.kind == "M"
+    assert result[-1] == np.datetime64("2020-01-01T00:00:00")
+
+
+def test_possibly_convert_objects_large_with_non_datetime_at_end():
+    # Large array (exceeding 10000 limit) with nulls first, and a string at the end
+    data = np.array([None] * 10000 + ["a"], dtype=object)
+    result = _possibly_convert_objects(data)
+    assert result is data
+    assert result.dtype == object
+
+
+def test_possibly_convert_objects_non_object_dtype():
+    # Non-object dtype array (should be converted to a numpy array via pd.Series)
+    data = np.array([1, 2, 3], dtype=int)
+    result = _possibly_convert_objects(data)
+    np.testing.assert_array_equal(result, data)


### PR DESCRIPTION
### Description
optimise _possibly_convert_objects in xarray/core/variable.py by adding a scan for object arrays.
Here is the logic:
• We scan up the first 10,000(in 99% cases it will usually stop at 1 element and if an array is very large we do it to cap the limit so it doesnt lag in the scan) elements of the flattened object array.
• If a datetime-like type (such as datetime, np.datetime64, pd.Timestamp, pd.NaT, etc.) is found, we flag it as datetime-like and stop the scan.
• If a non-null, non-datetime element is found, we immediately determine it is not datetime-like and stop the scan.
• If no conclusive type is found in the first 10,000 elements (e.g., all elements are null) and the array is larger, we fall back to pandas' highly optimized C-compiled pd.api.types.infer_dtype on the entire array.
### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [✓] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### Tests
 
  
  • python -m pytest -o addopts="" xarray/tests/test_possibly_convert_objects.py — 11     
  passed
  • ruff check xarray/core/variable.py xarray/tests/test_possibly_convert_objects.py —    
  passed
  • git diff --check — passed
  
  ### AI Disclosure
  
  [✓] This PR contains AI-generated content.
      [✓] I have tested any AI-generated content in my PR.
      [✓] I take responsibility for any AI-generated content in my PR.
      Tools: Google Antigravity.
