### PR TITLE
CI: run slow Hypothesis job on schedule and dispatch

### DIFF
--- a/.github/workflows/hypothesis.yaml
+++ b/.github/workflows/hypothesis.yaml
@@ -69,6 +69,8 @@ jobs:
     runs-on: "ubuntu-latest"
 
     needs: cache-pixi-lock
+    if: |
+      always() && needs.cache-pixi-lock.result == 'success'
 
     defaults:
       run:


### PR DESCRIPTION
## Summary

The nightly `Slow Hypothesis CI` workflow has reported run-level success since 2026-02-12 while its `Slow Hypothesis Tests` job was skipped in every run — the slow property-test tier has produced no signal for ~6 months (gh #11517).

## Cause and fix

`#11096` made `detect-ci-trigger` skip on `schedule`/`workflow_dispatch` (its `if:` requires a `pull_request` event). `cache-pixi-lock` survives via `always()`, but the `hypothesis` job had no `if:` at all, so its implicit `success()` saw the skipped `detect-ci-trigger` in the transitive `needs` chain and skipped — while the run still concluded "success".

This applies exactly the two lines from #11184 (which fixed `upstream-dev-ci.yaml`) to the `hypothesis` job:

```yaml
    if: |
      always() && needs.cache-pixi-lock.result == 'success'
```

The PR-label path (`run-slow-hypothesis`) is unchanged since `cache-pixi-lock` already encodes that gating. The issue includes fork-verified run evidence (unpatched: skipped; patched: `31 passed, 3 skipped, 2 xfailed`).

## Validation

- YAML parses cleanly (jobs and the new `if:` verified)
- `git diff --check` — clean
- Fix pattern is identical to the merged #11184 in `upstream-dev-ci.yaml`
