### PR TITLE
Return an empty result from rolling and cumulative on a zero-length dimension

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -56,7 +56,7 @@ Bug Fixes
 - :py:meth:`DataArray.cumulative` and :py:meth:`Dataset.cumulative` no longer raise
   ``ValueError: window must be > 0`` on a dimension of length 0, and
   :py:meth:`DataArray.rolling` no longer raises on one either. Both now return an
-  empty result, matching :py:meth:`DataArray.cumsum` (:pull:`PRNUM`).
+  empty result, matching :py:meth:`DataArray.cumsum` (:pull:`11572`).
   By `Chirag Gupta <https://github.com/chiruu12>`_.
 - Fix async zarr tests using ``wraps`` with ``autospec=True`` on async methods,
   which caused ``AsyncMock`` objects to leak through instead of real array data

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -53,6 +53,11 @@ Deprecations
 Bug Fixes
 ~~~~~~~~~
 
+- :py:meth:`DataArray.cumulative` and :py:meth:`Dataset.cumulative` no longer raise
+  ``ValueError: window must be > 0`` on a dimension of length 0, and
+  :py:meth:`DataArray.rolling` no longer raises on one either. Both now return an
+  empty result, matching :py:meth:`DataArray.cumsum` (:pull:`PRNUM`).
+  By `Chirag Gupta <https://github.com/chiruu12>`_.
 - Fix async zarr tests using ``wraps`` with ``autospec=True`` on async methods,
   which caused ``AsyncMock`` objects to leak through instead of real array data
   (:pull:`11232`).

--- a/xarray/computation/rolling.py
+++ b/xarray/computation/rolling.py
@@ -276,6 +276,17 @@ class Rolling(Generic[T_Xarray]):
 
     count.__doc__ = _ROLLING_REDUCE_DOCSTRING_TEMPLATE.format(name="count")
 
+    @property
+    def _rolls_an_empty_dim(self) -> bool:
+        """Whether any rolled dimension has length 0.
+
+        Both accelerated paths reject a window wider than the axis, which a
+        window over 0 elements always is: numbagg raises "window not in valid
+        range" and bottleneck has its own limit. The result is empty either
+        way, so the generic path handles it.
+        """
+        return any(self.obj.sizes[d] == 0 for d in self.dim)
+
     def _mapping_to_list(
         self,
         arg: _T | Mapping[Any, _T],
@@ -775,6 +786,7 @@ class DataArrayRolling(Rolling["DataArray"]):
             # Numbagg doesn't handle object arrays and generally has dtype consistency,
             # so doesn't deal well with bool arrays which are expected to change type.
             and self.obj.data.dtype.kind not in "ObMm"
+            and not self._rolls_an_empty_dim
             # TODO: we could also allow this, probably as part of a refactoring of this
             # module, so we can use the machinery in `self.reduce`.
             and self.ndim == 1
@@ -802,6 +814,7 @@ class DataArrayRolling(Rolling["DataArray"]):
             )
             and self.ndim == 1
             and xp is np
+            and not self._rolls_an_empty_dim
         ):
             return self._bottleneck_reduce(
                 bottleneck_move_func, keep_attrs=keep_attrs, **kwargs

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -7455,14 +7455,19 @@ class DataArray(
                 raise ValueError(
                     f"Dimension {dim} not found in data dimensions: {self.dims}"
                 )
-            dim = {dim: self.sizes[dim]}
+            # A window of the dimension's own size, floored at 1. Rolling
+            # refuses a window of 0, but that guard is for a window the caller
+            # chose; here it is derived from the data, and an empty selection
+            # is ordinary. cumsum returns an empty result for the same input,
+            # and a window of 1 over 0 elements returns one too.
+            dim = {dim: max(self.sizes[dim], 1)}
         else:
             missing_dims = set(dim) - set(self.dims)
             if missing_dims:
                 raise ValueError(
                     f"Dimensions {missing_dims} not found in data dimensions: {self.dims}"
                 )
-            dim = {d: self.sizes[d] for d in dim}
+            dim = {d: max(self.sizes[d], 1) for d in dim}
 
         return DataArrayRolling(self, dim, min_periods=min_periods, center=False)
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -10572,14 +10572,19 @@ class Dataset(
                 raise ValueError(
                     f"Dimension {dim} not found in data dimensions: {self.dims}"
                 )
-            dim = {dim: self.sizes[dim]}
+            # A window of the dimension's own size, floored at 1. Rolling
+            # refuses a window of 0, but that guard is for a window the caller
+            # chose; here it is derived from the data, and an empty selection
+            # is ordinary. cumsum returns an empty result for the same input,
+            # and a window of 1 over 0 elements returns one too.
+            dim = {dim: max(self.sizes[dim], 1)}
         else:
             missing_dims = set(dim) - set(self.dims)
             if missing_dims:
                 raise ValueError(
                     f"Dimensions {missing_dims} not found in data dimensions: {self.dims}"
                 )
-            dim = {d: self.sizes[d] for d in dim}
+            dim = {d: max(self.sizes[d], 1) for d in dim}
 
         return DatasetRolling(self, dim, min_periods=min_periods, center=False)
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -2240,15 +2240,30 @@ class Variable(NamedArray, AbstractArray, VariableArithmetic):
             else:
                 pads[d] = (win - 1, 0)
 
+        # A dimension of length 0 yields 0 windows, but the left pad of
+        # ``win - 1`` leaves fewer elements than the window, and
+        # sliding_window_view refuses that outright. Padding it out to a full
+        # window produces one window instead of none, so the extra is sliced
+        # back off below. Doing it this way keeps the array in its own
+        # namespace rather than reaching for an empty numpy array.
+        empty_dims = {d for d in dim if self.sizes[d] == 0}
+        for d, win in zip(dim, window, strict=True):
+            if d in empty_dims:
+                start, end = pads[d]
+                pads[d] = (start, end + win)
+
         padded = var.pad(pads, mode="constant", constant_values=fill_value)
         axis = self.get_axis_num(dim)
         new_dims = self.dims + tuple(window_dim)
-        return Variable(
-            new_dims,
-            duck_array_ops.sliding_window_view(
-                padded.data, window_shape=window, axis=axis, **kwargs
-            ),
+        windowed = duck_array_ops.sliding_window_view(
+            padded.data, window_shape=window, axis=axis, **kwargs
         )
+        if empty_dims:
+            trim = tuple(
+                slice(0, 0) if d in empty_dims else slice(None) for d in self.dims
+            )
+            windowed = windowed[trim]
+        return Variable(new_dims, windowed)
 
     def coarsen(
         self, windows, func, boundary="exact", side="left", keep_attrs=None, **kwargs

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -1000,3 +1000,63 @@ class TestDatasetRollingExp:
             match="Passing ``keep_attrs`` to ``rolling_exp`` has no effect.",
         ):
             ds.rolling_exp(time=10, keep_attrs=True)
+
+
+@pytest.mark.parametrize("dim_arg", ["x", ["x"]])
+def test_cumulative_on_empty_dimension(dim_arg) -> None:
+    """cumulative derives its window from the data, so length 0 is not a bad window.
+
+    cumsum returns an empty result for the same input. Before the fix the
+    derived window of 0 hit Rolling's window guard, and the user saw
+    "window must be > 0" about a window they never chose.
+    """
+    da = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("x", "y"),
+        coords={"x": [0, 1], "y": [0, 1, 2]},
+    )
+    empty = da.isel(x=slice(0, 0))
+
+    actual = empty.cumulative(dim_arg).sum()
+
+    assert actual.shape == (0, 3)
+    assert_allclose(actual, empty.cumsum("x"))
+
+
+def test_cumulative_on_empty_dimension_dataset() -> None:
+    ds = xr.Dataset(
+        {"v": (("x", "y"), np.arange(6.0).reshape(2, 3))},
+        coords={"x": [0, 1], "y": [0, 1, 2]},
+    )
+    empty = ds.isel(x=slice(0, 0))
+
+    actual = empty.cumulative("x").sum()
+
+    assert actual["v"].shape == (0, 3)
+    assert_allclose(actual, empty.cumsum("x"))
+
+
+@pytest.mark.parametrize("window", [1, 3])
+@pytest.mark.parametrize("center", [True, False])
+def test_rolling_on_empty_dimension(window, center) -> None:
+    """A window wider than an empty dimension yields no windows, not an error."""
+    da = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("x", "y"),
+        coords={"x": [0, 1], "y": [0, 1, 2]},
+    )
+    empty = da.isel(x=slice(0, 0))
+
+    assert empty.rolling(x=window, center=center).mean().shape == (0, 3)
+    assert empty.rolling(x=window, center=center).construct("w").shape == (0, 3, window)
+
+
+def test_rolling_on_two_empty_dimensions() -> None:
+    da = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("x", "y"),
+        coords={"x": [0, 1], "y": [0, 1, 2]},
+    )
+    empty = da.isel(x=slice(0, 0), y=slice(0, 0))
+
+    assert empty.cumulative(["x", "y"]).sum().shape == (0, 0)


### PR DESCRIPTION
`cumulative` derives its window from the size of the dimension, so on a dimension of
length 0 it asks `Rolling` for a window of 0 and gets back `ValueError: window must be
> 0`, about a window the caller never chose. `cumsum` returns an empty result for the
same input.

```python
da = xr.DataArray(np.arange(6.0).reshape(2, 3), dims=("x", "y"))
empty = da.isel(x=slice(0, 0))

empty.cumsum("x")               # <xarray.DataArray (x: 0, y: 3)>
empty.cumulative("x").sum()     # ValueError: window must be > 0
```

An empty selection is ordinary, so this shows up on data that happens to filter down to
nothing rather than on anything malformed.

The window guard is right for a window the caller picked, so `cumulative` now floors its
derived window at 1 instead. That alone was not enough. `rolling_window` pads by
`win - 1`, which leaves a zero-length dimension shorter than the window, and
`sliding_window_view` refuses that outright, so plain `rolling` failed on an empty
dimension too:

```python
empty.rolling(x=1).mean()       # ValueError: window shape cannot be larger than input array shape
```

A zero-length dimension yields zero windows. Padding it out to one full window gives
`sliding_window_view` something it accepts, and the one window it produces is sliced back
off. Slicing rather than building a fresh empty array keeps the data in whatever
namespace it arrived in.

Not fixed here: the same call on a dask-backed array still fails, in `dask.array.pad`
with `ZeroDivisionError` for a window above 1 and `The overlapping depth 1 is larger than
your array 0` for a window of 1. Both reproduce on an unmodified main, so this is a dask
limitation upstream of the change rather than something it introduced. Happy to look at
it separately if you want it in scope.

Tests cover both entry points, both container types, `dim` as a string and as a list,
centered and not, windows of 1 and 3, and two empty dimensions at once. All eight fail on
the commit before the fix.

`test_rolling.py test_dataarray.py test_dataset.py test_computation.py`: 4300 passed. Three
failures in `test_dataset.py` (`test_sel`, two `test_chunk_by_season_resampler`) reproduce
on an unmodified main and look like a local pandas version. `test_variable.py` does not
collect on main here for the same reason. `ruff check` and `ruff format --check` clean.