### PR TITLE
Avoid densifying sparse.COO data in to_series()/to_dataframe()

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -74,6 +74,14 @@ Bug Fixes
   of silently creating a broken coordinate. Pass the object directly with
   ``ds.assign_coords(coords)`` (:issue:`10194`).
   By `NoiceHex <https://github.com/NoiceHax>`_.
+- :py:meth:`DataArray.to_series` and :py:meth:`Dataset.to_dataframe` no longer
+  call ``.todense()`` on ``sparse.COO``-backed variables, which could raise
+  ``MemoryError`` for large, genuinely sparse arrays, or (for
+  ``Dataset.to_dataframe``) crash outright since ``sparse.COO`` refuses to
+  densify implicitly. ``to_series`` now returns only the array's stored
+  entries; ``to_dataframe`` indexes by the union of stored entries across all
+  sparse variables sharing the same dims (:issue:`4007`).
+  By `patnr <https://github.com/patnr>`_.
 
 
 Documentation

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -35,7 +35,7 @@ from xarray.core.coordinates import (
     create_coords_with_default_indexes,
     validate_dataarray_coords,
 )
-from xarray.core.dataset import Dataset
+from xarray.core.dataset import Dataset, _sparse_coo_to_index
 from xarray.core.extension_array import PandasExtensionArray
 from xarray.core.formatting import format_item
 from xarray.core.indexes import (
@@ -72,6 +72,7 @@ from xarray.core.variable import (
     as_compatible_data,
     as_variable,
 )
+from xarray.namedarray.pycompat import array_type
 from xarray.plot.accessor import DataArrayPlotAccessor
 from xarray.plot.utils import _get_units_from_attrs
 from xarray.structure import alignment
@@ -4034,6 +4035,12 @@ class DataArray(
         The Series is indexed by the Cartesian product of index coordinates
         (in the form of a :py:class:`pandas.MultiIndex`).
 
+        If the underlying data is a :py:class:`sparse.COO` array, the result
+        instead only contains that array's stored (non-fill-value) entries,
+        indexed by their coordinates - the full Cartesian product is never
+        materialized, which avoids a `.todense()` call that could raise
+        MemoryError for large, genuinely sparse data.
+
         Returns
         -------
         result : Series
@@ -4044,6 +4051,15 @@ class DataArray(
         DataArray.to_pandas
         DataArray.to_dataframe
         """
+        if isinstance(self.data, array_type("sparse")):
+            from sparse import COO
+
+            if isinstance(self.data, COO):
+                index = _sparse_coo_to_index(self.data, self.dims, self.get_index)
+                return pd.Series(self.data.data, index=index, name=self.name)
+            # TODO: other SparseArray subclasses, e.g. DOK, lack the
+            # .coords/.data attributes _sparse_coo_to_index relies on.
+
         index = self.coords.to_index()
         return pd.Series(self.values.reshape(-1), index=index, name=self.name)
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -7343,12 +7343,8 @@ class Dataset(
             ]
 
         if sparse_columns:
-            # Avoid densifying sparse variables (which could raise
-            # MemoryError, and - unlike a plain ndarray - sparse.COO never
-            # does this implicitly): index the DataFrame by the union of
-            # their stored (non-fill-value) coordinates instead of the full
-            # Cartesian product, and fill each column - sparse or dense -
-            # from only that reduced set of positions.
+            # Avoid densifying sparse variables.
+            # Instead index the DataFrame by the stored coordinates.
             sparse_indexes = [
                 self._sparse_column_index(self._variables[k], ordered_dim_names)
                 for k in sparse_columns

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -200,6 +200,32 @@ _DATETIMEINDEX_COMPONENTS = [
 ]
 
 
+def _sparse_coo_to_index(
+    coo, dims: Sequence[Hashable], get_index: Callable[[Hashable], pd.Index]
+) -> pd.Index:
+    """Build a pandas Index (a MultiIndex if ``len(dims) > 1``) over exactly
+    the stored (non-fill-value) entries of a ``sparse.COO`` array.
+
+    ``coo.coords`` gives, per dimension, the integer position of each stored
+    entry — not the dimension's actual coordinate labels. Those integer
+    positions are also not guaranteed to be a 0..n-1 range: whichever unique
+    positions happen to occur become the codes/levels of an initial
+    `pandas.MultiIndex.from_arrays`, in the order `factorize` assigns them.
+    `set_levels` is then used to map each level's codes back to the real
+    coordinate values through `get_index`, rather than assuming (as one
+    could naively) that the codes already run in coordinate order. This is
+    the read-side inverse of `Dataset._set_sparse_data_from_dataframe`.
+    """
+    mindex = pd.MultiIndex.from_arrays(coo.coords, names=dims)
+    mindex = mindex.set_levels(
+        [
+            get_index(dim).values[np.asarray(level)]
+            for dim, level in zip(dims, mindex.levels, strict=True)
+        ]
+    )
+    return mindex.get_level_values(0) if len(dims) == 1 else mindex
+
+
 class Dataset(
     DataWithCoords,
     DatasetAggregations,
@@ -7295,11 +7321,53 @@ class Dataset(
             for k in extension_array_columns
             if k not in extension_array_columns_different_index
         ]
-        data = [
-            self._variables[k].set_dims(ordered_dims).values.reshape(-1)
+        ordered_dim_names = tuple(ordered_dims)
+        sparse_columns = [
+            k
             for k in non_extension_array_columns
+            if isinstance(self._variables[k].data, array_type("sparse"))
         ]
-        index = self.coords.to_index([*ordered_dims])
+        if sparse_columns:
+            from sparse import COO
+
+            # Other SparseArray subclasses (e.g. DOK) lack the .coords/.data
+            # attributes _sparse_coo_to_index relies on, and a variable whose
+            # dims need broadcasting to reach ordered_dim_names would have
+            # to be densified to do that anyway - both fall back to the
+            # dense path below, same as before this feature existed.
+            sparse_columns = [
+                k
+                for k in sparse_columns
+                if isinstance(self._variables[k].data, COO)
+                and set(self._variables[k].dims) == set(ordered_dim_names)
+            ]
+
+        if sparse_columns:
+            # Avoid densifying sparse variables (which could raise
+            # MemoryError, and - unlike a plain ndarray - sparse.COO never
+            # does this implicitly): index the DataFrame by the union of
+            # their stored (non-fill-value) coordinates instead of the full
+            # Cartesian product, and fill each column - sparse or dense -
+            # from only that reduced set of positions.
+            sparse_indexes = [
+                self._sparse_column_index(self._variables[k], ordered_dim_names)
+                for k in sparse_columns
+            ]
+            index = sparse_indexes[0]
+            for other in sparse_indexes[1:]:
+                index = index.union(other)
+            data = [
+                self._to_dataframe_sparse_column(
+                    self._variables[k], ordered_dim_names, index
+                )
+                for k in non_extension_array_columns
+            ]
+        else:
+            data = [
+                self._variables[k].set_dims(ordered_dims).values.reshape(-1)
+                for k in non_extension_array_columns
+            ]
+            index = self.coords.to_index([*ordered_dims])
         broadcasted_df = pd.DataFrame(
             {
                 **dict(zip(non_extension_array_columns, data, strict=True)),
@@ -7357,6 +7425,51 @@ class Dataset(
         ordered_dims = self._normalize_dim_order(dim_order=dim_order)
 
         return self._to_dataframe(ordered_dims=ordered_dims)
+
+    def _sparse_column_index(
+        self, variable: Variable, ordered_dims: tuple[Hashable, ...]
+    ) -> pd.Index:
+        """`_sparse_coo_to_index` for `variable.data`, a `sparse.COO` array,
+        reordered (a metadata-only operation - no densifying) to match
+        ``ordered_dims`` when `variable.dims` uses some other order over the
+        same set of dims.
+        """
+        index = _sparse_coo_to_index(variable.data, variable.dims, self.get_index)
+        if len(ordered_dims) > 1 and variable.dims != ordered_dims:
+            index = index.reorder_levels(ordered_dims)
+        return index
+
+    def _to_dataframe_sparse_column(
+        self,
+        variable: Variable,
+        ordered_dims: tuple[Hashable, ...],
+        index: pd.Index,
+    ) -> np.ndarray | pd.Series:
+        """Compute one `_to_dataframe` column, densifying only where
+        needed: a ``sparse.COO`` variable over the same set of dims as
+        ``ordered_dims`` (in any order) is turned into its own (partial)
+        index via `_sparse_column_index` and reindexed onto the combined
+        ``index`` using its own fill value; anything else still goes
+        through the original dense `.values.reshape(-1)` path (a no-op for
+        already-dense variables, and unchanged - already broken, see
+        `_to_dataframe` - behavior for sparse variables that need
+        broadcasting) and is aligned onto ``index`` positionally or via
+        reindexing.
+        """
+        from sparse import COO
+
+        data = variable.data
+        if isinstance(data, COO) and set(variable.dims) == set(ordered_dims):
+            sparse_index = self._sparse_column_index(variable, ordered_dims)
+            return pd.Series(data.data, index=sparse_index).reindex(
+                index, fill_value=data.fill_value
+            )
+
+        flat = variable.set_dims(ordered_dims).values.reshape(-1)
+        if len(flat) == len(index):
+            return flat
+        full_index = self.coords.to_index(list(ordered_dims))
+        return pd.Series(flat, index=full_index).reindex(index)
 
     def _set_sparse_data_from_dataframe(
         self, idx: pd.Index, arrays: list[tuple[Hashable, np.ndarray]], dims: tuple

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -201,7 +201,7 @@ _DATETIMEINDEX_COMPONENTS = [
 
 
 def _sparse_coo_to_index(
-    coo, dims: Sequence[Hashable], get_index: Callable[[Hashable], pd.Index]
+    coo, dims: tuple[Hashable, ...], get_index: Callable[[Hashable], pd.Index]
 ) -> pd.Index:
     """Build a pandas Index (a MultiIndex if ``len(dims) > 1``) over exactly
     the stored (non-fill-value) entries of a ``sparse.COO`` array.
@@ -7435,7 +7435,11 @@ class Dataset(
         same set of dims.
         """
         index = _sparse_coo_to_index(variable.data, variable.dims, self.get_index)
-        if len(ordered_dims) > 1 and variable.dims != ordered_dims:
+        if (
+            len(ordered_dims) > 1
+            and variable.dims != ordered_dims
+            and isinstance(index, pd.MultiIndex)
+        ):
             index = index.reorder_levels(ordered_dims)
         return index
 

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3871,6 +3871,66 @@ class TestDataArray:
 
         np.testing.assert_equal(actual_coords, expected_coords)
 
+    @requires_sparse
+    def test_to_series_sparse(self) -> None:
+        import sparse
+
+        # A sparsity pattern where no dimension has every one of its labels
+        # represented in the stored entries, and the missing labels aren't
+        # all at the same (e.g. trailing) position - this is the case a
+        # naive positional mapping from `sparse.COO.coords` to per-dimension
+        # coordinate labels gets wrong.
+        dense = np.array(
+            [
+                [0, 0, 3, 0],
+                [0, 0, 0, 9],
+                [7, 0, 0, 0],
+            ]
+        )
+        da = DataArray(
+            sparse.COO.from_numpy(dense),
+            dims=["x", "y"],
+            coords={"x": list("abc"), "y": list("wxyz")},
+            name="foo",
+        )
+        actual = da.to_series()
+
+        dense_da = DataArray(
+            dense,
+            dims=["x", "y"],
+            coords={"x": list("abc"), "y": list("wxyz")},
+            name="foo",
+        )
+        expected = dense_da.to_series()
+        expected = expected[expected != 0]
+
+        assert_array_equal(actual.sort_index().index, expected.sort_index().index)
+        assert_array_equal(actual.sort_index().values, expected.sort_index().values)
+        assert actual.name == "foo"
+        # only the stored entries are present - the full Cartesian product
+        # (which to_series() never materializes for sparse data) is not
+        assert len(actual) == dense[dense != 0].size
+
+    @requires_sparse
+    def test_to_series_sparse_1d(self) -> None:
+        import sparse
+
+        dense = np.array([0, 0, 5, 0, 7])
+        da = DataArray(
+            sparse.COO.from_numpy(dense),
+            dims=["x"],
+            coords={"x": list("pqrst")},
+            name="foo",
+        )
+        actual = da.to_series()
+
+        # a single dim should give a plain Index, matching the dense/non
+        # -sparse behavior of to_series(), not a length-1-level MultiIndex
+        assert isinstance(actual.index, pd.Index)
+        assert not isinstance(actual.index, pd.MultiIndex)
+        assert_array_equal(actual.sort_index().index, ["r", "t"])
+        assert_array_equal(actual.sort_index().values, [5, 7])
+
     def test_nbytes_does_not_load_data(self) -> None:
         array = InaccessibleArray(np.zeros((3, 3), dtype="uint8"))
         da = xr.DataArray(array, dims=["x", "y"])

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5442,6 +5442,68 @@ class TestDataset:
         expected = pd.DataFrame([[]], index=idx)
         assert expected.equals(actual), (expected, actual)
 
+    @requires_sparse
+    def test_to_dataframe_sparse_crash_regression(self) -> None:
+        # `Dataset.to_dataframe()` used to unconditionally call `.values` on
+        # every variable, which crashes for a sparse.COO-backed variable
+        # (sparse arrays refuse to densify implicitly) instead of raising a
+        # clear error or, preferably, working.
+        import sparse
+
+        ds = Dataset(
+            {"u": (("x", "y"), sparse.COO.from_numpy(np.array([[0, 1], [0, 0]])))},
+            coords={"x": ["a", "b"], "y": ["c", "d"]},
+        )
+        ds.to_dataframe()  # should not raise
+
+    @requires_sparse
+    def test_to_dataframe_sparse(self) -> None:
+        import sparse
+
+        x = ["a", "b", "c"]
+        y = ["w", "x", "y", "z"]
+
+        # Two sparse variables with different, non-overlapping-except-once
+        # sparsity patterns, plus one fully dense variable, so the test
+        # covers: per-column fill values, union-of-coordinates alignment,
+        # and mixing sparse with dense columns in one DataFrame.
+        dense_u = np.array([[0, 0, 3, 0], [0, 0, 0, 9], [7, 0, 0, 0]])
+        dense_v = np.array([[0, 11, 0, 0], [0, 0, 0, 0], [0, 0, 0, 22]])
+        dense_w = np.arange(12).reshape(3, 4)
+
+        ds = Dataset(
+            {
+                "u": (("x", "y"), sparse.COO.from_numpy(dense_u)),
+                "v": (("x", "y"), sparse.COO.from_numpy(dense_v)),
+                "w": (("x", "y"), dense_w),
+            },
+            coords={"x": x, "y": y},
+        )
+        ds_dense = Dataset(
+            {
+                "u": (("x", "y"), dense_u),
+                "v": (("x", "y"), dense_v),
+                "w": (("x", "y"), dense_w),
+            },
+            coords={"x": x, "y": y},
+        )
+
+        actual = ds.to_dataframe()
+        expected_full = ds_dense.to_dataframe()
+
+        # Rows where every sparse column is at its fill value are dropped
+        # rather than materialized - the whole point of not densifying.
+        stored = (dense_u.reshape(-1) != 0) | (dense_v.reshape(-1) != 0)
+        assert len(actual) == stored.sum()
+        assert expected_full.loc[actual.index].equals(actual)
+
+        # dim_order permutation: sparse columns must line up on the same
+        # (relabeled) index as everything else, not just their native order.
+        actual_t = ds.to_dataframe(dim_order=["y", "x"])
+        expected_t = ds_dense.to_dataframe(dim_order=["y", "x"])
+        assert expected_t.loc[actual_t.index].equals(actual_t)
+        assert len(actual_t) == stored.sum()
+
     def test_from_dataframe_categorical_dtype_index(self) -> None:
         cat = pd.CategoricalIndex(list("abcd"))
         df = pd.DataFrame({"f": [0, 1, 2, 3]}, index=cat)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5504,6 +5504,38 @@ class TestDataset:
         assert expected_t.loc[actual_t.index].equals(actual_t)
         assert len(actual_t) == stored.sum()
 
+    @requires_sparse
+    def test_to_dataframe_sparse_disjoint_union(self) -> None:
+        # Regression test for a question raised in review of gh-11528: two
+        # sparse columns with zero overlapping stored positions, together
+        # covering every cell - the union of their stored coordinates is the
+        # full Cartesian product, so this exercises the case where indexing
+        # by that union saves no memory over just densifying, while still
+        # having to remain correct (not raise, not drop or misplace rows).
+        import sparse
+
+        dense_u = np.array([[1, 0, 2], [0, 3, 0]])
+        dense_v = np.array([[0, 4, 0], [5, 0, 6]])
+        assert not np.any((dense_u != 0) & (dense_v != 0))  # disjoint
+        assert np.all((dense_u != 0) | (dense_v != 0))  # covers every cell
+
+        ds = Dataset(
+            {
+                "u": (("x", "y"), sparse.COO.from_numpy(dense_u)),
+                "v": (("x", "y"), sparse.COO.from_numpy(dense_v)),
+            },
+            coords={"x": ["a", "b"], "y": ["p", "q", "r"]},
+        )
+        ds_dense = Dataset(
+            {"u": (("x", "y"), dense_u), "v": (("x", "y"), dense_v)},
+            coords={"x": ["a", "b"], "y": ["p", "q", "r"]},
+        )
+
+        actual = ds.to_dataframe()
+        expected = ds_dense.to_dataframe()
+        assert len(actual) == dense_u.size
+        assert expected.loc[actual.index].equals(actual)
+
     def test_from_dataframe_categorical_dtype_index(self) -> None:
         cat = pd.CategoricalIndex(list("abcd"))
         df = pd.DataFrame({"f": [0, 1, 2, 3]}, index=cat)


### PR DESCRIPTION
Continuation of #4007, per @khaeru's offer there to close it in favor of a fresh PR (https://github.com/pydata/xarray/pull/4007#issuecomment-2663312263).

## Summary

`DataArray.to_series()` and `Dataset.to_dataframe()` both densify `sparse.COO`-backed variables via `.values` before building the pandas result:

- For `to_dataframe()` this doesn't just defeat the purpose of using a sparse array - it **crashes outright** on current `main`, since `sparse.COO` refuses to densify implicitly (`RuntimeError: Cannot convert a sparse array to dense automatically`).
- For `to_series()`, #4007 already proposed avoiding this densification, but (per [this review comment](https://github.com/pydata/xarray/pull/4007#issuecomment-2663030145)) its `set_levels()` call maps `sparse.COO`'s stored integer coordinates back to coordinate labels incorrectly whenever a dimension doesn't have every one of its labels represented among the stored entries - i.e. almost always, for genuinely sparse data. I confirmed this experimentally: it silently returns wrong labels rather than raising.

This PR:
- Adds a `_sparse_coo_to_index()` helper that does this coordinate mapping correctly (mapping `sparse.COO.coords`' per-dimension integer codes back through each dimension's actual coordinate index, rather than assuming the codes already run in coordinate order), and returns a plain `Index` rather than a 1-level `MultiIndex` for 1-D data (matching the non-sparse code path).
- Uses it in `DataArray.to_series()`, which now returns only the array's stored (non-fill-value) entries for `sparse.COO` data, never materializing the full Cartesian product.
- Extends the same approach to `Dataset._to_dataframe()` (per [dcherian's review](https://github.com/pydata/xarray/pull/4007#issuecomment-633745037) on #4007 asking for this), indexing the resulting DataFrame by the union of stored coordinates across all matching sparse columns, with other columns (sparse or dense) reindexed onto that reduced index using each sparse column's own fill value. `dim_order` permutation is handled via a cheap `reorder_levels()` (metadata-only, no densifying).
- Both fall back to the original dense behavior for other `sparse.SparseArray` subclasses (e.g. `DOK`, which lack the `.coords`/`.data` attributes this relies on) and for variables that need broadcasting to reach the target dims - unchanged (and, for `to_dataframe()`, still broken) in exactly the way they are on `main` today, i.e. no regression.

## Testing

- New tests in `test_dataarray.py`: `test_to_series_sparse` (labeling-correctness, verified against a dense ground truth with a non-trivial/non-edge sparsity pattern) and `test_to_series_sparse_1d` (index-type fix).
- New tests in `test_dataset.py`: `test_to_dataframe_sparse_crash_regression` and `test_to_dataframe_sparse` (multiple sparse columns with different sparsity patterns + a dense column, verified against dense ground truth, including `dim_order` permutation).
- Full `test_dataset.py`, `test_dataarray.py`, and `test_sparse.py` suites pass locally.

Opening as a draft for initial feedback on the approach (particularly the `Dataset.to_dataframe()` union-of-coordinates strategy) before marking ready for review.

- [x] Closes/supersedes #4007 (to be closed once this is ready)
- [x] Tests added
- [x] `whats-new.rst` entry added