### PR TITLE
Fix eager import of cftime in _maybe_cast_to_cftimeindex

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -110,6 +110,9 @@ Bug Fixes
   use of ``origin`` and ``offset`` options (:pull:`11546`). This effectively
   rolls back the resample-related changes introduced in :pull:`10650`. By
   `Spencer Clark <https://github.com/spencerkclark>`_.
+- Fix regression where accessing an object-dtype index eagerly attempts to
+  import cftime, slowing down operations.
+  By `Peter Hron <https://github.com/peterhron>`_.
 
 .. _`pandas-dev/pandas#64793`: https://github.com/pandas-dev/pandas/pull/64793
 

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -491,7 +491,12 @@ class Index:
 def _maybe_cast_to_cftimeindex(index: pd.Index) -> pd.Index:
     from xarray.coding.cftimeindex import CFTimeIndex
 
-    if len(index) > 0 and index.dtype == "O" and not isinstance(index, CFTimeIndex):
+    if (
+        len(index) > 0 
+        and index.dtype == "O"
+        and utils.module_available("cftime")
+        and not isinstance(index, CFTimeIndex)
+    ):
         try:
             return CFTimeIndex(index)
         except (ImportError, TypeError):

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -492,7 +492,7 @@ def _maybe_cast_to_cftimeindex(index: pd.Index) -> pd.Index:
     from xarray.coding.cftimeindex import CFTimeIndex
 
     if (
-        len(index) > 0 
+        len(index) > 0
         and index.dtype == "O"
         and utils.module_available("cftime")
         and not isinstance(index, CFTimeIndex)

--- a/xarray/tests/test_indexes.py
+++ b/xarray/tests/test_indexes.py
@@ -740,7 +740,7 @@ def test_safe_cast_to_index_datetime_datetime():
     assert isinstance(actual, pd.Index)
 
 
-def test_safe_cast_to_index_does_not_import_missing_cftime(monkeypatch):
+def test_safe_cast_to_index_does_not_import_missing_cftime(monkeypatch) -> None:
     original_module_available = indexes.utils.module_available
     original_attempt_import = cftimeindex.attempt_import
 

--- a/xarray/tests/test_indexes.py
+++ b/xarray/tests/test_indexes.py
@@ -9,7 +9,9 @@ import pandas as pd
 import pytest
 
 import xarray as xr
+from xarray.coding import cftimeindex
 from xarray.coding.cftimeindex import CFTimeIndex
+from xarray.core import indexes
 from xarray.core.indexes import (
     Hashable,
     Index,
@@ -736,6 +738,34 @@ def test_safe_cast_to_index_datetime_datetime():
     actual = safe_cast_to_index(np.array(dates))
     assert_array_equal(expected, actual)
     assert isinstance(actual, pd.Index)
+
+
+def test_safe_cast_to_index_does_not_import_missing_cftime(monkeypatch):
+    original_module_available = indexes.utils.module_available
+    original_attempt_import = cftimeindex.attempt_import
+
+    def mock_cftime_not_available(module: str, minversion: str | None = None) -> bool:
+        if module == "cftime":
+            return False
+        return original_module_available(module, minversion)
+
+    cftime_imports = 0
+
+    def cftime_import_counter(module: str):
+        nonlocal cftime_imports
+        if module == "cftime":
+            cftime_imports += 1
+        return original_attempt_import(module)
+
+    monkeypatch.setattr(indexes.utils, "module_available", mock_cftime_not_available)
+    monkeypatch.setattr(cftimeindex, "attempt_import", cftime_import_counter)
+
+    values = np.array(["a", "b", "c"], dtype=object)
+    for _ in range(3):
+        safe_cast_to_index(values)
+
+    # module_available returns False, so import should not be attempted
+    assert cftime_imports == 0
 
 
 @pytest.mark.parametrize("dtype", ["int32", "float32"])


### PR DESCRIPTION
### Description

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #11559
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
    <!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
    Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

Fixes a regression with eagerly-importing cftime, leading to performance degradation.