### PR TITLE
fix: Don't drop orphaned dims on weighted reductions 

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -117,7 +117,7 @@ Bug Fixes
   type error when applying reduction methods, due to the reduction methods being
   dynamically generated (:issue:`8136`).
   By `Andrew Scherer <https://github.com/andrew-s28>`_.
-- Fix DatasetWeighted dropping coordinates/dimensions which are not affected by 
+- Fix DatasetWeighted dropping coordinates/dimensions which are not affected by
   the reduction nor in the weights array (:issue:`11560`, :pull:`11562`).
   By `Charles Turner` <https://github.com/charles-turner-1>
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -119,7 +119,7 @@ Bug Fixes
   By `Andrew Scherer <https://github.com/andrew-s28>`_.
 - Fix DatasetWeighted dropping coordinates/dimensions which are not affected by 
   the reduction nor in the weights array (:issue:`11560`, :pull:`11562`).
-  By `Charles Turner` <https://github.com/charles-turner-1>
+  By `Charles Turner <https://github.com/charles-turner-1>`_.
 
 .. _`pandas-dev/pandas#64793`: https://github.com/pandas-dev/pandas/pull/64793
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -117,6 +117,9 @@ Bug Fixes
   type error when applying reduction methods, due to the reduction methods being
   dynamically generated (:issue:`8136`).
   By `Andrew Scherer <https://github.com/andrew-s28>`_.
+- Fix DatasetWeighted dropping coordinates/dimensions which are not affected by 
+  the reduction nor in the weights array (:issue:`11560`, :pull:`11562`).
+  By `Charles Turner` <https://github.com/charles-turner-1>
 
 .. _`pandas-dev/pandas#64793`: https://github.com/pandas-dev/pandas/pull/64793
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -477,3 +477,6 @@ build-package = { features = [
   "release",
 ], no-default-feature = true }
 test-nightly = { features = ["nightly"], no-default-feature = true }
+
+[pypi-dependencies]
+pdbpp = ">=0.12.1, <0.13"

--- a/pixi.toml
+++ b/pixi.toml
@@ -477,6 +477,3 @@ build-package = { features = [
   "release",
 ], no-default-feature = true }
 test-nightly = { features = ["nightly"], no-default-feature = true }
-
-[pypi-dependencies]
-pdbpp = ">=0.12.1, <0.13"

--- a/xarray/computation/weighted.py
+++ b/xarray/computation/weighted.py
@@ -195,21 +195,18 @@ class Weighted(Generic[T_Xarray]):
     def _check_dim(self, dim: Dims):
         """raise an error if any dimension is missing"""
 
-        dims, all_dims = self._all_dims(dim)
-        missing_dims = set(dims) - all_dims
-        if missing_dims:
-            raise ValueError(
-                f"Dimensions {tuple(missing_dims)} not found in {self.__class__.__name__} dimensions {tuple(all_dims)}"
-            )
-
-    def _all_dims(self, dim: Dims) -> tuple[list[Hashable], set[Hashable]]:
         dims: list[Hashable]
         if isinstance(dim, str) or not isinstance(dim, Iterable):
             dims = [dim] if dim else []
         else:
             dims = list(dim)
         all_dims = set(self.obj.dims).union(set(self.weights.dims))
-        return dims, all_dims
+
+        missing_dims = set(dims) - all_dims
+        if missing_dims:
+            raise ValueError(
+                f"Dimensions {tuple(missing_dims)} not found in {self.__class__.__name__} dimensions {tuple(all_dims)}"
+            )
 
     @staticmethod
     def _reduce(
@@ -554,15 +551,8 @@ class DataArrayWeighted(Weighted["DataArray"]):
 class DatasetWeighted(Weighted["Dataset"]):
     def _expand_weights(self, dim: Dims):
         """expand weights to include any missing dimensions"""
-        dims, all_dims = self._all_dims(dim)
 
-        if set(self.obj.dims) == set(self.weights.dims):
-            return
-
-        if not dims:
-            return
-
-        if not (missing_weightdims := (set(all_dims) - set(dims))):
+        if not (missing_weightdims := set(self.obj.dims) - set(self.weights.dims)):
             return
 
         exp_dims = {k: self.obj.sizes.get(k, None) for k in missing_weightdims}

--- a/xarray/computation/weighted.py
+++ b/xarray/computation/weighted.py
@@ -201,11 +201,22 @@ class Weighted(Generic[T_Xarray]):
         else:
             dims = list(dim)
         all_dims = set(self.obj.dims).union(set(self.weights.dims))
-        missing_dims = set(dims) - all_dims
-        if missing_dims:
+        if missing_obj_dims := (set(dims) - all_dims):
             raise ValueError(
-                f"Dimensions {tuple(missing_dims)} not found in {self.__class__.__name__} dimensions {tuple(all_dims)}"
+                f"Dimensions {tuple(missing_obj_dims)} not found in {self.__class__.__name__} dimensions {tuple(all_dims)}"
             )
+
+        if set(self.obj.dims) == set(self.weights.dims):
+            return
+
+        if not dims:
+            return
+
+        if missing_weightdims := (set(all_dims) - set(dims)):
+            exp_dims = {k: self.obj.sizes.get(k, None) for k in missing_weightdims}
+            exp_dims = {k: v for k, v in exp_dims.items() if v is not None}
+            self.weights = self.weights.expand_dims(dims=exp_dims)
+            # ^expand_dims - sequence of hashable - should this be a list, not a tuple
 
     @staticmethod
     def _reduce(

--- a/xarray/computation/weighted.py
+++ b/xarray/computation/weighted.py
@@ -201,7 +201,6 @@ class Weighted(Generic[T_Xarray]):
         else:
             dims = list(dim)
         all_dims = set(self.obj.dims).union(set(self.weights.dims))
-
         missing_dims = set(dims) - all_dims
         if missing_dims:
             raise ValueError(

--- a/xarray/computation/weighted.py
+++ b/xarray/computation/weighted.py
@@ -195,28 +195,21 @@ class Weighted(Generic[T_Xarray]):
     def _check_dim(self, dim: Dims):
         """raise an error if any dimension is missing"""
 
+        dims, all_dims = self._all_dims(dim)
+        missing_dims = set(dims) - all_dims
+        if missing_dims:
+            raise ValueError(
+                f"Dimensions {tuple(missing_dims)} not found in {self.__class__.__name__} dimensions {tuple(all_dims)}"
+            )
+
+    def _all_dims(self, dim: Dims) -> tuple[list[Hashable], set[Hashable]]:
         dims: list[Hashable]
         if isinstance(dim, str) or not isinstance(dim, Iterable):
             dims = [dim] if dim else []
         else:
             dims = list(dim)
         all_dims = set(self.obj.dims).union(set(self.weights.dims))
-        if missing_obj_dims := (set(dims) - all_dims):
-            raise ValueError(
-                f"Dimensions {tuple(missing_obj_dims)} not found in {self.__class__.__name__} dimensions {tuple(all_dims)}"
-            )
-
-        if set(self.obj.dims) == set(self.weights.dims):
-            return
-
-        if not dims:
-            return
-
-        if missing_weightdims := (set(all_dims) - set(dims)):
-            exp_dims = {k: self.obj.sizes.get(k, None) for k in missing_weightdims}
-            exp_dims = {k: v for k, v in exp_dims.items() if v is not None}
-            self.weights = self.weights.expand_dims(dims=exp_dims)
-            # ^expand_dims - sequence of hashable - should this be a list, not a tuple
+        return dims, all_dims
 
     @staticmethod
     def _reduce(
@@ -559,8 +552,24 @@ class DataArrayWeighted(Weighted["DataArray"]):
 
 
 class DatasetWeighted(Weighted["Dataset"]):
+    def _expand_weights(self, dim: Dims):
+        """expand weights to include any missing dimensions"""
+        dims, all_dims = self._all_dims(dim)
+
+        if set(self.obj.dims) == set(self.weights.dims):
+            return
+
+        if not dims:
+            return
+
+        if missing_weightdims := (set(all_dims) - set(dims)):
+            exp_dims = {k: self.obj.sizes.get(k, None) for k in missing_weightdims}
+            exp_dims = {k: v for k, v in exp_dims.items() if v is not None}
+            self.weights = self.weights.expand_dims(dims=exp_dims)
+
     def _implementation(self, func, dim, **kwargs) -> Dataset:
         self._check_dim(dim)
+        self._expand_weights(dim)
         return self.obj.map(func, dim=dim, **kwargs)
 
 

--- a/xarray/computation/weighted.py
+++ b/xarray/computation/weighted.py
@@ -562,10 +562,12 @@ class DatasetWeighted(Weighted["Dataset"]):
         if not dims:
             return
 
-        if missing_weightdims := (set(all_dims) - set(dims)):
-            exp_dims = {k: self.obj.sizes.get(k, None) for k in missing_weightdims}
-            exp_dims = {k: v for k, v in exp_dims.items() if v is not None}
-            self.weights = self.weights.expand_dims(dims=exp_dims)
+        if not (missing_weightdims := (set(all_dims) - set(dims))):
+            return
+
+        exp_dims = {k: self.obj.sizes.get(k, None) for k in missing_weightdims}
+        exp_dims = {k: v for k, v in exp_dims.items() if v is not None}
+        self.weights = self.weights.expand_dims(dim=exp_dims)
 
     def _implementation(self, func, dim, **kwargs) -> Dataset:
         self._check_dim(dim)

--- a/xarray/computation/weighted.py
+++ b/xarray/computation/weighted.py
@@ -565,15 +565,13 @@ class DatasetWeighted(Weighted["Dataset"]):
         existing_dims = {dim for v in ds.variables.values() for dim in v.dims}
         dims_to_restore = set(self.obj.dims) - set(dims) - existing_dims
 
-        dims_to_restore = {d: self.obj.coords[d] for d in dims_to_restore}
-        ds = ds.assign_coords(dims_to_restore)
-        return ds
+        coords = {d: self.obj.coords[d] for d in dims_to_restore}
+        return ds.assign_coords(coords)
 
     def _implementation(self, func, dim, **kwargs) -> Dataset:
         self._check_dim(dim)
         mapped_ds = self.obj.map(func, dim=dim, **kwargs)
-        mapped_ds = self._restore_dims(dim, mapped_ds)
-        return mapped_ds
+        return self._restore_dims(dim, mapped_ds)
 
 
 def _inject_docstring(cls, cls_name):

--- a/xarray/computation/weighted.py
+++ b/xarray/computation/weighted.py
@@ -195,17 +195,22 @@ class Weighted(Generic[T_Xarray]):
     def _check_dim(self, dim: Dims):
         """raise an error if any dimension is missing"""
 
-        dims: list[Hashable]
-        if isinstance(dim, str) or not isinstance(dim, Iterable):
-            dims = [dim] if dim else []
-        else:
-            dims = list(dim)
+        dims = self._dims_to_list(dim)
         all_dims = set(self.obj.dims).union(set(self.weights.dims))
         missing_dims = set(dims) - all_dims
         if missing_dims:
             raise ValueError(
                 f"Dimensions {tuple(missing_dims)} not found in {self.__class__.__name__} dimensions {tuple(all_dims)}"
             )
+
+    def _dims_to_list(self, dim: Dims) -> list[Hashable]:
+        dims: list[Hashable]
+        if isinstance(dim, str) or not isinstance(dim, Iterable):
+            dims = [dim] if dim else []
+        else:
+            dims = list(dim)
+
+        return dims
 
     @staticmethod
     def _reduce(
@@ -548,20 +553,27 @@ class DataArrayWeighted(Weighted["DataArray"]):
 
 
 class DatasetWeighted(Weighted["Dataset"]):
-    def _expand_weights(self, dim: Dims):
-        """expand weights to include any missing dimensions"""
+    def _restore_dims(self, dim: Dims, ds: Dataset) -> Dataset:
+        """self.obj.map will drop orphaned coordinates & dims that are not in
+        the weights DataArray. This restores them.
+        """
+        if dim is None:
+            return ds
 
-        if not (missing_weightdims := set(self.obj.dims) - set(self.weights.dims)):
-            return
+        dims = self._dims_to_list(dim)
 
-        exp_dims = {k: self.obj.sizes.get(k, None) for k in missing_weightdims}
-        exp_dims = {k: v for k, v in exp_dims.items() if v is not None}
-        self.weights = self.weights.expand_dims(dim=exp_dims)
+        existing_dims = {dim for v in ds.variables.values() for dim in v.dims}
+        dims_to_restore = set(self.obj.dims) - set(dims) - existing_dims
+
+        dims_to_restore = {d: self.obj.coords[d] for d in dims_to_restore}
+        ds = ds.assign_coords(dims_to_restore)
+        return ds
 
     def _implementation(self, func, dim, **kwargs) -> Dataset:
         self._check_dim(dim)
-        self._expand_weights(dim)
-        return self.obj.map(func, dim=dim, **kwargs)
+        res = self.obj.map(func, dim=dim, **kwargs)
+        res = self._restore_dims(dim, res)
+        return res
 
 
 def _inject_docstring(cls, cls_name):

--- a/xarray/computation/weighted.py
+++ b/xarray/computation/weighted.py
@@ -571,9 +571,9 @@ class DatasetWeighted(Weighted["Dataset"]):
 
     def _implementation(self, func, dim, **kwargs) -> Dataset:
         self._check_dim(dim)
-        res = self.obj.map(func, dim=dim, **kwargs)
-        res = self._restore_dims(dim, res)
-        return res
+        mapped_ds = self.obj.map(func, dim=dim, **kwargs)
+        mapped_ds = self._restore_dims(dim, mapped_ds)
+        return mapped_ds
 
 
 def _inject_docstring(cls, cls_name):

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -8,9 +8,13 @@ import pytest
 
 import xarray as xr
 from xarray import DataArray, Dataset
-from xarray.tests import (assert_allclose, assert_equal,
-                          raise_if_dask_computes, requires_cftime,
-                          requires_dask)
+from xarray.tests import (
+    assert_allclose,
+    assert_equal,
+    raise_if_dask_computes,
+    requires_cftime,
+    requires_dask,
+)
 
 
 @pytest.mark.parametrize("as_dataset", (True, False))
@@ -523,7 +527,6 @@ def expected_weighted(da, weights, dim, skipna, operation):
     Generate expected result using ``*`` and ``sum``. This is checked against
     the result of da.weighted which uses ``dot``
     """
-    breakpoint()
 
     weighted_sum = (da * weights).sum(dim=dim, skipna=skipna)
 

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -8,13 +8,9 @@ import pytest
 
 import xarray as xr
 from xarray import DataArray, Dataset
-from xarray.tests import (
-    assert_allclose,
-    assert_equal,
-    raise_if_dask_computes,
-    requires_cftime,
-    requires_dask,
-)
+from xarray.tests import (assert_allclose, assert_equal,
+                          raise_if_dask_computes, requires_cftime,
+                          requires_dask)
 
 
 @pytest.mark.parametrize("as_dataset", (True, False))
@@ -527,6 +523,7 @@ def expected_weighted(da, weights, dim, skipna, operation):
     Generate expected result using ``*`` and ``sum``. This is checked against
     the result of da.weighted which uses ``dot``
     """
+    breakpoint()
 
     weighted_sum = (da * weights).sum(dim=dim, skipna=skipna)
 

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -808,3 +808,31 @@ def test_weighted_bad_dim(operation, as_dataset):
         ),
     ):
         getattr(data.weighted(weights), operation)(**kwargs)
+
+
+def test_dataset_weighted_mean_preserves_orphaned_dims():
+    """
+    Can't test against `check_weighted_operations` - this is an edge case where
+    the dataset has a dimension not present in the weights dataarray or on any
+    of it's variables.
+    """
+    data = Dataset(
+        {
+            "a": (("x", "y"), np.random.randn(2, 2)),
+        },
+        coords={
+            "x": ("x", [0, 1]),
+            "y": ("y", [0, 1]),
+            "t": ("t", [0, 1]),
+        },
+    )
+    weights = DataArray(np.random.randn(2), dims="x")
+
+    weighted_mean = data.weighted(weights).mean(dim="x")
+    mean = data.mean(dim="x")
+
+    # Don't promote dims *on the dataarray*
+    assert weighted_mean["a"].dims == mean["a"].dims
+    # Retain orphaned dims on the dataset
+    assert set(weighted_mean.dims) == set(mean.dims)
+    assert set(weighted_mean.dims) == set(mean.dims)


### PR DESCRIPTION
### Description

Adds a `_restore_dims` method to `DatasetWeighted` which restored orphaned dims after a disjoint reduction.


### Checklist


- [x] Closes #11560
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

### AI Disclosure

I asked Claude Opus 4.8 for help after getting stuck around [294d9e5](https://github.com/pydata/xarray/pull/11562/commits/294d9e5f9419ef4538d06d69c83cc0c50adb20d4). 

All code human written.