### PR TITLE
BUG clarify DataTree constructor error for mappings

### DIFF
--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -140,7 +140,7 @@ def _to_new_dataset(data: Dataset | Coordinates | None) -> Dataset:
     elif data is None:
         ds = Dataset()
     else:
-        raise TypeError(f"data object is not an xarray.Dataset, dict, or None: {data}")
+        raise TypeError(f"data object is not an xarray.Dataset, Coordinates, or None: {data}")
     return ds
 
 

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -140,7 +140,9 @@ def _to_new_dataset(data: Dataset | Coordinates | None) -> Dataset:
     elif data is None:
         ds = Dataset()
     else:
-        raise TypeError(f"data object is not an xarray.Dataset, Coordinates, or None: {data}")
+        raise TypeError(
+            f"data object is not an xarray.Dataset, Coordinates, or None: {data}"
+        )
     return ds
 
 

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -201,6 +201,12 @@ class TestStoreDatasets:
         with pytest.raises(TypeError):
             DataTree(name="mary", dataset="junk")  # type: ignore[arg-type]
 
+        with pytest.raises(
+            TypeError,
+            match=r"data object is not an xarray.Dataset, Coordinates, or None: \{\}",
+        ):
+            DataTree(name="mary", dataset={})  # type: ignore[arg-type]
+
     def test_set_data(self) -> None:
         john = DataTree(name="john")
         dat = xr.Dataset({"a": 0})


### PR DESCRIPTION
Fixes #11514

`DataTree` accepts `Dataset`, `Coordinates`, or `None`, but its `TypeError` text incorrectly says `dict` is accepted. Update the message to list `Coordinates` and add regression coverage for a mapping input.

Testing:
- `uv run --no-project --python 3.13 --with pytest --with numpy --with pandas --with packaging --with hypothesis python -m pytest -q -o addopts= xarray/tests/test_datatree.py -k "test_create_with_data"`

Prepared with AI assistance; maintainer review is requested.