### PR TITLE
Fix bug in rechunking cftime arrays along a subset of dimensions

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -117,6 +117,9 @@ Bug Fixes
   type error when applying reduction methods, due to the reduction methods being
   dynamically generated (:issue:`8136`).
   By `Andrew Scherer <https://github.com/andrew-s28>`_.
+- Fixed a bug that caused rechunking a multi-dimensional cftime array along a
+  subset of its dimensions to raise an error (:issue:`11567`, :pull:`11576`).
+  By `Spencer Clark <https://github.com/spencerkclark>`_.
 
 .. _`pandas-dev/pandas#64793`: https://github.com/pandas-dev/pandas/pull/64793
 

--- a/xarray/namedarray/parallelcompat.py
+++ b/xarray/namedarray/parallelcompat.py
@@ -359,12 +359,12 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
         if _contains_cftime_datetimes(data):
             preferred_chunks = dict(enumerate(data.chunks))
             chunks2 = _get_chunk(
-                data,
+                data,  # type: ignore[arg-type]
                 chunks,
                 self,
                 preferred_chunks=preferred_chunks,
                 dims=preferred_chunks.keys(),
-            )  # type: ignore[arg-type]
+            )
         else:
             chunks2 = chunks  # type: ignore[assignment]
         return data.rechunk(chunks2, **kwargs)

--- a/xarray/namedarray/parallelcompat.py
+++ b/xarray/namedarray/parallelcompat.py
@@ -357,7 +357,14 @@ class ChunkManagerEntrypoint(ABC, Generic[T_ChunkedArray]):
         from xarray.namedarray.utils import _get_chunk
 
         if _contains_cftime_datetimes(data):
-            chunks2 = _get_chunk(data, chunks, self, preferred_chunks={})  # type: ignore[arg-type]
+            preferred_chunks = dict(enumerate(data.chunks))
+            chunks2 = _get_chunk(
+                data,
+                chunks,
+                self,
+                preferred_chunks=preferred_chunks,
+                dims=preferred_chunks.keys(),
+            )  # type: ignore[arg-type]
         else:
             chunks2 = chunks  # type: ignore[assignment]
         return data.rechunk(chunks2, **kwargs)

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -1237,6 +1237,20 @@ def test_auto_chunk_da_cftime():
     assert actual.chunks == expected.chunks
 
 
+@pytest.mark.parametrize(
+    ("chunks", "expected"),
+    [({"x": 2, "y": 3}, ((2,), (3,))), ({"x": 2}, ((2,), (1, 1, 1)))],
+    ids=lambda x: f"{x}",
+)
+def test_rechunk_multi_dimensional_da_cftime(chunks, expected):
+    times = xr.date_range("2000", periods=6, use_cftime=True)
+    times = times.to_numpy().reshape((2, 3))
+    da = xr.DataArray(times, dims=["x", "y"])
+    da = da.chunk({"x": 1, "y": 1})
+    result = da.chunk(chunks).chunks
+    assert result == expected
+
+
 def test_map_blocks_error(map_da, map_ds):
     def bad_func(darray):
         return (darray * darray.x + 5 * darray.y)[:1, :1]


### PR DESCRIPTION
### Description

This PR proposes a fix for the issue that prevents rechunking multi-dimensional cftime arrays along a subset of its dimensions.  It does so by preserving the chunks along dimensions that were not specified in the new target chunks, as is done for non-cftime arrays.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #11567 
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

### AI Disclosure

This PR was created without AI.
