### PR TITLE
Fix silent byte-swapping of non-native-endian attribute values in the netcdf4 backend

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -53,6 +53,10 @@ Deprecations
 Bug Fixes
 ~~~~~~~~~
 
+- Fix the ``netcdf4`` engine silently writing byte-swapped values for
+  non-native-endian numeric attribute arrays, such as attributes of netCDF-3
+  files read with the ``scipy`` engine (:pull:`11543`).
+  By `glaziermag <https://github.com/glaziermag>`_.
 - Fix async zarr tests using ``wraps`` with ``autospec=True`` on async methods,
   which caused ``AsyncMock`` objects to leak through instead of real array data
   (:pull:`11232`).

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -252,6 +252,15 @@ def _force_native_endianness(var):
     return var
 
 
+def _force_native_endianness_attr(value):
+    # netCDF4-python writes non-native-endian attribute arrays without
+    # byte-swapping, silently corrupting the stored values (variable data
+    # is handled by _force_native_endianness above).
+    if isinstance(value, np.ndarray) and value.dtype.byteorder not in ("=", "|"):
+        value = value.astype(value.dtype.newbyteorder("="))
+    return value
+
+
 def _extract_nc4_variable_encoding(
     variable: Variable,
     raise_on_invalid=False,
@@ -632,6 +641,7 @@ class NetCDF4DataStore(WritableCFDataStore):
         self.ds.createDimension(name, size=dim_length)
 
     def set_attribute(self, key, value):
+        value = _force_native_endianness_attr(value)
         if self.format != "NETCDF4":
             value = encode_nc3_attr_value(value)
         if _is_list_of_strings(value):
@@ -652,7 +662,9 @@ class NetCDF4DataStore(WritableCFDataStore):
         self, name, variable: Variable, check_encoding=False, unlimited_dims=None
     ):
         _ensure_no_forward_slash_in_name(name)
-        attrs = variable.attrs.copy()
+        attrs = {
+            k: _force_native_endianness_attr(v) for k, v in variable.attrs.items()
+        }
         fill_value = attrs.pop("_FillValue", None)
         datatype: np.dtype | ncEnumType | h5EnumType
         datatype = _get_datatype(

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -662,9 +662,7 @@ class NetCDF4DataStore(WritableCFDataStore):
         self, name, variable: Variable, check_encoding=False, unlimited_dims=None
     ):
         _ensure_no_forward_slash_in_name(name)
-        attrs = {
-            k: _force_native_endianness_attr(v) for k, v in variable.attrs.items()
-        }
+        attrs = {k: _force_native_endianness_attr(v) for k, v in variable.attrs.items()}
         fill_value = attrs.pop("_FillValue", None)
         datatype: np.dtype | ncEnumType | h5EnumType
         datatype = _get_datatype(

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -7252,6 +7252,31 @@ def test_load_single_value_h5netcdf(tmp_path: Path) -> None:
         ds2["test"][0].load()
 
 
+@requires_netCDF4
+def test_roundtrip_non_native_endian_attrs(tmp_path: Path) -> None:
+    """Test that non-native-endian numeric attribute values round-trip.
+
+    The scipy backend returns attribute values of netCDF-3 files as big-endian
+    arrays; netCDF4-python does not byte-swap attribute arrays on write, so
+    writing them back with the netCDF4 backend silently stored byte-swapped
+    values (e.g. valid_range [0.0, 1.0] became [0.0, 3.03865e-319]).
+    """
+    ds = xr.Dataset(
+        {
+            "x": xr.DataArray(
+                [1.0],
+                dims=("d",),
+                attrs={"valid_range": np.array([0.0, 1.0], dtype=">f8")},
+            )
+        },
+        attrs={"levels": np.array([1, 2], dtype=">i4")},
+    )
+    ds.to_netcdf(tmp_path / "test.nc", engine="netcdf4")
+    with xr.open_dataset(tmp_path / "test.nc", engine="netcdf4") as ds2:
+        assert_array_equal(ds2["x"].attrs["valid_range"], [0.0, 1.0])
+        assert_array_equal(ds2.attrs["levels"], [1, 2])
+
+
 @requires_zarr
 @requires_dask
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

Writing a dataset whose attributes hold non-native-endian numpy arrays silently stores byte-swapped values with the `netcdf4` engine. The easiest way to get such attributes is reading a netCDF-3 file with the `scipy` engine, which returns attribute arrays big-endian — so this fully-default round-trip corrupts metadata on disk:

```python
import xarray as xr
ds = xr.open_dataset("xarray/tests/data/example_1.nc.gz")  # scipy engine guessed
ds.load().to_netcdf("out.nc")                              # netcdf4 engine guessed
xr.open_dataset("out.nc")["rh"].attrs["valid_range"]
# array([0.00000e+000, 3.03865e-319])  — was [0., 1.]; 3.03865e-319 is byte-swapped 1.0
```

The same happens for integer attributes (`>i4` `[1, 2]` → `[16777216, 33554432]`), for both variable and global attributes, and in NETCDF4 as well as NETCDF3 formats via this engine. No warning or error is raised; inspecting the written file with h5py shows the byte-swapped values are committed to disk at write time.

Cause: netCDF4-python's `setncattr`/`setncatts` do not byte-swap. The backend already converts *variable data* to native endianness for exactly this reason (`_force_native_endianness`, whose comment notes this "is not supported by the netCDF4 python library"), but attribute values reach `setncatts`/`setncattr` unconverted. This PR applies the same native-endianness conversion to attribute values at both write sites (`prepare_variable` and `set_attribute`), with a regression test. The `h5netcdf` writer already handles identical input correctly and is unchanged.

### Checklist

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Claude (Claude Code). The defect was found by round-tripping the committed files in `xarray/tests/data/` through default `open_dataset`/`to_netcdf`. The repro above was confirmed twice in a clean environment at 551ced5 (netCDF4 1.7.4, scipy 1.18.1, numpy 2.5.2), the fix verified to clear it, and the `TestNetCDF4Data`/`TestScipy`/`TestGenericNetCDFData` suites run against the patch (427 passed). Prompt: a standing instruction to find, verify, and fix one upstream defect.

[This is Claude Code on behalf of glaziermag]

