### PR TITLE
use a maintained version of emscripten-forge

### DIFF
--- a/doc/environment_template.yml
+++ b/doc/environment_template.yml
@@ -1,6 +1,6 @@
 name: xeus-python-kernel
 channels:
-  - https://prefix.dev/emscripten-forge-dev
+  - https://prefix.dev/emscripten-forge-4x
   - https://prefix.dev/conda-forge
 dependencies:
   - xeus-python


### PR DESCRIPTION
As recommended in the post-merge reviews of #10299, it is better to not use `emscripten-forge-dev` anymore.