### PR TITLE
Don't warn about a missing _FillValue for CF coordinate variables

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -69,6 +69,11 @@ Bug Fixes
   for zarr writes. Existing zarr stores written with the old ``int8`` encoding
   are still read correctly. (:issue:`2937`, :pull:`11318`)
   By `Evan Lyall <https://github.com/elyall>`_.
+- No longer emit a ``SerializationWarning`` about a missing ``_FillValue`` when
+  encoding a CF coordinate variable (a 1D variable named after its dimension) to
+  an integer dtype. CF forbids missing values in coordinate variables, so a
+  ``_FillValue`` is not expected there (:issue:`10305`).
+  By `NoiceHax <https://github.com/NoiceHax>`_.
 
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -73,7 +73,7 @@ Bug Fixes
   encoding a CF coordinate variable (a 1D variable named after its dimension) to
   an integer dtype. CF forbids missing values in coordinate variables, so a
   ``_FillValue`` is not expected there (:issue:`10305`).
-  By `NoiceHex <https://github.com/NoiceHax>`_.
+  By `NoiceHax <https://github.com/NoiceHax>`_.
 
 
 Documentation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -73,7 +73,7 @@ Bug Fixes
   encoding a CF coordinate variable (a 1D variable named after its dimension) to
   an integer dtype. CF forbids missing values in coordinate variables, so a
   ``_FillValue`` is not expected there (:issue:`10305`).
-  By `NoiceHax <https://github.com/NoiceHax>`_.
+  By `NoiceHex <https://github.com/NoiceHax>`_.
 
 
 Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -424,6 +424,7 @@ Claus = "Claus"
 Celles = "Celles"
 slowy = "slowy"
 Commun = "Commun"
+Noice = "Noice"
 
 # Tests
 Ome = "Ome"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -425,6 +425,7 @@ Celles = "Celles"
 slowy = "slowy"
 Commun = "Commun"
 Noice = "Noice"
+Hax = "Hax"
 
 # Tests
 Ome = "Ome"

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -635,9 +635,8 @@ class NonStringCoder(VariableCoder):
             dtype = np.dtype(encoding.pop("dtype"))
             if dtype != variable.dtype:
                 if np.issubdtype(dtype, np.integer):
-                    # CF coordinate variables (1D variables with the same name as
-                    # their dimension) are not allowed to have missing values, so
-                    # they do not need a _FillValue.
+                    # CF coordinate variables are not allowed to have missing values, so
+                    # they do not need a _FillValue. For simplicity we don't warn with 1D dimension coordinates.
                     # http://cfconventions.org/cf-conventions/cf-conventions.html#missing-data
                     if (
                         np.issubdtype(variable.dtype, np.floating)

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -635,10 +635,15 @@ class NonStringCoder(VariableCoder):
             dtype = np.dtype(encoding.pop("dtype"))
             if dtype != variable.dtype:
                 if np.issubdtype(dtype, np.integer):
+                    # CF coordinate variables (1D variables with the same name as
+                    # their dimension) are not allowed to have missing values, so
+                    # they do not need a _FillValue.
+                    # http://cfconventions.org/cf-conventions/cf-conventions.html#missing-data
                     if (
                         np.issubdtype(variable.dtype, np.floating)
                         and "_FillValue" not in variable.attrs
                         and "missing_value" not in variable.attrs
+                        and dims != (name,)
                     ):
                         warnings.warn(
                             f"saving variable {name} with floating "

--- a/xarray/tests/test_conventions.py
+++ b/xarray/tests/test_conventions.py
@@ -173,6 +173,27 @@ class TestEncodeCFVariable:
             "invalid value encountered in cast" in msg for msg in warning_messages
         )
 
+    def test_missing_fillvalue_coordinate_variable(self) -> None:
+        # regression test for GH10305
+        # CF coordinate variables cannot have missing values, so they do not
+        # need a _FillValue and should not warn about one being absent
+        v = Variable(["x"], np.array([0.0, 1.0, 2.0]), encoding={"dtype": "int16"})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            encoded = conventions.encode_cf_variable(v, name="x")
+        assert encoded.dtype == np.dtype("int16")
+
+    def test_missing_fillvalue_non_coordinate_variable(self) -> None:
+        # data variables and multidimensional (auxiliary) coordinates may hold
+        # missing values, so they still warn
+        v = Variable(["x"], np.array([0.0, 1.0, 2.0]), encoding={"dtype": "int16"})
+        with pytest.warns(SerializationWarning, match="floating point data"):
+            conventions.encode_cf_variable(v, name="data")
+
+        v2d = Variable(["y", "x"], np.zeros((2, 3)), encoding={"dtype": "int16"})
+        with pytest.warns(SerializationWarning, match="floating point data"):
+            conventions.encode_cf_variable(v2d, name="lat")
+
     def test_multidimensional_coordinates(self) -> None:
         # regression test for GH1763
         # Set up test case with coordinates that have overlapping (but not


### PR DESCRIPTION
### Description

Closes #10305.

When a float variable is encoded to an integer dtype, `NonStringCoder.encode` warns that there is no `_FillValue` to use for NaNs. That warning also fired for CF coordinate variables, meaning 1D variables named after their own dimension. CF says missing data is not allowed in coordinate variables, so those variables are not supposed to carry a `_FillValue` at all. The warning pushed people toward adding one, which a CF checker then flags.

The fix skips the warning when a variable's dims are exactly `(name,)`, which is the check @kmuehlbauer suggested on the issue. Rounding and the dtype cast are left alone, so the encoded output is the same as before. Data variables and multidimensional auxiliary coordinates still warn, and there are tests for both cases.

This covers only the first part of the issue. The other part, what to do when someone sets `_FillValue = None` and the float data really does contain NaN, is left out on purpose. @kmuehlbauer noted that the cast result there depends on the platform, so it seems better to handle it separately.

### Checklist

- [x] Closes #10305
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    <!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
    Tools: Claude Code. I used it to write the fix and the tests from the issue and from kmuehlbauer's suggested check, and I reviewed and ran everything myself.