### PR TITLE
Raise AlignmentError when alignment would reorder an already-aligned index (closes #10714)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -104,6 +104,12 @@ Bug Fixes
   entries; ``to_dataframe`` indexes by the union of stored entries across all
   sparse variables sharing the same dims (:issue:`4007`).
   By `patnr <https://github.com/patnr>`_.
+- :py:func:`align` now raises ``AlignmentError`` when one index would reorder a
+  dimension that another, already aligned, index shares. Previously an index
+  requiring no reindexing was skipped by the conflict check, so conflicting
+  indexes aligned silently and the mismatched index was used to combine the data
+  (:issue:`10714`).
+  By `Kayvan Zahiri <https://github.com/Kayvan-Zahiri>`_.
 
 
 Documentation

--- a/xarray/structure/alignment.py
+++ b/xarray/structure/alignment.py
@@ -561,6 +561,21 @@ class Aligner(Generic[T_Alignable]):
         dim_pos_indexers: dict[Hashable, Any] = {}
         dim_index: dict[Hashable, Index] = {}
 
+        # An index that needs no reindexing is equal across all objects, so it pins
+        # its dimensions in place. It never produces an indexer of its own, which
+        # means the conflict check below would otherwise never see it and a second
+        # index sharing the same dimension could silently reorder it.
+        unchanged_dim_index: dict[Hashable, Index] = {}
+        for key in self.aligned_indexes:
+            obj_idx = matching_indexes.get(key)
+            if obj_idx is not None and not self.reindex[key]:
+                for dim in {
+                    d
+                    for var in self.aligned_index_vars[key].values()
+                    for d in var.dims
+                }:
+                    unchanged_dim_index.setdefault(dim, obj_idx)
+
         for key, aligned_idx in self.aligned_indexes.items():
             obj_idx = matching_indexes.get(key)
             if obj_idx is not None and self.reindex[key]:
@@ -572,6 +587,19 @@ class Aligner(Generic[T_Alignable]):
                             "it is explicitly excluded from alignment. This is likely caused by "
                             "wrong results returned by the `reindex_like` method of this index:\n"
                             f"{obj_idx!r}"
+                        )
+                    idxer_arr = np.asarray(idxer)
+                    reorders = not (
+                        idxer_arr.ndim == 1
+                        and np.array_equal(idxer_arr, np.arange(idxer_arr.size))
+                    )
+                    if dim in unchanged_dim_index and reorders:
+                        raise AlignmentError(
+                            f"cannot reindex or align along dimension {dim!r} because "
+                            "it would reorder another index that is already aligned along "
+                            "that dimension\n"
+                            f"first index: {obj_idx!r}\n"
+                            f"second index: {unchanged_dim_index[dim]!r}\n"
                         )
                     if dim in dim_pos_indexers and not np.array_equal(
                         idxer, dim_pos_indexers[dim]

--- a/xarray/structure/alignment.py
+++ b/xarray/structure/alignment.py
@@ -570,9 +570,7 @@ class Aligner(Generic[T_Alignable]):
             obj_idx = matching_indexes.get(key)
             if obj_idx is not None and not self.reindex[key]:
                 for dim in {
-                    d
-                    for var in self.aligned_index_vars[key].values()
-                    for d in var.dims
+                    d for var in self.aligned_index_vars[key].values() for d in var.dims
                 }:
                     unchanged_dim_index.setdefault(dim, obj_idx)
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2729,6 +2729,23 @@ class TestDataset:
         with pytest.raises(AlignmentError, match=r".*conflicting re-indexers"):
             align(a, c)
 
+    def test_align_multiple_indexes_common_dim_no_reindex(self) -> None:
+        # An index that needs no reindexing produces no re-indexer, so it used to
+        # escape the conflict check entirely and a second index sharing its
+        # dimension could silently reorder it. See GH10714.
+        a = Dataset(coords={"x": [1, 2, 3], "xb": ("x", [4, 5, 6])}).set_xindex("xb")
+        # "x" is equal in both and needs no reindexing; only "xb" conflicts
+        b = Dataset(coords={"x": [1, 2, 3], "xb": ("x", [4, 6, 5])}).set_xindex("xb")
+
+        with pytest.raises(AlignmentError, match=r".*would reorder another index"):
+            align(a, b)
+
+        # reordering a dimension is still fine when nothing else pins it
+        d = Dataset(coords={"x": [3, 1, 2], "xb": ("x", [6, 4, 5])}).set_xindex("xb")
+        (a2, d2) = align(a, d)
+        assert_identical(a2, a, check_default_indexes=False)
+        assert_identical(d2, a, check_default_indexes=False)
+
     def test_align_conflicting_indexes(self) -> None:
         class CustomIndex(PandasIndex): ...
 


### PR DESCRIPTION
Closes #10714.

### The bug

`align` is documented to raise `AlignmentError` when objects carry conflicting
indexes, but the consistency check in `_get_dim_pos_indexers` only runs for
indexes that need reindexing:

```python
if obj_idx is not None and self.reindex[key]:
```

`_need_reindex` returns `False` precisely when the matching indexes are already
equal, so such an index **pins its dimension in place** while producing no
re-indexer of its own. Nothing is ever registered for that dimension, so a second
index sharing it has nothing to conflict with and silently wins.

Using @abaarsma's MVCE, `x` is identical in both objects and `xb` is not:

```python
ds1 = Dataset(coords={"x": [1, 2, 3], "xb": ("x", [4, 5, 6])}).set_xindex("xb")
ds2 = Dataset(coords={"x": [1, 2, 3], "xb": ("x", [4, 6, 5])}).set_xindex("xb")

align(ds1, ds2)   # no error
```

It is not only a missing error. `ds2.xb` is `[4, 6, 5]` going in and `[4, 5, 6]`
coming out: the conflicting index is silently rewritten and the mismatched index
is used to combine the data. `align(ds1, ds3)`, where both indexes need
reindexing, raises correctly today, so the difference is purely whether the
second index happened to need reindexing.

### The fix

Record the dimensions pinned by non-reindexed indexes, then reject any re-indexer
that would reorder one of them.

The identity check matters and is not redundant. `_need_reindex` can return `True`
for reasons other than index inequality, notably differing unindexed dimension
sizes, and in that case `reindex_like` returns an identity indexer that reorders
nothing. Treating "needs reindexing" as "conflicts" would break those cases, so
the guard is specifically "would reorder", not "would reindex".

`dim_pos_indexers` is unchanged, so the actual reindexing behaviour is untouched.
The only difference is that a previously silent case now raises.

### Verification

- The MVCE now raises; `align(ds1, ds3)` still raises; `align(ds1, ds1)` and
  `align(ds1)` are unaffected.
- Reordering a dimension is still legal when nothing else pins it, which the new
  test asserts explicitly rather than leaving to inference.
- `test_indexes.py`, `test_concat.py`, `test_merge.py`: 300 passed, 2 skipped.
- Every file containing an `align` test: 1279 passed, 433 skipped, 14 xfailed,
  4 xpassed. Two failures in `test_chunk_by_season_resampler` are an `ImportError`
  for `cftime` and reproduce identically on an unmodified checkout, so they are
  environmental rather than caused by this change.
- The new test fails with `DID NOT RAISE` on `main` and passes with the fix.

### Credit

The diagnosis is @abaarsma's, including pinpointing the exact branch in
`_get_dim_pos_indexers`, and @dcherian confirmed it. Nobody had opened a PR, so I
have written it up with a regression test and a whatsnew entry.


### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

    Tools: Claude (Claude Code), used to diagnose the root cause, draft the fix and the
    regression test, and draft this description.
