### PR TITLE
Let concat promote a mix of numpy and pandas extension coord dtypes

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -120,6 +120,12 @@ Bug Fixes
 - Fixed a bug that caused rechunking a multi-dimensional cftime array along a
   subset of its dimensions to raise an error (:issue:`11567`, :pull:`11576`).
   By `Spencer Clark <https://github.com/spencerkclark>`_.
+- :py:func:`concat` no longer raises ``TypeError: Cannot interpret
+  '<StringDtype(...)>' as a data type`` when the objects being joined carry
+  index coordinates with a mix of numpy and pandas extension dtypes, which
+  happens routinely under pandas 3 when one dimension coordinate came from a
+  :py:class:`pandas.Index` and another from a plain list (:issue:`11317`).
+  By `Dipak Chaudhari <https://github.com/dchaudhari7177>`_.
 
 .. _`pandas-dev/pandas#64793`: https://github.com/pandas-dev/pandas/pull/64793
 

--- a/xarray/core/indexes.py
+++ b/xarray/core/indexes.py
@@ -789,6 +789,16 @@ class PandasIndex(Index):
             indexes_coord_dtypes = {idx.coord_dtype for idx in indexes}
             if len(indexes_coord_dtypes) == 1:
                 coord_dtype = next(iter(indexes_coord_dtypes))
+            elif any(
+                isinstance(dtype, pd.api.extensions.ExtensionDtype)
+                for dtype in indexes_coord_dtypes
+            ):
+                # np.result_type cannot interpret a pandas extension dtype, and
+                # mixing one with a numpy dtype is ordinary now that pandas
+                # gives string indexes a StringDtype. _concat_indexes above has
+                # already had pandas promote these, so use the dtype it settled
+                # on rather than reimplementing pandas' rules here.
+                coord_dtype = new_pd_index.dtype
             else:
                 coord_dtype = np.result_type(*indexes_coord_dtypes)
 

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -1491,6 +1491,29 @@ def test_concat_index_not_same_dim() -> None:
         concat([ds1, ds2], dim="x")
 
 
+def test_concat_mixed_numpy_and_extension_coord_dtype() -> None:
+    # GH11317. Passing a pd.Index as the concat dim gives that index a pandas
+    # extension dtype (StringDtype under pandas 3), while a coord built from a
+    # plain list keeps a numpy <U dtype. PandasIndex.concat promoted the two
+    # with np.result_type, which cannot interpret an extension dtype at all.
+    da = DataArray([0], dims=["dim_a"], coords={"dim_a": ["a"]})
+    db = concat([DataArray([0])], pd.Index(["b"], name="dim_a"))
+
+    actual = concat([da, db], dim="dim_a")
+
+    assert list(actual.coords["dim_a"].values) == ["a", "b"]
+    assert actual.sizes["dim_a"] == 2
+
+
+def test_concat_same_numpy_coord_dtypes_still_promote_with_numpy() -> None:
+    # The extension-dtype branch must not swallow the ordinary case: two numpy
+    # string coords of different widths still promote to the wider numpy dtype.
+    da = DataArray([0], dims=["d"], coords={"d": ["aaa"]})
+    db = DataArray([1], dims=["d"], coords={"d": ["b"]})
+
+    assert concat([da, db], dim="d").coords["d"].dtype == np.dtype("<U3")
+
+
 class TestNewDefaults:
     def test_concat_second_empty_with_scalar_data_var_only_on_first(self) -> None:
         ds1 = Dataset(data_vars={"a": ("y", [0.1]), "b": 0.1}, coords={"x": 0.1})


### PR DESCRIPTION
Fixes #11317

### The failure

`PandasIndex.concat` promotes the coordinate dtypes of the indexes it joins with `np.result_type` (`xarray/core/indexes.py:793`), which cannot interpret a pandas extension dtype. Under pandas 3 a string index carries a `StringDtype`, so the reporter's case has one coord at `<U1` and the other at `StringDtype` and raises:

```
TypeError: Cannot interpret '<StringDtype(na_value=nan)>' as a data type
```

This is not an exotic mix — it is what you get whenever one dimension coordinate came from a `pd.Index` (which is how `concat` is documented to add a new labelled dimension) and another from a plain list.

### The fix

By the time the dtypes are promoted, `_concat_indexes` has already built the joined index, and pandas promoted the dtypes to do so. When any input coord dtype is a `pd.api.extensions.ExtensionDtype`, use the dtype pandas settled on rather than reimplementing its promotion rules here:

```python
elif any(
    isinstance(dtype, pd.api.extensions.ExtensionDtype)
    for dtype in indexes_coord_dtypes
):
    coord_dtype = new_pd_index.dtype
```

Two numpy dtypes still go through `np.result_type` unchanged, so ordinary promotion (`<U1` + `<U3` → `<U3`) is untouched.

I deliberately did not touch `xarray.core.dtypes.result_type`, which fails the same way on this pair. Making the general promotion path extension-aware is a larger decision about the pandas-3 string transition and would likely collide with in-flight work such as #11474; this keeps the change to the one site the issue is about.

### Verified

- The issue's reproducer now returns a 2-element `dim_a` with values `['a', 'b']`.
- The `xr.Variable` form the reporter noted still works is unchanged (`<U1`).
- Red before green: with both new tests in place and `indexes.py` reverted, `test_concat_mixed_numpy_and_extension_coord_dtype` fails with the original `TypeError`, and the numpy-path test passes either way — so it is guarding against the new branch swallowing the ordinary case.
- `pytest xarray/tests/test_concat.py xarray/tests/test_indexes.py xarray/tests/test_dataset.py` — 680 passed, 59 skipped, 1 xfailed, 1 xpassed.
- `ruff check` clean at the pinned v0.15.20.

Environment: pandas 3.0.3, numpy 2.x, Windows.

`whats-new.rst` entry added under Bug fixes.
