### PR TITLE
Fix alignment and copy of transposed CoordinateTransformIndex-backed arrays

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -74,6 +74,14 @@ Bug Fixes
   of silently creating a broken coordinate. Pass the object directly with
   ``ds.assign_coords(coords)`` (:issue:`10194`).
   By `NoiceHex <https://github.com/NoiceHax>`_.
+- Fixed two bugs affecting a :py:class:`~xarray.indexes.CoordinateTransformIndex`-backed
+  coordinate after ``.transpose()``: :py:meth:`~xarray.indexes.CoordinateTransformIndex.create_variables`
+  (used by, e.g., ``.copy()`` and ``.reindex_like()``-based alignment) discarded the
+  transposed dims order and silently reverted to the transform's original order; and
+  ``xr.align(..., join="exact")`` raised a spurious ``AlignmentError`` for two objects
+  sharing an equal multi-dimensional index whose associated coordinate variables
+  simply had a different dims order (:issue:`11530`).
+  By `Samuel Le Meur-Diebolt <https://github.com/sdiebolt>`_.
 
 
 Documentation

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -1517,15 +1517,23 @@ class CoordinateTransformIndex(Index):
         for name in self.transform.coord_names:
             # copy attributes, if any
             attrs: Mapping[Hashable, Any] | None
+            dims = self.transform.dims
 
             if variables is not None and name in variables:
                 var = variables[name]
                 attrs = var.attrs
+                # preserve a dims order that only differs from the transform's own
+                # by a transpose (e.g. set by a prior `Variable.transpose()` call),
+                # instead of silently reverting to the transform's original order.
+                # `CoordinateTransform.dims` is always `tuple[str, ...]`, so a
+                # `var.dims` matching it as a set is too.
+                if set(var.dims) == set(dims):
+                    dims = cast(tuple[str, ...], var.dims)
             else:
                 attrs = None
 
-            data = CoordinateTransformIndexingAdapter(self.transform, name)
-            new_variables[name] = Variable(self.transform.dims, data, attrs=attrs)
+            data = CoordinateTransformIndexingAdapter(self.transform, name, dims)
+            new_variables[name] = Variable(dims, data, attrs=attrs)
 
         return new_variables
 

--- a/xarray/structure/alignment.py
+++ b/xarray/structure/alignment.py
@@ -415,11 +415,22 @@ class Aligner(Generic[T_Alignable]):
                 if name in new_indexes:
                     other_idx = new_indexes[name]
                     other_var = new_index_vars[name]
-                    raise AlignmentError(
-                        f"cannot align objects on coordinate {name!r} because of conflicting indexes\n"
-                        f"first index: {idx!r}\nsecond index: {other_idx!r}\n"
-                        f"first variable: {var!r}\nsecond variable: {other_var!r}\n"
-                    )
+                    # `idx` and `other_idx` may be genuinely equal (e.g., a
+                    # multi-dimensional CoordinateTransformIndex covering the same
+                    # grid) yet fall into different `MatchingIndexKey` groups because
+                    # their associated coordinate variables have a different `dims`
+                    # order (e.g. one object was transposed). Only raise once we know
+                    # they are not actually equal.
+                    if not indexes_all_equal(
+                        [(idx, {name: var}), (other_idx, {name: other_var})],
+                        self.exclude_dims,
+                    ):
+                        raise AlignmentError(
+                            f"cannot align objects on coordinate {name!r} because of conflicting indexes\n"
+                            f"first index: {idx!r}\nsecond index: {other_idx!r}\n"
+                            f"first variable: {var!r}\nsecond variable: {other_var!r}\n"
+                        )
+                    continue
                 new_indexes[name] = idx
                 new_index_vars[name] = var
 

--- a/xarray/tests/test_coordinate_transform.py
+++ b/xarray/tests/test_coordinate_transform.py
@@ -214,8 +214,8 @@ def test_coordinate_transform_align_transposed() -> None:
         actual1, actual2 = xr.align(ds1, ds2, join=join)
         assert actual1.dims == ds1.dims
         assert actual2.dims == ds2.dims
-        assert actual1.equals(ds1)
-        assert actual2.equals(ds2)
+        assert assert_identical(actual1, ds1)
+        assert assert_identical(actual2, ds2)
 
     # a genuinely different grid (different scale) must still be rejected, even
     # when it also differs from `ds1` by dims order (exercising the cross-group

--- a/xarray/tests/test_coordinate_transform.py
+++ b/xarray/tests/test_coordinate_transform.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 import xarray as xr
+from xarray import AlignmentError
 from xarray.core.coordinate_transform import CoordinateTransform
 from xarray.core.indexes import CoordinateTransformIndex
 from xarray.tests import assert_equal, assert_identical
@@ -197,6 +198,39 @@ def test_coordinate_transform_transpose_non_square() -> None:
     assert actual.shape == (3, 2)
     expected = [[0.0, 0.0], [2.0, 2.0], [4.0, 4.0]]
     np.testing.assert_array_equal(actual.values, expected)
+
+
+def test_coordinate_transform_align_transposed() -> None:
+    # regression test: two Dataset objects sharing the same (equal)
+    # CoordinateTransformIndex but with a differently-transposed dim order
+    # for their coordinate variables used to raise a spurious "conflicting
+    # indexes" AlignmentError, because indexes are grouped for comparison by
+    # (coordinate name, dims order) before Index.equals() is ever called.
+    ds1 = create_coords(scale=2.0, shape=(2, 3)).to_dataset()
+    ds1["data"] = (("y", "x"), np.arange(6).reshape(2, 3))
+    ds2 = ds1.transpose("x", "y")
+
+    for join in ("exact", "outer", "inner"):
+        actual1, actual2 = xr.align(ds1, ds2, join=join)
+        assert actual1.dims == ds1.dims
+        assert actual2.dims == ds2.dims
+        assert actual1.equals(ds1)
+        assert actual2.equals(ds2)
+
+    # a genuinely different grid (different scale) must still be rejected, even
+    # when it also differs from `ds1` by dims order (exercising the cross-group
+    # comparison the fix above adds to `update_dicts`).
+    ds3 = create_coords(scale=4.0, shape=(2, 3)).to_dataset().transpose("x", "y")
+    with pytest.raises(
+        AlignmentError, match=r"cannot align objects.*conflicting indexes"
+    ):
+        xr.align(ds1, ds3, join="exact")
+
+    # same scale, same dims order as `ds1`: still correctly rejected through the
+    # pre-existing (same-group) "not equal" path.
+    ds4 = create_coords(scale=4.0, shape=(2, 3)).to_dataset()
+    with pytest.raises(AlignmentError, match=r"cannot align objects"):
+        xr.align(ds1, ds4, join="exact")
 
 
 def test_coordinate_transform_equals() -> None:

--- a/xarray/tests/test_coordinate_transform.py
+++ b/xarray/tests/test_coordinate_transform.py
@@ -214,8 +214,8 @@ def test_coordinate_transform_align_transposed() -> None:
         actual1, actual2 = xr.align(ds1, ds2, join=join)
         assert actual1.dims == ds1.dims
         assert actual2.dims == ds2.dims
-        assert assert_identical(actual1, ds1)
-        assert assert_identical(actual2, ds2)
+        assert_identical(actual1, ds1, check_default_indexes=False)
+        assert_identical(actual2, ds2, check_default_indexes=False)
 
     # a genuinely different grid (different scale) must still be rejected, even
     # when it also differs from `ds1` by dims order (exercising the cross-group


### PR DESCRIPTION
### Description

Fixes two bugs affecting `CoordinateTransformIndex`-backed coordinates after `.transpose()`:

- `Aligner.align_indexes` (`xarray/structure/alignment.py`) grouped indexes for comparison by `(coordinate name, dims order)` before ever calling `Index.equals()`. Two objects sharing an equal multi-dimensional index but differing only in the dims order of their coordinate variables (e.g. one was transposed) landed in different groups and raised a spurious `AlignmentError: conflicting indexes`, even though the indexes were genuinely equal. Now defers to `Index.equals()` (via `indexes_all_equal`, with its existing `NotImplementedError` fallback to variable comparison) before treating a coordinate-name collision across groups as a real conflict.
- `CoordinateTransformIndex.create_variables()` (`xarray/core/indexes.py`) always rebuilt coordinate variables with `Variable(self.transform.dims, ...)` (the transform's *original* dims order) discarding any prior `.transpose()`. Since `Variable.transpose()` never mutates the underlying transform, this silently reverted the transpose on `.copy()`, `copy.deepcopy()`, and the `join="exact"` fast path in `xr.align()`, leaving the array's data and coordinate dims orders inconsistent. Now preserves the incoming variable's dims order when it's a permutation of the transform's own.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #11530
- [x] Closes #11531
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    <!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
    Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}
