### PR TITLE
TYP: annotate open_zarr chunks argument

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -29,6 +29,7 @@ from xarray.core import indexing
 from xarray.core.treenode import NodePath
 from xarray.core.types import ZarrWriteModes
 from xarray.core.utils import (
+    Default,
     FrozenDict,
     HiddenKeyDict,
     _default,
@@ -1405,7 +1406,7 @@ class ZarrStore(AbstractWritableDataStore):
 def open_zarr(
     store,
     group=None,
-    chunks: int | dict | None | Literal["auto", _default] = _default,
+    chunks: int | dict | None | Literal["auto"] | Default = _default,
     decode_cf=True,
     mask_and_scale=True,
     decode_times=True,

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -27,7 +27,7 @@ from xarray.backends.store import StoreBackendEntrypoint
 from xarray.conventions import ZARR_CODERS
 from xarray.core import indexing
 from xarray.core.treenode import NodePath
-from xarray.core.types import T_Chunks, ZarrWriteModes
+from xarray.core.types import ZarrWriteModes
 from xarray.core.utils import (
     FrozenDict,
     HiddenKeyDict,
@@ -1405,7 +1405,7 @@ class ZarrStore(AbstractWritableDataStore):
 def open_zarr(
     store,
     group=None,
-    chunks: T_Chunks | Literal[_default] = _default,
+    chunks: int | dict | None | Literal["auto", _default] = _default,
     decode_cf=True,
     mask_and_scale=True,
     decode_times=True,

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -27,7 +27,7 @@ from xarray.backends.store import StoreBackendEntrypoint
 from xarray.conventions import ZARR_CODERS
 from xarray.core import indexing
 from xarray.core.treenode import NodePath
-from xarray.core.types import ZarrWriteModes
+from xarray.core.types import T_Chunks, ZarrWriteModes
 from xarray.core.utils import (
     FrozenDict,
     HiddenKeyDict,
@@ -1405,7 +1405,7 @@ class ZarrStore(AbstractWritableDataStore):
 def open_zarr(
     store,
     group=None,
-    chunks=_default,
+    chunks: T_Chunks | Literal[_default] = _default,
     decode_cf=True,
     mask_and_scale=True,
     decode_times=True,


### PR DESCRIPTION
### Description

Adds a precise type annotation for the `chunks` argument of `open_zarr`.

The annotation reflects the values accepted by the public API:
- `int`
- `dict`
- `None`
- `"auto"`
- the internal `_default` sentinel

This fixes the type-checking issue where `"auto"` was incorrectly rejected by static type checkers.

### Checklist

- [x] Closes #11221
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`

### AI Disclosure

- [x] This PR contains AI-generated content.
    - [x] I have tested any AI-generated content in my PR.
    - [x] I take responsibility for any AI-generated content in my PR.

Tools: ChatGPT, Codex