### PR TITLE
Fix pandas roundtrip property test

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -4,14 +4,7 @@ import copy
 import datetime
 import json
 import warnings
-from collections.abc import (
-    Callable,
-    Collection,
-    Hashable,
-    Iterable,
-    Mapping,
-    Sequence,
-)
+from collections.abc import Callable, Collection, Hashable, Iterable, Mapping, Sequence
 from functools import partial
 from os import PathLike
 from types import EllipsisType
@@ -4778,6 +4771,10 @@ class DataArray(
         Dataset.from_dataframe
         """
         temp_name = "__temporary_name"
+        if temp_name == series.index.name:
+            # See properties/test_pandas_roundtrip.py:
+            # @reproduce_failure('6.155.2', b'AEEAQQBBAQFBAEEBAJBfX3RlbXBvcmFyeV9uYW1l')
+            temp_name = "__temporary_name_fallback"
         df = pd.DataFrame({temp_name: series})
         ds = Dataset.from_dataframe(df, sparse=sparse)
         result = ds[temp_name]


### PR DESCRIPTION
### Description

If the series index name clashes with the temporary name (`"__temporary_name"`), then just append (`_fallback`) to that name. Chance in a million, probably less, and might be worth altering the Hypothesis generation strategy to exclude this case instead.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #11574 
- [x] Fixes existing test failure


I had AI (Claude Opus 4.8) pin down the cause of the failing property test and generate the MRE on the issue. Fix was written by hand.