### PR TITLE
fix typo/grammar in `Dataset._rename()` docstring

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -966,7 +966,7 @@ class Dataset(
     ) -> Self:
         """Fastpath constructor for internal use.
 
-        Returns an object with optionally with replaced attributes.
+        Returns an object with optionally replaced attributes.
 
         Explicitly passed arguments are *not* copied when placed on the new
         dataset. It is up to the caller to ensure that they have the right type


### PR DESCRIPTION
### Description

Trivial fix, came across whilst looking at internal semantics of `Dataset/DataArray.rename()`

### Checklist

### AI Disclosure
No AI used here.
