### PR TITLE
Fix Dataset.from_dataframe indexed assignment with pandas 3 (#11527)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -53,6 +53,10 @@ Deprecations
 Bug Fixes
 ~~~~~~~~~
 
+- Fixed read-only data variables from :py:meth:`Dataset.from_dataframe`
+  with pandas 3, allowing indexed assignment to converted numeric columns
+  (:issue:`11527`).
+
 - Fix async zarr tests using ``wraps`` with ``autospec=True`` on async methods,
   which caused ``AsyncMock`` objects to leak through instead of real array data
   (:pull:`11232`).

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -7509,6 +7509,8 @@ class Dataset(
     ) -> None:
         if not isinstance(idx, pd.MultiIndex):
             for name, values in arrays:
+                if not values.flags.writeable:
+                    values = values.copy()
                 self[name] = (dims, values)
             return
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -5536,6 +5536,18 @@ class TestDataset:
         assert len(actual) == dense_u.size
         assert expected.loc[actual.index].equals(actual)
 
+    @pytest.mark.parametrize("dtype", [np.int64, np.float64])
+    def test_from_dataframe_writable(self, dtype) -> None:
+        frame = pd.DataFrame(
+            {"value": np.array([1, 2], dtype=dtype)},
+            index=pd.Index(["a", "b"], name="location"),
+        )
+        actual = Dataset.from_dataframe(frame)
+
+        actual["value"].loc[{"location": "a"}] = 3
+
+        assert_array_equal(actual["value"], [3, 2])
+
     def test_from_dataframe_categorical_dtype_index(self) -> None:
         cat = pd.CategoricalIndex(list("abcd"))
         df = pd.DataFrame({"f": [0, 1, 2, 3]}, index=cat)


### PR DESCRIPTION
### Description

With pandas 3, `Dataset.from_dataframe` retains read-only NumPy column views, so assigning to a normal data variable through `.loc` raises `ValueError`. Copy read-only columns when installing them as data variables; writable columns keep their existing behavior. The regression test covers integer and float columns.

Reproduction on the unpatched commit with pandas 3.0.5:

```python
import pandas as pd

frame = pd.DataFrame({"value": [1.0, 2.0]}, index=pd.Index(["a", "b"], name="location"))
ds = frame.to_xarray()
ds["value"].loc[{"location": "a"}] = 3.0
```

The [indexing documentation at the tested base](https://github.com/pydata/xarray/blob/8de862c29544c2fb1957ce20985745952bc81de7/doc/user-guide/indexing.md#L441-L442) says: “To select and assign values to a portion of a DataArray you can use indexing with `.loc`”.

Validation: two clean pandas 3 runs each passed 513 existing Dataset tests; the two new cases failed before the fix and passed afterward (515 passed). [Checks on the exact PR commit](https://github.com/glaziermag/xarray/actions/runs/34665930329) passed the reproduction, conversion tests, and repository-pinned Ruff checks. Pandas 2 conversion tests also passed; its broader Dataset run encountered an unrelated NumPy 2.5 timedelta deprecation in `test_sel`.

### Checklist

- [x] Closes #11527
- [x] Tests added
- [x] User-visible changes documented in `whats-new.rst`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested the AI-generated content through the remote runs above.
  - [x] I take responsibility for the submitted content.

Tool: Codex, used for the patch, tests, and draft text. Task summary: investigate the reported DataFrame assignment failure and verify a minimal fix remotely.
