### PR TITLE
Support iterator keys in Dataset variable selection

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -53,6 +53,11 @@ Deprecations
 Bug Fixes
 ~~~~~~~~~
 
+- Allow :py:class:`Dataset` variable selection with one-shot iterators, consuming
+  the iterator once instead of treating the iterator object as a variable name
+  (:pull:`11586`).
+  By `Ahmet Kamer <https://github.com/lowgame>`_.
+
 - Fix async zarr tests using ``wraps`` with ``autospec=True`` on async methods,
   which caused ``AsyncMock`` objects to leak through instead of real array data
   (:pull:`11232`).

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -1428,25 +1428,29 @@ class Dataset(
         """
         from xarray.core.formatting import shorten_list_repr
 
+        key_is_iterator = isinstance(cast(Any, key), Iterator)
         if utils.is_dict_like(key):
             return self.isel(**key)
         if utils.hashable(key):
             try:
                 return self._construct_dataarray(key)
             except KeyError as e:
-                message = f"No variable named {key!r}."
+                if not key_is_iterator:
+                    message = f"No variable named {key!r}."
 
-                best_guess = utils.did_you_mean(key, self.variables.keys())
-                if best_guess:
-                    message += f" {best_guess}"
-                else:
-                    message += f" Variables on the dataset include {shorten_list_repr(list(self.variables.keys()), max_items=10)}"
+                    best_guess = utils.did_you_mean(key, self.variables.keys())
+                    if best_guess:
+                        message += f" {best_guess}"
+                    else:
+                        message += f" Variables on the dataset include {shorten_list_repr(list(self.variables.keys()), max_items=10)}"
 
-                # If someone attempts `ds['foo' , 'bar']` instead of `ds[['foo', 'bar']]`
-                if isinstance(key, tuple):
-                    message += f"\nHint: use a list to select multiple variables, for example `ds[{list(key)}]`"
-                raise KeyError(message) from e
+                    # If someone attempts `ds['foo' , 'bar']` instead of `ds[['foo', 'bar']]`
+                    if isinstance(key, tuple):
+                        message += f"\nHint: use a list to select multiple variables, for example `ds[{list(key)}]`"
+                    raise KeyError(message) from e
 
+        if key_is_iterator:
+            key = list(cast(Iterator[Hashable], key))
         if utils.iterable_of_hashable(key):
             return self._copy_listed(key)
         raise ValueError(f"Unsupported key-type {type(key)}")

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -4,7 +4,7 @@ import pickle
 import re
 import sys
 import warnings
-from collections.abc import Hashable
+from collections.abc import Hashable, Iterator, Mapping
 from copy import copy, deepcopy
 from io import StringIO
 from textwrap import dedent
@@ -4540,6 +4540,50 @@ class TestDataset:
         actual3 = data[dict(dim1=0)]
         expected3 = data.isel(dim1=0)
         assert_identical(expected3, actual3)
+
+    def test_getitem_iterator(self) -> None:
+        data = create_test_data()
+        keys = iter(["var1", "var2"])
+
+        actual = data[keys]
+
+        expected = data[["var1", "var2"]]
+        assert_identical(expected, actual)
+
+    def test_getitem_iterator_mapping(self) -> None:
+        class IteratorMapping(Mapping[str, int], Iterator[str]):
+            def __init__(self, values: dict[str, int]) -> None:
+                self._values = values
+                self._iterator = iter(values)
+
+            def __getitem__(self, key: str) -> int:
+                return self._values[key]
+
+            def __iter__(self) -> IteratorMapping:
+                return self
+
+            def __next__(self) -> str:
+                return next(self._iterator)
+
+            def __len__(self) -> int:
+                return len(self._values)
+
+        data = create_test_data()
+        key = IteratorMapping({"dim1": 0})
+
+        actual = data[key]
+
+        expected = data.isel(dim1=0)
+        assert_identical(expected, actual)
+
+    def test_getitem_iterator_variable_name(self) -> None:
+        key = cast(Hashable, iter(["not", "variable", "selection"]))
+        data = Dataset({key: ("x", [1, 2])})
+
+        actual = data[key]
+
+        expected = DataArray([1, 2], dims="x", name=key)
+        assert_identical(expected, actual)
 
     def test_getitem_hashable(self) -> None:
         data = create_test_data()


### PR DESCRIPTION
### Description

`Dataset.__getitem__` accepts `Iterable[Hashable]`, but one-shot iterators were not usable for multi-variable selection. Hashable iterators were treated as scalar variable names, while unhashable iterators could be exhausted during validation.

This change preserves the existing dispatch order for mapping indexers and existing hashable variable names. If a missing scalar key is an iterator, it is materialized once before normal multi-variable selection.

Regression tests cover ordinary iterator selection, an object implementing both `Mapping` and `Iterator`, and an iterator object used as an existing variable name.

### Checklist

- [x] Tests added
- [x] User visible changes are documented in `whats-new.rst`

### Test results

- `uv run pytest xarray/tests/test_dataset.py -q`: 512 passed, 7 skipped, 1 xfailed, 1 xpassed
- `uv run pre-commit run --files xarray/core/dataset.py xarray/tests/test_dataset.py doc/whats-new.rst`: passed

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested the AI-generated content in this PR.
  - [x] I take responsibility for the AI-generated content in this PR.
    Tools: OpenAI Codex

Prepared by OpenAI Codex on behalf of @lowgame; the behavior was reproduced, the diff was independently reviewed, and the listed checks were executed locally.