### PR TITLE
Fix stacking dimensions with falsy names

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,6 +30,9 @@ Bug Fixes
   differ from the dtype returned by the matching numpy-backed bottleneck path,
   notably ``object`` instead of ``float64`` for boolean inputs.
   By `Matthew Rocklin <https://github.com/mrocklin>`_.
+- Fixed :py:meth:`Dataset.stack` raising ``KeyError`` when a stacked dimension
+  has a falsy but valid name such as ``""``, ``False`` or ``0`` (:issue:`9969`).
+  By `JOhnsonKC201 <https://github.com/JOhnsonKC201>`_.
 
 
 Documentation

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -1038,7 +1038,9 @@ class PandasMultiIndex(PandasIndex):
         # default index level names
         names = []
         for i, idx in enumerate(self.index.levels):
-            name = idx.name or f"{dim}_level_{i}"
+            # only unnamed levels get a synthetic name: ``""``, ``False`` and
+            # ``0`` are all valid (if unusual) level names
+            name = idx.name if idx.name is not None else f"{dim}_level_{i}"
             if name == dim:
                 raise ValueError(
                     f"conflicting multi-index level name {name!r} with dimension {dim!r}"

--- a/xarray/tests/test_indexes.py
+++ b/xarray/tests/test_indexes.py
@@ -429,6 +429,20 @@ class TestPandasMultiIndex:
                 "z",
             )
 
+    @pytest.mark.parametrize("dim", ["", False, 0], ids=["empty_str", "false", "zero"])
+    def test_stack_falsy_level_names(self, dim: Hashable) -> None:
+        # falsy names are valid hashables and must not be replaced by a
+        # synthetic "<dim>_level_<i>" name, see GH9969
+        prod_vars = {
+            dim: xr.Variable((dim,), pd.Index(["b", "a"])),
+            "y": xr.Variable("y", pd.Index([1, 2])),
+        }
+
+        index_xr = PandasMultiIndex.stack(prod_vars, "z")
+
+        assert list(index_xr.index.names) == [dim, "y"]
+        assert set(index_xr.create_variables()) == {"z", dim, "y"}
+
     def test_stack_non_unique(self) -> None:
         prod_vars = {
             "x": xr.Variable("x", pd.Index(["b", "a"]), attrs={"foo": "bar"}),


### PR DESCRIPTION
- Closes #9969
- Tests added
- User visible changes (including notable bug fixes) are documented in `whats-new.rst`

## Problem

Stacking a dimension whose name is falsy but perfectly valid raises `KeyError`:

```python
ds = xr.Dataset({"a": (("",), np.arange(3))})
ds.stack(s=[""])
# KeyError: 's_level_0'
```

`False` and `0` fail the same way. A plain `"x"` works.

## Cause

`PandasMultiIndex.__init__` derived level names with

```python
name = idx.name or f"{dim}_level_{i}"
```

That `or` conflates "this level has no name" (`None`) with "this level's name is
falsy". `PandasMultiIndex.stack` builds `level_coords_dtype` keyed by the real
level names, but `__init__` then rewrote `self.index.names` to the synthetic
`s_level_0`. The two mappings no longer agreed, so the later
`self.level_coords_dtype[name]` lookup in `create_variables` raised `KeyError`.

## Fix

Substitute a synthetic name only when the level name is actually `None`. This is
the approach @keewis suggested in the issue. One line, plus a comment noting why
`or` is not enough.

I checked that this round-trips, not just stacks: `ds.stack(...).unstack(...)`
returns the original dimension name and values for `""`, `False` and `0`.

## Test plan

- New `TestPandasMultiIndex::test_stack_falsy_level_names`, parametrised over
  `""`, `False` and `0`. It fails on main with `KeyError` for all three and
  passes with the fix.
- `xarray/tests/test_indexes.py`: 77 passed, 2 skipped.
- `xarray/tests/test_dataset.py -k stack`: 18 passed, 1 skipped.
- `ruff check` and `ruff format --check` on the touched files report the same
  two pre-existing errors before and after this change, none of them mine.

## AI usage disclosure

Per the repository's AI usage policy: this change was written with AI assistance
(Claude Code). I read the issue and the surrounding code, reviewed every line,
and verified the failure and the fix locally, including the unstack round-trip.
The commit carries the `Co-authored-by: Claude` trailer that `CLAUDE.md` asks
for. I am happy to explain any part of it.

[This is Claude Code on behalf of JOhnsonKC201]
