### PR TITLE
DOC explain how open_dataset handles grouped files

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -574,6 +574,12 @@ def open_dataset(
 
     Notes
     -----
+    For files with multiple groups, ``open_dataset`` reads only the selected
+    group (the root group by default). Use ``open_datatree`` to load the groups
+    into a tree, or ``open_groups`` to load each group into a dictionary. To
+    open one non-root group with ``open_dataset``, pass its path with the
+    ``group`` keyword argument.
+
     ``open_dataset`` opens the file with read-only access. When you modify
     values of a Dataset, even one linked to files on disk, only the in-memory
     copy you are manipulating in xarray is modified: the original file on disk


### PR DESCRIPTION
## Summary

- explain that `open_dataset` opens only the selected group, using the root by default
- point users to `open_datatree` and `open_groups` when a file contains multiple groups

Fixes #9891