### PR TITLE
Show inherited indexes separately in DataTree repr

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -114,6 +114,11 @@ Bug Fixes
   type error when applying reduction methods, due to the reduction methods being
   dynamically generated (:issue:`8136`).
   By `Andrew Scherer <https://github.com/andrew-s28>`_.
+- The text and HTML reprs of :py:class:`DataTree` now split indexes into
+  ``Indexes:`` (defined at this node) and ``Inherited indexes:`` (inherited from
+  an ancestor), mirroring the existing treatment of ``Coordinates`` versus
+  ``Inherited coordinates`` (:issue:`10578`).
+  By `mokashang <https://github.com/mokashang>`_.
 
 .. _`pandas-dev/pandas#64793`: https://github.com/pandas-dev/pandas/pull/64793
 

--- a/xarray/core/formatting.py
+++ b/xarray/core/formatting.py
@@ -1182,6 +1182,39 @@ def inherited_vars(mapping: ChainMap) -> dict:
     return {k: v for k, v in mapping.parents.items() if k not in mapping.maps[0]}
 
 
+def _split_node_indexes(node: DataTree) -> tuple[dict, dict]:
+    """Split a node's indexes into those defined locally and those inherited.
+
+    Returns dicts of the form ``{tuple_of_coord_names: Index}`` as produced by
+    :func:`_get_indexes_dict`, split so that entries where every coord name is
+    inherited from an ancestor land in the "inherited" mapping and everything
+    else in the "node" mapping.
+    """
+    inherited_names = set(inherited_vars(node._indexes))
+    all_indexes = _get_indexes_dict(node.xindexes)
+    node_indexes = {}
+    inherited_indexes = {}
+    for names, idx in all_indexes.items():
+        if names and all(name in inherited_names for name in names):
+            inherited_indexes[names] = idx
+        else:
+            node_indexes[names] = idx
+    return node_indexes, inherited_indexes
+
+
+def inherited_indexes_repr(node: DataTree, max_rows=None) -> str:
+    display_default_indexes = _get_boolean_with_default(
+        "display_default_indexes", False
+    )
+    _, inherited_indexes = _split_node_indexes(node)
+    inherited_indexes = filter_nondefault_indexes(
+        inherited_indexes, not display_default_indexes
+    )
+    if not inherited_indexes:
+        return ""
+    return indexes_repr(inherited_indexes, max_rows=max_rows, title="Inherited indexes")
+
+
 def _datatree_node_repr(node: DataTree, root: bool) -> str:
     summary = [f"Group: {node.path}"]
 
@@ -1228,16 +1261,18 @@ def _datatree_node_repr(node: DataTree, root: bool) -> str:
             data_vars_repr(node._data_variables, col_width=col_width, max_rows=max_rows)
         )
 
-    # TODO: only show indexes defined at this node, with a separate section for
-    # inherited indexes (if root=True)
     display_default_indexes = _get_boolean_with_default(
         "display_default_indexes", False
     )
-    xindexes = filter_nondefault_indexes(
-        _get_indexes_dict(node.xindexes), not display_default_indexes
-    )
-    if xindexes:
-        summary.append(indexes_repr(xindexes, max_rows=max_rows))
+    node_indexes, _ = _split_node_indexes(node)
+    node_indexes = filter_nondefault_indexes(node_indexes, not display_default_indexes)
+    if node_indexes:
+        summary.append(indexes_repr(node_indexes, max_rows=max_rows))
+
+    if root:
+        inherited_indexes_str = inherited_indexes_repr(node, max_rows=max_rows)
+        if inherited_indexes_str:
+            summary.append(inherited_indexes_str)
 
     if node.attrs:
         summary.append(attrs_repr(node.attrs, max_rows=max_rows))

--- a/xarray/core/formatting_html.py
+++ b/xarray/core/formatting_html.py
@@ -401,6 +401,33 @@ inherited_coord_section = partial(
     expand_option_name="display_expand_coords",
 )
 
+inherited_index_section = partial(
+    _mapping_section,
+    name="Inherited indexes",
+    details_func=summarize_indexes,
+    max_items_collapse=0,
+    expand_option_name="display_expand_indexes",
+)
+
+
+def _split_node_indexes(node: DataTree) -> tuple[dict, dict]:
+    """Split a node's indexes into node-local and inherited groups.
+
+    Each dict maps ``tuple_of_coord_names`` to its underlying Index. An entry
+    lands in the inherited mapping when every coord name in the tuple comes
+    from an ancestor node.
+    """
+    inherited_names = set(inherited_vars(node._indexes))
+    all_indexes = _get_indexes_dict(node.xindexes)
+    node_indexes: dict = {}
+    inherited_indexes: dict = {}
+    for names, idx in all_indexes.items():
+        if names and all(name in inherited_names for name in names):
+            inherited_indexes[names] = idx
+        else:
+            node_indexes[names] = idx
+    return node_indexes, inherited_indexes
+
 
 def _datatree_node_sections(node: DataTree, root: bool) -> tuple[list[str], int]:
     from xarray.core.coordinates import Coordinates
@@ -420,8 +447,12 @@ def _datatree_node_sections(node: DataTree, root: bool) -> tuple[list[str], int]
     display_default_indexes = _get_boolean_with_default(
         "display_default_indexes", False
     )
-    xindexes = filter_nondefault_indexes(
-        _get_indexes_dict(ds.xindexes), not display_default_indexes
+    node_xindexes, inherited_xindexes = _split_node_indexes(node)
+    node_xindexes = filter_nondefault_indexes(
+        node_xindexes, not display_default_indexes
+    )
+    inherited_xindexes = filter_nondefault_indexes(
+        inherited_xindexes, not display_default_indexes
     )
 
     sections = []
@@ -433,8 +464,10 @@ def _datatree_node_sections(node: DataTree, root: bool) -> tuple[list[str], int]
         sections.append(inherited_coord_section(inherited_coords))
     if ds.data_vars:
         sections.append(datavar_section(ds.data_vars))
-    if xindexes:
-        sections.append(index_section(xindexes))
+    if node_xindexes:
+        sections.append(index_section(node_xindexes))
+    if root and inherited_xindexes:
+        sections.append(inherited_index_section(inherited_xindexes))
     if ds.attrs:
         sections.append(attr_section(ds.attrs))
 
@@ -446,8 +479,9 @@ def _datatree_node_sections(node: DataTree, root: bool) -> tuple[list[str], int]
         + int(root) * (int(bool(inherited_coords)) + len(inherited_coords))
         + int(bool(ds.data_vars))
         + len(ds.data_vars)
-        + int(bool(xindexes))
-        + len(xindexes)
+        + int(bool(node_xindexes))
+        + len(node_xindexes)
+        + int(root) * (int(bool(inherited_xindexes)) + len(inherited_xindexes))
         + int(bool(ds.attrs))
         + len(ds.attrs)
     )

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -1433,6 +1433,36 @@ class TestRepr:
         ).strip()
         assert result == expected
 
+    def test_repr_inherited_indexes(self) -> None:
+        # regression test for https://github.com/pydata/xarray/issues/10578
+        from xarray.indexes import RangeIndex
+
+        coords = xr.Coordinates.from_xindex(RangeIndex.arange(0, 4, 1, dim="x"))
+        tree = DataTree.from_dict(
+            {
+                "/": Dataset(coords=coords),
+                "/child": Dataset({"data": ("x", [10.0, 20.0, 30.0, 40.0])}),
+            }
+        )
+
+        # In the whole-tree text repr, the child inherits from its parent, so
+        # the child's inherited indexes are not repeated (root=False for it).
+        # The root shows its local indexes under "Indexes:".
+        full_result = repr(tree)
+        assert "Indexes:" in full_result
+        assert "Inherited indexes" not in full_result
+
+        # When the child is treated as the root of its own view, we expect
+        # "Inherited indexes:" to appear alongside "Inherited coordinates:".
+        child_result = repr(tree["child"])
+        assert "Inherited coordinates:" in child_result
+        assert "Inherited indexes:" in child_result
+        assert "RangeIndex" in child_result
+
+        child_html = tree["child"]._repr_html_()
+        assert "Inherited coordinates" in child_html
+        assert "Inherited indexes" in child_html
+
     @pytest.mark.skipif(
         ON_WINDOWS, reason="windows (pre NumPy2) uses int32 instead of int64"
     )


### PR DESCRIPTION
### Description

DataTree already distinguishes ``Coordinates:`` (defined at this node)
from ``Inherited coordinates:`` (inherited from an ancestor), but its
text and HTML reprs lump every index into a single ``Indexes:`` section.
That makes it easy to mistake an inherited index for one added at the
current node, and there was a ``TODO`` in ``_datatree_node_repr``
calling this out.

Fix: split the indexes the same way coordinates are split.

* ``Indexes:`` shows only indexes whose coord names come from
  ``node._node_indexes``.
* ``Inherited indexes:`` shows only indexes whose coord names all come
  from ``inherited_vars(node._indexes)``. Like ``Inherited coordinates:``,
  it is only rendered when ``root=True``, so the whole-tree repr still
  attributes each inherited index to the ancestor that defines it and
  does not repeat it on every descendant.

Both the text repr (``_datatree_node_repr`` in ``formatting.py``) and
the HTML repr (``_datatree_node_sections`` in ``formatting_html.py``)
use the same split helper, ``_split_node_indexes``, which walks
``_get_indexes_dict(node.xindexes)`` once and buckets each ``(names,
Index)`` pair by whether every name in the group is inherited. That
preserves the existing grouping behaviour for indexes that span
multiple coordinates (e.g. ``PandasMultiIndex``).

``filter_nondefault_indexes`` is applied independently to each bucket,
so the ``display_default_indexes`` option keeps its current meaning.
The HTML ``displayed_line_count`` accounting is updated to include the
new section.

Before, for a tree where the child inherits a non-default ``RangeIndex``
from its parent, the child's repr looked like this:

```
<xarray.DataTree 'child'>
Group: /child
    Dimensions:  (x: 4)
    Inherited coordinates:
      * x        (x) float64 32B 0 1 2 3
    Data variables:
        data     (x) float64 32B 10.0 20.0 30.0 40.0
```

After:

```
<xarray.DataTree 'child'>
Group: /child
    Dimensions:  (x: 4)
    Inherited coordinates:
      * x        (x) float64 32B 0 1 2 3
    Data variables:
        data     (x) float64 32B 10.0 20.0 30.0 40.0
    Inherited indexes:
        x        RangeIndex (start=0, stop=4, step=1)
```

### Checklist

- [x] Closes #10578
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`