### PR TITLE
Fix type error for Coarsen reduction methods

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -110,6 +110,10 @@ Bug Fixes
   use of ``origin`` and ``offset`` options (:pull:`11546`). This effectively
   rolls back the resample-related changes introduced in :pull:`10650`. By
   `Spencer Clark <https://github.com/spencerkclark>`_.
+- Fixed :py:meth:`DataArray.coarsen()` and :py:meth:`Dataset.coarsen()` raising a
+  type error when applying reduction methods, due to the reduction methods being
+  dynamically generated (:issue:`8136`).
+  By `Andrew Scherer <https://github.com/andrew-s28>`_.
 
 .. _`pandas-dev/pandas#64793`: https://github.com/pandas-dev/pandas/pull/64793
 

--- a/xarray/computation/arithmetic.py
+++ b/xarray/computation/arithmetic.py
@@ -6,7 +6,7 @@ import numbers
 
 import numpy as np
 
-from xarray.computation.ops import IncludeNumpySameMethods, IncludeReduceMethods
+from xarray.computation.ops import IncludeNumpySameMethods
 
 # _typed_ops.py is a generated file
 from xarray.core._typed_ops import (
@@ -137,8 +137,4 @@ class DatasetGroupbyArithmetic(
     SupportsArithmetic,
     DatasetGroupByOpsMixin,
 ):
-    __slots__ = ()
-
-
-class CoarsenArithmetic(IncludeReduceMethods):
     __slots__ = ()

--- a/xarray/computation/ops.py
+++ b/xarray/computation/ops.py
@@ -8,14 +8,11 @@ functions.
 from __future__ import annotations
 
 import operator
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 import numpy as np
 
 from xarray.core import dtypes, duck_array_ops
-
-if TYPE_CHECKING:
-    pass
 
 try:
     import bottleneck as bn
@@ -45,83 +42,6 @@ NUM_BINARY_OPS = [
 # methods which pass on the numpy return value unchanged
 # be careful not to list methods that we would want to wrap later
 NUMPY_SAME_METHODS = ["item", "searchsorted"]
-
-# methods which remove an axis
-REDUCE_METHODS = ["all", "any"]
-NAN_REDUCE_METHODS = [
-    "max",
-    "min",
-    "mean",
-    "prod",
-    "sum",
-    "std",
-    "var",
-    "median",
-]
-# TODO: wrap take, dot, sort
-
-
-_CUM_DOCSTRING_TEMPLATE = """\
-Apply `{name}` along some dimension of {cls}.
-
-Parameters
-----------
-{extra_args}
-skipna : bool, optional
-    If True, skip missing values (as marked by NaN). By default, only
-    skips missing values for float dtypes; other dtypes either do not
-    have a sentinel missing value (int) or skipna=True has not been
-    implemented (object, datetime64 or timedelta64).
-keep_attrs : bool, optional
-    If True, the attributes (`attrs`) will be copied from the original
-    object to the new one.  If False (default), the new object will be
-    returned without attributes.
-**kwargs : dict
-    Additional keyword arguments passed on to `{name}`.
-
-Returns
--------
-cumvalue : {cls}
-    New {cls} object with `{name}` applied to its data along the
-    indicated dimension.
-"""
-
-_REDUCE_DOCSTRING_TEMPLATE = """\
-Reduce this {cls}'s data by applying `{name}` along some dimension(s).
-
-Parameters
-----------
-{extra_args}{skip_na_docs}{min_count_docs}
-keep_attrs : bool, optional
-    If True, the attributes (`attrs`) will be copied from the original
-    object to the new one.  If False (default), the new object will be
-    returned without attributes.
-**kwargs : dict
-    Additional keyword arguments passed on to the appropriate array
-    function for calculating `{name}` on this object's data.
-
-Returns
--------
-reduced : {cls}
-    New {cls} object with `{name}` applied to its data and the
-    indicated dimension(s) removed.
-"""
-
-_SKIPNA_DOCSTRING = """
-skipna : bool, optional
-    If True, skip missing values (as marked by NaN). By default, only
-    skips missing values for float dtypes; other dtypes either do not
-    have a sentinel missing value (int) or skipna=True has not been
-    implemented (object, datetime64 or timedelta64)."""
-
-_MINCOUNT_DOCSTRING = """
-min_count : int, default: None
-    The required number of valid values to perform the operation. If
-    fewer than min_count non-NA values are present the result will be
-    NA. Only used if skipna is set to True or defaults to True for the
-    array's dtype. New in version 0.10.8: Added with the default being
-    None. Changed in version 0.17.0: if specified on an integer array
-    and skipna=True, the result will be a float array."""
 
 
 def fillna(data, other, join="left", dataset_join="left"):
@@ -241,33 +161,6 @@ def _func_slash_method_wrapper(f, name=None):
     return func
 
 
-def inject_reduce_methods(cls):
-    methods = (
-        [
-            (name, getattr(duck_array_ops, f"array_{name}"), False)
-            for name in REDUCE_METHODS
-        ]
-        + [(name, getattr(duck_array_ops, name), True) for name in NAN_REDUCE_METHODS]
-        + [("count", duck_array_ops.count, False)]
-    )
-    for name, f, include_skipna in methods:
-        numeric_only = getattr(f, "numeric_only", False)
-        available_min_count = getattr(f, "available_min_count", False)
-        skip_na_docs = _SKIPNA_DOCSTRING if include_skipna else ""
-        min_count_docs = _MINCOUNT_DOCSTRING if available_min_count else ""
-
-        func = cls._reduce_method(f, include_skipna, numeric_only)
-        func.__name__ = name
-        func.__doc__ = _REDUCE_DOCSTRING_TEMPLATE.format(
-            name=name,
-            cls=cls.__name__,
-            extra_args=cls._reduce_extra_args_docstring.format(name=name),
-            skip_na_docs=skip_na_docs,
-            min_count_docs=min_count_docs,
-        )
-        setattr(cls, name, func)
-
-
 def op_str(name):
     return f"__{name}__"
 
@@ -295,16 +188,6 @@ def inject_numpy_same(cls):
     # don't try to patch these in for Dataset objects
     for name in NUMPY_SAME_METHODS:
         setattr(cls, name, _values_method_wrapper(name))
-
-
-class IncludeReduceMethods:
-    __slots__ = ()
-
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-
-        if getattr(cls, "_reduce_method", None):
-            inject_reduce_methods(cls)
 
 
 class IncludeNumpySameMethods:

--- a/xarray/computation/rolling.py
+++ b/xarray/computation/rolling.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 import numpy as np
 
 from xarray.compat import dask_array_ops
-from xarray.computation.arithmetic import CoarsenArithmetic
 from xarray.core import dtypes, duck_array_ops, utils
 from xarray.core.options import OPTIONS, _get_keep_attrs
 from xarray.core.types import CoarsenBoundaryOptions, SideOptions, T_Xarray
@@ -51,6 +50,43 @@ Returns
 reduced : same type as caller
     New object with `{name}` applied along its rolling dimension.
 """
+
+_COARSEN_REDUCE_DOCSTRING_TEMPLATE = """\
+Reduce this object's data by applying `{name}` along some dimension(s).
+
+Parameters
+----------
+{skip_na_docs}{min_count_docs}
+keep_attrs : bool, optional
+    If True, the attributes (`attrs`) will be copied from the original
+    object to the new one.  If False (default), the new object will be
+    returned without attributes.
+**kwargs : dict
+    Additional keyword arguments passed on to the appropriate array
+    function for calculating `{name}` on this object's data.
+
+Returns
+-------
+reduced : same type as caller
+    New object with `{name}` applied to its data and the
+    indicated dimension(s) removed.
+"""
+
+_SKIPNA_DOCSTRING = """
+skipna : bool, optional
+    If True, skip missing values (as marked by NaN). By default, only
+    skips missing values for float dtypes; other dtypes either do not
+    have a sentinel missing value (int) or skipna=True has not been
+    implemented (object, datetime64 or timedelta64)."""
+
+_MINCOUNT_DOCSTRING = """
+min_count : int, default: None
+    The required number of valid values to perform the operation. If
+    fewer than min_count non-NA values are present the result will be
+    NA. Only used if skipna is set to True or defaults to True for the
+    array's dtype. New in version 0.10.8: Added with the default being
+    None. Changed in version 0.17.0: if specified on an integer array
+    and skipna=True, the result will be a float array."""
 
 
 class Rolling(Generic[T_Xarray]):
@@ -1035,7 +1071,7 @@ class DatasetRolling(Rolling["Dataset"]):
         return Dataset(dataset, coords=coords, attrs=attrs)
 
 
-class Coarsen(CoarsenArithmetic, Generic[T_Xarray]):
+class Coarsen(Generic[T_Xarray]):
     """A object that implements the coarsen.
 
     See Also
@@ -1125,6 +1161,45 @@ class Coarsen(CoarsenArithmetic, Generic[T_Xarray]):
             if getattr(self, k, None) is not None
         )
         return f"{self.__class__.__name__} [{attrs}]"
+
+    def _reduce_method_impl(name: str, include_skipna: bool) -> Callable[..., T_Xarray]:
+        """Creates methods that mirror the implementation in Rolling."""
+
+        kwargs: dict[str, Any] = {}
+        if include_skipna:
+            kwargs["skipna"] = None
+
+        func = getattr(duck_array_ops, name)
+
+        available_min_count = getattr(func, "available_min_count", False)
+        skip_na_docs = _SKIPNA_DOCSTRING if include_skipna else ""
+        min_count_docs = _MINCOUNT_DOCSTRING if available_min_count else ""
+
+        def method(self, keep_attrs: bool | None = None, **kwargs) -> T_Xarray:
+            return self._reduce_method(
+                func,
+                **kwargs,
+            )(self, keep_attrs=keep_attrs, **kwargs)
+
+        method.__name__ = name
+        method.__doc__ = _COARSEN_REDUCE_DOCSTRING_TEMPLATE.format(
+            name=name,
+            skip_na_docs=skip_na_docs,
+            min_count_docs=min_count_docs,
+        )
+        return method
+
+    any = _reduce_method_impl("array_any", include_skipna=False)
+    all = _reduce_method_impl("array_all", include_skipna=False)
+    max = _reduce_method_impl("max", include_skipna=True)
+    min = _reduce_method_impl("min", include_skipna=True)
+    mean = _reduce_method_impl("mean", include_skipna=True)
+    prod = _reduce_method_impl("prod", include_skipna=True)
+    sum = _reduce_method_impl("sum", include_skipna=True)
+    std = _reduce_method_impl("std", include_skipna=True)
+    var = _reduce_method_impl("var", include_skipna=True)
+    median = _reduce_method_impl("median", include_skipna=True)
+    count = _reduce_method_impl("count", include_skipna=False)
 
     def construct(
         self,

--- a/xarray/computation/rolling.py
+++ b/xarray/computation/rolling.py
@@ -1162,6 +1162,7 @@ class Coarsen(Generic[T_Xarray]):
         )
         return f"{self.__class__.__name__} [{attrs}]"
 
+    @staticmethod
     def _reduce_method_impl(name: str, include_skipna: bool) -> Callable[..., T_Xarray]:
         """Creates methods that mirror the implementation in Rolling."""
 

--- a/xarray/tests/test_coarsen.py
+++ b/xarray/tests/test_coarsen.py
@@ -63,14 +63,14 @@ def test_coarsen_coords(ds, dask):
         dims="time",
         coords={"time": pd.date_range("1999-12-15", periods=364)},
     )
-    actual = da.coarsen(time=2).mean()  # type: ignore[attr-defined]
+    actual = da.coarsen(time=2).mean()
 
 
 @requires_cftime
 def test_coarsen_coords_cftime():
     times = xr.date_range("2000", periods=6, use_cftime=True)
     da = xr.DataArray(range(6), [("time", times)])
-    actual = da.coarsen(time=3).mean()  # type: ignore[attr-defined]
+    actual = da.coarsen(time=3).mean()
     expected_times = xr.date_range("2000-01-02", freq="3D", periods=2, use_cftime=True)
     np.testing.assert_array_equal(actual.time, expected_times)
 

--- a/xarray/tests/test_sparse.py
+++ b/xarray/tests/test_sparse.py
@@ -784,8 +784,8 @@ class TestSparseDataArrayAndDataset:
     def test_coarsen(self):
         a1 = self.ds_xr
         a2 = self.sp_xr
-        m1 = a1.coarsen(x=2, boundary="trim").mean()  # type: ignore[attr-defined]
-        m2 = a2.coarsen(x=2, boundary="trim").mean()  # type: ignore[attr-defined]
+        m1 = a1.coarsen(x=2, boundary="trim").mean()
+        m2 = a2.coarsen(x=2, boundary="trim").mean()
 
         assert isinstance(m2.data, sparse.SparseArray)
         assert np.allclose(m1.data, m2.data.todense())


### PR DESCRIPTION
### Description
The methods for the documented reduction operations on `Dataset.coarsen()` and `DataArray.coarsen()` were dynamically generated via injected methods that relied on code in several different modules. The dynamic generation of these methods also meant that type errors were raised when trying to access reduction methods, e.g., the following code example.

<details>
  <summary>Minimal working example</summary>

  ```python
  import numpy as np
  import xarray as xr
  
  rng = np.random.default_rng(42)
  data = rng.random((10, 10))
  
  ds = xr.Dataset(
      {
          "z": (("x", "y"), data)
      },
      coords={
          "x": np.arange(10),
          "y": np.arange(10)
      },
  )

  # raises Object of type `DatasetCoarsen` has no attribute `mean` ty[unresolved-attribute]
  ds_coarsen = ds.coarsen(x=2).mean() 
  ```
</details>

This PR moves all the logic for `Coarsen` into `xarray.computation.rolling` and attempts to mirror the implementation of `xarray.computation.rolling.Rolling`. It should result in no functional changes as far as I can tell and should make future maintenance slightly easier (not having to track the injection across files).

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #8136 
- [ ] Tests added (note: I don't think any tests needed to be added here, but maybe in a larger refactoring, see below)
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

PS: I think the `xarray.computation.rolling` module might be due for a refactoring and don't seem to have been touched a lot in recent years. There's also #8059 related to this module, which I didn't address here to keep the scope limited. Happy to discuss a larger refactoring effort if there's any interest 😄 