### PR TITLE
Support a single chunk spec in DataTree.chunk

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -117,6 +117,11 @@ Bug Fixes
   type error when applying reduction methods, due to the reduction methods being
   dynamically generated (:issue:`8136`).
   By `Andrew Scherer <https://github.com/andrew-s28>`_.
+- :py:meth:`DataTree.chunk` now accepts a single chunk specification such as
+  ``"auto"`` or an integer and applies it to every dimension in the tree, as
+  :py:meth:`Dataset.chunk` does, instead of raising ``TypeError``
+  (:issue:`11315`, :pull:`11569`).
+  By `fredrikblau <https://github.com/fredrikblau>`_.
 
 .. _`pandas-dev/pandas#64793`: https://github.com/pandas-dev/pandas/pull/64793
 

--- a/xarray/core/datatree.py
+++ b/xarray/core/datatree.py
@@ -2613,9 +2613,10 @@ class DataTree(
 
         Parameters
         ----------
-        chunks : int, tuple of int, "auto" or mapping of hashable to int or a TimeResampler, optional
+        chunks : int, "auto" or mapping of hashable to int or a TimeResampler, optional
             Chunk sizes along each dimension, e.g., ``5``, ``"auto"``, or
             ``{"x": 5, "y": 5}`` or ``{"x": 5, "time": TimeResampler(freq="YE")}``.
+            A single value is applied to every dimension in the tree.
         name_prefix : str, default: "xarray-"
             Prefix for the name of any new dask arrays.
         token : str, optional
@@ -2650,14 +2651,23 @@ class DataTree(
         xarray.unify_chunks
         dask.array.from_array
         """
-        # don't support deprecated ways of passing chunks
-        if not isinstance(chunks, Mapping):
-            raise TypeError(
-                f"invalid type for chunks: {type(chunks)}. Only mappings are supported."
-            )
-        combined_chunks = either_dict_or_kwargs(chunks, chunks_kwargs, "chunk")
-
         all_dims = self._get_all_dims()
+
+        combined_chunks: Mapping[Any, T_ChunkDimFreq]
+        if not isinstance(chunks, Mapping):
+            # don't support deprecated ways of passing chunks: sequences of
+            # dimension-order sizes are deprecated for Dataset.chunk, and are
+            # additionally ambiguous for a tree whose groups need not share an
+            # ordering of their dimensions
+            if chunks is None or isinstance(chunks, tuple | list):
+                raise TypeError(
+                    f"invalid type for chunks: {type(chunks)}. Only mappings and "
+                    'single chunk specifications (e.g. 5 or "auto") to be applied '
+                    "to every dimension are supported."
+                )
+            combined_chunks = dict.fromkeys(all_dims, chunks)
+        else:
+            combined_chunks = either_dict_or_kwargs(chunks, chunks_kwargs, "chunk")
 
         bad_dims = combined_chunks.keys() - all_dims
         if bad_dims:

--- a/xarray/tests/test_datatree.py
+++ b/xarray/tests/test_datatree.py
@@ -2784,3 +2784,20 @@ class TestDask:
 
         with pytest.raises(ValueError, match="not found in data dimensions"):
             tree.chunk({"u": 2})
+
+    @pytest.mark.parametrize("chunks", ["auto", 5, "20B"])
+    def test_chunk_single_spec(self, chunks):
+        ds1 = xr.Dataset({"a": ("x", np.arange(10))})
+        ds2 = xr.Dataset({"b": ("y", np.arange(6))})
+
+        tree = xr.DataTree.from_dict({"/": ds1, "/group1": ds2})
+        actual = tree.chunk(chunks)
+
+        expected = xr.DataTree.from_dict(
+            {"/": ds1.chunk(chunks), "/group1": ds2.chunk(chunks)}
+        )
+
+        assert_identical(actual, expected)
+        assert actual.chunksizes == expected.chunksizes
+        assert set(actual.chunksizes["/"]) == {"x"}
+        assert set(actual.chunksizes["/group1"]) == {"y"}


### PR DESCRIPTION
- Closes #11315
- Tests added
- User visible changes (including notable bug fixes) are documented in `whats-new.rst`

`DataTree.chunk` rejects anything that isn't a mapping:

```python
>>> ds = xr.Dataset({"a": ("x", np.arange(10))})
>>> ds.chunk("auto").chunksizes
Frozen({'x': (10,)})
>>> xr.DataTree(ds).chunk("auto")
TypeError: invalid type for chunks: <class 'str'>. Only mappings are supported.
```

That contradicts the method's own docstring and its `chunks: T_ChunksFreq` annotation, both of which advertise `int`, `"auto"` or a mapping, and it diverges from `Dataset.chunk`, which broadcasts a single value across every dimension with `dict.fromkeys(self.dims, chunks)`.

This does the same for trees: a non-mapping `chunks` is expanded with `dict.fromkeys(self._get_all_dims(), chunks)` before the existing per-group dispatch, so `dt.chunk("auto")`, `dt.chunk(5)` and `dt.chunk("20B")` work and each group gets chunk sizes for its own dimensions only.

The existing guard was commented "don't support deprecated ways of passing chunks", and that part is kept. Tuples and lists still raise `TypeError`: they are the form `Dataset.chunk` emits a `FutureWarning` for, and for a tree they are ambiguous anyway, since groups need not share an ordering of their dimensions and there is no well-defined sequence to zip against `_get_all_dims()`. `None` also still raises, matching the behaviour `test_chunk` already asserts. The message is reworded to say what is accepted while keeping the `invalid type for chunks:` prefix, so both existing `pytest.raises(TypeError, match="invalid type")` assertions still pass unchanged.

`tuple of int` was dropped from the docstring's `chunks` line, since that form is deliberately not accepted here.

I left `T_ChunksFreq` alone — it still nominally includes `tuple` and `None`, but it is shared with `Dataset.chunk` and narrowing it would be a wider change than this fix warrants.

## Testing

`TestDask::test_chunk_single_spec` is parametrized over `"auto"`, `5` and `"20B"` and compares against the per-group `Dataset.chunk` result rather than just asserting no exception, so it pins the actual chunk sizes: `tree.chunk(5)` gives `{'/': {'x': (5, 5)}, '/group1': {'y': (5, 1)}}` and `tree.chunk("20B")` gives `{'/': {'x': (2, 2, 2, 2, 2)}, '/group1': {'y': (2, 2, 2)}}` — different per group, which is what a broadcast should produce.

Reverting `datatree.py` alone fails all three parametrizations with the original `TypeError`; with the change they pass.

`xarray/tests/test_datatree.py`: 159 passed, 5 xfailed. `xarray/tests/test_dask.py`: 219 passed, 2 skipped, 3 xfailed.
