### PR TITLE
11518: Fix keepdims in `DatasetGroupBy.xyz` and `DatasetRolling.xyz`

### DIFF
--- a/xarray/computation/rolling.py
+++ b/xarray/computation/rolling.py
@@ -176,6 +176,15 @@ class Rolling(Generic[T_Xarray]):
 
         def method(self, keep_attrs=None, **kwargs):
             keep_attrs = self._get_keep_attrs(keep_attrs)
+            if "keepdims" in kwargs:
+                warnings.warn(
+                    "Reductions are applied along the rolling dimension. "
+                    "Passing the 'keepdims' kwarg to reduction is not "
+                    "supported and will be ignored.",
+                    FutureWarning,
+                    stacklevel=3,
+                )
+                del kwargs["keepdims"]
 
             return self._array_reduce(
                 array_agg_func=array_agg_func,

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -31,10 +31,7 @@ from xarray.core.common import (
 from xarray.core.coordinates import Coordinates, coordinates_from_variable
 from xarray.core.duck_array_ops import where
 from xarray.core.formatting import format_array_flat
-from xarray.core.indexes import (
-    PandasMultiIndex,
-    filter_indexes_from_coords,
-)
+from xarray.core.indexes import PandasMultiIndex, filter_indexes_from_coords
 from xarray.core.options import OPTIONS, _get_keep_attrs
 from xarray.core.types import (
     Dims,
@@ -1765,6 +1762,16 @@ class DataArrayGroupByBase(GroupBy["DataArray"], DataArrayGroupbyArithmetic):
 
         if keep_attrs is None:
             keep_attrs = _get_keep_attrs(default=True)
+
+        if "keepdims" in kwargs:
+            warnings.warn(
+                "Reductions are applied along the rolling dimension. "
+                "Passing the 'keepdims' kwarg to reduction is not "
+                "supported and will be ignored.",
+                FutureWarning,
+                stacklevel=3,
+            )
+            del kwargs["keepdims"]
 
         def reduce_array(ar: DataArray) -> DataArray:
             return ar.reduce(

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -1768,7 +1768,7 @@ class DataArrayGroupByBase(GroupBy["DataArray"], DataArrayGroupbyArithmetic):
 
         if "keepdims" in kwargs:
             warnings.warn(
-                "Reductions are applied along the rolling dimension. "
+                "Reductions are applied along the grouping or resampling dimension. "
                 "Passing the 'keepdims' kwarg to reduction is not "
                 "supported and will be ignored.",
                 FutureWarning,
@@ -1943,7 +1943,7 @@ class DatasetGroupByBase(GroupBy["Dataset"], DatasetGroupbyArithmetic):
 
         if "keepdims" in kwargs:
             warnings.warn(
-                "Reductions are applied along the rolling dimension. "
+                "Reductions are applied along the grouping or resampling dimension. "
                 "Passing the 'keepdims' kwarg to reduction is not "
                 "supported and will be ignored.",
                 FutureWarning,

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -1073,7 +1073,7 @@ class GroupBy(Generic[T_Xarray]):
 
         if "keepdims" in kwargs:
             warnings.warn(
-                "Reductions are applied along the rolling dimension. "
+                "Reductions are applied along the grouping or resampling dimension. "
                 "Passing the 'keepdims' kwarg to reduction is not "
                 "supported and will be ignored.",
                 FutureWarning,

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -1773,7 +1773,7 @@ class DataArrayGroupByBase(GroupBy["DataArray"], DataArrayGroupbyArithmetic):
                 dim=dim,
                 axis=axis,
                 keep_attrs=keep_attrs,
-                keepdims=keepdims,
+                keepdims=False,
                 **kwargs,
             )
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -1722,7 +1722,6 @@ class DataArrayGroupByBase(GroupBy["DataArray"], DataArrayGroupbyArithmetic):
         *,
         axis: int | Sequence[int] | None = None,
         keep_attrs: bool | None = None,
-        keepdims: bool = False,
         shortcut: bool = True,
         **kwargs: Any,
     ) -> DataArray:
@@ -1886,7 +1885,6 @@ class DatasetGroupByBase(GroupBy["Dataset"], DatasetGroupbyArithmetic):
         *,
         axis: int | Sequence[int] | None = None,
         keep_attrs: bool | None = None,
-        keepdims: bool = False,
         shortcut: bool = True,
         **kwargs: Any,
     ) -> Dataset:

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -31,7 +31,10 @@ from xarray.core.common import (
 from xarray.core.coordinates import Coordinates, coordinates_from_variable
 from xarray.core.duck_array_ops import where
 from xarray.core.formatting import format_array_flat
-from xarray.core.indexes import PandasMultiIndex, filter_indexes_from_coords
+from xarray.core.indexes import (
+    PandasMultiIndex,
+    filter_indexes_from_coords,
+)
 from xarray.core.options import OPTIONS, _get_keep_attrs
 from xarray.core.types import (
     Dims,

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -1938,6 +1938,16 @@ class DatasetGroupByBase(GroupBy["Dataset"], DatasetGroupbyArithmetic):
         if keep_attrs is None:
             keep_attrs = _get_keep_attrs(default=True)
 
+        if "keepdims" in kwargs:
+            warnings.warn(
+                "Reductions are applied along the rolling dimension. "
+                "Passing the 'keepdims' kwarg to reduction is not "
+                "supported and will be ignored.",
+                FutureWarning,
+                stacklevel=3,
+            )
+            del kwargs["keepdims"]
+
         def reduce_dataset(ds: Dataset) -> Dataset:
             return ds.reduce(
                 func=func,

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -1939,7 +1939,7 @@ class DatasetGroupByBase(GroupBy["Dataset"], DatasetGroupbyArithmetic):
                 dim=dim,
                 axis=axis,
                 keep_attrs=keep_attrs,
-                keepdims=keepdims,
+                keepdims=False,
                 **kwargs,
             )
 

--- a/xarray/core/groupby.py
+++ b/xarray/core/groupby.py
@@ -1071,6 +1071,16 @@ class GroupBy(Generic[T_Xarray]):
         import flox
         from flox.xarray import xarray_reduce
 
+        if "keepdims" in kwargs:
+            warnings.warn(
+                "Reductions are applied along the rolling dimension. "
+                "Passing the 'keepdims' kwarg to reduction is not "
+                "supported and will be ignored.",
+                FutureWarning,
+                stacklevel=3,
+            )
+            del kwargs["keepdims"]
+
         from xarray.core.dataset import Dataset
 
         obj = self._original_obj

--- a/xarray/core/resample.py
+++ b/xarray/core/resample.py
@@ -264,7 +264,6 @@ class DataArrayResample(
         *,
         axis: int | Sequence[int] | None = None,
         keep_attrs: bool | None = None,
-        keepdims: bool = False,
         shortcut: bool = True,
         **kwargs: Any,
     ) -> DataArray:
@@ -297,7 +296,6 @@ class DataArrayResample(
             dim=dim,
             axis=axis,
             keep_attrs=keep_attrs,
-            keepdims=keepdims,
             shortcut=shortcut,
             **kwargs,
         )
@@ -471,7 +469,6 @@ class DatasetResample(
         *,
         axis: int | Sequence[int] | None = None,
         keep_attrs: bool | None = None,
-        keepdims: bool = False,
         shortcut: bool = True,
         **kwargs: Any,
     ) -> Dataset:
@@ -504,7 +501,6 @@ class DatasetResample(
             dim=dim,
             axis=axis,
             keep_attrs=keep_attrs,
-            keepdims=keepdims,
             shortcut=shortcut,
             **kwargs,
         )

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -1920,7 +1920,7 @@ class TestDataArrayGroupBy:
         with (
             pytest.warns(
                 FutureWarning,
-                match="Reductions are applied along the rolling dimension. Passing the 'keepdims' kwarg to reduction is not supported and will be ignored.",
+                match="Passing the 'keepdims' kwarg",
             ),
             xr.set_options(use_flox=use_flox),
         ):

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -2394,7 +2394,7 @@ class TestDataArrayResample:
         with (
             pytest.warns(
                 FutureWarning,
-                match="Reductions are applied along the rolling dimension. Passing the 'keepdims' kwarg to reduction is not supported and will be ignored.",
+                match="Reductions are applied along the grouping or resampling dimension. Passing the 'keepdims' kwarg to reduction is not supported and will be ignored.",
             ),
             xr.set_options(use_flox=use_flox),
         ):
@@ -2623,7 +2623,7 @@ class TestDatasetResample:
         with (
             pytest.warns(
                 FutureWarning,
-                match="Reductions are applied along the rolling dimension. Passing the 'keepdims' kwarg to reduction is not supported and will be ignored.",
+                match="Reductions are applied along the grouping or resampling dimension. Passing the 'keepdims' kwarg to reduction is not supported and will be ignored.",
             ),
             xr.set_options(use_flox=use_flox),
         ):

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -2593,6 +2593,22 @@ class TestDatasetResample:
         actual = ds.resample(time="D").map(func, args=(1.0,), arg3=1.0)
         assert_identical(expected, actual)
 
+    @pytest.mark.parametrize("func", ["mean", "sum", "std"])
+    @pytest.mark.parametrize("use_flox", [True, False])
+    def test_resample_ignores_keepdims(self, use_flox: bool, func) -> None:
+        times = pd.date_range("2000-01-01", "2001-01-01", freq="MS")
+        vals = np.random.rand(len(times))
+        da = DataArray(vals, coords={"time": times}, dims="time")
+
+        with (
+            pytest.warns(
+                FutureWarning,
+                match="Reductions are applied along the rolling dimension. Passing the 'keepdims' kwarg to reduction is not supported and will be ignored.",
+            ),
+            xr.set_options(use_flox=use_flox),
+        ):
+            getattr(da.resample(time="MS"), func)(keepdims=True)
+
 
 @pytest.mark.parametrize("use_lazy_group_idx", [True, False])
 @pytest.mark.parametrize("use_dask", [True, False])

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -14,7 +14,11 @@ from packaging.version import Version
 import xarray as xr
 from xarray import DataArray, Dataset, Variable, date_range
 from xarray.core.groupby import _consolidate_slices
-from xarray.core.types import InterpOptions, PDDatetimeUnitOptions, ResampleCompatible
+from xarray.core.types import (
+    InterpOptions,
+    PDDatetimeUnitOptions,
+    ResampleCompatible,
+)
 from xarray.core.utils import module_available
 from xarray.groupers import (
     BinGrouper,

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import operator
 import warnings
-from typing import Literal, cast
+from typing import Callable, Literal, cast
 from unittest import mock
 
 import numpy as np
@@ -14,11 +14,7 @@ from packaging.version import Version
 import xarray as xr
 from xarray import DataArray, Dataset, Variable, date_range
 from xarray.core.groupby import _consolidate_slices
-from xarray.core.types import (
-    InterpOptions,
-    PDDatetimeUnitOptions,
-    ResampleCompatible,
-)
+from xarray.core.types import InterpOptions, PDDatetimeUnitOptions, ResampleCompatible
 from xarray.core.utils import module_available
 from xarray.groupers import (
     BinGrouper,
@@ -1909,6 +1905,22 @@ class TestDataArrayGroupBy:
         with xr.set_options(use_flox=use_flox):
             assert_identical(fwd.sum(), array)
             assert_identical(rev.sum(), array_rev)
+
+    @pytest.mark.parametrize("func", ["mean", "sum", "std"])
+    @pytest.mark.parametrize("use_flox", [True, False])
+    def test_groupby_ignores_keepdims(self, use_flox: bool, func) -> None:
+        times = pd.date_range("2000-01-01", "2001-01-01", freq="MS")
+        vals = np.random.rand(len(times))
+        da = DataArray(vals, coords={"time": times}, dims="time")
+
+        with (
+            pytest.warns(
+                FutureWarning,
+                match="Reductions are applied along the rolling dimension. Passing the 'keepdims' kwarg to reduction is not supported and will be ignored.",
+            ),
+            xr.set_options(use_flox=use_flox),
+        ):
+            getattr(da.groupby("time.month"), func)(keepdims=True)
 
 
 class TestDataArrayResample:

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import operator
 import warnings
-from typing import Callable, Literal, cast
+from typing import Literal, cast
 from unittest import mock
 
 import numpy as np

--- a/xarray/tests/test_groupby.py
+++ b/xarray/tests/test_groupby.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import operator
 import warnings
-from typing import Callable, Literal, cast
+from typing import Literal, cast
 from unittest import mock
 
 import numpy as np
@@ -2380,6 +2380,22 @@ class TestDataArrayResample:
         expected = DataArray(array.to_series().resample("24h", origin=origin).mean())
         assert_identical(expected, actual)
 
+    @pytest.mark.parametrize("func", ["mean", "sum", "std"])
+    @pytest.mark.parametrize("use_flox", [True, False])
+    def test_resample_ignores_keepdims(self, use_flox: bool, func) -> None:
+        times = pd.date_range("2000-01-01", "2001-01-01", freq="MS")
+        vals = np.random.rand(len(times))
+        da = DataArray(vals, coords={"time": times}, dims="time")
+
+        with (
+            pytest.warns(
+                FutureWarning,
+                match="Reductions are applied along the rolling dimension. Passing the 'keepdims' kwarg to reduction is not supported and will be ignored.",
+            ),
+            xr.set_options(use_flox=use_flox),
+        ):
+            getattr(da.resample(time="MS"), func)(keepdims=True)
+
 
 class TestDatasetResample:
     @pytest.mark.parametrize(
@@ -2598,7 +2614,7 @@ class TestDatasetResample:
     def test_resample_ignores_keepdims(self, use_flox: bool, func) -> None:
         times = pd.date_range("2000-01-01", "2001-01-01", freq="MS")
         vals = np.random.rand(len(times))
-        da = DataArray(vals, coords={"time": times}, dims="time")
+        ds = Dataset({"foo": ("time", vals), "time": times})
 
         with (
             pytest.warns(
@@ -2607,7 +2623,7 @@ class TestDatasetResample:
             ),
             xr.set_options(use_flox=use_flox),
         ):
-            getattr(da.resample(time="MS"), func)(keepdims=True)
+            getattr(ds.resample(time="MS"), func)(keepdims=True)
 
 
 @pytest.mark.parametrize("use_lazy_group_idx", [True, False])

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -936,6 +936,16 @@ class TestDatasetRolling:
         expected = getattr(getattr(ds.rolling(time=4), name)().rolling(x=3), name)()
         assert_allclose(actual, expected)
 
+    @pytest.mark.parametrize("func", ["mean", "sum", "std"])
+    def test_rolling_keepdims_warns(self, func) -> None:
+        ds = Dataset({"da": ("x", np.arange(10))})
+        with pytest.warns(
+            FutureWarning,
+            match="Passing the 'keepdims' kwarg to reduction is not supported and will be ignored.",
+        ):
+            ds = ds.rolling(x=3)
+            getattr(ds, func)(keepdims=True)
+
 
 @requires_numbagg
 class TestDatasetRollingExp:

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -486,6 +486,16 @@ class TestDataArrayRolling:
         result = bool_raster.rolling(x=3, center=True).mean()
         assert_allclose(result, expected)
 
+    @pytest.mark.parametrize("func", ["mean", "sum", "std"])
+    def test_rolling_keepdims_warns(self, func) -> None:
+        da = DataArray(np.arange(10), dims="x")
+        with pytest.warns(
+            FutureWarning,
+            match="Passing the 'keepdims' kwarg to reduction is not supported and will be ignored.",
+        ):
+            da = da.rolling(x=3)
+            getattr(da, func)(keepdims=True)
+
 
 @requires_numbagg
 class TestDataArrayRollingExp:

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -493,8 +493,7 @@ class TestDataArrayRolling:
             FutureWarning,
             match="Passing the 'keepdims' kwarg to reduction is not supported and will be ignored.",
         ):
-            da = da.rolling(x=3)
-            getattr(da, func)(keepdims=True)
+            getattr(da.rolling(x=3), func)(keepdims=True)
 
 
 @requires_numbagg
@@ -943,8 +942,7 @@ class TestDatasetRolling:
             FutureWarning,
             match="Passing the 'keepdims' kwarg to reduction is not supported and will be ignored.",
         ):
-            ds = ds.rolling(x=3)
-            getattr(ds, func)(keepdims=True)
+            getattr(ds.rolling(x=3), func)(keepdims=True)
 
 
 @requires_numbagg


### PR DESCRIPTION
### Description

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #11518 
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst` *
- [ ] N/A New functions/methods are listed in `api.rst`

* Not sure if this is user visible?

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
    <!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
    Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

I used Claude Opus 4.8 to help me trace a couple of code paths when I got a bit lost with the resample class here. No AI generated code though.

