### PR TITLE
docs: fix backend indexing example

### DIFF
--- a/doc/internals/how-to-add-new-backend.md
+++ b/doc/internals/how-to-add-new-backend.md
@@ -463,7 +463,7 @@ array([[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]])
 
 ```python
 # shall support integers
-backend_array._raw_indexing_method(1, 1)
+backend_array._raw_indexing_method((1, 1))
 ```
 
 ```
@@ -495,7 +495,7 @@ array([[0, 1, 2], [4, 5, 6]])
 
 ```python
 # shall support integers
-backend_array._raw_indexing_method(1, 1)
+backend_array._raw_indexing_method((1, 1))
 ```
 
 ```


### PR DESCRIPTION
Fixes #7450.

Pass the two-dimensional index as a tuple in the basic backend indexing example.