### PR TITLE
Fix polyval returning a sentinel value for NaT in timedelta coordinates

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -30,6 +30,9 @@ Bug Fixes
   differ from the dtype returned by the matching numpy-backed bottleneck path,
   notably ``object`` instead of ``float64`` for boolean inputs.
   By `Matthew Rocklin <https://github.com/mrocklin>`_.
+- :py:func:`polyval` now propagates ``NaN`` for ``NaT`` entries in ``timedelta64``
+  coordinates instead of returning a large sentinel value (:issue:`11462`).
+  By `Dipak Chaudhari <https://github.com/dchaudhari7177>`_.
 
 
 Documentation

--- a/xarray/computation/computation.py
+++ b/xarray/computation/computation.py
@@ -947,8 +947,9 @@ def _ensure_numeric(data: Dataset | DataArray) -> Dataset | DataArray:
                 data=datetime_to_numeric(x.data, offset=offset, datetime_unit="ns"),
             )
         elif x.dtype.kind == "m":
-            # timedeltas
-            return duck_array_ops.astype(x, dtype=float)
+            # timedeltas: a plain astype(float) maps NaT to a large sentinel value
+            # (e.g. -1.8e19) instead of NaN, so mask those positions back to NaN.
+            return duck_array_ops.astype(x, dtype=float).where(x.notnull())
         return x
 
     if isinstance(data, Dataset):

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -2475,6 +2475,15 @@ def test_polyval_degree_dim_checks() -> None:
         xr.polyval(x, coeffs.assign_coords(degree=coeffs.degree.astype(float)))
 
 
+def test_polyval_timedelta_nat() -> None:
+    # NaT in a timedelta coordinate must propagate as NaN, not a huge sentinel value (GH #11462).
+    x = xr.DataArray(np.array([0, "NaT", 2], dtype="timedelta64[D]"), dims="x")
+    coeffs = xr.DataArray([2.0, 1.0], dims="degree", coords={"degree": [1, 0]})
+    actual = xr.polyval(x, coeffs)
+    assert np.isnan(actual.values[1])
+    assert not np.isnan(actual.values[[0, 2]]).any()
+
+
 @pytest.mark.parametrize(
     "use_dask", [pytest.param(False, id="nodask"), pytest.param(True, id="dask")]
 )


### PR DESCRIPTION
Fixes #11462.

`_ensure_numeric` (used by `polyval` and `polyfit`) converts a `timedelta64` coordinate with a plain `astype(float)`. `NaT` is stored as the int64 minimum, so that cast turned it into a large sentinel (`-1.84e19`) rather than propagating a missing value.

Fix: mask the `NaT` positions back to `NaN` after the cast (`.where(x.notnull())`), mirroring the `datetime_to_numeric` path used for the datetime branch. Valid values keep their existing numeric scale, so only the previously-bogus `NaT` output changes.

MCVE from the issue now returns `[1.0, nan, 345601.0]` as expected. Added `test_polyval_timedelta_nat` (fails on `main`, passes with the fix); the existing `polyval` tests stay green. Added a `whats-new.rst` entry.

- [x] Closes #11462
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
