### PR TITLE
DOC fix kwargs parameter name in curvefit docstrings

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -79,6 +79,11 @@ Documentation
 - Migrated from nbsphinx/jupyter-execute to myst-nb (:issue:`7924`, :pull:`11456`).
   By `Nick Hodgskin <https://github.com/VeckoTheGecko>`_.
 
+- Fixed the ``kwargs`` entry in the :py:meth:`Dataset.curvefit` and
+  :py:meth:`DataArray.curvefit` docstrings: both take a ``kwargs`` dict, not
+  ``**kwargs`` (:issue:`6891`).
+  By `Advit Arora <https://github.com/advitrocks9>`_.
+
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -6563,7 +6563,7 @@ class DataArray(
             If 'raise', any errors from the `scipy.optimize_curve_fit` optimization will
             raise an exception. If 'ignore', the coefficients and covariances for the
             coordinates where the fitting failed will be NaN.
-        **kwargs : optional
+        kwargs : optional
             Additional keyword arguments to passed to scipy curve_fit.
 
         Returns

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -9904,7 +9904,7 @@ class Dataset(
             If 'raise', any errors from the `scipy.optimize_curve_fit` optimization will
             raise an exception. If 'ignore', the coefficients and covariances for the
             coordinates where the fitting failed will be NaN.
-        **kwargs : optional
+        kwargs : optional
             Additional keyword arguments to passed to scipy curve_fit.
 
         Returns


### PR DESCRIPTION
### Description

Fixes #6891.

`Dataset.curvefit` and `DataArray.curvefit` both document their scipy passthrough as
`**kwargs : optional`, so calling them the way the docstring describes fails:

```python
import numpy as np
import xarray as xr

def exp(t, a, b):
    return a * np.exp(b * t)

t = np.linspace(0, 1, 20)
da = xr.DataArray(exp(t, 2.0, -1.0), dims="t", coords={"t": t})
da.curvefit("t", exp, method="trf")
```

```
TypeError: DataArray.curvefit() got an unexpected keyword argument 'method'
```

Same on `Dataset`. Neither method actually has a `VAR_KEYWORD` parameter, they take a single `kwargs: dict[str, Any] | None = None`, and `kwargs={"method": "trf"}` works fine. So the docstrings are wrong, not the behaviour. [`computation/fit.py`](https://github.com/pydata/xarray/blob/abdc46498ddaf623e057c18ce35799be865bed54/xarray/computation/fit.py#L371),
which both methods delegate to, already documents the parameter correctly, the class docstrings
just drifted from it in #5182. headtr1ck
[scoped this fix on the issue](https://github.com/pydata/xarray/issues/6891#issuecomment-1484199176):
change `**kwargs` to `kwargs` in both docstrings.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #6891
- [ ] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`