### PR TITLE
Fix object array infer string perf 11470

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -233,7 +233,7 @@ def _possibly_convert_objects(values):
         as_series = pd.Series(values.ravel(), copy=False)
         result = np.asarray(as_series).reshape(values.shape)
     else:
-        result = values
+        return values
 
     if not result.flags.writeable:
         # GH8843, pandas copy-on-write mode creates read-only arrays by default

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -231,7 +231,7 @@ def _possibly_convert_objects(values):
         result = pd.to_timedelta(values.ravel()).to_numpy().reshape(values.shape)
     elif inferred in ["datetime64", "timedelta64"]:
         # Casting drops unit info for these cases;
-        # fall back to pd.Series which preserves them.
+        # fall back to pd.Series roundtrip, which preserves them.
         as_series = pd.Series(values.ravel(), copy=False)
         result = np.asarray(as_series).reshape(values.shape)
     else:

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -229,9 +229,11 @@ def _possibly_convert_objects(values):
         result = pd.to_datetime(values.ravel()).to_numpy().reshape(values.shape)
     elif inferred == "timedelta":
         result = pd.to_timedelta(values.ravel()).to_numpy().reshape(values.shape)
-    else:
+    elif inferred in ["datetime64", "timedelta64"]:
         as_series = pd.Series(values.ravel(), copy=False)
         result = np.asarray(as_series).reshape(values.shape)
+    else:
+        result = values
 
     if not result.flags.writeable:
         # GH8843, pandas copy-on-write mode creates read-only arrays by default

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -230,6 +230,8 @@ def _possibly_convert_objects(values):
     elif inferred == "timedelta":
         result = pd.to_timedelta(values.ravel()).to_numpy().reshape(values.shape)
     elif inferred in ["datetime64", "timedelta64"]:
+        # Casting drops unit info for these cases;
+        # fall back to pd.Series which preserves them.
         as_series = pd.Series(values.ravel(), copy=False)
         result = np.asarray(as_series).reshape(values.shape)
     else:

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -210,8 +210,9 @@ def _maybe_wrap_data(data):
 
 def _possibly_convert_objects(values):
     """Convert object arrays into datetime64 and timedelta64 according
-    to the pandas convention.  For backwards compat, as of 3.0.0 pandas,
-    object dtype inputs are cast to strings by `pandas.Series`
+    to the pandas convention. Object dtype inputs that are inferred to be
+    strings are returned unchanged. For backwards compat, as of 3.0.0 pandas,
+    the remaining object dtype inputs are cast to strings by `pandas.Series`
     but we output them as object dtype with the input metadata preserved as well.
 
 
@@ -220,8 +221,18 @@ def _possibly_convert_objects(values):
     * pd.Timestamp
     * pd.Timedelta
     """
-    as_series = pd.Series(values.ravel(), copy=False)
-    result = np.asarray(as_series).reshape(values.shape)
+    inferred = pd.api.types.infer_dtype(values.ravel(), skipna=True)
+
+    if inferred == "string":
+        return values
+    elif inferred == "datetime":
+        result = pd.to_datetime(values.ravel()).to_numpy().reshape(values.shape)
+    elif inferred == "timedelta":
+        result = pd.to_timedelta(values.ravel()).to_numpy().reshape(values.shape)
+    else:
+        as_series = pd.Series(values.ravel(), copy=False)
+        result = np.asarray(as_series).reshape(values.shape)
+
     if not result.flags.writeable:
         # GH8843, pandas copy-on-write mode creates read-only arrays by default
         try:

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -70,6 +70,9 @@ def var():
     [
         np.array(["a", "bc", "def"], dtype=object),
         np.array(["2019-01-01", "2019-01-02", "2019-01-03"], dtype="datetime64[ns]"),
+        np.array([datetime(2000, 1, 1), datetime(2000, 1, 2)], dtype=object),
+        np.array([timedelta(seconds=1), timedelta(seconds=2)], dtype=object),
+        np.array([1, "a"], dtype=object),
     ],
 )
 def test_as_compatible_data_writeable(data):


### PR DESCRIPTION
### Description

As discussed in #11470, this PR optimizes the `_possibly_convert_objects` function. It uses `pd.api.types.infer_dtype` to classify the values, then converts using a targeted `pd.to_datetime`/`pd.to_timedelta` call instead of the generic `pd.Series` roundtrip where safe to do so. This is only the case for `string`, `datetime`, and `timedelta`. 

`datetime64` and `timedelta64` get tricky because `pd.to_datetime`/`pd.to_timedelta` re-infer units rather than preserving the input's existing unit. So for these 2 cases, and all other return types of the `infer_dtype`, I still use the `pd.Series` roundtrip for now.

Is there a way to cast these 2 datatypes while preserving their units? 


I added 3 new cases to `test_as_compatible_data_writeable` covering the datetime and timedelta fast paths. Without them, an implementation that returns the `pd.to_datetime`/`pd.to_timedelta` result directly (bypassing the existing writeable fix) would still pass the full test suite, but would silently return read only arrays instead of the writeable arrays xarray currently guarantees.

### Results
With the example from the issue, we now get:
```bash
infer_string=False: 55.3ms # was 0.1ms
infer_string=True: 56.0ms # was 606.3ms
```

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #11470 
- [x] Tests added

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
    <!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
    Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}
