### PR TITLE
Fix Dataset.isin and DataArray.isin when passed a set

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -69,6 +69,11 @@ Bug Fixes
   for zarr writes. Existing zarr stores written with the old ``int8`` encoding
   are still read correctly. (:issue:`2937`, :pull:`11318`)
   By `Evan Lyall <https://github.com/elyall>`_.
+- :py:meth:`~xarray.DataArray.isin` and :py:meth:`~xarray.Dataset.isin` now
+  accept sets, frozensets and other set-like objects such as ``dict.keys()``.
+  Previously these were turned into a 0-dimensional object array by numpy, so
+  the result was ``False`` everywhere (:issue:`10022`).
+  By `Chandan P <https://github.com/NoiceHax>`_.
 
 
 Documentation

--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import warnings
 from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping
+from collections.abc import Set as AbstractSet
 from contextlib import suppress
 from html import escape
 from textwrap import dedent
@@ -1366,6 +1367,8 @@ class DataWithCoords(AttrAccessMixin):
         test_elements : array_like
             The values against which to test each value of `element`.
             This argument is flattened if an array or array_like.
+            Sets (and other set-like objects such as ``dict.keys()``) are
+            converted to a list first.
             See numpy notes for behavior with non-array-like parameters.
 
         Returns
@@ -1394,6 +1397,10 @@ class DataWithCoords(AttrAccessMixin):
             raise TypeError(
                 f"isin() argument must be convertible to an array: {test_elements}"
             )
+        elif isinstance(test_elements, AbstractSet):
+            # numpy converts a set to a 0d object array, which never compares
+            # equal to any element, so convert it to a sequence first
+            test_elements = list(test_elements)
         elif isinstance(test_elements, Variable | DataArray):
             # need to explicitly pull out data to support dask arrays as the
             # second argument

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -7018,6 +7018,13 @@ def test_isin(da) -> None:
     result = da.isin([2, 3]).sel(y=list("de"), z=0)
     assert_equal(result, expected)
 
+    # set-like objects give the same answer as the equivalent list, GH10022
+    result = da.isin({2, 3}).sel(y=list("de"), z=0)
+    assert_equal(result, expected)
+
+    result = da.isin({2: "a", 3: "b"}.keys()).sel(y=list("de"), z=0)
+    assert_equal(result, expected)
+
 
 def test_raise_no_warning_for_nan_in_binary_ops() -> None:
     with assert_no_warnings():

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -7815,7 +7815,10 @@ class TestDataset:
 # pytest tests — new tests should go here, rather than in the class.
 
 
-@pytest.mark.parametrize("test_elements", ([1, 2], np.array([1, 2]), DataArray([1, 2])))
+@pytest.mark.parametrize(
+    "test_elements",
+    ([1, 2], np.array([1, 2]), DataArray([1, 2]), {1, 2}, frozenset({1, 2})),
+)
 def test_isin(test_elements, backend) -> None:
     expected = Dataset(
         data_vars={


### PR DESCRIPTION
### Description

`isin` passed its argument straight to numpy, and numpy turns a set into a 0-dimensional object array. That array never compares equal to any element, so `xr.DataArray([1, 2, 3, 4]).isin({1, 2})` came back False everywhere instead of matching 1 and 2. The same happened with a `frozenset` or with `dict.keys()`. pandas returns the answer you would expect here, so the difference is easy to trip over.

The fix adds one branch to the existing isinstance chain in `DataWithCoords.isin` that converts a `collections.abc.Set` to a list before the numpy call. That covers sets, frozensets and dict views. Passing a `Dataset` still raises `TypeError` as before.

Tests: set and frozenset added to the parametrize on `test_isin` in `test_dataset.py`, set and `dict.keys()` added to `test_isin` in `test_dataarray.py`. Both fail before the change.

The issue thread also floats raising for scalars and strings the way pandas does. That is a larger behavior change and is not part of this PR.

### Checklist

- [x] Closes #10022
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Claude Code. I asked it to special-case sets in `isin` as suggested in the issue, then reviewed the change and ran the isin tests and pre-commit locally.