### PR TITLE
Raise when to_zarr(append_dim=...) would mislabel data

### DIFF
--- a/doc/user-guide/io.md
+++ b/doc/user-guide/io.md
@@ -1121,9 +1121,16 @@ single call to `to_zarr()` will write all of your data in parallel.
 ```
 
 ```{warning}
-Alignment of coordinates is currently not checked when modifying an
-existing Zarr store. It is up to the user to ensure that coordinates are
-consistent.
+Appending does not align the new data to the store: it is written in the order
+given by the object being written. Xarray therefore refuses to append when an
+existing coordinate that does not have `append_dim` among its dimensions
+disagrees with the store, since either the existing data or the newly appended
+data would end up mislabelled. Align explicitly before appending, e.g. with
+{py:meth}`Dataset.reindex_like`.
+
+Data variables are not checked: `mode='a'` overwrites them and `mode='a-'` leaves
+them alone, as documented above. `region` writes without `append_dim` are not
+checked either. It remains up to the user to ensure those are consistent.
 ```
 
 To add or overwrite entire variables, simply call {py:meth}`~Dataset.to_zarr`

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -41,6 +41,12 @@ Breaking Changes
   the compatibility features with ``netCDF4`` that the harmonized encoding relies
   on (:issue:`10657`, :pull:`11067`).
   By `Mark Harfouche <https://github.com/hmaarrfk>`_.
+- :py:meth:`Dataset.to_zarr` with ``append_dim`` now raises ``ValueError`` when an
+  existing coordinate that does not have ``append_dim`` among its dimensions
+  disagrees with the store, instead of silently mislabelling data. This applies to
+  both ``mode="a"`` and ``mode="a-"``. Align the dataset to the store before
+  appending, e.g. with :py:meth:`Dataset.reindex_like` (:issue:`11101`).
+  By `Aman Kumar <https://github.com/ghostiee-11>`_.
 
 Deprecations
 ~~~~~~~~~~~~
@@ -63,6 +69,11 @@ Bug Fixes
 - :py:func:`polyval` now propagates ``NaN`` for ``NaT`` entries in ``timedelta64``
   coordinates instead of returning a large sentinel value (:issue:`11462`).
   By `Dipak Chaudhari <https://github.com/dchaudhari7177>`_.
+- Fixed :py:meth:`Dataset.to_zarr` with ``append_dim`` silently corrupting a store
+  when a coordinate without ``append_dim`` differed from the one already written:
+  ``mode="a"`` relabelled the existing data and ``mode="a-"`` mislabelled the
+  appended data. Both now raise (:issue:`11101`). See Breaking Changes.
+  By `Aman Kumar <https://github.com/ghostiee-11>`_.
 
 
 Documentation

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -24,7 +24,7 @@ from xarray.backends.common import (
     ensure_dtype_not_object,
 )
 from xarray.backends.store import StoreBackendEntrypoint
-from xarray.core import indexing
+from xarray.core import duck_array_ops, indexing
 from xarray.core.treenode import NodePath
 from xarray.core.types import ZarrWriteModes
 from xarray.core.utils import (
@@ -612,6 +612,47 @@ def _validate_and_transpose_existing_dims(
     return new_var
 
 
+def _coordinate_names(variables, attributes):
+    """Names of the variables that are written to the store as coordinates."""
+    names = {k for k, v in variables.items() if v.dims == (k,)}
+    names.update(attributes.get("coordinates", "").split())
+    for var in variables.values():
+        names.update(var.attrs.get("coordinates", "").split())
+    return names
+
+
+def _validate_existing_coord_values(
+    var_name, new_var, existing_var, region, append_dim
+):
+    """Raise if appending would mislabel data.
+
+    ``to_zarr`` writes the appended block in the order given by the dataset being
+    written, and does not align it to the store. A coordinate without ``append_dim``
+    among its dimensions is therefore either overwritten (``mode="a"``, relabelling
+    the data already in the store) or kept while the new block is written in a
+    different order (``mode="a-"``, mislabelling the data being appended). Values
+    are compared as encoded, so a lossy or value-changing encoding does not raise
+    spuriously.
+    """
+    if append_dim in new_var.dims:
+        return
+    if region:
+        existing_var = existing_var[
+            tuple(region.get(dim, slice(None)) for dim in existing_var.dims)
+        ]
+    if not duck_array_ops.array_equiv(new_var.values, existing_var.values):
+        raise ValueError(
+            f"cannot append along {append_dim!r}: coordinate {var_name!r} already "
+            f"exists in the Zarr store with different values, and does not have "
+            f"{append_dim!r} among its dimensions. to_zarr() writes appended data "
+            f"in the order given by the dataset being written and does not align "
+            f"it to the store, so appending would silently mislabel data. Align "
+            f"the dataset to the store before appending, e.g. ``ds = "
+            f"ds.reindex_like(xr.open_zarr(store))``, or write the new coordinate "
+            f"values in a separate call with mode='r+'."
+        )
+
+
 def _put_attrs(zarr_obj, attrs):
     """Raise a more informative error message for invalid attrs."""
     try:
@@ -970,6 +1011,9 @@ class ZarrStore(AbstractWritableDataStore):
         else:
             zarr = attempt_import("zarr")
 
+        # read before ``attributes`` is reassigned by ``self.encode`` below
+        coord_names = _coordinate_names(variables, attributes)
+
         if self._mode == "w":
             # always overwrite, so we don't care about existing names,
             # and consistency of encoding
@@ -1015,10 +1059,11 @@ class ZarrStore(AbstractWritableDataStore):
             # To do so, we decode variables directly to access the proper encoding,
             # without going via xarray.Dataset to avoid needing to load
             # index variables into memory.
+            existing_store_vars = {
+                k: self.open_store_variable(name=k) for k in existing_variable_names
+            }
             existing_vars, _, _ = conventions.decode_cf_variables(
-                variables={
-                    k: self.open_store_variable(name=k) for k in existing_variable_names
-                },
+                variables=existing_store_vars,
                 # attributes = {} since we don't care about parsing the global
                 # "coordinates" attribute
                 attributes={},
@@ -1042,6 +1087,14 @@ class ZarrStore(AbstractWritableDataStore):
                     self._write_region,
                     self._append_dim,
                 )
+                if self._append_dim is not None and var_name in coord_names:
+                    _validate_existing_coord_values(
+                        var_name,
+                        variables_encoded[var_name],
+                        existing_store_vars[var_name],
+                        self._write_region,
+                        self._append_dim,
+                    )
 
         if self._mode not in ["r", "r+"]:
             self.set_attributes(attributes)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4378,6 +4378,10 @@ class DataArray(
         append_dim : hashable, optional
             If set, the dimension along which the data will be appended. All
             other dimensions on overridden variables must remain the same size.
+            The data is appended in the order given by this object and is not
+            aligned to the store, so any existing coordinate that does not have
+            ``append_dim`` among its dimensions must match the one already in the
+            store; a mismatch raises a ``ValueError``.
         region : dict, optional
             Optional mapping from dimension names to integer slices along
             dataarray dimensions to indicate the region of existing zarr array(s)

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2317,6 +2317,10 @@ class Dataset(
         append_dim : hashable, optional
             If set, the dimension along which the data will be appended. All
             other dimensions on overridden variables must remain the same size.
+            The data is appended in the order given by this dataset and is not
+            aligned to the store, so any existing coordinate that does not have
+            ``append_dim`` among its dimensions must match the one already in the
+            store; a mismatch raises a ``ValueError``.
         region : dict or "auto", optional
             Optional mapping from dimension names to either a) ``"auto"``, or b) integer
             slices, indicating the region of existing zarr array(s) in which to write

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3324,30 +3324,167 @@ class ZarrBase(CFEncodedBase):
 
     def test_append_with_append_dim_no_overwrite(self) -> None:
         ds, ds_to_append, _ = create_append_test_data()
+        # a variable without the append_dim among its dimensions. Dimension
+        # coordinates cannot be used here: a mismatched one is rejected outright,
+        # see test_append_with_mismatched_dim_coord_raises.
+        ds["static"] = (("lat", "lon"), np.zeros((3, 3)))
+        ds_to_append["static"] = (("lat", "lon"), np.ones((3, 3)))
+
+        concat_kwargs = {
+            "data_vars": "minimal",
+            "coords": "minimal",
+            "compat": "override",
+        }
         with self.create_zarr_target() as store_target:
             ds.to_zarr(store_target, mode="w", **self.version_kwargs)
-            original = xr.concat([ds, ds_to_append], dim="time")
-            original2 = xr.concat([original, ds_to_append], dim="time")
+            original = xr.concat([ds, ds_to_append], dim="time", **concat_kwargs)
+            original2 = xr.concat([original, ds_to_append], dim="time", **concat_kwargs)
 
-            # overwrite a coordinate;
-            # for mode='a-', this will not get written to the store
+            # for mode='a-', "static" will not get written to the store
             # because it does not have the append_dim as a dim
-            lon = ds_to_append.lon.to_numpy().copy()
-            lon[:] = -999
-            ds_to_append["lon"] = lon
             ds_to_append.to_zarr(
                 store_target, mode="a-", append_dim="time", **self.version_kwargs
             )
             actual = xr.open_dataset(store_target, engine="zarr", **self.version_kwargs)
             assert_identical(original, actual)
 
-            # by default, mode="a" will overwrite all coordinates.
+            # by default, mode="a" will overwrite it
             ds_to_append.to_zarr(store_target, append_dim="time", **self.version_kwargs)
             actual = xr.open_dataset(store_target, engine="zarr", **self.version_kwargs)
-            lon = original2.lon.to_numpy().copy()
-            lon[:] = -999
-            original2["lon"] = lon
+            original2["static"] = ds_to_append["static"]
             assert_identical(original2, actual)
+
+    @pytest.mark.parametrize("mode", [None, "a", "a-"])
+    def test_append_with_mismatched_dim_coord_raises(self, mode) -> None:
+        # regression test for GH11101. Appending writes the new block in the
+        # order of the dataset being written, so a dimension coordinate that
+        # disagrees with the store mislabels either the data already in the
+        # store (mode="a") or the data being appended (mode="a-").
+        ds = Dataset(
+            {"var": (("time", "level"), np.arange(5).reshape(1, 5))},
+            coords={"time": [0], "level": [0, 1, 2, 3, 4]},
+        )
+        flipped = ds.isel(level=slice(None, None, -1)).assign_coords(time=[1])
+
+        with self.create_zarr_target() as store_target:
+            ds.to_zarr(store_target, mode="w", **self.version_kwargs)
+            with pytest.raises(ValueError, match="would silently mislabel data"):
+                flipped.to_zarr(
+                    store_target,
+                    mode=mode,
+                    append_dim="time",
+                    **self.version_kwargs,
+                )
+            # the write is refused before anything is written
+            with self.open(store_target) as actual:
+                assert_identical(ds, actual)
+
+    @pytest.mark.parametrize("kind", ["non-dim-index", "multi-dim", "chunked"])
+    def test_append_with_mismatched_coord_raises(self, kind) -> None:
+        # GH11101 applies to every coordinate that labels existing data, not just
+        # the dimension coordinates
+        if kind == "non-dim-index":
+            ds = Dataset(
+                {"var": (("time", "pos"), np.zeros((1, 3)))},
+                coords={"time": [0], "pf": ("pos", [1.0, 2.0, 3.0])},
+            ).set_xindex("pf")
+            mismatched = ds.assign_coords(pf=("pos", [3.0, 2.0, 1.0]))
+        elif kind == "multi-dim":
+            ds = Dataset(
+                {"var": (("time", "y", "x"), np.zeros((1, 2, 2)))},
+                coords={"time": [0], "lat": (("y", "x"), np.zeros((2, 2)))},
+            )
+            mismatched = ds.assign_coords(lat=(("y", "x"), np.ones((2, 2))))
+        else:
+            ds = Dataset(
+                {"var": (("time", "level"), np.zeros((1, 4)))},
+                coords={"time": [0], "level": [0, 1, 2, 3]},
+            )
+            # a dimension coordinate only reaches the store chunked once its index
+            # has been dropped; comparing it must not be skipped
+            mismatched = (
+                ds.assign_coords(level=("level", np.array([3, 2, 1, 0])))
+                .drop_indexes("level")
+                .chunk({"level": -1})
+            )
+
+        with self.create_zarr_target() as store_target:
+            ds.to_zarr(store_target, mode="w", **self.version_kwargs)
+            with pytest.raises(ValueError, match="would silently mislabel data"):
+                mismatched.assign_coords(time=[1]).to_zarr(
+                    store_target, append_dim="time", **self.version_kwargs
+                )
+
+    def test_append_with_region_and_mismatched_coord_raises(self) -> None:
+        # ``region`` and ``append_dim`` on different dimensions: the coordinate is
+        # compared against the region of the store it is written into
+        def build(xc):
+            return Dataset(
+                {"var": (("time", "x"), np.zeros((1, 4)))}, coords={"xc": ("x", xc)}
+            )
+
+        kwargs = {"append_dim": "time", "region": {"x": slice(0, 4)}, "mode": "a"}
+        with self.create_zarr_target() as store_target:
+            build([0.0, 1.0, 2.0, 3.0]).to_zarr(
+                store_target, mode="w", **self.version_kwargs
+            )
+            build([0.0, 1.0, 2.0, 3.0]).to_zarr(
+                store_target, **kwargs, **self.version_kwargs
+            )
+            with pytest.raises(ValueError, match="would silently mislabel data"):
+                build([9.0, 9.0, 9.0, 9.0]).to_zarr(
+                    store_target, **kwargs, **self.version_kwargs
+                )
+
+    @pytest.mark.parametrize(
+        "level",
+        [
+            pytest.param(np.array([0.0, 1.0, np.nan]), id="float-nan"),
+            pytest.param(
+                np.array(["2001-01-01", "NaT", "2001-01-03"], dtype="datetime64[ns]"),
+                id="datetime-nat",
+            ),
+            pytest.param(np.array(["a", "bc", "def"], dtype=object), id="object-str"),
+        ],
+    )
+    def test_append_with_matching_dim_coord(self, level) -> None:
+        # the GH11101 check must not fire when the coordinate is unchanged,
+        # including for values that are not equal to themselves. The datetime
+        # case also pins the comparison to the *encoded* on-disk values: it
+        # fails if the check is pointed at the CF-decoded ones instead.
+        ds = Dataset(
+            {"var": (("time", "level"), np.zeros((1, 3)))},
+            coords={"time": [0], "level": level},
+        )
+        with self.create_zarr_target() as store_target:
+            ds.to_zarr(store_target, mode="w", **self.version_kwargs)
+            appended = ds.assign_coords(time=[1])
+            appended.to_zarr(store_target, append_dim="time", **self.version_kwargs)
+            with self.open(store_target) as actual:
+                assert_identical(xr.concat([ds, appended], dim="time"), actual)
+
+    def test_append_with_lossy_dim_coord_encoding(self) -> None:
+        # the store holds float32 while the dataset holds float64 values that do
+        # not round-trip exactly. The values on disk are unchanged by the append,
+        # so this must not raise: the GH11101 check compares the coordinate as it
+        # will be encoded, not as it is held in memory.
+        ds = Dataset(
+            {"var": (("time", "level"), np.zeros((1, 3)))},
+            coords={"time": [0], "level": np.array([0.1, 0.2, 0.3])},
+        )
+        with self.create_zarr_target() as store_target:
+            ds.to_zarr(
+                store_target,
+                mode="w",
+                encoding={"level": {"dtype": "float32"}},
+                **self.version_kwargs,
+            )
+            ds.assign_coords(time=[1]).to_zarr(
+                store_target, append_dim="time", **self.version_kwargs
+            )
+            with self.open(store_target) as actual:
+                assert actual.sizes["time"] == 2
+                assert actual.level.dtype == np.float32
 
     @requires_dask
     def test_to_zarr_compute_false_roundtrip(self) -> None:

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3384,7 +3384,15 @@ class ZarrBase(CFEncodedBase):
             with self.open(store_target) as actual:
                 assert_identical(ds, actual)
 
-    @pytest.mark.parametrize("kind", ["non-dim-index", "multi-dim", "chunked"])
+    def _assert_append_rejects(self, ds, mismatched) -> None:
+        with self.create_zarr_target() as store_target:
+            ds.to_zarr(store_target, mode="w", **self.version_kwargs)
+            with pytest.raises(ValueError, match="would silently mislabel data"):
+                mismatched.assign_coords(time=[1]).to_zarr(
+                    store_target, append_dim="time", **self.version_kwargs
+                )
+
+    @pytest.mark.parametrize("kind", ["non-dim-index", "multi-dim"])
     def test_append_with_mismatched_coord_raises(self, kind) -> None:
         # GH11101 applies to every coordinate that labels existing data, not just
         # the dimension coordinates
@@ -3394,31 +3402,30 @@ class ZarrBase(CFEncodedBase):
                 coords={"time": [0], "pf": ("pos", [1.0, 2.0, 3.0])},
             ).set_xindex("pf")
             mismatched = ds.assign_coords(pf=("pos", [3.0, 2.0, 1.0]))
-        elif kind == "multi-dim":
+        else:
             ds = Dataset(
                 {"var": (("time", "y", "x"), np.zeros((1, 2, 2)))},
                 coords={"time": [0], "lat": (("y", "x"), np.zeros((2, 2)))},
             )
             mismatched = ds.assign_coords(lat=(("y", "x"), np.ones((2, 2))))
-        else:
-            ds = Dataset(
-                {"var": (("time", "level"), np.zeros((1, 4)))},
-                coords={"time": [0], "level": [0, 1, 2, 3]},
-            )
-            # a dimension coordinate only reaches the store chunked once its index
-            # has been dropped; comparing it must not be skipped
-            mismatched = (
-                ds.assign_coords(level=("level", np.array([3, 2, 1, 0])))
-                .drop_indexes("level")
-                .chunk({"level": -1})
-            )
 
-        with self.create_zarr_target() as store_target:
-            ds.to_zarr(store_target, mode="w", **self.version_kwargs)
-            with pytest.raises(ValueError, match="would silently mislabel data"):
-                mismatched.assign_coords(time=[1]).to_zarr(
-                    store_target, append_dim="time", **self.version_kwargs
-                )
+        self._assert_append_rejects(ds, mismatched)
+
+    @requires_dask
+    def test_append_with_mismatched_chunked_coord_raises(self) -> None:
+        # a dimension coordinate only reaches the store chunked once its index has
+        # been dropped; comparing it must not be skipped
+        ds = Dataset(
+            {"var": (("time", "level"), np.zeros((1, 4)))},
+            coords={"time": [0], "level": [0, 1, 2, 3]},
+        )
+        mismatched = (
+            ds.assign_coords(level=("level", np.array([3, 2, 1, 0])))
+            .drop_indexes("level")
+            .chunk({"level": -1})
+        )
+
+        self._assert_append_rejects(ds, mismatched)
 
     def test_append_with_region_and_mismatched_coord_raises(self) -> None:
         # ``region`` and ``append_dim`` on different dimensions: the coordinate is

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3330,15 +3330,20 @@ class ZarrBase(CFEncodedBase):
         ds["static"] = (("lat", "lon"), np.zeros((3, 3)))
         ds_to_append["static"] = (("lat", "lon"), np.ones((3, 3)))
 
-        concat_kwargs = {
-            "data_vars": "minimal",
-            "coords": "minimal",
-            "compat": "override",
-        }
+        # "static" is taken from the first dataset rather than concatenated
+        def concat(objs):
+            return xr.concat(
+                objs,
+                dim="time",
+                data_vars="minimal",
+                coords="minimal",
+                compat="override",
+            )
+
         with self.create_zarr_target() as store_target:
             ds.to_zarr(store_target, mode="w", **self.version_kwargs)
-            original = xr.concat([ds, ds_to_append], dim="time", **concat_kwargs)
-            original2 = xr.concat([original, ds_to_append], dim="time", **concat_kwargs)
+            original = concat([ds, ds_to_append])
+            original2 = concat([original, ds_to_append])
 
             # for mode='a-', "static" will not get written to the store
             # because it does not have the append_dim as a dim


### PR DESCRIPTION
### Description

`to_zarr(append_dim=...)` writes the new block in the incoming order without aligning it to the store, so a mismatched coordinate silently mislabels data: `mode="a"` relabels what's already there, `mode="a-"` mislabels what's appended. Now raises before writing.

### Checklist

- [x] Closes #11101
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    <!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
    Tools: Claude
