### PR TITLE
Adapt to change in behavior of `pd.DateOffset` in `isinstance`

### DIFF
--- a/xarray/coding/cftime_offsets.py
+++ b/xarray/coding/cftime_offsets.py
@@ -771,7 +771,7 @@ def _emit_freq_deprecation_warning(deprecated_freq):
 
 
 def to_offset(
-    freq: BaseCFTimeOffset | str | timedelta | pd.Timedelta | pd.DateOffset,
+    freq: BaseCFTimeOffset | str | timedelta | pd.Timedelta | pd.offsets.BaseOffset,
     warn: bool = True,
 ) -> BaseCFTimeOffset:
     """Convert a frequency string to the appropriate subclass of
@@ -780,7 +780,7 @@ def to_offset(
         return freq
     if isinstance(freq, timedelta | pd.Timedelta):
         return delta_to_tick(freq)
-    if isinstance(freq, pd.DateOffset):
+    if isinstance(freq, pd.offsets.BaseOffset):
         freq = freq.freqstr
 
     match = re.match(_PATTERN, freq)

--- a/xarray/core/types.py
+++ b/xarray/core/types.py
@@ -367,7 +367,9 @@ Bins = Union[
     int, Sequence[int], Sequence[float], Sequence[pd.Timestamp], np.ndarray, pd.Index
 ]
 
-ResampleCompatible: TypeAlias = str | datetime.timedelta | pd.Timedelta | pd.DateOffset
+ResampleCompatible: TypeAlias = (
+    str | datetime.timedelta | pd.Timedelta | pd.offsets.BaseOffset
+)
 
 
 class Closable(Protocol):

--- a/xarray/tests/test_cftime_offsets.py
+++ b/xarray/tests/test_cftime_offsets.py
@@ -202,6 +202,18 @@ def test_to_offset_offset_input(offset):
 
 
 @pytest.mark.parametrize(
+    ("pandas_offset", "expected"),
+    [
+        (pd.offsets.Second(n=3), Second(n=3)),
+        (pd.offsets.MonthBegin(n=3), MonthBegin(n=3)),
+    ],
+    ids=_id_func,
+)
+def test_to_offset_pandas_offset_input(pandas_offset, expected):
+    assert to_offset(pandas_offset) == expected
+
+
+@pytest.mark.parametrize(
     ("freq", "expected"),
     [
         ("M", MonthEnd()),


### PR DESCRIPTION
### Description

This PR addresses the `pandas.errors.Pandas4Warning` messages surfaced in #11501 related to a change in behavior of `pd.DateOffset` in `isinstance`.  The added test ensures that we also do not emit the warning in the `cftime_offsets.to_offset` function, where we used the same pattern, but no error was surfaced in our current test suite.

Since these are purely internal changes, I do not believe they require a what's new entry.

### Checklist

- [x] Tests added

### AI Disclosure

This PR was created without AI.
