### PR TITLE
Harmonize platforms in nightly `pixi.toml` with main `pixi.toml`

### DIFF
--- a/ci/nightly/pixi.toml
+++ b/ci/nightly/pixi.toml
@@ -1,7 +1,7 @@
 [workspace]
 preview = ["pixi-build"]
 channels = ["conda-forge", "nodefaults"]
-platforms = ["linux-64"]
+platforms = ["win-64", "linux-64", "osx-arm64"]
 requires-pixi = ">=0.63.2,!=0.68.0"
 
 [feature.test.dependencies]


### PR DESCRIPTION
### Description

I find it helpful to be able to run tests in the nightly environment locally when trying to address upstream issues.  Currently I've been editing this file locally to enable this.  This PR proposes committing these changes to the repo.

### AI Disclosure

This PR was created without AI.
