### PR TITLE
Fix quantile raising on an empty result

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -53,6 +53,11 @@ Deprecations
 Bug Fixes
 ~~~~~~~~~
 
+- Fixed :py:meth:`Dataset.quantile`, :py:meth:`DataArray.quantile` and
+  :py:meth:`Variable.quantile` raising on an empty result, where
+  :py:meth:`~xarray.DataArray.mean`, :py:meth:`~xarray.DataArray.median` and
+  pandas all return ``NaN`` (:issue:`11549`).
+  By `Chirag Gupta <https://github.com/chiruu12>`_.
 - Fix async zarr tests using ``wraps`` with ``autospec=True`` on async methods,
   which caused ``AsyncMock`` objects to leak through instead of real array data
   (:pull:`11232`).

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -54,9 +54,10 @@ Bug Fixes
 ~~~~~~~~~
 
 - Fixed :py:meth:`Dataset.quantile`, :py:meth:`DataArray.quantile` and
-  :py:meth:`Variable.quantile` raising on an empty result, where
-  :py:meth:`~xarray.DataArray.mean`, :py:meth:`~xarray.DataArray.median` and
-  pandas all return ``NaN`` (:issue:`11549`).
+  :py:meth:`Variable.quantile` raising on an empty result. Numeric data now
+  gives ``NaN``, matching :py:meth:`~xarray.DataArray.mean`,
+  :py:meth:`~xarray.DataArray.median` and pandas, and datetime and timedelta
+  data gives ``NaT`` (:issue:`11549`).
   By `Chirag Gupta <https://github.com/chiruu12>`_.
 - Fix async zarr tests using ``wraps`` with ``autospec=True`` on async methods,
   which caused ``AsyncMock`` objects to leak through instead of real array data

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2080,7 +2080,7 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
                 # nan there would make concat of an empty and a non-empty
                 # result fail to promote.
                 if npa.dtype.kind in "mM":
-                    fill_value = np.array("NaT", dtype=npa.dtype)
+                    fill_value = npa.dtype.type("NaT")
                     result_dtype = npa.dtype
                 else:
                     fill_value = np.nan

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2080,7 +2080,10 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
                 # nan there would make concat of an empty and a non-empty
                 # result fail to promote.
                 if npa.dtype.kind in "mM":
-                    fill_value = npa.dtype.type("NaT")
+                    # Indexed to a scalar, but built through an array so that
+                    # it keeps the unit. dtype.type("NaT") drops it, and a
+                    # unitless datetime64 is deprecated in numpy.
+                    fill_value = np.array("NaT", dtype=npa.dtype)[()]
                     result_dtype = npa.dtype
                 else:
                     fill_value = np.nan

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2062,8 +2062,10 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
                 except TypeError:
                     # A pandas extension dtype, which numpy cannot build an
                     # array from. q and method do not depend on the dtype, so
-                    # check those and leave the dtype itself to the non-empty
-                    # path, which accepts these anyway.
+                    # check those here and leave the dtype to the non-empty
+                    # path. An extension dtype that path rejects is therefore
+                    # still accepted when empty, as it already is for object
+                    # arrays.
                     probe = np.zeros((1,) * npa.ndim)
                 _quantile_func(probe, **kwargs)
                 reduced_axes = {axis % npa.ndim for axis in kwargs["axis"]}
@@ -2072,8 +2074,19 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
                     for axis, size in enumerate(npa.shape)
                     if axis not in reduced_axes
                 )
+                # Datetimes and timedeltas keep their own dtype and their
+                # own NA, which is what the non-empty path, median and
+                # groupby over an empty bin all return. Handing back float64
+                # nan there would make concat of an empty and a non-empty
+                # result fail to promote.
+                if npa.dtype.kind in "mM":
+                    fill_value = np.array("NaT", dtype=npa.dtype)
+                    result_dtype = npa.dtype
+                else:
+                    fill_value = np.nan
+                    result_dtype = np.float64
                 return xp.full(
-                    kept_shape + (len(kwargs["q"]),), np.nan, dtype=np.float64
+                    kept_shape + (len(kwargs["q"]),), fill_value, dtype=result_dtype
                 )
             # move quantile axis to end. required for apply_ufunc
             return xp.moveaxis(_quantile_func(npa, **kwargs), 0, -1)

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2045,6 +2045,22 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
         xp = duck_array_ops.get_array_namespace(self.data)
 
         def _wrapper(npa, **kwargs):
+            if npa.size == 0:
+                # Every quantile here is undefined, which is the nan that
+                # mean, median and pandas already return. Neither backing
+                # function can supply it in the expected shape: nanquantile
+                # drops the leading q axis whenever the result is empty, and
+                # quantile raises outright. The empty axis need not be one of
+                # the reduced ones for that to happen.
+                reduced_axes = {axis % npa.ndim for axis in kwargs["axis"]}
+                kept_shape = tuple(
+                    size
+                    for axis, size in enumerate(npa.shape)
+                    if axis not in reduced_axes
+                )
+                return xp.full(
+                    kept_shape + (len(kwargs["q"]),), np.nan, dtype=np.float64
+                )
             # move quantile axis to end. required for apply_ufunc
             return xp.moveaxis(_quantile_func(npa, **kwargs), 0, -1)
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2052,6 +2052,12 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
                 # drops the leading q axis whenever the result is empty, and
                 # quantile raises outright. The empty axis need not be one of
                 # the reduced ones for that to happen.
+                #
+                # Run the same call over one element first, purely so that a
+                # bad q, method or dtype is rejected with numpy's own message.
+                # Whether an argument is valid must not depend on how much
+                # data it was handed.
+                _quantile_func(np.zeros((1,) * npa.ndim, dtype=npa.dtype), **kwargs)
                 reduced_axes = {axis % npa.ndim for axis in kwargs["axis"]}
                 kept_shape = tuple(
                     size

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2057,7 +2057,15 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
                 # bad q, method or dtype is rejected with numpy's own message.
                 # Whether an argument is valid must not depend on how much
                 # data it was handed.
-                _quantile_func(np.zeros((1,) * npa.ndim, dtype=npa.dtype), **kwargs)
+                try:
+                    probe = np.zeros((1,) * npa.ndim, dtype=npa.dtype)
+                except TypeError:
+                    # A pandas extension dtype, which numpy cannot build an
+                    # array from. q and method do not depend on the dtype, so
+                    # check those and leave the dtype itself to the non-empty
+                    # path, which accepts these anyway.
+                    probe = np.zeros((1,) * npa.ndim)
+                _quantile_func(probe, **kwargs)
                 reduced_axes = {axis % npa.ndim for axis in kwargs["axis"]}
                 kept_shape = tuple(
                     size

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -3229,6 +3229,16 @@ class TestDataArray:
 
         assert actual.attrs == self.attrs
 
+    @pytest.mark.parametrize("q", [0.5, [0.25, 0.75]])
+    def test_quantile_empty_dim(self, q) -> None:
+        # nan, like mean and median, rather than the AxisError numpy raises.
+        da = DataArray(np.array([], dtype=np.float64), dims="x", coords={"x": []})
+
+        actual = da.quantile(q, dim="x")
+
+        assert np.isnan(actual.values).all()
+        assert np.isnan(da.median("x").values)
+
     @pytest.mark.parametrize("method", ["midpoint", "lower"])
     def test_quantile_method(self, method) -> None:
         q = [0.25, 0.5, 0.75]

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6565,6 +6565,15 @@ class TestDataset:
         expected = Dataset({"a": value}, coords={"quantile": q})
         assert_identical(result, expected)
 
+    @pytest.mark.parametrize("q", [0.5, [0.25, 0.75]])
+    def test_quantile_empty_dim(self, q) -> None:
+        ds = Dataset({"a": ("x", np.array([], dtype=np.float64))}, coords={"x": []})
+
+        actual = ds.quantile(q, dim="x")
+
+        assert np.isnan(actual["a"].values).all()
+        assert np.isnan(ds.median("x")["a"].values)
+
     @pytest.mark.parametrize("method", ["midpoint", "lower"])
     def test_quantile_method(self, method) -> None:
         ds = create_test_data(seed=123)

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -2011,6 +2011,36 @@ class TestVariable(VariableSubclassobjects):
         ):
             v.quantile(q, dim="x")
 
+    @pytest.mark.parametrize("skipna", [True, False, None])
+    @pytest.mark.parametrize("q", [0.5, [0.5], [0.25, 0.75]])
+    def test_quantile_empty_dim(self, q, skipna):
+        # An empty reduction is nan for mean, median and std, and pandas
+        # agrees for quantile. numpy does not: nanquantile drops the leading
+        # q axis and quantile raises.
+        v = Variable(["x"], np.array([], dtype=np.float64))
+
+        actual = v.quantile(q, dim="x", skipna=skipna)
+
+        assert actual.shape == (() if np.isscalar(q) else (len(q),))
+        assert np.isnan(actual.values).all()
+
+    @pytest.mark.parametrize("skipna", [True, False, None])
+    def test_quantile_empty_dim_is_not_the_reduced_one(self, skipna):
+        # Reducing over y, which has length 3. Only x is empty, and the
+        # result is empty because of it.
+        v = Variable(["x", "y"], np.zeros((0, 3), dtype=np.float64))
+
+        actual = v.quantile([0.25, 0.75], dim="y", skipna=skipna)
+
+        assert actual.dims == ("quantile", "x")
+        assert actual.shape == (2, 0)
+
+    def test_quantile_empty_dim_agrees_with_median(self):
+        v = Variable(["x"], np.array([], dtype=np.float64))
+
+        assert np.isnan(v.quantile(0.5, dim="x").values)
+        assert np.isnan(v.median("x").values)
+
     @requires_dask
     @requires_bottleneck
     def test_rank_dask(self):

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -2054,6 +2054,20 @@ class TestVariable(VariableSubclassobjects):
         with pytest.raises(ValueError, match=r"(Q|q)uantiles must be in the range"):
             v.quantile(q, dim="x")
 
+    @pytest.mark.parametrize("dtype", ["Int64", "Float64"])
+    def test_quantile_empty_dim_with_an_extension_dtype(self, dtype):
+        # numpy cannot build an array from a pandas extension dtype, so the
+        # empty path must not try to and must still agree with the non-empty
+        # one about succeeding.
+        empty = Variable(["x"], pd.array([], dtype=dtype))
+        non_empty = Variable(["x"], pd.array([1, 3], dtype=dtype))
+
+        assert np.isnan(empty.quantile(0.5, dim="x").values)
+        assert non_empty.quantile(0.5, dim="x").values == 2.0
+
+        with pytest.raises(ValueError, match=r"(Q|q)uantiles must be in the range"):
+            empty.quantile(1.5, dim="x")
+
     def test_quantile_empty_dim_still_rejects_an_unknown_method(self):
         v = Variable(["x"], np.array([], dtype=np.float64))
 

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -20,7 +20,7 @@ from xarray import (
     Variable,
     set_options,
 )
-from xarray.core import dtypes, duck_array_ops, indexing
+from xarray.core import dtypes, duck_array_ops, indexing, utils
 from xarray.core.common import full_like, ones_like, zeros_like
 from xarray.core.extension_array import PandasExtensionArray
 from xarray.core.indexing import (
@@ -2012,7 +2012,7 @@ class TestVariable(VariableSubclassobjects):
             v.quantile(q, dim="x")
 
     @pytest.mark.parametrize("skipna", [True, False, None])
-    @pytest.mark.parametrize("q", [0.5, [0.5], [0.25, 0.75]])
+    @pytest.mark.parametrize("q", [0.5, np.array(0.5), [0.5], [0.25, 0.75]])
     def test_quantile_empty_dim(self, q, skipna):
         # An empty reduction is nan for mean, median and std, and pandas
         # agrees for quantile. numpy does not: nanquantile drops the leading
@@ -2021,25 +2021,44 @@ class TestVariable(VariableSubclassobjects):
 
         actual = v.quantile(q, dim="x", skipna=skipna)
 
-        assert actual.shape == (() if np.isscalar(q) else (len(q),))
-        assert np.isnan(actual.values).all()
+        expected_shape = () if utils.is_scalar(q) else (len(q),)
+        assert actual.shape == expected_shape
+        np.testing.assert_equal(actual.values, np.full(expected_shape, np.nan))
 
     @pytest.mark.parametrize("skipna", [True, False, None])
-    def test_quantile_empty_dim_is_not_the_reduced_one(self, skipna):
-        # Reducing over y, which has length 3. Only x is empty, and the
-        # result is empty because of it.
+    def test_quantile_empty_dim_not_reduced(self, skipna):
+        # Reducing over y, which has length 3: only x is empty. The result is
+        # empty because of x, which is what makes nanquantile drop the q axis
+        # even though the reduced axis is not the empty one.
         v = Variable(["x", "y"], np.zeros((0, 3), dtype=np.float64))
 
         actual = v.quantile([0.25, 0.75], dim="y", skipna=skipna)
 
-        assert actual.dims == ("quantile", "x")
-        assert actual.shape == (2, 0)
+        expected = Variable(
+            ["quantile", "x"], np.empty((2, 0), dtype=np.float64), attrs=actual.attrs
+        )
+        assert_identical(actual, expected)
 
     def test_quantile_empty_dim_agrees_with_median(self):
         v = Variable(["x"], np.array([], dtype=np.float64))
 
         assert np.isnan(v.quantile(0.5, dim="x").values)
         assert np.isnan(v.median("x").values)
+
+    @pytest.mark.parametrize("q", [1.5, -0.5])
+    def test_quantile_empty_dim_still_rejects_an_out_of_range_q(self, q):
+        # An empty dimension says nothing about whether q is a quantile, so
+        # the same call must fail the same way it does with data.
+        v = Variable(["x"], np.array([], dtype=np.float64))
+
+        with pytest.raises(ValueError, match=r"(Q|q)uantiles must be in the range"):
+            v.quantile(q, dim="x")
+
+    def test_quantile_empty_dim_still_rejects_an_unknown_method(self):
+        v = Variable(["x"], np.array([], dtype=np.float64))
+
+        with pytest.raises(ValueError, match="not a valid method"):
+            v.quantile(0.5, dim="x", method="not-a-method")
 
     @requires_dask
     @requires_bottleneck

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -2078,11 +2078,21 @@ class TestVariable(VariableSubclassobjects):
         assert actual.dtype == np.dtype(dtype)
         assert np.isnat(actual.values)
 
+    @requires_dask
+    @pytest.mark.parametrize("dtype", ["float64", "M8[ns]", "m8[ns]"])
+    def test_quantile_empty_dim_chunked(self, dtype):
+        v = Variable(["x"], np.array([], dtype=dtype)).chunk({"x": 1})
+
+        actual = v.quantile([0.25, 0.75], dim="x")
+
+        assert actual.dtype == np.dtype(dtype)
+        assert actual.shape == (2,)
+
     def test_quantile_empty_dim_still_rejects_an_unknown_method(self):
         v = Variable(["x"], np.array([], dtype=np.float64))
 
         with pytest.raises(ValueError, match="not a valid method"):
-            v.quantile(0.5, dim="x", method="not-a-method")
+            v.quantile(0.5, dim="x", method="not-a-method")  # type: ignore[arg-type]
 
     @requires_dask
     @requires_bottleneck

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -2034,9 +2034,7 @@ class TestVariable(VariableSubclassobjects):
 
         actual = v.quantile([0.25, 0.75], dim="y", skipna=skipna)
 
-        expected = Variable(
-            ["quantile", "x"], np.empty((2, 0), dtype=np.float64), attrs=actual.attrs
-        )
+        expected = Variable(["quantile", "x"], np.empty((2, 0), dtype=np.float64))
         assert_identical(actual, expected)
 
     def test_quantile_empty_dim_agrees_with_median(self):
@@ -2067,6 +2065,18 @@ class TestVariable(VariableSubclassobjects):
 
         with pytest.raises(ValueError, match=r"(Q|q)uantiles must be in the range"):
             empty.quantile(1.5, dim="x")
+
+    @pytest.mark.parametrize("dtype", ["M8[ns]", "m8[ns]"])
+    def test_quantile_empty_dim_keeps_datetime_dtype(self, dtype):
+        # NaT, not a float64 nan: the non-empty path, median and groupby over
+        # an empty bin all keep the dtype, and concat of an empty and a
+        # non-empty result would not promote otherwise.
+        v = Variable(["x"], np.array([], dtype=dtype))
+
+        actual = v.quantile(0.5, dim="x")
+
+        assert actual.dtype == np.dtype(dtype)
+        assert np.isnat(actual.values)
 
     def test_quantile_empty_dim_still_rejects_an_unknown_method(self):
         v = Variable(["x"], np.array([], dtype=np.float64))


### PR DESCRIPTION
Closes #11549.

`_wrapper` builds the empty result itself instead of moving a `q` axis that is not there. Both backing functions are unusable on this input: `np.nanquantile` returns the nan but drops the leading `q` axis, so `moveaxis` hands `apply_ufunc` the wrong rank, and `np.quantile` raises before returning anything.

The trigger is `npa.size == 0`, not an empty reduced axis. `DataArray(zeros((0, 3))).quantile(0.5, dim="y")` reduces over `y`, which has length 3, and is still empty because `x` is.

| | before | after |
|---|---|---|
| `empty.quantile(0.5)` | `AxisError` | `nan` |
| `empty.quantile(0.5, skipna=False)` | `IndexError` | `nan` |
| `zeros((0,3)).quantile(0.5, dim="y")` | `ValueError` | shape `(0,)` |
| empty `datetime64` / `timedelta64` | `IndexError` | `NaT`, dtype kept |

Datetimes keep their own dtype and NA. That matches the non-empty path, `median`, and `groupby_bins(...).quantile()` over an empty bin. Returning float64 nan instead made `concat` of an empty and a non-empty result fail to promote.

Empty input is validated exactly as non-empty input is, by running the call over one element first so numpy owns the message. Without that, `q=1.5` raised on a 5-element array and returned nan on a 0-element one.

`skipna=False` returns nan too, so both paths agree. That differs from numpy, where `np.quantile([], 0.5)` raises, but it is what `median(skipna=False)` and `mean(skipna=False)` already do on an empty dimension.

Known gap: a pandas extension dtype the non-empty path rejects (`string`, `category`, `interval`, `period`, `boolean`) is still accepted when empty, as it already is for `object` arrays. numpy cannot build a probe array from those dtypes, so only `q` and `method` are checked there.

Tests at `Variable`, `DataArray` and `Dataset` level cover the empty reduction, the empty-but-not-reduced dimension, datetime dtype retention, extension dtypes, and the argument validation. Against `origin/main`, 24 fail and 3 pass; the 3 are guards, two of them against a regression this PR introduced and then fixed.

`test_variable`, `test_dataarray`, `test_dataset`, `test_groupby`, `test_weighted`, `test_computation`, `test_duck_array_ops`, `test_units`, `test_concat`: 2961 passed. `ruff check` and `format` clean.

I could not exercise the dask path; dask is not installed in my environment.