### PR TITLE
Fix interp performance regression from #9881

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,6 +35,18 @@ Deprecations
 ~~~~~~~~~~~~
 
 
+Performance
+~~~~~~~~~~~
+
+- Fix performance regression in :py:meth:`DataArray.interp` and
+  :py:meth:`Dataset.interp` introduced in :pull:`9881`. When the target coordinate
+  varied along a dimension of the interpolated object, ``np.vectorize`` looped in
+  Python over every remaining non-core dimension as well, so interpolating an
+  array with dimensions ``(t, r, z)`` along ``z`` at targets varying with ``t``
+  made ``t * r`` calls into the interpolator instead of ``t`` (:issue:`10683`).
+  By `Osho Kothari <https://github.com/oshokothari07-ai>`_.
+
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/xarray/core/missing.py
+++ b/xarray/core/missing.py
@@ -720,11 +720,28 @@ def interpolate_variable(
     # so it is in exclude_dims.
     vectorize_dims = (result_dims - all_in_core_dims) & set(var.dims)
 
+    # When vectorizing, apply_ufunc uses np.vectorize, which loops in Python over
+    # *every* non-core dimension, not just the ones that actually need vectorizing.
+    # In the example above, `q` is a core dimension and `lat`, `lon` are vectorized,
+    # but any remaining dimension of `var` is also peeled off one element at a time
+    # purely because it is not a core dimension. For
+    # `da[t, r, z].interp(z=target[t])` that means t*r calls instead of t (GH10683).
+    # Declaring those dimensions core hands them to the interpolator in bulk;
+    # _interpnd already supports leading "constant" dimensions.
+    #
+    # Only do this for in-memory arrays: making a dimension a core dimension forces
+    # dask to rechunk along it, which can blow up memory for chunked inputs.
+    bulk_dims: tuple[Hashable, ...] = ()
+    if vectorize_dims and not is_chunked_array(var._data):
+        bulk_dims = tuple(
+            d for d in var.dims if d not in all_in_core_dims and d not in vectorize_dims
+        )
+
     # remove any output broadcast dimensions from the list of core dimensions
     output_core_dims = tuple(d for d in result_dims if d not in vectorize_dims)
     input_core_dims = (
         # all coordinates on the input that we interpolate along
-        [tuple(indexes_coords)]
+        [bulk_dims + tuple(indexes_coords)]
         # the input coordinates are always 1D at the moment, so we just need to list out their names
         + [tuple(_.dims) for _ in in_coords]
         # The last set of inputs are the coordinates we are interpolating to.
@@ -734,6 +751,7 @@ def interpolate_variable(
         ]
     )
     output_sizes = {k: result_sizes[k] for k in output_core_dims}
+    output_core_dims = bulk_dims + output_core_dims
 
     # scipy.interpolate.interp1d always forces to float.
     dtype = float if not issubclass(var.dtype.type, np.inexact) else var.dtype

--- a/xarray/tests/test_missing.py
+++ b/xarray/tests/test_missing.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 import xarray as xr
-from xarray.core import indexing
+from xarray.core import indexing, missing
 from xarray.core.missing import (
     NumpyInterpolator,
     ScipyInterpolator,
@@ -799,3 +799,67 @@ def test_indexing_localize():
         ds["sigma_a"].interp(w=15000.5)
     actual_indexer = mock_func.mock_calls[0].args[1]._key
     assert actual_indexer == (slice(None), slice(None), slice(18404, 18408))
+
+
+def _interp_vectorize_example():
+    # da[t, r, z] interpolated along `z` at targets that vary with `t`.
+    # `t` is a genuine vectorize dimension; `r` is a free dimension.
+    n_t, n_r, n_z = 4, 3, 5
+    rng = np.random.default_rng(seed=0)
+    da = xr.DataArray(
+        rng.random((n_t, n_r, n_z)),
+        dims=["t", "r", "z"],
+        coords={
+            "t": np.arange(n_t),
+            "r": np.arange(n_r),
+            "z": np.linspace(0.0, 1.0, n_z),
+        },
+    )
+    target = xr.DataArray(np.linspace(0.1, 0.9, n_t), dims=["t"], coords={"t": da["t"]})
+    return da, target
+
+
+@requires_scipy
+def test_interp_vectorize_does_not_loop_over_free_dims():
+    # regression test for GH10683
+    # `da[t, r, z].interp(z=target[t])` must vectorize over `t` only. `r` is neither
+    # interpolated along nor varying with the target, so it should be handed to the
+    # interpolator in bulk rather than peeled off one element at a time by
+    # np.vectorize, which made this O(t * r) Python calls instead of O(t).
+    from scipy.interpolate import interp1d
+
+    da, target = _interp_vectorize_example()
+    n_t = da.sizes["t"]
+
+    with mock.patch.object(
+        missing, "_interpnd", side_effect=missing._interpnd, autospec=True
+    ) as mock_interpnd:
+        actual = da.interp(z=target)
+
+    assert mock_interpnd.call_count == n_t
+
+    # independent reference: interpolate each `t` separately with scipy
+    expected = np.stack(
+        [
+            interp1d(da["z"].values, da.values[i], axis=-1)(target.values[i])
+            for i in range(n_t)
+        ]
+    )
+    assert actual.dims == ("t", "r")
+    np.testing.assert_allclose(actual.values, expected)
+
+
+@requires_scipy
+@requires_dask
+def test_interp_vectorize_preserves_chunks_along_free_dims():
+    # companion to GH10683: the bulk-dimension optimization must not apply to chunked
+    # arrays. Declaring `r` a core dimension would force dask to rechunk along it,
+    # so a preserved chunk structure is what shows the optimization was skipped.
+    da, target = _interp_vectorize_example()
+
+    expected = da.interp(z=target)
+    actual = da.chunk({"r": 1}).interp(z=target)
+
+    assert actual.chunks is not None
+    assert actual.chunks[actual.dims.index("r")] == (1, 1, 1)
+    assert_allclose(actual.compute(), expected)


### PR DESCRIPTION
## Description

Closes #10683.

This PR addresses the performance regression in `DataArray.interp` and `Dataset.interp` introduced by #9881 when the target coordinate varies along a dimension of the source array.

The regression occurs because `interpolate_variable` enables `vectorize=True` when calling `apply_ufunc`. With `np.vectorize`, every non-core dimension is iterated in Python, including dimensions that do not actually require vectorization. For cases such as `da[t, r, z].interp(z=target[t])`, this causes the interpolator to be called once for every `(t, r)` pair instead of once per `t`.

The fix promotes the remaining non-vectorized dimensions to core dimensions so they are passed to `_interpnd` in bulk. `_interpnd` already treats these leading dimensions as constant, so this avoids the unnecessary Python-level looping while preserving interpolation behavior. This optimization is applied only to in-memory arrays because making these dimensions core for chunked arrays would force dask to rechunk along them.

On the example from the issue, this reduces `_interpnd` calls from 7930 to 122 and reduces runtime from roughly 2.2 s to around 110 ms in my local testing.

## Testing

* Added a regression test that verifies the interpolator is not repeatedly called over free dimensions.
* Added a companion test that verifies chunking is preserved for dask-backed arrays.
* Verified that the regression test fails without the fix.
* Local results for `xarray/tests/test_interp.py` and `xarray/tests/test_missing.py`: **283 passed, 74 skipped, 1 xfailed**.
* `ruff check` and `ruff format` pass.

## Limitations

This is a targeted workaround rather than the more general redesign of the `apply_ufunc` interpolation path discussed in the issue. It recovers most of the regression but does not restore the performance seen in 2024.11.0.

I was not able to run the full test suite on `main` locally because the repository currently requires Python 3.11+, while my local environment is Python 3.10.11. The implementation was validated against byte-identical code for the affected functions, but CI will provide the final verification across supported Python versions, platforms, the full dask test matrix, and minimum-version configurations.

I also did not run `mypy` locally. The only typed addition is `bulk_dims: tuple[Hashable, ...]`, and CI will validate type checking against both the current and minimum supported environments.

## Checklist

* [x] Closes #10683
* [x] Added regression tests
* [x] Updated `doc/whats-new.rst`
* [x] `api.rst` update not required

## AI Disclosure

* [x] This PR contains AI-generated content.

  * [x] I have tested any AI-generated content in my PR.
  * [x] I take responsibility for any AI-generated content in my PR.

    * **Tools:** Claude

I used Claude as an engineering assistant during the investigation and implementation. I reviewed the changes, validated the implementation and tests, and take responsibility for the final code and this pull request.
