### PR TITLE
Fix misleading `DataTree` constructor error message (#11514)

### DIFF
--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -140,7 +140,7 @@ def _to_new_dataset(data: Dataset | Coordinates | None) -> Dataset:
     elif data is None:
         ds = Dataset()
     else:
-        raise TypeError(f"data object is not an xarray.Dataset, dict, or None: {data}")
+        raise TypeError(f"data object is not an xarray.Dataset, xarray.Coordinates, or None: {data}")
     return ds
 
 

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -140,7 +140,9 @@ def _to_new_dataset(data: Dataset | Coordinates | None) -> Dataset:
     elif data is None:
         ds = Dataset()
     else:
-        raise TypeError(f"data object is not an xarray.Dataset, xarray.Coordinates, or None: {data}")
+        raise TypeError(
+            f"data object is not an xarray.Dataset, xarray.Coordinates, or None: {data}"
+        )
     return ds
 
 

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -69,6 +69,11 @@ class TestTreeCreation:
         with pytest.raises(TypeError):
             DataTree(dataset=xr.DataArray(42, name="foo"))  # type: ignore[arg-type]
 
+        # A dict is not an accepted data object; the error message must not
+        # advertise ``dict`` as a valid type (regression test for #11514).
+        with pytest.raises(TypeError, match=r"xarray\.Coordinates"):
+            DataTree(dataset=dict())  # type: ignore[arg-type]
+
     def test_child_data_not_copied(self) -> None:
         # regression test for https://github.com/pydata/xarray/issues/9683
         class NoDeepCopy:


### PR DESCRIPTION
Fixes #11514.

## What happened

`xr.DataTree(dict())` raises

```
TypeError: data object is not an xarray.Dataset, dict, or None: {}
```

but `DataTree.__init__` only accepts an `xarray.Dataset`, `xarray.Coordinates`, or `None` for its `dataset` argument — `_to_new_dataset` has branches for exactly those three. The `dict` in the message is a leftover from an earlier API iteration and is misleading (it advertises a type the constructor does not accept).

## Change

Update the `TypeError` message in `_to_new_dataset` (`xarray/core/datatree.py`) to name `xarray.Coordinates` instead of `dict`. This is a copy-only fix — it does not change constructor behaviour (accepting `dict` would be a separate, larger API decision).

## Test

Added a regression assertion to `TestTreeCreation.test_data_arg`: `DataTree(dataset=dict())` must raise a `TypeError` whose message references `xarray.Coordinates`.

## Validation
- reproduces on pristine code (message still said `dict`), fixed version passes
- full `test_datatree.py` passes (151 passed, 5 skipped, 5 xfailed), no regressions
- `DataTree(xr.Coordinates(...))` still constructs as expected