### PR TITLE
Fix str.replace(..., n=0) replacing every occurrence instead of none

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -53,6 +53,11 @@ Deprecations
 Bug Fixes
 ~~~~~~~~~
 
+- Fixed ``DataArray.str.replace`` replacing every occurrence instead of none when
+  ``n=0``. ``re.sub`` treats ``count=0`` as "replace all", so the regex code path
+  collapsed ``n=0`` onto ``n=-1``, while the ``regex=False`` path already handled
+  ``n=0`` correctly.
+  By `Alexander Kropiunig <https://github.com/Kropiunig>`_.
 - Fix async zarr tests using ``wraps`` with ``autospec=True`` on async methods,
   which caused ``AsyncMock`` objects to leak through instead of real array data
   (:pull:`11232`).

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -56,7 +56,7 @@ Bug Fixes
 - Fixed ``DataArray.str.replace`` replacing every occurrence instead of none when
   ``n=0``. ``re.sub`` treats ``count=0`` as "replace all", so the regex code path
   collapsed ``n=0`` onto ``n=-1``, while the ``regex=False`` path already handled
-  ``n=0`` correctly.
+  ``n=0`` correctly (:pull:`11545`).
   By `Alexander Kropiunig <https://github.com/Kropiunig>`_.
 - Fix async zarr tests using ``wraps`` with ``autospec=True`` on async methods,
   which caused ``AsyncMock`` objects to leak through instead of real array data

--- a/xarray/core/accessor_str.py
+++ b/xarray/core/accessor_str.py
@@ -1944,8 +1944,10 @@ class StringAccessor(Generic[T_DataArray]):
 
         if regex:
             pat = self._re_compile(pat=pat, flags=flags, case=case)
-            func = lambda x, ipat, irepl, i_n: ipat.sub(
-                repl=irepl, string=x, count=max(i_n, 0)
+            # ``re.sub`` interprets ``count=0`` as "replace every occurrence",
+            # so ``n=0`` has to be special-cased to mean "replace nothing".
+            func = lambda x, ipat, irepl, i_n: (
+                x if i_n == 0 else ipat.sub(repl=irepl, string=x, count=max(i_n, 0))
             )
         else:
             pat = self._stringify(pat)

--- a/xarray/tests/test_accessor_str.py
+++ b/xarray/tests/test_accessor_str.py
@@ -381,6 +381,28 @@ def test_replace(dtype) -> None:
     assert_equal(result, expected)
 
 
+def test_replace_n_zero(dtype) -> None:
+    # ``n=0`` means "make no replacements", for regex and literal patterns alike
+    values = xr.DataArray(["fooBAD__barBAD"], dims=["x"]).astype(dtype)
+
+    result = values.str.replace("BAD[_]*", "", n=0)
+    assert result.dtype == values.dtype
+    assert_equal(result, values)
+
+    result = values.str.replace("BAD", "", n=0, regex=False)
+    assert result.dtype == values.dtype
+    assert_equal(result, values)
+
+    # ``n`` is broadcast, so a single zero must not spill over to its neighbours
+    n = xr.DataArray([0, 1, -1], dims=["y"])
+    result = values.str.replace("BAD[_]*", "", n=n)
+    expected = xr.DataArray(
+        [["fooBAD__barBAD", "foobarBAD", "foobar"]], dims=["x", "y"]
+    ).astype(dtype)
+    assert result.dtype == expected.dtype
+    assert_equal(result, expected)
+
+
 def test_replace_callable() -> None:
     values = xr.DataArray(["fooBAD__barBAD"])
 


### PR DESCRIPTION
### Description

`StringAccessor.replace` documents `n` as *"Number of replacements to make from start. Use `-1` to replace all."* The regex code path (the default, `regex=True`) forwards `count=max(n, 0)` to `re.Pattern.sub`, and `re.sub` treats `count=0` as *replace every occurrence*. So `n=0` collapses onto `n=-1` and replaces everything instead of nothing — silently, with no error.

The literal path (`regex=False`) calls `str.replace(pat, repl, n)`, which honours `n=0` correctly. The same call therefore gives two different answers depending on `regex`:

```python
>>> import xarray as xr
>>> da = xr.DataArray(["fooBAD__barBAD"], dims="x")

>>> da.str.replace("BAD", "", n=0).item()          # regex=True (default)
'foo__bar'                                          # expected 'fooBAD__barBAD'

>>> da.str.replace("BAD", "", n=0, regex=False).item()
'fooBAD__barBAD'                                    # correct
```

This is most damaging where `n` is array-like, which is a documented feature ("If `pat`, `repl`, or `n` is array-like, they are broadcast against the array and applied elementwise"). A single `0` in the broadcast `n` silently becomes "replace all" for that element:

```python
>>> n = xr.DataArray([0, 1, -1], dims="y")
>>> da.str.replace("BAD[_]*", "", n=n).values
array([['foobar', 'foobarBAD', 'foobar']], dtype='<U9')
#        ^^^^^^ should be 'fooBAD__barBAD'
```

Two further references agree that `n=0` means "no replacements": `pandas.Series.str.replace(..., n=0)` is a no-op for both `regex=True` and `regex=False`, and xarray's own `str.split(..., maxsplit=0)` already performs zero splits.

The fix special-cases `n == 0` in the regex branch. Negative `n` still maps to "replace all" exactly as before, so no other behaviour changes.

Added `test_replace_n_zero`, which covers the regex path, the literal path and the broadcast case. It fails on `main` (2 failed / 12 passed for `-k replace`) and passes with this change (14 passed); the full `xarray/tests/test_accessor_str.py` module is 228 passed, 1 skipped.

### Checklist

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
    Tools: Claude Code. Prompt: audit the xarray source for a provably-correct, unclaimed bug with a user-visible symptom on the default code path, then produce a minimal fix plus a regression test that fails before and passes after.
