### PR TITLE
Fix bool test arrays in construct_dataarray being all False

### DIFF
--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -379,7 +379,7 @@ def construct_dataarray(dim_num, dtype, contains_nan, dask):
     elif np.issubdtype(dtype, np.integer):
         array = rng.integers(0, 10, size=shapes).astype(dtype)
     elif np.issubdtype(dtype, np.bool_):
-        array = rng.integers(0, 1, size=shapes).astype(dtype)
+        array = rng.integers(0, 2, size=shapes).astype(dtype)
     elif dtype is str:
         array = rng.choice(["a", "b", "c", "d"], size=shapes)
     else:


### PR DESCRIPTION
### Description

The bool branch used `rng.integers(0, 1)`, which always returns 0 because the upper bound is exclusive, so boolean test arrays were entirely `False`. Changed to `rng.integers(0, 2)` so they contain a random mix of `True` and `False`.

Test-only change; the seeded RNG keeps results deterministic.

### Checklist

None applicable. Test-only fix.

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    <!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
    Tools: OpenAI Codex gpt-5.6-sol (xhigh)

I didn't actually use AI to write any code or comments here, but I technically found this bug during an AI-assisted static analysis project that I've been working on. The AI assisting me was OpenAI Codex gpt-5.6-sol (xhigh). Just stating that for transparency; maintainers, just yell if this disclosure is too pedantic.