### PR TITLE
Add `xarray.open_zarr_async()`

### DIFF
--- a/doc/api/io.rst
+++ b/doc/api/io.rst
@@ -13,6 +13,7 @@ Dataset methods
    open_dataset
    open_mfdataset
    open_zarr
+   open_zarr_async
    save_mfdataset
    Dataset.as_numpy
    Dataset.from_dataframe

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -13,6 +13,9 @@ v2026.07.1 (unreleased)
 
 New Features
 ~~~~~~~~~~~~
+- Add :py:func:`open_zarr_async` to open Zarr datasets on the caller's event loop,
+  including asynchronous coordinate loading, without the synchronous Zarr bridge.
+
 - Added `PyArrowCapsule interface <https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html#arrow-pycapsule-interface>`_
   to :py:class:`DataArray` (``__arrow_c_schema__`` and ``__arrow_c_stream__``), enabling near zero-copy
   export to pyarrow, polars or duckdb.

--- a/xarray/__init__.py
+++ b/xarray/__init__.py
@@ -12,7 +12,7 @@ from xarray.backends.api import (
     open_mfdataset,
 )
 from xarray.backends.writers import save_mfdataset
-from xarray.backends.zarr import open_zarr
+from xarray.backends.zarr import open_zarr, open_zarr_async
 from xarray.coding.cftime_offsets import cftime_range, date_range, date_range_like
 from xarray.coding.cftimeindex import CFTimeIndex
 from xarray.coding.frequencies import infer_freq
@@ -108,6 +108,7 @@ __all__ = (  # noqa: RUF022
     "open_groups",
     "open_mfdataset",
     "open_zarr",
+    "open_zarr_async",
     "polyval",
     "register_dataarray_accessor",
     "register_dataset_accessor",

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -851,13 +851,15 @@ class ZarrStore(AbstractWritableDataStore):
         # TODO: consider deprecating this in favor of zarr_group
         return self.zarr_group
 
-    def open_store_variable(self, name):
+    def open_store_variable(self, name, *, dimensions_and_attributes=None):
         zarr_array = self.members[name]
         data = indexing.LazilyIndexedArray(ZarrArrayWrapper(zarr_array))
         try_nczarr = self._mode == "r"
-        dimensions, attributes = _get_zarr_dims_and_attrs(
-            zarr_array, DIMENSION_KEY, try_nczarr
-        )
+        if dimensions_and_attributes is None:
+            dimensions_and_attributes = _get_zarr_dims_and_attrs(
+                zarr_array, DIMENSION_KEY, try_nczarr
+            )
+        dimensions, attributes = dimensions_and_attributes
         attributes = dict(attributes)
 
         encoding = {
@@ -1601,6 +1603,220 @@ def open_zarr(
         use_zarr_fill_value_as_mask=use_zarr_fill_value_as_mask,
     )
     return ds
+
+
+class _AsyncOpenZarrStore(ZarrStore):
+    """A ZarrStore whose variables have been prepared on the caller's loop."""
+
+    __slots__ = ("_variables",)
+    _variables: dict[str, Variable]
+
+    def get_variables(self):
+        return self._variables
+
+
+async def open_zarr_async(
+    store,
+    group=None,
+    *,
+    decode_cf=True,
+    mask_and_scale=True,
+    decode_times=True,
+    concat_characters=True,
+    decode_coords: Literal["coordinates", "all"] | bool = True,
+    drop_variables=None,
+    consolidated=None,
+    storage_options=None,
+    decode_timedelta=None,
+    use_cftime=None,
+    zarr_format=None,
+    use_zarr_fill_value_as_mask=None,
+    create_default_indexes=True,
+) -> Dataset:
+    """Asynchronously open a Zarr dataset without a synchronous Zarr bridge.
+
+    Requires Zarr-Python 3. Metadata and any eager reads run on the caller's
+    event loop. Data variables remain lazy and can be selected with ``isel``
+    and read with ``await dataset.load_async()``. No Dask arrays are created.
+    Synchronous access to unloaded data still uses Zarr's synchronous API.
+
+    Parameters
+    ----------
+    store : str, PathLike or zarr.abc.store.Store
+        Zarr store or path to open in read-only mode.
+    group : str, optional
+        Group path within the store.
+    decode_cf : bool, default: True
+        Whether to decode CF conventions.
+    mask_and_scale : bool or dict-like, default: True
+        Apply missing-value masks and scale/offset decoding.
+    decode_times : bool, CFDatetimeCoder or dict-like, default: True
+        Decode CF datetimes. These variables are loaded asynchronously before
+        decoding, even with indexes disabled. Set to False to keep them lazy.
+    concat_characters : bool or dict-like, default: True
+        Concatenate character arrays into strings.
+    decode_coords : bool or {"coordinates", "all"}, default: True
+        Promote variables referenced by coordinate attributes to coordinates.
+    drop_variables : str or iterable of str, optional
+        Variables to exclude before decoding or reading their data.
+    consolidated : bool, optional
+        Require consolidated metadata if True, ignore it if False, or use it
+        when available if None. Root consolidated metadata is used for subgroups.
+    storage_options : dict, optional
+        Storage options passed to Zarr.
+    decode_timedelta : bool, CFTimedeltaCoder or dict-like, optional
+        Control timedelta decoding, as in :func:`open_zarr`.
+    use_cftime : bool, optional
+        Control cftime decoding, as in :func:`open_zarr`.
+    zarr_format : {2, 3}, optional
+        Zarr format. By default, infer it from the store.
+    use_zarr_fill_value_as_mask : bool, optional
+        Interpret the Zarr fill value as missing data. Defaults to True for
+        format 2 and False for format 3.
+    create_default_indexes : bool, default: True
+        Load dimension coordinates asynchronously and create pandas indexes.
+        Set to False to leave those coordinates lazy.
+
+    Returns
+    -------
+    Dataset
+        An opened dataset with lazy arrays and optional in-memory indexes.
+
+    Notes
+    -----
+    This function does not start worker threads. The store and codecs must
+    themselves support thread-free asynchronous I/O for use in WebAssembly.
+
+    Examples
+    --------
+    Open metadata, select a region lazily, then await its data:
+
+    >>> ds = await xr.open_zarr_async(store, create_default_indexes=False)  # doctest: +SKIP
+    >>> subset = await ds.isel(x=slice(0, 100)).load_async()  # doctest: +SKIP
+
+    See Also
+    --------
+    open_zarr
+    Dataset.load_async
+    """
+    from zarr import Array, AsyncGroup, Group
+    from zarr.api import asynchronous as zarr_async
+
+    from xarray.backends.api import (
+        _dataset_from_backend_dataset,
+        _maybe_create_default_indexes,
+    )
+
+    store = _normalize_path(store)
+    if not getattr(store, "supports_consolidated_metadata", True):
+        consolidated = False
+    # Open the root first so consolidated metadata can describe a subgroup.
+    root = await zarr_async.open_group(
+        store,
+        mode="r",
+        path=group if consolidated is False else None,
+        storage_options=storage_options,
+        zarr_format=zarr_format,
+        use_consolidated=consolidated,
+    )
+    owns_store = root.store is not store
+    try:
+        opened = root
+        if consolidated is not False and group and group != "/":
+            opened = await root.getitem(group.removeprefix("/"))
+        if not isinstance(opened, AsyncGroup):
+            raise TypeError(f"Expected a Zarr group at {group!r}")
+        if use_zarr_fill_value_as_mask is None:
+            use_zarr_fill_value_as_mask = opened.metadata.zarr_format == 2
+        backend = _AsyncOpenZarrStore(
+            Group(opened),
+            mode="r",
+            close_store_on_close=owns_store,
+            use_zarr_fill_value_as_mask=use_zarr_fill_value_as_mask,
+            cache_members=False,
+        )
+        # These synchronous wrappers only expose already-loaded metadata.
+        # All member discovery and subsequent data loading are awaited.
+        backend._members = {
+            name: Group(member) if isinstance(member, AsyncGroup) else Array(member)
+            async for name, member in opened.members()
+        }
+        backend._cache_members = True
+        backend._variables = {}
+        dropped = (
+            {drop_variables}
+            if isinstance(drop_variables, str)
+            else set(drop_variables or ())
+        )
+        for name in backend.array_keys():
+            if name in dropped:
+                continue
+            array = backend._members[name]
+            dimensions_and_attributes = None
+            if opened.metadata.zarr_format == 2 and DIMENSION_KEY not in array.attrs:
+                # NCZarr stores dimensions in .zarray rather than attributes.
+                buffer = await (opened.store_path / name / ".zarray").get()
+                metadata = json.loads(buffer.to_bytes()) if buffer is not None else {}
+                try:
+                    dimensions = [
+                        os.path.basename(dim)
+                        for dim in metadata["_NCZARR_ARRAY"]["dimrefs"]
+                    ]
+                except KeyError as error:
+                    raise KeyError(
+                        f"Zarr array {name!r} is missing dimension metadata"
+                    ) from error
+                attributes = {
+                    k: v
+                    for k, v in array.attrs.items()
+                    if not k.lower().startswith("_nc")
+                }
+                dimensions_and_attributes = dimensions, attributes
+            variable = backend.open_store_variable(
+                name, dimensions_and_attributes=dimensions_and_attributes
+            )
+            # CF datetime decoding probes values synchronously to infer dtype.
+            # Materialize these variables asynchronously before that step.
+            times = (
+                decode_times.get(name, True)
+                if isinstance(decode_times, Mapping)
+                else decode_times
+            )
+            units = variable.attrs.get("units")
+            if decode_cf and times and isinstance(units, str) and "since" in units:
+                await variable.load_async()
+            backend._variables[name] = variable
+        ds = StoreBackendEntrypoint().open_dataset(
+            backend,
+            mask_and_scale=mask_and_scale if decode_cf else False,
+            decode_times=decode_times if decode_cf else False,
+            concat_characters=concat_characters if decode_cf else False,
+            decode_coords=decode_coords if decode_cf else False,
+            decode_timedelta=decode_timedelta if decode_cf else False,
+            use_cftime=use_cftime,
+        )
+        if create_default_indexes:
+            for name, coord in ds.coords.items():
+                if coord.dims == (name,) and name not in ds.xindexes:
+                    await ds.variables[name].load_async()
+            ds = _maybe_create_default_indexes(ds)
+        ds.set_close(backend.close)
+        return _dataset_from_backend_dataset(
+            ds,
+            store,
+            "zarr",
+            chunks=None,
+            cache=False,
+            overwrite_encoded_chunks=False,
+            inline_array=False,
+            chunked_array_type=None,
+            from_array_kwargs={},
+            create_default_indexes=False,
+        )
+    except BaseException:
+        if owns_store:
+            root.store.close()
+        raise
 
 
 class ZarrBackendEntrypoint(BackendEntrypoint):

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1723,9 +1723,11 @@ async def open_zarr_async(
     )
     owns_store = root.store is not store
     try:
-        opened = root
-        if consolidated is not False and group and group != "/":
-            opened = await root.getitem(group.removeprefix("/"))
+        opened = (
+            await root.getitem(group.removeprefix("/"))
+            if consolidated is not False and group and group != "/"
+            else root
+        )
         if not isinstance(opened, AsyncGroup):
             raise TypeError(f"Expected a Zarr group at {group!r}")
         if use_zarr_fill_value_as_mask is None:
@@ -1798,9 +1800,9 @@ async def open_zarr_async(
             use_cftime=use_cftime,
         )
         if create_default_indexes:
-            for name, coord in ds.coords.items():
-                if coord.dims == (name,) and name not in ds.xindexes:
-                    await ds.variables[name].load_async()
+            for coord_name, coord in ds.coords.items():
+                if coord.dims == (coord_name,) and coord_name not in ds.xindexes:
+                    await ds.variables[coord_name].load_async()
             ds = _maybe_create_default_indexes(ds)
         ds.set_close(backend.close)
         return _dataset_from_backend_dataset(

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -1691,7 +1691,9 @@ async def open_zarr_async(
     --------
     Open metadata, select a region lazily, then await its data:
 
-    >>> ds = await xr.open_zarr_async(store, create_default_indexes=False)  # doctest: +SKIP
+    >>> ds = await xr.open_zarr_async(
+    ...     store, create_default_indexes=False
+    ... )  # doctest: +SKIP
     >>> subset = await ds.isel(x=slice(0, 100)).load_async()  # doctest: +SKIP
 
     See Also

--- a/xarray/tests/test_zarr_async.py
+++ b/xarray/tests/test_zarr_async.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import numpy as np
+import pytest
+
+import xarray as xr
+from xarray.testing import assert_identical
+
+zarr = pytest.importorskip("zarr", minversion="3.0")
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def forbid_sync(monkeypatch):
+    def fail(*args, **kwargs):
+        raise AssertionError("async opening must not start threads or call Zarr sync")
+
+    import zarr.core.sync
+
+    monkeypatch.setattr(zarr.core.sync, "sync", fail)
+    monkeypatch.setattr(zarr.core.sync.SyncMixin, "_sync", fail)
+    monkeypatch.setattr(zarr.core.sync.SyncMixin, "_sync_iter", fail)
+
+
+@pytest.fixture
+def forbid_threads(monkeypatch):
+    def fail(*args, **kwargs):
+        raise AssertionError("async opening must not use a thread executor")
+
+    monkeypatch.setattr(threading.Thread, "start", fail)
+    monkeypatch.setattr(asyncio, "to_thread", fail)
+    monkeypatch.setattr(asyncio.get_running_loop(), "run_in_executor", fail)
+
+
+async def make_store(zarr_format=3, consolidated=False):
+    from zarr.api import asynchronous as za
+
+    store = zarr.storage.MemoryStore()
+    root = await za.open_group(store, mode="w", zarr_format=zarr_format)
+    group = await root.create_group("nested", attributes={"title": "async"})
+    for name, data, dims, attrs in [
+        ("x", np.arange(4), ("x",), {}),
+        ("value", np.arange(4, dtype="int16"), ("x",), {"scale_factor": 2.0}),
+        ("time", np.arange(4), ("x",), {"units": "days since 2000-01-01"}),
+    ]:
+        if zarr_format == 2:
+            attrs = dict(attrs, _ARRAY_DIMENSIONS=list(dims))
+        array = await group.create_array(
+            name,
+            shape=data.shape,
+            dtype=data.dtype,
+            chunks=(2,),
+            attributes=attrs,
+            dimension_names=dims if zarr_format == 3 else None,
+            compressors=None,
+            fill_value=None if zarr_format == 2 else 0,
+        )
+        await array.setitem(slice(None), data)
+    if consolidated:
+        await za.consolidate_metadata(store)
+    return store
+
+
+@pytest.mark.parametrize("zarr_format", [2, 3])
+@pytest.mark.parametrize("consolidated", [False, True])
+@pytest.mark.parametrize("indexes", [False, True])
+async def test_open_and_load_without_sync(zarr_format, consolidated, indexes, request):
+    store = await make_store(zarr_format, consolidated)
+    expected = xr.open_zarr(
+        store, group="nested", consolidated=consolidated, chunks=None
+    ).load()
+    request.getfixturevalue("forbid_sync")
+    # Zarr's format-2 codec itself uses asyncio.to_thread. This is independent
+    # of xarray's opening path; format-3 BytesCodec permits a thread-free test.
+    if zarr_format == 3:
+        request.getfixturevalue("forbid_threads")
+    ds = await xr.open_zarr_async(
+        store, group="nested", consolidated=consolidated, create_default_indexes=indexes
+    )
+    assert bool(ds.xindexes) is indexes
+    assert not isinstance(ds["value"].variable._data, np.ndarray)
+    subset = await ds.isel(x=slice(1, 3)).load_async()
+    if not indexes:
+        expected = expected.drop_indexes("x")
+    assert_identical(subset, expected.isel(x=slice(1, 3)))
+    ds.close()
+    assert store._is_open  # A caller-owned store remains open.
+
+
+async def test_raw_drop_and_missing(request):
+    store = await make_store()
+    request.getfixturevalue("forbid_sync")
+    ds = await xr.open_zarr_async(
+        store,
+        group="nested",
+        decode_cf=False,
+        drop_variables="time",
+        create_default_indexes=False,
+    )
+    assert "time" not in ds
+    assert ds["value"].attrs["scale_factor"] == 2.0
+    result = await ds.isel(x=[3, 1]).load_async()
+    np.testing.assert_array_equal(result["value"], [3, 1])
+    with pytest.raises((KeyError, FileNotFoundError)):
+        await xr.open_zarr_async(store, group="missing")
+    with pytest.raises(TypeError, match="Expected a Zarr group"):
+        await xr.open_zarr_async(store, group="nested/value")
+
+
+async def test_decode_times_false_keeps_time_lazy(request):
+    store = await make_store()
+    request.getfixturevalue("forbid_sync")
+    ds = await xr.open_zarr_async(
+        store, group="nested", decode_times=False, create_default_indexes=False
+    )
+    assert not isinstance(ds["time"].variable._data, np.ndarray)
+    np.testing.assert_array_equal((await ds["time"].load_async()).values, np.arange(4))
+
+
+async def test_store_reads_stay_on_callers_loop(request):
+    from zarr.storage import WrapperStore
+
+    store = await make_store()
+    loop = asyncio.get_running_loop()
+    reads = []
+
+    class LoopBoundStore(WrapperStore):
+        async def get(self, key, *args, **kwargs):
+            assert asyncio.get_running_loop() is loop
+            reads.append(key)
+            return await self._store.get(key, *args, **kwargs)
+
+    request.getfixturevalue("forbid_sync")
+    request.getfixturevalue("forbid_threads")
+    ds = await xr.open_zarr_async(
+        LoopBoundStore(store),
+        group="nested",
+        decode_times=False,
+        create_default_indexes=False,
+    )
+    assert not any("/c/" in key for key in reads)
+    await ds.isel(x=slice(0, 1)).load_async()
+    assert any("/c/" in key for key in reads)
+
+
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_owned_store_closed_on_failure(monkeypatch, cancel):
+    from zarr.api import asynchronous as za
+
+    store = await make_store()
+    root = await za.open_group(store, mode="r")
+
+    async def open_group(*args, **kwargs):
+        return root
+
+    async def getitem(*args, **kwargs):
+        if cancel:
+            raise asyncio.CancelledError
+        raise KeyError("missing")
+
+    monkeypatch.setattr(za, "open_group", open_group)
+    monkeypatch.setattr(type(root), "getitem", getitem)
+    error = asyncio.CancelledError if cancel else KeyError
+    with pytest.raises(error):
+        await xr.open_zarr_async("owned-store", group="missing")
+    assert not root.store._is_open
+
+
+@pytest.mark.parametrize("valid", [False, True])
+async def test_nczarr_dimensions(valid, request):
+    import json
+
+    from zarr.api import asynchronous as za
+    from zarr.core.buffer import default_buffer_prototype
+
+    store = zarr.storage.MemoryStore()
+    group = await za.open_group(store, mode="w", zarr_format=2)
+    await group.create_array("value", shape=(2,), dtype="int32", compressors=None)
+    prototype = default_buffer_prototype()
+    raw = await store.get("value/.zarray", prototype=prototype)
+    metadata = json.loads(raw.to_bytes())
+    if valid:
+        metadata["_NCZARR_ARRAY"] = {"dimrefs": ["/x"]}
+        await store.set(
+            "value/.zarray", prototype.buffer.from_bytes(json.dumps(metadata).encode())
+        )
+    request.getfixturevalue("forbid_sync")
+    if valid:
+        ds = await xr.open_zarr_async(store, consolidated=False)
+        assert ds["value"].dims == ("x",)
+        assert ds.sizes == {"x": 2}
+    else:
+        with pytest.raises(KeyError, match="missing dimension metadata"):
+            await xr.open_zarr_async(store, consolidated=False)
+    assert store._is_open

--- a/xarray/tests/test_zarr_async.py
+++ b/xarray/tests/test_zarr_async.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 
 import xarray as xr
 from xarray.testing import assert_identical
+
+if TYPE_CHECKING:
+    from zarr.core.common import JSON
 
 zarr = pytest.importorskip("zarr", minversion="3.0")
 pytestmark = pytest.mark.asyncio
@@ -41,11 +45,12 @@ async def make_store(zarr_format=3, consolidated=False):
     store = zarr.storage.MemoryStore()
     root = await za.open_group(store, mode="w", zarr_format=zarr_format)
     group = await root.create_group("nested", attributes={"title": "async"})
-    for name, data, dims, attrs in [
+    variables: list[tuple[str, np.ndarray, tuple[str, ...], dict[str, JSON]]] = [
         ("x", np.arange(4), ("x",), {}),
         ("value", np.arange(4, dtype="int16"), ("x",), {"scale_factor": 2.0}),
         ("time", np.arange(4), ("x",), {"units": "days since 2000-01-01"}),
-    ]:
+    ]
+    for name, data, dims, attrs in variables:
         if zarr_format == 2:
             attrs = dict(attrs, _ARRAY_DIMENSIONS=list(dims))
         array = await group.create_array(

--- a/xarray/tests/test_zarr_async.py
+++ b/xarray/tests/test_zarr_async.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 import xarray as xr
+from xarray.backends.zarr import has_zarr_async_index
 from xarray.testing import assert_identical
 
 if TYPE_CHECKING:
@@ -107,8 +108,8 @@ async def test_raw_drop_and_missing(request):
     )
     assert "time" not in ds
     assert ds["value"].attrs["scale_factor"] == 2.0
-    result = await ds.isel(x=[3, 1]).load_async()
-    np.testing.assert_array_equal(result["value"], [3, 1])
+    result = await ds.isel(x=slice(1, 3)).load_async()
+    np.testing.assert_array_equal(result["value"], [1, 2])
     with pytest.raises((KeyError, FileNotFoundError)):
         await xr.open_zarr_async(store, group="missing")
     with pytest.raises(TypeError, match="Expected a Zarr group"):
@@ -141,7 +142,7 @@ async def test_store_reads_stay_on_callers_loop(request):
     request.getfixturevalue("forbid_sync")
     request.getfixturevalue("forbid_threads")
     ds = await xr.open_zarr_async(
-        LoopBoundStore(store),
+        LoopBoundStore(store.with_read_only(True)),
         group="nested",
         decode_times=False,
         create_default_indexes=False,
@@ -201,3 +202,18 @@ async def test_nczarr_dimensions(valid, request):
         with pytest.raises(KeyError, match="missing dimension metadata"):
             await xr.open_zarr_async(store, consolidated=False)
     assert store._is_open
+
+
+@pytest.mark.skipif(
+    not has_zarr_async_index(),
+    reason="Async orthogonal indexing requires Zarr >= 3.1.2",
+)
+async def test_async_fancy_indexing(request):
+    store = await make_store()
+    request.getfixturevalue("forbid_sync")
+    request.getfixturevalue("forbid_threads")
+    ds = await xr.open_zarr_async(
+        store, group="nested", decode_cf=False, create_default_indexes=False
+    )
+    result = await ds.isel(x=[3, 1]).load_async()
+    np.testing.assert_array_equal(result["value"], [3, 1])


### PR DESCRIPTION
### Description

It looks like Zarr has an async API for opening a store, but xarray doesn't. There is only the sync `open_zarr()`, which calls the sync Zarr API which runs the async API in an event loop in a separate thread. I understand that this is not in the critical path (it's metadata), but that prevents using xarray in WASM Python, since threads are not supported there.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`

### AI Disclosure

<!--- Please review our AI & contribution guidelines: https://docs.xarray.dev/en/stable/contribute/ai-policy.html. Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

    Tools: Codex
    Prompt: "it looks like xarray's `open_zarr` is a synchronous function that eventually calls zarr's sync API that runs the async API in an event loop in a separate thread, so that won't work for WASM python where threads are not supported. is there a way to open a zarr store asynchronously in xarray? if not, could you make changes that add the async equivalent to `open_zarr`?"