### PR TITLE
fix the failing docs builds

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -78,6 +78,7 @@ extlinks = {
 copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.{3,}: | {5,8}: "
 copybutton_prompt_is_regexp = True
 
+# myst-nb
 nb_execution_excludepatterns = ["examples/apply_ufunc_vectorize_1d.ipynb"]
 # RTD does not publish the .err.log report, so print tracebacks in the build log
 nb_execution_show_tb = True

--- a/pixi.toml
+++ b/pixi.toml
@@ -213,7 +213,6 @@ doc = { cmd = "make html", cwd = "doc", description = "Build the HTML documentat
   "_prepare-environment",
 ] }
 doc-clean = { cmd = "make clean && make html", cwd = "doc", description = "Clean build artifacts and rebuild the HTML documentation from scratch.", depends-on = [
-  "build",
   "_prepare-environment",
 ] }
 host-static-doc = { cmd = "python -m http.server -b 127.0.0.1 -d _build/html 5455", cwd = "doc", description = "serve the static documentation" }

--- a/pixi.toml
+++ b/pixi.toml
@@ -177,6 +177,7 @@ generate-aggregations-ci = { cmd = 'test -z "$(git status --porcelain)" && echo 
 ] }
 
 [feature.doc.dependencies]
+python-gil = "3.14.*"
 kerchunk = "*"
 ipykernel = "*"
 ipywidgets = "*"                   # silence nbsphinx warning

--- a/pixi.toml
+++ b/pixi.toml
@@ -177,7 +177,7 @@ generate-aggregations-ci = { cmd = 'test -z "$(git status --porcelain)" && echo 
 ] }
 
 [feature.doc.dependencies]
-python-gil = "3.14.*"
+python = "3.12.*"
 kerchunk = "*"
 ipykernel = "*"
 ipywidgets = "*"                   # silence nbsphinx warning

--- a/pixi.toml
+++ b/pixi.toml
@@ -180,7 +180,7 @@ generate-aggregations-ci = { cmd = 'test -z "$(git status --porcelain)" && echo 
 kerchunk = "*"
 ipykernel = "*"
 ipywidgets = "*"                   # silence nbsphinx warning
-iris = "*"
+iris = "!=3.16.0"                  # avoid ncdata failing. See https://github.com/SciTools/ncdata/issues/255
 ipython = "*"
 jupyter_client = "*"
 jupyter_sphinx = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -334,7 +334,7 @@ build-package = { cmd = "pixi publish --path ci/recipe/pixi.toml --target-dir di
 
 [tasks]
 build-and-host-doc = [
-  { task = "build" },
+  { task = "build-package" },
   { task = "doc" },
   { task = "host-static-doc" },
 ]

--- a/xarray/core/accessor_str.py
+++ b/xarray/core/accessor_str.py
@@ -147,49 +147,49 @@ class StringAccessor(Generic[T_DataArray]):
     Similar to pandas, fields can be accessed through the `.str` attribute
     for applicable DataArrays.
 
-        >>> da = xr.DataArray(["some", "text", "in", "an", "array"])
-        >>> da.str.len()
-        <xarray.DataArray (dim_0: 5)> Size: 40B
-        array([4, 4, 2, 2, 5])
-        Dimensions without coordinates: dim_0
+    >>> da = xr.DataArray(["some", "text", "in", "an", "array"])
+    >>> da.str.len()
+    <xarray.DataArray (dim_0: 5)> Size: 40B
+    array([4, 4, 2, 2, 5])
+    Dimensions without coordinates: dim_0
 
     It also implements ``+``, ``*``, and ``%``, which operate as elementwise
     versions of the corresponding ``str`` methods. These will automatically
     broadcast for array-like inputs.
 
-        >>> da1 = xr.DataArray(["first", "second", "third"], dims=["X"])
-        >>> da2 = xr.DataArray([1, 2, 3], dims=["Y"])
-        >>> da1.str + da2
-        <xarray.DataArray (X: 3, Y: 3)> Size: 252B
-        array([['first1', 'first2', 'first3'],
-               ['second1', 'second2', 'second3'],
-               ['third1', 'third2', 'third3']], dtype='<U7')
-        Dimensions without coordinates: X, Y
+    >>> da1 = xr.DataArray(["first", "second", "third"], dims=["X"])
+    >>> da2 = xr.DataArray([1, 2, 3], dims=["Y"])
+    >>> da1.str + da2
+    <xarray.DataArray (X: 3, Y: 3)> Size: 252B
+    array([['first1', 'first2', 'first3'],
+           ['second1', 'second2', 'second3'],
+           ['third1', 'third2', 'third3']], dtype='<U7')
+    Dimensions without coordinates: X, Y
 
-        >>> da1 = xr.DataArray(["a", "b", "c", "d"], dims=["X"])
-        >>> reps = xr.DataArray([3, 4], dims=["Y"])
-        >>> da1.str * reps
-        <xarray.DataArray (X: 4, Y: 2)> Size: 128B
-        array([['aaa', 'aaaa'],
-               ['bbb', 'bbbb'],
-               ['ccc', 'cccc'],
-               ['ddd', 'dddd']], dtype='<U4')
-        Dimensions without coordinates: X, Y
+    >>> da1 = xr.DataArray(["a", "b", "c", "d"], dims=["X"])
+    >>> reps = xr.DataArray([3, 4], dims=["Y"])
+    >>> da1.str * reps
+    <xarray.DataArray (X: 4, Y: 2)> Size: 128B
+    array([['aaa', 'aaaa'],
+           ['bbb', 'bbbb'],
+           ['ccc', 'cccc'],
+           ['ddd', 'dddd']], dtype='<U4')
+    Dimensions without coordinates: X, Y
 
-        >>> da1 = xr.DataArray(["%s_%s", "%s-%s", "%s|%s"], dims=["X"])
-        >>> da2 = xr.DataArray([1, 2], dims=["Y"])
-        >>> da3 = xr.DataArray([0.1, 0.2], dims=["Z"])
-        >>> da1.str % (da2, da3)
-        <xarray.DataArray (X: 3, Y: 2, Z: 2)> Size: 240B
-        array([[['1_0.1', '1_0.2'],
-                ['2_0.1', '2_0.2']],
-        <BLANKLINE>
-               [['1-0.1', '1-0.2'],
-                ['2-0.1', '2-0.2']],
-        <BLANKLINE>
-               [['1|0.1', '1|0.2'],
-                ['2|0.1', '2|0.2']]], dtype='<U5')
-        Dimensions without coordinates: X, Y, Z
+    >>> da1 = xr.DataArray(["%s_%s", "%s-%s", "%s|%s"], dims=["X"])
+    >>> da2 = xr.DataArray([1, 2], dims=["Y"])
+    >>> da3 = xr.DataArray([0.1, 0.2], dims=["Z"])
+    >>> da1.str % (da2, da3)
+    <xarray.DataArray (X: 3, Y: 2, Z: 2)> Size: 240B
+    array([[['1_0.1', '1_0.2'],
+            ['2_0.1', '2_0.2']],
+    <BLANKLINE>
+           [['1-0.1', '1-0.2'],
+            ['2-0.1', '2-0.2']],
+    <BLANKLINE>
+           [['1|0.1', '1|0.2'],
+            ['2|0.1', '2|0.2']]], dtype='<U5')
+    Dimensions without coordinates: X, Y, Z
 
     .. note::
         When using ``%`` formatting with a dict, the values are always used as a


### PR DESCRIPTION
`iris=3.16.0` apparently didn't test some changes enough, so some bugs in its interaction with `ncdata` slipped through. Until that is resolved in `iris`, we'll avoid `3.16.0`.

Also, for one reason or another the indented string accessor examples (on the class) started to fail.