### PR TITLE
docs: document stable sortby ordering

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -5234,6 +5234,8 @@ class DataArray(
         https://numpy.org/doc/stable/reference/generated/numpy.lexsort.html
         and the FIRST key in the sequence is used as the primary sort key,
         followed by the 2nd key, etc.
+        Sorting is stable: when all sort keys compare equal, the original order is
+        preserved.
 
         Parameters
         ----------

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -8124,6 +8124,8 @@ class Dataset(
         https://numpy.org/doc/stable/reference/generated/numpy.lexsort.html
         and the FIRST key in the sequence is used as the primary sort key,
         followed by the 2nd key, etc.
+        Sorting is stable: when all sort keys compare equal, the original order is
+        preserved.
 
         Parameters
         ----------


### PR DESCRIPTION
Fixes #3712.

Document that DataArray.sortby and Dataset.sortby use stable sorting, preserving the original order when all sort keys compare equal.