### PR TITLE
Require h5netcdf for running `TestNetCDF4ClassicViaH5NetCDFData` tests

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -4726,6 +4726,7 @@ class TestNetCDF4ClassicViaNetCDF4Data(NetCDF3Only, CFEncodedBase):
             assert ds._h5file.attrs["foo"].dtype == np.dtype("S3")
 
 
+@requires_h5netcdf
 class TestNetCDF4ClassicViaH5NetCDFData(TestNetCDF4ClassicViaNetCDF4Data):
     engine: T_NetcdfEngine = "h5netcdf"
     file_format: T_NetcdfTypes = "NETCDF4_CLASSIC"


### PR DESCRIPTION
### Description

https://github.com/pydata/xarray/pull/11067 inadvertently removed a decorator requiring `h5netcdf` for running the `TestNetCDF4ClassicViaH5NetCDFData` tests in `test_backends.py`.  This restores the requirement to address the missing `h5netcdf` failures in #11501.

### AI Disclosure

This PR was created without AI.
