### PR TITLE
fix: Raise error for unsupported keepdims in DatasetRolling (closes #11518)

### DIFF
--- a/xarray/typing.py
+++ b/xarray/typing.py
@@ -2,24 +2,29 @@
 Public typing utilities for use by external libraries.
 """
 
+# Add a check for keepdims in DatasetRolling.mean to avoid silent ignoring.
+# This is a temporary fix until upstream provides proper validation.
+import functools
+
 from xarray.computation.rolling import (
     DataArrayCoarsen,
     DataArrayRolling,
     DatasetRolling,
 )
 
-# Add a check for keepdims in DatasetRolling.mean to avoid silent ignoring.
-# This is a temporary fix until upstream provides proper validation.
-import functools
 
 def _validate_keepdims(method):
     @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
-        if 'keepdims' in kwargs:
-            raise TypeError("keepdims is not supported in DatasetRolling operations. "
-                            "Remove the argument.")
+        if "keepdims" in kwargs:
+            raise TypeError(
+                "keepdims is not supported in DatasetRolling operations. "
+                "Remove the argument."
+            )
         return method(self, *args, **kwargs)
+
     return wrapper
+
 
 # Patch the mean method for DatasetRolling (and potentially others).
 _DatasetRolling_mean_original = DatasetRolling.mean

--- a/xarray/typing.py
+++ b/xarray/typing.py
@@ -7,6 +7,23 @@ from xarray.computation.rolling import (
     DataArrayRolling,
     DatasetRolling,
 )
+
+# Add a check for keepdims in DatasetRolling.mean to avoid silent ignoring.
+# This is a temporary fix until upstream provides proper validation.
+import functools
+
+def _validate_keepdims(method):
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        if 'keepdims' in kwargs:
+            raise TypeError("keepdims is not supported in DatasetRolling operations. "
+                            "Remove the argument.")
+        return method(self, *args, **kwargs)
+    return wrapper
+
+# Patch the mean method for DatasetRolling (and potentially others).
+_DatasetRolling_mean_original = DatasetRolling.mean
+DatasetRolling.mean = _validate_keepdims(_DatasetRolling_mean_original)
 from xarray.computation.weighted import DataArrayWeighted, DatasetWeighted, Weighted
 from xarray.core.groupby import DataArrayGroupBy
 from xarray.core.resample import DataArrayResample


### PR DESCRIPTION
## What

`DatasetRolling.mean(keepdims=False/True)` currently accepts the `keepdims` argument without raising or warning, silently ignoring it and producing the same output. This is confusing and can lead to incorrect user expectations.

## Fix

Added a wrapper around `DatasetRolling.mean` in `xarray/typing.py` (where the type is re-exported) that inspects keyword arguments and raises a `TypeError` if `keepdims` is passed, since it is not supported. This ensures users get clear feedback.

Closes #11518