### PR TITLE
Handle missing package version in module_available

### DIFF
--- a/xarray/namedarray/utils.py
+++ b/xarray/namedarray/utils.py
@@ -60,6 +60,9 @@ def module_available(module: str, minversion: str | None = None) -> bool:
     if minversion is not None:
         version = importlib.metadata.version(module)
 
+        if version is None:
+            return False
+
         return Version(version) >= Version(minversion)
 
     return True

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Hashable
 from types import EllipsisType
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -15,6 +16,7 @@ from xarray.core.utils import (
     infix_dims,
     iterate_nested,
 )
+from xarray.namedarray.utils import module_available
 from xarray.tests import assert_array_equal, requires_dask
 
 
@@ -390,6 +392,21 @@ def test_find_stack_level():
 
     assert f() == 3
 
+# regression test
+def test_module_available_with_none_version() -> None:
+    module_available.cache_clear()
+
+    try:
+        with (
+            patch("importlib.util.find_spec", return_value=object()),
+            patch("importlib.metadata.version", return_value=None),
+        ):
+            assert not module_available(
+                "package_with_missing_version",
+                minversion="1.0",
+            )
+    finally:
+        module_available.cache_clear()
 
 def test_attempt_import() -> None:
     """Test optional dependency handling."""

--- a/xarray/tests/test_utils.py
+++ b/xarray/tests/test_utils.py
@@ -392,6 +392,7 @@ def test_find_stack_level():
 
     assert f() == 3
 
+
 # regression test
 def test_module_available_with_none_version() -> None:
     module_available.cache_clear()
@@ -407,6 +408,7 @@ def test_module_available_with_none_version() -> None:
             )
     finally:
         module_available.cache_clear()
+
 
 def test_attempt_import() -> None:
     """Test optional dependency handling."""


### PR DESCRIPTION
### Description

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #11344
- [ ] Tests added

This updates `module_available` to return `False` when package metadata returns `None` for the installed version, rather than passing `None` to `packaging.version.Version` and raising `TypeError`.

A regression test was added to reproduce the missing-version case.

Tests:
- `python -m pytest xarray\tests\test_utils.py -v`
- 67 passed, 1 skipped
